### PR TITLE
[cli] Coerce @sanity/core version string before performing satisfaction check

### DIFF
--- a/packages/@sanity/cli/src/util/mergeCommands.js
+++ b/packages/@sanity/cli/src/util/mergeCommands.js
@@ -13,7 +13,10 @@ export default (baseCommands, corePath, options = {}) => {
   const {cwd, workDir} = options
   const core = dynamicRequire(corePath)
 
-  if (core.requiredCliVersionRange && !semver.satisfies(version, core.requiredCliVersionRange)) {
+  if (
+    core.requiredCliVersionRange &&
+    !semver.satisfies(semver.coerce(version), core.requiredCliVersionRange)
+  ) {
     const upgradeCmd = chalk.yellow(getUpgradeCommand({cwd, workDir}))
     /* eslint-disable no-console, no-process-exit */
     console.error(


### PR DESCRIPTION
E.g. `0.131.0-alpha.7b4bcb14` --> `0.131.0`