### PR TITLE
[base] 50% opacity only affects text-input with readonly

### DIFF
--- a/packages/@sanity/base/src/styles/forms/text-input.css
+++ b/packages/@sanity/base/src/styles/forms/text-input.css
@@ -16,10 +16,6 @@
   @nest &:disabled {
     opacity: 0.5;
   }
-
-  @nest &:read-only {
-    opacity: 0.5;
-  }
 }
 
 .textInput {
@@ -27,6 +23,10 @@
   color: var(--input-color);
   background-color: var(--input-bg);
   box-shadow: var(--input-box-shadow);
+
+  @nest &:read-only {
+    opacity: 0.5;
+  }
 
   @nest &:not(:disabled) {
     @nest &:not(:read-only) {


### PR DESCRIPTION
For some reason an select is :read-only in some cases, and select inherits styling from text-input root. 