### PR TITLE
[form-builder] Show validation status in reference inputs

### DIFF
--- a/packages/test-studio/schemas/validation.js
+++ b/packages/test-studio/schemas/validation.js
@@ -151,7 +151,7 @@ export default {
                 return resolve(true)
               }
 
-              return client.fetch('*[_id == $id].coverImage', {id: value._ref}).then(cover => {
+              return client.fetch('*[_id == $id][0].coverImage', {id: value._ref}).then(cover => {
                 resolve(cover ? true : 'Referenced book must have a cover image')
               })
             })


### PR DESCRIPTION
The reference input was not showing markers or validation errors as other inputs did. This passes the appropriate markers and errors on to the right components.