### PR TITLE
[chore] Require node >= 8 for all packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: node_js
 node_js:
-  - '6'
   - '8'
   - '10'
 
 cache:
   directories:
-  - "$HOME/.npm"
+    - '$HOME/.npm'
 
 install:
   # todo: remove the `|| npm install` part below when we no run CI with node 6

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,7 @@
 environment:
   matrix:
-    - nodejs_version: "10"
-    - nodejs_version: "8"
-    - nodejs_version: "6"
+    - nodejs_version: '10'
+    - nodejs_version: '8'
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-commonjs, import/no-unassigned-import */
-// Note: Node 6 compat, please!
+// Note: Node 8 compat, please!
 require('hard-rejection/register')
 
 const path = require('path')
@@ -11,7 +11,7 @@ const watch = require('gulp-watch')
 const gutil = require('gulp-util')
 const filter = require('gulp-filter')
 const plumber = require('gulp-plumber')
-const ts = require('@rexxars/gulp-typescript')
+const ts = require('gulp-typescript')
 const sourcemaps = require('gulp-sourcemaps')
 const through = require('through2')
 const chalk = require('chalk')

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@babel/preset-flow": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.0.0",
-    "@rexxars/gulp-typescript": "^5.0.0-alpha.3",
     "babel-eslint": "^9.0.0",
     "babel-jest": "^23.6.0",
     "babel-loader": "^8.0.0",
@@ -76,6 +75,7 @@
     "gulp-newer": "^1.4.0",
     "gulp-plumber": "^1.2.0",
     "gulp-sourcemaps": "^2.6.4",
+    "gulp-typescript": "^5.0.0",
     "gulp-util": "^3.0.8",
     "gulp-watch": "^5.0.1",
     "hard-rejection": "^1.0.0",
@@ -92,7 +92,7 @@
     "stylelint-config-css-modules": "^1.1.0",
     "stylelint-config-standard": "^18.0.0",
     "through2": "^2.0.3",
-    "typescript": "^2.9.2",
+    "typescript": "^3.2.2",
     "yarn": "^1.3.2"
   }
 }

--- a/packages/@sanity/check/package.json
+++ b/packages/@sanity/check/package.json
@@ -8,7 +8,7 @@
   },
   "author": "Sanity.io <hello@sanity.io>",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "license": "MIT",
   "scripts": {

--- a/packages/@sanity/cli/.babelrc
+++ b/packages/@sanity/cli/.babelrc
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "6"
+          "node": "8"
         }
       }
     ]

--- a/packages/@sanity/cli/bin/sanity.js
+++ b/packages/@sanity/cli/bin/sanity.js
@@ -10,8 +10,8 @@
  */
 
 const nodeVersion = Number(process.version.replace(/^v/i, '').split('.', 2)[0])
-if (nodeVersion < 6) {
-  console.error('ERROR: Node.js version 6 or higher required. You are running ' + process.version)
+if (nodeVersion < 8) {
+  console.error('ERROR: Node.js version 8 or higher required. You are running ' + process.version)
   process.exit(1)
 }
 

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -15,7 +15,7 @@
     "prepublishOnly": "npm run build"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/code-input/.babelrc
+++ b/packages/@sanity/code-input/.babelrc
@@ -1,3 +1,4 @@
 {
-  presets: ['@babel/react']
+  "extends": "../../../.babelrc.js",
+  "presets": ["@babel/react"]
 }

--- a/packages/@sanity/color-input/.babelrc
+++ b/packages/@sanity/color-input/.babelrc
@@ -1,3 +1,4 @@
 {
-  presets: ['@babel/react']
+  "extends": "../../../.babelrc.js",
+  "presets": ["@babel/react"]
 }

--- a/packages/@sanity/components/.babelrc
+++ b/packages/@sanity/components/.babelrc
@@ -1,3 +1,4 @@
 {
-  presets: ['@babel/react', '@babel/flow']
+  "extends": "../../../.babelrc.js",
+  "presets": ["@babel/react", "@babel/flow"]
 }

--- a/packages/@sanity/core/package.json
+++ b/packages/@sanity/core/package.json
@@ -9,7 +9,7 @@
     "clean": "rimraf lib"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "keywords": [
     "sanity",

--- a/packages/@sanity/default-layout/.babelrc
+++ b/packages/@sanity/default-layout/.babelrc
@@ -1,3 +1,4 @@
 {
-  presets: ['@babel/react']
+  "extends": "../../../.babelrc.js",
+  "presets": ["@babel/react"]
 }

--- a/packages/@sanity/default-login/.babelrc
+++ b/packages/@sanity/default-login/.babelrc
@@ -1,3 +1,4 @@
 {
-  presets: ['@babel/react']
+  "extends": "../../../.babelrc.js",
+  "presets": ["@babel/react"]
 }

--- a/packages/@sanity/desk-tool/.babelrc
+++ b/packages/@sanity/desk-tool/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": ["@babel/react"],
-  "extends": "../../../.babelrc.js"
+  "extends": "../../../.babelrc.js",
+  "presets": ["@babel/react"]
 }

--- a/packages/@sanity/export/package.json
+++ b/packages/@sanity/export/package.json
@@ -4,7 +4,7 @@
   "description": "Export Sanity documents and assets",
   "main": "lib/export.js",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",

--- a/packages/@sanity/google-maps-input/.babelrc
+++ b/packages/@sanity/google-maps-input/.babelrc
@@ -1,3 +1,4 @@
 {
-  presets: ['@babel/react']
+  "extends": "../../../.babelrc.js",
+  "presets": ["@babel/react"]
 }

--- a/packages/@sanity/imagetool/.babelrc
+++ b/packages/@sanity/imagetool/.babelrc
@@ -1,11 +1,14 @@
 {
-  presets: [
-    '@babel/preset-flow',
-    '@babel/preset-react',
-    ['@babel/preset-env', {
-        targets: {
-          ie: '9'
+  "presets": [
+    "@babel/preset-flow",
+    "@babel/preset-react",
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "ie": "9"
         }
-    }]
+      }
+    ]
   ]
 }

--- a/packages/@sanity/import-cli/.babelrc
+++ b/packages/@sanity/import-cli/.babelrc
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "6"
+          "node": "8"
         }
       }
     ]

--- a/packages/@sanity/import-cli/package.json
+++ b/packages/@sanity/import-cli/package.json
@@ -7,7 +7,7 @@
     "sanity-import": "./lib/sanity-import.js"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",

--- a/packages/@sanity/import/.babelrc
+++ b/packages/@sanity/import/.babelrc
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "6"
+          "node": "8"
         }
       }
     ]

--- a/packages/@sanity/import/package.json
+++ b/packages/@sanity/import/package.json
@@ -4,7 +4,7 @@
   "description": "Import documents to a Sanity dataset",
   "main": "lib/import.js",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",

--- a/packages/@sanity/plugin-loader/package.json
+++ b/packages/@sanity/plugin-loader/package.json
@@ -8,7 +8,7 @@
     "coverage": "nyc --reporter=html ava"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/resolver/package.json
+++ b/packages/@sanity/resolver/package.json
@@ -9,7 +9,7 @@
     "test": "#todo: mocha test/**/*.test.js"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/schema/package.json
+++ b/packages/@sanity/schema/package.json
@@ -31,7 +31,7 @@
     "object-inspect": "^1.3.0"
   },
   "devDependencies": {
-    "@types/node": "6.0.52",
+    "@types/node": "^8.0.0",
     "empty": "^0.10.1",
     "flow-typed": "^2.2.3",
     "jest": "^23.6.0",

--- a/packages/@sanity/server/package.json
+++ b/packages/@sanity/server/package.json
@@ -12,7 +12,7 @@
     "sanity-server": "./bin/sanity-server.js"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/server/src/configs/babel-env-config.js
+++ b/packages/@sanity/server/src/configs/babel-env-config.js
@@ -1,6 +1,6 @@
 module.exports = {
   targets: {
-    node: '6',
+    node: '8',
     chrome: '59',
     safari: '10',
     firefox: '56',

--- a/packages/@sanity/structure/package.json
+++ b/packages/@sanity/structure/package.json
@@ -6,7 +6,7 @@
   "types": "./lib/index.d.ts",
   "author": "Sanity.io <hello@sanity.io>",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "license": "MIT",
   "scripts": {
@@ -39,7 +39,7 @@
     "rimraf": "^2.6.2",
     "rxjs": "^6.1.0",
     "ts-jest": "^22.4.3",
-    "typescript": "^2.9.2"
+    "typescript": "^3.2.2"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/util/package.json
+++ b/packages/@sanity/util/package.json
@@ -8,7 +8,7 @@
     "test": "jest test/**.test.js"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/webpack-integration/package.json
+++ b/packages/@sanity/webpack-integration/package.json
@@ -20,7 +20,7 @@
     "webpack"
   ],
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",

--- a/packages/@sanity/webpack-loader/package.json
+++ b/packages/@sanity/webpack-loader/package.json
@@ -7,7 +7,7 @@
     "clean": "rimraf lib"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/create-sanity/package.json
+++ b/packages/create-sanity/package.json
@@ -4,7 +4,7 @@
   "description": "Initialize a new Sanity project",
   "bin": "index.js",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "keywords": [
     "sanity",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -18,7 +18,7 @@
     "content"
   ],
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "homepage": "https://www.sanity.io/",
   "license": "MIT",

--- a/scripts/normalizePackageFields.js
+++ b/scripts/normalizePackageFields.js
@@ -2,7 +2,7 @@ const uniq = require('lodash/uniq')
 const transformPkgs = require('./transformPkgs')
 
 const COMMON_KEYWORDS = ['sanity', 'cms', 'headless', 'realtime', 'content']
-const supportedNodeVersionRange = '>=6.0.0'
+const supportedNodeVersionRange = '>=8.0.0'
 
 transformPkgs(pkgManifest => {
   const name = pkgManifest.name.split('/').slice(-1)[0]


### PR DESCRIPTION
It's time to say goodbye to Node 6. More and more packages do not support it anymore, and this makes it harder and harder to keep supporting it, obviously.
