### PR TITLE
[imagetool] Hotfix hotspot

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ImageToolInput/styles/ImageToolInput.css
+++ b/packages/@sanity/form-builder/src/inputs/ImageToolInput/styles/ImageToolInput.css
@@ -27,8 +27,10 @@
   position: relative;
   flex-grow: 1;
   max-height: 70vh;
+  min-width: 250px;
 
   @media (--screen-medium) {
+    min-width: 500px;
     margin-right: var(--medium-padding);
     max-height: 60vh;
     max-width: 70vw;

--- a/packages/@sanity/imagetool/src/styles/ImageTool.css
+++ b/packages/@sanity/imagetool/src/styles/ImageTool.css
@@ -1,5 +1,3 @@
-@import 'part:@sanity/base/theme/variables-style';
-
 .root {
   width: 100%;
   height: 100%;
@@ -13,9 +11,4 @@
   max-width: 100%;
   max-height: 100%;
   user-select: none;
-  min-width: 250px;
-
-  @media (--screen-medium) {
-    min-width: 500px;
-  }
 }


### PR DESCRIPTION
The fix in #636 made matters worse by making the crop/hotspot handles not respond to user input at all. This reverts it, and fixes it by setting min-width on the container instead.

(Also snuck in a little optimization that avoids a superfluous setState too)