### PR TITLE
[image-url] Fix parsing image source

### DIFF
--- a/packages/@sanity/image-url/src/urlForImage.js
+++ b/packages/@sanity/image-url/src/urlForImage.js
@@ -65,19 +65,19 @@ export function parseSource(source) {
   let image
 
   // Did we just get an asset id?
-  if (typeof source == 'string') {
+  if (typeof source === 'string') {
     image = {
       asset: {_ref: source}
     }
   } else if (
-    source._type == 'sanity.imageAsset' ||
-    (typeof source == 'object' && typeof source._ref == 'string')
+    source._type === 'sanity.imageAsset' ||
+    (typeof source === 'object' && typeof source._ref === 'string')
   ) {
     // We just got passed an asset directly
     image = {
       asset: source
     }
-  } else if (typeof source == 'object' && typeof source.asset == 'object') {
+  } else if (typeof source === 'object' && typeof source.asset === 'object') {
     image = source
   } else {
     // We got something that does not look like an image, or it is an image

--- a/packages/@sanity/image-url/src/urlForImage.js
+++ b/packages/@sanity/image-url/src/urlForImage.js
@@ -61,15 +61,18 @@ export default function urlForImage(options) {
 }
 
 // Convert an asset-id, asset or image to an image record suitable for processing
-function parseSource(source) {
+export function parseSource(source) {
   let image
 
   // Did we just get an asset id?
   if (typeof source == 'string') {
     image = {
-      asset: {_ref: image}
+      asset: {_ref: source}
     }
-  } else if (source._type == 'sanity.imageAsset') {
+  } else if (
+    source._type == 'sanity.imageAsset' ||
+    (typeof source == 'object' && typeof source._ref == 'string')
+  ) {
     // We just got passed an asset directly
     image = {
       asset: source

--- a/packages/@sanity/image-url/test/parseSource.test.js
+++ b/packages/@sanity/image-url/test/parseSource.test.js
@@ -9,7 +9,7 @@ function compareParsedSource(outputSource, exptectedSource) {
   should(outputSource).have.keys('crop', 'hotspot')
 }
 
-describe.only('[image-url] parseSource', () => {
+describe('[image-url] parseSource', () => {
   it('does correctly parse full image object', () => {
     const parsedSource = parseSource(imageWithNoCropSpecified())
     compareParsedSource(parsedSource, imageWithNoCropSpecified())

--- a/packages/@sanity/image-url/test/parseSource.test.js
+++ b/packages/@sanity/image-url/test/parseSource.test.js
@@ -1,0 +1,28 @@
+import should from 'should'
+import {parseSource} from '../src/urlForImage'
+import {imageWithNoCropSpecified, croppedImage} from './fixtures'
+
+function compareParsedSource(outputSource, exptectedSource) {
+  should(outputSource).be.an.Object()
+  should(outputSource.asset).be.an.Object()
+  should(outputSource.asset._ref).be.eql(exptectedSource.asset._ref)
+  should(outputSource).have.keys('crop', 'hotspot')
+}
+
+describe.only('[image-url] parseSource', () => {
+  it('does correctly parse full image object', () => {
+    const parsedSource = parseSource(imageWithNoCropSpecified())
+    compareParsedSource(parsedSource, imageWithNoCropSpecified())
+  })
+  it('does correctly parse asset object', () => {
+    const parsedSource = parseSource(imageWithNoCropSpecified().asset._ref)
+    compareParsedSource(parsedSource, imageWithNoCropSpecified())
+  })
+  it('does correctly parse image asset _ref', () => {
+    const parsedSource = parseSource(imageWithNoCropSpecified().asset)
+    compareParsedSource(parsedSource, imageWithNoCropSpecified())
+  })
+  it('does not overwrite cropp or hotspot settings', () => {
+    should(parseSource(croppedImage())).deepEqual(croppedImage())
+  })
+})


### PR DESCRIPTION
According to documentation `image(source)` "Accepts either a Sanity image record, an asset record, or just the asset id as a string."

`@sanity/image-url` from master works only when whole Sanity image record is passed. For an asset record it is returning `null` and for asset id as string (`_ref`) is trowing an exception.