### PR TITLE
[block-tools] Recursively attempt to find block type

### DIFF
--- a/packages/@sanity/block-tools/src/util/blockContentTypeToOptions.js
+++ b/packages/@sanity/block-tools/src/util/blockContentTypeToOptions.js
@@ -42,11 +42,23 @@ function resolveEnabledListItems(blockType) {
   return listItems
 }
 
+function findBlockType(type) {
+  if (type.name === 'block') {
+    return type
+  }
+
+  if (type.type) {
+    return findBlockType(type.type)
+  }
+
+  return null
+}
+
 export default function blockContentTypeToOptions(blockContentType) {
   if (!blockContentType) {
     throw new Error("Parameter 'blockContentType' required")
   }
-  const blockType = blockContentType.of.find(field => field.name === 'block')
+  const blockType = blockContentType.of.find(findBlockType)
   if (!blockType) {
     throw new Error("'block' type is not defined in this schema (required).")
   }


### PR DESCRIPTION
The following pattern will currently fail:
```js
export default {
  name: 'richBlock',
  title: 'Rich block',
  type: 'block',
  styles: [
    // ...
  ]
}
```

```js
export default {
  title: 'Block Content',
  name: 'blockContent',
  type: 'array',
  of: [
    {type: 'richBlock'},
  ]
}
```

This PR fixes this issue.