### PR TITLE
[vision] Fixing background label being selectable (.inputLabelQuery)

### DIFF
--- a/packages/@sanity/vision/src/css/visionGui.css
+++ b/packages/@sanity/vision/src/css/visionGui.css
@@ -110,6 +110,7 @@
   font-size: 2em;
   opacity: 0.2;
   z-index: 10;
+  pointer-events: none;
 }
 
 .inputLabelParams {


### PR DESCRIPTION
When in Vision (`/vision`), the background label is selectable which interfere with selection of QUERY and text from RESULT.

This PR fixes this. Although I have tested in our Content Studio running locally. I can not test it in this repo since I don't have a login. I'm not sure if I'm suppose to add our own `sanity.json` to this repo when contributing. Would be nice if the [Contributing guide](https://github.com/sanity-io/sanity/blob/master/CONTRIBUTING.md) would specify what the requirements are for running this repo locally.