### PR TITLE
[form-builder] Block editor: improve block action patch functions

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/BlockExtrasOverlay.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/BlockExtrasOverlay.js
@@ -109,6 +109,7 @@ export default class BlockExtrasOverlay extends React.Component<Props, State> {
             element={element}
             block={block}
             value={value}
+            path={[{_key: block._key}]}
             set={createBlockActionPatchFn('set', block, onPatch)}
             unset={createBlockActionPatchFn('unset', block, onPatch)}
             insert={createBlockActionPatchFn('insert', block, onPatch)}

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createBlockActionPatchFn.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createBlockActionPatchFn.js
@@ -2,26 +2,24 @@
 
 import type {FormBuilderValue, Block} from '../typeDefs'
 import PatchEvent, {insert, unset, set} from '../../../../PatchEvent'
-import {randomKey, normalizeBlock} from '@sanity/block-tools'
+import {normalizeBlock} from '@sanity/block-tools'
 
 export default function createBlockActionPatchFn(
   type: string,
   block: FormBuilderValue,
   onPatch: PatchEvent => void
 ) {
+  let toInsert
   return (givenBlock: Block) => {
     switch (type) {
       case 'set':
-        return onPatch(PatchEvent.from(set(givenBlock, [{_key: block._key}])))
+        return onPatch(PatchEvent.from(set(normalizeBlock(givenBlock), [{_key: block._key}])))
       case 'unset':
         return onPatch(PatchEvent.from(unset([{_key: block._key}])))
       case 'insert':
-        // Make sure the given block key's are unique and normalized
-        givenBlock._key = randomKey(12)
-        if (givenBlock._type === 'block') {
-          normalizeBlock(givenBlock)
-        }
-        return onPatch(PatchEvent.from(insert([givenBlock], 'after', [{_key: block._key}])))
+        toInsert = Array.isArray(givenBlock) ? givenBlock : [givenBlock]
+        toInsert = toInsert.map(blk => normalizeBlock(blk))
+        return onPatch(PatchEvent.from(insert(toInsert, 'after', [{_key: block._key}])))
       default:
         throw new Error(`Patch type ${type} not supported`)
     }


### PR DESCRIPTION
Improved the patch function given as props to renderBlockActions. The `insert` function now accepts both a block and an array of blocks to insert below the block whose block action is being called.

Also, normalization of the set function block input.
