### PR TITLE
[base] Solve swallowed error without defering to next tick

### DIFF
--- a/packages/@sanity/base/src/datastores/user/createUserStore.js
+++ b/packages/@sanity/base/src/datastores/user/createUserStore.js
@@ -20,15 +20,17 @@ errorChannel.subscribe(val => {
 })
 
 function fetchInitial() {
-  return authenticationFetcher.getCurrentUser()
-    .then(user => setTimeout(() => userChannel.publish(user), 5))
-    .catch(err => errorChannel.publish(err))
+  return authenticationFetcher.getCurrentUser().then(
+    user => userChannel.publish(user),
+    err => errorChannel.publish(err)
+  )
 }
 
 function logout() {
-  return authenticationFetcher.logout()
-    .then(() => userChannel.publish(null))
-    .catch(err => errorChannel.publish(err))
+  return authenticationFetcher.logout().then(
+    () => userChannel.publish(null),
+    err => errorChannel.publish(err)
+  )
 }
 
 const currentUser = new Observable(observer => {


### PR DESCRIPTION
Instead of doing a `setTimeout()` to prevent swallowing errors in the `then`-handler on the user store, use the `.then(onSuccess, onError)` form, which prevents errors happening in the `onSuccess` handler from being caught in the `onError` handler.
