### PR TITLE
[core] Re-initialize plugin configs before building to static assets

### DIFF
--- a/packages/@sanity/core/src/actions/build/buildStaticAssets.js
+++ b/packages/@sanity/core/src/actions/build/buildStaticAssets.js
@@ -7,11 +7,8 @@ import compressJavascript from './compressJavascript'
 import getConfig from '@sanity/util/lib/getConfig'
 import sortModulesBySize from '../../stats/sortModulesBySize'
 import checkReactCompatibility from '../../util/checkReactCompatibility'
-import {
-  getWebpackCompiler,
-  getDocumentElement,
-  ReactDOM
-} from '@sanity/server'
+import {tryInitializePluginConfigs} from '../config/reinitializePluginConfigs'
+import {getWebpackCompiler, getDocumentElement, ReactDOM} from '@sanity/server'
 
 const rimraf = thenify(rimTheRaf)
 const absoluteMatch = /^https?:\/\//i
@@ -31,6 +28,8 @@ export default async (args, context) => {
     skipMinify: flags['skip-minify'] || false,
     profile: flags.profile || false
   }
+
+  await tryInitializePluginConfigs({workDir, output})
 
   checkReactCompatibility(workDir)
 

--- a/packages/test-studio/.gitignore
+++ b/packages/test-studio/.gitignore
@@ -10,3 +10,7 @@ node_modules
 
 # Built assets
 dist
+
+# Plugin config
+config/@sanity/default-login.json
+config/.checksums


### PR DESCRIPTION
This PR ensures that the plugin re-initialization is ran before building static assets. Currently, if you've bootstrapped a studio and run `sanity build` or `sanity deploy` before running `sanity start`, the build might fail due to missing configs.
