### PR TITLE
[schema] Resolve search fields at schema parse time

### DIFF
--- a/packages/@sanity/schema/src/legacy/resolveSearchFields.js
+++ b/packages/@sanity/schema/src/legacy/resolveSearchFields.js
@@ -1,0 +1,35 @@
+const stringFieldsSymbol = Symbol('__cachedStringFields')
+
+function reduceType(type, reducer, accumulator, path = [], maxDepth = 10) {
+  if (maxDepth < 0) {
+    return accumulator
+  }
+  if (Array.isArray(type.fields)) {
+    return type.fields.reduce(
+      (acc, field, index) => reduceType(field.type, reducer, acc, path.concat(field.name), maxDepth - 1),
+      reducer(accumulator, type, path)
+    )
+  }
+  return reducer(accumulator, type, path)
+}
+
+function getCachedStringFieldPaths(type, maxDepth) {
+  if (!type[stringFieldsSymbol]) {
+    type[stringFieldsSymbol] = getStringFieldPaths(type, maxDepth)
+  }
+  return type[stringFieldsSymbol]
+}
+
+function getStringFieldPaths(type, maxDepth) {
+  const reducer = (accumulator, childType, path) =>
+    (childType.jsonType === 'string'
+      ? [...accumulator, path]
+      : accumulator
+    )
+
+  return reduceType(type, reducer, [], [], maxDepth)
+}
+
+export default function resolveSearchFields(type) {
+  return getCachedStringFieldPaths(type, 4).map(path => path.join('.'))
+}

--- a/packages/@sanity/schema/src/legacy/types/object.js
+++ b/packages/@sanity/schema/src/legacy/types/object.js
@@ -2,6 +2,7 @@ import {pick, keyBy, startCase} from 'lodash'
 import {lazyGetter} from './utils'
 import createPreviewGetter from '../preview/createPreviewGetter'
 import guessOrderingConfig from '../ordering/guessOrderingConfig'
+import resolveSearchFields from '../resolveSearchFields'
 
 const OVERRIDABLE_FIELDS = [
   'jsonType',
@@ -12,6 +13,7 @@ const OVERRIDABLE_FIELDS = [
   'readOnly',
   'hidden',
   'description',
+  '__unstable_searchFields',
   'options',
   'inputComponent'
 ]
@@ -57,6 +59,8 @@ export const ObjectType = {
 
     lazyGetter(parsed, 'preview', createPreviewGetter(subTypeDef))
 
+    lazyGetter(parsed, '__unstable_searchFields', () => resolveSearchFields(parsed), {enumerable: false})
+
     return subtype(parsed)
 
     function subtype(parent) {
@@ -72,6 +76,7 @@ export const ObjectType = {
             title: extensionDef.title || subTypeDef.title,
             type: parent
           })
+          lazyGetter(current, '__unstable_searchFields', () => parent.__unstable_searchFields)
           return subtype(current)
         }
       }

--- a/packages/@sanity/schema/src/legacy/types/utils.js
+++ b/packages/@sanity/schema/src/legacy/types/utils.js
@@ -1,7 +1,7 @@
-export function lazyGetter(target, key, getter) {
+export function lazyGetter(target, key, getter, config = {}) {
   Object.defineProperty(target, key, {
     configurable: true,
-    enumerable: true,
+    enumerable: config.enumerable !== false,
     get() {
       const val = getter()
       Object.defineProperty(target, key, {
@@ -14,6 +14,7 @@ export function lazyGetter(target, key, getter) {
   })
   return target
 }
+
 //
 // const o = lazyGetter({}, 'expensive', function() {
 //   console.log('doing expensive calculations')


### PR DESCRIPTION
The previous workaround for targeting string fields at deeper levels than root (#279) was implemented for reference search only. This moves the traversal to look for string fields on an object type to the `@sanity/schema` and exposes the field paths on `type. __unstable_searchFields`, so that the list of fields can be shared between the reference search and the global studio search. We may consider standardizing the search config in the future, but I think its a good idea to keep it "hidden" for now.