### PR TITLE
[client] Check for presence of window.location to determine if browser env

### DIFF
--- a/packages/@sanity/client/src/config.js
+++ b/packages/@sanity/client/src/config.js
@@ -57,7 +57,7 @@ exports.initConfig = (config, prevConfig) => {
     throw new Error('Configuration must contain `projectId`')
   }
 
-  const isBrowser = typeof window !== 'undefined'
+  const isBrowser = typeof window !== 'undefined' && window.location && window.location.hostname
   const isLocalhost = isBrowser && isLocal(window.location.hostname)
 
   if (isBrowser && isLocalhost && newConfig.token && newConfig.ignoreBrowserTokenWarning !== true) {


### PR DESCRIPTION
Fixes an issue where using the client in React Native environment would fail because `window` is present, but not `window.location`.