### PR TITLE
[form-builder] Add a separate part for patch-event

### DIFF
--- a/packages/@sanity/form-builder/sanity.json
+++ b/packages/@sanity/form-builder/sanity.json
@@ -74,6 +74,10 @@
     {
       "implements": "part:@sanity/form-builder",
       "path": "sanity/index.js"
+    },
+    {
+      "name": "part:@sanity/form-builder/patch-event",
+      "path": "PatchEvent.js"
     }
   ]
 }

--- a/packages/example-studio/components/CustomObjectInput.js
+++ b/packages/example-studio/components/CustomObjectInput.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import FormField from 'part:@sanity/components/formfields/default'
-import {setIfMissing} from '@sanity/form-builder/PatchEvent'
+import {setIfMissing} from 'part:@sanity/form-builder/patch-event'
 import {FormBuilderInput} from 'part:@sanity/form-builder'
 
 export default class CustomObjectInput extends React.PureComponent {

--- a/packages/example-studio/components/Slider/Slider.js
+++ b/packages/example-studio/components/Slider/Slider.js
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import FormField from 'part:@sanity/components/formfields/default'
-import PatchEvent, {set, unset} from '@sanity/form-builder/PatchEvent'
+import PatchEvent, {set, unset} from 'part:@sanity/form-builder/patch-event'
+
 import styles from './Slider.css'
 
 export default class Slider extends React.Component {

--- a/packages/example-studio/components/VideoEmbedInput/VideoEmbedInput.js
+++ b/packages/example-studio/components/VideoEmbedInput/VideoEmbedInput.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import FormField from 'part:@sanity/components/formfields/default'
-import PatchEvent, {set, unset} from '@sanity/form-builder/PatchEvent'
+import PatchEvent, {set, unset} from 'part:@sanity/form-builder/patch-event'
 import Preview from 'part:@sanity/base/preview'
 import styles from './VideoEmbedInput.css'
 import getVideoId from 'get-video-id'

--- a/packages/example-studio/schemas/author.js
+++ b/packages/example-studio/schemas/author.js
@@ -2,7 +2,7 @@ import AuthorPreview from '../parts/AuthorPreview'
 
 export default {
   name: 'author',
-  type: 'object',
+  type: 'document',
   title: 'Author',
   preview: {
     select: {

--- a/packages/example-studio/schemas/blogpost.js
+++ b/packages/example-studio/schemas/blogpost.js
@@ -12,7 +12,7 @@ const LANGUAGE_PRIORITY = ['nb', 'nn', 'en']
 
 export default {
   name: 'blogpost',
-  type: 'object',
+  type: 'document',
   title: 'Blogpost',
   preview: {
     select: {
@@ -45,16 +45,13 @@ export default {
     {
       name: 'publishAt',
       title: 'Publish at',
-      type: 'richDate',
+      type: 'datetime',
       description: 'Blogpost goes live at this date/time',
       options: {
         dateFormat: 'YYYY-MM-DD',
         timeFormat: 'HH:mm',
         timeStep: 60,
-        calendarTodayLabel: 'Today',
-        inputUtc: false,
-        inputDate: true,
-        inputTime: true
+        calendarTodayLabel: 'Today'
       }
     },
     {

--- a/packages/example-studio/schemas/customObject.js
+++ b/packages/example-studio/schemas/customObject.js
@@ -1,7 +1,7 @@
 import CustomObjectInput from '../components/CustomObjectInput'
 
 export default {
-  type: 'object',
+  type: 'document',
   name: 'customObject',
   title: 'Custom object',
   fields: [

--- a/packages/example-studio/schemas/localeString.js
+++ b/packages/example-studio/schemas/localeString.js
@@ -3,9 +3,7 @@ import {SUPPORTED_LANGUAGES} from './languages'
 export default {
   type: 'object',
   name: 'localeString',
-  fieldsets: [
-    {name: 'translations', title: 'Translations', options: {collapsable: true}}
-  ],
+  fieldsets: [{name: 'translations', title: 'Translations', options: {collapsable: true}}],
   fields: SUPPORTED_LANGUAGES.map(lang => (
     {
       name: lang.id,

--- a/packages/example-studio/schemas/protein.js
+++ b/packages/example-studio/schemas/protein.js
@@ -1,9 +1,16 @@
 import ProteinInput from '../components/ProteinInput/ProteinInput'
 
+// todo
+const XYZ = ['v0', 'v1', 'v2'].map(n => ({
+  name: n,
+  title: n.toUpperCase(),
+  type: 'number'
+}))
+
 export default {
   name: 'protein',
   title: 'Protein',
-  type: 'object',
+  type: 'document',
   inputComponent: ProteinInput,
   fields: [
     {
@@ -18,15 +25,18 @@ export default {
       fields: [
         {
           name: 'rotation',
-          type: 'object'
+          type: 'object',
+          fields: XYZ
         },
         {
           name: 'center',
-          type: 'object'
+          type: 'object',
+          fields: XYZ
         },
         {
           name: 'zoom',
-          type: 'object'
+          type: 'object',
+          fields: XYZ
         }
       ]
     }


### PR DESCRIPTION
This adds a separate part for patch-events, so that you can do:
```
import PatchEvent, {set, unset} from 'part:@sanity/form-builder/patch-event'
```

Also updates example-studio