### PR TITLE
[form-builder] Fix nesting level on forms

### DIFF
--- a/packages/@sanity/base/src/styles/typography/forms.css
+++ b/packages/@sanity/base/src/styles/typography/forms.css
@@ -1,17 +1,13 @@
 @import 'part:@sanity/base/theme/variables-style';
 
-.headingLevel_0 {
-  font-size: var(--font-size-h4);
-  font-weight: 400;
-}
-
 .headingLevel_1 {
   font-size: var(--font-size-h4);
   font-weight: 400;
 }
 
 .headingLevel_2 {
-  font-size: var(--font-size-base);
+  font-size: var(--font-size-h4);
+  font-weight: 400;
 }
 
 .headingLevel_3 {
@@ -19,6 +15,10 @@
 }
 
 .headingLevel_4 {
+  font-size: var(--font-size-base);
+}
+
+.headingLevel_5 {
   font-size: var(--font-size-base);
 }
 

--- a/packages/@sanity/components/src/fieldsets/styles/DefaultFieldset.css
+++ b/packages/@sanity/components/src/fieldsets/styles/DefaultFieldset.css
@@ -97,12 +97,6 @@
     box-shadow: none;
   }
 
-  @nest .level1 & {
-    background-color: transparent;
-    border: none;
-    padding: 0;
-  }
-
   @nest .level2 & {
     background-color: transparent;
     border: none;
@@ -120,6 +114,12 @@
     border: none;
     padding: 0;
   }
+
+  @nest .level5 & {
+    background-color: transparent;
+    border: none;
+    padding: 0;
+  }
 }
 
 .inner {
@@ -131,7 +131,7 @@
 }
 
 .legend {
-  composes: headingLevel_0 from 'part:@sanity/base/theme/typography/forms-style';
+  composes: headingLevel_1 from 'part:@sanity/base/theme/typography/forms-style';
   display: block;
   width: 100%;
   margin: 0;
@@ -155,6 +155,11 @@
   }
 
   @nest .level4 & {
+    font-size: var(--font-size-h4);
+    text-transform: none;
+  }
+
+  @nest .level5 & {
     font-size: var(--font-size-h4);
     text-transform: none;
   }

--- a/packages/@sanity/components/src/formfields/styles/DefaultFormField.css
+++ b/packages/@sanity/components/src/formfields/styles/DefaultFormField.css
@@ -67,10 +67,6 @@
   }
 }
 
-.level_0 {
-  composes: root;
-}
-
 .level_1 {
   composes: root;
 }
@@ -80,5 +76,9 @@
 }
 
 .level_3 {
+  composes: root;
+}
+
+.level_4 {
   composes: root;
 }

--- a/packages/@sanity/components/src/imageinput/styles/ImageInputFieldset.css
+++ b/packages/@sanity/components/src/imageinput/styles/ImageInputFieldset.css
@@ -20,7 +20,7 @@
   flex-direction: column;
   justify-content: flex-start;
 
-  @nest .level0 & {
+  @nest .level1 & {
     margin: calc(var(--medium-padding) * -1) !important;
   }
 

--- a/packages/@sanity/components/src/labels/styles/DefaultLabel.css
+++ b/packages/@sanity/components/src/labels/styles/DefaultLabel.css
@@ -2,11 +2,10 @@
   display: block;
 }
 
-.level_0 {
-  composes: headingLevel_0 from 'part:@sanity/base/theme/typography/forms-style';
+.level_1 {
+  composes: headingLevel_1 from 'part:@sanity/base/theme/typography/forms-style';
 }
 
-.level_1,
 .level_2,
 .level_3,
 .level_4 {

--- a/packages/@sanity/form-builder/src/inputs/Array/Array.js
+++ b/packages/@sanity/form-builder/src/inputs/Array/Array.js
@@ -204,7 +204,7 @@ export default class ArrayInput extends React.Component {
     const itemField = this.getItemType(item)
 
     // Reset level if a full screen modal
-    const level = (type.options && type.options.editModal == 'fullscreen') ? 0 : this.props.level + 1
+    const level = (type.options && type.options.editModal == 'fullscreen') ? 1 : this.props.level + 1
 
     const content = (
       <MemberValue path={{_key: item._key}}>

--- a/packages/@sanity/form-builder/src/inputs/Object/Object.js
+++ b/packages/@sanity/form-builder/src/inputs/Object/Object.js
@@ -50,8 +50,6 @@ export default class ObjectInput extends React.PureComponent {
   }
 
   renderField(field, level, index) {
-    // todo: reiterate how we deal with incrementing levels
-
     const {value, hasFocus, validation} = this.props
     const fieldValidation = validation && validation.fields[field.name]
 
@@ -71,7 +69,8 @@ export default class ObjectInput extends React.PureComponent {
     )
   }
 
-  renderFieldset(fieldset, level, index) {
+  renderFieldset(fieldset, fieldsetIndex) {
+    const {level} = this.props
     const columns = fieldset.options && fieldset.options.columns
     const collapsable = fieldset.options && fieldset.options.collapsable
     return (
@@ -79,26 +78,29 @@ export default class ObjectInput extends React.PureComponent {
         key={fieldset.name}
         legend={fieldset.title}
         description={fieldset.description}
-        level={level}
+        level={level + 1}
         columns={columns}
         collapsable={collapsable}
       >
         {fieldset.fields.map((field, fieldIndex) => {
-          return this.renderField(field, level + 1, index + fieldIndex)
+          return this.renderField(field, level + 2, fieldsetIndex + fieldIndex)
         })}
       </Fieldset>
     )
   }
 
-  getRenderedFields(type, level) {
+  getRenderedFields() {
+    const {type, level} = this.props
+
     if (!type.fieldsets) {
-      return (type.fields || []).map((field, i) => this.renderField(field, level === 0 ? level : level + 1, i))
+      // this is a fallback for schema types that are not parsed to be objects, but still has jsonType == 'object'
+      return (type.fields || []).map((field, i) => this.renderField(field, level + 1, i))
     }
 
     return type.fieldsets.map((fieldset, i) => {
       return fieldset.single
-        ? this.renderField(fieldset.field, level === 0 ? level : level + 1, i)
-        : this.renderFieldset(fieldset, level, i)
+        ? this.renderField(fieldset.field, level + 1, i)
+        : this.renderFieldset(fieldset, i)
     })
 
   }
@@ -106,7 +108,7 @@ export default class ObjectInput extends React.PureComponent {
 
     const {type, level} = this.props
 
-    const renderedFields = this.getRenderedFields(type, level)
+    const renderedFields = this.getRenderedFields()
 
     if (level === 0) {
       return <div>{renderedFields}</div>

--- a/packages/example-studio/schemas/block-array.js
+++ b/packages/example-studio/schemas/block-array.js
@@ -71,9 +71,11 @@ export default [
         title: 'Blocks deep down',
         type: 'object',
         fields: [
+          {name: 'something', title: 'Something', type: 'string'},
           {
             name: 'blocks',
             type: 'array',
+            title: 'Blocks',
             of: [
               {type: 'image', title: 'Image'},
               {type: 'author', title: 'Author'},

--- a/packages/example-studio/schemas/schema.js
+++ b/packages/example-studio/schemas/schema.js
@@ -160,6 +160,23 @@ export default createSchema({
           type: 'boolean'
         },
         {
+          name: 'someObject',
+          title: 'An object',
+          type: 'object',
+          fields: [
+            {
+              name: 'first',
+              type: 'string',
+              title: 'First field'
+            },
+            {
+              name: 'second',
+              type: 'string',
+              title: 'Second field'
+            }
+          ]
+        },
+        {
           name: 'body',
           type: 'array',
           title: 'Blocks',


### PR DESCRIPTION
Fixes a bug that caused nested objects to not render their headings properly.

As an added bonus, the code that increases nesting levels in the Object input should now be a bit easier to reason about.

## Before:
<img width="400" alt="image" src="https://cloud.githubusercontent.com/assets/876086/25345029/219de6e8-2914-11e7-9325-2fd247fcf840.png">

## After:
<img width="400" alt="image" src="https://cloud.githubusercontent.com/assets/876086/25345056/3a228764-2914-11e7-9f8a-f67c5a728b33.png">
