### PR TITLE
[block-tools] Set keys on blocks and spans

### DIFF
--- a/packages/@sanity/block-tools/src/converters/blocksToSlateState.js
+++ b/packages/@sanity/block-tools/src/converters/blocksToSlateState.js
@@ -1,6 +1,8 @@
 // @flow
 
+import randomKey from '../util/randomKey'
 import resolveJsType from '../util/resolveJsType'
+
 import {SLATE_DEFAULT_BLOCK} from '../constants'
 
 function resolveTypeName(value) {
@@ -22,7 +24,12 @@ function toRawMark(markName) {
   }
 }
 
-function sanitySpanToRawSlateBlockNode(span, sanityBlock, spanIndex) {
+function sanitySpanToRawSlateBlockNode(span, sanityBlock) {
+
+  if (!span._key) {
+    span._key = randomKey(12)
+  }
+
   if (span._type !== 'span') {
     return {
       kind: 'inline',
@@ -63,7 +70,7 @@ function sanitySpanToRawSlateBlockNode(span, sanityBlock, spanIndex) {
     key: span._key,
     type: 'span',
     data: {annotations},
-    nodes: [{kind: 'text', ranges: [range]}]
+    nodes: [{kind: 'text', key: `${span._key}0`, ranges: [range]}]
   }
 }
 
@@ -73,21 +80,29 @@ function sanityBlockToRawNode(sanityBlock, type) {
   const {children, _type, markDefs, ...rest} = sanityBlock
 
   const restData = hasKeys(rest) ? {data: {_type, ...rest}} : {}
-  let spanIndex = 0
+
+  if (!sanityBlock._key) {
+    sanityBlock._key = randomKey(12)
+  }
+
   return {
     kind: 'block',
     key: sanityBlock._key,
     isVoid: false,
     type: 'contentBlock',
     ...restData,
-    nodes: children.map(child => sanitySpanToRawSlateBlockNode(child, sanityBlock, spanIndex++))
+    nodes: children.map(child => sanitySpanToRawSlateBlockNode(child, sanityBlock))
   }
 }
 
 // Embedded object
 function sanityBlockItemToRaw(blockItem, type) {
+  if (!blockItem._key) {
+    blockItem._key = randomKey(12)
+  }
   return {
     kind: 'block',
+    key: blockItem._key,
     type: type ? type.name : '__unknown', // __unknown is needed to map to component in slate schema, see prepareSlateForBlockEditor.js
     isVoid: true,
     data: {value: blockItem},

--- a/packages/@sanity/block-tools/src/converters/blocksToSlateState.js
+++ b/packages/@sanity/block-tools/src/converters/blocksToSlateState.js
@@ -22,7 +22,7 @@ function toRawMark(markName) {
   }
 }
 
-function sanitySpanToRawSlateBlockNode(span, sanityBlock) {
+function sanitySpanToRawSlateBlockNode(span, sanityBlock, spanIndex) {
   if (span._type !== 'span') {
     return {
       kind: 'inline',
@@ -47,7 +47,6 @@ function sanitySpanToRawSlateBlockNode(span, sanityBlock) {
       annotations[annotation._type] = annotation
     })
   }
-
   const range = {
     kind: 'range',
     text: text,
@@ -55,33 +54,37 @@ function sanitySpanToRawSlateBlockNode(span, sanityBlock) {
   }
 
   if (!annotations) {
-    return {kind: 'text', ranges: [range]}
+    return {kind: 'text', key: span._key, ranges: [range]}
   }
 
   return {
     kind: 'inline',
     isVoid: false,
+    key: span._key,
     type: 'span',
     data: {annotations},
     nodes: [{kind: 'text', ranges: [range]}]
   }
 }
 
+// Block type object
 function sanityBlockToRawNode(sanityBlock, type) {
   // eslint-disable-next-line no-unused-vars
   const {children, _type, markDefs, ...rest} = sanityBlock
 
   const restData = hasKeys(rest) ? {data: {_type, ...rest}} : {}
-
+  let spanIndex = 0
   return {
     kind: 'block',
+    key: sanityBlock._key,
     isVoid: false,
     type: 'contentBlock',
     ...restData,
-    nodes: children.map(child => sanitySpanToRawSlateBlockNode(child, sanityBlock))
+    nodes: children.map(child => sanitySpanToRawSlateBlockNode(child, sanityBlock, spanIndex++))
   }
 }
 
+// Embedded object
 function sanityBlockItemToRaw(blockItem, type) {
   return {
     kind: 'block',

--- a/packages/@sanity/block-tools/src/converters/slateStateToBlocks.js
+++ b/packages/@sanity/block-tools/src/converters/slateStateToBlocks.js
@@ -2,25 +2,26 @@
 
 import {get, flatten} from 'lodash'
 
-function toSanitySpan(blockNode, sanityBlock) {
-  if (blockNode.kind === 'text') {
-    return blockNode.ranges
-      .map(range => {
+function toSanitySpan(node, sanityBlock, spanIndex) {
+  if (node.kind === 'text') {
+    return node.ranges
+      .map((range, index) => {
         return {
           _type: 'span',
+          _key: `${sanityBlock._key}${spanIndex()}`,
           text: range.text,
           marks: range.marks.map(mark => mark.type)
         }
       })
   }
-  if (blockNode.kind === 'inline') {
-    const {nodes, data} = blockNode
-    return flatten(nodes.map(node => {
-      if (node.kind !== 'text') {
-        throw new Error(`Unexpected non-text child node for inline text: ${node.kind}`)
+  if (node.kind === 'inline') {
+    const {nodes, data} = node
+    return flatten(nodes.map(nodesNode => {
+      if (nodesNode.kind !== 'text') {
+        throw new Error(`Unexpected non-text child node for inline text: ${nodesNode.kind}`)
       }
-      if (blockNode.type !== 'span') {
-        return blockNode.data.value
+      if (node.type !== 'span') {
+        return node.data.value
       }
       const annotations = data.annotations
       const annotationKeys = []
@@ -32,15 +33,16 @@ function toSanitySpan(blockNode, sanityBlock) {
           annotationKeys.push(annotationKey)
         })
       }
-      return node.ranges
-        .map(range => ({
+      return nodesNode.ranges
+        .map((range, index) => ({
           _type: 'span',
+          _key: `${sanityBlock._key}${spanIndex()}`,
           text: range.text,
           marks: range.marks.map(mark => mark.type).concat(annotationKeys),
         }))
     }))
   }
-  throw new Error(`Unsupported kind ${blockNode.kind}`)
+  throw new Error(`Unsupported kind ${node.kind}`)
 }
 
 function toSanityBlock(block) {
@@ -48,10 +50,15 @@ function toSanityBlock(block) {
     const sanityBlock = {
       ...block.data,
       _type: 'block',
+      _key: block.key,
       markDefs: block.data.markDefs || []
     }
+    let index = 0
+    const spanIndex = () => {
+      return index++
+    }
     sanityBlock.children = flatten(block.nodes.map(node => {
-      return toSanitySpan(node, sanityBlock)
+      return toSanitySpan(node, sanityBlock, spanIndex)
     }))
     return sanityBlock
   }

--- a/packages/@sanity/block-tools/src/converters/slateStateToBlocks.js
+++ b/packages/@sanity/block-tools/src/converters/slateStateToBlocks.js
@@ -1,6 +1,7 @@
 // @flow
 
 import {get, flatten} from 'lodash'
+import randomKey from '../util/randomKey'
 
 function toSanitySpan(node, sanityBlock, spanIndex) {
   if (node.kind === 'text') {
@@ -50,7 +51,7 @@ function toSanityBlock(block) {
     const sanityBlock = {
       ...block.data,
       _type: 'block',
-      _key: block.key,
+      _key: block.key || block.data._key || randomKey(12),
       markDefs: block.data.markDefs || []
     }
     let index = 0

--- a/packages/@sanity/block-tools/test/tests/converters/blocksToSlateState/decorators/output.json
+++ b/packages/@sanity/block-tools/test/tests/converters/blocksToSlateState/decorators/output.json
@@ -7,6 +7,7 @@
       {
         "kind": "block",
         "isVoid": false,
+        "key": "37369d86a5ce",
         "type": "contentBlock",
         "data": {
           "_type": "block",
@@ -15,6 +16,7 @@
         },
         "nodes": [
           {
+            "key": "randomKey0",
             "kind": "text",
             "ranges": [
               {
@@ -25,6 +27,7 @@
             ]
           },
           {
+            "key": "randomKey1",
             "kind": "text",
             "ranges": [
               {
@@ -41,6 +44,7 @@
       },
       {
         "kind": "block",
+        "key": "745d6428661b",
         "isVoid": false,
         "type": "contentBlock",
         "data": {
@@ -50,6 +54,7 @@
         },
         "nodes": [
           {
+            "key": "randomKey2",
             "kind": "text",
             "ranges": [
               {
@@ -64,6 +69,7 @@
       {
         "kind": "block",
         "isVoid": false,
+        "key": "5c7d58f13d18",
         "type": "contentBlock",
         "data": {
           "_type": "block",
@@ -72,6 +78,7 @@
         },
         "nodes": [
           {
+            "key": "randomKey3",
             "kind": "text",
             "ranges": [
               {

--- a/packages/@sanity/block-tools/test/tests/converters/blocksToSlateState/markDefs/input.json
+++ b/packages/@sanity/block-tools/test/tests/converters/blocksToSlateState/markDefs/input.json
@@ -1,14 +1,17 @@
 [
   {
     "_type": "block",
+    "_key": "37369d86a5ce",
     "children": [
       {
         "_type": "span",
+        "_key": "37369d86a5ce0",
         "marks": [],
         "text": ""
       },
       {
         "_type": "span",
+        "_key": "37369d86a5ce1",
         "marks": [
           "4713633924e9"
         ],
@@ -16,6 +19,7 @@
       },
       {
         "_type": "span",
+        "_key": "37369d86a5ce2",
         "marks": [],
         "text": ""
       }

--- a/packages/@sanity/block-tools/test/tests/converters/blocksToSlateState/markDefs/output.json
+++ b/packages/@sanity/block-tools/test/tests/converters/blocksToSlateState/markDefs/output.json
@@ -7,19 +7,23 @@
       {
         "kind": "block",
         "isVoid": false,
+        "key": "37369d86a5ce",
         "type": "contentBlock",
         "data": {
           "_type": "block",
+          "_key": "37369d86a5ce",
           "style": "normal"
         },
         "nodes": [
           {
             "kind": "text",
+            "key": "37369d86a5ce0",
             "ranges": [{ "kind": "range", "text": "", "marks": [] }]
           },
           {
             "kind": "inline",
             "isVoid": false,
+            "key": "37369d86a5ce1",
             "type": "span",
             "data": {
               "annotations": {
@@ -32,6 +36,7 @@
             },
             "nodes": [
               {
+                "key": "37369d86a5ce10",
                 "kind": "text",
                 "ranges": [{ "kind": "range", "text": "Link", "marks": [] }]
               }
@@ -39,6 +44,7 @@
           },
           {
             "kind": "text",
+            "key": "37369d86a5ce2",
             "ranges": [{ "kind": "range", "text": "", "marks": [] }]
           }
         ]

--- a/packages/@sanity/block-tools/test/tests/converters/slateStateToBlocks/decorators/output.json
+++ b/packages/@sanity/block-tools/test/tests/converters/slateStateToBlocks/decorators/output.json
@@ -3,8 +3,8 @@
     "_key": "37369d86a5ce",
     "_type": "block",
     "children": [
-      { "_type": "span", "marks": ["strong"], "text": "Bold " },
-      { "_type": "span", "marks": ["strong", "em"], "text": "italic" }
+      { "_type": "span", "_key": "37369d86a5ce0", "marks": ["strong"], "text": "Bold " },
+      { "_type": "span", "_key": "37369d86a5ce1", "marks": ["strong", "em"], "text": "italic" }
     ],
     "markDefs": [],
     "style": "normal"
@@ -12,14 +12,14 @@
   {
     "_key": "745d6428661b",
     "_type": "block",
-    "children": [{ "_type": "span", "marks": ["em"], "text": "Italic" }],
+    "children": [{ "_type": "span", "_key": "745d6428661b0", "marks": ["em"], "text": "Italic" }],
     "markDefs": [],
     "style": "normal"
   },
   {
     "_key": "5c7d58f13d18",
     "_type": "block",
-    "children": [{ "_type": "span", "marks": ["code"], "text": "Code" }],
+    "children": [{ "_type": "span", "_key": "5c7d58f13d180", "marks": ["code"], "text": "Code" }],
     "markDefs": [],
     "style": "normal"
   }

--- a/packages/@sanity/block-tools/test/tests/converters/slateStateToBlocks/markDefs/index.js
+++ b/packages/@sanity/block-tools/test/tests/converters/slateStateToBlocks/markDefs/index.js
@@ -1,0 +1,3 @@
+export default (slateJsonToBlocks, input) => {
+  return slateJsonToBlocks(input)
+}

--- a/packages/@sanity/block-tools/test/tests/converters/slateStateToBlocks/markDefs/input.json
+++ b/packages/@sanity/block-tools/test/tests/converters/slateStateToBlocks/markDefs/input.json
@@ -1,0 +1,48 @@
+{
+  "kind": "state",
+  "document": {
+    "kind": "document",
+    "data": {},
+    "nodes": [
+      {
+        "kind": "block",
+        "isVoid": false,
+        "type": "contentBlock",
+        "data": {
+          "_type": "block",
+          "style": "normal"
+        },
+        "nodes": [
+          {
+            "kind": "text",
+            "ranges": [{ "kind": "range", "text": "", "marks": [] }]
+          },
+          {
+            "kind": "inline",
+            "isVoid": false,
+            "type": "span",
+            "data": {
+              "annotations": {
+                "link": {
+                  "_key": "4713633924e9",
+                  "_type": "link",
+                  "href": "1234"
+                }
+              }
+            },
+            "nodes": [
+              {
+                "kind": "text",
+                "ranges": [{ "kind": "range", "text": "Link", "marks": [] }]
+              }
+            ]
+          },
+          {
+            "kind": "text",
+            "ranges": [{ "kind": "range", "text": "", "marks": [] }]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/@sanity/block-tools/test/tests/converters/slateStateToBlocks/markDefs/output.json
+++ b/packages/@sanity/block-tools/test/tests/converters/slateStateToBlocks/markDefs/output.json
@@ -1,0 +1,32 @@
+[
+  {
+    "_type": "block",
+    "children": [
+      {
+        "_type": "span",
+        "marks": [],
+        "text": ""
+      },
+      {
+        "_type": "span",
+        "marks": [
+          "4713633924e9"
+        ],
+        "text": "Link"
+      },
+      {
+        "_type": "span",
+        "marks": [],
+        "text": ""
+      }
+    ],
+    "markDefs": [
+      {
+        "_key": "4713633924e9",
+        "_type": "link",
+        "href": "1234"
+      }
+    ],
+    "style": "normal"
+  }
+]

--- a/packages/@sanity/block-tools/test/tests/converters/slateStateToBlocks/markDefs/output.json
+++ b/packages/@sanity/block-tools/test/tests/converters/slateStateToBlocks/markDefs/output.json
@@ -1,14 +1,17 @@
 [
   {
     "_type": "block",
+    "_key": "randomKey0",
     "children": [
       {
         "_type": "span",
+        "_key": "randomKey00",
         "marks": [],
         "text": ""
       },
       {
         "_type": "span",
+        "_key": "randomKey01",
         "marks": [
           "4713633924e9"
         ],
@@ -16,6 +19,7 @@
       },
       {
         "_type": "span",
+        "_key": "randomKey02",
         "marks": [],
         "text": ""
       }

--- a/packages/example-studio/schemas/richText.js
+++ b/packages/example-studio/schemas/richText.js
@@ -1,0 +1,34 @@
+export default {
+  name: 'richText',
+  type: 'document',
+  title: 'Rich text',
+  fields: [
+    {
+      name: 'title',
+      title: 'Title',
+      type: 'string'
+    },
+    {
+      name: 'body',
+      type: 'array',
+      title: 'Content',
+      of: [
+        {
+          title: 'Block',
+          type: 'block'
+        },
+        {
+          title: 'Image',
+          type: 'image',
+          fields: [
+            {
+              name: 'caption',
+              type: 'string',
+              title: 'Caption'
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/example-studio/schemas/schema.js
+++ b/packages/example-studio/schemas/schema.js
@@ -9,6 +9,7 @@ import localeString from './localeString'
 import localeSlug from './localeSlug'
 import proteinTest from './proteinTest'
 import customObject from './customObject'
+import richText from './richText'
 import protein from '../components/ProteinInput/schema'
 
 export default createSchema({
@@ -23,5 +24,6 @@ export default createSchema({
     videoEmbed,
     proteinTest,
     protein,
+    richText
   ])
 })


### PR DESCRIPTION
This will set keys on blocks and spans, and make them persistent going back and forth from the frontend and backend. If you load old data into the editor, keys will be generated and populated when syncing.
