### PR TITLE
[base] A fix + example schema demonstrating named reference types

### DIFF
--- a/packages/@sanity/base/src/preview/createPreviewObserver.js
+++ b/packages/@sanity/base/src/preview/createPreviewObserver.js
@@ -9,9 +9,7 @@ function resolveMissingHeads(value, paths) {
 }
 
 function isReference(value) {
-  return value._type === 'reference'
-    // should not happen as all references should have _type === 'reference'
-    || (!('_type' in value) && ('_ref' in value))
+  return '_ref' in value
 }
 
 function isDocument(value) {

--- a/packages/@sanity/base/src/preview/observeForPreview.js
+++ b/packages/@sanity/base/src/preview/observeForPreview.js
@@ -6,9 +6,13 @@ import Observable from '@sanity/observable'
 
 const observe = createPreviewObserver(observeWithPaths)
 
+function is(typeName, type) {
+  return type.name === typeName || (type.type && is(typeName, type.type))
+}
+
 // Takes a value and its type and prepares a snapshot for it that can be passed to a preview component
 export default function observeForPreview(value, type, fields) {
-  if (type.name === 'reference') {
+  if (is('reference', type)) {
     // if the value is of type reference, but has no _ref property, we cannot prepare any value for the preview
     // and the most sane thing to do is to return `null` for snapshot
     if (!value._ref) {

--- a/packages/example-studio/schemas/blocks.js
+++ b/packages/example-studio/schemas/blocks.js
@@ -1,4 +1,3 @@
-
 export const blocksTest = {
   name: 'blocksTest',
   title: 'Blocks test',
@@ -15,9 +14,32 @@ export const blocksTest = {
       type: 'array',
       of: [
         {type: 'image', title: 'Image'},
-        {type: 'reference', to: {type: 'author'}, title: 'Reference to author'},
+        {
+          type: 'reference', name: 'authorReference',
+          to: {type: 'author'},
+          title: 'Reference to author'
+        },
+        {
+          type: 'reference',
+          name: 'blogpostReference',
+          to: {type: 'blogpost'},
+          title: 'Reference to blogpost'
+        },
         {type: 'author', title: 'Embedded author'},
         {type: 'code', title: 'Code'},
+        {
+          type: 'object', title: 'Test object', name: 'testObject',
+          fields: [
+            {name: 'field1', type: 'string'}
+          ]
+        },
+        {
+          type: 'object', title: 'Other test object', name: 'otherTestObject',
+          fields: [
+            {name: 'field1', type: 'string'},
+            {name: 'field2', type: 'string'}
+          ]
+        },
         {type: 'block'},
         {type: 'videoEmbed', title: 'Video embed'}
       ]
@@ -43,27 +65,27 @@ export const blocksTest = {
       title: 'Customized with block types',
       type: 'array',
       of: [
-          {type: 'image', title: 'Image'},
-          {type: 'author', title: 'Author'},
+        {type: 'image', title: 'Image'},
+        {type: 'author', title: 'Author'},
         {
           type: 'block',
           styles: [
-              {title: 'Normal', value: 'normal'},
-              {title: 'H1', value: 'h1'},
-              {title: 'H2', value: 'h2'},
-              {title: 'Quote', value: 'blockquote'}
+            {title: 'Normal', value: 'normal'},
+            {title: 'H1', value: 'h1'},
+            {title: 'H2', value: 'h2'},
+            {title: 'Quote', value: 'blockquote'}
           ],
           lists: [
-              {title: 'Bullet', value: 'bullet'},
-              {title: 'Numbered', value: 'number'}
+            {title: 'Bullet', value: 'bullet'},
+            {title: 'Numbered', value: 'number'}
           ],
           span: {
             marks: [
-                {title: 'Strong', value: 'strong'},
-                {title: 'Emphasis', value: 'em'}
+              {title: 'Strong', value: 'strong'},
+              {title: 'Emphasis', value: 'em'}
             ],
             fields: [
-                {name: 'Author', title: 'Author', type: 'reference', to: {type: 'author'}}
+              {name: 'Author', title: 'Author', type: 'reference', to: {type: 'author'}}
             ]
           }
         }
@@ -74,33 +96,33 @@ export const blocksTest = {
       title: 'Blocks deep down',
       type: 'object',
       fields: [
-          {name: 'something', title: 'Something', type: 'string'},
+        {name: 'something', title: 'Something', type: 'string'},
         {
           name: 'blocks',
           type: 'array',
           title: 'Blocks',
           of: [
-              {type: 'image', title: 'Image'},
-              {type: 'author', title: 'Author'},
+            {type: 'image', title: 'Image'},
+            {type: 'author', title: 'Author'},
             {
               type: 'block',
               styles: [
-                  {title: 'Normal', value: 'normal'},
-                  {title: 'H1', value: 'h1'},
-                  {title: 'H2', value: 'h2'},
-                  {title: 'Quote', value: 'blockquote'}
+                {title: 'Normal', value: 'normal'},
+                {title: 'H1', value: 'h1'},
+                {title: 'H2', value: 'h2'},
+                {title: 'Quote', value: 'blockquote'}
               ],
               lists: [
-                  {title: 'Bullet', value: 'bullet'},
-                  {title: 'Numbered', value: 'number'}
+                {title: 'Bullet', value: 'bullet'},
+                {title: 'Numbered', value: 'number'}
               ],
               span: {
                 marks: [
-                    {title: 'Strong', value: 'strong'},
-                    {title: 'Emphasis', value: 'em'}
+                  {title: 'Strong', value: 'strong'},
+                  {title: 'Emphasis', value: 'em'}
                 ],
                 fields: [
-                    {name: 'Author', title: 'Author', type: 'reference', to: {type: 'author'}}
+                  {name: 'Author', title: 'Author', type: 'reference', to: {type: 'author'}}
                 ]
               }
             }

--- a/packages/example-studio/schemas/referenceTest.js
+++ b/packages/example-studio/schemas/referenceTest.js
@@ -4,6 +4,22 @@ export default {
   title: 'Reference Test',
   fields: [
     {name: 'title', type: 'string'},
-    {name: 'selfRef', type: 'reference', to: {type: 'referenceTest'}}
+    {name: 'selfRef', type: 'reference', to: {type: 'referenceTest'}},
+    {
+      name: 'arrayOfNamedReferences',
+      type: 'array',
+      of: [
+        {
+          type: 'reference',
+          name: 'authorReference',
+          to: [{type: 'author', title: 'Reference to author'}]
+        },
+        {
+          type: 'reference',
+          name: 'blogpostReference',
+          to: [{type: 'blogpost', title: 'Reference to blog post'}]
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
This fixes an issue with previews that broke when you had named reference types in arrays / block editor, and adds a few examples of named reference types to the example-studio schema, see:

https://github.com/sanity-io/sanity/blob/b26fafff070ebf4bcbb1c99866029af3a5225747/packages/example-studio/schemas/referenceTest.js#L8-L24
and
https://github.com/sanity-io/sanity/blob/b26fafff070ebf4bcbb1c99866029af3a5225747/packages/example-studio/schemas/blocks.js#L17-L27
(cc @skogsmaskin, @simen)