### PR TITLE
[desk-tool] Clear reconnect state when receiving new snapshots

### DIFF
--- a/packages/@sanity/desk-tool/src/pane/EditorPane.js
+++ b/packages/@sanity/desk-tool/src/pane/EditorPane.js
@@ -127,6 +127,7 @@ export default withDocumentType(
         this.setState(prevState => {
           const version = event.version // either 'draft' or 'published'
           return {
+            isReconnecting: event.type === 'reconnect',
             validationPending: true,
             [version]: {
               ...(prevState[version] || {}),
@@ -158,10 +159,6 @@ export default withDocumentType(
     }
 
     receiveDraftEvent = event => {
-      this.setState({isReconnecting: event.type === 'reconnect'})
-      if (event.type !== 'mutation') {
-        return
-      }
       // Broadcast incoming patches to input components that applies patches on their own
       // Note: This is *experimental*
       this.patchChannel.receivePatches({


### PR DESCRIPTION
This fixes a bug introduced in #1003 that could cause the disconnected-state in the editor UI to persist even when connection is restored.

Will release in a hotfix after merge.