### PR TITLE
[chore] Upgrade get-it to v4

### DIFF
--- a/packages/@sanity/client/package.json
+++ b/packages/@sanity/client/package.json
@@ -25,7 +25,7 @@
     "@sanity/generate-help-url": "^0.113.7",
     "@sanity/observable": "^0.113.7",
     "deep-assign": "^2.0.0",
-    "get-it": "^3.0.0",
+    "get-it": "^4.0.0",
     "make-error": "^1.3.0",
     "object-assign": "^4.1.1"
   },

--- a/packages/@sanity/import/package.json
+++ b/packages/@sanity/import/package.json
@@ -37,7 +37,7 @@
     "eslint-config-prettier": "^2.4.0",
     "eslint-config-sanity": "^3.0.1",
     "file-url": "^2.0.2",
-    "get-it": "^3.0.0",
+    "get-it": "^4.0.0",
     "jest": "^21.0.1",
     "prettier": "^1.6.1",
     "rimraf": "^2.6.1"


### PR DESCRIPTION
get-it v4 fixes an issue where certain streams and other objects (those with a `toJSON()` method) would be serialized to JSON. This was preventing image uploads in @sanity/client from those kinds of streams.
