### PR TITLE
Feature/define sorting

### DIFF
--- a/packages/@sanity/base/sanity.json
+++ b/packages/@sanity/base/sanity.json
@@ -584,6 +584,10 @@
       "path": "components/icons/SortAlphaDesc.js"
     },
     {
+      "implements": "part:@sanity/base/sort-icon",
+      "path": "components/icons/Sort.js"
+    },
+    {
       "implements": "part:@sanity/base/bars-icon",
       "path": "components/icons/Bars.js"
     },

--- a/packages/@sanity/base/src/components/icons/Sort.js
+++ b/packages/@sanity/base/src/components/icons/Sort.js
@@ -1,0 +1,1 @@
+export {default} from 'react-icons/lib/fa/sort'

--- a/packages/@sanity/base/src/preview/PreviewSubscriber.js
+++ b/packages/@sanity/base/src/preview/PreviewSubscriber.js
@@ -13,6 +13,7 @@ export default class PreviewSubscriber extends React.PureComponent {
     type: PropTypes.object.isRequired,
     fields: PropTypes.arrayOf(PropTypes.oneOf(['title', 'description', 'imageUrl'])),
     value: PropTypes.any.isRequired,
+    sorting: PropTypes.object,
     children: PropTypes.func
   }
 
@@ -46,6 +47,10 @@ export default class PreviewSubscriber extends React.PureComponent {
   subscribe(value, type, fields) {
     this.unsubscribe()
 
+    const viewOptions = this.props.sorting
+      ? {sorting: this.props.sorting}
+      : {}
+
     const visibilityOn$ = Observable.of(!document.hidden)
        .merge(visibilityChange$.map(event => !event.target.hidden))
 
@@ -58,7 +63,7 @@ export default class PreviewSubscriber extends React.PureComponent {
       .distinctUntilChanged()
       .switchMap(isInViewport => {
         return isInViewport
-          ? observeForPreview(value, type, fields)
+          ? observeForPreview(value, type, fields, viewOptions)
           : Observable.of(null)
       })
       .subscribe(result => {

--- a/packages/@sanity/base/src/preview/PreviewSubscriber.js
+++ b/packages/@sanity/base/src/preview/PreviewSubscriber.js
@@ -13,7 +13,7 @@ export default class PreviewSubscriber extends React.PureComponent {
     type: PropTypes.object.isRequired,
     fields: PropTypes.arrayOf(PropTypes.oneOf(['title', 'description', 'imageUrl'])),
     value: PropTypes.any.isRequired,
-    sorting: PropTypes.object,
+    ordering: PropTypes.object,
     children: PropTypes.func
   }
 
@@ -47,8 +47,8 @@ export default class PreviewSubscriber extends React.PureComponent {
   subscribe(value, type, fields) {
     this.unsubscribe()
 
-    const viewOptions = this.props.sorting
-      ? {sorting: this.props.sorting}
+    const viewOptions = this.props.ordering
+      ? {ordering: this.props.ordering}
       : {}
 
     const visibilityOn$ = Observable.of(!document.hidden)

--- a/packages/@sanity/base/src/preview/SanityPreview.js
+++ b/packages/@sanity/base/src/preview/SanityPreview.js
@@ -8,14 +8,15 @@ export default class SanityPreview extends React.PureComponent {
   static propTypes = {
     layout: PropTypes.string,
     value: PropTypes.any,
+    sorting: PropTypes.object,
     type: PropTypes.object.isRequired
   }
 
 
   render() {
-    const {type, value, layout} = this.props
+    const {type, value, layout, sorting} = this.props
     return (
-      <PreviewSubscriber type={type} value={value} layout={layout}>
+      <PreviewSubscriber type={type} value={value} layout={layout} sorting={sorting}>
         {RenderPreviewSnapshot}
       </PreviewSubscriber>
     )

--- a/packages/@sanity/base/src/preview/SanityPreview.js
+++ b/packages/@sanity/base/src/preview/SanityPreview.js
@@ -8,15 +8,15 @@ export default class SanityPreview extends React.PureComponent {
   static propTypes = {
     layout: PropTypes.string,
     value: PropTypes.any,
-    sorting: PropTypes.object,
+    ordering: PropTypes.object,
     type: PropTypes.object.isRequired
   }
 
 
   render() {
-    const {type, value, layout, sorting} = this.props
+    const {type, value, layout, ordering} = this.props
     return (
-      <PreviewSubscriber type={type} value={value} layout={layout} sorting={sorting}>
+      <PreviewSubscriber type={type} value={value} layout={layout} ordering={ordering}>
         {RenderPreviewSnapshot}
       </PreviewSubscriber>
     )

--- a/packages/@sanity/base/src/preview/observeForPreview.js
+++ b/packages/@sanity/base/src/preview/observeForPreview.js
@@ -11,7 +11,7 @@ function is(typeName, type) {
 }
 
 // Takes a value and its type and prepares a snapshot for it that can be passed to a preview component
-export default function observeForPreview(value, type, fields) {
+export default function observeForPreview(value, type, fields, viewOptions) {
   if (is('reference', type)) {
     // if the value is of type reference, but has no _ref property, we cannot prepare any value for the preview
     // and the most sane thing to do is to return `null` for snapshot
@@ -31,7 +31,13 @@ export default function observeForPreview(value, type, fields) {
     const targetFields = fields ? configFields.filter(fieldName => fields.includes(fieldName)) : configFields
     const paths = targetFields.map(key => selection[key].split('.'))
     return observe(value, paths)
-      .map(snapshot => ({type: type, snapshot: prepareForPreview(snapshot, type)}))
+      .map(snapshot => ({
+        type: type,
+        snapshot: prepareForPreview(snapshot, type, viewOptions)
+      }))
   }
-  return Observable.of({type: type, snapshot: invokePrepare(type, value)})
+  return Observable.of({
+    type: type,
+    snapshot: invokePrepare(type, value, viewOptions)
+  })
 }

--- a/packages/@sanity/base/src/preview/prepareForPreview.js
+++ b/packages/@sanity/base/src/preview/prepareForPreview.js
@@ -34,13 +34,13 @@ const reportErrors = debounce(() => {
   /* eslint-enable no-console */
 }, 1000)
 
-function invokePrepareChecked(type, value) {
+function invokePrepareChecked(type, value, viewOptions) {
   const prepare = type.preview.prepare
   if (!prepare) {
     return value
   }
   try {
-    return prepare(value)
+    return prepare(value, viewOptions)
   } catch (error) {
     if (!COLLECTED_ERRORS[type.name]) {
       COLLECTED_ERRORS[type.name] = []
@@ -57,7 +57,7 @@ function invokePrepareUnchecked(type, value) {
 
 export const invokePrepare = __DEV__ ? invokePrepareChecked : invokePrepareUnchecked
 
-export default function prepareForPreview(rawValue, type) {
+export default function prepareForPreview(rawValue, type, viewOptions) {
   const selection = type.preview.select
   const targetKeys = Object.keys(selection)
 
@@ -66,5 +66,5 @@ export default function prepareForPreview(rawValue, type) {
     return acc
   }, pick(rawValue, PRESERVE_KEYS))
 
-  return invokePrepare(type, remapped)
+  return invokePrepare(type, remapped, viewOptions)
 }

--- a/packages/@sanity/desk-tool/src/pane/DocumentsPane.js
+++ b/packages/@sanity/desk-tool/src/pane/DocumentsPane.js
@@ -40,18 +40,19 @@ function toGradientOrderClause(orderBy) {
   return Object.keys(orderBy).map(fieldName => `${fieldName} ${orderBy[fieldName]}`).join(', ')
 }
 
-const DEFAULT_SORT_OPTIONS = [
-  {
-    title: 'Last edited',
-    name: '__updatedAt',
-    orderBy: {_updatedAt: 'desc'}
-  },
-  {
-    title: 'Created',
-    name: '__createdAt',
-    orderBy: {_createdAt: 'desc'}
-  }
-]
+const SORT_BY_UPDATED_AT = {
+  title: 'Last edited',
+  name: '__updatedAt',
+  orderBy: {_updatedAt: 'desc'}
+}
+const SORT_BY_CREATED_AT = {
+  title: 'Created',
+  name: '__createdAt',
+  orderBy: {_createdAt: 'desc'}
+}
+
+const DEFAULT_SELECTED_SORT_OPTION = SORT_BY_UPDATED_AT
+const DEFAULT_SORT_OPTIONS = [SORT_BY_UPDATED_AT, SORT_BY_CREATED_AT]
 
 function removePublishedWithDrafts(documents) {
 
@@ -109,7 +110,7 @@ export default withRouterHOC(class DocumentsPane extends React.PureComponent {
     this.state = {
       settings: (settings && settings[props.selectedType]) || {
         listLayout: 'default',
-        sorting: DEFAULT_SORT_OPTIONS[1].name
+        sorting: DEFAULT_SELECTED_SORT_OPTION
       },
       menuIsOpen: false
     }
@@ -142,9 +143,12 @@ export default withRouterHOC(class DocumentsPane extends React.PureComponent {
 
   getSortOptions(selectedType) {
     const type = schema.get(selectedType)
-    return (type.sorting
-      ? DEFAULT_SORT_OPTIONS.concat(type.sorting)
-      : DEFAULT_SORT_OPTIONS).map(option => {
+    return (
+      type.sorting
+        ? DEFAULT_SORT_OPTIONS.concat(type.sorting)
+        : DEFAULT_SORT_OPTIONS
+    )
+      .map(option => {
         return {
           ...option,
           icon: SortIcon,
@@ -243,11 +247,11 @@ export default withRouterHOC(class DocumentsPane extends React.PureComponent {
     } = this.props
 
     const {settings} = this.state
-    const sorting = this.getSortOptions(schemaType.name)
-      .find(option => option.name === settings.sorting) || DEFAULT_SORT_OPTIONS[1]
+    const currentSortOption = this.getSortOptions(schemaType.name)
+      .find(option => option.name === settings.sorting) || DEFAULT_SELECTED_SORT_OPTION
 
     const params = {type: schemaType.name, draftsPath: `${DRAFTS_FOLDER}.**`}
-    const query = `*[_type == $type] | order(${toGradientOrderClause(sorting.orderBy)}) [0...10000] {_id, _type}`
+    const query = `*[_type == $type] | order(${toGradientOrderClause(currentSortOption.orderBy)}) [0...10000] {_id, _type}`
     return (
       <Pane
         {...this.props}

--- a/packages/@sanity/desk-tool/src/pane/DocumentsPane.js
+++ b/packages/@sanity/desk-tool/src/pane/DocumentsPane.js
@@ -119,10 +119,7 @@ export default withRouterHOC(class DocumentsPane extends React.PureComponent {
     this.setState(prevState => ({
       settings: {
         ...prevState.settings,
-        sorting: sorting.name,
-        invertSorting: (prevState.settings.sorting === sorting.name)
-          ? !prevState.settings.invertSorting
-          : false
+        sorting: sorting.name
       }
     }), this.writeSettings)
   }

--- a/packages/@sanity/desk-tool/src/pane/DocumentsPane.js
+++ b/packages/@sanity/desk-tool/src/pane/DocumentsPane.js
@@ -152,7 +152,7 @@ export default withRouterHOC(class DocumentsPane extends React.PureComponent {
       .map(option => {
         return {
           ...option,
-          icon: SortIcon,
+          icon: option.icon || SortIcon,
           title: <span>Sort by <b>{option.title}</b></span>
         }
       })

--- a/packages/@sanity/desk-tool/src/pane/DocumentsPane.js
+++ b/packages/@sanity/desk-tool/src/pane/DocumentsPane.js
@@ -6,7 +6,7 @@ import {StateLink, IntentLink, withRouterHOC} from 'part:@sanity/base/router'
 import SortIcon from 'part:@sanity/base/sort-icon'
 
 import ListView from './ListView'
-import {partition} from 'lodash'
+import {partition, uniqBy} from 'lodash'
 import VisibilityOffIcon from 'part:@sanity/base/visibility-off-icon'
 import EditIcon from 'part:@sanity/base/edit-icon'
 import QueryContainer from 'part:@sanity/base/query-container'
@@ -42,12 +42,12 @@ function toGradientOrderClause(orderBy) {
 
 const SORT_BY_UPDATED_AT = {
   title: 'Last edited',
-  name: '__updatedAt',
+  name: 'updatedAt',
   orderBy: {_updatedAt: 'desc'}
 }
 const SORT_BY_CREATED_AT = {
   title: 'Created',
-  name: '__createdAt',
+  name: 'createdAt',
   orderBy: {_createdAt: 'desc'}
 }
 
@@ -143,11 +143,12 @@ export default withRouterHOC(class DocumentsPane extends React.PureComponent {
 
   getSortOptions(selectedType) {
     const type = schema.get(selectedType)
-    return (
-      type.sorting
-        ? DEFAULT_SORT_OPTIONS.concat(type.sorting)
-        : DEFAULT_SORT_OPTIONS
-    )
+
+    const optionsWithDefaults = type.sorting
+      ? type.sorting.concat(DEFAULT_SORT_OPTIONS)
+      : DEFAULT_SORT_OPTIONS
+
+    return uniqBy(optionsWithDefaults, 'name')
       .map(option => {
         return {
           ...option,

--- a/packages/@sanity/desk-tool/src/pane/DocumentsPaneMenu.js
+++ b/packages/@sanity/desk-tool/src/pane/DocumentsPaneMenu.js
@@ -53,10 +53,10 @@ export default class DocumentsPaneMenu extends React.PureComponent {
 
   static propTypes = {
     onSetListLayout: PropTypes.func,
-    onSetSorting: PropTypes.func,
+    onSetOrdering: PropTypes.func,
     onGoToCreateNew: PropTypes.func,
     onMenuClose: PropTypes.func,
-    sortOptions: PropTypes.array
+    orderingOptions: PropTypes.array
   }
 
   handleMenuAction = item => {
@@ -64,8 +64,8 @@ export default class DocumentsPaneMenu extends React.PureComponent {
       this.props.onSetListLayout(item)
     }
 
-    if (item.action === 'setSorting') {
-      this.props.onSetSorting(item.sorting)
+    if (item.action === 'setOrdering') {
+      this.props.onSetOrdering(item.ordering)
     }
 
     if (item.action === 'createNew') {
@@ -75,20 +75,20 @@ export default class DocumentsPaneMenu extends React.PureComponent {
   }
 
   render() {
-    const {sortOptions} = this.props
-    const sortItems = sortOptions.map(sortConfig => ({
-      title: sortConfig.title,
-      icon: sortConfig.icon || NULL_COMPONENT,
-      sorting: sortConfig,
-      action: 'setSorting',
-      key: sortConfig.name
+    const {orderingOptions} = this.props
+    const orderingItems = orderingOptions.map(orderingOption => ({
+      title: orderingOption.title,
+      icon: orderingOption.icon || NULL_COMPONENT,
+      ordering: orderingOption,
+      action: 'setOrdering',
+      key: orderingOption.name
     }))
       .concat(LIST_VIEW_ITEMS)
 
     return (
       <Menu
         onAction={this.handleMenuAction}
-        items={sortItems}
+        items={orderingItems}
         origin="top-right"
         {...this.props}
       />

--- a/packages/@sanity/desk-tool/src/pane/DocumentsPaneMenu.js
+++ b/packages/@sanity/desk-tool/src/pane/DocumentsPaneMenu.js
@@ -10,31 +10,7 @@ import IconNew from 'part:@sanity/base/plus-circle-icon'
 
 const TEST_CARDS_AND_THUMBNAILS = false
 
-const menuItems = [
-  // Todo: Disabled for now as we need to rethink how sorting should
-  // work wrt. previews and what is actually displayed on screen
-
-  // {
-  //   title: 'Alphabetical',
-  //   icon: IconSortAlphaDesc,
-  //   action: 'setSorting',
-  //   key: 'byAlphabetical',
-  //   sorting: 'name'
-  // },
-  {
-    title: 'Last edited',
-    icon: undefined,
-    action: 'setSorting',
-    key: 'byLastEdited',
-    sorting: '_updatedAt desc'
-  },
-  {
-    title: 'Created',
-    icon: undefined,
-    action: 'setSorting',
-    key: 'byCreated',
-    sort: '_createdAt desc'
-  },
+const LIST_VIEW_ITEMS = [
   {
     title: 'List',
     icon: IconList,
@@ -71,18 +47,21 @@ const menuItems = [
   }
 ].filter(Boolean)
 
+const NULL_COMPONENT = () => null
+
 export default class DocumentsPaneMenu extends React.PureComponent {
 
   static propTypes = {
     onSetListLayout: PropTypes.func,
     onSetSorting: PropTypes.func,
     onGoToCreateNew: PropTypes.func,
-    onMenuClose: PropTypes.func
+    onMenuClose: PropTypes.func,
+    sortOptions: PropTypes.array
   }
 
   handleMenuAction = item => {
     if (item.action === 'setListLayout') {
-      this.props.onSetListLayout(item.key)
+      this.props.onSetListLayout(item)
     }
 
     if (item.action === 'setSorting') {
@@ -92,15 +71,24 @@ export default class DocumentsPaneMenu extends React.PureComponent {
     if (item.action === 'createNew') {
       this.props.onGoToCreateNew()
     }
-
     this.props.onMenuClose()
   }
 
   render() {
+    const {sortOptions} = this.props
+    const sortItems = sortOptions.map(sortConfig => ({
+      title: sortConfig.title,
+      icon: sortConfig.icon || NULL_COMPONENT,
+      sorting: sortConfig,
+      action: 'setSorting',
+      key: sortConfig.name
+    }))
+      .concat(LIST_VIEW_ITEMS)
+
     return (
       <Menu
         onAction={this.handleMenuAction}
-        items={menuItems}
+        items={sortItems}
         origin="top-right"
         {...this.props}
       />

--- a/packages/@sanity/schema/src/ordering/guessOrderingConfig.js
+++ b/packages/@sanity/schema/src/ordering/guessOrderingConfig.js
@@ -6,7 +6,7 @@ const PRIMITIVES = ['string', 'boolean', 'number']
 
 const isPrimitive = field => PRIMITIVES.includes(field.type)
 
-export default function guessSortConfig(objectTypeDef) {
+export default function guessOrderingConfig(objectTypeDef) {
 
   let candidates = CANDIDATES.filter(candidate => objectTypeDef.fields.some(field => field.name === candidate))
 
@@ -19,6 +19,6 @@ export default function guessSortConfig(objectTypeDef) {
     .map(name => ({
       name: name,
       title: capitalize(startCase(name)),
-      orderBy: {[name]: 'asc'}
+      by: [{field: name, direction: 'asc'}]
     }))
 }

--- a/packages/@sanity/schema/src/sort/guessSortConfig.js
+++ b/packages/@sanity/schema/src/sort/guessSortConfig.js
@@ -1,0 +1,24 @@
+import {capitalize, startCase} from 'lodash'
+
+const CANDIDATES = ['title', 'name', 'label', 'heading', 'header', 'caption', 'description']
+
+const PRIMITIVES = ['string', 'boolean', 'number']
+
+const isPrimitive = field => PRIMITIVES.includes(field.type)
+
+export default function guessSortConfig(objectTypeDef) {
+
+  let candidates = CANDIDATES.filter(candidate => objectTypeDef.fields.some(field => field.name === candidate))
+
+  // None of the candidates were found, fallback to all fields
+  if (candidates.length === 0) {
+    candidates = objectTypeDef.fields.filter(isPrimitive).map(field => field.name)
+  }
+
+  return candidates
+    .map(name => ({
+      name: name,
+      title: capitalize(startCase(name)),
+      orderBy: {[name]: 'asc'}
+    }))
+}

--- a/packages/@sanity/schema/src/types/object.js
+++ b/packages/@sanity/schema/src/types/object.js
@@ -3,7 +3,18 @@ import {lazyGetter} from './utils'
 import createPreviewGetter from '../preview/createPreviewGetter'
 import guessSortConfig from '../sort/guessSortConfig'
 
-const OVERRIDABLE_FIELDS = ['jsonType', 'sorting', 'type', 'name', 'title', 'description', 'options', 'inputComponent']
+const OVERRIDABLE_FIELDS = [
+  'jsonType',
+  'sorting',
+  'type',
+  'name',
+  'title',
+  'readOnly',
+  'hidden',
+  'description',
+  'options',
+  'inputComponent'
+]
 
 const OBJECT_CORE = {
   name: 'object',

--- a/packages/@sanity/schema/src/types/object.js
+++ b/packages/@sanity/schema/src/types/object.js
@@ -1,11 +1,11 @@
 import {pick, keyBy, startCase} from 'lodash'
 import {lazyGetter} from './utils'
 import createPreviewGetter from '../preview/createPreviewGetter'
-import guessSortConfig from '../sort/guessSortConfig'
+import guessOrderingConfig from '../ordering/guessOrderingConfig'
 
 const OVERRIDABLE_FIELDS = [
   'jsonType',
-  'sorting',
+  'orderings',
   'type',
   'name',
   'title',
@@ -32,7 +32,7 @@ export const ObjectType = {
       type: OBJECT_CORE,
       title: subTypeDef.title || (subTypeDef.name ? startCase(subTypeDef.name) : ''),
       options: options,
-      sorting: subTypeDef.sorting || guessSortConfig(subTypeDef),
+      orderings: subTypeDef.orderings || guessOrderingConfig(subTypeDef),
       fields: subTypeDef.fields.map(fieldDef => {
         const {name, fieldset, ...rest} = fieldDef
 

--- a/packages/@sanity/schema/src/types/object.js
+++ b/packages/@sanity/schema/src/types/object.js
@@ -1,8 +1,9 @@
 import {pick, keyBy, startCase} from 'lodash'
 import {lazyGetter} from './utils'
 import createPreviewGetter from '../preview/createPreviewGetter'
+import guessSortConfig from '../sort/guessSortConfig'
 
-const OVERRIDABLE_FIELDS = ['jsonType', 'type', 'name', 'title', 'description', 'options', 'inputComponent']
+const OVERRIDABLE_FIELDS = ['jsonType', 'sorting', 'type', 'name', 'title', 'description', 'options', 'inputComponent']
 
 const OBJECT_CORE = {
   name: 'object',
@@ -20,6 +21,7 @@ export const ObjectType = {
       type: OBJECT_CORE,
       title: subTypeDef.title || (subTypeDef.name ? startCase(subTypeDef.name) : ''),
       options: options,
+      sorting: subTypeDef.sorting || guessSortConfig(subTypeDef),
       fields: subTypeDef.fields.map(fieldDef => {
         const {name, fieldset, ...rest} = fieldDef
 

--- a/packages/test-studio/schemas/book.js
+++ b/packages/test-studio/schemas/book.js
@@ -1,22 +1,30 @@
+function formatSubtitle(book) {
+  if (book.authorName && book.publicationYear) {
+    return `By ${book.authorName} (${book.publicationYear})`
+  }
+  return book.authorName ? `By ${book.authorName}` : book.publicationYear
+}
+
 export default {
   name: 'book',
   type: 'object',
   title: 'Book',
   description: 'This is just a simple type for generating some test data',
-  preview: {
-    select: {
-      title: 'title',
-      createdAt: '_createdAt',
-      lead: 'lead',
-      imageUrl: 'mainImage.asset.url',
-      author: 'authorRef.name'
-    }
-  },
   fields: [
     {
       name: 'title',
       title: 'Title',
       type: 'string'
+    },
+    {
+      name: 'translations',
+      title: 'Translations',
+      type: 'object',
+      fields: [
+        {name: 'no', type: 'string', title: 'Norwegian (Bokmål)'},
+        {name: 'nn', type: 'string', title: 'Norwegian (Nynorsk)'},
+        {name: 'se', type: 'string', title: 'Swedish'}
+      ]
     },
     {
       name: 'author',
@@ -25,11 +33,52 @@ export default {
       to: {type: 'author', title: 'Author'}
     },
     {
+      name: 'coverImage',
+      title: 'Cover Image',
+      type: 'image'
+    },
+    {
+      name: 'publicationYear',
+      title: 'Year of publication',
+      type: 'number'
+    },
+    {
       name: 'isbn',
       title: 'ISBN number',
       description: 'ISBN-number of the book. Not shown in studio.',
       type: 'number',
       hidden: true
     }
-  ]
+  ],
+  sorting: [
+    {
+      title: 'Title',
+      name: 'title',
+      orderBy: {title: 'asc', publicationYear: 'asc'}
+    },
+    {
+      title: 'Swedish title',
+      name: 'swedishTitle',
+      orderBy: {
+        'translations.se': 'asc',
+        title: 'asc'
+      }
+    }
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      translations: 'translations',
+      createdAt: '_createdAt',
+      authorName: 'author.name',
+      publicationYear: 'publicationYear',
+      imageUrl: 'coverImage.asset.url'
+    },
+    prepare(book, options = {}) {
+      return Object.assign({}, book, {
+        title: ((options.sorting || {}).name === 'swedishTitle' && (book.translations || {}).se) || book.title,
+        subtitle: formatSubtitle(book)
+      })
+    }
+  }
 }

--- a/packages/test-studio/schemas/book.js
+++ b/packages/test-studio/schemas/book.js
@@ -50,19 +50,22 @@ export default {
       hidden: true
     }
   ],
-  sorting: [
+  orderings: [
     {
       title: 'Title',
       name: 'title',
-      orderBy: {title: 'asc', publicationYear: 'asc'}
+      by: [
+        {field: 'title', direction: 'asc'},
+        {field: 'publicationYear', direction: 'asc'}
+      ]
     },
     {
       title: 'Swedish title',
       name: 'swedishTitle',
-      orderBy: {
-        'translations.se': 'asc',
-        title: 'asc'
-      }
+      by: [
+        {field: 'translations.se', direction: 'asc'},
+        {field: 'title', direction: 'asc'}
+      ]
     }
   ],
   preview: {

--- a/packages/test-studio/schemas/objects.js
+++ b/packages/test-studio/schemas/objects.js
@@ -41,7 +41,12 @@ export default {
       description: 'This is a field of (anonymous, inline) object type. Values here should never get a `_type` property',
       fields: [
         {name: 'field1', type: 'string', description: 'This is a string field'},
-        {name: 'field2', type: 'myObject', title: 'A field of myObject', description: 'This is another field of "myObject"'},
+        {
+          name: 'field2',
+          type: 'myObject',
+          title: 'A field of myObject',
+          description: 'This is another field of "myObject"'
+        },
       ]
     },
     {


### PR DESCRIPTION
This adds support for defining a set of sort options on schema types:

Example:
```js
{
  type: 'object',
  name: 'myType',
  // ...
  sorting: [
    {
      title: 'Title',
      name: 'title',
      orderBy: {
        title: 'asc',
        publicationYear: 'asc'
      }
    }
  ]
  //...
}
```

These will be options for sorting the list of documents, together with `_createdAt` and `_updatedAt`

This also introduces a second argument to `preview.prepare` called `viewOptions`. If the document to be previewed is subject to a certain sort order, the sorting will be passed in on `viewOptions.sorting`. This allows for returning another preview title if the list of documents should be sorted by a field that is not normally visible, e.g. a localized field.
