### PR TITLE
[default-layout] Only select _id and _type when searching

### DIFF
--- a/packages/@sanity/default-layout/src/components/SearchContainer.js
+++ b/packages/@sanity/default-layout/src/components/SearchContainer.js
@@ -60,7 +60,7 @@ function search(query) {
     uniqueFields.map(joinedPath => `${joinedPath} match $t${i}`)
   )
   const constraintString = constraints.map(constraint => `(${constraint.join('||')})`).join('&&')
-  return client.observable.fetch(`*[${constraintString}][0...100]`, params)
+  return client.observable.fetch(`*[${constraintString}][0...100] {_id, _type}`, params)
 }
 
 class SearchContainer extends React.PureComponent {


### PR DESCRIPTION
When doing a search, the query generated currently does not use any projection, and instead returns complete documents. This will load (and parse) a lot more JSON data than actually needed.

This patch selects only `_type` and `_id` which is the only fields we need in order to delegate to preview components (which will lazily load fields mandated by the preview config when preview components appear on screen).