### PR TITLE
[form-builder] Don't check propType using instanceOf

### DIFF
--- a/packages/@sanity/form-builder/src/FormBuilderContext.js
+++ b/packages/@sanity/form-builder/src/FormBuilderContext.js
@@ -55,7 +55,7 @@ export default class FormBuilderContext extends React.Component {
   }
 
   static propTypes = {
-    schema: PropTypes.instanceOf(Schema).isRequired,
+    schema: PropTypes.object.isRequired,
     value: PropTypes.any,
     children: PropTypes.any.isRequired,
     filterField: PropTypes.func.isRequired,
@@ -71,7 +71,7 @@ export default class FormBuilderContext extends React.Component {
     onPatch: PropTypes.func,
     filterField: PropTypes.func,
     formBuilder: PropTypes.shape({
-      schema: PropTypes.instanceOf(Schema),
+      schema: PropTypes.object,
       resolveInputComponent: PropTypes.func,
       document: PropTypes.any
     })


### PR DESCRIPTION
Fixes an annoying warning if, for some reason, the schema prop is not an instanceof the schema constructor (this may be a symptom of the schema package being included as two separate packages in the studio and worth investigating separately, but since things still would work, there's no reason to include this warning).