### PR TITLE
[form-builder] Fix bug causing form-builder to fail on patches w/ifRevisionID

### DIFF
--- a/packages/@sanity/form-builder/src/sanity/utils/gradientPatchAdapter.js
+++ b/packages/@sanity/form-builder/src/sanity/utils/gradientPatchAdapter.js
@@ -15,10 +15,12 @@ export function toFormBuilder(origin: Origin, patches: GradientPatch[]): Patch[]
   return flatten(patches.map(patch => toFormBuilderPatch(origin, patch)))
 }
 
+const notIn = values => value => !values.includes(value)
+
 function toFormBuilderPatch(origin: Origin, patch: GradientPatch): Patch {
   return flatten(
     Object.keys(patch)
-      .filter(key => key !== 'id')
+      .filter(notIn(['id', 'ifRevisionID', 'query']))
       .map(type => {
         if (type === 'unset') {
           return patch.unset.map(path => {
@@ -70,13 +72,6 @@ function toFormBuilderPatch(origin: Origin, patch: GradientPatch): Patch {
                 type: 'diffMatchPatch',
                 path: convertPath.toFormBuilder(gradientPath),
                 value: patch[type][gradientPath],
-                origin
-              }
-            }
-            if (type === 'ifRevisionID') {
-              return {
-                type: 'ifRevisionID',
-                value: patch[type],
                 origin
               }
             }


### PR DESCRIPTION
This fixes a bug causing an error when form builder code expected the recieved patch to include a path property.

Fixed it by filtering out the `ifRevisionID`-field from received patches and not treating `ifRevisionID` as a kind of patch.