### PR TITLE
[desk-tool] Prefer assigned titles over document titles when both exist

### DIFF
--- a/packages/@sanity/desk-tool/src/components/DocumentPaneItemPreview.js
+++ b/packages/@sanity/desk-tool/src/components/DocumentPaneItemPreview.js
@@ -1,11 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {combineLatest, concat, of} from 'rxjs'
+import {assignWith} from 'lodash'
 import {map} from 'rxjs/operators'
+import WarningIcon from 'part:@sanity/base/warning-icon'
 import {observeForPreview, SanityDefaultPreview} from 'part:@sanity/base/preview'
 import NotPublishedStatus from './NotPublishedStatus'
 import DraftStatus from './DraftStatus'
-import WarningIcon from 'part:@sanity/base/warning-icon'
 
 const isLiveEditEnabled = schemaType => schemaType.liveEdit === true
 
@@ -26,15 +27,15 @@ const getMissingDocumentFallback = item => ({
   media: WarningIcon
 })
 
-const getValueWithFallback = ({isLoading, value, schemaType, draft, published}) => {
+const getValueWithFallback = ({value, draft, published}) => {
   const snapshot = draft || published
   if (!snapshot) {
     return getMissingDocumentFallback(value)
   }
-  return {
-    ...snapshot,
-    ...value
-  }
+
+  return assignWith({}, snapshot, value, (objValue, srcValue) => {
+    return typeof srcValue === 'undefined' ? objValue : srcValue
+  })
 }
 
 export default class DocumentPaneItemPreview extends React.Component {


### PR DESCRIPTION
Currently, if you have a document list item and have not assigned a title explicitly, you will end up with `Untitled` as the title, since the spread operator overrides `title` in the fetched value with an `undefined` value for the same property.

This PR changes this so that only _defined_ values are overriden. This fixes the above issue while allowing an explicitly defined title to have precedence over the value in the document.