### PR TITLE
[components] Allow disabling media in previews

### DIFF
--- a/packages/@sanity/components/src/previews/CardPreview.js
+++ b/packages/@sanity/components/src/previews/CardPreview.js
@@ -106,17 +106,19 @@ export default class CardPreview extends React.PureComponent {
       return (
         <div className={styles.placeholder}>
           <div className={styles.svg} style={svgStyles}>
-            <div className={styles.media}>
-              {aspect && (
-                <div
-                  className={styles.mediaPadding}
-                  style={{
-                    paddingTop: `${100 / aspect}%`
-                  }}
-                />
-              )}
-              <div className={styles.mediaContent} />
-            </div>
+            {media && (
+              <div className={styles.media}>
+                {aspect && (
+                  <div
+                    className={styles.mediaPadding}
+                    style={{
+                      paddingTop: `${100 / aspect}%`
+                    }}
+                  />
+                )}
+                <div className={styles.mediaContent} />
+              </div>
+            )}
             <div className={styles.meta}>
               <div className={styles.heading}>
                 <div className={styles.title}>&nbsp;</div>

--- a/packages/@sanity/components/src/previews/DefaultPreview.js
+++ b/packages/@sanity/components/src/previews/DefaultPreview.js
@@ -48,7 +48,7 @@ class DefaultPreview extends React.PureComponent {
     if (isPlaceholder) {
       return (
         <div className={styles.placeholder}>
-          <div className={styles.media} />
+          {media !== false && <div className={styles.media} />}
           <div className={styles.heading}>
             <h2 className={styles.title}>Loading…</h2>
             <h3 className={styles.subtitle}>Loading…</h3>
@@ -65,11 +65,13 @@ class DefaultPreview extends React.PureComponent {
           ${media ? styles.hasMedia : ''}
         `}
       >
-        <div className={styles.media}>
-          {typeof media === 'function' && media({dimensions: mediaDimensions, layout: 'default'})}
-          {typeof media === 'string' && <div className={styles.mediaString}>{media}</div>}
-          {React.isValidElement(media) && media}
-        </div>
+        {media !== false && (
+          <div className={styles.media}>
+            {typeof media === 'function' && media({dimensions: mediaDimensions, layout: 'default'})}
+            {typeof media === 'string' && <div className={styles.mediaString}>{media}</div>}
+            {React.isValidElement(media) && media}
+          </div>
+        )}
 
         <div className={styles.heading}>
           <h2 className={styles.title}>

--- a/packages/@sanity/components/src/previews/DetailPreview.js
+++ b/packages/@sanity/components/src/previews/DetailPreview.js
@@ -51,7 +51,7 @@ export default class DetailPreview extends React.PureComponent {
     if (isPlaceholder) {
       return (
         <div className={styles.placeholder}>
-          <div className={styles.media} />
+          {media !== false && <div className={styles.media} />}
           <div className={styles.content}>
             <h2 className={styles.title}>Loading</h2>
             <h3 className={styles.subtitle}>Loading</h3>
@@ -63,11 +63,13 @@ export default class DetailPreview extends React.PureComponent {
 
     return (
       <div className={styles.root}>
-        <div className={styles.media}>
-          {typeof media === 'function' && media({dimensions: mediaDimensions, layout: 'default'})}
-          {typeof media === 'string' && <div className={styles.mediaString}>{media}</div>}
-          {React.isValidElement(media) && media}
-        </div>
+        {media !== false && (
+          <div className={styles.media}>
+            {typeof media === 'function' && media({dimensions: mediaDimensions, layout: 'default'})}
+            {typeof media === 'string' && <div className={styles.mediaString}>{media}</div>}
+            {React.isValidElement(media) && media}
+          </div>
+        )}
         <div className={styles.content}>
           <div className={styles.top}>
             <div className={styles.heading}>

--- a/packages/@sanity/desk-tool/src/components/DocumentPaneItemPreview.js
+++ b/packages/@sanity/desk-tool/src/components/DocumentPaneItemPreview.js
@@ -6,6 +6,7 @@ import {map} from 'rxjs/operators'
 import {getDraftId, getPublishedId} from 'part:@sanity/base/util/draft-utils'
 import WarningIcon from 'part:@sanity/base/warning-icon'
 import {observeForPreview, SanityDefaultPreview} from 'part:@sanity/base/preview'
+import getIconWithTypeFallback from '../utils/getIconWithTypeFallback'
 import NotPublishedStatus from './NotPublishedStatus'
 import DraftStatus from './DraftStatus'
 
@@ -84,7 +85,7 @@ export default class DocumentPaneItemPreview extends React.Component {
       <SanityDefaultPreview
         value={getValueWithFallback({isLoading, value, schemaType, draft, published})}
         isPlaceholder={isLoading}
-        icon={icon || schemaType.icon}
+        icon={getIconWithTypeFallback(icon, schemaType)}
         layout={layout}
         type={schemaType}
         status={isLoading ? null : getStatusIndicator(draft, published)}
@@ -95,7 +96,7 @@ export default class DocumentPaneItemPreview extends React.Component {
 
 DocumentPaneItemPreview.propTypes = {
   layout: PropTypes.string,
-  icon: PropTypes.func,
+  icon: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
   value: PropTypes.object,
   schemaType: PropTypes.object
 }

--- a/packages/@sanity/desk-tool/src/pane/PaneItem.js
+++ b/packages/@sanity/desk-tool/src/pane/PaneItem.js
@@ -3,6 +3,7 @@ import React from 'react'
 import schema from 'part:@sanity/base/schema'
 import {SanityDefaultPreview} from 'part:@sanity/base/preview'
 import DocumentPaneItemPreview from '../components/DocumentPaneItemPreview'
+import getIconWithTypeFallback from '../utils/getIconWithTypeFallback'
 import MissingSchemaType from '../components/MissingSchemaType'
 import PaneItemWrapper from './PaneItemWrapper'
 
@@ -15,14 +16,19 @@ export default function PaneItem(props) {
   let preview
   if (value && value._id) {
     preview = hasSchemaType ? (
-      <DocumentPaneItemPreview icon={icon} layout={layout} schemaType={schemaType} value={value} />
+      <DocumentPaneItemPreview
+        icon={getIconWithTypeFallback(icon, schemaType)}
+        layout={layout}
+        schemaType={schemaType}
+        value={value}
+      />
     ) : (
       <MissingSchemaType value={value} />
     )
   } else {
     preview = (
       <SanityDefaultPreview
-        icon={icon || (schemaType && schemaType.icon)}
+        icon={getIconWithTypeFallback(icon, schemaType)}
         layout={layout}
         value={value}
       />
@@ -46,7 +52,7 @@ PaneItem.propTypes = {
   getLinkState: PropTypes.func.isRequired,
   layout: PropTypes.string,
   isSelected: PropTypes.bool,
-  icon: PropTypes.func,
+  icon: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   value: PropTypes.shape({
     _id: PropTypes.string,
     _type: PropTypes.string,
@@ -62,6 +68,7 @@ PaneItem.propTypes = {
 
 PaneItem.defaultProps = {
   layout: 'default',
+  icon: undefined,
   value: null,
   isSelected: false,
   schemaType: null

--- a/packages/@sanity/desk-tool/src/utils/getIconWithTypeFallback.js
+++ b/packages/@sanity/desk-tool/src/utils/getIconWithTypeFallback.js
@@ -1,0 +1,9 @@
+// Return false if we explicitly disable the icon, otherwise use the
+// passed icon or the schema type icon as a backup
+export default (icon, schemaType) => {
+  if (icon === false) {
+    return false
+  }
+
+  return icon || (schemaType && schemaType.icon)
+}

--- a/packages/@sanity/preview/src/components/SanityDefaultPreview.js
+++ b/packages/@sanity/preview/src/components/SanityDefaultPreview.js
@@ -35,7 +35,7 @@ export default class SanityDefaultPreview extends React.PureComponent {
     _renderAsBlockImage: PropTypes.bool,
     layout: PropTypes.oneOf(Object.keys(previewComponentMap)),
     value: PropTypes.object,
-    icon: PropTypes.func
+    icon: PropTypes.oneOfType([PropTypes.func, PropTypes.bool])
   }
 
   renderMedia = options => {
@@ -78,8 +78,13 @@ export default class SanityDefaultPreview extends React.PureComponent {
   }
 
   resolveMedia = () => {
-    const {value} = this.props
+    const {value, icon} = this.props
     const {media} = value
+
+    if (icon === false) {
+      // Explicitly disabled
+      return false
+    }
 
     if (typeof media === 'function' || React.isValidElement(media)) {
       return media


### PR DESCRIPTION
This PR enables you to pass `false` as `media` to previews to explicitly disable the rendering of it. This differs from the default `undefined` or `null`, which still renders the gray square placeholder.

Certain previews already had handling for this which was weaker - any falsey value would skip the rendering of the media element. In the cases where this was true, I chose to leave it as-is.