### PR TITLE
[chore] Normalize engines and author fields

### DIFF
--- a/packages/@sanity/check/package.json
+++ b/packages/@sanity/check/package.json
@@ -6,7 +6,10 @@
   "bin": {
     "sanity-check": "./src/bin.js"
   },
-  "author": "Espen Hovlandsdal <espen@hovlandsdal.com>",
+  "author": "Sanity.io <hello@sanity.io>",
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "license": "MIT",
   "scripts": {
     "prepublish": "in-publish && ./src/bin.js || not-in-publish"

--- a/packages/@sanity/document-store/package.json
+++ b/packages/@sanity/document-store/package.json
@@ -17,7 +17,7 @@
     "content",
     "document-store"
   ],
-  "author": "",
+  "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",
   "dependencies": {
     "@sanity/mutator": "^0.125.6",

--- a/packages/@sanity/import/package.json
+++ b/packages/@sanity/import/package.json
@@ -4,7 +4,7 @@
   "description": "Import documents to a Sanity dataset",
   "main": "lib/import.js",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=6.0.0"
   },
   "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",
@@ -12,7 +12,15 @@
     "clean": "rimraf lib",
     "test": "jest"
   },
-  "keywords": ["sanity", "cms", "headless", "realtime", "content", "import", "ndjson"],
+  "keywords": [
+    "sanity",
+    "cms",
+    "headless",
+    "realtime",
+    "content",
+    "import",
+    "ndjson"
+  ],
   "dependencies": {
     "@rexxars/get-uri": "^2.0.2",
     "@sanity/mutator": "^0.125.6",

--- a/packages/@sanity/plugin-loader/package.json
+++ b/packages/@sanity/plugin-loader/package.json
@@ -7,6 +7,9 @@
     "test": "ava",
     "coverage": "nyc --reporter=html ava"
   },
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sanity-io/sanity.git"

--- a/packages/@sanity/preview/package.json
+++ b/packages/@sanity/preview/package.json
@@ -19,7 +19,7 @@
     "content",
     "preview"
   ],
-  "author": "",
+  "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/packages/@sanity/production-preview/package.json
+++ b/packages/@sanity/production-preview/package.json
@@ -14,6 +14,7 @@
     "headless",
     "realtime",
     "content",
+    "production-preview",
     "color-input",
     "sanity-plugin"
   ],

--- a/packages/@sanity/resolver/package.json
+++ b/packages/@sanity/resolver/package.json
@@ -8,6 +8,9 @@
     "coverage": "nyc --report=lcov --report=text _mocha -- test/**/*.test.js",
     "test": "mocha test/**/*.test.js"
   },
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sanity-io/sanity.git"

--- a/packages/@sanity/schema/package.json
+++ b/packages/@sanity/schema/package.json
@@ -19,7 +19,7 @@
     "content",
     "schema"
   ],
-  "author": "",
+  "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",
   "dependencies": {
     "@sanity/generate-help-url": "^0.125.6",

--- a/packages/@sanity/server/package.json
+++ b/packages/@sanity/server/package.json
@@ -11,6 +11,9 @@
   "bin": {
     "sanity-server": "./bin/sanity-server.js"
   },
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sanity-io/sanity.git"

--- a/packages/@sanity/util/package.json
+++ b/packages/@sanity/util/package.json
@@ -7,6 +7,9 @@
     "clean": "rimraf lib",
     "test": "mocha test/**/*.test.js"
   },
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sanity-io/sanity.git"

--- a/packages/@sanity/uuid/package.json
+++ b/packages/@sanity/uuid/package.json
@@ -11,7 +11,7 @@
     "content",
     "uuid"
   ],
-  "author": "",
+  "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",
   "dependencies": {
     "uuid": "3.1.0"

--- a/packages/@sanity/webpack-integration/package.json
+++ b/packages/@sanity/webpack-integration/package.json
@@ -17,6 +17,9 @@
     "webpack-integration",
     "webpack"
   ],
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",
   "bugs": {

--- a/packages/@sanity/webpack-loader/package.json
+++ b/packages/@sanity/webpack-loader/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "clean": "rimraf lib"
   },
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sanity-io/sanity.git"

--- a/packages/blog-studio/package.json
+++ b/packages/blog-studio/package.json
@@ -11,7 +11,12 @@
     "test": "sanity check"
   },
   "keywords": [
-    "sanity"
+    "sanity",
+    "cms",
+    "headless",
+    "realtime",
+    "content",
+    "blog-studio"
   ],
   "dependencies": {
     "@sanity/base": "^0.125.6",
@@ -25,5 +30,13 @@
     "@sanity/vision": "^0.125.6",
     "react": "^15.4.2",
     "react-dom": "^15.4.2"
+  },
+  "bugs": {
+    "url": "https://github.com/sanity-io/sanity/issues"
+  },
+  "homepage": "https://www.sanity.io/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sanity-io/sanity.git"
   }
 }

--- a/packages/movies-studio/package.json
+++ b/packages/movies-studio/package.json
@@ -11,7 +11,12 @@
     "test": "sanity check"
   },
   "keywords": [
-    "sanity"
+    "sanity",
+    "cms",
+    "headless",
+    "realtime",
+    "content",
+    "movies-studio"
   ],
   "dependencies": {
     "@sanity/base": "^0.125.6",
@@ -27,5 +32,13 @@
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-icons": "^2.2.5"
+  },
+  "bugs": {
+    "url": "https://github.com/sanity-io/sanity/issues"
+  },
+  "homepage": "https://www.sanity.io/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sanity-io/sanity.git"
   }
 }

--- a/scripts/normalizePackageFields.js
+++ b/scripts/normalizePackageFields.js
@@ -2,18 +2,23 @@ const uniq = require('lodash/uniq')
 const transformPkgs = require('./transformPkgs')
 
 const COMMON_KEYWORDS = ['sanity', 'cms', 'headless', 'realtime', 'content']
+const supportedNodeVersionRange = '>=6.0.0'
 
 transformPkgs(pkgManifest => {
   const name = pkgManifest.name.split('/').slice(-1)[0]
+
+  const engines = pkgManifest.engines
+  if (engines && engines.node) {
+    engines.node = supportedNodeVersionRange
+  }
+
   return Object.assign({}, pkgManifest, {
+    engines,
+    author: 'Sanity.io <hello@sanity.io>',
     bugs: {
       url: 'https://github.com/sanity-io/sanity/issues'
     },
-    keywords: uniq(
-      COMMON_KEYWORDS
-        .concat(name)
-        .concat(pkgManifest.keywords || [])
-    ),
+    keywords: uniq(COMMON_KEYWORDS.concat(name).concat(pkgManifest.keywords || [])),
     homepage: 'https://www.sanity.io/',
     license: 'MIT',
     repository: {


### PR DESCRIPTION
This PR ensures that any package that has a declared `engines.node` property in its `package.json` will be on the same level (node >= 6, currently) as well as setting the author field to `Sanity.io <hello@sanity.io>`.

I also added the engines field to all node-only packages.
