### PR TITLE
[desk-tool] Fix keyboard shortcut for inspect view on Linux

### DIFF
--- a/packages/@sanity/desk-tool/src/pane/Editor.js
+++ b/packages/@sanity/desk-tool/src/pane/Editor.js
@@ -137,7 +137,7 @@ export default withRouterHOC(class Editor extends React.PureComponent {
   componentDidMount() {
     this.unlistenForKey = listen(window, 'keyup', event => {
       const shouldToggle = event.ctrlKey
-        && event.key === 'i'
+        && (event.key === 'i' || event.key === 'ı' /* alt + i becomes ı on macos */)
         && event.altKey
         && !event.shiftKey
 

--- a/packages/@sanity/desk-tool/src/pane/Editor.js
+++ b/packages/@sanity/desk-tool/src/pane/Editor.js
@@ -137,7 +137,7 @@ export default withRouterHOC(class Editor extends React.PureComponent {
   componentDidMount() {
     this.unlistenForKey = listen(window, 'keyup', event => {
       const shouldToggle = event.ctrlKey
-        && (event.key === 'i' || event.key === 'ı' /* alt + i becomes ı on macos */)
+        && event.code === 'KeyI'
         && event.altKey
         && !event.shiftKey
 

--- a/packages/@sanity/desk-tool/src/pane/Editor.js
+++ b/packages/@sanity/desk-tool/src/pane/Editor.js
@@ -27,7 +27,7 @@ import {PreviewFields} from 'part:@sanity/base/preview'
 
 const preventDefault = ev => ev.preventDefault()
 
-// Want a nicer api for listen/ulinsten
+// Want a nicer api for listen/unlisten
 function listen(target, eventType, callback, useCapture = false) {
   target.addEventListener(eventType, callback, useCapture)
   return function unlisten() {
@@ -135,9 +135,9 @@ export default withRouterHOC(class Editor extends React.PureComponent {
   state = INITIAL_STATE
 
   componentDidMount() {
-    this.unlistenForKey = listen(window, 'keypress', event => {
+    this.unlistenForKey = listen(window, 'keyup', event => {
       const shouldToggle = event.ctrlKey
-        && event.charCode === 9
+        && event.key === 'i'
         && event.altKey
         && !event.shiftKey
 


### PR DESCRIPTION
The keyboard shortcut for the inspect view has never worked on Linux+Chrome.

After some debugging, it seems `keypress` is never fired when I press ctrl+alt+i.
`keyup` works as expected, but the `charCode` property is a non-standard and deprecated property, so I replaced it with the `key` property. This also makes the code slightly more readable, in my opinion.

Please test on Mac and ensure it still works as expected.
