### PR TITLE
[form-builder] Minor fixes

### DIFF
--- a/packages/@sanity/form-builder/src/FormBuilderInput.js
+++ b/packages/@sanity/form-builder/src/FormBuilderInput.js
@@ -172,7 +172,7 @@ export const FormBuilderInput = class FormBuilderInput extends React.PureCompone
 
     const childFocusPath = this.getChildFocusPath()
 
-    const isLeaf = childFocusPath.length === 0
+    const isLeaf = childFocusPath.length === 0 || childFocusPath[0] === PathUtils.FOCUS_TERMINATOR
     const leafProps = isLeaf ? {} : {focusPath: childFocusPath}
 
     return (

--- a/packages/@sanity/form-builder/src/inputs/Array/ConfirmButton.js
+++ b/packages/@sanity/form-builder/src/inputs/Array/ConfirmButton.js
@@ -47,7 +47,8 @@ export default class ConfirmButton extends React.Component {
 
   componentDidUpdate(prevProps, prevState) {
     if (!prevState.showConfirmDialog && this.state.showConfirmDialog) {
-      this._confirmButton.focus()
+      // todo: does not work as the popover is not in sync
+      //this._confirmButton.focus()
     }
   }
 

--- a/packages/@sanity/form-builder/src/inputs/Reference/ReferenceInput.js
+++ b/packages/@sanity/form-builder/src/inputs/Reference/ReferenceInput.js
@@ -163,7 +163,10 @@ export default class ReferenceInput extends React.Component<Props, State> {
   renderOpenItemElement = () => {
     const {value} = this.props
     const {previewSnapshot} = this.state
-    return (value && previewSnapshot !== MISSING_SNAPSHOT) && (
+    if (!value || !value._ref || previewSnapshot === MISSING_SNAPSHOT) {
+      return null
+    }
+    return (
       <IntentLink
         title={previewSnapshot && `Open ${previewSnapshot.title}`}
         intent="edit"


### PR DESCRIPTION
This fixes a few minor issues/annoyances:

- Calling .focus() on confirmButton threw an error because of render/timing issues with popover, so disabled for now
- The `focusPath`-prop was sometimes passed to input components and caused an _invalid prop type_-warning
- The reference select would display a link even if there were no `_ref`-property on the value.
