### PR TITLE
[form-builder] Make out-of-sync warning full-width

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/styles/Syncer.css
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/styles/Syncer.css
@@ -12,6 +12,7 @@
 
 .isOutOfSyncWarning {
   composes: warning;
+  width: 100%;
   position: absolute;
   top: 2em;
   bottom: 0;


### PR DESCRIPTION
The "out of sync" dialog only fills a certain portion of the screen, which looks... less than great.
We should be able to remove this dialog altogether soon, but until then..
