### PR TITLE
Referring documents plugin

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,9 +3,9 @@
   "npmClient": "yarn",
   "packages": [
     "packages/@sanity/*",
+    "packages/sanity-plugin-*",
     "packages/example-studio",
     "packages/test-studio",
-    "packages/sanity-plugin-vision",
     "packages/storybook"
   ],
   "version": "0.110.0"

--- a/packages/@sanity/desk-tool/sanity.json
+++ b/packages/@sanity/desk-tool/sanity.json
@@ -13,6 +13,11 @@
     {
       "implements": "part:@sanity/base/tool",
       "path": "index.js"
+    },
+
+    {
+      "name": "part:@sanity/desk-tool/after-editor-component",
+      "description": "[DEPRECATED] Components to render directly after the editor form. Will be removed in future release."
     }
   ]
 }

--- a/packages/@sanity/desk-tool/src/pane/Editor.js
+++ b/packages/@sanity/desk-tool/src/pane/Editor.js
@@ -16,15 +16,15 @@ import VisibilityOffIcon from 'part:@sanity/base/visibility-off-icon'
 import BinaryIcon from 'part:@sanity/base/binary-icon'
 import styles from './styles/Editor.css'
 import copyDocument from '../utils/copyDocument'
-import IconMoreVert from 'part:@sanity/base/more-vert-icon'
 import Menu from 'part:@sanity/components/menus/default'
 import ContentCopyIcon from 'part:@sanity/base/content-copy-icon'
 import documentStore from 'part:@sanity/base/datastore/document'
-import {debounce, truncate, capitalize, startCase} from 'lodash'
+import {debounce} from 'lodash'
 import {getPublishedId, newDraftFrom} from '../utils/draftUtils'
 import TimeAgo from '../components/TimeAgo'
 import {PreviewFields} from 'part:@sanity/base/preview'
 import Pane from 'part:@sanity/components/panes/default'
+import afterEditorComponents from 'all:part:@sanity/desk-tool/after-editor-component'
 
 const preventDefault = ev => ev.preventDefault()
 
@@ -98,7 +98,6 @@ const INITIAL_STATE = {
 }
 
 function getToggleKeyState(event) {
-
   if (event.ctrlKey
     && event.code === 'KeyI'
     && event.altKey
@@ -112,6 +111,8 @@ function getToggleKeyState(event) {
     && !event.shiftKey) {
     return 'showConfirmPublish'
   }
+
+  return undefined
 }
 
 export default withRouterHOC(class Editor extends React.PureComponent {
@@ -415,6 +416,10 @@ export default withRouterHOC(class Editor extends React.PureComponent {
               onChange={this.handleChange}
             />
           </form>
+
+          {afterEditorComponents.map((AfterEditorComponent, i) =>
+            <AfterEditorComponent key={i} documentId={published._id} />
+          )}
 
           {inspect && (
             <InspectView

--- a/packages/example-studio/package.json
+++ b/packages/example-studio/package.json
@@ -35,6 +35,7 @@
     "react-ace": "^4.3.0",
     "react-dom": "^15.5.4",
     "react-icons": "^2.2.5",
+    "sanity-plugin-referring-documents": "0.110.0",
     "sanity-plugin-vision": "0.110.0"
   },
   "devDependencies": {

--- a/packages/example-studio/sanity.json
+++ b/packages/example-studio/sanity.json
@@ -16,6 +16,7 @@
     "@sanity/code-input",
     "@sanity/desk-tool",
     "@sanity/storybook",
+    "referring-documents",
     "vision"
   ],
   "parts": [

--- a/packages/sanity-plugin-referring-documents/.babelrc
+++ b/packages/sanity-plugin-referring-documents/.babelrc
@@ -1,0 +1,10 @@
+{
+  "presets": ["es2015", "react"],
+  "plugins": [
+    "syntax-class-properties",
+    "syntax-object-rest-spread",
+    "transform-object-rest-spread",
+    "transform-class-properties",
+    "lodash"
+  ]
+}

--- a/packages/sanity-plugin-referring-documents/.eslintrc
+++ b/packages/sanity-plugin-referring-documents/.eslintrc
@@ -1,0 +1,14 @@
+{
+  "env": {
+    "node": true
+  },
+  "parser": "babel-eslint",
+  "extends": [
+    "sanity",
+    "sanity/react"
+  ],
+  "rules": {
+    "newline-per-chained-call": 0,
+    "sort-imports": 0
+  }
+}

--- a/packages/sanity-plugin-referring-documents/.gitignore
+++ b/packages/sanity-plugin-referring-documents/.gitignore
@@ -1,0 +1,13 @@
+# Logs
+*.log
+
+# Compiled files
+lib
+
+# Coverage directory used by tools like istanbul
+coverage
+
+# Dependency directories
+node_modules
+
+.vscode

--- a/packages/sanity-plugin-referring-documents/package.json
+++ b/packages/sanity-plugin-referring-documents/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "sanity-plugin-referring-documents",
+  "version": "0.110.0",
+  "description": "Referring documents list plugin",
+  "main": "lib/ReferringDocumentsList.js",
+  "author": "Sanity.io <hello@sanity.io>",
+  "license": "MIT",
+  "scripts": {
+    "clean": "rimraf lib"
+  },
+  "keywords": [
+    "sanity",
+    "sanity-plugin"
+  ],
+  "devDependencies": {
+    "eslint": "^3.19.0",
+    "eslint-config-sanity": "^2.1.4",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-react": "^6.10.0",
+    "prop-types": "^15.5.10",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
+    "rimraf": "^2.6.1"
+  }
+}

--- a/packages/sanity-plugin-referring-documents/sanity.json
+++ b/packages/sanity-plugin-referring-documents/sanity.json
@@ -1,0 +1,13 @@
+{
+  "paths": {
+    "source": "./src",
+    "compiled": "./lib"
+  },
+
+  "parts": [
+    {
+      "implements": "part:@sanity/desk-tool/after-editor-component",
+      "path": "ReferringDocumentsList.js"
+    }
+  ]
+}

--- a/packages/sanity-plugin-referring-documents/src/ReferringDocumentListItem.js
+++ b/packages/sanity-plugin-referring-documents/src/ReferringDocumentListItem.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import schema from 'part:@sanity/base/schema'
+import Preview from 'part:@sanity/base/preview'
+import {Item} from 'part:@sanity/components/lists/default'
+import {StateLink} from 'part:@sanity/base/router'
+
+function ReferringDocumentListItem(props) {
+  const item = props.document
+  const typeName = item._type
+  const schemaType = schema.get(typeName)
+  const linkState = {
+    selectedDocumentId: item._id,
+    selectedType: typeName,
+    action: 'edit'
+  }
+
+  return (
+    <Item>
+      {schemaType
+        ? (
+          <StateLink state={linkState}>
+            <Preview value={item} type={schemaType} />
+          </StateLink>
+        )
+        : <div>A document of the unknown type <em>{typeName}</em></div>
+      }
+    </Item>
+  )
+}
+
+ReferringDocumentListItem.propTypes = {
+  document: PropTypes.shape({
+    _id: PropTypes.string.isRequired,
+    _type: PropTypes.string.isRequired
+  }).isRequired
+}
+
+export default ReferringDocumentListItem

--- a/packages/sanity-plugin-referring-documents/src/ReferringDocumentsList.js
+++ b/packages/sanity-plugin-referring-documents/src/ReferringDocumentsList.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {List, Item} from 'part:@sanity/components/lists/default'
+import QueryContainer from 'part:@sanity/base/query-container'
+import ReferringDocumentListItem from './ReferringDocumentListItem'
+
+const ReferringDocumentsList = props => (
+  <QueryContainer
+    query="*[!(_id in path('drafts.*')) && references($docId)] [0...101] {_id, _type}"
+    params={{docId: props.documentId}}>
+    {({result, loading, error, onRetry}) => {
+      if (error) {
+        return <div>Error: {error}</div>
+      }
+
+      if (loading) {
+        return null
+      }
+
+      const docs = result.documents
+      if (docs.length === 0) {
+        return null
+      }
+
+      return (
+        <div>
+          <h2>Referring documents:</h2>
+
+          <List>
+            {docs.map(doc =>
+              <ReferringDocumentListItem key={doc._id} document={doc} />
+            )}
+
+            {docs.length > 100 && (
+              <Item>+ More documents</Item>
+            )}
+          </List>
+        </div>
+      )
+    }}
+  </QueryContainer>
+)
+
+ReferringDocumentsList.propTypes = {
+  documentId: PropTypes.string.isRequired
+}
+
+export default ReferringDocumentsList


### PR DESCRIPTION
This is a very early, hacked-together implementation of a plugin that displays documents that refer to the one being currently edited.

The UI for this is going to change, but as of now it renders below the editor. Loading state, error messages and pagination has not been given any concern, and drafts are not displayed. This should in other words be considered very early work and not something ment for production use.
