### PR TITLE
[chore] Replace uglify with terser

### DIFF
--- a/packages/@sanity/client/package.json
+++ b/packages/@sanity/client/package.json
@@ -12,7 +12,7 @@
     "size": "node -r @babel/register src/scripts/print-bundle-size",
     "clean": "rimraf lib coverage .nyc_output umd/*.js",
     "coverage": "DEBUG=sanity NODE_ENV=test nyc --reporter=html --reporter=lcov --reporter=text npm test",
-    "minify": "uglifyjs -c -m -- umd/sanityClient.js > umd/sanityClient.min.js",
+    "minify": "terser -c -m -- umd/sanityClient.js > umd/sanityClient.min.js",
     "prepublishOnly": "npm run build",
     "test": "NODE_ENV=test tape -r @babel/register test/*.test.js"
   },
@@ -43,8 +43,8 @@
     "rimraf": "^2.6.2",
     "sse-channel": "^2.0.6",
     "tape": "^4.8.0",
-    "uglify-js": "^3.1.10",
-    "uglifyify": "^3.0.4"
+    "terser": "^3.10.11",
+    "uglifyify": "^5.0.1"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/core/package.json
+++ b/packages/@sanity/core/package.json
@@ -57,7 +57,7 @@
     "simple-get": "^3.0.2",
     "tar-fs": "^1.16.0",
     "through2": "^2.0.3",
-    "uglify-es": "3.3.9"
+    "terser": "3.10.11"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/packages/@sanity/core/src/actions/build/compressJavascript.js
+++ b/packages/@sanity/core/src/actions/build/compressJavascript.js
@@ -1,5 +1,5 @@
 import fse from 'fs-extra'
-import UglifyJS from 'uglify-es'
+import Terser from 'terser'
 
 export default async inputFile => {
   const content = await fse.readFile(inputFile, 'utf8')
@@ -9,7 +9,7 @@ export default async inputFile => {
 
 function minify(content, fileName) {
   return new Promise((resolve, reject) => {
-    const result = UglifyJS.minify(content)
+    const result = Terser.minify(content)
 
     if (result.error) {
       reject(formatError(result.error, fileName, content))

--- a/packages/@sanity/image-url/package.json
+++ b/packages/@sanity/image-url/package.json
@@ -12,7 +12,7 @@
     "compile": "babel --source-maps --copy-files -d lib/ src/",
     "clean": "rimraf lib",
     "postpublish": "npm run clean",
-    "minify": "uglifyjs -c -m -- umd/sanityImageUrl.js > umd/sanityImageUrl.min.js",
+    "minify": "terser -c -m -- umd/sanityImageUrl.js > umd/sanityImageUrl.min.js",
     "prepublishOnly": "npm run build",
     "test": "jest"
   },
@@ -28,8 +28,8 @@
     "envify": "^4.0.0",
     "jest": "^23.6.0",
     "rimraf": "^2.6.2",
-    "uglify-js": "^3.1.10",
-    "uglifyify": "^3.0.4"
+    "terser": "^3.10.11",
+    "uglifyify": "^5.0.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`UglifyJS`/`uglify-es` is no longer maintained and has been superceded by `terser`. Also, uglify-es has some pretty seriuous issues with React: https://twitter.com/sebmarkbage/status/1060053812075872256

This replaces uglify-js/es with terser (still sticking with `uglifyify` since it's using terser under the hood)