### PR TITLE
[validation] Move slug validation to @sanity/validation

### DIFF
--- a/packages/@sanity/schema/src/legacy/types/slug.js
+++ b/packages/@sanity/schema/src/legacy/types/slug.js
@@ -1,73 +1,12 @@
-import {pick, get} from 'lodash'
-import client from 'part:@sanity/base/client'
-import {lazyGetter} from './utils'
+import {pick} from 'lodash'
 
-const OVERRIDABLE_FIELDS = [
-  'jsonType',
-  'type',
-  'name',
-  'title',
-  'description',
-  'options',
-  'validation'
-]
-
-function getDocumentIds(id) {
-  const isDraft = id.indexOf('drafts.') === 0
-  return {
-    published: isDraft ? id.slice('drafts.'.length) : id,
-    draft: isDraft ? id : `drafts.${id}`
-  }
-}
-
-function serializePath(path) {
-  return path.reduce((target, part, i) => {
-    const isIndex = typeof part === 'number'
-    const isKey = part && part._key
-    const separator = i === 0 ? '' : '.'
-    const add = isIndex || isKey ? '[]' : `${separator}${part}`
-    return `${target}${add}`
-  }, '')
-}
-
-const defaultIsUnique = (slug, options) => {
-  const {document, path} = options
-  const {published, draft} = getDocumentIds(document._id)
-  const docType = document._type
-  const atPath = serializePath(path.concat('current'))
-
-  const constraints = [
-    '_type == $docType',
-    `!(_id in [$draft, $published])`,
-    `${atPath} == $slug`
-  ].join(' && ')
-
-  return client.fetch(`!defined(*[${constraints}][0]._id)`, {docType, draft, published, slug})
-}
-
-const slugValidator = Rule =>
-  Rule.custom((value, options) => {
-    if (!value) {
-      return true
-    }
-
-    if (!value.current) {
-      return 'Slug must have a value'
-    }
-
-    const errorMessage = 'Slug is already in use'
-    const isUnique = get(options, 'type.options.isUnique', defaultIsUnique)
-    return Promise.resolve(isUnique(value.current, {...options, defaultIsUnique})).then(
-      slugIsUnique => (slugIsUnique ? true : errorMessage)
-    )
-  })
+const OVERRIDABLE_FIELDS = ['jsonType', 'type', 'name', 'title', 'description', 'options']
 
 const SLUG_CORE = {
   name: 'slug',
   title: 'Slug',
   type: null,
-  jsonType: 'object',
-  validation: slugValidator
+  jsonType: 'object'
 }
 
 export const SlugType = {
@@ -81,16 +20,6 @@ export const SlugType = {
         select: {title: 'current'}
       }
     })
-
-    lazyGetter(
-      parsed,
-      'validation',
-      () =>
-        subTypeDef.validation
-          ? Rule => [subTypeDef.validation(Rule), slugValidator(Rule)]
-          : slugValidator,
-      {writable: true}
-    )
 
     return subtype(parsed)
 

--- a/packages/@sanity/validation/src/inferFromSchemaType.js
+++ b/packages/@sanity/validation/src/inferFromSchemaType.js
@@ -1,4 +1,5 @@
 const Rule = require('./Rule')
+const {slugValidator} = require('./validators/slugValidator')
 
 // eslint-disable-next-line complexity
 function inferFromSchemaType(typeDef) {
@@ -25,6 +26,10 @@ function inferFromSchemaType(typeDef) {
 
   if (type && type.name === 'url') {
     base = base.uri()
+  }
+
+  if (type && type.name === 'slug') {
+    base = base.custom(slugValidator)
   }
 
   if (type && type.name === 'reference') {

--- a/packages/@sanity/validation/src/inferFromSchemaType.js
+++ b/packages/@sanity/validation/src/inferFromSchemaType.js
@@ -17,7 +17,7 @@ function inferFromSchemaType(typeDef) {
   }
 
   const type = typeDef.type
-  const typed = Rule[typeDef.jsonType] && Rule[typeDef.jsonType]
+  const typed = Rule[typeDef.jsonType]
   let base = typed ? typed() : new Rule()
 
   if (type && type.name === 'datetime') {
@@ -47,11 +47,11 @@ function inferFromSchemaType(typeDef) {
   typeDef.validation = inferValidation(typeDef, base)
 
   if (typeDef.fields) {
-    typeDef.fields.forEach(field => inferFromSchemaType(field.type, false))
+    typeDef.fields.forEach(field => inferFromSchemaType(field.type))
   }
 
   if (typeDef.of && typeDef.jsonType === 'array') {
-    typeDef.of.forEach(candidate => inferFromSchemaType(candidate, false))
+    typeDef.of.forEach(candidate => inferFromSchemaType(candidate))
   }
 
   return typeDef

--- a/packages/@sanity/validation/src/validators/slugValidator.js
+++ b/packages/@sanity/validation/src/validators/slugValidator.js
@@ -1,0 +1,51 @@
+const {get} = require('lodash')
+
+function getDocumentIds(id) {
+  const isDraft = id.indexOf('drafts.') === 0
+  return {
+    published: isDraft ? id.slice('drafts.'.length) : id,
+    draft: isDraft ? id : `drafts.${id}`
+  }
+}
+
+function serializePath(path) {
+  return path.reduce((target, part, i) => {
+    const isIndex = typeof part === 'number'
+    const isKey = part && part._key
+    const separator = i === 0 ? '' : '.'
+    const add = isIndex || isKey ? '[]' : `${separator}${part}`
+    return `${target}${add}`
+  }, '')
+}
+
+const defaultIsUnique = (slug, options) => {
+  const client = require('part:@sanity/base/client')
+  const {document, path} = options
+  const {published, draft} = getDocumentIds(document._id)
+  const docType = document._type
+  const atPath = serializePath(path.concat('current'))
+
+  const constraints = [
+    '_type == $docType',
+    `!(_id in [$draft, $published])`,
+    `${atPath} == $slug`
+  ].join(' && ')
+
+  return client.fetch(`!defined(*[${constraints}][0]._id)`, {docType, draft, published, slug})
+}
+
+export const slugValidator = (value, options) => {
+  if (!value) {
+    return true
+  }
+
+  if (!value.current) {
+    return 'Slug must have a value'
+  }
+
+  const errorMessage = 'Slug is already in use'
+  const isUnique = get(options, 'type.options.isUnique', defaultIsUnique)
+  return Promise.resolve(isUnique(value.current, {...options, defaultIsUnique})).then(
+    slugIsUnique => (slugIsUnique ? true : errorMessage)
+  )
+}


### PR DESCRIPTION
This moves slug validation from the @sanity/schema package to the @sanity/validation package and makes it possible to import the @sanity/schema package without having a registered parts loader.

Also includes a few minor code cleanups (bf95bfd)