### PR TITLE
[default-layout] Defer intent redirect to fix empty tool state

### DIFF
--- a/packages/@sanity/default-layout/src/datastores/urlState.js
+++ b/packages/@sanity/default-layout/src/datastores/urlState.js
@@ -72,7 +72,8 @@ function maybeHandleIntent(prevEvent, currentEvent) {
   if (currentEvent && currentEvent.state && currentEvent.state.intent) {
     const redirectState = resolveIntentState(prevEvent ? prevEvent.state : {}, currentEvent.state)
     if (redirectState) {
-      navigate(rootRouter.encode(redirectState), {replace: true})
+      const newUrl = rootRouter.encode(redirectState)
+      setTimeout(() => navigate(newUrl, {replace: true}), 0)
       return null
     }
   }


### PR DESCRIPTION
Bug details explained on Slack, but tl;dr: resolving an intent twice in a row would yield an empty tool state for the second `getIntentState()` call.
