### PR TITLE
[document-store] Defer listener to fix issue with stalled requests

### DIFF
--- a/packages/@sanity/base/src/datastores/document/index.js
+++ b/packages/@sanity/base/src/datastores/document/index.js
@@ -1,4 +1,4 @@
-import {of as observableOf} from 'rxjs'
+import {defer, of as observableOf} from 'rxjs'
 
 import createDocumentStore from '@sanity/document-store'
 import client from 'part:@sanity/base/client'
@@ -42,16 +42,16 @@ const serverConnection = {
   },
 
   query(query, params) {
-    return client.observable
-      .listen(query, params || {}, {
+    return defer(() =>
+      client.observable.listen(query, params || {}, {
         includeResult: false,
         events: ['welcome', 'mutation', 'reconnect']
       })
-      .pipe(
-        concatMap(event => {
-          return event.type === 'welcome' ? fetchQuerySnapshot(query, params) : observableOf(event)
-        })
-      )
+    ).pipe(
+      concatMap(event => {
+        return event.type === 'welcome' ? fetchQuerySnapshot(query, params) : observableOf(event)
+      })
+    )
   },
 
   mutate(mutations) {


### PR DESCRIPTION
For some reason the listener requests coming from the QueryContainer component were not disposed properly, causing old eventsource requests to stay open even though they should have been unsubscribed/cancelled. I don't have a clear idea exactly why that happens, but at least deferring the query until subscription time fixes the issue for now.

This is a semi-critical issue, so I'll do a patch release right after merge.