### PR TITLE
[cli] Add unattended init mode

### DIFF
--- a/packages/@sanity/cli/src/actions/yarn/yarnWithProgress.js
+++ b/packages/@sanity/cli/src/actions/yarn/yarnWithProgress.js
@@ -8,6 +8,7 @@ import progrescii from 'progrescii'
 import {noop, padEnd, throttle} from 'lodash'
 
 // Use require.resolve to ensure it actually exists
+const useProgress = (process.stderr && process.stderr.isTTY) && !process.env.CI
 const binDir = path.join(__dirname, '..', '..', '..', 'vendor')
 const yarnPath = require.resolve(path.join(binDir, 'yarn'))
 
@@ -124,10 +125,14 @@ export default function yarnWithProgress(args, options = {}) {
       state.spinner.stop()
     }
 
-    state.progress = progrescii.create({
-      template: getProgressTemplate(chalk.yellow('●'), state.step.message),
-      total: event.data.total
-    })
+    if (useProgress) {
+      state.progress = progrescii.create({
+        template: getProgressTemplate(chalk.yellow('●'), state.step.message),
+        total: event.data.total
+      })
+    } else {
+      print(`${chalk.yellow('●')} ${state.step.message}`)
+    }
   }
 
   function onProgressTick(event) {
@@ -140,7 +145,7 @@ export default function yarnWithProgress(args, options = {}) {
       return // Will be taken care of by onProgressFinish
     }
 
-    state.progress.set(event.data.current)
+    prog.set(event.data.current)
   }
 
   function onProgressFinish(event) {

--- a/packages/@sanity/cli/src/commands/init/bootstrapTemplate.js
+++ b/packages/@sanity/cli/src/commands/init/bootstrapTemplate.js
@@ -43,6 +43,7 @@ export default async (opts, context) => {
   spinner.succeed()
 
   // Now create a package manifest (`package.json`) with the merged dependencies
+  spinner = output.spinner('Creating default project files').start()
   const packageManifest = await createPackageManifest({...opts, dependencies})
 
   // ...and a `sanity.json` manifest
@@ -70,6 +71,7 @@ export default async (opts, context) => {
   ])
 
   // Finish up by providing init process with template-specific info
+  spinner.succeed()
   return template
 
   async function writeFileIfNotExists(fileName, content) {

--- a/packages/@sanity/cli/src/commands/init/initCommand.js
+++ b/packages/@sanity/cli/src/commands/init/initCommand.js
@@ -1,8 +1,22 @@
 import lazyRequire from '@sanity/util/lib/lazyRequire'
 
+const helpText = `
+Options
+  -y, --yes Use unattended mode, accepting defaults and using only flags for choices
+  --project <projectId> Project ID to use for the studio
+  --dataset <dataset> Dataset name for the studio
+  --output-path <path> Path to write studio project to
+  --template <template> Project template to use [default: "clean"]
+
+Examples
+  sanity init -y --project abc123 --dataset production --output-path ~/myproj
+  sanity init -y --project abc123 --dataset staging --template moviedb --output-path .
+`
+
 export default {
   name: 'init',
   signature: 'init [plugin]',
   description: 'Initialize a new Sanity project',
-  action: lazyRequire(require.resolve('./initAction'))
+  action: lazyRequire(require.resolve('./initAction')),
+  helpText
 }

--- a/packages/@sanity/cli/src/commands/init/initPlugin.js
+++ b/packages/@sanity/cli/src/commands/init/initPlugin.js
@@ -18,7 +18,7 @@ export default async function initPlugin(args, context, initOpts = {}) {
     + 'recommended that the plugin name is prefixed with `sanity-plugin-`'
   )
 
-  const pluginOpts = {isPlugin: true, workDir}
+  const pluginOpts = {isPlugin: true, workDir, context}
   const defaults = await getProjectDefaults(workDir, pluginOpts)
   const answers = await gatherInput(prompt, defaults, pluginOpts)
   const finalAnswers = {outputPath: workDir, ...answers}

--- a/packages/@sanity/cli/src/commands/init/initSanity.js
+++ b/packages/@sanity/cli/src/commands/init/initSanity.js
@@ -56,7 +56,12 @@ export default async function initSanity(args, context) {
 
   // Now let's pick or create a dataset
   debug('Prompting user to select or create a dataset')
-  const {datasetName} = await getOrCreateDataset({projectId, displayName})
+  const {datasetName} = await getOrCreateDataset({
+    projectId,
+    displayName,
+    dataset: flags.dataset
+  })
+
   debug(`Dataset with name ${datasetName} selected`)
 
   // Gather project defaults based on environment


### PR DESCRIPTION
This PR adds a new unattended mode to the `sanity init` command.

By doing `sanity init -y --project abc123 --dataset staging --output-path=/some/path`, a new studio project will be created in the directory specified, optionally with a given template.
It will (by design and main purpose) not ask any questions along the way, instead throwing on anything that cannot be resolved without user interaction.

This will help us integrate the init process into other tools, as well as making testing and CI easier.

Another step was also added to the yarn install process to make up for the time spent between spawning yarn and the time it first emits progress events. This is to prevent people from thinking lack of output means the process has stalled.
