### PR TITLE
[form-builder] Use && for each term when searching for references

### DIFF
--- a/packages/@sanity/form-builder/src/sanity/inputs/client-adapters/reference.js
+++ b/packages/@sanity/form-builder/src/sanity/inputs/client-adapters/reference.js
@@ -23,8 +23,8 @@ function buildConstraintFromType(type, terms) {
     return typeConstraint
   }
 
-  const stringFieldConstraints = flatten(
-    stringFieldPaths.map(fieldPath => terms.map(term => `${fieldPath} match '${term}*'`))
+  const stringFieldConstraints = stringFieldPaths.map(fieldPath =>
+    terms.map(term => `${fieldPath} match '${term}*'`).join(' && ')
   )
 
   return `${typeConstraint} && (${stringFieldConstraints.join(' || ')})`


### PR DESCRIPTION
This makes it possible to _narrow_ the reference search by adding more words/search terms.