### PR TITLE
[cli] Allow providing auth token through environment variable

### DIFF
--- a/packages/@sanity/cli/src/commands/debug/debugCommand.js
+++ b/packages/@sanity/cli/src/commands/debug/debugCommand.js
@@ -2,11 +2,11 @@ import printDebugInfo from './printDebugInfo'
 
 const help = `
 Gathers information on user and local/global Sanity environment, to help
-debugging Sanity-related issues. Pass --full to include API keys in output.`
+debugging Sanity-related issues. Pass --secrets to include API keys in output.`
 
 export default {
   name: 'debug',
-  signature: '[--full]',
+  signature: '[--secrets]',
   description: 'Gathers information on Sanity environment',
   helpText: help,
   action: printDebugInfo

--- a/packages/@sanity/cli/src/commands/debug/printDebugInfo.js
+++ b/packages/@sanity/cli/src/commands/debug/printDebugInfo.js
@@ -11,6 +11,7 @@ import {printResult as printVersionsResult} from '../versions/printVersionResult
 import findSanityModuleVersions from '../../actions/versions/findSanityModuleVersions'
 
 export default async (args, context) => {
+  const flags = args.extOptions
   const {user, globalConfig, projectConfig, project, versions} = await gatherInfo(context)
   const {chalk} = context
 
@@ -37,15 +38,21 @@ export default async (args, context) => {
   }
 
   // Auth info
-  if (globalConfig.authToken) {
+  // eslint-disable-next-line no-process-env
+  const authToken = process.env.SANITY_AUTH_TOKEN || globalConfig.authToken
+  if (authToken) {
     context.output.print('Authentication:')
     printKeyValue(
       {
         'User type': globalConfig.authType || 'normal',
-        'Auth token': globalConfig.authToken
+        'Auth token': flags.secrets ? authToken : `<redacted>`
       },
       context
     )
+
+    if (!flags.secrets) {
+      context.output.print('  (run with --secrets to reveal token)\n')
+    }
   }
 
   // Global configuration (user home dir config file)

--- a/packages/@sanity/cli/src/util/clientWrapper.js
+++ b/packages/@sanity/cli/src/util/clientWrapper.js
@@ -1,7 +1,11 @@
 import client from '@sanity/client'
 import getUserConfig from './getUserConfig'
 
-const sanityEnv = process.env.SANITY_ENV || 'production' // eslint-disable-line no-process-env
+/* eslint-disable no-process-env */
+const envAuthToken = process.env.SANITY_AUTH_TOKEN
+const sanityEnv = process.env.SANITY_ENV || 'production'
+/* eslint-enable no-process-env */
+
 const apiHosts = {
   staging: 'https://api.sanity.work',
   development: 'http://api.sanity.wtf'
@@ -19,7 +23,7 @@ const defaults = {
 
 const authErrors = () => ({
   onError: err => {
-    if (!err || !err.response) {
+    if (envAuthToken || !err || !err.response) {
       return err
     }
 
@@ -45,7 +49,7 @@ export default function clientWrapper(manifest, configPath) {
     const {requireUser, requireProject, api} = {...defaults, ...opts}
     const userConfig = getUserConfig()
     const userApiConf = userConfig.get('api')
-    const token = userConfig.get('authToken')
+    const token = envAuthToken || userConfig.get('authToken')
     const apiHost = apiHosts[sanityEnv]
     const apiConfig = Object.assign(
       {},


### PR DESCRIPTION
This PR makes the CLI read `SANITY_AUTH_TOKEN` environment variable for authentication purposes, making it easier for scripts and CI-environments to use the CLI tool. 
