### PR TITLE
[client] Set User-Agent in non-browser environments

### DIFF
--- a/packages/@sanity/client/src/http/request.js
+++ b/packages/@sanity/client/src/http/request.js
@@ -28,10 +28,16 @@ const middleware = [
   observable({implementation: SanityObservable})
 ]
 
-// Don't include debug middleware in browsers
+// Node-specifics
 if (process.env.BROWSERIFY_ENV !== 'build') {
+  // Only include debug middleware in browsers
   const debug = require('get-it/lib/middleware/debug')
   middleware.unshift(debug({verbose: true, namespace: 'sanity:client'}))
+
+  // Assign user agent in node
+  const headers = require('get-it/lib/middleware/headers')
+  const pkg = require('../../package.json')
+  middleware.unshift(headers({'User-Agent': `${pkg.name} ${pkg.version}`}))
 }
 
 const request = getIt(middleware)

--- a/packages/@sanity/client/test/client.test.js
+++ b/packages/@sanity/client/test/client.test.js
@@ -1364,6 +1364,18 @@ test('includes token if set', t => {
     .then(t.end)
 })
 
+test('includes user agent in node', t => {
+  const pkg = require('../package.json')
+  const reqheaders = {'User-Agent': `${pkg.name} ${pkg.version}`}
+  nock(projectHost(), {reqheaders})
+    .get('/v1/data/doc/foo/bar')
+    .reply(200, {documents: []})
+
+  getClient().getDocument('bar')
+    .catch(t.ifError)
+    .then(t.end)
+})
+
 // Don't rely on this unless you're working at Sanity Inc ;)
 test('can use alternative http requester', t => {
   const requester = () => sanityObservable.of({


### PR DESCRIPTION
We're not allowed to override the user agent in browsers, but in Node, we want to include a user agent to help track down potential issues and get a general feel of client usage.
