### PR TITLE
[form-builder] Set project ID for tests, allow local module resolution

### DIFF
--- a/packages/@sanity/form-builder/test/.init.js
+++ b/packages/@sanity/form-builder/test/.init.js
@@ -16,7 +16,7 @@ function setupJSDom() {
 setupJSDom()
 
 const registerLoader = require('@sanity/plugin-loader')
-registerLoader({basePath: __dirname})
+registerLoader({basePath: __dirname, allowLocalDependencies: true})
 
 require('babel-register')
 require('babel-polyfill')

--- a/packages/@sanity/form-builder/test/sanity.json
+++ b/packages/@sanity/form-builder/test/sanity.json
@@ -1,4 +1,8 @@
 {
+  "api": {
+    "projectId": "ppsg7ml5",
+    "dataset": "mock"
+  },
   "server": {
     "hostname": "0.0.0.0"
   },


### PR DESCRIPTION
The tests were not passing due to some issues in the resolver. This has been fixed in #381.
Once that was fixed, there were a few more issues; project ID not being defined, as well as a few modules that needs to be resolved in a different way due to being development dependencies.

There are still issues with the tests, but they seem to be form-builder related now, at least.