### PR TITLE
[client] Always reconnect listeners, even when auto-reconnect fails

### DIFF
--- a/packages/@sanity/client/test/helpers/sseServer.js
+++ b/packages/@sanity/client/test/helpers/sseServer.js
@@ -9,7 +9,10 @@ const SseChannel = require('sse-channel')
 module.exports = (onRequest, cb) => {
   const server = http.createServer((request, response) => {
     let channel
-    if (request.url.indexOf('/v1/data/listen/') === 0 || request.url.indexOf('/listen/beerns?query=') === 0) {
+    if (
+      request.url.indexOf('/v1/data/listen/') === 0 ||
+      request.url.indexOf('/listen/beerns?query=') === 0
+    ) {
       channel = new SseChannel({jsonEncode: true})
       channel.addClient(request, response)
     }

--- a/packages/@sanity/client/test/listen.test.js
+++ b/packages/@sanity/client/test/listen.test.js
@@ -8,23 +8,31 @@ const assign = require('xtend')
 const sanityClient = require('../src/sanityClient')
 const sseServer = require('./helpers/sseServer')
 
-const getClient = options => sanityClient(assign({
-  dataset: 'prod',
-  namespace: 'beerns',
-  apiHost: `http://localhost:${options.port}`,
-  useProjectHostname: false
-}, options))
+const getClient = options =>
+  sanityClient(
+    assign(
+      {
+        dataset: 'prod',
+        namespace: 'beerns',
+        apiHost: `http://localhost:${options.port}`,
+        useProjectHostname: false,
+        useCdn: false
+      },
+      options
+    )
+  )
 
-const testSse = (onRequest, options) => new Promise((resolve, reject) => {
-  sseServer(onRequest, (err, server) => {
-    if (err) {
-      return reject(err)
-    }
+const testSse = (onRequest, options) =>
+  new Promise((resolve, reject) => {
+    sseServer(onRequest, (err, server) => {
+      if (err) {
+        return reject(err)
+      }
 
-    const client = getClient(assign({port: server.address().port}, options))
-    return resolve({server, client})
+      const client = getClient(assign({port: server.address().port}, options))
+      return resolve({server, client})
+    })
   })
-})
 
 /*****************
  * LISTENER      *
@@ -36,62 +44,83 @@ test('[listener] can listen for mutations', t => {
     identity: 'uid',
     mutations: [{patch: {id: 'beer-123', set: {abv: 8}}}],
     previousRev: 'MOmofa',
-    result: {_id: 'beer-123', _type: 'beer', brewery: 'Trillium', title: 'Headroom Double IPA', abv: 8},
+    result: {
+      _id: 'beer-123',
+      _type: 'beer',
+      brewery: 'Trillium',
+      title: 'Headroom Double IPA',
+      abv: 8
+    },
     resultRev: 'Blatti',
     timestamp: '2017-03-29T12:36:20.506516Z',
     transactionId: 'foo',
-    transition: 'update',
+    transition: 'update'
   }
 
   testSse(({request, channel}) => {
-    t.equal(request.url, [
-      '/v1/data/listen/prod',
-      '?query=*%5Bis%20%22beer%22%20%26%26%20title%20%3D%3D%20%24beerName%5D',
-      '&%24beerName=%22Headroom%20Double%20IPA%22&includeResult=true'
-    ].join(''), 'url should be correct')
+    t.equal(
+      request.url,
+      [
+        '/v1/data/listen/prod',
+        '?query=*%5Bis%20%22beer%22%20%26%26%20title%20%3D%3D%20%24beerName%5D',
+        '&%24beerName=%22Headroom%20Double%20IPA%22&includeResult=true'
+      ].join(''),
+      'url should be correct'
+    )
 
     channel.send({event: 'mutation', data: eventData})
     process.nextTick(() => channel.close())
-  }).then(({server, client}) => {
-    const query = '*[is "beer" && title == $beerName]'
-    const params = {beerName: 'Headroom Double IPA'}
+  })
+    .then(({server, client}) => {
+      const query = '*[is "beer" && title == $beerName]'
+      const params = {beerName: 'Headroom Double IPA'}
 
-    const subscription = client.listen(query, params).subscribe({
-      next: msg => {
-        t.deepEqual(msg, assign({}, eventData, {type: 'mutation'}), 'event data should be correct')
-        subscription.unsubscribe()
-        server.close()
-        t.end()
-      },
-      error: err => {
-        subscription.unsubscribe()
-        server.close()
-        t.end(err)
-      }
+      const subscription = client.listen(query, params).subscribe({
+        next: msg => {
+          t.deepEqual(
+            msg,
+            assign({}, eventData, {type: 'mutation'}),
+            'event data should be correct'
+          )
+          subscription.unsubscribe()
+          server.close()
+          t.end()
+        },
+        error: err => {
+          subscription.unsubscribe()
+          server.close()
+          t.end(err)
+        }
+      })
     })
-  }).catch(t.end)
+    .catch(t.end)
 })
 
 test('[listener] listener sends auth token if given (node)', t => {
   let httpServer = null
-  testSse(({request, channel}) => {
-    t.equal(request.headers.authorization, 'Bearer foobar', 'should send token')
-    channel.send({event: 'disconnect'})
-    process.nextTick(() => {
-      channel.close()
-      httpServer.close()
-      t.end()
+  testSse(
+    ({request, channel}) => {
+      t.equal(request.headers.authorization, 'Bearer foobar', 'should send token')
+      channel.send({event: 'disconnect'})
+      process.nextTick(() => {
+        channel.close()
+        httpServer.close()
+        t.end()
+      })
+    },
+    {token: 'foobar'}
+  )
+    .then(({server, client}) => {
+      httpServer = server
+      const subscription = client.listen('*').subscribe({
+        error: err => {
+          subscription.unsubscribe()
+          server.close()
+          t.end(err)
+        }
+      })
     })
-  }, {token: 'foobar'}).then(({server, client}) => {
-    httpServer = server
-    const subscription = client.listen('*').subscribe({
-      error: err => {
-        subscription.unsubscribe()
-        server.close()
-        t.end(err)
-      }
-    })
-  }).catch(t.end)
+    .catch(t.end)
 })
 
 test('[listener] reconnects if disconnected', t => {
@@ -99,21 +128,23 @@ test('[listener] reconnects if disconnected', t => {
     channel.send({event: 'welcome'})
     channel.close()
     process.nextTick(() => channel.close())
-  }).then(({server, client}) => {
-    const subscription = client.listen('*', {}, {events: ['reconnect']}).subscribe({
-      next: msg => {
-        t.equal(msg.type, 'reconnect', 'emits reconnect events if told to')
-        subscription.unsubscribe()
-        server.close()
-        t.end()
-      },
-      error: err => {
-        subscription.unsubscribe()
-        server.close()
-        t.end(err)
-      }
+  })
+    .then(({server, client}) => {
+      const subscription = client.listen('*', {}, {events: ['reconnect']}).subscribe({
+        next: msg => {
+          t.equal(msg.type, 'reconnect', 'emits reconnect events if told to')
+          subscription.unsubscribe()
+          server.close()
+          t.end()
+        },
+        error: err => {
+          subscription.unsubscribe()
+          server.close()
+          t.end(err)
+        }
+      })
     })
-  }).catch(t.end)
+    .catch(t.end)
 })
 
 test('[listener] emits channel errors', t => {
@@ -121,16 +152,18 @@ test('[listener] emits channel errors', t => {
     channel.send({event: 'channelError', data: {message: 'Unfortunate error'}})
     channel.close()
     process.nextTick(() => channel.close())
-  }).then(({server, client}) => {
-    const subscription = client.listen('*').subscribe({
-      error: err => {
-        t.equal(err.message, 'Unfortunate error', 'should have passed error message')
-        subscription.unsubscribe()
-        server.close()
-        t.end()
-      }
+  })
+    .then(({server, client}) => {
+      const subscription = client.listen('*').subscribe({
+        error: err => {
+          t.equal(err.message, 'Unfortunate error', 'should have passed error message')
+          subscription.unsubscribe()
+          server.close()
+          t.end()
+        }
+      })
     })
-  }).catch(t.end)
+    .catch(t.end)
 })
 
 test('[listener] emits channel errors with deep error description', t => {
@@ -138,14 +171,16 @@ test('[listener] emits channel errors with deep error description', t => {
     channel.send({event: 'channelError', data: {error: {description: 'Expected error'}}})
     channel.close()
     process.nextTick(() => channel.close())
-  }).then(({server, client}) => {
-    const subscription = client.listen('*').subscribe({
-      error: err => {
-        t.equal(err.message, 'Expected error', 'should have passed error message')
-        subscription.unsubscribe()
-        server.close()
-        t.end()
-      }
+  })
+    .then(({server, client}) => {
+      const subscription = client.listen('*').subscribe({
+        error: err => {
+          t.equal(err.message, 'Expected error', 'should have passed error message')
+          subscription.unsubscribe()
+          server.close()
+          t.end()
+        }
+      })
     })
-  }).catch(t.end)
+    .catch(t.end)
 })


### PR DESCRIPTION
While the EventSource implementation in browsers will generally reconnect automatically, there are certain cases where it does not. An example of this is when a laptop lid is closed - this will set the `readyState` to `CLOSED` (indicating that it won't reconnect) and trigger an `error` event on the EventSource.

Currently we are simply saying that the observable is `complete`, but we don't have the necessary pieces in place to reconnect, which causes for instance the studio to stop receiving mutation events in these cases.

After some discussion, we find that it makes more sense to never treat the observable as "completed" unless we receive an explicit unsubscribe from the user or a `disconnect` event from the server.

This PR ensures that we _always_ reconnect, manually setting a timer and reconnecting in the case of a "hard" disconnect. This operation is _lossy_, because it has to open a new EventSource instance to the server, which will lose the last received event ID. We currently aren't using this feature, but in the future we might want to, so we need to keep this in mind when implementing listener history.
