### PR TITLE
[components] Fix BlockPreview rendering

### DIFF
--- a/packages/@sanity/components/src/previews/BlockPreview.js
+++ b/packages/@sanity/components/src/previews/BlockPreview.js
@@ -34,38 +34,30 @@ export default class BlockPreview extends React.Component {
   render() {
     const {item, emptyText, assetSize, children, type} = this.props
 
-    if (!item) {
-      return (
-        <div className={`${styles.empty}`}>
-          {emptyText}
-        </div>
-      )
-    }
-
     return (
       <div
         className={`
           ${styles.root}
-          ${item.subtitle ? styles.hasSubtitle : ''}
+          ${(item && item.subtitle) ? styles.hasSubtitle : ''}
         `}
       >
         <div className={styles.type}>
           {type.title || type.name}
         </div>
         {
-          (item.media || item.sanityImage || item.imageUrl) && <div className={`${styles.media}`}>
+          (item && (item.media || item.sanityImage || item.imageUrl)) && <div className={`${styles.media}`}>
             <MediaRender size={assetSize} item={item} />
           </div>
         }
         <div className={styles.heading}>
           <h2 className={styles.title}>
-            {item.title || emptyText}
+            {item && item.title || emptyText}
           </h2>
           <h3 className={styles.subtitle}>
-            {item.subtitle}
+            {item && item.subtitle}
           </h3>
           {
-            item.description && (
+            item && item.description && (
               <p className={styles.description}>
                 {item.description}
               </p>


### PR DESCRIPTION
Instead of rendering an empty line, we should render the type name etc.