### PR TITLE
[validation] Allow field validation overrides for top-level objects

### DIFF
--- a/packages/@sanity/schema/src/legacy/types/object.js
+++ b/packages/@sanity/schema/src/legacy/types/object.js
@@ -15,7 +15,8 @@ const OVERRIDABLE_FIELDS = [
   'description',
   '__unstable_searchFields',
   'options',
-  'inputComponent'
+  'inputComponent',
+  'validation'
 ]
 
 export const ObjectType = {

--- a/packages/@sanity/validation/src/Rule.js
+++ b/packages/@sanity/validation/src/Rule.js
@@ -56,6 +56,7 @@ class Rule {
     this._message = null
     this._required = undefined
     this._level = 'error'
+    this._fieldRules = undefined
     return this
   }
 
@@ -70,6 +71,7 @@ class Rule {
     rule._required = this._required
     rule._rules = cloneDeep(this._rules)
     rule._level = this._level
+    rule._fieldRules = this._fieldRules
     return rule
   }
 
@@ -245,6 +247,16 @@ class Rule {
   // Objects only
   reference() {
     return this.cloneWithRules([{flag: 'reference'}])
+  }
+
+  fields(rules) {
+    if (this._type !== 'Object') {
+      throw new Error('fields() can only be called on an object type')
+    }
+
+    const rule = this.cloneWithRules([])
+    rule._fieldRules = rules
+    return rule
   }
 }
 

--- a/packages/@sanity/validation/src/inferFromSchema.js
+++ b/packages/@sanity/validation/src/inferFromSchema.js
@@ -4,7 +4,7 @@ const inferFromSchemaType = require('./inferFromSchemaType')
 function inferFromSchema(schema) {
   const typeNames = schema.getTypeNames()
   typeNames.forEach(typeName => {
-    inferFromSchemaType(schema.get(typeName))
+    inferFromSchemaType(schema.get(typeName), schema)
   })
   return schema
 }

--- a/packages/test-studio/schemas/localeString.js
+++ b/packages/test-studio/schemas/localeString.js
@@ -1,0 +1,24 @@
+const supportedLanguages = [
+  {title: 'English', id: 'en', isDefault: true},
+  {title: 'Norwegian', id: 'nb'},
+  {title: 'Swedish', id: 'se'}
+]
+
+export default {
+  name: 'localeString',
+  type: 'object',
+  fieldsets: [
+    {
+      title: 'Translations',
+      name: 'translations',
+      options: {collapsible: true}
+    }
+  ],
+  fields: supportedLanguages.map(lang => ({
+    title: lang.title,
+    name: lang.id,
+    type: 'string',
+    validation: lang.isDefault ? Rule => Rule.required() : null,
+    fieldset: lang.isDefault ? null : 'translations'
+  }))
+}

--- a/packages/test-studio/schemas/schema.js
+++ b/packages/test-studio/schemas/schema.js
@@ -17,6 +17,7 @@ import files from './files'
 import uploads from './uploads'
 import code from './code'
 import customNumber from './customNumber'
+import localeString from './localeString'
 import color from './color'
 import liveEdit from './liveEdit'
 import recursive from './recursive'
@@ -81,6 +82,7 @@ export default createSchema({
     slugs,
     customInputs,
     myImage,
+    localeString,
     recursive,
     recursiveArray,
     recursivePopover,

--- a/packages/test-studio/schemas/strings.js
+++ b/packages/test-studio/schemas/strings.js
@@ -101,6 +101,16 @@ export default {
           }
         ]
       }
+    },
+    {
+      name: 'localeTitle',
+      title: 'Localized title',
+      type: 'localeString',
+      description: 'English required by localeString, swedish from field',
+      validation: Rule =>
+        Rule.fields({
+          se: fieldRule => fieldRule.required().max(80)
+        })
     }
   ]
 }


### PR DESCRIPTION
## Background

You have defined a `localeString` type at the root level, and you have certain validation rules you generally apply ("english is required, because it is the default").

In certain locations, you want to override the validation with more rules. For instance, for a `title` field, you may want to set all the languages as required, or set the max length of all fields as 80 characters.

This is currently not possible, since validation is applied at definition time. 

## Implementation

This PR implements a `.fields()` validation rule on objects, which takes an object where the keys represent the name of the fields to provide rules for, which will override the previously declared rule. Should be used sparingly, but in certain situations (like the above), I think it makes sense.

## Usage

```js
{
  name: 'localeTitle',
  title: 'Localized title',
  type: 'localeString',
  description: 'English required by localeString, swedish from field',
  validation: Rule =>
    Rule.fields({
      se: fieldRule => fieldRule.required().max(80),
      no: fieldRule => fieldRule.optional().max(80)
    })
}
```

Feedback welcome!