### PR TITLE
[core] Improve minification error messages

### DIFF
--- a/packages/@sanity/core/src/actions/build/compressJavascript.js
+++ b/packages/@sanity/core/src/actions/build/compressJavascript.js
@@ -3,18 +3,48 @@ import UglifyJS from 'uglify-js'
 
 export default async inputFile => {
   const content = await fse.readFile(inputFile, 'utf8')
-  const minified = await minify(content)
+  const minified = await minify(content, inputFile)
   await fse.outputFile(inputFile, minified)
 }
 
-function minify(content) {
+function minify(content, fileName) {
   return new Promise((resolve, reject) => {
     const result = UglifyJS.minify(content)
 
     if (result.error) {
-      reject(result.error)
+      reject(formatError(result.error, fileName, content))
     } else {
       resolve(result.code)
     }
   })
+}
+
+function formatError(err, fileName, content) {
+  let msg = `Parse error at ${fileName}:${err.line},${err.col}`
+
+  const limit = 70
+  const lines = content.split(/\r?\n/)
+  let col = err.col
+  let line = lines[err.line - 1]
+
+  if (!line && !col) {
+    line = lines[err.line - 2]
+    col = line.length
+  }
+
+  if (line) {
+    if (col > limit) {
+      line = line.slice(col - limit)
+      col = limit
+    }
+
+    msg += '\n\n'
+    msg += line.slice(0, 80)
+    msg += '\n'
+    msg += line.slice(0, col).replace(/\S/g, ' ')
+    msg += '^'
+  }
+
+  err.message = msg
+  return err
 }


### PR DESCRIPTION
Previously:
```
espenh@plumm ~/webdev/some-studio $ sanity build
✔ Clearing output folder (161ms)
✔ Building Sanity (40934ms)
✔ Building index document (1360ms)
✖ Minifying Javascript bundles
Unexpected token keyword «function», expected punc «,»
```

With this PR:
```
espenh@plumm ~/webdev/some-studio $ sanity build
✔ Clearing output folder (221ms)
✔ Building Sanity (33110ms)
✔ Building index document (451ms)
✖ Minifying Javascript bundles
Parse error at /home/espenh/webdev/some-studio/dist/static/js/app.bundle.js:225035,17

    value: async function fetchData() {
                 ^
```