### PR TITLE
[default-layout] Close search on select and escape

### DIFF
--- a/packages/@sanity/default-layout/src/components/Search.js
+++ b/packages/@sanity/default-layout/src/components/Search.js
@@ -133,6 +133,9 @@ export default enhanceClickOutside(class Search extends React.Component {
     if (event.key === 'Backspace') {
       this.inputElement.focus()
     }
+    if (event.key === 'Escape') {
+      this.close()
+    }
     if (event.key === 'Enter') {
       this.listElement.querySelector(`[data-hit-index="${this.state.activeIndex}"]`).click()
     }
@@ -164,6 +167,10 @@ export default enhanceClickOutside(class Search extends React.Component {
   }
 
   handleClickOutside = el => {
+    this.close()
+  }
+
+  handleClick = el => {
     this.close()
   }
 
@@ -216,6 +223,7 @@ export default enhanceClickOutside(class Search extends React.Component {
         data-hit-index={index}
         onMouseDown={this.handleHitMouseDown}
         onMouseUp={this.handleHitMouseUp}
+        onClick={this.handleClick}
         tabIndex={-1}
       >
         <div className={styles.itemType}>{type.title}</div>

--- a/packages/@sanity/form-builder/src/sanity/SanityFormBuilder.js
+++ b/packages/@sanity/form-builder/src/sanity/SanityFormBuilder.js
@@ -28,6 +28,8 @@ export default function SanityFormBuilder(props: Props) {
         onChange={props.onChange}
         level={0}
         value={props.value}
+        isRoot
+        autoFocus
       />
     </SanityFormBuilderContext>
   )


### PR DESCRIPTION
This closes the search suggestions on Escape and when clicking an element. It also fixes a bug causing focus not being set on first field when editing document.