### PR TITLE
[core] Coerce semver to allow prereleases of React

### DIFF
--- a/packages/@sanity/core/src/util/checkReactCompatibility.js
+++ b/packages/@sanity/core/src/util/checkReactCompatibility.js
@@ -35,7 +35,7 @@ module.exports = workDir => {
         )} `
       )
     }
-    if (!semver.satisfies(installed, supported[pkg])) {
+    if (!semver.satisfies(semver.coerce(installed), supported[pkg])) {
       throw new Error(
         `Sanity currently only supports ${pkg}@${supported[pkg]}. Installed version: ${installed}.`
       )


### PR DESCRIPTION
Currently our React version check disallows prereleases of React, which I don't think there are any good reasons to do. This coerces the semver before calling the satisifes check.

For reference
```js
semver.satisfies(semver.coerce('16.8.0-alpha.0'), '^16.2') // true
semver.satisfies(semver.coerce('16.6'), '^16.2') // true
semver.satisfies(semver.coerce('16.1'), '^16.2') // false
semver.satisfies(semver.coerce('17.0.0'), '^16.2') // false
```