### PR TITLE
[preview] Refactor and expose WithVisibility helper component

### DIFF
--- a/packages/@sanity/preview/components.js
+++ b/packages/@sanity/preview/components.js
@@ -2,3 +2,4 @@
 exports.PreviewFields = require('./lib/components/PreviewFields').default
 exports.SanityPreview = require('./lib/components/SanityPreview').default
 exports.PreviewSubscriber = require('./lib/components/PreviewSubscriber').default
+exports.WithVisibility = require('./lib/components/WithVisibility').default

--- a/packages/@sanity/preview/src/components/ObserveForPreview.js
+++ b/packages/@sanity/preview/src/components/ObserveForPreview.js
@@ -1,0 +1,67 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import shallowEquals from 'shallow-equals'
+import WarningIcon from 'part:@sanity/base/warning-icon'
+import observeForPreview from '../observeForPreview'
+import {INVALID_PREVIEW_CONFIG} from '../constants'
+
+const INVALID_PREVIEW_FALLBACK = {
+  title: <span style={{fontStyle: 'italic'}}>Invalid preview config</span>,
+  subtitle: <span style={{fontStyle: 'italic'}}>Check the error log in the console</span>,
+  media: WarningIcon
+}
+
+export default class PreviewSubscriber extends React.Component {
+  static propTypes = {
+    type: PropTypes.object.isRequired,
+    fields: PropTypes.arrayOf(PropTypes.oneOf(['title', 'description', 'imageUrl'])),
+    value: PropTypes.any.isRequired,
+    ordering: PropTypes.object,
+    children: PropTypes.func
+  }
+
+  state = {
+    error: null,
+    result: {snapshot: null, type: null}
+  }
+
+  componentDidMount() {
+    this.subscribe(this.props.value, this.props.type, this.props.fields)
+  }
+
+  componentWillUnmount() {
+    this.unsubscribe()
+  }
+
+  unsubscribe() {
+    if (this.subscription) {
+      this.subscription.unsubscribe()
+      this.subscription = null
+    }
+  }
+
+  componentWillUpdate(nextProps) {
+    if (!shallowEquals(nextProps.value, this.props.value)) {
+      this.subscribe(nextProps.value, nextProps.type)
+    }
+  }
+
+  subscribe(value, type, fields) {
+    this.unsubscribe()
+
+    const viewOptions = this.props.ordering ? {ordering: this.props.ordering} : {}
+
+    this.subscription = observeForPreview(value, type, fields, viewOptions).subscribe(result => {
+      this.setState({result})
+    })
+  }
+
+  render() {
+    const {result, error} = this.state
+    const {children} = this.props
+    const snapshot =
+      result.snapshot === INVALID_PREVIEW_CONFIG ? INVALID_PREVIEW_FALLBACK : result.snapshot
+
+    return children({result: {...result, snapshot}, error: error})
+  }
+}

--- a/packages/@sanity/preview/src/components/WithVisibility.js
+++ b/packages/@sanity/preview/src/components/WithVisibility.js
@@ -1,0 +1,78 @@
+import React from 'react'
+import {defer, concat, of as observableOf} from 'rxjs'
+
+import intersectionObservableFor from '../streams/intersectionObservableFor'
+import visibilityChange$ from '../streams/visibilityChange'
+import {
+  map,
+  tap,
+  switchMap,
+  distinctUntilChanged,
+  refCount,
+  publishReplay,
+  delay
+} from 'rxjs/operators'
+
+const isVisible$ = visibilityChange$.pipe(map(event => !event.target.hidden))
+
+// note: the root element here should be  since this component may be used to display inline elements
+const STYLE = {display: 'inline-block', minHeight: '1px', minWidth: '1px'}
+
+// A stream of booleans to signal whether preview component should keep
+// subscriptions active or not
+const documentVisibility$ = concat(defer(() => observableOf(!document.hidden)), isVisible$).pipe(
+  distinctUntilChanged(),
+  publishReplay(1),
+  refCount()
+)
+
+type Props = {
+  // How long to wait before signalling hide
+  hideDelay: Number,
+  children: (isVisible: boolean) => React.Element<*>
+}
+
+type State = {
+  isVisible: boolean
+}
+
+export default class WithVisibility extends React.Component<Props, State> {
+  element = React.createRef()
+
+  state = {isVisible: null}
+
+  componentDidMount() {
+    const {hideDelay = 0} = this.props
+    const inViewport$ = intersectionObservableFor(this.element.current).pipe(
+      map(event => event.isIntersecting)
+    )
+
+    this.subscription = documentVisibility$
+      .pipe(
+        switchMap(isVisible => (isVisible ? inViewport$ : observableOf(false))),
+        switchMap(
+          isVisible => (isVisible ? observableOf(true) : observableOf(false).pipe(delay(hideDelay)))
+        ),
+        distinctUntilChanged(),
+        tap(isVisible => {
+          this.setState({isVisible})
+        })
+      )
+      .subscribe()
+  }
+
+  componentWillUnmount() {
+    this.subscription.unsubscribe()
+    this.subscription = null
+  }
+
+  render() {
+    const {isVisible} = this.state
+    const {children} = this.props
+    return (
+      <div style={STYLE} ref={this.element}>
+        {children(isVisible)}
+      </div>
+    )
+  }
+}


### PR DESCRIPTION
This is a refactor of the existing PreviewSubscriber component, which is now split it into two different components.

Exposes a new `WithVisibility` component that will call its child function component with a boolean value indicating whether the component is on screen or not, e.g:

```jsx
<WithVisibility>
  {isVisible => isVisible ? 'Component is visible' : 'Component is hidden'}
</WithVisibility>
```

This could probably be promoted to an official API building block at some point, but let's just keep it in here for now.