### PR TITLE
[form-builder] Handle readOnly on unknown fields

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ObjectInput/ObjectInput.js
+++ b/packages/@sanity/form-builder/src/inputs/ObjectInput/ObjectInput.js
@@ -154,7 +154,7 @@ export default class ObjectInput extends React.PureComponent {
   }
 
   renderUnknownFields() {
-    const {value, type, onChange} = this.props
+    const {value, type, onChange, readOnly} = this.props
     if (!type.fields) {
       return null
     }
@@ -168,7 +168,7 @@ export default class ObjectInput extends React.PureComponent {
       return null
     }
 
-    return <UnknownFields fieldNames={unknownFields} value={value} onChange={onChange} />
+    return <UnknownFields readOnly={readOnly} fieldNames={unknownFields} value={value} onChange={onChange} />
   }
 
   setFirstField = el => {

--- a/packages/@sanity/form-builder/src/inputs/ObjectInput/UnknownFields.js
+++ b/packages/@sanity/form-builder/src/inputs/ObjectInput/UnknownFields.js
@@ -6,26 +6,28 @@ import PatchEvent, {unset} from '../../PatchEvent'
 import styles from './styles/UnknownFields.css'
 import ActivateOnFocus from 'part:@sanity/components/utilities/activate-on-focus'
 
-export default class UnknownFields extends React.Component {
-  props: {
-    fieldNames: string[],
-    value: Object,
-    onChange: (PatchEvent) => void
-  }
+type Props = {
+  fieldNames: string[],
+  value: Object,
+  onChange: PatchEvent => void,
+  readOnly?: boolean
+}
 
+export default class UnknownFields extends React.Component<Props> {
   handleUnsetClick = fieldName => {
     this.props.onChange(PatchEvent.from(unset([fieldName])))
   }
 
   render() {
-    const {fieldNames, value} = this.props
+    const {fieldNames, value, readOnly} = this.props
     return (
       <div className={styles.root}>
         <h2 className={styles.heading}>Found {fieldNames.length} unknown fields</h2>
         <div className={styles.content}>
           <Details>
-            These are not defined in the current schema as valid fields for this value.
-            This could mean that the field has been removed, or that someone else has added it to their own local schema that is not yet deployed.
+            These are not defined in the current schema as valid fields for this value. This could
+            mean that the field has been removed, or that someone else has added it to their own
+            local schema that is not yet deployed.
             {fieldNames.map(fieldName => {
               return (
                 <div key={fieldName}>
@@ -35,9 +37,16 @@ export default class UnknownFields extends React.Component {
                       {JSON.stringify(value[fieldName], null, 2)}
                     </pre>
                   </ActivateOnFocus>
-                  <DefaultButton onClick={() => this.handleUnsetClick(fieldName)} color="danger">
-                    Unset {fieldName}
-                  </DefaultButton>
+                  {readOnly ? (
+                    <div>
+                      This value is <em>read only</em> according to its enclosing schema type and cannot be unset.
+                      If you want to unset, make sure you remove the <strong>readOnly</strong> property from the enclosing type
+                    </div>
+                  ) : (
+                    <DefaultButton onClick={() => this.handleUnsetClick(fieldName)} color="danger">
+                      Unset {fieldName}
+                    </DefaultButton>
+                  )}
                 </div>
               )
             })}


### PR DESCRIPTION
If you have a `readOnly` object that unknown fields, you will get a warning that includes an _Unset_-button. This will not work, as read-only inputs do not forward onChange-events from their children.

This removes the Unset-button if the enclosing input is `readOnly`, and gives the user an explanation of why the value can't be unset.