### PR TITLE
[cli] Add more commands to list of core cmds

### DIFF
--- a/packages/@sanity/cli/src/util/noSuchCommandText.js
+++ b/packages/@sanity/cli/src/util/noSuchCommandText.js
@@ -3,7 +3,18 @@ import chalk from 'chalk'
 
 const commonMistakes = {get: 'list'}
 const levenThreshold = 3
-const coreCommands = ['build', 'check', 'config', 'dataset', 'start', 'install', 'uninstall']
+const coreCommands = [
+  'build',
+  'check',
+  'configcheck',
+  'dataset',
+  'deploy',
+  'documents',
+  'exec',
+  'hook',
+  'start',
+  'uninstall'
+]
 
 const helpText = `
 Run the command again within a Sanity project directory, where "@sanity/core"


### PR DESCRIPTION
When you type `sanity deploy` or other Sanity core commands in a non-project context, tis' nice to get a little help telling you they are only available in project context. A few commands were missing from the list, so added the missing ones.
