### PR TITLE
[client] Retry failed GET/HEAD-requests

### DIFF
--- a/packages/@sanity/client/package.json
+++ b/packages/@sanity/client/package.json
@@ -25,7 +25,7 @@
     "@sanity/generate-help-url": "^0.112.0",
     "@sanity/observable": "^0.112.0",
     "deep-assign": "^2.0.0",
-    "get-it": "^2.1.3",
+    "get-it": "^3.0.0",
     "in-publish": "^2.0.0",
     "make-error": "^1.3.0",
     "object-assign": "^4.1.1"

--- a/packages/@sanity/client/src/http/nodeMiddleware.js
+++ b/packages/@sanity/client/src/http/nodeMiddleware.js
@@ -1,10 +1,13 @@
-const debug = require('get-it/lib/middleware/debug')
-const headers = require('get-it/lib/middleware/headers')
+const retry = require('get-it/lib-node/middleware/retry')
+const debug = require('get-it/lib-node/middleware/debug')
+const headers = require('get-it/lib-node/middleware/headers')
+
 const pkg = require('../../package.json')
 
 const middleware = [
   debug({verbose: true, namespace: 'sanity:client'}),
-  headers({'User-Agent': `${pkg.name} ${pkg.version}`})
+  headers({'User-Agent': `${pkg.name} ${pkg.version}`}),
+  retry()
 ]
 
 module.exports = middleware

--- a/packages/@sanity/client/src/http/nodeMiddleware.js
+++ b/packages/@sanity/client/src/http/nodeMiddleware.js
@@ -7,7 +7,7 @@ const pkg = require('../../package.json')
 const middleware = [
   debug({verbose: true, namespace: 'sanity:client'}),
   headers({'User-Agent': `${pkg.name} ${pkg.version}`}),
-  retry()
+  retry({maxRetries: 3})
 ]
 
 module.exports = middleware

--- a/packages/@sanity/import/package.json
+++ b/packages/@sanity/import/package.json
@@ -37,7 +37,7 @@
     "eslint-config-prettier": "^2.4.0",
     "eslint-config-sanity": "^3.0.1",
     "file-url": "^2.0.2",
-    "get-it": "^2.1.3",
+    "get-it": "^3.0.0",
     "jest": "^21.0.1",
     "prettier": "^1.6.1",
     "rimraf": "^2.6.1"


### PR DESCRIPTION
This PR reintroduces retrying of GET and HEAD requests to the client.
Currently only enabled for node since browsers has it's own retrying logic that we need to experiment with a bit with before enabling retries there.
