### PR TITLE
[server] Fix invalid paths being ignored for babel loader on windows

### DIFF
--- a/packages/@sanity/server/src/configs/webpack.config.js
+++ b/packages/@sanity/server/src/configs/webpack.config.js
@@ -79,11 +79,11 @@ export default (config = {}) => {
       loaders: [{
         test: /\.jsx?/,
         exclude: modPath => {
-          if (sanityDev && modPath.indexOf('/@sanity/') >= 0) {
+          if (sanityDev && modPath.includes(['', '@sanity', ''].join(path.sep))) {
             return false
           }
 
-          return modPath.indexOf('/node_modules/') >= 0
+          return modPath.includes(['', 'node_modules', ''].join(path.sep))
         },
         loader: require.resolve('babel-loader'),
         query: babelConfig || {


### PR DESCRIPTION
The babel loader was excluding `node_modules`, but only in unixy paths. This PR changes it to be platform-agnostic.
