### PR TITLE
[schema] Improve default preview config for image/file assets

### DIFF
--- a/packages/@sanity/schema/src/preview/guessPreviewConfig.js
+++ b/packages/@sanity/schema/src/preview/guessPreviewConfig.js
@@ -5,18 +5,41 @@ import {createFallbackPrepare} from './fallbackPrepare'
 const TITLE_CANDIDATES = ['title', 'name', 'label', 'heading', 'header', 'caption']
 const DESCRIPTION_CANDIDATES = ['description', ...TITLE_CANDIDATES]
 
-function isImageField(fieldDef) {
-  return fieldDef.type === 'image'
+
+function fieldHasReferenceTo(fieldDef, refType) {
+  return arrify(fieldDef.to || []).some(memberTypeDef => memberTypeDef.type === refType)
 }
 
 function isImageAssetField(fieldDef) {
-  return fieldDef.type === 'reference'
-    && arrify(fieldDef.to).some(memberTypeDef => memberTypeDef.type === 'imageAsset')
+  return fieldHasReferenceTo(fieldDef, 'imageAsset')
 }
 
-function resolveImageAssetPath(fieldDefs) {
-  const found = fieldDefs.find(field => isImageAssetField(field) || isImageField(field))
-  return found && (isImageField(found) ? `${found.name}.asset.url` : `${found.name}.url`)
+function resolveImageAssetPath(typeDef) {
+  const fields = typeDef.fields || []
+  const imageAssetField = fields.find(isImageAssetField)
+  if (imageAssetField) {
+    return imageAssetField.name
+  }
+  const fieldWithImageAsset = fields.find(fieldDef => (fieldDef.fields || []).some(isImageAssetField))
+  if (fieldWithImageAsset) {
+    return `${fieldWithImageAsset.name}.asset`
+  }
+}
+
+function isFileAssetField(fieldDef) {
+  return fieldHasReferenceTo(fieldDef, 'fileAsset')
+}
+
+function resolveFileAssetPath(typeDef) {
+  const fields = typeDef.fields || []
+  const assetField = fields.find(isFileAssetField)
+  if (assetField) {
+    return assetField.name
+  }
+  const fieldWithFileAsset = fields.find(fieldDef => (fieldDef.fields || []).some(isFileAssetField))
+  if (fieldWithFileAsset) {
+    return `${fieldWithFileAsset.name}.asset`
+  }
 }
 
 export default function guessPreviewFields(objectTypeDef) {
@@ -39,7 +62,14 @@ export default function guessPreviewFields(objectTypeDef) {
     descField = stringFieldNames[1]
   }
 
-  const imageAssetPath = resolveImageAssetPath(objectTypeDef.fields)
+  const imageAssetPath = resolveImageAssetPath(objectTypeDef)
+
+  if (!titleField) {
+    const fileAssetPath = resolveFileAssetPath(objectTypeDef)
+    if (fileAssetPath) {
+      titleField = `${fileAssetPath}.originalFilename`
+    }
+  }
 
   if (!titleField && !imageAssetPath) {
     // last resort, pick all fields and concat them
@@ -58,7 +88,7 @@ export default function guessPreviewFields(objectTypeDef) {
   const select = omitBy({
     title: titleField,
     description: descField,
-    imageUrl: imageAssetPath
+    imageUrl: imageAssetPath ? `${imageAssetPath}.url` : undefined
   }, isUndefined)
 
   return {


### PR DESCRIPTION
This is a small rewrite of how we identify image asset and file assets on object types. This will also pick `asset.originalFilename` as the default value for `preview.title` for files.

This also fixes a minor issue that would fail to infer image asset field for custom reference types.