### PR TITLE
[form-builder] Remove setTimeout workaround for popover focus issue

### DIFF
--- a/packages/@sanity/form-builder/src/FormBuilderInput.js
+++ b/packages/@sanity/form-builder/src/FormBuilderInput.js
@@ -60,10 +60,10 @@ export const FormBuilderInput = class FormBuilderInput extends React.PureCompone
     }
   }
 
-  componentDidUpdate(prevProps: Props) {
-    const hadFocus = PathUtils.hasFocus(prevProps.focusPath, prevProps.path)
+  componentWillReceiveProps(nextProps: Props) {
+    const willHaveFocus = PathUtils.hasFocus(nextProps.focusPath, nextProps.path)
     const hasFocus = PathUtils.hasFocus(this.props.focusPath, this.props.path)
-    if (!hadFocus && hasFocus) {
+    if (willHaveFocus && !hasFocus) {
       this.focus()
     }
   }
@@ -95,13 +95,7 @@ export const FormBuilderInput = class FormBuilderInput extends React.PureCompone
       return
     }
 
-    // This is a hack needed because popovers doesn't render its children immediately.
-    // When this is fixed, we can call this._confirmButton.focus() immediately
-    setTimeout(() => {
-      if (this._input) {
-        this._input.focus()
-      }
-    }, 0)
+    this._input.focus()
   }
 
   handleChange = patchEvent => {

--- a/packages/@sanity/form-builder/src/inputs/Array/ConfirmButton.js
+++ b/packages/@sanity/form-builder/src/inputs/Array/ConfirmButton.js
@@ -47,13 +47,7 @@ export default class ConfirmButton extends React.Component {
 
   componentDidUpdate(prevProps, prevState) {
     if (!prevState.showConfirmDialog && this.state.showConfirmDialog) {
-      // This is a hack needed because popovers doesn't render its children immediately.
-      // When this is fixed, we can call this._confirmButton.focus() immediately
-      setTimeout(() => {
-        if (this._confirmButton) {
-          this._confirmButton.focus()
-        }
-      }, 0)
+      this._confirmButton.focus()
     }
   }
 


### PR DESCRIPTION
So turns out the `setTimeout`-hack that I used to fix an issue with focus in popovers caused more problems than it solved (who could have guessed?!).

It caused focus to sometimes get stuck jumping really fast between inputs, which is less desirable than losing focus state on an element inside a popover (which should be fixed separately).