### PR TITLE
[form-builder] Fix crash when input/preview cannot be resolved

### DIFF
--- a/packages/@sanity/form-builder/src/FormBuilderContext.js
+++ b/packages/@sanity/form-builder/src/FormBuilderContext.js
@@ -28,7 +28,9 @@ function memoizeMap(method) {
       return map.get(arg)
     }
     const val = method.call(this, arg)
-    map.set(arg, val)
+    if (arg) {
+      map.set(arg, val)
+    }
     return val
   }
 }


### PR DESCRIPTION
Sometimes you get into weird cases where there is no preview component or input component available. The memoization introduced recently breaks when this happens, because it tries to use `undefined` as the key on a WeakMap.

This PR simply checks if the key is truthy, and skips memoization if it isn't.
