### PR TITLE
[components] Use default cursor

### DIFF
--- a/packages/@sanity/components/src/buttons/styles/DefaultButton.css
+++ b/packages/@sanity/components/src/buttons/styles/DefaultButton.css
@@ -50,7 +50,6 @@
   font-size: 1em;
   line-height: 1.25;
   font-family: inherit;
-  cursor: default;
   user-select: none;
   transition: border-color 0.15s, background-color 0.15s, color 0.15s, opacity 0.15s, box-shadow 0.1s;
   text-decoration: none;


### PR DESCRIPTION
Use browser default instead of explicit default cursor.

This way the `<AnchorButton />` gets the pointer cursor.