### PR TITLE
[form-builder] Block editor: fix scrollcontainer width issues

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/styles/BlockEditor.css
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/styles/BlockEditor.css
@@ -23,6 +23,7 @@
   border: 1px solid var(--input-border-color);
   border-radius: var(--input-border-radius);
   box-sizing: border-box;
+  overflow-y: overlay;
 
   @nest &.hasBlockExtras::after {
     content: '';

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/styles/BlockExtras.css
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/styles/BlockExtras.css
@@ -11,7 +11,7 @@
 }
 
 .content {
-  margin-left: calc(100% - 1px - var(--block-extras-width) + var(--medium-padding));
+  margin-left: calc(100% - var(--block-extras-width));
   pointer-events: all;
   border-left: 2px solid transparent;
   padding-left: var(--small-padding);


### PR DESCRIPTION
Mystery bug, scrollbar eats of scroll-container width differently on same Chrome version and MacOS. Also different in various Chrome on Linux versions.

I added ``overflow-y: 'overlay';`` to make it calculate the same width everywhere.