### PR TITLE
[chore] Make appveyor use npm ci if available

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm install
+  - npm ci || npm install
   - npm run bootstrap
   - npm run build
 


### PR DESCRIPTION
This should fix the build failure we're currently seeing on AppVeyor