### PR TITLE
[schema] Add missing fields for reference and slug types

### DIFF
--- a/packages/@sanity/schema/src/legacy/types/reference.js
+++ b/packages/@sanity/schema/src/legacy/types/reference.js
@@ -1,6 +1,20 @@
-import {pick} from 'lodash'
 import arrify from 'arrify'
+import {pick} from 'lodash'
 import {lazyGetter} from './utils'
+
+export const REF_FIELD = {
+  name: '_ref',
+  title: 'Referenced document ID',
+  type: 'string'
+}
+
+export const WEAK_FIELD = {
+  name: '_weak',
+  title: 'Weak reference',
+  type: 'boolean'
+}
+
+const REFERENCE_FIELDS = [REF_FIELD, WEAK_FIELD]
 
 const OVERRIDABLE_FIELDS = ['jsonType', 'type', 'name', 'title', 'description', 'options']
 
@@ -46,6 +60,16 @@ export const ReferenceType = {
     const parsed = Object.assign(pick(REFERENCE_CORE, OVERRIDABLE_FIELDS), subTypeDef, {
       type: REFERENCE_CORE,
       title: subTypeDef.title || buildTitle(subTypeDef)
+    })
+
+    lazyGetter(parsed, 'fields', () => {
+      return REFERENCE_FIELDS.map(fieldDef => {
+        const {name, ...type} = fieldDef
+        return {
+          name: name,
+          type: createMemberType(type)
+        }
+      })
     })
 
     lazyGetter(parsed, 'to', () => {

--- a/packages/@sanity/schema/src/legacy/types/slug.js
+++ b/packages/@sanity/schema/src/legacy/types/slug.js
@@ -1,6 +1,15 @@
 import {pick} from 'lodash'
+import {lazyGetter} from './utils'
 
 const OVERRIDABLE_FIELDS = ['jsonType', 'type', 'name', 'title', 'description', 'options']
+
+export const CURRENT_FIELD = {
+  name: 'current',
+  title: 'Current slug',
+  type: 'string'
+}
+
+const SLUG_FIELDS = [CURRENT_FIELD]
 
 const SLUG_CORE = {
   name: 'slug',
@@ -13,12 +22,22 @@ export const SlugType = {
   get() {
     return SLUG_CORE
   },
-  extend(subTypeDef) {
+  extend(subTypeDef, extendMember) {
     const parsed = Object.assign(pick(SLUG_CORE, OVERRIDABLE_FIELDS), subTypeDef, {
       type: SLUG_CORE,
       preview: {
         select: {title: 'current'}
       }
+    })
+
+    lazyGetter(parsed, 'fields', () => {
+      return SLUG_FIELDS.map(fieldDef => {
+        const {name, ...type} = fieldDef
+        return {
+          name: name,
+          type: extendMember(type)
+        }
+      })
     })
 
     return subtype(parsed)


### PR DESCRIPTION
The reference and slug types were missing their fields. If the default input component was not in play, the form builder would not render any input/field. The validation infrastructure also traverses the schema definition, and missing fields will prevent it from functioning as intended.

An interesting thought would be whether or not we should add fields to the document type as well, for `_id`, `_type`, `_createdAt` etc. They could be marked as hidden and read only, but it would make schema traversal more complete/correct. Thoughts?