### PR TITLE
[core] Skip system documents when exporting a dataset

### DIFF
--- a/packages/@sanity/core/src/commands/dataset/exportDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/exportDatasetCommand.js
@@ -1,7 +1,9 @@
 import path from 'path'
 import fsp from 'fs-promise'
+import split from 'split2'
 import prettyMs from 'pretty-ms'
 import streamDataset from '../../actions/dataset/streamDataset'
+import skipSystemDocuments from '../../util/skipSystemDocuments'
 
 export default {
   name: 'export',
@@ -44,6 +46,8 @@ export default {
     const startTime = Date.now()
 
     streamDataset(client, dataset)
+      .pipe(split())
+      .pipe(skipSystemDocuments)
       .pipe(outputPath ? fsp.createWriteStream(outputPath) : process.stdout)
       .on('error', err => output.error(err))
       .on('close', () => {

--- a/packages/@sanity/core/src/util/skipSystemDocuments.js
+++ b/packages/@sanity/core/src/util/skipSystemDocuments.js
@@ -1,0 +1,21 @@
+const through2 = require('through2')
+
+const parseJson = json => {
+  try {
+    return JSON.parse(json)
+  } catch (err) {
+    return null
+  }
+}
+
+const isSystemDocument = doc => doc && doc._id && doc._id.indexOf('_.') === 0
+
+module.exports = through2((line, enc, callback) => {
+  const doc = parseJson(line)
+
+  if (isSystemDocument(doc)) {
+    return callback()
+  }
+
+  return callback(null, `${line}\n`)
+})


### PR DESCRIPTION
Currently, when you export a dataset, both system groups and listeners are included.
When you try to import this into a new dataset, you get permission errors since these kind of documents cannot be inserted by a regular user without the `manage` flag.

The best solution would be if we could filter these documents on the server side, but as of now we can't do this. This PR filters them on the client side when you run `sanity dataset export`.

