### PR TITLE
[test-studio] Proof of concept bundle analyzer tool

### DIFF
--- a/packages/@sanity/server/package.json
+++ b/packages/@sanity/server/package.json
@@ -66,6 +66,7 @@
   "devDependencies": {
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
+    "webpack-bundle-analyzer": "^2.9.0",
     "cross-env": "^5.0.5",
     "prop-types": "^15.6.0",
     "react": "^15.6.1",

--- a/packages/@sanity/server/src/configs/webpack.config.dev.js
+++ b/packages/@sanity/server/src/configs/webpack.config.dev.js
@@ -1,6 +1,8 @@
 import webpack from 'webpack'
 import getBaseConfig from './webpack.config'
 import applyStaticLoaderFix from '../util/applyStaticLoaderFix'
+import path from 'path'
+import {BundleAnalyzerPlugin} from 'webpack-bundle-analyzer'
 
 export default config => {
   const baseConfig = getBaseConfig(config)
@@ -21,7 +23,14 @@ export default config => {
     },
     plugins: (baseConfig.plugins || []).concat([
       new webpack.HotModuleReplacementPlugin(),
-      new webpack.NoEmitOnErrorsPlugin()
+      new webpack.NoEmitOnErrorsPlugin(),
+      new BundleAnalyzerPlugin(
+        {
+          analyzerMode: 'static',
+          reportFilename: path.join(process.cwd(), 'static/bundle-analyzer-report.html'),
+          openAnalyzer: false
+        }
+      )
     ]),
     module: Object.assign({}, baseConfig.module, {
       rules: applyStaticLoaderFix(baseConfig, config)

--- a/packages/test-studio/.gitignore
+++ b/packages/test-studio/.gitignore
@@ -10,3 +10,5 @@ node_modules
 
 # Built assets
 dist
+
+static/bundle-analyzer-report.html

--- a/packages/test-studio/plugins/bundle-report/index.js
+++ b/packages/test-studio/plugins/bundle-report/index.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import PieChart from 'react-icons/lib/fa/pie-chart'
+
+const IFRAME_STYLE = {
+  border: 0,
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: '100%',
+  height: '100%',
+  display: 'block',
+  boxSizing: 'border-box'
+
+}
+export default {
+  name: 'bundle',
+  title: 'Bundle analyzer',
+  icon: PieChart,
+  component() {
+    return <iframe src="/static/bundle-analyzer-report.html" style={IFRAME_STYLE} />
+  }
+}

--- a/packages/test-studio/sanity.json
+++ b/packages/test-studio/sanity.json
@@ -25,6 +25,10 @@
       "path": "./schemas/schema.js"
     },
     {
+      "implements": "part:@sanity/base/tool",
+      "path": "./plugins/bundle-report"
+    },
+    {
       "implements": "part:@sanity/base/brand-logo",
       "path": "src/components/BrandLogo.js"
     }


### PR DESCRIPTION
It would be super cool if we had easy access to bundle size stats during development, so I made this proof of concept tool that displays webpack-bundle-analyzer output.

Issues:
- This adds the bundle analyzer plugin to all studios in dev. Its likely to inflict a performance penalty on studio startup time.
- Puts the generated bundle analyzer report in every studio's static folder.
- No gzip/minified sizes, so it doesn't give a very accurate picture of how the production bundle will be.

Possible ideas to explore:
- Introduce a flag to `sanity start` that enables the plugin and adds the tool to the studio?
- Provide a way to for a tool to somehow declare that it requires this plugin?

![image](https://user-images.githubusercontent.com/876086/32315245-b2e02318-bfab-11e7-92b5-1f44586d3256.png)
