### PR TITLE
[schema] Make sure we don't create fallback order config for non-primitive field types

### DIFF
--- a/packages/@sanity/schema/src/legacy/ordering/guessOrderingConfig.js
+++ b/packages/@sanity/schema/src/legacy/ordering/guessOrderingConfig.js
@@ -8,7 +8,7 @@ const isPrimitive = field => PRIMITIVES.includes(field.type)
 
 export default function guessOrderingConfig(objectTypeDef) {
   let candidates = CANDIDATES.filter(candidate =>
-    objectTypeDef.fields.some(field => field.name === candidate)
+    objectTypeDef.fields.some(field => isPrimitive(field) && field.name === candidate)
   )
 
   // None of the candidates were found, fallback to all fields

--- a/packages/test-studio/schemas/typeWithNoToplevelStrings.js
+++ b/packages/test-studio/schemas/typeWithNoToplevelStrings.js
@@ -17,6 +17,17 @@ export default {
       ]
     },
     {
+      name: 'name',
+      title: "Name field (can't be sorted)",
+      type: 'object',
+      fieldsets: [{name: 'other', title: 'Translations'}],
+      fields: [
+        {name: 'no', type: 'string', title: 'Norwegian (Bokmål)'},
+        {name: 'nn', type: 'string', title: 'Norwegian (Nynorsk)', fieldset: 'other'},
+        {name: 'se', type: 'string', title: 'Swedish', fieldset: 'other'}
+      ]
+    },
+    {
       name: 'externalId',
       title: 'External id',
       type: 'string'


### PR DESCRIPTION
When creating a default sort order in the studio, we looked for fields on the document type that was named either `title`, `name`, `label`, `heading`, `header`, `caption` or `description`, and assumed they were primitive fields that could be included in an order clause.

This assumption turns out to be wrong in many cases, so this PR includes a check to ensure the candidate fields are also primitives.