### PR TITLE
Deprecate button collection

### DIFF
--- a/packages/@sanity/components/sanity.json
+++ b/packages/@sanity/components/sanity.json
@@ -26,6 +26,10 @@
       "description": "Use this to wrap buttons"
     },
     {
+      "name": "part:@sanity/components/buttons/button-collection",
+      "description": "Deprecated. Use button-grid"
+    },
+    {
       "name": "part:@sanity/components/buttons/button-group",
       "description": "Use this to group buttons with no spacing"
     },
@@ -437,6 +441,10 @@
     {
       "implements": "part:@sanity/components/buttons/button-grid",
       "path": "buttons/ButtonGrid.js"
+    },
+    {
+      "implements": "part:@sanity/components/buttons/button-collection",
+      "path": "buttons/ButtonCollection.js"
     },
     {
       "implements": "part:@sanity/components/buttons/button-group",

--- a/packages/@sanity/components/src/buttons/ButtonCollection.js
+++ b/packages/@sanity/components/src/buttons/ButtonCollection.js
@@ -1,0 +1,5 @@
+import ButtonGrid from './ButtonGrid'
+
+console.warn('part:@sanity/components/buttons/button-collection is deprecated. Use part:@sanity/components/buttons/button-grid')
+
+export default ButtonGrid


### PR DESCRIPTION
Some plugins seems to use button-collection. Lets give a warning that it is deprecated