### PR TITLE
[form-builder] Improve UX of PrimitiveArray

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ArrayOfPrimitives/ArrayOfPrimitives.js
+++ b/packages/@sanity/form-builder/src/inputs/ArrayOfPrimitives/ArrayOfPrimitives.js
@@ -25,6 +25,12 @@ function move(arr, from, to) {
   return copy
 }
 
+function insertAt(arr, index, item) {
+  const copy = arr.slice()
+  copy.splice(index + 1, 0, item)
+  return copy
+}
+
 type Props = {
   type: Type,
   value: Array<ItemValue>,
@@ -45,10 +51,17 @@ export default class ArrayOfPrimitivesInput extends React.PureComponent<Props> {
 
   removeAt(index: number) {
     this.set(this.props.value.filter((_, i) => i !== index))
+    this.props.onFocus([Math.max(0, index - 1)])
   }
 
   append(type) {
     this.set((this.props.value || []).concat(getEmptyValue(type)))
+    this.props.onFocus([this.props.value.length])
+  }
+
+  insertAt(index, type) {
+    this.set(insertAt(this.props.value || [], index, getEmptyValue(type)))
+    this.props.onFocus([index + 1])
   }
 
   handleRemoveItem = (index: number) => {
@@ -67,7 +80,11 @@ export default class ArrayOfPrimitivesInput extends React.PureComponent<Props> {
     this.props.onChange(event)
   }
 
-  handleSort = event => {
+  handleItemEnterKey = index => {
+    this.insertAt(index, this.props.type.of[0])
+  }
+
+  handleSortEnd = event => {
     const {value} = this.props
     const {oldIndex, newIndex} = event
     this.set(move(value, oldIndex, newIndex))
@@ -109,6 +126,7 @@ export default class ArrayOfPrimitivesInput extends React.PureComponent<Props> {
           focusPath={focusPath}
           onFocus={onFocus}
           onBlur={onBlur}
+          onEnterKey={this.handleItemEnterKey}
           onChange={this.handleItemChange}
           onRemove={this.handleRemoveItem}
         />
@@ -123,7 +141,7 @@ export default class ArrayOfPrimitivesInput extends React.PureComponent<Props> {
       ? (
         <SortableList
           className={styles.list}
-          onSort={this.handleSort}
+          onSortEnd={this.handleSortEnd}
           movingItemClass={styles.movingItem}
           useDragHandle
         >
@@ -138,9 +156,6 @@ export default class ArrayOfPrimitivesInput extends React.PureComponent<Props> {
 
   }
 
-  handleFocus = (ev: SyntheticEvent<*>) => {
-
-  }
   setElement = (el: ?Fieldset) => {
     this._element = el
   }
@@ -167,14 +182,14 @@ export default class ArrayOfPrimitivesInput extends React.PureComponent<Props> {
   }
 
   render() {
-    const {type, value, level} = this.props
+    const {type, value, level, onFocus} = this.props
     return (
       <Fieldset
         legend={type.title}
         description={type.description}
         level={level}
         tabIndex={0}
-        onFocus={this.handleFocus}
+        onFocus={onFocus}
         ref={this.setElement}
       >
         <div className={styles.root}>

--- a/packages/@sanity/form-builder/src/inputs/ArrayOfPrimitives/ArrayOfPrimitives.js
+++ b/packages/@sanity/form-builder/src/inputs/ArrayOfPrimitives/ArrayOfPrimitives.js
@@ -43,8 +43,10 @@ type Props = {
 
 export default class ArrayOfPrimitivesInput extends React.PureComponent<Props> {
   _element: ?Fieldset
+  _lastAddedIndex = -1
 
   set(nextValue: any[]) {
+    this._lastAddedIndex = -1
     const patch = nextValue.length === 0 ? unset() : set(nextValue)
     this.props.onChange(PatchEvent.from(patch))
   }
@@ -77,11 +79,20 @@ export default class ArrayOfPrimitivesInput extends React.PureComponent<Props> {
   }
 
   handleItemChange = event => {
+    this._lastAddedIndex = -1
     this.props.onChange(event)
   }
 
   handleItemEnterKey = index => {
     this.insertAt(index, this.props.type.of[0])
+    this._lastAddedIndex = index + 1
+  }
+
+  handleItemEscapeKey = index => {
+    const {value} = this.props
+    if (index === this._lastAddedIndex && value[index] === '') {
+      this.removeAt(index)
+    }
   }
 
   handleSortEnd = event => {
@@ -127,6 +138,7 @@ export default class ArrayOfPrimitivesInput extends React.PureComponent<Props> {
           onFocus={onFocus}
           onBlur={onBlur}
           onEnterKey={this.handleItemEnterKey}
+          onEscapeKey={this.handleItemEscapeKey}
           onChange={this.handleItemChange}
           onRemove={this.handleRemoveItem}
         />

--- a/packages/@sanity/form-builder/src/inputs/ArrayOfPrimitives/Item.js
+++ b/packages/@sanity/form-builder/src/inputs/ArrayOfPrimitives/Item.js
@@ -18,6 +18,8 @@ const DragHandle = createDragHandle(() => <span className={styles.dragHandle}><D
 type Props = {
   type: Type,
   onChange: PatchEvent => void,
+  onRemove: number => void,
+  onEnterKey: number => void,
   onFocus: (Path) => void,
   onBlur: () => void,
   focusPath: Path,
@@ -29,8 +31,22 @@ type Props = {
 export default class Item extends React.PureComponent<Props> {
 
   handleRemove = () => {
-    const {index, onChange} = this.props
-    onChange(PatchEvent.from(unset([index])))
+    const {index, onRemove} = this.props
+    onRemove(index)
+  }
+
+  handleKeyPress = event => {
+    const {index, onEnterKey} = this.props
+    if (event.key === 'Enter') {
+      onEnterKey(index)
+    }
+  }
+
+  handleKeyUp = (event: SyntheticKeyEvent<*>) => {
+    const {index, onRemove, value} = this.props
+    if (event.shiftKey && event.key === 'Backspace' && value === '') {
+      onRemove(index)
+    }
   }
 
   handleChange = (patchEvent: PatchEvent) => {
@@ -56,6 +72,8 @@ export default class Item extends React.PureComponent<Props> {
             onFocus={onFocus}
             onBlur={onBlur}
             type={type}
+            onKeyUp={this.handleKeyUp}
+            onKeyPress={this.handleKeyPress}
             onChange={this.handleChange}
             level={level}
           />

--- a/packages/@sanity/form-builder/src/inputs/ArrayOfPrimitives/Item.js
+++ b/packages/@sanity/form-builder/src/inputs/ArrayOfPrimitives/Item.js
@@ -5,7 +5,7 @@ import styles from './styles/Item.css'
 import Button from 'part:@sanity/components/buttons/default'
 import TrashIcon from 'part:@sanity/base/trash-icon'
 
-import PatchEvent, {set, unset} from '../../PatchEvent'
+import PatchEvent, {set} from '../../PatchEvent'
 import getEmptyValue from './getEmptyValue'
 
 import {createDragHandle} from 'part:@sanity/components/lists/sortable'
@@ -20,6 +20,7 @@ type Props = {
   onChange: PatchEvent => void,
   onRemove: number => void,
   onEnterKey: number => void,
+  onEscapeKey: number => void,
   onFocus: (Path) => void,
   onBlur: () => void,
   focusPath: Path,
@@ -43,9 +44,12 @@ export default class Item extends React.PureComponent<Props> {
   }
 
   handleKeyUp = (event: SyntheticKeyEvent<*>) => {
-    const {index, onRemove, value} = this.props
+    const {index, onRemove, onEscapeKey, value} = this.props
     if (event.shiftKey && event.key === 'Backspace' && value === '') {
       onRemove(index)
+    }
+    if (event.key === 'Escape') {
+      onEscapeKey(index)
     }
   }
 


### PR DESCRIPTION
- Fixes a bug that broke sorting of items in PrimitiveArray
- Adds support for "add item on enter key" (#457)
- Sets focus on newly added items.
- shift + backspace in an empty item will delete it (not sure if this is sane, thoughts welcome)

Pinging @kristofferj and @evenwestvang for review/opinions.