### PR TITLE
[form-builder] Better handling of unsetting field when block editor is empty

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Editor.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Editor.js
@@ -36,12 +36,14 @@ import buildEditorSchema from './utils/buildEditorSchema'
 import findInlineByAnnotationKey from './utils/findInlineByAnnotationKey'
 
 import ExpandToWordPlugin from './plugins/ExpandToWordPlugin'
-import EnsureEmptyTextBlockPlugin from './plugins/ensureEmptyTextBlockPlugin'
+import EnsurePlaceHolderBlockPlugin from './plugins/EnsurePlaceHolderBlockPlugin'
 import InsertBlockObjectPlugin from './plugins/InsertBlockObjectPlugin'
 import InsertInlineObjectPlugin from './plugins/InsertInlineObjectPlugin'
 import ListItemOnEnterKeyPlugin from './plugins/ListItemOnEnterKeyPlugin'
 import ListItemOnTabKeyPlugin from './plugins/ListItemOnTabKeyPlugin'
 import OnDropPlugin from './plugins/OnDropPlugin'
+import OnFocusPlugin from './plugins/OnFocusPlugin'
+import TogglePlaceHolderPlugin from './plugins/TogglePlaceHolderPlugin'
 import PastePlugin from './plugins/PastePlugin'
 import QueryPlugin from './plugins/QueryPlugin'
 import SetBlockStylePlugin from './plugins/SetBlockStylePlugin'
@@ -148,13 +150,16 @@ export default class Editor extends React.Component<Props> {
       }),
       insertBlockOnEnter(EDITOR_DEFAULT_BLOCK_TYPE),
       OnDropPlugin(),
+      OnFocusPlugin(),
+      // OnBlurPlugin(),
+      TogglePlaceHolderPlugin(),
       SetBlockStylePlugin(),
       ToggleAnnotationPlugin(),
       ExpandToWordPlugin(),
       WrapSpanPlugin(),
       InsertInlineObjectPlugin(props.type),
       InsertBlockObjectPlugin(),
-      EnsureEmptyTextBlockPlugin(props.blockContentFeatures),
+      EnsurePlaceHolderBlockPlugin(props.blockContentFeatures),
       UndoRedoPlugin({stack: props.undoRedoStack}),
       FireFoxVoidNodePlugin(),
       FocusNoScrollPlugin(props.scrollContainer),
@@ -238,9 +243,9 @@ export default class Editor extends React.Component<Props> {
     return onChange(editor)
   }
 
-  handleEditorFocus = () => {
-    const {setFocus} = this.props
-    setFocus()
+  handleEditorFocus = (event: any, editor: SlateEditor, next: void => void) => {
+    this.props.setFocus() // Tell the formbuilder to set focus here
+    next() // Continue Slate's focus plugin stack
   }
 
   getValue = () => {

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Input.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Input.js
@@ -80,15 +80,10 @@ export default class BlockEditorInput extends React.Component<Props, State> {
     const {focusPath, onFocus, readOnly} = this.props
     const blockEditor = this.blockEditor && this.blockEditor.current
     const editor = blockEditor && blockEditor.getEditor()
-
-    if (editor && !readOnly) {
-      editor.command('ensureEmptyTextBlock')
-    }
-
     window.requestAnimationFrame(() => {
       if (editor && !readOnly) {
         editor.focus()
-        if (!focusPath || focusPath.length === 0) {
+        if (editor.value.focusBlock && (!focusPath || focusPath.length === 0)) {
           onFocus([{_key: editor.value.focusBlock.key}])
         }
       }

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/plugins/EnsurePlaceHolderBlockPlugin.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/plugins/EnsurePlaceHolderBlockPlugin.js
@@ -3,20 +3,22 @@
 import createEmptyBlock from '../utils/createEmptyBlock'
 import type {SlateEditor, BlockContentFeatures} from '../typeDefs'
 
-export default function InsertEmptyTextBlockPlugin(blockContentFeatures: BlockContentFeatures) {
+export default function EnsurePlaceHolderBlockPlugin(blockContentFeatures: BlockContentFeatures) {
   return {
     onCommand(command: any, editor: SlateEditor, next: void => void) {
-      if (command.type !== 'ensureEmptyTextBlock') {
+      if (command.type !== 'ensurePlaceHolderBlock') {
         return next()
       }
       if (editor.value.document.nodes.size !== 0) {
         return next()
       }
       const block = createEmptyBlock(blockContentFeatures)
+      const node = block.toJSON({preserveKeys: true, preserveData: true})
+      node.data = {...node.data, placeholder: true}
       editor.applyOperation({
         type: 'insert_node',
         path: [0],
-        node: block.toJSON({preserveKeys: true, preserveData: true})
+        node: node
       })
       return editor
     }

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/plugins/OnFocusPlugin.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/plugins/OnFocusPlugin.js
@@ -1,0 +1,15 @@
+// @flow
+
+// This plugin runs when the editor receives focus
+// Ensures that an empty block is inserted when the editor gets focus and it's empty.
+
+import type {SlateEditor} from '../typeDefs'
+
+export default function OnFocusPlugin() {
+  return {
+    onFocus(event: any, editor: SlateEditor, next: void => void) {
+      editor.command('ensurePlaceHolderBlock')
+      return next()
+    }
+  }
+}

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/plugins/TogglePlaceHolderPlugin.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/plugins/TogglePlaceHolderPlugin.js
@@ -1,0 +1,33 @@
+// @flow
+
+// This plugin toggles data prop 'placeholder' on a contenBlock
+// The block is considered a placeholder if it is the single one
+// in the document and and empty. A unset patch for the field will be
+// sent by createOperationToPatches if the placeholder block is the
+// only thing left in the document
+
+import type {SlateEditor} from '../typeDefs'
+
+export default function TogglePlaceHolderAttributePlugin() {
+  return {
+    onKeyUp(event: any, editor: SlateEditor, next: void => void) {
+      if (editor.value.document.nodes.size === 1) {
+        const block = editor.value.document.nodes.first()
+        if (
+          block.type === 'contentBlock' &&
+          block.nodes.every(node => node.object === 'text') &&
+          block.text === ''
+        ) {
+          const newData = block.data.toObject()
+          newData.placeholder = true
+          editor.setNodeByKey(block.key, {data: newData})
+        } else if (block.type === 'contentBlock' && block.data.get('placeholder')) {
+          const newData = block.data.toObject()
+          delete newData.placeholder
+          editor.setNodeByKey(block.key, {data: newData})
+        }
+      }
+      return next()
+    }
+  }
+}

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createEmptyBlock.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createEmptyBlock.js
@@ -1,24 +1,20 @@
 import {randomKey, normalizeBlock} from '@sanity/block-tools'
 import deserialize from './deserialize'
 
-export default function createEmptyBlock(blockContentFeatures) {
-  const key = randomKey(12)
-  return deserialize(
-    [
-      normalizeBlock({
-        _key: key,
-        _type: 'block',
-        children: [
-          {
-            _type: 'span',
-            _key: `${key}0`,
-            text: '',
-            marks: []
-          }
-        ],
-        style: 'normal'
-      })
+export default function createEmptyBlock(blockContentFeatures, options = {}) {
+  const key = options.key || randomKey(12)
+  const raw = {
+    _key: key,
+    _type: 'block',
+    children: [
+      {
+        _type: 'span',
+        _key: `${key}0`,
+        text: '',
+        marks: []
+      }
     ],
-    blockContentFeatures.types.block
-  ).document.nodes.first()
+    style: options.style || 'normal'
+  }
+  return deserialize([normalizeBlock(raw)], blockContentFeatures.types.block).document.nodes.first()
 }


### PR DESCRIPTION
The last PR on this issue broke the tests because there were no longer a 1-1 relationship between the editor state and the actual data.

This is now handled in a way that the editors content gets in a placeholder state (a single block  with no text in the document gets a data attribute `placeholder` toggled by an own plugin on `keyUp`).

The function that converts editor operations to patches looks for this state and will send an unset patch if that is the case. Any other operations on a placeholder block is just ignored until there is actual content.

Also included are some minor fixes (setifMissing patches in additional required contexts) plus some minor other fixes.