### PR TITLE
[components] Bump default media preview to 160px

### DIFF
--- a/packages/@sanity/components/src/previews/MediaPreview.js
+++ b/packages/@sanity/components/src/previews/MediaPreview.js
@@ -26,7 +26,7 @@ export default class MediaPreview extends React.Component {
   }
 
   static defaultProps = {
-    assetSize: {width: 120, height: 120},
+    assetSize: {width: 160, height: 160},
     aspect: 1,
     emptyText: 'Untitled…'
   }


### PR DESCRIPTION
We have a plan for replacing all of these hardcoded sizes with a richer sourceset based solution, but for now let's bump the default image size up to 160px as this is what the grid component uses. Makes images sharp again! :+1: 