### PR TITLE
[form-builder] Preserve _key on items when applying patches

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/FormBuilderBlock.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/FormBuilderBlock.js
@@ -69,12 +69,12 @@ export default class FormBuilderBlock extends React.Component {
 
   handleChange = event => {
     const {onPatch, node} = this.props
-    onPatch(event.prefixAll(node.key))
+    onPatch(event.prefixAll({_key: node.key}))
   }
 
   handleInvalidValueChange = event => {
     const {onPatch, node} = this.props
-    onPatch(event.prefixAll(node.key))
+    onPatch(event.prefixAll({_key: node.key}))
   }
 
   handleDragStart = event => {

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/Syncer.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/Syncer.js
@@ -78,10 +78,15 @@ export default withPatchSubscriber(
           return prevState
         }
         const nextValue = patchEvent.patches.reduce((state, patch) => {
-          const [key, ...path] = patch.path
-          const nodeValue = state.document.getDescendant(key).data.get('value')
-          const change = state.change().setNodeByKey(key, {
-            data: {value: apply(nodeValue, {...patch, path})}
+          const [root, ...path] = patch.path
+          const nodeValue = state.document.getDescendant(root._key).data.get('value')
+          const change = state.change().setNodeByKey(root._key, {
+            data: {
+              value: {
+                ...apply(nodeValue, {...patch, path}),
+                _key: root._key
+              }
+            }
           })
           return change.state
         }, prevState.value)

--- a/packages/@sanity/form-builder/src/utils/pathUtils.js
+++ b/packages/@sanity/form-builder/src/utils/pathUtils.js
@@ -91,6 +91,6 @@ export function toString(path) {
       return `${target}[_key=="${segment._key}"]`
     }
 
-    throw new Error(`Unsupported path segment "${segment}"`)
+    throw new Error(`Unsupported path segment \`${JSON.stringify(segment)}\``)
   }, '')
 }


### PR DESCRIPTION
Currently, when the block editor embeds an input that just emits set-patches of objects, the associated `_key` gets lost and eventually crashes the UI. This fixes it by always setting the key back on the node data.