### PR TITLE
[code-input] Add a filename field to code input blocks

### DIFF
--- a/packages/@sanity/code-input/src/CodeInput.js
+++ b/packages/@sanity/code-input/src/CodeInput.js
@@ -7,6 +7,7 @@ import styles from './CodeInput.css'
 import FormField from 'part:@sanity/components/formfields/default'
 import Fieldset from 'part:@sanity/components/fieldsets/default'
 import DefaultSelect from 'part:@sanity/components/selects/default'
+import TextInput from 'part:@sanity/components/textinputs/default'
 import createHighlightMarkers from './createHighlightMarkers'
 import {
   ACE_EDITOR_PROPS,
@@ -44,6 +45,7 @@ export default class CodeInput extends PureComponent {
     value: PropTypes.shape({
       _type: PropTypes.string,
       code: PropTypes.string,
+      filename: PropTypes.string,
       language: PropTypes.string,
       highlightedLines: PropTypes.array
     }),
@@ -149,6 +151,18 @@ export default class CodeInput extends PureComponent {
     )
   }
 
+  handleFilenameChange = item => {
+    const {type, onChange} = this.props
+    const path = ['filename']
+
+    onChange(
+      PatchEvent.from([
+        setIfMissing({_type: type.name}),
+        item ? set(item.target.value, path) : unset(path)
+      ])
+    )
+  }
+
   getLanguageAlternatives() {
     return get(this.props.type, 'options.languageAlternatives') || SUPPORTED_LANGUAGES
   }
@@ -204,6 +218,7 @@ export default class CodeInput extends PureComponent {
       languages.unshift({title: 'Select language'})
     }
     const languageField = type.fields.find(field => field.name === 'language')
+    const filenameField = type.fields.find(field => field.name === 'filename')
 
     return (
       <Fieldset legend={type.title} description={type.description} level={level}>
@@ -214,6 +229,17 @@ export default class CodeInput extends PureComponent {
             items={languages}
           />
         </FormField>
+        { get(type, 'options.withFilename', false) && (
+          <FormField label={filenameField.title || 'Filename'} level={level + 1}>
+            <TextInput
+              type="text"
+              name="filename"
+              value={value.filename}
+              placeholder={filenameField.placeholder}
+              onChange={this.handleFilenameChange}
+            />
+          </FormField>
+        ) }
         <FormField label={(selectedLanguage && selectedLanguage.title) || 'Code'} level={level + 1}>
           {this.renderEditor()}
         </FormField>

--- a/packages/@sanity/code-input/src/schema.js
+++ b/packages/@sanity/code-input/src/schema.js
@@ -88,6 +88,11 @@ export default {
       type: 'string'
     },
     {
+      name: 'filename',
+      title: 'Filename',
+      type: 'string'
+    },
+    {
       title: 'Highlighted lines',
       name: 'highlightedLines',
       type: 'array',
@@ -103,11 +108,12 @@ export default {
     select: {
       language: 'language',
       code: 'code',
+      filename: 'filename',
       highlightedLines: 'highlightedLines'
     },
     prepare: value => {
       return {
-        title: (value.language || 'unknown').toUpperCase(),
+        title: value.filename || (value.language || 'unknown').toUpperCase(),
         media: getMedia(value.language),
         extendedPreview: <Preview value={value} />
       }


### PR DESCRIPTION
This adds a filename input field for the code-input blocks:

<img width="558" alt="Screenshot 2019-03-12 at 12 06 23" src="https://user-images.githubusercontent.com/45449/54195667-97ef5e80-44bf-11e9-9e27-76ddcd0e3e23.png">

The filename will be used for the previewing instead of the language as the language is both represented as the file ending as well as with a logo

<img width="687" alt="Screenshot 2019-03-12 at 12 06 30" src="https://user-images.githubusercontent.com/45449/54195670-99b92200-44bf-11e9-9b36-8e7c4559716a.png">
