### PR TITLE
Upgrade storybook

### DIFF
--- a/packages/@sanity/components/src/previews/styles/DefaultPreview.css
+++ b/packages/@sanity/components/src/previews/styles/DefaultPreview.css
@@ -62,10 +62,10 @@
   margin: 0;
   padding: 0;
   padding-bottom: 0.25em;
-  height: 1em;
+  line-height: 1.5em;
+  height: 1.5em;
   font-size: 0.7em;
   font-weight: 300;
-  line-height: 1.5em;
 }
 
 .media {

--- a/packages/@sanity/storybook/package.json
+++ b/packages/@sanity/storybook/package.json
@@ -27,9 +27,9 @@
   "dependencies": {
     "@sanity/server": "0.136.0",
     "@sanity/webpack-integration": "0.136.0",
-    "@storybook/addon-knobs": "^3.2.8",
-    "@storybook/addons": "^3.2.6",
-    "@storybook/react": "3.2.8",
+    "@storybook/addon-knobs": "^4.0.9",
+    "@storybook/addons": "^4.0.9",
+    "@storybook/react": "4.0.9",
     "normalize.css": "^5.0.0",
     "react-addons-create-fragment": "^15.4.2",
     "shelljs": "^0.7.6",

--- a/packages/@sanity/storybook/src/config/webpack.config.js
+++ b/packages/@sanity/storybook/src/config/webpack.config.js
@@ -1,7 +1,7 @@
 const webpack = require('webpack')
 const sanityServer = require('@sanity/server')
 const wpIntegration = require('@sanity/webpack-integration/v3')
-const genDefaultConfig = require('@storybook/react/dist/server/config/defaults/webpack.config.js')
+const genDefaultConfig = require('@storybook/core/dist/server/config/webpack.config.default.js')
 
 const skipCssLoader = rule => !rule.test || (rule.test && !rule.test.toString().includes('.css'))
 const isCssLoader = rule => rule.test && rule.test.toString().includes('.css')

--- a/packages/@sanity/storybook/src/server/server.js
+++ b/packages/@sanity/storybook/src/server/server.js
@@ -3,9 +3,10 @@
 /* eslint-disable no-process-exit, no-console */
 const path = require('path')
 const express = require('express')
-const middleware = require('@storybook/react/dist/server/middleware')
+const utils = require('@storybook/core/dist/server/utils')
+// const options = require('@storybook/react/dist/server/options.js')
 const webpackConfig = require('../config/webpack.config')
-const storybook = middleware.default || middleware
+// const genDefaultConfig = require('@storybook/core/dist/server/config/webpack.config.default.js')
 
 let app = null
 
@@ -32,7 +33,8 @@ function startServer(msg) {
 
   app = express()
   app.use(express.static(msg.config.staticPath, {index: false}))
-  app.use(storybook(path.join(__dirname, '..', 'config')))
+
+  app.use(utils.getMiddleware(path.join(__dirname, '..', 'config')))
 
   app.listen(port, msg.config.httpHost, error => {
     if (error) {

--- a/packages/storybook/config/.checksums
+++ b/packages/storybook/config/.checksums
@@ -3,5 +3,6 @@
   "@sanity/default-layout": "bb034f391ba508a6ca8cd971967cbedeb131c4d19b17b28a0895f32db5d568ea",
   "@sanity/data-aspects": "ba5c2649cc1b1c39ae92b7daf2661f95fa79d7325073ffd410245d2717b240e9",
   "@sanity/google-maps-input": "57ae3a403ce6a070b31ec6fa1f3c8339cafa66661eaddba1d4d5ee3cc2197ec2",
-  "@sanity/storybook": "526dea3b461fda217e7150d12395d0ec639cba0155c05a084b85bcf2c44995a3"
+  "@sanity/storybook": "526dea3b461fda217e7150d12395d0ec639cba0155c05a084b85bcf2c44995a3",
+  "@sanity/default-login": "6fb6d3800aa71346e1b84d95bbcaa287879456f2922372bb0294e30b968cd37f"
 }

--- a/packages/storybook/config/@sanity/default-login.json
+++ b/packages/storybook/config/@sanity/default-login.json
@@ -1,0 +1,7 @@
+{
+  "providers": {
+    "mode": "append",
+    "redirectOnSingle": false,
+    "entries": []
+  }
+}


### PR DESCRIPTION
Don't know if I did the middleware thing correctly. It works, but it generates a warning:
```Storybook: (node:8943) DeprecationWarning: importing default webpack config generator from '@storybook/react/dist/server/config/defaults/webpack.config.js' is deprecated. Use third argument of your exported function instead. See https://storybook.js.org/configurations/custom-webpack-config/#full-control-mode--default```