### PR TITLE
[base] Expose schema creator as CommonJS

### DIFF
--- a/packages/@sanity/base/src/schema/createSchema.js
+++ b/packages/@sanity/base/src/schema/createSchema.js
@@ -2,10 +2,8 @@ import geopoint from './types/geopoint'
 import imageAsset from './types/imageAsset'
 import fileAsset from './types/fileAsset'
 import Schema from '@sanity/schema'
-export default schemaDef => {
-  return Schema.compile({
-    name: schemaDef.name,
-    types: [...schemaDef.types, geopoint, imageAsset, fileAsset]
-  })
-}
 
+module.exports = schemaDef => Schema.compile({
+  name: schemaDef.name,
+  types: [...schemaDef.types, geopoint, imageAsset, fileAsset]
+})


### PR DESCRIPTION
Being able to use CommonJS when defining your schemas is a feature I've wanted without doing the `.default`-dance.