### PR TITLE
[import] Fix serialization of numeric object keys

### DIFF
--- a/packages/@sanity/import/src/serializePath.js
+++ b/packages/@sanity/import/src/serializePath.js
@@ -1,8 +1,13 @@
 module.exports = function serializePath(item) {
   return item.path.reduce((target, part, i) => {
     const isIndex = typeof part === 'number'
+    const isNumericStringKey = !isIndex && isFinite(part)
     const seperator = i === 0 ? '' : '.'
-    const add = isIndex ? `[${part}]` : `${seperator}${part}`
+    if (!isIndex && !isNumericStringKey) {
+      return `${target}${seperator}${part}`
+    }
+
+    const add = isIndex ? `[${part}]` : `["${part}"]`
     return `${target}${add}`
   }, '')
 }


### PR DESCRIPTION
While this generally shouldn't be used, there are cases where someone creates an object with numeric keys:
```json
{
  "0": {
    "_type": "foo",
    "text": "moo"
  },
  "1": {
    "_type": "foo",
    "text": "moo"
  }
}
```

The import module currently serializes this to something along the lines of `body.0.text`, but this is not an allowed path. Instead, we need to use `body["0"].text`. 