### PR TITLE
add missing asset type check

### DIFF
--- a/packages/@sanity/client/src/validators.js
+++ b/packages/@sanity/client/src/validators.js
@@ -16,8 +16,17 @@ exports.projectId = id => {
 }
 
 exports.validateAssetType = type => {
+  const VALID_ASSET_TYPES_LIST = VALID_ASSET_TYPES.join(', ')
+  if (!type) {
+    const errorMessage = `
+      Asset type is not specified.
+      Have you remebered prefixing your import string with <type>@?
+      These types are valid: ${VALID_ASSET_TYPES_LIST}
+    `
+    throw new Error(errorMessage)
+  }
   if (VALID_ASSET_TYPES.indexOf(type) === -1) {
-    throw new Error(`Invalid asset type: ${type}. Must be one of ${VALID_ASSET_TYPES.join(', ')}`)
+    throw new Error(`Invalid asset type: ${type}. Must be one of ${VALID_ASSET_TYPES_LIST}`)
   }
 }
 


### PR DESCRIPTION
Not sure if I hit the mark on this. I thought about validating the import strings in the import script but was not sure where to write that in. The goal is to relay a more helpful error message if the user has forgotten to specify the type-prefix.