### PR TITLE
[schema] Allow problems from external schema creators to flow through

### DIFF
--- a/packages/@sanity/schema/src/sanity/validateSchema.js
+++ b/packages/@sanity/schema/src/sanity/validateSchema.js
@@ -35,7 +35,7 @@ function combine(...visitors) {
           _problems: result._problems.concat(res._problems)
         }
       },
-      {...schemaType, _problems: []}
+      {_problems: [], ...schemaType}
     )
   }
 }


### PR DESCRIPTION
This PR enables external schema builders/schema creators to use the schema error machinery, by manually applying `_problems: [{severity: 'error', message: 'foo'}]` to the returned types/fields.

