### PR TITLE
[default-layout] Give active tool precedence when resolving intent links

### DIFF
--- a/packages/@sanity/default-layout/src/components/DefaultLayout.js
+++ b/packages/@sanity/default-layout/src/components/DefaultLayout.js
@@ -35,21 +35,6 @@ export default withRouterHOC(class DefaultLayout extends React.Component {
     mobileMenuIsOpen: false
   }
 
-  maybeRedirectToFirstTool() {
-    const {router} = this.props
-    if (!router.state.tool && this.props.tools.length > 0) {
-      router.navigate({tool: this.props.tools[0].name}, {replace: true})
-    }
-  }
-
-  componentWillMount() {
-    this.maybeRedirectToFirstTool()
-  }
-
-  componentDidUpdate() {
-    this.maybeRedirectToFirstTool()
-  }
-
   handleCreateButtonClick = () => {
     this.setState({
       createMenuIsOpen: !this.state.createMenuIsOpen

--- a/packages/@sanity/default-layout/src/components/DefaultLayoutContainer.js
+++ b/packages/@sanity/default-layout/src/components/DefaultLayoutContainer.js
@@ -1,52 +1,17 @@
 import React from 'react'
 import DefaultLayout from './DefaultLayout'
-import locationStore from 'part:@sanity/base/location'
 import LoginWrapper from 'part:@sanity/base/login-wrapper?'
 import {RouterProvider} from 'part:@sanity/base/router'
 import NotFound from './NotFound'
 import getOrderedTools from '../util/getOrderedTools'
 import rootRouter from '../defaultLayoutRouter'
-
-function maybeHandleIntent(urlStateEvent) {
-  if (urlStateEvent.state && urlStateEvent.state.intent) {
-    const {intent, params} = urlStateEvent.state
-    const matchingTool = getOrderedTools().find(tool => tool.canHandleIntent && tool.canHandleIntent(intent, params))
-    if (matchingTool) {
-      const toolState = matchingTool.getIntentState(intent, params)
-      const state = {
-        tool: matchingTool.name,
-        [matchingTool.name]: toolState
-      }
-      const redirectUrl = rootRouter.encode(state)
-      locationStore.actions.navigate(redirectUrl, {replace: true})
-      return null
-    }
-    return {
-      isNotFound: true,
-      intent: {name: intent, params}
-    }
-
-  }
-  return urlStateEvent
-}
-
-function decodeUrlState(locationEvent) {
-  return {
-    type: locationEvent.type,
-    state: rootRouter.decode(location.pathname),
-    isNotFound: rootRouter.isNotFound(location.pathname)
-  }
-}
+import * as urlStateStore from '../datastores/urlState'
 
 export default class DefaultLayoutContainer extends React.PureComponent {
   state = {}
 
   componentWillMount() {
-    this.pathSubscription = locationStore
-      .state
-      .map(decodeUrlState)
-      .map(maybeHandleIntent)
-      .filter(Boolean)
+    this.urlStateSubscription = urlStateStore.state
       .subscribe({
         next: event => this.setState({
           urlState: event.state,
@@ -57,11 +22,11 @@ export default class DefaultLayoutContainer extends React.PureComponent {
   }
 
   componentWillUnmount() {
-    this.pathSubscription.unsubscribe()
+    this.urlStateSubscription.unsubscribe()
   }
 
   handleNavigate(newUrl, options) {
-    locationStore.actions.navigate(newUrl, options)
+    urlStateStore.navigate(newUrl, options)
   }
 
   render() {

--- a/packages/@sanity/default-layout/src/components/ToolSwitcher.js
+++ b/packages/@sanity/default-layout/src/components/ToolSwitcher.js
@@ -1,12 +1,12 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import {StateLink} from 'part:@sanity/base/router'
+import {StateLink, withRouterHOC} from 'part:@sanity/base/router'
 import styles from './styles/ToolSwitcher.css'
 import PluginIcon from 'part:@sanity/base/plugin-icon'
 import Ink from 'react-ink'
 
 function ToolSwitcher(props) {
-  const {tools, activeToolName, onSwitchTool} = props
+  const {tools, router, activeToolName, onSwitchTool} = props
   return (
     <div className={`${styles.toolSwitcher} ${props.className}`}>
       <ul className={styles.toolList}>
@@ -17,9 +17,10 @@ function ToolSwitcher(props) {
 
           const ToolIcon = tool.icon || PluginIcon
 
+          const state = Object.assign({}, router.state, {tool: tool.name})
           return (
             <li key={tool.name} className={itemClass}>
-              <StateLink className={styles.toolLink} state={{tool: tool.name}} onClick={onSwitchTool}>
+              <StateLink className={styles.toolLink} state={state} onClick={onSwitchTool}>
                 <div className={styles.iconContainer}>
                   <ToolIcon />
                 </div>
@@ -44,6 +45,7 @@ ToolSwitcher.propTypes = {
   activeToolName: PropTypes.string,
   onSwitchTool: PropTypes.func,
   className: PropTypes.string,
+  router: PropTypes.shape({state: PropTypes.object}),
   tools: PropTypes.arrayOf(
     PropTypes.shape({
       name: PropTypes.string.isRequired,
@@ -52,4 +54,4 @@ ToolSwitcher.propTypes = {
   )
 }
 
-export default ToolSwitcher
+export default withRouterHOC(ToolSwitcher)

--- a/packages/@sanity/default-layout/src/datastores/urlState.js
+++ b/packages/@sanity/default-layout/src/datastores/urlState.js
@@ -1,0 +1,81 @@
+import getOrderedTools from '../util/getOrderedTools'
+import rootRouter from '../defaultLayoutRouter'
+import locationStore from 'part:@sanity/base/location'
+
+function resolveUrlStateWithDefaultTool(state) {
+  if (!state || state.tool) {
+    return state
+  }
+  return Object.assign({}, state, {
+    tool: getOrderedTools()[0].name
+  })
+}
+
+function resolveIntentState(currentState, intentState) {
+  const {intent, params} = intentState
+
+  const tools = getOrderedTools()
+
+  const currentTool = currentState.tool ? tools.find(tool => tool.name === currentState.tool) : null
+
+  // If current tool can handle intent and if so, give it precedence
+  const matchingTool = (currentTool ? [currentTool, ...tools] : tools)
+    .find(tool =>
+      (tool && typeof tool.canHandleIntent === 'function' && tool.canHandleIntent(intent, params)))
+
+  if (matchingTool) {
+    const toolState = matchingTool.getIntentState(intent, params)
+    const prevWithDefaults = resolveUrlStateWithDefaultTool(currentState) || currentState
+    return Object.assign({}, prevWithDefaults, {
+      tool: matchingTool.name,
+      [matchingTool.name]: toolState
+    })
+  }
+  return {
+    isNotFound: true,
+    intent: {name: intent, params}
+  }
+}
+
+function maybeHandleIntent(prevEvent, currentEvent) {
+  if (currentEvent.state && currentEvent.state.intent) {
+    const redirectState = resolveIntentState(prevEvent.state, currentEvent.state)
+    if (redirectState) {
+      navigate(rootRouter.encode(redirectState), {replace: true})
+      return null
+    }
+  }
+  return currentEvent
+}
+
+function decodeUrlState(locationEvent) {
+  return {
+    type: locationEvent.type,
+    state: rootRouter.decode(location.pathname),
+    isNotFound: rootRouter.isNotFound(location.pathname)
+  }
+}
+
+function maybeRedirectDefaultState(event) {
+  const redirectState = resolveUrlStateWithDefaultTool(event.state)
+  if (redirectState !== event.state) {
+    navigate(rootRouter.encode(redirectState), {replace: true})
+    return null
+  }
+  return event
+}
+
+export function navigate(newUrl, options) {
+  locationStore.actions.navigate(newUrl, options)
+}
+
+export const state = locationStore
+  .state
+  .map(decodeUrlState)
+  .scan(maybeHandleIntent)
+  .filter(Boolean)
+  .map(maybeRedirectDefaultState)
+  .filter(Boolean)
+  .publishReplay(1)
+  .refCount()
+

--- a/packages/test-studio/sanity.json
+++ b/packages/test-studio/sanity.json
@@ -31,6 +31,10 @@
     {
       "implements": "part:@sanity/base/schema-type",
       "path": "src/components/PertEstimateSchema.js"
+    },
+    {
+      "implements": "part:@sanity/base/tool",
+      "path": "src/test-intent-tool"
     }
   ],
   "env": {

--- a/packages/test-studio/src/test-intent-tool.js
+++ b/packages/test-studio/src/test-intent-tool.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import {route, withRouterHOC} from 'part:@sanity/base/router'
+
+export default {
+  router: route('/:type/:id'),
+  canHandleIntent(intentName, params) {
+    return (intentName === 'edit' && params.id)
+      || (intentName === 'create' && params.type)
+  },
+  getIntentState(intentName, params) {
+    return {
+      type: params.type || '*',
+      id: params.id
+    }
+  },
+  title: 'Test intent',
+  name: 'test-intent',
+  component: withRouterHOC(props => (
+    <div style={{padding: 10}}>
+      <h2>Test intent precedence</h2>
+      If you click an intent link (e.g. from search results) while this tool is open, it should be opened here.
+      <pre>{JSON.stringify(props.router.state, null, 2)}</pre>
+    </div>
+  ))
+}


### PR DESCRIPTION
This refactors the url state management out of the components layer and into its own store and gives current active tool precedence when resolving intent links.