### PR TITLE
[document-store] Refactor document store

### DIFF
--- a/packages/@sanity/document-store/src/createDocumentStore.js
+++ b/packages/@sanity/document-store/src/createDocumentStore.js
@@ -1,150 +1,40 @@
-import {Observable, merge} from 'rxjs'
-import {share, filter, map, concat, switchMap, tap} from 'rxjs/operators'
-
-import {omit} from 'lodash'
-import pubsub from 'nano-pubsub'
-import {BufferedDocument, Mutation} from '@sanity/mutator'
-
-const NOOP = () => {}
+import {merge, Observable} from 'rxjs'
+import {filter, share} from 'rxjs/operators'
+import {createObservableBufferedDocument} from './createObservableBufferedDocument'
 
 function createBufferedDocument(documentId, serverEvents$, doCommit) {
+  const bufferedDocument = createObservableBufferedDocument(serverEvents$, doCommit)
+
   const reconnects$ = serverEvents$.pipe(filter(event => event.type === 'reconnect'))
 
-  const saves = pubsub()
-
-  const bufferedDocs$ = serverEvents$.pipe(
-    filter(event => event.type === 'snapshot'),
-    map(event => event.document),
-    map(snapshot => {
-      const bufferedDocument = new BufferedDocument(snapshot || null)
-
-      bufferedDocument.commitHandler = function commitHandler(opts) {
-        const payload = opts.mutation.params
-
-        // TODO:
-        // right now the BufferedDocument just commits fire-and-forget-ish
-        // We should be able to handle failures and retry here
-
-        doCommit(omit(payload, 'resultRev')).subscribe({
-          next: res => {
-            opts.success(res)
-            saves.publish()
-          },
-          error: opts.failure
-        })
-      }
-
-      const rebase$ = new Observable(rebaseObserver => {
-        bufferedDocument.onRebase = edge => {
-          rebaseObserver.next({type: 'rebase', document: edge})
-        }
-        return () => {
-          bufferedDocument.onRebase = NOOP
-        }
-      }).pipe(share())
-
-      const mutation$ = new Observable(mutationObserver => {
-        bufferedDocument.onMutation = ({mutation, remote}) => {
-          mutationObserver.next({
-            type: 'mutation',
-            document: bufferedDocument.LOCAL,
-            mutations: mutation.mutations,
-            origin: remote ? 'remote' : 'local'
-          })
-        }
-
-        const serverMutations = serverEvents$
-          .pipe(filter(event => event.type === 'mutation'))
-          .subscribe(event => bufferedDocument.arrive(new Mutation(event)))
-
-        return () => {
-          serverMutations.unsubscribe()
-          bufferedDocument.onMutation = NOOP
-        }
-      }).pipe(share())
-
-      return {
-        events: new Observable(observer => {
-          observer.next({type: 'snapshot', document: bufferedDocument.LOCAL})
-          observer.complete()
-        }).pipe(concat(merge(mutation$, rebase$, reconnects$))),
-
-        patch(patches) {
-          const mutations = patches.map(patch => ({patch: {...patch, id: documentId}}))
-
-          bufferedDocument.add(new Mutation({mutations: mutations}))
-        },
-        create(document) {
-          const mutation = {
-            create: Object.assign({id: documentId}, document)
-          }
-          bufferedDocument.add(new Mutation({mutations: [mutation]}))
-        },
-        createIfNotExists(document) {
-          bufferedDocument.add(new Mutation({mutations: [{createIfNotExists: document}]}))
-        },
-        createOrReplace(document) {
-          bufferedDocument.add(new Mutation({mutations: [{createOrReplace: document}]}))
-        },
-        delete() {
-          bufferedDocument.add(new Mutation({mutations: [{delete: {id: documentId}}]}))
-        },
-        commit() {
-          return new Observable(observer => {
-            // todo: connect observable with request from bufferedDocument.commit somehow
-            bufferedDocument.commit()
-            return saves.subscribe(() => {
-              observer.next()
-              observer.complete()
-            })
-          })
-        }
-      }
-    }),
-    share()
-  )
-
-  let currentBuffered
-  const cachedBuffered = new Observable(observer => {
-    if (currentBuffered) {
-      observer.next(currentBuffered)
-      observer.complete()
-    }
-    return bufferedDocs$
-      .pipe(
-        tap(doc => {
-          currentBuffered = doc
-        })
-      )
-      .subscribe(observer)
-  })
-
   return {
-    events: cachedBuffered.pipe(switchMap(bufferedDoc => bufferedDoc.events)),
+    events: merge(reconnects$, bufferedDocument.updates$),
     patch(patches) {
-      cachedBuffered.subscribe(bufferedDoc => bufferedDoc.patch(patches))
+      bufferedDocument.addMutations(patches.map(patch => ({patch: {...patch, id: documentId}})))
     },
     create(document) {
-      cachedBuffered.subscribe(bufferedDoc => bufferedDoc.create(document))
+      bufferedDocument.addMutation({
+        create: Object.assign({id: documentId}, document)
+      })
     },
     createIfNotExists(document) {
-      cachedBuffered.subscribe(bufferedDoc => bufferedDoc.createIfNotExists(document))
+      bufferedDocument.addMutation({createIfNotExists: document})
     },
     createOrReplace(document) {
-      cachedBuffered.subscribe(bufferedDoc => bufferedDoc.createOrReplace(document))
+      bufferedDocument.addMutation({createOrReplace: document})
     },
     delete() {
-      cachedBuffered.subscribe(bufferedDoc => bufferedDoc.delete())
+      bufferedDocument.addMutation({delete: {id: documentId}})
     },
     commit() {
-      return cachedBuffered.pipe(switchMap(bufferedDoc => bufferedDoc.commit()))
+      return bufferedDocument.commit()
     }
   }
 }
 
-const isDocId = id => event => event.documentId === id
+const isEventForDocId = id => event => event.type === 'reconnect' || event.documentId === id
 
-module.exports = function createDocumentStore({serverConnection}) {
+export default function createDocumentStore({serverConnection}) {
   return {
     byId,
     byIds,
@@ -181,12 +71,13 @@ module.exports = function createDocumentStore({serverConnection}) {
 
     const draft = createBufferedDocument(
       draftId,
-      serverEvents$.pipe(filter(isDocId(draftId))),
+      serverEvents$.pipe(filter(isEventForDocId(draftId))),
       doCommit
     )
+
     const published = createBufferedDocument(
       publishedId,
-      serverEvents$.pipe(filter(isDocId(publishedId))),
+      serverEvents$.pipe(filter(isEventForDocId(publishedId))),
       doCommit
     )
     return {draft, published}

--- a/packages/@sanity/document-store/src/createObservableBufferedDocument.js
+++ b/packages/@sanity/document-store/src/createObservableBufferedDocument.js
@@ -1,0 +1,122 @@
+import {BufferedDocument, Mutation} from '@sanity/mutator'
+import {defer, merge, of, Subject} from 'rxjs'
+import {
+  filter,
+  map,
+  distinctUntilChanged,
+  publishReplay,
+  refCount,
+  scan,
+  share,
+  tap,
+  withLatestFrom
+} from 'rxjs/operators'
+
+export const snapshotEventFrom = snapshot => ({
+  type: 'snapshot',
+  document: snapshot
+})
+
+// This is an observable interface for BufferedDocument in an attempt
+// to make it easier to work with the api provided by it
+export const createObservableBufferedDocument = (serverEvents$, doCommit) => {
+  // Incoming local actions (e.g. a mutation, a commit)
+  const actions$ = new Subject()
+
+  // Stream of events that has happened (e.g. a mutation, a rebase).
+  // These are "after the fact" events.
+  const updates$ = new Subject()
+
+  const createInitialBufferedDocument = snapshot => {
+    const bufferedDocument = new BufferedDocument(snapshot)
+    bufferedDocument.onMutation = ({mutation, remote}) => {
+      updates$.next({
+        type: 'mutation',
+        document: bufferedDocument.LOCAL,
+        mutations: mutation.mutations,
+        origin: remote ? 'remote' : 'local'
+      })
+    }
+
+    bufferedDocument.onRebase = edge => {
+      updates$.next({type: 'rebase', document: edge})
+    }
+
+    bufferedDocument.commitHandler = opts => {
+      const {resultRev, ...mutation} = opts.mutation.params
+      doCommit(mutation)
+        .pipe(tap(() => updates$.next({type: 'committed'})))
+        .subscribe({next: opts.success, error: opts.failure})
+    }
+    return bufferedDocument
+  }
+
+  const bufferedDocument$ = serverEvents$.pipe(
+    scan((bufferedDocument, serverEvent) => {
+      if (serverEvent.type === 'snapshot') {
+        if (bufferedDocument) {
+          // we received a new snapshot and already got an old one. When we receive a snapshot again
+          // it is usually because the connection has been down. Attempt to save pending changes (if any)
+          bufferedDocument.commit()
+        }
+        return createInitialBufferedDocument(serverEvent.document || null)
+      }
+      if (!bufferedDocument) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          'Ignoring event of type "%s" since buffered document has not yet been set up with snapshot',
+          serverEvent.type
+        )
+        return bufferedDocument
+      }
+      if (serverEvent.type === 'mutation') {
+        bufferedDocument.arrive(new Mutation(serverEvent))
+      } else if (serverEvent.type !== 'reconnect') {
+        // eslint-disable-next-line no-console
+        console.warn('Received unexpected server event of type "%s"', serverEvent.type)
+      }
+      return bufferedDocument
+    }, null),
+    publishReplay(1),
+    refCount()
+  )
+
+  // this is where the side effects actually happens
+  const actionHandler$ = actions$.pipe(
+    withLatestFrom(bufferedDocument$),
+    map(([action, bufferedDocument]) => {
+      if (action.type === 'mutation') {
+        bufferedDocument.add(new Mutation({mutations: action.mutations}))
+      }
+      if (action.type === 'commit') {
+        bufferedDocument.commit()
+      }
+      return null
+    }),
+    filter(Boolean),
+    share()
+  )
+
+  const emitAction = action => actions$.next(action)
+
+  const addMutations = mutations => emitAction({type: 'mutation', mutations})
+  const addMutation = mutation => addMutations([mutation])
+
+  const commit = () =>
+    defer(() => {
+      emitAction({type: 'commit'})
+      return of(null)
+    })
+
+  const snapshot$ = bufferedDocument$.pipe(
+    distinctUntilChanged((bufDoc, prevBufDoc) => bufDoc.LOCAL === prevBufDoc.LOCAL),
+    map(buf => snapshotEventFrom(buf.LOCAL))
+  )
+
+  return {
+    updates$: merge(snapshot$, actionHandler$, updates$),
+    addMutation,
+    addMutations,
+    commit
+  }
+}


### PR DESCRIPTION
This is a refactor of the part of the document store that deals with document editing (checking out drafts/published, listening for events, adding mutations, etc.).

It fixes an issue with listener connections not getting closed when switching between documents. As a bonus it also fixes a regression that caused the "reconnect" message not being displayed (and disabling the form) if the internet connection went down while editing.