### PR TITLE
[form-builder] Fix: grid items was not draggable

### DIFF
--- a/packages/@sanity/base/src/styles/layout/helpers.css
+++ b/packages/@sanity/base/src/styles/layout/helpers.css
@@ -24,7 +24,7 @@
 }
 
 .movingItem {
-  background-color: var(--component-bg);
+  background-color: var(--selected-item-color);
   opacity: 0.9;
   composes: shadow-5dp from 'part:@sanity/base/theme/shadows-style';
 }

--- a/packages/@sanity/base/src/styles/layout/helpers.css
+++ b/packages/@sanity/base/src/styles/layout/helpers.css
@@ -24,7 +24,8 @@
 }
 
 .movingItem {
-  background-color: var(--selected-item-color);
-  opacity: 0.9;
+  background-color: var(--selectable-item-color-active);
+  opacity: 0.8;
   composes: shadow-5dp from 'part:@sanity/base/theme/shadows-style';
+  z-index: var(--zindex-moving-item);
 }

--- a/packages/@sanity/base/src/styles/variables/layers.css
+++ b/packages/@sanity/base/src/styles/variables/layers.css
@@ -10,4 +10,5 @@
   --zindex-tooltip: 1100;
   --zindex-modal-background: 2000;
   --zindex-modal: 2010;
+  --zindex-moving-item: 3000;
 }

--- a/packages/@sanity/base/src/styles/variables/selectable-item.css
+++ b/packages/@sanity/base/src/styles/variables/selectable-item.css
@@ -6,6 +6,8 @@
   --selectable-item-color--inverted: var(--white);
   --selectable-item-color-hover: var(--gray-lighter);
   --selectable-item-color-hover--inverted: var(--white);
+  --selectable-item-color-active: var(--brand-primary);
+  --selectable-item-color-active--inverted: var(--white);
   --selected-item-color: var(--brand-primary);
   --selected-item-color--inverted: var(--white);
   --selected-item-color-hover: color(var(--brand-primary) lightness(+10%));

--- a/packages/@sanity/form-builder/src/inputs/Array/Array.js
+++ b/packages/@sanity/form-builder/src/inputs/Array/Array.js
@@ -206,7 +206,6 @@ export default class ArrayInput<T: ItemValue> extends React.Component<*, *, Stat
       <List
         movingItemClass={styles.movingItem}
         onSort={this.handleSort}
-        useDragHandle
       >
         {value.map((item, index) => {
           const {editItemKey} = this.state

--- a/packages/@sanity/form-builder/src/inputs/Array/styles/Array.css
+++ b/packages/@sanity/form-builder/src/inputs/Array/styles/Array.css
@@ -3,6 +3,7 @@
 .root {
   display: block;
   position: relative;
+  z-index: 1;
 }
 
 .list {
@@ -23,7 +24,6 @@
 
 .movingItem {
   composes: movingItem from 'part:@sanity/base/theme/layout/helpers';
-  z-index: 100;
 }
 
 .item {

--- a/packages/@sanity/form-builder/src/inputs/Array/styles/Array.css
+++ b/packages/@sanity/form-builder/src/inputs/Array/styles/Array.css
@@ -23,6 +23,7 @@
 
 .movingItem {
   composes: movingItem from 'part:@sanity/base/theme/layout/helpers';
+  z-index: 100;
 }
 
 .item {

--- a/packages/@sanity/form-builder/src/inputs/Array/styles/ItemValue.css
+++ b/packages/@sanity/form-builder/src/inputs/Array/styles/ItemValue.css
@@ -23,19 +23,6 @@
   outline: none;
 }
 
-.dragHandle {
-  flex-grow: 0;
-  cursor: ns-resize;
-  opacity: 0.5;
-  font-size: 1em;
-  padding: 0.5em;
-  border: 1px solid transparent;
-  z-index: 1;
-  &:hover {
-    opacity: 1;
-  }
-}
-
 .functions {
   flex-grow: 0;
   font-size: 0.9rem;


### PR DESCRIPTION
It was caused by `useDragHandle` being set on list
Also includes minor style changes

Should be safe to merge straight into master