### PR TITLE
[schema] Add missing fields to span type

### DIFF
--- a/packages/@sanity/schema/src/legacy/types/blocks/span.js
+++ b/packages/@sanity/schema/src/legacy/types/blocks/span.js
@@ -18,6 +18,19 @@ const SPAN_CORE = {
   jsonType: 'object'
 }
 
+const MARKS_FIELD = {
+  name: 'marks',
+  title: 'Marks',
+  type: 'array',
+  of: [{type: 'string'}]
+}
+
+const TEXT_FIELD = {
+  name: 'text',
+  title: 'Text',
+  type: 'string'
+}
+
 const DEFAULT_OPTIONS = {}
 
 export const SpanType = {
@@ -27,7 +40,9 @@ export const SpanType = {
   extend(subTypeDef, extendMember) {
     const options = {...(subTypeDef.options || DEFAULT_OPTIONS)}
 
-    const {fields = [], annotations = [], marks = []} = subTypeDef
+    const {annotations = [], marks = []} = subTypeDef
+
+    const fields = [MARKS_FIELD, TEXT_FIELD]
 
     const parsed = Object.assign(pick(SPAN_CORE, INHERITED_FIELDS), subTypeDef, {
       type: SPAN_CORE,


### PR DESCRIPTION
This PR adds the two missing fields `marks` and `text` to the `span` type, as well as removing the ability to pass custom fields. Since we're never exposing the span configuration other than through the block type, I don't think this should cause any problems.

 Necessary for the GraphQL API to have visibility of these fields.