### PR TITLE
[image-url] Add `auto('format')` support for automatic WebP switching

### DIFF
--- a/packages/@sanity/image-url/README.md
+++ b/packages/@sanity/image-url/README.md
@@ -14,7 +14,7 @@ In addition to the core use case, this library provides a handy builder to acces
 
 The most common way to use this library in your project is to configure it by passing it your configured sanityClient. That way it will automatically be preconfigured to your current project and dataset:
 
-``` js
+```js
 import React from 'react'
 import myConfiguredSanityClient from './sanityClient'
 import imageUrlBuilder from '@sanity/image-url'
@@ -28,19 +28,23 @@ function urlFor(source) {
 
 Then you can use the handy builder syntax to generate your urls:
 
-``` js
-  <img src={urlFor(author.image).width(200).url()} />
+```js
+<img
+  src={urlFor(author.image)
+    .width(200)
+    .url()}
+/>
 ```
 
 This will ensure that the author image is alway 200 pixels wide, automatically applying any crop specified by the editor and cropping towards the hot-spot she drew. You can specify both width and height like this:
 
-``` js
+```js
   <img src={urlFor(movie.poster).width(500).height(300).url()}>
 ```
 
 There are a huge number of useful options you can specify, like e.g. blur:
 
-``` js
+```js
   <img src={urlFor(mysteryPerson.mugshot).width(200).height(200).blur(50).url()}>
 ```
 
@@ -85,6 +89,12 @@ Specify the crop in pixels. Overrides any crop/hotspot in the image record.
 ### `format(name)`
 
 Specify the image format of the image. 'jpg', 'pjpg', 'png', 'webp'
+
+### `auto(mode)`
+
+Specify transformations to automatically apply based on browser capabilities. Supported values:
+
+- `format` - Automatically uses WebP if supported
 
 ### `orientation(angle)`
 

--- a/packages/@sanity/image-url/src/builder.js
+++ b/packages/@sanity/image-url/src/builder.js
@@ -2,6 +2,7 @@ import urlForImage from './urlForImage'
 
 const validFits = ['clip', 'crop', 'fill', 'fillmax', 'max', 'scale', 'min']
 const validCrops = ['top', 'bottom', 'left', 'right', 'center', 'focalpoint', 'entropy']
+const validAutoModes = ['format']
 
 class ImageUrlBuilder {
   constructor(parent, options) {
@@ -141,6 +142,14 @@ class ImageUrlBuilder {
     }
 
     return this.withOptions({crop: value})
+  }
+
+  auto(value) {
+    if (validAutoModes.indexOf(value) === -1) {
+      throw new Error(`Invalid auto mode "${value}"`)
+    }
+
+    return this.withOptions({auto: value})
   }
 
   // Gets the url based on the submitted parameters

--- a/packages/@sanity/image-url/src/urlForImage.js
+++ b/packages/@sanity/image-url/src/urlForImage.js
@@ -16,7 +16,8 @@ const SPEC_NAME_TO_URL_NAME_MAPPINGS = [
   ['maxWidth', 'max-w'],
   ['quality', 'q'],
   ['fit', 'fit'],
-  ['crop', 'crop']
+  ['crop', 'crop'],
+  ['auto', 'auto']
 ]
 
 export default function urlForImage(options) {

--- a/packages/@sanity/image-url/test/__snapshots__/builder.test.js.snap
+++ b/packages/@sanity/image-url/test/__snapshots__/builder.test.js.snap
@@ -1,8 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`builder all hotspot/crop-compatible params 1`] = `"rect=200,300,1600,2400&flip=hv&fm=png&dl=a.png&blur=50&sharp=7&invert=true&or=90&min-h=150&max-h=300&min-w=100&max-w=200&q=50&fit=crop"`;
+exports[`builder all hotspot/crop-compatible params 1`] = `"rect=200,300,1600,2400&flip=hv&fm=png&dl=a.png&blur=50&sharp=7&invert=true&or=90&min-h=150&max-h=300&min-w=100&max-w=200&q=50&fit=crop&auto=format"`;
 
-exports[`builder all params 1`] = `"rect=10,20,30,40&bg=bf1942&fp-x=10&fp-x=20&flip=hv&fm=png&dl=a.png&blur=50&invert=true&or=90&min-h=150&max-h=300&min-w=100&max-w=200&q=50&fit=crop&crop=center"`;
+exports[`builder all params 1`] = `"rect=10,20,30,40&bg=bf1942&fp-x=10&fp-x=20&flip=hv&fm=png&dl=a.png&blur=50&invert=true&or=90&min-h=150&max-h=300&min-w=100&max-w=200&q=50&fit=crop&crop=center&auto=format"`;
+
+exports[`builder automatic format 1`] = `"auto=format"`;
 
 exports[`builder can be told to ignore hotspot 1`] = `"https://cdn.sanity.io/images/zp7mbokg/production/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg?w=100&h=80"`;
 

--- a/packages/@sanity/image-url/test/builder.test.js
+++ b/packages/@sanity/image-url/test/builder.test.js
@@ -166,6 +166,16 @@ const cases = [
   },
 
   {
+    name: 'automatic format',
+    url: stripPath(
+      urlFor
+        .image(noHotspotImage())
+        .auto('format')
+        .url()
+    )
+  },
+
+  {
     name: 'sub zero top/left',
     url: stripPath(
       urlFor
@@ -191,6 +201,7 @@ const cases = [
         .orientation(90)
         .quality(50)
         .sharpen(7)
+        .auto('format')
         .forceDownload('a.png')
         .flipHorizontal()
         .flipVertical()
@@ -216,6 +227,7 @@ const cases = [
         .invert(true)
         .orientation(90)
         .quality(50)
+        .auto('format')
         .forceDownload('a.png')
         .flipHorizontal()
         .flipVertical()


### PR DESCRIPTION
Adds support for the `auto=format` feature.
