### PR TITLE
[form-builder] Tolerate missing keys and provide a way of fixing

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ArrayInput/ItemValue.js
+++ b/packages/@sanity/form-builder/src/inputs/ArrayInput/ItemValue.js
@@ -21,7 +21,7 @@ import Preview from '../../Preview'
 
 import {resolveTypeName} from '../../utils/resolveTypeName'
 import type {Path} from '../../typedefs/path'
-import type {Type, Marker} from '../../typedefs'
+import type {Marker, Type} from '../../typedefs'
 import * as PathUtils from '../../utils/pathUtils'
 import ConfirmButton from './ConfirmButton'
 import styles from './styles/ItemValue.css'
@@ -74,6 +74,7 @@ function hasFocusInPath(path, value) {
 }
 
 const IGNORE_KEYS = ['_key', '_type', '_weak']
+
 function isEmpty(value) {
   return Object.keys(value).every(key => IGNORE_KEYS.includes(key))
 }
@@ -88,7 +89,7 @@ export default class RenderItemValue extends React.Component<Props> {
 
   componentDidMount() {
     const {focusPath, value} = this.props
-    if (hasFocusInPath(focusPath, value)) {
+    if (value._key && hasFocusInPath(focusPath, value)) {
       this.focus()
     }
   }
@@ -270,13 +271,19 @@ export default class RenderItemValue extends React.Component<Props> {
         item: marker.item.cloneWithMessage(`Contains ${level}`)
       })
     })
+    const classNames = [
+      errors.length > 0 ? styles.innerWithError : styles.inner,
+      !value._key && styles.warning
+    ]
+      .filter(Boolean)
+      .join(' ')
 
     return (
-      <div className={errors.length > 0 ? styles.innerWithError : styles.inner}>
+      <div className={classNames}>
         {!isGrid && isSortable && <DragHandle />}
         <div
           tabIndex={0}
-          onClick={this.handleEditStart}
+          onClick={value._key && this.handleEditStart}
           onKeyPress={this.handleKeyPress}
           className={styles.previewWrapper}
         >
@@ -286,6 +293,7 @@ export default class RenderItemValue extends React.Component<Props> {
             className={styles.previewWrapperHelper}
             onFocus={this.handleFocus}
           >
+            {!value._key && <div className={styles.missingKeyMessage}>Missing key</div>}
             <Preview layout={previewLayout} value={value} type={this.getMemberType()} />
           </div>
         </div>

--- a/packages/@sanity/form-builder/src/inputs/ArrayInput/styles/ArrayInput.css
+++ b/packages/@sanity/form-builder/src/inputs/ArrayInput/styles/ArrayInput.css
@@ -55,11 +55,16 @@
 .warning {
   composes: root from 'part:@sanity/components/fieldsets/default-style';
   padding: var(--medium-padding);
-  border: 5px dashed var(--state-warning-color);
+  border: 2px dashed var(--state-warning-color);
+}
 
-  @nest & > h3 {
-    color: var(--state-warning-color);
-  }
+.missingKeysWarning {
+  composes: warning;
+  padding: 1em;
+}
+
+.fixMissingKeysButtonWrapper {
+  margin: 1em 0;
 }
 
 .functions {

--- a/packages/@sanity/form-builder/src/inputs/ArrayInput/styles/ItemValue.css
+++ b/packages/@sanity/form-builder/src/inputs/ArrayInput/styles/ItemValue.css
@@ -37,6 +37,19 @@
   width: calc(100% + var(--medium-padding) * 2);
   margin-left: calc(var(--medium-padding) * -1);
 }
+.warning {
+  border: 1px dashed var(--state-warning-color);
+}
+
+.missingKeyMessage {
+  color: var(--state-warning-color);
+  position: absolute;
+  top: 1px;
+  right: 1px;
+  z-index: 200;
+  padding: 0.2em 0.4em;
+  background-color: var(--input-bg);
+}
 
 .dragHandle {
   composes: default from 'part:@sanity/components/drag-handle-style';

--- a/packages/@sanity/form-builder/src/inputs/common/Details.js
+++ b/packages/@sanity/form-builder/src/inputs/common/Details.js
@@ -12,14 +12,15 @@ const CONTAINER_STYLE = {
   cursor: 'default',
   userSelect: 'none',
   WebkitUserSelect: 'none',
-  outline: 'none'
+  outline: 'none',
+  marginBottom: '0.5em'
 }
 
 export default class Details extends React.Component {
   static propTypes = {
     children: PropTypes.node,
     isOpen: PropTypes.bool,
-    title: PropTypes.string
+    title: PropTypes.node
   }
 
   static defaultProps = {


### PR DESCRIPTION
This makes the array input tolerate items that is missing `_key`, and provides a way for the user to fix it from within the content studio UI.