### PR TITLE
[base] Use span instead of div as wrapper element in PreviewSubscriber

### DIFF
--- a/packages/@sanity/base/src/preview/PreviewSubscriber.js
+++ b/packages/@sanity/base/src/preview/PreviewSubscriber.js
@@ -81,9 +81,9 @@ export default class PreviewSubscriber extends React.PureComponent {
     const {result, isLive, error} = this.state
     const {children: Child, ...props} = this.props
     return (
-      <div ref={this.setElement}>
+      <span ref={this.setElement}>
         <Child snapshot={result.snapshot} type={result.type} isLive={isLive} error={error} {...props} />
-      </div>
+      </span>
     )
   }
 }


### PR DESCRIPTION
Unfortunately, wrapping the PreviewSubscriber in a div ( #247) introduced a few UI bugs in a few places that we used it do display document fields inline, e.g:
![image](https://user-images.githubusercontent.com/876086/31428513-42a957b4-ae6b-11e7-951d-4e056b043380.png)

This fix it by wrapping it in a span instead.