### PR TITLE
[chore] Add Drone CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,26 @@
+clone:
+  clone:
+    image: plugins/git
+    depth: 1
+
+pipeline:
+  build:
+    image: node:8
+    pull: true
+    when:
+      event: push
+      branches: [next, drone-ci]
+    secrets: [sanity_auth_token, npm_token]
+    commands:
+    # Install dependencies
+    - npm install -s
+    - npm run bootstrap
+    - npm run build
+
+    # Deploy the test-studio
+    - cd /drone/src/github.com/sanity-io/sanity/packages/test-studio
+    - /drone/src/github.com/sanity-io/sanity/packages/@sanity/cli/bin/sanity deploy
+
+    # Publish a new `next`
+    #- echo "//registry.npmjs.org/:_authToken=$${NPM_TOKEN}" > ~/.npmrc
+    #- /drone/src/github.com/sanity-io/sanity/node_modules/.bin/lerna publish --npm-tag=next --skip-git --cd-version=prepatch --preid=next --yes


### PR DESCRIPTION
This adds a drone build that will deploy the test-studio when new changes are pushed to `next`. We could in theory keep this in Travis, but I feel slightly safer keeping credentials in Drone.

I'm not sure what the deal should be regarding publishing of a `next` release. Should it be done on every single commit? Should it be need to be tagged somehow? I don't know how npm behaves when you have a gazillion published releases. Thoughts?