### PR TITLE
[schema] Fix block annotation validation not handling certain objects

### DIFF
--- a/packages/@sanity/schema/src/sanity/validation/types/block.js
+++ b/packages/@sanity/schema/src/sanity/validation/types/block.js
@@ -183,7 +183,8 @@ function validateAnnotations(annotations, visitorContext, problems) {
 
     const {_problems} = visitorContext.visit(annotation, visitorContext)
     const targetType = annotation.type && visitorContext.getType(annotation.type)
-    if (targetType && targetType.jsonType !== 'object') {
+    const jsonType = targetType && (targetType.jsonType || targetType.type)
+    if (jsonType && jsonType !== 'object') {
       _problems.push(
         error(
           `Annotation cannot have type "${

--- a/packages/@sanity/schema/src/sanity/validation/types/block.js
+++ b/packages/@sanity/schema/src/sanity/validation/types/block.js
@@ -2,6 +2,7 @@
 import {omit, isPlainObject} from 'lodash'
 import humanizeList from 'humanize-list'
 import {error, warning} from '../createValidationResult'
+import {isJSONTypeOf} from '../utils/isJSONTypeOf'
 
 const getTypeOf = thing => (Array.isArray(thing) ? 'array' : typeof thing)
 const quote = str => `"${str}"`
@@ -183,8 +184,7 @@ function validateAnnotations(annotations, visitorContext, problems) {
 
     const {_problems} = visitorContext.visit(annotation, visitorContext)
     const targetType = annotation.type && visitorContext.getType(annotation.type)
-    const jsonType = targetType && (targetType.jsonType || targetType.type)
-    if (jsonType && jsonType !== 'object') {
+    if (targetType && !isJSONTypeOf(targetType, 'object', visitorContext)) {
       _problems.push(
         error(
           `Annotation cannot have type "${

--- a/packages/@sanity/schema/src/sanity/validation/utils/isJSONTypeOf.js
+++ b/packages/@sanity/schema/src/sanity/validation/utils/isJSONTypeOf.js
@@ -1,0 +1,10 @@
+export function isJSONTypeOf(type, jsonType, visitorContext) {
+  if ('jsonType' in type) {
+    return type.jsonType === jsonType
+  }
+  const parentType = visitorContext.getType(type.type)
+  if (!parentType) {
+    throw new Error(`Could not resolve jsonType of ${type.name}. No parent type found`)
+  }
+  return isJSONTypeOf(parentType, jsonType, visitorContext)
+}

--- a/packages/example-studio/schemas/customBlockEditor.js
+++ b/packages/example-studio/schemas/customBlockEditor.js
@@ -75,6 +75,7 @@ export default {
                   {name: 'href', type: 'string', title: 'Url', validation: Rule => Rule.required()}
                 ]
               },
+              {type: 'videoEmbed'},
               {
                 name: 'author',
                 title: 'Author',


### PR DESCRIPTION
In certain cases, it seems `jsonType` is not returned when validating the schema types. For instance, when using the color schema type as a block annotation, `type` is returned as `object`, but `jsonType` is not present. Maybe @bjoerge has some insight on whether this approach is wrong in the  first place.

Example:
```js
export default {
  name: 'pageBody',
  title: 'Page body',
  type: 'array',
  of: [
    {
      type: 'block',
      marks: {
        annotations: [
          {
            name: 'link',
            title: 'URL',
            type: 'object',
            fields: [
              {
                title: 'URL',
                name: 'href',
                type: 'url'
              }
            ]
          },
          {name: 'color', title: 'Color', type: 'color'}
        ]
      }
    },
    {type: 'image'},
    {type: 'callToAction'},
    {type: 'placeholder'}
  ]
}
```