### PR TITLE
[desk-tool] Refactor QueryContainer

### DIFF
--- a/packages/@sanity/base/package.json
+++ b/packages/@sanity/base/package.json
@@ -46,6 +46,7 @@
     "react-icon-base": "^2.1.2",
     "react-icons": "^2.2.7",
     "react-intl": "^2.2.2",
+    "react-props-stream": "^1.0.0",
     "rxjs": "^6.1.0",
     "semver-compare": "^1.0.0",
     "shallow-equals": "^1.0.0"

--- a/packages/@sanity/base/src/components/listenQuery.js
+++ b/packages/@sanity/base/src/components/listenQuery.js
@@ -1,0 +1,45 @@
+import client from 'part:@sanity/base/client'
+import {auditTime, take, share, filter, mergeMap, switchMapTo} from 'rxjs/operators'
+import {defer, concat, throwError} from 'rxjs'
+
+const fetch = (query, params) => defer(() => client.observable.fetch(query, params))
+const listen = (query, params) =>
+  defer(() =>
+    client.listen(query, params, {
+      events: ['welcome', 'mutation', 'reconnect'],
+      includeResult: false
+    })
+  )
+
+// todo: promote as building block for better re-use
+// todo: optimize by patching collection in-place
+export const listenQuery = (query, params) => {
+  const fetchOnce$ = fetch(query, params)
+
+  const events$ = listen(query, params).pipe(share())
+  const mutations$ = events$.pipe(filter(ev => ev.type === 'mutation'))
+
+  return concat(
+    events$.pipe(
+      mergeMap(first => {
+        if (first.type === 'welcome') {
+          return fetchOnce$
+        }
+        return throwError(
+          new Error(
+            first.type === 'reconnect'
+              ? // if the first event is not welcome, it is most likely a reconnect and
+                'Could not establish EventSource connection'
+              : // if it's not a reconnect something is very wrong
+                `Received unexpected type of first event "${first.type}"`
+          )
+        )
+      }),
+      take(1)
+    ),
+    mutations$.pipe(
+      auditTime(1000),
+      switchMapTo(fetchOnce$)
+    )
+  )
+}

--- a/packages/@sanity/desk-tool/src/pane/DocumentsListPane.js
+++ b/packages/@sanity/desk-tool/src/pane/DocumentsListPane.js
@@ -290,9 +290,21 @@ export default withRouterHOC(
                 )
               }
 
+              if (loading) {
+                return (
+                  <div className={styles[`layout__${layout}`]}>
+                    {loading && <Spinner center message="Loading items…" />}
+                  </div>
+                )
+              }
+
+              if (!result) {
+                return null
+              }
+
               const items = removePublishedWithDrafts(result ? result.documents : [])
 
-              if (!loading && !hasItems(items)) {
+              if (!hasItems(items)) {
                 const schemaType = schema.get(typeName)
                 return (
                   <div className={styles.empty}>
@@ -316,7 +328,6 @@ export default withRouterHOC(
 
               return (
                 <div className={styles[`layout__${layout}`]}>
-                  {loading && <Spinner center message="Loading items…" />}
                   {items && (
                     <InfiniteList
                       className={listStyles.scroll}


### PR DESCRIPTION
This is a complete rewrite of the rather messy QueryContainer Component. The data flow should be a bit more explicit now.

Also did a few tweaks to make the data fetching a bit more robust.
- Will waits 400ms before displaying spinner in documents pane
- Will display an error message if eventsource connection fails
- Removed deprecated child component