### PR TITLE
[default-layout] Only show version status to administrators

### DIFF
--- a/packages/@sanity/default-layout/package.json
+++ b/packages/@sanity/default-layout/package.json
@@ -34,6 +34,7 @@
     "lodash": "^4.17.4",
     "react-click-outside": "^3.0.0",
     "react-ink": "^6.1.0",
+    "react-props-stream": "^1.0.0",
     "react-tippy": "^1.2.3",
     "rxjs": "^6.1.0"
   },

--- a/packages/@sanity/default-layout/src/components/SanityStatusContainer.js
+++ b/packages/@sanity/default-layout/src/components/SanityStatusContainer.js
@@ -1,27 +1,20 @@
 import React from 'react'
+import {of} from 'rxjs'
+import {flatMap, catchError} from 'rxjs/operators'
+import userStore from 'part:@sanity/base/user'
+import {withPropsStream} from 'react-props-stream'
 import VersionChecker from 'part:@sanity/base/version-checker'
 import versions from 'sanity:versions'
 import SanityStatus from './SanityStatus'
 
 // eslint-disable-next-line no-console
-const logError = err => console.error(err)
 const levels = ['low', 'medium', 'high']
 const getHighestLevel = outdated =>
   outdated.reduce((acc, pkg) => Math.max(acc, levels.indexOf(pkg.severity)), 0)
 
 class SanityStatusContainer extends React.PureComponent {
   state = {
-    isSupported: true,
-    isUpToDate: true,
-    level: 'low',
-    outdated: undefined,
     showDialog: false
-  }
-
-  componentDidMount() {
-    VersionChecker.checkVersions()
-      .then(this.handleVersionReply)
-      .catch(logError)
   }
 
   handleHideDialog = () => {
@@ -32,16 +25,18 @@ class SanityStatusContainer extends React.PureComponent {
     this.setState({showDialog: true})
   }
 
-  handleVersionReply = ({result}) => {
-    const {isSupported, isUpToDate, outdated} = result
-    const level = levels[getHighestLevel(outdated || [])]
-    this.setState({isSupported, isUpToDate, level, outdated})
-  }
-
   render() {
+    if (!this.props.showStatus) {
+      return null
+    }
+
+    const {outdated} = this.props.versionReply
+    const level = levels[getHighestLevel(outdated || [])]
     return (
       <SanityStatus
-        {...this.state}
+        {...this.props.versionReply}
+        level={level}
+        showDialog={this.state.showDialog}
         onHideDialog={this.handleHideDialog}
         onShowDialog={this.handleShowDialog}
         versions={versions}
@@ -50,4 +45,17 @@ class SanityStatusContainer extends React.PureComponent {
   }
 }
 
-export default SanityStatusContainer
+export default withPropsStream(
+  userStore.currentUser.pipe(
+    flatMap(event =>
+      event.user && event.user.role === 'administrator'
+        ? VersionChecker.checkVersions().then(({result}) => ({
+            versionReply: result,
+            showStatus: true
+          }))
+        : {showStatus: false}
+    ),
+    catchError(err => of({error: err, showStatus: false}))
+  ),
+  SanityStatusContainer
+)


### PR DESCRIPTION
This PR ensures that the Sanity version check is only run for administrators. Since read/read+write users can't really do anything about being on an outdated version, it just creates clutter. 

Requested by a user on the [community slack](https://sanity-io-land.slack.com/archives/CB2F69QBU/p1545215180051300)