### PR TITLE
[form-builder] Include note about the format of _key in the missing keys warning

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ArrayInput/ArrayInput.js
+++ b/packages/@sanity/form-builder/src/inputs/ArrayInput/ArrayInput.js
@@ -340,6 +340,10 @@ export default class ArrayInput extends React.Component<Props, State> {
               This usually happens when items are created through the API client from outside the
               Content Studio and someone forgets to set the <code>_key</code>-property of list
               items.
+              <p>
+                The value of the <code>_key</code> can be any <b>string</b> as long as it is{' '}
+                <b>unique</b> for each element within the array.
+              </p>
             </Details>
           </div>
           {this.renderList()}


### PR DESCRIPTION
This adds a note about the expected format of `_key` in arrays when displaying the _missing keys_ warning

![image](https://user-images.githubusercontent.com/876086/51748212-feedbb00-20ab-11e9-81cf-de5640eb5dcc.png)
