### PR TITLE
[client] Deprecate asset delete method

### DIFF
--- a/packages/@sanity/client/README.md
+++ b/packages/@sanity/client/README.md
@@ -329,12 +329,14 @@ client.assets.upload('image', someFile, {extract: ['palette', 'location']})
 
 ### Deleting an asset
 
+Deleting an asset document will also trigger deletion of the actual asset.
+
 ```
-client.assets.delete(type: 'image' | 'file', id: string): Promise
+client.delete(id: string): Promise
 ```
 
 ```js
-client.assets.delete('image', '1a2b3c')
+client.delete('image-abc123_someAssetId-500x500-png')
   .then(result => {
     console.log('deleted imageAsset', result)
   })

--- a/packages/@sanity/client/src/assets/assetsClient.js
+++ b/packages/@sanity/client/src/assets/assetsClient.js
@@ -83,24 +83,19 @@ assign(AssetsClient.prototype, {
   },
 
   delete(type, id) {
-    let assetType = type
-    let docId = id
+    // eslint-disable-next-line no-console
+    console.warn('client.assets.delete() is deprecated, please use client.delete(<document-id>)')
 
-    // We could be passing an entire asset document instead of an ID
-    if (type._type) {
-      assetType = type._type.replace(/(^sanity\.|Asset$)/g, '')
+    let docId = id || ''
+    if (!/^(image|file)-/.test(docId)) {
+      docId = `${type}-${docId}`
+    } else if (type._id) {
+      // We could be passing an entire asset document instead of an ID
       docId = type._id
     }
 
-    const dataset = validators.hasDataset(this.client.clientConfig)
-    validators.validateAssetType(assetType)
-    validators.validateDocumentId('delete', docId)
-
-    const assetEndpoint = assetType === 'image' ? 'images' : 'files'
-    return this.client.request({
-      method: 'DELETE',
-      uri: `/assets/${assetEndpoint}/${dataset}/${docId}`
-    })
+    validators.hasDataset(this.client.clientConfig)
+    return this.client.delete(docId)
   },
 
   getImageUrl(ref, query) {
@@ -111,7 +106,7 @@ assign(AssetsClient.prototype, {
       )
     }
 
-    if (!/^image-[A-Za-z0-9]+-\d+x\d+-[a-z]{1,5}$/.test(id)) {
+    if (!/^image-[A-Za-z0-9_]+-\d+x\d+-[a-z]{1,5}$/.test(id)) {
       throw new Error(
         `Unsupported asset ID "${id}". URL generation only works for auto-generated IDs.`
       )

--- a/packages/@sanity/client/test/client.test.js
+++ b/packages/@sanity/client/test/client.test.js
@@ -1231,22 +1231,31 @@ test('uploads images and can cast to promise', t => {
 })
 
 test('delete assets', t => {
-  nock(projectHost()).delete('/v1/assets/images/foo/image.abc123').reply(200, {some: 'prop'})
+  const expectedBody = {mutations: [{delete: {id: 'image-abc123_foobar-123x123-png'}}]}
+  nock(projectHost())
+    .post('/v1/data/mutate/foo?returnIds=true&returnDocuments=true&visibility=sync', expectedBody)
+    .reply(200, {transactionId: 'abc123', results: [{id: 'abc123', operation: 'delete'}]})
 
-  getClient().assets.delete('image', 'image.abc123').then(body => {
-    t.equal(body.some, 'prop')
-    t.end()
-  }, ifError(t))
+  getClient().assets.delete('image', 'image-abc123_foobar-123x123-png').catch(t.ifError).then(() => t.end())
+})
+
+test('delete assets with prefix', t => {
+  const expectedBody = {mutations: [{delete: {id: 'image-abc123_foobar-123x123-png'}}]}
+  nock(projectHost())
+    .post('/v1/data/mutate/foo?returnIds=true&returnDocuments=true&visibility=sync', expectedBody)
+    .reply(200, {transactionId: 'abc123', results: [{id: 'abc123', operation: 'delete'}]})
+
+  getClient().assets.delete('image', 'abc123_foobar-123x123-png').catch(t.ifError).then(() => t.end())
 })
 
 test('delete assets given whole asset document', t => {
-  nock(projectHost()).delete('/v1/assets/images/foo/moo987').reply(200, {some: 'prop'})
+  const expectedBody = {mutations: [{delete: {id: 'image-abc123_foobar-123x123-png'}}]}
+  nock(projectHost())
+    .post('/v1/data/mutate/foo?returnIds=true&returnDocuments=true&visibility=sync', expectedBody)
+    .reply(200, {transactionId: 'abc123', results: [{id: 'abc123', operation: 'delete'}]})
 
-  const doc = {_id: 'moo987', _type: 'sanity.imageAsset'}
-  getClient().assets.delete(doc).then(body => {
-    t.equal(body.some, 'prop')
-    t.end()
-  }, ifError(t))
+  const doc = {_id: 'image-abc123_foobar-123x123-png', _type: 'sanity.imageAsset'}
+  getClient().assets.delete(doc, 'image-abc123_foobar-123x123-png').catch(t.ifError).then(() => t.end())
 })
 
 test('can get an image URL from a reference ID string', t => {


### PR DESCRIPTION
The `client.assets.delete()` method should no longer be used, as the operation is now handled by deleting the associated asset document.

This PR deprecates the method - we'll remove the method entirely in an upcoming release.
