### PR TITLE
[base] Optimize preview snapshot fetching

### DIFF
--- a/packages/@sanity/base/src/preview/observeWithPaths.js
+++ b/packages/@sanity/base/src/preview/observeWithPaths.js
@@ -49,12 +49,13 @@ function toGradientQuery(combinedSelections) {
 }
 
 function reproject(queryResult, combinedSelections) {
-  return queryResult.reduce((mapped, subResult, index) => {
+  return queryResult.reduce((reprojected, subResult, index) => {
     const map = combinedSelections[index].map
     map.forEach((resultIdx, i) => {
-      mapped[resultIdx] = subResult[i]
+      const id = combinedSelections[index].ids[i]
+      reprojected[resultIdx] = subResult.find(doc => doc._id === id)
     })
-    return mapped
+    return reprojected
   }, [])
 }
 

--- a/packages/@sanity/base/src/preview/observeWithPaths.js
+++ b/packages/@sanity/base/src/preview/observeWithPaths.js
@@ -1,4 +1,4 @@
-import {sortBy, identity} from 'lodash'
+import {values, sortBy, identity} from 'lodash'
 import client from 'part:@sanity/base/client'
 import Observable from '@sanity/observable'
 import debounceCollect from './utils/debounceCollect'
@@ -20,7 +20,7 @@ function listen(id) {
 }
 
 function combineSelections(selections) {
-  return Object.values(selections.reduce((output, [id, paths], index) => {
+  return values(selections.reduce((output, [id, paths], index) => {
     const key = sortBy(paths.join(','), identity)
     if (!output[key]) {
       output[key] = {paths, ids: [], map: []}

--- a/packages/@sanity/base/src/preview/observeWithPaths.js
+++ b/packages/@sanity/base/src/preview/observeWithPaths.js
@@ -1,4 +1,4 @@
-import {keyBy} from 'lodash'
+import {sortBy, identity} from 'lodash'
 import client from 'part:@sanity/base/client'
 import Observable from '@sanity/observable'
 import debounceCollect from './utils/debounceCollect'
@@ -19,40 +19,50 @@ function listen(id) {
     .filter(event => event.documentId === id)
 }
 
-function fetchAllDocumentSnapshots(selections) {
-  let prevPaths
-  let canBeCombined = true
-
-  const ids = []
-  const optimizedParams = {}
-  const queryParts = selections.map(([id, paths], queryIndex) => {
-    // While we're iterating, see if there are differing paths requested
-    const currentPaths = paths.join(',')
-    if (canBeCombined && prevPaths && currentPaths !== prevPaths) {
-      canBeCombined = false
+function combineSelections(selections) {
+  return Object.values(selections.reduce((output, [id, paths], index) => {
+    const key = sortBy(paths.join(','), identity)
+    if (!output[key]) {
+      output[key] = {paths, ids: [], map: []}
     }
+    const idx = output[key].ids.length
+    output[key].ids[idx] = id
+    output[key].map[idx] = index
+    return output
+  }, {}))
+}
 
-    ids.push(id)
-    prevPaths = currentPaths
-    optimizedParams[[`id_${queryIndex}`]] = id
-    return `*[_id==$id_${queryIndex}]{_id,_type,${currentPaths}}`
-  })
+function stringifyId(id) {
+  return JSON.stringify(id)
+}
+function toSubQuery({ids, paths}) {
+  const stringifiedIds = ids.map(stringifyId)
+  const filter = stringifiedIds.length === 1
+    ? `*[_id == ${stringifiedIds[0]}]`
+    : `*[_id in [${stringifiedIds.join(',')}]]`
+  return `${filter}{_id,_type,${paths.join(',')}}`
+}
 
-  // If we have different paths (fields selected), we can't combine the queries, so do an array selection
-  if (!canBeCombined) {
-    const optimizedQuery = `[${queryParts.join(',\n')}]`
-    return client.observable
-      .fetch(optimizedQuery, optimizedParams)
-      .map(result => result.map(res => res[0]))
-  }
+function toGradientQuery(combinedSelections) {
+  const subQueries = combinedSelections.map(toSubQuery)
+  return `[${subQueries.join(',')}]`
+}
 
-  // All paths (fields selected) are the same, so we can create a simpler, faster query
-  // Note that we have to reassemble results into same order as the input, however
-  const query = `*[_id in [${ids.map(id => JSON.stringify(id)).join(',')}]]{_id,_type,${prevPaths}}`
-  return client.observable.fetch(query).map(result => {
-    const byId = keyBy(result, '_id')
-    return selections.map(([id]) => byId[id])
-  })
+function reproject(queryResult, combinedSelections) {
+  return queryResult.reduce((mapped, subResult, index) => {
+    const map = combinedSelections[index].map
+    map.forEach((resultIdx, i) => {
+      mapped[resultIdx] = subResult[i]
+    })
+    return mapped
+  }, [])
+}
+
+function fetchAllDocumentSnapshots(selections) {
+  const combinedSelections = combineSelections(selections)
+  return client.observable
+    .fetch(toGradientQuery(combinedSelections))
+    .map(result => reproject(result, combinedSelections))
 }
 
 const debouncedFetchDocumentSnapshot = debounceCollect(fetchAllDocumentSnapshots, 50)


### PR DESCRIPTION
When resolving previews, we often end up with queries such as:
```js
[
  *[_id==$id_0]{_id,_type,url},
  *[_id==$id_1]{_id,_type,url},
  *[_id==$id_2]{_id,_type,url},
  *[_id==$id_3]{_id,_type,url},
  *[_id==$id_4]{_id,_type,url},
  *[_id==$id_5]{_id,_type,url}
]
```

Which currently is not optimized on the server side. This PR optimizes the cases where the projects are equal, such as in the case above, and instead creates a query like the following:

```js
*[_id in ["someId_0", "someId_1", "someId_2", "someId_3", "someId_4"]]{_id, _type, url}
```

When the response arrives, we reassemble the array so that the results are in the same order as the selection passed to the `observeWithPaths`.

I'm sure this could be solved slightly cleaner, but this reduces a 15-document query from ~250ms to ~15ms.

  