### PR TITLE
Autocollapse hover & click area

### DIFF
--- a/packages/@sanity/components/sanity.json
+++ b/packages/@sanity/components/sanity.json
@@ -845,14 +845,6 @@
       "path": "panes/DefaultPane.js"
     },
     {
-      "name": "part:@sanity/components/panes/controller",
-      "description": "Panes controller"
-    },
-    {
-      "implements": "part:@sanity/components/panes/controller",
-      "path": "panes/Controller.js"
-    },
-    {
       "name": "part:@sanity/components/panes/split-controller",
       "description": "Resizeable split controller for panes"
     },

--- a/packages/@sanity/components/src/panes/DefaultPane.js
+++ b/packages/@sanity/components/src/panes/DefaultPane.js
@@ -224,6 +224,18 @@ class Pane extends React.Component {
     this.setState(prev => ({menuIsOpen: !prev.menuIsOpen}))
   }
 
+  handleRootClick = event => {
+    if (this.props.isCollapsed) {
+      this.props.onExpand()
+    }
+  }
+
+  handleTitleClick = event => {
+    if (!this.props.isCollapsed) {
+      this.props.onCollapse()
+    }
+  }
+
   handleMenuAction = item => {
     // When closing the menu outright, the menu button will be focused and the "enter" keypress
     // will bouble up to it and trigger a re-open of the menu. To work around this, use rAF to
@@ -347,6 +359,7 @@ class Pane extends React.Component {
           isCollapsed ? styles.isCollapsed : styles.root,
           isSelected ? styles.isActive : styles.isDisabled
         ])}
+        onClick={this.handleRootClick}
         ref={this.setRootElement}
       >
         <div className={styles.header} style={{boxShadow: headerStyle.boxShadow}}>
@@ -354,7 +367,7 @@ class Pane extends React.Component {
             className={styles.headerContent}
             style={contentMaxWidth ? {maxWidth: `${contentMaxWidth}px`} : {}}
           >
-            <h2 className={styles.title} onClick={this.handleToggleCollapsed}>
+            <h2 className={styles.title} onClick={this.handleTitleClick}>
               {title}
             </h2>
             <div className={styles.actions}>

--- a/packages/@sanity/components/src/panes/story.js
+++ b/packages/@sanity/components/src/panes/story.js
@@ -6,7 +6,6 @@ import {withKnobs, boolean, number, text, object} from 'part:@sanity/storybook/a
 import {RouterProvider, route} from 'part:@sanity/base/router'
 import Sanity from 'part:@sanity/storybook/addons/sanity'
 import DefaultPane from 'part:@sanity/components/panes/default'
-import PanesController from 'part:@sanity/components/panes/controller'
 import SplitController from 'part:@sanity/components/panes/split-controller'
 import SplitPaneWrapper from 'part:@sanity/components/panes/split-pane-wrapper'
 import PlusIcon from 'part:@sanity/base/plus-icon'

--- a/packages/@sanity/components/src/panes/styles/DefaultPane.css
+++ b/packages/@sanity/components/src/panes/styles/DefaultPane.css
@@ -45,6 +45,10 @@
     transition: box-shadow 0.2s 0.2s linear;
     box-shadow: -5px -10px 10px rgba(0, 0, 0, 0.1) inset;
     height: 100vh; /* make the bottom shadow go out of bounderies */
+
+    @nest &:hover {
+      background-color: color(var(--text-color) a(1%));
+    }
   }
 }
 
@@ -196,6 +200,7 @@
   white-space: nowrap;
   overflow: hidden;
   max-width: 100%;
+  width: stretch;
   text-overflow: ellipsis;
   margin-right: auto;
   transform-origin: 0.5em 1.5em;


### PR DESCRIPTION
Larger click area on panes to collapse/expand and slightly gray (text-color alpha 1%) background color on hovered collapsed panes