### PR TITLE
[form-builder] Expose the withDocument HOC

### DIFF
--- a/packages/@sanity/form-builder/src/sanity/SanityFormBuilder.js
+++ b/packages/@sanity/form-builder/src/sanity/SanityFormBuilder.js
@@ -6,6 +6,7 @@ import * as patches from '../utils/patches'
 
 import {createFormBuilder, defaultConfig} from '../'
 export {default as WithFormBuilderValue} from './WithFormBuilderValue'
+export {default as withDocument} from '../utils/withDocument'
 export {checkout} from './formBuilderValueStore'
 export {default as PatchEvent} from '../PatchEvent'
 


### PR DESCRIPTION
This exposes a higher order component that makes the current document available for any component in a form-builder context. By default, input components are *not* given the document, but there are cases you might want it, e.g. if you are a slug input that depends on another document field.

Example usage:
```jsx
import {withDocument} from 'part:@sanity/form-builder'

function MyInput(props) {
  return (
    <div>
      Document title: {props.document.title}
      {/* ... */}
    </div>
  )
}

export default withDocument(MyInput)
```