### PR TITLE
[chore] Support React 16.0.0-rc.2 as peer dependency

### DIFF
--- a/packages/@sanity/base/package.json
+++ b/packages/@sanity/base/package.json
@@ -52,8 +52,13 @@
     "nyc": "^10.1.2",
     "prop-types": "^15.5.8",
     "proxyquire": "^1.7.10",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4",
+    "react": "^16.0.0-rc.2",
+    "react-dom": "^16.0.0-rc.2",
     "rimraf": "^2.6.1"
+  },
+  "peerDependencies": {
+    "prop-types": "15.x || ^16.0.0-rc.2",
+    "react": "15.x || ^16.0.0-rc.2",
+    "react-dom": "15.x || ^16.0.0-rc.2"
   }
 }

--- a/packages/@sanity/components/package.json
+++ b/packages/@sanity/components/package.json
@@ -63,13 +63,14 @@
     "eslint-config-sanity": "^2.1.4",
     "eslint-plugin-react": "^6.10.0",
     "pre-commit": "^1.1.3",
+    "react": "^16.0.0-rc.2",
     "react-styleguidist": "^2.3.1",
+    "prop-types": "^15.5.10",
     "rimraf": "^2.6.1"
   },
   "peerDependencies": {
-    "prop-types": ">=15.0.0",
-    "react": ">=15.0.0",
-    "react-dom": ">=15.0.0"
+    "prop-types": "15.x || ^16.0.0-rc.2",
+    "react": "15.x || ^16.0.0-rc.2"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/default-layout/package.json
+++ b/packages/@sanity/default-layout/package.json
@@ -25,7 +25,8 @@
   },
   "homepage": "https://github.com/sanity-io/default-layout#readme",
   "dependencies": {
-    "react-click-outside": "^2.2.0"
+    "react-click-outside": "^2.2.0",
+    "lodash": "^4.17.4"
   },
   "devDependencies": {
     "@sanity/base": "^0.111.2",
@@ -42,8 +43,13 @@
     "mocha": "^3.2.0",
     "nyc": "^10.1.2",
     "prop-types": "^15.5.8",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4",
+    "react": "^16.0.0-rc.2",
+    "react-dom": "^16.0.0-rc.2",
     "rimraf": "^2.6.1"
+  },
+  "peerDependencies": {
+    "prop-types": "15.x || ^16.0.0-rc.2",
+    "react": "15.x || ^16.0.0-rc.2",
+    "react-dom": "15.x || ^16.0.0-rc.2"
   }
 }

--- a/packages/@sanity/desk-tool/package.json
+++ b/packages/@sanity/desk-tool/package.json
@@ -32,7 +32,7 @@
     "lodash": "^4.17.4",
     "moment": "^2.18.1",
     "react-click-outside": "^2.2.0",
-    "react-json-inspector": "^7.0.0",
+    "react-json-inspector": "rexxars/react-json-inspector#react-15",
     "react-tiny-virtual-list": "^2.0.5",
     "shallow-equals": "^1.0.0"
   },
@@ -50,9 +50,12 @@
     "history": "^4.5.1",
     "postcss-cssnext": "2.10.0",
     "prop-types": "^15.5.8",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4",
+    "react": "^16.0.0-rc.2",
     "rimraf": "^2.6.1"
+  },
+  "peerDependencies": {
+    "prop-types": "15.x || ^16.0.0-rc.2",
+    "react": "15.x || ^16.0.0-rc.2"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/form-builder/package.json
+++ b/packages/@sanity/form-builder/package.json
@@ -79,12 +79,17 @@
     "path-to-regexp": "^1.7.0",
     "postcss-cssnext": "2.10.0",
     "prop-types": "^15.5.8",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4",
+    "react": "^16.0.0-rc.2",
+    "react-dom": "^16.0.0-rc.2",
     "react-enroute": "^1.0.0",
     "rimraf": "^2.6.1",
     "tap": "^10.3.0",
     "zen-observable": "^0.4.0"
+  },
+  "peerDependencies": {
+    "prop-types": "15.x || ^16.0.0-rc.2",
+    "react": "15.x || ^16.0.0-rc.2",
+    "react-dom": "15.x || ^16.0.0-rc.2"
   },
   "directories": {
     "example": "example",

--- a/packages/@sanity/google-maps-input/package.json
+++ b/packages/@sanity/google-maps-input/package.json
@@ -29,6 +29,11 @@
     "lodash": "^4.17.4",
     "rimraf": "^2.6.1"
   },
+  "peerDependencies": {
+    "prop-types": "15.x || ^16.0.0-rc.2",
+    "react": "15.x || ^16.0.0-rc.2",
+    "react-dom": "15.x || ^16.0.0-rc.2"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:sanity-io/sanity.git"

--- a/packages/@sanity/imagetool/package.json
+++ b/packages/@sanity/imagetool/package.json
@@ -31,8 +31,8 @@
     "mocha": "^3.2.0",
     "prop-types": "^15.5.8",
     "quickreload": "^2.1.2",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4",
+    "react": "^16.0.0-rc.2",
+    "react-dom": "^16.0.0-rc.2",
     "rebundler": "^0.3.0",
     "remon": "^1.0.2",
     "rimraf": "^2.6.1",
@@ -40,8 +40,9 @@
     "staticr": "^4.0.2"
   },
   "peerDependencies": {
-    "prop-types": ">=15.3",
-    "react": ">=15.3"
+    "prop-types": "15.x || ^16.0.0-rc.2",
+    "react": "15.x || ^16.0.0-rc.2",
+    "react-dom": "15.x || ^16.0.0-rc.2"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/server/package.json
+++ b/packages/@sanity/server/package.json
@@ -50,9 +50,6 @@
     "normalize.css": "^5.0.0",
     "parents": "^1.0.1",
     "postcss-loader": "^1.2.2",
-    "prop-types": "^15.5.8",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4",
     "react-hot-loader": "^3.0.0-beta.6",
     "require-uncached": "^1.0.2",
     "resolve": "^1.3.3",
@@ -66,6 +63,14 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
     "cross-env": "^3.1.4",
+    "react": "^16.0.0-rc.2",
+    "react-dom": "^16.0.0-rc.2",
+    "prop-types": "^15.5.8",
     "rimraf": "^2.6.1"
+  },
+  "peerDependencies": {
+    "prop-types": "15.x || ^16.0.0-rc.2",
+    "react": "15.x || ^16.0.0-rc.2",
+    "react-dom": "15.x || ^16.0.0-rc.2"
   }
 }

--- a/packages/@sanity/state-router/package.json
+++ b/packages/@sanity/state-router/package.json
@@ -41,13 +41,18 @@
     "object-inspect": "^1.2.1",
     "prop-types": "^15.5.8",
     "quickreload": "^2.1.2",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4",
+    "react": "^16.0.0-rc.2",
+    "react-dom": "^16.0.0-rc.2",
     "rebundler": "^0.3.0",
     "remon": "^1.0.2",
     "rimraf": "^2.6.1",
     "staticr": "^4.0.2",
     "tap": "^10.3.0"
+  },
+  "peerDependencies": {
+    "prop-types": "15.x || ^16.0.0-rc.2",
+    "react": "15.x || ^16.0.0-rc.2",
+    "react-dom": "15.x || ^16.0.0-rc.2"
   },
   "repository": {
     "type": "git",

--- a/packages/example-studio/package.json
+++ b/packages/example-studio/package.json
@@ -31,9 +31,9 @@
     "get-video-id": "^2.1.4",
     "humanize-list": "^1.0.1",
     "prop-types": "^15.5.8",
-    "react": "^15.5.4",
+    "react": "^15.6.1",
     "react-ace": "^4.3.0",
-    "react-dom": "^15.5.4",
+    "react-dom": "^15.6.1",
     "react-icons": "^2.2.5",
     "sanity-plugin-vision": "^0.111.2"
   },

--- a/packages/example-studio/parts/AuthorPreview.js
+++ b/packages/example-studio/parts/AuthorPreview.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import DefaultPreview from 'part:@sanity/components/previews/default'
 import previewStyles from './AuthorPreview.css'
 

--- a/packages/sanity-plugin-vision/package.json
+++ b/packages/sanity-plugin-vision/package.json
@@ -19,9 +19,9 @@
     "json-lexer": "^1.1.1",
     "moment": "^2.17.1",
     "query-string": "^4.3.2",
-    "react-codemirror": "^0.3.0",
+    "react-codemirror2": "^1.0.0",
     "react-icon-base": "^2.0.4",
-    "react-json-inspector": "^7.0.0",
+    "react-json-inspector": "rexxars/react-json-inspector#react-15",
     "react-spinner": "^0.2.6",
     "react-split-pane": "^0.1.63"
   },
@@ -38,8 +38,13 @@
     "eslint-config-sanity": "^2.0.2",
     "eslint-plugin-react": "^6.10.0",
     "prop-types": "^15.5.8",
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2"
+    "react": "^16.0.0-rc.2",
+    "react-dom": "^16.0.0-rc.2"
+  },
+  "peerDependencies": {
+    "prop-types": "15.x || ^16.0.0-rc.2",
+    "react": "15.x || ^16.0.0-rc.2",
+    "react-dom": "15.x || ^16.0.0-rc.2"
   },
   "repository": {
     "type": "git",

--- a/packages/sanity-plugin-vision/src/Vision.js
+++ b/packages/sanity-plugin-vision/src/Vision.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import VisionContainer from './containers/VisionContainer'
 
 // Passes the given Sanity client and components to use down

--- a/packages/sanity-plugin-vision/src/components/DelayedSpinner.js
+++ b/packages/sanity-plugin-vision/src/components/DelayedSpinner.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import LoadingSpinner from './LoadingSpinner'
 
 // Waits for X ms before showing a spinner

--- a/packages/sanity-plugin-vision/src/components/Dropdown.js
+++ b/packages/sanity-plugin-vision/src/components/Dropdown.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 
 function Dropdown(props) {
   const {id, value, className, values, onChange} = props

--- a/packages/sanity-plugin-vision/src/components/ErrorDialog.js
+++ b/packages/sanity-plugin-vision/src/components/ErrorDialog.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 
 function ErrorDialog(props) {
   return (

--- a/packages/sanity-plugin-vision/src/components/JsonDump.js
+++ b/packages/sanity-plugin-vision/src/components/JsonDump.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types, react/no-multi-comp */
-import React, {PropTypes} from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import tokenize from 'json-lexer'
 
 const punctuator = token => <span className={token.className}>{token.raw}</span>

--- a/packages/sanity-plugin-vision/src/components/NoResultsDialog.js
+++ b/packages/sanity-plugin-vision/src/components/NoResultsDialog.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 
 function NoResultsDialog(props) {
   return (

--- a/packages/sanity-plugin-vision/src/components/ParamsEditor.js
+++ b/packages/sanity-plugin-vision/src/components/ParamsEditor.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
-import ReactCodeMirror from 'react-codemirror'
+import ReactCodeMirror from 'react-codemirror2'
 import isPlainObject from '../util/isPlainObject'
 import tryParseParams from '../util/tryParseParams'
 
@@ -25,7 +25,7 @@ class ParamsEditor extends React.PureComponent {
     }
   }
 
-  handleChange(value) {
+  handleChange(editor, metadata, value) {
     const params = tryParseParams(value)
     this.setState({valid: isPlainObject(params)})
     this.props.onChange({parsed: params, raw: value})

--- a/packages/sanity-plugin-vision/src/components/QueryEditor.js
+++ b/packages/sanity-plugin-vision/src/components/QueryEditor.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import ReactCodeMirror from 'react-codemirror'
+import ReactCodeMirror from 'react-codemirror2'
 import CodeMirror from 'codemirror'
 require('codemirror/mode/javascript/javascript')
 require('codemirror/addon/hint/show-hint')
@@ -41,7 +41,7 @@ class QueryEditor extends React.PureComponent {
     }
   }
 
-  handleChange(value) {
+  handleChange(editor, metadata, value) {
     this.props.onChange({query: value})
   }
 
@@ -61,6 +61,7 @@ class QueryEditor extends React.PureComponent {
         value={this.props.value}
         onChange={this.handleChange}
         options={options}
+        className={this.props.className}
       />
     )
   }

--- a/packages/sanity-plugin-vision/src/components/QueryErrorDetails.js
+++ b/packages/sanity-plugin-vision/src/components/QueryErrorDetails.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 
 function QueryErrorDetails(props) {
   const details = props.error.details

--- a/packages/sanity-plugin-vision/src/components/QueryErrorDialog.js
+++ b/packages/sanity-plugin-vision/src/components/QueryErrorDialog.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import QueryErrorDetails from './QueryErrorDetails'
 
 function QueryErrorDialog(props) {

--- a/packages/sanity-plugin-vision/src/components/ResultCollection.js
+++ b/packages/sanity-plugin-vision/src/components/ResultCollection.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import JsonInspector from 'react-json-inspector'
 import JsonDump from './JsonDump'
 

--- a/packages/sanity-plugin-vision/src/components/ResultTable.js
+++ b/packages/sanity-plugin-vision/src/components/ResultTable.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import calendarDate from '../util/calendarDate'
 
 class ResultTable extends React.PureComponent {

--- a/packages/sanity-plugin-vision/src/components/ResultView.js
+++ b/packages/sanity-plugin-vision/src/components/ResultView.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import ResultCollection from './ResultCollection'
 import JsonDump from './JsonDump'
 

--- a/packages/sanity-plugin-vision/src/components/VisionGui.js
+++ b/packages/sanity-plugin-vision/src/components/VisionGui.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import queryString from 'query-string'
 import {storeState, getState} from '../util/localState'
 import parseApiQueryString from '../util/parseApiQueryString'

--- a/packages/sanity-plugin-vision/src/containers/LoadingContainer.js
+++ b/packages/sanity-plugin-vision/src/containers/LoadingContainer.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import request from '../util/request'
 
 // Yeah, inheritance and all that. Deal with it.

--- a/packages/sanity-plugin-vision/src/css/visionGui.css
+++ b/packages/sanity-plugin-vision/src/css/visionGui.css
@@ -29,6 +29,14 @@
   margin-right: 0.5em;
 }
 
+.queryEditor {
+  height: 100%
+}
+
+.paramsEditor {
+  height: 100%
+}
+
 .queryTimingContainer {
   flex-grow: 1;
   text-align: right;

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -20,7 +20,7 @@
     "@sanity/server": "^0.111.2",
     "@sanity/storybook": "^0.111.2",
     "prop-types": "^15.5.8",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4"
+    "react": "^16.0.0-rc.2",
+    "react-dom": "^16.0.0-rc.2"
   }
 }

--- a/packages/test-studio/package.json
+++ b/packages/test-studio/package.json
@@ -31,9 +31,9 @@
     "get-video-id": "^2.1.4",
     "humanize-list": "^1.0.1",
     "prop-types": "^15.5.8",
-    "react": "^15.5.4",
+    "react": "^15.6.1",
     "react-ace": "^4.3.0",
-    "react-dom": "^15.5.4",
+    "react-dom": "^15.6.1",
     "react-icons": "^2.2.5",
     "sanity-plugin-vision": "^0.111.2"
   },


### PR DESCRIPTION
This also upgrades React to 16.0.0-rc.2 in _test studio_ and _example studio_.

Ran into a few issues along the way:
- I had to switch from the official `react-json-inspector` to @rexxars'  react-15 branch [here](https://github.com/rexxars/react-json-inspector/tree/react-15), which fixes the deprecation warnings in React 15 that are hard errors in 16. (we should probably look for an alternative, since react-json-inspector doesn't seem like its actively maintained anymore).
- Switched to react-codemirror2, since [JedWatson/react-codemirror](https://github.com/JedWatson/react-codemirror) looks pretty much abandoned.
- The storybook tool is currently broken. I've started the process of upgrading to the latest @storybook packages in #165 . (If we want to merge this immediately we should probably pin react on 15.x in the test/example studios)

Apart from that, everything seems to work fine with 16.0.0-rc.2 🎉

