### PR TITLE
[preview] Optimize preview fetching

### DIFF
--- a/packages/@sanity/preview/src/observeWithPaths.js
+++ b/packages/@sanity/preview/src/observeWithPaths.js
@@ -6,37 +6,35 @@ import {combineSelections, reassemble, toGradientQuery} from './utils/optimizeQu
 let _globalListener
 const getGlobalListener = () => {
   if (!_globalListener) {
-    _globalListener = Observable
-      .from(client.listen('*[!(_id in path("_.**"))]', {}, {includeResult: false}))
-      .share()
+    _globalListener = Observable.from(
+      client.listen('*[!(_id in path("_.**"))]', {}, {includeResult: false})
+    ).share()
   }
   return _globalListener
 }
 
 function listen(id) {
-  return Observable.of({type: 'welcome', documentId: id})
-    .concat(getGlobalListener())
-    .filter(event => event.documentId === id)
+  return getGlobalListener().filter(event => event.documentId === id)
 }
 
-function fetchAllDocumentSnapshots(selections) {
+function fetchAllDocumentPaths(selections) {
   const combinedSelections = combineSelections(selections)
   return client.observable
     .fetch(toGradientQuery(combinedSelections))
     .map(result => reassemble(result, combinedSelections))
 }
 
-const debouncedFetchDocumentSnapshot = debounceCollect(fetchAllDocumentSnapshots, 50)
+const fetchDocumentPathsFast = debounceCollect(fetchAllDocumentPaths, 0)
+const fetchDocumentPathsSlow = debounceCollect(fetchAllDocumentPaths, 1000)
 
 // todo: keep for debugging purposes for now
-// function fetchDocumentSnapshot(id, selection) {
+// function fetchDocumentPaths(id, selection) {
 //   return client.observable.fetch(`*[_id==$id]{_id,_type,${selection.join(',')}}`, {id})
 //     .map(result => result[0])
 // }
 
 export default function observeWithPaths(id, paths) {
-  return debouncedFetchDocumentSnapshot(id, paths)
-    .concat(listen(id)
-      .debounceTime(1000)
-      .switchMap(event => debouncedFetchDocumentSnapshot(id, paths)))
+  return fetchDocumentPathsFast(id, paths).concat(
+    listen(id).switchMap(event => fetchDocumentPathsSlow(id, paths))
+  )
 }


### PR DESCRIPTION
This is an optimization of preview fetching that uses a lower debounce time for initial fetch, and a higher delay for subsequent fetches (e.g. when the previewed document has changed).

It should give a small perceived speedup on the first load of everything that is previewed, and fewer refresher requests when something changed.