### PR TITLE
[structure] Add @types/node for proper node.js typings

### DIFF
--- a/packages/@sanity/structure/package.json
+++ b/packages/@sanity/structure/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@types/lodash": "^4.14.116",
     "@types/memoize-one": "^3.1.1",
+    "@types/node": "^8.0.0",
     "lodash": "^4.17.4",
     "memoize-one": "^3.1.1"
   },


### PR DESCRIPTION
In order to call `require()`, we should now have the typings for node as a dependency, apparently.
 