### PR TITLE
[components] Pin version of popper.js (fixes #709)

### DIFF
--- a/packages/@sanity/components/package.json
+++ b/packages/@sanity/components/package.json
@@ -51,6 +51,7 @@
     "react-element-query": "^3.0.2",
     "react-ink": "^6.1.0",
     "react-popper": "^0.8.2",
+    "popper.js": "1.14.1",
     "react-sortable-hoc": "^0.6.3",
     "react-split-pane": "^0.1.63",
     "scroll": "^2.0.0"


### PR DESCRIPTION
Due to a regression in a recent patch release of popper.js (which we depend on through react-popper), the reference input suddenly stopped displaying hits (see #709).   

Related issue in react-popper here: souporserious/react-popper/issues/122

This fixes it by pinning the popper.js version.