### PR TITLE
[schema] Allow tel: and mailto: as URI schemes for block link annotation

### DIFF
--- a/packages/@sanity/schema/src/legacy/types/blocks/defaults.js
+++ b/packages/@sanity/schema/src/legacy/types/blocks/defaults.js
@@ -9,7 +9,11 @@ export const DEFAULT_LINK_ANNOTATION = {
       name: 'href',
       type: 'url',
       title: 'Url',
-      validation: Rule => Rule.uri({scheme: ['http', 'https', 'tel', 'mailto']})
+      validation: Rule =>
+        Rule.uri({
+          scheme: ['http', 'https', 'tel', 'mailto'],
+          allowRelative: true
+        })
     }
   ]
 }

--- a/packages/@sanity/schema/src/legacy/types/blocks/defaults.js
+++ b/packages/@sanity/schema/src/legacy/types/blocks/defaults.js
@@ -8,7 +8,8 @@ export const DEFAULT_LINK_ANNOTATION = {
     {
       name: 'href',
       type: 'url',
-      title: 'Url'
+      title: 'Url',
+      validation: Rule => Rule.uri({scheme: ['http', 'https', 'tel', 'mailto']})
     }
   ]
 }


### PR DESCRIPTION
We previously did not do any validation on annotations. After the new block editor, we do.

This PR will allow the mailto and tel schemes in the default link annotation.
