### PR TITLE
[form-builder] Don't fail if wrapped input is missing a .focus-method

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/Syncer.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/Syncer.js
@@ -1,3 +1,4 @@
+// @flow
 import PropTypes from 'prop-types'
 import React from 'react'
 import blockTools from '@sanity/block-tools'
@@ -52,6 +53,8 @@ export default withPatchSubscriber(class Syncer extends React.PureComponent {
     subscribe: PropTypes.func
   }
 
+  _blockEditor: null
+
   constructor(props) {
     super()
     const deprecatedSchema = isDeprecatedBlockSchema(props.type)
@@ -102,6 +105,16 @@ export default withPatchSubscriber(class Syncer extends React.PureComponent {
     // }
   }
 
+  focus() {
+    if (this._blockEditor) {
+      this._blockEditor.focus()
+    }
+  }
+
+  setBlockEditor(blockEditor: ?BlockEditor) {
+    this._blockEditor = blockEditor
+  }
+
   componentWillUnmount() {
     // This is a defensive workaround for an issue causing content to be overwritten
     // It cancels any pending saves, so if the component gets unmounted within the
@@ -150,6 +163,7 @@ export default withPatchSubscriber(class Syncer extends React.PureComponent {
             onChange={this.handleChange}
             onNodePatch={this.handleNodePatch}
             value={value}
+            ref={this._setBlockEditor}
           />)
         }
 

--- a/packages/@sanity/form-builder/src/utils/withPatchSubscriber.js
+++ b/packages/@sanity/form-builder/src/utils/withPatchSubscriber.js
@@ -87,8 +87,11 @@ export default function withPatchSubscriber(ComposedComponent: any) {
     }
 
     focus() {
-      this._input.focus()
+      if (this._input && this._input.focus) {
+        this._input.focus()
+      }
     }
+
     setInput = input => {
       this._input = input
     }


### PR DESCRIPTION
This fixes a bug in a higher order component that we use for subscribing to incoming patch events. It was just forwarding `.focus()`-calls to the composed component, but that failed if the composed input did not implement a `.focus()` method. This fix will guard against it by only forwarding `focus()` calls if the composed component exposes a `focus`-method.