### PR TITLE
[preview] Apply incoming mutations to previewed documents

### DIFF
--- a/packages/@sanity/desk-tool/src/pane/DocumentsListPane.js
+++ b/packages/@sanity/desk-tool/src/pane/DocumentsListPane.js
@@ -21,9 +21,7 @@ import styles from './styles/DocumentsListPane.css'
 import listStyles from './styles/ListView.css'
 import InfiniteList from './InfiniteList'
 import PaneItem from './PaneItem'
-import settingsStore from 'part:@sanity/base/settings'
-
-const settings = settingsStore.forNamespace('desk-tool')
+import settings from '../settings'
 
 const DEFAULT_ORDERING = [{field: '_createdAt', direction: 'desc'}]
 

--- a/packages/@sanity/preview/package.json
+++ b/packages/@sanity/preview/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@sanity/image-url": "0.134.1",
+    "@sanity/mutator": "^0.134.0",
     "lodash": "^4.17.4",
     "observable-props": "^2.0.0",
     "rxjs": "^6.1.0",

--- a/packages/@sanity/preview/src/observeFields.js
+++ b/packages/@sanity/preview/src/observeFields.js
@@ -1,35 +1,38 @@
 // @flow
 import client from 'part:@sanity/base/client'
-import {Observable, merge, combineLatest, from as observableFrom, of as observableOf} from 'rxjs'
-import {
-  map,
-  filter,
-  share,
-  publishReplay,
-  refCount,
-  switchMap,
-  mergeMap,
-  tap,
-  distinctUntilChanged
-} from 'rxjs/operators'
+import {combineLatest, merge, Observable, of as observableOf} from 'rxjs'
+import {difference, flatten} from 'lodash'
 import debounceCollect from './utils/debounceCollect'
 import {combineSelections, reassemble, toGradientQuery} from './utils/optimizeQuery'
-import {flatten, difference} from 'lodash'
 import type {FieldName, Id} from './types'
 import {INCLUDE_FIELDS} from './constants'
 import hasEqualFields from './utils/hasEqualFields'
 import isUniqueBy from './utils/isUniqueBy'
+import applyMutations from './utils/applyMutation'
+import {
+  catchError,
+  concatMap,
+  distinctUntilChanged,
+  filter,
+  map,
+  mergeMap,
+  mergeScan,
+  publishReplay,
+  refCount,
+  share,
+  tap
+} from 'rxjs/operators'
 
 let _globalListener
 const getGlobalEvents = () => {
   if (!_globalListener) {
-    const allEvents$ = observableFrom(
-      client.listen(
+    const allEvents$ = client
+      .listen(
         '*[!(_id in path("_.**"))]',
         {},
         {events: ['welcome', 'mutation'], includeResult: false}
       )
-    ).pipe(share())
+      .pipe(share())
 
     // This will keep the listener active forever and in turn reduce the number of initial fetches
     // as less 'welcome' events will be emitted.
@@ -70,22 +73,76 @@ const fetchDocumentPathsFast = debounceCollect(fetchAllDocumentPaths, 100)
 const fetchDocumentPathsSlow = debounceCollect(fetchAllDocumentPaths, 1000)
 
 function listenFields(id: Id, fields: FieldName[]) {
-  return listen(id).pipe(
-    switchMap(event => {
-      if (event.type === 'welcome') {
-        return fetchDocumentPathsFast(id, fields).pipe(
-          mergeMap(result => {
-            return result === undefined
-              ? // hack: if we get undefined as result here it is most likely because the document has
-                // just been created and is not yet indexed. We therefore need to wait a bit and then re-fetch.
-                fetchDocumentPathsSlow(id, fields)
-              : observableOf(result)
-          })
-        )
-      }
-      return fetchDocumentPathsSlow(id, fields)
-    })
-  )
+  return listen(id)
+    .pipe(
+      concatMap(event => {
+        if (event.type === 'welcome') {
+          return fetchDocumentPathsFast(id, fields).pipe(
+            mergeMap(result => {
+              return result === undefined
+                ? // hack: if we get undefined as result here it is most likely because the document has
+                  // just been created and is not yet indexed. We therefore need to wait a bit and then re-fetch.
+                  fetchDocumentPathsSlow(id, fields)
+                : observableOf(result)
+            }),
+            map(snapshot => ({
+              type: 'snapshot',
+              snapshot: snapshot
+            }))
+          )
+        }
+        return observableOf(event)
+      })
+    )
+    .pipe(
+      mergeScan(
+        (prevSnapshot, event) => {
+          if (event.type === 'snapshot') {
+            return observableOf(event.snapshot || null)
+          }
+          if (event.type === 'mutation') {
+            if (!prevSnapshot || event.previousRev === prevSnapshot._rev) {
+              return new Observable(observer => {
+                let res
+                try {
+                  res = applyMutations(prevSnapshot, event.mutations)
+                } catch (err) {
+                  observer.error(err)
+                  return
+                }
+                observer.next(res)
+                observer.complete()
+              }).pipe(
+                catchError(err => {
+                  // This happens because change events come in the wrong order
+                  // todo: keep a list of the past <n> mutations, apply them in order
+                  err.message = `Mutations could not be applied, entering recovery mode: ${
+                    err.message
+                  }`
+                  // eslint-disable-next-line no-console
+                  console.warn(err)
+                  return fetchDocumentPathsSlow(id, fields)
+                })
+              )
+            }
+            console.warn(
+              'Revision mismatch: Cannot apply %s on %s (event: %O, prevSnapshot: %O)',
+              event.previousRev,
+              prevSnapshot._rev,
+              event,
+              prevSnapshot
+            )
+            // Fallback to re-fetch current snapshot
+            return fetchDocumentPathsSlow(id, fields)
+          }
+          // eslint-disable-next-line no-console
+          console.warn(new Error(`Invalid event: ${event.type}`))
+          return prevSnapshot
+        },
+        null,
+        1
+      )
+    )
 }
 
 // keep for debugging purposes for now
@@ -139,16 +196,19 @@ export default function cachedObserveFields(id: Id, fields: FieldName[]) {
     .filter(observer => observer.fields.some(fieldName => fields.includes(fieldName)))
     .map(cached => cached.changes$)
 
-  return combineLatest(cachedFieldObservers).pipe(
-    // in the event that a document gets deleted, the cached values will be updated to store `undefined`
-    // if this happens, we should not pick any fields from it, but rather just return null
-    map(snapshots => snapshots.filter(Boolean)),
-    // make sure all snapshots agree on same revision
-    filter(snapshots => isUniqueBy(snapshots, snapshot => snapshot._rev)),
-    // pass on value with the requested fields (or null if value is deleted)
-    map(snapshots => (snapshots.length === 0 ? null : pickFrom(snapshots, fields))),
-    // emit values only if changed
-    distinctUntilChanged(hasEqualFields(fields))
+  return (
+    combineLatest(cachedFieldObservers)
+      // in the event that a document gets deleted, the cached values will be updated to store `undefined`
+      // if this happens, we should not pick any fields from it, but rather just return null
+      .pipe(
+        map(snapshots => snapshots.filter(Boolean)),
+        // make sure all snapshots agree on same revision
+        filter(snapshots => isUniqueBy(snapshots, snapshot => snapshot._rev)),
+        // pass on value with the requested fields (or null if value is deleted)
+        map(snapshots => (snapshots.length === 0 ? null : pickFrom(snapshots, fields))),
+        // emit values only if changed
+        distinctUntilChanged(hasEqualFields(fields))
+      )
   )
 }
 

--- a/packages/@sanity/preview/src/utils/applyMutation.js
+++ b/packages/@sanity/preview/src/utils/applyMutation.js
@@ -1,0 +1,6 @@
+// @flow
+import {Mutation} from '@sanity/mutator'
+
+export default function applyMutations(doc: Document, mutations: Mutation[]) {
+  return new Mutation({mutations: mutations}).apply(doc)
+}


### PR DESCRIPTION
Note: this is experimental and based on the refactoring done in #612.

This applies mutations to cached representations of previewed documents as they arrive. It will significantly reduce requests from the studio and will result in more instant UI updates of content that is currently being edited.

Consider this a proof of concept, we need to test this extensively before merging.