### PR TITLE
[vision] Add auto close brackets to editors in Vision

### DIFF
--- a/packages/@sanity/vision/src/components/ParamsEditor.js
+++ b/packages/@sanity/vision/src/components/ParamsEditor.js
@@ -7,6 +7,7 @@ import tryParseParams from '../util/tryParseParams'
 
 require('codemirror/mode/javascript/javascript')
 require('codemirror/addon/hint/show-hint')
+require('codemirror/addon/edit/closebrackets')
 
 const ENTER_KEY = 13
 
@@ -36,7 +37,8 @@ class ParamsEditor extends React.PureComponent {
     const options = {
       lineNumbers: true,
       tabSize: 2,
-      mode: {name: 'javascript', json: true}
+      mode: {name: 'javascript', json: true},
+      autoCloseBrackets: true
     }
     return (
       <ReactCodeMirror

--- a/packages/@sanity/vision/src/components/QueryEditor.js
+++ b/packages/@sanity/vision/src/components/QueryEditor.js
@@ -2,8 +2,10 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import ReactCodeMirror from 'react-codemirror2'
 import CodeMirror from 'codemirror'
+
 require('codemirror/mode/javascript/javascript')
 require('codemirror/addon/hint/show-hint')
+require('codemirror/addon/edit/closebrackets')
 
 class QueryEditor extends React.PureComponent {
   constructor(props) {
@@ -55,7 +57,8 @@ class QueryEditor extends React.PureComponent {
       extraKeys: {
         'Ctrl-Space': 'autocomplete',
         'Ctrl-Enter': this.props.onExecute
-      }
+      },
+      autoCloseBrackets: true
     }
     return (
       <ReactCodeMirror


### PR DESCRIPTION
This adds the auto close brackets option to the Vision plugin. It may be opinionated, but I think it adds some improved DX to the tool. Requested by @finiteattention in the [community slack](https://sanity.slack.com). 