### PR TITLE
[core] Use Uglify-JS API to compress files

### DIFF
--- a/packages/@sanity/core/src/actions/build/compressJavascript.js
+++ b/packages/@sanity/core/src/actions/build/compressJavascript.js
@@ -1,33 +1,20 @@
 import fse from 'fs-extra'
-import {spawn} from 'child_process'
-import concat from 'simple-concat'
+import UglifyJS from 'uglify-js'
 
-export default inputFile => {
-  const uglifyPath = require.resolve('uglify-js/bin/uglifyjs')
-  const sourceFile = `${inputFile}.source`
+export default async inputFile => {
+  const content = await fse.readFile(inputFile, 'utf8')
+  const minified = await minify(content)
+  await fse.outputFile(inputFile, minified)
+}
 
-  return new Promise(async (resolve, reject) => {
-    await fse.rename(inputFile, sourceFile)
+function minify(content) {
+  return new Promise((resolve, reject) => {
+    const result = UglifyJS.minify(content)
 
-    const uglify = spawn(uglifyPath, ['-c', '-m', '--', sourceFile])
-    uglify.stdout.pipe(fse.createWriteStream(inputFile))
-
-    let error = ''
-    concat(uglify.stderr, (err, buf) => {
-      if (err) {
-        reject(err)
-      } else {
-        error = buf.toString()
-      }
-    })
-
-    uglify.on('close', async code => {
-      if (code > 0) {
-        return reject(new Error(error))
-      }
-
-      await fse.unlink(sourceFile)
-      return resolve()
-    })
+    if (result.error) {
+      reject(result.error)
+    } else {
+      resolve(result.code)
+    }
   })
 }


### PR DESCRIPTION
This PR makes the minifying process use the uglify-js API instead of spawning the binary. It should be more reliable and fixes a cross-platform issue where spawning the binary wouldn't work on windows.

Based this on master since it would be nice to get a fix out for our windows users ASAP.
