### PR TITLE
[import] Do not overwrite `_type` on references

### DIFF
--- a/packages/@sanity/import/src/references.js
+++ b/packages/@sanity/import/src/references.js
@@ -36,7 +36,7 @@ function setTypeOnReferences(doc) {
   extractWithPath('..[_ref]', doc)
     .map(match => match.path.slice(0, -1))
     .map(path => ({path, ref: get(doc, path)}))
-    .filter(item => item.ref._type !== 'reference')
+    .filter(item => typeof item.ref._type === 'undefined')
     .forEach(item => {
       item.ref._type = 'reference'
     })


### PR DESCRIPTION
We don't want to overwrite `_type: "someCustomRefType"`, only set `_type: "reference"` on objects that are missing the property. This PR fixes that.