### PR TITLE
[webpack-integration] Allow passing webpack instance to use

### DIFF
--- a/packages/@sanity/server/src/configs/webpack.config.js
+++ b/packages/@sanity/server/src/configs/webpack.config.js
@@ -13,7 +13,7 @@ const resolve = mod => require.resolve(mod)
 export default (config = {}) => {
   const staticPath = getStaticBasePath(config)
   const env = config.env || 'development'
-  const wpIntegrationOptions = {basePath: config.basePath, env: config.env}
+  const wpIntegrationOptions = {basePath: config.basePath, env: config.env, webpack}
   const basePath = config.basePath || process.cwd()
   const skipMinify = config.skipMinify || false
 

--- a/packages/@sanity/storybook/package.json
+++ b/packages/@sanity/storybook/package.json
@@ -32,6 +32,7 @@
     "@storybook/react": "3.2.8",
     "normalize.css": "^5.0.0",
     "react-addons-create-fragment": "^15.4.2",
-    "shelljs": "^0.7.6"
+    "shelljs": "^0.7.6",
+    "webpack": "^3.0.0"
   }
 }

--- a/packages/@sanity/storybook/src/config/webpack.config.js
+++ b/packages/@sanity/storybook/src/config/webpack.config.js
@@ -1,3 +1,4 @@
+const webpack = require('webpack')
 const sanityServer = require('@sanity/server')
 const wpIntegration = require('@sanity/webpack-integration/v3')
 const genDefaultConfig = require('@storybook/react/dist/server/config/defaults/webpack.config.js')
@@ -26,8 +27,9 @@ function getWebpackConfig(baseConfig, env) {
   const wpConfig = Object.assign({}, sanityContext, {commonChunkPlugin: false})
   const sanityWpConfig = sanityServer.getWebpackDevConfig(wpConfig)
   const config = Object.assign({}, genDefaultConfig(baseConfig, env))
-  config.plugins = config.plugins.concat(wpIntegration.getPlugins(sanityContext))
-  config.module.rules = (config.module.rules || []).concat(wpIntegration.getLoaders(sanityContext))
+  const context = Object.assign({}, sanityContext, {webpack})
+  config.plugins = config.plugins.concat(wpIntegration.getPlugins(context))
+  config.module.rules = (config.module.rules || []).concat(wpIntegration.getLoaders(context))
   config.module.rules = config.module.rules.filter(skipCssLoader)
   config.module.rules.unshift(sanityWpConfig.module.rules.find(isCssLoader))
 

--- a/packages/@sanity/webpack-integration/src/v3/index.js
+++ b/packages/@sanity/webpack-integration/src/v3/index.js
@@ -1,5 +1,4 @@
 const lost = require('lost')
-const webpack = require('webpack')
 const postcssImport = require('postcss-import')
 const postcssCssnext = require('postcss-cssnext')
 const PartResolverPlugin = require('@sanity/webpack-loader')
@@ -16,7 +15,7 @@ function getEnvPlugin(options) {
   const bundleEnv = options.bundleEnv || process.env.BUNDLE_ENV || 'development'
   const env = options.env || 'development'
   const isProd = env === 'production'
-
+  const webpack = options.webpack || require('webpack')
   return new webpack.DefinePlugin({__DEV__: !isProd && bundleEnv === 'development'})
 }
 


### PR DESCRIPTION
The webpack-integration module was simply requiring webpack and expecting it to be the right version. This usually works, but there is no guarantees. With this change, we allow webpack to be injected, and use this from `@sanity/server` and `@sanity/storybook`. We fall back to regular require as before in order to maintain backwards compatibility.