### PR TITLE
[cli] Ensure CLI exits with positive error code on error

### DIFF
--- a/packages/@sanity/cli/src/cli.js
+++ b/packages/@sanity/cli/src/cli.js
@@ -72,7 +72,7 @@ module.exports = function runCli() {
       const error = (debug && err.details) || err
       const errMessage = debug ? (error.stack || error) : (error.message || error)
       console.error(chalk.red(errMessage)) // eslint-disable-line no-console
-      process.exit(error.code || 1) // eslint-disable-line no-process-exit
+      process.exit(1) // eslint-disable-line no-process-exit
     })
 }
 


### PR DESCRIPTION
Currently, if the error thrown from a CLI command has a `code` property that is truthy but non-numeric, the process exits with code `0`.

This PR ensures that it always exits with a positive numbered error code (we've never used a custom error code in any commands, so I didn't see the need for any smarter logic than simply using `1`).
