### PR TITLE
[chore] Drop support for React 15

### DIFF
--- a/packages/@sanity/base/package.json
+++ b/packages/@sanity/base/package.json
@@ -62,7 +62,7 @@
   },
   "peerDependencies": {
     "prop-types": "^15.6 || ^16",
-    "react": "^15.6 || ^16",
-    "react-dom": "^15.6 || ^16"
+    "react": "^16.2",
+    "react-dom": "^16.2"
   }
 }

--- a/packages/@sanity/components/package.json
+++ b/packages/@sanity/components/package.json
@@ -68,8 +68,8 @@
   },
   "peerDependencies": {
     "prop-types": "^15.6 || ^16",
-    "react": "^15.6 || ^16",
-    "react-dom": "^15.6 || ^16"
+    "react": "^16.2",
+    "react-dom": "^16.2"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/core/src/util/checkReactCompatibility.js
+++ b/packages/@sanity/core/src/util/checkReactCompatibility.js
@@ -4,12 +4,12 @@ const resolveFrom = require('resolve-from')
 const generateHelpUrl = require('@sanity/generate-help-url')
 
 const supported = {
-  react: '^15 || ^16',
-  'react-dom': '^15 || ^16'
+  react: '^16.2',
+  'react-dom': '^16.2'
 }
+
 const deprecated = {
-  react: '^15',
-  'react-dom': '^15'
+  // add packages to deprecate support for here
 }
 
 module.exports = workDir => {
@@ -30,8 +30,8 @@ module.exports = workDir => {
       console.warn(
         `[WARN] ${pkg} ${
           deprecated[pkg]
-        } is deprecated and will be unsupported as of the next release of Sanity. Please upgrade the ${pkg} package. Read more at ${generateHelpUrl(
-          'upgrade-react'
+        } is deprecated and will be unsupported in an upcoming release of Sanity. Please upgrade the ${pkg} package. Read more at ${generateHelpUrl(
+          'upgrade-package'
         )} `
       )
     }

--- a/packages/@sanity/default-layout/package.json
+++ b/packages/@sanity/default-layout/package.json
@@ -55,7 +55,7 @@
   },
   "peerDependencies": {
     "prop-types": "^15.6 || ^16",
-    "react": "^15.6 || ^16",
-    "react-dom": "^15.6 || ^16"
+    "react": "^16.2",
+    "react-dom": "^16.2"
   }
 }

--- a/packages/@sanity/desk-tool/package.json
+++ b/packages/@sanity/desk-tool/package.json
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "prop-types": "^15.6 || ^16",
-    "react": "^15.6 || ^16"
+    "react": "^16"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/form-builder/package.json
+++ b/packages/@sanity/form-builder/package.json
@@ -81,8 +81,8 @@
   },
   "peerDependencies": {
     "prop-types": "^15.6 || ^16",
-    "react": "^15.6 || ^16",
-    "react-dom": "^15.6 || ^16"
+    "react": "^16.2",
+    "react-dom": "^16.2"
   },
   "directories": {
     "example": "example",

--- a/packages/@sanity/google-maps-input/package.json
+++ b/packages/@sanity/google-maps-input/package.json
@@ -33,8 +33,8 @@
     "rimraf": "^2.6.2"
   },
   "peerDependencies": {
-    "react": "^15.6 || ^16",
-    "react-dom": "^15.6 || ^16"
+    "react": "^16.2",
+    "react-dom": "^16.2"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/imagetool/package.json
+++ b/packages/@sanity/imagetool/package.json
@@ -37,8 +37,8 @@
   },
   "peerDependencies": {
     "prop-types": "^15.6 || ^16",
-    "react": "^15.6 || ^16",
-    "react-dom": "^15.6 || ^16"
+    "react": "^16.2",
+    "react-dom": "^16.2"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/preview/package.json
+++ b/packages/@sanity/preview/package.json
@@ -42,7 +42,7 @@
   },
   "peerDependencies": {
     "prop-types": "^15.6 || ^16",
-    "react": "^15.6 || ^16"
+    "react": "^16"
   },
   "homepage": "https://www.sanity.io/",
   "repository": {

--- a/packages/@sanity/server/package.json
+++ b/packages/@sanity/server/package.json
@@ -76,7 +76,7 @@
   },
   "peerDependencies": {
     "prop-types": "^15.6 || ^16",
-    "react": "^15.6 || ^16",
-    "react-dom": "^15.6 || ^16"
+    "react": "^16.2",
+    "react-dom": "^16.2"
   }
 }

--- a/packages/@sanity/state-router/package.json
+++ b/packages/@sanity/state-router/package.json
@@ -48,8 +48,8 @@
   },
   "peerDependencies": {
     "prop-types": "^15.6 || ^16",
-    "react": "^15.6 || ^16",
-    "react-dom": "^15.6 || ^16"
+    "react": "^16.2",
+    "react-dom": "^16.2"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -42,8 +42,8 @@
   },
   "peerDependencies": {
     "prop-types": "^15.6 || ^16",
-    "react": "^15.6 || ^16",
-    "react-dom": "^15.6 || ^16"
+    "react": "^16.2",
+    "react-dom": "^16.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
It's hard to track usage of React 16 specific features in our own code base, especially since we develop against React 16.2, so lets officially drop support for React < v16.2.

It should be safe to do this as using React 15 with sanity studios has yielded an upgrade warning since v0.127.0.

Side note: since we still officially support React 16.2 we should be careful not to use features introduced in React after 16.2.