### PR TITLE
[chore] Upgrade react-json-inspector

### DIFF
--- a/packages/@sanity/desk-tool/package.json
+++ b/packages/@sanity/desk-tool/package.json
@@ -39,7 +39,7 @@
     "promise-latest": "^1.0.4",
     "react-click-outside": "^2.3.1",
     "react-ink": "^6.1.0",
-    "react-json-inspector": "rexxars/react-json-inspector#react-15",
+    "react-json-inspector": "^7.1.1",
     "react-tiny-virtual-list": "^2.0.5",
     "rxjs": "^6.1.0",
     "shallow-equals": "^1.0.0"

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -26,7 +26,7 @@
     "query-string": "^4.3.2",
     "react-codemirror2": "^1.0.0",
     "react-icon-base": "^2.0.4",
-    "react-json-inspector": "rexxars/react-json-inspector#react-15",
+    "react-json-inspector": "^7.1.1",
     "react-spinner": "^0.2.6",
     "react-split-pane": "^0.1.63"
   },


### PR DESCRIPTION
Since the official react-json-inspector now supports react 15 and above, there is no need to depend on an unofficial branch anymore.