### PR TITLE
[preview] Fix issue with accumulated queries + default pagination limit

### DIFF
--- a/packages/@sanity/preview/src/utils/optimizeQuery.js
+++ b/packages/@sanity/preview/src/utils/optimizeQuery.js
@@ -33,7 +33,7 @@ function stringifyId(id: string) {
 }
 
 function toSubQuery({ids, paths}) {
-  return `*[_id in [${ids.map(stringifyId).join(',')}]]{_id,_type,${paths.join(',')}}`
+  return `*[_id in [${ids.map(stringifyId).join(',')}]][0...${ids.length}]{_id,_type,${paths.join(',')}}`
 }
 
 export function toGradientQuery(combinedSelections: CombinedSelection[]) {

--- a/packages/@sanity/preview/src/utils/optimizeQuery.js
+++ b/packages/@sanity/preview/src/utils/optimizeQuery.js
@@ -37,7 +37,7 @@ function toSubQuery({ids, paths}) {
 }
 
 export function toGradientQuery(combinedSelections: CombinedSelection[]) {
-  return `[${combinedSelections.map(toSubQuery).join(',')}]`
+  return `[${combinedSelections.map(toSubQuery).join(',')}][0...${combinedSelections.length}]`
 }
 
 export function reassemble(queryResult: Result[], combinedSelections: CombinedSelection[]) {


### PR DESCRIPTION
When performing accumulated preview queries we need to ensure we get the whole result set back. This prevents implicit default slices from being applied to accumulated queries.