### PR TITLE
[form-builder] Don't blindly forward props to wrapped input components

### DIFF
--- a/packages/@sanity/form-builder/src/FormBuilderContext.js
+++ b/packages/@sanity/form-builder/src/FormBuilderContext.js
@@ -58,7 +58,7 @@ export default class FormBuilderContext extends React.Component {
     schema: PropTypes.instanceOf(Schema).isRequired,
     value: PropTypes.any,
     children: PropTypes.any.isRequired,
-    filterField: PropTypes.func.isRequired,
+    filterField: PropTypes.func,
     patchChannel: PropTypes.shape({
       onPatch: PropTypes.func
     }),

--- a/packages/@sanity/form-builder/src/inputs/BooleanInput.js
+++ b/packages/@sanity/form-builder/src/inputs/BooleanInput.js
@@ -38,7 +38,6 @@ export default class BooleanInput extends React.Component<Props> {
     const isCheckbox = type.options && type.options.layout === 'checkbox'
     return isCheckbox ? (
       <Checkbox
-        {...rest}
         readOnly={readOnly}
         onChange={this.handleChange}
         checked={value}
@@ -49,7 +48,6 @@ export default class BooleanInput extends React.Component<Props> {
       </Checkbox>
     ) : (
       <Switch
-        {...rest}
         readOnly={readOnly}
         onChange={this.handleChange}
         checked={value}

--- a/packages/@sanity/form-builder/src/inputs/EmailInput.js
+++ b/packages/@sanity/form-builder/src/inputs/EmailInput.js
@@ -40,7 +40,6 @@ export default class EmailInput extends React.Component<Props> {
     return (
       <FormField markers={markers} level={level} label={type.title} description={type.description}>
         <TextInput
-          {...rest}
           type="email"
           customValidity={errors && errors.length > 0 ? errors[0].item.message : ''}
           value={value}

--- a/packages/@sanity/form-builder/src/inputs/NumberInput.js
+++ b/packages/@sanity/form-builder/src/inputs/NumberInput.js
@@ -40,7 +40,6 @@ export default class NumberInput extends React.Component<Props> {
     return (
       <FormField markers={markers} level={level} label={type.title} description={type.description}>
         <TextInput
-          {...rest}
           customValidity={errors && errors.length > 0 ? errors[0].item.message : ''}
           type="number"
           value={value}

--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.js
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.js
@@ -233,7 +233,6 @@ export default class ReferenceInput extends React.Component<Props, State> {
             </div>
           )}
           <SearchableSelect
-            {...rest}
             placeholder="Type to search…"
             title={
               isMissing && hasRef

--- a/packages/@sanity/form-builder/src/inputs/SelectInput.js
+++ b/packages/@sanity/form-builder/src/inputs/SelectInput.js
@@ -59,7 +59,6 @@ export default class StringSelect extends React.Component<Props> {
         {isRadio ? (
           // todo: make separate inputs
           <RadioSelect
-            {...rest}
             name={this.name}
             legend={type.title}
             items={items}
@@ -71,7 +70,6 @@ export default class StringSelect extends React.Component<Props> {
           />
         ) : (
           <Select
-            {...rest}
             label={type.title}
             value={currentItem}
             placeholder={type.placeholder}

--- a/packages/@sanity/form-builder/src/inputs/Slug/SlugInput.js
+++ b/packages/@sanity/form-builder/src/inputs/Slug/SlugInput.js
@@ -159,7 +159,6 @@ export default withValuePath(
             <div className={styles.wrapper}>
               <div className={styles.input}>
                 <TextInput
-                  {...rest}
                   ref={this.setTextInput}
                   customValidity={errors.length > 0 ? errors[0].item.message : ''}
                   disabled={loading}

--- a/packages/@sanity/form-builder/src/inputs/StringInput.js
+++ b/packages/@sanity/form-builder/src/inputs/StringInput.js
@@ -40,7 +40,6 @@ export default class StringInput extends React.Component<Props> {
     return (
       <FormField markers={markers} level={level} label={type.title} description={type.description}>
         <TextInput
-          {...rest}
           customValidity={errors.length > 0 ? errors[0].item.message : ''}
           type="text"
           value={value}

--- a/packages/@sanity/form-builder/src/inputs/TagsArrayInput.js
+++ b/packages/@sanity/form-builder/src/inputs/TagsArrayInput.js
@@ -40,7 +40,6 @@ export default class TagsArrayInput extends React.PureComponent<Props> {
     return (
       <FormField level={level} label={type.title} description={type.description}>
         <TagInput
-          {...rest}
           readOnly={readOnly}
           value={value}
           onChange={this.handleChange}

--- a/packages/@sanity/form-builder/src/inputs/TelephoneInput.js
+++ b/packages/@sanity/form-builder/src/inputs/TelephoneInput.js
@@ -40,7 +40,6 @@ export default class TelephoneInput extends React.Component<Props> {
     return (
       <FormField markers={markers} level={level} label={type.title} description={type.description}>
         <TextInput
-          {...rest}
           customValidity={errors && errors.length > 0 ? errors[0].item.message : ''}
           type="tel"
           value={value}

--- a/packages/@sanity/form-builder/src/inputs/TextInput.js
+++ b/packages/@sanity/form-builder/src/inputs/TextInput.js
@@ -40,7 +40,6 @@ export default class TextInput extends React.Component<Props> {
     return (
       <FormField markers={markers} level={level} label={type.title} description={type.description}>
         <TextArea
-          {...rest}
           customValidity={errors && errors.length > 0 ? errors[0].item.message : ''}
           value={value}
           readOnly={readOnly}

--- a/packages/@sanity/form-builder/src/inputs/UrlInput.js
+++ b/packages/@sanity/form-builder/src/inputs/UrlInput.js
@@ -40,7 +40,6 @@ export default class UrlInput extends React.Component<Props> {
     return (
       <FormField markers={markers} level={level} label={type.title} description={type.description}>
         <TextInput
-          {...rest}
           customValidity={errors && errors.length > 0 ? errors[0].item.message : ''}
           type="url"
           value={value}


### PR DESCRIPTION
This removes forwarding of props to the underlying input component. I'd rather prefer us to be explicit about the props we'd like to forward (both in order to state intent, and to avoid causing unnecessary warnings about non-supported props passed to underlying native dom elements).

It _should_ be safe, but can potentially break stuff, so we should keep this in mind if we get error reports on something related to inputs not receiving expected props (I've also tested pretty thoroughly, and everything looks fine).