### PR TITLE
[validation] Allow disabling validation for field and document types

### DIFF
--- a/packages/@sanity/validation/src/inferFromSchema.js
+++ b/packages/@sanity/validation/src/inferFromSchema.js
@@ -4,7 +4,7 @@ const inferFromSchemaType = require('./inferFromSchemaType')
 function inferFromSchema(schema) {
   const typeNames = schema.getTypeNames()
   typeNames.forEach(typeName => {
-    inferFromSchemaType(schema.get(typeName), {types: []})
+    inferFromSchemaType(schema.get(typeName))
   })
   return schema
 }

--- a/packages/@sanity/validation/src/inferFromSchemaType.js
+++ b/packages/@sanity/validation/src/inferFromSchemaType.js
@@ -1,7 +1,12 @@
 const Rule = require('./Rule')
 
 // eslint-disable-next-line complexity
-function inferFromSchemaType(typeDef, isRoot = true) {
+function inferFromSchemaType(typeDef) {
+  if (typeDef.validation === false) {
+    typeDef.validation = []
+    return typeDef
+  }
+
   const isInitialized =
     Array.isArray(typeDef.validation) &&
     typeDef.validation.every(item => typeof item.validate === 'function')

--- a/packages/@sanity/validation/src/validateDocument.js
+++ b/packages/@sanity/validation/src/validateDocument.js
@@ -55,7 +55,7 @@ function validateObject(obj, type, path, options) {
   const fieldChecks = fields.map(field => {
     const validation = field.type.validation
     if (!validation) {
-      return null
+      return []
     }
 
     const fieldPath = appendPath(path, field.name)


### PR DESCRIPTION
This PR ensures that you can disable validation for a given field or document type by specifying `validation: false` in the schema declaration.