### PR TITLE
[base] Define schema type part for better plugin support

### DIFF
--- a/packages/@sanity/base/sanity.json
+++ b/packages/@sanity/base/sanity.json
@@ -224,6 +224,10 @@
       "name": "part:@sanity/base/app-loading-screen",
       "description": "Loading screen when sanity is initializing. Only static html and css. No javascript."
     },
+    {
+      "name": "part:@sanity/base/schema-type",
+      "description": "Schema types provided by plugins, for easy usage in studio schemas"
+    },
 
     {
       "implements": "part:@sanity/base/sanity-root",

--- a/packages/@sanity/cli/src/commands/init/templates/schema
+++ b/packages/@sanity/cli/src/commands/init/templates/schema
@@ -1,8 +1,9 @@
 import createSchema from 'part:@sanity/base/schema-creator'
+import schemaTypes from 'all:part:@sanity/base/schema-type'
 
 export default createSchema({
   name: 'example-blog',
-  types: [
+  types: schemaTypes.concat([
     {
       name: 'blogpost',
       type: 'object',
@@ -84,5 +85,5 @@ export default createSchema({
         }
       ]
     }
-  ]
+  ])
 })

--- a/packages/@sanity/cli/templates/clean/schemas/schema.js
+++ b/packages/@sanity/cli/templates/clean/schemas/schema.js
@@ -1,6 +1,7 @@
 const createSchema = require('part:@sanity/base/schema-creator')
+const schemaTypes = require('all:part:@sanity/base/schema-type')
 
 module.exports = createSchema({
   name: 'default',
-  types: [/* Your types here! */]
+  types: schemaTypes.concat([/* Your types here! */])
 })

--- a/packages/@sanity/cli/templates/moviedb/schemas/schema.js
+++ b/packages/@sanity/cli/templates/moviedb/schemas/schema.js
@@ -1,4 +1,5 @@
 import createSchema from 'part:@sanity/base/schema-creator'
+import schemaTypes from 'all:part:@sanity/base/schema-type'
 import blockContent from './blockContent'
 import crewMember from './crewMember'
 import castMember from './castMember'
@@ -8,5 +9,5 @@ import screening from './screening'
 
 export default createSchema({
   name: 'default',
-  types: [blockContent, castMember, crewMember, movie, person, screening]
+  types: schemaTypes.concat([blockContent, castMember, crewMember, movie, person, screening])
 })

--- a/packages/example-studio/schemas/schema.js
+++ b/packages/example-studio/schemas/schema.js
@@ -1,4 +1,5 @@
 import createSchema from 'part:@sanity/base/schema-creator'
+import schemaTypes from 'all:part:@sanity/base/schema-type'
 import code from 'part:@sanity/form-builder/input/code/schema'
 
 import author from './author'
@@ -12,7 +13,7 @@ import protein from '../components/ProteinInput/schema'
 
 export default createSchema({
   name: 'example-blog',
-  types: [
+  types: schemaTypes.concat([
     blogpost,
     author,
     code,
@@ -22,5 +23,5 @@ export default createSchema({
     videoEmbed,
     proteinTest,
     protein,
-  ]
+  ])
 })

--- a/packages/storybook/schema.js
+++ b/packages/storybook/schema.js
@@ -1,8 +1,9 @@
 import createSchema from 'part:@sanity/base/schema-creator'
+import schemaTypes from 'all:part:@sanity/base/schema-type'
 
 export default createSchema({
   name: 'example-blog',
-  types: [
+  types: schemaTypes.concat([
     {
       name: 'blogpost',
       type: 'object',
@@ -138,5 +139,5 @@ export default createSchema({
         }
       ]
     }
-  ]
+  ])
 })

--- a/packages/test-studio/config/@sanity/data-aspects.json
+++ b/packages/test-studio/config/@sanity/data-aspects.json
@@ -1,4 +1,4 @@
 {
-  "hiddenTypes": ["block", "span", "richDate", "mark", "link", "address", "code", "myObject"],
+  "hiddenTypes": ["block", "span", "richDate", "mark", "link", "address", "code", "myObject", "pertEstimate"],
   "listOptions": {}
 }

--- a/packages/test-studio/config/@sanity/data-aspects.json
+++ b/packages/test-studio/config/@sanity/data-aspects.json
@@ -1,4 +1,4 @@
 {
-  "hiddenTypes": ["block", "span", "richDate", "mark", "link", "address", "code", "myObject", "pertEstimate"],
+  "hiddenTypes": ["block", "span", "richDate", "mark", "link", "address", "code", "myObject"],
   "listOptions": {}
 }

--- a/packages/test-studio/sanity.json
+++ b/packages/test-studio/sanity.json
@@ -15,7 +15,6 @@
     "@sanity/rich-date-input",
     "@sanity/code-input",
     "@sanity/desk-tool",
-    "@sanity/storybook",
     "@sanity/google-maps-input",
     "vision"
   ],
@@ -27,6 +26,10 @@
     {
       "implements": "part:@sanity/base/brand-logo",
       "path": "src/components/BrandLogo.js"
+    },
+    {
+      "implements": "part:@sanity/base/schema-type",
+      "path": "src/components/PertEstimateSchema.js"
     }
   ]
 }

--- a/packages/test-studio/sanity.json
+++ b/packages/test-studio/sanity.json
@@ -15,6 +15,7 @@
     "@sanity/rich-date-input",
     "@sanity/code-input",
     "@sanity/desk-tool",
+    "@sanity/storybook",
     "@sanity/google-maps-input",
     "vision"
   ],

--- a/packages/test-studio/schemas/customInputs.js
+++ b/packages/test-studio/schemas/customInputs.js
@@ -1,7 +1,6 @@
 import CustomStringInput from '../src/components/CustomStringInput'
 import CustomMyObjectInput from '../src/components/CustomMyObjectInput'
 import CustomFontStringInput from '../src/components/CustomFontStringInput'
-import PertEstimateInput from '../src/components/PertEstimateInput'
 
 export default {
   name: 'customInputsTest',
@@ -33,8 +32,7 @@ export default {
     {
       name: 'taskEstimate',
       title: 'Task estimate',
-      type: 'pertEstimate',
-      inputComponent: PertEstimateInput
+      type: 'pertEstimate'
     }
   ]
 }

--- a/packages/test-studio/schemas/customInputs.js
+++ b/packages/test-studio/schemas/customInputs.js
@@ -1,6 +1,7 @@
 import CustomStringInput from '../src/components/CustomStringInput'
 import CustomMyObjectInput from '../src/components/CustomMyObjectInput'
 import CustomFontStringInput from '../src/components/CustomFontStringInput'
+import PertEstimateInput from '../src/components/PertEstimateInput'
 
 export default {
   name: 'customInputsTest',
@@ -28,6 +29,12 @@ export default {
       description: 'Custom input that has a bundled, custom font',
       type: 'string',
       inputComponent: CustomFontStringInput
+    },
+    {
+      name: 'taskEstimate',
+      title: 'Task estimate',
+      type: 'pertEstimate',
+      inputComponent: PertEstimateInput
     }
   ]
 }

--- a/packages/test-studio/schemas/schema.js
+++ b/packages/test-studio/schemas/schema.js
@@ -1,5 +1,6 @@
 import createSchema from 'part:@sanity/base/schema-creator'
 import codeInputType from 'part:@sanity/form-builder/input/code/schema'
+import schemaTypes from 'all:part:@sanity/base/schema-type'
 
 import book from './book'
 import author from './author'
@@ -30,7 +31,7 @@ import richDateType from 'part:@sanity/form-builder/input/rich-date/schema'
 
 export default createSchema({
   name: 'test-examples',
-  types: [
+  types: schemaTypes.concat([
     book,
     author,
     strings,
@@ -57,5 +58,5 @@ export default createSchema({
     codeInputType,
     notitle,
     typeWithNoToplevelStrings,
-  ]
+  ])
 })

--- a/packages/test-studio/src/components/PertEstimate.js
+++ b/packages/test-studio/src/components/PertEstimate.js
@@ -1,0 +1,2 @@
+export {default as Input} from './PertEstimateInput'
+export {default as schema} from './PertEstimateSchema'

--- a/packages/test-studio/src/components/PertEstimateInput.js
+++ b/packages/test-studio/src/components/PertEstimateInput.js
@@ -1,0 +1,63 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import PatchEvent, {set, unset, setIfMissing} from '@sanity/form-builder/PatchEvent'
+
+const calculateEstimate = estimates => {
+  const {optimistic, nominal, pessimistic} = estimates || {}
+  if (!optimistic || !nominal || !pessimistic) {
+    return {optimistic, nominal, pessimistic, calculated: null}
+  }
+
+  // µ = (O + (4 * N) + P) / 6
+  const calculated = Number(((optimistic + (4 * nominal) + pessimistic) / 6).toFixed(2))
+  return {optimistic, nominal, pessimistic, calculated}
+}
+
+export default class PertEstimateInput extends React.Component {
+  static propTypes = {
+    value: PropTypes.object,
+    type: PropTypes.object,
+    onChange: PropTypes.func
+  }
+
+  handleChange = (field, event) => {
+    const {type, onChange} = this.props
+    const value = Object.assign({}, this.props.value || {}, {[field.name]: event.target.valueAsNumber})
+    const {calculated} = calculateEstimate(value)
+
+    onChange(PatchEvent.from(
+      setIfMissing({_type: type.name}),
+      set(event.target.valueAsNumber, [field.name]),
+      calculated ? set(calculated, ['calculated']) : unset(['calculated'])
+    ))
+  }
+
+  render() {
+    const {value, type} = this.props
+    return (
+      <div>
+        <h3>{type.title}</h3>
+        <p>{type.description}</p>
+        <table>
+          <tbody>
+            {type.fields.filter(field => !field.type.readOnly).map(field => (
+              <tr key={field.name}>
+                <td>{field.type.title}</td>
+                <td>
+                  <input
+                    type="number"
+                    value={(value && value[field.name]) || ''}
+                    placeholder={type.placeholder}
+                    onChange={event => this.handleChange(field, event)}
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        {value && value.calculated && <p>PERT-estimate: {value.calculated}</p>}
+      </div>
+    )
+  }
+}

--- a/packages/test-studio/src/components/PertEstimateSchema.js
+++ b/packages/test-studio/src/components/PertEstimateSchema.js
@@ -1,0 +1,28 @@
+export default {
+  name: 'pertEstimate',
+  type: 'object',
+  title: 'PERT-estimate',
+  fields: [
+    {
+      title: 'Optimistic estimate',
+      name: 'optimistic',
+      type: 'number',
+    },
+    {
+      title: 'Nominal estimate',
+      name: 'nominal',
+      type: 'number'
+    },
+    {
+      title: 'Pessimistic estimate',
+      name: 'pessimistic',
+      type: 'number'
+    },
+    {
+      title: 'Pert estimate',
+      name: 'calculated',
+      type: 'number',
+      readOnly: true
+    }
+  ]
+}

--- a/packages/test-studio/src/components/PertEstimateSchema.js
+++ b/packages/test-studio/src/components/PertEstimateSchema.js
@@ -1,7 +1,10 @@
+import PertEstimateInput from './PertEstimateInput'
+
 export default {
   name: 'pertEstimate',
   type: 'object',
   title: 'PERT-estimate',
+  inputComponent: PertEstimateInput,
   fields: [
     {
       title: 'Optimistic estimate',


### PR DESCRIPTION
We talked about this briefly back in August, but I thought I would take an initial stab at it;

By having a designated schema type part that plugins can implement, you are able to import schema types without explicitly defining each and every one. By having it simple by an array, you can still do operations such as filtering or mapping to remove or customize certain types, and you can also choose not to use the part at all and stick with explicit imports.

What's lacking currently is some sort of neat way to hint that an input component can be used for the type, without hard-wiring it. I'd be interested in hearing if @bjoerge has any suggestions or ideas here.
