### PR TITLE
[form-builder] Let InvalidValueInput be focusable like any other input

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/InvalidValueInput/InvalidValueInput.js
+++ b/packages/@sanity/form-builder/src/inputs/InvalidValueInput/InvalidValueInput.js
@@ -35,13 +35,17 @@ export default class InvalidValue extends React.PureComponent {
     value: PropTypes.any,
     onChange: PropTypes.func
   }
-
+  element = React.createRef()
   handleClearClick = () => {
     this.props.onChange(PatchEvent.from(unset()))
   }
 
   handleConvertTo = converted => {
     this.props.onChange(PatchEvent.from(set(converted)))
+  }
+
+  focus() {
+    this.element.current.focus()
   }
 
   renderValidTypes() {
@@ -69,7 +73,7 @@ export default class InvalidValue extends React.PureComponent {
     const {value, actualType, validTypes} = this.props
     const converters = getConverters(value, actualType, validTypes)
     return (
-      <div className={styles.root}>
+      <div className={styles.root} tabIndex={0} ref={this.element}>
         <h3>
           Content has invalid type: <code>{actualType}</code>
         </h3>

--- a/packages/@sanity/form-builder/src/inputs/InvalidValueInput/InvalidValueInput.js
+++ b/packages/@sanity/form-builder/src/inputs/InvalidValueInput/InvalidValueInput.js
@@ -35,7 +35,7 @@ export default class InvalidValue extends React.PureComponent {
     value: PropTypes.any,
     onChange: PropTypes.func
   }
-  element = React.createRef()
+
   handleClearClick = () => {
     this.props.onChange(PatchEvent.from(unset()))
   }
@@ -45,7 +45,9 @@ export default class InvalidValue extends React.PureComponent {
   }
 
   focus() {
-    this.element.current.focus()
+    if (this.element) {
+      this.element.focus()
+    }
   }
 
   renderValidTypes() {
@@ -69,11 +71,14 @@ export default class InvalidValue extends React.PureComponent {
     )
   }
 
+  setElement = element => {
+    this.element = element
+  }
   render() {
     const {value, actualType, validTypes} = this.props
     const converters = getConverters(value, actualType, validTypes)
     return (
-      <div className={styles.root} tabIndex={0} ref={this.element}>
+      <div className={styles.root} tabIndex={0} ref={this.setElement}>
         <h3>
           Content has invalid type: <code>{actualType}</code>
         </h3>

--- a/packages/@sanity/form-builder/src/inputs/ObjectInput/Field.js
+++ b/packages/@sanity/form-builder/src/inputs/ObjectInput/Field.js
@@ -62,6 +62,7 @@ export default class Field extends React.Component {
                 onChange={this.handleChange}
                 validTypes={[field.type.name]}
                 actualType={actualType}
+                ref={this.setInput}
               />
             </Fieldset>
           </div>


### PR DESCRIPTION
This fixes a bug in the invalid value warning input that could sometimes cause an error saying `Uncaught TypeError: Cannot read property 'focus' of undefined`