### PR TITLE
[form-builder] Support inc + dec patches

### DIFF
--- a/packages/@sanity/form-builder/src/PatchEvent.js
+++ b/packages/@sanity/form-builder/src/PatchEvent.js
@@ -1,10 +1,10 @@
 // @flow
 import type {PathSegment, Patch} from './utils/patches'
-import {prefixPath, set, unset, setIfMissing, insert} from './utils/patches'
+import {prefixPath, set, unset, setIfMissing, insert, inc, dec} from './utils/patches'
 
 import {flatten} from 'lodash'
 
-export {set, unset, setIfMissing, insert}
+export {set, unset, setIfMissing, insert, inc, dec}
 
 type PatchArg = Patch | Array<Patch>
 

--- a/packages/@sanity/form-builder/src/sanity/utils/gradientPatchAdapter.js
+++ b/packages/@sanity/form-builder/src/sanity/utils/gradientPatchAdapter.js
@@ -49,6 +49,14 @@ function toFormBuilderPatch(origin: Origin, patch: GradientPatch): Patch {
                 origin
               }
             }
+            if (type === 'inc' || type === 'dec') {
+              return {
+                type: type,
+                path: convertPath.toFormBuilder(gradientPath),
+                value: patch[type][gradientPath],
+                origin
+              }
+            }
             if (type === 'setIfMissing') {
               return {
                 type: 'setIfMissing',

--- a/packages/@sanity/form-builder/src/utils/patches.js
+++ b/packages/@sanity/form-builder/src/utils/patches.js
@@ -25,6 +25,14 @@ export function unset(path: Path = []): UnsetPatch {
   return {type: 'unset', path}
 }
 
+export function inc(amount = 1, path: Path = []): IncPatch {
+  return {type: 'inc', path, value: amount}
+}
+
+export function dec(amount = 1, path: Path = []): DecPatch {
+  return {type: 'dec', path, value: amount}
+}
+
 export function prefixPath<T: HasPath>(patch: T, segment: PathSegment): T {
   return {
     ...patch,


### PR DESCRIPTION
This adds support for creating `inc` and `dec` patches from the form-builder

 - `inc(amount?: number, path?: Array)`
 - `dec(amount?: number, path?: Array)`

For example:
```js
import PatchEvent, {inc, dec} from 'part:@sanity/form-builder/patch-event'
// ...
this.props.onChange(
  PatchEvent.from([
    inc(1, ['someField']),
    dec(2, ['someOtherField'])
  ]))
)
```
