### PR TITLE
[validation] Include $ in path on reference validation errors

### DIFF
--- a/packages/@sanity/validation/src/validators/objectValidator.js
+++ b/packages/@sanity/validation/src/validators/objectValidator.js
@@ -19,7 +19,7 @@ const reference = (unused, value, message) => {
   }
 
   if (typeof value._ref !== 'string') {
-    return new ValidationError(message || 'Must be a reference to a document')
+    return new ValidationError(message || 'Must be a reference to a document', {paths: ['$']})
   }
 
   return true


### PR DESCRIPTION
This will ensure that the reference search dialog is opened