### PR TITLE
[code-input] Implement schema part, better readme, use lazy requires

### DIFF
--- a/packages/@sanity/code-input/README.md
+++ b/packages/@sanity/code-input/README.md
@@ -1,18 +1,64 @@
-# code-editor
+# @sanity/code-input
 
-Ace editor for editing code.
+Code input for [Sanity](https://sanity.io/).
 
-Use `type: text` and `options.editor = 'code'`
+Currently only a subset of languages and features are exposed, over time we will implement a richer set of options.
 
-## In schema
+## Installation
 
 ```
-import code from 'part:@sanity/form-builder/input/code/schema'
+sanity install @sanity/code-input
+```
 
+## Usage
+
+Use it in your schema types:
+
+```js
+// [...]
 {
-  name: 'myCode',
-  title: 'Code editor (default)',
-  description: 'Code editor',
-  type: 'code'
+  fields: [
+    // [...]
+    {
+      name: 'exampleUsage',
+      title: 'Example usage',
+      type: 'code'
+    }
+  ]
 }
 ```
+
+Note that the above only works if you import and use the `all:part:@sanity/base/schema-type` part in your schema.
+
+## Options
+
+- `language` - Default language for this coe field
+- `languageAlternatives` - Array of languages that should be available
+- `theme` - Name of the theme to use. Possible values: `['github', 'monokai', 'terminal', 'tomorrow']`
+
+```js
+// ...fields...
+{
+  name: 'exampleUsage',
+  title: 'Example usage',
+  type: 'code',
+  options: {
+    language: 'js'
+  }
+}
+```
+
+## Data model
+
+```js
+{
+  _type: 'code',
+  language: 'js',
+  highlightedLines: [1, 2],
+  code: 'const foo = "bar"\nconsole.log(foo.toUpperCase())\n// BAR'
+}
+```
+
+## License
+
+MIT-licensed. See LICENSE.

--- a/packages/@sanity/code-input/sanity.json
+++ b/packages/@sanity/code-input/sanity.json
@@ -17,6 +17,10 @@
       "description": "An editor for code in sanity"
     },
     {
+      "implements": "part:@sanity/base/schema-type",
+      "path": "schema.js"
+    },
+    {
       "implements": "part:@sanity/form-builder/input/code/schema",
       "path": "schema.js"
     }

--- a/packages/@sanity/code-input/src/schema.js
+++ b/packages/@sanity/code-input/src/schema.js
@@ -1,9 +1,21 @@
-import Preview from './Preview'
+/* eslint-disable react/no-multi-comp */
+import React from 'react'
+
+const Input = props => {
+  const CodeInput = require('./CodeInput').default
+  return <CodeInput {...props} />
+}
+
+const Preview = props => {
+  const CodePreview = require('./Preview').default
+  return <CodePreview {...props} />
+}
 
 export default {
   name: 'code',
   type: 'object',
   title: 'Code',
+  inputComponent: Input,
   fields: [
     {
       title: 'Code',


### PR DESCRIPTION
This PR does three things:

- Implement the schema type part so you don't have to explicitly require it
- Use lazy require statements in order to fix the issue where ace depend on window globals at require-time, which prevents schema introspection in Node.js
- Brush up the readme to reflect the latest changes, the name of the plugin, the correct usage, the available options as well as the data model
