### PR TITLE
[preview] Don't write ref attributes on materialized values

### DIFF
--- a/packages/@sanity/preview/src/createPathMaterializer.js
+++ b/packages/@sanity/preview/src/createPathMaterializer.js
@@ -36,12 +36,16 @@ export default function createPathMaterializer(observeWithPaths) {
 
       const nextHeads = uniq(missingHeads.map(path => [path[0]]))
 
+      const isRef = isReference(value)
       if (isReference(value) || isDocument(value)) {
-        const id = isReference(value) ? value._ref : value._id
-        return observeWithPaths(id, nextHeads)
-          .switchMap(snapshot => {
-            return materializePaths({...createEmpty(nextHeads), ...value, ...snapshot}, paths)
-          })
+        const id = isRef ? value._ref : value._id
+        return observeWithPaths(id, nextHeads).switchMap(snapshot => {
+          return materializePaths({
+              ...createEmpty(nextHeads),
+              ...(isRef ? {} : value),
+              ...snapshot
+            }, paths)
+        })
       }
     }
 


### PR DESCRIPTION
When the preview was called with a value that was materialized, it was extending it afterwards with the original passed value. This caused the `_ref` (and sometimes `_key`) attributes to be added to the resulting value, and could potentially cause subsequent calls with the same value to identify it as a reference and (needlessly) materialize it again.

This patch omits writing the original attributes if the passed value was a reference.