### PR TITLE
[cli] Filter yarn output

### DIFF
--- a/packages/@sanity/cli/src/actions/yarn/yarnWithProgress.js
+++ b/packages/@sanity/cli/src/actions/yarn/yarnWithProgress.js
@@ -11,6 +11,13 @@ import {noop, padEnd, throttle} from 'lodash'
 const useProgress = (process.stderr && process.stderr.isTTY) && !process.env.CI
 const binDir = path.join(__dirname, '..', '..', '..', 'vendor')
 const yarnPath = require.resolve(path.join(binDir, 'yarn'))
+const parseJson = data => {
+  try {
+    return JSON.parse(data)
+  } catch (err) {
+    return undefined
+  }
+}
 
 export default function yarnWithProgress(args, options = {}) {
   /* eslint-disable no-console */
@@ -47,7 +54,7 @@ export default function yarnWithProgress(args, options = {}) {
 
   [proc.stdout, proc.stderr].forEach(stream => {
     stream
-      .pipe(split2(JSON.parse))
+      .pipe(split2(parseJson))
       .on('data', onChunk)
       .on('error', onNativeError)
   })


### PR DESCRIPTION
This fixes #301 - when encountering non-JSON output from yarn, skip it.
It also adds some logic to prevent duplicate steps from appearing in the output, which is often the case with the `Linking dependencies`-step.