### PR TITLE
[base] Add `hasAlpha`, `isOpaque` fields to image metadata fields

### DIFF
--- a/packages/@sanity/base/src/schema/types/imageMetadata.js
+++ b/packages/@sanity/base/src/schema/types/imageMetadata.js
@@ -33,6 +33,18 @@ export default {
       title: 'LQIP (Low-Quality Image Placeholder)',
       type: 'string',
       readOnly: true
+    },
+    {
+      name: 'hasAlpha',
+      title: 'Has alpha channel',
+      type: 'boolean',
+      readOnly: true
+    },
+    {
+      name: 'isOpaque',
+      title: 'Is opaque',
+      type: 'boolean',
+      readOnly: true
     }
   ]
 }


### PR DESCRIPTION
Our image pipeline now populates two new fields on upload: `hasAlpha` and `isOpaque`. In order for these to be exposed in GraphQL APIs and be easier to discover, we should add them to the schema definition, so here goes.