### PR TITLE
[client] Fix passing clientless transaction to mutate(). Fixes #889

### DIFF
--- a/packages/@sanity/client/src/data/dataMethods.js
+++ b/packages/@sanity/client/src/data/dataMethods.js
@@ -79,10 +79,14 @@ module.exports = {
   },
 
   mutate(mutations, options) {
-    const mut = mutations instanceof Patch ? mutations.serialize() : mutations
-    const muts = Array.isArray(mut) ? mut : [mut]
+    const mut =
+      mutations instanceof Patch || mutations instanceof Transaction
+        ? mutations.serialize()
+        : mutations
 
-    return this.dataRequest('mutate', {mutations: muts}, options)
+    const muts = Array.isArray(mut) ? mut : [mut]
+    const transactionId = options && options.transactionId
+    return this.dataRequest('mutate', {mutations: muts, transactionId}, options)
   },
 
   transaction(operations) {

--- a/packages/@sanity/client/test/client.test.js
+++ b/packages/@sanity/client/test/client.test.js
@@ -1297,6 +1297,21 @@ test('Transaction is available on client and can be used without instantiated cl
   t.end()
 })
 
+test('transaction can be created without client and passed to mutate()', t => {
+  const trx = new sanityClient.Transaction()
+  trx.delete('foo')
+
+  const mutations = [{delete: {id: 'foo'}}]
+  nock(projectHost())
+    .post('/v1/data/mutate/foo?returnIds=true&returnDocuments=true&visibility=sync', {mutations})
+    .reply(200, {results: [{id: 'foo', operation: 'delete'}]})
+
+  getClient()
+    .mutate(trx)
+    .catch(t.ifError)
+    .then(() => t.end())
+})
+
 test('transaction commit() throws if called without a client', t => {
   const trans = new sanityClient.Transaction()
   t.throws(() => trans.delete('foo.bar').commit(), /client.*mutate/i)


### PR DESCRIPTION
This fixes #889 - transactions were not called `serialize()` on and this resulted in incorrect JSON.
It also fixes a regression introduced by #768 where transaction IDs would not be passed correctly.