### PR TITLE
[schema] Fix combining slug validation rules with custom ones

### DIFF
--- a/packages/@sanity/schema/src/legacy/types/utils.js
+++ b/packages/@sanity/schema/src/legacy/types/utils.js
@@ -6,7 +6,7 @@ export function lazyGetter(target, key, getter, config = {}) {
       const val = getter()
       Object.defineProperty(target, key, {
         value: val,
-        writable: false,
+        writable: Boolean(config.writable),
         configurable: false
       })
       return val

--- a/packages/test-studio/schemas/slugs.js
+++ b/packages/test-studio/schemas/slugs.js
@@ -33,6 +33,17 @@ export default {
       }
     },
     {
+      name: 'requiredSlug',
+      type: 'slug',
+      title: 'Required slug',
+      description: 'Slug field that is required',
+      validation: Rule => Rule.required(),
+      options: {
+        source: 'title',
+        maxLength: 96
+      }
+    },
+    {
       name: 'slugWithFunction',
       type: 'slug',
       title: 'Slug with function to get source',


### PR DESCRIPTION
Note: This reveals some flaws in how we can provide default validation for core types and should be addressed separately. This is a hot-fix.

Fixes an issue where specifying your own validation rules for a slug field would override the built-in rules.
