### PR TITLE
[cli] Add support for private datasets

### DIFF
--- a/packages/@sanity/cli/src/commands/init/initCommand.js
+++ b/packages/@sanity/cli/src/commands/init/initCommand.js
@@ -8,6 +8,7 @@ Options
   --dataset <dataset> Dataset name for the studio
   --output-path <path> Path to write studio project to
   --template <template> Project template to use [default: "clean"]
+  --visibility <mode> Visibility mode for dataset (public/private)
   --create-project <name> Create a new project with the given name
 
 Examples
@@ -28,6 +29,7 @@ Examples
   sanity init -y \\
     --create-project "Movies Unlimited" \\
     --dataset moviedb \\
+    --visibility private \\
     --template moviedb \\
     --output-path /Users/espenh/movies-unlimited
 `

--- a/packages/@sanity/client/src/datasets/datasetsClient.js
+++ b/packages/@sanity/client/src/datasets/datasetsClient.js
@@ -6,8 +6,8 @@ function DatasetsClient(client) {
 }
 
 assign(DatasetsClient.prototype, {
-  create(name) {
-    return this._modify('PUT', name)
+  create(name, options) {
+    return this._modify('PUT', name, options)
   },
 
   delete(name) {
@@ -18,9 +18,9 @@ assign(DatasetsClient.prototype, {
     return this.request({uri: '/datasets'})
   },
 
-  _modify(method, name) {
+  _modify(method, name, body) {
     validate.dataset(name)
-    return this.request({method, uri: `/datasets/${name}`})
+    return this.request({method, uri: `/datasets/${name}`, body})
   }
 })
 

--- a/packages/@sanity/client/src/datasets/datasetsClient.js
+++ b/packages/@sanity/client/src/datasets/datasetsClient.js
@@ -10,6 +10,10 @@ assign(DatasetsClient.prototype, {
     return this._modify('PUT', name, options)
   },
 
+  edit(name, options) {
+    return this._modify('PATCH', name, options)
+  },
+
   delete(name) {
     return this._modify('DELETE', name)
   },

--- a/packages/@sanity/core/src/commands/dataset/createDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/createDatasetCommand.js
@@ -1,18 +1,49 @@
 import promptForDatasetName from '../../actions/dataset/datasetNamePrompt'
 
+const helpText = `
+Options
+--acl-mode <mode> Set ACL mode for this dataset (public/private)
+
+Examples
+sanity dataset create
+sanity dataset create <name>
+sanity dataset create <name> --acl-mode private
+`
+
+const allowedModes = ['private', 'public']
+
 export default {
   name: 'create',
   group: 'dataset',
   signature: '[NAME]',
+  helpText,
   description: 'Create a new dataset within your project',
   action: async (args, context) => {
     const {apiClient, output, prompt} = context
+    const flags = args.extOptions
     const [dataset] = args.argsWithoutOptions
     const client = apiClient()
+
+    const [datasets, projectFeatures] = await Promise.all([
+      client.datasets.list().then(sets => sets.map(ds => ds.name)),
+      client.request({uri: '/features'})
+    ])
+
+    if (flags['acl-mode'] && allowedModes.includes(flags['acl-mode'])) {
+      throw new Error(`ACL mode "${flags['acl-mode']}" not allowed`)
+    }
+
     const datasetName = await (dataset || promptForDatasetName(prompt))
+    if (datasets.includes(datasetName)) {
+      throw new Error(`Dataset "${datasetName}" already exists`)
+    }
+
+    const canCreatePrivate = projectFeatures.includes('privateDataset')
+    const defaultAclMode = canCreatePrivate ? flags['acl-mode'] : 'public'
+    const aclMode = await (defaultAclMode || promptForAclMode(prompt))
 
     try {
-      await client.datasets.create(datasetName)
+      await client.datasets.create(datasetName, {aclMode})
       output.print('Dataset created successfully')
     } catch (err) {
       throw new Error(`Dataset creation failed:\n${err.message}`)
@@ -20,3 +51,31 @@ export default {
   }
 }
 
+async function promptForAclMode(prompt, options = {}) {
+  const mode = await prompt.single({
+    type: 'list',
+    message: 'Dataset ACL mode',
+    choices: [
+      {
+        value: 'public',
+        name: 'Public (all documents visible)'
+      },
+      {
+        value: 'private',
+        name: 'Private (requires token to read documents)'
+      }
+    ]
+  })
+
+  if (mode !== 'private') {
+    return mode
+  }
+
+  const confirmed = await prompt.single({
+    type: 'confirm',
+    message: 'Note: Assets (images, files) will still be public (accessible by URL). Continue?',
+    default: true
+  })
+
+  return confirmed ? mode : promptForAclMode(prompt, options)
+}

--- a/packages/@sanity/core/src/commands/dataset/datasetVisibilityCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/datasetVisibilityCommand.js
@@ -1,0 +1,53 @@
+export default {
+  name: 'visibility',
+  group: 'dataset',
+  signature: 'get/set [dataset] [mode]',
+  description: 'Set visibility of a dataset',
+  // eslint-disable-next-line complexity
+  action: async (args, context) => {
+    const {apiClient, output} = context
+    const [action, ds, aclMode] = args.argsWithoutOptions
+    if (!action) {
+      throw new Error('Action must be provided (get/set)')
+    }
+
+    if (!['set', 'get'].includes(action)) {
+      throw new Error('Invalid action (only get/set allowed)')
+    }
+
+    if (!ds) {
+      throw new Error('Dataset name must be provided')
+    }
+
+    if (action === 'set' && !aclMode) {
+      throw new Error('Please provide a visibility mode (public/private)')
+    }
+
+    const dataset = `${ds}`
+    const client = apiClient()
+    const current = (await client.datasets.list()).find(curr => curr.name === dataset)
+
+    if (!current) {
+      throw new Error('Dataset not found')
+    }
+
+    if (action === 'get') {
+      output.print(current.aclMode)
+      return
+    }
+
+    if (current.aclMode === aclMode) {
+      output.print(`Dataset already in "${aclMode}"-mode`)
+      return
+    }
+
+    if (aclMode === 'private') {
+      output.print(
+        'Please note that while documents are private, assets (files and images) are still public\n'
+      )
+    }
+
+    await apiClient().datasets.edit(dataset, {aclMode})
+    output.print('Dataset visibility changed')
+  }
+}

--- a/packages/@sanity/core/src/commands/index.js
+++ b/packages/@sanity/core/src/commands/index.js
@@ -5,6 +5,7 @@ import datasetGroup from './dataset/datasetGroup'
 import deployCommand from './deploy/deployCommand'
 import listDatasetsCommand from './dataset/listDatasetsCommand'
 import createDatasetCommand from './dataset/createDatasetCommand'
+import datasetVisibilityCommand from './dataset/datasetVisibilityCommand'
 import deleteDatasetCommand from './dataset/deleteDatasetCommand'
 import exportDatasetCommand from './dataset/exportDatasetCommand'
 import importDatasetCommand from './dataset/importDatasetCommand'
@@ -30,6 +31,7 @@ export default [
   deployCommand,
   listDatasetsCommand,
   createDatasetCommand,
+  datasetVisibilityCommand,
   exportDatasetCommand,
   importDatasetCommand,
   deleteDatasetCommand,


### PR DESCRIPTION
This PR adds support for private datasets in four different parts:
- `@sanity/client` gets a new method to edit properties on existing datasets as well as specifying properties for new ones
- `@sanity/core` gets a new `sanity dataset visibility` command that can get and set the visibility mode
- `@sanity/core` now prompts for visibility mode when running `sanity dataset create`
- `@sanity/cli` prompts for dataset visibility mode when running `sanity init`
