### PR TITLE
[client] Warn about using a token with listeners in the browser

### DIFF
--- a/packages/@sanity/client/src/data/listen.js
+++ b/packages/@sanity/client/src/data/listen.js
@@ -4,11 +4,20 @@ const polyfilledEventSource = require('@sanity/eventsource')
 const pick = require('../util/pick')
 const defaults = require('../util/defaults')
 const encodeQueryString = require('./encodeQueryString')
+const generateHelpUrl = require('@sanity/generate-help-url')
+const once = require('../util/once')
 
-const EventSource =
-  typeof window !== 'undefined' && window.EventSource
-    ? window.EventSource // Native browser EventSource
-    : polyfilledEventSource // Node.js, IE etc
+const tokenWarning = [
+  'Using token with listeners is not supported in browsers. ',
+  `For more info, see ${generateHelpUrl('js-client-listener-tokens-browser')}.`
+]
+// eslint-disable-next-line no-console
+const printTokenWarning = once(() => console.warn(tokenWarning.join(' ')))
+
+const isWindowEventSource = Boolean(typeof window !== 'undefined' && window.EventSource)
+const EventSource = isWindowEventSource
+  ? window.EventSource // Native browser EventSource
+  : polyfilledEventSource // Node.js, IE etc
 
 const possibleOptions = ['includePreviousRevision', 'includeResult']
 const defaultOptions = {
@@ -24,6 +33,10 @@ module.exports = function listen(query, params, opts = {}) {
   const uri = `${url}${this.getDataUrl('listen', qs)}`
   const listenFor = options.events ? options.events : ['mutation']
   const shouldEmitReconnect = listenFor.indexOf('reconnect') !== -1
+
+  if (token && isWindowEventSource) {
+    printTokenWarning()
+  }
 
   const esOptions = {}
   if (token || withCredentials) {

--- a/packages/@sanity/client/src/util/once.js
+++ b/packages/@sanity/client/src/util/once.js
@@ -1,0 +1,12 @@
+module.exports = fn => {
+  let didCall = false
+  let returnValue
+  return (...args) => {
+    if (didCall) {
+      return returnValue
+    }
+    returnValue = fn(...args)
+    didCall = true
+    return returnValue
+  }
+}


### PR DESCRIPTION
The EventSource implementation in browsers does not allow specifying headers, so to help people debug unexpected issues, this will warn in the browser when calling client.listen(..) and the Sanity client is configured with a token.