### PR TITLE
[import] Add `--allow-failing-assets` flag

### DIFF
--- a/packages/@sanity/cli/src/outputters/cliOutputter.js
+++ b/packages/@sanity/cli/src/outputters/cliOutputter.js
@@ -9,6 +9,10 @@ export default {
     console.log(...args)
   },
 
+  warn(...args) {
+    console.warn(...args)
+  },
+
   error(...args) {
     if (args[0] instanceof Error) {
       console.error(chalk.red(args[0].stack))

--- a/packages/@sanity/import-cli/.babelrc
+++ b/packages/@sanity/import-cli/.babelrc
@@ -1,0 +1,12 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "node": "6"
+        }
+      }
+    ]
+  ]
+}

--- a/packages/@sanity/import-cli/src/sanity-import.js
+++ b/packages/@sanity/import-cli/src/sanity-import.js
@@ -9,8 +9,9 @@ const prettyMs = require('pretty-ms')
 const sanityClient = require('@sanity/client')
 const sanityImport = require('@sanity/import')
 
-const red = str => `\u001b[31mERROR: ${str}\u001b[39m`
-const error = str => console.error(red(str))
+const red = str => `\u001b[31m${str}\u001b[39m`
+const yellow = str => `\u001b[33m${str}\u001b[39m`
+const printError = str => console.error(red(`ERROR: ${str}`))
 
 const cli = meow(
   `
@@ -23,6 +24,7 @@ const cli = meow(
     -t, --token <token> Token to authenticate with
     --replace Replace documents with the same IDs
     --missing Skip documents that already exist
+    --allow-failing-assets Skip assets that cannot be fetched/uploaded
     --help Show this help
 
   Examples
@@ -36,7 +38,7 @@ const cli = meow(
     --token = SANITY_IMPORT_TOKEN
 `,
   {
-    boolean: ['replace', 'missing'],
+    boolean: ['replace', 'missing', 'allow-failing-assets'],
     alias: {
       p: 'project',
       d: 'dataset',
@@ -46,35 +48,35 @@ const cli = meow(
 )
 
 const {flags, input, showHelp} = cli
+const {dataset, allowFailingAssets} = flags
 const token = flags.token || process.env.SANITY_IMPORT_TOKEN
 const projectId = flags.project
-const dataset = flags.dataset
 const source = input[0]
 
 if (!projectId) {
-  error('Flag `--project` is required')
+  printError('Flag `--project` is required')
   showHelp()
 }
 
 if (!dataset) {
-  error('Flag `--dataset` is required')
+  printError('Flag `--dataset` is required')
   showHelp()
 }
 
 if (!token) {
-  error('Flag `--token` is required (or set SANITY_IMPORT_TOKEN)')
+  printError('Flag `--token` is required (or set SANITY_IMPORT_TOKEN)')
   showHelp()
 }
 
 if (!source) {
-  error('Source file is required, use `-` to read from stdin')
+  printError('Source file is required, use `-` to read from stdin')
   showHelp()
 }
 
 let operation = 'create'
 if (flags.replace || flags.missing) {
   if (flags.replace && flags.missing) {
-    error('Cannot use both `--replace` and `--missing`')
+    printError('Cannot use both `--replace` and `--missing`')
     showHelp()
   }
 
@@ -94,21 +96,39 @@ const client = sanityClient({
 })
 
 getStream()
-  .then(stream => sanityImport(stream, {client, operation, onProgress}))
-  .then(imported => {
+  .then(stream => sanityImport(stream, {client, operation, onProgress, allowFailingAssets}))
+  .then(({numDocs, warnings}) => {
     const timeSpent = prettyMs(Date.now() - stepStart, {secDecimalDigits: 2})
     currentProgress.text = `[100%] ${currentStep} (${timeSpent})`
     currentProgress.succeed()
 
-    console.log('Done! Imported %d documents to dataset "%s"', imported, dataset)
+    console.log('Done! Imported %d documents to dataset "%s"\n', numDocs, dataset)
+    printWarnings(warnings)
   })
   .catch(err => {
     if (currentProgress) {
       currentProgress.fail()
     }
 
-    error(err.message)
+    printError(err.stack)
   })
+
+function printWarnings(warnings) {
+  const assetFails = warnings.filter(warn => warn.type === 'asset')
+
+  if (!assetFails.length) {
+    return
+  }
+
+  console.warn(
+    yellow('⚠ Failed to import the following %s:'),
+    assetFails.length > 1 ? 'assets' : 'asset'
+  )
+
+  warnings.forEach(warning => {
+    console.warn(`  ${warning.url}`)
+  })
+}
 
 function getStream() {
   if (/^https:\/\//i.test(source)) {
@@ -120,7 +140,7 @@ function getStream() {
 
 function getUriStream(uri) {
   return new Promise((resolve, reject) => {
-    get(source, (err, res) => {
+    get(uri, (err, res) => {
       if (err) {
         reject(new Error(`Error fetching source:\n${err.message}`))
         return

--- a/packages/@sanity/import-cli/src/sanity-import.js
+++ b/packages/@sanity/import-cli/src/sanity-import.js
@@ -103,6 +103,10 @@ getStream()
     console.log('Done! Imported %d documents to dataset "%s"', imported, dataset)
   })
   .catch(err => {
+    if (currentProgress) {
+      currentProgress.fail()
+    }
+
     error(err.message)
   })
 

--- a/packages/@sanity/import/.babelrc
+++ b/packages/@sanity/import/.babelrc
@@ -1,0 +1,12 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "node": "6"
+        }
+      }
+    ]
+  ]
+}

--- a/packages/@sanity/import/README.md
+++ b/packages/@sanity/import/README.md
@@ -26,12 +26,15 @@ const client = sanityClient({
 const input = fs.createReadStream('my-documents.ndjson')
 sanityImport(input, {
   client: client,
-  operation: 'create', // `create`, `createOrReplace` or `createIfNotExists`
-}).then(numDocs => {
-  console.log('Imported %d documents', numDocs)
-}).catch(err => {
-  console.error('Import failed: %s', err.message)
+  operation: 'create' // `create`, `createOrReplace` or `createIfNotExists`
 })
+  .then(({numDocs, warnings}) => {
+    console.log('Imported %d documents', numDocs)
+    // Note: There might be warnings! Check `warnings`
+  })
+  .catch(err => {
+    console.error('Import failed: %s', err.message)
+  })
 ```
 
 ## CLI-tool

--- a/packages/@sanity/import/src/assetRefs.js
+++ b/packages/@sanity/import/src/assetRefs.js
@@ -9,7 +9,16 @@ const assetMatcher = /^(file|image)@([a-z]+:\/\/.*)/
 // Note: mutates in-place
 function unsetAssetRefs(doc) {
   findAssetRefs(doc).forEach(path => {
-    unset(doc, path)
+    const parentPath = path.slice(0, -1)
+    const parent = get(doc, parentPath)
+
+    // If the only key in the object is `_sanityAsset`, unset the whole thing,
+    // as we will be using a `setIfMissing({[path]: {}})` patch to enforce it.
+    // Prevents empty objects from appearing while import is running
+    const isOnlyKey = parent && Object.keys(parent).length === 1 && parent[assetKey]
+    const unsetPath = isOnlyKey ? parentPath : path
+
+    unset(doc, unsetPath)
   })
 
   return doc

--- a/packages/@sanity/import/src/importFromArray.js
+++ b/packages/@sanity/import/src/importFromArray.js
@@ -56,14 +56,14 @@ async function importDocuments(documents, options, importers) {
 
   // Documents are imported, now proceed with post-import operations
   debug('Uploading assets')
-  await uploadAssets(assetRefs, options)
+  const {failures: assetWarnings} = await uploadAssets(assetRefs, options)
 
   // Strengthen references
   debug('Strengthening references')
   await strengthenReferences(strongRefs, options)
 
   // Return number of documents imported
-  return docsImported
+  return {numDocs: docsImported, warnings: assetWarnings}
 }
 
 module.exports = importDocuments

--- a/packages/@sanity/import/src/uploadAssets.js
+++ b/packages/@sanity/import/src/uploadAssets.js
@@ -25,7 +25,10 @@ async function uploadAssets(assets, options) {
   })
 
   if (assetRefMap.size === 0) {
-    return Promise.resolve(0)
+    return {
+      batches: [0],
+      failures: []
+    }
   }
 
   // Create a function we can call for every completed upload to report progress
@@ -34,17 +37,26 @@ async function uploadAssets(assets, options) {
     total: assetRefMap.size
   })
 
+  // If we should allow failures, we need to use a custom catch handler in order
+  // to not set the asset references for the broken assets
+  const ensureAssetExists = ensureAssetWithRetries.bind(null, options, progress)
+  const ensureMethod = options.allowFailingAssets
+    ? (...args) => ensureAssetExists(...args).catch(err => err)
+    : ensureAssetExists
+
   // Loop over all unique URLs and ensure they exist, and if not, upload them
   const mapOptions = {concurrency: ASSET_UPLOAD_CONCURRENCY}
-  const assetIds = await pMap(
-    assetRefMap.keys(),
-    ensureAssetWithRetries.bind(null, options, progress),
-    mapOptions
-  )
+  const assetIds = await pMap(assetRefMap.keys(), ensureMethod, mapOptions)
+
+  // Extract a list of all failures so we may report them and possibly retry them later
+  const assetFailures = getUploadFailures(assetRefMap, assetIds)
 
   // Loop over all documents that need asset references to be set
   const batches = await setAssetReferences(assetRefMap, assetIds, options)
-  return batches.reduce((prev, add) => prev + add, 0)
+  return {
+    batches: batches.reduce((prev, add) => prev + add, 0),
+    failures: assetFailures
+  }
 }
 
 function getAssetRefMap(assets) {
@@ -66,6 +78,9 @@ async function ensureAssetWithRetries(options, progress, assetKey, i) {
   const [type, url] = assetKey.split('#', 2)
 
   const {buffer, sha1hash} = await retryOnFailure(() => downloadAsset(url, i)).catch(err => {
+    progress()
+    err.type = type
+    err.url = url
     err.message = err.message.includes(url)
       ? err.message
       : `Failed to download ${type} @ ${url}:\n${err.message}`
@@ -74,13 +89,18 @@ async function ensureAssetWithRetries(options, progress, assetKey, i) {
   })
 
   const asset = {buffer, sha1hash, type, url}
-  return retryOnFailure(() => ensureAsset(asset, options, progress, i)).catch(err => {
-    err.message = err.message.includes(url)
-      ? err.message
-      : `Failed to upload ${type} @ ${url}:\n${err.message}`
+  return retryOnFailure(() => ensureAsset(asset, options, i))
+    .then(progress)
+    .catch(err => {
+      progress()
+      err.type = type
+      err.url = url
+      err.message = err.message.includes(url)
+        ? err.message
+        : `Failed to upload ${type} @ ${url}:\n${err.message}`
 
-    throw err
-  })
+      throw err
+    })
 }
 
 function downloadAsset(url, i) {
@@ -89,7 +109,7 @@ function downloadAsset(url, i) {
   return getHashedBufferForUri(url)
 }
 
-async function ensureAsset(asset, options, progress, i) {
+async function ensureAsset(asset, options, i) {
   const {buffer, sha1hash, type, url} = asset
   const {client, assetMap = {}} = options
 
@@ -99,7 +119,6 @@ async function ensureAsset(asset, options, progress, i) {
   if (assetDocId) {
     // Same hash means we want to reuse the asset
     debug('[Asset #%d] Found %s for hash %s', i, type, sha1hash)
-    progress()
     return assetDocId
   }
 
@@ -112,7 +131,6 @@ async function ensureAsset(asset, options, progress, i) {
   // If it doesn't exist, we want to upload it
   debug('[Asset #%d] Uploading %s with URL %s', i, type, url)
   const assetDoc = await client.assets.upload(type, buffer, {filename})
-  progress()
 
   // If we have more metadata to provide, update the asset document
   if (hasNonFilenameMeta) {
@@ -139,11 +157,35 @@ async function getAssetDocumentIdForHash(client, type, sha1hash, attemptNum = 0)
   }
 }
 
+function getUploadFailures(assetRefMap, assetIds) {
+  const lookup = assetRefMap.values()
+
+  return assetIds.reduce((failures, assetId) => {
+    const documents = lookup.next().value
+    if (typeof assetId === 'string') {
+      return failures
+    }
+
+    return failures.concat({
+      type: 'asset',
+      url: assetId.url,
+      documents: documents.map(({documentId, path}) => ({
+        documentId,
+        path
+      }))
+    })
+  }, [])
+}
+
 function setAssetReferences(assetRefMap, assetIds, options) {
   const {client} = options
   const lookup = assetRefMap.values()
   const patchTasks = assetIds.reduce((tasks, assetId) => {
     const documents = lookup.next().value
+    if (typeof assetId !== 'string') {
+      return tasks
+    }
+
     return tasks.concat(
       documents.map(({documentId, path}) => ({
         documentId,
@@ -173,7 +215,8 @@ function setAssetReferences(assetRefMap, assetIds, options) {
 
   // Now perform the batch operations in parallel with a given concurrency
   const mapOptions = {concurrency: ASSET_PATCH_CONCURRENCY}
-  return pMap(batches, setAssetReferenceBatch.bind(null, client, progress), mapOptions)
+  const setAssetRefs = setAssetReferenceBatch.bind(null, client, progress)
+  return pMap(batches, setAssetRefs, mapOptions)
 }
 
 function setAssetReferenceBatch(client, progress, batch) {
@@ -193,7 +236,7 @@ function getAssetType(assetId) {
 
 function reducePatch(trx, task) {
   return trx.patch(task.documentId, patch =>
-    patch.set({
+    patch.setIfMissing({[task.path]: {}}).set({
       [`${task.path}._type`]: getAssetType(task.assetId),
       [`${task.path}.asset`]: {
         _type: 'reference',

--- a/packages/@sanity/import/src/util/getHashedBufferForUri.js
+++ b/packages/@sanity/import/src/util/getHashedBufferForUri.js
@@ -5,31 +5,29 @@ const retryOnFailure = require('./retryOnFailure')
 
 module.exports = uri => retryOnFailure(() => getHashedBufferForUri(uri))
 
-function getHashedBufferForUri(uri) {
-  return getStream(uri).then(
-    stream =>
-      new Promise((resolve, reject) => {
-        const hash = crypto.createHash('sha1')
-        const chunks = []
+async function getHashedBufferForUri(uri) {
+  const stream = await getStream(uri)
+  return new Promise((resolve, reject) => {
+    const hash = crypto.createHash('sha1')
+    const chunks = []
 
-        stream.on('data', chunk => {
-          chunks.push(chunk)
-          hash.update(chunk)
-        })
+    stream.on('data', chunk => {
+      chunks.push(chunk)
+      hash.update(chunk)
+    })
 
-        miss.finished(stream, err => {
-          if (err) {
-            reject(err)
-            return
-          }
+    miss.finished(stream, err => {
+      if (err) {
+        reject(err)
+        return
+      }
 
-          resolve({
-            buffer: Buffer.concat(chunks),
-            sha1hash: hash.digest('hex')
-          })
-        })
+      resolve({
+        buffer: Buffer.concat(chunks),
+        sha1hash: hash.digest('hex')
       })
-  )
+    })
+  })
 }
 
 function getStream(uri) {


### PR DESCRIPTION
Fixes #54

With this flag enabled, we'll just continue as if the asset wasn't there, then print a list of failing URLs at the end.

In the future, we'll probably want to write the generated warnings to a file and add a flag for retrying the failed operations.
