### PR TITLE
[base] Make settings store observable + integrate with DocumentsListPane

### DIFF
--- a/packages/@sanity/base/src/datastores/settings/backends/localStorage.js
+++ b/packages/@sanity/base/src/datastores/settings/backends/localStorage.js
@@ -1,0 +1,29 @@
+import {of as observableOf} from 'rxjs'
+
+const tryParse = (val, defValue) => {
+  try {
+    return JSON.parse(val)
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(`Failed to parse settings: ${err.message}`)
+    return defValue
+  }
+}
+
+const get = (key, defValue) => {
+  const val = localStorage.getItem(key)
+  return observableOf(val === null ? defValue : tryParse(val, defValue))
+}
+
+const set = (key, nextValue) => {
+  // Can't stringify undefined, and nulls are what
+  // `getItem` returns when key does not exist
+  if (typeof nextValue === 'undefined' || nextValue === null) {
+    localStorage.removeItem(key)
+  } else {
+    localStorage.setItem(key, JSON.stringify(nextValue))
+  }
+  return observableOf(nextValue)
+}
+
+export default {get, set}

--- a/packages/@sanity/base/src/datastores/settings/backends/memory.js
+++ b/packages/@sanity/base/src/datastores/settings/backends/memory.js
@@ -1,0 +1,16 @@
+import {of as observableOf} from 'rxjs'
+
+const DB = Object.create(null)
+
+const get = (key, defValue) => observableOf(key in DB ? DB[key] : defValue)
+
+const set = (key, nextValue) => {
+  if (typeof nextValue === 'undefined' || nextValue === null) {
+    delete DB[key]
+  } else {
+    DB[key] = nextValue
+  }
+  return observableOf(nextValue)
+}
+
+export default {get, set}

--- a/packages/@sanity/base/src/datastores/settings/backends/resolve.js
+++ b/packages/@sanity/base/src/datastores/settings/backends/resolve.js
@@ -1,0 +1,22 @@
+import localStorageBackend from './localStorage'
+import memoryBackend from './memory'
+
+let isSupported = null
+const supportsLocalStorage = () => {
+  if (isSupported !== null) {
+    return isSupported
+  }
+
+  const testKey = '__test__'
+  try {
+    localStorage.setItem(testKey, testKey)
+    localStorage.removeItem(testKey)
+    isSupported = true
+  } catch (evt) {
+    isSupported = false
+  }
+
+  return isSupported
+}
+
+export const resolveBackend = () => (supportsLocalStorage() ? localStorageBackend : memoryBackend)


### PR DESCRIPTION
This includes a small refactor of the settings store so that changes in keys can be subscribed to. It fixes a regression from the structure feature that broke persisting of sort order/layout for document lists.

I also refactored out the localStorage/noop storage parts into a more generic concept of "storage backends", (of which `localStorage` is just one of several possible), and replaced the noop store with an in-memory storage that we fall back to if localStorage is not supported. Hope it's not too overengineered 😅 

Note: I also took the liberty of removing the `clear()`-method for now, as it's not currently needed. It should be pretty trivial to add later.