### PR TITLE
[plugin-loader] Use postcss plugins, improved resolving

### DIFF
--- a/packages/@sanity/plugin-loader/package.json
+++ b/packages/@sanity/plugin-loader/package.json
@@ -42,7 +42,8 @@
   "dependencies": {
     "@sanity/resolver": "^0.120.0",
     "@sanity/util": "^0.120.0",
-    "css-modules-require-hook": "^4.2.2",
+    "@sanity/webpack-integration": "^0.120.0",
+    "css-modules-require-hook": "4.1.0",
     "interop-require": "^1.0.0"
   }
 }


### PR DESCRIPTION
The plugin-loader was not using postcss plugins, which _might_ result in different hashes.
Additionally, there was no way to resolve from the current module parent directory. This is now fixed with an option (defaults to false).
