### PR TITLE
[base] Support excluding drafts from search

### DIFF
--- a/packages/@sanity/base/src/search/weighted/createWeightedSearch.js
+++ b/packages/@sanity/base/src/search/weighted/createWeightedSearch.js
@@ -37,10 +37,12 @@ export function createWeightedSearch(types, client) {
     const constraints = terms.map((term, i) =>
       combinedSearchPaths.map(joinedPath => `${joinedPath} match $t${i}`)
     )
+
     const filters = [
       '_type in $types',
+      opts.includeDrafts === false && `!(_id in path('drafts.**'))`,
       ...constraints.map(constraint => `(${constraint.join('||')})`)
-    ]
+    ].filter(Boolean)
 
     const query = `*[${filters.join('&&')}][0...$limit]{_type, _id, ...select(${selections.join(
       ',\n'

--- a/packages/@sanity/form-builder/src/sanity/inputs/client-adapters/reference.js
+++ b/packages/@sanity/form-builder/src/sanity/inputs/client-adapters/reference.js
@@ -8,6 +8,8 @@ export function getPreviewSnapshot(value, referenceType) {
 }
 
 export function search(textTerm, referenceType) {
-  const forTypes = createWeightedSearch(referenceType.to, client)
-  return forTypes(textTerm).pipe(map(results => results.map(res => res.hit)))
+  const doSearch = createWeightedSearch(referenceType.to, client)
+  return doSearch(textTerm, {includeDrafts: false}).pipe(
+    map(results => results.map(res => res.hit))
+  )
 }


### PR DESCRIPTION
In #1168 we united the reference search with the global search, so that they both follow the same ranking/weighting rules. This accidentally made draft documents appear in reference search, making it possible to reference drafts. This caused problems when publishing documents later on. This PR provides a fix by adding an `includeDrafts` option (which is true by default).