### PR TITLE
[components] Cleanup fieldset - support isExpanded by default

### DIFF
--- a/packages/@sanity/components/src/fieldsets/DefaultFieldset.js
+++ b/packages/@sanity/components/src/fieldsets/DefaultFieldset.js
@@ -10,7 +10,8 @@ export default class Fieldset extends React.Component {
     description: PropTypes.string,
     legend: PropTypes.string.isRequired,
     columns: PropTypes.number,
-    collapsable: PropTypes.bool,
+    isCollapsible: PropTypes.bool,
+    isCollapsed: PropTypes.bool,
     fieldset: PropTypes.shape({
       description: PropTypes.string,
       legend: PropTypes.string
@@ -22,34 +23,48 @@ export default class Fieldset extends React.Component {
     styles: PropTypes.object
   }
 
-  state = {
-    isOpen: (typeof (this.props.collapsable) == 'undefined')
-  }
-
   static defaultProps = {
     level: 1,
     fieldset: {},
-    className: ''
+    className: '',
+    isCollapsed: false,
+    isCollapsible: false // can collapsing be toggled by user?
   }
 
-  handleToggle = () => {
-    if (this.props.collapsable) {
-      this.setState({
-        isOpen: !this.state.isOpen
-      })
+  constructor(props) {
+    super()
+    this.state = {
+      isCollapsed: props.isCollapsed
     }
   }
 
+  handleToggle = () => {
+    this.setState(prevState => ({isCollapsed: !prevState.isCollapsed}))
+  }
+
   render() {
-    const {fieldset, legend, description, columns, level, className, children, collapsable, transparent, ...rest} = this.props
-    const {isOpen} = this.state
+    const {
+      fieldset,
+      legend,
+      description,
+      columns,
+      level,
+      className,
+      isCollapsible,
+      isCollapsed: _ignore,
+      children,
+      transparent,
+      ...rest
+    } = this.props
+
+    const {isCollapsed} = this.state
 
     const styles = {
       ...defaultStyles,
       ...this.props.styles
     }
 
-    const rootClass = [
+    const rootClassName = [
       styles.root,
       styles[`columns${columns}`],
       styles[`level${level}`],
@@ -60,28 +75,24 @@ export default class Fieldset extends React.Component {
       .join(' ')
 
     return (
-      <fieldset {...rest} className={rootClass} data-nesting-level={level}>
+      <fieldset {...rest} className={rootClassName} data-nesting-level={level}>
         <div className={styles.inner}>
-          <legend className={`${styles.legend} ${isOpen ? styles.isOpen : ''}`} onClick={this.handleToggle}>
-            {
-              collapsable && (
-                <div className={`${styles.arrow} ${isOpen ? styles.isOpen : ''}`}>
-                  <ArrowDropDown />
-                </div>
-              )
-            }
+          <legend className={`${styles.legend} ${isCollapsed ? '' : styles.isOpen}`} onClick={isCollapsible && this.handleToggle}>
+            {isCollapsible && (
+              <div className={`${styles.arrow} ${isCollapsed ? '' : styles.isOpen}`}>
+                <ArrowDropDown />
+              </div>
+            )}
             {legend || fieldset.legend}
           </legend>
-          {
-            (description || fieldset.description) && (
-              <p className={`${styles.description} ${isOpen ? styles.isOpen : ''}`}>
-                {description || fieldset.description}
-              </p>
-            )
-          }
-          <div className={`${styles.content} ${isOpen ? styles.isOpen : ''}`}>
+          {(description || fieldset.description) && (
+            <p className={`${styles.description} ${isCollapsed ? '' : styles.isOpen}`}>
+              {description || fieldset.description}
+            </p>
+          )}
+          <div className={`${styles.content} ${isCollapsed ? '' : styles.isOpen}`}>
             <div className={styles.fieldWrapper}>
-              {isOpen && children}
+              {!isCollapsed && children}
             </div>
           </div>
         </div>

--- a/packages/@sanity/components/src/fieldsets/story.js
+++ b/packages/@sanity/components/src/fieldsets/story.js
@@ -74,33 +74,33 @@ storiesOf('Fieldsets')
 )
 
 .add(
-  'Collapsable (demo)',
+  'Collapsible (demo)',
   () => {
     const level = number('start level', 0)
-    const collapsable = boolean('collapsable', true)
+    const isCollapsible = boolean('isCollapsible', true)
     return (
       <Sanity part="part:@sanity/components/fieldsets/default" propTables={[Fieldset]}>
         <div>
-          <Fieldset collapsable={collapsable} legend="Noooo, pick me, pick me!" description={chance.sentence()} level={level}>
+          <Fieldset isCollapsible={isCollapsible} legend="Noooo, pick me, pick me!" description={chance.sentence()} level={level}>
             <DefaultTextField label="Content" level={level + 1} />
             <DefaultTextField label="Content" level={level + 1} description="Test this one" />
             <DefaultTextField label="Content" level={level + 1} />
             <DefaultTextField label="Content" level={level + 1} />
           </Fieldset>
           <Fieldset legend="Fieldsets can be collapsed" description={chance.sentence()} level={level}>
-            <Fieldset collapsable={collapsable} legend="Open me" description={chance.sentence()} level={level + 1}>
+            <Fieldset isCollapsible={isCollapsible} legend="Open me" description={chance.sentence()} level={level + 1}>
               <DefaultTextField label="Content" level={level + 2} />
               <DefaultTextField label="Content" level={level + 2} description="Test this one" />
               <DefaultTextField label="Content" level={level + 2} />
               <DefaultTextField label="Content" level={level + 2} />
             </Fieldset>
-            <Fieldset collapsable={collapsable} legend="No, open me!" description={chance.sentence()} level={level + 1}>
+            <Fieldset isCollapsible={isCollapsible} legend="No, open me!" description={chance.sentence()} level={level + 1}>
               <DefaultTextField label="Content" level={level + 2} />
               <DefaultTextField label="Content" level={level + 2} description="Test this one" />
               <DefaultTextField label="Content" level={level + 2} />
               <DefaultTextField label="Content" level={level + 2} />
             </Fieldset>
-            <Fieldset collapsable={collapsable} legend="Noooo, pick me, pick me!" description={chance.sentence()} level={level + 1}>
+            <Fieldset isCollapsible={isCollapsible} legend="Noooo, pick me, pick me!" description={chance.sentence()} level={level + 1}>
               <DefaultTextField label="Content" level={level + 2} />
               <DefaultTextField label="Content" level={level + 2} description="Test this one" />
               <DefaultTextField label="Content" level={level + 2} />
@@ -151,10 +151,10 @@ storiesOf('Fieldsets')
               <DefaultTextField label="Content" level={2} />
             </Fieldset>
           </Fieldset>
-          <Fieldset collapsable legend="Collapsable Level 0" level={0}>
+          <Fieldset isCollapsible legend="Collapsible Level 0" level={0}>
             <DefaultTextField label="Content" level={1} />
           </Fieldset>
-          <Fieldset collapsable legend="Collapsable Level 0, 2 columns" level={0} columns={2}>
+          <Fieldset isCollapsible legend="Collapsible Level 0, 2 columns" level={0} columns={2}>
             <Fieldset legend="Level 1" description="This is the desription" level={1}>
               <DefaultTextField label="Content" level={2} />
             </Fieldset>
@@ -197,11 +197,11 @@ storiesOf('Fieldsets')
             <Fieldset legend="Level 1" level={1}><DefaultTextField label="Content" level={1} /></Fieldset>
           </Fieldset>
 
-          <Fieldset legend="Level 0 with 2 columns. Collapsable" level={0} columns={2}>
-            <Fieldset collapsable legend="Level 1" level={1}><DefaultTextField label="Content" level={2} /></Fieldset>
-            <Fieldset collapsable legend="Level 1" level={1}><DefaultTextField label="Content" level={2} /></Fieldset>
-            <Fieldset collapsable legend="Level 1" level={1}><DefaultTextField label="Content" level={2} /></Fieldset>
-            <Fieldset collapsable legend="Level 1" level={1}><DefaultTextField label="Content" level={2} /></Fieldset>
+          <Fieldset legend="Level 0 with 2 columns. Collapsible" level={0} columns={2}>
+            <Fieldset isCollapsible legend="Level 1" level={1}><DefaultTextField label="Content" level={2} /></Fieldset>
+            <Fieldset isCollapsible legend="Level 1" level={1}><DefaultTextField label="Content" level={2} /></Fieldset>
+            <Fieldset isCollapsible legend="Level 1" level={1}><DefaultTextField label="Content" level={2} /></Fieldset>
+            <Fieldset isCollapsible legend="Level 1" level={1}><DefaultTextField label="Content" level={2} /></Fieldset>
           </Fieldset>
 
           <Fieldset legend="Level 0 with 3 columns. No desriptions" level={0} columns={3}>

--- a/packages/@sanity/form-builder/examples/schema-testbed/schemas/fieldsets.js
+++ b/packages/@sanity/form-builder/examples/schema-testbed/schemas/fieldsets.js
@@ -16,7 +16,7 @@ export default {
         },
         {
           name: 'author',
-          title: 'Author details (collapsable)',
+          title: 'Author details (collapsible)',
           description: 'Author details with 2 column grid',
           options: {
             columns: 2,
@@ -25,7 +25,7 @@ export default {
         },
         {
           name: 'checkboxes',
-          title: 'Checkbox (collapsable)',
+          title: 'Checkbox (collapsible)',
           description: 'Lets put 3 checkboxes in an a 3 column',
           options: {
             columns: 3,

--- a/packages/@sanity/form-builder/src/inputs/Object/Object.js
+++ b/packages/@sanity/form-builder/src/inputs/Object/Object.js
@@ -88,10 +88,11 @@ export default class ObjectInput extends React.PureComponent {
   renderFieldset(fieldset, fieldsetIndex) {
     const {level, focusPath} = this.props
     const columns = fieldset.options && fieldset.options.columns
-    const collapsable = fieldset.options && fieldset.options.collapsable
+    const isCollapsible = fieldset.options && (fieldset.options.collapsable || fieldset.options.collapsible)
     const isExpanded = focusPath.length > 0 && fieldset.fields.some(field => (
       focusPath[0] === field.name
     ))
+
     return (
       <div key={fieldset.name} className={fieldStyles.root}>
         <Fieldset
@@ -99,7 +100,8 @@ export default class ObjectInput extends React.PureComponent {
           description={fieldset.description}
           level={level + 1}
           columns={columns}
-          isExpanded={collapsable === false || isExpanded}
+          isCollapsible={isCollapsible}
+          isCollapsed={!isExpanded}
         >
           {fieldset.fields.map((field, fieldIndex) => {
             return this.renderField(field, level + 2, fieldsetIndex + fieldIndex)
@@ -174,7 +176,7 @@ export default class ObjectInput extends React.PureComponent {
     }
 
     const columns = type.options && type.options.columns
-    const collapsable = type.options && type.options.collapsable
+    const isCollapsible = type.options && (type.options.collapsable || type.options.collapsible)
 
     return (
       <Fieldset
@@ -182,7 +184,8 @@ export default class ObjectInput extends React.PureComponent {
         legend={type.title}
         description={type.description}
         columns={columns}
-        collapsable={collapsable}
+        isCollapsible={isCollapsible}
+        isCollapsed={isCollapsible}
       >
         {renderedFields}
         {renderedUnknownFields}

--- a/packages/@sanity/schema/test/legacy/fixtures/schemas/fieldsets.js
+++ b/packages/@sanity/schema/test/legacy/fixtures/schemas/fieldsets.js
@@ -16,7 +16,7 @@ export default {
         },
         {
           name: 'author',
-          title: 'Author details (collapsable)',
+          title: 'Author details (collapsible)',
           description: 'Author details with 2 column grid',
           options: {
             columns: 2,
@@ -25,7 +25,7 @@ export default {
         },
         {
           name: 'checkboxes',
-          title: 'Checkbox (collapsable)',
+          title: 'Checkbox (collapsible)',
           description: 'Lets put 3 checkboxes in an a 3 column',
           options: {
             columns: 3,


### PR DESCRIPTION
In order to be able to deep link to form builder fields, the default fieldset must support being expanded initially. This PR fixes that.

Summary:
- Adds a `isCollapsible`-prop that must be true to make the fieldset collapsible.
- Adds a `isCollapsed`-prop that, renders the fieldset as collapsed initially.
- Fixes a typo: _collapsable_ should be _collapsible_ (preserved backwards compatibility with schema options)
- General cleanup