### PR TITLE
[client] Make Promise polyfill details clearer, add url to thrown error

### DIFF
--- a/packages/@sanity/client/README.md
+++ b/packages/@sanity/client/README.md
@@ -2,10 +2,11 @@
 
 [![npm version](https://img.shields.io/npm/v/@sanity/client.svg?style=flat-square)](https://www.npmjs.com/package/@sanity/client)
 
-Javascript client for Sanity. Works in browsers (IE9+) and node.js.
+Javascript client for Sanity. Works in node.js and modern browsers (older browsers needs a [Promise polyfill](https://www.sanity.io/help/js-client-promise-polyfill)).
 
 ## Requirements
-Sanity Client requires the JavaScript runtime to have a global ES6-compliant `Promise` available. If your runtime environment doesn't provide a spec compliant `Promise` implementation, we recommend using [native-promise-only](https://www.npmjs.com/package/native-promise-only), [es6-promise](https://www.npmjs.com/package/es6-promise) or another [spec-compliant](https://promisesaplus.com/implementations) implementation.
+
+Sanity Client requires the JavaScript runtime to have a global ES6-compliant `Promise` available. If your runtime environment doesn't provide a spec compliant `Promise` implementation, we recommend using [native-promise-only](https://www.npmjs.com/package/native-promise-only), [es6-promise](https://www.npmjs.com/package/es6-promise) or another [spec-compliant](https://promisesaplus.com/implementations) implementation. See [this article](https://www.sanity.io/help/js-client-promise-polyfill) for more information.
 
 ## Installation
 

--- a/packages/@sanity/client/src/config.js
+++ b/packages/@sanity/client/src/config.js
@@ -38,8 +38,8 @@ exports.initConfig = (config, prevConfig) => {
   const projectBased = !gradientMode && newConfig.useProjectHostname
 
   if (typeof Promise === 'undefined') {
-    // @todo add help url?
-    throw new Error('No native `Promise`-implementation found, polyfill needed')
+    const helpUrl = generateHelpUrl('js-client-promise-polyfill')
+    throw new Error(`No native Promise-implementation found, polyfill needed - see ${helpUrl}`)
   }
 
   if (gradientMode && !newConfig.namespace) {


### PR DESCRIPTION
Make it clearer that a Promise polyfill is needed in older browsers