### PR TITLE
[example-studio] Add duration w/derived seconds input example

### DIFF
--- a/packages/example-studio/components/DurationWithSecondsInput.js
+++ b/packages/example-studio/components/DurationWithSecondsInput.js
@@ -1,0 +1,80 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import {PatchEvent, set, setIfMissing, unset} from 'part:@sanity/form-builder/patch-event'
+import Fieldset from 'part:@sanity/components/fieldsets/default'
+import TextInput from 'part:@sanity/components/textinputs/default'
+
+const durationToSeconds = duration => {
+  const [hh = 0, mm = 0, ss = 0] = duration.split(':').map(Number)
+  return hh * 60 * 60 + mm * 60 + ss
+}
+
+export default class DurationWithSecondsInput extends React.PureComponent {
+  static propTypes = {
+    type: PropTypes.shape({
+      title: PropTypes.string,
+      name: PropTypes.string,
+      fields: PropTypes.array
+    }).isRequired,
+    level: PropTypes.number,
+    value: PropTypes.shape({
+      _type: PropTypes.string,
+      duration: PropTypes.string,
+      asSeconds: PropTypes.number
+    }),
+    onFocus: PropTypes.func.isRequired,
+    onChange: PropTypes.func.isRequired,
+    onBlur: PropTypes.func.isRequired
+  }
+
+  durationInput = React.createRef()
+
+  handleDurationInputChange = event => {
+    const {onChange, type} = this.props
+    const durationInputValue = event.currentTarget.value.trim()
+    if (!durationInputValue) {
+      onChange(PatchEvent.from(unset()))
+      return
+    }
+
+    onChange(
+      PatchEvent.from([
+        setIfMissing({_type: type.name}),
+        set(durationInputValue, ['duration']),
+        set(durationToSeconds(durationInputValue), ['asSeconds'])
+      ])
+    )
+  }
+
+  focus() {
+    this.durationInput.current.focus()
+  }
+
+  render() {
+    const {type, value, level, onFocus, onBlur} = this.props
+    const durationField = type.fields.find(field => field.name === 'duration')
+    const asSecondsField = type.fields.find(field => field.name === 'asSeconds')
+    return (
+      <Fieldset level={level} legend={type.title} description={type.description}>
+        <label>
+          {/* you may want to display additional fields here as well, e.g. description  */}
+          {durationField.type.title}
+          <TextInput
+            type="text"
+            ref={this.durationInput}
+            value={value && value.duration}
+            onChange={this.handleDurationInputChange}
+            placeholder={durationField.type.placeholder}
+            onFocus={onFocus}
+            onBlur={onBlur}
+          />
+        </label>
+        {value && (
+          <div>
+            {asSecondsField.type.title}: {value.asSeconds}
+          </div>
+        )}
+      </Fieldset>
+    )
+  }
+}

--- a/packages/example-studio/schemas/durationWithSeconds.js
+++ b/packages/example-studio/schemas/durationWithSeconds.js
@@ -1,0 +1,18 @@
+import DurationWithSecondsInput from '../components/DurationWithSecondsInput'
+
+export default {
+  type: 'document',
+  name: 'durationWithSecondsExample',
+  fields: [
+    {title: 'Title', name: 'title', type: 'string'},
+    {
+      type: 'object',
+      name: 'durationWithSeconds',
+      fields: [
+        {name: 'duration', title: 'Duration (hh:mm:ss)', type: 'string'},
+        {name: 'asSeconds', title: 'In seconds', type: 'number'}
+      ],
+      inputComponent: DurationWithSecondsInput
+    }
+  ]
+}

--- a/packages/example-studio/schemas/schema.js
+++ b/packages/example-studio/schemas/schema.js
@@ -13,6 +13,7 @@ import protein from '../components/ProteinInput/schema'
 import localeBlockContent from './localeBlockContent'
 import {blockContent} from './blockContent'
 import customBlockEditor from './customBlockEditor'
+import durationWithSeconds from './durationWithSeconds'
 
 export default createSchema({
   name: 'example-blog',
@@ -21,6 +22,7 @@ export default createSchema({
     author,
     code,
     customObject,
+    durationWithSeconds,
     localeString,
     localeBlockContent,
     localeSlug,


### PR DESCRIPTION
This adds an example of how to create a custom input that preserves a user typed value (duration on format `hh:mm:ss`), while at the same time storing a derived value (the duration converted to seconds).