### PR TITLE
[cli] Add CLI methods for manage and docs

### DIFF
--- a/packages/@sanity/cli/src/commands/docs/docsCommand.js
+++ b/packages/@sanity/cli/src/commands/docs/docsCommand.js
@@ -1,0 +1,15 @@
+import opn from 'opn'
+
+export default {
+  name: 'docs',
+  signature: 'docs',
+  description: 'Opens the Sanity documentation',
+  action(args, context) {
+    const {output} = context
+    const {print} = output
+    const url = 'https://www.sanity.io/docs/content-studio'
+
+    print(`Opening ${url}`)
+    opn(url)
+  }
+}

--- a/packages/@sanity/cli/src/commands/index.js
+++ b/packages/@sanity/cli/src/commands/index.js
@@ -1,10 +1,23 @@
+import debugCommand from './debug/debugCommand'
+import docsCommand from './docs/docsCommand'
 import helpCommand from './help/helpCommand'
 import initCommand from './init/initCommand'
 import installCommand from './install/installCommand'
-import upgradeCommand from './upgrade/upgradeCommand'
 import loginCommand from './login/loginCommand'
 import logoutCommand from './logout/logoutCommand'
+import manageCommand from './manage/manageCommand'
+import upgradeCommand from './upgrade/upgradeCommand'
 import versionsCommand from './versions/versionsCommand'
-import debugCommand from './debug/debugCommand'
 
-export default [initCommand, loginCommand, logoutCommand, installCommand, upgradeCommand, versionsCommand, debugCommand, helpCommand]
+export default [
+  initCommand,
+  loginCommand,
+  logoutCommand,
+  installCommand,
+  upgradeCommand,
+  versionsCommand,
+  docsCommand,
+  manageCommand,
+  debugCommand,
+  helpCommand
+]

--- a/packages/@sanity/cli/src/commands/init/initSanity.js
+++ b/packages/@sanity/cli/src/commands/init/initSanity.js
@@ -139,9 +139,12 @@ export default async function initSanity(args, context) {
   const successMessage = template.getSuccessMessage
     ? template.getSuccessMessage(initOptions, context)
     : ''
+
   if (successMessage) {
     print(`\n${successMessage}`)
   }
+
+  print('\nNeed some help to get you started? Run "sanity docs" for documentation!\n')
 
   async function getOrCreateUser() {
     print("We can't find any auth credentials in your Sanity config - looks like you")

--- a/packages/@sanity/cli/src/commands/manage/manageCommand.js
+++ b/packages/@sanity/cli/src/commands/manage/manageCommand.js
@@ -1,0 +1,29 @@
+import path from 'path'
+import opn from 'opn'
+import fse from 'fs-extra'
+
+export default {
+  name: 'manage',
+  signature: 'manage',
+  description: 'Opens the Sanity project management UI',
+  async action(args, context) {
+    const {workDir, output} = context
+    const {print} = output
+    const configLocation = path.join(workDir, 'sanity.json')
+
+    let projectId
+    try {
+      const config = await fse.readJson(configLocation)
+      projectId = config.api && config.api.projectId
+    } catch (err) {
+      // Noop.
+    }
+
+    const url = projectId
+      ? `https://manage.sanity.io/projects/${projectId}`
+      : 'https://manage.sanity.io/'
+
+    print(`Opening ${url}`)
+    opn(url)
+  }
+}


### PR DESCRIPTION
This PR adds two new CLI commands:
`sanity docs` opens a browser and points it at https://www.sanity.io/docs/content-studio

`sanity manage` opens a browser and points it at https://manage.sanity.io/, or if you are in a project context, https://manage.sanity.io/projects/<projectId>
