### PR TITLE
[core] Fix visibility mode flag on dataset creation

### DIFF
--- a/packages/@sanity/core/src/commands/dataset/createDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/createDatasetCommand.js
@@ -30,7 +30,7 @@ export default {
       client.request({uri: '/features'})
     ])
 
-    if (flags.visibility && allowedModes.includes(flags.visibility)) {
+    if (flags.visibility && !allowedModes.includes(flags.visibility)) {
       throw new Error(`Visibility mode "${flags.visibility}" not allowed`)
     }
 

--- a/packages/@sanity/core/src/commands/dataset/deleteDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/deleteDatasetCommand.js
@@ -16,6 +16,7 @@ export default {
       type: 'input',
       message:
         'Are you ABSOLUTELY sure you want to delete this dataset?\n  Type the name of the dataset to confirm delete:',
+      filter: input => `${input}`.trim(),
       validate: input => {
         return input === dataset || 'Incorrect dataset name. Ctrl + C to cancel delete.'
       }


### PR DESCRIPTION
The `--visibility` flag was broken on `sanity dataset create`. In addition, I added a basic filter to trim whitespace when confirming dataset deletes since its hard to see whitespace in the terminal.