### PR TITLE
[preview] Ignore image cdn parameters from preview.imageUrl

### DIFF
--- a/packages/@sanity/base/src/assets/asset-url-builder.js
+++ b/packages/@sanity/base/src/assets/asset-url-builder.js
@@ -2,7 +2,14 @@ const sanityUrlMatch = /^https?:\/\/cdn.sanity.\w+\/images\//
 
 export default function assetUrlBuilder(url, options) {
   const {width, height, fit} = options
-  if (!sanityUrlMatch.test(url) || url.indexOf('?') !== -1) {
+
+  if (!sanityUrlMatch.test(url)) {
+    return url
+  }
+
+  if (url.includes('?')) {
+    // todo: this is an sanity cdn url that already has parameters specified
+    // Consider merging with options instead of just bypassing
     return url
   }
 

--- a/packages/@sanity/preview/src/components/SanityDefaultPreview.js
+++ b/packages/@sanity/preview/src/components/SanityDefaultPreview.js
@@ -69,7 +69,7 @@ export default class SanityDefaultPreview extends React.PureComponent {
     const {value} = this.props
     const imageUrl = value.imageUrl
     if (imageUrl) {
-      const assetUrl = assetUrlBuilder(imageUrl, dimensions)
+      const assetUrl = assetUrlBuilder(imageUrl.split('?')[0], dimensions)
       return <img src={assetUrl} alt={value.title} />
     }
     return undefined


### PR DESCRIPTION
This will ignore params targeted at our image CDN API like `w=200` from any `imageUrl`-s returned from previews.