### PR TITLE
[block-tools] Fix bug when annotations were converted to a Slate state 

### DIFF
--- a/packages/@sanity/block-tools/src/converters/blocksToSlateState.js
+++ b/packages/@sanity/block-tools/src/converters/blocksToSlateState.js
@@ -69,7 +69,7 @@ function sanitySpanToRawSlateBlockNode(span, sanityBlock) {
 
 function sanityBlockToRawNode(sanityBlock, type) {
   // eslint-disable-next-line no-unused-vars
-  const {children, _type, ...rest} = sanityBlock
+  const {children, _type, markDefs, ...rest} = sanityBlock
 
   const restData = hasKeys(rest) ? {data: {_type, ...rest}} : {}
 

--- a/packages/@sanity/block-tools/test/tests/converters/blocksToSlateState/decorators/index.js
+++ b/packages/@sanity/block-tools/test/tests/converters/blocksToSlateState/decorators/index.js
@@ -1,0 +1,9 @@
+import defaultSchema from '../../../../fixtures/defaultSchema'
+
+const blockContentType = defaultSchema.get('blogPost')
+  .fields.find(field => field.name === 'body').type
+
+
+export default (blockToSlateState, input) => {
+  return blockToSlateState(input, blockContentType)
+}

--- a/packages/@sanity/block-tools/test/tests/converters/blocksToSlateState/decorators/input.json
+++ b/packages/@sanity/block-tools/test/tests/converters/blocksToSlateState/decorators/input.json
@@ -1,0 +1,26 @@
+[
+  {
+    "_key": "37369d86a5ce",
+    "_type": "block",
+    "children": [
+      { "_type": "span", "marks": ["strong"], "text": "Bold " },
+      { "_type": "span", "marks": ["strong", "em"], "text": "italic" }
+    ],
+    "markDefs": [],
+    "style": "normal"
+  },
+  {
+    "_key": "745d6428661b",
+    "_type": "block",
+    "children": [{ "_type": "span", "marks": ["em"], "text": "Italic" }],
+    "markDefs": [],
+    "style": "normal"
+  },
+  {
+    "_key": "5c7d58f13d18",
+    "_type": "block",
+    "children": [{ "_type": "span", "marks": ["code"], "text": "Code" }],
+    "markDefs": [],
+    "style": "normal"
+  }
+]

--- a/packages/@sanity/block-tools/test/tests/converters/blocksToSlateState/decorators/output.json
+++ b/packages/@sanity/block-tools/test/tests/converters/blocksToSlateState/decorators/output.json
@@ -1,0 +1,88 @@
+{
+  "kind": "state",
+  "document": {
+    "data": {},
+    "kind": "document",
+    "nodes": [
+      {
+        "kind": "block",
+        "isVoid": false,
+        "type": "contentBlock",
+        "data": {
+          "_type": "block",
+          "_key": "37369d86a5ce",
+          "style": "normal"
+        },
+        "nodes": [
+          {
+            "kind": "text",
+            "ranges": [
+              {
+                "kind": "range",
+                "text": "Bold ",
+                "marks": [{ "kind": "mark", "type": "strong" }]
+              }
+            ]
+          },
+          {
+            "kind": "text",
+            "ranges": [
+              {
+                "kind": "range",
+                "text": "italic",
+                "marks": [
+                  { "kind": "mark", "type": "strong" },
+                  { "kind": "mark", "type": "em" }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "block",
+        "isVoid": false,
+        "type": "contentBlock",
+        "data": {
+          "_type": "block",
+          "_key": "745d6428661b",
+          "style": "normal"
+        },
+        "nodes": [
+          {
+            "kind": "text",
+            "ranges": [
+              {
+                "kind": "range",
+                "text": "Italic",
+                "marks": [{ "kind": "mark", "type": "em" }]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "block",
+        "isVoid": false,
+        "type": "contentBlock",
+        "data": {
+          "_type": "block",
+          "_key": "5c7d58f13d18",
+          "style": "normal"
+        },
+        "nodes": [
+          {
+            "kind": "text",
+            "ranges": [
+              {
+                "kind": "range",
+                "text": "Code",
+                "marks": [{ "kind": "mark", "type": "code" }]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/@sanity/block-tools/test/tests/converters/blocksToSlateState/index.test.js
+++ b/packages/@sanity/block-tools/test/tests/converters/blocksToSlateState/index.test.js
@@ -1,0 +1,21 @@
+import assert from 'assert'
+import fs from 'fs'
+import path from 'path'
+import blockTools from '../../../../src'
+
+describe('blocksToSlateState', () => {
+  const tests = fs.readdirSync(__dirname)
+  tests.forEach(test => {
+    if (test[0] === '.' || path.extname(test).length > 0) {
+      return
+    }
+    it(test, () => {
+      const dir = path.resolve(__dirname, test)
+      const input = JSON.parse(fs.readFileSync(path.resolve(dir, 'input.json')))
+      const expected = JSON.parse(fs.readFileSync(path.resolve(dir, 'output.json')))
+      const fn = require(path.resolve(dir)).default // eslint-disable-line import/no-dynamic-require
+      const output = fn(blockTools.blocksToSlateState, input)
+      assert.deepEqual(output, expected)
+    })
+  })
+})

--- a/packages/@sanity/block-tools/test/tests/converters/blocksToSlateState/markDefs/index.js
+++ b/packages/@sanity/block-tools/test/tests/converters/blocksToSlateState/markDefs/index.js
@@ -1,0 +1,11 @@
+import defaultSchema from '../../../../fixtures/defaultSchema'
+
+const blockContentType = defaultSchema.get('blogPost')
+  .fields.find(field => field.name === 'body').type
+
+
+export default (blockToSlateState, input) => {
+  const result = blockToSlateState(input, blockContentType)
+  // console.log(JSON.stringify(result))
+  return result
+}

--- a/packages/@sanity/block-tools/test/tests/converters/blocksToSlateState/markDefs/input.json
+++ b/packages/@sanity/block-tools/test/tests/converters/blocksToSlateState/markDefs/input.json
@@ -1,0 +1,32 @@
+[
+  {
+    "_type": "block",
+    "children": [
+      {
+        "_type": "span",
+        "marks": [],
+        "text": ""
+      },
+      {
+        "_type": "span",
+        "marks": [
+          "4713633924e9"
+        ],
+        "text": "Link"
+      },
+      {
+        "_type": "span",
+        "marks": [],
+        "text": ""
+      }
+    ],
+    "markDefs": [
+      {
+        "_key": "4713633924e9",
+        "_type": "link",
+        "href": "1234"
+      }
+    ],
+    "style": "normal"
+  }
+]

--- a/packages/@sanity/block-tools/test/tests/converters/blocksToSlateState/markDefs/output.json
+++ b/packages/@sanity/block-tools/test/tests/converters/blocksToSlateState/markDefs/output.json
@@ -1,0 +1,48 @@
+{
+  "kind": "state",
+  "document": {
+    "kind": "document",
+    "data": {},
+    "nodes": [
+      {
+        "kind": "block",
+        "isVoid": false,
+        "type": "contentBlock",
+        "data": {
+          "_type": "block",
+          "style": "normal"
+        },
+        "nodes": [
+          {
+            "kind": "text",
+            "ranges": [{ "kind": "range", "text": "", "marks": [] }]
+          },
+          {
+            "kind": "inline",
+            "isVoid": false,
+            "type": "span",
+            "data": {
+              "annotations": {
+                "link": {
+                  "_key": "4713633924e9",
+                  "_type": "link",
+                  "href": "1234"
+                }
+              }
+            },
+            "nodes": [
+              {
+                "kind": "text",
+                "ranges": [{ "kind": "range", "text": "Link", "marks": [] }]
+              }
+            ]
+          },
+          {
+            "kind": "text",
+            "ranges": [{ "kind": "range", "text": "", "marks": [] }]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
There was an issue where marksDefs were written to the Slate block's data props when they really shouldn't.