### PR TITLE
Make client API CDN aware

### DIFF
--- a/packages/@sanity/client/README.md
+++ b/packages/@sanity/client/README.md
@@ -22,7 +22,8 @@ const sanityClient = require('@sanity/client')
 const client = sanityClient({
   projectId: 'your-project-id',
   dataset: 'bikeshop',
-  token: 'sanity-auth-token' // or leave blank to be anonymous user
+  token: 'sanity-auth-token', // or leave blank to be anonymous user
+  useCdn: true // `false` if you want to ensure fresh data
 })
 ```
 
@@ -95,6 +96,45 @@ client.create(doc).then(res => {
 `client.create(doc)`
 
 Create a document. Argument is a plain JS object representing the document. It must contain a `_type` attribute. It *may* contain an `_id`. If an ID is not specified, it will automatically be created.
+
+
+### Creating/replacing documents
+
+```js
+const doc = {
+  _id: 'my-bike',
+  _type: 'bike',
+  name: 'Bengler Tandem Extraordinaire',
+  seats: 2
+}
+
+client.createOrReplace(doc).then(res => {
+  console.log(`Bike was created, document ID is ${res._id}`)
+})
+```
+
+`client.createOrReplace(doc)`
+
+If you are not sure whether or not a document exists but want to overwrite it if it does, you can use the `createOrReplace()` method. When using this method, the document must contain an `_id` attribute.
+
+### Creating if not already present
+
+```js
+const doc = {
+  _id: 'my-bike',
+  _type: 'bike',
+  name: 'Bengler Tandem Extraordinaire',
+  seats: 2
+}
+
+client.createIfNotExists(doc).then(res => {
+  console.log('Bike was created (or was already present)')
+})
+```
+
+`client.createIfNotExists(doc)`
+
+If you want to create a document if it does not already exist, but fall back without error if it does, you can use the `createIfNotExists()` method. When using this method, the document must contain an `_id` attribute.
 
 
 ### Patch/update a document

--- a/packages/@sanity/client/package.json
+++ b/packages/@sanity/client/package.json
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "@sanity/eventsource": "^0.108.0",
-    "@sanity/observable": "0.110.0",
+    "@sanity/generate-help-url": "^0.108.0",
+    "@sanity/observable": "^0.110.0",
     "deep-assign": "^2.0.0",
     "get-it": "^2.0.2",
     "in-publish": "^2.0.0",

--- a/packages/@sanity/client/src/config.js
+++ b/packages/@sanity/client/src/config.js
@@ -1,12 +1,34 @@
+const generateHelpUrl = require('@sanity/generate-help-url')
 const assign = require('object-assign')
 const validate = require('./validators')
 
+const defaultCdnHost = 'cdnapi.sanity.io'
 const defaultConfig = {
   apiHost: 'https://api.sanity.io',
   useProjectHostname: true,
   gradientMode: false,
   isPromiseAPI: true
 }
+
+const cdnWarning = [
+  'You are not using the Sanity CDN. That means your data is always fresh, but the CDN is faster and',
+  `cheaper. Think about it! For more info, see ${generateHelpUrl('js-client-cdn-configuration')}.`,
+  'To hide this warning, please set the `useCdn` option to either `true` or `false` when creating',
+  'the client.'
+]
+
+const printCdnWarning = (() => {
+  let hasWarned = false
+  return () => {
+    if (hasWarned) {
+      return
+    }
+
+    // eslint-disable-next-line no-console
+    console.warn(cdnWarning.join(' '))
+    hasWarned = true
+  }
+})()
 
 exports.defaultConfig = defaultConfig
 
@@ -36,18 +58,29 @@ exports.initConfig = (config, prevConfig) => {
     validate.dataset(newConfig.dataset, newConfig.gradientMode)
   }
 
+  newConfig.isDefaultApi = newConfig.apiHost === defaultConfig.apiHost
+  newConfig.useCdn = Boolean(newConfig.useCdn) && !newConfig.token && !newConfig.withCredentials
+
   if (newConfig.gradientMode) {
     newConfig.url = newConfig.apiHost
+    newConfig.cdnUrl = newConfig.apiHost
   } else {
     const hostParts = newConfig.apiHost.split('://', 2)
     const protocol = hostParts[0]
     const host = hostParts[1]
+    const cdnHost = newConfig.isDefaultApi ? defaultCdnHost : host
 
     if (newConfig.useProjectHostname) {
       newConfig.url = `${protocol}://${newConfig.projectId}.${host}/v1`
+      newConfig.cdnUrl = `${protocol}://${newConfig.projectId}.${cdnHost}/v1`
     } else {
       newConfig.url = `${newConfig.apiHost}/v1`
+      newConfig.cdnUrl = newConfig.url
     }
+  }
+
+  if (typeof config.useCdn === 'undefined') {
+    printCdnWarning()
   }
 
   return newConfig

--- a/packages/@sanity/client/src/sanityClient.js
+++ b/packages/@sanity/client/src/sanityClient.js
@@ -52,8 +52,9 @@ assign(SanityClient.prototype, {
     return this
   },
 
-  getUrl(uri) {
-    return `${this.clientConfig.url}/${uri.replace(/^\//, '')}`
+  getUrl(uri, canUseCdn = false) {
+    const base = canUseCdn ? this.clientConfig.cdnUrl : this.clientConfig.url
+    return `${base}/${uri.replace(/^\//, '')}`
   },
 
   isPromiseAPI() {
@@ -61,10 +62,17 @@ assign(SanityClient.prototype, {
   },
 
   _requestObservable(options) {
+    const uri = options.url || options.uri
+    const canUseCdn = (
+      this.clientConfig.useCdn
+      && ['GET', 'HEAD'].indexOf(options.method || 'GET') >= 0
+      && uri.indexOf('/data/') === 0
+    )
+
     return httpRequest(mergeOptions(
       getRequestOptions(this.clientConfig),
       options,
-      {url: this.getUrl(options.url || options.uri)}
+      {url: this.getUrl(uri, canUseCdn)}
     ), this.clientConfig.requester)
   },
 


### PR DESCRIPTION
This PR will make the client aware of our new API CDN.

If no `useCdn` option is specified when constructing, a warning is presented to the user (once), prompting them to take a stand and set it to true or false.

Even if a user has set `useCdn` to true, the client will fall back to using the live API for:
- Listeners
- Authenticated requests (tokens, cookies)
- Mutations
- Non-data requests

Also snuck in documentation for `createOrReplace()` / `createIfNotExists()`, which was missing. Sorry about that.