### PR TITLE
[components] Collapse pane when too narrow

### DIFF
--- a/packages/@sanity/components/src/panes/SplitController.js
+++ b/packages/@sanity/components/src/panes/SplitController.js
@@ -56,10 +56,14 @@ export default class PanesSplitController extends React.Component {
   }
 
   handleSplitPaneChange = debounce((size, pane) => {
+    const index = React.Children.toArray(this.props.children).findIndex(
+      curr => curr.key === pane.key
+    )
+
     if (size <= pane.props.minWidth) {
-      this.props.onShouldCollapse(pane)
+      this.props.onShouldCollapse(index)
     } else {
-      this.props.onShouldExpand(pane)
+      this.props.onShouldExpand(index)
     }
 
     this.lastPaneSize = size

--- a/packages/@sanity/desk-tool/src/DeskToolPanes.js
+++ b/packages/@sanity/desk-tool/src/DeskToolPanes.js
@@ -38,8 +38,12 @@ export default class DeskToolPanes extends React.Component {
     }
   }
 
-  handleControllerCollapse = pane => {}
-  handleControllerUnCollapse = pane => {}
+  handleControllerCollapse = index => {
+    this.handlePaneCollapse(index)
+  }
+  handleControllerUnCollapse = index => {
+    this.handlePaneExpand(index)
+  }
 
   handlePaneExpand = index => {
     this.setState(prevState => ({


### PR DESCRIPTION
Fixes a bug that I think was introduced in "structure" where the pane does not collapse when resized  smaller than minWidth