### PR TITLE
[cli] Fix issue where command group roots would not list commands

### DIFF
--- a/packages/@sanity/cli/src/CommandRunner.js
+++ b/packages/@sanity/cli/src/CommandRunner.js
@@ -80,12 +80,20 @@ export default class CommandRunner {
       commandRunner: this
     }
 
+    if (command.isGroupRoot) {
+      return context.output.print(generateCommandsDocumentation(
+        this.commandGroups,
+        command.name
+      ))
+    }
+
     if (typeof command.action !== 'function') {
       const cmdName = command.name || commandOrGroup || '<unknown>'
       debug(`Command "${cmdName}" doesnt have a valid "action"-property, showing help`)
+      const groupName = command.group && command.group !== 'default' ? command.group : null
       return context.output.print(generateCommandDocumentation(
         command,
-        command.group && command.group !== 'default' ? command.group : null,
+        groupName,
         subCommandName
       ))
     }

--- a/packages/@sanity/cli/src/commands/help/showHelp.js
+++ b/packages/@sanity/cli/src/commands/help/showHelp.js
@@ -45,6 +45,7 @@ export default (args, context) => {
     throw new Error(noSuchCommandText(subCommandName, commandName, commandGroups))
   }
 
+  debug('Subcommand "%s" for group "%s" found, showing help', subCommandName, commandName)
   context.output.print(generateCommandDocumentation(
     subCommand.command,
     commandName,

--- a/packages/@sanity/core/src/commands/documents/queryDocumentsCommand.js
+++ b/packages/@sanity/core/src/commands/documents/queryDocumentsCommand.js
@@ -1,10 +1,20 @@
 const colorizeJson = require('../../util/colorizeJson')
 
+const help = `
+Runs a query against the projects configured dataset. Specify --pretty to get
+colorized JSON output. Example:
+
+  sanity documents query '*[_type == "movie"][0...5]'
+
+Will fetch 5 documents of type "movie"
+`
+
 export default {
   name: 'query',
   group: 'documents',
   signature: '[QUERY]',
   description: 'Query for documents',
+  helpText: help,
   action: async (args, context) => {
     const {apiClient, output, chalk} = context
     const {pretty} = args.extOptions


### PR DESCRIPTION
Group roots currently do not list it's subcommands. This PR fixes this issue and also adds an example on how to add help text to subcommands.