### PR TITLE
[cli] Don't show upgrade prompt on same version

### DIFF
--- a/packages/@sanity/cli/src/util/updateNotifier.js
+++ b/packages/@sanity/cli/src/util/updateNotifier.js
@@ -72,7 +72,7 @@ export default options => {
       return
     }
 
-    if (!newVersion) {
+    if (!newVersion || semverCompare(newVersion, version) <= 0) {
       return
     }
 


### PR DESCRIPTION
In certain edge cases, we displayed a prompt telling the user that an upgrade was available when it actually wasn't. This PR checks whether we have a diff in the versions before prompting.