### PR TITLE
add postcss-url dependency to webpack-integration

### DIFF
--- a/packages/@sanity/webpack-integration/package.json
+++ b/packages/@sanity/webpack-integration/package.json
@@ -33,6 +33,7 @@
     "lost": "^8.0.0",
     "p-async-cache": "^1.0.2",
     "postcss-cssnext": "^3.0.2",
+    "postcss-url": "^7.3.1",
     "postcss-import": "^11.0.0",
     "resolve": "^1.3.3"
   },


### PR DESCRIPTION
v1 and v2 need it and it's not listed as a dependency