### PR TITLE
Responsive dialogs width

### DIFF
--- a/packages/@sanity/base/src/styles/layout/tippy.css
+++ b/packages/@sanity/base/src/styles/layout/tippy.css
@@ -1,3 +1,5 @@
+@import 'part:@sanity/base/theme/variables-style';
+
 :global(.tippy-touch) {
   cursor: pointer !important;
 }
@@ -600,7 +602,7 @@
   float: left;
 }
 
-@media (max-width: 450px) {
+@media (--max-screen-medium) {
   :global(.tippy-popper) {
     max-width: calc(100% - 20px);
   }

--- a/packages/@sanity/code-input/src/CodeInput.js
+++ b/packages/@sanity/code-input/src/CodeInput.js
@@ -189,7 +189,11 @@ export default class CodeInput extends PureComponent {
 
     if (has(type, 'options.language')) {
       return (
-        <Fieldset styles={fieldsetStyles} legend={type.title} description={type.description}>
+        <Fieldset
+          className={fieldsetStyles.content}
+          legend={type.title}
+          description={type.description}
+        >
           {this.renderEditor()}
         </Fieldset>
       )
@@ -206,7 +210,11 @@ export default class CodeInput extends PureComponent {
     const languageField = type.fields.find(field => field.name === 'language')
 
     return (
-      <Fieldset legend={type.title} description={type.description}>
+      <Fieldset
+        legend={type.title}
+        description={type.description}
+        className={fieldsetStyles.content}
+      >
         <FormField level={level + 1} label={languageField.type.title}>
           <DefaultSelect
             onChange={this.handleLanguageChange}

--- a/packages/@sanity/code-input/src/Fieldset.css
+++ b/packages/@sanity/code-input/src/Fieldset.css
@@ -5,6 +5,7 @@
     All styleable components have a styling-part.
   */
   composes: content from 'part:@sanity/components/fieldsets/default-style';
+  composes: largeContent from 'part:@sanity/components/dialogs/default-style';
 
   /* Now it is has its original styling, and we can tweak the styling */
   padding: 0;

--- a/packages/@sanity/components/src/dialogs/styles/DefaultDialog.css
+++ b/packages/@sanity/components/src/dialogs/styles/DefaultDialog.css
@@ -163,7 +163,8 @@
 
   @media (--screen-medium) {
     max-height: 90vh;
-    max-width: 80vw;
+    max-width: calc(100vw - var(--medium-padding) * 4);
+    min-width: 25em;
   }
 
   @nest .hasFunctions & {
@@ -259,5 +260,23 @@
 
   @nest .danger & {
     background-color: color(var(--white) a(60%));
+  }
+}
+
+/*
+  Composed by content that needs sizing only inside
+  the dialog.
+*/
+.root .largeContent {
+  @media (--screen-medium) {
+    min-width: 27rem;
+  }
+
+  @media (--screen-default) {
+    min-width: 33rem;
+  }
+
+  @media (--screen-large) {
+    min-width: 35rem;
   }
 }

--- a/packages/@sanity/components/src/textareas/styles/DefaultTextArea.css
+++ b/packages/@sanity/components/src/textareas/styles/DefaultTextArea.css
@@ -3,6 +3,9 @@
 .root {
   width: 100%;
   position: relative;
+
+  /* forces bigger dialog when in dialog */
+  composes: largeContent from 'part:@sanity/components/dialogs/default-style';
 }
 
 .textarea {

--- a/packages/@sanity/default-layout/src/components/styles/RenderTool.css
+++ b/packages/@sanity/default-layout/src/components/styles/RenderTool.css
@@ -1,13 +1,11 @@
-:root {
-  @custom-media --error-expand-at (min-width: 700px);
-}
+@import 'part:@sanity/base/theme/variables-style';
 
 .error {
   display: block;
   justify-content: center;
   margin: 0 10px;
 
-  @media (--error-expand-at) {
+  @media (--screen-default) {
     display: flex;
   }
 }
@@ -19,7 +17,7 @@
   min-width: 212px;
   margin: 20px auto;
 
-  @media (--error-expand-at) {
+  @media (--screen-default) {
     margin: 20px 0;
   }
 }
@@ -27,7 +25,7 @@
 .errorSplash svg {
   max-height: 35vh;
 
-  @media (--error-expand-at) {
+  @media (--screen-default) {
     max-height: 50vh;
   }
 }

--- a/packages/@sanity/desk-tool/src/components/InspectView.js
+++ b/packages/@sanity/desk-tool/src/components/InspectView.js
@@ -81,12 +81,12 @@ export default class InspectView extends React.PureComponent {
         isOpen
         showHeader
         title={`Inspecting ${getPublishedId(value._id)}`}
-        className={styles.dialog}
         onClose={onClose}
       >
         <div className={styles.content}>
-          <div style={{display: 'flex', justifyContent: 'flex-end'}}>
+          <div className={styles.toolbar}>
             <ToggleButtons
+              label="View"
               value={viewMode}
               items={VIEW_MODES}
               onChange={this.handleChangeViewMode}

--- a/packages/@sanity/desk-tool/src/components/styles/InspectView.css
+++ b/packages/@sanity/desk-tool/src/components/styles/InspectView.css
@@ -1,12 +1,17 @@
-.dialog {
-  background: #fefefe;
-}
+@import 'part:@sanity/base/theme/variables-style';
 
 .content {
   padding: 1rem;
+  box-sizing: border-box;
+  width: 80vw;
+  height: 80vw;
+}
+
+.toolbar {
+  margin-bottom: 1rem;
 }
 
 .raw {
   font: 14px/1.4 Consolas, monospace;
-  outline-color: #2097ac;
+  outline-color: var(--brand-primary);
 }

--- a/packages/@sanity/desk-tool/src/pane/styles/Editor.css
+++ b/packages/@sanity/desk-tool/src/pane/styles/Editor.css
@@ -63,6 +63,7 @@
 
 .editor {
   padding: var(--medium-padding);
+  max-width: 40em;
 }
 
 .syncStatus {

--- a/packages/@sanity/form-builder/src/inputs/ArrayInput/styles/ItemValue.css
+++ b/packages/@sanity/form-builder/src/inputs/ArrayInput/styles/ItemValue.css
@@ -122,10 +122,20 @@
 
 .defaultDialogContent {
   padding: var(--medium-padding);
-  min-width: 10rem;
+  box-sizing: border-box;
+  width: 100%;
 
+  /* Guessed default sizes for different screens */
   @media (--screen-medium) {
-    min-width: 30rem;
+    min-width: 28rem;
+  }
+
+  @media (--screen-default) {
+    min-width: 35rem;
+  }
+
+  @media (--screen-large) {
+    min-width: 40rem;
   }
 }
 

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/styles/BlockEditor.css
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/styles/BlockEditor.css
@@ -6,6 +6,9 @@
 
 .root {
   composes: root from 'part:@sanity/base/theme/forms/control-style';
+
+  /* forces bigger dialog when in dialog */
+  composes: largeContent from 'part:@sanity/components/dialogs/default-style';
   position: static;
 }
 
@@ -31,10 +34,6 @@
     clip: auto;
     outline: none;
   }
-}
-
-.fullscreen {
-
 }
 
 .blockDragMarker {


### PR DESCRIPTION
- Dialog now has a min-width
- Array input sets its min-width of the content in dialog
- Composable CSS to use when components wants to make the dialog bigger
- Max-width on editor in desk-tool to prevent too wide inputs
