### PR TITLE
[base] Use credentialed requests in studio

### DIFF
--- a/packages/@sanity/base/src/client/index.js
+++ b/packages/@sanity/base/src/client/index.js
@@ -2,6 +2,7 @@ import sanityClient from '@sanity/client'
 import config from 'config:sanity'
 import configureClient from 'part:@sanity/base/configure-client?'
 
-const client = sanityClient(config.api)
+const apiConfig = {...config.api, withCredentials: true}
+const client = sanityClient(apiConfig)
 
-export default configureClient ? configureClient(sanityClient(config.api)) : client
+export default configureClient ? configureClient(sanityClient(apiConfig)) : client


### PR DESCRIPTION
Follow-up to #114  - we now need to specify that we want credentialed requests in the studio.
