### PR TITLE
[import] Fix JSON parse errors not being emitted

### DIFF
--- a/packages/@sanity/import/src/util/getJsonStreamer.js
+++ b/packages/@sanity/import/src/util/getJsonStreamer.js
@@ -21,9 +21,16 @@ module.exports = function getJsonStreamer() {
 
       return doc
     } catch (err) {
-      this.emit('error', new Error(`Failed to parse line #${lineNumber}: ${err.message}`))
+      this.emit('error', new Error(getErrorMessage(err)))
     }
 
     return undefined
+  }
+
+  function getErrorMessage(err) {
+    const suffix =
+      lineNumber === 1 ? '\n\nMake sure this is valid ndjson (one JSON-document *per line*)' : ''
+
+    return `Failed to parse line #${lineNumber}: ${err.message}${suffix}`
   }
 }


### PR DESCRIPTION
Because of the new "peek at the stream to see if it's an ndjson or a tarball" behavior, JSON parse errors were not being surfaced. With this PR we apply a separate error handler on the ndjson stream and reject if encountering any errors. Because the concatenation stream finishes prior to the pipeline callback, I had to slightly change the flow to assign the gathered JSON-documents to a variable and resolving only on pipeline completion.
