### PR TITLE
[default-layout] Add update notifier for outdated modules

### DIFF
--- a/packages/@sanity/base/package.json
+++ b/packages/@sanity/base/package.json
@@ -44,6 +44,7 @@
     "promise-props": "^1.0.0",
     "react-icons": "^2.2.5",
     "react-intl": "^2.2.2",
+    "semver-compare": "^1.0.0",
     "shallow-equals": "^1.0.0",
     "stylelint-config-standard": "^17.0.0"
   },

--- a/packages/@sanity/base/sanity.json
+++ b/packages/@sanity/base/sanity.json
@@ -38,6 +38,10 @@
       "description": "Function that configures the default sanity client"
     },
     {
+      "implements": "part:@sanity/base/version-checker",
+      "path": "components/VersionChecker.js"
+    },
+    {
       "name": "part:@sanity/base/asset-url-builder-default",
       "implements": "part:@sanity/base/asset-url-builder",
       "description": "Function that generates or modifies asset URLs for display in various contexts",

--- a/packages/@sanity/base/src/components/VersionChecker.js
+++ b/packages/@sanity/base/src/components/VersionChecker.js
@@ -1,12 +1,28 @@
+import {omit} from 'lodash'
 import React, {PureComponent} from 'react'
-import FullscreenError from './FullscreenError'
+import semverCompare from 'semver-compare'
+import versions from 'sanity:versions'
 import FullscreenDialog from 'part:@sanity/components/dialogs/fullscreen?'
 import client from 'part:@sanity/base/client'
-import versions from 'sanity:versions'
+import FullscreenError from './FullscreenError'
 
-const onIdle = typeof window.requestIdleCallback === 'function'
-  ? window.requestIdleCallback
-  : cb => setTimeout(cb, 0)
+const fakeOutdatedModule = false
+const fakeOutdatedModuleSeverity = 'high'
+let applySeverity = inp => inp
+
+if (fakeOutdatedModule) {
+  versions['@sanity/base'] = '0.118.0'
+  applySeverity = inp => {
+    const mod = (inp && inp.outdated.find(item => item.name === '@sanity/base')) || {}
+    mod.severity = fakeOutdatedModuleSeverity
+    return inp
+  }
+}
+
+const onIdle =
+  typeof window.requestIdleCallback === 'function'
+    ? window.requestIdleCallback
+    : cb => setTimeout(cb, 0)
 
 // eslint-disable-next-line id-length
 const buildQueryString = () => ({m: Object.keys(versions).map(pkg => `${pkg}@${versions[pkg]}`)})
@@ -37,24 +53,35 @@ const paragraphify = text => {
   })
 }
 
-const checkVersions = () => {
+const getLatestInstalled = () => {
+  const versionNums = Object.keys(versions).map(pkg => versions[pkg])
+  const sorted = versionNums.sort(semverCompare)
+  return sorted[sorted.length - 1]
+}
+
+const checkVersions = (options = {}) => {
+  const {getOutdated} = options
   const query = buildQueryString()
   const hash = hashQuery(query.m)
-  const local = (
-    storage.versionCheck
-    && storage.versionCheck.indexOf(hash) === 0
-    && storage.versionCheck.slice(hash.length + 1)
-  )
+  const local =
+    storage.versionCheck &&
+    storage.versionCheck.indexOf(hash) === 0 &&
+    storage.versionCheck.slice(hash.length + 1)
 
-  if (local) {
+  if (!getOutdated && local) {
     return Promise.resolve({result: JSON.parse(local)})
   }
 
-  return client.request({
-    uri: '/versions',
-    query: buildQueryString(),
-    json: true
-  }).then(result => ({hash, result}))
+  return client
+    .request({
+      uri: '/versions',
+      query: buildQueryString(),
+      json: true
+    })
+    .then(result => ({
+      hash,
+      result: applySeverity(result)
+    }))
 }
 
 class VersionChecker extends PureComponent {
@@ -66,15 +93,18 @@ class VersionChecker extends PureComponent {
   }
 
   onResponse(res) {
-    if (res.hash && storage) {
-      storage.versionCheck = [res.hash, JSON.stringify(res.result)].join('|')
+    // Don't include outdated modules in the stored result
+    const result = omit(res.result, ['outdated'])
+    if (result.hash && storage) {
+      storage.versionCheck = [res.hash, JSON.stringify(result)].join('|')
     }
 
-    if (!res.result.isSupported) {
-      this.setState({result: res.result})
+    // If we have unsupported modules, we want to show a dialog
+    if (!result.isSupported) {
+      this.setState({result})
     }
 
-    if (__DEV__ && res.result.outdated) {
+    if (__DEV__ && res.result && res.result.outdated) {
       const modules = res.result.outdated.map(mod => mod.name).join('\n  - ')
       const instructions = 'Run `sanity upgrade` to update them'
       // eslint-disable-next-line no-console
@@ -87,7 +117,11 @@ class VersionChecker extends PureComponent {
   }
 
   componentDidMount() {
-    onIdle(() => checkVersions().then(this.onResponse).catch(onVersionCheckError))
+    onIdle(() => {
+      checkVersions()
+        .then(this.onResponse)
+        .catch(onVersionCheckError)
+    })
   }
 
   render() {
@@ -104,11 +138,16 @@ class VersionChecker extends PureComponent {
         {paragraphify(result.message || '')}
 
         {result.helpUrl && (
-          <p>For more information, please read <a href={result.helpUrl}>{result.helpUrl}</a></p>
+          <p>
+            For more information, please read <a href={result.helpUrl}>{result.helpUrl}</a>
+          </p>
         )}
       </Dialog>
     )
   }
 }
+
+VersionChecker.checkVersions = checkVersions
+VersionChecker.getLatestInstalled = getLatestInstalled
 
 export default VersionChecker

--- a/packages/@sanity/default-layout/src/components/DefaultLayout.js
+++ b/packages/@sanity/default-layout/src/components/DefaultLayout.js
@@ -18,169 +18,176 @@ import Button from 'part:@sanity/components/buttons/default'
 import {SchemaErrorReporter} from './SchemaErrorReporter'
 import SpaceSwitcher from './SpaceSwitcher'
 import {HAS_SPACES} from '../util/spaces'
+import UpdateNotifier from './UpdateNotifier'
 import AppLoadingScreen from 'part:@sanity/base/app-loading-screen'
 
 const dataAspects = new DataAspectsResolver(schema)
 
-export default withRouterHOC(class DefaultLayout extends React.Component {
-  static propTypes = {
-    router: PropTypes.shape({
-      state: PropTypes.object,
-      navigate: PropTypes.func
-    }),
-    tools: PropTypes.arrayOf(PropTypes.shape({
-      name: PropTypes.string
-    }))
-  }
-
-  state = {
-    createMenuIsOpen: false,
-    mobileMenuIsOpen: false,
-    showLoadingScreen: true,
-    loaded: false
-  }
-
-  componentDidMount() {
-    if (this._loadingScreenElement && this.state.showLoadingScreen) {
-      this._loadingScreenElement.addEventListener('animationend', this.handleAnimationEnd, false)
+export default withRouterHOC(
+  class DefaultLayout extends React.Component {
+    static propTypes = {
+      router: PropTypes.shape({
+        state: PropTypes.object,
+        navigate: PropTypes.func
+      }),
+      tools: PropTypes.arrayOf(
+        PropTypes.shape({
+          name: PropTypes.string
+        })
+      )
     }
-  }
 
-  componentWillUnmount() {
-    if (this._loadingScreenElement) {
-      this._loadingScreenElement.removeEventListener('animationend', this.handleAnimationEnd, false)
+    state = {
+      createMenuIsOpen: false,
+      mobileMenuIsOpen: false,
+      showLoadingScreen: true,
+      loaded: false
     }
-  }
 
-  handleAnimationEnd = event => {
-    this.setState({
-      showLoadingScreen: false
-    })
-  }
+    componentDidMount() {
+      if (this._loadingScreenElement && this.state.showLoadingScreen) {
+        this._loadingScreenElement.addEventListener('animationend', this.handleAnimationEnd, false)
+      }
+    }
 
-  componentDidUpdate(prevProps) {
-    if (!this.state.loaded) {
+    componentWillUnmount() {
+      if (this._loadingScreenElement) {
+        this._loadingScreenElement.removeEventListener(
+          'animationend',
+          this.handleAnimationEnd,
+          false
+        )
+      }
+    }
+
+    handleAnimationEnd = event => {
       this.setState({
-        loaded: true
+        showLoadingScreen: false
       })
     }
-  }
 
-  handleCreateButtonClick = () => {
-    this.setState({
-      createMenuIsOpen: !this.state.createMenuIsOpen
-    })
-  }
-
-  handleActionModalClose = () => {
-    this.setState({
-      createMenuIsOpen: false
-    })
-  }
-
-  handleMobileMenuToggle = () => {
-    this.setState({
-      mobileMenuIsOpen: !this.state.mobileMenuIsOpen
-    })
-  }
-
-  handleSwitchTool = () => {
-    this.setState({
-      mobileMenuIsOpen: false
-    })
-  }
-
-  setLoadingScreenElement = element => {
-    this._loadingScreenElement = element
-  }
-
-  renderContent = () => {
-    const {tools, router} = this.props
-    const {createMenuIsOpen, mobileMenuIsOpen} = this.state
-
-    const TYPE_ITEMS = dataAspects.getInferredTypes().map(typeName => ({
-      key: typeName,
-      name: typeName,
-      title: dataAspects.getDisplayName(typeName)
-    }))
-
-    const modalActions = TYPE_ITEMS.map(item => {
-      return {
-        title: item.title,
-        params: {type: item.name}
+    componentDidUpdate(prevProps) {
+      if (!this.state.loaded) {
+        this.setState({
+          loaded: true
+        })
       }
-    })
+    }
 
-    return (
-      <div className={`${styles.defaultLayout} ${mobileMenuIsOpen ? styles.mobileMenuIsOpen : ''}`}>
-        {
-          this.state.showLoadingScreen && (
+    handleCreateButtonClick = () => {
+      this.setState({
+        createMenuIsOpen: !this.state.createMenuIsOpen
+      })
+    }
+
+    handleActionModalClose = () => {
+      this.setState({
+        createMenuIsOpen: false
+      })
+    }
+
+    handleMobileMenuToggle = () => {
+      this.setState({
+        mobileMenuIsOpen: !this.state.mobileMenuIsOpen
+      })
+    }
+
+    handleSwitchTool = () => {
+      this.setState({
+        mobileMenuIsOpen: false
+      })
+    }
+
+    setLoadingScreenElement = element => {
+      this._loadingScreenElement = element
+    }
+
+    renderContent = () => {
+      const {tools, router} = this.props
+      const {createMenuIsOpen, mobileMenuIsOpen} = this.state
+
+      const TYPE_ITEMS = dataAspects.getInferredTypes().map(typeName => ({
+        key: typeName,
+        name: typeName,
+        title: dataAspects.getDisplayName(typeName)
+      }))
+
+      const modalActions = TYPE_ITEMS.map(item => {
+        return {
+          title: item.title,
+          params: {type: item.name}
+        }
+      })
+
+      return (
+        <div
+          className={`${styles.defaultLayout} ${mobileMenuIsOpen ? styles.mobileMenuIsOpen : ''}`}>
+          {this.state.showLoadingScreen && (
             <div
               className={this.state.loaded ? styles.loadingScreenLoaded : styles.loadingScreen}
-              ref={this.setLoadingScreenElement}
-            >
+              ref={this.setLoadingScreenElement}>
               <AppLoadingScreen text="Restoring Sanity" />
             </div>
-          )
-        }
-        <div className={styles.secondaryNavigation}>
-          <div className={styles.branding}>
-            <Branding />
-          </div>
-          {HAS_SPACES && (
-            <div className={styles.spaceSwitcher}>
-              <SpaceSwitcher />
-            </div>
           )}
-          <a className={styles.createButton} onClick={this.handleCreateButtonClick}>
-            <span className={styles.createButtonIcon}><PlusIcon /></span>
-            <span className={styles.createButtonText}>New</span>
-            <Ink duration={200} opacity={0.10} radius={200} />
-          </a>
-          <div className={styles.mobileMenuButton}>
-            <Button
-              kind="simple"
-              onClick={this.handleMobileMenuToggle}
-              title="Menu"
-              icon={HamburgerIcon}
+          <div className={styles.secondaryNavigation}>
+            <div className={styles.branding}>
+              <Branding />
+            </div>
+            {HAS_SPACES && (
+              <div className={styles.spaceSwitcher}>
+                <SpaceSwitcher />
+              </div>
+            )}
+            <a className={styles.createButton} onClick={this.handleCreateButtonClick}>
+              <span className={styles.createButtonIcon}>
+                <PlusIcon />
+              </span>
+              <span className={styles.createButtonText}>New</span>
+              <Ink duration={200} opacity={0.1} radius={200} />
+            </a>
+            <div className={styles.mobileMenuButton}>
+              <Button
+                kind="simple"
+                onClick={this.handleMobileMenuToggle}
+                title="Menu"
+                icon={HamburgerIcon}
+              />
+            </div>
+            <ToolSwitcher
+              tools={this.props.tools}
+              activeToolName={router.state.tool}
+              onSwitchTool={this.handleSwitchTool}
+              className={styles.toolSwitcher}
             />
           </div>
-          <ToolSwitcher
-            tools={this.props.tools}
-            activeToolName={router.state.tool}
-            onSwitchTool={this.handleSwitchTool}
-            className={styles.toolSwitcher}
-          />
-        </div>
-        <div className={styles.mainArea}>
-          <div className={styles.navigation}>
-            <Navigation tools={tools} />
+          <div className={styles.mainArea}>
+            <div className={styles.navigation}>
+              <Navigation tools={tools} />
+            </div>
+            <div className={styles.toolContainer}>
+              <RouteScope scope={router.state.tool}>
+                <RenderTool tool={router.state.tool} />
+              </RouteScope>
+            </div>
           </div>
-          <div className={styles.toolContainer}>
-            <RouteScope scope={router.state.tool}>
-              <RenderTool tool={router.state.tool} />
-            </RouteScope>
-          </div>
+
+          {createMenuIsOpen && (
+            <ActionModal onClose={this.handleActionModalClose} actions={modalActions} />
+          )}
+
+          <UpdateNotifier />
+
+          <a className={styles.sanityStudioLogoContainer} href="http://sanity.io">
+            <SanityStudioLogo />
+          </a>
+
+          {absolutes.map((Abs, i) => <Abs key={i} />)}
         </div>
+      )
+    }
 
-        {
-          createMenuIsOpen && <ActionModal onClose={this.handleActionModalClose} actions={modalActions} />
-        }
-
-        <a className={styles.sanityStudioLogoContainer} href="http://sanity.io">
-          <SanityStudioLogo />
-        </a>
-
-        {absolutes.map((Abs, i) => <Abs key={i} />)}
-      </div>
-    )
+    render() {
+      return <SchemaErrorReporter>{this.renderContent}</SchemaErrorReporter>
+    }
   }
-
-  render() {
-    return (
-      <SchemaErrorReporter>
-        {this.renderContent}
-      </SchemaErrorReporter>
-    )
-  }
-})
+)

--- a/packages/@sanity/default-layout/src/components/UpdateNotifier.js
+++ b/packages/@sanity/default-layout/src/components/UpdateNotifier.js
@@ -1,0 +1,66 @@
+import React, {Component} from 'react'
+import WarningIcon from 'part:@sanity/base/warning-icon'
+import VersionChecker from 'part:@sanity/base/version-checker'
+import UpdateNotifierDialog from './UpdateNotifierDialog'
+import styles from './styles/UpdateNotifier.css'
+
+const logError = err => console.error(err)
+const classes = {low: 'notice', medium: 'warn', high: 'critical'}
+const levels = ['low', 'medium', 'high']
+const getHighestLevel = outdated =>
+  outdated.reduce((acc, pkg) => Math.max(acc, levels.indexOf(pkg.severity)), 0)
+
+class UpdateNotifier extends Component {
+  state = {}
+
+  componentDidMount() {
+    VersionChecker.checkVersions()
+      .then(this.handleVersionReply)
+      .catch(logError)
+  }
+
+  handleVersionReply = ({result}) => {
+    const {isSupported, isUpToDate, outdated} = result
+    const level = levels[getHighestLevel(outdated || [])]
+    this.setState({isSupported, isUpToDate, level, outdated})
+  }
+
+  handleShowUpdateNotifier = () => {
+    this.setState({showUpdateNotifier: true})
+  }
+
+  handleHideUpdateNotifier = () => {
+    this.setState({showUpdateNotifier: false})
+  }
+
+  render() {
+    const {level, outdated, isUpToDate, isSupported, showUpdateNotifier} = this.state
+    const severity = isSupported ? level : 'high'
+    const className = styles[classes[severity] || 'button']
+
+    return (
+      <div className={styles.container}>
+        {showUpdateNotifier && (
+          <UpdateNotifierDialog
+            severity={severity}
+            outdated={outdated}
+            onClose={this.handleHideUpdateNotifier}
+          />
+        )}
+
+        {!isUpToDate && (
+          <button onClick={this.handleShowUpdateNotifier} className={className}>
+            <div className={styles.warningIcon}>
+              <WarningIcon />
+            </div>
+            <div className={styles.upgradeText}>Upgrade</div>
+          </button>
+        )}
+
+        <span>v{VersionChecker.getLatestInstalled()}</span>
+      </div>
+    )
+  }
+}
+
+export default UpdateNotifier

--- a/packages/@sanity/default-layout/src/components/UpdateNotifierDialog.js
+++ b/packages/@sanity/default-layout/src/components/UpdateNotifierDialog.js
@@ -1,8 +1,9 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
+import Button from 'part:@sanity/components/buttons/default'
 import Dialog from 'part:@sanity/components/dialogs/default'
 import VersionChecker from 'part:@sanity/base/version-checker'
-import styles from './styles/UpdateNotifier.css'
+import styles from './styles/UpdateNotifierDialog.css'
 
 const upperFirst = str => `${str.slice(0, 1).toUpperCase()}${str.slice(1)}`
 
@@ -54,7 +55,7 @@ class UpdateNotifierDialog extends Component {
           </tbody>
         </table>
 
-        <p>
+        <p className={styles.upgradeText}>
           To upgrade, run <code className={styles.code}>sanity upgrade</code> in your studio.
         </p>
       </div>
@@ -86,16 +87,21 @@ class UpdateNotifierDialog extends Component {
   }
 
   render() {
-    const {severity} = this.props
+    const {severity, onClose} = this.props
     return (
       <Dialog
         isOpen
-        showHeader
-        onAction={this.props.onClose}
-        actions={[{index: 1, title: 'OK'}]}
-        onClose={this.props.onClose}
-        title={severity === 'low' ? 'New versions available' : 'Studio is outdated'}>
-        {__DEV__ ? this.renderInfo() : this.renderContactDeveloper()}
+        onClose={onClose}
+      >
+        <div className={styles.content}>
+          <div>
+            <h2>
+              {severity === 'low' ? 'New versions available' : 'Studio is outdated'}
+            </h2>
+            {__DEV__ ? this.renderInfo() : this.renderContactDeveloper()}
+            <Button color="primary" onClick={onClose}>Close</Button>
+          </div>
+        </div>
       </Dialog>
     )
   }

--- a/packages/@sanity/default-layout/src/components/UpdateNotifierDialog.js
+++ b/packages/@sanity/default-layout/src/components/UpdateNotifierDialog.js
@@ -1,0 +1,104 @@
+import React, {Component} from 'react'
+import PropTypes from 'prop-types'
+import Dialog from 'part:@sanity/components/dialogs/default'
+import VersionChecker from 'part:@sanity/base/version-checker'
+import styles from './styles/UpdateNotifier.css'
+
+const upperFirst = str => `${str.slice(0, 1).toUpperCase()}${str.slice(1)}`
+
+class UpdateNotifierDialog extends Component {
+  static propTypes = {
+    onClose: PropTypes.func.isRequired,
+    severity: PropTypes.string.isRequired,
+    outdated: PropTypes.arrayOf(
+      PropTypes.shape({
+        name: PropTypes.string,
+        latest: PropTypes.string,
+        severity: PropTypes.string
+      })
+    )
+  }
+
+  static defaultProps = {
+    outdated: []
+  }
+
+  componentWillMount() {
+    VersionChecker.checkVersions({getOutdated: true})
+      .then(this.handleVersionReply)
+      .catch(this.handleError)
+  }
+
+  renderTable() {
+    const {outdated} = this.props
+    return (
+      <div>
+        <table className={styles.versionsTable}>
+          <thead>
+            <tr>
+              <th>Module</th>
+              <th>Installed</th>
+              <th>Latest</th>
+              <th>Importance</th>
+            </tr>
+          </thead>
+          <tbody>
+            {outdated.map(pkg => (
+              <tr key={pkg.name}>
+                <td>{pkg.name}</td>
+                <td>{pkg.version}</td>
+                <td>{pkg.latest}</td>
+                <td>{upperFirst(pkg.severity || 'low')}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        <p>
+          To upgrade, run <code className={styles.code}>sanity upgrade</code> in your studio.
+        </p>
+      </div>
+    )
+  }
+
+  renderInfo() {
+    return this.renderTable()
+  }
+
+  renderContactDeveloper() {
+    const {severity} = this.props
+    return (
+      <div>
+        <p>You are running an outdated studio.</p>
+
+        {severity === 'high' ? (
+          <p>Please get in touch with your developers and ask them to upgrade it for you.</p>
+        ) : (
+          <p>Consider getting in touch with your developers and ask them to upgrade it for you.</p>
+        )}
+
+        <details>
+          <summary>Developer info</summary>
+          {this.renderTable()}
+        </details>
+      </div>
+    )
+  }
+
+  render() {
+    const {severity} = this.props
+    return (
+      <Dialog
+        isOpen
+        showHeader
+        onAction={this.props.onClose}
+        actions={[{index: 1, title: 'OK'}]}
+        onClose={this.props.onClose}
+        title={severity === 'low' ? 'New versions available' : 'Studio is outdated'}>
+        {__DEV__ ? this.renderInfo() : this.renderContactDeveloper()}
+      </Dialog>
+    )
+  }
+}
+
+export default UpdateNotifierDialog

--- a/packages/@sanity/default-layout/src/components/styles/UpdateNotifier.css
+++ b/packages/@sanity/default-layout/src/components/styles/UpdateNotifier.css
@@ -1,0 +1,56 @@
+@import 'part:@sanity/base/theme/variables-style';
+
+.container {
+  position: fixed;
+  bottom: 2rem;
+  left: 0;
+  z-index: var(--zindex-navbar);
+}
+
+.button {
+  display: flex;
+  flex-direction: column;
+  cursor: pointer;
+  color: #fff;
+  opacity: 0.9;
+  border: 0;
+  background: var(--component-bg);
+  border-radius: 50%;
+  height: 4rem;
+  width: 4rem;
+
+  @nest &:hover {
+    opacity: 1;
+  }
+
+  @nest & span {
+    padding-left: var(--small-padding);
+    font-size: var(--font-size-tiny);
+  }
+}
+
+.critical {
+  composes: button;
+  color: var(--state-danger-color);
+}
+
+.warning {
+  composes: button;
+  color: var(--state-warning-color);
+}
+
+.notice {
+  composes: button;
+  color: var(--state-info-color);
+}
+
+.versionsTable td,
+.versionsTable th {
+  padding: 10px;
+  text-align: left;
+}
+
+.code {
+  background: #ccc;
+  padding: 0.25rem;
+}

--- a/packages/@sanity/default-layout/src/components/styles/UpdateNotifier.css
+++ b/packages/@sanity/default-layout/src/components/styles/UpdateNotifier.css
@@ -1,32 +1,43 @@
 @import 'part:@sanity/base/theme/variables-style';
 
 .container {
-  position: fixed;
+  position: absolute;
   bottom: 2rem;
   left: 0;
-  z-index: var(--zindex-navbar);
+  font-size: var(--font-size-xsmall);
+  color: color(var(--white) a(50%));
+  text-align: center;
+
+  @media (--screen-medium) {
+    padding: 0 var(--small-padding);
+  }
 }
 
 .button {
   display: flex;
   flex-direction: column;
+  align-items: center;
   cursor: pointer;
-  color: #fff;
   opacity: 0.9;
   border: 0;
-  background: var(--component-bg);
   border-radius: 50%;
-  height: 4rem;
-  width: 4rem;
+  text-align: center;
+  overflow: hidden;
+  background-color: transparent;
+  margin-bottom: 1em;
+  outline: none !important;
+
+  @nest &:active {
+    opacity: 1;
+  }
 
   @nest &:hover {
     opacity: 1;
   }
+}
 
-  @nest & span {
-    padding-left: var(--small-padding);
-    font-size: var(--font-size-tiny);
-  }
+.warningIcon {
+  font-size: 1.5em;
 }
 
 .critical {
@@ -42,15 +53,4 @@
 .notice {
   composes: button;
   color: var(--state-info-color);
-}
-
-.versionsTable td,
-.versionsTable th {
-  padding: 10px;
-  text-align: left;
-}
-
-.code {
-  background: #ccc;
-  padding: 0.25rem;
 }

--- a/packages/@sanity/default-layout/src/components/styles/UpdateNotifierDialog.css
+++ b/packages/@sanity/default-layout/src/components/styles/UpdateNotifierDialog.css
@@ -1,0 +1,32 @@
+@import 'part:@sanity/base/theme/variables-style';
+
+.content {
+  composes: flexCenter from 'part:@sanity/base/theme/layout/positioning-style';
+  text-align: center;
+}
+
+.versionsTable {
+  border-collapse: collapse;
+  border-bottom: 1px solid #ccc;
+  margin-bottom: calc(var(--large-padding) * 2);
+}
+
+.versionsTable tr td {
+  border-top: 1px solid #ccc;
+}
+
+.versionsTable td,
+.versionsTable th {
+  padding: var(--small-padding);
+  text-align: left;
+}
+
+.upgradeText {
+  margin-bottom: calc(var(--large-padding) * 2);
+}
+
+.code {
+  background: #333;
+  color: #fff;
+  padding: 0.5rem;
+}


### PR DESCRIPTION
Warning: This needs styling before merge.

Basically, checks for outdated modules and gives a little indication in the lower left corner of the screen. In the future, we'll want to move this functionality to a separate plugin, but I don't think it's worth doing right now.

You can fake the functionality by setting `fakeOutdatedModule` to `true` in `packages/@sanity/base/src/components/VersionChecker.js`.

Sorry about the large number of changes in the default layout component - Prettier had a field day on it.
