### PR TITLE
[default-layout] Not showing loadingscreen if not loading

### DIFF
--- a/packages/@sanity/default-layout/src/components/styles/DefaultLayout.css
+++ b/packages/@sanity/default-layout/src/components/styles/DefaultLayout.css
@@ -63,6 +63,10 @@
   animation-delay: 1s;
 }
 
+.loadingScreenLoaded {
+  display: none;
+}
+
 .navigation {
   border-bottom: 1px solid var(--component-border-color);
 }


### PR DESCRIPTION
Fixes a bug where the loading screen stays on screen after loading.
Maybe that animationend happends before the listener is added