### PR TITLE
[core] Fix missing 'dataset' prefix in import/export help

### DIFF
--- a/packages/@sanity/core/src/commands/dataset/exportDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/exportDatasetCommand.js
@@ -17,10 +17,10 @@ Options
   --overwrite   Overwrite any file with the same name
 
 Examples
-  sanity export moviedb localPath.tar.gz
-  sanity export moviedb assetless.tar.gz --no-assets
-  sanity export staging staging.tar.gz --raw
-  sanity export staging staging.tar.gz --types products,shops
+  sanity dataset export moviedb localPath.tar.gz
+  sanity dataset export moviedb assetless.tar.gz --no-assets
+  sanity dataset export staging staging.tar.gz --raw
+  sanity dataset export staging staging.tar.gz --types products,shops
 `
 
 export default {

--- a/packages/@sanity/core/src/commands/dataset/importDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/importDatasetCommand.js
@@ -14,19 +14,19 @@ Options
 
 Examples
   # Import "moviedb.ndjson" from the current directory to the dataset called "moviedb"
-  sanity import moviedb.ndjson moviedb
+  sanity dataset import moviedb.ndjson moviedb
 
   # Import "moviedb.tar.gz" from the current directory to the dataset called "moviedb",
   # replacing any documents encountered that have the same document IDs
-  sanity import moviedb.tar.gz moviedb --replace
+  sanity dataset import moviedb.tar.gz moviedb --replace
 
   # Import from a folder containing an ndjson file, such as an extracted tarball
   # retrieved through "sanity dataset export".
-  sanity import ~/some/folder moviedb
+  sanity dataset import ~/some/folder moviedb
 
   # Import from a remote URL. Will download and extract the tarball to a temporary
   # location before importing it.
-  sanity import https://some.url/moviedb.tar.gz moviedb --replace
+  sanity dataset import https://some.url/moviedb.tar.gz moviedb --replace
 `
 
 export default {


### PR DESCRIPTION
The `sanity dataset import` and `sanity dataset export` commands had left out the `dataset` part from the help text/examples. 