### PR TITLE
[client] Retrieve original filename and content type from File instances

### DIFF
--- a/packages/@sanity/client/src/assets/assetsClient.js
+++ b/packages/@sanity/client/src/assets/assetsClient.js
@@ -12,12 +12,24 @@ function toPromise(observable) {
     .toPromise()
 }
 
+function optionsFromFile(opts, file) {
+  if (typeof window === 'undefined' || !(file instanceof window.File)) {
+    return opts
+  }
+
+  return assign({
+    filename: opts.preserveFilename === false ? undefined : file.name,
+    contentType: file.type
+  }, opts)
+}
+
 assign(AssetsClient.prototype, {
-  upload(assetType, body, options = {}) {
+  upload(assetType, body, opts = {}) {
     validators.validateAssetType(assetType)
 
     const dataset = validators.hasDataset(this.client.clientConfig)
     const assetEndpoint = assetType === 'image' ? 'images' : 'files'
+    const options = optionsFromFile(opts, body)
     const {id, label, filename, meta} = options
     const query = {id, label, filename, meta}
 


### PR DESCRIPTION
This PR checks whether a File instance is passed to the asset uploader, and if so, includes the original filename and mime type when uploading.

A user can opt-out of this behavior by specifying `preserveFilename: false` in the options, and can also specify a specific filename for the file with `filename: 'my-filename.ext'`.

The filename is stored as metadata on the asset (`originalFilename` property).