### PR TITLE
Fix/blockquote css

### DIFF
--- a/packages/@sanity/base/src/styles/typography/text-blocks.css
+++ b/packages/@sanity/base/src/styles/typography/text-blocks.css
@@ -45,6 +45,7 @@
   font-size: var(--blockquote-font-size);
   font-family: var(--font-family-serif);
   font-style: italic;
+  padding-left: 1.1rem;
 
   @nest &:before {
     content: "“";
@@ -54,6 +55,9 @@
     left: -3rem;
     top: -2rem;
     opacity: 0.5;
+    height: 4rem;
+    width: 4rem;
+    overflow: hidden;
   }
 }
 

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/styles/contentStyles/Blockquote.css
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/styles/contentStyles/Blockquote.css
@@ -1,8 +1,8 @@
 .root {
   margin: 0;
   padding: 0;
-  padding: 1em 0;
-  text-indent: 1em;
+  padding: 1em 1em;
+  margin-left: 2em;
 }
 
 .quote {


### PR DESCRIPTION
There was a problem where the block-quote quote symbol was overlayed on block below making it unfocusable. This will limit the width and height of the quote symbol.

Also, nicer indentation of the text when multi-line.
