### PR TITLE
 [schema] Fix wrong asset type names and use asset.originalFilename as default preview title for images

### DIFF
--- a/packages/@sanity/base/src/schema/types/fileAsset.js
+++ b/packages/@sanity/base/src/schema/types/fileAsset.js
@@ -1,6 +1,6 @@
 export default {
   name: 'sanity.fileAsset',
-  title: 'File asset',
+  title: 'File',
   type: 'object',
   fieldsets: [
     {

--- a/packages/@sanity/base/src/schema/types/fileAsset.js
+++ b/packages/@sanity/base/src/schema/types/fileAsset.js
@@ -2,21 +2,28 @@ export default {
   name: 'sanity.fileAsset',
   title: 'File asset',
   type: 'object',
+  fieldsets: [
+    {
+      name: 'system',
+      title: 'System fields',
+      description: 'These are read only'
+    }
+  ],
   fields: [
-    {
-      name: 'assetId',
-      type: 'string',
-      title: 'Asset ID'
-    },
-    {
-      name: 'project',
-      type: 'string',
-      title: 'Project'
-    },
     {
       name: 'originalFilename',
       type: 'string',
       title: 'Original file name'
+    },
+    {
+      name: 'extension',
+      type: 'string',
+      title: 'File extension'
+    },
+    {
+      name: 'mimeType',
+      type: 'string',
+      title: 'Mime type'
     },
     {
       name: 'label',
@@ -24,14 +31,30 @@ export default {
       title: 'Label'
     },
     {
+      name: 'assetId',
+      type: 'string',
+      title: 'Asset ID',
+      readOnly: true,
+      fieldset: 'system'
+    },
+    {
       name: 'path',
       type: 'string',
-      title: 'Path'
+      title: 'Path',
+      readOnly: true,
+      fieldset: 'system'
     },
     {
       name: 'url',
       type: 'string',
-      title: 'Url'
+      title: 'Url',
+      readOnly: true,
+      fieldset: 'system'
     }
-  ]
+  ],
+  preview: {
+    select: {
+      title: 'originalFilename'
+    }
+  }
 }

--- a/packages/@sanity/base/src/schema/types/fileAsset.js
+++ b/packages/@sanity/base/src/schema/types/fileAsset.js
@@ -1,5 +1,5 @@
 export default {
-  name: 'fileAsset',
+  name: 'sanity.fileAsset',
   title: 'File asset',
   type: 'object',
   fields: [
@@ -12,6 +12,11 @@ export default {
       name: 'project',
       type: 'string',
       title: 'Project'
+    },
+    {
+      name: 'originalFilename',
+      type: 'string',
+      title: 'Original file name'
     },
     {
       name: 'label',

--- a/packages/@sanity/base/src/schema/types/imageAsset.js
+++ b/packages/@sanity/base/src/schema/types/imageAsset.js
@@ -1,5 +1,5 @@
 export default {
-  name: 'imageAsset',
+  name: 'sanity.imageAsset',
   title: 'Image asset',
   type: 'object',
   fields: [
@@ -17,6 +17,11 @@ export default {
       name: 'label',
       type: 'string',
       title: 'Label'
+    },
+    {
+      name: 'originalFilename',
+      type: 'string',
+      title: 'Original file name'
     },
     {
       name: 'path',
@@ -49,5 +54,11 @@ export default {
         }
       ]
     }
-  ]
+  ],
+  preview: {
+    select: {
+      title: 'originalFilename',
+      imageUrl: 'url'
+    }
+  }
 }

--- a/packages/@sanity/base/src/schema/types/imageAsset.js
+++ b/packages/@sanity/base/src/schema/types/imageAsset.js
@@ -6,7 +6,7 @@ const PALETTE_FIELDS = [
 ]
 export default {
   name: 'sanity.imageAsset',
-  title: 'Image asset',
+  title: 'Image',
   type: 'object',
   fieldsets: [
     {

--- a/packages/@sanity/base/src/schema/types/imageAsset.js
+++ b/packages/@sanity/base/src/schema/types/imageAsset.js
@@ -1,17 +1,42 @@
+const PALETTE_FIELDS = [
+  {name: 'background', type: 'string', title: 'Background'},
+  {name: 'foreground', type: 'string', title: 'Foreground'},
+  {name: 'population', type: 'number', title: 'Population'},
+  {name: 'title', type: 'string', title: 'String'},
+]
 export default {
   name: 'sanity.imageAsset',
   title: 'Image asset',
   type: 'object',
-  fields: [
+  fieldsets: [
     {
-      name: 'assetId',
-      type: 'string',
-      title: 'Asset ID'
+      name: 'system',
+      title: 'System fields',
+      description: 'These are read only'
     },
     {
-      name: 'project',
+      name: 'metadata',
+      title: 'Extra metadata…',
+      options: {
+        collapsable: true
+      }
+    }
+  ],
+  fields: [
+    {
+      name: 'originalFilename',
       type: 'string',
-      title: 'Project'
+      title: 'Original file name'
+    },
+    {
+      name: 'extension',
+      type: 'string',
+      title: 'File extension'
+    },
+    {
+      name: 'mimeType',
+      type: 'string',
+      title: 'Mime type'
     },
     {
       name: 'label',
@@ -19,25 +44,37 @@ export default {
       title: 'Label'
     },
     {
-      name: 'originalFilename',
+      name: 'assetId',
       type: 'string',
-      title: 'Original file name'
+      title: 'Asset ID',
+      readOnly: true,
+      fieldset: 'system'
     },
     {
       name: 'path',
       type: 'string',
-      title: 'Path'
+      title: 'Path',
+      readOnly: true,
+      fieldset: 'system'
     },
     {
       name: 'url',
       type: 'string',
-      title: 'Url'
+      title: 'Url',
+      readOnly: true,
+      fieldset: 'system'
     },
     {
       name: 'metadata',
       type: 'object',
       title: 'Metadata',
+      readOnly: true,
+      fieldset: 'metadata',
       fields: [
+        {
+          name: 'location',
+          type: 'geopoint'
+        },
         {
           name: 'dimensions',
           type: 'object',
@@ -49,8 +86,18 @@ export default {
           ]
         },
         {
-          name: 'location',
-          type: 'geopoint'
+          name: 'palette',
+          type: 'object',
+          title: 'Palette',
+          fields: [
+            {name: 'darkMuted', type: 'object', title: 'Dark Muted', fields: PALETTE_FIELDS},
+            {name: 'lightVibrant', type: 'object', title: 'Light Vibrant', fields: PALETTE_FIELDS},
+            {name: 'darkVibrant', type: 'object', title: 'Dark Vibrant', fields: PALETTE_FIELDS},
+            {name: 'vibrant', type: 'object', title: 'Vibrant', fields: PALETTE_FIELDS},
+            {name: 'dominant', type: 'object', title: 'Dominant', fields: PALETTE_FIELDS},
+            {name: 'lightMuted', type: 'object', title: 'Light Muted', fields: PALETTE_FIELDS},
+            {name: 'muted', type: 'object', title: 'Muted', fields: PALETTE_FIELDS}
+          ]
         }
       ]
     }

--- a/packages/@sanity/data-aspects/src/DataAspectsResolver.js
+++ b/packages/@sanity/data-aspects/src/DataAspectsResolver.js
@@ -1,6 +1,6 @@
 import config from 'config:@sanity/data-aspects'
 import {startCase} from 'lodash'
-const bundledTypeNames = ['geopoint', 'richDate', 'date', 'imageAsset', 'fileAsset']
+const bundledTypeNames = ['geopoint', 'richDate', 'date', 'sanity.imageAsset', 'sanity.fileAsset']
 
 class DataAspectsResolver {
 

--- a/packages/@sanity/schema/src/preview/guessPreviewConfig.js
+++ b/packages/@sanity/schema/src/preview/guessPreviewConfig.js
@@ -11,7 +11,7 @@ function fieldHasReferenceTo(fieldDef, refType) {
 }
 
 function isImageAssetField(fieldDef) {
-  return fieldHasReferenceTo(fieldDef, 'imageAsset')
+  return fieldHasReferenceTo(fieldDef, 'sanity.imageAsset')
 }
 
 function resolveImageAssetPath(typeDef) {
@@ -26,7 +26,7 @@ function resolveImageAssetPath(typeDef) {
 }
 
 function isFileAssetField(fieldDef) {
-  return fieldHasReferenceTo(fieldDef, 'fileAsset')
+  return fieldHasReferenceTo(fieldDef, 'sanity.fileAsset')
 }
 
 function resolveFileAssetPath(typeDef) {
@@ -66,6 +66,9 @@ export default function guessPreviewFields(rawObjectTypeDef) {
     const fileAssetPath = resolveFileAssetPath(objectTypeDef)
     if (fileAssetPath) {
       titleField = `${fileAssetPath}.originalFilename`
+    }
+    if (imageAssetPath) {
+      titleField = `${imageAssetPath}.originalFilename`
     }
   }
 

--- a/packages/@sanity/schema/src/types/file.js
+++ b/packages/@sanity/schema/src/types/file.js
@@ -5,7 +5,7 @@ import createPreviewGetter from '../preview/createPreviewGetter'
 export const ASSET_FIELD = {
   name: 'asset',
   type: 'reference',
-  to: {type: 'fileAsset'}
+  to: {type: 'sanity.fileAsset'}
 }
 
 const OVERRIDABLE_FIELDS = [

--- a/packages/@sanity/schema/src/types/image/fieldDefs.js
+++ b/packages/@sanity/schema/src/types/image/fieldDefs.js
@@ -1,7 +1,7 @@
 export const ASSET_FIELD = {
   name: 'asset',
   type: 'reference',
-  to: [{type: 'imageAsset'}]
+  to: [{type: 'sanity.imageAsset'}]
 }
 
 export const HOTSPOT_FIELD = {


### PR DESCRIPTION
I noticed that we are prefixing the type of asset documents with `sanity.`. Found a few places that did not follow this convention.

This patch:
- Prefixes the imageAsset and fileAsset schema types with `sanity.`
- Renames invalid schema type name from `fileAsset` to `sanity.sanityAsset`
- Adds the `originalFilename` to the internal schema definition for imageAssets and fileAssets
- Uses `asset.originalFilename` as default preview title on images