### PR TITLE
[base] Use same active/hover/focus styles for textarea as inputs

### DIFF
--- a/packages/@sanity/base/src/styles/forms/textarea.css
+++ b/packages/@sanity/base/src/styles/forms/textarea.css
@@ -1,52 +1,7 @@
 @import 'part:@sanity/base/theme/variables-style';
 
 .root {
-  appearance: none;
-  border: var(--input-border-size) solid var(--input-border-color);
-  width: 100%;
-  max-width: 100%;
-  outline: 0;
-  box-sizing: border-box;
+  composes: textInput from './text-input.css';
   resize: vertical;
   padding: 0.5em;
-  font-size: 1em;
-  box-shadow: var(--input-box-shadow--hover);
-  background-color: var(--input-bg);
-  border-radius: var(--input-border-radius);
-
-  @nest &:disabled {
-    background-color: var(--input-bg-disabled);
-  }
-
-  @nest &:read-only {
-    opacity: 0.5;
-  }
-
-  @nest &:read-only {
-    opacity: 0.5;
-  }
-
-  @nest &:not(:disabled) {
-    @nest &:not(:read-only) {
-      @nest &:hover {
-        box-shadow: var(--input-box-shadow--hover);
-        border-color: var(--input-border-color-hover);
-      }
-
-      @nest &:focus, &:focus-within {
-        box-shadow: var(--input-box-shadow--focus);
-        border-color: var(--input-border-color-focus);
-      }
-
-      @nest &:active {
-        border-color: var(--input-border-color-active);
-      }
-
-      @nest &:invalid {
-        border-color: var(--input-border-color-invalid);
-        background-color: var(--input-bg-error);
-        box-shadow: var(--input-box-shadow--error);
-      }
-    }
-  }
 }

--- a/packages/@sanity/base/src/styles/forms/textarea.css
+++ b/packages/@sanity/base/src/styles/forms/textarea.css
@@ -14,31 +14,39 @@
   background-color: var(--input-bg);
   border-radius: var(--input-border-radius);
 
-  @nest &:not(:disabled) {
-    @nest &:hover {
-      box-shadow: var(--input-box-shadow--hover);
-    }
-
-    @nest &:focus, &:active {
-      box-shadow: var(--input-box-shadow--focus);
-    }
-
-    @nest &:invalid {
-      border-color: var(--input-border-color-invalid);
-      background-color: var(--input-bg-error);
-      box-shadow: var(--input-box-shadow--error);
-
-      @nest &:focus, &:focus-within {
-        box-shadow: var(--input-box-shadow--error-focus);
-      }
-    }
-  }
-
   @nest &:disabled {
     background-color: var(--input-bg-disabled);
   }
 
   @nest &:read-only {
     opacity: 0.5;
+  }
+
+  @nest &:read-only {
+    opacity: 0.5;
+  }
+
+  @nest &:not(:disabled) {
+    @nest &:not(:read-only) {
+      @nest &:hover {
+        box-shadow: var(--input-box-shadow--hover);
+        border-color: var(--input-border-color-hover);
+      }
+
+      @nest &:focus, &:focus-within {
+        box-shadow: var(--input-box-shadow--focus);
+        border-color: var(--input-border-color-focus);
+      }
+
+      @nest &:active {
+        border-color: var(--input-border-color-active);
+      }
+
+      @nest &:invalid {
+        border-color: var(--input-border-color-invalid);
+        background-color: var(--input-bg-error);
+        box-shadow: var(--input-box-shadow--error);
+      }
+    }
   }
 }

--- a/packages/@sanity/components/src/textareas/DefaultTextArea.js
+++ b/packages/@sanity/components/src/textareas/DefaultTextArea.js
@@ -91,7 +91,7 @@ export default class DefaultTextArea extends React.Component {
         />
         {isClearable &&
           !this.props.disabled && (
-            <button className={styles.clearButton} onClick={onClear}>
+            <button type="button" className={styles.clearButton} onClick={onClear}>
               <IoAndroidClose color="inherit" />
             </button>
           )}

--- a/packages/@sanity/components/src/textareas/story.js
+++ b/packages/@sanity/components/src/textareas/story.js
@@ -20,6 +20,7 @@ storiesOf('Text areas')
           rows={number('rows (prop)', 2)}
           value={text('value (prop)')}
           disabled={boolean('disabled (prop)', false)}
+          readOnly={boolean('readOnly (prop)', false)}
         />
       </Sanity>
     )

--- a/packages/@sanity/components/src/textareas/styles/DefaultTextArea.css
+++ b/packages/@sanity/components/src/textareas/styles/DefaultTextArea.css
@@ -16,9 +16,10 @@
 
 .clearButton {
   composes: textarea from 'part:@sanity/base/theme/forms/clear-button-style';
+  position: absolute;
   z-index: 1;
-  top: 0.35em;
-  right: 0.1em;
+  top: 0.5em;
+  right: 0.5em;
 
   @nest & svg {
     color: inherit;

--- a/packages/@sanity/components/src/textinputs/story.js
+++ b/packages/@sanity/components/src/textinputs/story.js
@@ -60,6 +60,7 @@ storiesOf('Text inputs')
           type={select('type (prop)', ['text', 'number', 'email', 'tel'], 'text')}
           isSelected={boolean('isSelected (prop)', false)}
           disabled={boolean('disabled (prop)', false)}
+          readOnly={boolean('readOnly (prop)', false)}
           onChange={action('onChange')}
           onFocus={action('onFocus')}
           onKeyPress={action('onKeyPress')}


### PR DESCRIPTION
Regular text inputs (`type: string`) has a subtle but pretty hover effect, whereas text areas do not. I suppose this is an oversight rather than a feature? Copy+pasted some styles from the text input styles, please double-check that this looks sane.