### PR TITLE
[chore] CI: Symlink dependencies of newly created project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,5 @@ script:
   # Test initializing a project in unattended mode and building it
   - sanity init -y --project=ppsg7ml5 --dataset=test --output-path=/tmp/test-project
   - cd /tmp/test-project
+  - $TRAVIS_BUILD_DIR/scripts/symlinkDependencies.js .
   - $TRAVIS_BUILD_DIR/packages/@sanity/cli/bin/sanity build --skip-minify


### PR DESCRIPTION
When testing on travis, when initialize a new project, the latest _published_ dependencies are used, which isn't really testing the checked-in code. This PR uses the new `symlinkDependencies`-script in order to use the checked-in code instead.
