### PR TITLE
[chore] Add missing clean tasks

### DIFF
--- a/packages/@sanity/check/package.json
+++ b/packages/@sanity/check/package.json
@@ -12,7 +12,8 @@
   },
   "license": "MIT",
   "scripts": {
-    "prepublish": "in-publish && ./src/bin.js || not-in-publish"
+    "prepublish": "in-publish && ./src/bin.js || not-in-publish",
+    "clean": "rimraf lib"
   },
   "keywords": [
     "sanity",

--- a/packages/@sanity/date-input/package.json
+++ b/packages/@sanity/date-input/package.json
@@ -5,6 +5,9 @@
   "main": "index.js",
   "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",
+  "scripts": {
+    "clean": "rimraf lib"
+  },
   "dependencies": {
     "@sanity/generate-help-url": "0.132.5",
     "@sanity/rich-date-input": "0.132.8"

--- a/packages/@sanity/document-window/package.json
+++ b/packages/@sanity/document-window/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "clean": "rimraf lib"
   },
   "keywords": [
     "sanity",

--- a/packages/@sanity/generate-help-url/package.json
+++ b/packages/@sanity/generate-help-url/package.json
@@ -4,7 +4,8 @@
   "description": "Generates URLs to specific sections of the Sanity documentation",
   "main": "index.js",
   "scripts": {
-    "test": "tape test/**/*.test.js"
+    "test": "tape test/**/*.test.js",
+    "clean": "rimraf lib"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/storybook/package.json
+++ b/packages/@sanity/storybook/package.json
@@ -3,7 +3,9 @@
   "version": "0.132.8",
   "description": "Sanity plugin for running react-storybook in a Sanity studio",
   "main": "./lib/index.js",
-  "scripts": {},
+  "scripts": {
+    "clean": "rimraf lib"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sanity-io/sanity.git"

--- a/packages/@sanity/validation/package.json
+++ b/packages/@sanity/validation/package.json
@@ -5,7 +5,8 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "clean": "rimraf lib"
   },
   "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",

--- a/packages/@sanity/webpack-integration/package.json
+++ b/packages/@sanity/webpack-integration/package.json
@@ -3,7 +3,9 @@
   "version": "0.132.8",
   "description": "Tools and modules required for making partisan (the part system) work with webpack",
   "main": "src/v1/index.js",
-  "scripts": {},
+  "scripts": {
+    "clean": "rimraf lib"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sanity-io/sanity.git"

--- a/packages/ecommerce-studio/package.json
+++ b/packages/ecommerce-studio/package.json
@@ -8,7 +8,8 @@
   "license": "MIT",
   "scripts": {
     "start": "sanity start",
-    "test": "sanity check"
+    "test": "sanity check",
+    "clean": "rimraf lib"
   },
   "keywords": [
     "sanity",

--- a/packages/movies-studio/package.json
+++ b/packages/movies-studio/package.json
@@ -8,7 +8,8 @@
   "license": "MIT",
   "scripts": {
     "start": "cd ../.. && npm run movies-studio",
-    "test": "sanity check"
+    "test": "sanity check",
+    "clean": "rimraf lib"
   },
   "keywords": [
     "sanity",


### PR DESCRIPTION
I noticed a few projects did not have a clean task, so their `lib` folder didn't get removed on `npm run clean`. This fixes that.