### PR TITLE
[code-input] Add react-icons as dependency (fixes #1149)

### DIFF
--- a/packages/@sanity/code-input/package.json
+++ b/packages/@sanity/code-input/package.json
@@ -21,7 +21,8 @@
   ],
   "dependencies": {
     "lodash": "^4.17.4",
-    "react-ace": "^5.0.1"
+    "react-ace": "^5.0.1",
+    "react-icons": "^2.2.7"
   },
   "devDependencies": {
     "@sanity/check": "0.140.3",


### PR DESCRIPTION
We are currently implicitly depending on the react-icons package, which seems like an oversight.
This adds it as an explicit dependency.
