### PR TITLE
[import] Throw error when encountering duplicate IDs

### DIFF
--- a/packages/@sanity/import/package.json
+++ b/packages/@sanity/import/package.json
@@ -10,7 +10,8 @@
   "license": "MIT",
   "scripts": {
     "clean": "rimraf lib",
-    "test": "#todo: jest"
+    "coverage": "jest --coverage",
+    "test": "jest"
   },
   "keywords": [
     "sanity",
@@ -44,6 +45,9 @@
     "get-it": "^4.0.1",
     "jest": "^23.6.0",
     "rimraf": "^2.6.2"
+  },
+  "jest": {
+    "testEnvironment": "node"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/import/src/importFromArray.js
+++ b/packages/@sanity/import/src/importFromArray.js
@@ -1,5 +1,6 @@
 const debug = require('debug')('sanity:import:array')
 const flatten = require('lodash/flatten')
+const ensureUniqueIds = require('./util/ensureUniqueIds')
 const {getAssetRefs, unsetAssetRefs, absolutifyPaths} = require('./assetRefs')
 const assignArrayKeys = require('./assignArrayKeys')
 const assignDocumentId = require('./assignDocumentId')
@@ -7,6 +8,7 @@ const uploadAssets = require('./uploadAssets')
 const documentHasErrors = require('./documentHasErrors')
 const batchDocuments = require('./batchDocuments')
 const importBatches = require('./importBatches')
+
 const {
   getStrongRefs,
   weakenStrongRefs,
@@ -17,6 +19,9 @@ const {
 async function importDocuments(documents, options, importers) {
   options.onProgress({step: 'Reading/validating data file'})
   documents.some(documentHasErrors.validate)
+
+  // Validate that there are no duplicate IDs in the documents
+  ensureUniqueIds(documents)
 
   // Replace relative asset paths if one is defined
   // (file://./images/foo-bar.png -> file:///abs/olute/images/foo-bar.png)

--- a/packages/@sanity/import/src/util/ensureUniqueIds.js
+++ b/packages/@sanity/import/src/util/ensureUniqueIds.js
@@ -1,0 +1,27 @@
+function reduceDuplicateIds(ids, doc) {
+  if (!doc._id) {
+    return ids
+  }
+
+  if (ids.seen.includes(doc._id)) {
+    ids.duplicates.push(doc._id)
+  } else {
+    ids.seen.push(doc._id)
+  }
+
+  return ids
+}
+
+module.exports = function ensureUniqueIds(documents) {
+  const {duplicates} = documents.reduce(reduceDuplicateIds, {
+    seen: [],
+    duplicates: []
+  })
+
+  const numDupes = duplicates.length
+  if (numDupes === 0) {
+    return
+  }
+
+  throw new Error(`Found ${numDupes} duplicate IDs:\n- ${duplicates.join('\n- ')}`)
+}

--- a/packages/@sanity/import/test/__snapshots__/uploadAssets.test.js.snap
+++ b/packages/@sanity/import/test/__snapshots__/uploadAssets.test.js.snap
@@ -5,12 +5,6 @@ exports[`fails if asset download fails 1`] = `
 connect ECONNREFUSED 127.0.0.1:49999]
 `;
 
-exports[`fails if asset lookup fails 1`] = `
-[Error: Failed to upload image @ file:///Users/espenh/webdev/sanity-voof/packages/@sanity/import/test/fixtures/img.gif:
-Error while attempt to query Sanity API:
-Some network err]
-`;
-
 exports[`will reuse an existing asset if it exists: single asset mutation 1`] = `
 Object {
   "mutations": Array [

--- a/packages/@sanity/import/test/fixtures/duplicate-ids.ndjson
+++ b/packages/@sanity/import/test/fixtures/duplicate-ids.ndjson
@@ -1,0 +1,32 @@
+{"_id": "espen", "_type": "employee", "name": "Espen"}
+{"_id": "pk", "_type": "employee", "name": "Per-Kristian"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_type": "nondupe", "dummy": "value"}
+{"_id": "pk", "_type": "employee", "name": "Per-Kristian"}
+{"_id": "espen", "_type": "employee", "name": "Espen"}

--- a/packages/@sanity/import/test/import.test.js
+++ b/packages/@sanity/import/test/import.test.js
@@ -2,7 +2,7 @@
 const fs = require('fs')
 const path = require('path')
 const sanityClient = require('@sanity/client')
-const importer = require('../')
+const importer = require('../src/import')
 const {getSanityClient} = require('./helpers')
 
 const defaultClient = sanityClient({
@@ -79,6 +79,14 @@ test('rejects on missing `_type` property (from array)', async () => {
   await expect(importer(getFixtureArray('missing-type'), importOptions)).rejects.toHaveProperty(
     'message',
     'Failed to parse document at index #2: Document did not contain required "_type" property of type string'
+  )
+})
+
+test('rejects on duplicate IDs', async () => {
+  expect.assertions(1)
+  await expect(importer(getFixtureStream('duplicate-ids'), importOptions)).rejects.toHaveProperty(
+    'message',
+    'Found 2 duplicate IDs:\n- pk\n- espen'
   )
 })
 

--- a/packages/@sanity/import/test/uploadAssets.test.js
+++ b/packages/@sanity/import/test/uploadAssets.test.js
@@ -27,10 +27,14 @@ test('fails if asset download fails', () => {
   return expect(uploadAssets([asset], {client: null, onProgress: noop})).rejects.toMatchSnapshot()
 })
 
-test('fails if asset lookup fails', () => {
+test('fails if asset lookup fails', async () => {
   const options = {client: fetchFailClient, onProgress: noop}
-  const upload = uploadAssets([fileAsset], options)
-  return expect(upload).rejects.toMatchSnapshot()
+  try {
+    const result = await uploadAssets([fileAsset], options)
+    expect(result).toBeFalsy()
+  } catch (err) {
+    expect(err.message).toMatch(/Some network err/)
+  }
 })
 
 test('will reuse an existing asset if it exists', () => {


### PR DESCRIPTION
When importing documents with specified IDs, the order of them are not guaranteed since we're doing multiple transactions in parallel. When running without `--replace`, they will yield error messages about the document already existing, which can be confusing if you are not aware that the duplicate was from the dataset you were _importing_ rather than in the dataset from before.

This PR ensures that we throw an error when encountering explicitly defined, duplicate IDs.