### PR TITLE
[webpack-loader] Fix invalid paths on Windows when using `all:`-parts

### DIFF
--- a/packages/@sanity/webpack-loader/src/multiImplementationHandler.js
+++ b/packages/@sanity/webpack-loader/src/multiImplementationHandler.js
@@ -15,11 +15,17 @@ const normalizer = [
   '}', ''
 ]
 
+// Use JSON.stringify to ensure paths are proper strings
+// (eg, if they contain a `\`, things will blow up without a proper serializer)
+function pathToRequire(path) {
+  return `  require(${JSON.stringify(path)})`
+}
+
 module.exports = function multiImplementationHandler(partName, implementations) {
   return banner
     .concat(normalizer)
     .concat(['\nmodule.exports = ['])
-    .concat(implementations.reverse().map((implementer, i) => `  require('${implementer}')`).join(',\n'))
+    .concat(implementations.reverse().map(pathToRequire).join(',\n'))
     .concat(['].map(normalize)\n'])
     .join('\n')
     .replace(/PART_NAME/g, partName)


### PR DESCRIPTION
Paths are currently naively put into a string, which results in things like:
```js
module.exports = [
  require('C:\Webdev\Some Project\Blah.js')
]
```

Because the Windows path delimiter is the same character as the escape character for strings, basically the paths won't contain slashes. A basic, embarrassing oversight.

This PR switches to using JSON.stringify to ensure valid strings are used.
