### PR TITLE
[block-tools] Support for Word pasted footnotes and endnotes

### DIFF
--- a/packages/@sanity/block-tools/package.json
+++ b/packages/@sanity/block-tools/package.json
@@ -41,7 +41,7 @@
     "in-publish": "^2.0.0",
     "jest": "^21.2.1",
     "jest-cli": "^21.2.1",
-    "jsdom": "11.3.0",
+    "jsdom": "^11.3.0",
     "wgxpath": "^1.2.0"
   },
   "directories": {

--- a/packages/@sanity/block-tools/package.json
+++ b/packages/@sanity/block-tools/package.json
@@ -41,7 +41,8 @@
     "in-publish": "^2.0.0",
     "jest": "^21.2.1",
     "jest-cli": "^21.2.1",
-    "jsdom": "^11.3.0",
+    "jsdom": "11.3.0",
+    "wgxpath": "^1.2.0",
     "xpath": "^0.0.24"
   },
   "directories": {

--- a/packages/@sanity/block-tools/package.json
+++ b/packages/@sanity/block-tools/package.json
@@ -42,8 +42,7 @@
     "jest": "^21.2.1",
     "jest-cli": "^21.2.1",
     "jsdom": "11.3.0",
-    "wgxpath": "^1.2.0",
-    "xpath": "^0.0.24"
+    "wgxpath": "^1.2.0"
   },
   "directories": {
     "test": "test"

--- a/packages/@sanity/block-tools/src/HtmlDeserializer/helpers.js
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/helpers.js
@@ -104,6 +104,8 @@ export function flattenNestedBlocks(blocks) {
   return flattened
 }
 
+// Trim whitespace from the DOM that is between HTML-elements and
+// become appended to block spans in the wrong places
 export function trimWhitespace(blocks) {
   blocks.forEach(block => {
     const nextSpan = (child, index) => {
@@ -142,6 +144,9 @@ export function trimWhitespace(blocks) {
         block.children.splice(index, 1)
       }
     })
+    if (block.children.length === 0) {
+      block.children.push({_type: 'span', marks: [], text: ''})
+    }
   })
   return blocks
 }

--- a/packages/@sanity/block-tools/src/HtmlDeserializer/index.js
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/index.js
@@ -48,6 +48,7 @@ export default class HtmlDeserializer {
       const doc = preprocess(html, parseHtml)
       return doc.body
     }
+    this.blocks = []
   }
 
   /**
@@ -85,6 +86,9 @@ export default class HtmlDeserializer {
           break
         case 'object':
           nodes.push(node)
+          if (node._type === 'block') {
+            this.blocks.push(node)
+          }
           break
         default:
           throw new Error(`Don't know what to do with: ${JSON.stringify(node)}`)
@@ -130,7 +134,7 @@ export default class HtmlDeserializer {
       if (!rule.deserialize) {
         continue
       }
-      const ret = rule.deserialize(element, next)
+      const ret = rule.deserialize(element, next, this.blocks, this.deserializeElements)
       const type = resolveJsType(ret)
 
       if (type != 'array' && type != 'object' && type != 'null' && type != 'undefined') {

--- a/packages/@sanity/block-tools/src/HtmlDeserializer/preprocessors/word.js
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/preprocessors/word.js
@@ -10,7 +10,10 @@ export default (html, doc) => {
   }
 
   // xPaths for elements that will be removed from the document
-  const unwantedPaths = ["//*[name() = 'o:p']"]
+  const unwantedPaths = [
+    "//*[name() = 'o:p']"
+    // "//span[@style='mso-list:Ignore']",
+  ]
 
   // xPaths for elements that needs to be remapped into other tags
   const mappedPaths = [
@@ -61,8 +64,8 @@ export default (html, doc) => {
   for (let i = mappedElements.snapshotLength - 1; i >= 0; i--) {
     const mappedElm = mappedElements.snapshotItem(i)
     const tags = elementMap[mappedElm.className]
-    const text = new Text(mappedElm.textContent)
-    const parentElement = document.createElement(tags[0])
+    const text = doc.createTextNode(mappedElm.textContent)
+    const parentElement = doc.createElement(tags[0])
     let parent = parentElement
     let child = parentElement
     tags.slice(1).forEach(tag => {

--- a/packages/@sanity/block-tools/src/HtmlDeserializer/preprocessors/word.js
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/preprocessors/word.js
@@ -10,10 +10,7 @@ export default (html, doc) => {
   }
 
   // xPaths for elements that will be removed from the document
-  const unwantedPaths = [
-    "//*[name() = 'o:p']"
-    // "//span[@style='mso-list:Ignore']",
-  ]
+  const unwantedPaths = ["//*[name() = 'o:p']"]
 
   // xPaths for elements that needs to be remapped into other tags
   const mappedPaths = [

--- a/packages/@sanity/block-tools/src/HtmlDeserializer/rules/word.js
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/rules/word.js
@@ -1,15 +1,18 @@
 import {DEFAULT_BLOCK} from '../../constants'
 import {tagName} from '../helpers'
 
+// https://gist.github.com/webtobesocial/ac9d052595b406d5a5c1
+
+function notesEnabled(options) {
+  return options.enabledBlockAnnotations.includes('note')
+}
+
 function getListItemStyle(el) {
-  let style
-  if ((style = el.getAttribute('style'))) {
-    if (!style.match(/lfo\d+/)) {
-      return undefined
-    }
-    return style.match('lfo1') ? 'bullet' : 'number'
+  const symbol = el.textContent.trim()
+  if (symbol.match(/\b\./)) {
+    return 'number'
   }
-  return undefined
+  return 'bullet'
 }
 
 function getListItemLevel(el) {
@@ -25,7 +28,7 @@ function getListItemLevel(el) {
   return undefined
 }
 
-function isWordListElement(el) {
+function isListElement(el) {
   if (el.className) {
     return el.className === 'MsoListParagraphCxSpFirst'
       || el.className === 'MsoListParagraphCxSpMiddle'
@@ -34,19 +37,146 @@ function isWordListElement(el) {
   return undefined
 }
 
+function getFootnoteContentElementId(el) {
+  const style = el.getAttribute('style')
+  if (style && style === 'mso-element:footnote') {
+    return el.getAttribute('id').trim()
+  }
+  return null
+}
+
+function getFootnoteLinkElementId(el) {
+  const style = el.getAttribute('style')
+  if (style && style.match(/mso-footnote-id/)) {
+    return style.split(':')[1].trim()
+  }
+  return null
+}
+
+function getEndnoteContentElementId(el) {
+  const style = el.getAttribute('style')
+  if (style && style === 'mso-element:endnote') {
+    return el.getAttribute('id').trim()
+  }
+  return null
+}
+
+function getEndnoteLinkElementId(el) {
+  const style = el.getAttribute('style')
+  if (style && style.match(/mso-endnote-id/)) {
+    return style.split(':')[1].trim()
+  }
+  return null
+}
+
 export default function createWordRules(blockContentType, options = {}) {
 
   return [
     {
       deserialize(el, next) {
-        if (tagName(el) === 'p' && isWordListElement(el)) {
+        if (tagName(el) === 'p' && isListElement(el)) {
+          const listItem = el.querySelector("span[style='mso-list:Ignore']")
+          const listItemStyle = getListItemStyle(listItem)
+          listItem.parentNode.removeChild(listItem)
           return {
             ...DEFAULT_BLOCK,
-            listItem: getListItemStyle(el),
+            listItem: listItemStyle,
             level: getListItemLevel(el),
             style: 'normal',
             children: next(el.childNodes)
           }
+        }
+        return undefined
+      }
+    },
+    // Fotnote links
+    {
+      deserialize(el, next) {
+        let footnoteId
+        if (tagName(el) === 'a' && (footnoteId = getFootnoteLinkElementId(el))) {
+          if (!notesEnabled(options)) {
+            return undefined
+          }
+          const markDef = {
+            _key: footnoteId,
+            _type: 'note',
+            style: 'footnote'
+          }
+          return {
+            _type: '__annotation',
+            markDef: markDef,
+            children: next(el.childNodes)
+          }
+
+        }
+        return undefined
+      }
+    },
+    // Footnote content
+    {
+      deserialize(el, next, blocks, deserialize) {
+        let footnoteId
+        if (tagName(el) === 'div' && (footnoteId = getFootnoteContentElementId(el))) {
+          if (!notesEnabled(options)) {
+            return undefined
+          }
+          // Find the block where the footnote occured
+          const markDef = blocks
+            .map(blk => blk.markDefs.find(def => def._key === footnoteId))
+            .filter(Boolean)[0]
+          if (markDef) {
+            el.querySelectorAll(`a[name='_${footnoteId}']`).forEach(elm => {
+              elm.parentNode.removeChild(elm)
+            })
+            markDef.content = deserialize(el.childNodes)
+          }
+          return next([])
+        }
+        return undefined
+      }
+    },
+    // Endnote links
+    {
+      deserialize(el, next) {
+        let endnoteId
+        if (tagName(el) === 'a' && (endnoteId = getEndnoteLinkElementId(el))) {
+          if (!notesEnabled(options)) {
+            return undefined
+          }
+          const markDef = {
+            _key: endnoteId,
+            _type: 'note',
+            style: 'endnote'
+          }
+          return {
+            _type: '__annotation',
+            markDef: markDef,
+            children: next(el.childNodes)
+          }
+
+        }
+        return undefined
+      }
+    },
+    // Endnote content
+    {
+      deserialize(el, next, blocks, deserialize) {
+        let endnoteId
+        if (tagName(el) === 'div' && (endnoteId = getEndnoteContentElementId(el))) {
+          if (!notesEnabled(options)) {
+            return undefined
+          }
+          // Find the block where the footnote occured
+          const markDef = blocks
+            .map(blk => blk.markDefs.find(def => def._key === endnoteId))
+            .filter(Boolean)[0]
+          if (markDef) {
+            el.querySelectorAll(`a[name='_${endnoteId}']`).forEach(elm => {
+              elm.parentNode.removeChild(elm)
+            })
+            markDef.content = deserialize(el.childNodes)
+          }
+          return next([])
         }
         return undefined
       }

--- a/packages/@sanity/block-tools/src/HtmlDeserializer/rules/word.js
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/rules/word.js
@@ -1,3 +1,4 @@
+import randomKey from '../../util/randomKey'
 import {DEFAULT_BLOCK} from '../../constants'
 import {tagName} from '../helpers'
 
@@ -124,9 +125,10 @@ export default function createWordRules(blockContentType, options = {}) {
             return undefined
           }
           const markDef = {
-            _key: footnoteId,
+            _key: randomKey(12),
             _type: 'blockNote',
-            style: 'footnote'
+            style: 'footnote',
+            blockNoteId: footnoteId
           }
           return {
             _type: '__annotation',
@@ -148,13 +150,14 @@ export default function createWordRules(blockContentType, options = {}) {
           }
           // Find the block where the footnote occured
           const markDef = blocks
-            .map(blk => blk.markDefs.find(def => def._key === footnoteId))
+            .map(blk => blk.markDefs.find(def => def.blockNoteId === footnoteId))
             .filter(Boolean)[0]
           if (markDef) {
             el.querySelectorAll(`a[name='_${footnoteId}']`).forEach(elm => {
               elm.parentNode.removeChild(elm)
             })
             markDef.content = deserialize(el.childNodes)
+            delete markDef.blockNoteId
           }
           return next([])
         }
@@ -170,9 +173,10 @@ export default function createWordRules(blockContentType, options = {}) {
             return undefined
           }
           const markDef = {
-            _key: endnoteId,
+            _key: randomKey(12),
             _type: 'blockNote',
-            style: 'endnote'
+            style: 'endnote',
+            blockNoteId: endnoteId
           }
           return {
             _type: '__annotation',
@@ -194,13 +198,14 @@ export default function createWordRules(blockContentType, options = {}) {
           }
           // Find the block where the footnote occured
           const markDef = blocks
-            .map(blk => blk.markDefs.find(def => def._key === endnoteId))
+            .map(blk => blk.markDefs.find(def => def.blockNoteId === endnoteId))
             .filter(Boolean)[0]
           if (markDef) {
             el.querySelectorAll(`a[name='_${endnoteId}']`).forEach(elm => {
               elm.parentNode.removeChild(elm)
             })
             markDef.content = deserialize(el.childNodes)
+            delete markDef.blockNoteId
           }
           return next([])
         }

--- a/packages/@sanity/block-tools/src/HtmlDeserializer/rules/word.js
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/rules/word.js
@@ -142,7 +142,7 @@ export default function createWordRules(blockContentType, options = {}) {
     },
     // Footnote content
     {
-      deserialize(el, next, blocks, deserialize) {
+      deserialize(el, next, {blocks, deserialize}) {
         let footnoteId
         if (tagName(el) === 'div' && (footnoteId = getFootnoteContentElementId(el))) {
           if (!notesEnabled(options)) {
@@ -190,7 +190,7 @@ export default function createWordRules(blockContentType, options = {}) {
     },
     // Endnote content
     {
-      deserialize(el, next, blocks, deserialize) {
+      deserialize(el, next, {blocks, deserialize}) {
         let endnoteId
         if (tagName(el) === 'div' && (endnoteId = getEndnoteContentElementId(el))) {
           if (!notesEnabled(options)) {

--- a/packages/@sanity/block-tools/src/HtmlDeserializer/rules/word.js
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/rules/word.js
@@ -4,7 +4,7 @@ import {tagName} from '../helpers'
 // https://gist.github.com/webtobesocial/ac9d052595b406d5a5c1
 
 function notesEnabled(options) {
-  return options.enabledBlockAnnotations.includes('note')
+  return options.enabledBlockAnnotations.includes('blockNote')
 }
 
 function getListItemStyle(el) {
@@ -99,7 +99,7 @@ export default function createWordRules(blockContentType, options = {}) {
           }
           const markDef = {
             _key: footnoteId,
-            _type: 'note',
+            _type: 'blockNote',
             style: 'footnote'
           }
           return {
@@ -145,7 +145,7 @@ export default function createWordRules(blockContentType, options = {}) {
           }
           const markDef = {
             _key: endnoteId,
-            _type: 'note',
+            _type: 'blockNote',
             style: 'endnote'
           }
           return {

--- a/packages/@sanity/block-tools/test/fixtures/wordSchema.js
+++ b/packages/@sanity/block-tools/test/fixtures/wordSchema.js
@@ -40,9 +40,7 @@ export default Schema.compile({
                         name: 'content',
                         title: 'Content',
                         type: 'array',
-                        of: {
-                          type: 'block'
-                        }
+                        of: [{type: 'block'}]
                       }
                     ]
                   }

--- a/packages/@sanity/block-tools/test/fixtures/wordSchema.js
+++ b/packages/@sanity/block-tools/test/fixtures/wordSchema.js
@@ -1,0 +1,69 @@
+import Schema from '@sanity/schema'
+
+export default Schema.compile({
+  name: 'myBlog',
+  types: [
+    {
+      type: 'object',
+      name: 'blogPost',
+      fields: [
+        {
+          title: 'Title',
+          type: 'string',
+          name: 'title'
+        },
+        {
+          title: 'Body',
+          name: 'body',
+          type: 'array',
+          of: [
+            {
+              type: 'block',
+              marks: {
+                annotations: [
+                  {
+                    type: 'object',
+                    name: 'link',
+                    title: 'Link',
+                    fields: [
+                      {
+                        name: 'href',
+                        type: 'string',
+                        title: 'Url'
+                      }
+                    ]
+                  },
+                  {
+                    type: 'object',
+                    name: 'note',
+                    title: 'Note',
+                    fields: [
+                      {
+                        type: 'string',
+                        name: 'style',
+                        options: {
+                          list: [
+                            {title: 'Footnote', value: 'footnote'},
+                            {title: 'Endnote', value: 'endnote'}
+                          ]
+                        }
+                      },
+                      {
+                        name: 'content',
+                        title: 'Content',
+                        type: 'array',
+                        of: {
+                          type: 'block'
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+})

--- a/packages/@sanity/block-tools/test/fixtures/wordSchema.js
+++ b/packages/@sanity/block-tools/test/fixtures/wordSchema.js
@@ -23,20 +23,8 @@ export default Schema.compile({
                 annotations: [
                   {
                     type: 'object',
-                    name: 'link',
-                    title: 'Link',
-                    fields: [
-                      {
-                        name: 'href',
-                        type: 'string',
-                        title: 'Url'
-                      }
-                    ]
-                  },
-                  {
-                    type: 'object',
-                    name: 'note',
-                    title: 'Note',
+                    name: 'blockNote',
+                    title: 'Block note',
                     fields: [
                       {
                         type: 'string',

--- a/packages/@sanity/block-tools/test/fixtures/wordSchema.js
+++ b/packages/@sanity/block-tools/test/fixtures/wordSchema.js
@@ -25,6 +25,7 @@ export default Schema.compile({
                     type: 'object',
                     name: 'blockNote',
                     title: 'Block note',
+                    annotationMarker: '*',
                     fields: [
                       {
                         type: 'string',

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/index.test.js
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/index.test.js
@@ -3,6 +3,7 @@ import fs from 'fs'
 import path from 'path'
 import {JSDOM} from 'jsdom'
 import blockTools from '../../../src'
+import wgxpath from 'wgxpath'
 
 describe('HtmlDeserializer', () => {
   const tests = fs.readdirSync(__dirname)
@@ -16,7 +17,12 @@ describe('HtmlDeserializer', () => {
       const expected = JSON.parse(fs.readFileSync(path.resolve(dir, 'output.json')))
       const fn = require(path.resolve(dir)).default // eslint-disable-line import/no-dynamic-require
       const commonOptions = {
-        parseHtml: html => new JSDOM(html).window.document
+        parseHtml: html => new JSDOM(html, {
+          // Use wgxpath for xpath handling
+          beforeParse: window => {
+            wgxpath.install(window, true)
+          }
+        }).window.document
       }
       const output = fn(input, blockTools, commonOptions)
       assert.deepEqual(output, expected)

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/index.test.js
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/index.test.js
@@ -18,7 +18,7 @@ describe('HtmlDeserializer', () => {
       const fn = require(path.resolve(dir)).default // eslint-disable-line import/no-dynamic-require
       const commonOptions = {
         parseHtml: html => new JSDOM(html, {
-          // Use wgxpath for xpath handling
+          // Use wgxpath for document.evaluate (JSDOM's built in one is buggy)
           beforeParse: window => {
             wgxpath.install(window, true)
           }

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/word/index.js
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/word/index.js
@@ -1,6 +1,13 @@
+import wordSchema from '../../../fixtures/wordSchema'
+const blockContentType = wordSchema.get('blogPost')
+  .fields.find(field => field.name === 'body').type
+
 export default (html, blockTools, commonOptions) => {
   const options = {
-    ...commonOptions
+    ...commonOptions,
+    blockContentType
   }
-  return blockTools.htmlToBlocks(html, options)
+  const result = blockTools.htmlToBlocks(html, options)
+  // console.log(JSON.stringify(result, null, 2))
+  return result
 }

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/word/input.html
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/word/input.html
@@ -1220,8 +1220,12 @@ table.MsoNormalTable
 
 <p class=MsoNormal><o:p>&nbsp;</o:p></p>
 
+<p class=MsoNormal><o:p>&nbsp;</o:p></p>
+
 <p class=MsoNormal>This is a paragraph.</p>
 
+<p class=MsoNormal><o:p>&nbsp;</o:p></p>
+<p class=MsoNormal><o:p>&nbsp;</o:p></p>
 <p class=MsoNormal><o:p>&nbsp;</o:p></p>
 
 <p class=MsoListParagraphCxSpFirst style='text-indent:-18.0pt;mso-list:l2 level1 lfo2'><![if !supportLists]><span

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/word/input.html
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/word/input.html
@@ -1,26 +1,47 @@
-<html xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-microsoft-com:office:word" xmlns:m="http://schemas.microsoft.com/office/2004/12/omml"
-  xmlns="http://www.w3.org/TR/REC-html40">
+<html xmlns:o="urn:schemas-microsoft-com:office:office"
+xmlns:w="urn:schemas-microsoft-com:office:word"
+xmlns:m="http://schemas.microsoft.com/office/2004/12/omml"
+xmlns="http://www.w3.org/TR/REC-html40">
 
 <head>
-  <meta name=Title content="">
-  <meta name=Keywords content="">
-  <meta http-equiv=Content-Type content="text/html; charset=utf-8">
-  <meta name=ProgId content=Word.Document>
-  <meta name=Generator content="Microsoft Word 15">
-  <meta name=Originator content="Microsoft Word 15">
-  <link rel=File-List href="file:////Users/pk101/Library/Group%20Containers/UBF8T346G9.Office/msoclip1/01/clip_filelist.xml">
-  <!--[if gte mso 9]><xml>
+<meta name=Title content="">
+<meta name=Keywords content="">
+<meta http-equiv=Content-Type content="text/html; charset=macintosh">
+<meta name=ProgId content=Word.Document>
+<meta name=Generator content="Microsoft Word 15">
+<meta name=Originator content="Microsoft Word 15">
+<link rel=File-List href="word-test-document.fld/filelist.xml">
+<!--[if gte mso 9]><xml>
+ <o:DocumentProperties>
+  <o:Author>Per-Kristian Nordnes</o:Author>
+  <o:LastAuthor>Per-Kristian Nordnes</o:LastAuthor>
+  <o:Revision>4</o:Revision>
+  <o:TotalTime>18</o:TotalTime>
+  <o:Created>2017-12-13T08:35:00Z</o:Created>
+  <o:LastSaved>2017-12-13T10:38:00Z</o:LastSaved>
+  <o:Pages>1</o:Pages>
+  <o:Words>54</o:Words>
+  <o:Characters>308</o:Characters>
+  <o:Lines>2</o:Lines>
+  <o:Paragraphs>1</o:Paragraphs>
+  <o:CharactersWithSpaces>361</o:CharactersWithSpaces>
+  <o:Version>15.0</o:Version>
+ </o:DocumentProperties>
  <o:OfficeDocumentSettings>
-  <o:RelyOnVML/>
   <o:AllowPNG/>
+  <o:PixelsPerInch>96</o:PixelsPerInch>
  </o:OfficeDocumentSettings>
 </xml><![endif]-->
-  <link rel=themeData href="file:////Users/pk101/Library/Group%20Containers/UBF8T346G9.Office/msoclip1/01/clip_themedata.thmx">
-  <!--[if gte mso 9]><xml>
+<link rel=dataStoreItem href="word-test-document.fld/item0001.xml"
+target="word-test-document.fld/props002.xml">
+<link rel=themeData href="word-test-document.fld/themedata.thmx">
+<!--[if gte mso 9]><xml>
  <w:WordDocument>
-  <w:View>Normal</w:View>
-  <w:Zoom>0</w:Zoom>
-  <w:TrackMoves/>
+  <w:View>Print</w:View>
+  <w:Zoom>281</w:Zoom>
+  <w:SpellingState>Clean</w:SpellingState>
+  <w:GrammarState>Clean</w:GrammarState>
+  <w:TrackMoves>false</w:TrackMoves>
   <w:TrackFormatting/>
   <w:PunctuationKerning/>
   <w:ValidateAgainstSchemas/>
@@ -28,9 +49,9 @@
   <w:IgnoreMixedContent>false</w:IgnoreMixedContent>
   <w:AlwaysShowPlaceholderText>false</w:AlwaysShowPlaceholderText>
   <w:DoNotPromoteQF/>
-  <w:LidThemeOther>DE-CH</w:LidThemeOther>
-  <w:LidThemeAsian>JA</w:LidThemeAsian>
-  <w:LidThemeComplexScript>AR-SA</w:LidThemeComplexScript>
+  <w:LidThemeOther>EN-US</w:LidThemeOther>
+  <w:LidThemeAsian>X-NONE</w:LidThemeAsian>
+  <w:LidThemeComplexScript>X-NONE</w:LidThemeComplexScript>
   <w:Compatibility>
    <w:BreakWrappedTables/>
    <w:SnapToGridInCell/>
@@ -41,7 +62,6 @@
    <w:EnableOpenTypeKerning/>
    <w:DontFlipMirrorIndents/>
    <w:OverrideTableStyleHps/>
-   <w:UseFELayout/>
   </w:Compatibility>
   <m:mathPr>
    <m:mathFont m:val="Cambria Math"/>
@@ -56,16 +76,15 @@
    <m:intLim m:val="subSup"/>
    <m:naryLim m:val="undOvr"/>
   </m:mathPr></w:WordDocument>
-</xml><![endif]-->
-  <!--[if gte mso 9]><xml>
+</xml><![endif]--><!--[if gte mso 9]><xml>
  <w:LatentStyles DefLockedState="false" DefUnhideWhenUsed="false"
   DefSemiHidden="false" DefQFormat="false" DefPriority="99"
   LatentStyleCount="382">
   <w:LsdException Locked="false" Priority="0" QFormat="true" Name="Normal"/>
   <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 1"/>
-  <w:LsdException Locked="false" Priority="0" SemiHidden="true"
+  <w:LsdException Locked="false" Priority="9" SemiHidden="true"
    UnhideWhenUsed="true" QFormat="true" Name="heading 2"/>
-  <w:LsdException Locked="false" Priority="0" SemiHidden="true"
+  <w:LsdException Locked="false" Priority="9" SemiHidden="true"
    UnhideWhenUsed="true" QFormat="true" Name="heading 3"/>
   <w:LsdException Locked="false" Priority="9" SemiHidden="true"
    UnhideWhenUsed="true" QFormat="true" Name="heading 4"/>
@@ -103,7 +122,7 @@
    UnhideWhenUsed="true" Name="toc 2"/>
   <w:LsdException Locked="false" Priority="39" SemiHidden="true"
    UnhideWhenUsed="true" Name="toc 3"/>
-  <w:LsdException Locked="false" Priority="0" SemiHidden="true"
+  <w:LsdException Locked="false" Priority="39" SemiHidden="true"
    UnhideWhenUsed="true" Name="toc 4"/>
   <w:LsdException Locked="false" Priority="39" SemiHidden="true"
    UnhideWhenUsed="true" Name="toc 5"/>
@@ -117,14 +136,14 @@
    UnhideWhenUsed="true" Name="toc 9"/>
   <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"
    Name="Normal Indent"/>
-  <w:LsdException Locked="false" Priority="0" SemiHidden="true"
-   UnhideWhenUsed="true" Name="footnote text"/>
+  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"
+   Name="footnote text"/>
   <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"
    Name="annotation text"/>
-  <w:LsdException Locked="false" Priority="0" SemiHidden="true"
-   UnhideWhenUsed="true" Name="header"/>
-  <w:LsdException Locked="false" Priority="0" SemiHidden="true"
-   UnhideWhenUsed="true" Name="footer"/>
+  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"
+   Name="header"/>
+  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"
+   Name="footer"/>
   <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"
    Name="index heading"/>
   <w:LsdException Locked="false" Priority="35" SemiHidden="true"
@@ -147,12 +166,12 @@
    Name="endnote reference"/>
   <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"
    Name="endnote text"/>
-  <w:LsdException Locked="false" Priority="0" SemiHidden="true"
-   UnhideWhenUsed="true" Name="table of authorities"/>
+  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"
+   Name="table of authorities"/>
   <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"
    Name="macro"/>
-  <w:LsdException Locked="false" Priority="0" SemiHidden="true"
-   UnhideWhenUsed="true" Name="toa heading"/>
+  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"
+   Name="toa heading"/>
   <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"
    Name="List"/>
   <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"
@@ -407,7 +426,7 @@
   <w:LsdException Locked="false" Priority="64" Name="Medium Shading 2 Accent 1"/>
   <w:LsdException Locked="false" Priority="65" Name="Medium List 1 Accent 1"/>
   <w:LsdException Locked="false" SemiHidden="true" Name="Revision"/>
-  <w:LsdException Locked="false" Priority="0" QFormat="true"
+  <w:LsdException Locked="false" Priority="34" QFormat="true"
    Name="List Paragraph"/>
   <w:LsdException Locked="false" Priority="29" QFormat="true" Name="Quote"/>
   <w:LsdException Locked="false" Priority="30" QFormat="true"
@@ -649,95 +668,527 @@
    Name="Smart Hyperlink"/>
  </w:LatentStyles>
 </xml><![endif]-->
-  <style>
-    <!--
-    /* Font Definitions */
-
-    @font-face {
-      font-family: "Cambria Math";
-      panose-1: 2 4 5 3 5 4 6 3 2 4;
-      mso-font-charset: 0;
-      mso-generic-font-family: auto;
-      mso-font-pitch: variable;
-      mso-font-signature: -536870145 1107305727 0 0 415 0;
-    }
-
-    @font-face {
-      font-family: "Arial Unicode MS";
-      panose-1: 2 11 6 4 2 2 2 2 2 4;
-      mso-font-charset: 0;
-      mso-generic-font-family: auto;
-      mso-font-pitch: variable;
-      mso-font-signature: -134238209 -371195905 63 0 4129279 0;
-    }
-    /* Style Definitions */
-
-    p.MsoNormal,
-    li.MsoNormal,
-    div.MsoNormal {
-      mso-style-unhide: no;
-      mso-style-parent: "";
-      margin: 0cm;
-      margin-bottom: .0001pt;
-      mso-pagination: widow-orphan;
-      font-size: 12.0pt;
-      font-family: "Times New Roman";
-      mso-fareast-font-family: "Arial Unicode MS";
-      border: none;
-      mso-ansi-language: EN-GB;
-    }
-
-    p.BodyA,
-    li.BodyA,
-    div.BodyA {
-      mso-style-name: "Body A";
-      mso-style-unhide: no;
-      mso-style-parent: "";
-      margin: 0cm;
-      margin-bottom: .0001pt;
-      mso-pagination: widow-orphan;
-      tab-stops: 17.85pt 36.0pt 53.85pt 70.9pt 5.0cm 212.65pt 10.0cm 354.4pt 15.0cm;
-      font-size: 10.0pt;
-      font-family: "Times New Roman";
-      mso-fareast-font-family: "Arial Unicode MS";
-      mso-bidi-font-family: "Arial Unicode MS";
-      color: black;
-      border: none;
-      mso-fareast-language: DE-CH;
-      text-underline: black;
-    }
-
-    .MsoChpDefault {
-      mso-style-type: export-only;
-      mso-default-props: yes;
-      font-size: 10.0pt;
-      mso-ansi-font-size: 10.0pt;
-      mso-bidi-font-size: 10.0pt;
-      mso-fareast-font-family: "Arial Unicode MS";
-      border: none;
-      mso-ansi-language: DE-CH;
-      mso-fareast-language: DE-CH;
-    }
-
-    .MsoPapDefault {
-      mso-style-type: export-only;
-    }
-
-    @page WordSection1 {
-      size: 612.0pt 792.0pt;
-      margin: 70.85pt 70.85pt 70.85pt 70.85pt;
-      mso-header-margin: 36.0pt;
-      mso-footer-margin: 36.0pt;
-      mso-paper-source: 0;
-    }
-
-    div.WordSection1 {
-      page: WordSection1;
-    }
-
-    -->
-  </style>
-  <!--[if gte mso 10]>
+<style>
+<!--
+ /* Font Definitions */
+@font-face
+	{font-family:"Courier New";
+	panose-1:2 7 3 9 2 2 5 2 4 4;
+	mso-font-charset:0;
+	mso-generic-font-family:auto;
+	mso-font-pitch:variable;
+	mso-font-signature:-536859905 -1073711037 9 0 511 0;}
+@font-face
+	{font-family:Wingdings;
+	panose-1:5 0 0 0 0 0 0 0 0 0;
+	mso-font-charset:2;
+	mso-generic-font-family:auto;
+	mso-font-pitch:variable;
+	mso-font-signature:0 268435456 0 0 -2147483648 0;}
+@font-face
+	{font-family:"Cambria Math";
+	panose-1:2 4 5 3 5 4 6 3 2 4;
+	mso-font-charset:1;
+	mso-generic-font-family:roman;
+	mso-font-format:other;
+	mso-font-pitch:variable;
+	mso-font-signature:0 0 0 0 0 0;}
+@font-face
+	{font-family:"Calibri Light";
+	panose-1:2 15 3 2 2 2 4 3 2 4;
+	mso-font-charset:0;
+	mso-generic-font-family:auto;
+	mso-font-pitch:variable;
+	mso-font-signature:-1610611985 1073750139 0 0 415 0;}
+@font-face
+	{font-family:Calibri;
+	panose-1:2 15 5 2 2 2 4 3 2 4;
+	mso-font-charset:0;
+	mso-generic-font-family:auto;
+	mso-font-pitch:variable;
+	mso-font-signature:-536870145 1073786111 1 0 415 0;}
+ /* Style Definitions */
+p.MsoNormal, li.MsoNormal, div.MsoNormal
+	{mso-style-unhide:no;
+	mso-style-qformat:yes;
+	mso-style-parent:"";
+	margin:0cm;
+	margin-bottom:.0001pt;
+	mso-pagination:widow-orphan;
+	font-size:12.0pt;
+	font-family:Calibri;
+	mso-ascii-font-family:Calibri;
+	mso-ascii-theme-font:minor-latin;
+	mso-fareast-font-family:Calibri;
+	mso-fareast-theme-font:minor-latin;
+	mso-hansi-font-family:Calibri;
+	mso-hansi-theme-font:minor-latin;
+	mso-bidi-font-family:"Times New Roman";
+	mso-bidi-theme-font:minor-bidi;}
+p.MsoFootnoteText, li.MsoFootnoteText, div.MsoFootnoteText
+	{mso-style-priority:99;
+	mso-style-link:"Footnote Text Char";
+	margin:0cm;
+	margin-bottom:.0001pt;
+	mso-pagination:widow-orphan;
+	font-size:12.0pt;
+	font-family:Calibri;
+	mso-ascii-font-family:Calibri;
+	mso-ascii-theme-font:minor-latin;
+	mso-fareast-font-family:Calibri;
+	mso-fareast-theme-font:minor-latin;
+	mso-hansi-font-family:Calibri;
+	mso-hansi-theme-font:minor-latin;
+	mso-bidi-font-family:"Times New Roman";
+	mso-bidi-theme-font:minor-bidi;}
+span.MsoFootnoteReference
+	{mso-style-priority:99;
+	vertical-align:super;}
+span.MsoEndnoteReference
+	{mso-style-priority:99;
+	vertical-align:super;}
+p.MsoEndnoteText, li.MsoEndnoteText, div.MsoEndnoteText
+	{mso-style-priority:99;
+	mso-style-link:"Endnote Text Char";
+	margin:0cm;
+	margin-bottom:.0001pt;
+	mso-pagination:widow-orphan;
+	font-size:12.0pt;
+	font-family:Calibri;
+	mso-ascii-font-family:Calibri;
+	mso-ascii-theme-font:minor-latin;
+	mso-fareast-font-family:Calibri;
+	mso-fareast-theme-font:minor-latin;
+	mso-hansi-font-family:Calibri;
+	mso-hansi-theme-font:minor-latin;
+	mso-bidi-font-family:"Times New Roman";
+	mso-bidi-theme-font:minor-bidi;}
+p.MsoTitle, li.MsoTitle, div.MsoTitle
+	{mso-style-priority:10;
+	mso-style-unhide:no;
+	mso-style-qformat:yes;
+	mso-style-link:"Title Char";
+	mso-style-next:Normal;
+	margin:0cm;
+	margin-bottom:.0001pt;
+	mso-add-space:auto;
+	mso-pagination:widow-orphan;
+	font-size:28.0pt;
+	font-family:"Calibri Light";
+	mso-ascii-font-family:"Calibri Light";
+	mso-ascii-theme-font:major-latin;
+	mso-fareast-font-family:"Times New Roman";
+	mso-fareast-theme-font:major-fareast;
+	mso-hansi-font-family:"Calibri Light";
+	mso-hansi-theme-font:major-latin;
+	mso-bidi-font-family:"Times New Roman";
+	mso-bidi-theme-font:major-bidi;
+	letter-spacing:-.5pt;
+	mso-font-kerning:14.0pt;}
+p.MsoTitleCxSpFirst, li.MsoTitleCxSpFirst, div.MsoTitleCxSpFirst
+	{mso-style-priority:10;
+	mso-style-unhide:no;
+	mso-style-qformat:yes;
+	mso-style-link:"Title Char";
+	mso-style-next:Normal;
+	mso-style-type:export-only;
+	margin:0cm;
+	margin-bottom:.0001pt;
+	mso-add-space:auto;
+	mso-pagination:widow-orphan;
+	font-size:28.0pt;
+	font-family:"Calibri Light";
+	mso-ascii-font-family:"Calibri Light";
+	mso-ascii-theme-font:major-latin;
+	mso-fareast-font-family:"Times New Roman";
+	mso-fareast-theme-font:major-fareast;
+	mso-hansi-font-family:"Calibri Light";
+	mso-hansi-theme-font:major-latin;
+	mso-bidi-font-family:"Times New Roman";
+	mso-bidi-theme-font:major-bidi;
+	letter-spacing:-.5pt;
+	mso-font-kerning:14.0pt;}
+p.MsoTitleCxSpMiddle, li.MsoTitleCxSpMiddle, div.MsoTitleCxSpMiddle
+	{mso-style-priority:10;
+	mso-style-unhide:no;
+	mso-style-qformat:yes;
+	mso-style-link:"Title Char";
+	mso-style-next:Normal;
+	mso-style-type:export-only;
+	margin:0cm;
+	margin-bottom:.0001pt;
+	mso-add-space:auto;
+	mso-pagination:widow-orphan;
+	font-size:28.0pt;
+	font-family:"Calibri Light";
+	mso-ascii-font-family:"Calibri Light";
+	mso-ascii-theme-font:major-latin;
+	mso-fareast-font-family:"Times New Roman";
+	mso-fareast-theme-font:major-fareast;
+	mso-hansi-font-family:"Calibri Light";
+	mso-hansi-theme-font:major-latin;
+	mso-bidi-font-family:"Times New Roman";
+	mso-bidi-theme-font:major-bidi;
+	letter-spacing:-.5pt;
+	mso-font-kerning:14.0pt;}
+p.MsoTitleCxSpLast, li.MsoTitleCxSpLast, div.MsoTitleCxSpLast
+	{mso-style-priority:10;
+	mso-style-unhide:no;
+	mso-style-qformat:yes;
+	mso-style-link:"Title Char";
+	mso-style-next:Normal;
+	mso-style-type:export-only;
+	margin:0cm;
+	margin-bottom:.0001pt;
+	mso-add-space:auto;
+	mso-pagination:widow-orphan;
+	font-size:28.0pt;
+	font-family:"Calibri Light";
+	mso-ascii-font-family:"Calibri Light";
+	mso-ascii-theme-font:major-latin;
+	mso-fareast-font-family:"Times New Roman";
+	mso-fareast-theme-font:major-fareast;
+	mso-hansi-font-family:"Calibri Light";
+	mso-hansi-theme-font:major-latin;
+	mso-bidi-font-family:"Times New Roman";
+	mso-bidi-theme-font:major-bidi;
+	letter-spacing:-.5pt;
+	mso-font-kerning:14.0pt;}
+p.MsoListParagraph, li.MsoListParagraph, div.MsoListParagraph
+	{mso-style-priority:34;
+	mso-style-unhide:no;
+	mso-style-qformat:yes;
+	margin-top:0cm;
+	margin-right:0cm;
+	margin-bottom:0cm;
+	margin-left:36.0pt;
+	margin-bottom:.0001pt;
+	mso-add-space:auto;
+	mso-pagination:widow-orphan;
+	font-size:12.0pt;
+	font-family:Calibri;
+	mso-ascii-font-family:Calibri;
+	mso-ascii-theme-font:minor-latin;
+	mso-fareast-font-family:Calibri;
+	mso-fareast-theme-font:minor-latin;
+	mso-hansi-font-family:Calibri;
+	mso-hansi-theme-font:minor-latin;
+	mso-bidi-font-family:"Times New Roman";
+	mso-bidi-theme-font:minor-bidi;}
+p.MsoListParagraphCxSpFirst, li.MsoListParagraphCxSpFirst, div.MsoListParagraphCxSpFirst
+	{mso-style-priority:34;
+	mso-style-unhide:no;
+	mso-style-qformat:yes;
+	mso-style-type:export-only;
+	margin-top:0cm;
+	margin-right:0cm;
+	margin-bottom:0cm;
+	margin-left:36.0pt;
+	margin-bottom:.0001pt;
+	mso-add-space:auto;
+	mso-pagination:widow-orphan;
+	font-size:12.0pt;
+	font-family:Calibri;
+	mso-ascii-font-family:Calibri;
+	mso-ascii-theme-font:minor-latin;
+	mso-fareast-font-family:Calibri;
+	mso-fareast-theme-font:minor-latin;
+	mso-hansi-font-family:Calibri;
+	mso-hansi-theme-font:minor-latin;
+	mso-bidi-font-family:"Times New Roman";
+	mso-bidi-theme-font:minor-bidi;}
+p.MsoListParagraphCxSpMiddle, li.MsoListParagraphCxSpMiddle, div.MsoListParagraphCxSpMiddle
+	{mso-style-priority:34;
+	mso-style-unhide:no;
+	mso-style-qformat:yes;
+	mso-style-type:export-only;
+	margin-top:0cm;
+	margin-right:0cm;
+	margin-bottom:0cm;
+	margin-left:36.0pt;
+	margin-bottom:.0001pt;
+	mso-add-space:auto;
+	mso-pagination:widow-orphan;
+	font-size:12.0pt;
+	font-family:Calibri;
+	mso-ascii-font-family:Calibri;
+	mso-ascii-theme-font:minor-latin;
+	mso-fareast-font-family:Calibri;
+	mso-fareast-theme-font:minor-latin;
+	mso-hansi-font-family:Calibri;
+	mso-hansi-theme-font:minor-latin;
+	mso-bidi-font-family:"Times New Roman";
+	mso-bidi-theme-font:minor-bidi;}
+p.MsoListParagraphCxSpLast, li.MsoListParagraphCxSpLast, div.MsoListParagraphCxSpLast
+	{mso-style-priority:34;
+	mso-style-unhide:no;
+	mso-style-qformat:yes;
+	mso-style-type:export-only;
+	margin-top:0cm;
+	margin-right:0cm;
+	margin-bottom:0cm;
+	margin-left:36.0pt;
+	margin-bottom:.0001pt;
+	mso-add-space:auto;
+	mso-pagination:widow-orphan;
+	font-size:12.0pt;
+	font-family:Calibri;
+	mso-ascii-font-family:Calibri;
+	mso-ascii-theme-font:minor-latin;
+	mso-fareast-font-family:Calibri;
+	mso-fareast-theme-font:minor-latin;
+	mso-hansi-font-family:Calibri;
+	mso-hansi-theme-font:minor-latin;
+	mso-bidi-font-family:"Times New Roman";
+	mso-bidi-theme-font:minor-bidi;}
+span.TitleChar
+	{mso-style-name:"Title Char";
+	mso-style-priority:10;
+	mso-style-unhide:no;
+	mso-style-locked:yes;
+	mso-style-link:Title;
+	mso-ansi-font-size:28.0pt;
+	mso-bidi-font-size:28.0pt;
+	font-family:"Calibri Light";
+	mso-ascii-font-family:"Calibri Light";
+	mso-ascii-theme-font:major-latin;
+	mso-fareast-font-family:"Times New Roman";
+	mso-fareast-theme-font:major-fareast;
+	mso-hansi-font-family:"Calibri Light";
+	mso-hansi-theme-font:major-latin;
+	mso-bidi-font-family:"Times New Roman";
+	mso-bidi-theme-font:major-bidi;
+	letter-spacing:-.5pt;
+	mso-font-kerning:14.0pt;}
+span.FootnoteTextChar
+	{mso-style-name:"Footnote Text Char";
+	mso-style-priority:99;
+	mso-style-unhide:no;
+	mso-style-locked:yes;
+	mso-style-link:"Footnote Text";}
+span.EndnoteTextChar
+	{mso-style-name:"Endnote Text Char";
+	mso-style-priority:99;
+	mso-style-unhide:no;
+	mso-style-locked:yes;
+	mso-style-link:"Endnote Text";}
+span.SpellE
+	{mso-style-name:"";
+	mso-spl-e:yes;}
+.MsoChpDefault
+	{mso-style-type:export-only;
+	mso-default-props:yes;
+	font-family:Calibri;
+	mso-ascii-font-family:Calibri;
+	mso-ascii-theme-font:minor-latin;
+	mso-fareast-font-family:Calibri;
+	mso-fareast-theme-font:minor-latin;
+	mso-hansi-font-family:Calibri;
+	mso-hansi-theme-font:minor-latin;
+	mso-bidi-font-family:"Times New Roman";
+	mso-bidi-theme-font:minor-bidi;}
+ /* Page Definitions */
+@page
+	{mso-footnote-separator:url("word-test-document.fld/header.html") fs;
+	mso-footnote-continuation-separator:url("word-test-document.fld/header.html") fcs;
+	mso-endnote-separator:url("word-test-document.fld/header.html") es;
+	mso-endnote-continuation-separator:url("word-test-document.fld/header.html") ecs;}
+@page WordSection1
+	{size:595.0pt 842.0pt;
+	margin:70.85pt 70.85pt 70.85pt 70.85pt;
+	mso-header-margin:35.4pt;
+	mso-footer-margin:35.4pt;
+	mso-paper-source:0;}
+div.WordSection1
+	{page:WordSection1;}
+ /* List Definitions */
+@list l0
+	{mso-list-id:736367639;
+	mso-list-type:hybrid;
+	mso-list-template-ids:-96860366 67698689 67698691 67698693 67698689 67698691 67698693 67698689 67698691 67698693;}
+@list l0:level1
+	{mso-level-number-format:bullet;
+	mso-level-text:_;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l0:level2
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";}
+@list l0:level3
+	{mso-level-number-format:bullet;
+	mso-level-text:_;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l0:level4
+	{mso-level-number-format:bullet;
+	mso-level-text:_;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l0:level5
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";}
+@list l0:level6
+	{mso-level-number-format:bullet;
+	mso-level-text:_;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l0:level7
+	{mso-level-number-format:bullet;
+	mso-level-text:_;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l0:level8
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";}
+@list l0:level9
+	{mso-level-number-format:bullet;
+	mso-level-text:_;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l1
+	{mso-list-id:1612082973;
+	mso-list-type:hybrid;
+	mso-list-template-ids:-106794618 67698703 67698713 67698715 67698703 67698713 67698715 67698703 67698713 67698715;}
+@list l1:level1
+	{mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;}
+@list l1:level2
+	{mso-level-number-format:alpha-lower;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;}
+@list l1:level3
+	{mso-level-number-format:roman-lower;
+	mso-level-tab-stop:none;
+	mso-level-number-position:right;
+	text-indent:-9.0pt;}
+@list l1:level4
+	{mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;}
+@list l1:level5
+	{mso-level-number-format:alpha-lower;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;}
+@list l1:level6
+	{mso-level-number-format:roman-lower;
+	mso-level-tab-stop:none;
+	mso-level-number-position:right;
+	text-indent:-9.0pt;}
+@list l1:level7
+	{mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;}
+@list l1:level8
+	{mso-level-number-format:alpha-lower;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;}
+@list l1:level9
+	{mso-level-number-format:roman-lower;
+	mso-level-tab-stop:none;
+	mso-level-number-position:right;
+	text-indent:-9.0pt;}
+@list l2
+	{mso-list-id:1805922137;
+	mso-list-type:hybrid;
+	mso-list-template-ids:1638068078 67698689 67698691 67698693 67698689 67698691 67698693 67698689 67698691 67698693;}
+@list l2:level1
+	{mso-level-number-format:bullet;
+	mso-level-text:_;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l2:level2
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";}
+@list l2:level3
+	{mso-level-number-format:bullet;
+	mso-level-text:_;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l2:level4
+	{mso-level-number-format:bullet;
+	mso-level-text:_;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l2:level5
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";}
+@list l2:level6
+	{mso-level-number-format:bullet;
+	mso-level-text:_;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l2:level7
+	{mso-level-number-format:bullet;
+	mso-level-text:_;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l2:level8
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";}
+@list l2:level9
+	{mso-level-number-format:bullet;
+	mso-level-text:_;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+ol
+	{margin-bottom:0cm;}
+ul
+	{margin-bottom:0cm;}
+-->
+</style>
+<!--[if gte mso 10]>
 <style>
  /* Style Definitions */
 table.MsoNormalTable
@@ -751,61 +1202,132 @@ table.MsoNormalTable
 	mso-para-margin:0cm;
 	mso-para-margin-bottom:.0001pt;
 	mso-pagination:widow-orphan;
-	font-size:10.0pt;
-	font-family:"Times New Roman";
-	border:none;
-	mso-ansi-language:DE-CH;
-	mso-fareast-language:DE-CH;}
+	font-size:12.0pt;
+	font-family:Calibri;
+	mso-ascii-font-family:Calibri;
+	mso-ascii-theme-font:minor-latin;
+	mso-hansi-font-family:Calibri;
+	mso-hansi-theme-font:minor-latin;}
 </style>
 <![endif]-->
 </head>
 
 <body bgcolor=white lang=EN-US style='tab-interval:36.0pt'>
-  <!--StartFragment-->
 
-  <p class=BodyA style='text-align:justify;text-justify:inter-ideograph'><b style='mso-bidi-font-weight:normal'><span lang=EN-GB style='font-size:11.0pt;
-mso-ansi-language:EN-GB'>Keywords <o:p></o:p></span></b></p>
+<div class=WordSection1>
 
-  <p class=BodyA style='text-align:justify;text-justify:inter-ideograph'><span lang=EN-GB style='font-size:11.0pt;mso-ansi-language:EN-GB'>Natural resource
-management, oil, minerals, resource curse, commodity trading, corruption, national
-oil companies, state-owned enterprises, extractive revenue misappropriation.<o:p></o:p></span></p>
+<p class=MsoTitle>This is a title</p>
 
-  <p class=BodyA style='text-align:justify;text-justify:inter-ideograph'><span lang=EN-GB style='font-size:11.0pt;mso-ansi-language:EN-GB'><o:p>&nbsp;</o:p></span></p>
+<p class=MsoNormal><o:p>&nbsp;</o:p></p>
 
-  <p class=BodyA style='text-align:justify;text-justify:inter-ideograph'><b style='mso-bidi-font-weight:normal'><span lang=EN-GB style='font-size:11.0pt;
-mso-ansi-language:EN-GB;mso-bidi-font-style:italic'>About the authors</span></b><b style='mso-bidi-font-weight:normal'><span lang=EN-GB style='font-size:11.0pt;
-mso-ansi-language:EN-GB'><o:p></o:p></span></b></p>
+<p class=MsoNormal>This is a paragraph.</p>
 
-  <p class=BodyA style='text-align:justify;text-justify:inter-ideograph'><span lang=EN-GB style='font-size:11.0pt;mso-ansi-language:EN-GB'>Olivier Longchamp
-is in charge of tax policy and international finance at Public Eye. Nathalie
-Perrot is a legal advisor. She previously worked for Public Eye as a project
-manager.<o:p></o:p></span></p>
+<p class=MsoNormal><o:p>&nbsp;</o:p></p>
 
-  <p class=BodyA style='text-align:justify;text-justify:inter-ideograph'><span lang=EN-GB style='font-size:11.0pt;mso-ansi-language:EN-GB'><o:p>&nbsp;</o:p></span></p>
+<p class=MsoListParagraphCxSpFirst style='text-indent:-18.0pt;mso-list:l2 level1 lfo2'><![if !supportLists]><span
+style='font-family:Symbol;mso-fareast-font-family:Symbol;mso-bidi-font-family:
+Symbol'><span style='mso-list:Ignore'>�<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]>This is a bullet list element</p>
 
-  <p class=BodyA style='text-align:justify;text-justify:inter-ideograph'><b style='mso-bidi-font-weight:normal'><span lang=EN-GB style='font-size:11.0pt;
-mso-ansi-language:EN-GB;mso-bidi-font-style:italic'>About Public Eye<o:p></o:p></span></b></p>
+<p class=MsoListParagraphCxSpLast style='margin-left:72.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l2 level2 lfo2'><![if !supportLists]><span
+style='font-family:"Courier New";mso-fareast-font-family:"Courier New"'><span
+style='mso-list:Ignore'>o<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;
+</span></span></span><![endif]>This is another bullet list element (level 2)</p>
 
-  <p class=BodyA style='text-align:justify;text-justify:inter-ideograph'><span lang=EN-GB style='font-size:11.0pt;mso-ansi-language:EN-GB'>Created in 1968 and
-now with 25,000 members, Public Eye (formerly the Berne Declaration) is an
-independent Swiss NGO that uses a mixture of research, advocacy, and
-campaigning to fight for human rights and justice around the world, especially in
-poorer countries where Switzerland and its companies are involved. Public Eye
-has worked on Switzerland’s commodity trading sector since 2011.<o:p></o:p></span></p>
+<p class=MsoNormal><o:p>&nbsp;</o:p></p>
 
-  <p class=BodyA style='text-align:justify;text-justify:inter-ideograph'><span lang=EN-GB style='font-size:11.0pt;mso-ansi-language:EN-GB'><o:p>&nbsp;</o:p></span></p>
+<p class=MsoNormal>This is a paragraph with <b style='mso-bidi-font-weight:
+normal'>bold</b> and <i style='mso-bidi-font-style:normal'>emphasis.<o:p></o:p></i></p>
 
-  <p class=BodyA style='text-align:justify;text-justify:inter-ideograph'><b style='mso-bidi-font-weight:normal'><span lang=EN-GB style='font-size:11.0pt;
-mso-ansi-language:EN-GB'>Acknowledgements<o:p></o:p></span></b></p>
+<p class=MsoNormal><i style='mso-bidi-font-style:normal'><o:p>&nbsp;</o:p></i></p>
 
-  <p class=BodyA style='text-align:justify;text-justify:inter-ideograph'><span lang=EN-GB style='font-size:11.0pt;mso-ansi-language:EN-GB'>We would like to
-thank the following people for providing information and constructive comments
-on earlier drafts of this paper: Alexandra Gillies, Aaron Sayne and Joe
-Williams (NRGI); Laure Brillaud (TI); Werner Thut (SDC); Marc Guéniat, Silvie
-Lang, Andreas Missbach, Urs Rybi, Lyssandra Sears, and Valentino Viredaz
-(Public Eye). Kendra Dupuy and Aled Williams (U4-CMI).<o:p></o:p></span></p>
+<p class=MsoListParagraphCxSpFirst style='text-indent:-18.0pt;mso-list:l1 level1 lfo3'><a
+name="_Ref500922036"><![if !supportLists]><span style='mso-bidi-font-family:
+Calibri;mso-bidi-theme-font:minor-latin'><span style='mso-list:Ignore'>1.<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><![endif]>This
+is a numbered list item</a></p>
 
-  <!--EndFragment-->
+<p class=MsoListParagraphCxSpLast style='margin-left:72.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l1 level2 lfo3'><![if !supportLists]><span
+style='mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin'><span
+style='mso-list:Ignore'>a.<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]>This is another numbered list item (level 2)</p>
+
+<p class=MsoNormal><i style='mso-bidi-font-style:normal'><o:p>&nbsp;</o:p></i></p>
+
+<p class=MsoNormal>This paragraph contains a footnote.<a style='mso-footnote-id:
+ftn1' href="#_ftn1" name="_ftnref1" title=""><span class=MsoFootnoteReference><span
+style='mso-special-character:footnote'><![if !supportFootnotes]><span
+class=MsoFootnoteReference><span style='font-size:12.0pt;font-family:Calibri;
+mso-ascii-theme-font:minor-latin;mso-fareast-font-family:Calibri;mso-fareast-theme-font:
+minor-latin;mso-hansi-theme-font:minor-latin;mso-bidi-font-family:"Times New Roman";
+mso-bidi-theme-font:minor-bidi;mso-ansi-language:EN-US;mso-fareast-language:
+EN-US;mso-bidi-language:AR-SA'>[1]</span></span><![endif]></span></span></a></p>
+
+<p class=MsoNormal>This paragraph contains an endnote <a style='mso-endnote-id:
+edn1' href="#_edn1" name="_ednref1" title=""><span class=MsoEndnoteReference><span
+style='mso-special-character:footnote'><![if !supportFootnotes]><span
+class=MsoEndnoteReference><span style='font-size:12.0pt;font-family:Calibri;
+mso-ascii-theme-font:minor-latin;mso-fareast-font-family:Calibri;mso-fareast-theme-font:
+minor-latin;mso-hansi-theme-font:minor-latin;mso-bidi-font-family:"Times New Roman";
+mso-bidi-theme-font:minor-bidi;mso-ansi-language:EN-US;mso-fareast-language:
+EN-US;mso-bidi-language:AR-SA'>[i]</span></span><![endif]></span></span></a></p>
+
+<p class=MsoNormal><o:p>&nbsp;</o:p></p>
+
+<p class=MsoNormal><span class=SpellE>Eewrewr</span> <span class=SpellE>ewr</span>
+ewer ewr<!--[if supportFields]><span style='mso-element:field-begin'></span> REF
+_Ref500922036 \r \h <span style='mso-element:field-separator'></span><![endif]-->1<!--[if gte mso 9]><xml>
+ <w:data>08D0C9EA79F9BACE118C8200AA004BA90B02000000080000000E0000005F005200650066003500300030003900320032003000330036000000</w:data>
+</xml><![endif]--><!--[if supportFields]><span style='mso-element:field-end'></span><![endif]--></p>
+
+</div>
+
+<div style='mso-element:footnote-list'><![if !supportFootnotes]><br clear=all>
+
+<hr align=left size=1 width="33%">
+
+<![endif]>
+
+<div style='mso-element:footnote' id=ftn1>
+
+<p class=MsoFootnoteText><a style='mso-footnote-id:ftn1' href="#_ftnref1"
+name="_ftn1" title=""><span class=MsoFootnoteReference><span style='mso-special-character:
+footnote'><![if !supportFootnotes]><span class=MsoFootnoteReference><span
+style='font-size:12.0pt;font-family:Calibri;mso-ascii-theme-font:minor-latin;
+mso-fareast-font-family:Calibri;mso-fareast-theme-font:minor-latin;mso-hansi-theme-font:
+minor-latin;mso-bidi-font-family:"Times New Roman";mso-bidi-theme-font:minor-bidi;
+mso-ansi-language:EN-US;mso-fareast-language:EN-US;mso-bidi-language:AR-SA'>[1]</span></span><![endif]></span></span></a>
+<span lang=NO-BOK style='mso-ansi-language:NO-BOK'>This is <span class=SpellE>the</span>
+<span class=SpellE>footnote</span> <span class=SpellE>text</span><o:p></o:p></span></p>
+
+</div>
+
+</div>
+
+<div style='mso-element:endnote-list'><![if !supportEndnotes]><br clear=all>
+
+<hr align=left size=1 width="33%">
+
+<![endif]>
+
+<div style='mso-element:endnote' id=edn1>
+
+<p class=MsoEndnoteText><a style='mso-endnote-id:edn1' href="#_ednref1"
+name="_edn1" title=""><span class=MsoEndnoteReference><span style='mso-special-character:
+footnote'><![if !supportFootnotes]><span class=MsoEndnoteReference><span
+style='font-size:12.0pt;font-family:Calibri;mso-ascii-theme-font:minor-latin;
+mso-fareast-font-family:Calibri;mso-fareast-theme-font:minor-latin;mso-hansi-theme-font:
+minor-latin;mso-bidi-font-family:"Times New Roman";mso-bidi-theme-font:minor-bidi;
+mso-ansi-language:EN-US;mso-fareast-language:EN-US;mso-bidi-language:AR-SA'>[i]</span></span><![endif]></span></span></a>
+<span lang=NO-BOK style='mso-ansi-language:NO-BOK'>This is <span class=SpellE>the</span>
+<span class=SpellE>endnote</span> <span class=SpellE>text</span><o:p></o:p></span></p>
+
+</div>
+
+</div>
+
 </body>
 
 </html>

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/word/output.json
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/word/output.json
@@ -15,7 +15,13 @@
     "_type": "block",
     "markDefs": [],
     "style": "normal",
-    "children": []
+    "children": [
+      {
+        "_type": "span",
+        "marks": [],
+        "text": ""
+      }
+    ]
   },
   {
     "_type": "block",
@@ -33,7 +39,25 @@
     "_type": "block",
     "markDefs": [],
     "style": "normal",
-    "children": []
+    "children": [
+      {
+        "_type": "span",
+        "marks": [],
+        "text": ""
+      }
+    ]
+  },
+  {
+    "_type": "block",
+    "markDefs": [],
+    "style": "normal",
+    "children": [
+      {
+        "_type": "span",
+        "marks": [],
+        "text": ""
+      }
+    ]
   },
   {
     "_type": "block",
@@ -62,12 +86,6 @@
         "text": "This is another bullet list element (level 2)"
       }
     ]
-  },
-  {
-    "_type": "block",
-    "markDefs": [],
-    "style": "normal",
-    "children": []
   },
   {
     "_type": "block",
@@ -104,12 +122,6 @@
     "_type": "block",
     "markDefs": [],
     "style": "normal",
-    "children": []
-  },
-  {
-    "_type": "block",
-    "markDefs": [],
-    "style": "normal",
     "listItem": "number",
     "level": 1,
     "children": [
@@ -133,12 +145,6 @@
         "text": "This is another numbered list item (level 2)"
       }
     ]
-  },
-  {
-    "_type": "block",
-    "markDefs": [],
-    "style": "normal",
-    "children": []
   },
   {
     "_type": "block",
@@ -247,12 +253,6 @@
         "text": "[i]"
       }
     ]
-  },
-  {
-    "_type": "block",
-    "markDefs": [],
-    "style": "normal",
-    "children": []
   },
   {
     "_type": "block",

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/word/output.json
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/word/output.json
@@ -150,7 +150,7 @@
     "_type": "block",
     "markDefs": [
       {
-        "_key": "ftn1",
+        "_key": "randomKey0",
         "_type": "blockNote",
         "style": "footnote",
         "content": [
@@ -194,7 +194,7 @@
       {
         "_type": "span",
         "marks": [
-          "ftn1"
+          "randomKey0"
         ],
         "text": "[1]"
       }
@@ -204,7 +204,7 @@
     "_type": "block",
     "markDefs": [
       {
-        "_key": "edn1",
+        "_key": "randomKey1",
         "_type": "blockNote",
         "style": "endnote",
         "content": [
@@ -248,7 +248,7 @@
       {
         "_type": "span",
         "marks": [
-          "edn1"
+          "randomKey1"
         ],
         "text": "[i]"
       }

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/word/output.json
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/word/output.json
@@ -145,7 +145,7 @@
     "markDefs": [
       {
         "_key": "ftn1",
-        "_type": "note",
+        "_type": "blockNote",
         "style": "footnote",
         "content": [
           {
@@ -199,7 +199,7 @@
     "markDefs": [
       {
         "_key": "edn1",
-        "_type": "note",
+        "_type": "blockNote",
         "style": "endnote",
         "content": [
           {

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/word/output.json
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/word/output.json
@@ -1,26 +1,301 @@
 [
   {
     "_type": "block",
+    "markDefs": [],
+    "style": "h1",
     "children": [
       {
         "_type": "span",
         "marks": [],
-        "text": "Header"
+        "text": "This is a title"
       }
-    ],
-    "markDefs": [],
-    "style": "h5"
+    ]
   },
   {
     "_type": "block",
+    "markDefs": [],
+    "style": "normal",
+    "children": []
+  },
+  {
+    "_type": "block",
+    "markDefs": [],
+    "style": "normal",
     "children": [
       {
         "_type": "span",
         "marks": [],
-        "text": "Paragraph"
+        "text": "This is a paragraph."
+      }
+    ]
+  },
+  {
+    "_type": "block",
+    "markDefs": [],
+    "style": "normal",
+    "children": []
+  },
+  {
+    "_type": "block",
+    "markDefs": [],
+    "style": "normal",
+    "listItem": "bullet",
+    "level": 1,
+    "children": [
+      {
+        "_type": "span",
+        "marks": [],
+        "text": "This is a bullet list element"
+      }
+    ]
+  },
+  {
+    "_type": "block",
+    "markDefs": [],
+    "style": "normal",
+    "listItem": "bullet",
+    "level": 2,
+    "children": [
+      {
+        "_type": "span",
+        "marks": [],
+        "text": "This is another bullet list element (level 2)"
+      }
+    ]
+  },
+  {
+    "_type": "block",
+    "markDefs": [],
+    "style": "normal",
+    "children": []
+  },
+  {
+    "_type": "block",
+    "markDefs": [],
+    "style": "normal",
+    "children": [
+      {
+        "_type": "span",
+        "marks": [],
+        "text": "This is a paragraph with "
+      },
+      {
+        "_type": "span",
+        "marks": [
+          "strong"
+        ],
+        "text": "bold"
+      },
+      {
+        "_type": "span",
+        "marks": [],
+        "text": " and "
+      },
+      {
+        "_type": "span",
+        "marks": [
+          "em"
+        ],
+        "text": "emphasis."
+      }
+    ]
+  },
+  {
+    "_type": "block",
+    "markDefs": [],
+    "style": "normal",
+    "children": []
+  },
+  {
+    "_type": "block",
+    "markDefs": [],
+    "style": "normal",
+    "listItem": "number",
+    "level": 1,
+    "children": [
+      {
+        "_type": "span",
+        "marks": [],
+        "text": "This is a numbered list item"
+      }
+    ]
+  },
+  {
+    "_type": "block",
+    "markDefs": [],
+    "style": "normal",
+    "listItem": "number",
+    "level": 2,
+    "children": [
+      {
+        "_type": "span",
+        "marks": [],
+        "text": "This is another numbered list item (level 2)"
+      }
+    ]
+  },
+  {
+    "_type": "block",
+    "markDefs": [],
+    "style": "normal",
+    "children": []
+  },
+  {
+    "_type": "block",
+    "markDefs": [
+      {
+        "_key": "ftn1",
+        "_type": "note",
+        "style": "footnote",
+        "content": [
+          {
+            "_type": "block",
+            "markDefs": [],
+            "style": "normal",
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "This is "
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "the"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "footnote"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "text"
+              }
+            ]
+          }
+        ]
       }
     ],
+    "style": "normal",
+    "children": [
+      {
+        "_type": "span",
+        "marks": [],
+        "text": "This paragraph contains a footnote."
+      },
+      {
+        "_type": "span",
+        "marks": [
+          "ftn1"
+        ],
+        "text": "[1]"
+      }
+    ]
+  },
+  {
+    "_type": "block",
+    "markDefs": [
+      {
+        "_key": "edn1",
+        "_type": "note",
+        "style": "endnote",
+        "content": [
+          {
+            "_type": "block",
+            "markDefs": [],
+            "style": "normal",
+            "children": [
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "This is "
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "the"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "endnote"
+              },
+              {
+                "_type": "span",
+                "marks": [],
+                "text": "text"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "style": "normal",
+    "children": [
+      {
+        "_type": "span",
+        "marks": [],
+        "text": "This paragraph contains an endnote "
+      },
+      {
+        "_type": "span",
+        "marks": [
+          "edn1"
+        ],
+        "text": "[i]"
+      }
+    ]
+  },
+  {
+    "_type": "block",
     "markDefs": [],
-    "style": "normal"
+    "style": "normal",
+    "children": []
+  },
+  {
+    "_type": "block",
+    "markDefs": [],
+    "style": "normal",
+    "children": [
+      {
+        "_type": "span",
+        "marks": [],
+        "text": "Eewrewr"
+      },
+      {
+        "_type": "span",
+        "marks": [],
+        "text": "ewr"
+      },
+      {
+        "_type": "span",
+        "marks": [],
+        "text": " ewer ewr"
+      },
+      {
+        "_type": "span",
+        "marks": [],
+        "text": "1"
+      }
+    ]
+  },
+  {
+    "_type": "block",
+    "markDefs": [],
+    "style": "normal",
+    "children": [
+      {
+        "_type": "span",
+        "marks": [],
+        "text": "\n"
+      },
+      {
+        "_type": "span",
+        "marks": [],
+        "text": "\n"
+      }
+    ]
   }
 ]

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/word/output.json
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/word/output.json
@@ -196,7 +196,7 @@
         "marks": [
           "randomKey0"
         ],
-        "text": "[1]"
+        "text": "*"
       }
     ]
   },
@@ -250,7 +250,7 @@
         "marks": [
           "randomKey1"
         ],
-        "text": "[i]"
+        "text": "*"
       }
     ]
   },

--- a/packages/example-studio/schemas/richText.js
+++ b/packages/example-studio/schemas/richText.js
@@ -14,8 +14,35 @@ export default {
       title: 'Content',
       of: [
         {
-          title: 'Block',
-          type: 'block'
+          type: 'block',
+          marks: {
+            annotations: [
+              {
+                type: 'object',
+                name: 'blockNote',
+                title: 'Block note',
+                annotationMarker: '*',
+                fields: [
+                  {
+                    type: 'string',
+                    name: 'style',
+                    options: {
+                      list: [
+                        {title: 'Footnote', value: 'footnote'},
+                        {title: 'Endnote', value: 'endnote'}
+                      ]
+                    }
+                  },
+                  {
+                    name: 'content',
+                    title: 'Content',
+                    type: 'array',
+                    of: [{type: 'block'}]
+                  }
+                ]
+              }
+            ]
+          }
         },
         {
           title: 'Image',


### PR DESCRIPTION
This will add support for copy/pasting footnotes and endnotes from Word into the block editor.

In order to get that support, you will have to add the type `blockNote` into the annotations array of your block type.

Example:

```
    {
      type: 'object',
      name: 'report',
      fields: [
        {
          title: 'Title',
          type: 'string',
          name: 'title'
        },
        {
          title: 'Body',
          name: 'body',
          type: 'array',
          of: [
            {
              type: 'block',
              marks: {
                annotations: [
                  {
                    type: 'object',
                    name: 'blockNote',
                    title: 'Block note',
                    annotationMarker: '*',
                    fields: [
                      {
                        type: 'string',
                        name: 'style',
                        options: {
                          list: [
                            {title: 'Footnote', value: 'footnote'},
                            {title: 'Endnote', value: 'endnote'}
                          ]
                        }
                      },
                      {
                        name: 'content',
                        title: 'Content',
                        type: 'array',
                        of: [{type: 'block'}]
                      }
                    ]
                  }
                ]
              }
            }
          ]
        }
    }
```

This PR also includes various other fixes for the deserializer. No breaking changes though.