### PR TITLE
[client] Uncredentialed requests if `withCredentials` + `token` is undefined

### DIFF
--- a/packages/@sanity/client/src/http/requestOptions.js
+++ b/packages/@sanity/client/src/http/requestOptions.js
@@ -14,7 +14,7 @@ module.exports = config => {
   return {
     headers: headers,
     timeout: ('timeout' in config) ? config.timeout : 30000,
-    withCredentials: config.withCredentials !== false,
-    json: true
+    json: true,
+    withCredentials: Boolean(config.token || config.withCredentials)
   }
 }


### PR DESCRIPTION
Currently, the client is credentialed by default - that is, if the user has a session, every request from the client will include a cookie or authorization header, unless `withCredentials` is explicitly set to `false`.

This PR inverts this behaviour; all requests are uncredentialed (sent without Authorization/Cookie) by default, unless the `token` or `withCredentials` options are set to `true`.

Since server-side uses of the client usually includes a token, this mainly affects front-ends. For instance, the sanity studio needs to specify `withCredentials` when instantiating the client. Front-end applications that previews drafts and implicitly depend on the user being authenticated also needs to include the `withCredentials` option (set to true).

The rationale behind this change is that most front-ends using this client wants to retrieve data without exposing "private" data such as drafts. Now, this should work out of the box, whereas performing more complex operations such as writes will need a small change. Optimize for the common use case, in other words.
