### PR TITLE
[image-url] Allow using materialized assets

### DIFF
--- a/packages/@sanity/image-url/src/parseSource.js
+++ b/packages/@sanity/image-url/src/parseSource.js
@@ -43,6 +43,11 @@ export default function parseSource(source) {
     return null
   }
 
+  if (source && (source.crop || source.hotspot)) {
+    image.crop = source.crop
+    image.hotspot = source.hotspot
+  }
+
   return applyDefaultHotspot(image)
 }
 
@@ -51,8 +56,8 @@ function isUrl(url) {
 }
 
 function urlToId(url) {
-  const [filename] = url.split('/').slice(-1)
-  return `image-${filename}`.replace(/\.([a-z]+)$/, '-$1')
+  const parts = url.split('/').slice(-1)
+  return `image-${parts[0]}`.replace(/\.([a-z]+)$/, '-$1')
 }
 
 // Mock crop and hotspot if image lacks it

--- a/packages/@sanity/image-url/test/fixtures.js
+++ b/packages/@sanity/image-url/test/fixtures.js
@@ -30,6 +30,29 @@ export function uncroppedImage() {
   }
 }
 
+export function materializedAssetWithCrop() {
+  return {
+    _type: 'image',
+    asset: {
+      _id: 'image-Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000-jpg',
+      _type: 'sanity.imageAsset',
+      url: 'https://cdn.sanity.io/images/ppsg7ml5/test/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg'
+    },
+    crop: {
+      bottom: 0.1,
+      left: 0.1,
+      right: 0.1,
+      top: 0.1
+    },
+    hotspot: {
+      height: 0.3,
+      width: 0.3,
+      x: 0.3,
+      y: 0.3
+    }
+  }
+}
+
 export function croppedImage() {
   return {
     _type: 'image',

--- a/packages/@sanity/image-url/test/parseSource.test.js
+++ b/packages/@sanity/image-url/test/parseSource.test.js
@@ -1,6 +1,7 @@
 import parseSource from '../src/parseSource'
 import {
   imageWithNoCropSpecified,
+  materializedAssetWithCrop,
   croppedImage,
   assetDocument,
   noHotspotImage,
@@ -48,6 +49,17 @@ describe('parseSource', () => {
 
   test('does not overwrite crop or hotspot settings', () => {
     expect(parseSource(croppedImage())).toEqual(croppedImage())
+  })
+
+  test('does not overwrite crop or hotspot settings', () => {
+    expect(parseSource(materializedAssetWithCrop())).toMatchObject({
+      asset: {
+        _ref: 'image-Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000-jpg'
+      },
+      crop: {
+        bottom: 0.1
+      }
+    })
   })
 
   test('returns null on non-image object', () => {

--- a/packages/@sanity/image-url/test/urlForHotspotImage.test.js
+++ b/packages/@sanity/image-url/test/urlForHotspotImage.test.js
@@ -1,5 +1,5 @@
 import urlForHotspotImage from '../src/urlForImage'
-import {uncroppedImage, croppedImage, noHotspotImage} from './fixtures'
+import {uncroppedImage, croppedImage, noHotspotImage, materializedAssetWithCrop} from './fixtures'
 
 describe('urlForHotspotImage', () => {
   test('does not crop when no crop is required', () => {
@@ -125,6 +125,19 @@ describe('urlForHotspotImage', () => {
       })
     ).toBe(
       'https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg?h=100'
+    )
+  })
+
+  test('gracefully handles materialized asset', () => {
+    expect(
+      urlForHotspotImage({
+        source: materializedAssetWithCrop(),
+        projectId: 'zp7mbokg',
+        dataset: 'production',
+        height: 100
+      })
+    ).toBe(
+      'https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg?rect=200,300,1600,2400&h=100'
     )
   })
 })


### PR DESCRIPTION
Allows using things like:
```js
{
  _type: 'image',
  asset: {
    _id: 'image-Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000-jpg',
    _type: 'sanity.imageAsset',
    url: 'https://cdn.sanity.io/images/ppsg7ml5/test/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg'
  },
  crop: {
    bottom: 0.1,
    left: 0.1,
    right: 0.1,
    top: 0.1
  },
  hotspot: {
    height: 0.3,
    width: 0.3,
    x: 0.3,
    y: 0.3
  }
}
```