### PR TITLE
[core] Improve help text for deploy, build and import commands

### DIFF
--- a/packages/@sanity/core/src/actions/build/buildStaticAssets.js
+++ b/packages/@sanity/core/src/actions/build/buildStaticAssets.js
@@ -15,7 +15,11 @@ const absoluteMatch = /^https?:\/\//i
 
 export default async (args, context) => {
   const {output, prompt, workDir} = context
-  const flags = args.extOptions
+  const flags = Object.assign(
+    {minify: true, profile: false, stats: false, 'source-maps': false},
+    args.extOptions
+  )
+
   const defaultOutputDir = path.resolve(path.join(workDir, 'dist'))
   const outputDir = path.resolve(args.argsWithoutOptions[0] || defaultOutputDir)
   const config = getConfig(workDir)
@@ -25,8 +29,8 @@ export default async (args, context) => {
     basePath: workDir,
     outputPath: path.join(outputDir, 'static'),
     sourceMaps: flags['source-maps'],
-    skipMinify: flags['skip-minify'] || false,
-    profile: flags.profile || false
+    skipMinify: !flags.minify,
+    profile: flags.profile
   }
 
   await tryInitializePluginConfigs({workDir, output})

--- a/packages/@sanity/core/src/actions/dataset/chooseDatasetPrompt.js
+++ b/packages/@sanity/core/src/actions/dataset/chooseDatasetPrompt.js
@@ -1,7 +1,7 @@
 import debug from '../../debug'
 import promptForDatasetName from './datasetNamePrompt'
 
-module.exports = async (context, options = {}) => {
+export default async (context, options = {}) => {
   const {apiClient, prompt} = context
   const {message, allowCreation} = options
   const client = apiClient()

--- a/packages/@sanity/core/src/actions/deploy/deployAction.js
+++ b/packages/@sanity/core/src/actions/deploy/deployAction.js
@@ -41,7 +41,7 @@ export default async (args, context) => {
   const shouldBuild = flags.build
   if (shouldBuild) {
     const buildStaticAssets = lazyRequire(require.resolve('../build/buildStaticAssets'))
-    await buildStaticAssets({extOptions: {}, argsWithoutOptions: []}, context)
+    await buildStaticAssets({extOptions: flags, argsWithoutOptions: []}, context)
   }
 
   // Ensure that the directory exists, is a directory and seems to have valid content

--- a/packages/@sanity/core/src/commands/build/buildCommand.js
+++ b/packages/@sanity/core/src/commands/build/buildCommand.js
@@ -1,8 +1,19 @@
 import lazyRequire from '@sanity/util/lib/lazyRequire'
 
+const helpText = `
+Options
+  --source-maps Enable source maps for built bundles (increases size of bundle)
+  --no-minify Skip minifying built Javascript (speeds up build, increases size of bundle)
+
+Examples
+  sanity build
+  sanity build --no-minify --source-maps
+`
+
 export default {
   name: 'build',
   signature: '[OUTPUT_DIR]',
   description: 'Builds the current Sanity configuration to a static bundle',
-  action: lazyRequire(require.resolve('../../actions/build/buildStaticAssets'))
+  action: lazyRequire(require.resolve('../../actions/build/buildStaticAssets')),
+  helpText
 }

--- a/packages/@sanity/core/src/commands/dataset/importDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/importDatasetCommand.js
@@ -8,11 +8,22 @@ import linecount from 'linecount/promise'
 import chooseDatasetPrompt from '../../actions/dataset/chooseDatasetPrompt'
 import debug from '../../debug'
 
+const helpText = `
+Options
+  --missing On duplicate document IDs, skip importing document in question
+  --replace On duplicate document IDs, replace existing document with imported document
+
+Examples
+  sanity import moviedb.ndjson moviedb
+  sanity import moviedb.ndjson moviedb --replace
+`
+
 export default {
   name: 'import',
   group: 'dataset',
   signature: '[FILE] [TARGET_DATASET]',
-  description: 'Import dataset from local filesystem',
+  description: 'Import documents to given dataset from ndjson file',
+  helpText,
   action: async (args, context) => {
     const {apiClient, output, chalk, prompt} = context
 

--- a/packages/@sanity/core/src/commands/deploy/deployCommand.js
+++ b/packages/@sanity/core/src/commands/deploy/deployCommand.js
@@ -1,8 +1,20 @@
 import lazyRequire from '@sanity/util/lib/lazyRequire'
 
+const helpText = `
+Options
+  --source-maps Enable source maps for built bundles (increases size of bundle)
+  --no-minify Skip minifying built Javascript (speeds up build, increases size of bundle)
+  --no-build Don't build the studio prior to deploy, instead deploying the version currently in \`dist/\`
+
+Examples
+  sanity deploy
+  sanity deploy --no-minify --source-maps
+`
+
 export default {
   name: 'deploy',
-  signature: '[SOURCE_DIR]',
+  signature: '[SOURCE_DIR] [--no-build]  [--source-maps] [--no-minify]',
   description: 'Deploys a statically built Sanity studio',
-  action: lazyRequire(require.resolve('../../actions/deploy/deployAction'))
+  action: lazyRequire(require.resolve('../../actions/deploy/deployAction')),
+  helpText
 }


### PR DESCRIPTION
This PR adds help text that describes the available flags for deploy, build and import commands.
