### PR TITLE
[reflector-client] Add basic WebSocket support

### DIFF
--- a/packages/@sanity/reflector-client/package.json
+++ b/packages/@sanity/reflector-client/package.json
@@ -14,7 +14,9 @@
   },
   "dependencies": {
     "@sanity/eventsource": "0.147.0",
-    "rxjs": "^6.5.3"
+    "isomorphic-ws": "^4.0.1",
+    "rxjs": "^6.5.3",
+    "ws": "^6.1.3"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
As the title says - basic.

In the next iteration, I would want to try websockets first, then check if we get a close/error event from the socket before an open event is triggered. In this case, we would switch to EventSource mode instead.  We also need to add reconnect handling to the websocket implementation at some point. Probably a simple task for RxJS extraordinaire @bjoerge :)
