### PR TITLE
[chore] Add a release-notes script that outputs a release notes template

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "watch": "gulp watch",
     "install-husky": "node node_modules/husky/bin/install",
     "commitmsg": "node scripts/validateCommitMessage.js",
+    "release-notes": "node scripts/printReleaseNotesTemplate.js",
     "versions": "node scripts/normalizeDependencyVersions.js",
     "normalize-pkgfields": "node scripts/normalizePackageFields.js"
   },
@@ -43,6 +44,7 @@
     "eslint-config-sanity": "^3.1.0",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-react": "^7.4.0",
+    "execa": "^0.8.0",
     "glob": "^7.1.2",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",

--- a/scripts/printReleaseNotesTemplate.js
+++ b/scripts/printReleaseNotesTemplate.js
@@ -1,0 +1,41 @@
+const CHANGELOG_COMMAND = 'git log --pretty=format:\'%aN | %s | %h\' --abbrev-commit --reverse origin/master..origin/next'
+
+const execa = require('execa')
+const TEMPLATE = `
+Upgrade with:
+
+    sanity upgrade
+
+And install the latest Command Line Interface (CLI) with:
+
+    npm install --global @sanity/cli
+
+# ✨ Highlights
+## Awesome feature X
+A few words about the awesome feature X, preferably with screengifs
+
+## Awesome feature Y
+A few words about the awesome feature Y, preferably with screengifs
+
+## Other features
+- This is feature is not that important, but worth mentioning anyway
+
+# 🐛 Notable bugfixes
+- Fixed 🐞
+- Fixed 🐛
+- Fixed 🦗
+
+# 📓 Full changelog
+Author | Message | Commit
+------------ | ------------- | -------------
+${execa.shellSync(CHANGELOG_COMMAND).stdout}
+`
+
+console.log(`
+-------- SANITY RELEASE NOTES TEMPLATE --------
+Use the following template as a starting point for next release:
+A draft can be created here: https://github.com/sanity-io/sanity/releases/new
+
+-------- BEGIN TEMPLATE --------
+${TEMPLATE}
+-------- END TEMPLATE --------`)


### PR DESCRIPTION
This adds a script that outputs a starting point for release notes on `npm run release-notes`