### PR TITLE
[import] Fix importing of unreferenced assets

### DIFF
--- a/packages/@sanity/import/package.json
+++ b/packages/@sanity/import/package.json
@@ -26,6 +26,7 @@
     "@sanity/mutator": "^0.125.8",
     "@sanity/uuid": "^0.125.8",
     "debug": "^3.1.0",
+    "file-url": "^2.0.2",
     "fs-extra": "^5.0.0",
     "globby": "^8.0.0",
     "gunzip-maybe": "^1.4.1",
@@ -42,7 +43,6 @@
   },
   "devDependencies": {
     "@sanity/client": "^0.125.8",
-    "file-url": "^2.0.2",
     "get-it": "^4.0.1",
     "jest": "^22.0.5",
     "prettier": "^1.10.2",

--- a/packages/@sanity/import/src/assetRefs.js
+++ b/packages/@sanity/import/src/assetRefs.js
@@ -1,3 +1,4 @@
+const getFileUrl = require('file-url')
 const {get, set, unset} = require('lodash')
 const {extractWithPath} = require('@sanity/mutator')
 const serializePath = require('./serializePath')
@@ -22,7 +23,7 @@ function absolutifyPaths(doc, absPath) {
 
   const modifier = value =>
     value
-      .replace(/file:\/\/\.\//i, `file://${absPath}/`)
+      .replace(/file:\/\/\.\//i, `${getFileUrl(absPath, {resolve: false})}/`)
       .replace(/(https?):\/\/\.\//, `$1://${absPath}/`)
 
   findAssetRefs(doc).forEach(path => {

--- a/packages/@sanity/import/src/importFromFolder.js
+++ b/packages/@sanity/import/src/importFromFolder.js
@@ -1,5 +1,6 @@
 const fse = require('fs-extra')
 const globby = require('globby')
+const getFileUrl = require('file-url')
 const debug = require('debug')('sanity:import:folder')
 
 module.exports = async function importFromFolder(fromDir, options, importers) {
@@ -20,8 +21,8 @@ module.exports = async function importFromFolder(fromDir, options, importers) {
   const images = await globby('images/*', {cwd: fromDir, absolute: true})
   const files = await globby('files/*', {cwd: fromDir, absolute: true})
   const unreferencedAssets = []
-    .concat(images.map(path => `image#${path}`))
-    .concat(files.map(path => `file#${path}`))
+    .concat(images.map(path => `image#${getFileUrl(path, {resolve: false})}`))
+    .concat(files.map(path => `file#${getFileUrl(path, {resolve: false})}`))
 
   debug('Queueing %d assets', unreferencedAssets.length)
 


### PR DESCRIPTION
There was an issue where the import would add all found assets as queued uploads, but would fail to include the `file://`-prefix, which resulted in the import failing due to a missing protocol.
