### PR TITLE
[vision] Replace JSON viewer

### DIFF
--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -21,12 +21,10 @@
   ],
   "dependencies": {
     "classnames": "^2.2.5",
-    "json-lexer": "^1.1.1",
     "moment": "^2.19.1",
     "query-string": "^4.3.2",
     "react-codemirror2": "^1.0.0",
     "react-icon-base": "^2.1.2",
-    "react-json-inspector": "^7.1.1",
     "react-json-view": "^1.19.1",
     "react-spinner": "^0.2.6",
     "react-split-pane": "^0.1.63"

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -27,6 +27,7 @@
     "react-codemirror2": "^1.0.0",
     "react-icon-base": "^2.1.2",
     "react-json-inspector": "^7.1.1",
+    "react-json-view": "^1.19.1",
     "react-spinner": "^0.2.6",
     "react-split-pane": "^0.1.63"
   },

--- a/packages/@sanity/vision/src/components/JsonDump.js
+++ b/packages/@sanity/vision/src/components/JsonDump.js
@@ -3,7 +3,7 @@ import React, {Fragment} from 'react'
 import PropTypes from 'prop-types'
 import ReactJson from 'react-json-view'
 
-class JsonBlock extends React.PureComponent {
+class JsonBlock extends React.Component {
   render() {
     const styles = this.context.styles.jsonDump
     return (

--- a/packages/@sanity/vision/src/components/JsonDump.js
+++ b/packages/@sanity/vision/src/components/JsonDump.js
@@ -1,41 +1,14 @@
 /* eslint-disable react/prop-types, react/no-multi-comp */
-import React from 'react'
+import React, {Fragment} from 'react'
 import PropTypes from 'prop-types'
-import tokenize from 'json-lexer'
-
-const punctuator = token => <span className={token.className}>{token.raw}</span>
-const number = token => <span className={token.className}>{token.raw}</span>
-const string = token => <span className={token.className}>{token.raw}</span>
-const key = token => <span className={token.className}>{token.raw.slice(1, -1)}</span>
-const formatters = {punctuator, key, string, number}
+import ReactJson from 'react-json-view'
 
 class JsonBlock extends React.PureComponent {
   render() {
     const styles = this.context.styles.jsonDump
-    const json = JSON.stringify(this.props.data, null, 2)
-    const tokens = tokenize(json).map((token, i, arr) => {
-      const prevToken = i === 0 ? token : arr[i - 1]
-      if (
-        token.type === 'string' &&
-        prevToken.type === 'whitespace' &&
-        /^\n\s+$/.test(prevToken.value)
-      ) {
-        token.type = 'key'
-      }
-
-      return token
-    })
-
     return (
       <pre className={styles.block}>
-        {tokens.map((token, i) => {
-          const Formatter = formatters[token.type]
-          return Formatter ? (
-            <Formatter key={i} className={styles[token.type]} raw={token.raw} />
-          ) : (
-            token.raw
-          )
-        })}
+        <ReactJson displayDataTypes={false} src={this.props.data} />
       </pre>
     )
   }
@@ -51,8 +24,10 @@ export default function JsonDump(props) {
   }
 
   return (
-    <code>
-      {props.data.map((row, i) => <JsonBlock key={row._id || row.eventId || i} data={row} />)}
-    </code>
+    <Fragment>
+      {props.data.map((row, i) => (
+        <JsonBlock key={row._id || row.eventId || i} data={row} />
+      ))}
+    </Fragment>
   )
 }


### PR DESCRIPTION
This replaces the JS(ON)-viewer in Vision with the [react-json-view](https://www.npmjs.com/package/react-json-view) component. The previous had formatting errors (strings in arrays). This also features a copy-function so that you can actually get sensible data out of vision.


