### PR TITLE
[form-builder] Fix bug with fieldsets

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/Object/Object.js
+++ b/packages/@sanity/form-builder/src/inputs/Object/Object.js
@@ -9,6 +9,10 @@ import isEmpty from '../../utils/isEmpty'
 import UnknownFields from './UnknownFields'
 import fieldStyles from './styles/Field.css'
 
+function checkIsCollapsible(options = {}) {
+  return options.collapsible !== false && options.collapsable !== false
+}
+
 export default class ObjectInput extends React.PureComponent {
 
   static propTypes = {
@@ -88,10 +92,12 @@ export default class ObjectInput extends React.PureComponent {
   renderFieldset(fieldset, fieldsetIndex) {
     const {level, focusPath} = this.props
     const columns = fieldset.options && fieldset.options.columns
-    const isCollapsible = fieldset.options && (fieldset.options.collapsable || fieldset.options.collapsible)
-    const isExpanded = focusPath.length > 0 && fieldset.fields.some(field => (
+
+    const isCollapsed = (fieldset.options || {}).collapsed === true
+
+    const isExpanded = !isCollapsed || (focusPath.length > 0 && fieldset.fields.some(field => (
       focusPath[0] === field.name
-    ))
+    )))
 
     return (
       <div key={fieldset.name} className={fieldStyles.root}>
@@ -100,7 +106,7 @@ export default class ObjectInput extends React.PureComponent {
           description={fieldset.description}
           level={level + 1}
           columns={columns}
-          isCollapsible={isCollapsible}
+          isCollapsible={checkIsCollapsible(fieldset.options)}
           isCollapsed={!isExpanded}
         >
           {fieldset.fields.map((field, fieldIndex) => {
@@ -176,7 +182,7 @@ export default class ObjectInput extends React.PureComponent {
     }
 
     const columns = type.options && type.options.columns
-    const isCollapsible = type.options && (type.options.collapsable || type.options.collapsible)
+    const isCollapsible = checkIsCollapsible(type.options)
 
     return (
       <Fieldset


### PR DESCRIPTION
Something got messed up with the defaults here, so fieldsets ended up being non-collapsible and collapsed by default, which was unfortunate. This fixed it so that the defaults are:

``` 
collapsible: true
collapsed: true
```

