### PR TITLE
[components] Make a distinction between onClickOutside and onClose dialog events

### DIFF
--- a/packages/@sanity/components/src/dialogs/DefaultDialog.js
+++ b/packages/@sanity/components/src/dialogs/DefaultDialog.js
@@ -23,6 +23,7 @@ export default class DefaultDialog extends React.PureComponent {
     onOpen: PropTypes.func,
     onClose: PropTypes.func,
     onEscape: PropTypes.func,
+    onClickOutside: PropTypes.func,
     onAction: PropTypes.func,
     showCloseButton: PropTypes.bool,
     actionsAlign: PropTypes.oneOf(['start', 'end']),
@@ -138,7 +139,16 @@ export default class DefaultDialog extends React.PureComponent {
   }
 
   render() {
-    const {title, actions, color, onClose, onEscape, className, showCloseButton} = this.props
+    const {
+      title,
+      actions,
+      color,
+      onClose,
+      onClickOutside,
+      onEscape,
+      className,
+      showCloseButton
+    } = this.props
     const {contentHasOverflow} = this.state
     const classNames = `
       ${styles.root}
@@ -157,7 +167,7 @@ export default class DefaultDialog extends React.PureComponent {
               <div className={styles.dialog}>
                 <Escapable onEscape={event => (isActive || event.shiftKey) && handleEscape()} />
                 <CaptureOutsideClicks
-                  onClickOutside={isActive ? onClose : undefined}
+                  onClickOutside={isActive ? onClickOutside : undefined}
                   className={styles.inner}
                 >
                   {!title &&

--- a/packages/@sanity/default-layout/src/components/CurrentVersionsDialog.js
+++ b/packages/@sanity/default-layout/src/components/CurrentVersionsDialog.js
@@ -8,7 +8,7 @@ function CurrentVersionsDialog(props) {
   const {onClose, versions} = props
 
   return (
-    <Dialog isOpen onClose={onClose}>
+    <Dialog isOpen onClose={onClose} onClickOutside={onClose}>
       <div className={styles.content}>
         <div>
           <h2>Studio is up to date</h2>

--- a/packages/@sanity/default-layout/src/components/UpdateNotifierDialog.js
+++ b/packages/@sanity/default-layout/src/components/UpdateNotifierDialog.js
@@ -79,7 +79,7 @@ class UpdateNotifierDialog extends Component {
   render() {
     const {severity, onClose} = this.props
     return (
-      <Dialog isOpen onClose={onClose}>
+      <Dialog isOpen onClose={onClose} onClickOutside={onClose}>
         <div className={styles.content}>
           <div>
             <h2>{severity === 'low' ? 'New versions available' : 'Studio is outdated'}</h2>


### PR DESCRIPTION
This adds a distinction between onClickOutside and onClose on the `DefaultDialog` component. These events is currently conflated in a single `onClose` event.

Being able to distinguish between these events makes it possible to disable close on _click outside_ for array item edit dialog, which again fixes an issue with the default input for `datetime` types. The current onClickOutside handling could potentially also have caused issues for other custom inputs that renders parts of its UI in portals.