### PR TITLE
[core] Fix missing dependencies for 'sanity exec' command

### DIFF
--- a/packages/@sanity/core/package.json
+++ b/packages/@sanity/core/package.json
@@ -28,6 +28,8 @@
     "@sanity/resolver": "0.125.0",
     "@sanity/server": "^0.125.3",
     "@sanity/util": "0.125.0",
+    "babel-preset-env": "^1.6.1",
+    "babel-register": "^6.26.0",
     "batch-stream-operation": "^1.0.2",
     "debug": "^3.1.0",
     "deep-sort-object": "^1.0.1",

--- a/packages/@sanity/core/src/actions/exec/babel.js
+++ b/packages/@sanity/core/src/actions/exec/babel.js
@@ -1,5 +1,14 @@
-const presets = ['es2015-node4', 'stage-2']
+import registerBabel from 'babel-register'
 
-require('babel-register')({
-  presets: presets.map(preset => require.resolve(`babel-preset-${preset}`)),
+registerBabel({
+  presets: [
+    [
+      'env',
+      {
+        targets: {
+          node: 'current'
+        }
+      }
+    ]
+  ]
 })


### PR DESCRIPTION
The latest infra changes broke the `sanity exec` command. This PR should fix that again, and also switches to using `preset-env`.