### PR TITLE
[core] Fix numeric datasets being treated as missing

### DIFF
--- a/packages/@sanity/core/src/commands/dataset/deleteDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/deleteDatasetCommand.js
@@ -5,10 +5,12 @@ export default {
   description: 'Delete a dataset within your project',
   action: async (args, context) => {
     const {apiClient, prompt, output} = context
-    const [dataset] = args.argsWithoutOptions
-    if (!dataset) {
+    const [ds] = args.argsWithoutOptions
+    if (!ds) {
       throw new Error('Dataset name must be provided')
     }
+
+    const dataset = `${ds}`
 
     await prompt.single({
       type: 'input',

--- a/packages/@sanity/core/src/commands/dataset/exportDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/exportDatasetCommand.js
@@ -18,7 +18,7 @@ export default {
     const [targetDataset, targetDestination] = args.argsWithoutOptions
     const {absolutify} = pathTools
 
-    let dataset = targetDataset
+    let dataset = targetDataset ? `${targetDataset}` : null
     if (!dataset) {
       dataset = await chooseDatasetPrompt(context, {message: 'Select dataset to export'})
     }

--- a/packages/@sanity/core/src/commands/dataset/importDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/importDatasetCommand.js
@@ -34,7 +34,7 @@ export default {
     const datasets = await client.datasets.list()
     spinner.succeed('[100%] Fetching available datasets')
 
-    let targetDataset = target
+    let targetDataset = target ? `${target}` : null
     if (!targetDataset) {
       targetDataset = await chooseDatasetPrompt(context, {
         message: 'Select target dataset',


### PR DESCRIPTION
If you have a numeric dataset name, say `2018`, certain dataset commands will fail because the CLI casts it to a number. When fetching available datasets and comparing it with a strict equals operator, it misses. This PR manually casts all dataset names to strings.