### PR TITLE
[plugin-loader] Add option to stub CSS loading

### DIFF
--- a/packages/@sanity/plugin-loader/test/loader.test.js
+++ b/packages/@sanity/plugin-loader/test/loader.test.js
@@ -96,6 +96,14 @@ test('should be able to load CSS files through PostCSS', t => {
   t.is(styles.zebra, 'datepicker__zebra___1_qke')
 })
 
+test('should be able stub CSS loading', t => {
+  pluginLoader({basePath: path.join(__dirname, 'fixture'), stubCss: true})
+
+  const styles = require('part:date/datepicker-style')
+  t.is(typeof styles, 'object')
+  t.is(Object.keys(styles).length, 0)
+})
+
 test('should resolve correctly when using optional part requires (?-postfix)', t => {
   pluginLoader({basePath: path.join(__dirname, 'fixture')})
 


### PR DESCRIPTION
Sometimes you are running scripts which utilize the parts system, but you don't need the class names of the CSS modules referenced by any imports. This PR adds a `stubCss` option to skip the overhead of PostCSS compilation.