### PR TITLE
[cli] Make upgrade message less confusing

### DIFF
--- a/packages/@sanity/default-layout/src/components/UpdateNotifierDialog.js
+++ b/packages/@sanity/default-layout/src/components/UpdateNotifierDialog.js
@@ -49,7 +49,7 @@ class UpdateNotifierDialog extends Component {
         </table>
 
         <p className={styles.upgradeText}>
-          To upgrade, run <code className={styles.code}>sanity upgrade</code> in your studio.
+          To upgrade, run the Sanity CLI command <code className={styles.code}>sanity upgrade</code> in your project folder.
         </p>
       </div>
     )


### PR DESCRIPTION
The previous copy assumed contextual knowledge of the CLI, this text makes it a bit clearer.
