### PR TITLE
[form-builder] Respect editModal schema option on Block Editor

### DIFF
--- a/packages/@sanity/components/src/edititem/PopOver.js
+++ b/packages/@sanity/components/src/edititem/PopOver.js
@@ -183,6 +183,7 @@ export default class EditItemPopOver extends React.Component {
           isOpen={isOpen}
           scrollContainer={scrollContainer}
           onResize={this.handlePortalResize}
+          stickToTop
         >
           <div
             ref={this.setPopoverInnerElement}

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/FormBuilderBlock.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/FormBuilderBlock.js
@@ -255,7 +255,7 @@ export default class FormBuilderBlock extends React.Component {
     const value = this.getValue()
     const memberType = this.getMemberTypeOf(value)
 
-    const fieldsQty = (get(memberType, 'fields') || []).length
+    const fieldsQty = ((memberType && memberType.fields) || []).length
 
     let editModalLayout = get(this, 'props.type.options.editModal')
 

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/styles/FormBuilderBlock.css
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/styles/FormBuilderBlock.css
@@ -39,8 +39,16 @@
   background-color: var(--form-builder-block-background-selected);
 }
 
-.editBlockContainer {
+.editBlockContainerPopOver {
   position: absolute;
   top: 50%;
   left: 25%;
+}
+
+.editBlockContainerFold {
+  position: absolute;
+  left: 0;
+  top: 50%;
+  height: 1px;
+  width: 100%;
 }


### PR DESCRIPTION
Respect editModal option in schema options (like on array), and choose proper edit modal when not set, based on number of fields in the type.