### PR TITLE
[form-builder] Allow specifying metadata to extract for images/files

### DIFF
--- a/packages/@sanity/base/src/schema/types/imageAsset.js
+++ b/packages/@sanity/base/src/schema/types/imageAsset.js
@@ -120,6 +120,12 @@ export default {
             {name: 'muted', type: 'object', title: 'Muted', fields: PALETTE_FIELDS}
           ],
           fieldset: 'extra'
+        },
+        {
+          name: 'lqip',
+          title: 'LQIP (Low-Quality Image Placeholder)',
+          type: 'string',
+          readOnly: true
         }
       ]
     }

--- a/packages/@sanity/form-builder/src/inputs/FileInput/FileInput.js
+++ b/packages/@sanity/form-builder/src/inputs/FileInput/FileInput.js
@@ -108,11 +108,12 @@ export default class FileInput extends React.PureComponent<Props, State> {
 
   uploadWith(uploader: Uploader, file: File) {
     const {type, onChange} = this.props
+    const options = {metadata: get(type, 'options.metadata')}
     this.cancelUpload()
     this.setState({isUploading: true})
     onChange(PatchEvent.from([setIfMissing({_type: type.name})]))
 
-    this.uploadSubscription = uploader.upload(file, type).subscribe({
+    this.uploadSubscription = uploader.upload(file, type, options).subscribe({
       next: uploadEvent => {
         if (uploadEvent.patches) {
           onChange(PatchEvent.from(uploadEvent.patches))

--- a/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.js
+++ b/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.js
@@ -113,11 +113,12 @@ export default class ImageInput extends React.PureComponent<Props, State> {
 
   uploadWith(uploader: Uploader, file: File) {
     const {type, onChange} = this.props
+    const options = {metadata: get(type, 'options.metadata')}
     this.cancelUpload()
     this.setState({isUploading: true})
     onChange(PatchEvent.from([setIfMissing({_type: type.name})]))
 
-    this.uploadSubscription = uploader.upload(file, type).subscribe({
+    this.uploadSubscription = uploader.upload(file, type, options).subscribe({
       next: uploadEvent => {
         if (uploadEvent.patches) {
           onChange(PatchEvent.from(uploadEvent.patches))

--- a/packages/@sanity/form-builder/src/sanity/inputs/client-adapters/assets.js
+++ b/packages/@sanity/form-builder/src/sanity/inputs/client-adapters/assets.js
@@ -6,7 +6,8 @@ import {withMaxConcurrency} from '../../utils/withMaxConcurrency'
 
 const MAX_CONCURRENT_UPLOADS = 4
 
-function uploadSanityAsset(assetType, file) {
+function uploadSanityAsset(assetType, file, options = {}) {
+  const extract = options.metadata
   return observableFrom(hashFile(file)).pipe(
     catchError(error =>
       // ignore if hashing fails for some reason
@@ -22,7 +23,7 @@ function uploadSanityAsset(assetType, file) {
           asset: existing
         })
       }
-      return client.observable.assets.upload(assetType, file).pipe(
+      return client.observable.assets.upload(assetType, file, {extract}).pipe(
         map(
           event =>
             event.type === 'response'
@@ -41,8 +42,8 @@ function uploadSanityAsset(assetType, file) {
 
 const uploadAsset = withMaxConcurrency(uploadSanityAsset, MAX_CONCURRENT_UPLOADS)
 
-export const uploadImageAsset = file => uploadAsset('image', file)
-export const uploadFileAsset = file => uploadAsset('file', file)
+export const uploadImageAsset = (file, options) => uploadAsset('image', file, options)
+export const uploadFileAsset = (file, options) => uploadAsset('file', file, options)
 
 export function materializeReference(id) {
   return observePaths(id, ['originalFilename', 'url', 'metadata'])

--- a/packages/@sanity/form-builder/src/sanity/uploads/typedefs.js
+++ b/packages/@sanity/form-builder/src/sanity/uploads/typedefs.js
@@ -7,6 +7,10 @@ export type UploadEvent = {
   patches: ?Array<Patch>
 }
 
+export type UploadOptions = {
+  metadata: ?Array<String>
+}
+
 export type UploaderDef = {
   type: string,
   accepts: string,
@@ -16,7 +20,7 @@ export type UploaderDef = {
 export type Uploader = {
   type: string,
   accepts: string,
-  upload: (file: File, type: Type) => ObservableI<UploadEvent>,
+  upload: (file: File, type: Type, options?: UploadOptions) => ObservableI<UploadEvent>,
   priority: number
 }
 

--- a/packages/@sanity/form-builder/src/sanity/uploads/uploadFile.js
+++ b/packages/@sanity/form-builder/src/sanity/uploads/uploadFile.js
@@ -4,12 +4,12 @@ import type {Observable} from 'rxjs'
 import {map, concat} from 'rxjs/operators'
 import {uploadFileAsset} from '../inputs/client-adapters/assets'
 import {set} from '../../utils/patches'
-import type {UploadEvent} from './typedefs'
+import type {UploadEvent, UploadOptions} from './typedefs'
 import {UPLOAD_STATUS_KEY} from './constants'
 import {createUploadEvent, createInitialUploadEvent, CLEANUP_EVENT} from './utils'
 
-export default function uploadFile(file: File): Observable<UploadEvent> {
-  const upload$ = uploadFileAsset(file).pipe(
+export default function uploadFile(file: File, options?: UploadOptions): Observable<UploadEvent> {
+  const upload$ = uploadFileAsset(file, options).pipe(
     map(event => {
       if (event.type === 'complete') {
         return createUploadEvent([

--- a/packages/@sanity/form-builder/src/sanity/uploads/uploadImage.js
+++ b/packages/@sanity/form-builder/src/sanity/uploads/uploadImage.js
@@ -5,7 +5,7 @@ import readExif from './image/readExif'
 import rotateImage from './image/rotateImage'
 import {DEFAULT_ORIENTATION} from './image/orient'
 import {set} from '../../utils/patches'
-import type {UploadEvent} from './typedefs'
+import type {UploadEvent, UploadOptions} from './typedefs'
 
 // The eslint import plugin doesn't work well with opaque types
 // https://github.com/benmosher/eslint-plugin-import/issues/921
@@ -22,8 +22,8 @@ type Exif = {
   orientation: OrientationId
 }
 
-export default function uploadImage(file: File): ObservableI<UploadEvent> {
-  const upload$ = uploadImageAsset(file).pipe(
+export default function uploadImage(file: File, options?: UploadOptions): ObservableI<UploadEvent> {
+  const upload$ = uploadImageAsset(file, options).pipe(
     filter(event => event.stage !== 'download'),
     map(event => ({
       ...event,

--- a/packages/@sanity/form-builder/src/sanity/uploads/uploaders.js
+++ b/packages/@sanity/form-builder/src/sanity/uploads/uploaders.js
@@ -2,26 +2,26 @@
 import uploadImage from './uploadImage'
 import uploadFile from './uploadFile'
 import type {Uploader, UploaderDef} from './typedefs'
-import type {Type} from '../../typedefs'
+import type {Type, UploadOptions} from '../../typedefs'
 import {set} from '../../utils/patches'
 
 const UPLOAD_IMAGE: UploaderDef = {
   type: 'image',
   accepts: 'image/*',
-  upload: (file: File, type?: Type) => uploadImage(file)
+  upload: (file: File, type?: Type, options?: UploadOptions) => uploadImage(file, options)
 }
 
 const UPLOAD_FILE: UploaderDef = {
   type: 'file',
   accepts: '',
-  upload: (file: File, type: Type) => uploadFile(file)
+  upload: (file: File, type: Type, options?: UploadOptions) => uploadFile(file, options)
 }
 
 const UPLOAD_TEXT: UploaderDef = {
   type: 'string',
   accepts: 'text/*',
-  upload: (file: File, type: Type) =>
-    uploadFile(file).map(content => ({
+  upload: (file: File, type: Type, options?: UploadOptions) =>
+    uploadFile(file, options).map(content => ({
       patches: [set(content)]
     }))
 }

--- a/packages/@sanity/schema/src/sanity/validateSchema.js
+++ b/packages/@sanity/schema/src/sanity/validateSchema.js
@@ -3,6 +3,8 @@ import object from './validation/types/object'
 import reference from './validation/types/reference'
 import array from './validation/types/array'
 import slug from './validation/types/slug'
+import file from './validation/types/file'
+import image from './validation/types/image'
 import common from './validation/types/common'
 import rootType from './validation/types/rootType'
 
@@ -10,6 +12,8 @@ const typeVisitors = {
   array,
   object,
   slug,
+  file,
+  image,
   document: object,
   reference: reference
 }

--- a/packages/@sanity/schema/src/sanity/validation/createValidationResult.js
+++ b/packages/@sanity/schema/src/sanity/validation/createValidationResult.js
@@ -15,7 +15,8 @@ export const HELP_IDS = {
   ARRAY_OF_NOT_UNIQUE: 'schema-array-of-invalid',
   REFERENCE_TO_INVALID: 'schema-reference-to-invalid',
   REFERENCE_TO_NOT_UNIQUE: 'schema-reference-to-invalid',
-  SLUG_SLUGIFY_FN_RENAMED: 'slug-slugifyfn-renamed'
+  SLUG_SLUGIFY_FN_RENAMED: 'slug-slugifyfn-renamed',
+  ASSET_METADATA_FIELD_INVALID: 'asset-metadata-field-invalid'
 }
 
 function createValidationResult(

--- a/packages/@sanity/schema/src/sanity/validation/types/file.js
+++ b/packages/@sanity/schema/src/sanity/validation/types/file.js
@@ -1,0 +1,23 @@
+import {error, HELP_IDS} from '../createValidationResult'
+
+export default (typeDef, visitorContext) => {
+  const problems = []
+
+  if (
+    typeDef.options &&
+    typeof typeDef.options.metadata !== 'undefined' &&
+    !Array.isArray(typeDef.options.metadata)
+  ) {
+    problems.push(
+      error(
+        `Invalid type for file \`metadata\` field - must be an array of strings`,
+        HELP_IDS.ASSET_METADATA_FIELD_INVALID
+      )
+    )
+  }
+
+  return {
+    ...typeDef,
+    _problems: problems
+  }
+}

--- a/packages/@sanity/schema/src/sanity/validation/types/image.js
+++ b/packages/@sanity/schema/src/sanity/validation/types/image.js
@@ -1,0 +1,23 @@
+import {error, HELP_IDS} from '../createValidationResult'
+
+export default (typeDef, visitorContext) => {
+  const problems = []
+
+  if (
+    typeDef.options &&
+    typeof typeDef.options.metadata !== 'undefined' &&
+    !Array.isArray(typeDef.options.metadata)
+  ) {
+    problems.push(
+      error(
+        `Invalid type for image \`metadata\` field - must be an array of strings`,
+        HELP_IDS.ASSET_METADATA_FIELD_INVALID
+      )
+    )
+  }
+
+  return {
+    ...typeDef,
+    _problems: problems
+  }
+}

--- a/packages/test-studio/schemas/images.js
+++ b/packages/test-studio/schemas/images.js
@@ -77,6 +77,16 @@ export default {
       }
     },
     {
+      name: 'jpegImageWithLqip',
+      title: 'JPEG image',
+      type: 'image',
+      description: 'Should only accept JPEGs and will extract only LQIP and location metadata',
+      options: {
+        accept: 'image/jpeg',
+        metadata: ['location', 'lqip']
+      }
+    },
+    {
       name: 'imageWithImage',
       title: 'Image with image',
       type: 'image',


### PR DESCRIPTION
This PR allows users to specify which metadata the server should attempt to extract on a per-field basis. Some information on this here: https://www.sanity.io/help/asset-metadata-field-invalid

Asset documentation should be updated to include more examples and information on which metadata is available for extraction, but I think this is a good start.