### PR TITLE
[form-builder] Optimize reference search query

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.js
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.js
@@ -130,7 +130,7 @@ export default class ReferenceInput extends React.Component<Props, State> {
   }
 
   handleOpen = () => {
-    this.search('*')
+    this.search('')
   }
 
   search = (query: string) => {

--- a/packages/@sanity/form-builder/src/sanity/inputs/client-adapters/reference.js
+++ b/packages/@sanity/form-builder/src/sanity/inputs/client-adapters/reference.js
@@ -19,7 +19,7 @@ function buildConstraintFromType(type, terms) {
   const typeConstraint = `_type == '${type.name}'`
 
   const stringFieldPaths = type.__unstable_searchFields || []
-  if (stringFieldPaths.length === 0) {
+  if (terms.length === 0 || stringFieldPaths.length === 0) {
     return typeConstraint
   }
 
@@ -31,7 +31,7 @@ function buildConstraintFromType(type, terms) {
 }
 
 export function search(textTerm, referenceType) {
-  const terms = textTerm.split(/\s+/)
+  const terms = textTerm.split(/\s+/).filter(Boolean)
   const typeConstraints = referenceType.to.map(type => buildConstraintFromType(type, terms))
 
   const query = `*[!(_id in path('drafts.**')) && (${typeConstraints


### PR DESCRIPTION
This optimises the query generated when the user opens the reference search dropdown with an empty search term. Previously we generated a filter that matched `**` on all text fields on possible referenced types. This PR fixes it by only constraining on referenced types.