### PR TITLE
[form-builder] Extract FormBuilderContext  and let WithFormBuilder take schema as prop

### DIFF
--- a/packages/@sanity/form-builder/src/FormBuilder.js
+++ b/packages/@sanity/form-builder/src/FormBuilder.js
@@ -1,23 +1,9 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import {FormBuilderInput} from './FormBuilderInput'
-import * as defaultConfig from './defaultConfig'
 import Schema from '@sanity/schema'
 import pubsub from 'nano-pubsub'
-
-const NOOP = () => {}
-
-function resolve(type, providedResolve = NOOP, defaultResolve = NOOP) {
-  let itType = type
-  while (itType) {
-    const resolved = providedResolve(itType) || defaultResolve(itType)
-    if (resolved) {
-      return resolved
-    }
-    itType = itType.type
-  }
-  return undefined
-}
+import FormBuilderContext from './FormBuilderContext'
 
 function createPatchChannel() {
   const channel = pubsub()
@@ -30,7 +16,6 @@ export default class FormBuilder extends React.Component {
     value: PropTypes.any,
     schema: PropTypes.instanceOf(Schema).isRequired,
     type: PropTypes.object,
-    children: PropTypes.any,
     onChange: PropTypes.func,
     patchChannel: PropTypes.shape({
       onPatch: PropTypes.func
@@ -39,65 +24,38 @@ export default class FormBuilder extends React.Component {
     resolvePreviewComponent: PropTypes.func
   }
 
-  static childContextTypes = {
-    getValuePath: PropTypes.func,
-    onPatch: PropTypes.func,
-    formBuilder: PropTypes.shape({
-      schema: PropTypes.instanceOf(Schema),
-      resolveInputComponent: PropTypes.func,
-      document: PropTypes.any
-    })
-  }
-
-  getDocument = () => {
-    return this.props.value
-  }
-
-  resolveInputComponent = type => {
-    const {resolveInputComponent} = this.props
-    return resolve(type, resolveInputComponent, defaultConfig.resolveInputComponent)
-      || defaultConfig.jsonTypeFallbacks[type.jsonType]
-  }
-
-  resolvePreviewComponent = type => {
-    const {resolvePreviewComponent} = this.props
-
-    return resolve(type, resolvePreviewComponent, defaultConfig.resolvePreviewComponent)
-  }
-
-  getChildContext() {
-    const {schema, patchChannel} = this.props
-    return {
-      getValuePath: () => ([]),
-      formBuilder: {
-        onPatch: patchChannel ? patchChannel.onPatch : () => {
-          // eslint-disable-next-line no-console
-          console.log('No patch channel provided to form-builder. If you need input based patch updates, please provide one')
-        },
-        schema: schema,
-        resolveInputComponent: this.resolveInputComponent,
-        resolvePreviewComponent: this.resolvePreviewComponent,
-        getDocument: this.getDocument
-      }
-    }
-  }
-
   render() {
-    const {schema, value, type, onChange} = this.props
+    const {
+      schema,
+      value,
+      type,
+      onChange,
+      resolveInputComponent,
+      resolvePreviewComponent,
+      patchChannel
+    } = this.props
 
     if (!schema) {
       throw new TypeError('You must provide a schema to <FormBuilder (...)')
     }
 
     return (
-      <FormBuilderInput
+      <FormBuilderContext
+        schema={schema}
         value={value}
-        type={type}
-        onChange={onChange}
-        level={0}
-        isRoot
-        autoFocus
-      />
+        resolveInputComponent={resolveInputComponent}
+        resolvePreviewComponent={resolvePreviewComponent}
+        patchChannel={patchChannel}
+      >
+        <FormBuilderInput
+          value={value}
+          type={type}
+          onChange={onChange}
+          level={0}
+          isRoot
+          autoFocus
+        />
+      </FormBuilderContext>
     )
   }
 }

--- a/packages/@sanity/form-builder/src/FormBuilderContext.js
+++ b/packages/@sanity/form-builder/src/FormBuilderContext.js
@@ -1,0 +1,85 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import * as defaultConfig from './defaultConfig'
+import Schema from '@sanity/schema'
+import pubsub from 'nano-pubsub'
+
+const NOOP = () => {}
+
+function resolve(type, providedResolve = NOOP, defaultResolve = NOOP) {
+  let itType = type
+  while (itType) {
+    const resolved = providedResolve(itType) || defaultResolve(itType)
+    if (resolved) {
+      return resolved
+    }
+    itType = itType.type
+  }
+  return undefined
+}
+
+function createPatchChannel() {
+  const channel = pubsub()
+  return {onPatch: channel.subscribe, receivePatches: channel.publish}
+}
+
+export default class FormBuilderContext extends React.Component {
+  static createPatchChannel = createPatchChannel;
+  static propTypes = {
+    schema: PropTypes.instanceOf(Schema).isRequired,
+    value: PropTypes.any,
+    children: PropTypes.any,
+    patchChannel: PropTypes.shape({
+      onPatch: PropTypes.func
+    }),
+    resolveInputComponent: PropTypes.func,
+    resolvePreviewComponent: PropTypes.func
+  }
+
+  static childContextTypes = {
+    getValuePath: PropTypes.func,
+    onPatch: PropTypes.func,
+    formBuilder: PropTypes.shape({
+      schema: PropTypes.instanceOf(Schema),
+      resolveInputComponent: PropTypes.func,
+      document: PropTypes.any
+    })
+  }
+
+  getDocument = () => {
+    return this.props.value
+  }
+
+  resolveInputComponent = type => {
+    const {resolveInputComponent} = this.props
+    return resolve(type, resolveInputComponent, defaultConfig.resolveInputComponent)
+      || defaultConfig.jsonTypeFallbacks[type.jsonType]
+  }
+
+  resolvePreviewComponent = type => {
+    const {resolvePreviewComponent} = this.props
+
+    return resolve(type, resolvePreviewComponent, defaultConfig.resolvePreviewComponent)
+  }
+
+  getChildContext() {
+    const {schema, patchChannel} = this.props
+    return {
+      getValuePath: () => ([]),
+      formBuilder: {
+        onPatch: patchChannel ? patchChannel.onPatch : () => {
+          // eslint-disable-next-line no-console
+          console.log('No patch channel provided to form-builder. If you need input based patch updates, please provide one')
+        },
+        schema: schema,
+        resolveInputComponent: this.resolveInputComponent,
+        resolvePreviewComponent: this.resolvePreviewComponent,
+        getDocument: this.getDocument
+      }
+    }
+  }
+
+  render() {
+    return this.props.children
+  }
+}

--- a/packages/@sanity/form-builder/src/index.js
+++ b/packages/@sanity/form-builder/src/index.js
@@ -9,6 +9,7 @@ export {defaultInputs}
 export {defaultConfig}
 
 export {default as FormBuilder} from './FormBuilder'
+export {default as FormBuilderContext} from './FormBuilderContext'
 export {default as BlockEditor} from './inputs/BlockEditor-slate'
 
 // Input component factories

--- a/packages/@sanity/form-builder/src/sanity/SanityFormBuilder.js
+++ b/packages/@sanity/form-builder/src/sanity/SanityFormBuilder.js
@@ -8,6 +8,7 @@ import * as patches from '../utils/patches'
 import {FormBuilder, defaultConfig} from '..'
 
 export {default as WithFormBuilderValue} from './WithFormBuilderValue'
+export {default as FormBuilderContext} from '../FormBuilderContext'
 export {default as withDocument} from '../utils/withDocument'
 export {checkout} from './formBuilderValueStore'
 export {default as PatchEvent} from '../PatchEvent'

--- a/packages/@sanity/form-builder/src/sanity/WithFormBuilderValue.js
+++ b/packages/@sanity/form-builder/src/sanity/WithFormBuilderValue.js
@@ -152,10 +152,19 @@ export default class WithFormBuilderValue extends React.PureComponent<Props, Sta
 
   render() {
     const {typeName, documentId, schema, children: Component} = this.props
+    const {isLoading, isSaving, value, deletedSnapshot} = this.state
+
     return (
-      <FormBuilderContext schema={schema} patchChannel={this.patchChannel}>
+      <FormBuilderContext
+        value={value}
+        schema={schema}
+        patchChannel={this.patchChannel}
+      >
         <Component
-          {...this.state}
+          value={value}
+          isLoading={isLoading}
+          isSaving={isSaving}
+          deletedSnapshot={deletedSnapshot}
           documentId={documentId}
           type={schema.get(typeName)}
           onChange={this.handleChange}


### PR DESCRIPTION
This extracts all the context stuff from the `FormBuilder` component into a separate `FormBuilderContext`.

In addition to better separation of concerns, it also fixes an issue with the `WithFormBuilderValue` component that we're using in Vega.

This is a backwards compatible change.