### PR TITLE
[base] Not using height on text input

### DIFF
--- a/packages/@sanity/base/src/styles/forms/text-input.css
+++ b/packages/@sanity/base/src/styles/forms/text-input.css
@@ -7,7 +7,6 @@
   width: 100%;
   outline: none;
   line-height: var(--input-line-height);
-  height: calc(var(--input-line-height) + var(--input-padding-horizontal) * 2);
   font-size: inherit;
   box-sizing: border-box;
   padding: var(--input-padding-horizontal) var(--input-padding-vertical);


### PR DESCRIPTION
Fixes this:
![image 2](https://user-images.githubusercontent.com/568562/36793441-b2dd9856-1c9d-11e8-97bf-7ac09f1b0614.png)
