### PR TITLE
[cli] Add react-icons as dev dependency

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -69,6 +69,7 @@
     "package-json": "^4.0.1",
     "promise-props-recursive": "^1.0.0",
     "resolve-from": "^4.0.0",
+    "react-icons": "^2.2.5",
     "rimraf": "^2.6.2",
     "semver": "^5.5.0",
     "semver-compare": "^1.0.0",


### PR DESCRIPTION
In order to run the movie-studio during development, the `@sanity/cli` package must have all modules required from schema files as declared dependencies in its package.json.

Added `react-icons` as devDependency.