### PR TITLE
[core] Introduce `sanity undeploy`

### DIFF
--- a/packages/@sanity/core/src/actions/deploy/undeployAction.js
+++ b/packages/@sanity/core/src/actions/deploy/undeployAction.js
@@ -1,0 +1,52 @@
+export default async (args, context) => {
+  const {apiClient, chalk, output, prompt} = context
+
+  const client = apiClient({
+    requireUser: true,
+    requireProject: true
+  })
+
+  // Check that the project has a studio hostname
+  let spinner = output.spinner('Checking project info').start()
+  const project = await client.projects.getById(client.config().projectId)
+  const studioHost = project && (project.studioHost || project.studioHost)
+  spinner.succeed()
+
+  if (!studioHost) {
+    output.print('Your project has not been assigned a studio hostname.')
+    output.print('Nothing to undeploy.')
+    return
+  }
+
+  // Double-check
+  output.print('')
+
+  const url = `https://${chalk.yellow(studioHost)}.sanity.studio`
+  const shouldUndeploy = await prompt.single({
+    type: 'confirm',
+    default: false,
+    message: `This will undeploy ${url} and make it unavailable for your users.
+  The hostname will be available for anyone to claim.
+  Are you ${chalk.red('sure')} you want to undeploy?`.trim()
+  })
+
+  if (!shouldUndeploy) {
+    return
+  }
+
+  const projectId = client.config().projectId
+  const uri = `/projects/${projectId}`
+
+  spinner = output.spinner('Undeploying studio').start()
+  try {
+    await client.request({uri, method: 'PATCH', body: {studioHost: null}})
+    spinner.succeed()
+  } catch (err) {
+    spinner.fail()
+    throw err
+  }
+
+  output.print(
+    `Studio undeploy scheduled. It might take a few minutes before ${url} is unavailable.`
+  )
+}

--- a/packages/@sanity/core/src/commands/deploy/undeployCommand.js
+++ b/packages/@sanity/core/src/commands/deploy/undeployCommand.js
@@ -1,0 +1,14 @@
+import lazyRequire from '@sanity/util/lib/lazyRequire'
+
+const helpText = `
+Examples
+  sanity undeploy
+`
+
+export default {
+  name: 'undeploy',
+  signature: '',
+  description: 'Removes the deployed studio from <hostname>.sanity.studio',
+  action: lazyRequire(require.resolve('../../actions/deploy/undeployAction')),
+  helpText
+}

--- a/packages/@sanity/core/src/commands/index.js
+++ b/packages/@sanity/core/src/commands/index.js
@@ -3,6 +3,7 @@ import checkCommand from './check/checkCommand'
 import configCheckCommand from './config/configCheckCommand'
 import datasetGroup from './dataset/datasetGroup'
 import deployCommand from './deploy/deployCommand'
+import undeployCommand from './deploy/undeployCommand'
 import listDatasetsCommand from './dataset/listDatasetsCommand'
 import createDatasetCommand from './dataset/createDatasetCommand'
 import datasetVisibilityCommand from './dataset/datasetVisibilityCommand'
@@ -35,6 +36,7 @@ export default [
   configCheckCommand,
   datasetGroup,
   deployCommand,
+  undeployCommand,
   listDatasetsCommand,
   createDatasetCommand,
   datasetVisibilityCommand,


### PR DESCRIPTION
This command will both remove the deployed files as well as unassigning a hostname so it can be reassigned to a different value.

Important to note that this will free up the hostname for others to use.

Not 100% sure if "undeploy" is the right word, but opening it for the functionality - feel free to suggest a better alternative name.