### PR TITLE
[cli] Fix potential yarn spawn problems

### DIFF
--- a/packages/@sanity/cli/src/actions/yarn/yarnWithProgress.js
+++ b/packages/@sanity/cli/src/actions/yarn/yarnWithProgress.js
@@ -26,8 +26,16 @@ export default function yarnWithProgress(args, options = {}) {
     env: {PATH: [binDir, process.env.PATH].join(path.delimiter)}
   }, options.execOpts || {})
 
-  const proc = execa(yarnPath, args.concat(['--json', '--non-interactive']), execOpts)
-  proc.catch(onNativeError);
+  const nodePath = process.argv[0]
+  const nodeArgs = [yarnPath].concat(args, ['--json', '--non-interactive'])
+
+  const proc = execa(nodePath, nodeArgs, execOpts)
+  proc.catch(onNativeError)
+
+  // Will throw error async through the promise above
+  if (!proc.stdout) {
+    return
+  }
 
   [proc.stdout, proc.stderr].forEach(stream => {
     stream
@@ -143,7 +151,7 @@ export default function yarnWithProgress(args, options = {}) {
       state.spinner.stop()
     }
 
-    print(`${chalk.green('✔')} Saved lockfile`)
+    print(`\n${chalk.green('✔')} Saved lockfile`)
   }
 
   function onFinished(event) {


### PR DESCRIPTION
Encountered a weird case where the yarn executable did not have the executable bit set, which caused a spawn error. In this case, `stdout`/`stderr` was not set, and because the promise rejects asyncronously, node crashed because we tried to pipe on stderr/stdout.

With this PR, instead of executing the yarn executable directly, we launch node and specify yarns path as the first argument. This works around the executable bit issue.

I've also addressed potential other problems with spawning by verifying that `stdout` actually exists on process before trying to use it.