### PR TITLE
[client] Warn when token is used with useCdn set to true

### DIFF
--- a/packages/@sanity/client/src/config.js
+++ b/packages/@sanity/client/src/config.js
@@ -17,18 +17,22 @@ const cdnWarning = [
   'the client.'
 ]
 
-const printCdnWarning = (() => {
-  let hasWarned = false
-  return () => {
-    if (hasWarned) {
-      return
-    }
+const cdnTokenWarning = [
+  'You have set the `useCdn` setting to `true` while also specifying a token. This is usually not',
+  'what you want. The CDN cannot be used with an authorization token, since private data cannot',
+  `be cached. See ${generateHelpUrl('js-client-usecdn-token')} for more information.`
+]
 
-    // eslint-disable-next-line no-console
-    console.warn(cdnWarning.join(' '))
-    hasWarned = true
+const hasWarned = {}
+const printWarning = (id, msg) => {
+  if (hasWarned[id]) {
+    return
   }
-})()
+
+  // eslint-disable-next-line no-console
+  console.warn(msg)
+  hasWarned[id] = true
+}
 
 exports.defaultConfig = defaultConfig
 
@@ -50,8 +54,10 @@ exports.initConfig = (config, prevConfig) => {
     throw new Error('Configuration must contain `projectId`')
   }
 
-  if (typeof newConfig.useCdn === 'undefined') {
-    printCdnWarning()
+  if (typeof newConfig.useCdn === 'undefined' && !newConfig.token) {
+    printWarning('cdn', cdnWarning.join(' '))
+  } else if (newConfig.useCdn && newConfig.token) {
+    printWarning('cdn-token', cdnTokenWarning.join(' '))
   }
 
   if (projectBased) {

--- a/packages/@sanity/client/src/config.js
+++ b/packages/@sanity/client/src/config.js
@@ -18,9 +18,9 @@ const cdnWarning = [
 ]
 
 const cdnTokenWarning = [
-  'You have set the `useCdn` setting to `true` while also specifying a token. This is usually not',
-  'what you want. The CDN cannot be used with an authorization token, since private data cannot',
-  `be cached. See ${generateHelpUrl('js-client-usecdn-token')} for more information.`
+  'You have set `useCdn` to `true` while also specifying a token. This is usually not what you',
+  'want. The CDN cannot be used with an authorization token, since private data cannot be cached.',
+  `See ${generateHelpUrl('js-client-usecdn-token')} for more information.`
 ]
 
 const hasWarned = {}
@@ -56,7 +56,12 @@ exports.initConfig = (config, prevConfig) => {
 
   if (typeof newConfig.useCdn === 'undefined' && !newConfig.token) {
     printWarning('cdn', cdnWarning.join(' '))
-  } else if (newConfig.useCdn && newConfig.token) {
+  } else if (
+    newConfig.useCdn &&
+    newConfig.token &&
+    (typeof window === 'undefined' ||
+      ['localhost', '127.0.0.1', '0.0.0.0'].indexOf(window.location.hostname) !== -1)
+  ) {
     printWarning('cdn-token', cdnTokenWarning.join(' '))
   }
 


### PR DESCRIPTION
`useCdn: true` + `token` is usually a bad combination, since it will "silently" use the live API for queries and listeners. This PR adds a warning when combining the two, encouraging people to use a different combination (a few examples outlined in the linked help article)