### PR TITLE
[preview] Tolerate invalid values returned from preview config and provide helpful errors

### DIFF
--- a/packages/@sanity/preview/src/components/PreviewSubscriber.js
+++ b/packages/@sanity/preview/src/components/PreviewSubscriber.js
@@ -5,6 +5,14 @@ import observeForPreview from '../observeForPreview'
 import shallowEquals from 'shallow-equals'
 import intersectionObservableFor from '../streams/intersectionObservableFor'
 import visibilityChange$ from '../streams/visibilityChange'
+import {INVALID_PREVIEW_CONFIG} from '../constants'
+import WarningIcon from 'part:@sanity/base/warning-icon'
+
+const INVALID_PREVIEW_FALLBACK = {
+  title: <span style={{fontStyle: 'italic'}}>Invalid preview config</span>,
+  subtitle: <span style={{fontStyle: 'italic'}}>Check the error log in the console</span>,
+  media: WarningIcon
+}
 
 // How long to wait before signalling tear down of subscriptions
 const DELAY_MS = 20 * 1000
@@ -95,16 +103,13 @@ export default class PreviewSubscriber extends React.PureComponent {
   render() {
     const {result, isLive, error} = this.state
     const {children: Child, ...props} = this.props
+    const snapshot =
+      result.snapshot === INVALID_PREVIEW_CONFIG ? INVALID_PREVIEW_FALLBACK : result.snapshot
+
     return (
       // note: the root element here should be a span since this component may be used to display inline previews
       <span ref={this.setElement}>
-        <Child
-          snapshot={result.snapshot}
-          type={result.type}
-          isLive={isLive}
-          error={error}
-          {...props}
-        />
+        <Child snapshot={snapshot} type={result.type} isLive={isLive} error={error} {...props} />
       </span>
     )
   }

--- a/packages/@sanity/preview/src/constants.js
+++ b/packages/@sanity/preview/src/constants.js
@@ -1,4 +1,4 @@
 export const INCLUDE_FIELDS_QUERY = ['_id', '_rev', '_type']
 export const INCLUDE_FIELDS = [...INCLUDE_FIELDS_QUERY, '_key']
 
-export const INVALID_PREVIEW_CONFIG = {}
+export const INVALID_PREVIEW_CONFIG = Symbol('invalid preview config')

--- a/packages/@sanity/preview/src/constants.js
+++ b/packages/@sanity/preview/src/constants.js
@@ -1,2 +1,4 @@
 export const INCLUDE_FIELDS_QUERY = ['_id', '_rev', '_type']
 export const INCLUDE_FIELDS = [...INCLUDE_FIELDS_QUERY, '_key']
+
+export const INVALID_PREVIEW_CONFIG = {}

--- a/packages/@sanity/preview/src/prepareForPreview.js
+++ b/packages/@sanity/preview/src/prepareForPreview.js
@@ -1,74 +1,243 @@
-import {get, pick, debounce, flatten, uniqBy} from 'lodash'
+// @flow
+import {debounce, flatten, get, isPlainObject, pick, uniqBy} from 'lodash'
+import {INVALID_PREVIEW_CONFIG} from './constants'
 
-const pass = v => v
+const identity = v => v
 const PRESERVE_KEYS = ['_id', '_type', '_upload']
+const EMPTY = []
 
-let COLLECTED_ERRORS = {}
+type __DEV__ = boolean
+
+type ViewOptions = {}
+
+type SelectedValue = {}
+
+type PreparedValue = {
+  title: string,
+  subtitle: string,
+  description: string
+}
+
+type PreviewConfig = {
+  select: {[string]: string},
+  prepare?: (SelectedValue, ViewOptions) => PreparedValue
+}
+
+type Type = {
+  name: string,
+  preview: PreviewConfig
+}
+
+type PrepareInvocationResult = {|
+  selectedValue: SelectedValue,
+  returnValue: PreparedValue,
+  errors: Error[]
+|}
+
+const errorCollector = (() => {
+  let errorsByType = {}
+
+  return {
+    add: (type: Type, value: SelectedValue, error: Error) => {
+      if (!errorsByType[type.name]) {
+        errorsByType[type.name] = []
+      }
+      errorsByType[type.name].push({error: error, type: type, value})
+    },
+    getAll() {
+      return errorsByType
+    },
+    clear() {
+      errorsByType = {}
+    }
+  }
+})()
 
 const reportErrors = debounce(() => {
   /* eslint-disable no-console */
+  const errorsByType = errorCollector.getAll()
   const uniqueErrors = flatten(
-    Object.keys(COLLECTED_ERRORS).map(typeName => {
-      const entries = COLLECTED_ERRORS[typeName]
+    Object.keys(errorsByType).map(typeName => {
+      const entries = errorsByType[typeName]
       return uniqBy(entries, entry => entry.error.message)
     })
   )
   const errorCount = uniqueErrors.length
+  if (errorCount === 0) {
+    return
+  }
+
   console.groupCollapsed(
     `%cHeads up! Got ${
       errorCount === 1 ? 'error' : `${errorCount} errors`
     } while preparing data for preview. Click for details.` +
-      ' This may be a hard failure in production and cause your application to crash.',
+      ' This may be a hard failure in production and cause your Studio to crash.',
     'color: #ff7e7c'
   )
 
-  Object.keys(COLLECTED_ERRORS).forEach(typeName => {
-    const entries = COLLECTED_ERRORS[typeName]
+  Object.keys(errorsByType).forEach(typeName => {
+    const entries = errorsByType[typeName]
     const first = entries[0]
-    console.group(`%o for type "${typeName}" (x${entries.length})`, first.type.preview.prepare)
-    uniqBy(entries, entry => entry.error.message).forEach(entry => {
-      const {value, error} = entry
-      console.log('The call to prepare(%o) failed with:', value)
-      console.error(error)
+    console.group(`Check the preview config for schema type "${typeName}": %o`, first.type.preview)
+    const uniqued = uniqBy(entries, entry => entry.error.message)
+    uniqued.forEach(entry => {
+      if (entry.error.type === 'returnValueError') {
+        const hasPrepare = typeof entry.type.preview.prepare === 'function'
+        const {value, error} = entry
+        console.log(
+          `Encountered an invalid ${
+            hasPrepare
+              ? 'return value when calling prepare(%o)'
+              : 'value targeted by preview.select'
+          }:`,
+          value
+        )
+        console.error(error)
+      }
+      if (entry.error.type === 'prepareError') {
+        const {value, error} = entry
+        console.log('Encountered an error when calling prepare(%o):', value)
+        console.error(error)
+      }
     })
     console.groupEnd()
   })
   console.groupEnd()
-  COLLECTED_ERRORS = {}
+  errorCollector.clear()
   /* eslint-enable no-console */
 }, 1000)
 
-function invokePrepareChecked(type, value, viewOptions) {
-  const prepare = type.preview.prepare
-  if (!prepare) {
-    return value
-  }
-  try {
-    return prepare(value, viewOptions)
-  } catch (error) {
-    if (!COLLECTED_ERRORS[type.name]) {
-      COLLECTED_ERRORS[type.name] = []
-    }
-    COLLECTED_ERRORS[type.name].push({error: error, type, value})
-    reportErrors()
-  }
-  return value
+const stringValidatorFor = fieldName => value =>
+  typeof value === 'string'
+    ? EMPTY
+    : [
+        assignType(
+          'returnValueError',
+          new Error(`The "${fieldName}" field should be a string, instead saw ${inspect(value)}`)
+        )
+      ]
+
+const FIELD_NAME_VALIDATORS = {
+  media: () => {
+    // not sure how to validate media as it would  possibly involve executing a function and check the
+    // return value
+    return EMPTY
+  },
+  title: stringValidatorFor('title'),
+  subtitle: stringValidatorFor('subtitle'),
+  description: stringValidatorFor('description'),
+  imageUrl: stringValidatorFor('imageUrl'),
+  date: stringValidatorFor('date')
 }
 
-function invokePrepareUnchecked(type, value, viewOptions) {
-  return (type.preview.prepare || pass)(value, viewOptions)
+function inspect(val, prefixType = true) {
+  if (isPlainObject(val)) {
+    const keys = Object.keys(val)
+    const ellipse = keys.length > 3 ? '...' : ''
+    const prefix = `object with keys `
+    return `${prefixType ? prefix : ''}{${keys.slice(0, 3).join(', ')}${ellipse}}`
+  }
+  if (Array.isArray(val)) {
+    const ellipse = val.length > 3 ? '...' : ''
+    const prefix = `array with `
+    return `${prefixType ? prefix : ''}[${val.map(v => inspect(v, false))}${ellipse}]`
+  }
+  return `the ${typeof val} ${val}`
+}
+
+function validateFieldValue(fieldName, fieldValue) {
+  if (typeof fieldValue === 'undefined') {
+    return EMPTY
+  }
+  const validator = FIELD_NAME_VALIDATORS[fieldName]
+  return (validator && validator(fieldValue)) || EMPTY
+}
+
+function assignType(type, error) {
+  return Object.assign(error, {type})
+}
+
+function validatePreparedValue(preparedValue: PreparedValue) {
+  if (!isPlainObject(preparedValue)) {
+    return [
+      assignType(
+        'returnValueError',
+        new Error(
+          `Invalid return value. Expected a plain object with at least a 'title' field, instead saw ${inspect(
+            preparedValue
+          )}`
+        )
+      )
+    ]
+  }
+  return Object.keys(preparedValue).reduce((acc, fieldName) => {
+    return [...acc, ...validateFieldValue(fieldName, preparedValue[fieldName])]
+  }, EMPTY)
+}
+
+function validateReturnedPreview(result: PrepareInvocationResult) {
+  return {
+    ...result,
+    errors: [...result.errors, ...validatePreparedValue(result.returnValue)]
+  }
+}
+
+function invokePrepareChecked(
+  type: Type,
+  value: SelectedValue,
+  viewOptions: ViewOptions
+): PrepareInvocationResult {
+  const prepare = type.preview.prepare
+  try {
+    return {
+      returnValue: prepare ? prepare(value, viewOptions) : value,
+      errors: EMPTY
+    }
+  } catch (error) {
+    return {
+      returnValue: null,
+      errors: [assignType(error, 'prepareError')]
+    }
+  }
+}
+
+function invokePrepareUnchecked(
+  type: Type,
+  value: SelectedValue,
+  viewOptions: ViewOptions
+): PrepareInvocationResult {
+  return {
+    selectedValue: value,
+    returnValue: (type.preview.prepare || identity)(value, viewOptions),
+    errors: EMPTY
+  }
 }
 
 export const invokePrepare = __DEV__ ? invokePrepareChecked : invokePrepareUnchecked
 
-export default function prepareForPreview(rawValue, type, viewOptions) {
+function withErrors(result, type, selectedValue) {
+  result.errors.forEach(error => errorCollector.add(type, selectedValue, error))
+  reportErrors()
+
+  return INVALID_PREVIEW_CONFIG
+}
+
+export default function prepareForPreview(rawValue, type, viewOptions): PreparedValue {
   const selection = type.preview.select
   const targetKeys = Object.keys(selection)
 
-  const remapped = targetKeys.reduce((acc, key) => {
+  const selectedValue = targetKeys.reduce((acc, key) => {
     acc[key] = get(rawValue, selection[key])
     return acc
-  }, pick(rawValue, PRESERVE_KEYS))
+  }, {})
 
-  return invokePrepare(type, remapped, viewOptions)
+  const prepareResult = invokePrepare(type, selectedValue, viewOptions)
+  if (prepareResult.errors.length > 0) {
+    return withErrors(prepareResult, type, selectedValue)
+  }
+
+  const returnValueResult = validateReturnedPreview(invokePrepare(type, selectedValue, viewOptions))
+  return returnValueResult.errors.length > 0
+    ? withErrors(returnValueResult, type, selectedValue)
+    : {...pick(rawValue, PRESERVE_KEYS), ...prepareResult.returnValue}
 }

--- a/packages/test-studio/schemas/invalidPreviews.js
+++ b/packages/test-studio/schemas/invalidPreviews.js
@@ -1,0 +1,76 @@
+const rnd = Math.random()
+
+export default {
+  name: 'invalidPreviews',
+  type: 'document',
+  title: 'Preview: Invalid preview configs',
+  preview: {
+    select: {
+      title: 'title',
+      media: 'array'
+    },
+    prepare(invalue) {
+      if (rnd < 0.2) {
+        throw new Error('nope')
+      }
+      if (rnd < 0.4) {
+        return null
+      }
+      if (rnd < 0.6) {
+        return 'WILLNOTWORK'
+      }
+      if (rnd < 0.8) {
+        return {title: new Date()}
+      }
+      return invalue
+    }
+  },
+  fields: [
+    {
+      name: 'title',
+      title: 'Title',
+      type: 'object',
+      fields: [
+        {name: 'en', type: 'string', title: 'English'},
+        {name: 'no', type: 'string', title: 'Norwegian'}
+      ]
+    },
+    {
+      name: 'image',
+      title: 'Image',
+      type: 'image'
+    },
+    {
+      name: 'array',
+      type: 'array',
+      title: 'Array',
+      of: [
+        {
+          type: 'object',
+          name: 'customObjectWithInvalidPreview',
+          fields: [
+            {
+              name: 'objectWithInvalidPreview',
+              title: 'Title',
+              type: 'object',
+              fields: [
+                {
+                  name: 'someObj',
+                  type: 'object',
+                  title: 'Object',
+                  fields: [{name: 'someString', type: 'string'}]
+                }
+              ],
+              preview: {
+                select: {title: 'objectWithInvalidPreview'}
+              }
+            }
+          ],
+          preview: {
+            select: {title: 'objectWithInvalidPreview'}
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/test-studio/schemas/schema.js
+++ b/packages/test-studio/schemas/schema.js
@@ -41,6 +41,7 @@ import focus from './focus'
 import previewImageUrlTest from './previewImageUrlTest'
 import previewMediaTest from './previewMediaTest'
 import species from './species'
+import invalidPreviews from './invalidPreviews'
 
 export default createSchema({
   name: 'test-examples',
@@ -84,6 +85,7 @@ export default createSchema({
     typeWithNoToplevelStrings,
     previewImageUrlTest,
     previewMediaTest,
+    invalidPreviews,
     readOnly,
     empty
   ])


### PR DESCRIPTION
This will prevent the studio from crashing if preview config targets values that cannot be handled by the preview component (e.g. `{title: {foo: 'bar'}}`). It will show a warning in stead of the placeholder preview, and provide a detailed explanation in the developer console.

![image](https://user-images.githubusercontent.com/876086/39306089-704cfaec-495f-11e8-9bf7-3dee3fb47f27.png)

![prepare-guard](https://user-images.githubusercontent.com/876086/39306105-793b9122-495f-11e8-9d21-4643c148d0a5.gif)