### PR TITLE
[export] Fix bug where streams would be reused across invocations

### DIFF
--- a/packages/@sanity/export/src/filterDrafts.js
+++ b/packages/@sanity/export/src/filterDrafts.js
@@ -2,10 +2,11 @@ const miss = require('mississippi')
 
 const isDraft = doc => doc && doc._id && doc._id.indexOf('drafts.') === 0
 
-module.exports = miss.through.obj((doc, enc, callback) => {
-  if (isDraft(doc)) {
-    return callback()
-  }
+module.exports = () =>
+  miss.through.obj((doc, enc, callback) => {
+    if (isDraft(doc)) {
+      return callback()
+    }
 
-  return callback(null, doc)
-})
+    return callback(null, doc)
+  })

--- a/packages/@sanity/export/src/filterSystemDocuments.js
+++ b/packages/@sanity/export/src/filterSystemDocuments.js
@@ -3,11 +3,12 @@ const debug = require('./debug')
 
 const isSystemDocument = doc => doc && doc._id && doc._id.indexOf('_.') === 0
 
-module.exports = miss.through.obj((doc, enc, callback) => {
-  if (isSystemDocument(doc)) {
-    debug('%s is a system document, skipping', doc && doc._id)
-    return callback()
-  }
+module.exports = () =>
+  miss.through.obj((doc, enc, callback) => {
+    if (isSystemDocument(doc)) {
+      debug('%s is a system document, skipping', doc && doc._id)
+      return callback()
+    }
 
-  return callback(null, doc)
-})
+    return callback(null, doc)
+  })

--- a/packages/@sanity/export/src/logFirstChunk.js
+++ b/packages/@sanity/export/src/logFirstChunk.js
@@ -1,0 +1,15 @@
+const miss = require('mississippi')
+const debug = require('./debug')
+
+module.exports = () => {
+  let firstChunk = true
+  return miss.through((chunk, enc, callback) => {
+    if (firstChunk) {
+      const string = chunk.toString('utf8').split('\n')[0]
+      debug('First chunk received: %s', string.slice(0, 300))
+      firstChunk = false
+    }
+
+    callback(null, chunk)
+  })
+}

--- a/packages/@sanity/export/src/rejectOnApiError.js
+++ b/packages/@sanity/export/src/rejectOnApiError.js
@@ -1,10 +1,11 @@
 const miss = require('mississippi')
 
-module.exports = miss.through.obj((doc, enc, callback) => {
-  if (doc.error && doc.statusCode) {
-    callback(new Error([doc.statusCode, doc.error].join(': ')))
-    return
-  }
+module.exports = () =>
+  miss.through.obj((doc, enc, callback) => {
+    if (doc.error && doc.statusCode) {
+      callback(new Error([doc.statusCode, doc.error].join(': ')))
+      return
+    }
 
-  callback(null, doc)
-})
+    callback(null, doc)
+  })

--- a/packages/@sanity/export/src/stringifyStream.js
+++ b/packages/@sanity/export/src/stringifyStream.js
@@ -1,5 +1,4 @@
 const miss = require('mississippi')
 
-module.exports = miss.through.obj((doc, enc, callback) =>
-  callback(null, `${JSON.stringify(doc)}\n`)
-)
+module.exports = () =>
+  miss.through.obj((doc, enc, callback) => callback(null, `${JSON.stringify(doc)}\n`))


### PR DESCRIPTION
Has been working so far because people usually only export once per node.js process.
This should fix it by calling functions that return new streams on each invocation