### PR TITLE
[schema] Remove stray assertions

### DIFF
--- a/packages/@sanity/schema/src/legacy/types/reference.js
+++ b/packages/@sanity/schema/src/legacy/types/reference.js
@@ -1,5 +1,4 @@
 import {pick} from 'lodash'
-import assert from 'assert'
 import arrify from 'arrify'
 import {lazyGetter} from './utils'
 
@@ -66,28 +65,3 @@ export const ReferenceType = {
     }
   }
 }
-
-const CustomRef = ReferenceType.extend({
-  name: 'customRef',
-  title: 'Custom ref',
-  to: []
-})
-
-const TypeOfCustomStr = CustomRef.extend({
-  name: 'typeOfCustomRef',
-  title: 'Type Of CustomRef'
-})
-
-const TypeOfTypeOfCustomStr = TypeOfCustomStr.extend({
-  name: 'typeOfTypeOfCustomRef',
-  title: 'Type Of Type Of CustomRef'
-})
-
-assert.equal(TypeOfTypeOfCustomStr.get().type, TypeOfCustomStr.get())
-assert.equal(TypeOfTypeOfCustomStr.get().type, TypeOfCustomStr.get())
-assert.equal(TypeOfTypeOfCustomStr.get().name, 'typeOfTypeOfCustomRef')
-assert.equal(TypeOfTypeOfCustomStr.get().type.name, 'typeOfCustomRef')
-assert.equal(TypeOfTypeOfCustomStr.get().type.type.name, 'customRef')
-assert.equal(TypeOfTypeOfCustomStr.get().type.type.type.name, 'reference')
-assert.equal(TypeOfTypeOfCustomStr.get().type.type.type.jsonType, 'object')
-assert.equal(TypeOfTypeOfCustomStr.get().to, CustomRef.get().to)

--- a/packages/@sanity/schema/src/legacy/types/string.js
+++ b/packages/@sanity/schema/src/legacy/types/string.js
@@ -1,5 +1,4 @@
 import {pick} from 'lodash'
-import assert from 'assert'
 import primitivePreview from '../preview/primitivePreview'
 
 const OVERRIDABLE_FIELDS = ['jsonType', 'type', 'name', 'title', 'description', 'options', 'fieldsets']
@@ -35,26 +34,3 @@ export const StringType = {
     }
   }
 }
-const CustomString = StringType.extend({
-  name: 'someStr',
-  title: 'Custom String'
-})
-
-const TypeOfCustomStr = CustomString.extend({
-  name: 'typeOfSomeStr',
-  title: 'Type Of CustomString'
-}, v => v)
-
-const TypeOfTypeOfCustomStr = TypeOfCustomStr.extend({
-  name: 'typeoftypeofcustomstr',
-  title: 'Type Of Type Of CustomString'
-}, v => v)
-
-assert.equal(TypeOfTypeOfCustomStr.get().type, TypeOfCustomStr.get())
-assert.equal(TypeOfTypeOfCustomStr.get().type, TypeOfCustomStr.get())
-assert.equal(TypeOfTypeOfCustomStr.get().name, 'typeoftypeofcustomstr')
-assert.equal(TypeOfTypeOfCustomStr.get().type.name, 'typeOfSomeStr')
-assert.equal(TypeOfTypeOfCustomStr.get().type.type.name, 'someStr')
-assert.equal(TypeOfTypeOfCustomStr.get().type.type.type.name, 'string')
-assert.equal(TypeOfTypeOfCustomStr.get().type.type.type.jsonType, 'string')
-assert.equal(TypeOfTypeOfCustomStr.get().fields, CustomString.get().fields)


### PR DESCRIPTION
This is rather embarrassing. These were only useful at the early stage of writing the (now legacy) schema code, so it should have been removed a long time ago.