### PR TITLE
[storybook] Pin version of @storybook/react

### DIFF
--- a/packages/@sanity/storybook/package.json
+++ b/packages/@sanity/storybook/package.json
@@ -27,7 +27,7 @@
     "@sanity/webpack-integration": "0.128.5",
     "@storybook/addon-knobs": "^3.2.8",
     "@storybook/addons": "^3.2.6",
-    "@storybook/react": "^3.2.8",
+    "@storybook/react": "3.2.8",
     "normalize.css": "^5.0.0",
     "react-addons-create-fragment": "^15.4.2",
     "shelljs": "^0.7.6"


### PR DESCRIPTION
Seems like `@storybook/react` has released a breaking change, or we're relying on some internal module exported by the package. Either way, the latest version gives the following error:
```
Storybook: module.js:540
    throw err;
    ^

Error: Cannot find module '@storybook/react/dist/server/middleware'
    at Function.Module._resolveFilename (module.js:538:15)
    at Function.Module._load (module.js:468:25)
    at Module.require (module.js:587:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (~/sanity/packages/@sanity/storybook/lib/server/server.js:7:20)
    at Module._compile (module.js:643:30)
    at Object.Module._extensions..js (module.js:654:10)
    at Module.load (module.js:556:32)
    at tryModuleLoad (module.js:499:12)
    at Function.Module._load (module.js:491:3)
```

Don't have time to investigate further right now. This fixes it by pinning the version of `@react/storybook` to `3.2.8`.
