### PR TITLE
[client] Include error message in stack

### DIFF
--- a/packages/@sanity/client/package.json
+++ b/packages/@sanity/client/package.json
@@ -19,10 +19,10 @@
   "dependencies": {
     "@sanity/eventsource": "^0.108.0",
     "@sanity/observable": "^0.108.0",
-    "create-error-class": "^3.0.2",
     "deep-assign": "^2.0.0",
     "get-it": "^2.0.2",
     "in-publish": "^2.0.0",
+    "make-error": "^1.3.0",
     "object-assign": "^4.1.1"
   },
   "devDependencies": {

--- a/packages/@sanity/client/src/http/errors.js
+++ b/packages/@sanity/client/src/http/errors.js
@@ -1,0 +1,57 @@
+const makeError = require('make-error')
+const assign = require('object-assign')
+
+function ClientError(res) {
+  const props = extractErrorProps(res)
+  ClientError.super.call(this, props.message)
+  assign(this, props)
+}
+
+function ServerError(res) {
+  const props = extractErrorProps(res)
+  ServerError.super.call(this, props.message)
+  assign(this, props)
+}
+
+function extractErrorProps(res) {
+  const body = res.body
+  const props = {
+    response: res,
+    statusCode: res.statusCode,
+    responseBody: stringifyBody(body, res),
+  }
+
+  // API/Boom style errors ({statusCode, error, message})
+  if (body.error && body.message) {
+    props.message = `${body.error} - ${body.message}`
+    return props
+  }
+
+  // Query/database errors ({error: {description, other, arb, props}})
+  if (body.error && body.error.description) {
+    props.message = body.error.description
+    props.details = body.error
+    return props
+  }
+
+  // Other, more arbitrary errors
+  props.message = body.error || body.message || httpErrorMessage(res)
+  return props
+}
+
+function httpErrorMessage(res) {
+  const statusMessage = res.statusMessage ? ` ${res.statusMessage}` : ''
+  return `${res.method}-request to ${res.url} resulted in HTTP ${res.statusCode}${statusMessage}`
+}
+
+function stringifyBody(body, res) {
+  const contentType = (res.headers['content-type'] || '').toLowerCase()
+  const isJson = contentType.indexOf('application/json') !== -1
+  return isJson ? JSON.stringify(body, null, 2) : body
+}
+
+makeError(ClientError)
+makeError(ServerError)
+
+exports.ClientError = ClientError
+exports.ServerError = ServerError

--- a/packages/@sanity/client/src/http/request.js
+++ b/packages/@sanity/client/src/http/request.js
@@ -1,15 +1,12 @@
 /* eslint-disable no-empty-function, no-process-env */
 const getIt = require('get-it')
 const assign = require('object-assign')
-const createErrorClass = require('create-error-class')
 const observable = require('get-it/lib/middleware/observable')
 const jsonRequest = require('get-it/lib/middleware/jsonRequest')
 const jsonResponse = require('get-it/lib/middleware/jsonResponse')
 const SanityObservable = require('@sanity/observable/minimal')
 const progress = require('get-it/lib/middleware/progress')
-
-const ClientError = createErrorClass('ClientError', extractError)
-const ServerError = createErrorClass('ServerError', extractError)
+const {ClientError, ServerError} = require('./errors')
 
 const httpError = ({
   onResponse: res => {
@@ -22,40 +19,6 @@ const httpError = ({
     return res
   }
 })
-
-function extractError(res) {
-  const body = res.body
-  this.response = res
-  this.statusCode = res.statusCode
-  this.responseBody = stringifyBody(body, res)
-
-  // API/Boom style errors ({statusCode, error, message})
-  if (body.error && body.message) {
-    this.message = `${body.error} - ${body.message}`
-    return
-  }
-
-  // Query/database errors ({error: {description, other, arb, props}})
-  if (body.error && body.error.description) {
-    this.message = body.error.description
-    this.details = body.error
-    return
-  }
-
-  // Other, more arbitrary errors
-  this.message = body.error || body.message || httpErrorMessage(res)
-}
-
-function httpErrorMessage(res) {
-  const statusMessage = res.statusMessage ? ` ${res.statusMessage}` : ''
-  return `${res.method}-request to ${res.url} resulted in HTTP ${res.statusCode}${statusMessage}`
-}
-
-function stringifyBody(body, res) {
-  const contentType = (res.headers['content-type'] || '').toLowerCase()
-  const isJson = contentType.indexOf('application/json') !== -1
-  return isJson ? JSON.stringify(body, null, 2) : body
-}
 
 const middleware = [
   jsonRequest(),

--- a/packages/@sanity/client/test/client.test.js
+++ b/packages/@sanity/client/test/client.test.js
@@ -1292,6 +1292,21 @@ test('can use alternative http requester', t => {
     })
 })
 
+test('ClientError includes message in stack', t => {
+  const body = {error: {description: 'Invalid query'}}
+  const error = new SanityClient.ClientError({statusCode: 400, headers: {}, body})
+  t.ok(error.stack.includes(body.error.description))
+  t.end()
+})
+
+test('ServerError includes message in stack', t => {
+  const body = {error: 'Gateway Time-Out', message: 'The upstream service did not respond in time'}
+  const error = new SanityClient.ClientError({statusCode: 504, headers: {}, body})
+  t.ok(error.stack.includes(body.error))
+  t.ok(error.stack.includes(body.message))
+  t.end()
+})
+
 test('exposes ClientError', t => {
   t.equal(typeof sanityClient.ClientError, 'function')
   const error = new SanityClient.ClientError({statusCode: 400, headers: {}, body: {}})


### PR DESCRIPTION
When ClientError or ServerError is created, the client currently does not pass on the message to the super constructor, which causes stacks to be unhelpful:

```
ServerError
    at onResponse (~/webdev/test/node_modules/@sanity/client/lib/http/request.js:31:13)
    at middleware.(anonymous function).reduce (~/webdev/test/node_modules/get-it/lib-node/util/middlewareReducer.js:10:22)
    at Array.reduce (native)
```

With this change, the stack traces are more helpful:
```
ServerError: The mutation(s) failed: Insufficient permissions; permission "create" required
    at onResponse (~/webdev/test/node_modules/@sanity/client/lib/http/request.js:31:13)
    at middleware.(anonymous function).reduce (~/webdev/test/node_modules/get-it/lib-node/util/middlewareReducer.js:10:22)
    at Array.reduce (native)
```
