### PR TITLE
[client] Allow specifying ID of transactions

### DIFF
--- a/packages/@sanity/client/src/data/dataMethods.js
+++ b/packages/@sanity/client/src/data/dataMethods.js
@@ -91,7 +91,11 @@ module.exports = {
       : mutations
     const muts = Array.isArray(mut) ? mut : [mut]
 
-    return this.dataRequest('mutate', {mutations: muts}, options)
+    return this.dataRequest(
+      'mutate',
+      {mutations: muts, transactionId: options && options.transactionId},
+      options
+    )
   },
 
   transaction(operations) {

--- a/packages/@sanity/client/test/client.test.js
+++ b/packages/@sanity/client/test/client.test.js
@@ -1076,6 +1076,26 @@ test('transaction commit() throws if called without a client', t => {
   t.end()
 })
 
+test('transaction can be given an explicit transaction ID', t => {
+  const transactionId = 'moop'
+  const mutations = [{create: {bar: true}}, {delete: {id: 'barfoo'}}]
+  nock(projectHost())
+    .post('/v1/data/mutate/foo?returnIds=true&visibility=sync', {mutations, transactionId})
+    .reply(200, {transactionId})
+
+  getClient().transaction()
+    .create({bar: true})
+    .delete('barfoo')
+    .transactionId(transactionId)
+    .commit()
+    .then(res => {
+      t.equal(res.transactionId, transactionId, 'applies given transaction')
+    })
+    .catch(t.ifError)
+    .then(t.end)
+})
+
+
 /*****************
  * LISTENERS     *
  *****************/


### PR DESCRIPTION
This PR allows specifying a transaction ID on transactions. Not necessarily an important feature for most users, but for some use cases (like listeners and webhooks) it's helpful to match a mutation back to it's source.
