### PR TITLE
[desk-tool] Allow hamburger menus to be toggled

### DIFF
--- a/packages/@sanity/desk-tool/src/pane/DocumentsPane.js
+++ b/packages/@sanity/desk-tool/src/pane/DocumentsPane.js
@@ -140,16 +140,14 @@ export default withRouterHOC(
       writeSettingsForType(this.props.selectedType, this.state.settings)
     }
 
-    handleToggleMenu = () => {
-      this.setState({
-        menuIsOpen: !this.state.menuIsOpen
-      })
+    handleToggleMenu = evt => {
+      evt.stopPropagation()
+      this.setState(prevState => ({menuIsOpen: !prevState.menuIsOpen}))
     }
 
-    handleCloseMenu = () => {
-      this.setState({
-        menuIsOpen: !this.state.menuIsOpen
-      })
+    handleCloseMenu = evt => {
+      evt.stopPropagation()
+      this.setState(prevState => ({menuIsOpen: !prevState.menuIsOpen}))
     }
 
     getOrderingOptions(selectedType) {

--- a/packages/@sanity/desk-tool/src/pane/Editor.js
+++ b/packages/@sanity/desk-tool/src/pane/Editor.js
@@ -297,16 +297,14 @@ export default withRouterHOC(
       this.props.onCreate(deletedSnapshot)
     }
 
-    handleMenuToggle = () => {
-      this.setState(prevState => ({
-        isMenuOpen: !prevState.isMenuOpen
-      }))
+    handleMenuToggle = evt => {
+      evt.stopPropagation()
+      this.setState(prevState => ({isMenuOpen: !prevState.isMenuOpen}))
     }
 
-    handleMenuClose = () => {
-      this.setState({
-        isMenuOpen: false
-      })
+    handleMenuClose = evt => {
+      evt.stopPropagation()
+      this.setState({isMenuOpen: false})
     }
 
     handlePublishRequested = () => {


### PR DESCRIPTION
Clicking on the "hamburger icon" in the desk tool currently does not allow *toggling*. That is, when it is open, it won't close when clicking the icon. This is because both the "click outside" and the "click" action happens. This PR stops propagation when handling the event, which seems to do the trick without breaking anything else as far as I can tell.
