### PR TITLE
[client] Warn if client is configured with a token in the browser

### DIFF
--- a/packages/@sanity/client/src/config.js
+++ b/packages/@sanity/client/src/config.js
@@ -1,6 +1,7 @@
 const generateHelpUrl = require('@sanity/generate-help-url')
 const assign = require('object-assign')
 const validate = require('./validators')
+const once = require('./util/once')
 
 const defaultCdnHost = 'apicdn.sanity.io'
 const defaultConfig = {
@@ -10,29 +11,31 @@ const defaultConfig = {
   isPromiseAPI: true
 }
 
-const cdnWarning = [
+const LOCALHOSTS = ['localhost', '127.0.0.1', '0.0.0.0']
+const isLocal = host => LOCALHOSTS.indexOf(host) !== -1
+
+// eslint-disable-next-line no-console
+const printWarning = message => once(() => console.warn(message.join(' ')))
+
+const printCdnWarning = printWarning([
   'You are not using the Sanity CDN. That means your data is always fresh, but the CDN is faster and',
   `cheaper. Think about it! For more info, see ${generateHelpUrl('js-client-cdn-configuration')}.`,
   'To hide this warning, please set the `useCdn` option to either `true` or `false` when creating',
   'the client.'
-]
+])
 
-const cdnTokenWarning = [
+const printBrowserTokenWarning = printWarning([
+  'You have configured Sanity client to use a token in the browser. This may cause unintentional security issues.',
+  `See ${generateHelpUrl(
+    'js-client-browser-token'
+  )} for more information and how to hide this warning.`
+])
+
+const printCdnTokenWarning = printWarning([
   'You have set `useCdn` to `true` while also specifying a token. This is usually not what you',
   'want. The CDN cannot be used with an authorization token, since private data cannot be cached.',
   `See ${generateHelpUrl('js-client-usecdn-token')} for more information.`
-]
-
-const hasWarned = {}
-const printWarning = (id, msg) => {
-  if (hasWarned[id]) {
-    return
-  }
-
-  // eslint-disable-next-line no-console
-  console.warn(msg)
-  hasWarned[id] = true
-}
+])
 
 exports.defaultConfig = defaultConfig
 
@@ -54,15 +57,15 @@ exports.initConfig = (config, prevConfig) => {
     throw new Error('Configuration must contain `projectId`')
   }
 
-  if (typeof newConfig.useCdn === 'undefined' && !newConfig.token) {
-    printWarning('cdn', cdnWarning.join(' '))
-  } else if (
-    newConfig.useCdn &&
-    newConfig.token &&
-    (typeof window === 'undefined' ||
-      ['localhost', '127.0.0.1', '0.0.0.0'].indexOf(window.location.hostname) !== -1)
-  ) {
-    printWarning('cdn-token', cdnTokenWarning.join(' '))
+  const isBrowser = typeof window !== 'undefined'
+  const isLocalhost = isBrowser && isLocal(window.location.hostname)
+
+  if (isBrowser && isLocalhost && newConfig.token && newConfig.ignoreBrowserTokenWarning !== true) {
+    printBrowserTokenWarning()
+  } else if ((!isBrowser || isLocalhost) && newConfig.useCdn && newConfig.token) {
+    printCdnTokenWarning()
+  } else if (typeof newConfig.useCdn === 'undefined') {
+    printCdnWarning()
   }
 
   if (projectBased) {

--- a/packages/@sanity/client/src/config.js
+++ b/packages/@sanity/client/src/config.js
@@ -15,23 +15,23 @@ const LOCALHOSTS = ['localhost', '127.0.0.1', '0.0.0.0']
 const isLocal = host => LOCALHOSTS.indexOf(host) !== -1
 
 // eslint-disable-next-line no-console
-const printWarning = message => once(() => console.warn(message.join(' ')))
+const createWarningPrinter = message => once(() => console.warn(message.join(' ')))
 
-const printCdnWarning = printWarning([
+const printCdnWarning = createWarningPrinter([
   'You are not using the Sanity CDN. That means your data is always fresh, but the CDN is faster and',
   `cheaper. Think about it! For more info, see ${generateHelpUrl('js-client-cdn-configuration')}.`,
   'To hide this warning, please set the `useCdn` option to either `true` or `false` when creating',
   'the client.'
 ])
 
-const printBrowserTokenWarning = printWarning([
+const printBrowserTokenWarning = createWarningPrinter([
   'You have configured Sanity client to use a token in the browser. This may cause unintentional security issues.',
   `See ${generateHelpUrl(
     'js-client-browser-token'
   )} for more information and how to hide this warning.`
 ])
 
-const printCdnTokenWarning = printWarning([
+const printCdnTokenWarning = createWarningPrinter([
   'You have set `useCdn` to `true` while also specifying a token. This is usually not what you',
   'want. The CDN cannot be used with an authorization token, since private data cannot be cached.',
   `See ${generateHelpUrl('js-client-usecdn-token')} for more information.`

--- a/packages/@sanity/client/test/warnings.test.disabled.js
+++ b/packages/@sanity/client/test/warnings.test.disabled.js
@@ -1,0 +1,63 @@
+// This test suite fails using tape but should pass if running with as a node script
+const test = require('tape')
+const SanityClient = require('../src/sanityClient')
+
+const stub = (target, prop, stubbed) => {
+  const original = target[prop]
+  target[prop] = stubbed
+  return () => {
+    target[prop] = original
+  }
+}
+
+const combine = (...fns) => () => {
+  const [head, ...tail] = fns
+  return tail.reduce((acc, fn) => fn(acc), head())
+}
+
+/**************************
+ * CLIENT CONFIG WARNINGS *
+ **************************/
+
+test('warns if useCdn is not given', t => {
+  const restore = combine(
+    stub(console, 'warn', message => {
+      t.equal(
+        message,
+        'You are not using the Sanity CDN. That means your data is always fresh, but the CDN is faster and cheaper. Think about it! For more info, see https://docs.sanity.io/help/js-client-cdn-configuration. To hide this warning, please set the `useCdn` option to either `true` or `false` when creating the client.'
+      )
+      restore()
+      t.end()
+    })
+  )
+  new SanityClient({projectId: 'abc123'})
+})
+
+test('warns if in browser on localhost and a token is provided', t => {
+  const restore = combine(
+    stub(global, 'window', {location: {hostname: 'localhost'}}),
+    stub(console, 'warn', message => {
+      t.equal(
+        message,
+        'You have configured Sanity client to use a token in the browser. This may cause unintentional security issues. See https://docs.sanity.io/help/js-client-browser-token for more information and how to hide this warning.'
+      )
+      restore()
+      t.end()
+    })
+  )
+  new SanityClient({projectId: 'abc123', useCdn: false, token: 'foo'})
+})
+
+test('warns a token is provided together with useCdn:true (and not in browser)', t => {
+  const restore = combine(
+    stub(console, 'warn', message => {
+      t.equal(
+        message,
+        'You have set `useCdn` to `true` while also specifying a token. This is usually not what you want. The CDN cannot be used with an authorization token, since private data cannot be cached. See https://docs.sanity.io/help/js-client-usecdn-token for more information.'
+      )
+      restore()
+      t.end()
+    })
+  )
+  new SanityClient({projectId: 'abc123', token: 'foo', useCdn: true})
+})

--- a/packages/@sanity/client/warnings.js
+++ b/packages/@sanity/client/warnings.js
@@ -1,7 +1,0 @@
-const SanityClient = require('./src/sanityClient')
-
-global.window = {
-  location: {hostname: 'prod.com'}
-}
-// should warn
-new SanityClient({projectId: 'skajfie', useCdn: false, token: 'foo'})

--- a/packages/@sanity/client/warnings.js
+++ b/packages/@sanity/client/warnings.js
@@ -1,0 +1,7 @@
+const SanityClient = require('./src/sanityClient')
+
+global.window = {
+  location: {hostname: 'prod.com'}
+}
+// should warn
+new SanityClient({projectId: 'skajfie', useCdn: false, token: 'foo'})


### PR DESCRIPTION
This issues a console warning if you configure the sanity client to use a token in the browser. The warning will only be visible on local hosts.

Changed the order of appearances of warnings so that you get them in the following order (and only one at a time):

1) Token in browser (fixing this may invalidate the warning below)
2) Token together with `useCdn: true` (fixing this may invalidate the warning below)
3) Missing `useCdn`
