### PR TITLE
[image-url] Allow specifying a baseUrl

### DIFF
--- a/packages/@sanity/image-url/src/builder.js
+++ b/packages/@sanity/image-url/src/builder.js
@@ -154,6 +154,7 @@ export default function urlBuilder(options) {
   if (options && typeof options.clientConfig == 'object') {
     // Inherit config from client
     return new ImageUrlBuilder(null, {
+      baseUrl: options.clientConfig.apiHost.replace(/^https:\/\/api\./, 'https://cdn.'),
       projectId: options.clientConfig.projectId,
       dataset: options.clientConfig.dataset
     })

--- a/packages/@sanity/image-url/src/urlForImage.js
+++ b/packages/@sanity/image-url/src/urlForImage.js
@@ -138,9 +138,9 @@ function parseAssetId(ref) {
 
 /* eslint-disable complexity */
 function specToImageUrl(spec) {
-  const baseUrl = `https://cdn.sanity.io/images/${spec.projectId}/${spec.dataset}/${
-    spec.asset.id
-  }-${spec.asset.width}x${spec.asset.height}.${spec.asset.format}`
+  const cdnUrl = spec.baseUrl || 'https://cdn.sanity.io'
+  const filename = `${spec.asset.id}-${spec.asset.width}x${spec.asset.height}.${spec.asset.format}`
+  const baseUrl = `${cdnUrl}/images/${spec.projectId}/${spec.dataset}/${filename}`
 
   const params = []
 

--- a/packages/@sanity/image-url/test/urlForHotspotImage.test.js
+++ b/packages/@sanity/image-url/test/urlForHotspotImage.test.js
@@ -1,5 +1,5 @@
-import urlForHotspotImage from '../src/urlForImage'
 import should from 'should'
+import urlForHotspotImage from '../src/urlForImage'
 import {uncroppedImage, croppedImage, noHostpotImage} from './fixtures'
 
 describe('urlForHotspotImage', () => {


### PR DESCRIPTION
When developing Sanity, we sometimes use a different host than `cdn.sanity.io`. This PR allows us to override the base url for generated URLs, and if the builder is instantiated with a client, infers it from the API URL.
