### PR TITLE
[form-builder] Fallback to default array input when resolving

### DIFF
--- a/packages/@sanity/form-builder/src/sanity/inputResolver/resolveArrayInput.js
+++ b/packages/@sanity/form-builder/src/sanity/inputResolver/resolveArrayInput.js
@@ -4,6 +4,7 @@ import ArrayOfPrimitivesInput from '../../inputs/ArrayOfPrimitivesInput'
 import TagsArrayInput from '../../inputs/TagsArrayInput'
 import * as is from '../../utils/is'
 import {get} from 'lodash'
+import SanityArrayInput from '../inputs/SanityArrayInput'
 
 const PRIMITIVES = ['string', 'number', 'boolean']
 
@@ -46,5 +47,5 @@ export default function resolveArrayInput(type) {
   }
 
   // use default
-  return null
+  return SanityArrayInput
 }

--- a/packages/test-studio/schemas/arrays.js
+++ b/packages/test-studio/schemas/arrays.js
@@ -1,6 +1,33 @@
 import React from 'react'
 import icon from 'react-icons/lib/md/format-list-numbered'
 
+export const topLevelArrayType = {
+  name: 'topLevelArrayType',
+  type: 'array',
+  of: [
+    {
+      type: 'object',
+      title: 'Content',
+      fields: [{name: 'textContent', type: 'text'}, {name: 'imageContent', type: 'image'}],
+      preview: {select: {title: 'textContent'}}
+    }
+  ]
+}
+export const topLevelPrimitiveArrayType = {
+  name: 'topLevelPrimitiveArrayType',
+  type: 'array',
+  of: [
+    {
+      type: 'string',
+      title: 'A string'
+    },
+    {
+      type: 'number',
+      title: 'A number'
+    }
+  ]
+}
+
 export default {
   name: 'arraysTest',
   type: 'document',
@@ -177,6 +204,16 @@ export default {
           {value: 'publications', title: 'Publications'}
         ]
       }
+    },
+    {
+      name: 'fieldOfTopLevelArrayType',
+      title: 'Field of top level array type',
+      type: 'topLevelArrayType'
+    },
+    {
+      name: 'fieldOfTopLevelPrimitiveArrayType',
+      title: 'Field of top level primitive array type',
+      type: 'topLevelPrimitiveArrayType'
     },
     {
       name: 'imageArrayInGrid',

--- a/packages/test-studio/schemas/schema.js
+++ b/packages/test-studio/schemas/schema.js
@@ -12,7 +12,7 @@ import strings from './strings'
 import texts from './texts'
 import objects, {myObject} from './objects'
 import recursiveObjectTest, {recursiveObject} from './recursiveObject'
-import arrays from './arrays'
+import arrays, {topLevelArrayType, topLevelPrimitiveArrayType} from './arrays'
 import files from './files'
 import uploads from './uploads'
 import code from './code'
@@ -63,6 +63,8 @@ export default createSchema({
     date,
     richDateTest,
     validation,
+    topLevelArrayType,
+    topLevelPrimitiveArrayType,
     arrays,
     uploads,
     code,


### PR DESCRIPTION
This fixes a bug that resolved the array-of-primitives-input to be resolved for "root level" array types (even if they contained non-primitive types).