### PR TITLE
[export] Temporarily store files to filesystem before archiving

### DIFF
--- a/packages/@sanity/export/package.json
+++ b/packages/@sanity/export/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "archiver": "^2.1.1",
     "debug": "^3.1.0",
+    "fs-extra": "^5.0.0",
     "lodash": "^4.17.4",
     "mississippi": "^2.0.0",
     "p-queue": "^2.3.0",

--- a/packages/@sanity/export/test/AssetHandler.test.js
+++ b/packages/@sanity/export/test/AssetHandler.test.js
@@ -11,7 +11,9 @@ describe('asset handler', () => {
       {_id: 'doc1', _type: 'bike', name: 'Scooter', image: {asset: {_ref: 'image-idx_abc123-3360x840-png'}}},
       {_id: 'doc2', _type: 'bike', name: 'Dupe', image: {asset: {_ref: 'image-idx_abc123-3360x840-png'}}},
       {_id: 'doc3', _type: 'bike', name: 'Tandem', image: {asset: {_ref: 'image-idx_abc456-310x282-jpg'}}},
-      {_id: 'image-idx_abc123-3360x840-png', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/idx_abc123-3360x840.png'},
+      {_id: 'old4', _type: 'bike', name: 'Cool', image: {asset: {_ref: 'mzFgq1cvHSEeGscxBsRFoqKG'}}},
+      {_id: 'mzFgq1cvHSEeGscxBsRFoqKG', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/mzFgq1cvHSEeGscxBsRFoqKG-2048x1364.jpg'},
+      {_id: 'image-idx_abc123-dads3360x840-png', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/idx_abc123-3360x840.png'},
       {_id: 'image-idx_abc456-310x282-jpg', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/idx_abc456-310x282.jpg'},
       {_id: 'plain', _type: 'bike', name: 'Broom'}
     ]
@@ -23,14 +25,15 @@ describe('asset handler', () => {
       .pipe(miss.concat(onComplete))
 
     async function onComplete(newDocs) {
-      expect(newDocs).toHaveLength(4)
+      expect(newDocs).toHaveLength(5)
       expect(docById(newDocs, 'doc1')).toMatchSnapshot('Rewritten asset for doc1')
       expect(docById(newDocs, 'doc2')).toMatchSnapshot('Rewritten asset for doc2')
       expect(docById(newDocs, 'doc3')).toMatchSnapshot('Rewritten asset for doc3')
+      expect(docById(newDocs, 'old4')).toMatchSnapshot('Rewritten asset for old4')
       expect(docById(newDocs, 'plain')).toMatchSnapshot('Nothing rewritten in assetless doc')
 
       await assetHandler.finish()
-      expect(assetHandler.archive.append.mock.calls).toHaveLength(2)
+      expect(assetHandler.archive.append.mock.calls).toHaveLength(3)
       done()
     }
   })
@@ -41,6 +44,8 @@ describe('asset handler', () => {
       {_id: 'doc1', _type: 'bike', name: 'Scooter', image: {asset: {_ref: 'image-idx_abc123-3360x840-png'}}},
       {_id: 'doc2', _type: 'bike', name: 'Dupe', image: {asset: {_ref: 'image-idx_abc123-3360x840-png'}}},
       {_id: 'doc3', _type: 'bike', name: 'Tandem', image: {asset: {_ref: 'image-idx_abc456-310x282-jpg'}}},
+      {_id: 'old4', _type: 'bike', name: 'Cool', image: {asset: {_ref: 'mzFgq1cvHSEeGscxBsRFoqKG'}}},
+      {_id: 'mzFgq1cvHSEeGscxBsRFoqKG', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/mzFgq1cvHSEeGscxBsRFoqKG-2048x1364.jpg'},
       {_id: 'image-idx_abc123-3360x840-png', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/idx_abc123-3360x840.png'},
       {_id: 'image-idx_abc456-310x282-jpg', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/idx_abc456-310x282.jpg'},
       {_id: 'plain', _type: 'bike', name: 'Broom'}
@@ -53,10 +58,11 @@ describe('asset handler', () => {
       .pipe(miss.concat(onComplete))
 
     async function onComplete(newDocs) {
-      expect(newDocs).toHaveLength(4)
+      expect(newDocs).toHaveLength(5)
       expect(docById(newDocs, 'doc1')).toMatchSnapshot('doc1 with no image asset')
       expect(docById(newDocs, 'doc2')).toMatchSnapshot('doc2 with no image asset')
       expect(docById(newDocs, 'doc3')).toMatchSnapshot('doc3 with no image asset')
+      expect(docById(newDocs, 'old4')).toMatchSnapshot('old4 with no image asset')
       expect(docById(newDocs, 'plain')).toMatchSnapshot('Nothing removed in assetless doc')
 
       await assetHandler.finish()
@@ -69,6 +75,7 @@ describe('asset handler', () => {
     // prettier-ignore
     const docs = [
       {_id: 'image-idx_abc123-3360x840-png', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/idx_abc123-3360x840.png'},
+      {_id: 'mzFgq1cvHSEeGscxBsRFoqKG', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/mzFgq1cvHSEeGscxBsRFoqKG-2048x1364.jpg'},
       {_id: 'plain', _type: 'bike', name: 'Broom'}
     ]
 
@@ -80,10 +87,10 @@ describe('asset handler', () => {
 
     async function onComplete(newDocs) {
       expect(newDocs).toHaveLength(1)
-      expect(docById(newDocs, 'plain')).toMatchObject(docs[1])
+      expect(docById(newDocs, 'plain')).toMatchObject(docs[2])
 
       await assetHandler.finish()
-      expect(assetHandler.archive.append.mock.calls).toHaveLength(1)
+      expect(assetHandler.archive.append.mock.calls).toHaveLength(2)
       done()
     }
   })
@@ -94,6 +101,7 @@ describe('asset handler', () => {
       {_id: 'doc1', _type: 'bike', name: 'Scooter', image: {asset: {_ref: 'image-idx_abc123-3360x840-png'}}},
       {_id: 'doc2', _type: 'bike', name: 'Dupe', image: {asset: {_ref: 'image-idx_abc123-3360x840-png'}}},
       {_id: 'doc3', _type: 'bike', name: 'Tandem', image: {asset: {_ref: 'image-idx_abc456-310x282-jpg'}}},
+      {_id: 'mzFgq1cvHSEeGscxBsRFoqKG', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/mzFgq1cvHSEeGscxBsRFoqKG-2048x1364.jpg'},
       {_id: 'image-idx_abc123-3360x840-png', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/idx_abc123-3360x840.png'},
       {_id: 'image-idx_abc456-310x282-jpg', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/idx_abc456-310x282.jpg'},
       {_id: 'plain', _type: 'bike', name: 'Broom'}
@@ -110,7 +118,7 @@ describe('asset handler', () => {
       expect(docById(newDocs, 'doc1')).toMatchObject(docs[0])
       expect(docById(newDocs, 'doc2')).toMatchObject(docs[1])
       expect(docById(newDocs, 'doc3')).toMatchObject(docs[2])
-      expect(docById(newDocs, 'plain')).toMatchObject(docs[5])
+      expect(docById(newDocs, 'plain')).toMatchObject(docs[6])
 
       await assetHandler.finish()
       expect(assetHandler.archive.append.mock.calls).toHaveLength(0)

--- a/packages/@sanity/export/test/AssetHandler.test.js
+++ b/packages/@sanity/export/test/AssetHandler.test.js
@@ -1,3 +1,6 @@
+const os = require('os')
+const path = require('path')
+const fse = require('fs-extra')
 const miss = require('mississippi')
 const split = require('split2')
 const {getAssetHandler, arrayToStream} = require('./helpers')
@@ -5,6 +8,10 @@ const {getAssetHandler, arrayToStream} = require('./helpers')
 const docById = (docs, id) => docs.find(doc => doc._id === id)
 
 describe('asset handler', () => {
+  afterAll(async () => {
+    await fse.remove(path.join(os.tmpdir(), 'asset-handler-tests'))
+  })
+
   test('can rewrite documents / queue downloads', done => {
     // prettier-ignore
     const docs = [
@@ -33,7 +40,7 @@ describe('asset handler', () => {
       expect(docById(newDocs, 'plain')).toMatchSnapshot('Nothing rewritten in assetless doc')
 
       await assetHandler.finish()
-      expect(assetHandler.archive.append.mock.calls).toHaveLength(3)
+      expect(assetHandler.filesWritten).toEqual(3)
       done()
     }
   })
@@ -66,7 +73,7 @@ describe('asset handler', () => {
       expect(docById(newDocs, 'plain')).toMatchSnapshot('Nothing removed in assetless doc')
 
       await assetHandler.finish()
-      expect(assetHandler.archive.append.mock.calls).toHaveLength(0)
+      expect(assetHandler.filesWritten).toEqual(0)
       done()
     }
   })
@@ -90,7 +97,7 @@ describe('asset handler', () => {
       expect(docById(newDocs, 'plain')).toMatchObject(docs[2])
 
       await assetHandler.finish()
-      expect(assetHandler.archive.append.mock.calls).toHaveLength(2)
+      expect(assetHandler.filesWritten).toEqual(2)
       done()
     }
   })
@@ -121,7 +128,7 @@ describe('asset handler', () => {
       expect(docById(newDocs, 'plain')).toMatchObject(docs[6])
 
       await assetHandler.finish()
-      expect(assetHandler.archive.append.mock.calls).toHaveLength(0)
+      expect(assetHandler.filesWritten).toEqual(0)
       done()
     }
   })

--- a/packages/@sanity/export/test/__snapshots__/AssetHandler.test.js.snap
+++ b/packages/@sanity/export/test/__snapshots__/AssetHandler.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Nothing removed in assetless doc 1`] = `
+exports[`asset handler can remove asset documents: Nothing removed in assetless doc 1`] = `
 Object {
   "_id": "plain",
   "_type": "bike",
@@ -8,7 +8,39 @@ Object {
 }
 `;
 
-exports[`Nothing rewritten in assetless doc 1`] = `
+exports[`asset handler can remove asset documents: doc1 with no image asset 1`] = `
+Object {
+  "_id": "doc1",
+  "_type": "bike",
+  "name": "Scooter",
+}
+`;
+
+exports[`asset handler can remove asset documents: doc2 with no image asset 1`] = `
+Object {
+  "_id": "doc2",
+  "_type": "bike",
+  "name": "Dupe",
+}
+`;
+
+exports[`asset handler can remove asset documents: doc3 with no image asset 1`] = `
+Object {
+  "_id": "doc3",
+  "_type": "bike",
+  "name": "Tandem",
+}
+`;
+
+exports[`asset handler can remove asset documents: old4 with no image asset 1`] = `
+Object {
+  "_id": "old4",
+  "_type": "bike",
+  "name": "Cool",
+}
+`;
+
+exports[`asset handler can rewrite documents / queue downloads: Nothing rewritten in assetless doc 1`] = `
 Object {
   "_id": "plain",
   "_type": "bike",
@@ -16,7 +48,7 @@ Object {
 }
 `;
 
-exports[`Rewritten asset for doc1 1`] = `
+exports[`asset handler can rewrite documents / queue downloads: Rewritten asset for doc1 1`] = `
 Object {
   "_id": "doc1",
   "_type": "bike",
@@ -27,7 +59,7 @@ Object {
 }
 `;
 
-exports[`Rewritten asset for doc2 1`] = `
+exports[`asset handler can rewrite documents / queue downloads: Rewritten asset for doc2 1`] = `
 Object {
   "_id": "doc2",
   "_type": "bike",
@@ -38,7 +70,7 @@ Object {
 }
 `;
 
-exports[`Rewritten asset for doc3 1`] = `
+exports[`asset handler can rewrite documents / queue downloads: Rewritten asset for doc3 1`] = `
 Object {
   "_id": "doc3",
   "_type": "bike",
@@ -49,26 +81,13 @@ Object {
 }
 `;
 
-exports[`doc1 with no image asset 1`] = `
+exports[`asset handler can rewrite documents / queue downloads: Rewritten asset for old4 1`] = `
 Object {
-  "_id": "doc1",
+  "_id": "old4",
   "_type": "bike",
-  "name": "Scooter",
-}
-`;
-
-exports[`doc2 with no image asset 1`] = `
-Object {
-  "_id": "doc2",
-  "_type": "bike",
-  "name": "Dupe",
-}
-`;
-
-exports[`doc3 with no image asset 1`] = `
-Object {
-  "_id": "doc3",
-  "_type": "bike",
-  "name": "Tandem",
+  "image": Object {
+    "_sanityAsset": "image@file://./images/mzFgq1cvHSEeGscxBsRFoqKG.bin",
+  },
+  "name": "Cool",
 }
 `;

--- a/packages/@sanity/export/test/helpers/index.js
+++ b/packages/@sanity/export/test/helpers/index.js
@@ -3,7 +3,8 @@ const AssetHandler = require('../../src/AssetHandler')
 
 const getMockClient = () => ({
   config: () => ({projectId: '__fixtures__', dataset: '__test__'}),
-  fetch: (query, params) => `http://localhost:32323/${params.id}.jpg`
+  fetch: (query, params) =>
+    query.endsWith('._type') ? `sanity.imageAsset` : `http://localhost:32323/${params.id}.jpg`
 })
 
 const getMockArchive = () => ({append: jest.fn(), abort: jest.fn()})

--- a/packages/@sanity/export/test/helpers/index.js
+++ b/packages/@sanity/export/test/helpers/index.js
@@ -1,3 +1,5 @@
+const os = require('os')
+const path = require('path')
 const stringToStream = require('string-to-stream')
 const AssetHandler = require('../../src/AssetHandler')
 
@@ -31,7 +33,7 @@ const getAssetHandler = () =>
   new AssetHandler({
     prefix: 'test',
     client: getMockClient(),
-    archive: getMockArchive()
+    tmpDir: path.join(os.tmpdir(), 'asset-handler-tests', `${Date.now()}`)
   })
 
 module.exports = {


### PR DESCRIPTION
There is a sporadic issue where downloaded assets are not correctly added to the exported archive, resulting in half-completed images and such. Obviously this has to be fixed ASAP. This PR ensures that assets are stored to the filesystem temporarily and added to the archive using a simpler method in the underlying library, which should prove more reliable.

I also managed to sneak in a fix for old asset IDs that don't follow the same document ID pattern that we use nowadays. 
