### PR TITLE
[observable] Add publishReplay operator

### DIFF
--- a/packages/@sanity/observable/src/SanityObservable.js
+++ b/packages/@sanity/observable/src/SanityObservable.js
@@ -15,6 +15,7 @@ const {withLatestFrom} = require('rxjs/operator/withLatestFrom')
 const {merge} = require('rxjs/operator/merge')
 const {share} = require('rxjs/operator/share')
 const {mergeMap} = require('rxjs/operator/mergeMap')
+const {publishReplay} = require('rxjs/operator/publishReplay')
 const {_catch} = require('rxjs/operator/catch')
 const {switchMap} = require('rxjs/operator/switchMap')
 const {_do} = require('rxjs/operator/do')
@@ -55,6 +56,7 @@ Object.assign(SanityObservable.prototype, {
   switchMap: switchMap,
   concatMap: concatMap,
   share,
+  publishReplay,
   debounceTime,
   distinctUntilChanged,
   withLatestFrom,

--- a/packages/@sanity/observable/test/exposed-api.test.js
+++ b/packages/@sanity/observable/test/exposed-api.test.js
@@ -50,6 +50,7 @@ function run(t) {
       'switchMap',
       'concatMap',
       'share',
+      'publishReplay',
       'debounceTime',
       'distinctUntilChanged',
       'withLatestFrom',


### PR DESCRIPTION
This operator in combination with `refCount()` is super useful when we want to share a value represented by a single underlying resource between multiple subscribers.

Pseudo-ish example:
```js
const snapshots = new Observable(observer => {
  // will be called when first observer subscribes
  const connection = server.listen('someDocument', currentSnapshot => {
    observer.next(currentSnapshot)
  })
  return () => {
    // will be called when last subscriber unsubscribes
    connection.close()
  }
})
.publishReplay(1)
.refCount()

const first = snapshots.subscribe(snapshot => console.log(snapshot))

// later
const second = snapshots.subscribe(snapshot => console.log(snapshot))
```
Here, both subscribers will immediately receive the most recent snapshot, but only one connection to the server will be kept open (for as long as there are subscribers). When the last subscriber unsubscribes, the connection will be closed. (and if someone subscribes again later, the connection will be re-established again).


