### PR TITLE
[form-builder] Remove empty values when array dialog closes and pass undefined as item values if empty

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ArrayInput/ItemValue.js
+++ b/packages/@sanity/form-builder/src/inputs/ArrayInput/ItemValue.js
@@ -66,6 +66,11 @@ function hasFocusInPath(path, value) {
   return path.length === 1 && PathUtils.isSegmentEqual(path[0], pathSegmentFrom(value))
 }
 
+const IGNORE_KEYS = ['_key', '_type', '_weak']
+function isEmpty(value) {
+  return Object.keys(value).every(key => IGNORE_KEYS.includes(key))
+}
+
 export default class RenderItemValue extends React.Component<Props> {
   _focusArea: ?FocusArea
 
@@ -98,7 +103,11 @@ export default class RenderItemValue extends React.Component<Props> {
   }
 
   handleEditStop = () => {
-    this.setFocus()
+    if (isEmpty(this.props.value)) {
+      this.handleRemove()
+    } else {
+      this.setFocus()
+    }
   }
 
   handleKeyPress = (event: SyntheticKeyboardEvent<*>) => {
@@ -163,7 +172,7 @@ export default class RenderItemValue extends React.Component<Props> {
       <FormBuilderInput
         type={memberType}
         level={0}
-        value={item}
+        value={isEmpty(item) ? undefined : item}
         onChange={this.handleChange}
         onFocus={onFocus}
         onBlur={onBlur}


### PR DESCRIPTION
This is a twofold change:

1. When the user closes an edit dialog and the edited item value is "empty", the item will now be removed from the array. This is a partial fix for #727 and #725, and should make it a lot less annoying. I suggest we still keeps those issues open, as the problems still exists to a lesser extent (e.g if the browser window closes, network disconnects, etc.).

2. Passing `undefined` as `value`-prop to the input for "empty" placeholder array items. When making a form builder input, a check for undefined should be enough in order to determine if the input has a value or not. In the case of object types contained in an array, the input will currently be passed the placeholder value (e.g. `{_key: 'adebee222'}`, and any _has value_ check inside the input component easily becomes complicated. (This actually broke the GoogleMapsInput when used to edit `geopoint`-values in an array). After this change, any `if (value) {...}`-check should work as expected for inputs editing array items.
