### PR TITLE
[desk-tool] Force update of documents pane with key

### DIFF
--- a/packages/@sanity/desk-tool/src/SchemaPaneResolver.js
+++ b/packages/@sanity/desk-tool/src/SchemaPaneResolver.js
@@ -98,6 +98,7 @@ export default class SchemaPaneResolver extends React.Component {
                 isCollapsed={!!collapsedPanes.find(pane => pane === 'documentsPane')}
               >
                 <DocumentsPane
+                  key={selectedType}
                   isCollapsed={!!collapsedPanes.find(pane => pane === 'documentsPane')}
                   selectedType={selectedType}
                   title={dataAspects.getDisplayName(selectedType) || 'Untitled'}


### PR DESCRIPTION
Fixes a bug where documentspane did not display correct view/ordering without reload.