### PR TITLE
[cli] Add missing dependency: latest-version

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -46,6 +46,7 @@
     "git-user-info": "^1.0.1",
     "gitconfiglocal": "^2.0.1",
     "inquirer": "^2.0.0",
+    "latest-version": "^3.1.0",
     "leven": "^2.0.0",
     "lodash": "^4.17.4",
     "minimist": "^1.2.0",


### PR DESCRIPTION
This currently causes an error on `sanity init` so should be released immediately.