### PR TITLE
[server] Configure custom properties with preserve: false

### DIFF
--- a/packages/@sanity/server/src/configs/postcss.config.js
+++ b/packages/@sanity/server/src/configs/postcss.config.js
@@ -3,6 +3,13 @@ const webpackIntegration = require('@sanity/webpack-integration/v3')
 
 module.exports = {
   plugins: webpackIntegration.getPostcssPlugins({
-    basePath: resolveProjectRoot({sync: true})
+    basePath: resolveProjectRoot({sync: true}),
+    cssnext: {
+      features: {
+        customProperties: {
+          preserve: false
+        }
+      }
+    }
   })
 }


### PR DESCRIPTION
The maintainers of `postcss-custom-properties`-module changed a default in a minor release, which broke the studio styling.

Big ups to @rexxars for debugging.