### PR TITLE
[image-url] Use global form of isFinite

### DIFF
--- a/packages/@sanity/image-url/src/parseAssetId.js
+++ b/packages/@sanity/image-url/src/parseAssetId.js
@@ -12,7 +12,7 @@ export default function parseAssetId(ref) {
   const width = +imgWidthStr
   const height = +imgHeightStr
 
-  const isValidAssetId = Number.isFinite(width) && Number.isFinite(height)
+  const isValidAssetId = isFinite(width) && isFinite(height)
   if (!isValidAssetId) {
     throw new Error(`Malformed asset _ref '${ref}'. Expected an id like "${example}".`)
   }


### PR DESCRIPTION
`Number.isFinite` is not defined in IE11 and below, so use the global form instead