### PR TITLE
[core] Add ability to override project basePath option with an environment variable

### DIFF
--- a/packages/@sanity/default-layout/src/defaultLayoutRouter.js
+++ b/packages/@sanity/default-layout/src/defaultLayoutRouter.js
@@ -3,7 +3,10 @@ import {project} from 'config:sanity'
 import {route} from 'part:@sanity/base/router'
 import {CONFIGURED_SPACES, HAS_SPACES} from './util/spaces'
 
-const basePath = ((project && project.basePath) || '').replace(/\/+$/, '')
+const basePath = (process.env.STUDIO_BASEPATH || (project && project.basePath) || '').replace(
+  /\/+$/,
+  ''
+)
 
 const toolRoute = route('/:tool', toolParams => {
   const foundTool = tools.find(current => current.name === toolParams.tool)

--- a/packages/@sanity/default-layout/src/defaultLayoutRouter.js
+++ b/packages/@sanity/default-layout/src/defaultLayoutRouter.js
@@ -3,10 +3,7 @@ import {project} from 'config:sanity'
 import {route} from 'part:@sanity/base/router'
 import {CONFIGURED_SPACES, HAS_SPACES} from './util/spaces'
 
-const basePath = (process.env.STUDIO_BASEPATH || (project && project.basePath) || '').replace(
-  /\/+$/,
-  ''
-)
+const basePath = ((project && project.basePath) || '').replace(/\/+$/, '')
 
 const toolRoute = route('/:tool', toolParams => {
   const foundTool = tools.find(current => current.name === toolParams.tool)

--- a/packages/@sanity/server/src/baseServer.js
+++ b/packages/@sanity/server/src/baseServer.js
@@ -49,7 +49,7 @@ export function getDocumentElement({project, basePath, hashes}, props = {}) {
       Object.assign(
         {
           // URL base path
-          basePath: (project && project.basePath) || '',
+          basePath: process.env.STUDIO_BASEPATH || (project && project.basePath) || '',
           title: getTitle(project),
           stylesheets: ['css/main.css'].map(item => assetify(item, assetHashes)),
           scripts: ['js/vendor.bundle.js', 'js/app.bundle.js'].map(item =>

--- a/packages/@sanity/server/src/util/getStaticBasePath.js
+++ b/packages/@sanity/server/src/util/getStaticBasePath.js
@@ -1,5 +1,6 @@
+/* eslint-disable no-process-env */
 const getStaticBasePath = config => {
-  if (!process.env.STUDIO_BASEPATH || !config.project || !config.project.basePath) {
+  if (!process.env.STUDIO_BASEPATH && (!config.project || !config.project.basePath)) {
     return '/static'
   }
 

--- a/packages/@sanity/server/src/util/getStaticBasePath.js
+++ b/packages/@sanity/server/src/util/getStaticBasePath.js
@@ -1,9 +1,14 @@
 const getStaticBasePath = config => {
-  if (!config.project || !config.project.basePath) {
+  if (!process.env.STUDIO_BASEPATH || !config.project || !config.project.basePath) {
     return '/static'
   }
 
-  const basePath = ((config.project && config.project.basePath) || '').replace(/\/+$/, '')
+  const basePath = (
+    process.env.STUDIO_BASEPATH ||
+    (config.project && config.project.basePath) ||
+    ''
+  ).replace(/\/+$/, '')
+
   return `${basePath}/static`
 }
 

--- a/packages/@sanity/util/src/reduceConfig.js
+++ b/packages/@sanity/util/src/reduceConfig.js
@@ -1,9 +1,14 @@
+/* eslint-disable no-process-env */
 import {mergeWith} from 'lodash'
 
-const sanityEnv = process.env.SANITY_ENV || 'production' // eslint-disable-line no-process-env
+const sanityEnv = process.env.SANITY_ENV || 'production'
 const apiHosts = {
   staging: 'https://api.sanity.work',
   development: 'http://api.sanity.wtf'
+}
+
+const processEnvConfig = {
+  project: process.env.STUDIO_BASEPATH ? {basePath: process.env.STUDIO_BASEPATH} : {}
 }
 
 function merge(objValue, srcValue, key) {
@@ -19,7 +24,7 @@ export default (rawConfig, env = 'development') => {
   const apiHost = apiHosts[sanityEnv]
   const sanityConf = apiHost ? {api: {apiHost}} : {}
   const envConfig = (rawConfig.env || {})[env] || {}
-  const config = mergeWith({}, rawConfig, envConfig, sanityConf, merge)
+  const config = mergeWith({}, rawConfig, envConfig, sanityConf, processEnvConfig, merge)
   delete config.env
   return config
 }


### PR DESCRIPTION
Solves #817 

Better than specifying it in the cli as I did in #818 , as basePath is used in files that aren't referring to cli flags (throw that PR away)