### PR TITLE
[components] Pass action item to menu action handler

### DIFF
--- a/packages/@sanity/components/src/panes/DefaultPane.js
+++ b/packages/@sanity/components/src/panes/DefaultPane.js
@@ -227,7 +227,7 @@ class Pane extends React.Component {
         icon={act.icon}
         color="primary"
         kind="simple"
-        onClick={this.handleMenuAction}
+        onClick={this.handleMenuAction.bind(this, act)}
       />
     )
   }


### PR DESCRIPTION
Currently, we are not passing the actual action to the menu action handler, so it's hard to do anything helpful with it. This PR fixes action handlers in custom desk tool panes. 