### PR TITLE
[block-tools] Fix bug in link deserialization fallback

### DIFF
--- a/packages/@sanity/block-tools/src/HtmlDeserializer/rules/html.js
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/rules/html.js
@@ -195,14 +195,13 @@ export default function createHTMLRules(blockContentType, options = {}) {
             _type: 'link',
             href: href
           }
+          return {
+            _type: '__annotation',
+            markDef: markDef,
+            children: next(el.childNodes)
+          }
         }
-        return {
-          _type: '__annotation',
-          markDef: markDef,
-          children: linkEnabled
-            ? next(el.childNodes)
-            : el.appendChild(el.ownerDocument.createTextNode(` (${href})`)) && next(el.childNodes)
-        }
+        return el.appendChild(el.ownerDocument.createTextNode(` (${href})`)) && next(el.childNodes)
       }
     }
   ]


### PR DESCRIPTION
There were a bug in the HTML Deserializer where when you had not defined a link type (but had other annotation types thus overwriting the default ones), the intended fallback deserialization of anchor tags (write out the hrefs in plain text) errored. This fixes this.