### PR TITLE
[components] Disable fit parameter in media preview for now

### DIFF
--- a/packages/@sanity/preview/src/components/SanityDefaultPreview.js
+++ b/packages/@sanity/preview/src/components/SanityDefaultPreview.js
@@ -55,7 +55,8 @@ export default class SanityDefaultPreview extends React.PureComponent {
           imageBuilder.image(media)
             .width(dimensions.width || 100)
             .height(dimensions.height || 100)
-            .fit(dimensions.fit)
+            // todo: disable for now due to a bug with the order options are applied in the image service
+            // .fit(dimensions.fit)
             .url()
         }
       />


### PR DESCRIPTION
Due to a bug in the image service that applies rect/fit parameters in the wrong order, this must be disabled in order to display cropped images properly.