### PR TITLE
[cli] Allow reconfiguring studio projects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ script:
   - sanity build
 
   # Test initializing a project in unattended mode
+  - cd /tmp
   - sanity init -y --project=ppsg7ml5 --dataset=test --output-path=/tmp/test-project
 
   # Use the newly commited changes instead of the latest dependencies from NPM

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,10 +33,10 @@ test_script:
 
   # Test initializing a project in unattended mode
   - mkdir %APPVEYOR_BUILD_FOLDER%\tmp
+  - cd %APPVEYOR_BUILD_FOLDER%\tmp
   - sanity init -y --project=ppsg7ml5 --dataset=test --output-path=%APPVEYOR_BUILD_FOLDER%\tmp
 
   # Use the newly commited changes instead of the latest dependencies from NPM
-  - cd %APPVEYOR_BUILD_FOLDER%\tmp
   - node %APPVEYOR_BUILD_FOLDER%\scripts\symlinkDependencies.js .
 
   # Test building the project with latest dependencies

--- a/packages/@sanity/cli/src/actions/init-project/initProject.js
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.js
@@ -59,7 +59,7 @@ export default async function initSanity(args, context) {
     reconfigure = await promptImplicitReconfigure(prompt)
     if (!reconfigure) {
       print(
-        'Init cancelled. If you want to create a new project, try running `sanity init` in an empty folder!'
+        'Init cancelled. If you want to create a new project, try running `sanity init` in an empty folder'
       )
       return
     }

--- a/packages/@sanity/cli/src/actions/init-project/initProject.js
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.js
@@ -68,20 +68,19 @@ export default async function initSanity(args, context) {
   }
 
   if (reconfigure) {
-    print(`You're reconfiguring an existing Sanity project!`)
+    print(`The Sanity Studio in this folder will be tied to a new project on Sanity.io!`)
     if (hasProjectId) {
-      print('Selected values will overwrite any previously set values')
+      print('The previous project configuration will be overwritten.')
     }
-
-    print('')
+    print(`We're first going to make sure you have an account with Sanity.io. Hang on.`)
+    print('Press ctrl + C at any time to quit.\n')
   } else {
     print(`You're setting up a new project!`)
+    print(`We'll make sure you have an account with Sanity.io. Then we'll`)
+    print('install an open-source JS content editor that connects to')
+    print('the real-time hosted API on Sanity.io. Hang on.')
+    print('Press ctrl + C at any time to quit.\n')
   }
-
-  print(`We'll make sure you have an account with Sanity.io. Then we'll`)
-  print('locally install an open-source JS content editor that connects to')
-  print('the real-time hosted API on Sanity.io. Hang on.')
-  print('Press ctrl + C at any time to quit.\n')
 
   // If the user isn't already authenticated, make it so
   const userConfig = getUserConfig()
@@ -553,7 +552,7 @@ function promptImplicitReconfigure(prompt) {
   return prompt.single({
     type: 'confirm',
     message:
-      'The current folder holds a configured Sanity studio. Would you like to reconfigure it?',
+      'The current folder contains a configured Sanity studio. Would you like to reconfigure it?',
     default: true
   })
 }

--- a/packages/@sanity/cli/src/actions/init-project/initProject.js
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.js
@@ -24,14 +24,60 @@ const sanityEnv = process.env.SANITY_ENV
 const environment = sanityEnv ? sanityEnv : process.env.NODE_ENV
 /* eslint-enable no-process-env */
 
-// eslint-disable-next-line max-statements
+// eslint-disable-next-line max-statements, complexity
 export default async function initSanity(args, context) {
   const {output, prompt, workDir, apiClient, yarn, chalk} = context
   const cliFlags = args.extOptions
   const unattended = cliFlags.y || cliFlags.yes
   const print = unattended ? noop : output.print
+  let reconfigure = cliFlags.reconfigure
 
-  print(`You're setting up a new project!`)
+  // Check if we have a project manifest already
+  const manifestPath = path.join(workDir, 'sanity.json')
+  let inProjectContext = false
+  let projectManifest
+  try {
+    projectManifest = await fse.readJson(manifestPath)
+    inProjectContext = Boolean(projectManifest.root)
+  } catch (err) {
+    // Intentional noop
+  }
+
+  // If explicitly reconfiguring, make sure we have something to reconfigure
+  if (reconfigure && !inProjectContext) {
+    throw new Error(
+      projectManifest
+        ? 'Reconfigure flag passed, but no `sanity.json` found'
+        : 'Reconfigure flag passed, but `sanity.json` does not have "root" property set'
+    )
+  }
+
+  // If we are in a Sanity studio project folder and the project manifest has projectId/dataset,
+  // ASK if we want to reconfigure. If no projectId/dataset is present, we assume reconfigure
+  const hasProjectId = projectManifest && projectManifest.api && projectManifest.api.projectId
+  if (hasProjectId && !reconfigure) {
+    reconfigure = await promptImplicitReconfigure(prompt)
+    if (!reconfigure) {
+      print(
+        'Init cancelled. If you want to create a new project, try running `sanity init` in an empty folder!'
+      )
+      return
+    }
+  } else {
+    reconfigure = inProjectContext
+  }
+
+  if (reconfigure) {
+    print(`You're reconfiguring an existing Sanity project!`)
+    if (hasProjectId) {
+      print('Selected values will overwrite any previously set values')
+    }
+
+    print('')
+  } else {
+    print(`You're setting up a new project!`)
+  }
+
   print(`We'll make sure you have an account with Sanity.io. Then we'll`)
   print('locally install an open-source JS content editor that connects to')
   print('the real-time hosted API on Sanity.io. Hang on.')
@@ -71,69 +117,117 @@ export default async function initSanity(args, context) {
 
   debug(`Dataset with name ${datasetName} selected`)
 
-  // Gather project defaults based on environment
-  const defaults = await getProjectDefaults(workDir, {isPlugin: false, context})
+  let outputPath = workDir
+  let successMessage
+  let defaults
 
-  // Prompt the user for required information
-  const answers = await getProjectInfo()
+  if (reconfigure) {
+    // Rewrite project manifest (sanity.json)
+    const projectInfo = projectManifest.project || {}
+    const newProps = {
+      root: true,
+      api: {
+        ...(projectManifest.api || {}),
+        projectId,
+        dataset: datasetName
+      },
+      project: {
+        ...projectInfo,
+        // Keep original name if present
+        name: projectInfo.name || displayName
+      }
+    }
 
-  // Ensure we are using the output path provided by user
-  const outputPath = answers.outputPath || workDir
+    // Ensure root, api and project keys are at top to follow sanity.json key order convention
+    projectManifest = {
+      ...newProps,
+      ...projectManifest,
+      ...newProps
+    }
 
-  // Prompt for template to use
-  const templateName = await selectProjectTemplate()
+    await fse.outputJSON(manifestPath, projectManifest, {spaces: 2})
 
-  // Build a full set of resolved options
-  const initOptions = {
-    template: templateName,
-    outputDir: outputPath,
-    name: sluggedName,
-    displayName: displayName,
-    dataset: datasetName,
-    projectId: projectId,
-    ...answers
-  }
+    const hasNodeModules = await fse.pathExists(path.join(workDir, 'node_modules'))
+    if (hasNodeModules) {
+      print('Skipping installation of dependencies since node_modules exists.')
+      print('Run sanity install to reinstall dependencies')
+    } else {
+      try {
+        await yarn(['install'], {...output, rootDir: workDir})
+      } catch (err) {
+        throw err
+      }
+    }
+  } else {
+    // Gather project defaults based on environment
+    defaults = await getProjectDefaults(workDir, {isPlugin: false, context})
 
-  const template = templates[templateName]
-  if (!template) {
-    throw new Error(`Template "${templateName}" not found`)
-  }
+    // Prompt the user for required information
+    const answers = await getProjectInfo()
 
-  // If the template has a sample dataset, prompt the user whether or not we should import it
-  const shouldImport =
-    !unattended && template.datasetUrl && (await promptForDatasetImport(template.importPrompt))
+    // Ensure we are using the output path provided by user
+    outputPath = answers.outputPath || workDir
 
-  // Bootstrap Sanity, creating required project files, manifests etc
-  await bootstrapTemplate(initOptions, context)
+    // Prompt for template to use
+    const templateName = await selectProjectTemplate()
 
-  // Now for the slow part... installing dependencies
-  try {
-    await yarn(['install'], {...output, rootDir: outputPath})
-  } catch (err) {
-    throw err
-  }
+    // Build a full set of resolved options
+    const initOptions = {
+      template: templateName,
+      outputDir: outputPath,
+      name: sluggedName,
+      displayName: displayName,
+      dataset: datasetName,
+      projectId: projectId,
+      ...answers
+    }
 
-  // Make sure we have the required configs
-  const coreCommands = dynamicRequire(resolveFrom.silent(outputPath, '@sanity/core')).commands
-  const configCheckCmd = coreCommands.find(cmd => cmd.name === 'configcheck')
-  await configCheckCmd.action(
-    {extOptions: {quiet: true}},
-    Object.assign({}, context, {
-      workDir: outputPath
-    })
-  )
+    const template = templates[templateName]
+    if (!template) {
+      throw new Error(`Template "${templateName}" not found`)
+    }
 
-  // Prompt for dataset import (if a dataset is defined)
-  if (shouldImport) {
-    await doDatasetImport()
-  }
+    // If the template has a sample dataset, prompt the user whether or not we should import it
+    const shouldImport =
+      !unattended && template.datasetUrl && (await promptForDatasetImport(template.importPrompt))
 
-  if (shouldImport) {
-    print('')
-    print('If you want to delete the imported data, use')
-    print(`\t${chalk.cyan(`sanity dataset delete ${datasetName}`)}`)
-    print('and create a new clean dataset with')
-    print(`\t${chalk.cyan(`sanity dataset create <name>`)}\n`)
+    // Bootstrap Sanity, creating required project files, manifests etc
+    await bootstrapTemplate(initOptions, context)
+
+    // Now for the slow part... installing dependencies
+    try {
+      await yarn(['install'], {...output, rootDir: outputPath})
+    } catch (err) {
+      throw err
+    }
+
+    // Make sure we have the required configs
+    const coreCommands = dynamicRequire(resolveFrom.silent(outputPath, '@sanity/core')).commands
+    const configCheckCmd = coreCommands.find(cmd => cmd.name === 'configcheck')
+    await configCheckCmd.action(
+      {extOptions: {quiet: true}},
+      Object.assign({}, context, {
+        workDir: outputPath
+      })
+    )
+
+    // Prompt for dataset import (if a dataset is defined)
+    if (shouldImport) {
+      await doDatasetImport()
+    }
+
+    if (shouldImport) {
+      print('')
+      print('If you want to delete the imported data, use')
+      print(`\t${chalk.cyan(`sanity dataset delete ${datasetName}`)}`)
+      print('and create a new clean dataset with')
+      print(`\t${chalk.cyan(`sanity dataset create <name>`)}\n`)
+    }
+
+    // See if the template has a success message handler and print it
+    successMessage = template.getSuccessMessage
+      ? template.getSuccessMessage(initOptions, context)
+      : ''
   }
 
   print(`\n${chalk.green('Success!')} Now what?\n`)
@@ -147,11 +241,6 @@ export default async function initSanity(args, context) {
   print(`▪ ${chalk.cyan('sanity manage')} to open the project settings in a browser`)
   print(`▪ ${chalk.cyan('sanity help')} to explore the CLI manual`)
   print(`▪ ${chalk.green('sanity start')} to run your studio\n`)
-
-  // See if the template has a success message handler and print it
-  const successMessage = template.getSuccessMessage
-    ? template.getSuccessMessage(initOptions, context)
-    : ''
 
   if (successMessage) {
     print(`\n${successMessage}`)
@@ -458,6 +547,15 @@ export default async function initSanity(args, context) {
 
     return cliFlags
   }
+}
+
+function promptImplicitReconfigure(prompt) {
+  return prompt.single({
+    type: 'confirm',
+    message:
+      'The current folder holds a configured Sanity studio. Would you like to reconfigure it?',
+    default: true
+  })
 }
 
 function validateEmptyPath(dir) {

--- a/packages/@sanity/cli/src/commands/init/initCommand.js
+++ b/packages/@sanity/cli/src/commands/init/initCommand.js
@@ -10,6 +10,7 @@ Options
   --template <template> Project template to use [default: "clean"]
   --visibility <mode> Visibility mode for dataset (public/private)
   --create-project <name> Create a new project with the given name
+  --reconfigure Reconfigure Sanity studio in current folder with new project/dataset
 
 Examples
   # Initialize a new project, prompt for required information along the way

--- a/packages/@sanity/core/src/actions/start/startAction.js
+++ b/packages/@sanity/core/src/actions/start/startAction.js
@@ -1,15 +1,22 @@
 import path from 'path'
 import chalk from 'chalk'
+import fse from 'fs-extra'
+import {isPlainObject} from 'lodash'
 import {promisify} from 'es6-promisify'
 import {getDevServer} from '@sanity/server'
 import getConfig from '@sanity/util/lib/getConfig'
+import chooseDatasetPrompt from '../dataset/chooseDatasetPrompt'
 import {tryInitializePluginConfigs} from '../../actions/config/reinitializePluginConfigs'
 import checkReactCompatibility from '../../util/checkReactCompatibility'
+import debug from '../../debug'
 import {formatMessage, isLikelyASyntaxError} from './formatMessage'
 
 export default async (args, context) => {
   const flags = args.extOptions
   const {output, workDir} = context
+
+  await ensureProjectConfig(context)
+
   const sanityConfig = getConfig(workDir)
   const config = sanityConfig.get('server')
   const {port, hostname} = config
@@ -81,9 +88,7 @@ export default async (args, context) => {
       printWarnings(output, warnings)
     }
 
-    output.print(
-      chalk.green(`Content Studio listening on http://${httpHost}:${httpPort}`)
-    )
+    output.print(chalk.green(`Content Studio listening on http://${httpHost}:${httpPort}`))
   })
 
   function resetSpinner() {
@@ -95,6 +100,71 @@ export default async (args, context) => {
   }
 }
 
+async function ensureProjectConfig(context) {
+  const {workDir, output} = context
+  const manifestPath = path.join(workDir, 'sanity.json')
+  const projectManifest = await fse.readJson(manifestPath)
+  const apiConfig = projectManifest.api
+  if (typeof apiConfig !== 'undefined' && !isPlainObject(apiConfig)) {
+    throw new Error('Invalid `api` property in `sanity.json` - should be an object')
+  }
+
+  let displayName = projectManifest.project && projectManifest.project.displayName
+  let {projectId, dataset} = apiConfig || {}
+  const configMissing = !projectId || !dataset
+  if (!configMissing) {
+    return
+  }
+
+  output.print('Project configuration required before starting studio')
+  output.print('')
+
+  if (!projectId) {
+    const selected = await getOrCreateProject(context)
+    projectId = selected.projectId
+    displayName = selected.displayName
+  }
+
+  if (!dataset) {
+    const client = context
+      .apiClient({requireUser: true, requireProject: false})
+      .config({projectId, useProjectHostname: true})
+
+    const apiClient = () => client
+    const projectContext = {...context, apiClient}
+    dataset = await chooseDatasetPrompt(projectContext, {allowCreation: true})
+  }
+
+  // Rewrite project manifest (sanity.json)
+  const projectInfo = projectManifest.project || {}
+  const newProps = {
+    root: true,
+    api: {
+      ...(projectManifest.api || {}),
+      projectId,
+      dataset
+    },
+    project: {
+      ...projectInfo,
+      // Keep original name if present
+      name: projectInfo.name || displayName
+    }
+  }
+
+  // Ensure root, api and project keys are at top to follow sanity.json key order convention
+  await fse.outputJSON(
+    manifestPath,
+    {
+      ...newProps,
+      ...projectManifest,
+      ...newProps
+    },
+    {spaces: 2}
+  )
+
+  output.print('Project ID / dataset configured')
+}
+
 function resolveStaticPath(rootDir, config) {
   const {staticPath} = config
   return path.isAbsolute(staticPath) ? staticPath : path.resolve(path.join(rootDir, staticPath))
@@ -102,9 +172,7 @@ function resolveStaticPath(rootDir, config) {
 
 function gracefulDeath(httpHost, config, err) {
   if (err.code === 'EADDRINUSE') {
-    throw new Error(
-      'Port number is already in use, configure `server.port` in `sanity.json`'
-    )
+    throw new Error('Port number is already in use, configure `server.port` in `sanity.json`')
   }
 
   if (err.code === 'EACCES') {
@@ -113,7 +181,9 @@ function gracefulDeath(httpHost, config, err) {
         ? 'port numbers below 1024 requires root privileges'
         : `do you have access to listen to the given host (${httpHost})?`
 
-    throw new Error(`The Content Studio server does not have access to listen to given port - ${help}`) // eslint-disable-line max-len
+    throw new Error(
+      `The Content Studio server does not have access to listen to given port - ${help}`
+    ) // eslint-disable-line max-len
   }
 
   throw err
@@ -138,8 +208,71 @@ function printWarnings(output, warnings) {
   output.print(chalk.yellow('Compiled with warnings.'))
   output.print()
 
-  warnings.map(message => `Warning in ${formatMessage(message)}`).forEach(message => {
-    output.print(message)
-    output.print()
+  warnings
+    .map(message => `Warning in ${formatMessage(message)}`)
+    .forEach(message => {
+      output.print(message)
+      output.print()
+    })
+}
+
+async function getOrCreateProject(context) {
+  const {prompt, apiClient} = context
+
+  let projects
+  try {
+    projects = await apiClient({requireProject: false}).projects.list()
+  } catch (err) {
+    throw new Error(`Failed to communicate with the Sanity API:\n${err.message}`)
+  }
+
+  if (projects.length === 0) {
+    debug('No projects found for user, prompting for name')
+    const projectName = await prompt.single({message: 'Project name'})
+    return createProject(apiClient, {displayName: projectName})
+  }
+
+  debug(`User has ${projects.length} project(s) already, showing list of choices`)
+
+  const projectChoices = projects.map(project => ({
+    value: project.id,
+    name: `${project.displayName} [${project.id}]`
+  }))
+
+  const selected = await prompt.single({
+    message: 'Select project to use',
+    type: 'list',
+    choices: [{value: 'new', name: 'Create new project'}, new prompt.Separator(), ...projectChoices]
   })
+
+  if (selected === 'new') {
+    debug('User wants to create a new project, prompting for name')
+    return createProject(apiClient, {
+      displayName: await prompt.single({
+        message: 'Informal name for your project'
+      })
+    })
+  }
+
+  debug(`Returning selected project (${selected})`)
+  return {
+    projectId: selected,
+    displayName: projects.find(proj => proj.id === selected).displayName
+  }
+}
+
+function createProject(apiClient, options) {
+  return apiClient({
+    requireUser: true,
+    requireProject: false
+  })
+    .request({
+      method: 'POST',
+      uri: '/projects',
+      body: options
+    })
+    .then(response => ({
+      projectId: response.projectId || response.id,
+      displayName: options.displayName || ''
+    }))
 }


### PR DESCRIPTION
This PR introduces the ability to configure the project ID and dataset of a studio project in the following cases:

- When running `sanity init` in a studio folder with the `--reconfigure` flag
- When running `sanity init` in a studio folder that has no `projectId` in `sanity.json` (prompts for confirmation first)
- When running `sanity start` in a studio folder that has no `projectId` in `sanity.json`

This allows a user to more easily "restart" a project, or ship a template for a studio that can easily by bootstrapped.