### PR TITLE
[schema] Validate that type name is a string

### DIFF
--- a/packages/@sanity/schema/src/sanity/validation/utils/validateTypeName.js
+++ b/packages/@sanity/schema/src/sanity/validation/utils/validateTypeName.js
@@ -14,6 +14,13 @@ export function validateTypeName(typeName: string, visitorContext) {
     ]
   }
 
+  if (typeof typeName !== 'string') {
+    return [
+      error(`Type has an invalid "type"-property - should be a string. Valid types are: ${humanize(possibleTypeNames)}`,
+        HELP_IDS.TYPE_MISSING_TYPE)
+    ]
+  }
+
   const isValid = possibleTypeNames.includes(typeName)
 
   if (!isValid) {


### PR DESCRIPTION
If you have an error in your schema where a `type`-field is a non-string, the schema validation will fail when trying to figure out the closest match to it it with a levenshtein distance comparator.

This adds an additional step ensuring that the type is a string.
