### PR TITLE
 [observable] Add .babelrc to .npmignore + some dotfiles cleanup

### DIFF
--- a/packages/@sanity/observable/.gitignore
+++ b/packages/@sanity/observable/.gitignore
@@ -1,2 +1,3 @@
+.idea
 lib
 node_modules

--- a/packages/@sanity/observable/.npmignore
+++ b/packages/@sanity/observable/.npmignore
@@ -1,1 +1,7 @@
+node_modules
+src
 .idea
+.babelrc
+.eslintignore
+.eslintrc
+.gitignore

--- a/packages/@sanity/observable/.travis.yml
+++ b/packages/@sanity/observable/.travis.yml
@@ -1,4 +1,0 @@
-language: node_js
-node_js:
-  - "4"
-  - "6"


### PR DESCRIPTION
Looks like the React native packager reads .babelrc from dependencies. Since babel-preset-es2105 is a devDependency for `@sanity/observable`, and .babelrc was included in the published package, the React Native packager errored when it could not resolve the babel-preset-es2105 dependency.

This should fix it.

I also removed an old .travis.yml and did some minor housekeeping.