### PR TITLE
Feature: allow global logins with the default-login

### DIFF
--- a/packages/@sanity/default-login/README.md
+++ b/packages/@sanity/default-login/README.md
@@ -1,3 +1,25 @@
 # @sanity/default-login
 
 Lets the user log in to Sanity.
+
+
+## Props
+
+```
+static propTypes = {
+  children: PropTypes.node.isRequired,
+  title: PropTypes.string,
+  description: PropTypes.string,
+  sanityLogo: PropTypes.node,
+  showSanityLogo: PropTypes.bool
+}
+```
+
+```
+static defaultProps = {
+  title: 'Choose login provider',
+  description: null,
+  sanityLogo: null,
+  showSanityLogo: true
+}
+```

--- a/packages/@sanity/default-login/package.json
+++ b/packages/@sanity/default-login/package.json
@@ -19,7 +19,8 @@
     "prop-types": "^15.5.10"
   },
   "devDependencies": {
-    "@sanity/check": "^0.116.0",
+    "@sanity/check": "^0.115.2",
+    "babel-preset-env": "^1.6.0",
     "rimraf": "^2.6.1"
   },
   "repository": {

--- a/packages/@sanity/default-login/src/LoginDialog.js
+++ b/packages/@sanity/default-login/src/LoginDialog.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/no-multi-comp */
 import React from 'react'
+import PropTypes from 'prop-types'
 import authenticationFetcher from 'part:@sanity/base/authentication-fetcher'
 import client from 'part:@sanity/base/client'
 import cancelWrap from './cancelWrap'
@@ -28,6 +29,13 @@ const GoogleLogo = () => (
 /* eslint-enable max-len */
 
 export default class LoginDialog extends React.Component {
+  static propTypes = {
+    title: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired,
+    sanityLogo: PropTypes.node.isRequired,
+    showSanityLogo: PropTypes.bool.isRequired
+  };
+
   state = {
     providers: [],
     error: null
@@ -55,9 +63,11 @@ export default class LoginDialog extends React.Component {
     return (
       <div className={styles.root}>
 
-        <div className={styles.sanityStudioLogo}>
-          <SanityStudioLogo />
-        </div>
+        { this.props.showSanityLogo && (
+          <div className={styles.sanityStudioLogo}>
+            { this.props.sanityLogo ? this.props.sanityLogo : <SanityStudioLogo />}
+          </div>
+        )}
 
         <div className={styles.branding}>
           <h1 className={BrandLogo ? styles.projectNameHidden : styles.projectName}>{projectName}</h1>
@@ -67,9 +77,12 @@ export default class LoginDialog extends React.Component {
         </div>
 
         <div className={styles.inner}>
-          <h2 className={styles.headline}>
-            Choose login provider
+          <h2 className={styles.title}>
+            {this.props.title}
           </h2>
+          { this.props.description && (
+            <div className={styles.description}>{this.props.description}</div>
+          )}
           <ul className={styles.providers}>
             {this.state.providers.map(provider => {
               const onLoginClick = this.handleLoginButtonClicked.bind(this, provider)

--- a/packages/@sanity/default-login/src/LoginWrapper.js
+++ b/packages/@sanity/default-login/src/LoginWrapper.js
@@ -1,11 +1,15 @@
 import PropTypes from 'prop-types'
 import React from 'react'
+import client from 'part:@sanity/base/client'
 import userStore from 'part:@sanity/base/user'
 import LoginDialog from 'part:@sanity/base/login-dialog'
 import UnauthorizedUser from './UnauthorizedUser'
 import ErrorDialog from './ErrorDialog'
 import Spinner from 'part:@sanity/components/loading/spinner'
 import CookieTest from './CookieTest'
+
+const isProjectLogin = client.config().useProjectHostname
+
 export default class LoginWrapper extends React.PureComponent {
 
   static propTypes = {
@@ -50,7 +54,7 @@ export default class LoginWrapper extends React.PureComponent {
       )
     }
 
-    if (!user.role) {
+    if (isProjectLogin && !user.role) {
       return <UnauthorizedUser user={user} />
     }
 

--- a/packages/@sanity/default-login/src/LoginWrapper.js
+++ b/packages/@sanity/default-login/src/LoginWrapper.js
@@ -13,8 +13,19 @@ const isProjectLogin = client.config().useProjectHostname
 export default class LoginWrapper extends React.PureComponent {
 
   static propTypes = {
-    children: PropTypes.node.isRequired
+    children: PropTypes.node.isRequired,
+    title: PropTypes.string,
+    description: PropTypes.string,
+    sanityLogo: PropTypes.node,
+    showSanityLogo: PropTypes.bool
   }
+
+  static defaultProps = {
+    title: 'Choose login provider',
+    description: null,
+    sanityLogo: null,
+    showSanityLogo: true
+  };
 
   state = {isLoading: true, user: null, error: null}
 
@@ -49,7 +60,12 @@ export default class LoginWrapper extends React.PureComponent {
     if (!user) {
       return (
         <CookieTest>
-          <LoginDialog />
+          <LoginDialog
+            title={this.props.title}
+            description={this.props.description}
+            sanityLogo={this.props.sanityLogo}
+            showSanityLogo={this.props.showSanityLogo}
+          />
         </CookieTest>
       )
     }

--- a/packages/@sanity/default-login/src/styles/LoginDialog.css
+++ b/packages/@sanity/default-login/src/styles/LoginDialog.css
@@ -5,10 +5,16 @@
   text-align: center;
 }
 
-.headline {
+.title {
   text-align: center;
   font-weight: 100;
   text-transform: uppercase;
+}
+
+.description {
+  text-align: center;
+  font-size: var(--font-size-small);
+  color: var(--text-color);
 }
 
 .sanityStudioLogo {


### PR DESCRIPTION
This makes it possible to reuse the default-login plugin in other contexts which deals with global users (like the new manage-app).

Bonus: make it possible to ``npm link`` the module from the mono-repo (add missing dev-dependency ``babel-preset-env``) for development purposes.