### PR TITLE
[block-tools] Fix bug in deserializing annotations within list item block

### DIFF
--- a/packages/@sanity/block-tools/src/HtmlDeserializer/index.js
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/index.js
@@ -141,13 +141,6 @@ export default class HtmlDeserializer {
         continue
       } else if (ret === null) {
         return null
-      } else if (ret && ret._type === 'block' && ret.listItem) {
-        let parent = element.parentNode.parentNode
-        while (tagName(parent) === 'li') { // eslint-disable-line max-depth
-          parent = parent.parentNode.parentNode
-          ret.level++
-        }
-        node = ret
       } else if (ret._type === '__decorator') {
         node = this.deserializeDecorator(ret)
       } else if (ret._type === '__annotation') {
@@ -159,7 +152,14 @@ export default class HtmlDeserializer {
       } else {
         node = ret
       }
-
+      // Set list level on list item
+      if (ret && ret._type === 'block' && ret.listItem) {
+        let parent = element.parentNode.parentNode
+        while (tagName(parent) === 'li') {
+          parent = parent.parentNode.parentNode
+          ret.level++
+        }
+      }
       break
     }
     return node || next(element.childNodes)

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/fromTheWild/output.json
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/fromTheWild/output.json
@@ -474,7 +474,13 @@
   },
   {
     "_type": "block",
-    "markDefs": [],
+    "markDefs": [
+      {
+        "_key": "randomKey8",
+        "_type": "link",
+        "href": "https://lovdata.no/dokument/LTI/lov/2008-06-20-42/%C2%A79#§9"
+      }
+    ],
     "style": "normal",
     "level": 1,
     "listItem": "bullet",
@@ -489,13 +495,7 @@
   },
   {
     "_type": "block",
-    "markDefs": [
-      {
-        "_key": "randomKey8",
-        "_type": "link",
-        "href": "https://lovdata.no/dokument/LTI/lov/2008-06-20-42/%C2%A79#§9"
-      }
-    ],
+    "markDefs": [],
     "style": "normal",
     "children": [
       {

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/lists/input.html
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/lists/input.html
@@ -17,7 +17,10 @@
           </ul>
         </li>
         <li>
-          1 b
+          1 <strong>b</strong>
+        </li>
+        <li>
+          <a href="/">Link</a>
         </li>
       </ul>
   </body>

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/lists/output.json
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/lists/output.json
@@ -41,10 +41,21 @@
   },
   {
     "_type": "block",
-    "children": [{ "_type": "span", "marks": [], "text": "1 b" }],
+    "children": [
+      { "_type": "span", "marks": [], "text": "1 " },
+      { "_type": "span", "marks": ["strong"], "text": "b" }
+    ],
     "level": 1,
     "listItem": "bullet",
     "markDefs": [],
+    "style": "normal"
+  },
+  {
+    "_type": "block",
+    "children": [{ "_type": "span", "marks": ["randomKey0"], "text": "Link" }],
+    "level": 1,
+    "listItem": "bullet",
+    "markDefs": [{ "_key": "randomKey0", "_type": "link", "href": "/" }],
     "style": "normal"
   }
 ]


### PR DESCRIPTION
The deserializer did not put the annotation mark in the blocks's ``markDefs`` array when originating from a list item. This will fix it.