### PR TITLE
[base] Use deep compare when diffing query parameters

### DIFF
--- a/packages/@sanity/base/package.json
+++ b/packages/@sanity/base/package.json
@@ -42,6 +42,7 @@
     "nano-pubsub": "^1.0.2",
     "postcss-cssnext": "^3.0.2",
     "promise-props": "^1.0.0",
+    "react-fast-compare": "^2.0.2",
     "react-icon-base": "^2.1.2",
     "react-icons": "^2.2.7",
     "react-intl": "^2.2.2",

--- a/packages/@sanity/base/src/components/QueryContainer.js
+++ b/packages/@sanity/base/src/components/QueryContainer.js
@@ -3,6 +3,7 @@ import React from 'react'
 import {throttle, union} from 'lodash'
 import {filter} from 'rxjs/operators'
 import store from 'part:@sanity/base/datastore/document'
+import deepEquals from 'react-fast-compare'
 import shallowEquals from 'shallow-equals'
 
 function deprecatedCheck(props, propName, componentName, ...rest) {
@@ -77,7 +78,7 @@ export default class QueryContainer extends React.Component {
   next = event => {
     switch (event.type) {
       case 'snapshot': {
-        this.setState({error: null, loading: false, result: {documents: event.documents}})
+        this.setState({error: false, loading: false, result: {documents: event.documents}})
         break
       }
       case 'mutation': {
@@ -153,7 +154,7 @@ export default class QueryContainer extends React.Component {
 
   componentWillUpdate(nextProps) {
     const sameQuery = nextProps.query === this.props.query
-    const sameParams = shallowEquals(nextProps.params, this.props.params)
+    const sameParams = deepEquals(nextProps.params, this.props.params)
 
     if (!sameQuery || !sameParams) {
       this.setState(createInitialState())
@@ -165,10 +166,12 @@ export default class QueryContainer extends React.Component {
     if (!shallowEquals(this.state, nextState)) {
       return true
     }
-    if (
-      nextProps.query !== this.props.query ||
-      !shallowEquals(nextProps.params, this.props.params)
-    ) {
+
+    if (nextProps.query !== this.props.query) {
+      return true
+    }
+
+    if (!deepEquals(nextProps.params, this.props.params)) {
       return true
     }
 


### PR DESCRIPTION
When using arrays for parameters (think *[_id in $ids]), if the array of ids have the same members for the array itself does not have referential identity, the query container currently resubscribes.

This PR fixes this by using a deep compare for the parameters. I also took the liberty of changing a potential rerender when going from `error: null` to `error: false` - I couldn't see any reason why it was built this way initially, correct me if this has some specific purpose.
