### PR TITLE
[desk-tool] Keep info about type mismatch, and do type mismatch check…

### DIFF
--- a/packages/@sanity/desk-tool/src/pane/Editor.js
+++ b/packages/@sanity/desk-tool/src/pane/Editor.js
@@ -187,6 +187,16 @@ export default withRouterHOC(class Editor extends React.PureComponent {
     })
   }
 
+  handleEditAsActualType = () => {
+    const {router, draft, published} = this.props
+    const actualTypeName = (draft._type || published._type)
+    router.navigate({
+      ...router.state,
+      selectedType: actualTypeName,
+      action: 'edit'
+    })
+  }
+
   handleChange = changeEvent => {
     const {onChange} = this.props
     onChange(changeEvent)
@@ -383,6 +393,9 @@ export default withRouterHOC(class Editor extends React.PureComponent {
       return (
         <div className={styles.typeMisMatchMessage}>
           This document is of type <code>{value._type}</code> and cannot be edited as <code>{type.name}</code>
+          <div>
+            <Button onClick={this.handleEditAsActualType}>Edit as {value._type} instead</Button>
+          </div>
         </div>
       )
     }


### PR DESCRIPTION
In the previous version we did automatic redirect whenever a document was attempted to be edited as a wrong type. This patch restores the original warning so the user is made aware of it, but instead adds a button that leads to the page for editing as correct type.

It also does the type mismatch check on componentWillReceiveProps. Which is needed in order to support intent links without type (for now). The type mismatch check will only trigger if type is `*` (which I've tend to think of as "infer").