### PR TITLE
[form-builder] Guard against missing metadata on image asset

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.js
+++ b/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.js
@@ -138,11 +138,12 @@ export default class ImageInput extends React.PureComponent<Props, State> {
 
   renderMaterializedAsset = (assetDocument: Object): Node => {
     const {value = {}} = this.props
-    return (
+    const srcAspectRatio = get(assetDocument, 'metadata.dimensions.aspectRatio')
+    return typeof srcAspectRatio === 'undefined' ? null : (
       <HotspotImage
         aspectRatio="auto"
         src={assetDocument.url}
-        srcAspectRatio={assetDocument.metadata.dimensions.aspectRatio}
+        srcAspectRatio={srcAspectRatio}
         hotspot={value.hotspot}
         crop={value.crop}
       />


### PR DESCRIPTION
This fixes an issue that could under some circumstances cause an error due to `assetDocument.metadata` not being set.

Even though this particular document type (`sanity.imageAsset`) never will have an undefined value for `metadata` in the data store, it can still be missing in the frontend as a consequence of how we optimize data fetching for previews. This will most likely not be an issue after #613 is in place.
