### PR TITLE
[structure] Reset `canHandleIntent` on doc type list spec changes

### DIFF
--- a/packages/@sanity/structure/src/DocumentList.ts
+++ b/packages/@sanity/structure/src/DocumentList.ts
@@ -49,7 +49,7 @@ const resolveEditorChildForItem: ChildResolver = (
   )
 }
 
-interface PartialDocumentList extends BuildableGenericList {
+export interface PartialDocumentList extends BuildableGenericList {
   options?: DocumentListOptions
   schemaTypeName?: string
 }

--- a/packages/@sanity/structure/src/DocumentTypeList.ts
+++ b/packages/@sanity/structure/src/DocumentTypeList.ts
@@ -1,6 +1,7 @@
 import {DocumentListBuilder, DocumentListInput, PartialDocumentList} from './DocumentList'
 import {SchemaType} from './parts/Schema'
 import {Child} from './StructureNodes'
+import {DEFAULT_INTENT_HANDLER} from './documentTypeListItems'
 
 // 1:1 with document list builder, but when modifying key parameters (filter, params, child)
 // remove canHandleIntent function since we can't guarantee child editor can handle intent
@@ -13,33 +14,39 @@ export class DocumentTypeListBuilder extends DocumentListBuilder {
   }
 
   filter(filter: string): DocumentListBuilder {
-    return this.clone({
-      options: {...(this.spec.options || {}), filter},
-      canHandleIntent: undefined
+    return this.cloneWithoutDefaultIntentHandler({
+      options: {...(this.spec.options || {}), filter}
     })
   }
 
   params(params: {}): DocumentListBuilder {
-    return this.clone({
-      options: {...(this.spec.options || {filter: ''}), params},
-      canHandleIntent: undefined
+    return this.cloneWithoutDefaultIntentHandler({
+      options: {...(this.spec.options || {filter: ''}), params}
     })
   }
 
   schemaType(type: SchemaType | string): DocumentListBuilder {
-    return this.clone({
-      schemaTypeName: typeof type === 'string' ? type : type.name,
-      canHandleIntent: undefined
+    return this.cloneWithoutDefaultIntentHandler({
+      schemaTypeName: typeof type === 'string' ? type : type.name
     })
   }
 
   child(child: Child) {
-    return this.clone({child, canHandleIntent: undefined})
+    return this.cloneWithoutDefaultIntentHandler({child})
   }
 
   clone(withSpec?: PartialDocumentList): DocumentTypeListBuilder {
     const builder = new DocumentTypeListBuilder()
     builder.spec = {...this.spec, ...(withSpec || {})}
+    return builder
+  }
+
+  cloneWithoutDefaultIntentHandler(withSpec?: PartialDocumentList): DocumentTypeListBuilder {
+    const builder = new DocumentTypeListBuilder()
+    const canHandleIntent = this.spec.canHandleIntent
+    const shouldOverride = canHandleIntent && canHandleIntent.identity === DEFAULT_INTENT_HANDLER
+    const override = shouldOverride ? {canHandleIntent: undefined} : {}
+    builder.spec = {...this.spec, ...(withSpec || {}), ...override}
     return builder
   }
 }

--- a/packages/@sanity/structure/src/DocumentTypeList.ts
+++ b/packages/@sanity/structure/src/DocumentTypeList.ts
@@ -1,0 +1,45 @@
+import {DocumentListBuilder, DocumentListInput, PartialDocumentList} from './DocumentList'
+import {SchemaType} from './parts/Schema'
+import {Child} from './StructureNodes'
+
+// 1:1 with document list builder, but when modifying key parameters (filter, params, child)
+// remove canHandleIntent function since we can't guarantee child editor can handle intent
+export class DocumentTypeListBuilder extends DocumentListBuilder {
+  protected spec: PartialDocumentList
+
+  constructor(spec?: DocumentListInput) {
+    super()
+    this.spec = spec ? spec : {}
+  }
+
+  filter(filter: string): DocumentListBuilder {
+    return this.clone({
+      options: {...(this.spec.options || {}), filter},
+      canHandleIntent: undefined
+    })
+  }
+
+  params(params: {}): DocumentListBuilder {
+    return this.clone({
+      options: {...(this.spec.options || {filter: ''}), params},
+      canHandleIntent: undefined
+    })
+  }
+
+  schemaType(type: SchemaType | string): DocumentListBuilder {
+    return this.clone({
+      schemaTypeName: typeof type === 'string' ? type : type.name,
+      canHandleIntent: undefined
+    })
+  }
+
+  child(child: Child) {
+    return this.clone({child, canHandleIntent: undefined})
+  }
+
+  clone(withSpec?: PartialDocumentList): DocumentTypeListBuilder {
+    const builder = new DocumentTypeListBuilder()
+    builder.spec = {...this.spec, ...(withSpec || {})}
+    return builder
+  }
+}

--- a/packages/@sanity/structure/src/Intent.ts
+++ b/packages/@sanity/structure/src/Intent.ts
@@ -5,4 +5,5 @@ export interface Intent {
 
 export interface IntentChecker {
   (intentName: string, params?: {[key: string]: any}): boolean
+  identity?: Symbol
 }

--- a/packages/@sanity/structure/src/StructureNodes.ts
+++ b/packages/@sanity/structure/src/StructureNodes.ts
@@ -7,6 +7,7 @@ import {MenuItemGroupBuilder} from './MenuItemGroup'
 import {Component, ComponentBuilder} from './Component'
 import {DocumentListItemBuilder} from './DocumentListItem'
 import {ChildResolver} from './ChildResolver'
+import {DocumentTypeListBuilder} from './DocumentTypeList'
 
 export interface StructureNode {
   id: string
@@ -35,7 +36,12 @@ export interface Serializable {
 
 export type Collection = List | DocumentList | EditorNode | Component
 
-export type CollectionBuilder = ListBuilder | DocumentListBuilder | EditorBuilder | ComponentBuilder
+export type CollectionBuilder =
+  | ListBuilder
+  | DocumentListBuilder
+  | DocumentTypeListBuilder
+  | EditorBuilder
+  | ComponentBuilder
 
 export type Child = Collection | CollectionBuilder | ChildResolver
 

--- a/packages/@sanity/structure/src/documentTypeListItems.ts
+++ b/packages/@sanity/structure/src/documentTypeListItems.ts
@@ -8,6 +8,7 @@ import {DocumentListBuilder} from './DocumentList'
 import {ListItemBuilder} from './ListItem'
 import {EditorBuilder} from './Editor'
 import {isActionEnabled} from './parts/documentActionUtils'
+import {DocumentTypeListBuilder} from './DocumentTypeList'
 
 const PlusIcon = getPlusIcon()
 const ListIcon = getListIcon()
@@ -45,18 +46,13 @@ export function getDocumentTypeList(
 
   const canCreate = isActionEnabled(type, 'create')
 
-  return new DocumentListBuilder()
+  return new DocumentTypeListBuilder()
     .id(typeName)
     .title(title)
     .filter('_type == $type')
     .params({type: typeName})
     .schemaType(type)
     .defaultOrdering(DEFAULT_SELECTED_ORDERING_OPTION.by)
-    .canHandleIntent(
-      (intentName, params): boolean =>
-        Boolean(intentName === 'edit' && params && params.id && params.type === typeName) ||
-        Boolean(intentName === 'create' && params && params.type === typeName)
-    )
     .menuItemGroups([
       {id: 'sorting', title: 'Sort'},
       {id: 'layout', title: 'Layout'},
@@ -67,6 +63,11 @@ export function getDocumentTypeList(
         .id('editor')
         .schemaType(type)
         .documentId(documentId)
+    )
+    .canHandleIntent(
+      (intentName, params): boolean =>
+        Boolean(intentName === 'edit' && params && params.id && params.type === typeName) ||
+        Boolean(intentName === 'create' && params && params.type === typeName)
     )
     .menuItems([
       // Create new (from action button)

--- a/packages/@sanity/structure/src/documentTypeListItems.ts
+++ b/packages/@sanity/structure/src/documentTypeListItems.ts
@@ -9,12 +9,15 @@ import {ListItemBuilder} from './ListItem'
 import {EditorBuilder} from './Editor'
 import {isActionEnabled} from './parts/documentActionUtils'
 import {DocumentTypeListBuilder} from './DocumentTypeList'
+import {IntentChecker} from './Intent'
 
 const PlusIcon = getPlusIcon()
 const ListIcon = getListIcon()
 const DetailsIcon = getDetailsIcon()
 
 const getDataAspectsForSchema: (schema: Schema) => DataAspectsResolver = memoizeOne(dataAspects)
+
+export const DEFAULT_INTENT_HANDLER = Symbol('Document type list canHandleIntent')
 
 export function getDocumentTypeListItems(schema: Schema = defaultSchema): ListItemBuilder[] {
   const resolver = getDataAspectsForSchema(schema)
@@ -43,8 +46,13 @@ export function getDocumentTypeList(
   const type = schema.get(typeName)
   const resolver = getDataAspectsForSchema(schema)
   const title = resolver.getDisplayName(typeName)
-
   const canCreate = isActionEnabled(type, 'create')
+
+  const intentChecker: IntentChecker = (intentName, params): boolean =>
+    Boolean(intentName === 'edit' && params && params.id && params.type === typeName) ||
+    Boolean(intentName === 'create' && params && params.type === typeName)
+
+  intentChecker.identity = DEFAULT_INTENT_HANDLER
 
   return new DocumentTypeListBuilder()
     .id(typeName)
@@ -64,11 +72,7 @@ export function getDocumentTypeList(
         .schemaType(type)
         .documentId(documentId)
     )
-    .canHandleIntent(
-      (intentName, params): boolean =>
-        Boolean(intentName === 'edit' && params && params.id && params.type === typeName) ||
-        Boolean(intentName === 'create' && params && params.type === typeName)
-    )
+    .canHandleIntent(intentChecker)
     .menuItems([
       // Create new (from action button)
       ...(canCreate

--- a/packages/@sanity/structure/test/__snapshots__/documentTypeListItems.test.ts.snap
+++ b/packages/@sanity/structure/test/__snapshots__/documentTypeListItems.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`generates correct document type list item for specific type 1`] = `
 ListItemBuilder {
   "spec": Object {
-    "child": DocumentListBuilder {
+    "child": DocumentTypeListBuilder {
       "spec": Object {
         "canHandleIntent": [Function],
         "child": [Function],
@@ -168,7 +168,7 @@ ListItemBuilder {
 exports[`generates correct document type list item for specific type 2`] = `
 ListItemBuilder {
   "spec": Object {
-    "child": DocumentListBuilder {
+    "child": DocumentTypeListBuilder {
       "spec": Object {
         "canHandleIntent": [Function],
         "child": [Function],
@@ -334,7 +334,7 @@ exports[`generates correct document type list items from given schema 1`] = `
 Array [
   ListItemBuilder {
     "spec": Object {
-      "child": DocumentListBuilder {
+      "child": DocumentTypeListBuilder {
         "spec": Object {
           "canHandleIntent": [Function],
           "child": [Function],
@@ -496,7 +496,7 @@ Array [
   },
   ListItemBuilder {
     "spec": Object {
-      "child": DocumentListBuilder {
+      "child": DocumentTypeListBuilder {
         "spec": Object {
           "canHandleIntent": [Function],
           "child": [Function],
@@ -776,7 +776,7 @@ exports[`generates correct document type list items from global schema 1`] = `
 Array [
   ListItemBuilder {
     "spec": Object {
-      "child": DocumentListBuilder {
+      "child": DocumentTypeListBuilder {
         "spec": Object {
           "canHandleIntent": [Function],
           "child": [Function],
@@ -938,7 +938,7 @@ Array [
   },
   ListItemBuilder {
     "spec": Object {
-      "child": DocumentListBuilder {
+      "child": DocumentTypeListBuilder {
         "spec": Object {
           "canHandleIntent": [Function],
           "child": [Function],

--- a/packages/@sanity/structure/test/documentTypeListItems.test.ts
+++ b/packages/@sanity/structure/test/documentTypeListItems.test.ts
@@ -49,3 +49,27 @@ test('generated document panes responds with correct editor child', done => {
     done()
   })
 })
+
+test('manually assigned canHandleIntent should not be overriden', () => {
+  const alwaysFalse = () => false
+  const list = S.documentTypeList('author')
+  const modified = list.canHandleIntent(alwaysFalse)
+
+  // Test default handler
+  const defHandler = list.getCanHandleIntent()
+  expect(defHandler('create', {type: 'author'})).toBe(true)
+
+  // Test modified handler
+  const modHandler = modified.getCanHandleIntent()
+  expect(modHandler('create', {type: 'author'})).toBe(false)
+
+  // Modifying child for default list _SHOULD_ reset canHandleIntent
+  const diffChild = list.child(() => null)
+  const diffHandler = diffChild.getCanHandleIntent()
+  expect(diffHandler).toBeUndefined()
+
+  // Modifying child for list with custom intent handler should _NOT_ reset canHandleIntent
+  const customChild = modified.child(() => null)
+  const customHandler = customChild.getCanHandleIntent()
+  expect(customHandler).toEqual(alwaysFalse)
+})


### PR DESCRIPTION
This fixes an issue where someone would start out with a document type list (`S.documentTypeList('author')`) but would then alter the specification - most importantly, override the  `child`.

When this happened, the pane was still configured as being able to handle an edit/create intent for the schema type, but in reality it just resolved the child that was configured, instead of the editor.

With this fix, we reset `canHandleIntent` when parts of the specification is changed which would make the intent resolving incorrect - but only if the `canHandleIntent` function is the default, generated one (we trust the user to know what they are doing if they provide their own).