### PR TITLE
[vision] Use document ID as key instead of revision

### DIFF
--- a/packages/sanity-plugin-vision/src/components/JsonDump.js
+++ b/packages/sanity-plugin-vision/src/components/JsonDump.js
@@ -46,9 +46,9 @@ export default function JsonDump(props) {
 
   return (
     <code>
-      {props.data.map(row =>
-        <JsonBlock key={row._rev || row.eventId} data={row} />
-      )}
+      {props.data.map((row, i) => (
+        <JsonBlock key={row._id || row.eventId || i} data={row} />
+      ))}
     </code>
   )
 }


### PR DESCRIPTION
When documents are created within the same transaction, `_rev` is set to the same value. Since we have used the revision as key, only the first item is rendered. This PR changes to use the document ID as the key if present and falls back to just using the array index.