### PR TITLE
[client] Make node-specific middleware be excluded from bundles

### DIFF
--- a/packages/@sanity/client/package.json
+++ b/packages/@sanity/client/package.json
@@ -16,6 +16,10 @@
     "prepublish": "in-publish && npm run build || not-in-publish",
     "test": "NODE_ENV=test tape -r babel-register test/*.test.js"
   },
+  "browser": {
+    "./src/http/nodeMiddleware.js": "./src/http/browserMiddleware.js",
+    "./lib/http/nodeMiddleware.js": "./lib/http/browserMiddleware.js"
+  },
   "dependencies": {
     "@sanity/eventsource": "^0.108.0",
     "@sanity/generate-help-url": "^0.108.0",

--- a/packages/@sanity/client/src/http/browserMiddleware.js
+++ b/packages/@sanity/client/src/http/browserMiddleware.js
@@ -1,0 +1,1 @@
+module.exports = []

--- a/packages/@sanity/client/src/http/nodeMiddleware.js
+++ b/packages/@sanity/client/src/http/nodeMiddleware.js
@@ -1,0 +1,10 @@
+const debug = require('get-it/lib/middleware/debug')
+const headers = require('get-it/lib/middleware/headers')
+const pkg = require('../../package.json')
+
+const middleware = [
+  debug({verbose: true, namespace: 'sanity:client'}),
+  headers({'User-Agent': `${pkg.name} ${pkg.version}`})
+]
+
+module.exports = middleware

--- a/packages/@sanity/client/src/http/request.js
+++ b/packages/@sanity/client/src/http/request.js
@@ -20,25 +20,16 @@ const httpError = ({
   }
 })
 
-const middleware = [
+// Environment-specific middleware.
+const envSpecific = require('./nodeMiddleware')
+
+const middleware = envSpecific.concat([
   jsonRequest(),
   jsonResponse(),
   progress(),
   httpError,
   observable({implementation: SanityObservable})
-]
-
-// Node-specifics
-if (process.env.BROWSERIFY_ENV !== 'build') {
-  // Only include debug middleware in browsers
-  const debug = require('get-it/lib/middleware/debug')
-  middleware.unshift(debug({verbose: true, namespace: 'sanity:client'}))
-
-  // Assign user agent in node
-  const headers = require('get-it/lib/middleware/headers')
-  const pkg = require('../../package.json')
-  middleware.unshift(headers({'User-Agent': `${pkg.name} ${pkg.version}`}))
-}
+])
 
 const request = getIt(middleware)
 


### PR DESCRIPTION
The `headers` and `debug` middleware were being included in browser bundles. Tried to find a clean solution, but using the `browser` field is the most reliable method I came up with which works both with browserify and with webpack.
