### PR TITLE
Release 0.123.1

### DIFF
--- a/packages/@sanity/base/src/datastores/user/createUserStore.js
+++ b/packages/@sanity/base/src/datastores/user/createUserStore.js
@@ -21,7 +21,7 @@ errorChannel.subscribe(val => {
 
 function fetchInitial() {
   return authenticationFetcher.getCurrentUser()
-    .then(user => userChannel.publish(user))
+    .then(user => setTimeout(() => userChannel.publish(user), 5))
     .catch(err => errorChannel.publish(err))
 }
 

--- a/packages/@sanity/base/src/datastores/user/createUserStore.js
+++ b/packages/@sanity/base/src/datastores/user/createUserStore.js
@@ -20,15 +20,17 @@ errorChannel.subscribe(val => {
 })
 
 function fetchInitial() {
-  return authenticationFetcher.getCurrentUser()
-    .then(user => setTimeout(() => userChannel.publish(user), 5))
-    .catch(err => errorChannel.publish(err))
+  return authenticationFetcher.getCurrentUser().then(
+    user => userChannel.publish(user),
+    err => errorChannel.publish(err)
+  )
 }
 
 function logout() {
-  return authenticationFetcher.logout()
-    .then(() => userChannel.publish(null))
-    .catch(err => errorChannel.publish(err))
+  return authenticationFetcher.logout().then(
+    () => userChannel.publish(null),
+    err => errorChannel.publish(err)
+  )
 }
 
 const currentUser = new Observable(observer => {

--- a/packages/@sanity/block-tools/src/HtmlDeserializer/index.js
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/index.js
@@ -194,7 +194,7 @@ export default class HtmlDeserializer {
         if (node.text.trim()) { // Only apply marks if this is an actual text
           node.marks.unshift(name)
         }
-      } else {
+      } else if (node.children) {
         node.children = node.children.map(applyDecorator)
       }
       return node
@@ -228,7 +228,7 @@ export default class HtmlDeserializer {
         if (node.text.trim()) { // Only apply marks if this is an actual text
           node.marks.unshift(markDef._key)
         }
-      } else {
+      } else if (node.children) {
         node.children = node.children.map(applyAnnotation)
       }
       return node

--- a/packages/@sanity/core/src/commands/dataset/deleteDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/deleteDatasetCommand.js
@@ -5,10 +5,12 @@ export default {
   description: 'Delete a dataset within your project',
   action: async (args, context) => {
     const {apiClient, prompt, output} = context
-    const [dataset] = args.argsWithoutOptions
-    if (!dataset) {
+    const [ds] = args.argsWithoutOptions
+    if (!ds) {
       throw new Error('Dataset name must be provided')
     }
+
+    const dataset = `${ds}`
 
     await prompt.single({
       type: 'input',

--- a/packages/@sanity/core/src/commands/dataset/exportDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/exportDatasetCommand.js
@@ -18,7 +18,7 @@ export default {
     const [targetDataset, targetDestination] = args.argsWithoutOptions
     const {absolutify} = pathTools
 
-    let dataset = targetDataset
+    let dataset = targetDataset ? `${targetDataset}` : null
     if (!dataset) {
       dataset = await chooseDatasetPrompt(context, {message: 'Select dataset to export'})
     }

--- a/packages/@sanity/core/src/commands/dataset/importDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/importDatasetCommand.js
@@ -34,7 +34,7 @@ export default {
     const datasets = await client.datasets.list()
     spinner.succeed('[100%] Fetching available datasets')
 
-    let targetDataset = target
+    let targetDataset = target ? `${target}` : null
     if (!targetDataset) {
       targetDataset = await chooseDatasetPrompt(context, {
         message: 'Select target dataset',

--- a/packages/@sanity/form-builder/src/FormBuilderContext.js
+++ b/packages/@sanity/form-builder/src/FormBuilderContext.js
@@ -28,7 +28,9 @@ function memoizeMap(method) {
       return map.get(arg)
     }
     const val = method.call(this, arg)
-    map.set(arg, val)
+    if (arg) {
+      map.set(arg, val)
+    }
     return val
   }
 }

--- a/packages/@sanity/image-url/README.md
+++ b/packages/@sanity/image-url/README.md
@@ -102,6 +102,10 @@ Make this an url to download the image. Specify the file name that will be sugge
 
 Flips the image.
 
+### `fit(value)`
+
+Configures the fit mode. See the [documentation](https://www.sanity.io/docs/reference/image-urls#fit-object-object) for details.
+
 ### `ignoreImageParams()`
 
 Ignore any specifications from the image record (i.e. crop and hotspot).

--- a/packages/@sanity/image-url/src/builder.js
+++ b/packages/@sanity/image-url/src/builder.js
@@ -1,5 +1,7 @@
 import urlForImage from './urlForImage'
 
+const validFits = ['clip', 'crop', 'fill', 'fillmax', 'max', 'scale', 'min']
+
 class ImageUrlBuilder {
   constructor(parent, options) {
     if (parent) {
@@ -120,6 +122,10 @@ class ImageUrlBuilder {
   }
 
   fit(value) {
+    if (validFits.indexOf(value) === -1) {
+      throw new Error(`Invalid fit mode "${value}"`)
+    }
+
     return this._withOptions({fit: value})
   }
 

--- a/packages/@sanity/image-url/src/builder.js
+++ b/packages/@sanity/image-url/src/builder.js
@@ -119,6 +119,10 @@ class ImageUrlBuilder {
     return this._withOptions({ignoreImageParams: true})
   }
 
+  fit(value) {
+    return this._withOptions({fit: value})
+  }
+
   // Gets the url based on the submitted parameters
   url() {
     return urlForImage(this.options)

--- a/packages/@sanity/image-url/src/urlForImage.js
+++ b/packages/@sanity/image-url/src/urlForImage.js
@@ -11,7 +11,8 @@ const SPEC_NAME_TO_URL_NAME_MAPPINGS = [
   ['maxHeight', 'max-h'],
   ['minWidth', 'min-w'],
   ['maxWidth', 'max-w'],
-  ['quality', 'q']
+  ['quality', 'q'],
+  ['fit', 'fit']
 ]
 
 export default function urlForImage(options) {

--- a/packages/@sanity/image-url/test/builder.test.js
+++ b/packages/@sanity/image-url/test/builder.test.js
@@ -31,8 +31,9 @@ const cases = [
       .forceDownload('a.png')
       .flipHorizontal()
       .flipVertical()
+      .fit('crop')
       .url()),
-    expect: 'rect=10,20,30,40&fp-x=10&fp-x=20&flip=hv&fm=png&dl=a.png&blur=50&invert=true&or=90&min-h=150&max-h=300&min-w=100&max-w=200&q=50'
+    expect: 'rect=10,20,30,40&fp-x=10&fp-x=20&flip=hv&fm=png&dl=a.png&blur=50&invert=true&or=90&min-h=150&max-h=300&min-w=100&max-w=200&q=50&fit=crop'
   }
 ]
 

--- a/packages/@sanity/image-url/test/builder.test.js
+++ b/packages/@sanity/image-url/test/builder.test.js
@@ -43,4 +43,8 @@ describe('builder', () => {
       should(testCase.url).equal(testCase.expect)
     })
   })
+
+  it('should throw on invalid fit mode', () => {
+    should.throws(() => urlFor.image(croppedImage()).fit('moo'), /Invalid fit mode "moo"/)
+  })
 })

--- a/packages/@sanity/import/package.json
+++ b/packages/@sanity/import/package.json
@@ -24,10 +24,10 @@
     "ndjson"
   ],
   "dependencies": {
+    "@rexxars/get-uri": "^2.0.2",
     "@sanity/mutator": "^0.120.0",
     "@sanity/uuid": "^0.120.0",
     "debug": "^2.6.3",
-    "get-uri": "^2.0.1",
     "lodash": "^4.17.4",
     "p-map": "^1.2.0",
     "simple-concat": "^1.0.0",

--- a/packages/@sanity/import/src/util/getBufferForUri.js
+++ b/packages/@sanity/import/src/util/getBufferForUri.js
@@ -1,4 +1,4 @@
-const getUri = require('get-uri')
+const getUri = require('@rexxars/get-uri')
 const simpleConcat = require('simple-concat')
 
 function getBufferForUri(uri) {

--- a/packages/@sanity/schema/src/legacy/types/array.js
+++ b/packages/@sanity/schema/src/legacy/types/array.js
@@ -1,5 +1,4 @@
-import {pick, omit} from 'lodash'
-import assert from 'assert'
+import {pick} from 'lodash'
 import {lazyGetter} from './utils'
 
 const OVERRIDABLE_FIELDS = ['jsonType', 'type', 'name', 'title', 'description', 'options', 'fieldsets']
@@ -43,29 +42,3 @@ export const ArrayType = {
     }
   }
 }
-const Person = ArrayType.extend({
-  name: 'person',
-  title: 'Person',
-  of: [
-    {type: 'string', name: 'lol'}
-  ]
-}, v => v)
-
-const TypeOfPerson = Person.extend({
-  name: 'typeofperson',
-  title: 'Type Of Person'
-}, v => v)
-
-const TypeOfTypeOfPerson = TypeOfPerson.extend({
-  name: 'typeoftypeofperson',
-  title: 'Type Of Type Of Person'
-}, v => v)
-
-assert.equal(TypeOfTypeOfPerson.get().type, TypeOfPerson.get())
-assert.equal(TypeOfTypeOfPerson.get().type, TypeOfPerson.get())
-assert.equal(TypeOfTypeOfPerson.get().fields, Person.get().fields)
-assert.throws(
-  () => TypeOfTypeOfPerson.extend({name: 'lol', of: []}),
-  /Cannot override `of` property of subtypes of "array"/
-)
-// console.log('TypeOfTypeOfPerson', TypeOfTypeOfPerson.get())

--- a/packages/@sanity/schema/src/sanity/validation/utils/validateTypeName.js
+++ b/packages/@sanity/schema/src/sanity/validation/utils/validateTypeName.js
@@ -14,6 +14,13 @@ export function validateTypeName(typeName: string, visitorContext) {
     ]
   }
 
+  if (typeof typeName !== 'string') {
+    return [
+      error(`Type has an invalid "type"-property - should be a string. Valid types are: ${humanize(possibleTypeNames)}`,
+        HELP_IDS.TYPE_MISSING_TYPE)
+    ]
+  }
+
   const isValid = possibleTypeNames.includes(typeName)
 
   if (!isValid) {

--- a/packages/@sanity/vision/src/SanityVision.js
+++ b/packages/@sanity/vision/src/SanityVision.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import client from 'part:@sanity/base/client'
+import sanityClient from 'part:@sanity/base/client'
 import Button from 'part:@sanity/components/buttons/default'
 import schema from 'part:@sanity/base/schema?'
 import Select from './sanity/Select'
@@ -19,6 +19,8 @@ const styles = {
   visionGui,
   jsonInspector
 }
+
+const client = sanityClient.clone()
 
 // Used in Sanity project
 function SanityVision() {


### PR DESCRIPTION
Upgrade with:

    sanity upgrade

And install the latest Command Line Interface (CLI) with:

    npm install --global @sanity/cli

# 🐛 Notable bugfixes
- Fix bug where certain studio errors (uncaught schema errors, for instance) would not give any indication or error message
- Vision no longer switches dataset for entire studio, but rather just for that tool
- When importing assets from a URL and the response is a redirect from http->https or https->http, the requests no longer fail
- Couple of issues with how the CLI tool treated numeric datasets is now fixed

# 📓 Full changelog
Author | Message | Commit
------------ | ------------- | -------------
Per-Kristian Nordnes | [block-tools] Fix bug which expected node.children which is not always the case | 84f24392
Espen Hovlandsdal | [import] Use forked get-uri with redirect fix | bd146383
Espen Hovlandsdal | [form-builder] Fix crash when input/preview component could not be resolved | 993fc09f
Espen Hovlandsdal | [core] Fix numeric datasets being treated as missing | 1e0969f4
Simen Svale Skogsrud | [image-url] Added support for the fit-parameter | 00f30d92
Espen Hovlandsdal | [image-url] Throw on invalid fit mode | 5860a65a
Espen Hovlandsdal | [schema] Remove stray test code from array schema type | f2d8b5a2
Espen Hovlandsdal | [schema] Validate that type name is a string | b0736b2b
Espen Hovlandsdal | [base] Asynchronously publish resolved user to bubble errors up | b8cb0757
Espen Hovlandsdal | [vision] Clone client on startup to prevent us from configuring the main studio client | bf5c98a4
Espen Hovlandsdal | [base] Solve swallowed error without defering to next tick | a73ef77d
