### PR TITLE
[form-builder] Optimize selectionchange event handlers in FormbuilderBlock/FormBuilderInline

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/FormBuilderBlock.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/FormBuilderBlock.js
@@ -110,6 +110,9 @@ export default class FormBuilderBlock extends React.Component {
   }
 
   handleSelectionChange = event => {
+    if (!this._editorNode.contains(event.target)) {
+      return
+    }
     const selection = document.getSelection()
     const isSelected = selection.containsNode
         && selection.containsNode(this.formBuilderBlock)

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/FormBuilderInline.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/FormBuilderInline.js
@@ -87,6 +87,9 @@ export default class FormBuilderInline extends React.Component {
   }
 
   handleSelectionChange = event => {
+    if (!this._editorNode.contains(event.target)) {
+      return
+    }
     const selection = document.getSelection()
     const isSelected = selection.containsNode
         && selection.containsNode(this.formBuilderInline)


### PR DESCRIPTION
This should give a pretty good perf boost on documents with a lot of block nodes.