### PR TITLE
[desk-tool] Make desk tool handle edit intents without type

### DIFF
--- a/packages/@sanity/default-layout/src/components/NotFound.js
+++ b/packages/@sanity/default-layout/src/components/NotFound.js
@@ -1,10 +1,11 @@
 import React from 'react'
 import {StateLink} from 'part:@sanity/base/router'
 
-export default function NotFound() {
+export default function NotFound(props) {
   return (
     <div>
       <h2>Page not found</h2>
+      {props.children}
       <StateLink toIndex>Go to index</StateLink>
     </div>
   )

--- a/packages/@sanity/desk-tool/src/DeskTool.js
+++ b/packages/@sanity/desk-tool/src/DeskTool.js
@@ -1,13 +1,36 @@
 import React from 'react'
 import styles from './styles/DeskTool.css'
 import SchemaPaneResolver from './SchemaPaneResolver'
+import client from 'part:@sanity/base/client'
+import {withRouterHOC} from 'part:@sanity/base/router'
+import PropTypes from 'prop-types'
 
-export default class DeskTool extends React.Component {
+export default withRouterHOC(class DeskTool extends React.Component {
+  static propTypes = {
+    router: PropTypes.shape({
+      state: PropTypes.object
+    }).isRequired
+  }
+  componentDidMount() {
+    const {router} = this.props
+    const {selectedType, selectedDocumentId} = router.state
+    if (selectedDocumentId && selectedType === '*') {
+      client.fetch('*[_id == $id][0]{_type}', {id: selectedDocumentId}).then(res => res._type)
+        .then(type => router.navigate({...router.state, selectedType: type}))
+    }
+  }
+
   render() {
+    const {router} = this.props
+
+    if (router.state.selectedType === '*') {
+      return <div>Loading…</div>
+    }
+
     return (
       <div className={styles.deskTool}>
-        <SchemaPaneResolver />
+        <SchemaPaneResolver router={router} />
       </div>
     )
   }
-}
+})

--- a/packages/@sanity/desk-tool/src/DeskTool.js
+++ b/packages/@sanity/desk-tool/src/DeskTool.js
@@ -14,18 +14,18 @@ export default withRouterHOC(class DeskTool extends React.Component {
   componentDidMount() {
     const {router} = this.props
     const {selectedType, selectedDocumentId} = router.state
-    if (selectedDocumentId && selectedType === '*') {
-      client.fetch('*[_id == $id][0]{_type}', {id: selectedDocumentId}).then(res => res._type)
-        .then(type => router.navigate({...router.state, selectedType: type}))
+    if (selectedDocumentId && selectedType) {
+      client.fetch('*[_id == $id][0]._type', {id: selectedDocumentId})
+        .then(type => {
+          if (type !== selectedType) {
+            router.navigate({...router.state, selectedType: type})
+          }
+        })
     }
   }
 
   render() {
     const {router} = this.props
-
-    if (router.state.selectedType === '*') {
-      return <div>Loading…</div>
-    }
 
     return (
       <div className={styles.deskTool}>

--- a/packages/@sanity/desk-tool/src/SchemaPaneResolver.js
+++ b/packages/@sanity/desk-tool/src/SchemaPaneResolver.js
@@ -4,7 +4,6 @@ import React from 'react'
 import dataAspects from './utils/dataAspects'
 import schema from 'part:@sanity/base/schema'
 import styles from './styles/SchemaPaneResolver.css'
-import {withRouterHOC} from 'part:@sanity/base/router'
 
 import TypePane from './pane/TypePane'
 import DocumentsPane from './pane/DocumentsPane'
@@ -20,7 +19,7 @@ const TYPE_ITEMS = dataAspects.getInferredTypes().map(typeName => ({
   title: dataAspects.getDisplayName(typeName)
 }))
 
-export default withRouterHOC(class SchemaPaneResolver extends React.Component {
+export default class SchemaPaneResolver extends React.Component {
   static propTypes = {
     router: PropTypes.shape({
       state: PropTypes.object
@@ -149,4 +148,4 @@ export default withRouterHOC(class SchemaPaneResolver extends React.Component {
       </div>
     )
   }
-})
+}

--- a/packages/@sanity/desk-tool/src/index.js
+++ b/packages/@sanity/desk-tool/src/index.js
@@ -10,12 +10,12 @@ export default {
     ])
   ]),
   canHandleIntent(intentName, params) {
-    return (intentName === 'edit' && params.type && params.id)
+    return (intentName === 'edit' && params.id)
             || (intentName === 'create' && params.type)
   },
   getIntentState(intentName, params) {
     return {
-      selectedType: params.type,
+      selectedType: params.type || '*',
       action: 'edit',
       selectedDocumentId: params.id || UUID()
     }


### PR DESCRIPTION
This makes desk-tool handle intent links for edit documents without specifying a type. Useful for creating links to e.g. "edit a document" when you don't have the document type at hand.