### PR TITLE
[create-sanity] Add create-sanity package

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -10,7 +10,8 @@
     "packages/example-studio",
     "packages/movies-studio",
     "packages/storybook",
-    "packages/test-studio"
+    "packages/test-studio",
+    "packages/create-sanity"
   ],
   "version": "0.136.3"
 }

--- a/packages/create-sanity/README.md
+++ b/packages/create-sanity/README.md
@@ -1,0 +1,3 @@
+#### [Sanity](https://www.sanity.io) is a real-time content infrastructure with a scalable, hosted backend featuring a Graph Oriented Query Language (GROQ), asset pipelines and fast edge caches.
+
+To get started with Sanity, please head over to our [getting started guide](https://sanity.io/docs/introduction/getting-started)

--- a/packages/create-sanity/index.js
+++ b/packages/create-sanity/index.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+var cli = require.resolve('@sanity/cli/bin/sanity')
+var child_process = require('child_process')
+child_process.fork(cli, ['init'], {
+  stdio: 'inherit'
+})

--- a/packages/create-sanity/index.js
+++ b/packages/create-sanity/index.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
-var cli = require.resolve('@sanity/cli/bin/sanity')
-var child_process = require('child_process')
-child_process.fork(cli, ['init'], {
-  stdio: 'inherit'
-})
+const cli = require.resolve('@sanity/cli/bin/sanity')
+const child_process = require('child_process')
+
+child_process.fork(cli, ['init'], {stdio: 'inherit'})

--- a/packages/create-sanity/package.json
+++ b/packages/create-sanity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-sanity",
   "version": "0.136.0",
-  "description": "Display info about how to create a new sanity app",
+  "description": "Initialize a new Sanity project",
   "bin": "index.js",
   "keywords": [
     "sanity",

--- a/packages/create-sanity/package.json
+++ b/packages/create-sanity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-sanity",
-  "version": "0.136.0",
+  "version": "0.136.1",
   "description": "Initialize a new Sanity project",
   "bin": "index.js",
   "keywords": [

--- a/packages/create-sanity/package.json
+++ b/packages/create-sanity/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "create-sanity",
+  "version": "0.136.0",
+  "description": "Display info about how to create a new sanity app",
+  "bin": "index.js",
+  "keywords": [
+    "sanity",
+    "cms",
+    "headless",
+    "realtime",
+    "content",
+    "create-sanity"
+  ],
+  "author": "Sanity.io <hello@sanity.io>",
+  "bugs": {
+    "url": "https://github.com/sanity-io/sanity/issues"
+  },
+  "homepage": "https://www.sanity.io/",
+  "license": "MIT",
+  "dependencies": {
+    "@sanity/cli": "^0.136.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sanity-io/sanity.git"
+  }
+}

--- a/packages/create-sanity/package.json
+++ b/packages/create-sanity/package.json
@@ -3,6 +3,9 @@
   "version": "0.136.1",
   "description": "Initialize a new Sanity project",
   "bin": "index.js",
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "keywords": [
     "sanity",
     "cms",


### PR DESCRIPTION
This adds the `create-sanity` package which enables `npm init sanity` scaffolding introduced in npm [5.10.0](https://github.com/npm/npm/releases/tag/v5.10.0).

More info here: https://docs.npmjs.com/cli/init#description

We could also consider adding `@sanity/create`