### PR TITLE
[form-builder] Block editor closes in dialog fix

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/BlockEditor.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/BlockEditor.js
@@ -7,6 +7,8 @@ import ScrollContainer from 'part:@sanity/components/utilities/scroll-container'
 import ActivateOnFocus from 'part:@sanity/components/utilities/activate-on-focus'
 import {uniqueId} from 'lodash'
 
+import StackedEscapeable from 'part:@sanity/components/utilities/stacked-escapable'
+
 import FormField from 'part:@sanity/components/formfields/default'
 import Toolbar from './toolbar/Toolbar'
 import createBlockEditorOperations from './createBlockEditorOperations'
@@ -431,13 +433,19 @@ export default class BlockEditor extends React.Component {
         >
           Jump to editor
         </button>
-        {fullscreen
-          ? this.renderPortal(
-              <ScrollContainer className={styles.portal} onScroll={this.handleFullScreenScroll}>
-                {blockEditor}
-              </ScrollContainer>
-            )
-          : blockEditor}
+        {fullscreen ? (
+          <StackedEscapeable onEscape={this.handleFullScreenClose}>
+            <div>
+              {this.renderPortal(
+                <ScrollContainer className={styles.portal} onScroll={this.handleFullScreenScroll}>
+                  {blockEditor}
+                </ScrollContainer>
+              )}
+            </div>
+          </StackedEscapeable>
+        ) : (
+          blockEditor
+        )}
       </FormField>
     )
   }

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/BlockEditor.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor-slate/BlockEditor.js
@@ -429,7 +429,7 @@ export default class BlockEditor extends React.Component {
           type="button"
           tabIndex={0}
           className={styles.focusSkipper}
-          onClick={() => this.focus()}
+          onClick={() => !fullscreen && this.focus()}
         >
           Jump to editor
         </button>


### PR DESCRIPTION
Fixes the problem where an blockeditor inside a dialog closes.
