### PR TITLE
[components] Make DefaultTextArea focusable

### DIFF
--- a/packages/@sanity/components/src/textareas/DefaultTextArea.js
+++ b/packages/@sanity/components/src/textareas/DefaultTextArea.js
@@ -33,6 +33,22 @@ export default class DefaultTextArea extends React.Component {
     this.props.onClear(event)
   }
 
+  select() {
+    if (this._input) {
+      this._input.select()
+    }
+  }
+
+  focus() {
+    if (this._input) {
+      this._input.focus()
+    }
+  }
+
+  setInput = element => {
+    this._input = element
+  }
+
   render() {
     const {
       value,
@@ -57,6 +73,7 @@ export default class DefaultTextArea extends React.Component {
           onFocus={onFocus}
           onBlur={onBlur}
           autoComplete="off"
+          ref={this._setInput}
           {...rest}
         />
         {

--- a/packages/test-studio/schemas/schema.js
+++ b/packages/test-studio/schemas/schema.js
@@ -9,6 +9,7 @@ import blocks from './blocks'
 import references from './references'
 import images, {myImage} from './images'
 import strings from './strings'
+import texts from './texts'
 import objects, {myObject} from './objects'
 import arrays from './arrays'
 import files from './files'
@@ -41,6 +42,7 @@ export default createSchema({
     author,
     focus,
     strings,
+    texts,
     numbers,
     booleans,
     richDateType,

--- a/packages/test-studio/schemas/texts.js
+++ b/packages/test-studio/schemas/texts.js
@@ -1,0 +1,20 @@
+export default {
+  name: 'textsTest',
+  type: 'document',
+  title: 'Texts tests',
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      title: 'Simple text',
+      description: 'This is a simple text field'
+    },
+    {
+      name: 'readonlyField',
+      type: 'text',
+      title: 'A read only text',
+      description: 'It may have a value, but it cannot be edited',
+      readOnly: true
+    }
+  ]
+}


### PR DESCRIPTION
This exposes both `.focus()` and `.select()` methods on DefaultTextArea instances.