### PR TITLE
[default-layout] Ensure error message inclusion in error boundary

### DIFF
--- a/packages/@sanity/default-layout/src/components/RenderTool.js
+++ b/packages/@sanity/default-layout/src/components/RenderTool.js
@@ -5,6 +5,12 @@ import Button from 'part:@sanity/components/buttons/default'
 import styles from './styles/RenderTool.css'
 import ErrorBorkImage from './ErrorBorkImage'
 
+function getErrorWithStack(err) {
+  const stack = err.stack.toString()
+  const message = err.message
+  return stack.indexOf(message) === -1 ? `${message}\n\n${stack}` : stack
+}
+
 export default class RenderTool extends Component {
   static propTypes = {
     tool: PropTypes.string
@@ -53,7 +59,7 @@ export default class RenderTool extends Component {
           <div className={styles.errorDetails}>
             <div className={styles.errorStackTrace}>
               <h3>Stack trace:</h3>
-              <pre>{error.stack}</pre>
+              <pre>{getErrorWithStack(error)}</pre>
             </div>
 
             <div className={styles.errorComponentStack}>


### PR DESCRIPTION
There seems to be some differences in how the `stack` property works in firefox and chrome.
In firefox, it did not seem to include the actual error message. This PR will ensure that the actual error message is included when printing the error on the error boundary screen.

If anyone can come up with a better way to do this, let me know.