### PR TITLE
[preview] Don't fail on numbers, booleans and empty values

### DIFF
--- a/packages/@sanity/preview/src/prepareForPreview.js
+++ b/packages/@sanity/preview/src/prepareForPreview.js
@@ -107,27 +107,39 @@ const reportErrors = debounce(() => {
   /* eslint-enable no-console */
 }, 1000)
 
-const stringValidatorFor = fieldName => value =>
-  typeof value === 'string'
-    ? EMPTY
-    : [
-        assignType(
-          'returnValueError',
-          new Error(`The "${fieldName}" field should be a string, instead saw ${inspect(value)}`)
-        )
-      ]
-
+const isRenderable = fieldName => value => {
+  const type = typeof value
+  if (
+    value === null ||
+    type === 'undefined' ||
+    type === 'string' ||
+    type === 'number' ||
+    type === 'boolean'
+  ) {
+    return EMPTY
+  }
+  return [
+    assignType(
+      'returnValueError',
+      new Error(
+        `The "${fieldName}" field should be a string, number, boolean, undefined or null, instead saw ${inspect(
+          value
+        )}`
+      )
+    )
+  ]
+}
 const FIELD_NAME_VALIDATORS = {
   media: () => {
     // not sure how to validate media as it would  possibly involve executing a function and check the
     // return value
     return EMPTY
   },
-  title: stringValidatorFor('title'),
-  subtitle: stringValidatorFor('subtitle'),
-  description: stringValidatorFor('description'),
-  imageUrl: stringValidatorFor('imageUrl'),
-  date: stringValidatorFor('date')
+  title: isRenderable('title'),
+  subtitle: isRenderable('subtitle'),
+  description: isRenderable('description'),
+  imageUrl: isRenderable('imageUrl'),
+  date: isRenderable('date')
 }
 
 function inspect(val, prefixType = true) {

--- a/packages/test-studio/schemas/numbers.js
+++ b/packages/test-studio/schemas/numbers.js
@@ -5,6 +5,12 @@ export default {
   type: 'document',
   title: 'Numbers test',
   icon,
+  preview: {
+    select: {
+      title: 'title',
+      subtitle: 'myNumberField'
+    }
+  },
   fields: [
     {
       name: 'title',

--- a/packages/test-studio/schemas/slugs.js
+++ b/packages/test-studio/schemas/slugs.js
@@ -1,5 +1,3 @@
-import React from 'react'
-
 export default {
   name: 'slugsTest',
   type: 'document',
@@ -12,7 +10,7 @@ export default {
     prepare: ({title, subtitle}) => {
       return {
         title: title,
-        subtitle: <span style={{fontFamily: 'monospace'}}>{`/${subtitle}/`}</span>
+        subtitle: `/${subtitle}/`
       }
     }
   },


### PR DESCRIPTION
This fixes a bug introduced in 0.130.0 triggering preview errors when having numbers (and null/undefined) on preview fields. This should be allowed as all of these can be rendered by React just fine (as React will coerce values of these types strings/nothing).

This also removes an example schema that had a React element set on one of its preview fields. Not sure about the value of keeping this "feature", and for the sake of simplicity I suggest we remove it for now (actually, the support for it was removed in the previous release, it was possible "by accident" and has never been documented)