### PR TITLE
[form-builder] Guard against this._editorNode being null

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/FormBuilderBlock.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/FormBuilderBlock.js
@@ -110,7 +110,7 @@ export default class FormBuilderBlock extends React.Component {
   }
 
   handleSelectionChange = event => {
-    if (!this._editorNode.contains(event.target)) {
+    if (!this._editorNode || !this._editorNode.contains(event.target)) {
       return
     }
     const selection = document.getSelection()

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/FormBuilderInline.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/FormBuilderInline.js
@@ -87,7 +87,7 @@ export default class FormBuilderInline extends React.Component {
   }
 
   handleSelectionChange = event => {
-    if (!this._editorNode.contains(event.target)) {
+    if (!this._editorNode || !this._editorNode.contains(event.target)) {
       return
     }
     const selection = document.getSelection()


### PR DESCRIPTION
This fixes an error thrown when switching between documents that have a block array.