### PR TITLE
[core] Add `--with-user-token` flag for exec command

### DIFF
--- a/packages/@sanity/core/package.json
+++ b/packages/@sanity/core/package.json
@@ -33,6 +33,7 @@
     "babel-preset-env": "^1.6.1",
     "babel-register": "^6.26.0",
     "batch-stream-operation": "^1.0.2",
+    "configstore": "^3.0.0",
     "debug": "^3.1.0",
     "deep-sort-object": "^1.0.1",
     "es6-promisify": "^6.0.0",

--- a/packages/@sanity/core/src/actions/exec/configClient.js
+++ b/packages/@sanity/core/src/actions/exec/configClient.js
@@ -1,0 +1,24 @@
+const ConfigStore = require('configstore')
+const client = require('part:@sanity/base/client?')
+
+if (!client) {
+  throw new Error('--with-user-token specified, but @sanity/base is not a plugin in this project')
+}
+
+// eslint-disable-next-line no-process-env
+const sanityEnv = (process.env.SANITY_ENV || '').toLowerCase()
+const defaults = {}
+const config = new ConfigStore(
+  sanityEnv && sanityEnv !== 'production' ? `sanity-${sanityEnv}` : 'sanity',
+  defaults,
+  {globalConfigPath: true}
+)
+
+const token = config.get('authToken')
+if (!token) {
+  throw new Error(
+    '--with-user-token specified, but no auth token could be found. Run `sanity login`'
+  )
+}
+
+client.config({token})

--- a/packages/@sanity/core/src/commands/exec/execCommand.js
+++ b/packages/@sanity/core/src/commands/exec/execCommand.js
@@ -1,8 +1,22 @@
 import lazyRequire from '@sanity/util/lib/lazyRequire'
 
+const helpText = `
+Options
+  --with-user-token
+
+Examples
+  # Run the script at some/script.js in Sanity context
+  sanity exec some/script.js
+
+  # Run the script at migrations/fullname.js and configure \`part:@sanity/base/client\`
+  # to include the current users token
+  sanity exec migrations/fullname.js --with-user-token
+`
+
 export default {
   name: 'exec',
   signature: 'SCRIPT',
   description: 'Runs a script in Sanity context',
+  helpText,
   action: lazyRequire(require.resolve('../../actions/exec/execScript'))
 }


### PR DESCRIPTION
With this PR, you can use the `--with-user-token` option when running `sanity exec` to easily be able to import a preconfigured, authenticated client from `part:@sanity/base/client`.
