### PR TITLE
[base] Asynchronously publish resolved user

### DIFF
--- a/packages/@sanity/base/src/datastores/user/createUserStore.js
+++ b/packages/@sanity/base/src/datastores/user/createUserStore.js
@@ -21,7 +21,7 @@ errorChannel.subscribe(val => {
 
 function fetchInitial() {
   return authenticationFetcher.getCurrentUser()
-    .then(user => userChannel.publish(user))
+    .then(user => setTimeout(() => userChannel.publish(user), 5))
     .catch(err => errorChannel.publish(err))
 }
 


### PR DESCRIPTION
... this fixes a case where the message is published, the observable triggers a `next`, state gets updated in the LoginWrapper and React updates it's tree but encounters an error during rendering. Currently this is caught by the `catch` clause in the user store, which makes it really hard to debug.

This is a *temporary hack*. We need a proper way of handling these situations soon.
  