### PR TITLE
[test-studio] Add missing name

### DIFF
--- a/packages/test-studio/schemas/uploads.js
+++ b/packages/test-studio/schemas/uploads.js
@@ -26,6 +26,7 @@ export default {
       of: [
         {type: 'block'},
         {
+          name: 'gallery',
           type: 'object',
           title: 'Gallery',
           fields: [


### PR DESCRIPTION
Fixes a bug that causes this error in test-studio.
<img width="1127" alt="screenshot 2019-01-29 at 12 35 15" src="https://user-images.githubusercontent.com/568562/51906015-38cc0380-23c3-11e9-80e2-4aaa8d718ff4.png">
