### PR TITLE
 [form-builder] Include deeper string fields in reference search

### DIFF
--- a/packages/test-studio/schemas/author.js
+++ b/packages/test-studio/schemas/author.js
@@ -32,6 +32,17 @@ export default {
           type: 'string'
         }
       ]
+    },
+    {
+      name: 'favoriteBooks',
+      title: 'Favorite books',
+      type: 'array',
+      of: [
+        {
+          type: 'reference',
+          to: {type: 'book'}
+        }
+      ]
     }
   ]
 }

--- a/packages/test-studio/schemas/references.js
+++ b/packages/test-studio/schemas/references.js
@@ -5,6 +5,11 @@ export default {
   description: 'Test cases for references',
   fields: [
     {name: 'title', type: 'string'},
-    {name: 'selfRef', type: 'reference', to: {type: 'referenceTest'}}
+    {name: 'selfRef', type: 'reference', to: {type: 'referenceTest'}},
+    {
+      name: 'refToTypeWithNoToplevelStrings',
+      type: 'reference',
+      to: {type: 'typeWithNoToplevelStrings'}
+    }
   ]
 }

--- a/packages/test-studio/schemas/schema.js
+++ b/packages/test-studio/schemas/schema.js
@@ -22,6 +22,7 @@ import slugs from './slugs'
 import geopoint from './geopoint'
 import customInputs from './customInputs'
 import notitle from './notitle'
+import typeWithNoToplevelStrings from './typeWithNoToplevelStrings'
 
 export default createSchema({
   name: 'test-examples',
@@ -48,6 +49,7 @@ export default createSchema({
     recursiveArray,
     myObject,
     codeInputType,
-    notitle
+    notitle,
+    typeWithNoToplevelStrings,
   ]
 })

--- a/packages/test-studio/schemas/typeWithNoToplevelStrings.js
+++ b/packages/test-studio/schemas/typeWithNoToplevelStrings.js
@@ -1,0 +1,25 @@
+export default {
+  name: 'typeWithNoToplevelStrings',
+  type: 'object',
+  title: 'Type without strings',
+  description: `This is an example of a type that has no meaningful top level strings.
+   It is used to test/demonstrate that reference search also includes deeper fields`,
+  fields: [
+    {
+      name: 'localizedTitle',
+      title: 'Localized title',
+      type: 'object',
+      fieldsets: [{name: 'other', title: 'Translations'}],
+      fields: [
+        {name: 'no', type: 'string', title: 'Norwegian (Bokmål)'},
+        {name: 'nn', type: 'string', title: 'Norwegian (Nynorsk)', fieldset: 'other'},
+        {name: 'se', type: 'string', title: 'Swedish', fieldset: 'other'}
+      ]
+    },
+    {
+      name: 'externalId',
+      title: 'External id',
+      type: 'string'
+    }
+  ]
+}


### PR DESCRIPTION
This is a bit of a dirty hack to ensure we target string fields at deeper levels when searching for references (currently, only root level string fields were included in search, causing weird behavior for e.g. localized strings, which are modelled as objects).