### PR TITLE
[form-builder] Remove unsupported scrollTo fn call with Microsoft Edge

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/plugins/ScrollAbsoluteTopBottomPlugin.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/plugins/ScrollAbsoluteTopBottomPlugin.js
@@ -2,6 +2,18 @@
 
 // This plugin scrolls the scrollcontainer to absolute top or bottom if first block or last block is selected
 
+function scrollToTop(scrollContainer, isEdge) {
+  if (window.navigator.userAgent.indexOf('Edge') > -1) {
+    scrollContainer.scrollTop = 0
+    return
+  }
+  scrollContainer.scrollTo({
+    left: 0,
+    top: 0,
+    behavior: 'smooth'
+  })
+}
+
 export default function ScrollAbsoluteTopBottomPlugin(scrollContainer: ElementRef<any>) {
   return {
     // eslint-disable-next-line complexity
@@ -17,11 +29,7 @@ export default function ScrollAbsoluteTopBottomPlugin(scrollContainer: ElementRe
         const isFirstBlock = focusBlock.key === document.nodes.first().key
         const isStartOffset = selection.focus.offset === 0
         if (isFirstBlock && isStartOffset) {
-          scrollContainer.current.scrollTo({
-            left: 0,
-            top: 0,
-            behavior: 'smooth'
-          })
+          scrollToTop(scrollContainer.current)
         }
       }
       return next()

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/styles/BlockEditor.css
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/styles/BlockEditor.css
@@ -40,7 +40,7 @@
 
   @nest .fullscreen & {
     position: absolute;
-    top: 0;
+    top: 60px;
     left: 0;
     height: 100vh;
     width: 100vw;
@@ -71,7 +71,7 @@
 .fullscreen .editorWrapper {
   max-width: 50em;
   min-height: 90vh;
-  margin: 3rem auto;
+  margin: 0 auto;
   background-color: var(--input-bg);
   width: 95vw;
   box-sizing: border-box;

--- a/packages/@sanity/schema/src/legacy/types/blocks/span.js
+++ b/packages/@sanity/schema/src/legacy/types/blocks/span.js
@@ -18,6 +18,19 @@ const SPAN_CORE = {
   jsonType: 'object'
 }
 
+const MARKS_FIELD = {
+  name: 'marks',
+  title: 'Marks',
+  type: 'array',
+  of: [{type: 'string'}]
+}
+
+const TEXT_FIELD = {
+  name: 'text',
+  title: 'Text',
+  type: 'string'
+}
+
 const DEFAULT_OPTIONS = {}
 
 export const SpanType = {
@@ -27,7 +40,9 @@ export const SpanType = {
   extend(subTypeDef, extendMember) {
     const options = {...(subTypeDef.options || DEFAULT_OPTIONS)}
 
-    const {fields = [], annotations = [], marks = []} = subTypeDef
+    const {annotations = [], marks = []} = subTypeDef
+
+    const fields = [MARKS_FIELD, TEXT_FIELD]
 
     const parsed = Object.assign(pick(SPAN_CORE, INHERITED_FIELDS), subTypeDef, {
       type: SPAN_CORE,


### PR DESCRIPTION
Also, adjust fullscreen block editor elements  top positions to get a more correct scrollTop position for the scroll container.