### PR TITLE
[structure] Disallow document lists to show editor for different type

### DIFF
--- a/packages/@sanity/structure/src/documentTypeListItems.ts
+++ b/packages/@sanity/structure/src/documentTypeListItems.ts
@@ -50,7 +50,7 @@ export function getDocumentTypeList(
     .defaultOrdering(DEFAULT_SELECTED_ORDERING_OPTION.by)
     .canHandleIntent(
       (intentName, params): boolean =>
-        Boolean(intentName === 'edit' && params && params.id) ||
+        Boolean(intentName === 'edit' && params && params.id && params.type === typeName) ||
         Boolean(intentName === 'create' && params && params.type === typeName)
     )
     .menuItemGroups([


### PR DESCRIPTION
For instance, when editing a `book` from a navigation structure using a document type list, if you navigate to an intent for an author, the document list will say that it can handle the intent, but the editor will give a 'cannot handle editing of document of type "author" as "book", do you want to edit as "author"?' type of message.

This tells the intent resolving that the document in question needs to be of the same type as we are displaying in the document list pane.