### PR TITLE
[form-builder] Fix: Subscribe to current document instead of relying on document being passed down

### DIFF
--- a/packages/@sanity/form-builder/src/FormBuilderInput.js
+++ b/packages/@sanity/form-builder/src/FormBuilderInput.js
@@ -35,7 +35,6 @@ export class FormBuilderInput extends React.Component {
       return <div>No input resolved for type {JSON.stringify(type.name)}</div>
     }
 
-    const docProps = InputComponent.passDocument ? {document: this.context.formBuilder.getDocument()} : {}
     const rootProps = isRoot ? {isRoot} : {}
 
     return (
@@ -46,7 +45,6 @@ export class FormBuilderInput extends React.Component {
         onChange={type.readOnly ? NOOP : onChange}
         validation={validation}
         level={level}
-        {...docProps}
         {...rootProps}
       />
     )

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/Syncer.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/Syncer.js
@@ -6,7 +6,7 @@ import sanityToSlateRaw from './conversion/sanityToSlateRaw'
 import slateRawToSanity from './conversion/slateRawToSanity'
 import {throttle} from 'lodash'
 import PatchEvent, {set, unset} from '../../PatchEvent'
-import SubscribePatchHOC from '../../utils/SubscribePatchHOC'
+import withPatchSubscriber from '../../utils/withPatchSubscriber'
 import Button from 'part:@sanity/components/buttons/default'
 import styles from './styles/Syncer.css'
 
@@ -21,7 +21,7 @@ function isDocumentEqual(slateState, otherSlateState) {
   return slateState.get('document') === otherSlateState.get('document')
 }
 
-export default SubscribePatchHOC(class Syncer extends React.PureComponent {
+export default withPatchSubscriber(class Syncer extends React.PureComponent {
   static propTypes = {
     value: PropTypes.array,
     type: PropTypes.object.isRequired,

--- a/packages/@sanity/form-builder/src/inputs/Slug/SlugInput.js
+++ b/packages/@sanity/form-builder/src/inputs/Slug/SlugInput.js
@@ -48,8 +48,6 @@ const vanillaState = {
 }
 
 export default class SlugInput extends React.Component {
-  static passDocument = true;
-
   static propTypes = {
     type: FormBuilderPropTypes.type.isRequired,
     level: PropTypes.number.isRequired,

--- a/packages/@sanity/form-builder/src/inputs/Slug/createSlugInput.js
+++ b/packages/@sanity/form-builder/src/inputs/Slug/createSlugInput.js
@@ -1,13 +1,13 @@
 import React from 'react'
 import SlugInput from './SlugInput'
+import withDocument from '../../utils/withDocument'
 
 export default function createSlugInput({validate, slugify}) {
-  return class CustomSlugInput extends React.PureComponent {
-    static passDocument = true;
+  return withDocument(class CustomSlugInput extends React.PureComponent {
     render() {
       return (
         <SlugInput {...this.props} checkValidityFn={validate} slugifyFn={slugify} />
       )
     }
-  }
+  })
 }

--- a/packages/@sanity/form-builder/src/utils/ValueSync.js
+++ b/packages/@sanity/form-builder/src/utils/ValueSync.js
@@ -4,7 +4,7 @@ import React from 'react'
 import type {Patch} from '../utils/patches'
 import {debounce} from 'lodash'
 import whyNotEqual from 'is-equal/why'
-import SubscribePatchHOC from './SubscribePatchHOC'
+import withPatchSubscriber from './withPatchSubscriber'
 
 declare var __DEV__: boolean
 
@@ -22,7 +22,7 @@ type Props = {
 }
 
 
-export default SubscribePatchHOC(class SubscribePatch extends React.Component {
+export default withPatchSubscriber(class ValueSync extends React.Component {
   props: Props
 
   static contextTypes = {

--- a/packages/@sanity/form-builder/src/utils/withDocument.js
+++ b/packages/@sanity/form-builder/src/utils/withDocument.js
@@ -1,0 +1,34 @@
+// @flow
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export default function withDocument(ComposedComponent: any) {
+
+  return class withDocument extends React.PureComponent {
+    static displayName = `withDocument(${ComposedComponent.displayName || ComposedComponent.name})`
+
+    static contextTypes = {
+      formBuilder: PropTypes.any,
+    }
+
+    state: {
+      document: Object
+    }
+    unsubscribe: () => void
+
+    constructor(props : any, context: any) {
+      super()
+      const {formBuilder} = context
+      this.state = {document: formBuilder.getDocument()}
+      this.unsubscribe = formBuilder.onPatch(({snapshot}) => {
+        this.setState({document: snapshot})
+      })
+    }
+    componentWillUnmount() {
+      this.unsubscribe()
+    }
+    render() {
+      return <ComposedComponent document={this.state.document} {...this.props}/>
+    }
+  }
+}

--- a/packages/@sanity/form-builder/src/utils/withPatchSubscriber.js
+++ b/packages/@sanity/form-builder/src/utils/withPatchSubscriber.js
@@ -1,6 +1,6 @@
-import PropTypes from 'prop-types'
 // @flow
 import React from 'react'
+import PropTypes from 'prop-types'
 import type {Patch} from '../utils/patches'
 import shallowEquals from 'shallow-equals'
 import {get, find} from 'lodash'
@@ -61,9 +61,9 @@ type SubscriberArg = {
 
 type Subscriber = (SubscriberArg) => void
 
-export default function SubscribePatchHOC(ComposedComponent: any) {
+export default function withPatchSubscriber(ComposedComponent: any) {
   return class SubscribePatch extends React.Component {
-    static displayName = `SubscribePatchHOC(${ComposedComponent.displayName || ComposedComponent.name})`
+    static displayName = `withPatches(${ComposedComponent.displayName || ComposedComponent.name})`
 
     static contextTypes = {
       getValuePath: PropTypes.func,


### PR DESCRIPTION
This sets up a subscriber to document snapshots instead of relying on props/component updates, which will can be broken by pure components.

This removes the `passDocument` option on inputs.

Added the `withDocument` HOC that sets up the subscription and passes document snapshots to the composed component as it changes.

I've also renamed the existing _SubscribePatchHOC_  so their naming conventions match.

This should go into master and be released asap.