### PR TITLE
[preview] Expose the materializePaths function used in the preview package

### DIFF
--- a/packages/@sanity/base/src/preview/index.js
+++ b/packages/@sanity/base/src/preview/index.js
@@ -1,2 +1,2 @@
 export {SanityPreview as default, PreviewSubscriber, PreviewFields} from '@sanity/preview/components'
-export {observeForPreview, observeWithPaths} from '@sanity/preview'
+export {observeForPreview, observeWithPaths, materializePaths} from '@sanity/preview'

--- a/packages/@sanity/preview/index.js
+++ b/packages/@sanity/preview/index.js
@@ -1,2 +1,3 @@
 exports.observeForPreview = require('./lib/observeForPreview').default
 exports.observeWithPaths = require('./lib/observeWithPaths').default
+exports.materializePaths = require('./lib/materializePaths').default

--- a/packages/@sanity/preview/src/materializePaths.js
+++ b/packages/@sanity/preview/src/materializePaths.js
@@ -1,0 +1,4 @@
+import observeWithPaths from './observeWithPaths'
+import createPathMaterializer from './createPathMaterializer'
+
+export default createPathMaterializer(observeWithPaths)

--- a/packages/@sanity/preview/src/observeForPreview.js
+++ b/packages/@sanity/preview/src/observeForPreview.js
@@ -1,10 +1,7 @@
-import createPreviewObserver from './createPreviewObserver'
-import observeWithPaths from './observeWithPaths'
 import resolveRefType from './resolveRefType'
 import prepareForPreview, {invokePrepare} from './prepareForPreview'
 import Observable from '@sanity/observable'
-
-const observe = createPreviewObserver(observeWithPaths)
+import materializePaths from './materializePaths'
 
 function is(typeName, type) {
   return type.name === typeName || (type.type && is(typeName, type.type))
@@ -34,7 +31,7 @@ export default function observeForPreview(value, type, fields, viewOptions) {
     const configFields = Object.keys(selection)
     const targetFields = fields ? configFields.filter(fieldName => fields.includes(fieldName)) : configFields
     const paths = targetFields.map(key => selection[key].split('.'))
-    return observe(value, paths)
+    return materializePaths(value, paths)
       .map(snapshot => ({
         type: type,
         snapshot: prepareForPreview(snapshot, type, viewOptions)


### PR DESCRIPTION
This exposes a function for materializing a set of paths on a given value. Useful e.g. when you have a partially fetched document but need to retrieve more of its properties, e.g.:
```js

import {materializePaths} from '@sanity/preview'

const partialDoc = {
  _id: 'abc'
}

materializePaths(partialDoc, ['title', 'publishDate'])
  .subscribe(doc => {
    console.log('Title: %s, publish at: %s', doc.title, doc.publishDate)
  })

```