### PR TITLE
[components] Set height on select for firefox

### DIFF
--- a/packages/@sanity/components/src/selects/styles/DefaultSelect.css
+++ b/packages/@sanity/components/src/selects/styles/DefaultSelect.css
@@ -30,6 +30,7 @@
   appearance: none;
   position: relative;
   overflow: hidden;
+  height: 2.5em;
 
   @nest &:not(:disabled) {
     @nest &:hover {


### PR DESCRIPTION
Fixes a bug where DefaultSelect on firefox is thinner than DefaultTextInput