### PR TITLE
[google-maps-input] Don't overwrite value, just set lat/lng

### DIFF
--- a/packages/@sanity/google-maps-input/src/GeopointInput.js
+++ b/packages/@sanity/google-maps-input/src/GeopointInput.js
@@ -1,13 +1,13 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import config from 'config:@sanity/google-maps-input'
-import GoogleMapsLoadProxy from './GoogleMapsLoadProxy'
-import GeopointSelect from './GeopointSelect'
 import Button from 'part:@sanity/components/buttons/default'
 import Dialog from 'part:@sanity/components/dialogs/default'
 import Fieldset from 'part:@sanity/components/fieldsets/default'
+import {PatchEvent, set, setIfMissing, unset} from 'part:@sanity/form-builder/patch-event'
 import styles from '../styles/GeopointInput.css'
-import {PatchEvent, set, unset} from 'part:@sanity/form-builder/patch-event'
+import GeopointSelect from './GeopointSelect'
+import GoogleMapsLoadProxy from './GoogleMapsLoadProxy'
 
 const getLocale = context => {
   const intl = context.intl || {}
@@ -72,19 +72,19 @@ class GeopointInput extends React.Component {
   }
 
   handleToggleModal() {
-    this.setState({modalOpen: !this.state.modalOpen})
+    this.setState(prevState => ({modalOpen: !prevState.modalOpen}))
   }
 
   handleChange = latLng => {
     const {type, onChange} = this.props
     onChange(
-      PatchEvent.from(
-        set({
-          _type: type.name,
-          lat: latLng.lat(),
-          lng: latLng.lng()
-        })
-      )
+      PatchEvent.from([
+        setIfMissing({
+          _type: type.name
+        }),
+        set(latLng.lat(), ['lat']),
+        set(latLng.lng(), ['lng'])
+      ])
     )
   }
 

--- a/packages/test-studio/schemas/geopoint.js
+++ b/packages/test-studio/schemas/geopoint.js
@@ -18,6 +18,17 @@ export default {
       type: 'geopoint',
       title: 'A geopoint',
       description: 'This is a geopoint field'
+    },
+    {
+      name: 'arrayOfLocations',
+      type: 'array',
+      of: [
+        {
+          type: 'geopoint',
+          title: 'A geopoint',
+          description: 'This is a geopoint field'
+        }
+      ]
     }
   ],
   preview: {
@@ -32,17 +43,18 @@ export default {
         subtitle:
           location &&
           `${Number(location.lat).toPrecision(5)}, ${Number(location.lng).toPrecision(5)}`,
-        media: ({dimensions}) => {
-          if (location && location.lat && location.lng && apiKey) {
-            return (
-              <img
-                src={`https://maps.googleapis.com/maps/api/staticmap?zoom=11&center=${
-                  location.lat
-                },${location.lng}&size=${dimensions.width}x${dimensions.height}&key=${apiKey}`}
-                alt={title}
-              />
-            )
+        media({dimensions}) {
+          if (!location || !location.lat || !location.lng || !apiKey) {
+            return null
           }
+          return (
+            <img
+              src={`https://maps.googleapis.com/maps/api/staticmap?zoom=11&center=${location.lat},${
+                location.lng
+              }&size=${dimensions.width}x${dimensions.height}&key=${apiKey}`}
+              alt={title}
+            />
+          )
         }
       }
     }


### PR DESCRIPTION
The Google Maps Input emitted a `set`-patch overwriting the whole value on change, causing any `_key`-property to be cleared for each edit. As a consequence, editing geopoints in an array did not work very well.

This makes the Google Maps input emit a `setIfMissing` + `set` patches targeting the `lat`+`lng`-fields.