### PR TITLE
[form-builder] Add ability to disable original filename for assets

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/FileInput/FileInput.js
+++ b/packages/@sanity/form-builder/src/inputs/FileInput/FileInput.js
@@ -108,7 +108,10 @@ export default class FileInput extends React.PureComponent<Props, State> {
 
   uploadWith(uploader: Uploader, file: File) {
     const {type, onChange} = this.props
-    const options = {metadata: get(type, 'options.metadata')}
+    const options = {
+      metadata: get(type, 'options.metadata'),
+      storeOriginalFilename: get(type, 'options.storeOriginalFilename')
+    }
     this.cancelUpload()
     this.setState({isUploading: true})
     onChange(PatchEvent.from([setIfMissing({_type: type.name})]))

--- a/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.js
+++ b/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.js
@@ -114,7 +114,10 @@ export default class ImageInput extends React.PureComponent<Props, State> {
 
   uploadWith(uploader: Uploader, file: File) {
     const {type, onChange} = this.props
-    const options = {metadata: get(type, 'options.metadata')}
+    const options = {
+      metadata: get(type, 'options.metadata'),
+      storeOriginalFilename: get(type, 'options.storeOriginalFilename')
+    }
     this.cancelUpload()
     this.setState({isUploading: true})
     onChange(PatchEvent.from([setIfMissing({_type: type.name})]))

--- a/packages/@sanity/form-builder/src/sanity/inputs/client-adapters/assets.js
+++ b/packages/@sanity/form-builder/src/sanity/inputs/client-adapters/assets.js
@@ -8,6 +8,7 @@ const MAX_CONCURRENT_UPLOADS = 4
 
 function uploadSanityAsset(assetType, file, options = {}) {
   const extract = options.metadata
+  const preserveFilename = options.storeOriginalFilename
   return observableFrom(hashFile(file)).pipe(
     catchError(error =>
       // ignore if hashing fails for some reason
@@ -23,17 +24,16 @@ function uploadSanityAsset(assetType, file, options = {}) {
           asset: existing
         })
       }
-      return client.observable.assets.upload(assetType, file, {extract}).pipe(
-        map(
-          event =>
-            event.type === 'response'
-              ? {
-                  // rewrite to a 'complete' event
-                  type: 'complete',
-                  id: event.body.document._id,
-                  asset: event.body.document
-                }
-              : event
+      return client.observable.assets.upload(assetType, file, {extract, preserveFilename}).pipe(
+        map(event =>
+          event.type === 'response'
+            ? {
+                // rewrite to a 'complete' event
+                type: 'complete',
+                id: event.body.document._id,
+                asset: event.body.document
+              }
+            : event
         )
       )
     })

--- a/packages/@sanity/form-builder/src/sanity/uploads/typedefs.js
+++ b/packages/@sanity/form-builder/src/sanity/uploads/typedefs.js
@@ -8,7 +8,8 @@ export type UploadEvent = {
 }
 
 export type UploadOptions = {
-  metadata: ?Array<String>
+  metadata: ?Array<String>,
+  storeOriginalFilename: ?boolean
 }
 
 export type UploaderDef = {

--- a/packages/test-studio/schemas/files.js
+++ b/packages/test-studio/schemas/files.js
@@ -39,6 +39,14 @@ export default {
           type: 'string'
         }
       ]
+    },
+    {
+      name: 'fileWithoutOriginalFilename',
+      title: 'File without original filename',
+      type: 'file',
+      options: {
+        storeOriginalFilename: false
+      }
     }
   ]
 }


### PR DESCRIPTION
While the client has had the option to disable the original filename for assets for a while, it seems we have not exposed this functionality in the form-builder. This PR adds this functionality.

I went for the option `storeOriginalFilename` which seems to me more correct than the `preserveFilename` option used in the client (we should probably deprecate this and move to  `storeOriginalFilename` there as well in the near future, as the current name is misleading).

