### PR TITLE
[cli] Support specifying dependencies in plugin templates

### DIFF
--- a/packages/@sanity/cli/src/actions/init-plugin/bootstrapFromTemplate.js
+++ b/packages/@sanity/cli/src/actions/init-plugin/bootstrapFromTemplate.js
@@ -46,7 +46,7 @@ module.exports = async (context, url) => {
   const templateFiles = zip.filter(file => file.type === 'file' && file.path.indexOf(baseDir) === 0)
   const manifestContent = manifest.data.toString()
   const tplVars = parseJson(manifestContent).sanityTemplate || {}
-  const {minimumBaseVersion} = tplVars
+  const {minimumBaseVersion, minimumCliVersion} = tplVars
 
   if (minimumBaseVersion) {
     const installed = getSanityVersion(workDir)
@@ -55,6 +55,12 @@ module.exports = async (context, url) => {
         `Template requires Sanity at version ${minimumBaseVersion}, installed is ${installed}`
       )
     }
+  }
+
+  if (minimumCliVersion && semver.lt(pkg.version, minimumCliVersion)) {
+    throw new Error(
+      `Template requires @sanity/cli at version ${minimumCliVersion}, installed is ${pkg.version}`
+    )
   }
 
   const name = await prompt.single({

--- a/packages/@sanity/cli/src/actions/init-plugin/bootstrapFromTemplate.js
+++ b/packages/@sanity/cli/src/actions/init-plugin/bootstrapFromTemplate.js
@@ -106,7 +106,7 @@ module.exports = async (context, url) => {
     })
   )
 
-  return {name, outputPath, inPluginsPath: inProjectContext}
+  return {name, outputPath, inPluginsPath: inProjectContext, dependencies: tplVars.dependencies}
 }
 
 async function validateEmptyPath(dir) {

--- a/packages/@sanity/cli/src/debug.js
+++ b/packages/@sanity/cli/src/debug.js
@@ -1,3 +1,3 @@
-import debug from 'debug'
+const debug = require('debug')
 
-export default debug('sanity:cli')
+module.exports = debug('sanity:cli')


### PR DESCRIPTION
This PR allows plugin templates to define dependencies and prompts the user to install them if the user is in a project context.

I also snuck in a feature to allow specifying a minimum CLI version, so new features like this one can be added in a backwards "compatible" way.
