### PR TITLE
[block-tools] Fix deserialization of blockquotes containing block elements

### DIFF
--- a/packages/@sanity/block-tools/src/HtmlDeserializer/index.js
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/index.js
@@ -170,7 +170,6 @@ export default class HtmlDeserializer {
             }
           }
         })
-        delete ret.__blockStyleSpans
       }
       break
     }

--- a/packages/@sanity/block-tools/src/HtmlDeserializer/index.js
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/index.js
@@ -160,6 +160,18 @@ export default class HtmlDeserializer {
           ret.level++
         }
       }
+      // Set newlines on spans orginating from a block element within a blockquote
+      if (ret && ret._type === 'block' && ret.style === 'blockquote') {
+        ret.children.forEach((child, index) => {
+          if (child._type === 'span' && child.text === '\r') {
+            child.text = '\n\n'
+            if (index === 0 || index === ret.children.length - 1) {
+              ret.children.splice(index, 1)
+            }
+          }
+        })
+        delete ret.__blockStyleSpans
+      }
       break
     }
     return node || next(element.childNodes)

--- a/packages/@sanity/block-tools/src/HtmlDeserializer/preprocessors/default.js
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/preprocessors/default.js
@@ -7,8 +7,6 @@ export default (html, doc) => {
     '/html/text()',
     '/html/head/text()',
     '/html/body/text()',
-    '//p[not(.//text())]',
-    '//span[not(.//text())]',
     '//comment()',
     '//style',
     '//xml',

--- a/packages/@sanity/block-tools/src/HtmlDeserializer/rules/default.js
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/rules/default.js
@@ -45,6 +45,41 @@ export default function createDefaultRules(blockContentType, options = {}) {
       }
     },
 
+    // Blockquote element
+    {
+      deserialize(el, next) {
+        if (tagName(el) !== 'blockquote') {
+          return undefined
+        }
+        const blocks = {...HTML_BLOCK_TAGS, ...HTML_HEADER_TAGS}
+        delete blocks.blockquote
+        const children = []
+        el.childNodes.forEach((node, index) => {
+          if (node.nodeType === 1
+              && Object.keys(blocks).includes(node.localName.toLowerCase())) {
+            const span = el.ownerDocument.createElement('span')
+            span.appendChild(el.ownerDocument.createTextNode('\r'))
+            node.childNodes.forEach(cn => {
+              span.appendChild(cn.cloneNode(true))
+            })
+            if (index !== el.childNodes.length) {
+              span.appendChild(el.ownerDocument.createTextNode('\r'))
+            }
+            children.push(span)
+          } else {
+            children.push(node)
+          }
+        })
+
+        return {
+          _type: 'block',
+          style: 'blockquote',
+          markDefs: [],
+          children: next(children)
+        }
+      }
+    },
+
     // Block elements
     {
       deserialize(el, next) {

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/customRules/index.js
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/customRules/index.js
@@ -5,6 +5,19 @@ const blockContentType = defaultSchema.get('blogPost')
 
 
 const rules = [
+  // Map 'em' tags to 'strong'
+  {
+    deserialize(el, next) {
+      if (el.tagName.toLowerCase() !== 'em') {
+        return undefined
+      }
+      return {
+        _type: '__decorator',
+        name: 'strong',
+        children: next(el.childNodes)
+      }
+    }
+  },
   {
     // Special case for code blocks (wrapped in pre and code tag)
     deserialize(el, next) {

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/customRules/index.js
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/customRules/index.js
@@ -25,6 +25,17 @@ const rules = [
         text: text
       }
     }
+  },
+  {
+    deserialize(el, next) {
+      if (el.tagName.toLowerCase() !== 'img') {
+        return undefined
+      }
+      return {
+        _type: 'image',
+        src: el.getAttribute('src')
+      }
+    }
   }
 ]
 

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/customRules/input.html
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/customRules/input.html
@@ -1,5 +1,10 @@
 <html>
   <body>
     <pre><code>const foo = 'bar'</code></pre>
+    <blockquote>
+      <p>Quote <strong>with emphasis</strong></p>
+      <em>Emphasis!</em>
+    </blockquote>
+    <p><img src="http://image.gif" /></p>
   </body>
 </html>

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/customRules/output.json
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/customRules/output.json
@@ -6,5 +6,24 @@
     ],
     "markDefs": [],
     "style": "normal"
+  },
+  {
+    "_type": "block",
+    "children": [
+      {"_type": "span", "marks": [], "text": "Quote "},
+      {"_type": "span", "marks": ["strong"], "text": "with emphasis"},
+      {"_type": "span", "marks": [], "text": "\n\n"},
+      {"_type": "span", "marks": ["strong"], "text": "Emphasis!"}
+    ],
+    "markDefs": [],
+    "style": "blockquote"
+  },
+  {
+    "_type": "block",
+    "children": [
+      {"_type": "image", "src": "http://image.gif"}
+    ],
+    "markDefs": [],
+    "style": "normal"
   }
 ]

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/nestedContainers/input.html
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/nestedContainers/input.html
@@ -10,6 +10,7 @@
         And I'm a quote within a quote within a quote.
         <blockquote>
           And I'm a quote within a quote within a quote within a quote.
+          <p>I am a stupid paragraph within with a stupid <a href="foo">link</a></p>
         </blockquote>
       </blockquote>
     </blockquote>

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/nestedContainers/output.json
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/nestedContainers/output.json
@@ -43,9 +43,28 @@
         "marks": [],
         "text":
           "And I'm a quote within a quote within a quote within a quote."
+      },
+      {
+        "_type": "span",
+        "marks": [],
+        "text": "\n\n"
+      },
+      {
+        "_type": "span",
+        "marks": [],
+        "text": "I am a stupid paragraph within with a stupid "
+      },
+      {
+        "_type": "span",
+        "marks": ["randomKey0"],
+        "text": "link"
       }
     ],
-    "markDefs": [],
+    "markDefs": [{
+      "_key": "randomKey0",
+      "_type": "link",
+      "href": "foo"
+    }],
     "style": "blockquote"
   },
   {


### PR DESCRIPTION
This will handle block elements within blockquotes.
Also fix bug where non-text-elements only (like img) within block elements, made it be preprocessed away.

