### PR TITLE
[import] Don't require `_id` property

### DIFF
--- a/packages/@sanity/import/src/documentHasErrors.js
+++ b/packages/@sanity/import/src/documentHasErrors.js
@@ -1,6 +1,6 @@
 module.exports = function documentHasErrors(doc) {
-  if (typeof doc._id !== 'string') {
-    return `Document did not contain required "_id" property of type string`
+  if (typeof doc._id !== 'undefined' && typeof doc._id !== 'string') {
+    return `Document contained an invalid "_id" property - must be a string`
   }
 
   if (typeof doc._type !== 'string') {

--- a/packages/@sanity/import/test/__snapshots__/uploadAssets.test.js.snap
+++ b/packages/@sanity/import/test/__snapshots__/uploadAssets.test.js.snap
@@ -7,7 +7,8 @@ Object {
       "patch": Object {
         "id": "doc_1",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -18,7 +19,8 @@ Object {
       "patch": Object {
         "id": "doc_2",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -29,7 +31,8 @@ Object {
       "patch": Object {
         "id": "doc_3",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -40,7 +43,8 @@ Object {
       "patch": Object {
         "id": "doc_4",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -51,7 +55,8 @@ Object {
       "patch": Object {
         "id": "doc_5",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -62,7 +67,8 @@ Object {
       "patch": Object {
         "id": "doc_6",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -73,7 +79,8 @@ Object {
       "patch": Object {
         "id": "doc_7",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -84,7 +91,8 @@ Object {
       "patch": Object {
         "id": "doc_8",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -95,7 +103,8 @@ Object {
       "patch": Object {
         "id": "doc_9",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -106,7 +115,8 @@ Object {
       "patch": Object {
         "id": "doc_10",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -117,7 +127,8 @@ Object {
       "patch": Object {
         "id": "doc_11",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -128,7 +139,8 @@ Object {
       "patch": Object {
         "id": "doc_12",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -139,7 +151,8 @@ Object {
       "patch": Object {
         "id": "doc_13",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -150,7 +163,8 @@ Object {
       "patch": Object {
         "id": "doc_14",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -161,7 +175,8 @@ Object {
       "patch": Object {
         "id": "doc_15",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -172,7 +187,8 @@ Object {
       "patch": Object {
         "id": "doc_16",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -183,7 +199,8 @@ Object {
       "patch": Object {
         "id": "doc_17",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -194,7 +211,8 @@ Object {
       "patch": Object {
         "id": "doc_18",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -205,7 +223,8 @@ Object {
       "patch": Object {
         "id": "doc_19",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -216,7 +235,8 @@ Object {
       "patch": Object {
         "id": "doc_20",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -227,7 +247,8 @@ Object {
       "patch": Object {
         "id": "doc_21",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -238,7 +259,8 @@ Object {
       "patch": Object {
         "id": "doc_22",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -249,7 +271,8 @@ Object {
       "patch": Object {
         "id": "doc_23",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -260,7 +283,8 @@ Object {
       "patch": Object {
         "id": "doc_24",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -271,7 +295,8 @@ Object {
       "patch": Object {
         "id": "doc_25",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -282,7 +307,8 @@ Object {
       "patch": Object {
         "id": "doc_26",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -293,7 +319,8 @@ Object {
       "patch": Object {
         "id": "doc_27",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -304,7 +331,8 @@ Object {
       "patch": Object {
         "id": "doc_28",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -315,7 +343,8 @@ Object {
       "patch": Object {
         "id": "doc_29",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -326,7 +355,8 @@ Object {
       "patch": Object {
         "id": "doc_30",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -337,7 +367,8 @@ Object {
       "patch": Object {
         "id": "doc_31",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -348,7 +379,8 @@ Object {
       "patch": Object {
         "id": "doc_32",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -359,7 +391,8 @@ Object {
       "patch": Object {
         "id": "doc_33",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -370,7 +403,8 @@ Object {
       "patch": Object {
         "id": "doc_34",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -381,7 +415,8 @@ Object {
       "patch": Object {
         "id": "doc_35",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -392,7 +427,8 @@ Object {
       "patch": Object {
         "id": "doc_36",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -403,7 +439,8 @@ Object {
       "patch": Object {
         "id": "doc_37",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -414,7 +451,8 @@ Object {
       "patch": Object {
         "id": "doc_38",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -425,7 +463,8 @@ Object {
       "patch": Object {
         "id": "doc_39",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -436,7 +475,8 @@ Object {
       "patch": Object {
         "id": "doc_40",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -447,7 +487,8 @@ Object {
       "patch": Object {
         "id": "doc_41",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -458,7 +499,8 @@ Object {
       "patch": Object {
         "id": "doc_42",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -469,7 +511,8 @@ Object {
       "patch": Object {
         "id": "doc_43",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -480,7 +523,8 @@ Object {
       "patch": Object {
         "id": "doc_44",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -491,7 +535,8 @@ Object {
       "patch": Object {
         "id": "doc_45",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -502,7 +547,8 @@ Object {
       "patch": Object {
         "id": "doc_46",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -513,7 +559,8 @@ Object {
       "patch": Object {
         "id": "doc_47",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -524,7 +571,8 @@ Object {
       "patch": Object {
         "id": "doc_48",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -535,7 +583,8 @@ Object {
       "patch": Object {
         "id": "doc_49",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -546,7 +595,8 @@ Object {
       "patch": Object {
         "id": "doc_50",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -564,7 +614,8 @@ Object {
       "patch": Object {
         "id": "doc_51",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -575,7 +626,8 @@ Object {
       "patch": Object {
         "id": "doc_52",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -586,7 +638,8 @@ Object {
       "patch": Object {
         "id": "doc_53",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -597,7 +650,8 @@ Object {
       "patch": Object {
         "id": "doc_54",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -608,7 +662,8 @@ Object {
       "patch": Object {
         "id": "doc_55",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -619,7 +674,8 @@ Object {
       "patch": Object {
         "id": "doc_56",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -630,7 +686,8 @@ Object {
       "patch": Object {
         "id": "doc_57",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -641,7 +698,8 @@ Object {
       "patch": Object {
         "id": "doc_58",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -652,7 +710,8 @@ Object {
       "patch": Object {
         "id": "doc_59",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -663,7 +722,8 @@ Object {
       "patch": Object {
         "id": "doc_60",
         "set": Object {
-          "some.path": Object {
+          "some.path._type": "someAssetI",
+          "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -691,7 +751,8 @@ Object {
       "patch": Object {
         "id": "movie_1",
         "set": Object {
-          "metadata.poster": Object {
+          "metadata.poster._type": "someAssetI",
+          "metadata.poster.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
@@ -709,7 +770,8 @@ Object {
       "patch": Object {
         "id": "movie_1",
         "set": Object {
-          "metadata.poster": Object {
+          "metadata.poster._type": "newAssetI",
+          "metadata.poster.asset": Object {
             "_ref": "newAssetId",
             "_type": "reference",
           },

--- a/packages/@sanity/import/test/fixtures/invalid-id.ndjson
+++ b/packages/@sanity/import/test/fixtures/invalid-id.ndjson
@@ -1,3 +1,3 @@
 {"_id": "espen", "_type": "employee", "name": "Espen"}
-{"_type": "employee", "name": "Per-Kristian"}
+{"_id": 123, "_type": "employee", "name": "Per-Kristian"}
 {"_id": "Even", "_type": "employee", "name": "Even"}

--- a/packages/@sanity/import/test/import.test.js
+++ b/packages/@sanity/import/test/import.test.js
@@ -18,27 +18,21 @@ const getFixture = fix => {
 }
 
 test('rejects on invalid JSON', async () => {
-  await expect(
-    importer(getFixture('invalid-json'), options)
-  ).rejects.toHaveProperty(
+  await expect(importer(getFixture('invalid-json'), options)).rejects.toHaveProperty(
     'message',
     'Failed to parse line #3: Unexpected token _ in JSON at position 1'
   )
 })
 
 test('rejects on missing `_id` property', async () => {
-  await expect(
-    importer(getFixture('missing-id'), options)
-  ).rejects.toHaveProperty(
+  await expect(importer(getFixture('invalid-id'), options)).rejects.toHaveProperty(
     'message',
-    'Failed to parse line #2: Document did not contain required "_id" property of type string'
+    'Failed to parse line #2: Document contained an invalid "_id" property - must be a string'
   )
 })
 
 test('rejects on missing `_type` property', async () => {
-  await expect(
-    importer(getFixture('missing-type'), options)
-  ).rejects.toHaveProperty(
+  await expect(importer(getFixture('missing-type'), options)).rejects.toHaveProperty(
     'message',
     'Failed to parse line #3: Document did not contain required "_type" property of type string'
   )


### PR DESCRIPTION
Not sure how I missed this one. Imported documents shouldn't _require_ an `_id` property, as the API generates one for you if you don't specify one.