### PR TITLE
[desk-tool] Support ordering by fields on referenced documents.

### DIFF
--- a/packages/@sanity/desk-tool/src/pane/DocumentsPane.js
+++ b/packages/@sanity/desk-tool/src/pane/DocumentsPane.js
@@ -48,6 +48,33 @@ function toGradientOrderClause(orderBy) {
     .map(ordering => [ordering.field, ordering.direction].filter(Boolean).join(' '))
     .join(', ')
 }
+const IMPLICIT_FIELDS = ['_id', '_type', '_createdAt', '_updatedAt', '_rev']
+// Takes a path array and a schema type and builds a GROQ join every time it enters a reference field
+function joinReferences(schemaType, path) {
+  const [head, ...tail] = path
+  const schemaField = schemaType.fields.find(field => field.name === head)
+  if (!schemaField) {
+    if (!IMPLICIT_FIELDS.includes(head)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'The current ordering config targeted the nonexistent field "%s" on schema type "%s". It should be one of %o',
+        head,
+        schemaType.name,
+        schemaType.fields.map(field => field.name)
+      )
+    }
+    return ''
+  }
+  if (schemaField.type.name === 'reference') {
+    const refTypes = schemaField.type.to
+    return `${head}->{${refTypes.map(refType => joinReferences(refType, tail)).join(',')}}`
+  }
+  return head
+}
+
+function selectWithJoins(schemaType, orderBy) {
+  return orderBy.map(ordering => joinReferences(schemaType, ordering.field.split('.')))
+}
 
 const ORDER_BY_UPDATED_AT = {
   title: 'Last edited',
@@ -307,9 +334,10 @@ export default withRouterHOC(
           option => option.name === settings.ordering
         ) || DEFAULT_SELECTED_ORDERING_OPTION
       const params = {type: schemaType.name, draftsPath: `${DRAFTS_FOLDER}.**`}
-      const query = `*[_type == $type] | order(${toGradientOrderClause(
+      const query = `*[_type == $type] [0...10000] {_id, _type, ${selectWithJoins(
+        schemaType,
         currentOrderingOption.by
-      )}) [0...10000] {_id, _type}`
+      )}} | order(${toGradientOrderClause(currentOrderingOption.by)}){_id, _type}`
       const {selectedType, action} = router.state
       const isSelected = selectedType && !action && !selectedDocumentId
       return (

--- a/packages/test-studio/schemas/author.js
+++ b/packages/test-studio/schemas/author.js
@@ -30,6 +30,12 @@ export default {
       validation: Rule => Rule.required()
     },
     {
+      name: 'bestFriend',
+      title: 'Best friend',
+      type: 'reference',
+      to: [{type: 'author'}]
+    },
+    {
       name: 'image',
       title: 'Image',
       type: 'image',

--- a/packages/test-studio/schemas/book.js
+++ b/packages/test-studio/schemas/book.js
@@ -1,10 +1,14 @@
 import BookIcon from 'react-icons/lib/fa/book'
 
 function formatSubtitle(book) {
-  if (book.authorName && book.publicationYear) {
-    return `By ${book.authorName} (${book.publicationYear})`
-  }
-  return book.authorName ? `By ${book.authorName}` : String(book.publicationYear || '')
+  return [
+    'By',
+    book.authorName || '<unknown>',
+    book.authorBFF && `[BFF ${book.authorBFF} 🤞]`,
+    book.publicationYear && `(${book.publicationYear})`
+  ]
+    .filter(Boolean)
+    .join(' ')
 }
 
 export default {
@@ -61,6 +65,16 @@ export default {
       by: [{field: 'title', direction: 'asc'}, {field: 'publicationYear', direction: 'asc'}]
     },
     {
+      title: 'Author name',
+      name: 'authorName',
+      by: [{field: 'author.name', direction: 'asc'}]
+    },
+    {
+      title: 'Authors best friend',
+      name: 'authorBFF',
+      by: [{field: 'author.bestFriend.name', direction: 'asc'}]
+    },
+    {
       title: 'Swedish title',
       name: 'swedishTitle',
       by: [{field: 'translations.se', direction: 'asc'}, {field: 'title', direction: 'asc'}]
@@ -73,6 +87,7 @@ export default {
       createdAt: '_createdAt',
       date: '_updatedAt',
       authorName: 'author.name',
+      authorBFF: 'author.bestFriend.name',
       publicationYear: 'publicationYear',
       media: 'coverImage'
     },


### PR DESCRIPTION
This fixes #908 by making sure we join in any referenced fields targeted by the ordering config.

E.g.

```*[_type == 'book'] | order(author.name asc) {_id, _type}```

gets rewritten as

```*[_type == 'book'] {_id, _type, author -> {name}} | order(author.name asc) {_id, _type}```