### PR TITLE
[vision] Show query URL with copy functionality

### DIFF
--- a/packages/sanity-plugin-vision/src/components/VisionGui.js
+++ b/packages/sanity-plugin-vision/src/components/VisionGui.js
@@ -15,6 +15,18 @@ import encodeQueryString from '../util/encodeQueryString'
 
 const sanityUrl = /\.api\.sanity\.io.*?(?:query|listen)\/(.*?)\?(.*)/
 
+const handleCopyUrl = () => {
+  const emailLink = document.querySelector('#vision-query-url')
+  emailLink.select()
+
+  try {
+    document.execCommand('copy')
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('Unable to copy to clipboard :(')
+  }
+}
+
 class VisionGui extends React.PureComponent {
   constructor(props) {
     super(props)
@@ -134,7 +146,7 @@ class VisionGui extends React.PureComponent {
 
     const client = this.context.client
     const paramsError = params instanceof Error && params
-    const url = client.getDataUrl('listen', encodeQueryString(query, params))
+    const url = client.getUrl(client.getDataUrl('listen', encodeQueryString(query, params)))
     storeState('lastQuery', query)
     storeState('lastParams', rawParams)
 
@@ -188,7 +200,7 @@ class VisionGui extends React.PureComponent {
       return
     }
 
-    const url = client.getDataUrl('query', encodeQueryString(query, params))
+    const url = client.getUrl(client.getDataUrl('query', encodeQueryString(query, params)))
     const queryStart = Date.now()
 
     this.subscribers.query = client.fetch(query, params, {filterResponse: false}).subscribe({
@@ -225,7 +237,7 @@ class VisionGui extends React.PureComponent {
 
   render() {
     const {client, components} = this.context
-    const {error, result, query, queryInProgress, listenInProgress, queryTime, e2eTime, listenMutations} = this.state
+    const {error, result, url, query, queryInProgress, listenInProgress, queryTime, e2eTime, listenMutations} = this.state
     const {Button, Select} = components
     const styles = this.context.styles.visionGui
     const dataset = client.config().dataset
@@ -249,6 +261,15 @@ class VisionGui extends React.PureComponent {
                 onChange={this.handleChangeDataset}
               />
             </label>
+          </div>
+          <div className={styles.queryUrlContainer}>
+            {typeof url === 'string' && (
+              <span>
+                Query URL:
+                <input className={styles.queryUrl} readOnly id="vision-query-url" value={url} />
+                <button onClick={handleCopyUrl}>Copy</button>
+              </span>
+            )}
           </div>
           <div className={styles.queryTimingContainer}>
             {typeof queryTime === 'number' && (

--- a/packages/sanity-plugin-vision/src/css/visionGui.css
+++ b/packages/sanity-plugin-vision/src/css/visionGui.css
@@ -151,6 +151,28 @@
   font-weight: bold;
 }
 
+.queryUrlContainer {
+  flex-grow: 1;
+  text-align: right;
+}
+
+.queryUrlContainer > span {
+  font-size: 0.8em;
+}
+
+.queryUrl {
+  composes: queryTiming;
+  margin-left: 5px;
+  font-size: 1em;
+  max-width: 50%;
+  max-height: 48px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  border: 0;
+  background-color: transparent;
+}
+
 /* BASICS */
 
 :global(.CodeMirror) {

--- a/packages/sanity-plugin-vision/src/util/encodeQueryString.js
+++ b/packages/sanity-plugin-vision/src/util/encodeQueryString.js
@@ -1,0 +1,8 @@
+const enc = encodeURIComponent
+
+module.exports = (query, params = {}) => {
+  return Object.keys(params).reduce((qs, param) =>
+    `${qs}&${enc(`$${param}`)}=${enc(JSON.stringify(params[param]))}`,
+    `?query=${enc(query)}`
+  )
+}


### PR DESCRIPTION
Sometimes you may want to link someone to a query result in order to debug a problem or prototype an idea. Instead of opening the browsers devtools and inspecting the outgoing requests, this PR shows the query/listen URL in an input field with a copy button next to it which will copy the URL to the clipboard.

It also overrides the default behavior of the client to force longer queries to a POST, which makes "all" queries linkable. It doesn't look all that good, so a brush-up on the styling front would probably be smart - I'll leave that to @kristofferj 

While adding the functionality I also encountered a bug where a non-existing dataset might be chosen upon startup, without the possibility to switch. Rolled a fix for that into this PR for good measure.
