### PR TITLE
[chore] Upgrade jest, chai and jsdom

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -41,7 +41,7 @@
     "@sanity/resolver": "0.135.0",
     "@sanity/util": "0.135.0",
     "boxen": "^1.3.0",
-    "chai": "^4.1.2",
+    "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chalk": "^2.3.0",
     "configstore": "^3.0.0",

--- a/packages/@sanity/core/package.json
+++ b/packages/@sanity/core/package.json
@@ -60,7 +60,7 @@
     "uglify-es": "3.3.9"
   },
   "devDependencies": {
-    "chai": "^4.1.2",
+    "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "mocha": "^5.0.1"
   },

--- a/packages/@sanity/default-layout/package.json
+++ b/packages/@sanity/default-layout/package.json
@@ -42,7 +42,7 @@
     "@sanity/components": "0.135.0",
     "@sanity/core": "0.135.0",
     "@sanity/schema": "0.135.0",
-    "chai": "^4.1.2",
+    "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "in-publish": "^2.0.0",
     "mocha": "^5.0.1",

--- a/packages/@sanity/form-builder/package.json
+++ b/packages/@sanity/form-builder/package.json
@@ -69,7 +69,7 @@
     "@sanity/server": "0.135.0",
     "flow-typed": "^2.2.3",
     "in-publish": "^2.0.0",
-    "jsdom": "^11.3.0",
+    "jsdom": "^12.0.0",
     "json-markup": "^1.1.0",
     "path-to-regexp": "^1.7.0",
     "postcss-cssnext": "^3.0.2",

--- a/packages/@sanity/resolver/package.json
+++ b/packages/@sanity/resolver/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://www.sanity.io/",
   "devDependencies": {
-    "chai": "^4.1.2",
+    "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "mocha": "^5.0.1",
     "mock-fs": "^4.4.2",

--- a/packages/@sanity/server/package.json
+++ b/packages/@sanity/server/package.json
@@ -66,7 +66,7 @@
     "webpack-hot-middleware": "^2.17.1"
   },
   "devDependencies": {
-    "chai": "^4.1.2",
+    "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "cross-env": "^5.0.5",
     "prop-types": "^15.6.0",

--- a/packages/@sanity/util/package.json
+++ b/packages/@sanity/util/package.json
@@ -34,7 +34,7 @@
     "resolve-from": "^4.0.0"
   },
   "devDependencies": {
-    "chai": "^4.1.2",
+    "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "mocha": "^5.0.1",
     "rimraf": "^2.6.2"


### PR DESCRIPTION
Bump versions. These are upgraded on my side in the branch that will be merged next week, so it will be nice if all packages uses the same (in regard to hoisting).

@rexxars, @bjoerge, @simen please confirm that this is OK with your respective packages.