### PR TITLE
[cli] Remove required: true from template schemas

### DIFF
--- a/packages/@sanity/cli/templates/blog/schemas/post.js
+++ b/packages/@sanity/cli/templates/blog/schemas/post.js
@@ -6,8 +6,7 @@ export default {
     {
       name: 'title',
       title: 'Title',
-      type: 'string',
-      required: true
+      type: 'string'
     },
     {
       name: 'slug',

--- a/packages/@sanity/cli/templates/moviedb/schemas/movie.js
+++ b/packages/@sanity/cli/templates/moviedb/schemas/movie.js
@@ -6,8 +6,7 @@ export default {
     {
       name: 'title',
       title: 'Title',
-      type: 'string',
-      required: true
+      type: 'string'
     },
     {
       name: 'slug',

--- a/packages/@sanity/cli/templates/moviedb/schemas/screening.js
+++ b/packages/@sanity/cli/templates/moviedb/schemas/screening.js
@@ -7,7 +7,6 @@ export default {
       name: 'title',
       title: 'Title',
       type: 'string',
-      required: true,
       description: 'E.g.: Our first ever screening of Gattaca'
     },
     {
@@ -45,7 +44,6 @@ export default {
       name: 'allowedGuests',
       title: 'Who can come?',
       type: 'string',
-      required: true,
       options: {
         list: [{title: 'Members', value: 'members'}, {title: 'Members and friends', value: 'friends'}, {title: 'Anyone', value: 'anyone'}],
         layout: 'radio'


### PR DESCRIPTION
These has never been supported and AFAIK the new validation format is different.