### PR TITLE
[schema] Ensure that members declaration is an array

### DIFF
--- a/packages/@sanity/schema/src/sanity/groupProblems.js
+++ b/packages/@sanity/schema/src/sanity/groupProblems.js
@@ -1,4 +1,5 @@
 import {get, flatten} from 'lodash'
+import {error} from './validation/createValidationResult'
 
 function createTypeWithMembersProblemsAccessor(
   memberPropertyName,
@@ -8,10 +9,17 @@ function createTypeWithMembersProblemsAccessor(
     const currentPath = [...parentPath, {kind: 'type', type: type.type, name: type.name}]
     const members = getMembers(type) || []
 
-    const memberProblems = members.map(memberType => {
-      const memberPath = [...currentPath, {kind: 'property', name: memberPropertyName}]
-      return getTypeProblems(memberType, memberPath)
-    })
+    const memberProblems = Array.isArray(members)
+      ? members.map(memberType => {
+          const memberPath = [...currentPath, {kind: 'property', name: memberPropertyName}]
+          return getTypeProblems(memberType, memberPath)
+        })
+      : [
+          {
+            path: currentPath,
+            problems: [error(`Member declaration (${memberPropertyName}) is not an array`)]
+          }
+        ]
 
     return [
       {


### PR DESCRIPTION
When a schema declaration has a `fields` declaration (for instance) that is _assumed_ to be an array, we blindly try to iterate over it. This PR introduces an array check and falls back to filling the problems with a member declaration error. 