### PR TITLE
[form-builder] Fix false weak mismatch false positive

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/Reference/ReferenceInput.js
+++ b/packages/@sanity/form-builder/src/inputs/Reference/ReferenceInput.js
@@ -188,8 +188,9 @@ export default class ReferenceInput extends React.Component<Props, State> {
     const weakIs = value && value._weak ? 'weak' : 'strong'
     const weakShouldBe = type.weak === true ? 'weak' : 'strong'
 
-    const isMissing = value && previewSnapshot === MISSING_SNAPSHOT
-    const hasWeakMismatch = !isMissing && weakIs !== weakShouldBe
+    const isMissing = previewSnapshot === MISSING_SNAPSHOT
+    const hasRef = value && value._ref
+    const hasWeakMismatch = hasRef && !isMissing && weakIs !== weakShouldBe
 
     return (
       <FormField label={type.title} level={level} description={type.description}>
@@ -205,7 +206,7 @@ export default class ReferenceInput extends React.Component<Props, State> {
           <SearchableSelect
             {...rest}
             placeholder="Type to search…"
-            title={(isMissing && value) ? `Document id: ${value._ref}` : (previewSnapshot && previewSnapshot.description)}
+            title={(isMissing && hasRef) ? `Document id: ${value._ref || 'unknown'}` : (previewSnapshot && previewSnapshot.description)}
             onOpen={this.handleOpen}
             onFocus={this.handleFocus}
             onSearch={this.handleSearch}

--- a/packages/test-studio/schemas/references.js
+++ b/packages/test-studio/schemas/references.js
@@ -23,6 +23,15 @@ export default {
       of: [
         {
           type: 'reference',
+          name: 'strongAuthorRef',
+          title: 'A strong author ref',
+          to: {type: 'author'}
+        },
+        {
+          type: 'reference',
+          name: 'weakAuthorRef',
+          title: 'A weak author ref',
+          weak: true,
           to: {type: 'author'}
         }
       ]


### PR DESCRIPTION
This fixes a minor UI issue with weak refs in arrays that would show a weak mismatch warning for the reference before the `_ref` key was set.