### PR TITLE
[schema] Fix validation of slugs in arrays

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/Slug/SlugInput.js
+++ b/packages/@sanity/form-builder/src/inputs/Slug/SlugInput.js
@@ -32,6 +32,7 @@ export default withDocument(
       }),
       document: PropTypes.shape({_id: PropTypes.string}).isRequired,
       onChange: PropTypes.func,
+      onFocus: PropTypes.func,
       markers: PropTypes.arrayOf(
         PropTypes.shape({
           type: PropTypes.string.isRequired
@@ -55,14 +56,14 @@ export default withDocument(
       this._isMounted = false
     }
 
-    updateValue(value) {
-      if (!value) {
-        this.props.onChange(PatchEvent.from(unset()))
+    updateCurrent(current) {
+      const {onChange, type} = this.props
+      if (!current) {
+        onChange(PatchEvent.from(unset(['current'])))
         return
       }
-
-      this.props.onChange(
-        PatchEvent.from(setIfMissing({_type: this.props.type.name}), set(value, ['current']))
+      onChange(
+        PatchEvent.from(setIfMissing({_type: type.name}), set(current, ['current']))
       )
     }
 
@@ -98,7 +99,11 @@ export default withDocument(
     }
 
     handleChange = event => {
-      this.updateValue(event.target.value.toString())
+      this.updateCurrent(event.target.value)
+    }
+
+    handleFocusCurrent = event => {
+      this.props.onFocus(['current'])
     }
 
     handleGenerateSlug = () => {
@@ -114,7 +119,7 @@ export default withDocument(
       const newFromSource = typeof source === 'function' ? source(document) : get(document, source)
       this.setState({loading: true})
       this.slugify(newFromSource || '')
-        .then(newSlug => this.updateValue(newSlug))
+        .then(newSlug => this.updateCurrent(newSlug))
         .catch(err => {
           // eslint-disable-next-line no-console
           console.error(
@@ -125,7 +130,7 @@ export default withDocument(
     }
 
     render() {
-      const {value, type, level, markers, document, ...rest} = this.props
+      const {value, type, level, markers, onFocus, document, ...rest} = this.props
       const {loading, inputText} = this.state
 
       const hasSourceField = type.options && type.options.source
@@ -154,6 +159,7 @@ export default withDocument(
                 disabled={loading}
                 placeholder={type.placeholder}
                 onChange={this.handleChange}
+                onFocus={this.handleFocusCurrent}
                 value={typeof inputText === 'string' ? inputText : value.current}
               />
             </div>

--- a/packages/@sanity/schema/src/legacy/types/slug.js
+++ b/packages/@sanity/schema/src/legacy/types/slug.js
@@ -19,11 +19,21 @@ function getDocumentIds(id) {
   }
 }
 
+function serializePath(path) {
+  return path.reduce((target, part, i) => {
+    const isIndex = typeof part === 'number'
+    const isKey = part && part._key
+    const separator = i === 0 ? '' : '.'
+    const add = isIndex || isKey ? '[]' : `${separator}${part}`
+    return `${target}${add}`
+  }, '')
+}
+
 const defaultIsUnique = (slug, options) => {
   const {document, path} = options
   const {published, draft} = getDocumentIds(document._id)
   const docType = document._type
-  const atPath = path.concat('current').join('.')
+  const atPath = serializePath(path.concat('current'))
 
   const constraints = [
     '_type == $docType',

--- a/packages/@sanity/schema/src/legacy/types/slug.js
+++ b/packages/@sanity/schema/src/legacy/types/slug.js
@@ -73,7 +73,10 @@ export const SlugType = {
   },
   extend(subTypeDef) {
     const parsed = Object.assign(pick(SLUG_CORE, OVERRIDABLE_FIELDS), subTypeDef, {
-      type: SLUG_CORE
+      type: SLUG_CORE,
+      preview: {
+        select: {title: 'current'}
+      }
     })
     return subtype(parsed)
 

--- a/packages/@sanity/schema/src/legacy/types/slug.js
+++ b/packages/@sanity/schema/src/legacy/types/slug.js
@@ -55,6 +55,10 @@ const SLUG_CORE = {
         return true
       }
 
+      if (!value.current) {
+        return 'Slug must have a value'
+      }
+
       const errorMessage = 'Slug is already in use'
       const isUnique = get(options, 'type.options.isUnique', defaultIsUnique)
       return Promise.resolve(isUnique(value.current, {...options, defaultIsUnique})).then(

--- a/packages/test-studio/schemas/slugs.js
+++ b/packages/test-studio/schemas/slugs.js
@@ -55,6 +55,18 @@ export default {
       }
     },
     {
+      name: 'arrayOfSlugs',
+      type: 'array',
+      of: [
+        {
+          options: {
+            source: 'title'
+          },
+          type: 'slug'
+        }
+      ]
+    },
+    {
       name: 'deprecatedSlugifyFnField',
       type: 'slug',
       title: 'Slug field using deprecated "slugifyFn" option',

--- a/packages/test-studio/schemas/validation.js
+++ b/packages/test-studio/schemas/validation.js
@@ -330,6 +330,25 @@ export default {
     },
 
     {
+      name: 'arrayOfSlugs',
+      title: 'Array of slugs',
+      type: 'array',
+      of: [
+        {
+          type: 'object',
+          name: 'slugEmbed',
+          fields: [
+            {
+              type: 'slug',
+              name: 'sku',
+              title: 'SKU'
+            }
+          ]
+        }
+      ]
+    },
+
+    {
       name: 'deepInline',
       type: 'object',
       title: 'Deep inline object',


### PR DESCRIPTION
Fix a bug where the uniqueness check of slugs fails because it is placed inside the path of an array, as well as the validation failing when placed directly inside of an array and not having a current value.