### PR TITLE
[client] Don't retry if SSE connection fails before open

### DIFF
--- a/packages/@sanity/core/src/actions/config/reinitializePluginConfigs.js
+++ b/packages/@sanity/core/src/actions/config/reinitializePluginConfigs.js
@@ -46,19 +46,24 @@ async function reinitializePluginConfigs(options, flags = {}) {
   }
 
   function warnOnDifferingChecksum(plugin) {
-    if (flags.quiet) {
-      return plugin
-    }
-
-    const local = localChecksums[plugin.name]
-    if (typeof local !== 'undefined' && local !== plugin.configChecksum) {
-      const name = normalizePluginName(plugin.name)
-      output.print(
-        `[WARN] Default configuration file for plugin "${name}" has changed since local copy was created`
-      )
-    }
-
     return plugin
+
+    // Disabled for now, until we can provide a way to fix.
+    // NOTE: A similar checksum diff check is also done when running the install command
+    // See https://github.com/sanity-io/sanity/pull/298
+    // if (flags.quiet) {
+    //   return plugin
+    // }
+    //
+    // const local = localChecksums[plugin.name]
+    // if (typeof local !== 'undefined' && local !== plugin.configChecksum) {
+    //   const name = normalizePluginName(plugin.name)
+    //   output.print(
+    //     `[WARN] Default configuration file for plugin "${name}" has changed since local copy was created`
+    //   )
+    // }
+    //
+    // return plugin
   }
 
   function saveNewChecksums(plugins) {


### PR DESCRIPTION
I'm not entirely sure this fix is correct, but it prevents retrying if the SSE connection fails before it's established. This prevents the client from retrying the eventsource connection if the server responds with 404. I wasn't able to find any other way to detect details around _why_ the SSE connection errored Don't seem like EventSource specifies any response status code (or headers) to be exposed.

Let me know if you know of better ways to solve this, @rexxars