### PR TITLE
[webpack-loader] Peg loader-utils at 1.1.0

### DIFF
--- a/packages/@sanity/webpack-loader/package.json
+++ b/packages/@sanity/webpack-loader/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@sanity/resolver": "0.139.0",
     "@sanity/util": "0.139.0",
-    "loader-utils": "^1.1.0"
+    "loader-utils": "1.1.0"
   },
   "devDependencies": {
     "rimraf": "^2.6.2"


### PR DESCRIPTION
Webpack's loader-utils was [upgraded today](https://github.com/webpack/loader-utils/releases) with the result that some of our CSS stopped loading / building. The end result is that text fields and all popups loose some crucial styling. :tada: 

![image](https://user-images.githubusercontent.com/172952/50426694-08a9b600-0895-11e9-9dd7-a131c851fbcb.png)

Comparing all updated packages to a local last known good narrowed the list of candidate packages down and the problem went away when pinning `loader-utils` to 1.1.0.  

I have an hunch it might be this fix causing the issues:
> isUrlRequest: ignore all url with extension (like moz-extension:, ms-browser-extension: and etc)

Didn't dig after root causes or an explanation for why it doesn't clobber all CSS parts.

