### PR TITLE
[cli] Make update check actually respect timeout

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -66,6 +66,7 @@
     "opn": "^5.2.0",
     "ora": "^1.3.0",
     "osenv": "^0.1.4",
+    "p-timeout": "^2.0.1",
     "package-json": "^4.0.1",
     "promise-props-recursive": "^1.0.0",
     "react-icons": "^2.2.7",


### PR DESCRIPTION
The update notifier has a max time it'll wait for a latest version reply, but it is totally useless at this point since it waits for the reply without actually using it. This PR implements the _intended_ behavior.