### PR TITLE
[import] Fix spinner issue on no references/assets

### DIFF
--- a/packages/@sanity/import/src/references.js
+++ b/packages/@sanity/import/src/references.js
@@ -60,6 +60,10 @@ function strengthenReferences(strongRefs, options) {
     batches.push(strongRefs.slice(i, i + STRENGTHEN_BATCH_SIZE))
   }
 
+  if (batches.length === 0) {
+    return Promise.resolve([0])
+  }
+
   const progress = progressStepper(options.onProgress, {
     step: 'Strengthening references',
     total: batches.length

--- a/packages/@sanity/import/src/uploadAssets.js
+++ b/packages/@sanity/import/src/uploadAssets.js
@@ -24,6 +24,10 @@ async function uploadAssets(assets, options) {
     }
   })
 
+  if (assetRefMap.size === 0) {
+    return Promise.resolve(0)
+  }
+
   // Create a function we can call for every completed upload to report progress
   const progress = progressStepper(options.onProgress, {
     step: 'Importing assets (files/images)',
@@ -136,6 +140,10 @@ function setAssetReferences(assetRefMap, assetIds, options) {
   const batches = []
   for (let i = 0; i < patchTasks.length; i += ASSET_PATCH_BATCH_SIZE) {
     batches.push(patchTasks.slice(i, i + ASSET_PATCH_BATCH_SIZE))
+  }
+
+  if (batches.length === 0) {
+    return Promise.resolve([0])
   }
 
   // Since separate progress step for batches of reference sets


### PR DESCRIPTION
When importing an ndjson stream without any references or assets, the progress indicator for those steps would never complete because the `progress()` function would never be called.

This PR ensures that in the case of empty batches, we don't even show the indicator.