### PR TITLE
Misc. file input improvements

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/File/FileInput.js
+++ b/packages/@sanity/form-builder/src/inputs/File/FileInput.js
@@ -100,10 +100,12 @@ export default class FileInput extends React.PureComponent {
   setRef(id) {
     this.props.onChange(PatchEvent.from(
       setIfMissing({
-        _type: this.props.type.name,
-        asset: {_type: 'reference'}
+        _type: this.props.type.name
       }),
-      set({_ref: id}, ['asset'])
+      set({
+        _ref: id,
+        _type: 'reference'
+      }, ['asset'])
     ))
   }
 

--- a/packages/@sanity/form-builder/src/inputs/File/FileInput.js
+++ b/packages/@sanity/form-builder/src/inputs/File/FileInput.js
@@ -263,7 +263,12 @@ export default class FileInput extends React.PureComponent {
           {value && fieldGroups.highlighted.length > 0 && this.renderFields(fieldGroups.highlighted)}
 
           {materializedFile && (
-            <AnchorButton href={materializedFile.url} download>Download</AnchorButton>
+            <div>{materializedFile.originalFilename}</div>
+          )}
+          {materializedFile && (
+            <AnchorButton href={materializedFile.url} download>
+              Download
+            </AnchorButton>
           )}
 
           <FileInputButton

--- a/packages/test-studio/schemas/files.js
+++ b/packages/test-studio/schemas/files.js
@@ -15,6 +15,12 @@ export default {
       type: 'file'
     },
     {
+      name: 'arrayOfFiles',
+      title: 'An array of files',
+      type: 'array',
+      of: [{type: 'file'}]
+    },
+    {
       name: 'fileWithFields',
       title: 'File with additional fields',
       type: 'file',


### PR DESCRIPTION
Fixes a bug where the asset file were overwritten and lost its `_type`. In addition, the `asset.originalFilename` is now displayed in the file input