### PR TITLE
[default-layout] Prevent unnecessary rerenders of Search

### DIFF
--- a/packages/@sanity/default-layout/src/components/Search.js
+++ b/packages/@sanity/default-layout/src/components/Search.js
@@ -170,7 +170,9 @@ export default enhanceClickOutside(class Search extends React.Component {
   }
 
   handleClickOutside = el => {
-    this.close()
+    if (this.state.isOpen) {
+      this.close()
+    }
   }
 
   handleHitClick = el => {


### PR DESCRIPTION
This avoids a setState call on _click outside_ and prevents an unneccessary rerenders of the search component on every click anywhere in the studio.