### PR TITLE
[test-studio] Testing rows

### DIFF
--- a/packages/test-studio/schemas/texts.js
+++ b/packages/test-studio/schemas/texts.js
@@ -13,6 +13,20 @@ export default {
       description: 'This is a simple text field'
     },
     {
+      name: 'text2row',
+      type: 'text',
+      title: 'Simple text',
+      description: 'Should have 2 rows',
+      rows: 2
+    },
+    {
+      name: 'text30row',
+      type: 'text',
+      title: 'Simple text',
+      description: 'Should have 30 rows',
+      rows: 30
+    },
+    {
       name: 'readonlyField',
       type: 'text',
       title: 'A read only text',


### PR DESCRIPTION
We already have `rows` in the text type in form builder to specify the height of the textarea. 
Added a test for this in the test studio.
We also need to provide documentation for this.