### PR TITLE
Add support for weak references

### DIFF
--- a/packages/@sanity/base/src/preview/observeForPreview.js
+++ b/packages/@sanity/base/src/preview/observeForPreview.js
@@ -16,13 +16,17 @@ export default function observeForPreview(value, type, fields, viewOptions) {
     // if the value is of type reference, but has no _ref property, we cannot prepare any value for the preview
     // and the most sane thing to do is to return `null` for snapshot
     if (!value._ref) {
-      return Observable.of({snapshot: null, type: type})
+      return Observable.of({snapshot: null})
     }
     // Previewing references actually means getting the referenced value,
     // and preview using the preview config of its type
     // todo: We need a way of knowing the type of the referenced value by looking at the reference record alone
     return resolveRefType(value, type)
-      .switchMap(refType => observeForPreview(value, refType))
+      .switchMap(refType =>
+        (refType
+          ? observeForPreview(value, refType)
+          : Observable.of({snapshot: null})
+        ))
   }
 
   const selection = type.preview.select

--- a/packages/@sanity/base/src/preview/resolveRefType.js
+++ b/packages/@sanity/base/src/preview/resolveRefType.js
@@ -1,17 +1,8 @@
 import client from 'part:@sanity/base/client'
 import Observable from '@sanity/observable'
 
-function removeSchemaPrefix(type) {
-  return type.split('.').pop()
-}
-
 function resolveRefTypeName(value) {
-  if (value._type && value._type.includes(':')) {
-    return Observable.of(value._type.split(':').pop())
-  }
-  return Observable.from(client.observable.fetch('*[_id == $id]{_type}', {id: value._ref}))
-    .map(result => removeSchemaPrefix(result[0]._type)
-  )
+  return Observable.from(client.observable.fetch('*[_id == $id][0]._type', {id: value._ref}))
 }
 
 export default function resolveRefType(value, type) {

--- a/packages/@sanity/desk-tool/package.json
+++ b/packages/@sanity/desk-tool/package.json
@@ -28,6 +28,7 @@
     "@sanity/data-aspects": "^0.120.0",
     "@sanity/form-builder": "^0.121.0",
     "@sanity/mutator": "^0.120.0",
+    "@sanity/observable": "^0.120.0",
     "@sanity/uuid": "^0.120.0",
     "classnames": "^2.2.5",
     "date-fns": "^1.29.0",

--- a/packages/@sanity/desk-tool/src/components/ConfirmDelete.js
+++ b/packages/@sanity/desk-tool/src/components/ConfirmDelete.js
@@ -32,15 +32,14 @@ export default enhanceWithReferringDocuments(class ConfirmDelete extends React.P
 
     const hasReferringDocuments = referringDocuments.length > 0
 
-    const canContinue = !isCheckingReferringDocuments && !hasReferringDocuments
+    const canContinue = !isCheckingReferringDocuments
 
     const actions = [
-      canContinue && {name: 'confirm', title: 'Delete now'},
-      {name: 'cancel', title: hasReferringDocuments ? 'Ok, got it' : 'Cancel', kind: 'secondary'}
+      canContinue && {name: 'confirm', title: hasReferringDocuments ? 'Try to delete anyway' : 'Delete now'},
+      {name: 'cancel', title: 'Cancel', kind: 'secondary'}
     ].filter(Boolean)
 
-    const title = (isCheckingReferringDocuments && 'Checking…')
-      || (hasReferringDocuments ? 'Cannot delete' : 'Confirm delete')
+    const title = isCheckingReferringDocuments ? 'Checking…' : 'Confirm delete'
 
     return (
       <Dialog
@@ -57,15 +56,14 @@ export default enhanceWithReferringDocuments(class ConfirmDelete extends React.P
         {hasReferringDocuments && (
           <div>
             <h3>
+              Warning:
               Found {referringDocuments.length === 1 ? 'a document' : `${referringDocuments.length} documents`} that
-              refers to <DocTitle document={(draft || published)} />
+              refers to {'"'}<DocTitle document={(draft || published)} />{'"'}
             </h3>
             <p>
-              You cannot delete a document that other documents are referring to.
-              In order to continue, every reference
-              to <strong><DocTitle document={(draft || published)} /></strong> needs
-              to be removed from
-              the following document{referringDocuments.length > 1 && 's'}:
+              You may not be allowed to delete
+              {' "'}<DocTitle document={(draft || published)} />{'" '}
+              as the following document{referringDocuments.length === 1 ? '' : 's'} refers to it:
             </p>
             <ReferringDocumentsList documents={referringDocuments} />
           </div>

--- a/packages/@sanity/desk-tool/src/components/ConfirmDiscard.js
+++ b/packages/@sanity/desk-tool/src/components/ConfirmDiscard.js
@@ -29,7 +29,7 @@ export default class ConfirmDiscard extends React.PureComponent {
     const {draft, published, onCancel} = this.props
     const confirmAction = {
       name: 'confirm',
-      title: `Yes, discard ${published ? 'changes' : 'document'}`,
+      title: `Discard ${published ? 'changes' : 'draft'} now`,
       color: 'danger'
     }
     return (

--- a/packages/@sanity/desk-tool/src/components/ConfirmPublish.js
+++ b/packages/@sanity/desk-tool/src/components/ConfirmPublish.js
@@ -6,7 +6,7 @@ import distanceInWordsToNow from 'date-fns/distance_in_words_to_now'
 import DocTitle from './DocTitle'
 
 const ACTIONS = [
-  {name: 'confirm', title: 'Yes, publish now', color: 'success', autoFocus: true},
+  {name: 'confirm', title: 'Publish now', color: 'success', autoFocus: true},
   {name: 'cancel', title: 'Cancel', kind: 'secondary'}
 ]
 const NOTHING_TO_PUBLISH_ACTIONS = [

--- a/packages/@sanity/desk-tool/src/components/ConfirmUnpublish.js
+++ b/packages/@sanity/desk-tool/src/components/ConfirmUnpublish.js
@@ -7,7 +7,7 @@ import enhanceWithReferringDocuments from './enhanceWithReferringDocuments'
 import DocTitle from './DocTitle'
 import ReferringDocumentsList from './ReferringDocumentsList'
 
-export default enhanceWithReferringDocuments(class ConfirmDelete extends React.PureComponent {
+export default enhanceWithReferringDocuments(class ConfirmUnpublish extends React.PureComponent {
   static propTypes = {
     onCancel: PropTypes.func.isRequired,
     onConfirm: PropTypes.func.isRequired,
@@ -31,14 +31,15 @@ export default enhanceWithReferringDocuments(class ConfirmDelete extends React.P
     const {isCheckingReferringDocuments, referringDocuments, draft, published, onCancel} = this.props
 
     const hasReferringDocuments = referringDocuments.length > 0
-    const canContinue = !isCheckingReferringDocuments && !hasReferringDocuments
+
+    const canContinue = !isCheckingReferringDocuments
+
     const actions = [
-      canContinue && {name: 'confirm', title: 'Unpublish now'},
-      {name: 'cancel', title: hasReferringDocuments ? 'Ok, got it' : 'Cancel', kind: 'secondary'}
+      canContinue && {name: 'confirm', title: hasReferringDocuments ? 'Try to unpublish anyway' : 'Unpublish now'},
+      {name: 'cancel', title: 'Cancel', kind: 'secondary'}
     ].filter(Boolean)
 
-    const title = (isCheckingReferringDocuments && 'Checking…')
-      || (hasReferringDocuments ? 'Cannot unpublish' : 'Confirm unpublish')
+    const title = isCheckingReferringDocuments ? 'Checking…' : 'Confirm unpublish'
 
     return (
       <Dialog
@@ -54,15 +55,14 @@ export default enhanceWithReferringDocuments(class ConfirmDelete extends React.P
         {hasReferringDocuments && (
           <div>
             <h3>
+              Warning:
               Found {referringDocuments.length === 1 ? 'a document' : `${referringDocuments.length} documents`} that
-              refers to <DocTitle document={(draft || published)} />
+              refers to {'"'}<DocTitle document={(draft || published)} />{'"'}
             </h3>
             <p>
-              You cannot unpublish a document that other documents are referring to.
-              In order to continue, every reference
-              to <strong><DocTitle document={(draft || published)} /></strong> needs
-              to be removed from
-              the following document{referringDocuments.length > 1 && 's'}:
+              You may not be allowed to unpublish
+              {' "'}<DocTitle document={(draft || published)} />{'" '}
+              as the following document{referringDocuments.length === 1 ? '' : 's'} refers to it:
             </p>
             <ReferringDocumentsList documents={referringDocuments} />
           </div>

--- a/packages/@sanity/desk-tool/src/pane/Editor.js
+++ b/packages/@sanity/desk-tool/src/pane/Editor.js
@@ -28,6 +28,7 @@ import Pane from 'part:@sanity/components/panes/default'
 import afterEditorComponents from 'all:part:@sanity/desk-tool/after-editor-component'
 import SyncIcon from 'part:@sanity/base/sync-icon'
 import CheckIcon from 'part:@sanity/base/check-icon'
+import Snackbar from 'part:@sanity/components/snackbar/default'
 
 const preventDefault = ev => ev.preventDefault()
 
@@ -128,6 +129,8 @@ export default withRouterHOC(class Editor extends React.PureComponent {
     onDiscardDraft: PropTypes.func,
     onPublish: PropTypes.func,
     onUnpublish: PropTypes.func,
+    transactionResult: PropTypes.func,
+    onClearTransactionResult: PropTypes.func,
 
     isCreatingDraft: PropTypes.bool,
     isUnpublishing: PropTypes.bool,
@@ -144,9 +147,11 @@ export default withRouterHOC(class Editor extends React.PureComponent {
     isPublishing: false,
     isCreatingDraft: false,
     deletedSnapshot: null,
+    transactionResult: null,
     onDelete() {},
     onCreate() {},
     onChange() {},
+    onClearTransactionResult() {}
   }
 
   state = INITIAL_STATE
@@ -367,7 +372,9 @@ export default withRouterHOC(class Editor extends React.PureComponent {
       isPublishing,
       isUnpublishing,
       isCreatingDraft,
-      patchChannel
+      patchChannel,
+      transactionResult,
+      onClearTransactionResult
     } = this.props
 
     const {
@@ -478,6 +485,19 @@ export default withRouterHOC(class Editor extends React.PureComponent {
               onCancel={this.handleCancelUnpublish}
               onConfirm={this.handleConfirmUnpublish}
             />
+          )}
+
+          {transactionResult && transactionResult.type === 'error' && (
+            <Snackbar
+              kind={'danger'}
+              action={{title: 'Ok, got it'}}
+              onAction={onClearTransactionResult}
+            >
+              <div>
+                {transactionResult.message}
+                <details>{transactionResult.error.message}</details>
+              </div>
+            </Snackbar>
           )}
         </div>
       </Pane>

--- a/packages/@sanity/form-builder/src/inputs/Reference/ReferenceInput.js
+++ b/packages/@sanity/form-builder/src/inputs/Reference/ReferenceInput.js
@@ -10,6 +10,7 @@ import type {ObservableI} from '../../typedefs/observable'
 import LinkIcon from 'part:@sanity/base/link-icon'
 import {IntentLink} from 'part:@sanity/base/router'
 import styles from './styles/ReferenceInput.css'
+import Button from 'part:@sanity/components/buttons/default'
 
 type SearchHit = {
   _id: string,
@@ -105,6 +106,13 @@ export default class ReferenceInput extends React.Component<Props, State> {
     ))
   }
 
+  handleFixWeak = () => {
+    const {type} = this.props
+    this.props.onChange(PatchEvent.from(
+      type.weak === true ? set(true, ['_weak']) : unset(['_weak'])
+    ))
+  }
+
   handleClear = () => {
     this.props.onChange(PatchEvent.from(unset()))
   }
@@ -175,13 +183,25 @@ export default class ReferenceInput extends React.Component<Props, State> {
     } = this.props
 
     const {previewSnapshot, isFetching, hits} = this.state
-
     const valueFromHit = value && hits.find(hit => hit._id === value._ref)
 
+    const weakIs = value && value._weak ? 'weak' : 'strong'
+    const weakShouldBe = type.weak === true ? 'weak' : 'strong'
+
     const isMissing = value && previewSnapshot === MISSING_SNAPSHOT
+    const hasWeakMismatch = !isMissing && weakIs !== weakShouldBe
+
     return (
       <FormField label={type.title} level={level} description={type.description}>
-        <div className={isMissing ? styles.brokenReferenceWarning : ''}>
+        <div className={(hasWeakMismatch || isMissing) ? styles.hasWarnings : ''}>
+          {hasWeakMismatch && (
+            <div className={styles.weakRefMismatchWarning}>
+              Warning: This reference is <em>{weakIs}</em>, but should be <em>{weakShouldBe}</em> according to schema.
+              <div>
+                <Button onClick={this.handleFixWeak}>Convert to {weakShouldBe}</Button>
+              </div>
+            </div>
+          )}
           <SearchableSelect
             {...rest}
             placeholder="Type to search…"

--- a/packages/@sanity/form-builder/src/inputs/Reference/styles/ReferenceInput.css
+++ b/packages/@sanity/form-builder/src/inputs/Reference/styles/ReferenceInput.css
@@ -1,0 +1,10 @@
+@import 'part:@sanity/base/theme/variables-style';
+
+.brokenReferenceWarning {
+
+}
+
+.brokenReferenceWarning input {
+  border: 1px dashed var(--state-warning-color);
+  color: var(--legend-color);
+}

--- a/packages/@sanity/form-builder/src/inputs/Reference/styles/ReferenceInput.css
+++ b/packages/@sanity/form-builder/src/inputs/Reference/styles/ReferenceInput.css
@@ -1,10 +1,13 @@
 @import 'part:@sanity/base/theme/variables-style';
 
-.brokenReferenceWarning {
-
+.weakRefMismatchWarning {
+  padding: var(--medium-padding);
 }
 
-.brokenReferenceWarning input {
+.hasWarnings {
   border: 1px dashed var(--state-warning-color);
+}
+
+.hasWarnings input {
   color: var(--legend-color);
 }

--- a/packages/@sanity/form-builder/src/sanity/inputs/SanityReference.js
+++ b/packages/@sanity/form-builder/src/sanity/inputs/SanityReference.js
@@ -1,8 +1,8 @@
 
 import React from 'react'
-import {search, valueToString} from './client-adapters/reference'
+import {search, getPreviewSnapshot} from './client-adapters/reference'
 import ReferenceInput from '../../inputs/Reference'
 
 export default function SanityReference(props) {
-  return <ReferenceInput {...props} onSearch={search} valueToString={valueToString} />
+  return <ReferenceInput {...props} onSearch={search} getPreviewSnapshot={getPreviewSnapshot} />
 }

--- a/packages/@sanity/form-builder/src/sanity/inputs/client-adapters/reference.js
+++ b/packages/@sanity/form-builder/src/sanity/inputs/client-adapters/reference.js
@@ -3,9 +3,8 @@ import {flatten} from 'lodash'
 
 import {observeForPreview} from 'part:@sanity/base/preview'
 
-export function valueToString(value, referenceType) {
-  return observeForPreview(value, referenceType)
-    .map(result => result.snapshot.title)
+export function getPreviewSnapshot(value, referenceType) {
+  return observeForPreview(value, referenceType).map(result => result.snapshot)
 }
 
 function wrapIn(chars = '') {

--- a/packages/test-studio/schemas/references.js
+++ b/packages/test-studio/schemas/references.js
@@ -10,6 +10,22 @@ export default {
       name: 'refToTypeWithNoToplevelStrings',
       type: 'reference',
       to: {type: 'typeWithNoToplevelStrings'}
+    },
+    {
+      name: 'someWeakRef',
+      type: 'reference',
+      weak: true,
+      to: {type: 'author'}
+    },
+    {
+      name: 'array',
+      type: 'array',
+      of: [
+        {
+          type: 'reference',
+          to: {type: 'author'}
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This adds support for marking references as weak in the schema, e.g.:

```js
{
  type: 'reference',
  to: [{type: 'author'}],
  weak: true
}
```

Since there's currently no way to know if a referring document is referring by a weak or strong reference, the desk tool UI needs to support "attempt to delete/unpublish". However, if delete/unpublish fails, we now display an error explaining that the reason is most likely due to strong references.