### PR TITLE
[form-builder] Support collapsible objects with default limit

### DIFF
--- a/packages/test-studio/schemas/objects.js
+++ b/packages/test-studio/schemas/objects.js
@@ -57,6 +57,18 @@ export default {
       title: 'This field is of type objectsTest',
       type: 'objectsTest',
       fieldset: 'recursive'
+    },
+    {
+      name: 'collapsibleObject',
+      title: 'Collapsible object',
+      type: 'object',
+      options: {collapsible: true, collapsed: false},
+      description:
+        'This is a field of (anonymous, inline) object type. Values here should never get a `_type` property',
+      fields: [
+        {name: 'field1', type: 'string', description: 'This is a string field'},
+        {name: 'field2', type: 'string', description: 'This is a collapsed field'}
+      ]
     }
   ]
 }

--- a/packages/test-studio/schemas/recursiveObject.js
+++ b/packages/test-studio/schemas/recursiveObject.js
@@ -1,0 +1,44 @@
+import icon from 'react-icons/lib/go/puzzle'
+
+export const recursiveObject = {
+  type: 'object',
+  name: 'recursiveObject',
+  title: 'Recursive object',
+  icon,
+  options: {collapsible: false, collapsed: false},
+  fields: [
+    {
+      name: 'first',
+      type: 'string',
+      title: 'First'
+    },
+    {
+      name: 'second',
+      type: 'string',
+      title: 'Second'
+    },
+    {
+      name: 'myself',
+      title: 'A field of my own type',
+      type: 'recursiveObject'
+    }
+  ]
+}
+
+export default {
+  name: 'recursiveObjectTest',
+  type: 'document',
+  title: 'Recursive Objects test',
+  preview: {
+    select: {
+      title: 'recursiveObject.first'
+    }
+  },
+  fields: [
+    {
+      name: 'recursiveObject',
+      type: 'recursiveObject',
+      title: 'A field of a recursive object type'
+    }
+  ]
+}

--- a/packages/test-studio/schemas/schema.js
+++ b/packages/test-studio/schemas/schema.js
@@ -11,6 +11,7 @@ import images, {myImage} from './images'
 import strings from './strings'
 import texts from './texts'
 import objects, {myObject} from './objects'
+import recursiveObjectTest, {recursiveObject} from './recursiveObject'
 import arrays from './arrays'
 import files from './files'
 import uploads from './uploads'
@@ -74,6 +75,8 @@ export default createSchema({
     recursive,
     recursiveArray,
     recursivePopover,
+    recursiveObjectTest,
+    recursiveObject,
     myObject,
     codeInputType,
     notitle,


### PR DESCRIPTION
This adds support for `options: {collapsible: boolean, collapsed: boolean}` for object types.

Additionally, it changes the default behavior, making objects on level (depth) 3 and above collapsible and collapsed by default.

If the default is overridden to be `{collapsible: false, collapsed: false}`, we still force-collapse when reaching level 10 and beyond (this is mainly to avoid infinite recursion on object types that have fields of its own type).

This requires doc updates on objects and fieldsets docs when released