### PR TITLE
[schema] Deprecate `slugifyFn` (now called `slugify`)

### DIFF
--- a/packages/@sanity/schema/src/sanity/validateSchema.js
+++ b/packages/@sanity/schema/src/sanity/validateSchema.js
@@ -2,12 +2,14 @@ import traverseSchema from './traverseSchema'
 import object from './validation/types/object'
 import reference from './validation/types/reference'
 import array from './validation/types/array'
+import slug from './validation/types/slug'
 import common from './validation/types/common'
 import rootType from './validation/types/rootType'
 
 const typeVisitors = {
   array,
   object,
+  slug,
   document: object,
   reference: reference
 }

--- a/packages/@sanity/schema/src/sanity/validation/createValidationResult.js
+++ b/packages/@sanity/schema/src/sanity/validation/createValidationResult.js
@@ -14,7 +14,8 @@ export const HELP_IDS = {
   ARRAY_OF_INVALID: 'schema-array-of-invalid',
   ARRAY_OF_NOT_UNIQUE: 'schema-array-of-invalid',
   REFERENCE_TO_INVALID: 'schema-reference-to-invalid',
-  REFERENCE_TO_NOT_UNIQUE: 'schema-reference-to-invalid'
+  REFERENCE_TO_NOT_UNIQUE: 'schema-reference-to-invalid',
+  SLUG_SLUGIFY_FN_RENAMED: 'slug-slugifyfn-renamed'
 }
 
 function createValidationResult(

--- a/packages/@sanity/schema/src/sanity/validation/types/slug.js
+++ b/packages/@sanity/schema/src/sanity/validation/types/slug.js
@@ -1,0 +1,21 @@
+import {warning, HELP_IDS} from '../createValidationResult'
+
+export default (typeDef, visitorContext) => {
+  const problems = []
+
+  if (typeDef.options && typeDef.options.slugifyFn) {
+    problems.push(
+      warning(
+        'Heads up! The "slugifyFn" option has been renamed to "slugify".',
+        HELP_IDS.SLUG_SLUGIFY_FN_RENAMED
+      )
+    )
+
+    typeDef.options.slugify = typeDef.options.slugifyFn
+  }
+
+  return {
+    ...typeDef,
+    _problems: problems
+  }
+}

--- a/packages/test-studio/schemas/slugs.js
+++ b/packages/test-studio/schemas/slugs.js
@@ -54,6 +54,22 @@ export default {
       }
     },
     {
+      name: 'deprecatedSlugifyFnField',
+      type: 'slug',
+      title: 'Slug field using deprecated "slugifyFn" option',
+      description: 'Should warn the developer about deprecated field',
+      options: {
+        source: 'title',
+        slugifyFn: value =>
+          value
+            .toLocaleLowerCase()
+            .split('')
+            .reverse()
+            .join('')
+            .replace(/\s+/g, '-')
+      }
+    },
+    {
       name: 'nested',
       type: 'object',
       fields: [


### PR DESCRIPTION
This provides backwards compatibility for the `slugifyFn` function while deprecating it with a warning, as we discussed in #585 