### PR TITLE
[desk-tool] Handle generic edit intents without type name

### DIFF
--- a/packages/@sanity/desk-tool/src/index.js
+++ b/packages/@sanity/desk-tool/src/index.js
@@ -27,7 +27,8 @@ export default {
     route('/edit/:type/:editDocumentId'),
     route({
       path: '/:panes',
-      children: [route('/:action', route('/:editDocumentId'))],
+      // Legacy URLs, used to handle redirects
+      children: [route('/:action', route('/:legacyEditDocumentId'))],
       transform: {
         panes: {toState, toPath}
       }
@@ -49,7 +50,7 @@ export default {
       }
     }
 
-    return {editDocumentId, type: params.type}
+    return {editDocumentId, type: params.type || '*'}
   },
   title: 'Desk',
   name: 'desk',


### PR DESCRIPTION
This PR fixes an issue where an edit intent for a document without a defined type would fail to render an editor as intended. It also renames one use of `editDocumentId` to `legacyEditDocumentId` in the route parameters in order to more easily distinguish the use case of redirecting old desk tool URLs from the use case of editing a specific document ID without a correlated structure item.