### PR TITLE
Add temporary part to inject components below the editor

### DIFF
--- a/packages/@sanity/desk-tool/sanity.json
+++ b/packages/@sanity/desk-tool/sanity.json
@@ -13,6 +13,11 @@
     {
       "implements": "part:@sanity/base/tool",
       "path": "index.js"
+    },
+
+    {
+      "name": "part:@sanity/desk-tool/after-editor-component",
+      "description": "[DEPRECATED] Components to render directly after the editor form. Will be removed in future release."
     }
   ]
 }

--- a/packages/@sanity/desk-tool/src/pane/Editor.js
+++ b/packages/@sanity/desk-tool/src/pane/Editor.js
@@ -16,11 +16,10 @@ import VisibilityOffIcon from 'part:@sanity/base/visibility-off-icon'
 import BinaryIcon from 'part:@sanity/base/binary-icon'
 import styles from './styles/Editor.css'
 import copyDocument from '../utils/copyDocument'
-import IconMoreVert from 'part:@sanity/base/more-vert-icon'
 import Menu from 'part:@sanity/components/menus/default'
 import ContentCopyIcon from 'part:@sanity/base/content-copy-icon'
 import documentStore from 'part:@sanity/base/datastore/document'
-import {debounce, truncate, capitalize, startCase} from 'lodash'
+import {debounce} from 'lodash'
 import {getPublishedId, newDraftFrom} from '../utils/draftUtils'
 import TimeAgo from '../components/TimeAgo'
 import {PreviewFields} from 'part:@sanity/base/preview'
@@ -98,7 +97,6 @@ const INITIAL_STATE = {
 }
 
 function getToggleKeyState(event) {
-
   if (event.ctrlKey
     && event.code === 'KeyI'
     && event.altKey
@@ -112,6 +110,8 @@ function getToggleKeyState(event) {
     && !event.shiftKey) {
     return 'showConfirmPublish'
   }
+
+  return undefined
 }
 
 export default withRouterHOC(class Editor extends React.PureComponent {

--- a/packages/@sanity/desk-tool/src/pane/Editor.js
+++ b/packages/@sanity/desk-tool/src/pane/Editor.js
@@ -24,6 +24,7 @@ import {getPublishedId, newDraftFrom} from '../utils/draftUtils'
 import TimeAgo from '../components/TimeAgo'
 import {PreviewFields} from 'part:@sanity/base/preview'
 import Pane from 'part:@sanity/components/panes/default'
+import afterEditorComponents from 'all:part:@sanity/desk-tool/after-editor-component'
 
 const preventDefault = ev => ev.preventDefault()
 
@@ -415,6 +416,10 @@ export default withRouterHOC(class Editor extends React.PureComponent {
               onChange={this.handleChange}
             />
           </form>
+
+          {afterEditorComponents.map((AfterEditorComponent, i) =>
+            <AfterEditorComponent key={i} documentId={published._id} />
+          )}
 
           {inspect && (
             <InspectView


### PR DESCRIPTION
This PR adds a part that can be used to inject components below the editor in the desk tool. 

We don't want to encourage using the main editor pane for functionality such as this, and as such I've marked the part as deprecated already. It will be removed once we get a meta pane or similar.

Also fixes a few lint errors that were present in the editor component.
