### PR TITLE
[server] Make babel use CommonJS modules

### DIFF
--- a/packages/@sanity/server/src/configs/babel-env-config.js
+++ b/packages/@sanity/server/src/configs/babel-env-config.js
@@ -5,5 +5,6 @@ module.exports = {
     safari: '10',
     firefox: '56',
     edge: '14'
-  }
+  },
+  modules: 'commonjs'
 }


### PR DESCRIPTION
We currently have an issue where if you combine `import` statements and `module.exports`, things seem to break. This PR might prevent tree shaking from working properly, but at least does not crash peoples studios.