### PR TITLE
[desk-tool] Preserve _createdAt between draft <=> published version of a document

### DIFF
--- a/packages/@sanity/desk-tool/src/pane/EditorWrapper.js
+++ b/packages/@sanity/desk-tool/src/pane/EditorWrapper.js
@@ -187,7 +187,7 @@ export default class EditorPane extends React.Component {
 
     if (published.snapshot) {
       tx = tx.createIfNotExists({
-        ...omit(published.snapshot, '_createdAt', '_updatedAt'),
+        ...omit(published.snapshot, '_updatedAt'),
         _id: getDraftId(documentId)
       })
     }
@@ -217,7 +217,7 @@ export default class EditorPane extends React.Component {
     const tx = client.observable
       .transaction()
       .createOrReplace({
-        ...omit(draft.snapshot, '_createdAt', '_updatedAt'),
+        ...omit(draft.snapshot, '_updatedAt'),
         _id: getPublishedId(documentId)
       })
       .delete(getDraftId(documentId))
@@ -250,7 +250,7 @@ export default class EditorPane extends React.Component {
 
     if (!draft.snapshot) {
       this.draft.createIfNotExists({
-        ...omit(published.snapshot, '_createdAt', '_updatedAt'),
+        ...omit(published.snapshot, '_updatedAt'),
         _id: this.getDraftId(),
         _type: typeName
       })


### PR DESCRIPTION
This is a partial fix for preserving `_createdAt` throughout the lifetime of a document. We still have a bug in the mutator that omits it from on setIfMissing patches, but that should be fixed separately.