### PR TITLE
[base] Split string on space and comma instead of using lodash.words for tokenization

### DIFF
--- a/packages/@sanity/base/src/search/common/tokenize.js
+++ b/packages/@sanity/base/src/search/common/tokenize.js
@@ -1,0 +1,5 @@
+const pattern = /([^\s,]+)/g
+
+export function tokenize(string) {
+  return string.match(pattern) || []
+}

--- a/packages/@sanity/base/src/search/common/tokenize.js
+++ b/packages/@sanity/base/src/search/common/tokenize.js
@@ -1,4 +1,4 @@
-const pattern = /([^\s,]+)/g
+const pattern = /([^\s,-])+/g
 
 export function tokenize(string) {
   return string.match(pattern) || []

--- a/packages/@sanity/base/src/search/weighted/createWeightedSearch.js
+++ b/packages/@sanity/base/src/search/weighted/createWeightedSearch.js
@@ -1,8 +1,9 @@
 import {map} from 'rxjs/operators'
 import {joinPath} from '../../util/searchUtils'
-import {compact, toLower, flatten, uniq, flow, sortBy, union, words} from 'lodash'
+import {compact, toLower, flatten, uniq, flow, sortBy, union} from 'lodash'
 import {removeDupes} from '../../util/draftUtils'
 import {applyWeights} from './applyWeights'
+import {tokenize} from '../common/tokenize'
 
 const combinePaths = flow([flatten, union, compact])
 
@@ -33,7 +34,7 @@ export function createWeightedSearch(types, client) {
 
   // this is the actual search function that takes the search string and returns the hits
   return function search(queryString, opts = {}) {
-    const terms = uniq(compact(words(toLower(queryString))))
+    const terms = uniq(compact(tokenize(toLower(queryString))))
     const constraints = terms.map((term, i) =>
       combinedSearchPaths.map(joinedPath => `${joinedPath} match $t${i}`)
     )

--- a/packages/@sanity/base/test/search-tokenize.test.js
+++ b/packages/@sanity/base/test/search-tokenize.test.js
@@ -1,0 +1,23 @@
+import {tokenize} from '../src/search/common/tokenize'
+
+const tests = [
+  ['', []],
+  ['foo', ['foo']],
+  ['0foo', ['0foo']],
+  ['a16z', ['a16z']],
+  ['0 foo', ['0', 'foo']],
+  ['foo 🤪🤪🤪', ['foo', '🤪🤪🤪']],
+  ['foo 🤪🤪🤪 bar', ['foo', '🤪🤪🤪', 'bar']],
+  ['1 2 3', ['1', '2', '3']],
+  ['foo, bar, baz', ['foo', 'bar', 'baz']],
+  ['foo   , bar   , baz', ['foo', 'bar', 'baz']],
+  ['a.b.c', ['a.b.c']],
+  ['fourty-two', ['fourty-two']],
+  ['abc -23 def', ['abc', '-23', 'def']]
+]
+
+tests.forEach(([input, expected]) => {
+  test('tokenization of search input string', () => {
+    expect(tokenize(input)).toEqual(expected)
+  })
+})

--- a/packages/@sanity/base/test/search-tokenize.test.js
+++ b/packages/@sanity/base/test/search-tokenize.test.js
@@ -5,6 +5,8 @@ const tests = [
   ['foo', ['foo']],
   ['0foo', ['0foo']],
   ['a16z', ['a16z']],
+  ['foo,,, ,    ,foo,bar', ['foo', 'foo', 'bar']],
+  ['pho-bar, foo-bar', ['pho', 'bar', 'foo', 'bar']],
   ['0 foo', ['0', 'foo']],
   ['foo 🤪🤪🤪', ['foo', '🤪🤪🤪']],
   ['foo 🤪🤪🤪 bar', ['foo', '🤪🤪🤪', 'bar']],
@@ -12,8 +14,8 @@ const tests = [
   ['foo, bar, baz', ['foo', 'bar', 'baz']],
   ['foo   , bar   , baz', ['foo', 'bar', 'baz']],
   ['a.b.c', ['a.b.c']],
-  ['fourty-two', ['fourty-two']],
-  ['abc -23 def', ['abc', '-23', 'def']]
+  ['fourty-two', ['fourty', 'two']],
+  ['abc -23 def', ['abc', '23', 'def']]
 ]
 
 tests.forEach(([input, expected]) => {


### PR DESCRIPTION
In #1168 we used `lodash.words` for tokenization of the search string. Can't really remember the rationale behind it (think it had something to do with unicode, but in retrospect it feels misguided). Using `lodash.words` had some unintended side effects, like splitting words like `2pac` into `['2', 'pac']`.

This PR replaces `lodash.words` with a simple regex that splits the search string on space+comma.
