### PR TITLE
[components] Prevent inner element in button from stealing focus

### DIFF
--- a/packages/@sanity/components/src/buttons/createButtonLike.js
+++ b/packages/@sanity/components/src/buttons/createButtonLike.js
@@ -90,7 +90,7 @@ export default function createButtonLike(Component, {displayName, defaultProps =
           ref={this.setRootElement}
           tabIndex={0}
         >
-          <span className={styles.inner} tabIndex={-1}>
+          <span className={styles.inner}>
             <span className={styles.content}>
               {loading && (
                 <span className={styles.spinner}>

--- a/packages/@sanity/form-builder/src/inputs/ArrayInput/ConfirmButton.js
+++ b/packages/@sanity/form-builder/src/inputs/ArrayInput/ConfirmButton.js
@@ -68,12 +68,7 @@ export default class ConfirmButton extends React.Component {
         />
         <div className={styles.popoverAnchor}>
           {showConfirmDialog && (
-            <PopOver
-              color="danger"
-              useOverlay={false}
-              onEscape={this.handleConfirmPopoverClose}
-              onClickOutside={this.handleConfirmPopoverClose}
-            >
+            <PopOver color="danger" useOverlay={false} onEscape={this.handleConfirmPopoverClose}>
               <div className={styles.wrapper}>
                 <Button
                   color="white"


### PR DESCRIPTION
All our buttons have an inner span with `tabIndex={-1}`. This makes the span receive focus on clicks before the button, and messes with the order the button itself receives focus/blur/click events. Currently when clicking a button, `onblur` is triggered on the button before `onclick` because the inner span receives focus first.

This made the "confirm delete button" on array items break as it had an `onBlur` trigger that closed it. Since onBlur was triggered when the inner span received focus, the confirm popup with the button inside got closed before the click event got triggered on the button at all.

The `tabIndex` on the inner span was there in the first place to be able to differentiate button styling based on whether focus came from tabbing into it, or from clicking on it.

I'll have to leave it up to @kristofferj to do the wizardry required to achieve this while also preserving the expected behavior/order of events on button components (will create a separate issue for it).

(also snuck in a removal of an `onClickOutside` on the ConfirmButton as it is now covered by onBlur)