### PR TITLE
[cli] Allow @sanity/core to declare CLI version requirement

### DIFF
--- a/packages/@sanity/cli/src/cli.js
+++ b/packages/@sanity/cli/src/cli.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-console, no-process-exit, no-sync */
+// eslint-disable-next-line import/no-unassigned-import
 import 'babel-polyfill'
 import path from 'path'
 import chalk from 'chalk'
@@ -38,8 +39,8 @@ module.exports = async function runCli(cliRoot) {
   const commands = mergeCommands(baseCommands, options.corePath)
 
   if (core.v || core.version) {
-    console.log(`${pkg.name} version ${pkg.version}`) // eslint-disable-line no-console
-    process.exit() // eslint-disable-line no-process-exit
+    console.log(`${pkg.name} version ${pkg.version}`)
+    process.exit()
   }
 
   // Translate `sanity -h <command>` to `sanity help <command>`

--- a/packages/@sanity/cli/src/util/getUpgradeCommand.js
+++ b/packages/@sanity/cli/src/util/getUpgradeCommand.js
@@ -1,0 +1,42 @@
+import path from 'path'
+import which from 'which'
+import isInstalledGlobally from 'is-installed-globally'
+import debug from '../debug'
+import {name} from '../../package.json'
+
+function getUpgradeCommand(options = {}) {
+  let {cwd, workDir} = options
+  cwd = cwd || process.cwd()
+  workDir = workDir || cwd
+
+  if (isInstalledGlobally && isInstalledUsingYarn()) {
+    debug('CLI is installed globally with yarn')
+    return `yarn global add ${name}`
+  }
+
+  if (isInstalledGlobally) {
+    debug('CLI is installed globally with npm')
+    return `npm install -g ${name}`
+  }
+
+  const cmds = cwd === workDir ? [] : [`cd ${path.relative(cwd, workDir)}`]
+  const hasGlobalYarn = Boolean(which.sync('yarn', {nothrow: true}))
+  if (hasGlobalYarn) {
+    cmds.push(`yarn upgrade ${name}`)
+  } else {
+    cmds.push(`./node_modules/.bin/sanity upgrade ${name}`)
+  }
+
+  return cmds.join(' && ')
+}
+
+function isInstalledUsingYarn() {
+  const isWindows = process.platform === 'win32'
+  const yarnPath = isWindows
+    ? path.join('Yarn', 'config', 'global')
+    : path.join('.config', 'yarn', 'global')
+
+  return __dirname.includes(yarnPath)
+}
+
+export default getUpgradeCommand

--- a/packages/@sanity/cli/src/util/mergeCommands.js
+++ b/packages/@sanity/cli/src/util/mergeCommands.js
@@ -1,12 +1,32 @@
 import {find} from 'lodash'
+import semver from 'semver'
+import chalk from 'chalk'
+import {version} from '../../package.json'
 import dynamicRequire from './dynamicRequire'
+import getUpgradeCommand from './getUpgradeCommand'
 
-export default (baseCommands, corePath) => {
+export default (baseCommands, corePath, options = {}) => {
   if (!corePath) {
     return baseCommands
   }
 
+  const {cwd, workDir} = options
   const core = dynamicRequire(corePath)
+
+  if (core.requiredCliVersionRange && !semver.satisfies(version, core.requiredCliVersionRange)) {
+    const upgradeCmd = chalk.yellow(getUpgradeCommand({cwd, workDir}))
+    /* eslint-disable no-console, no-process-exit */
+    console.error(
+      `The version of @sanity/core installed in this project requires @sanity/cli @ ${chalk.green(
+        core.requiredCliVersionRange
+      )}. Currently installed version is ${chalk.red(
+        version
+      )}.\n\nPlease upgrade by running:\n\n  ${upgradeCmd}\n\n`
+    )
+    process.exit(1)
+    /* eslint-enable no-console, no-process-exit */
+  }
+
   const merged = baseCommands.concat(core.commands).map(addDefaultGroup)
 
   // Remove duplicate commands when within the same group,

--- a/packages/@sanity/cli/src/util/updateNotifier.js
+++ b/packages/@sanity/cli/src/util/updateNotifier.js
@@ -1,13 +1,11 @@
 /* eslint-disable no-process-env */
-import path from 'path'
-import which from 'which'
 import boxen from 'boxen'
 import chalk from 'chalk'
 import latestVersion from 'latest-version'
 import semverCompare from 'semver-compare'
-import isInstalledGlobally from 'is-installed-globally'
 import debug from '../debug'
 import getUserConfig from './getUserConfig'
+import getUpgradeCommand from './getUpgradeCommand'
 
 const MAX_BLOCKING_TIME = 250
 const TWELVE_HOURS = 1000 * 60 * 60 * 12
@@ -17,7 +15,7 @@ const isDisabled =
   process.env.BUILD_NUMBER || // Jenkins, TeamCity
   process.env.NO_UPDATE_NOTIFIER // Explicitly disabled
 
-module.exports = options => {
+export default options => {
   debug('CLI installed at %s', __dirname)
 
   const {pkg, cwd, workDir} = options
@@ -78,7 +76,7 @@ module.exports = options => {
       return
     }
 
-    const upgradeCommand = getUpgradeCommand(newVersion)
+    const upgradeCommand = getUpgradeCommand({cwd, workDir})
     const message = [
       'Update available ',
       chalk.dim(version),
@@ -102,28 +100,6 @@ module.exports = options => {
     console.error(`\n${boxen(message, boxenOpts)}`)
 
     userConfig.set('cliLastUpdateNag', Date.now())
-  }
-
-  function getUpgradeCommand(newVersion) {
-    if (isInstalledGlobally && isInstalledUsingYarn()) {
-      debug('CLI is installed globally with yarn')
-      return `yarn global add ${name}`
-    }
-
-    if (isInstalledGlobally) {
-      debug('CLI is installed globally with npm')
-      return `npm install -g ${name}`
-    }
-
-    const cmds = cwd === workDir ? [] : [`cd ${path.relative(cwd, workDir)}`]
-    const hasGlobalYarn = Boolean(which.sync('yarn', {nothrow: true}))
-    if (hasGlobalYarn) {
-      cmds.push(`yarn upgrade ${name}`)
-    } else {
-      cmds.push('./node_modules/.bin/sanity upgrade @sanity/cli')
-    }
-
-    return cmds.join(' && ')
   }
 
   async function getLatestRemote() {
@@ -162,13 +138,4 @@ module.exports = options => {
     debug('Update is available (%s)', latestRemote)
     return latestRemote
   }
-}
-
-function isInstalledUsingYarn() {
-  const isWindows = process.platform === 'win32'
-  const yarnPath = isWindows
-    ? path.join('Yarn', 'config', 'global')
-    : path.join('.config', 'yarn', 'global')
-
-  return __dirname.includes(yarnPath)
 }

--- a/packages/@sanity/core/src/index.js
+++ b/packages/@sanity/core/src/index.js
@@ -1,6 +1,8 @@
 import commands from './commands'
+import requiredCliVersionRange from './requiredCliVersionRange'
 
 // Must be module.exports (commonjs)
 module.exports = {
-  commands
+  commands,
+  requiredCliVersionRange
 }

--- a/packages/@sanity/core/src/requiredCliVersionRange.js
+++ b/packages/@sanity/core/src/requiredCliVersionRange.js
@@ -1,0 +1,1 @@
+export default '>=0.127.1'


### PR DESCRIPTION
Certain functionality and dependencies are shared between `@sanity/cli` and `@sanity/core`. For instance, we bundle a version of @sanity/client with the CLI which is then exposed to the CLI commands in `@sanity/core` to prevent having to bundle the dependency in both projects.

Sometimes when we add new functionality to @sanity/core, it thus implicitly depends on a given version range of `@sanity/cli`, which is not currently enforced and thus can lead to unexpected crashes because of incorrect assumptions.

This PR adds a feature to `@sanity/cli` that allows `@sanity/core` to declare a minimum CLI version requirement, and if it does not satisfy it, exit with an error telling the user to upgrade.

We'll still have to explicitly add checks in `@sanity/core` commands until we are sure most people are using a version of the CLI with this check built-in.

As an interesting sidenote, it  might be worth investigating whether or not we are able to bundle all the commands and dependencies of `@sanity/core` and `@sanity/cli` into a single package. The original reason for splitting them up was to reduce the time it took to install the CLI module and start using yarn to install dependencies (back in the npm3 days) - but now that we are bundling all dependencies to a single file, this point doesn't make as much sense anymore.

