### PR TITLE
[cli] Make block text references to separate named types

### DIFF
--- a/packages/@sanity/cli/templates/moviedb/schemas/blockContent.js
+++ b/packages/@sanity/cli/templates/moviedb/schemas/blockContent.js
@@ -35,12 +35,21 @@ export default {
     },
     {
       type: 'reference',
-      title: 'Reference',
-      to: [
-        {title: 'Movie', type: 'movie'},
-        {title: 'Person', type: 'person'},
-        {title: 'Screening', type: 'screening'}
-      ]
+      title: 'Movie',
+      name: 'movieRef',
+      to: [{type: 'movie'}]
+    },
+    {
+      type: 'reference',
+      title: 'Person',
+      name: 'personRef',
+      to: {type: 'person'}
+    },
+    {
+      type: 'reference',
+      title: 'Screening',
+      name: 'screeningRef',
+      to: {type: 'screening'}
     },
     {
       title: 'Image',


### PR DESCRIPTION
This converts the different types of references into named types so the UI becomes clearer.

Before:
![image](https://user-images.githubusercontent.com/876086/35799183-8f5c2a90-0a97-11e8-82c3-0a38b4f52278.png)

After:
![image](https://user-images.githubusercontent.com/876086/35799309-dec3dbaa-0a97-11e8-994a-db2ace5e3d91.png)
