### PR TITLE
[webpack-integration] Allow passing options to CSSNext/Lost

### DIFF
--- a/packages/@sanity/webpack-integration/src/v3/index.js
+++ b/packages/@sanity/webpack-integration/src/v3/index.js
@@ -50,7 +50,9 @@ function getPostcssImportPlugin(options) {
 
 function getPostcssPlugins(options) {
   const importer = getPostcssImportPlugin(options)
-  return [importer, postcssCssnext, lost]
+  const nextOpts = options.cssnext
+  const lostOpts = options.lost
+  return [importer, postcssCssnext(nextOpts), lost(lostOpts)]
 }
 
 function getConfig(options) {


### PR DESCRIPTION
When calling `getPostcssPlugins`, there is currently no way to pass options to the cssnext and lost plugins. This PR adds this functionality.