### PR TITLE
[desk-tool] Lock to last-known local revision when publishing

### DIFF
--- a/packages/@sanity/form-builder/src/sanity/utils/gradientPatchAdapter.js
+++ b/packages/@sanity/form-builder/src/sanity/utils/gradientPatchAdapter.js
@@ -65,6 +65,13 @@ function toFormBuilderPatch(origin: Origin, patch: GradientPatch): Patch {
                 origin
               }
             }
+            if (type === 'ifRevisionID') {
+              return {
+                type: 'ifRevisionID',
+                value: patch[type],
+                origin
+              }
+            }
             console.warn(new Error(`Unsupported patch type: ${type}`))
             return null
           })


### PR DESCRIPTION
This is a less controversial version of #605 

By using a "noop patch" (unsetting an arbitrary field), we can use the `ifRevisionID` feature to lock the publishing process and prevent overwriting with a possibly outdated version.
