### PR TITLE
[desk-tool] Prevent empty draft from overwriting published document

### DIFF
--- a/packages/@sanity/desk-tool/src/pane/Editor.js
+++ b/packages/@sanity/desk-tool/src/pane/Editor.js
@@ -317,6 +317,9 @@ export default withRouterHOC(
 
     handlePublishRequested = () => {
       const {markers, validationPending, onPublish, draft} = this.props
+      if (!draft) {
+        return
+      }
       const errors = markers.filter(isValidationError)
       const hasErrors = errors.length > 0
 


### PR DESCRIPTION
This fixes a bug that could cause the published document to get overwritten by an empty draft when publishing using the hotkey.