### PR TITLE
[image-url] Now compatible with data from GraphQL apis

### DIFF
--- a/packages/@sanity/image-url/src/parseSource.js
+++ b/packages/@sanity/image-url/src/parseSource.js
@@ -68,19 +68,26 @@ function applyDefaults(image) {
     return image
   }
 
-  return {
-    crop: {
+  // We need to pad in default values for crop or hotspot
+  const result = Object.assign({}, image)
+
+  if (!result.crop) {
+    result.crop = {
       left: 0,
       top: 0,
       bottom: 0,
       right: 0
-    },
-    hotspot: {
+    }
+  }
+
+  if (!result.hotspot) {
+    result.hotspot = {
       x: 0.5,
       y: 0.5,
       height: 1.0,
       width: 1.0
-    },
-    ...image
+    }
   }
+
+  return result
 }

--- a/packages/@sanity/image-url/src/urlForImage.js
+++ b/packages/@sanity/image-url/src/urlForImage.js
@@ -29,7 +29,7 @@ export default function urlForImage(options) {
     return null
   }
 
-  const asset = parseAssetId(image.asset._ref)
+  const asset = parseAssetId(image.asset._ref || image.asset._id)
 
   // Compute crop rect in terms of pixel coordinates in the raw source image
   const crop = {

--- a/packages/@sanity/image-url/test/__snapshots__/builder.test.js.snap
+++ b/packages/@sanity/image-url/test/__snapshots__/builder.test.js.snap
@@ -18,9 +18,13 @@ exports[`builder flip horizontal 1`] = `"flip=h"`;
 
 exports[`builder flip vertical 1`] = `"flip=v"`;
 
+exports[`builder handles crop and hotspot being set to null (GraphQL) 1`] = `"https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg"`;
+
 exports[`builder handles crop but no hotspot 1`] = `"https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg?rect=200,300,1600,2400"`;
 
 exports[`builder handles hotspot but no crop 1`] = `"https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg"`;
+
+exports[`builder handles materialized assets (GraphQL) 1`] = `"https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg"`;
 
 exports[`builder skips hotspot/crop if crop mode specified 1`] = `"https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg?w=100&h=80&crop=center"`;
 

--- a/packages/@sanity/image-url/test/builder.test.js
+++ b/packages/@sanity/image-url/test/builder.test.js
@@ -46,6 +46,36 @@ const cases = [
       })
       .url()
   },
+
+  {
+    name: 'handles crop and hotspot being set to null (GraphQL)',
+    url: urlFor
+      .image({
+        _type: 'image',
+        asset: {
+          _ref: 'image-Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000-jpg',
+          _type: 'reference'
+        },
+        crop: null,
+        hotspot: null
+      })
+      .url()
+  },
+
+  {
+    name: 'handles materialized assets (GraphQL)',
+    url: urlFor
+      .image({
+        _type: 'image',
+        asset: {
+          _id: 'image-Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000-jpg'
+        },
+        crop: null,
+        hotspot: null
+      })
+      .url()
+  },
+
   {
     name: 'constrains aspect ratio',
     url: urlFor


### PR DESCRIPTION
Tolerant to crop/hotspot being null + fetching asset id from _id instead of _ref if asset is materialized.