### PR TITLE
[core] Add support for wildcard + credential-less CORS-origins

### DIFF
--- a/packages/@sanity/core/package.json
+++ b/packages/@sanity/core/package.json
@@ -44,6 +44,8 @@
     "json-lexer": "^1.1.1",
     "json5": "^1.0.1",
     "lodash": "^4.17.4",
+    "log-symbols": "^2.2.0",
+    "oneline": "^1.0.0",
     "path-exists": "^3.0.0",
     "pretty-ms": "^3.2.0",
     "resolve-from": "^4.0.0",

--- a/packages/@sanity/core/src/actions/cors/addCorsOrigin.js
+++ b/packages/@sanity/core/src/actions/cors/addCorsOrigin.js
@@ -56,7 +56,7 @@ function promptForCredentials(hasWildcard, context) {
       session cookies? Be aware that any script on this origin will be able to send
       requests ${chalk.underline('on your behalf')} to read and modify data if you
       are logged in to a Sanity studio. If this origin hosts a studio, you will need
-      this, otherwise you should answer "No" (n) in most cases.
+      this, otherwise you should probably answer "No" (n).
     `)
   }
 

--- a/packages/@sanity/core/src/actions/cors/addCorsOrigin.js
+++ b/packages/@sanity/core/src/actions/cors/addCorsOrigin.js
@@ -1,10 +1,23 @@
 const url = require('url')
+const logSymbols = require('log-symbols')
+const oneline = require('oneline')
+
+const wildcardReplacement = 'a-wild-card-r3pl4c3m3n7-a'
+const portReplacement = ':7777777'
 
 module.exports = async function addCorsOrigin(givenOrigin, context) {
-  const {apiClient, prompt} = context
+  const {apiClient, prompt, output} = context
   const origin = await (givenOrigin
     ? filterAndValidateOrigin(givenOrigin)
     : promptForOrigin(prompt))
+
+  if (givenOrigin !== origin) {
+    output.print(`Normalized origin to ${origin}`)
+  }
+
+  if (origin.includes('*') && !(await promptForWildcardConfirmation(origin, context))) {
+    return false
+  }
 
   const client = apiClient({
     requireUser: true,
@@ -19,6 +32,33 @@ module.exports = async function addCorsOrigin(givenOrigin, context) {
   })
 }
 
+function promptForWildcardConfirmation(origin, context) {
+  const {prompt, output, chalk} = context
+
+  output.print('')
+  output.print(chalk.yellow(`${logSymbols.warning} Warning: Examples of allowed origins:`))
+
+  if (origin === '*') {
+    output.print('- http://www.some-malicious.site')
+    output.print('- https://not.what-you-were-expecting.com')
+    output.print('- https://high-traffic-site.com')
+    output.print('- http://192.168.1.1:8080')
+  } else {
+    output.print(`- ${origin.replace(/:\*/, ':1234').replace(/\*/g, 'foo')}`)
+    output.print(`- ${origin.replace(/:\*/, ':3030').replace(/\*/g, 'foo.bar')}`)
+  }
+
+  output.print('')
+
+  return prompt.single({
+    type: 'confirm',
+    message: oneline`
+      Using wildcards can be ${chalk.red('risky')}.
+      Are you ${chalk.underline('absolutely sure')} you want to allow this origin?`,
+    default: false
+  })
+}
+
 function promptForOrigin(prompt) {
   return prompt.single({
     type: 'input',
@@ -29,25 +69,33 @@ function promptForOrigin(prompt) {
 }
 
 function filterOrigin(origin) {
-  if (origin === '*') {
-    return '*'
+  if (origin === '*' || origin === 'file:///*') {
+    return origin
   }
 
   try {
-    const parsed = url.parse(origin)
+    const example = origin
+      .replace(/([^:])\*/g, `$1${wildcardReplacement}`)
+      .replace(/:\*/, portReplacement)
+
+    const parsed = url.parse(example)
     if (!/^https?:$/.test(parsed.protocol || '')) {
       return null
     }
 
-    const host = parsed.host.replace(/:(80|443)$/, '')
+    const host = parsed.host
+      .replace(/:(80|443)$/, '')
+      .replace(portReplacement, ':*')
+      .replace(new RegExp(wildcardReplacement, 'g'), '*')
+
     return `${parsed.protocol}//${host}`
   } catch (err) {
     return null
   }
 }
 
-function validateOrigin(origin) {
-  if (origin === '*') {
+function validateOrigin(origin, givenOrigin) {
+  if (origin === '*' || origin === 'file:///*') {
     return true
   }
 
@@ -58,12 +106,16 @@ function validateOrigin(origin) {
     // Fall-through to error
   }
 
-  return 'Invalid origin, must include protocol (http://some.host)'
+  if (/^file:\/\//.test(givenOrigin)) {
+    return `Only a local file wildcard is currently allowed: file:///*`
+  }
+
+  return `Invalid origin "${givenOrigin}", must include protocol (https://some.host)`
 }
 
 function filterAndValidateOrigin(givenOrigin) {
   const origin = filterOrigin(givenOrigin)
-  const result = validateOrigin(origin)
+  const result = validateOrigin(origin, givenOrigin)
   if (result !== true) {
     throw new Error(result)
   }

--- a/packages/@sanity/core/src/commands/cors/addCorsOriginCommand.js
+++ b/packages/@sanity/core/src/commands/cors/addCorsOriginCommand.js
@@ -3,9 +3,13 @@ const fse = require('fs-extra')
 const addCorsOrigin = require('../../actions/cors/addCorsOrigin')
 
 const helpText = `
+Options
+  --credentials Allow credentials (token/cookie) to be sent from this origin
+  --no-credentials Disallow credentials (token/cookie) to be sent from this origin
+
 Examples
   sanity cors add
-  sanity cors add http://localhost:3000
+  sanity cors add http://localhost:3000 --no-credentials
 `
 
 export default {
@@ -17,12 +21,13 @@ export default {
   action: async (args, context) => {
     const {output} = context
     const [origin] = args.argsWithoutOptions
+    const flags = args.extOptions
     const isFile = await fse.pathExists(path.join(process.cwd(), origin))
     if (isFile) {
       output.warn(`Origin "${origin}?" Remember to quote values (sanity cors add "*")`)
     }
 
-    const success = await addCorsOrigin(origin, context)
+    const success = await addCorsOrigin(origin, flags, context)
     if (success) {
       output.print('CORS origin added successfully')
     }

--- a/packages/@sanity/core/src/commands/cors/addCorsOriginCommand.js
+++ b/packages/@sanity/core/src/commands/cors/addCorsOriginCommand.js
@@ -1,3 +1,5 @@
+const path = require('path')
+const fse = require('fs-extra')
 const addCorsOrigin = require('../../actions/cors/addCorsOrigin')
 
 const helpText = `
@@ -15,7 +17,14 @@ export default {
   action: async (args, context) => {
     const {output} = context
     const [origin] = args.argsWithoutOptions
-    await addCorsOrigin(origin, context)
-    output.print('CORS origin added successfully')
+    const isFile = await fse.pathExists(path.join(process.cwd(), origin))
+    if (isFile) {
+      output.warn(`Origin "${origin}?" Remember to quote values (sanity cors add "*")`)
+    }
+
+    const success = await addCorsOrigin(origin, context)
+    if (success) {
+      output.print('CORS origin added successfully')
+    }
   }
 }

--- a/packages/@sanity/core/src/commands/cors/deleteCorsOriginCommand.js
+++ b/packages/@sanity/core/src/commands/cors/deleteCorsOriginCommand.js
@@ -1,5 +1,3 @@
-const addCorsOrigin = require('../../actions/cors/addCorsOrigin')
-
 const helpText = `
 Examples
   sanity cors delete


### PR DESCRIPTION
This PR adds support for adding CORS-origins which can contain wildcards, as well as being able to disallow credentials from certain CORS-origins.  The messages might need some work, they are difficult to get the right tone of voice on. Feedback welcome.
