### PR TITLE
[image-url] Fix negative top/left crop in certain crops

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.0.0",
     "babel-eslint": "^9.0.0",
-    "babel-jest": "^23.4.2",
+    "babel-jest": "^23.6.0",
     "babel-loader": "^8.0.0",
     "babel-plugin-css-modules-transform": "^1.6.1",
     "babel-plugin-istanbul": "^5.0.1",

--- a/packages/@sanity/image-url/package.json
+++ b/packages/@sanity/image-url/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",
+    "babel-core": "^7.0.0-bridge.0",
     "browserify": "^14.3.0",
     "envify": "^4.0.0",
     "jest": "^23.5.0",

--- a/packages/@sanity/image-url/src/urlForImage.js
+++ b/packages/@sanity/image-url/src/urlForImage.js
@@ -164,8 +164,8 @@ function fit(source, spec) {
     top = crop.top + crop.height - height
   }
   result.rect = {
-    left: Math.floor(left),
-    top: Math.floor(top),
+    left: Math.max(0, Math.floor(left)),
+    top: Math.max(0, Math.floor(top)),
     width: Math.round(width),
     height: Math.round(height)
   }

--- a/packages/@sanity/image-url/test/__snapshots__/builder.test.js.snap
+++ b/packages/@sanity/image-url/test/__snapshots__/builder.test.js.snap
@@ -26,4 +26,6 @@ exports[`builder skips hotspot/crop if crop mode specified 1`] = `"https://cdn.s
 
 exports[`builder skips hotspot/crop if focal point specified 1`] = `"https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg?fp-x=10&fp-x=20&w=100&h=80"`;
 
+exports[`builder sub zero top/left 1`] = `"w=1000&h=805"`;
+
 exports[`builder toString() aliases url() 1`] = `"https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg?w=100&h=80"`;

--- a/packages/@sanity/image-url/test/builder.test.js
+++ b/packages/@sanity/image-url/test/builder.test.js
@@ -136,6 +136,17 @@ const cases = [
   },
 
   {
+    name: 'sub zero top/left',
+    url: stripPath(
+      urlFor
+        .image('image-928ac96d53b0c9049836c86ff25fd3c009039a16-1200x966-jpg')
+        .width(1000)
+        .height(805)
+        .url()
+    )
+  },
+
+  {
     name: 'all hotspot/crop-compatible params',
     url: stripPath(
       urlFor


### PR DESCRIPTION
Certain crops produced source rectangle parameters where the top/left coords were negative, which obviously won't work. This PR fixes this by ensuring we won't go below 0.

Also had to upgrade/install some dependencies to get the image url tests to work with Babel 7, apologize for not moving that commit to a separate PR.