### PR TITLE
[desk-tool] Fix document list items with only title being displayed as Untitled

### DIFF
--- a/packages/@sanity/desk-tool/src/components/DocumentPaneItemPreview.js
+++ b/packages/@sanity/desk-tool/src/components/DocumentPaneItemPreview.js
@@ -45,18 +45,19 @@ export default class DocumentPaneItemPreview extends React.Component {
   constructor(props) {
     super()
     const {value, schemaType} = props
+    const {title} = value
     let sync = true
     this.subscription = concat(
       of({isLoading: true}),
       combineLatest([
         isLiveEditEnabled(schemaType)
           ? of({snapshot: null})
-          : observeForPreview({...value, _id: getDraftId(value._id)}, schemaType),
-        observeForPreview({...value, _id: getPublishedId(value._id)}, schemaType)
+          : observeForPreview({_id: getDraftId(value._id)}, schemaType),
+        observeForPreview({_id: getPublishedId(value._id)}, schemaType)
       ]).pipe(
         map(([draft, published]) => ({
-          draft: draft.snapshot,
-          published: published.snapshot,
+          draft: draft.snapshot ? {title, ...draft.snapshot} : null,
+          published: published.snapshot ? {title, ...published.snapshot} : null,
           isLoading: false
         }))
       )


### PR DESCRIPTION
When a schema type has only a single field to select for preview and that field is called `title`, when splatting in the structure config for a list item of that type, the `observeForPreview` config would optimize this as "we already have the info we need" and not run a query.

This would lead to the list item being displayed as `Untitled` if no `title` was set, and showing a draft indicator when this was not actually true, caused by the draft snapshot returning the ID and title from the passed value as an optimization.

This fix applies the title on the receiving end instead, which seems to do the trick, though I am not 100% confident that this is the right place to fix this, or if it hints at an underlying issue - feedback welcome.
