### PR TITLE
[cli] Copy xdg-open binary to bin directory on pack

### DIFF
--- a/packages/@sanity/cli/.gitignore
+++ b/packages/@sanity/cli/.gitignore
@@ -16,3 +16,6 @@ node_modules
 
 # Packed version of Sanity binary
 /bin/sanity
+
+# Dependency of opn module
+/bin/xdg-open

--- a/packages/@sanity/cli/scripts/pack.js
+++ b/packages/@sanity/cli/scripts/pack.js
@@ -19,6 +19,10 @@ if (bindings.length > 0) {
   process.exit(1)
 }
 
+const opnDir = path.dirname(require.resolve('opn'))
+const xdgPath = path.join(opnDir, 'xdg-open')
+fse.copy(xdgPath, path.join(basedir, 'bin', 'xdg-open'))
+
 const babelRc = JSON.parse(fse.readFileSync(path.join(basedir, '.babelrc'), 'utf8'))
 
 // Use the real node __dirname and __filename in order to get Yarn's source


### PR DESCRIPTION
`xdg-open` is used to open things (like a URL) on Linux. The new "pack the whole CLI into one big file" change broke a bit because opn tries to find the xdg-open binary next to itself. This PR copies the binary over to the bin directory.
