### PR TITLE
[state-router] Tolerate (but warn) on missing router context

### DIFF
--- a/packages/@sanity/state-router/demo-server/components/Main.js
+++ b/packages/@sanity/state-router/demo-server/components/Main.js
@@ -1,12 +1,12 @@
 // @flow
-import type {ContextRouter} from '../../src/components/types'
+import type {Router} from '../../src/components/types'
 import React from 'react'
 import {StateLink, Link, RouteScope, withRouterHOC} from '../../src/components'
 import Product from './Product'
 import User from './User'
 
 type Props = {
-  router: ContextRouter
+  router: Router
 }
 
 export default withRouterHOC((props: Props) => {

--- a/packages/@sanity/state-router/demo-server/components/ProductCounter.js
+++ b/packages/@sanity/state-router/demo-server/components/ProductCounter.js
@@ -1,10 +1,10 @@
 // @flow
-import type {ContextRouter} from '../../src/components/types'
+import type {Router} from '../../src/components/types'
 import React from 'react'
 import withRouterHOC from '../../src/components/withRouterHOC'
 
 type Props = {
-  router: ContextRouter
+  router: Router
 }
 
 export default withRouterHOC((props: Props) => {

--- a/packages/@sanity/state-router/demo-server/components/SomeChild.js
+++ b/packages/@sanity/state-router/demo-server/components/SomeChild.js
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types'
 import React from 'react'
 
 export default class SomeChild extends React.Component {

--- a/packages/@sanity/state-router/demo-server/components/User.js
+++ b/packages/@sanity/state-router/demo-server/components/User.js
@@ -1,8 +1,9 @@
+// @flow
 import PropTypes from 'prop-types'
 import React from 'react'
 import StateLink from '../../src/components/StateLink'
 
-export default class User extends React.Component {
+export default class User extends React.Component<*> {
   static propTypes = {
     id: PropTypes.string
   }

--- a/packages/@sanity/state-router/demo-server/entry.js
+++ b/packages/@sanity/state-router/demo-server/entry.js
@@ -33,9 +33,15 @@ function handleNavigate(nextUrl, {replace} = {}) {
 
 function render(state, pathname) {
   ReactDOM.render((
-    <RouterProvider router={router} onNavigate={handleNavigate} state={state}>
-      {router.isNotFound(pathname) ? <NotFound pathname={pathname} /> : <Main />}
-    </RouterProvider>
+    <div>
+      <RouterProvider router={router} onNavigate={handleNavigate} state={state}>
+        {router.isNotFound(pathname) ? <NotFound pathname={pathname} /> : <Main />}
+      </RouterProvider>
+      <div>
+        <h2>Components outside provider context</h2>
+        <Main />
+      </div>
+    </div>
   ), document.getElementById('main'))
 }
 
@@ -64,6 +70,7 @@ function checkPath() {
       handleNavigate(router.encode(handler.resolveRedirectState(state.intent, state.params)), {replace: true})
       return
     }
+    // eslint-disable-next-line no-console
     console.log('No intent handler for intent "%s" with params %o', state.intent, state.params)
   }
   render(state || {}, pathname)

--- a/packages/@sanity/state-router/src/components/IntentLink.js
+++ b/packages/@sanity/state-router/src/components/IntentLink.js
@@ -1,22 +1,24 @@
-import PropTypes from 'prop-types'
 // @flow
-import React, { Element } from 'react';
+import * as React from 'react'
 import Link from './Link'
 import type {RouterProviderContext} from './types'
+import internalRouterContextTypeCheck from './internalRouterContextTypeCheck'
 
-export default class IntentLink extends React.PureComponent {
+export default class IntentLink extends React.PureComponent<*, *> {
   props: {
     intent: string,
     params?: Object,
-    children: Element<*>,
+    children: React.Node,
     className: string
   };
 
   context: RouterProviderContext
 
   static contextTypes = {
-    __internalRouter: PropTypes.object
+    __internalRouter: internalRouterContextTypeCheck
   }
+
+  _element: Link
 
   focus() {
     if (this._element) {
@@ -24,14 +26,22 @@ export default class IntentLink extends React.PureComponent {
     }
   }
 
-  setElement = element => {
-    this._element = element
+  setElement = (element: ?Link) => {
+    if (element) {
+      this._element = element
+    }
+  }
+
+  resolveIntentLink(intent: string, params?: Object) {
+    if (!this.context.__internalRouter) {
+      return `javascript://intent@${JSON.stringify({intent, params})}`
+    }
+    return this.context.__internalRouter.resolveIntentLink(intent, params)
   }
 
   render() {
     const {intent, params, ...rest} = this.props
 
-    const url = this.context.__internalRouter.resolveIntentLink(intent, params)
-    return <Link href={url} {...rest} ref={this.setElement} />
+    return <Link href={this.resolveIntentLink(intent, params)} {...rest} ref={this.setElement} />
   }
 }

--- a/packages/@sanity/state-router/src/components/Link.js
+++ b/packages/@sanity/state-router/src/components/Link.js
@@ -1,36 +1,41 @@
-import PropTypes from 'prop-types'
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {omit} from 'lodash'
 import type {RouterProviderContext} from './types'
+import internalRouterContextTypeCheck from './internalRouterContextTypeCheck'
 
-function isLeftClickEvent(event : SyntheticMouseEvent) {
+function isLeftClickEvent(event : SyntheticMouseEvent<*>) {
   return event.button === 0
 }
 
-function isModifiedEvent(event : SyntheticMouseEvent) {
+function isModifiedEvent(event : SyntheticMouseEvent<*>) {
   return !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey)
 }
 
-export default class Link extends React.PureComponent {
+export default class Link extends React.PureComponent<*, *> {
   props: {
     replace?: boolean,
-    onClick?: (event : SyntheticMouseEvent) => void,
+    onClick?: (event : SyntheticMouseEvent<*>) => void,
     href: string,
     target?: string
   }
 
   context: RouterProviderContext
+  _element: HTMLAnchorElement
 
   static defaultProps = {
     replace: false,
   }
 
   static contextTypes = {
-    __internalRouter: PropTypes.object
+    __internalRouter: internalRouterContextTypeCheck
   }
 
-  handleClick = (event : SyntheticMouseEvent) : void => {
+  handleClick = (event : SyntheticMouseEvent<*>) : void => {
+
+    if (!this.context.__internalRouter) {
+      return
+    }
 
     if (event.isDefaultPrevented()) {
       return
@@ -62,8 +67,10 @@ export default class Link extends React.PureComponent {
     }
   }
 
-  setElement = element => {
-    this._element = element
+  setElement = (element: ?HTMLAnchorElement) => {
+    if (element) {
+      this._element = element
+    }
   }
 
   render() {

--- a/packages/@sanity/state-router/src/components/RouteScope.js
+++ b/packages/@sanity/state-router/src/components/RouteScope.js
@@ -1,11 +1,11 @@
-import PropTypes from 'prop-types'
 // @flow
-import React, { Element } from 'react';
+import PropTypes from 'prop-types'
+import * as React from 'react'
 import isEmpty from '../utils/isEmpty'
 
 import type {RouterProviderContext, NavigateOptions, InternalRouter} from './types'
 
-function addScope(routerState : Object, scope : string, scopedState : Object) {
+function addScope(routerState: Object, scope: string, scopedState: Object) {
   return scopedState && {
     ...routerState,
     [scope]: scopedState
@@ -14,10 +14,10 @@ function addScope(routerState : Object, scope : string, scopedState : Object) {
 
 type Props = {
   scope: string,
-  children: Element<*>
+  children: React.Node
 }
 
-export default class RouteScope extends React.Component {
+export default class RouteScope extends React.Component<*, *> {
   props: Props
   __internalRouter: InternalRouter
 
@@ -25,7 +25,7 @@ export default class RouteScope extends React.Component {
     __internalRouter: PropTypes.object
   }
 
-  constructor(props : Props, context : RouterProviderContext) {
+  constructor(props: Props, context: RouterProviderContext) {
     super()
     const parentInternalRouter = context.__internalRouter
 
@@ -37,7 +37,7 @@ export default class RouteScope extends React.Component {
     }
   }
 
-  getChildContext() : RouterProviderContext {
+  getChildContext(): RouterProviderContext {
     return {
       __internalRouter: this.__internalRouter
     }
@@ -53,14 +53,14 @@ export default class RouteScope extends React.Component {
     const parentInternalRouter = this.context.__internalRouter
     const scope = this.props.scope
 
-    const nextStateScoped : Object = isEmpty(nextState)
+    const nextStateScoped: Object = isEmpty(nextState)
       ? {}
       : addScope(parentInternalRouter.getState(), scope, nextState)
 
     return parentInternalRouter.resolvePathFromState(nextStateScoped)
   }
 
-  navigate = (nextState: Object, options?: NavigateOptions) : void => {
+  navigate = (nextState: Object, options?: NavigateOptions): void => {
     const parentInternalRouter = this.context.__internalRouter
     const nextScopedState = addScope(parentInternalRouter.getState(), this.props.scope, nextState)
     parentInternalRouter.navigate(nextScopedState, options)

--- a/packages/@sanity/state-router/src/components/RouterProvider.js
+++ b/packages/@sanity/state-router/src/components/RouterProvider.js
@@ -1,18 +1,18 @@
-import PropTypes from 'prop-types'
 // @flow
-import React, { Element } from 'react';
+import * as React from 'react'
+import PropTypes from 'prop-types'
 import type {Router} from '../types'
 import type {RouterProviderContext, NavigateOptions, InternalRouter, RouterState} from './types'
 import pubsub from 'nano-pubsub'
 
 type Props = {
-  onNavigate: (nextPath: string) => void,
+  onNavigate: (nextPath: string, options?: NavigateOptions) => void,
   router: Router,
   state: RouterState,
-  children?: Element<*>
+  children: React.Node
 }
 
-export default class RouterProvider extends React.Component {
+export default class RouterProvider extends React.Component<*, *> {
   props: Props
 
   static childContextTypes = {
@@ -45,7 +45,7 @@ export default class RouterProvider extends React.Component {
     this.navigateUrl(this.resolvePathFromState(nextState), options)
   }
 
-  navigateIntent = (intentName : string, params : Object, options : NavigateOptions = {}) : void => {
+  navigateIntent = (intentName : string, params? : Object, options? : NavigateOptions = {}) : void => {
     this.navigateUrl(this.resolveIntentLink(intentName, params), options)
   }
 
@@ -55,8 +55,8 @@ export default class RouterProvider extends React.Component {
     return this.props.router.encode(state)
   }
 
-  resolveIntentLink = (intent : string, params? : Object) : string => {
-    return this.props.router.encode({intent, params})
+  resolveIntentLink = (intentName : string, params?: Object) : string => {
+    return this.props.router.encode({intent: intentName, params})
   }
 
   getChildContext() : RouterProviderContext {

--- a/packages/@sanity/state-router/src/components/StateLink.js
+++ b/packages/@sanity/state-router/src/components/StateLink.js
@@ -1,18 +1,18 @@
-import PropTypes from 'prop-types'
 // @flow
 import React from 'react'
-import {omit} from 'lodash'
 import Link from './Link'
 import type {RouterProviderContext} from './types'
+import internalRouterContextTypeCheck from './internalRouterContextTypeCheck'
 
 const EMPTY_STATE = {}
 
-export default class StateLink extends React.PureComponent {
+export default class StateLink extends React.PureComponent<*, *> {
   props: {
     state?: Object,
     toIndex?: boolean
   }
   context: RouterProviderContext
+  _element: Link
 
   static defaultProps = {
     replace: false,
@@ -20,7 +20,7 @@ export default class StateLink extends React.PureComponent {
   }
 
   static contextTypes = {
-    __internalRouter: PropTypes.object
+    __internalRouter: internalRouterContextTypeCheck
   }
 
   resolveUrl() : string {
@@ -37,7 +37,14 @@ export default class StateLink extends React.PureComponent {
 
     const nextState = toIndex ? EMPTY_STATE : (state || EMPTY_STATE)
 
-    return this.context.__internalRouter.resolvePathFromState(nextState)
+    return this.resolvePathFromState(nextState)
+  }
+
+  resolvePathFromState(state: Object) {
+    if (!this.context.__internalRouter) {
+      return `javascript://state@${JSON.stringify(state)}`
+    }
+    return this.context.__internalRouter.resolvePathFromState(state)
   }
 
 
@@ -47,8 +54,10 @@ export default class StateLink extends React.PureComponent {
     }
   }
 
-  setElement = element => {
-    this._element = element
+  setElement = (element: ?Link) => {
+    if (element) {
+      this._element = element
+    }
   }
 
   render() {

--- a/packages/@sanity/state-router/src/components/WithRouter.js
+++ b/packages/@sanity/state-router/src/components/WithRouter.js
@@ -1,14 +1,13 @@
 // @flow
-import {Element} from 'react'
-import type {ContextRouter} from './types'
+import * as React from 'react'
+import type {Router} from './types'
 import withRouterHOC from './withRouterHOC'
 
 type Props = {
-  router: ContextRouter,
-  children: (ContextRouter) => Element<*>
+  router: Router,
+  children: (Router) => React.Node
 }
 
-const WithRouter = withRouterHOC((props : Props) => props.children(props.router))
-WithRouter.displayName = 'WithRouter'
+const WithRouter = withRouterHOC((props: Props) => props.children(props.router))
 
 export default WithRouter

--- a/packages/@sanity/state-router/src/components/internalRouterContextTypeCheck.js
+++ b/packages/@sanity/state-router/src/components/internalRouterContextTypeCheck.js
@@ -1,0 +1,9 @@
+export default function internalRouterContextTypeCheck(context, propName, componentName) {
+  if (!context.__internalRouter) {
+    throw new Error(
+      'The router is accessed outside the context of a <RouterProvider>.'
+      + ' No router state will be accessible and links will not go anywhere. To fix this,'
+      + ` make sure ${componentName} is rendered in the context of a <RouterProvider /> element`
+    )
+  }
+}

--- a/packages/@sanity/state-router/src/components/types.js
+++ b/packages/@sanity/state-router/src/components/types.js
@@ -14,21 +14,21 @@ export type RouterState = Object
 
 export type InternalRouter = {
   resolvePathFromState: (nextState : RouterState) => string,
-  resolveIntentLink: (intent : string, params? : Object) => string,
+  resolveIntentLink: (intentName : string, params? : Object) => string,
   navigateUrl: (url : string, options? : NavigateOptions) => void,
   navigate: (nextState : RouterState, options? : NavigateOptions) => void,
+  navigateIntent: (intentName : string, params?: Object, options? : NavigateOptions) => void,
   getState: () => RouterState,
   channel: Channel<RouterState>
 }
 
-export type ContextRouter = {
+export type Router = {
   navigate: (nextState : Object, options? : NavigateOptions) => void,
+  navigateIntent: (intentName : string, params? : Object, options? : NavigateOptions) => void,
   state: Object
 }
 
-
 export type RouterProviderContext = {
-  __internalRouter: InternalRouter,
-  router: ContextRouter,
+  __internalRouter: InternalRouter
 }
 


### PR DESCRIPTION
Any component that relied on the router (e.g. LinkState, IntentLink) would fail hard if they were rendred outside of a `<RouterProvider ..>` context. Usually you should provide a context, but sometimes it makes sense to not, e.g. when testing. (In my case, testing components that used `<StateLink` in Storybook)

Also includes a few additional flowtype annotations and minor tweaks.