### PR TITLE
[desk-tool] Render pane content only when expanded

### DIFF
--- a/packages/@sanity/components/src/panes/DefaultPane.js
+++ b/packages/@sanity/components/src/panes/DefaultPane.js
@@ -364,7 +364,8 @@ class Pane extends React.Component {
             </div>
           </div>
         </div>
-        <div className={styles.main}>
+        {!isCollapsed && (
+          <div className={styles.main}>
           {isScrollable ? (
             <ScrollContainer className={styles.scrollContainer} onScroll={this.handleContentScroll}>
               <div style={contentMaxWidth ? {maxWidth: `${contentMaxWidth}px`} : {}}>
@@ -376,6 +377,7 @@ class Pane extends React.Component {
           )}
           {staticContent}
         </div>
+        )}
       </div>
     )
   }


### PR DESCRIPTION
This skips rendering of collapsed panes, which fixes an issue that made only the first item of collapsed panes visible.

As a bonus this means we now skip unnecessary DOM updates of contents that's not visible to the user. Also, we no longer refresh contents in collapsed panes, which should save a significant amount of API calls when editing contents on mobile devices

This also uncovered an issue with the global event listener that due to a race condition could cause the initial welcome event to be "consumed" before it got memoized with publishReplay.