### PR TITLE
[vision] Remove "root"-prefix in results

### DIFF
--- a/packages/@sanity/vision/src/components/JsonDump.js
+++ b/packages/@sanity/vision/src/components/JsonDump.js
@@ -15,7 +15,7 @@ class JsonBlock extends React.PureComponent {
     return (
       <pre className={styles.block}>
         {isJSONValue(data) ? (
-          <ReactJson displayDataTypes={false} src={data} />
+          <ReactJson displayDataTypes={false} src={data} name={null} />
         ) : (
           <span className={styles.primitive}>{data || 'null'}</span>
         )}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/48200/48709393-a7435700-ec05-11e8-9778-c60bca8b29fc.png)

Removes the confusing "root" name (as seen above) from the result view in vision 