### PR TITLE
[image-url] Use object rest spread instead of Object.assign

### DIFF
--- a/packages/@sanity/image-url/src/builder.js
+++ b/packages/@sanity/image-url/src/builder.js
@@ -6,7 +6,7 @@ const validCrops = ['top', 'bottom', 'left', 'right', 'center', 'focalpoint', 'e
 class ImageUrlBuilder {
   constructor(parent, options) {
     if (parent) {
-      this.options = Object.assign({}, parent.options, options || {})
+      this.options = {...(parent.options || {}), ...(options || {})}
     } else {
       this.options = options || {}
     }

--- a/packages/@sanity/image-url/src/parseSource.js
+++ b/packages/@sanity/image-url/src/parseSource.js
@@ -68,21 +68,19 @@ function applyDefaults(image) {
     return image
   }
 
-  return Object.assign(
-    {
-      crop: {
-        left: 0,
-        top: 0,
-        bottom: 0,
-        right: 0
-      },
-      hotspot: {
-        x: 0.5,
-        y: 0.5,
-        height: 1.0,
-        width: 1.0
-      }
+  return {
+    crop: {
+      left: 0,
+      top: 0,
+      bottom: 0,
+      right: 0
     },
-    image
-  )
+    hotspot: {
+      x: 0.5,
+      y: 0.5,
+      height: 1.0,
+      width: 1.0
+    },
+    ...image
+  }
 }

--- a/packages/@sanity/image-url/src/urlForImage.js
+++ b/packages/@sanity/image-url/src/urlForImage.js
@@ -20,7 +20,7 @@ const SPEC_NAME_TO_URL_NAME_MAPPINGS = [
 ]
 
 export default function urlForImage(options) {
-  let spec = Object.assign({}, options || {})
+  let spec = {...(options || {})}
   const source = spec.source
   delete spec.source
 
@@ -57,7 +57,7 @@ export default function urlForImage(options) {
   // If irrelevant, or if we are requested to: don't perform crop/fit based on
   // the crop/hotspot.
   if (!(spec.rect || spec.focalPoint || spec.ignoreImageParams || spec.crop)) {
-    spec = Object.assign(spec, fit({crop, hotspot}, spec))
+    spec = {...spec, ...fit({crop, hotspot}, spec)}
   }
 
   return specToImageUrl(spec)


### PR DESCRIPTION
Replaces all the uses of `Object.assign` with object rest spread (which babel compiles down to something else), adding support for older versions of IE.