### PR TITLE
[form-builder] Min width causes image dialog to fail

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/FormBuilderBlock.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/FormBuilderBlock.js
@@ -265,7 +265,7 @@ export default class FormBuilderBlock extends React.Component {
     const memberType = this.getMemberTypeOf(value)
 
     return (
-      <div style={{minWidth: '30rem', padding: '1rem'}}>
+      <div style={{padding: '1rem'}}>
         <FormBuilderInput
           type={memberType}
           level={1}


### PR DESCRIPTION
Fixes a bug where an insert dialog in block editor is too wide on mobile, and makes it clip

![image_uploaded_from_ios](https://user-images.githubusercontent.com/568562/38701437-211b5b74-3e9e-11e8-959d-d3cc70e1357d.png)
