### PR TITLE
[form-builder] More form-builder public api cleanup

### DIFF
--- a/packages/@sanity/desk-tool/src/pane/Editor.js
+++ b/packages/@sanity/desk-tool/src/pane/Editor.js
@@ -19,6 +19,7 @@ import copyDocument from '../utils/copyDocument'
 import Menu from 'part:@sanity/components/menus/default'
 import ContentCopyIcon from 'part:@sanity/base/content-copy-icon'
 import documentStore from 'part:@sanity/base/datastore/document'
+import schema from 'part:@sanity/base/schema'
 import {debounce} from 'lodash'
 import {getPublishedId, newDraftFrom} from '../utils/draftUtils'
 import TimeAgo from '../components/TimeAgo'
@@ -413,6 +414,7 @@ export default withRouterHOC(class Editor extends React.PureComponent {
           </div>
           <form className={styles.editor} onSubmit={preventDefault} id="Sanity_Default_DeskTool_Editor_ScrollContainer">
             <FormBuilder
+              schema={schema}
               patchChannel={patchChannel}
               value={draft || published || {_type: type.name}}
               type={type}

--- a/packages/@sanity/form-builder/sanity.json
+++ b/packages/@sanity/form-builder/sanity.json
@@ -83,7 +83,7 @@
     },
     {
       "implements": "part:@sanity/form-builder",
-      "path": "sanity/SanityFormBuilder.js"
+      "path": "sanity/index.js"
     }
   ]
 }

--- a/packages/@sanity/form-builder/src/FormBuilder.js
+++ b/packages/@sanity/form-builder/src/FormBuilder.js
@@ -2,26 +2,25 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import {FormBuilderInput} from './FormBuilderInput'
 import Schema from '@sanity/schema'
-import pubsub from 'nano-pubsub'
 import FormBuilderContext from './FormBuilderContext'
 
-function createPatchChannel() {
-  const channel = pubsub()
-  return {onPatch: channel.subscribe, receivePatches: channel.publish}
-}
-
+// Todo: consider deprecating this in favor of <FormBuilderContext ...><FormBuilderInput .../></FormBuilderContext>
 export default class FormBuilder extends React.Component {
-  static createPatchChannel = createPatchChannel;
+  static createPatchChannel = FormBuilderContext.createPatchChannel;
   static propTypes = {
     value: PropTypes.any,
     schema: PropTypes.instanceOf(Schema).isRequired,
-    type: PropTypes.object,
-    onChange: PropTypes.func,
+    type: PropTypes.object.isRequired,
+    onChange: PropTypes.func.isRequired,
     patchChannel: PropTypes.shape({
       onPatch: PropTypes.func
-    }),
-    resolveInputComponent: PropTypes.func,
-    resolvePreviewComponent: PropTypes.func
+    }).isRequired,
+    resolveInputComponent: PropTypes.func.isRequired,
+    resolvePreviewComponent: PropTypes.func.isRequired
+  }
+
+  static defaultProps = {
+    value: undefined,
   }
 
   render() {

--- a/packages/@sanity/form-builder/src/FormBuilderContext.js
+++ b/packages/@sanity/form-builder/src/FormBuilderContext.js
@@ -18,22 +18,20 @@ function resolve(type, providedResolve = NOOP, defaultResolve = NOOP) {
   return undefined
 }
 
-function createPatchChannel() {
-  const channel = pubsub()
-  return {onPatch: channel.subscribe, receivePatches: channel.publish}
-}
-
 export default class FormBuilderContext extends React.Component {
-  static createPatchChannel = createPatchChannel;
+  static createPatchChannel = () => {
+    const channel = pubsub()
+    return {onPatch: channel.subscribe, receivePatches: channel.publish}
+  }
   static propTypes = {
     schema: PropTypes.instanceOf(Schema).isRequired,
     value: PropTypes.any,
-    children: PropTypes.any,
+    children: PropTypes.any.isRequired,
     patchChannel: PropTypes.shape({
       onPatch: PropTypes.func
-    }),
-    resolveInputComponent: PropTypes.func,
-    resolvePreviewComponent: PropTypes.func
+    }).isRequired,
+    resolveInputComponent: PropTypes.func.isRequired,
+    resolvePreviewComponent: PropTypes.func.isRequired
   }
 
   static childContextTypes = {
@@ -62,21 +60,29 @@ export default class FormBuilderContext extends React.Component {
     return resolve(type, resolvePreviewComponent, defaultConfig.resolvePreviewComponent)
   }
 
-  getChildContext() {
-    const {schema, patchChannel} = this.props
-    return {
-      getValuePath: () => ([]),
-      formBuilder: {
-        onPatch: patchChannel ? patchChannel.onPatch : () => {
-          // eslint-disable-next-line no-console
-          console.log('No patch channel provided to form-builder. If you need input based patch updates, please provide one')
-        },
-        schema: schema,
-        resolveInputComponent: this.resolveInputComponent,
-        resolvePreviewComponent: this.resolvePreviewComponent,
-        getDocument: this.getDocument
+  _getMemoizedChildContext() {
+    if (!this._childContext) {
+      const {schema, patchChannel} = this.props
+      this._childContext = {
+        getValuePath: () => ([]),
+        formBuilder: {
+          onPatch: patchChannel ? patchChannel.onPatch : () => {
+            // eslint-disable-next-line no-console
+            console.warn('No patch channel provided to form-builder. If you need input based patch updates, please provide one')
+            return NOOP
+          },
+          schema,
+          resolveInputComponent: this.resolveInputComponent,
+          resolvePreviewComponent: this.resolvePreviewComponent,
+          getDocument: this.getDocument
+        }
       }
     }
+    return this._childContext
+  }
+
+  getChildContext() {
+    return this._getMemoizedChildContext()
   }
 
   render() {

--- a/packages/@sanity/form-builder/src/sanity/SanityFormBuilder.js
+++ b/packages/@sanity/form-builder/src/sanity/SanityFormBuilder.js
@@ -1,36 +1,36 @@
+// @flow
 import React from 'react'
-import schema from 'part:@sanity/base/schema'
+import SanityFormBuilderContext from './SanityFormBuilderContext'
+import {FormBuilderInput} from '../FormBuilderInput'
 
-import inputResolver from './inputResolver/inputResolver'
-import SanityPreview from 'part:@sanity/base/preview'
-import * as patches from '../utils/patches'
-
-import {FormBuilder, defaultConfig} from '..'
-
-export {default as WithFormBuilderValue} from './WithFormBuilderValue'
-export {default as FormBuilderContext} from '../FormBuilderContext'
-export {default as withDocument} from '../utils/withDocument'
-export {checkout} from './formBuilderValueStore'
-export {default as PatchEvent} from '../PatchEvent'
-export {FormBuilderInput} from '../FormBuilderInput'
-
-export {patches}
-export {BlockEditor} from '..'
-
-function previewResolver() {
-  return SanityPreview
+type PatchChannel = {
+  subscribe: () => () => {},
+  receivePatches: (patches: Array<*>) => void
 }
 
-export default function SanityFormBuilder(props) {
+type Props = {
+  value: ?any,
+  schema: any,
+  type: Object,
+  patchChannel: PatchChannel,
+  onChange: () => {}
+}
+
+export default function SanityFormBuilder(props: Props) {
   return (
-    <FormBuilder
-      {...props}
-      schema={schema}
-      resolveInputComponent={inputResolver}
-      resolvePreviewComponent={previewResolver}
-    />)
+    <SanityFormBuilderContext
+      value={props.value}
+      schema={props.schema}
+      patchChannel={props.patchChannel}
+    >
+      <FormBuilderInput
+        type={props.type}
+        onChange={props.onChange}
+        level={0}
+        value={props.value}
+      />
+    </SanityFormBuilderContext>
+  )
 }
 
-SanityFormBuilder.createPatchChannel = FormBuilder.createPatchChannel
-
-export {inputResolver, defaultConfig}
+SanityFormBuilder.createPatchChannel = SanityFormBuilderContext.createPatchChannel

--- a/packages/@sanity/form-builder/src/sanity/SanityFormBuilderContext.js
+++ b/packages/@sanity/form-builder/src/sanity/SanityFormBuilderContext.js
@@ -1,0 +1,32 @@
+// @flow
+// Default wiring for FormBuilderContext when used as a sanity part
+import React from 'react'
+import FormBuilderContext from '../FormBuilderContext'
+import SanityPreview from 'part:@sanity/base/preview'
+import inputResolver from './inputResolver/inputResolver'
+import type {Node} from 'react'
+
+const previewResolver = () => SanityPreview
+
+type Props = {
+  value: ?any,
+  schema: Object,
+  patchChannel: any,
+  children: Node
+}
+
+export default function SanityFormBuilderContext(props: Props) {
+  return (
+    <FormBuilderContext
+      value={props.value}
+      schema={props.schema}
+      patchChannel={props.patchChannel}
+      resolveInputComponent={inputResolver}
+      resolvePreviewComponent={previewResolver}
+    >
+      {props.children}
+    </FormBuilderContext>
+  )
+}
+
+SanityFormBuilderContext.createPatchChannel = FormBuilderContext.createPatchChannel

--- a/packages/@sanity/form-builder/src/sanity/WithFormBuilderValue.js
+++ b/packages/@sanity/form-builder/src/sanity/WithFormBuilderValue.js
@@ -1,12 +1,16 @@
 // @flow
-// Connects the FormBuilder with various sanity roles
+
+// Provides a utility component for easy editing a value of a schema type with the form builder
+// Manages server sync, mutations, etc. and passes a value + onChange to a child component
+// Note: Experimental, and likely to change in the future
+
 import PropTypes from 'prop-types'
 import React from 'react'
 import {throttle} from 'lodash'
 import subscriptionManager from '../utils/subscriptionManager'
 import PatchEvent from '../PatchEvent'
 import {checkout} from './formBuilderValueStore'
-import FormBuilderContext from '../FormBuilderContext'
+import SanityFormBuilderContext from './SanityFormBuilderContext'
 
 type State = {
   isLoading: boolean,
@@ -21,6 +25,7 @@ type Props = {
   schema: Object,
   children: Function
 }
+
 function getInitialState() : State {
   return {
     isLoading: true,
@@ -41,7 +46,7 @@ export default class WithFormBuilderValue extends React.PureComponent<Props, Sta
   subscriptions = subscriptionManager('documentEvents', 'commit')
 
   state = getInitialState();
-  patchChannel = FormBuilderContext.createPatchChannel()
+  patchChannel = SanityFormBuilderContext.createPatchChannel()
 
   checkoutDocument(documentId : string) {
     this.document = checkout(documentId)
@@ -153,9 +158,8 @@ export default class WithFormBuilderValue extends React.PureComponent<Props, Sta
   render() {
     const {typeName, documentId, schema, children: Component} = this.props
     const {isLoading, isSaving, value, deletedSnapshot} = this.state
-
     return (
-      <FormBuilderContext
+      <SanityFormBuilderContext
         value={value}
         schema={schema}
         patchChannel={this.patchChannel}
@@ -171,7 +175,7 @@ export default class WithFormBuilderValue extends React.PureComponent<Props, Sta
           onDelete={this.handleDelete}
           onCreate={this.handleCreate}
         />
-      </FormBuilderContext>
+      </SanityFormBuilderContext>
     )
   }
 }

--- a/packages/@sanity/form-builder/src/sanity/index.js
+++ b/packages/@sanity/form-builder/src/sanity/index.js
@@ -1,0 +1,13 @@
+// This exports the public api of 'part:@sanity/form-builder'
+
+import * as patches from '../utils/patches'
+
+export {default} from './SanityFormBuilder'
+export {default as FormBuilderContext} from './SanityFormBuilderContext'
+export {default as WithFormBuilderValue} from './WithFormBuilderValue'
+export {default as withDocument} from '../utils/withDocument'
+export {FormBuilderInput} from '../FormBuilderInput'
+export {checkout} from './formBuilderValueStore'
+export {default as PatchEvent} from '../PatchEvent'
+export {patches}
+export {BlockEditor} from '..'

--- a/packages/@sanity/form-builder/src/sanity/inputResolver/inputResolver.js
+++ b/packages/@sanity/form-builder/src/sanity/inputResolver/inputResolver.js
@@ -1,6 +1,3 @@
-import React from 'react'
-import customResolver from 'part:@sanity/form-builder/input-resolver?'
-
 import ArrayInput from 'part:@sanity/form-builder/input/array?'
 import BooleanInput from 'part:@sanity/form-builder/input/boolean?'
 import EmailInput from 'part:@sanity/form-builder/input/email?'
@@ -40,7 +37,21 @@ const typeInputMap = {
   url: UrlInput
 }
 
+function getExport(obj) {
+  return obj && obj.__esModule ? obj.default : obj
+}
+
+// this is needed to avoid errors due to circular imports
+// this can happen if a custom input component imports and tries
+// to access something from the form-builder immediately (top-level)
+let getCustomResolver = () => {
+  const resolver = getExport(require('part:@sanity/form-builder/input-resolver?'))
+  getCustomResolver = () => resolver
+  return resolver
+}
 export default function inputResolver(type) {
+  const customResolver = getCustomResolver()
+
   const custom = customResolver && customResolver(type)
   if (custom) {
     return custom

--- a/packages/@sanity/form-builder/src/utils/withDocument.js
+++ b/packages/@sanity/form-builder/src/utils/withDocument.js
@@ -31,7 +31,7 @@ export default function withDocument(ComposedComponent: any) {
       this.unsubscribe()
     }
     render() {
-      return <ComposedComponent document={this.state.document} {...this.props}/>
+      return <ComposedComponent document={this.state.document} {...this.props} />
     }
   }
 }


### PR DESCRIPTION
This expands on #213, and provides more cleanup of the form-builder part API. This rewrite was triggered by an issue with a circular import that I ran into yesterday and had to work around it with this (rather ugly) hack:

https://github.com/sanity-io/sanity/blob/06b9dcc25754ca5ec28e54dd2a5cb3c210e34000/packages/%40sanity/form-builder/src/sanity/inputResolver/inputResolver.js#L40-L53

[We should probably put some more energy into figuring out how to avoid future circular import issues like this, but for now, this hack will do the trick]

There's technically a breaking change in here, in that the FormBuilder now must be passed the schema as a prop (so you'll have to import it wherever the `<FormBuilder` is used), but AFAIK the only place we use the form builder today is a few places in Vega and in the desk tool. I also think this change is for the good, as it allows for using the form-builder with different schemas in the same enviroment.