### PR TITLE
[form-builder] Fix array index resolving bug

### DIFF
--- a/packages/@sanity/form-builder/src/patch/array.js
+++ b/packages/@sanity/form-builder/src/patch/array.js
@@ -15,7 +15,8 @@ function findTargetIndex(array, pathSegment) {
   if (typeof pathSegment === 'number') {
     return pathSegment
   }
-  return findIndex(array, pathSegment)
+  const index = findIndex(array, pathSegment)
+  return index === -1 ? false : index
 }
 
 export default function apply(value, patch) {
@@ -47,6 +48,11 @@ export default function apply(value, patch) {
   const [head, ...tail] = patch.path
 
   const index = findTargetIndex(value, head)
+
+  // If the given selector could not be found, return as-is
+  if (index === false) {
+    return nextValue
+  }
 
   if (tail.length === 0) {
     if (patch.type === 'insert') {


### PR DESCRIPTION
This took me a while to track down, and I'm not 100% sure it covers all cases, but it should provide a good starting point:

When you pass the form builder a (simplified) JSONPath selector (`{foo: bar}` == `'[foo == "bar"]'`), it is passed to lodash's `findIndex` function. If you pass it something where there is no match, it returns `-1`.

This value was being used "raw", so for an `unset` patch with a non-matching selector, it ended up calling `splice(-1, 1)`, which removes the last item in the array, instead of doing nothing, as is the intended result.

In the same way, saying "insert this item after the item where key is X" in a case where that item did not exist in the array would insert the item at the end of the list, whereas the API would not insert it at all.

I'm a little unsure if this will have any side-effects, so it should be tested thoroughly. This fixes the weird bug we were seeing with array operations inside of block content, by the way.
