### PR TITLE
[desk-tool] Publish documents by only applying diff 

### DIFF
--- a/packages/@sanity/desk-tool/package.json
+++ b/packages/@sanity/desk-tool/package.json
@@ -24,6 +24,7 @@
   ],
   "dependencies": {
     "@sanity/data-aspects": "^0.125.8",
+    "@sanity/diff-patch": "^0.125.8",
     "@sanity/form-builder": "^0.125.9",
     "@sanity/mutator": "^0.125.8",
     "@sanity/observable": "^0.125.8",


### PR DESCRIPTION
**Note:** This depends on #604.

Currently we are blindly replacing the remote document with our local draft copy. This PR introduces three important changes:

1. If we don't have a published document yet, use the `create` mutation instead of `createOrReplace`. This ensures there are no race conditions which might cause someone else document to be overwritten.
2. If we have a published document already, compute a minimal set of changes between the published  version and the draft and only apply those as a patch.
3. Use a `ifRevisionID` constraint on the patch to ensure the published document matches the one we have locally, preventing race conditions or outdated local content.

This does introduce a few interesting changes UI-wise which I have not given any thought yet:
* If the remote revision does not match the expected, we get an error. We should probably rebase the published document, recompute the draft changes and reapply the patch with the new remote revision. Not 100% sure how to go about this since I don't have a good understanding of the checkout/mutator at this point.
* If a document was published with the given ID before we manage to publish our own, the `create` patch will fail with an error. Not sure whether or not we should try to apply diffs in this case, as the document _might_ be a totally different document.

I'd love to hear your thoughts on how to deal with these situations. For reference, this is the current error if revision doesn't match:

![screen shot 2018-02-19 at 09 49 16](https://user-images.githubusercontent.com/48200/36370589-8cb176d8-155f-11e8-81db-5205a58de4c7.png)
