### PR TITLE
[webpack-integration] Resolve symlinks, cache imports

### DIFF
--- a/packages/@sanity/webpack-integration/package.json
+++ b/packages/@sanity/webpack-integration/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@sanity/webpack-integration",
   "version": "0.118.4",
-  "description": "Tools and modules required for making partisan (the part system) work with webpack",
+  "description":
+    "Tools and modules required for making partisan (the part system) work with webpack",
   "main": "src/v1/index.js",
   "scripts": {
     "test": "eslint ."
@@ -28,7 +29,9 @@
   "dependencies": {
     "@sanity/resolver": "^0.118.4",
     "@sanity/webpack-loader": "^0.118.4",
+    "fs.realpath": "^1.0.0",
     "lost": "^8.0.0",
+    "p-async-cache": "^1.0.2",
     "postcss-cssnext": "^3.0.2",
     "postcss-import": "^11.0.0",
     "resolve": "^1.3.3"

--- a/packages/@sanity/webpack-integration/src/v3/resolveStyleImport.js
+++ b/packages/@sanity/webpack-integration/src/v3/resolveStyleImport.js
@@ -1,33 +1,86 @@
-const resolveParts = require('@sanity/resolver').resolveParts
+const rp = require('fs.realpath')
+const PAC = require('p-async-cache')
 const resolveNodeModule = require('resolve')
+const resolveParts = require('@sanity/resolver').resolveParts
 
-function resolveStyleImport(moduleId, opts) {
-  const id = moduleId.replace(/^\.\/(part|all:)/, '$1')
-  if (!isSanityPart(id)) {
-    return resolveNodeModule.sync(id, opts)
-  }
+const partsCache = new PAC({
+  load: resolvePartsForPath,
+  maxAge: 1000
+})
 
-  const parts = resolveParts({basePath: opts.root, sync: true})
-  const loadAll = id.indexOf('all:') === 0
-  const partName = loadAll ? id.substr(4) : id
+const sanityCache = new PAC({
+  load: resolveSanityImport,
+  maxAge: 1000
+})
 
-  const part = parts.implementations[partName]
-  if (!part) {
-    throw new Error(`No implementers of part '${partName}'`)
-  }
+const nodeCache = new PAC({
+  load: resolveNodeImport,
+  maxAge: 1000
+})
 
-  const paths = part.map(implementer => implementer.path)
-  return loadAll
-    ? paths.reverse()
-    : paths[0]
+function resolvePartsForPath(basePath) {
+  return resolveParts({basePath})
+}
+
+function resolveNodeImport(moduleId, basedir) {
+  return resolveModule(moduleId, {basedir})
+}
+
+function resolveSanityImport(id, basePath) {
+  return partsCache.get(basePath).then(cached => {
+    const parts = cached.value
+    const loadAll = id.indexOf('all:') === 0
+    const partName = loadAll ? id.substr(4) : id
+
+    const part = parts.implementations[partName]
+    if (!part) {
+      throw new Error(`No implementers of part '${partName}'`)
+    }
+
+    const paths = part.map(implementer => realPath(implementer.path))
+    return loadAll ? Promise.all(paths.reverse()) : paths[0]
+  })
 }
 
 function isSanityPart(part) {
   return /^(all:)?part:[@A-Za-z0-9_-]+\/[A-Za-z0-9_/-]+/.test(part)
 }
 
-module.exports = function getStyleResolver(opts) {
-  return function resolveStyleProxy(moduleId, basedir, styleOptions) {
-    return resolveStyleImport(moduleId, Object.assign({root: opts.from, basedir}, styleOptions))
+function resolveModule(id, opts) {
+  return new Promise((resolve, reject) => {
+    resolveNodeModule(id, opts, (err, res) => {
+      if (err) {
+        reject(err)
+        return
+      }
+
+      resolve(res)
+    })
+  })
+}
+
+function realPath(path) {
+  return new Promise((resolve, reject) => {
+    rp.realpath(path, (err, real) => {
+      if (err) {
+        reject(err)
+        return
+      }
+
+      resolve(real)
+    })
+  })
+}
+
+function getStyleResolver(opts) {
+  return function resolveStyleProxy(moduleId, basedir) {
+    const id = moduleId.replace(/^\.\/(part|all:)/, '$1')
+    const resolveStyleImport = isSanityPart(id)
+      ? sanityCache.get(id, opts.from)
+      : nodeCache.get(id, basedir)
+
+    return resolveStyleImport.then(res => res.value)
   }
 }
+
+module.exports = getStyleResolver


### PR DESCRIPTION
When changing files that are imported through CSS which point to symlinks, webpack doesn't pick up the changes. This change resolves the symlinks before returning the path, which fixes that issue. It introduces a new penalty however, so I've added a cache with a short TTL that should prevent it from hammering the filesystem for the same file. Hopefully we'll find a way to invalidate and prime the cache on each compilation instead of doing this ad-hoc.
