### PR TITLE
[server] Allow importing CSS with ?raw to bypass CSS modules

### DIFF
--- a/packages/test-studio/src/components/PertEstimate.css
+++ b/packages/test-studio/src/components/PertEstimate.css
@@ -1,0 +1,8 @@
+body {
+  background: #bf1942;
+}
+
+.pert-global {
+  font-family: monospace !important;
+  background: #bf1942;
+}

--- a/packages/test-studio/src/components/PertEstimateInput.js
+++ b/packages/test-studio/src/components/PertEstimateInput.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {PatchEvent, set, unset, setIfMissing} from 'part:@sanity/form-builder/patch-event'
+import './PertEstimate.css?raw' // eslint-disable-line
 
 const calculateEstimate = estimates => {
   const {optimistic, nominal, pessimistic} = estimates || {}
@@ -39,7 +40,7 @@ export default class PertEstimateInput extends React.Component {
   render() {
     const {value, type} = this.props
     return (
-      <div>
+      <div className="pert-global">
         <h3>{type.title}</h3>
         <p>{type.description}</p>
         <table>


### PR DESCRIPTION
Needs discussion.

We've talked about having an "escape hatch" for using third party components with styling. Currently, importing CSS will always assume you want CSS modules, which doesn't work when people hardcode class names.

## The "right" approach

Probably we should find or create a postcss plugin which allows you to write a CSS module file (`thatPlugin.css`) with something like the following:
```css
@import-with-class-prefix('react-that-plugin/styles.css', 'container')
```

Which will find all selectors in the file and prefix them with a (CSS-module) class name:
```css
.thatPlugin_container_lkk7x .thatPlugin .datePicker { /* ... */ }
```

Which you can then use in your plugin:

```js
import ThatPlugin from 'react-that-plugin'
import styles from './thatPlugin.css'

export default () => (
  <div className={styles.container}>
    <ThatPlugin />
  </div>
)
```

This way there is less risk of class name collisions etc. 

## The shortcut (this PR)

However, there will always be cases where someone wants to just blindly import and pollute the global namespace. Should we allow them to do so?

With this PR, you enable the following syntax:
```js
import ThatPlugin from 'react-that-plugin'
import 'react-that-plugin/styles.css?raw'

export default ThatPlugin
```

Thoughts?