### PR TITLE
[core] More helpful CLI messages

### DIFF
--- a/packages/@sanity/core/src/actions/start/startAction.js
+++ b/packages/@sanity/core/src/actions/start/startAction.js
@@ -65,7 +65,7 @@ export default async (args, context) => {
 
     if (!hasErrors && !hasWarnings) {
       output.print(
-        chalk.green(`Sanity Content Studio compiled successfully! Open it locally at http://${httpHost}:${httpPort}`) // eslint-disable-line max-len
+        chalk.green(`Content Studio successfully compiled! Go to http://${httpHost}:${httpPort}`) // eslint-disable-line max-len
       )
       return
     }
@@ -82,7 +82,7 @@ export default async (args, context) => {
     }
 
     output.print(
-      chalk.green(`Open Sanity Content Studio locally at http://${httpHost}:${httpPort}`)
+      chalk.green(`Content Studio listening on http://${httpHost}:${httpPort}`)
     )
   })
 
@@ -103,7 +103,7 @@ function resolveStaticPath(rootDir, config) {
 function gracefulDeath(httpHost, config, err) {
   if (err.code === 'EADDRINUSE') {
     throw new Error(
-      'Port number for Sanity server is already in use, configure `server.port` in `sanity.json`'
+      'Port number is already in use, configure `server.port` in `sanity.json`'
     )
   }
 
@@ -113,7 +113,7 @@ function gracefulDeath(httpHost, config, err) {
         ? 'port numbers below 1024 requires root privileges'
         : `do you have access to listen to the given host (${httpHost})?`
 
-    throw new Error(`Sanity Content Studio server does not have access to listen to given port - ${help}`) // eslint-disable-line max-len
+    throw new Error(`The Content Studio server does not have access to listen to given port - ${help}`) // eslint-disable-line max-len
   }
 
   throw err

--- a/packages/@sanity/core/src/actions/start/startAction.js
+++ b/packages/@sanity/core/src/actions/start/startAction.js
@@ -65,8 +65,7 @@ export default async (args, context) => {
 
     if (!hasErrors && !hasWarnings) {
       output.print(
-        chalk.green(`Sanity Content Studio compiled successfully!
-        Open it locally at http://${httpHost}:${httpPort}`)
+        chalk.green(`Sanity Content Studio compiled successfully! Open it locally at http://${httpHost}:${httpPort}`) // eslint-disable-line max-len
       )
       return
     }
@@ -82,8 +81,9 @@ export default async (args, context) => {
       printWarnings(output, warnings)
     }
 
-    output.print(chalk.green(`Open Sanity Content Studio
-    locally at http://${httpHost}:${httpPort}`))
+    output.print(
+      chalk.green(`Open Sanity Content Studio locally at http://${httpHost}:${httpPort}`)
+    )
   })
 
   function resetSpinner() {
@@ -113,8 +113,7 @@ function gracefulDeath(httpHost, config, err) {
         ? 'port numbers below 1024 requires root privileges'
         : `do you have access to listen to the given host (${httpHost})?`
 
-    throw new Error(`Sanity Content Studio server
-    does not have access to listen to given port - ${help}`)
+    throw new Error(`Sanity Content Studio server does not have access to listen to given port - ${help}`) // eslint-disable-line max-len
   }
 
   throw err

--- a/packages/@sanity/core/src/actions/start/startAction.js
+++ b/packages/@sanity/core/src/actions/start/startAction.js
@@ -65,7 +65,8 @@ export default async (args, context) => {
 
     if (!hasErrors && !hasWarnings) {
       output.print(
-        chalk.green(`Compiled successfully! Server listening on http://${httpHost}:${httpPort}`)
+        chalk.green(`Sanity Content Studio compiled successfully!
+        Open it locally at http://${httpHost}:${httpPort}`)
       )
       return
     }
@@ -81,7 +82,8 @@ export default async (args, context) => {
       printWarnings(output, warnings)
     }
 
-    output.print(chalk.green(`Server listening on http://${httpHost}:${httpPort}`))
+    output.print(chalk.green(`Open Sanity Content Studio
+    locally at http://${httpHost}:${httpPort}`))
   })
 
   function resetSpinner() {
@@ -111,7 +113,8 @@ function gracefulDeath(httpHost, config, err) {
         ? 'port numbers below 1024 requires root privileges'
         : `do you have access to listen to the given host (${httpHost})?`
 
-    throw new Error(`Sanity server does not have access to listen to given port - ${help}`)
+    throw new Error(`Sanity Content Studio server
+    does not have access to listen to given port - ${help}`)
   }
 
   throw err

--- a/packages/@sanity/core/src/commands/start/startCommand.js
+++ b/packages/@sanity/core/src/commands/start/startCommand.js
@@ -16,7 +16,7 @@ Examples
 export default {
   name: 'start',
   signature: '[--port <port>] [--host <host>]',
-  description: 'Starts a webserver that serves Sanity Content Studio',
+  description: 'Starts a web server for the Content Studio',
   action: lazyRequire(require.resolve('../../actions/start/startAction')),
   helpText
 }

--- a/packages/@sanity/core/src/commands/start/startCommand.js
+++ b/packages/@sanity/core/src/commands/start/startCommand.js
@@ -16,7 +16,7 @@ Examples
 export default {
   name: 'start',
   signature: '[--port <port>] [--host <host>]',
-  description: 'Starts a webserver that serves Sanity',
+  description: 'Starts a webserver that serves Sanity Content Studio',
   action: lazyRequire(require.resolve('../../actions/start/startAction')),
   helpText
 }


### PR DESCRIPTION
Suggestion for some alternative wording at startup. We want to be clearer about what you're running locally, i.e. the Content Studio. Ideally, we could add wording about `the studio being connected to the project ${projectId} and the ${dataset} dataset through the Sanity API`, but I was not sure how to get to the configuration in startAction.js