### PR TITLE
[core] Allow importing datasets from directory 

### DIFF
--- a/packages/@sanity/core/package.json
+++ b/packages/@sanity/core/package.json
@@ -40,7 +40,6 @@
     "fs-extra": "^5.0.0",
     "get-uri": "^2.0.1",
     "json-lexer": "^1.1.1",
-    "linecount": "^1.0.1",
     "lodash": "^4.17.4",
     "path-exists": "^3.0.0",
     "pretty-ms": "^2.1.0",

--- a/packages/@sanity/core/src/commands/dataset/importDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/importDatasetCommand.js
@@ -13,15 +13,26 @@ Options
   --replace On duplicate document IDs, replace existing document with imported document
 
 Examples
+  # Import "moviedb.ndjson" from the current directory to the dataset called "moviedb"
   sanity import moviedb.ndjson moviedb
-  sanity import moviedb.ndjson moviedb --replace
+
+  # Import "moviedb.tar.gz" from the current directory to the dataset called "moviedb",
+  # replacing any documents encountered that have the same document IDs
+  sanity import moviedb.tar.gz moviedb --replace
+
+  # Import from a folder containing an ndjson file, such as an extracted tarball
+  # retrieved through "sanity dataset export".
+  sanity import ~/some/folder moviedb
+
+  # Import from a remote URL. Will download and extract the tarball to a temporary
+  # location before importing it.
   sanity import https://some.url/moviedb.tar.gz moviedb --replace
 `
 
 export default {
   name: 'import',
   group: 'dataset',
-  signature: '[FILE] [TARGET_DATASET]',
+  signature: '[FILE | FOLDER | URL] [TARGET_DATASET]',
   description: 'Import documents to given dataset from ndjson file',
   helpText,
   action: async (args, context) => {

--- a/packages/@sanity/import/src/import.js
+++ b/packages/@sanity/import/src/import.js
@@ -9,10 +9,20 @@ const importers = {
   fromArray
 }
 
-module.exports = (input, opts) => {
-  const options = validateOptions(input, opts)
+module.exports = async (input, opts) => {
+  const options = await validateOptions(input, opts)
 
-  return Array.isArray(input)
-    ? fromArray(input, options, importers)
-    : fromStream(input, options, importers)
+  if (typeof input.pipe === 'function') {
+    return fromStream(input, options, importers)
+  }
+
+  if (Array.isArray(input)) {
+    return fromArray(input, options, importers)
+  }
+
+  if (typeof input === 'string') {
+    return fromFolder(input, options, importers)
+  }
+
+  throw new Error('Stream does not seem to be a readable stream, an array or a path to a directory')
 }

--- a/packages/@sanity/import/src/uploadAssets.js
+++ b/packages/@sanity/import/src/uploadAssets.js
@@ -1,6 +1,5 @@
 const basename = require('path').basename
 const parseUrl = require('url').parse
-const crypto = require('crypto')
 const debug = require('debug')('sanity:import')
 const pMap = require('p-map')
 const progressStepper = require('./util/progressStepper')

--- a/packages/@sanity/import/src/util/getHashedBufferForUri.js
+++ b/packages/@sanity/import/src/util/getHashedBufferForUri.js
@@ -3,28 +3,30 @@ const miss = require('mississippi')
 const getUri = require('@rexxars/get-uri')
 
 module.exports = function getHashedBufferForUri(uri) {
-  return new Promise(async (resolve, reject) => {
-    const stream = await getStream(uri)
-    const hash = crypto.createHash('sha1')
-    const chunks = []
+  return getStream(uri).then(
+    stream =>
+      new Promise((resolve, reject) => {
+        const hash = crypto.createHash('sha1')
+        const chunks = []
 
-    stream.on('data', chunk => {
-      chunks.push(chunk)
-      hash.update(chunk)
-    })
+        stream.on('data', chunk => {
+          chunks.push(chunk)
+          hash.update(chunk)
+        })
 
-    miss.finished(stream, err => {
-      if (err) {
-        reject(err)
-        return
-      }
+        miss.finished(stream, err => {
+          if (err) {
+            reject(err)
+            return
+          }
 
-      resolve({
-        buffer: Buffer.concat(chunks),
-        sha1hash: hash.digest('hex')
+          resolve({
+            buffer: Buffer.concat(chunks),
+            sha1hash: hash.digest('hex')
+          })
+        })
       })
-    })
-  })
+  )
 }
 
 function getStream(uri) {

--- a/packages/@sanity/import/src/util/getJsonStreamer.js
+++ b/packages/@sanity/import/src/util/getJsonStreamer.js
@@ -21,7 +21,8 @@ module.exports = function getJsonStreamer() {
 
       return doc
     } catch (err) {
-      this.emit('error', new Error(getErrorMessage(err)))
+      const errorMessage = getErrorMessage(err)
+      this.emit('error', new Error(errorMessage))
     }
 
     return undefined

--- a/packages/@sanity/import/src/validateOptions.js
+++ b/packages/@sanity/import/src/validateOptions.js
@@ -1,3 +1,4 @@
+const fse = require('fs-extra')
 const noop = require('lodash/noop')
 const defaults = require('lodash/defaults')
 
@@ -11,8 +12,10 @@ function validateOptions(input, opts) {
     onProgress: noop
   })
 
-  if (!input || (typeof input.pipe !== 'function' && !Array.isArray(input))) {
-    throw new Error('Stream does not seem to be a readable stream or an array')
+  if (!isValidInput(input)) {
+    throw new Error(
+      'Stream does not seem to be a readable stream, an array or a path to a directory'
+    )
   }
 
   if (!options.client) {
@@ -37,6 +40,36 @@ function validateOptions(input, opts) {
   }
 
   return options
+}
+
+function isValidInput(input) {
+  if (!input) {
+    return false
+  }
+
+  if (typeof input.pipe === 'function') {
+    return true
+  }
+
+  if (Array.isArray(input)) {
+    return true
+  }
+
+  if (typeof input === 'string' && isDirectory(input)) {
+    return true
+  }
+
+  return false
+}
+
+function isDirectory(path) {
+  try {
+    // eslint-disable-next-line no-sync
+    const stats = fse.statSync(path)
+    return stats.isDirectory()
+  } catch (err) {
+    return false
+  }
 }
 
 module.exports = validateOptions

--- a/packages/@sanity/import/test/__snapshots__/import.test.js.snap
+++ b/packages/@sanity/import/test/__snapshots__/import.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`employee creation 1`] = `
+exports[`accepts a stream as source: employee creation 1`] = `
 Object {
   "mutations": Array [
     Object {
@@ -21,7 +21,7 @@ Object {
 }
 `;
 
-exports[`employee creation 2`] = `
+exports[`accepts an array as source: employee creation 1`] = `
 Object {
   "mutations": Array [
     Object {

--- a/packages/@sanity/import/test/__snapshots__/uploadAssets.test.js.snap
+++ b/packages/@sanity/import/test/__snapshots__/uploadAssets.test.js.snap
@@ -1,6 +1,54 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`batch patching (batch #1) 1`] = `
+exports[`fails if asset download fails 1`] = `
+[Error: Error while fetching asset from "http://127.0.0.1:49999/img.gif":
+connect ECONNREFUSED 127.0.0.1:49999]
+`;
+
+exports[`fails if asset lookup fails 1`] = `
+[Error: Error while attempt to query Sanity API:
+Some network err]
+`;
+
+exports[`will reuse an existing asset if it exists: single asset mutation 1`] = `
+Object {
+  "mutations": Array [
+    Object {
+      "patch": Object {
+        "id": "movie_1",
+        "set": Object {
+          "metadata.poster._type": "someAssetI",
+          "metadata.poster.asset": Object {
+            "_ref": "someAssetId",
+            "_type": "reference",
+          },
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`will upload asset that do not already exist: single create mutation 1`] = `
+Object {
+  "mutations": Array [
+    Object {
+      "patch": Object {
+        "id": "movie_1",
+        "set": Object {
+          "metadata.poster._type": "newAssetI",
+          "metadata.poster.asset": Object {
+            "_ref": "newAssetId",
+            "_type": "reference",
+          },
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`will upload once but batch patches: batch patching (batch #1) 1`] = `
 Object {
   "mutations": Array [
     Object {
@@ -607,7 +655,7 @@ Object {
 }
 `;
 
-exports[`batch patching (batch #2) 1`] = `
+exports[`will upload once but batch patches: batch patching (batch #2) 1`] = `
 Object {
   "mutations": Array [
     Object {
@@ -725,54 +773,6 @@ Object {
           "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
-            "_type": "reference",
-          },
-        },
-      },
-    },
-  ],
-}
-`;
-
-exports[`fails if asset download fails 1`] = `
-[Error: Error while fetching asset from "http://127.0.0.1:49999/img.gif":
-connect ECONNREFUSED 127.0.0.1:49999]
-`;
-
-exports[`fails if asset lookup fails 1`] = `
-[Error: Error while attempt to query Sanity API:
-Some network err]
-`;
-
-exports[`single asset mutation 1`] = `
-Object {
-  "mutations": Array [
-    Object {
-      "patch": Object {
-        "id": "movie_1",
-        "set": Object {
-          "metadata.poster._type": "someAssetI",
-          "metadata.poster.asset": Object {
-            "_ref": "someAssetId",
-            "_type": "reference",
-          },
-        },
-      },
-    },
-  ],
-}
-`;
-
-exports[`single create mutation 1`] = `
-Object {
-  "mutations": Array [
-    Object {
-      "patch": Object {
-        "id": "movie_1",
-        "set": Object {
-          "metadata.poster._type": "newAssetI",
-          "metadata.poster.asset": Object {
-            "_ref": "newAssetId",
             "_type": "reference",
           },
         },

--- a/packages/@sanity/import/test/helpers/helpers.js
+++ b/packages/@sanity/import/test/helpers/helpers.js
@@ -2,6 +2,11 @@ const noop = require('lodash/noop')
 const sanityClient = require('@sanity/client')
 const {injectResponse} = require('get-it/middleware')
 
+process.on('unhandledRejection', reason => {
+  // eslint-disable-next-line no-console
+  console.error('UNHANDLED REJECTION', reason)
+})
+
 const defaultClientOptions = {
   projectId: 'foo',
   dataset: 'bar',

--- a/packages/@sanity/import/test/import.test.js
+++ b/packages/@sanity/import/test/import.test.js
@@ -2,8 +2,8 @@
 const fs = require('fs')
 const path = require('path')
 const sanityClient = require('@sanity/client')
-const {getSanityClient} = require('./helpers')
 const importer = require('../')
+const {getSanityClient} = require('./helpers')
 
 const defaultClient = sanityClient({
   projectId: 'foo',
@@ -25,20 +25,23 @@ const getFixtureArray = fix =>
     .map(JSON.parse)
 
 test('rejects on invalid input type (null/undefined)', async () => {
+  expect.assertions(1)
   await expect(importer(null, importOptions)).rejects.toHaveProperty(
     'message',
-    'Stream does not seem to be a readable stream or an array'
+    'Stream does not seem to be a readable stream, an array or a path to a directory'
   )
 })
 
 test('rejects on invalid input type (non-array)', async () => {
+  expect.assertions(1)
   await expect(importer({}, importOptions)).rejects.toHaveProperty(
     'message',
-    'Stream does not seem to be a readable stream or an array'
+    'Stream does not seem to be a readable stream, an array or a path to a directory'
   )
 })
 
 test('rejects on invalid JSON', async () => {
+  expect.assertions(1)
   await expect(importer(getFixtureStream('invalid-json'), importOptions)).rejects.toHaveProperty(
     'message',
     'Failed to parse line #3: Unexpected token _ in JSON at position 1'
@@ -46,6 +49,7 @@ test('rejects on invalid JSON', async () => {
 })
 
 test('rejects on invalid `_id` property', async () => {
+  expect.assertions(1)
   await expect(importer(getFixtureStream('invalid-id'), importOptions)).rejects.toHaveProperty(
     'message',
     'Failed to parse line #2: Document contained an invalid "_id" property - must be a string'
@@ -53,6 +57,7 @@ test('rejects on invalid `_id` property', async () => {
 })
 
 test('rejects on invalid `_id` property format', async () => {
+  expect.assertions(1)
   await expect(
     importer(getFixtureStream('invalid-id-format'), importOptions)
   ).rejects.toHaveProperty(
@@ -62,6 +67,7 @@ test('rejects on invalid `_id` property format', async () => {
 })
 
 test('rejects on missing `_type` property', async () => {
+  expect.assertions(1)
   await expect(importer(getFixtureStream('missing-type'), importOptions)).rejects.toHaveProperty(
     'message',
     'Failed to parse line #3: Document did not contain required "_type" property of type string'
@@ -69,6 +75,7 @@ test('rejects on missing `_type` property', async () => {
 })
 
 test('rejects on missing `_type` property (from array)', async () => {
+  expect.assertions(1)
   await expect(importer(getFixtureArray('missing-type'), importOptions)).rejects.toHaveProperty(
     'message',
     'Failed to parse document at index #2: Document did not contain required "_type" property of type string'
@@ -76,6 +83,7 @@ test('rejects on missing `_type` property (from array)', async () => {
 })
 
 test('accepts an array as source', async () => {
+  expect.assertions(2)
   const docs = getFixtureArray('employees')
   const client = getSanityClient(getMockMutationHandler())
   const res = await importer(docs, {client})
@@ -83,12 +91,14 @@ test('accepts an array as source', async () => {
 })
 
 test('accepts a stream as source', async () => {
+  expect.assertions(2)
   const client = getSanityClient(getMockMutationHandler())
   const res = await importer(getFixtureStream('employees'), {client})
   expect(res).toBe(2)
 })
 
 test('generates uuids for documents without id', async () => {
+  expect.assertions(4)
   const match = body => {
     expect(body.mutations[0].create._id).toMatch(uuidMatcher)
     expect(body.mutations[1].create._id).toBe('pk')

--- a/packages/@sanity/import/test/uploadAssets.test.js
+++ b/packages/@sanity/import/test/uploadAssets.test.js
@@ -19,12 +19,12 @@ const fetchFailClient = {
 }
 
 test('fails if asset download fails', () => {
+  expect.assertions(1)
   const asset = Object.assign({}, fileAsset, {
     url: 'http://127.0.0.1:49999/img.gif'
   })
 
-  const upload = uploadAssets([asset], {client: null, onProgress: noop})
-  return expect(upload).rejects.toMatchSnapshot()
+  return expect(uploadAssets([asset], {client: null, onProgress: noop})).rejects.toMatchSnapshot()
 })
 
 test('fails if asset lookup fails', () => {

--- a/packages/@sanity/storybook/package.json
+++ b/packages/@sanity/storybook/package.json
@@ -27,7 +27,7 @@
     "@sanity/webpack-integration": "0.128.5",
     "@storybook/addon-knobs": "^3.2.8",
     "@storybook/addons": "^3.2.6",
-    "@storybook/react": "^3.2.8",
+    "@storybook/react": "3.2.8",
     "normalize.css": "^5.0.0",
     "react-addons-create-fragment": "^15.4.2",
     "shelljs": "^0.7.6"


### PR DESCRIPTION
As the title says. I also snuck in a few fixes for an issue where the streams would not be destroyed when encountering an error, leading to unnecessary work and API requests.