### PR TITLE
[desk-tool] Only duplicate published version if liveEdit is enabled

### DIFF
--- a/packages/@sanity/desk-tool/src/pane/Editor.js
+++ b/packages/@sanity/desk-tool/src/pane/Editor.js
@@ -305,18 +305,21 @@ export default withRouterHOC(
     handleCreateCopy = () => {
       const {router, draft, published, paneIndex} = this.props
       const prevId = getPublishedId((draft || published)._id)
-      this.duplicate$ = documentStore
-        .create(newDraftFrom(copyDocument(draft || published)))
-        .subscribe(copied => {
-          const copyDocId = getPublishedId(copied._id)
-          const newPanes = router.state.panes.map(
-            (prev, i) => (i === paneIndex - 1 && prev === prevId ? copyDocId : prev)
-          )
-          router.navigate({
-            ...router.state,
-            panes: newPanes
-          })
+
+      const duplicatedDocument = this.isLiveEditEnabled()
+        ? copyDocument(published)
+        : newDraftFrom(copyDocument(draft || published))
+
+      this.duplicate$ = documentStore.create(duplicatedDocument).subscribe(copied => {
+        const copyDocId = getPublishedId(copied._id)
+        const newPanes = router.state.panes.map((prev, i) =>
+          i === paneIndex - 1 && prev === prevId ? copyDocId : prev
+        )
+        router.navigate({
+          ...router.state,
+          panes: newPanes
         })
+      })
     }
 
     handleEditAsActualType = () => {


### PR DESCRIPTION
Currently, when duplicating a document of a type that has liveEdit enabled, we inadvertently created a draft document. This patch makes sure we only duplicate the published version.