### PR TITLE
[validation] Remove promise concurrency limitation for now

### DIFF
--- a/packages/@sanity/validation/package.json
+++ b/packages/@sanity/validation/package.json
@@ -35,7 +35,6 @@
   "dependencies": {
     "clone-deep": "^2.0.1",
     "es6-error": "^4.0.2",
-    "throat": "^4.1.0",
     "type-of-is": "^3.5.1"
   },
   "jest": {

--- a/packages/@sanity/validation/src/util/promiseLimiter.js
+++ b/packages/@sanity/validation/src/util/promiseLimiter.js
@@ -1,8 +1,0 @@
-const throat = require('throat')
-
-const CONCURRENCY = 3
-
-module.exports = {
-  root: throat(CONCURRENCY),
-  children: throat(CONCURRENCY)
-}

--- a/packages/@sanity/validation/src/validate.js
+++ b/packages/@sanity/validation/src/validate.js
@@ -1,7 +1,6 @@
 const {get, flatten} = require('lodash')
 const ValidationError = require('./ValidationError')
 const genericValidator = require('./validators/genericValidator')
-const promiseLimiter = require('./util/promiseLimiter')
 
 const typeValidators = {
   Boolean: require('./validators/booleanValidator'),
@@ -27,15 +26,10 @@ module.exports = (rule, value, options = {}) => {
   const type = rule._type
   const validators = typeValidators[type] || genericValidator
 
-  const tasks = rules.map(createValidationTask)
+  const tasks = rules.map(validateRule)
   return Promise.all(tasks)
     .then(results => results.filter(Boolean))
     .then(flatten)
-
-  function createValidationTask(curr) {
-    const limiter = options.isChild ? promiseLimiter.children : promiseLimiter.root
-    return limiter(() => validateRule(curr))
-  }
 
   // eslint-disable-next-line complexity
   function validateRule(curr) {


### PR DESCRIPTION
The concurrency limitation in the validation is causing stalled validation jobs and is probably a premature optimization without a thought-through implementation, so removing it for now seems like the best choice.