### PR TITLE
[core] Throw on dataset import failure instead of only printing error

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.js
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.js
@@ -362,7 +362,8 @@ export default async function initSanity(args, context) {
       {argsWithoutOptions: [template.datasetUrl, datasetName], extOptions: {}},
       Object.assign({}, context, {
         apiClient: clientWrapper(manifest, manifestPath),
-        workDir: outputPath
+        workDir: outputPath,
+        fromInitCommand: true
       })
     )
   }

--- a/packages/@sanity/core/src/commands/dataset/importDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/importDatasetCommand.js
@@ -36,7 +36,7 @@ export default {
   description: 'Import documents to given dataset from ndjson file',
   helpText,
   action: async (args, context) => {
-    const {apiClient, output, chalk} = context
+    const {apiClient, output, chalk, fromInitCommand} = context
 
     const operation = getMutationOperation(args.extOptions)
     const client = apiClient()
@@ -152,7 +152,7 @@ export default {
       endTask({success: false})
 
       let error = err.message
-      if (err.response && err.response.statusCode === 409) {
+      if (!fromInitCommand && err.response && err.response.statusCode === 409) {
         error = [
           err.message,
           '',
@@ -160,9 +160,11 @@ export default {
           ' --replace (replace existing documents with same IDs)',
           ' --missing (only import documents that do not already exist)'
         ].join('\n')
+
+        err.message = error
       }
 
-      output.error(chalk.red(`\n${error}\n`))
+      throw err
     }
   }
 }


### PR DESCRIPTION
When encountering errors during a dataset import, we are currently only printing the error. By not throwing, we cannot know if the operation succeeded however, so the `init` command thinks the init process is succesful when the import fails. It also prevents the CLI tool from printing a stack trace when passing the `-d`/`--debug` flag.

This PR fixes this and also hides the `--replace` and `--missing` flag hints when running it from the init command, since they are not available there.