### PR TITLE
[form-builder] Use drag handle *unless* layout is grid

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/Array/Array.js
+++ b/packages/@sanity/form-builder/src/inputs/Array/Array.js
@@ -224,7 +224,7 @@ export default class ArrayInput extends React.Component<Props, State> {
         onSortEnd: this.handleSortEnd,
         onSortStart: this.handleSortStart,
         lockToContainerEdges: true,
-        useDragHandle: isGrid
+        useDragHandle: !isGrid
       }
       : {}
     const listItemClassName = isMoving ? styles.listItemMute : styles.listItem

--- a/packages/test-studio/schemas/arrays.js
+++ b/packages/test-studio/schemas/arrays.js
@@ -201,6 +201,29 @@ export default {
       ]
     },
     {
+      name: 'polymorphicGridArray',
+      title: 'Polymorphic grid array',
+      description: 'An array of multiple types. options: {layout: "grid"}',
+      type: 'array',
+      options: {
+        layout: 'grid'
+      },
+      of: [
+        {
+          title: 'A book',
+          type: 'book'
+        },
+        {
+          title: 'An author',
+          type: 'author'
+        },
+        {
+          title: 'An image',
+          type: 'image'
+        }
+      ]
+    },
+    {
       name: 'imageArrayNotSortable',
       title: 'Image array in grid, *not* sortable',
       description: 'Images here should be append-only',


### PR DESCRIPTION
Sorting in arrays with grid view was accidentally broken in v0.124.0. This fixes it.

Let's merge it into master and release a fix immediately.

(Also added a test case to the example studio with grid array of mixed types)