### PR TITLE
[desk-tool] Add timestamp as title attribute on relative dates

### DIFF
--- a/packages/@sanity/desk-tool/src/components/TimeAgo.js
+++ b/packages/@sanity/desk-tool/src/components/TimeAgo.js
@@ -2,12 +2,12 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import shallowEquals from 'shallow-equals'
 import distanceInWordsToNow from 'date-fns/distance_in_words_to_now'
+import format from 'date-fns/format'
 
 export default class TimeAgo extends React.PureComponent {
-
   static propTypes = {
     refreshInterval: PropTypes.number,
-    time: PropTypes.string
+    time: PropTypes.string.isRequired
   }
 
   static defaultProps = {
@@ -41,7 +41,9 @@ export default class TimeAgo extends React.PureComponent {
   stop() {
     clearInterval(this.intervalId)
   }
+
   render() {
-    return <span>{distanceInWordsToNow(this.props.time, {addSuffix: true})}</span>
+    const timestamp = format(this.props.time, 'MMM D, YYYY, h:mm A Z')
+    return <span title={timestamp}>{distanceInWordsToNow(this.props.time, {addSuffix: true})}</span>
   }
 }


### PR DESCRIPTION
"4 hours ago" is not necessarily as specific as one might want. This PR adds the specific timestamp as title attribute on relative times, so the user might hover the relative timestamp to see a more specific version.

![image](https://user-images.githubusercontent.com/48200/35216787-1ee4477c-ff69-11e7-94c1-66062c77093b.png)

