### PR TITLE
[form-builder] Fix bug where pasting into an editor inside an editor would sometimes error

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/plugins/PastePlugin.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/plugins/PastePlugin.js
@@ -41,7 +41,20 @@ function handleHTML(html, editor, blockContentType, onProgress, pasteController)
     onProgress({status: 'blocks'})
     const value = deserialize(blocks, blockContentType)
     pasteController.setValue(value)
-    editor.insertFragment(pasteController.value.document)
+    // If we have a placeholder block, we cant do insertFragment,
+    // because that may create a new placeholder block,
+    // because insertFragment may empty the document while operating
+    const placeHolderBlock = editor.value.document.nodes.find(
+      blk => blk.get('data').toObject().placeholder === true
+    )
+    if (placeHolderBlock) {
+      pasteController.value.document.nodes.forEach(blk => {
+        editor.insertBlock(blk)
+      })
+      editor.removeNodeByKey(placeHolderBlock.key)
+    } else {
+      editor.insertFragment(pasteController.value.document)
+    }
     pasteController.setValue(deserialize(null, blockContentType))
     onProgress({status: null})
     return editor

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createOperationToPatches.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createOperationToPatches.js
@@ -153,8 +153,10 @@ export default function createOperationToPatches(
     afterValue: SlateValue,
     formBuilderValue: ?(FormBuilderValue[])
   ) {
-    // Unset the field if every node is a placeholder
-    if (afterValue.document.nodes.every(node => node.data.get('placeholder'))) {
+    if (
+      afterValue.document.nodes.size > 0 &&
+      afterValue.document.nodes.every(node => node.data.get('placeholder'))
+    ) {
       return [unset([])]
     }
     // Value is undefined
@@ -177,7 +179,10 @@ export default function createOperationToPatches(
     formBuilderValue: ?(FormBuilderValue[])
   ) {
     // Don't send anything if this is just a placeholder
-    if (afterValue.document.nodes.every(node => node.data.get('placeholder'))) {
+    if (
+      afterValue.document.nodes.size > 0 &&
+      afterValue.document.nodes.every(node => node.data.get('placeholder'))
+    ) {
       return []
     }
     // Value is undefined
@@ -330,6 +335,7 @@ export default function createOperationToPatches(
     afterValue: SlateValue,
     formBuilderValue?: ?(FormBuilderValue[]) // This is optional, but needed for setting setIfMissing patches correctly
   ) {
+    // console.log(JSON.stringify(operation.toJSON(), null, 2))
     switch (operation.type) {
       case 'insert_text':
         return insertTextPatch(operation, beforeValue, afterValue, formBuilderValue)


### PR DESCRIPTION
This is related to the placeholder blocks that ensures that there always is a cursor in the editor even though the data itself is empty.

When pasting HTML and trying to `insertFragment`, it must check if there only is a placeholder in the editor, and do things a little differently if it is.