### PR TITLE
[server] Exclude `packages/@sanity`-paths from babel-loader

### DIFF
--- a/packages/@sanity/server/src/configs/webpack.config.js
+++ b/packages/@sanity/server/src/configs/webpack.config.js
@@ -79,7 +79,7 @@ export default (config = {}) => {
     module: {
       rules: [{
         test: /\.jsx?/,
-        exclude: /(node_modules|bower_components)/,
+        exclude: /(packages\/@sanity|node_modules|bower_components)/,
         use: {
           loader: resolve('babel-loader'),
           options: babelConfig || {


### PR DESCRIPTION
Currently we are (in monorepo development) double-compiling modules. This is obviously unnecessary and also very confusing. While it would be optimal if webpack reported the symlink location instead of the resolved location, we'll use this hack for now. 