### PR TITLE
[cli] Use React 16 by default in new studios

### DIFF
--- a/packages/@sanity/cli/src/versionRanges.js
+++ b/packages/@sanity/cli/src/versionRanges.js
@@ -7,8 +7,9 @@ export default {
     '@sanity/default-layout': 'latest',
     '@sanity/default-login': 'latest',
     '@sanity/desk-tool': 'latest',
-    react: '^15.6',
-    'react-dom': '^15.6'
+    react: '^16.2',
+    'react-dom': '^16.2',
+    'prop-types': '^15.6'
   },
 
   // Only used for Sanity-style plugins (eg, the ones we build at Sanity.io)


### PR DESCRIPTION
This will use v16 as default React version for new studios (prop-types is still on 15.6).