### PR TITLE
Toggle sort direction on desk-tool documents-pane

### DIFF
--- a/packages/@sanity/base/sanity.json
+++ b/packages/@sanity/base/sanity.json
@@ -647,6 +647,14 @@
       "path": "components/icons/Sort.js"
     },
     {
+      "implements": "part:@sanity/base/sort-asc-icon",
+      "path": "components/icons/SortAsc.js"
+    },
+    {
+      "implements": "part:@sanity/base/sort-desc-icon",
+      "path": "components/icons/SortDesc.js"
+    },
+    {
       "implements": "part:@sanity/base/bars-icon",
       "path": "components/icons/Bars.js"
     },

--- a/packages/@sanity/base/src/components/icons/SortAsc.js
+++ b/packages/@sanity/base/src/components/icons/SortAsc.js
@@ -1,0 +1,1 @@
+export {default} from 'react-icons/lib/fa/sort-asc'

--- a/packages/@sanity/base/src/components/icons/SortDesc.js
+++ b/packages/@sanity/base/src/components/icons/SortDesc.js
@@ -1,0 +1,1 @@
+export {default} from 'react-icons/lib/fa/sort-desc'

--- a/packages/@sanity/components/src/menus/DefaultMenu.js
+++ b/packages/@sanity/components/src/menus/DefaultMenu.js
@@ -129,7 +129,8 @@ class DefaultMenu extends React.Component {
                 className={classNames([
                   item === focusedItem ? styles.focusedItem : styles.item,
                   item.isDisabled && styles.isDisabled,
-                  item.divider && styles.divider
+                  item.divider && styles.divider,
+                  item.active && styles.activeItem
                 ])}
               >
                 <a

--- a/packages/@sanity/components/src/menus/styles/DefaultMenu.css
+++ b/packages/@sanity/components/src/menus/styles/DefaultMenu.css
@@ -37,6 +37,10 @@
   margin-right: 0.5em;
 }
 
+.activeItem {
+  font-weight: 600;
+}
+
 .link {
   display: block;
   position: relative;

--- a/packages/@sanity/desk-tool/src/pane/DocumentsPane.js
+++ b/packages/@sanity/desk-tool/src/pane/DocumentsPane.js
@@ -3,6 +3,8 @@ import React from 'react'
 import Spinner from 'part:@sanity/components/loading/spinner'
 import {StateLink, withRouterHOC} from 'part:@sanity/base/router'
 import SortIcon from 'part:@sanity/base/sort-icon'
+import SortAscIcon from 'part:@sanity/base/sort-asc-icon'
+import SortDescIcon from 'part:@sanity/base/sort-desc-icon'
 import Ink from 'react-ink'
 import {partition, uniqBy, get} from 'lodash'
 import VisibilityOffIcon from 'part:@sanity/base/visibility-off-icon'
@@ -198,7 +200,17 @@ export default withRouterHOC(
       return selectedSchemaType.liveEdit === true
     }
 
-    getOrderingOptions(selectedType) {
+    getSortIcon = direction => {
+      if (direction === 'desc') {
+        return SortDescIcon
+      }
+      if (direction === 'asc') {
+        return SortAscIcon
+      }
+      return SortIcon
+    }
+
+    getOrderingOptions = selectedType => {
       const type = schema.get(selectedType)
 
       const optionsWithDefaults = type.orderings
@@ -206,12 +218,15 @@ export default withRouterHOC(
         : DEFAULT_ORDERING_OPTIONS
 
       return uniqBy(optionsWithDefaults, 'name').map(option => {
+        const direction = option.by[0] && option.by[0].direction
+
         return {
           ...option,
-          icon: option.icon || SortIcon,
+          icon: option.icon || this.getSortIcon(direction),
+          active: option.name === this.state.settings.ordering,
           title: (
             <span>
-              Sort by <b>{option.title}</b>
+              Sort by {option.title} ({direction})
             </span>
           )
         }

--- a/packages/@sanity/desk-tool/src/pane/DocumentsPaneMenu.js
+++ b/packages/@sanity/desk-tool/src/pane/DocumentsPaneMenu.js
@@ -80,6 +80,7 @@ export default class DocumentsPaneMenu extends React.PureComponent {
         icon: orderingOption.icon || NULL_COMPONENT,
         ordering: orderingOption,
         action: 'setOrdering',
+        active: orderingOption.active,
         key: orderingOption.name
       }))
       .concat(LIST_VIEW_ITEMS)

--- a/packages/test-studio/schemas/book.js
+++ b/packages/test-studio/schemas/book.js
@@ -62,7 +62,10 @@ export default {
     {
       title: 'Title',
       name: 'title',
-      by: [{field: 'title', direction: 'asc'}, {field: 'publicationYear', direction: 'asc'}]
+      by: [{field: 'title', direction: 'asc'}, {field: 'publicationYear', direction: 'asc'}],
+      toggle: {
+        by: [{field: 'title', direction: 'desc'}, {field: 'publicationYear', direction: 'asc'}]
+      }
     },
     {
       title: 'Author name',
@@ -82,7 +85,15 @@ export default {
     {
       title: 'Swedish title',
       name: 'swedishTitle',
-      by: [{field: 'translations.se', direction: 'asc'}, {field: 'title', direction: 'asc'}]
+      by: [{field: 'translations.se', direction: 'asc'}, {field: 'title', direction: 'asc'}],
+      toggle: {
+        by: [{field: 'translations.se', direction: 'desc'}, {field: 'title', direction: 'desc'}]
+      }
+    },
+    {
+      title: 'Publication year',
+      name: 'publicationYear',
+      by: [{field: 'publicationYear', direction: 'asc'}]
     }
   ],
   preview: {


### PR DESCRIPTION
Toggling between asc/desc is not possible, since the sort order are an array and can have multiple ordering. Just picking the first in array is not a good solution. I tried to solve this by setting a toggle on the ordering. This also solves other scenarios that could appear, like if it is needed to explain the scenario when toggling. By also providing a title (fallback to asc/desc) it is possible to change the title when it toggles (not good UI, but possible)

### Example
```
title: 'Newest',
  name: 'updatedAt',
  by: [{field: '_updatedAt', direction: 'desc'}],
  toggle: {
    title: 'Oldest',
    by: [{field: '_updatedAt', direction: 'asc'}]
  }
```
### Icons
If there is a toggle option, the icon will show an arrow up or down when it is toggled. If there is no toggle option the arrow goes both ways. It is also possible to provide your own icon to the ordering if that is needed.

If we go for this solution, we need to include this in the documentation.

