### PR TITLE
[cli] Use npm registry for modules. Upgrade yarn to 1.6.0

### DIFF
--- a/packages/@sanity/cli/src/actions/yarn/yarnWithProgress.js
+++ b/packages/@sanity/cli/src/actions/yarn/yarnWithProgress.js
@@ -40,7 +40,13 @@ export default function yarnWithProgress(args, options = {}) {
   )
 
   const nodePath = process.argv[0]
-  const nodeArgs = [yarnPath].concat(args, ['--json', '--non-interactive', '--ignore-engines'])
+  const nodeArgs = [yarnPath].concat(args, [
+    '--json',
+    '--non-interactive',
+    '--ignore-engines',
+    '--registry',
+    'https://registry.npmjs.org'
+  ])
 
   const state = {firstStepReceived: false, currentProgressStep: null}
   state.progress = new Gauge(process.stderr, {

--- a/packages/@sanity/cli/src/scripts/package-yarn.js
+++ b/packages/@sanity/cli/src/scripts/package-yarn.js
@@ -3,7 +3,7 @@ import path from 'path'
 import fse from 'fs-extra'
 import simpleGet from 'simple-get'
 
-const version = '1.3.2'
+const version = '1.6.0'
 const baseUrl = 'https://github.com/yarnpkg/yarn/releases/download'
 const bundleUrl = `${baseUrl}/v${version}/yarn-legacy-${version}.js`
 const licenseUrl = 'https://raw.githubusercontent.com/yarnpkg/yarn/master/LICENSE'


### PR DESCRIPTION
npm is working towards being [GDPR compliant](https://twitter.com/seldo/status/989637189259612160) by May 25th. I have yet to hear if yarn has any changes planned for their registry.

While our long term plan will probably be to replace yarn with npm, for now this will tell yarn to use the npm registry, minimizing the number of external providers we touch during a `sanity init`/`sanity upgrade`.
