### PR TITLE
[schema] Give image fields higher priority for media preview

### DIFF
--- a/packages/@sanity/schema/src/legacy/preview/guessPreviewConfig.js
+++ b/packages/@sanity/schema/src/legacy/preview/guessPreviewConfig.js
@@ -60,6 +60,8 @@ export default function guessPreviewFields(rawObjectTypeDef) {
     descField = stringFieldNames[1]
   }
 
+  const mediaField = rawObjectTypeDef.fields.find(field => field.type === 'image')
+
   const imageAssetPath = resolveImageAssetPath(objectTypeDef)
 
   if (!titleField) {
@@ -89,7 +91,8 @@ export default function guessPreviewFields(rawObjectTypeDef) {
   const select = omitBy({
     title: titleField,
     description: descField,
-    imageUrl: imageAssetPath ? `${imageAssetPath}.url` : undefined
+    imageUrl: (!mediaField && imageAssetPath) ? `${imageAssetPath}.url` : undefined,
+    media: mediaField ? mediaField.name : undefined
   }, isUndefined)
 
   return {

--- a/packages/test-studio/schemas/recursiveArray.js
+++ b/packages/test-studio/schemas/recursiveArray.js
@@ -24,7 +24,7 @@ export default {
           fields: [
             {name: 'first', type: 'string', title: 'First string'},
             {name: 'second', type: 'string', title: 'Second string'},
-            {name: 'image', type: 'image', title: 'An image'},
+            {name: 'image', type: 'image', title: 'An image', options: {hotspot: true}},
             {
               name: 'gallery',
               title: 'Image array',
@@ -40,12 +40,6 @@ export default {
                 {
                   title: 'Image',
                   type: 'image',
-                  preview: {
-                    select: {
-                      imageUrl: 'asset.url',
-                      title: 'caption'
-                    }
-                  },
                   fields: [
                     {
                       name: 'caption',


### PR DESCRIPTION
This supersedes #505.

This will pick any image field as `media` (unfortunately this solution still got all the shortcomings mentioned in #505, but is less intrusive).