### PR TITLE
[core] Use PATCH-endpoint for setting studio host

### DIFF
--- a/packages/@sanity/core/src/actions/deploy/deployAction.js
+++ b/packages/@sanity/core/src/actions/deploy/deployAction.js
@@ -107,16 +107,16 @@ async function checkDir(sourceDir) {
 
 function validateHostname(value, client) {
   const projectId = client.config().projectId
-  const uri = `/projects/${projectId}/host`
-  const host = value || ''
+  const uri = `/projects/${projectId}`
+  const studioHost = value || ''
 
   // Check that it matches allowed character range
-  if (!/^[a-z0-9_-]+$/i.test(host)) {
+  if (!/^[a-z0-9_-]+$/i.test(studioHost)) {
     return 'Hostname can contain only A-Z, 0-9, _ and -'
   }
 
   // Check that the hostname is not already taken
-  return client.request({uri, method: 'PUT', body: {studio: host}})
+  return client.request({uri, method: 'PATCH', body: {studioHost}})
     .then(() => true)
     .catch(() => 'Hostname already taken')
 }


### PR DESCRIPTION
The `/projects/<projectId>/host` endpoint is deprecated and will be removed in the future.
This PR changes to use the `PATCH` endpoint.