### PR TITLE
[validation] Fix wrong URL constructor invocation. Fixes #751

### DIFF
--- a/packages/@sanity/validation/src/validators/stringValidator.js
+++ b/packages/@sanity/validation/src/validators/stringValidator.js
@@ -39,7 +39,9 @@ const uri = (constraints, value, message) => {
 
   let url
   try {
-    url = new URL(strValue, allowRelative ? DUMMY_ORIGIN : undefined)
+    // WARNING: Safari checks for a given `base` param by looking at the length of arguments passed
+    // to new URL(str, base), and will fail if invoked with new URL(strValue, undefined)
+    url = allowRelative ? new URL(strValue, DUMMY_ORIGIN) : new URL(strValue)
   } catch (err) {
     return new ValidationError(message || 'Not a valid URL')
   }


### PR DESCRIPTION
Invoking `new URL(<insert valid url here>, undefined)` in Safari always throws an error.