### PR TITLE
[base] Opt-out of CDN usage

### DIFF
--- a/packages/@sanity/base/src/client/index.js
+++ b/packages/@sanity/base/src/client/index.js
@@ -11,7 +11,7 @@ To the following:
   \`const client = require('part:@sanity/base/client')\`
 `
 
-const apiConfig = {...config.api, withCredentials: true}
+const apiConfig = {...config.api, withCredentials: true, useCdn: false}
 const client = sanityClient(apiConfig)
 
 const configuredClient = configureClient


### PR DESCRIPTION
The Sanity client within the studio shouldn't use the CDN, and as such we should explicitly opt out to avoid the warning being logged.
