### PR TITLE
[schema] Tolerate object with missing fields. Fixes #196

### DIFF
--- a/packages/@sanity/schema/src/types/object.js
+++ b/packages/@sanity/schema/src/types/object.js
@@ -26,7 +26,10 @@ export const ObjectType = {
   get() {
     return OBJECT_CORE
   },
-  extend(subTypeDef, createMemberType) {
+  extend(rawSubTypeDef, createMemberType) {
+
+    const subTypeDef = {fields: [], ...rawSubTypeDef}
+
     const options = {...(subTypeDef.options || {})}
     const parsed = Object.assign(pick(OBJECT_CORE, OVERRIDABLE_FIELDS), subTypeDef, {
       type: OBJECT_CORE,

--- a/packages/test-studio/schemas/objects.js
+++ b/packages/test-studio/schemas/objects.js
@@ -35,6 +35,12 @@ export default {
       description: 'The first field here should be the title'
     },
     {
+      name: 'objectWithoutFields',
+      type: 'object',
+      title: 'Object without fields',
+      description: 'This object has no fields. Should not crash.'
+    },
+    {
       name: 'fieldWithObjectType',
       title: 'Field of object type',
       type: 'object',


### PR DESCRIPTION
This is a quickfix. Will be better safeguarded with schema validation.