### PR TITLE
[schema] Use a simpler (but inadequate) strategy for inferring media preview fields

### DIFF
--- a/packages/test-studio/schemas/authorWithoutPreview.js
+++ b/packages/test-studio/schemas/authorWithoutPreview.js
@@ -1,0 +1,17 @@
+// Example type that has no preview config. Useful for testing default preview config inference
+import author from './author'
+
+export default {
+  name: 'authorWithoutPreview',
+  type: 'document',
+  title: 'Author with no preview config. Useful for testing default preview config inference',
+  fields: [
+    ...author.fields,
+    {
+      name: 'favoriteAuthors',
+      title: 'Favorite authors',
+      type: 'array',
+      of: [{type: 'reference', to: {type: 'authorWithoutPreview'}}]
+    }
+  ]
+}

--- a/packages/test-studio/schemas/schema.js
+++ b/packages/test-studio/schemas/schema.js
@@ -35,6 +35,7 @@ import richDateType from 'part:@sanity/form-builder/input/rich-date/schema'
 import focus from './focus'
 import previewImageUrlTest from './previewImageUrlTest'
 import previewMediaTest from './previewMediaTest'
+import authorWithoutPreview from './authorWithoutPreview'
 
 export default createSchema({
   name: 'test-examples',
@@ -71,6 +72,7 @@ export default createSchema({
     typeWithNoToplevelStrings,
     previewImageUrlTest,
     previewMediaTest,
+    authorWithoutPreview,
     empty
   ])
 })


### PR DESCRIPTION
The fix in #499 re-introduced an old bug triggering a maximum call stack exceeded error (due to traversing over circular references in schema). This is really hard to work around atm (but will be a lot easier in an upcoming rewrite of the schema format), so for now we have to fallback to a simpler way of identifying image fields, that is: use the first field that has `type === 'image'`. This is inadequate for several reasons, and will not work if e.g.:

-  There's a custom image type that extends the default image type, e.g.:
    ```js
    {
      type: 'image',
      name: 'myImage',
      fields: [...]
    }
    
    // will not be able to tell that `myImage` is an image field:
    {
      ...,
      type: 'document'
      fields: [{name: 'coverImage', type: 'myImage', ...]
    }
    ```
- The image asset field is on the type itself, e.g.:

    ```js
    {
      type: 'document',
      name: 'docWithImageAsset',
      fields: [
        // will not be able to preview using the
        // image referred to from the imageAsset field
        {
          name: 'imageAsset',
           type: 'reference',
           to: [{type: 'sanity.imageAsset'}]
       }
      ]
    }
    ```

Still, having _some_ inference is arguably a lot better than _no inference_.