### PR TITLE
[cli] Support react 16

### DIFF
--- a/packages/@sanity/core/src/util/checkReactCompatibility.js
+++ b/packages/@sanity/core/src/util/checkReactCompatibility.js
@@ -3,8 +3,8 @@ const semver = require('semver')
 const resolveFrom = require('resolve-from')
 
 const supported = {
-  react: '^15.0.0',
-  'react-dom': '^15.0.0'
+  react: '^15 || ^16',
+  'react-dom': '^15 || ^16'
 }
 
 module.exports = workDir => {


### PR DESCRIPTION
Since #639 has landed, we can now support React 16 🎉

This allows React 16 when running `sanity start`