### PR TITLE
[image-url] Allow passing asset documents as source

### DIFF
--- a/packages/@sanity/image-url/src/parseAssetId.js
+++ b/packages/@sanity/image-url/src/parseAssetId.js
@@ -1,0 +1,21 @@
+const example = 'image-Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000-jpg'
+
+export default function parseAssetId(ref) {
+  const [, id, dimensionString, format] = ref.split('-')
+
+  if (!id || !dimensionString || !format) {
+    throw new Error(`Malformed asset _ref '${ref}'. Expected an id like "${example}".`)
+  }
+
+  const [imgWidthStr, imgHeightStr] = dimensionString.split('x')
+
+  const width = +imgWidthStr
+  const height = +imgHeightStr
+
+  const isValidAssetId = Number.isFinite(width) && Number.isFinite(height)
+  if (!isValidAssetId) {
+    throw new Error(`Malformed asset _ref '${ref}'. Expected an id like "${example}".`)
+  }
+
+  return {id, width, height, format}
+}

--- a/packages/@sanity/image-url/src/parseSource.js
+++ b/packages/@sanity/image-url/src/parseSource.js
@@ -1,0 +1,60 @@
+// Convert an asset-id, asset or image to an image record suitable for processing
+export default function parseSource(source) {
+  if (!source) {
+    return null
+  }
+
+  let image
+
+  // Did we just get an asset id?
+  if (typeof source === 'string') {
+    image = {
+      asset: {_ref: source}
+    }
+  } else if (typeof source._ref === 'string') {
+    // We just got passed an asset directly
+    image = {
+      asset: source
+    }
+  } else if (source._id) {
+    // If we were passed an image asset document
+    image = {
+      asset: {
+        _ref: source._id
+      }
+    }
+  } else if (typeof source.asset === 'object') {
+    image = source
+  } else {
+    // We got something that does not look like an image, or it is an image
+    // that currently isn't sporting an asset.
+    return null
+  }
+
+  return applyDefaultHotspot(image)
+}
+
+// Mock crop and hotspot if image lacks it
+function applyDefaultHotspot(image) {
+  if (image.crop && image.hotspot) {
+    return image
+  }
+
+  return Object.assign(
+    {
+      crop: {
+        left: 0,
+        top: 0,
+        bottom: 0,
+        right: 0
+      },
+      hotspot: {
+        x: 0.5,
+        y: 0.5,
+        height: 1.0,
+        width: 1.0
+      }
+    },
+    image
+  )
+}

--- a/packages/@sanity/image-url/src/urlForImage.js
+++ b/packages/@sanity/image-url/src/urlForImage.js
@@ -1,3 +1,6 @@
+import parseSource from './parseSource'
+import parseAssetId from './parseAssetId'
+
 const SPEC_NAME_TO_URL_NAME_MAPPINGS = [
   ['width', 'w'],
   ['height', 'h'],
@@ -60,85 +63,6 @@ export default function urlForImage(options) {
   return specToImageUrl(spec)
 }
 
-// Convert an asset-id, asset or image to an image record suitable for processing
-export function parseSource(source) {
-  let image
-
-  // Did we just get an asset id?
-  if (typeof source === 'string') {
-    image = {
-      asset: {_ref: source}
-    }
-  } else if (
-    source._type === 'sanity.imageAsset' ||
-    (typeof source === 'object' && typeof source._ref === 'string')
-  ) {
-    // We just got passed an asset directly
-    image = {
-      asset: source
-    }
-  } else if (typeof source === 'object' && typeof source.asset === 'object') {
-    image = source
-  } else {
-    // We got something that does not look like an image, or it is an image
-    // that currently isn't sporting an asset.
-    return null
-  }
-
-  if (!image.crop || !image.hotspot) {
-    // Mock crop and hotspot if image lacks it
-    image = Object.assign(
-      {
-        crop: {
-          left: 0,
-          top: 0,
-          bottom: 0,
-          right: 0
-        },
-        hotspot: {
-          x: 0.5,
-          y: 0.5,
-          height: 1.0,
-          width: 1.0
-        }
-      },
-      image
-    )
-  }
-
-  return image
-}
-
-function parseAssetId(ref) {
-  const [, id, dimensionString, format] = ref.split('-')
-
-  if (typeof dimensionString !== 'string') {
-    throw new Error(
-      `Malformed asset _ref '${ref}'. Expected an id on the form "image-Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000-jpg.`
-    )
-  }
-
-  const [imgWidthStr, imgHeightStr] = dimensionString.split('x')
-
-  const width = +imgWidthStr
-  const height = +imgHeightStr
-
-  if (
-    !(
-      typeof id === 'string' &&
-      typeof format === 'string' &&
-      Number.isFinite(width) &&
-      Number.isFinite(height)
-    )
-  ) {
-    throw new Error(
-      `Malformed asset _ref '${ref}'. Expected an id on the form "image-Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000-jpg.`
-    )
-  }
-
-  return {id, width, height, format}
-}
-
 // eslint-disable-next-line complexity
 function specToImageUrl(spec) {
   const cdnUrl = spec.baseUrl || 'https://cdn.sanity.io'
@@ -184,7 +108,6 @@ function specToImageUrl(spec) {
 
   return `${baseUrl}?${params.join('&')}`
 }
-/* eslint-enable complexity */
 
 function fit(source, spec) {
   const result = {
@@ -248,3 +171,6 @@ function fit(source, spec) {
   }
   return result
 }
+
+// For backwards-compatibility
+export {parseSource}

--- a/packages/@sanity/image-url/test/__snapshots__/parseAssetId.test.js.snap
+++ b/packages/@sanity/image-url/test/__snapshots__/parseAssetId.test.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`throws on invalid dimensions 1`] = `"Malformed asset _ref 'image-assetId-mooxmoo-png'. Expected an id like \\"image-Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000-jpg\\"."`;
+
+exports[`throws on invalid document id 1`] = `"Malformed asset _ref 'moop'. Expected an id like \\"image-Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000-jpg\\"."`;

--- a/packages/@sanity/image-url/test/builder.test.js
+++ b/packages/@sanity/image-url/test/builder.test.js
@@ -1,5 +1,5 @@
 import sanityImage from '../src/builder'
-import {imageWithNoCropSpecified, croppedImage} from './fixtures'
+import {imageWithNoCropSpecified, noHotspotImage, croppedImage} from './fixtures'
 
 const urlFor = sanityImage()
   .projectId('zp7mbokg')
@@ -93,6 +93,28 @@ const cases = [
       .url(),
     expect:
       'https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg?rect=200,300,1600,2400&w=320&h=240'
+  },
+
+  {
+    name: 'flip horizontal',
+    url: stripPath(
+      urlFor
+        .image(noHotspotImage())
+        .flipHorizontal()
+        .url()
+    ),
+    expect: 'flip=h'
+  },
+
+  {
+    name: 'flip vertical',
+    url: stripPath(
+      urlFor
+        .image(noHotspotImage())
+        .flipVertical()
+        .url()
+    ),
+    expect: 'flip=v'
   },
 
   {

--- a/packages/@sanity/image-url/test/fixtures.js
+++ b/packages/@sanity/image-url/test/fixtures.js
@@ -61,3 +61,24 @@ export function noHotspotImage() {
     }
   }
 }
+
+export function assetDocument() {
+  return {
+    _id: 'image-Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000-jpg',
+    _type: 'sanity.imageAsset',
+    assetId: 'Tb9Ew8CXIwaY6R1kjMvI0uRR',
+    extension: 'jpg',
+    metadata: {
+      dimensions: {
+        aspectRatio: 1.5,
+        height: 3000,
+        width: 2000
+      }
+    },
+    mimeType: 'image/jpeg',
+    path: 'images/ppsg7ml5/test/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg',
+    sha1hash: '075b7c7a434870280dab6613b3bf687988e36d75',
+    size: 12233794,
+    url: 'https://cdn.sanity.io/images/ppsg7ml5/test/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg'
+  }
+}

--- a/packages/@sanity/image-url/test/parseAssetId.test.js
+++ b/packages/@sanity/image-url/test/parseAssetId.test.js
@@ -1,0 +1,9 @@
+import parseAssetId from '../src/parseAssetId'
+
+test('throws on invalid document id', () => {
+  expect(() => parseAssetId('moop')).toThrowErrorMatchingSnapshot()
+})
+
+test('throws on invalid dimensions', () => {
+  expect(() => parseAssetId('image-assetId-mooxmoo-png')).toThrowErrorMatchingSnapshot()
+})

--- a/packages/@sanity/image-url/test/parseSource.test.js
+++ b/packages/@sanity/image-url/test/parseSource.test.js
@@ -1,10 +1,10 @@
-import {parseSource} from '../src/urlForImage'
-import {imageWithNoCropSpecified, croppedImage} from './fixtures'
+import parseSource from '../src/parseSource'
+import {imageWithNoCropSpecified, croppedImage, assetDocument, noHotspotImage} from './fixtures'
 
-function compareParsedSource(outputSource, exptectedSource) {
+function compareParsedSource(outputSource, expectedSource) {
   expect(typeof outputSource).toBe('object')
   expect(typeof outputSource.asset).toBe('object')
-  expect(outputSource.asset._ref).toEqual(exptectedSource.asset._ref)
+  expect(outputSource.asset._ref).toEqual(expectedSource.asset._ref)
   expect(outputSource).toHaveProperty('crop')
   expect(outputSource).toHaveProperty('hotspot')
 }
@@ -15,14 +15,19 @@ describe('parseSource', () => {
     compareParsedSource(parsedSource, imageWithNoCropSpecified())
   })
 
-  test('does correctly parse asset object', () => {
+  test('does correctly parse asset document ID', () => {
     const parsedSource = parseSource(imageWithNoCropSpecified().asset._ref)
     compareParsedSource(parsedSource, imageWithNoCropSpecified())
   })
 
-  test('does correctly parse image asset _ref', () => {
+  test('does correctly parse image asset object', () => {
     const parsedSource = parseSource(imageWithNoCropSpecified().asset)
     compareParsedSource(parsedSource, imageWithNoCropSpecified())
+  })
+
+  test('does correctly parse image asset document', () => {
+    const parsedSource = parseSource(assetDocument())
+    compareParsedSource(parsedSource, noHotspotImage())
   })
 
   test('does not overwrite crop or hotspot settings', () => {


### PR DESCRIPTION
As requested in #800.

Also took the liberty of splitting some logic into separate files and increasing test coverage for a bunch of cases.