### PR TITLE
[image-url] Support parsing asset objects with only URL

### DIFF
--- a/packages/@sanity/image-url/src/parseSource.js
+++ b/packages/@sanity/image-url/src/parseSource.js
@@ -1,4 +1,5 @@
 // Convert an asset-id, asset or image to an image record suitable for processing
+// eslint-disable-next-line complexity
 export default function parseSource(source) {
   if (!source) {
     return null
@@ -6,8 +7,13 @@ export default function parseSource(source) {
 
   let image
 
-  // Did we just get an asset id?
-  if (typeof source === 'string') {
+  if (typeof source === 'string' && isUrl(source)) {
+    // Someone passed an existing image url?
+    image = {
+      asset: {_ref: urlToId(source)}
+    }
+  } else if (typeof source === 'string') {
+    // Just an asset id
     image = {
       asset: {_ref: source}
     }
@@ -23,6 +29,12 @@ export default function parseSource(source) {
         _ref: source._id
       }
     }
+  } else if (source.asset && source.asset.url && !source.asset._ref) {
+    image = {
+      asset: {
+        _ref: urlToId(source.asset.url)
+      }
+    }
   } else if (typeof source.asset === 'object') {
     image = source
   } else {
@@ -32,6 +44,15 @@ export default function parseSource(source) {
   }
 
   return applyDefaultHotspot(image)
+}
+
+function isUrl(url) {
+  return /^https?:\/\//.test(`${url}`)
+}
+
+function urlToId(url) {
+  const [filename] = url.split('/').slice(-1)
+  return `image-${filename}`.replace(/\.([a-z]+)$/, '-$1')
 }
 
 // Mock crop and hotspot if image lacks it

--- a/packages/@sanity/image-url/test/fixtures.js
+++ b/packages/@sanity/image-url/test/fixtures.js
@@ -62,6 +62,14 @@ export function noHotspotImage() {
   }
 }
 
+export function assetWithUrl() {
+  return {
+    asset: {
+      url: 'https://cdn.sanity.io/images/ppsg7ml5/test/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg'
+    }
+  }
+}
+
 export function assetDocument() {
   return {
     _id: 'image-Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000-jpg',

--- a/packages/@sanity/image-url/test/parseSource.test.js
+++ b/packages/@sanity/image-url/test/parseSource.test.js
@@ -1,5 +1,11 @@
 import parseSource from '../src/parseSource'
-import {imageWithNoCropSpecified, croppedImage, assetDocument, noHotspotImage} from './fixtures'
+import {
+  imageWithNoCropSpecified,
+  croppedImage,
+  assetDocument,
+  noHotspotImage,
+  assetWithUrl
+} from './fixtures'
 
 function compareParsedSource(outputSource, expectedSource) {
   expect(typeof outputSource).toBe('object')
@@ -27,6 +33,16 @@ describe('parseSource', () => {
 
   test('does correctly parse image asset document', () => {
     const parsedSource = parseSource(assetDocument())
+    compareParsedSource(parsedSource, noHotspotImage())
+  })
+
+  test('does correctly parse asset object with only url', () => {
+    const parsedSource = parseSource(assetWithUrl())
+    compareParsedSource(parsedSource, noHotspotImage())
+  })
+
+  test('does correctly parse only asset url', () => {
+    const parsedSource = parseSource(assetWithUrl().asset.url)
     compareParsedSource(parsedSource, noHotspotImage())
   })
 


### PR DESCRIPTION
This PR allows the image url module to parse the following formats:

```
"https://cdn.sanity.io/images/projectId/datasetName/someImageFilename-200x200.jpg"
```

```json
{
  "asset": {
    "url": "https://cdn.sanity.io/images/projectId/datasetName/someImageFilename-200x200.jpg"
  }
}
```