### PR TITLE
[desk-tool] Allow setting editor title

### DIFF
--- a/packages/@sanity/desk-tool/src/pane/Editor.js
+++ b/packages/@sanity/desk-tool/src/pane/Editor.js
@@ -164,6 +164,7 @@ export default withRouterHOC(
   // eslint-disable-next-line
   class Editor extends React.PureComponent {
     static propTypes = {
+      title: PropTypes.string,
       paneIndex: PropTypes.number.isRequired,
       paneStyles: PropTypes.object,
       patchChannel: PropTypes.object,
@@ -199,6 +200,7 @@ export default withRouterHOC(
     }
 
     static defaultProps = {
+      title: null,
       markers: [],
       isLoading: false,
       isSaving: false,
@@ -432,7 +434,10 @@ export default withRouterHOC(
     }
 
     getTitle(value) {
-      const {type} = this.props
+      const {title: paneTitle, type} = this.props
+      if (paneTitle) {
+        return <span>{paneTitle}</span>
+      }
       if (!value) {
         return `Creating new ${type.title || type.name}`
       }

--- a/packages/@sanity/desk-tool/src/pane/EditorPane.js
+++ b/packages/@sanity/desk-tool/src/pane/EditorPane.js
@@ -77,11 +77,16 @@ function isRecoverable(draft, published) {
 export default withDocumentType(
   class EditorPane extends React.Component {
     static propTypes = {
+      title: PropTypes.string,
       index: PropTypes.number.isRequired,
       options: PropTypes.shape({
         id: PropTypes.string.isRequired,
         type: PropTypes.string.isRequired
       }).isRequired
+    }
+
+    static defaultProps = {
+      title: null
     }
 
     state = INITIAL_STATE
@@ -448,7 +453,7 @@ export default withDocumentType(
     }
 
     render() {
-      const {options, index} = this.props
+      const {options, index, title} = this.props
       const typeName = options.type
       const schemaType = schema.get(typeName)
       const {
@@ -474,6 +479,7 @@ export default withDocumentType(
 
       return (
         <Editor
+          title={title}
           paneIndex={index}
           patchChannel={this.patchChannel}
           type={schemaType}


### PR DESCRIPTION
Currently we have no way to override the editor title through the structure builder, even though we do expose a `title` setter. This PR fixes this by passing the set title through to the actual editor. Falls back to document title as before if no title is set.

This addresses a problem where certain documents do not have a title field (as is often the case for "singletons" such as "site config" etc)