### PR TITLE
[base] Use span instead of div as wrapper element in PreviewSubscriber

### DIFF
--- a/packages/@sanity/base/src/preview/PreviewSubscriber.js
+++ b/packages/@sanity/base/src/preview/PreviewSubscriber.js
@@ -81,9 +81,10 @@ export default class PreviewSubscriber extends React.PureComponent {
     const {result, isLive, error} = this.state
     const {children: Child, ...props} = this.props
     return (
-      <div ref={this.setElement}>
+      // note: the root element here should be a span since this component may be used to display inline previews
+      <span ref={this.setElement}>
         <Child snapshot={result.snapshot} type={result.type} isLive={isLive} error={error} {...props} />
-      </div>
+      </span>
     )
   }
 }


### PR DESCRIPTION
The root element of PreviewSubscriber was initially a `div`, but was changed to be a `span` in #252 for the reason mentioned there. This turns it back into a `span` again.