### PR TITLE
[form-builder] Remove scroll into view offset on FormBuilderInput

### DIFF
--- a/packages/@sanity/form-builder/src/FormBuilderInput.js
+++ b/packages/@sanity/form-builder/src/FormBuilderInput.js
@@ -99,8 +99,7 @@ export const FormBuilderInput = class FormBuilderInput extends React.PureCompone
     // console.log('Set focus: ', this.props.path)
     this._input.focus()
     scrollIntoViewIfNeeded(this._element, {
-      duration: 200,
-      offset: {bottom: 200}
+      duration: 200
     })
   }
 


### PR DESCRIPTION
This fixes an annoyance causing page scroll when dragging elements in an array

(cc @kristofferj)