### PR TITLE
[chore] Bump minimum node version requirement to >= v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - '4'
   - '6'
   - '8'
 cache: yarn

--- a/packages/@sanity/cli/bin/sanity.js
+++ b/packages/@sanity/cli/bin/sanity.js
@@ -12,8 +12,8 @@
 
 var nodeVersion = Number(process.version.replace(/^v/i, '').split('.', 2)[0])
 
-if (nodeVersion < 4) {
-  console.error('ERROR: Node.js version 4 or higher required. You are running ' + process.version)
+if (nodeVersion < 6) {
+  console.error('ERROR: Node.js version 6 or higher required. You are running ' + process.version)
   process.exit(1)
 } else {
   require('../lib/cli')()

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -15,7 +15,7 @@
     "posttest": "eslint ."
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=6.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/core/package.json
+++ b/packages/@sanity/core/package.json
@@ -10,6 +10,9 @@
     "test": "mocha --recursive test/**/*.test.js",
     "posttest": "eslint ."
   },
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "keywords": [
     "sanity",
     "cms",

--- a/packages/@sanity/import-cli/package.json
+++ b/packages/@sanity/import-cli/package.json
@@ -7,7 +7,7 @@
     "sanity-import": "./lib/sanity-import.js"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=6.0.0"
   },
   "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",


### PR DESCRIPTION
We are starting to run into several dependencies which are no longer supporting node 4. This is getting quite tedious, and even though Node 4 is still in LTS for another 6 months, we feel we can justify the bump because this is developer tooling that will run locally, not on servers which might be hard to upgrade.
