### PR TITLE
[form-builder] Move item remove logic to ConfirmButton

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/Array/ConfirmButton.js
+++ b/packages/@sanity/form-builder/src/inputs/Array/ConfirmButton.js
@@ -1,39 +1,63 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import Button from 'part:@sanity/components/buttons/default'
+import styles from './styles/ConfirmButton.css'
+import TrashIcon from 'part:@sanity/base/trash-icon'
+import PopOver from 'part:@sanity/components/dialogs/popover'
 
 export default class ConfirmButton extends React.Component {
   static propTypes = {
     children: PropTypes.func,
-    onClick: PropTypes.func
+    onConfirm: PropTypes.func
   }
 
   state = {
-    doConfirm: false
-  }
-
-  handleBlur = event => {
-    this.setState({doConfirm: false})
+    showConfirmDialog: false
   }
 
   handleClick = event => {
-    if (this.state.doConfirm) {
-      this.props.onClick(event)
-    } else {
-      this.setState({doConfirm: true})
-    }
+    this.setState({
+      showConfirmDialog: true
+    })
+  }
+
+  handleConfirmPopoverClose = event => {
+    this.setState({
+      showConfirmDialog: false
+    })
   }
 
   render() {
-    const {children, ...rest} = this.props
-    const {doConfirm} = this.state
+    const {showConfirmDialog} = this.state
+    const {onConfirm, ...rest} = this.props
     return (
       <Button
         {...rest}
+        tabIndex={0}
+        kind="simple"
+        color="danger"
+        icon={TrashIcon}
         onClick={this.handleClick}
-        onBlur={this.handleBlur}
       >
-        {children(doConfirm)}
+        <div className={styles.popoverAnchor}>
+          {
+            showConfirmDialog && (
+              <PopOver
+                color="danger"
+                useOverlay={false}
+                onClose={this.handleConfirmPopoverClose}
+              >
+                <Button
+                  kind="simple"
+                  onClick={onConfirm}
+                  icon={TrashIcon}
+                >
+                  Confirm remove
+                </Button>
+              </PopOver>
+            )
+          }
+        </div>
       </Button>
     )
   }

--- a/packages/@sanity/form-builder/src/inputs/Array/ItemValue.js
+++ b/packages/@sanity/form-builder/src/inputs/Array/ItemValue.js
@@ -6,12 +6,9 @@ import type {Node} from 'react'
 import styles from './styles/ItemValue.css'
 import ConfirmButton from './ConfirmButton'
 import LinkIcon from 'part:@sanity/base/link-icon'
-import Button from 'part:@sanity/components/buttons/default'
-import TrashIcon from 'part:@sanity/base/trash-icon'
 import EditItemFold from 'part:@sanity/components/edititem/fold'
 import EditItemPopOver from 'part:@sanity/components/edititem/popover'
 import FullscreenDialog from 'part:@sanity/components/dialogs/fullscreen'
-import PopOver from 'part:@sanity/components/dialogs/popover'
 
 import ItemForm from './ItemForm'
 import MemberValue from '../../Member'
@@ -37,10 +34,6 @@ type Props = {
 export default class Item extends React.Component<Props> {
 
   domElement: ?HTMLElement
-
-  state = {
-    showConfirmDialog: false
-  }
 
   handleRemove = () => {
     const {onRemove, value} = this.props
@@ -131,18 +124,6 @@ export default class Item extends React.Component<Props> {
     this.domElement = el
   }
 
-  handleDeleteButtonClick = event => {
-    this.setState({
-      showConfirmDialog: true
-    })
-  }
-
-  handleConfirmDialogClose = event => {
-    this.setState({
-      showConfirmDialog: false
-    })
-  }
-
   render() {
     const {value, type, isEditing} = this.props
 
@@ -185,34 +166,10 @@ export default class Item extends React.Component<Props> {
               )
             }
             {!type.readOnly && (
-              <Button
-                tabIndex={0}
-                kind="simple"
-                color="danger"
-                icon={TrashIcon}
-                title="Delete"
-                onClick={this.handleDeleteButtonClick}
-              >
-                <div className={styles.popoverAnchor}>
-                  {
-                    this.state.showConfirmDialog && (
-                      <PopOver
-                        color="danger"
-                        useOverlay={false}
-                        onClose={this.handleConfirmDialogClose}
-                      >
-                        <Button
-                          kind="simple"
-                          onClick={this.handleRemove}
-                          icon={TrashIcon}
-                        >
-                          Confirm delete
-                        </Button>
-                      </PopOver>
-                    )
-                  }
-                </div>
-              </Button>
+              <ConfirmButton
+                title="Remove this item"
+                onConfirm={this.handleRemove}
+              />
             )}
           </div>
         </div>

--- a/packages/@sanity/form-builder/src/inputs/Array/styles/ConfirmButton.css
+++ b/packages/@sanity/form-builder/src/inputs/Array/styles/ConfirmButton.css
@@ -1,0 +1,7 @@
+.popoverAnchor {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  top: 50%;
+  left: 50%;
+}

--- a/packages/@sanity/form-builder/src/inputs/Array/styles/ItemValue.css
+++ b/packages/@sanity/form-builder/src/inputs/Array/styles/ItemValue.css
@@ -85,11 +85,3 @@
   flex-grow: 0;
   font-size: 0.9rem;
 }
-
-.popoverAnchor {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  top: 50%;
-  left: 50%;
-}


### PR DESCRIPTION
Minor cleanup: Moves confirm button popover visibility state out of `ItemValue` and back into `ConfirmButton`