### PR TITLE
[import] Generate document IDs on client side

### DIFF
--- a/packages/@sanity/import/package.json
+++ b/packages/@sanity/import/package.json
@@ -25,6 +25,7 @@
   ],
   "dependencies": {
     "@sanity/mutator": "^0.120.0",
+    "@sanity/uuid": "^0.120.0",
     "debug": "^2.6.3",
     "get-uri": "^2.0.1",
     "lodash": "^4.17.4",

--- a/packages/@sanity/import/src/assignDocumentId.js
+++ b/packages/@sanity/import/src/assignDocumentId.js
@@ -1,0 +1,11 @@
+const uuid = require('@sanity/uuid')
+
+function assignDocumentId(doc) {
+  if (doc._id) {
+    return doc
+  }
+
+  return Object.assign({_id: uuid()}, doc)
+}
+
+module.exports = assignDocumentId

--- a/packages/@sanity/import/src/documentHasErrors.js
+++ b/packages/@sanity/import/src/documentHasErrors.js
@@ -3,6 +3,10 @@ function documentHasErrors(doc) {
     return `Document contained an invalid "_id" property - must be a string`
   }
 
+  if (typeof doc._id !== 'undefined' && !/^[a-z0-9_.-]+$/i.test(doc._id)) {
+    return `Document ID "${doc._id}" is not valid: Please use alphanumeric document IDs. Dashes (-) and underscores (_) are also allowed.`
+  }
+
   if (typeof doc._type !== 'string') {
     return `Document did not contain required "_type" property of type string`
   }

--- a/packages/@sanity/import/src/import.js
+++ b/packages/@sanity/import/src/import.js
@@ -4,6 +4,7 @@ const validateOptions = require('./validateOptions')
 const streamToArray = require('./streamToArray')
 const {getAssetRefs, unsetAssetRefs} = require('./assetRefs')
 const assignArrayKeys = require('./assignArrayKeys')
+const assignDocumentId = require('./assignDocumentId')
 const uploadAssets = require('./uploadAssets')
 const documentHasErrors = require('./documentHasErrors')
 const batchDocuments = require('./batchDocuments')
@@ -28,9 +29,13 @@ async function importDocuments(input, opts) {
     documents.some(documentHasErrors.validate)
   }
 
+  // Assign document IDs for document that do not have one. This is necessary
+  // for us to strengthen references and import assets properly.
+  const ided = documents.map(doc => assignDocumentId(doc))
+
   // User might not have applied `_key` on array elements which are objects;
   // if this is the case, generate random keys to help realtime engine
-  const keyed = documents.map(doc => assignArrayKeys(doc))
+  const keyed = ided.map(doc => assignArrayKeys(doc))
 
   // Sanity prefers to have a `_type` on every object. Make sure references
   // has `_type` set to `reference`.

--- a/packages/@sanity/import/test/fixtures/invalid-id-format.ndjson
+++ b/packages/@sanity/import/test/fixtures/invalid-id-format.ndjson
@@ -1,0 +1,3 @@
+{"_id": "espen", "_type": "employee", "name": "Espen"}
+{"_id": "pk#123", "_type": "employee", "name": "Per-Kristian"}
+{"_id": "Even", "_type": "employee", "name": "Even"}

--- a/packages/@sanity/import/test/fixtures/valid-but-missing-ids.ndjson
+++ b/packages/@sanity/import/test/fixtures/valid-but-missing-ids.ndjson
@@ -1,0 +1,3 @@
+{"_type": "employee", "name": "Espen"}
+{"_id":"pk", "_type": "employee", "name": "Per-Kristian"}
+{"_type": "employee", "name": "Bjørge"}


### PR DESCRIPTION
Certain operations, such as strengthening of references and asset document generation, currently require you to have document IDs, but do not warn you of this.

This PR adds document IDs for any documents that do not already have one, which should solve this in the easiest way I could think of.

Fixes #402