### PR TITLE
[core] Add `sanity exec` command that registers part loader + babel

### DIFF
--- a/packages/@sanity/core/package.json
+++ b/packages/@sanity/core/package.json
@@ -16,9 +16,13 @@
   "dependencies": {
     "@sanity/check": "^0.108.0",
     "@sanity/mutator": "^0.108.0",
+    "@sanity/plugin-loader": "^0.108.0",
     "@sanity/resolver": "^0.108.0",
     "@sanity/server": "^0.108.0",
     "@sanity/util": "^0.108.0",
+    "babel-preset-es2015-node4": "^2.1.1",
+    "babel-preset-stage-2": "^6.22.0",
+    "babel-register": "^6.26.0",
     "batch-stream-operation": "^1.0.2",
     "debug": "^2.6.3",
     "deep-sort-object": "^1.0.1",
@@ -43,8 +47,6 @@
   },
   "devDependencies": {
     "babel-plugin-lodash": "^3.2.11",
-    "babel-preset-es2015-node4": "^2.1.1",
-    "babel-preset-stage-2": "^6.22.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
     "eslint": "^3.19.0",

--- a/packages/@sanity/core/src/actions/exec/babel.js
+++ b/packages/@sanity/core/src/actions/exec/babel.js
@@ -1,0 +1,5 @@
+const presets = ['es2015-node4', 'stage-2']
+
+require('babel-register')({
+  presets: presets.map(preset => require.resolve(`babel-preset-${preset}`)),
+})

--- a/packages/@sanity/core/src/actions/exec/execScript.js
+++ b/packages/@sanity/core/src/actions/exec/execScript.js
@@ -1,0 +1,24 @@
+const spawn = require('child_process').spawn
+const fsp = require('fs-promise')
+const path = require('path')
+
+module.exports = async args => {
+  const [script] = args.argsWithoutOptions
+  const scriptPath = path.resolve(script)
+
+  if (!script) {
+    throw new Error('SCRIPT must be provided. `sanity exec <script>`')
+  }
+
+  if (!await fsp.exists(scriptPath)) {
+    throw new Error(`${scriptPath} does not exist`)
+  }
+
+  const babel = require.resolve('./babel')
+  const loader = require.resolve('@sanity/plugin-loader/register')
+  const proc = spawn(process.argv[0], ['-r', babel, '-r', loader, scriptPath])
+
+  proc.stdout.pipe(process.stdout)
+  proc.stderr.pipe(process.stderr)
+  proc.on('close', process.exit)
+}

--- a/packages/@sanity/core/src/commands/exec/execCommand.js
+++ b/packages/@sanity/core/src/commands/exec/execCommand.js
@@ -1,0 +1,8 @@
+import lazyRequire from '@sanity/util/lib/lazyRequire'
+
+export default {
+  name: 'exec',
+  signature: 'SCRIPT',
+  description: 'Runs a script in Sanity context',
+  action: lazyRequire(require.resolve('../../actions/exec/execScript'))
+}

--- a/packages/@sanity/core/src/commands/index.js
+++ b/packages/@sanity/core/src/commands/index.js
@@ -20,6 +20,7 @@ import deleteHookCommand from './hook/deleteHookCommand'
 import listHooksCommand from './hook/listHooksCommand'
 import printHookAttemptCommand from './hook/printHookAttemptCommand'
 import listHookLogsCommand from './hook/listHookLogsCommand'
+import execCommand from './exec/execCommand'
 
 export default [
   buildCommand,
@@ -43,5 +44,6 @@ export default [
   queryDocumentsCommand,
   installCommand,
   startCommand,
-  uninstallCommand
+  uninstallCommand,
+  execCommand
 ]


### PR DESCRIPTION
This adds a new command to the Sanity CLI: `exec`.
Basically, if you have a studio and have some scripts associated with it that you want to run, it would be nice to be able to use the parts system as you would otherwise, and preferably also be able to use ES6-features.

This is now possible with `sanity exec <script.js>`. It registers babel with the `es2015-node4` and `stage-2` presets, and registers the Sanity plugin loader.

For instance, you can now make a script like this:
```js
import client from 'part:@sanity/base/client'

const products = await client.fetch('*[_type == "product"]')
console.log(products)
```
