### PR TITLE
[mutator] Fix createOrReplace and createIfNotExists mutations

### DIFF
--- a/packages/@sanity/mutator/src/document/Mutation.js
+++ b/packages/@sanity/mutator/src/document/Mutation.js
@@ -78,10 +78,10 @@ export default class Mutation {
         )
       } else if (mutation.createIfNotExists) {
         operations.push(
-          doc => (doc === null ? Object.assign(mutation.createIfNotExists, {_createdAt: mutation.create._createdAt || this.params.timestamp}) : doc)
+          doc => (doc === null ? Object.assign(mutation.createIfNotExists, {_createdAt: mutation.createIfNotExists._createdAt || this.params.timestamp}) : doc)
         )
       } else if (mutation.createOrReplace) {
-        operations.push(() => Object.assign(mutation.createOrReplace, {_createdAt: mutation.create._createdAt || this.params.timestamp}))
+        operations.push(() => Object.assign(mutation.createOrReplace, {_createdAt: mutation.createOrReplace._createdAt || this.params.timestamp}))
       } else if (mutation.delete) {
         operations.push(() => null)
       } else if (mutation.patch) {

--- a/packages/@sanity/mutator/test/BufferedDocument.test.js
+++ b/packages/@sanity/mutator/test/BufferedDocument.test.js
@@ -181,7 +181,67 @@ test('document being deleted by remote', tap => {
   .end()
 })
 
+test('document being created with `createOrReplace`', tap => {
+  const createdAt = '2018-01-25T15:18:12.114Z';
+  (new BufferedDocumentTester(tap, {
+    _id: 'a',
+    _rev: '1',
+    text: 'hello'
+  }))
+  .hasNoLocalEdits()
 
+  .stage('when applying createOrReplace mutation')
+  .localMutation(null, '2', {
+    createOrReplace: {_id: 'a', text: 'good morning', _createdAt: createdAt}
+  })
+  .onMutationFired()
+  .hasLocalEdits()
+  .assertLOCAL('_createdAt', createdAt)
+  .end()
+})
+
+test('document being created with `createIfNotExists`', tap => {
+  const createdAt = '2018-01-25T15:18:12.114Z';
+  (new BufferedDocumentTester(tap, {
+    _id: 'a',
+    _rev: '1',
+    text: 'hello'
+  }))
+  .hasNoLocalEdits()
+  .localMutation('1', '2', {
+    delete: {id: 'a'}
+  })
+  .stage('when applying createIfNotExists mutation')
+  .localMutation(null, '3', {
+    createIfNotExists: {_id: 'a', text: 'good morning', _createdAt: createdAt}
+  })
+  .onMutationFired()
+  .hasLocalEdits()
+  .assertLOCAL('_createdAt', createdAt)
+  .end()
+})
+
+test('document being created with `create`', tap => {
+  const createdAt = '2018-01-25T15:18:12.114Z';
+  (new BufferedDocumentTester(tap, {
+    _id: 'a',
+    _rev: '1',
+    text: 'hello'
+  }))
+  .hasNoLocalEdits()
+  .localMutation('1', '2', {
+    delete: {id: 'a'}
+  })
+
+  .stage('when applying create mutation')
+  .localMutation(null, '2', {
+    create: {_id: 'a', text: 'good morning', _createdAt: createdAt}
+  })
+  .onMutationFired()
+  .hasLocalEdits()
+  .assertLOCAL('_createdAt', createdAt)
+  .end()
+})
 
 test('document being deleted by local', tap => {
   (new BufferedDocumentTester(tap, {


### PR DESCRIPTION
#525 introduced a bug where `createOrReplace` and `createIfNotExists`-mutations would fail when attempting to set `_createdAt`.  This PR fixes this and introduces tests to prevent similar issues in the future.