### PR TITLE
[schema] Guess preview config based on raw schema def instead of parsed

### DIFF
--- a/packages/@sanity/schema/src/preview/createPreviewGetter.js
+++ b/packages/@sanity/schema/src/preview/createPreviewGetter.js
@@ -29,11 +29,11 @@ function parsePreview(preview) {
   }
 }
 
-export default function createPreviewGetter(typeDef, parsed) {
+export default function createPreviewGetter(objectTypeDef) {
   return function previewGetter() {
-    warnIfPreviewOnOptions(typeDef)
-    warnIfPreviewHasFields(typeDef)
-    const preview = parsePreview(typeDef.preview || (typeDef.options || {}).preview)
-    return preview || guessPreviewConfig(parsed.fields)
+    warnIfPreviewOnOptions(objectTypeDef)
+    warnIfPreviewHasFields(objectTypeDef)
+    const preview = parsePreview(objectTypeDef.preview || (objectTypeDef.options || {}).preview)
+    return preview || guessPreviewConfig(objectTypeDef)
   }
 }

--- a/packages/@sanity/schema/src/types/blocks/block.js
+++ b/packages/@sanity/schema/src/types/blocks/block.js
@@ -64,7 +64,7 @@ export const BlockType = {
       })
     })
 
-    lazyGetter(parsed, 'preview', createPreviewGetter(subTypeDef, parsed))
+    lazyGetter(parsed, 'preview', createPreviewGetter(subTypeDef))
 
     return subtype(parsed)
 

--- a/packages/@sanity/schema/src/types/blocks/span.js
+++ b/packages/@sanity/schema/src/types/blocks/span.js
@@ -44,7 +44,7 @@ export const SpanType = {
       })
     })
 
-    lazyGetter(parsed, 'preview', createPreviewGetter(subTypeDef, parsed))
+    lazyGetter(parsed, 'preview', createPreviewGetter(subTypeDef))
 
     return subtype(parsed)
 

--- a/packages/@sanity/schema/src/types/file.js
+++ b/packages/@sanity/schema/src/types/file.js
@@ -1,6 +1,5 @@
 import {pick} from 'lodash'
 import {lazyGetter} from './utils'
-import guessPreviewConfig from '../preview/guessPreviewConfig'
 import createPreviewGetter from '../preview/createPreviewGetter'
 
 export const ASSET_FIELD = {
@@ -54,7 +53,7 @@ export const FileType = {
       })
     })
 
-    lazyGetter(parsed, 'preview', createPreviewGetter(subTypeDef, parsed))
+    lazyGetter(parsed, 'preview', createPreviewGetter(subTypeDef))
 
     return subtype(parsed)
 

--- a/packages/@sanity/schema/src/types/image.js
+++ b/packages/@sanity/schema/src/types/image.js
@@ -20,11 +20,6 @@ const IMAGE_CORE = {
 }
 
 const DEFAULT_OPTIONS = {}
-const DEFAULT_PREVIEW = {
-  select: {
-    imageUrl: 'asset.url'
-  }
-}
 
 export const ImageType = {
   get() {
@@ -56,9 +51,7 @@ export const ImageType = {
       })
     })
 
-    lazyGetter(parsed, 'preview', createPreviewGetter(
-      Object.assign({}, {preview: DEFAULT_PREVIEW}, subTypeDef), parsed)
-    )
+    lazyGetter(parsed, 'preview', createPreviewGetter(Object.assign({}, subTypeDef, {fields})))
 
     return subtype(parsed)
 

--- a/packages/@sanity/schema/src/types/image/fieldDefs.js
+++ b/packages/@sanity/schema/src/types/image/fieldDefs.js
@@ -1,7 +1,7 @@
 export const ASSET_FIELD = {
   name: 'asset',
   type: 'reference',
-  to: {type: 'imageAsset'}
+  to: [{type: 'imageAsset'}]
 }
 
 export const HOTSPOT_FIELD = {

--- a/packages/@sanity/schema/src/types/object.js
+++ b/packages/@sanity/schema/src/types/object.js
@@ -41,7 +41,7 @@ export const ObjectType = {
       return createFieldsets(subTypeDef, parsed.fields)
     })
 
-    lazyGetter(parsed, 'preview', createPreviewGetter(subTypeDef, parsed))
+    lazyGetter(parsed, 'preview', createPreviewGetter(subTypeDef))
 
     return subtype(parsed)
 

--- a/packages/example-studio/schemas/myImage.js
+++ b/packages/example-studio/schemas/myImage.js
@@ -2,14 +2,6 @@ export default {
   name: 'myImage',
   title: 'Some image type',
   type: 'image',
-  options: {
-    preview: {
-      select: {
-        imageUrl: 'asset.url',
-        title: 'caption'
-      }
-    }
-  },
   fields: [
     {
       name: 'caption',


### PR DESCRIPTION
This guesses preview fields based on the raw schema definition for an object instead of the parsed/compiled version.

It also re-enables a heuristic for guessing image asset url for a type.