### PR TITLE
[core] Use uglify-es instead of uglify-js for minifying

### DIFF
--- a/packages/@sanity/core/package.json
+++ b/packages/@sanity/core/package.json
@@ -50,7 +50,7 @@
     "tar-fs": "^1.15.2",
     "thenify": "^3.3.0",
     "through2": "^2.0.3",
-    "uglify-js": "^3.1.10"
+    "uglify-es": "3.3.9"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/packages/@sanity/core/src/actions/build/compressJavascript.js
+++ b/packages/@sanity/core/src/actions/build/compressJavascript.js
@@ -1,5 +1,5 @@
 import fse from 'fs-extra'
-import UglifyJS from 'uglify-js'
+import UglifyJS from 'uglify-es'
 
 export default async inputFile => {
   const content = await fse.readFile(inputFile, 'utf8')


### PR DESCRIPTION
After #533 and #534 we are only compiling source code to the targets defined in the toplevel `.babelrc`, that is:

https://github.com/sanity-io/sanity/blob/575ffa1c7b0af96a6247239fdea61035f19690dd/.babelrc#L6-L10

This means the minification step on sanity deploy will have to be able to parse non-ES5 code from  @sanity-modules (from node_modules), so lets replace uglify-js with uglify-es, which can handle  ES6+.

I pinned it to a version that I've tested, just to be on the safe side.