### PR TITLE
[form-builder] Make sure we pass down onFocus to wrapped input components

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BooleanInput.js
+++ b/packages/@sanity/form-builder/src/inputs/BooleanInput.js
@@ -9,8 +9,7 @@ type Props = {
   type: Type,
   value: ?boolean,
   readOnly: ?boolean,
-  level: number,
-  description: ?string,
+  onFocus: () => void,
   onChange: PatchEvent => void
 }
 
@@ -33,7 +32,7 @@ export default class BooleanInput extends React.Component<Props> {
   }
 
   render() {
-    const {value, type, readOnly, level, description, ...rest} = this.props
+    const {value, type, readOnly, onFocus} = this.props
 
     const isCheckbox = type.options && type.options.layout === 'checkbox'
     return isCheckbox ? (
@@ -49,10 +48,11 @@ export default class BooleanInput extends React.Component<Props> {
     ) : (
       <Switch
         readOnly={readOnly}
-        onChange={this.handleChange}
         checked={value}
         label={type.title}
         description={type.description}
+        onChange={this.handleChange}
+        onFocus={onFocus}
         ref={this.setInput}
       />
     )

--- a/packages/@sanity/form-builder/src/inputs/EmailInput.js
+++ b/packages/@sanity/form-builder/src/inputs/EmailInput.js
@@ -11,6 +11,7 @@ type Props = {
   value: ?string,
   readOnly: ?boolean,
   onChange: PatchEvent => void,
+  onFocus: () => void,
   markers: Array<Marker>
 }
 
@@ -33,7 +34,7 @@ export default class EmailInput extends React.Component<Props> {
   }
 
   render() {
-    const {value, readOnly, type, markers, level, ...rest} = this.props
+    const {value, readOnly, type, markers, level, onFocus} = this.props
     const validation = markers.filter(marker => marker.type === 'validation')
     const errors = validation.filter(marker => marker.level === 'error')
 
@@ -46,6 +47,7 @@ export default class EmailInput extends React.Component<Props> {
           readOnly={readOnly}
           placeholder={type.placeholder}
           onChange={this.handleChange}
+          onFocus={onFocus}
           ref={this.setInput}
         />
       </FormField>

--- a/packages/@sanity/form-builder/src/inputs/NumberInput.js
+++ b/packages/@sanity/form-builder/src/inputs/NumberInput.js
@@ -11,6 +11,7 @@ type Props = {
   value: ?string,
   readOnly: ?boolean,
   onChange: PatchEvent => void,
+  onFocus: () => void,
   markers: Array<Marker>
 }
 
@@ -33,7 +34,7 @@ export default class NumberInput extends React.Component<Props> {
   }
 
   render() {
-    const {value = '', readOnly, markers, type, level, ...rest} = this.props
+    const {value = '', readOnly, markers, type, level, onFocus} = this.props
     const validation = markers.filter(marker => marker.type === 'validation')
     const errors = validation.filter(marker => marker.level === 'error')
 
@@ -46,6 +47,7 @@ export default class NumberInput extends React.Component<Props> {
           readOnly={readOnly}
           placeholder={type.placeholder}
           onChange={this.handleChange}
+          onFocus={onFocus}
           ref={this.setInput}
         />
       </FormField>

--- a/packages/@sanity/form-builder/src/inputs/SelectInput.js
+++ b/packages/@sanity/form-builder/src/inputs/SelectInput.js
@@ -19,6 +19,7 @@ type Props = {
   value: ?string,
   readOnly: ?boolean,
   onChange: PatchEvent => void,
+  onFocus: () => void,
   markers: Array<Marker>
 }
 
@@ -47,7 +48,7 @@ export default class StringSelect extends React.Component<Props> {
   }
 
   render() {
-    const {value, readOnly, markers, type, level, ...rest} = this.props
+    const {value, readOnly, markers, type, level, onFocus} = this.props
     const items = toSelectItems(type.options.list || [])
 
     const currentItem = items.find(item => item.value === value)
@@ -63,6 +64,7 @@ export default class StringSelect extends React.Component<Props> {
             legend={type.title}
             items={items}
             onChange={this.handleChange}
+            onFocus={onFocus}
             value={currentItem}
             direction={type.options.direction || 'vertical'}
             ref={this.setInput}
@@ -74,6 +76,7 @@ export default class StringSelect extends React.Component<Props> {
             value={currentItem}
             placeholder={type.placeholder}
             onChange={this.handleChange}
+            onFocus={onFocus}
             items={[EMPTY_ITEM].concat(items)}
             ref={this.setInput}
             readOnly={readOnly}

--- a/packages/@sanity/form-builder/src/inputs/Slug/SlugInput.js
+++ b/packages/@sanity/form-builder/src/inputs/Slug/SlugInput.js
@@ -139,7 +139,7 @@ export default withValuePath(
       }
 
       render() {
-        const {value, type, level, markers, onFocus, document, getValuePath, ...rest} = this.props
+        const {value, type, level, markers} = this.props
         const {loading, inputText} = this.state
 
         const hasSourceField = type.options && type.options.source

--- a/packages/@sanity/form-builder/src/inputs/StringInput.js
+++ b/packages/@sanity/form-builder/src/inputs/StringInput.js
@@ -11,6 +11,7 @@ type Props = {
   value: ?string,
   readOnly: ?boolean,
   onChange: PatchEvent => void,
+  onFocus: () => void,
   markers: Array<Marker>
 }
 
@@ -33,7 +34,7 @@ export default class StringInput extends React.Component<Props> {
   }
 
   render() {
-    const {value, readOnly, type, markers, level, ...rest} = this.props
+    const {value, readOnly, type, markers, level, onFocus} = this.props
     const validation = markers.filter(marker => marker.type === 'validation')
     const errors = validation.filter(marker => marker.level === 'error')
 
@@ -46,6 +47,7 @@ export default class StringInput extends React.Component<Props> {
           readOnly={readOnly}
           placeholder={type.placeholder}
           onChange={this.handleChange}
+          onFocus={onFocus}
           ref={this.setInput}
         />
       </FormField>

--- a/packages/@sanity/form-builder/src/inputs/TagsArrayInput.js
+++ b/packages/@sanity/form-builder/src/inputs/TagsArrayInput.js
@@ -3,14 +3,15 @@ import React from 'react'
 import FormField from 'part:@sanity/components/formfields/default'
 import TagInput from 'part:@sanity/components/tags/textfield'
 import PatchEvent, {set, unset} from '../../PatchEvent'
-import type {Type} from '../../typedefs'
+import type {Type} from '../typedefs'
 
 type Props = {
   type: Type,
   value: Array<string>,
   level: number,
   readOnly: ?boolean,
-  onChange: PatchEvent => void
+  onChange: PatchEvent => void,
+  onFocus: () => void
 }
 
 export default class TagsArrayInput extends React.PureComponent<Props> {
@@ -36,13 +37,14 @@ export default class TagsArrayInput extends React.PureComponent<Props> {
   }
 
   render() {
-    const {type, value, readOnly, level, ...rest} = this.props
+    const {type, value, readOnly, level, onFocus} = this.props
     return (
       <FormField level={level} label={type.title} description={type.description}>
         <TagInput
           readOnly={readOnly}
           value={value}
           onChange={this.handleChange}
+          onFocus={onFocus}
           ref={this.setInput}
         />
       </FormField>

--- a/packages/@sanity/form-builder/src/inputs/TelephoneInput.js
+++ b/packages/@sanity/form-builder/src/inputs/TelephoneInput.js
@@ -11,6 +11,7 @@ type Props = {
   value: ?string,
   readOnly: ?boolean,
   onChange: PatchEvent => void,
+  onFocus: () => void,
   markers: Array<Marker>
 }
 
@@ -33,7 +34,7 @@ export default class TelephoneInput extends React.Component<Props> {
   }
 
   render() {
-    const {value, markers, type, readOnly, level, ...rest} = this.props
+    const {value, markers, type, readOnly, level, onFocus} = this.props
     const validation = markers.filter(marker => marker.type === 'validation')
     const errors = validation.filter(marker => marker.level === 'error')
 
@@ -46,6 +47,7 @@ export default class TelephoneInput extends React.Component<Props> {
           readOnly={readOnly}
           placeholder={type.placeholder}
           onChange={this.handleChange}
+          onFocus={onFocus}
           ref={this.setInput}
         />
       </FormField>

--- a/packages/@sanity/form-builder/src/inputs/TextInput.js
+++ b/packages/@sanity/form-builder/src/inputs/TextInput.js
@@ -11,6 +11,7 @@ type Props = {
   value: ?string,
   readOnly: ?boolean,
   onChange: PatchEvent => void,
+  onFocus: () => void,
   markers: Array<Marker>
 }
 
@@ -33,7 +34,7 @@ export default class TextInput extends React.Component<Props> {
   }
 
   render() {
-    const {value, markers, type, readOnly, level, ...rest} = this.props
+    const {value, markers, type, readOnly, level, onFocus} = this.props
     const validation = markers.filter(marker => marker.type === 'validation')
     const errors = validation.filter(marker => marker.level === 'error')
 
@@ -45,6 +46,7 @@ export default class TextInput extends React.Component<Props> {
           readOnly={readOnly}
           placeholder={type.placeholder}
           onChange={this.handleChange}
+          onFocus={onFocus}
           rows={type.rows}
           ref={this.setInput}
         />

--- a/packages/@sanity/form-builder/src/inputs/UrlInput.js
+++ b/packages/@sanity/form-builder/src/inputs/UrlInput.js
@@ -11,6 +11,7 @@ type Props = {
   value: ?string,
   readOnly: ?boolean,
   onChange: PatchEvent => void,
+  onFocus: () => void,
   markers: Array<Marker>
 }
 
@@ -33,7 +34,7 @@ export default class UrlInput extends React.Component<Props> {
   }
 
   render() {
-    const {value, markers, type, readOnly, level, ...rest} = this.props
+    const {value, markers, type, readOnly, level, onFocus} = this.props
     const validation = markers.filter(marker => marker.type === 'validation')
     const errors = validation.filter(marker => marker.level === 'error')
 
@@ -46,6 +47,7 @@ export default class UrlInput extends React.Component<Props> {
           readOnly={readOnly}
           placeholder={type.placeholder}
           onChange={this.handleChange}
+          onFocus={onFocus}
           ref={this.setInput}
         />
       </FormField>


### PR DESCRIPTION
I noticed that #942 accidentally broke focus handling in certain cases by not passing `onFocus` to the actual input component.

It's not super critical from what I can tell, so lets merge it into next for now (and instead cherry-pick it  into a hotfix if it turns out otherwise).