### PR TITLE
[cli] Make minor changes to copy

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.js
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.js
@@ -72,7 +72,7 @@ export default async function initSanity(args, context) {
     if (hasProjectId) {
       print('The previous project configuration will be overwritten.')
     }
-    print(`We're first going to make sure you have an account with Sanity. Hang on.`)
+    print(`We're first going to make sure you have an account with Sanity.io. Hang on.`)
     print('Press ctrl + C at any time to quit.\n')
   } else {
     print(`You're setting up a new project!`)

--- a/packages/@sanity/cli/src/actions/init-project/initProject.js
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.js
@@ -68,20 +68,19 @@ export default async function initSanity(args, context) {
   }
 
   if (reconfigure) {
-    print(`You're reconfiguring an existing Sanity project!`)
+    print(`The Sanity Studio in this folder will be tied to a new project on Sanity.io!`)
     if (hasProjectId) {
-      print('Selected values will overwrite any previously set values')
+      print('The previous project configuration will be overwritten.')
     }
-
-    print('')
+    print(`We're first going to make sure you have an account with Sanity. Hang on.`)
+    print('Press ctrl + C at any time to quit.\n')
   } else {
     print(`You're setting up a new project!`)
+    print(`We'll make sure you have an account with Sanity.io. Then we'll`)
+    print('install an open-source JS content editor that connects to')
+    print('the real-time hosted API on Sanity.io. Hang on.')
+    print('Press ctrl + C at any time to quit.\n')
   }
-
-  print(`We'll make sure you have an account with Sanity.io. Then we'll`)
-  print('locally install an open-source JS content editor that connects to')
-  print('the real-time hosted API on Sanity.io. Hang on.')
-  print('Press ctrl + C at any time to quit.\n')
 
   // If the user isn't already authenticated, make it so
   const userConfig = getUserConfig()
@@ -553,7 +552,7 @@ function promptImplicitReconfigure(prompt) {
   return prompt.single({
     type: 'confirm',
     message:
-      'The current folder holds a configured Sanity studio. Would you like to reconfigure it?',
+      'The current folder contains a configured Sanity studio. Would you like to reconfigure it?',
     default: true
   })
 }


### PR DESCRIPTION
Minor changes to copy. Split the introductory text when installing completely new projects and did a slight rewrite for reconfigurations as we can assume more knowledge. Also changed wording under reconfigure as it is slightly unclear what `project` (local JS, sanity.io, etc) refers to here.