### PR TITLE
[form-builder] Fix block editor patching issues

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/SyncWrapper.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/SyncWrapper.js
@@ -284,7 +284,7 @@ export default withPatchSubscriber(
         () => {
           if (localChangeGroups.length) {
             this._pendingLocalChanges.push(flatten(localChangeGroups))
-            this.sendLocalPatchesDebounced()
+            this.sendLocalPatches()
           }
           if (callback) {
             return callback()
@@ -294,7 +294,7 @@ export default withPatchSubscriber(
       )
     }
 
-    sendLocalPatchesDebounced = debounce(() => {
+    sendLocalPatches = () => {
       const {onChange} = this.props
       const cutLength = this._pendingLocalChanges.length
       let finalPatches = flatten(
@@ -324,7 +324,7 @@ export default withPatchSubscriber(
         // Send the final patches
         onChange(PatchEvent.from(finalPatches))
       }
-    }, 200)
+    }
 
     unsetUserIsWritingTextDebounced = debounce(() => {
       this.setState({userIsWritingText: false})


### PR DESCRIPTION
In an attempt to try to optimise the speed of the writing experience in the block editor, local patches was attempted to be sent debounced. This led to some side-effects, so we can't do that. We need instead to focus on optimising the Mutator (especially the aggressive rebasing) and probably also inside the form builder on a higher level.
