### PR TITLE
[image-url] Add missing `crop`-transformation

### DIFF
--- a/packages/@sanity/image-url/README.md
+++ b/packages/@sanity/image-url/README.md
@@ -102,6 +102,10 @@ Make this an url to download the image. Specify the file name that will be sugge
 
 Flips the image.
 
+### `crop(mode)`
+
+Specifies how to crop the image. When specified, overrides any crop or hotspot in the image record. See the [documentation](https://www.sanity.io/docs/reference/image-urls#crop-object-object) for details.
+
 ### `fit(value)`
 
 Configures the fit mode. See the [documentation](https://www.sanity.io/docs/reference/image-urls#fit-object-object) for details.

--- a/packages/@sanity/image-url/src/builder.js
+++ b/packages/@sanity/image-url/src/builder.js
@@ -1,6 +1,7 @@
 import urlForImage from './urlForImage'
 
 const validFits = ['clip', 'crop', 'fill', 'fillmax', 'max', 'scale', 'min']
+const validCrops = ['top', 'bottom', 'left', 'right', 'center', 'focalpoint', 'entropy']
 
 class ImageUrlBuilder {
   constructor(parent, options) {
@@ -45,10 +46,6 @@ class ImageUrlBuilder {
   // Specify focal point in fraction of image dimensions. Each component 0.0-1.0
   focalPoint(x, y) {
     return this._withOptions({focalPoint: {x, y}})
-  }
-
-  fit(fit) {
-    return this._withOptions({fit})
   }
 
   maxWidth(maxWidth) {
@@ -131,6 +128,14 @@ class ImageUrlBuilder {
     }
 
     return this._withOptions({fit: value})
+  }
+
+  crop(value) {
+    if (validCrops.indexOf(value) === -1) {
+      throw new Error(`Invalid crop mode "${value}"`)
+    }
+
+    return this._withOptions({crop: value})
   }
 
   // Gets the url based on the submitted parameters

--- a/packages/@sanity/image-url/src/urlForImage.js
+++ b/packages/@sanity/image-url/src/urlForImage.js
@@ -12,7 +12,8 @@ const SPEC_NAME_TO_URL_NAME_MAPPINGS = [
   ['minWidth', 'min-w'],
   ['maxWidth', 'max-w'],
   ['quality', 'q'],
-  ['fit', 'fit']
+  ['fit', 'fit'],
+  ['crop', 'crop']
 ]
 
 export default function urlForImage(options) {
@@ -53,7 +54,7 @@ export default function urlForImage(options) {
 
   // If irrelevant, or if we are requested to: don't perform crop/fit based on
   // the crop/hotspot.
-  if (!(spec.rect || spec.focalPoint || spec.ignoreImageParams)) {
+  if (!(spec.rect || spec.focalPoint || spec.ignoreImageParams || spec.crop)) {
     spec = Object.assign(spec, fit({crop, hotspot}, spec))
   }
 
@@ -83,7 +84,7 @@ function parseSource(source) {
   }
 
   if (!image.crop || !image.hotspot) {
-    // Mock crop and hostpot if image lacks it
+    // Mock crop and hotspot if image lacks it
     image = Object.assign({
       crop: {
         left: 0,

--- a/packages/@sanity/image-url/test/builder.test.js
+++ b/packages/@sanity/image-url/test/builder.test.js
@@ -14,6 +14,46 @@ const cases = [
     url: urlFor.image(croppedImage()).size(100, 80).url(),
     expect: 'https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg?rect=200,300,1600,1280&w=100&h=80'
   },
+
+  {
+    name: 'skips hotspot/crop if crop mode specified',
+    url: urlFor.image(croppedImage())
+      .size(100, 80)
+      .crop('center')
+      .url(),
+    expect: 'https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg?w=100&h=80&crop=center'
+  },
+
+  {
+    name: 'skips hotspot/crop if focal point specified',
+    url: urlFor.image(croppedImage())
+      .size(100, 80)
+      .focalPoint(10, 20)
+      .url(),
+    expect: 'https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg?fp-x=10&fp-x=20&w=100&h=80'
+  },
+
+  {
+    name: 'all hotspot/crop-compatible params',
+    url: stripPath(urlFor.image(croppedImage())
+      .maxWidth(200)
+      .minWidth(100)
+      .maxHeight(300)
+      .minHeight(150)
+      .blur(50)
+      .format('png')
+      .invert(true)
+      .orientation(90)
+      .quality(50)
+      .forceDownload('a.png')
+      .flipHorizontal()
+      .flipVertical()
+      .fit('crop')
+      .url()),
+    // eslint-disable-next-line max-len
+    expect: 'rect=200,300,1600,2400&flip=hv&fm=png&dl=a.png&blur=50&invert=true&or=90&min-h=150&max-h=300&min-w=100&max-w=200&q=50&fit=crop'
+  },
+
   {
     name: 'all params',
     url: stripPath(urlFor.image(croppedImage())
@@ -32,8 +72,10 @@ const cases = [
       .flipHorizontal()
       .flipVertical()
       .fit('crop')
+      .crop('center')
       .url()),
-    expect: 'rect=10,20,30,40&fp-x=10&fp-x=20&flip=hv&fm=png&dl=a.png&blur=50&invert=true&or=90&min-h=150&max-h=300&min-w=100&max-w=200&q=50&fit=crop'
+    // eslint-disable-next-line max-len
+    expect: 'rect=10,20,30,40&fp-x=10&fp-x=20&flip=hv&fm=png&dl=a.png&blur=50&invert=true&or=90&min-h=150&max-h=300&min-w=100&max-w=200&q=50&fit=crop&crop=center'
   }
 ]
 
@@ -46,5 +88,9 @@ describe('builder', () => {
 
   it('should throw on invalid fit mode', () => {
     should.throws(() => urlFor.image(croppedImage()).fit('moo'), /Invalid fit mode "moo"/)
+  })
+
+  it('should throw on invalid crop mode', () => {
+    should.throws(() => urlFor.image(croppedImage()).crop('moo'), /Invalid crop mode "moo"/)
   })
 })


### PR DESCRIPTION
We were missing the `crop`-transformation in the builder API.  This PR adds it.
