### PR TITLE
[client] Resolve the asset upload promise with the asset document, not the response

### DIFF
--- a/packages/@sanity/client/src/assets/assetsClient.js
+++ b/packages/@sanity/client/src/assets/assetsClient.js
@@ -12,6 +12,21 @@ function toPromise(observable) {
     .toPromise()
 }
 
+
+function resolveWithDocument(body) {
+  // todo: rewrite to just return body.document in a while
+  const document = body.document
+  Object.defineProperty(document, 'document', {
+    enumerable: false,
+    get: () => {
+      // eslint-disable-next-line no-console
+      console.warn('The promise returned from client.asset.upload(...) now resolves with the asset document')
+      return document
+    }
+  })
+  return document
+}
+
 function optionsFromFile(opts, file) {
   if (typeof window === 'undefined' || !(file instanceof window.File)) {
     return opts
@@ -43,7 +58,7 @@ assign(AssetsClient.prototype, {
     })
 
     return this.client.isPromiseAPI()
-      ? toPromise(observable).then(response => response.document)
+      ? toPromise(observable).then(resolveWithDocument)
       : observable
   },
 

--- a/packages/@sanity/client/src/assets/assetsClient.js
+++ b/packages/@sanity/client/src/assets/assetsClient.js
@@ -43,7 +43,7 @@ assign(AssetsClient.prototype, {
     })
 
     return this.client.isPromiseAPI()
-      ? toPromise(observable)
+      ? toPromise(observable).then(response => response.document)
       : observable
   },
 

--- a/packages/@sanity/client/test/client.test.js
+++ b/packages/@sanity/client/test/client.test.js
@@ -1065,11 +1065,11 @@ test('uploads images', t => {
 
   nock(projectHost())
     .post('/v1/assets/images/foo', isImage)
-    .reply(201, {url: 'https://some.asset.url'})
+    .reply(201, {document: {url: 'https://some.asset.url'}})
 
   getClient().assets.upload('image', fs.createReadStream(fixturePath))
-    .then(body => {
-      t.equal(body.url, 'https://some.asset.url')
+    .then(document => {
+      t.equal(document.url, 'https://some.asset.url')
       t.end()
     }, ifError(t))
 })
@@ -1080,11 +1080,11 @@ test('uploads images with given content type', t => {
 
   nock(projectHost(), {reqheaders: {'Content-Type': 'image/jpeg'}})
     .post('/v1/assets/images/foo', isImage)
-    .reply(201, {url: 'https://some.asset.url'})
+    .reply(201, {document: {url: 'https://some.asset.url'}})
 
   getClient().assets.upload('image', fs.createReadStream(fixturePath), {contentType: 'image/jpeg'})
-    .then(body => {
-      t.equal(body.url, 'https://some.asset.url')
+    .then(document => {
+      t.equal(document.url, 'https://some.asset.url')
       t.end()
     }, ifError(t))
 })
@@ -1113,7 +1113,7 @@ test('uploads images with custom label', t => {
   const label = 'xy zzy'
   nock(projectHost())
     .post(`/v1/assets/images/foo?label=${encodeURIComponent(label)}`, isImage)
-    .reply(201, {label: label})
+    .reply(201, {document: {label: label}})
 
   getClient().assets.upload('image', fs.createReadStream(fixturePath), {label: label})
     .then(body => {
@@ -1128,11 +1128,11 @@ test('uploads files', t => {
 
   nock(projectHost())
     .post('/v1/assets/files/foo', isFile)
-    .reply(201, {url: 'https://some.asset.url'})
+    .reply(201, {document: {url: 'https://some.asset.url'}})
 
   getClient().assets.upload('file', fs.createReadStream(fixturePath))
-    .then(body => {
-      t.equal(body.url, 'https://some.asset.url')
+    .then(document => {
+      t.equal(document.url, 'https://some.asset.url')
       t.end()
     }, ifError(t))
 })
@@ -1143,11 +1143,11 @@ test('uploads images and can cast to promise', t => {
 
   nock(projectHost())
     .post('/v1/assets/images/foo', isImage)
-    .reply(201, {url: 'https://some.asset.url'})
+    .reply(201, {document: {url: 'https://some.asset.url'}})
 
   getClient().assets.upload('image', fs.createReadStream(fixturePath))
-    .then(body => {
-      t.equal(body.url, 'https://some.asset.url')
+    .then(document => {
+      t.equal(document.url, 'https://some.asset.url')
       t.end()
     }, ifError(t))
 })

--- a/packages/@sanity/import/src/uploadAssets.js
+++ b/packages/@sanity/import/src/uploadAssets.js
@@ -76,7 +76,7 @@ async function ensureAsset(options, progress, assetKey, i) {
   debug('[Asset #%d] Uploading %s with URL %s', i, type, url)
   const asset = await client.assets.upload(type, buffer, {label, filename})
   progress()
-  return asset.document._id
+  return asset._id
 }
 
 async function getAssetIdForLabel(client, type, label, attemptNum = 0) {


### PR DESCRIPTION
According to current docs, the promise returned from `client.assets.upload(...)` resolves with the asset document. However, it was resolved to the http response body, which had the asset document on the `document` key.

Note: this is a breaking change. I doubt this api is very much used, but just to be sure, we could add a non-enumerable getter on the `assetDocument.document` that console logs a warning and returns the asset document. What do you think?