### PR TITLE
[block-tools] Robustify annotation conversion

### DIFF
--- a/packages/@sanity/block-tools/src/converters/blocksToSlateState.js
+++ b/packages/@sanity/block-tools/src/converters/blocksToSlateState.js
@@ -57,7 +57,7 @@ function sanitySpanToRawSlateBlockNode(span, sanityBlock) {
   const range = {
     kind: 'range',
     text: text,
-    marks: decorators.map(toRawMark)
+    marks: decorators.filter(Boolean).map(toRawMark)
   }
 
   if (!annotations) {

--- a/packages/@sanity/block-tools/src/converters/slateStateToBlocks.js
+++ b/packages/@sanity/block-tools/src/converters/slateStateToBlocks.js
@@ -30,7 +30,7 @@ function toSanitySpan(node, sanityBlock, spanIndex) {
         Object.keys(annotations).forEach(name => {
           const annotation = annotations[name]
           const annotationKey = annotation._key
-          if (annotation) {
+          if (annotation && annotationKey) {
             sanityBlock.markDefs.push(annotation)
             annotationKeys.push(annotationKey)
           }


### PR DESCRIPTION
As we cannot guarantee the integrity of the data block tools is trying to convert, do some extra checks that keys are truthy before putting them on a converted state,  so it is possible to recover from it in the editor.
