### PR TITLE
[desk-tool] Resolve only changed panes

### DIFF
--- a/packages/@sanity/desk-tool/src/utils/resolvePanes.js
+++ b/packages/@sanity/desk-tool/src/utils/resolvePanes.js
@@ -7,12 +7,24 @@ import validateStructure from './validateStructure'
 import serializeStructure from './serializeStructure'
 
 export const LOADING = Symbol('LOADING')
-export function resolvePanes(structure, ids) {
+export function resolvePanes(structure, ids, prevStructure, fromIndex) {
   const waitStructure = isSubscribable(structure) ? from(structure) : observableOf(structure)
-  return waitStructure.pipe(switchMap(struct => resolveForStructure(struct, ids)))
+  return waitStructure.pipe(
+    switchMap(struct => resolveForStructure(struct, ids, prevStructure, fromIndex))
+  )
 }
 
-function resolveForStructure(structure, ids) {
+function getInitialPanes(prevStructure, numPanes, fromIndex) {
+  const allLoading = new Array(numPanes).fill(LOADING)
+  if (!prevStructure) {
+    return allLoading
+  }
+
+  const remains = prevStructure.slice(0, fromIndex)
+  return remains.concat(allLoading.slice(fromIndex))
+}
+
+function resolveForStructure(structure, ids, prevStructure, fromIndex) {
   return Observable.create(subscriber => {
     try {
       validateStructure(structure)
@@ -22,14 +34,14 @@ function resolveForStructure(structure, ids) {
     }
 
     const paneIds = [structure.id].concat(ids).filter(Boolean)
-    let panes = new Array(paneIds.length).fill(LOADING)
+    let panes = getInitialPanes(prevStructure, paneIds.length, fromIndex + 1)
     const subscriptions = []
 
-    // Start with all-loading state
+    // Start with all-loading (or previous structure) state
     subscriber.next(panes)
 
     // Start resolving pane-by-pane
-    resolve(0)
+    resolve(fromIndex)
 
     return unsubscribe
 

--- a/packages/@sanity/desk-tool/src/utils/resolvePanes.js
+++ b/packages/@sanity/desk-tool/src/utils/resolvePanes.js
@@ -41,7 +41,7 @@ function resolveForStructure(structure, ids, prevStructure, fromIndex) {
     subscriber.next(panes)
 
     // Start resolving pane-by-pane
-    resolve(fromIndex)
+    resolve(Math.max(0, panes.indexOf(LOADING)))
 
     return unsubscribe
 


### PR DESCRIPTION
When navigating from:
> Content → Movies by genre → Sci-Fi → 2010 → Some Movie

to:
> Content → Movies by genre → Sci-Fi → 2010 → Some *Other* Movie

We are currently resolving the structure from the ground up. The way I see it, this isn't necessary, and causes potential rerendering/reflow issues, especially when using async operations in child resolvers. 

With this PR, we find the index of the first pane ID that changed (based on URL) from the previous, and derives panes from that index and upwards. By passing the previously resolved structure, we can then keep the existing, resolved panes.
