### PR TITLE
[cli] Fix issue where CLI stalls after login on MacOS

### DIFF
--- a/packages/@sanity/cli/src/actions/login/login.js
+++ b/packages/@sanity/cli/src/actions/login/login.js
@@ -45,7 +45,7 @@ function loginFlow({output, provider, apiClient}, resolve, reject) {
     const loginUrl = url.format(providerUrl)
     output.print(`\nOpening browser at ${loginUrl}\n`)
     spin.start()
-    open(loginUrl)
+    open(loginUrl, {wait: false})
   }
 
   function onServerRequest(req, res) {


### PR DESCRIPTION
There's an issue on MacOS where after logging in, there process doesn't exit. This is caused by node waiting for the browser process to exit. This small change resolves the promise right away and lets the process exit cleanly. Fixes #21