### PR TITLE
[components] Force pane max width to 100%

### DIFF
--- a/packages/@sanity/components/src/panes/styles/SplitController.css
+++ b/packages/@sanity/components/src/panes/styles/SplitController.css
@@ -38,6 +38,7 @@
     to avoide a re-render of the dom and to fill the entire width
   */
   @nest & :global(.Pane1) {
+    max-width: 100% !important;
     flex: 1 !important;
   }
 
@@ -96,5 +97,4 @@
 
 .hideResize > .splitPane > .Resizer {
   display: none;
-  border: 10px solid red !important;
 }

--- a/packages/test-studio/src/deskStructure.js
+++ b/packages/test-studio/src/deskStructure.js
@@ -50,7 +50,16 @@ export default () =>
                 .showAsAction(true)
             ])
         ),
-
+      S.listItem()
+        .title('Deep')
+        .child(
+          S.list()
+            .title('Deeper')
+            .items([
+              S.documentTypeListItem('book').title('Books'),
+              S.documentTypeListItem('author').title('Authors')
+            ])
+        ),
       S.listItem()
         .title('Deep panes')
         .child(


### PR DESCRIPTION
Fixes a bug where in some cases (often deep nested panes) stretches the last pane outside the viewport when having long titles in the header.