### PR TITLE
[cli] Use v8 compile cache

### DIFF
--- a/packages/@sanity/cli/bin/sanity
+++ b/packages/@sanity/cli/bin/sanity
@@ -9,6 +9,8 @@
  * └────────────────┘
  */
 
+require('v8-compile-cache')
+
 var err = '\u001b[31m\u001b[1mERROR:\u001b[22m\u001b[39m '
 var nodeVersion = Number(process.version.replace(/^v/i, '').split('.', 2)[0])
 if (nodeVersion < 8) {

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -36,6 +36,9 @@
     "url": "https://github.com/sanity-io/sanity/issues"
   },
   "homepage": "https://www.sanity.io/",
+  "dependencies": {
+    "v8-compile-cache": "^2.0.2"
+  },
   "devDependencies": {
     "@sanity/client": "0.140.11",
     "@sanity/resolver": "0.140.3",


### PR DESCRIPTION
Using the `v8-compile-cache` module speeds up the CLI bootup by ~100ms on my machine.