### PR TITLE
[desk-tool] Make sure DocumentPaneItemPreview listens on correct draft/published ids

### DIFF
--- a/packages/@sanity/desk-tool/src/components/DocumentPaneItemPreview.js
+++ b/packages/@sanity/desk-tool/src/components/DocumentPaneItemPreview.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import {combineLatest, concat, of} from 'rxjs'
 import {assignWith} from 'lodash'
 import {map} from 'rxjs/operators'
+import {getDraftId, getPublishedId} from 'part:@sanity/base/util/draft-utils'
 import WarningIcon from 'part:@sanity/base/warning-icon'
 import {observeForPreview, SanityDefaultPreview} from 'part:@sanity/base/preview'
 import NotPublishedStatus from './NotPublishedStatus'
@@ -50,8 +51,8 @@ export default class DocumentPaneItemPreview extends React.Component {
       combineLatest([
         isLiveEditEnabled(schemaType)
           ? of({snapshot: null})
-          : observeForPreview({...value, _id: `drafts.${value._id}`}, schemaType),
-        observeForPreview(value, schemaType)
+          : observeForPreview({...value, _id: getDraftId(value._id)}, schemaType),
+        observeForPreview({...value, _id: getPublishedId(value._id)}, schemaType)
       ]).pipe(
         map(([draft, published]) => ({
           draft: draft.snapshot,


### PR DESCRIPTION
The fix in 84e972bea709c0ce358dcabd5349f1fda7ad3ad8 incorrectly assumed that DocumentPaneItemPreview would be passed a value with a "normalized id" (e.g. the id of the published document, without the `draft.`-prefix), which caused the list item to signal "missing document" after publish. This fixes it by using id utils to ensure the correct ids when listening for events on draft/published version of the document.