### PR TITLE
[client] Expose observable API on client.observable

### DIFF
--- a/packages/@sanity/client/package.json
+++ b/packages/@sanity/client/package.json
@@ -30,6 +30,8 @@
     "browserify": "^13.1.1",
     "chalk": "^1.1.3",
     "envify": "^4.0.0",
+    "eslint": "^3.12.2",
+    "eslint-config-sanity": "^2.0.1",
     "gzip-size": "^3.0.0",
     "hard-rejection": "^0.1.0",
     "nock": "git://github.com/rexxars/nock.git#fix-socket-event-scope",

--- a/packages/@sanity/client/src/assets/assetsClient.js
+++ b/packages/@sanity/client/src/assets/assetsClient.js
@@ -5,6 +5,12 @@ function AssetsClient(client) {
   this.client = client
 }
 
+function toPromise(observable) {
+  return observable.filter(event => event.type === 'response')
+    .map(event => event.body)
+    .toPromise()
+}
+
 assign(AssetsClient.prototype, {
   upload(assetType, body, options = {}) {
     validators.validateAssetType(assetType)
@@ -12,7 +18,7 @@ assign(AssetsClient.prototype, {
     const dataset = validators.hasDataset(this.client.clientConfig)
     const assetEndpoint = assetType === 'image' ? 'images' : 'files'
 
-    return this.client.requestObservable({
+    const observable = this.client._requestObservable({
       method: 'POST',
       timeout: options.timeout || 0,
       query: options.label ? {label: options.label} : {},
@@ -20,6 +26,11 @@ assign(AssetsClient.prototype, {
       headers: options.contentType ? {'Content-Type': options.contentType} : {},
       body
     })
+
+    return this.client.isPromiseAPI()
+      ? toPromise(observable)
+      : observable
+
   },
 
   delete(type, id) {

--- a/packages/@sanity/client/src/data/dataMethods.js
+++ b/packages/@sanity/client/src/data/dataMethods.js
@@ -38,7 +38,10 @@ module.exports = {
   },
 
   fetch(query, params) {
-    return this.dataRequest('query', {query, params}).then(res => res.result || [])
+    const observable = this._dataRequest('query', {query, params}).map(res => res.result || [])
+    return this.isPromiseAPI()
+      ? toPromise(observable)
+      : observable
   },
 
   getDocument(id) {

--- a/packages/@sanity/client/src/http/request.js
+++ b/packages/@sanity/client/src/http/request.js
@@ -6,7 +6,7 @@ const observable = require('get-it/lib/middleware/observable')
 const retry = require('get-it/lib/middleware/retry')
 const jsonRequest = require('get-it/lib/middleware/jsonRequest')
 const jsonResponse = require('get-it/lib/middleware/jsonResponse')
-const sanityObservable = require('@sanity/observable/minimal')
+const SanityObservable = require('@sanity/observable/minimal')
 const progress = require('get-it/lib/middleware/progress')
 
 const ClientError = createErrorClass('ClientError', extractError)
@@ -72,7 +72,7 @@ const middleware = [
   jsonResponse(),
   progress(),
   httpError,
-  observable({implementation: sanityObservable}),
+  observable({implementation: SanityObservable}),
   retry({maxRetries: 5, shouldRetry: retry5xx})
 ]
 
@@ -85,14 +85,7 @@ if (process.env.BROWSERIFY_ENV !== 'build') {
 const request = getIt(middleware)
 
 function httpRequest(options, requester = request) {
-  const obs = requester(assign({maxRedirects: 0}, options))
-  obs.toPromise = () => new Promise((resolve, reject) => {
-    obs.filter(ev => ev.type === 'response').subscribe(
-      res => resolve(res.body),
-      reject
-    )
-  })
-  return obs
+  return requester(assign({maxRedirects: 0}, options))
 }
 
 httpRequest.defaultRequester = request

--- a/packages/@sanity/client/src/util/omit.js
+++ b/packages/@sanity/client/src/util/omit.js
@@ -1,0 +1,9 @@
+module.exports = (obj, props) =>
+  Object.keys(obj).reduce((selection, prop) => {
+    if (props.indexOf(prop) !== -1) {
+      return selection
+    }
+
+    selection[prop] = obj[prop]
+    return selection
+  }, {})

--- a/packages/@sanity/client/src/validators.js
+++ b/packages/@sanity/client/src/validators.js
@@ -60,7 +60,3 @@ exports.hasDataset = config => {
 
   return config.dataset || ''
 }
-
-exports.promise = {
-  hasDataset: config => new Promise(resolve => resolve(exports.hasDataset(config)))
-}

--- a/packages/@sanity/client/test/client.test.js
+++ b/packages/@sanity/client/test/client.test.js
@@ -271,17 +271,9 @@ test('populates response body on errors', t => {
     })
 })
 
-test('rejects if trying to perform data request without dataset', t => {
-  sanityClient({projectId: 'foo'}).fetch('blah')
-    .then(res => {
-      t.fail('Resolve handler should not be called on failure')
-      t.end()
-    })
-    .catch(err => {
-      t.ok(err instanceof Error, 'should be error')
-      t.ok(/dataset.*?must be provided/.test(err.message))
-      t.end()
-    })
+test('throws if trying to perform data request without dataset', t => {
+  t.throws(() => sanityClient({projectId: 'foo'}).fetch('blah'), Error, /dataset.*?must be provided/)
+  t.end()
 })
 
 test('can create documents', t => {
@@ -1035,9 +1027,7 @@ test('uploads images', t => {
     .reply(201, {url: 'https://some.asset.url'})
 
   getClient().assets.upload('image', fs.createReadStream(fixturePath))
-    .filter(event => event.type === 'response')
-    .map(event => event.body)
-    .subscribe(body => {
+    .then(body => {
       t.equal(body.url, 'https://some.asset.url')
       t.end()
     }, ifError(t))
@@ -1052,7 +1042,7 @@ test('uploads images with progress events', t => {
     .reply(201, {url: 'https://some.asset.url'})
 
   // @todo write a test that asserts upload events (slowness)
-  getClient().assets.upload('image', fs.createReadStream(fixturePath))
+  getClient().observable.assets.upload('image', fs.createReadStream(fixturePath))
     .filter(event => event.type === 'progress')
     .subscribe(
       event => t.equal(event.type, 'progress'),
@@ -1070,9 +1060,7 @@ test('uploads images with custom label', t => {
     .reply(201, {label: label})
 
   getClient().assets.upload('image', fs.createReadStream(fixturePath), {label: label})
-    .filter(event => event.type === 'response') // todo: test progress events too
-    .map(event => event.body)
-    .subscribe(body => {
+    .then(body => {
       t.equal(body.label, label)
       t.end()
     }, ifError(t))
@@ -1087,9 +1075,7 @@ test('uploads files', t => {
     .reply(201, {url: 'https://some.asset.url'})
 
   getClient().assets.upload('file', fs.createReadStream(fixturePath))
-    .filter(event => event.type === 'response')
-    .map(evt => evt.body)
-    .subscribe(body => {
+    .then(body => {
       t.equal(body.url, 'https://some.asset.url')
       t.end()
     }, ifError(t))
@@ -1104,7 +1090,6 @@ test('uploads images and can cast to promise', t => {
     .reply(201, {url: 'https://some.asset.url'})
 
   getClient().assets.upload('image', fs.createReadStream(fixturePath))
-    .toPromise()
     .then(body => {
       t.equal(body.url, 'https://some.asset.url')
       t.end()

--- a/packages/@sanity/client/test/client.test.js
+++ b/packages/@sanity/client/test/client.test.js
@@ -48,6 +48,14 @@ test('config getter returns a cloned object', t => {
   t.end()
 })
 
+test('calling config() reconfigures observable API too', t => {
+  const client = sanityClient({projectId: 'abc123'})
+
+  client.config({projectId: 'def456'})
+  t.equal(client.observable.config().projectId, 'def456', 'Observable API gets reconfigured')
+  t.end()
+})
+
 test('can clone client', t => {
   const client = sanityClient({projectId: 'abc123'})
   t.equal(client.config().projectId, 'abc123', 'constructor opts are set')

--- a/packages/@sanity/form-builder/src/sanity/inputs/File.js
+++ b/packages/@sanity/form-builder/src/sanity/inputs/File.js
@@ -2,7 +2,7 @@ import client from 'part:@sanity/base/client'
 import {FileInput} from '../../index'
 
 function upload(file) {
-  return client.assets.upload('file', file).map(event => {
+  return client.observable.assets.upload('file', file).map(event => {
 
     if (event.type !== 'response') {
       return event

--- a/packages/@sanity/form-builder/src/sanity/inputs/Image.js
+++ b/packages/@sanity/form-builder/src/sanity/inputs/Image.js
@@ -2,7 +2,7 @@ import client from 'part:@sanity/base/client'
 import {ImageInput} from '../../index'
 
 function upload(image) {
-  return client.assets.upload('image', image.file).map(event => {
+  return client.observable.assets.upload('image', image.file).map(event => {
 
     if (event.type === 'response') {
       // rewrite to a 'complete' event


### PR DESCRIPTION
This makes the default sanity client strictly promise based, and instead exposes an Observable-based API on `client.observable`.

This leaves current API *mostly* intact, with a few exceptions:

-  `client.assets.upload()` now returns a promise that resolves with the response body (and thus provides no way to track progress). If progress tracking is needed, the observable is available on `client.observable.assets.upload()`

- A data request without a configured dataset will throw a sync error and no longer propagate the error through the returned promise. This is (as far as I could assert) the behavior of other validation errors too.