### PR TITLE
[form-builder] Resolve array of primitives input for to array of primitive subtypes

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.js
+++ b/packages/@sanity/form-builder/src/inputs/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.js
@@ -109,7 +109,7 @@ export default class ArrayOfPrimitivesInput extends React.PureComponent<Props> {
 
   getMemberType(typeName) {
     const {type} = this.props
-    return type.of.find(memberType => memberType.name === typeName)
+    return type.of.find(memberType => memberType.name === typeName || memberType.jsonType === typeName)
   }
 
   renderItem = (item, index) => {

--- a/packages/@sanity/form-builder/src/sanity/inputResolver/resolveArrayInput.js
+++ b/packages/@sanity/form-builder/src/sanity/inputResolver/resolveArrayInput.js
@@ -5,8 +5,10 @@ import TagsArrayInput from '../../inputs/TagsArrayInput'
 import * as is from '../../utils/is'
 import {get} from 'lodash'
 
+const PRIMITIVES = ['string', 'number', 'boolean']
+
 export function isArrayOfPrimitives(type) {
-  return type.of.every(is.primitive)
+  return type.of.every(ofType => PRIMITIVES.includes(ofType.jsonType))
 }
 
 function isTagsArray(type) {

--- a/packages/test-studio/schemas/arrays.js
+++ b/packages/test-studio/schemas/arrays.js
@@ -144,6 +144,18 @@ export default {
       ]
     },
     {
+      name: 'arrayOfEmails',
+      title: 'Array of email addresses',
+      description: 'This array contains only email addresses',
+      type: 'array',
+      of: [
+        {
+          type: 'email',
+          title: ''
+        }
+      ]
+    },
+    {
       name: 'arrayOfStringsWithLegacyList',
       title: 'Array of strings with legacy format on lists',
       description:


### PR DESCRIPTION
This is a workaround for a bug where array of primitive subtypes (e.g. `url`, `email`) did not resolve to the input for array of primitives.