### PR TITLE
[groq] Add groq module for use with tagged template literals

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,8 +23,18 @@ const isWindows = /^win/.test(process.platform)
 const tsPaths = globby.sync(['./packages/@sanity/*/tsconfig.json'])
 const tsProjects = tsPaths.map(conf => ts.createProject(conf))
 const tsScripts = tsPaths.map(proj => `${path.dirname(proj)}/src/**/*.ts`)
-const scripts = ['./packages/@sanity/*/src/**/*.js', './packages/sanity-plugin-*/src/**/*.js']
-const assets = ['./packages/@sanity/*/src/**/*', './packages/sanity-plugin-*/src/**/*']
+const scripts = [
+  './packages/@sanity/*/src/**/*.js',
+  './packages/sanity-plugin-*/src/**/*.js',
+  './packages/groq/src/**/*.js'
+]
+
+const assets = [
+  './packages/@sanity/*/src/**/*',
+  './packages/sanity-plugin-*/src/**/*',
+  './packages/groq/src/**/*.js'
+]
+
 const srcOpts = {base: 'packages'}
 
 const getProjectEnv = projectPath => {
@@ -43,11 +53,11 @@ let libFragment
 
 if (path.win32 === path) {
   srcEx = /(@sanity\\[^\\]+)\\src\\/
-  srcRootEx = /(sanity-plugin-[^\\]+)\\src\\/
+  srcRootEx = /(groq|sanity-plugin-[^\\]+)\\src\\/
   libFragment = '$1\\lib\\'
 } else {
   srcEx = new RegExp('(@sanity/[^/]+)/src/')
-  srcRootEx = /(sanity-plugin-[^/]+)\/src\//
+  srcRootEx = /(groq|sanity-plugin-[^/]+)\/src\//
   libFragment = '$1/lib/'
 }
 

--- a/lerna.json
+++ b/lerna.json
@@ -4,6 +4,7 @@
   "ci": false,
   "packages": [
     "packages/@sanity/*",
+    "packages/groq",
     "packages/blog-studio",
     "packages/create-sanity",
     "packages/ecommerce-studio",

--- a/packages/groq/.gitignore
+++ b/packages/groq/.gitignore
@@ -1,0 +1,15 @@
+# Logs
+logs
+*.log
+
+# Coverage directory used by tools like istanbul
+coverage
+
+# Grunt intermediate storage
+.grunt
+
+# Dependency directories
+node_modules
+
+# Compiled code
+lib

--- a/packages/groq/README.md
+++ b/packages/groq/README.md
@@ -1,0 +1,31 @@
+# GROQ tagged template literal
+
+This module exports a single function that can be called with an ES2015 [template string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_template_literals) to signal that it represents a GROQ-query.
+
+The result will be the exact same string as the input, - this is currently helpful for getting syntax highlighting in editors, but in the future it might also parse and validate queries, strip unncessary whitespace and similar.
+
+Pairs well with [vscode-sanity](https://github.com/sanity-io/vscode-sanity)!
+
+## Installing
+
+```
+npm install --save groq
+```
+
+## Usage
+
+```js
+import groq from 'groq'
+
+const query = groq`*[_type == 'products'][0...10]`
+```
+
+## What is Sanity? What is GROQ?
+
+[Sanity](https://www.sanity.io) is a real-time content infrastructure with a scalable, hosted backend featuring a Graph Oriented Query Language (GROQ), asset pipelines and fast edge caches.
+
+To get started with Sanity, please head over to our [getting started guide](https://sanity.io/docs/introduction/getting-started)
+
+## License
+
+MIT-licensed. See LICENSE.

--- a/packages/groq/package.json
+++ b/packages/groq/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "groq",
+  "version": "0.137.0",
+  "description": "Tagged template literal for Sanity.io GROQ-queries",
+  "main": "lib/groq.js",
+  "directories": {
+    "lib": "lib",
+    "test": "test"
+  },
+  "engines": {
+    "node": ">=6"
+  },
+  "scripts": {
+    "test": "node test/groq.test.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sanity-io/sanity.git"
+  },
+  "keywords": [
+    "groq",
+    "tagged",
+    "template",
+    "literal",
+    "string",
+    "sanity",
+    "cms",
+    "headless",
+    "realtime",
+    "content"
+  ],
+  "author": "Sanity.io <hello@sanity.io>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/sanity-io/sanity/issues"
+  },
+  "homepage": "https://www.sanity.io/"
+}

--- a/packages/groq/src/groq.js
+++ b/packages/groq/src/groq.js
@@ -1,0 +1,8 @@
+/* eslint-disable import/no-commonjs */
+module.exports = function groq(strings, ...keys) {
+  const lastIndex = strings.length - 1
+  return (
+    strings.slice(0, lastIndex).reduce((acc, str, i) => acc + str + keys[i], '') +
+    strings[lastIndex]
+  )
+}

--- a/packages/groq/test/groq.test.js
+++ b/packages/groq/test/groq.test.js
@@ -1,0 +1,12 @@
+/* eslint-disable import/no-commonjs */
+const assert = require('assert')
+const groq = require('../src/groq')
+
+assert.equal(groq`foo${'bar'}`, `foo${'bar'}`)
+assert.equal(groq`${'bar'}`, `${'bar'}`)
+assert.equal(groq``, ``)
+assert.equal(groq`${'foo'}`, `${'foo'}`)
+assert.equal(groq`${/foo/}bar`, `${/foo/}bar`)
+assert.equal(groq`${'foo'}bar${347}`, `${'foo'}bar${347}`)
+assert.equal(groq`${'foo'}bar${347}${/qux/}`, `${'foo'}bar${347}${/qux/}`)
+assert.equal(groq`${'foo'}${347}qux`, `${'foo'}${347}qux`)


### PR DESCRIPTION
## Description

This module exports a single function that can be called with an ES2015 [template string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_template_literals) to signal that it represents a GROQ-query.

The result will be the exact same string as the input, - this is currently helpful for getting syntax highlighting in editors, but in the future it might also parse and validate queries, strip unncessary whitespace and similar.

Pairs well with [vscode-sanity](https://github.com/sanity-io/vscode-sanity)!

## Usage

```js
import groq from 'groq'

const query = groq`*[_type == 'products'][0...10]`
```

