### PR TITLE
[form-builder] Rename SlateInput export => BlockEditor

### DIFF
--- a/packages/@sanity/form-builder/examples/schema-testbed/schemas/blocks.js
+++ b/packages/@sanity/form-builder/examples/schema-testbed/schemas/blocks.js
@@ -1,5 +1,3 @@
-import SlateInput from '../../../src/inputs/BlockEditor-slate'
-
 export default {
   types: [
     {
@@ -16,7 +14,6 @@ export default {
           name: 'content',
           title: 'Content',
           type: 'array',
-          inputComponent: SlateInput,
           of: [
             {
               type: 'block',

--- a/packages/@sanity/form-builder/src/index.js
+++ b/packages/@sanity/form-builder/src/index.js
@@ -9,7 +9,7 @@ export {defaultInputs}
 export {defaultConfig}
 
 export {default as FormBuilder} from './FormBuilder'
-export {default as SlateInput} from './inputs/BlockEditor-slate'
+export {default as BlockEditor} from './inputs/BlockEditor-slate'
 
 // Input component factories
 export {ReferenceInput}

--- a/packages/@sanity/form-builder/src/sanity/SanityFormBuilder.js
+++ b/packages/@sanity/form-builder/src/sanity/SanityFormBuilder.js
@@ -5,7 +5,7 @@ import inputResolver from './inputResolver/inputResolver'
 import SanityPreview from 'part:@sanity/base/preview'
 import * as patches from '../utils/patches'
 
-import {FormBuilder, defaultConfig} from '../'
+import {FormBuilder, defaultConfig} from '..'
 
 export {default as WithFormBuilderValue} from './WithFormBuilderValue'
 export {default as withDocument} from '../utils/withDocument'
@@ -14,6 +14,7 @@ export {default as PatchEvent} from '../PatchEvent'
 export {FormBuilderInput} from '../FormBuilderInput'
 
 export {patches}
+export {BlockEditor} from '..'
 
 function previewResolver() {
   return SanityPreview


### PR DESCRIPTION
This is strictly speaking a breaking change, but I really doubt anyone is using the `SlateInput` export here.