### PR TITLE
CLI CDN fixes

### DIFF
--- a/packages/@sanity/client/src/config.js
+++ b/packages/@sanity/client/src/config.js
@@ -50,6 +50,10 @@ exports.initConfig = (config, prevConfig) => {
     throw new Error('Configuration must contain `projectId`')
   }
 
+  if (typeof newConfig.useCdn === 'undefined') {
+    printCdnWarning()
+  }
+
   if (projectBased) {
     validate.projectId(newConfig.projectId)
   }
@@ -77,10 +81,6 @@ exports.initConfig = (config, prevConfig) => {
       newConfig.url = `${newConfig.apiHost}/v1`
       newConfig.cdnUrl = newConfig.url
     }
-  }
-
-  if (typeof config.useCdn === 'undefined') {
-    printCdnWarning()
   }
 
   return newConfig

--- a/packages/@sanity/core/src/commands/dataset/importDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/importDatasetCommand.js
@@ -167,6 +167,7 @@ function getSanityClient(options) {
     apiHost: options.gradient,
     dataset: options.dataset || config.dataset,
     token: options.token || config.token,
+    useCdn: false
   })
 }
 


### PR DESCRIPTION
There were a couple of issues with the "please use the cdn"-warning when a client is cloned or a new configuration is passed to an existing client.

This PR ensures it now checks the merged result of the configuration instead of just the new configuration options.

Also made the dataset import command explicitly set `useCdn` to `false`.