### PR TITLE
[schema] Fix: too eager deprecation warning for the deprecated date-type

### DIFF
--- a/packages/@sanity/base/package.json
+++ b/packages/@sanity/base/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@sanity/client": "^0.113.3",
     "@sanity/document-store": "^0.113.3",
-    "@sanity/generate-help-url": "^0.112.0",
     "@sanity/observable": "^0.113.3",
     "@sanity/schema": "^0.113.3",
     "@sanity/state-router": "^0.113.3",

--- a/packages/@sanity/base/src/schema/types/deprecatedDate.js
+++ b/packages/@sanity/base/src/schema/types/deprecatedDate.js
@@ -1,17 +1,5 @@
 import richDate from './richDate'
-import generateHelpUrl from '@sanity/generate-help-url'
 
-let hasWarned = false
 export default Object.assign({}, richDate, {
-  get name() {
-    if (!hasWarned) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        'Heads up! The `date` type has been renamed to `richDate`. Please update your schema. See %s for more info.',
-        generateHelpUrl('migrate-to-rich-date')
-      )
-      hasWarned = true
-    }
-    return 'date'
-  }
+  name: 'date'
 })

--- a/packages/@sanity/schema/package.json
+++ b/packages/@sanity/schema/package.json
@@ -32,6 +32,7 @@
     "rimraf": "^2.6.1"
   },
   "dependencies": {
+    "@sanity/generate-help-url": "^0.113.3",
     "arrify": "^1.0.1",
     "lodash": "^4.17.4"
   }

--- a/packages/@sanity/schema/src/Schema.js
+++ b/packages/@sanity/schema/src/Schema.js
@@ -1,4 +1,7 @@
+import generateHelpUrl from '@sanity/generate-help-url'
 import * as types from './types'
+
+let hasWarned = false
 
 function compileRegistry(schemaDef) {
   const registry = Object.assign(Object.create(null), types)
@@ -25,6 +28,16 @@ function compileRegistry(schemaDef) {
 
   }
   function extendMember(memberDef) {
+    if (memberDef.type === 'date') {
+      if (!hasWarned) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          'Heads up! The `date` type has been renamed to `richDate`. Please update your schema. See %s for more info.',
+          generateHelpUrl('migrate-to-rich-date')
+        )
+        hasWarned = true
+      }
+    }
     ensure(memberDef.type)
     return registry[memberDef.type].extend(memberDef, extendMember).get()
   }


### PR DESCRIPTION
The deprecation warning for the `date` was implemented in a getter for `type.name`. The type name is used as a key in an internal registry, so the warning was triggered even if there were no fields with `type: date` in the schema. This fix makes sure the deprecation warning is issued only if we actually encounter a field that uses `type: date`.