### PR TITLE
[desk-tool] Support order by reference fields on level > 1

### DIFF
--- a/packages/@sanity/desk-tool/src/pane/DocumentsPane.js
+++ b/packages/@sanity/desk-tool/src/pane/DocumentsPane.js
@@ -69,7 +69,7 @@ function joinReferences(schemaType, path) {
     const refTypes = schemaField.type.to
     return `${head}->{${refTypes.map(refType => joinReferences(refType, tail)).join(',')}}`
   }
-  return head
+  return tail.length > 0 ? `${head}{${joinReferences(schemaField.type, tail)}}` : head
 }
 
 function selectWithJoins(schemaType, orderBy) {

--- a/packages/test-studio/schemas/book.js
+++ b/packages/test-studio/schemas/book.js
@@ -75,6 +75,11 @@ export default {
       by: [{field: 'author.bestFriend.name', direction: 'asc'}]
     },
     {
+      title: 'Size of coverImage',
+      name: 'coverImageSize',
+      by: [{field: 'coverImage.asset.size', direction: 'asc'}]
+    },
+    {
       title: 'Swedish title',
       name: 'swedishTitle',
       by: [{field: 'translations.se', direction: 'asc'}, {field: 'title', direction: 'asc'}]


### PR DESCRIPTION
The fix in #908 did not consider fields on deeper levels, e.g. `image.asset.size`. This fix ensures we support this too.