### PR TITLE
[form-builder] Don't open edit dialog for uploaded items

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ArrayInput/ArrayInput.js
+++ b/packages/@sanity/form-builder/src/inputs/ArrayInput/ArrayInput.js
@@ -244,7 +244,7 @@ export default class ArrayInput extends React.Component<Props, State> {
     const item = createProtoValue(type)
 
     const key = item._key
-    this.handleAppend(item)
+    this.insert(item, 'after', -1)
 
     const events$ = uploader
       .upload(file, type)


### PR DESCRIPTION
Currently drag + drop to upload multiple files to an array did trigger opening the edit dialog for the _last_ newly added item, which was a bit strange and confusing. This fixes it by only appending items.