### PR TITLE
[client] Specify metadata to extract with `extract`-option

### DIFF
--- a/packages/@sanity/client/README.md
+++ b/packages/@sanity/client/README.md
@@ -251,7 +251,7 @@ An important note on this approach is that you cannot call `commit()` on transac
 Assets can be uploaded using the `client.assets.upload(...)` method.
 
 ```
-client.asset.upload(type: 'file' | image', body: File | Blob | Buffer | NodeStream): Promise<AssetDocument>
+client.asset.upload(type: 'file' | image', body: File | Blob | Buffer | NodeStream, options = {}): Promise<AssetDocument>
 ```
 
 👉 Read more about [assets in Sanity](https://sanity.io/docs/http-api/assets)
@@ -314,6 +314,19 @@ function uploadImageBlob(blob) {
     })
 }
 ```
+
+#### Examples: Specify image metadata to extract
+```js
+// Extract palette of colors as well as GPS location from exif
+client.assets.upload('image', someFile, {extract: ['palette', 'location']})
+  .then(document => {
+    console.log('The file was uploaded!', document)
+  })
+  .catch(error => {
+    console.error('Upload failed:', error.message)
+  })
+````
+
 ### Deleting an asset
 
 ```

--- a/packages/@sanity/client/src/assets/assetsClient.js
+++ b/packages/@sanity/client/src/assets/assetsClient.js
@@ -39,14 +39,34 @@ function optionsFromFile(opts, file) {
 }
 
 assign(AssetsClient.prototype, {
+  /**
+   * Upload an asset
+   *
+   * @param  {String} assetType `image` or `file`
+   * @param  {File|Blob|Buffer|ReadableStream} body File to upload
+   * @param  {Object}  opts Options for the upload
+   * @param  {Boolean} opts.preserveFilename Whether or not to preserve the original filename (default: true)
+   * @param  {String}  opts.filename Filename for this file (optional)
+   * @param  {Number}  opts.timeout  Milliseconds to wait before timing the request out (default: 0)
+   * @param  {String}  opts.contentType Mime type of the file
+   * @param  {Array}   opts.extract Array of metadata parts to extract from image.
+   *                                 Possible values: `location`, `exif`, `image`, `palette`
+   * @return {Promise} Resolves with the created asset document
+   */
   upload(assetType, body, opts = {}) {
     validators.validateAssetType(assetType)
+
+    // If an empty array is given, explicitly set `none` to override API defaults
+    let meta = opts.extract || undefined
+    if (meta && !meta.length) {
+      meta = ['none']
+    }
 
     const dataset = validators.hasDataset(this.client.clientConfig)
     const assetEndpoint = assetType === 'image' ? 'images' : 'files'
     const options = optionsFromFile(opts, body)
-    const {id, label, filename, meta} = options
-    const query = {id, label, filename, meta}
+    const {label, filename} = options
+    const query = {label, filename, meta}
 
     const observable = this.client._requestObservable({
       method: 'POST',

--- a/packages/@sanity/client/src/data/encodeQueryString.js
+++ b/packages/@sanity/client/src/data/encodeQueryString.js
@@ -1,10 +1,9 @@
 const enc = encodeURIComponent
 
 module.exports = ({query, params = {}, options = {}}) => {
+  const base = `?query=${enc(query)}`
   const qString = Object.keys(params).reduce((qs, param) =>
-    `${qs}&${enc(`$${param}`)}=${enc(JSON.stringify(params[param]))}`,
-    `?query=${enc(query)}`
-  )
+    `${qs}&${enc(`$${param}`)}=${enc(JSON.stringify(params[param]))}`, base)
 
   return Object.keys(options).reduce((qs, option) => {
     // Only include the option if it is truthy

--- a/packages/@sanity/client/src/sanityClient.js
+++ b/packages/@sanity/client/src/sanityClient.js
@@ -78,8 +78,8 @@ assign(SanityClient.prototype, {
 
   request(options) {
     const observable = this._requestObservable(options)
-        .filter(event => event.type === 'response')
-        .map(event => event.body)
+      .filter(event => event.type === 'response')
+      .map(event => event.body)
 
     return this.isPromiseAPI()
       ? toPromise(observable)

--- a/packages/@sanity/client/test/client.test.js
+++ b/packages/@sanity/client/test/client.test.js
@@ -1106,6 +1106,38 @@ test('uploads images with given content type', t => {
     }, ifError(t))
 })
 
+test('uploads images with specified metadata to be extracted', t => {
+  const fixturePath = fixture('horsehead-nebula.jpg')
+  const isImage = body => bufferFrom(body, 'hex').compare(fs.readFileSync(fixturePath)) === 0
+
+  nock(projectHost())
+    .post('/v1/assets/images/foo?meta=palette&meta=location', isImage)
+    .reply(201, {document: {url: 'https://some.asset.url'}})
+
+  const options = {extract: ['palette', 'location']}
+  getClient().assets.upload('image', fs.createReadStream(fixturePath), options)
+    .then(document => {
+      t.equal(document.url, 'https://some.asset.url')
+      t.end()
+    }, ifError(t))
+})
+
+test('empty extract array sends `none` as metadata', t => {
+  const fixturePath = fixture('horsehead-nebula.jpg')
+  const isImage = body => bufferFrom(body, 'hex').compare(fs.readFileSync(fixturePath)) === 0
+
+  nock(projectHost())
+    .post('/v1/assets/images/foo?meta=none', isImage)
+    .reply(201, {document: {url: 'https://some.asset.url'}})
+
+  const options = {extract: []}
+  getClient().assets.upload('image', fs.createReadStream(fixturePath), options)
+    .then(document => {
+      t.equal(document.url, 'https://some.asset.url')
+      t.end()
+    }, ifError(t))
+})
+
 test('uploads images with progress events', t => {
   const fixturePath = fixture('horsehead-nebula.jpg')
   const isImage = body => bufferFrom(body, 'hex').compare(fs.readFileSync(fixturePath)) === 0


### PR DESCRIPTION
This PR allows specifying a `extract` option when uploading images that allows you to define what type of metadata to extract for the image.

Also fixed a bunch of code style issues after the latest eslint upgrade and removed a now disallowed option to specify the asset document ID.
