### PR TITLE
[form-builder] Not send inn the defaultList class in arrayInput

### DIFF
--- a/packages/@sanity/components/src/lists/default/List.js
+++ b/packages/@sanity/components/src/lists/default/List.js
@@ -1,6 +1,8 @@
 // @flow
 import React from 'react'
+import styles from '../styles/DefaultList.css'
+import classNames from 'classnames'
 
 export default function DefaultList(props) {
-  return <ul {...props} />
+  return <ul {...props} className={classNames([styles.root, props.className])} />
 }

--- a/packages/@sanity/components/src/lists/default/ListItem.js
+++ b/packages/@sanity/components/src/lists/default/ListItem.js
@@ -1,6 +1,8 @@
 // @flow
 import React from 'react'
+import styles from '../styles/DefaultListItem.css'
+import classNames from 'classnames'
 
 export default function CoreListItem(props: any) {
-  return <li {...props} />
+  return <li {...props} className={classNames([styles.root, props.className])} />
 }

--- a/packages/@sanity/form-builder/src/inputs/ArrayInput/styles/ArrayInput.css
+++ b/packages/@sanity/form-builder/src/inputs/ArrayInput/styles/ArrayInput.css
@@ -6,7 +6,6 @@
 }
 
 .list {
-  composes: root from 'part:@sanity/components/lists/default-style';
   user-select: none;
 }
 


### PR DESCRIPTION
This has not been picked up until now, since the css build added the grid-class later. Since this got the same specificity, we can not control it. The fix is to not set the defaultClass in array-input, but use the defaultList css in the defaultList component. 
