### PR TITLE
[form-builder] Block editor: reset field on delete all

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Editor.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Editor.js
@@ -36,6 +36,7 @@ import buildEditorSchema from './utils/buildEditorSchema'
 import findInlineByAnnotationKey from './utils/findInlineByAnnotationKey'
 
 import ExpandToWordPlugin from './plugins/ExpandToWordPlugin'
+import EnsureEmptyTextBlockPlugin from './plugins/ensureEmptyTextBlockPlugin'
 import InsertBlockObjectPlugin from './plugins/InsertBlockObjectPlugin'
 import InsertInlineObjectPlugin from './plugins/InsertInlineObjectPlugin'
 import ListItemOnEnterKeyPlugin from './plugins/ListItemOnEnterKeyPlugin'
@@ -153,6 +154,7 @@ export default class Editor extends React.Component<Props> {
       WrapSpanPlugin(),
       InsertInlineObjectPlugin(props.type),
       InsertBlockObjectPlugin(),
+      EnsureEmptyTextBlockPlugin(props.blockContentFeatures),
       UndoRedoPlugin({stack: props.undoRedoStack}),
       FireFoxVoidNodePlugin(),
       FocusNoScrollPlugin(props.scrollContainer),

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Input.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Input.js
@@ -78,9 +78,14 @@ export default class BlockEditorInput extends React.Component<Props, State> {
 
   focus = () => {
     const {focusPath, onFocus, readOnly} = this.props
+    const blockEditor = this.blockEditor && this.blockEditor.current
+    const editor = blockEditor && blockEditor.getEditor()
+
+    if (editor && !readOnly) {
+      editor.command('ensureEmptyTextBlock')
+    }
+
     window.requestAnimationFrame(() => {
-      const blockEditor = this.blockEditor && this.blockEditor.current
-      const editor = blockEditor && blockEditor.getEditor()
       if (editor && !readOnly) {
         editor.focus()
         if (!focusPath || focusPath.length === 0) {

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/plugins/EnsureEmptyTextBlockPlugin.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/plugins/EnsureEmptyTextBlockPlugin.js
@@ -1,0 +1,24 @@
+// @flow
+
+import createEmptyBlock from '../utils/createEmptyBlock'
+import type {SlateEditor, BlockContentFeatures} from '../typeDefs'
+
+export default function InsertEmptyTextBlockPlugin(blockContentFeatures: BlockContentFeatures) {
+  return {
+    onCommand(command: any, editor: SlateEditor, next: void => void) {
+      if (command.type !== 'ensureEmptyTextBlock') {
+        return next()
+      }
+      if (editor.value.document.nodes.size !== 0) {
+        return next()
+      }
+      const block = createEmptyBlock(blockContentFeatures)
+      editor.applyOperation({
+        type: 'insert_node',
+        path: [0],
+        node: block.toJSON({preserveKeys: true, preserveData: true})
+      })
+      return editor
+    }
+  }
+}

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/plugins/QueryPlugin.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/plugins/QueryPlugin.js
@@ -25,12 +25,14 @@ export default function QueryPlugin() {
         case 'activeStyles':
           return value.blocks.map(block => block.data.get('style')).sort()
         case 'hasAnnotation':
-          return value.inlines.filter(inline => inline.type === 'span').some(span => {
-            const annotations = span.data.get('annotations') || {}
-            return Object.keys(annotations).find(
-              key => annotations[key] && annotations[key]._type === query.args[0]
-            )
-          })
+          return value.inlines
+            .filter(inline => inline.type === 'span')
+            .some(span => {
+              const annotations = span.data.get('annotations') || {}
+              return Object.keys(annotations).find(
+                key => annotations[key] && annotations[key]._type === query.args[0]
+              )
+            })
         case 'hasListItem':
           return value.blocks.some(block => {
             return block.data.get('listItem') === query.args[0]

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/buildEditorSchema.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/buildEditorSchema.js
@@ -1,10 +1,5 @@
 // @flow
-
-import {randomKey, normalizeBlock} from '@sanity/block-tools'
-
-import type {BlockContentFeatures, SlateEditor, SlateNode} from '../typeDefs'
-
-import deserialize from './deserialize'
+import type {BlockContentFeatures} from '../typeDefs'
 
 export default function buildEditorSchema(
   blockContentFeatures: BlockContentFeatures,
@@ -19,53 +14,9 @@ export default function buildEditorSchema(
     inlines[type.name] = {isVoid: true}
   })
 
-  function createEmptyBlock() {
-    const key = randomKey(12)
-    return deserialize(
-      [
-        normalizeBlock({
-          _key: key,
-          _type: 'block',
-          children: [
-            {
-              _type: 'span',
-              _key: `${key}0`,
-              text: '',
-              marks: []
-            }
-          ],
-          style: 'normal'
-        })
-      ],
-      blockContentFeatures.types.block
-    ).document.nodes.first()
-  }
-
   return {
     blocks,
     inlines,
-    document: options.withNormalization
-      ? {
-          nodes: [
-            {
-              match: {object: 'block'},
-              min: 1
-            }
-          ],
-          normalize: (
-            editor: SlateEditor,
-            {code, node, child}: {code: string, node: SlateNode, child: SlateNode}
-          ) => {
-            if (code === 'child_min_invalid') {
-              const block = createEmptyBlock()
-              editor.applyOperation({
-                type: 'insert_node',
-                path: [0],
-                node: block.toJSON({preserveKeys: true, preserveData: true})
-              })
-            }
-          }
-        }
-      : {}
+    document: {}
   }
 }

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createEmptyBlock.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createEmptyBlock.js
@@ -1,0 +1,24 @@
+import {randomKey, normalizeBlock} from '@sanity/block-tools'
+import deserialize from './deserialize'
+
+export default function createEmptyBlock(blockContentFeatures) {
+  const key = randomKey(12)
+  return deserialize(
+    [
+      normalizeBlock({
+        _key: key,
+        _type: 'block',
+        children: [
+          {
+            _type: 'span',
+            _key: `${key}0`,
+            text: '',
+            marks: []
+          }
+        ],
+        style: 'normal'
+      })
+    ],
+    blockContentFeatures.types.block
+  ).document.nodes.first()
+}

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createOperationToPatches.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createOperationToPatches.js
@@ -296,6 +296,13 @@ export default function createOperationToPatches(
     afterValue: SlateValue,
     formBuilderValue?: ?(FormBuilderValue[]) // This is optional, but needed for setting setIfMissing patches correctly
   ) {
+    // Check if this is the last contentBlock, and if no text left unset the field
+    if (afterValue.document.nodes.size === 1) {
+      const afterBlock = afterValue.document.nodes.first()
+      if (afterBlock.type === 'contentBlock' && afterBlock.text === '') {
+        return unset([])
+      }
+    }
     switch (operation.type) {
       case 'insert_text':
         return insertTextPatch(operation, beforeValue, afterValue, formBuilderValue)

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createPatchToOperations.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createPatchToOperations.js
@@ -145,6 +145,18 @@ export default function createPatchesToChange(
   }
 
   function unsetPatch(patch: UnsetPatch, editor: SlateEditor) {
+    // Deal with patches unsetting the whole field
+    if (patch.path.length === 0) {
+      editor.value.document.nodes.forEach(node => {
+        editor.applyOperation({
+          type: 'remove_node',
+          path: [0],
+          node: node
+        })
+      })
+      return editor.operations
+    }
+    // Deal with patches unsetting something inside
     const lastKey = findLastKey(patch.path)
     editor.removeNodeByKey(lastKey)
     return editor.operations


### PR DESCRIPTION
Previously when deleting all the editor content, there would be left an empty block in the data (to ensure that it was possible to put the cursor there afterwards). This is now handled better so that the data is completely wiped, but an empty text bock placeholder will be inserted in the editor as soon as it gets focused. The block will be saved as soon as the user begins typing again.

Also this removes the need for the Slate schema normalization of min nodes (always keeping an empty block) which caused a lot of trouble when several clients were using the same document.