### PR TITLE
[desk-tool] Delay reconnect events to fix broken image upload on iOS

### DIFF
--- a/packages/@sanity/desk-tool/src/pane/EditorPane.js
+++ b/packages/@sanity/desk-tool/src/pane/EditorPane.js
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import promiseLatest from 'promise-latest'
-import {merge, of as observableOf} from 'rxjs'
-import {catchError, map, tap} from 'rxjs/operators'
+import {merge, timer, of as observableOf} from 'rxjs'
+import {catchError, switchMap, map, mapTo, tap} from 'rxjs/operators'
 import {validateDocument} from '@sanity/validation'
 import {omit, throttle, debounce} from 'lodash'
 import {FormBuilder, checkoutPair} from 'part:@sanity/form-builder'
@@ -129,6 +129,9 @@ export default withDocumentType(
         draft$.pipe(map(event => ({...event, version: 'draft'})))
       )
         .pipe(
+          switchMap(event =>
+            event.type === 'reconnect' ? timer(500).pipe(mapTo(event)) : observableOf(event)
+          ),
           catchError((err, _caught$) => {
             // eslint-disable-next-line no-console
             console.error(err)


### PR DESCRIPTION
This fixes a rather curious issue we had with image uploads on iOS Safari.

When the listener connection for the document your'e editing disconnects we were setting the form in read only mode while displaying a "connection lost, reconnecting…" message. Since Safari is pretty eager on the energy saving, the _browse image/take a photo dialog_ would cause Safari to shut down open connections (but _only_ after a few seconds). As a consequence - when coming back after taking/selecting a photo, the reconnect event from the listener would trigger, causing the whole form to be set in read only state. This would happen _just_ before the `onchange` event on the file input would normally trigger, but since `onchange` doesn't trigger on read only inputs, nothing would then happen.

This provides a fix for this issue by delaying the reconnect event by 500ms (using a switch which will make any other event received before the 500ms is over to ignore the reconnect event alltogether). In other words - when we now reconnect and the connection gets re-established within 500ms after, we will never display any "reconnect"-message and never set the form in read-only mode, wihch I think is better UX in any case.