### PR TITLE
Validate array type of types for object without a name when used in combination with a block type

### DIFF
--- a/packages/@sanity/default-layout/src/components/SchemaErrorReporter.js
+++ b/packages/@sanity/default-layout/src/components/SchemaErrorReporter.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import schema from 'part:@sanity/base/schema'
-import {SchemaErrors} from './SchemaErrors'
+import SchemaErrors from './SchemaErrors'
 
 function renderPath(path) {
   return path

--- a/packages/@sanity/default-layout/src/components/SchemaErrors.js
+++ b/packages/@sanity/default-layout/src/components/SchemaErrors.js
@@ -1,19 +1,22 @@
 import React from 'react'
-import styles from './styles/SchemaErrors.css'
+import PropTypes from 'prop-types'
 import ErrorIcon from 'part:@sanity/base/error-icon'
 import WarningIcon from 'part:@sanity/base/warning-icon'
 import generateHelpUrl from '@sanity/generate-help-url'
+import styles from './styles/SchemaErrors.css'
 
 function renderPath(path) {
   return path
-    .map(segment => {
+    .map((segment, i) => {
+      const key = `s_${i}`
       if (segment.kind === 'type') {
         return (
-          <span className={styles.segment}>
+          <span className={styles.segment} key={key}>
             <span key="name" className={styles.pathSegmentTypeName}>
               {segment.name}
             </span>
-            &ensp;<span key="type" className={styles.pathSegmentTypeType}>
+            &ensp;
+            <span key="type" className={styles.pathSegmentTypeType}>
               {segment.type}
             </span>
           </span>
@@ -21,14 +24,14 @@ function renderPath(path) {
       }
       if (segment.kind === 'property') {
         return (
-          <span className={styles.segment}>
+          <span className={styles.segment} key={key}>
             <span className={styles.pathSegmentProperty}>{segment.name}</span>
           </span>
         )
       }
       if (segment.kind === 'type') {
         return (
-          <span className={styles.segment}>
+          <span className={styles.segment} key={key}>
             <span key="name" className={styles.pathSegmentTypeName}>
               {segment.name}
             </span>
@@ -43,7 +46,7 @@ function renderPath(path) {
     .filter(Boolean)
 }
 
-export function SchemaErrors(props) {
+function SchemaErrors(props) {
   const {problemGroups} = props
   return (
     <div className={styles.root}>
@@ -51,11 +54,11 @@ export function SchemaErrors(props) {
       <ul className={styles.list}>
         {problemGroups.map((group, i) => {
           return (
-            <li key={i} className={styles.listItem}>
+            <li key={`g_${i}`} className={styles.listItem}>
               <h2 className={styles.path}>{renderPath(group.path)}</h2>
               <ul className={styles.problems}>
                 {group.problems.map((problem, j) => (
-                  <li key={j} className={styles[`problem_${problem.severity}`]}>
+                  <li key={`g_${i}_p_${j}`} className={styles[`problem_${problem.severity}`]}>
                     <div className={styles.problemSeverity}>
                       <span className={styles.problemSeverityIcon}>
                         {problem.severity === 'error' && <ErrorIcon />}
@@ -70,6 +73,7 @@ export function SchemaErrors(props) {
                           className={styles.problemLink}
                           href={generateHelpUrl(problem.helpId)}
                           target="_blank"
+                          rel="noopener noreferrer"
                         >
                           View documentation
                         </a>
@@ -85,3 +89,24 @@ export function SchemaErrors(props) {
     </div>
   )
 }
+
+SchemaErrors.propTypes = {
+  problemGroups: PropTypes.arrayOf(
+    PropTypes.shape({
+      path: PropTypes.arrayOf(
+        PropTypes.shape({
+          kind: PropTypes.string,
+          type: PropTypes.string,
+          name: PropTypes.string
+        })
+      ),
+      problems: PropTypes.arrayOf(
+        PropTypes.shape({
+          severity: PropTypes.string
+        })
+      )
+    }).isRequired
+  ).isRequired
+}
+
+export default SchemaErrors

--- a/packages/@sanity/schema/src/sanity/validation/types/array.js
+++ b/packages/@sanity/schema/src/sanity/validation/types/array.js
@@ -20,10 +20,25 @@ export default (typeDef, visitorContext) => {
           HELP_IDS.ARRAY_OF_INVALID
         )
   ])
+  const of = ofIsArray ? typeDef.of : []
+
+  // Don't allow object types without a name in block arrays
+  const hasObjectTypesWithoutName = of.some(
+    type => type.type === 'object' && typeof type.name === 'undefined'
+  )
+  const hasBlockType = of.some(ofType => ofType.type === 'block')
+  if (hasBlockType && hasObjectTypesWithoutName) {
+    problems.push(
+      error(
+        "The array type's 'of' attribute can't have an object type without a .name when used in together with a block type",
+        HELP_IDS.ARRAY_OF_INVALID
+      )
+    )
+  }
 
   return {
     ...typeDef,
-    of: (ofIsArray ? typeDef.of : []).map(visitorContext.visit),
+    of: of.map(visitorContext.visit),
     _problems: problems
   }
 }


### PR DESCRIPTION
When using a type ``block`` in an array, we must validate that it also doesn't use object types without a name, because the block editor is dependent on all the members having names.

In the future we probably should make it an overall requirement that every array member type should have a name.

There is also a commit here that fixes unique keys (we now have warnings) and completes propTypes for the SchemaErrorReporter component.