### PR TITLE
[form-builder] Support skipping directly to block editor

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/BlockEditor.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/BlockEditor.js
@@ -209,6 +209,10 @@ export default class BlockEditor extends React.Component {
     this.setState(prevState => ({fullscreen: !prevState.fullscreen}))
   }
 
+  focus() {
+    this.editor.focus()
+  }
+
   refEditor = editor => {
     this.editor = editor
   }
@@ -374,6 +378,7 @@ export default class BlockEditor extends React.Component {
         labelFor={this._inputId}
         level={level}
       >
+        <button tabIndex={0} className={styles.focusSkipper} onClick={() => this.focus()}>Jump to editor</button>
         {
           fullscreen ? (
             <FullscreenDialog isOpen onClose={this.handleFullScreenClose}>

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/styles/BlockEditor.css
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/styles/BlockEditor.css
@@ -13,6 +13,26 @@
   /* composes: inner from 'part:@sanity/base/theme/forms/control-style'; */
 }
 
+.focusSkipper {
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  margin: 0;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+  padding: 0.2em;
+  background-color: var(--body-bg);
+  border: 1px dotted var(--input-border-color-focus);
+
+  @nest &:focus {
+    z-index: 20;
+    width: auto;
+    height: auto;
+    clip: auto;
+    outline: none;
+  }
+}
+
 .fullscreen {
 
 }


### PR DESCRIPTION
This adds a "Jump to editor"-button when tabbing into the block editor:

![jump](https://user-images.githubusercontent.com/876086/33271772-7491f244-d388-11e7-84c1-f0176a24512a.gif)
