### PR TITLE
Fix/arrays can't handle anonymous objects

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/Array/Array.js
+++ b/packages/@sanity/form-builder/src/inputs/Array/Array.js
@@ -9,6 +9,7 @@ import styles from './styles/Array.css'
 import randomKey from './randomKey'
 import PatchEvent, {insert, setIfMissing, unset, set} from '../../PatchEvent'
 import resolveListComponents from './resolveListComponents'
+import {resolveTypeName} from '../../utils/resolveTypeName'
 
 function hasKeys(object, exclude = []) {
   for (const key in object) {
@@ -33,7 +34,7 @@ function createProtoValue(type): ItemValue {
   if (type.jsonType !== 'object') {
     throw new Error(`Invalid item type: "${type.type}". Default array input can only contain objects (for now)`)
   }
-  return {
+  return type.name === 'object' ? {_key: randomKey(12)} : {
     _type: type.name,
     _key: randomKey(12)
   }
@@ -194,7 +195,8 @@ export default class ArrayInput<T: ItemValue> extends React.Component<*, *, Stat
 
   getMemberTypeOfItem(item: T): ? Type {
     const {type} = this.props
-    return type.of.find(memberType => memberType.name === item._type)
+    const itemTypeName = resolveTypeName(item)
+    return type.of.find(memberType => memberType.name === itemTypeName)
   }
 
   renderList() {

--- a/packages/@sanity/form-builder/src/inputs/Array/ItemValue.js
+++ b/packages/@sanity/form-builder/src/inputs/Array/ItemValue.js
@@ -16,6 +16,7 @@ import MemberValue from '../../Member'
 import PatchEvent from '../../PatchEvent'
 
 import {DragHandle} from 'part:@sanity/components/lists/sortable'
+import {resolveTypeName} from '../../utils/resolveTypeName'
 
 type Props = {
   type: Type,
@@ -58,7 +59,8 @@ export default class Item<T: ItemValue> extends React.Component<*, Props, *> {
 
   getMemberType(): ?Type {
     const {value, type} = this.props
-    return type.of.find(memberType => memberType.name === value._type)
+    const itemTypeName = resolveTypeName(value)
+    return type.of.find(memberType => memberType.name === itemTypeName)
   }
 
   renderEditItemForm(item: any): ?React.Element<any> {

--- a/packages/test-studio/schemas/arrays.js
+++ b/packages/test-studio/schemas/arrays.js
@@ -53,11 +53,27 @@ export default {
     },
     {
       name: 'tags',
-      title: 'tags',
+      title: 'Tags',
       description: 'Enter a tag and press enter. Should result in an array of strings and should be possible to remove items',
       type: 'array',
       options: {layout: 'tags'},
       of: [{type: 'string'}]
+    },
+    {
+      name: 'arrayWithAnonymousObject',
+      title: 'Array with anonymous objects',
+      description: 'This array contains objects of type as defined inline',
+      type: 'array',
+      of: [
+        {
+          type: 'object',
+          title: 'Something',
+          fields: [
+            {name: 'first', type: 'string', title: 'First string'},
+            {name: 'second', type: 'string', title: 'Second string'}
+          ]
+        }
+      ]
     },
     {
       name: 'arrayOfStringsWithLegacyList',


### PR DESCRIPTION
This fixes an issue with arrays that includes unnamed objects, e.g.:

https://github.com/sanity-io/sanity/blob/8cc2a596d45512049316d17890e008575fdd942c/packages/test-studio/schemas/arrays.js#L62-L77

cc @evenwestvang 