### PR TITLE
[form-builder] Use `dl`-param on download to trigger attachment disposition

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/FileInput/FileInput.js
+++ b/packages/@sanity/form-builder/src/inputs/FileInput/FileInput.js
@@ -137,7 +137,7 @@ export default class FileInput extends React.PureComponent<Props, State> {
         </div>
         <div>
           {assetDocument.originalFilename}{' '}
-          <a href={assetDocument.url} download>
+          <a href={`${assetDocument.url}?dl`} download>
             Download
           </a>
         </div>


### PR DESCRIPTION
Currently they are served using `Content-Disposition: inline`, so even with a `download` attribute it may be up to the browser whether or not they are actually downloaded or displayed inline.