### PR TITLE
[form-builder] Feature: Hide fields by specifying `hidden` in schema

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/Object/Object.js
+++ b/packages/@sanity/form-builder/src/inputs/Object/Object.js
@@ -61,6 +61,10 @@ export default class ObjectInput extends React.PureComponent {
   }
 
   renderField(field, level, index) {
+    if (field.type.isHidden) {
+      return null
+    }
+
     const {value, validation, autoFocus} = this.props
     const fieldValidation = validation && validation.fields[field.name]
 
@@ -141,7 +145,6 @@ export default class ObjectInput extends React.PureComponent {
   }
 
   render() {
-
     const {type, level} = this.props
 
     const renderedFields = this.getRenderedFields()

--- a/packages/@sanity/form-builder/src/inputs/Object/Object.js
+++ b/packages/@sanity/form-builder/src/inputs/Object/Object.js
@@ -61,7 +61,7 @@ export default class ObjectInput extends React.PureComponent {
   }
 
   renderField(field, level, index) {
-    if (field.type.isHidden) {
+    if (field.type.hidden) {
       return null
     }
 

--- a/packages/test-studio/schemas/book.js
+++ b/packages/test-studio/schemas/book.js
@@ -25,11 +25,11 @@ export default {
       to: {type: 'author', title: 'Author'}
     },
     {
-      name: 'publicationYear',
-      title: 'Publication year',
-      description: 'Year the book was published. Not shown in studio.',
+      name: 'isbn',
+      title: 'ISBN number',
+      description: 'ISBN-number of the book. Not shown in studio.',
       type: 'number',
-      isHidden: true
+      hidden: true
     }
   ]
 }

--- a/packages/test-studio/schemas/book.js
+++ b/packages/test-studio/schemas/book.js
@@ -23,6 +23,13 @@ export default {
       title: 'Author',
       type: 'reference',
       to: {type: 'author', title: 'Author'}
+    },
+    {
+      name: 'publicationYear',
+      title: 'Publication year',
+      description: 'Year the book was published. Not shown in studio.',
+      type: 'number',
+      isHidden: true
     }
   ]
 }


### PR DESCRIPTION
Warning: Totally new to the form builder internals, so might be overlooking something.

PR is an attempt to introduce new `isHidden` property on schema which will prevent a field from being rendered. The use case is where you have properties which are populated by scripts and are part of the content model, but should not be editable/shown to the editors in the studio.
