### PR TITLE
Release 0.114.0

### DIFF
--- a/packages/@sanity/client/README.md
+++ b/packages/@sanity/client/README.md
@@ -305,7 +305,7 @@ ctx.fillText('Sanity', 8, 30)
 canvas.toBlob(uploadImageBlob, 'image/png')
 
 function uploadImageBlob(blob) {
-  client.assets.upload('image', blob, "image/png")
+  client.assets.upload('image', blob)
     .then(document => {
       console.log('The image was uploaded!', document)
     })

--- a/packages/@sanity/client/README.md
+++ b/packages/@sanity/client/README.md
@@ -251,10 +251,10 @@ An important note on this approach is that you cannot call `commit()` on transac
 Assets can be uploaded using the `client.assets.upload(...)` method.
 
 ```
-client.asset.upload(type: 'file' | image', body: File | Blob | NodeStream): Promise<AssetDocument>
+client.asset.upload(type: 'file' | image', body: File | Blob | Buffer | NodeStream): Promise<AssetDocument>
 ```
 
-Read more about [assets in Sanity](https://sanity.io/docs/http-api/assets)
+👉 Read more about [assets in Sanity](https://sanity.io/docs/http-api/assets)
 
 #### Examples: Uploading assets from Node.js
 ```js

--- a/packages/@sanity/client/README.md
+++ b/packages/@sanity/client/README.md
@@ -246,6 +246,87 @@ client.mutate(transaction)
 
 An important note on this approach is that you cannot call `commit()` on transactions or patches instantiated this way, instead you have to pass them to `client.mutate()`
 
+### Uploading assets
+
+Assets can be uploaded using the `client.assets.upload(...)` method.
+
+```
+client.asset.upload(type: 'file' | image', body: File | Blob | NodeStream): Promise<AssetDocument>
+```
+
+Read more about [assets in Sanity](https://sanity.io/docs/http-api/assets)
+
+#### Examples: Uploading assets from Node.js
+```js
+// Upload a file from the file system
+client.assets.upload('file', fs.createReadStream('myFile.txt'))
+  .then(document => {
+    console.log('The file was uploaded!', document)
+  })
+  .catch(error => {
+    console.error('Upload failed:', error.message)
+  })
+````
+```js
+
+// Upload an image file from the file system
+client.assets.upload('image', fs.createReadStream('myImage.jpg'))
+  .then(document => {
+    console.log('The image was uploaded!', document)
+  })
+  .catch(error => {
+    console.error('Upload failed:', error.message)
+  })
+```
+
+#### Examples: Uploading assets from the Browser
+```js
+// Create a file with "foo" as its content
+const file = new File(["foo"], "foo.txt", {type: "text/plain"})
+// Upload it
+client.assets.upload('file', file)
+  .then(document => {
+    console.log('The file was uploaded!', document)
+  })
+  .catch(error => {
+    console.error('Upload failed:', error.message)
+  })
+````
+
+```js
+// Draw something on a canvas and upload as image
+const canvas = document.getElementById('someCanvas')
+const ctx = canvas.getContext('2d');
+ctx.fillStyle = '#f85040'
+ctx.fillRect(0, 0, 50, 50);
+ctx.fillStyle = '#fff'
+ctx.font = '10px monospace'
+ctx.fillText('Sanity', 8, 30)
+canvas.toBlob(uploadImageBlob, 'image/png')
+
+function uploadImageBlob(blob) {
+  client.assets.upload('image', blob, "image/png")
+    .then(document => {
+      console.log('The image was uploaded!', document)
+    })
+    .catch(error => {
+      console.error('Upload failed:', error.message)
+    })
+}
+```
+### Deleting an asset
+
+```
+client.assets.delete(type: 'image' | 'file', id: string): Promise
+```
+
+```js
+client.assets.delete('image', '1a2b3c')
+  .then(result => {
+    console.log('deleted imageAsset', result)
+  })
+```
+
 ### Get client configuration
 
 ```js

--- a/packages/@sanity/client/src/assets/assetsClient.js
+++ b/packages/@sanity/client/src/assets/assetsClient.js
@@ -12,6 +12,21 @@ function toPromise(observable) {
     .toPromise()
 }
 
+
+function resolveWithDocument(body) {
+  // todo: rewrite to just return body.document in a while
+  const document = body.document
+  Object.defineProperty(document, 'document', {
+    enumerable: false,
+    get: () => {
+      // eslint-disable-next-line no-console
+      console.warn('The promise returned from client.asset.upload(...) now resolves with the asset document')
+      return document
+    }
+  })
+  return document
+}
+
 function optionsFromFile(opts, file) {
   if (typeof window === 'undefined' || !(file instanceof window.File)) {
     return opts
@@ -43,7 +58,7 @@ assign(AssetsClient.prototype, {
     })
 
     return this.client.isPromiseAPI()
-      ? toPromise(observable)
+      ? toPromise(observable).then(resolveWithDocument)
       : observable
   },
 

--- a/packages/@sanity/client/test/client.test.js
+++ b/packages/@sanity/client/test/client.test.js
@@ -1065,11 +1065,11 @@ test('uploads images', t => {
 
   nock(projectHost())
     .post('/v1/assets/images/foo', isImage)
-    .reply(201, {url: 'https://some.asset.url'})
+    .reply(201, {document: {url: 'https://some.asset.url'}})
 
   getClient().assets.upload('image', fs.createReadStream(fixturePath))
-    .then(body => {
-      t.equal(body.url, 'https://some.asset.url')
+    .then(document => {
+      t.equal(document.url, 'https://some.asset.url')
       t.end()
     }, ifError(t))
 })
@@ -1080,11 +1080,11 @@ test('uploads images with given content type', t => {
 
   nock(projectHost(), {reqheaders: {'Content-Type': 'image/jpeg'}})
     .post('/v1/assets/images/foo', isImage)
-    .reply(201, {url: 'https://some.asset.url'})
+    .reply(201, {document: {url: 'https://some.asset.url'}})
 
   getClient().assets.upload('image', fs.createReadStream(fixturePath), {contentType: 'image/jpeg'})
-    .then(body => {
-      t.equal(body.url, 'https://some.asset.url')
+    .then(document => {
+      t.equal(document.url, 'https://some.asset.url')
       t.end()
     }, ifError(t))
 })
@@ -1113,7 +1113,7 @@ test('uploads images with custom label', t => {
   const label = 'xy zzy'
   nock(projectHost())
     .post(`/v1/assets/images/foo?label=${encodeURIComponent(label)}`, isImage)
-    .reply(201, {label: label})
+    .reply(201, {document: {label: label}})
 
   getClient().assets.upload('image', fs.createReadStream(fixturePath), {label: label})
     .then(body => {
@@ -1128,11 +1128,11 @@ test('uploads files', t => {
 
   nock(projectHost())
     .post('/v1/assets/files/foo', isFile)
-    .reply(201, {url: 'https://some.asset.url'})
+    .reply(201, {document: {url: 'https://some.asset.url'}})
 
   getClient().assets.upload('file', fs.createReadStream(fixturePath))
-    .then(body => {
-      t.equal(body.url, 'https://some.asset.url')
+    .then(document => {
+      t.equal(document.url, 'https://some.asset.url')
       t.end()
     }, ifError(t))
 })
@@ -1143,11 +1143,11 @@ test('uploads images and can cast to promise', t => {
 
   nock(projectHost())
     .post('/v1/assets/images/foo', isImage)
-    .reply(201, {url: 'https://some.asset.url'})
+    .reply(201, {document: {url: 'https://some.asset.url'}})
 
   getClient().assets.upload('image', fs.createReadStream(fixturePath))
-    .then(body => {
-      t.equal(body.url, 'https://some.asset.url')
+    .then(document => {
+      t.equal(document.url, 'https://some.asset.url')
       t.end()
     }, ifError(t))
 })

--- a/packages/@sanity/form-builder/examples/schema-testbed/schemas/blocks.js
+++ b/packages/@sanity/form-builder/examples/schema-testbed/schemas/blocks.js
@@ -1,5 +1,3 @@
-import SlateInput from '../../../src/inputs/BlockEditor-slate'
-
 export default {
   types: [
     {
@@ -16,7 +14,6 @@ export default {
           name: 'content',
           title: 'Content',
           type: 'array',
-          inputComponent: SlateInput,
           of: [
             {
               type: 'block',

--- a/packages/@sanity/form-builder/src/index.js
+++ b/packages/@sanity/form-builder/src/index.js
@@ -9,7 +9,7 @@ export {defaultInputs}
 export {defaultConfig}
 
 export {default as FormBuilder} from './FormBuilder'
-export {default as SlateInput} from './inputs/BlockEditor-slate'
+export {default as BlockEditor} from './inputs/BlockEditor-slate'
 
 // Input component factories
 export {ReferenceInput}

--- a/packages/@sanity/form-builder/src/sanity/SanityFormBuilder.js
+++ b/packages/@sanity/form-builder/src/sanity/SanityFormBuilder.js
@@ -5,7 +5,7 @@ import inputResolver from './inputResolver/inputResolver'
 import SanityPreview from 'part:@sanity/base/preview'
 import * as patches from '../utils/patches'
 
-import {FormBuilder, defaultConfig} from '../'
+import {FormBuilder, defaultConfig} from '..'
 
 export {default as WithFormBuilderValue} from './WithFormBuilderValue'
 export {default as withDocument} from '../utils/withDocument'
@@ -14,6 +14,7 @@ export {default as PatchEvent} from '../PatchEvent'
 export {FormBuilderInput} from '../FormBuilderInput'
 
 export {patches}
+export {BlockEditor} from '..'
 
 function previewResolver() {
   return SanityPreview

--- a/packages/@sanity/import/src/uploadAssets.js
+++ b/packages/@sanity/import/src/uploadAssets.js
@@ -76,7 +76,7 @@ async function ensureAsset(options, progress, assetKey, i) {
   debug('[Asset #%d] Uploading %s with URL %s', i, type, url)
   const asset = await client.assets.upload(type, buffer, {label, filename})
   progress()
-  return asset.document._id
+  return asset._id
 }
 
 async function getAssetIdForLabel(client, type, label, attemptNum = 0) {

--- a/packages/example-studio/components/FunkyEditor/FunkyEditor.js
+++ b/packages/example-studio/components/FunkyEditor/FunkyEditor.js
@@ -1,0 +1,42 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import {BlockEditor} from 'part:@sanity/form-builder'
+
+function extractTextFromBlocks(blocks) {
+  return blocks
+    .filter(val => val._type === 'block')
+    .map(block => {
+      return block.children
+        .filter(child => child._type === 'span')
+        .map(span => span.text)
+        .join('')
+    }).join('')
+}
+
+export default class FunkyEditor extends React.Component {
+  static propTypes = {
+    type: PropTypes.shape({
+      title: PropTypes.string
+    }).isRequired,
+    level: PropTypes.number,
+    value: PropTypes.array,
+    onChange: PropTypes.func.isRequired
+  };
+
+  render() {
+    const {type, value = [], level, onChange} = this.props
+    return (
+      <div>
+        <BlockEditor
+          type={type}
+          level={level}
+          value={value}
+          onChange={onChange}
+        />
+        <p>
+          Your funkyness is <strong>{extractTextFromBlocks(value).length}</strong> characters long
+        </p>
+      </div>
+    )
+  }
+}

--- a/packages/example-studio/components/FunkyEditor/index.js
+++ b/packages/example-studio/components/FunkyEditor/index.js
@@ -1,0 +1,1 @@
+export {default} from './FunkyEditor'

--- a/packages/example-studio/parts/inputResolver.js
+++ b/packages/example-studio/parts/inputResolver.js
@@ -1,9 +1,14 @@
+import FunkyEditor from '../components/FunkyEditor/FunkyEditor'
 import Slider from '../components/Slider/Slider'
 import {get} from 'lodash'
 
 export default function resolveInput(type) {
   if (type.name === 'number' && get(type, 'options.range')) {
     return Slider
+  }
+
+  if (type.name === 'array' && type.of.find(ofType => ofType.name === 'block')) {
+    return FunkyEditor
   }
 
   return false

--- a/packages/example-studio/sanity.json
+++ b/packages/example-studio/sanity.json
@@ -26,6 +26,10 @@
     {
       "implements": "part:@sanity/base/brand-logo",
       "path": "components/BrandLogo.js"
+    },
+    {
+      "implements": "part:@sanity/form-builder/input-resolver",
+      "path": "./parts/inputResolver.js"
     }
   ],
   "env": {

--- a/packages/example-studio/schemas/localeSlug.js
+++ b/packages/example-studio/schemas/localeSlug.js
@@ -16,7 +16,7 @@ export default {
     title: lang.title,
     fieldset: lang.default ? null : 'translations',
     options: {
-      source: document => document.title[lang.id],
+      source: document => ((document && document.title) ? document.title[lang.id] : ''),
       maxLength: 96,
       auto: true,
     },


### PR DESCRIPTION
# 📓 Full changelog 
Author | Message | Commit
------------ | ------------- | -------------
Bjørge Næss | [form-builder] Rename SlateInput export => BlockEditor (#210) | c63b40c16
Bjørge Næss | [client] Resolve the asset upload promise with the asset document, not the response (#208) | 69b7d2eee
Bjørge Næss | [client] Add docs for asset uploads to README (#207) | 8ad48b39f
Bjørge Næss | [client] Minor: Remove invalid parameter from assets.upload(...) example | 0a7488a65
Per-Kristian Nordnes | [example-studio] Add example on how to wrap and customize the block editor (#209) | b8c730157