### PR TITLE
Start block markDefs from empty array

### DIFF
--- a/packages/@sanity/block-tools/src/converters/slateStateToBlocks.js
+++ b/packages/@sanity/block-tools/src/converters/slateStateToBlocks.js
@@ -30,8 +30,10 @@ function toSanitySpan(node, sanityBlock, spanIndex) {
         Object.keys(annotations).forEach(name => {
           const annotation = annotations[name]
           const annotationKey = annotation._key
-          sanityBlock.markDefs.push(annotation)
-          annotationKeys.push(annotationKey)
+          if (annotation) {
+            sanityBlock.markDefs.push(annotation)
+            annotationKeys.push(annotationKey)
+          }
         })
       }
       return nodesNode.ranges

--- a/packages/@sanity/block-tools/src/converters/slateStateToBlocks.js
+++ b/packages/@sanity/block-tools/src/converters/slateStateToBlocks.js
@@ -52,7 +52,7 @@ function toSanityBlock(block) {
       ...block.data,
       _type: 'block',
       _key: block.key || block.data._key || randomKey(12),
-      markDefs: block.data.markDefs || []
+      markDefs: []
     }
     let index = 0
     const spanIndex = () => {


### PR DESCRIPTION
Seems like there were a little snag in the code, where it would initiate the markDefs with existing values. It should always start from an empty array as it builds it up anyway from every span node.