### PR TITLE
[cli] Pass through stdio streams to child process when running sanity exec

### DIFF
--- a/packages/@sanity/core/src/actions/exec/execScript.js
+++ b/packages/@sanity/core/src/actions/exec/execScript.js
@@ -23,9 +23,6 @@ module.exports = async args => {
     .concat(scriptPath)
     .concat(args.extraArguments || [])
 
-  const proc = spawn(process.argv[0], nodeArgs)
-
-  proc.stdout.pipe(process.stdout)
-  proc.stderr.pipe(process.stderr)
+  const proc = spawn(process.argv[0], nodeArgs, {stdio: 'inherit'})
   proc.on('close', process.exit)
 }


### PR DESCRIPTION
Currently if you run a script with sanity exec, there's no way to read from stdin in it (this is useful to e.g. display user prompts or other kinds of interactive CLIs).

This fixes the issue by forwarding the parent process stdio streams to the child process.