### PR TITLE
[core] Allow specifying non-HTTP protocols for CORS-origins

### DIFF
--- a/packages/@sanity/core/src/actions/cors/addCorsOrigin.js
+++ b/packages/@sanity/core/src/actions/cors/addCorsOrigin.js
@@ -118,14 +118,12 @@ function filterOrigin(origin) {
       .replace(/:\*/, portReplacement)
 
     const parsed = url.parse(example)
-    if (!/^https?:$/.test(parsed.protocol || '')) {
-      return null
+    let host = parsed.host
+    if (/^https?:$/.test(parsed.protocol || '')) {
+      host = parsed.host.replace(/:(80|443)$/, '')
     }
 
-    const host = parsed.host
-      .replace(/:(80|443)$/, '')
-      .replace(portReplacement, ':*')
-      .replace(new RegExp(wildcardReplacement, 'g'), '*')
+    host = host.replace(portReplacement, ':*').replace(new RegExp(wildcardReplacement, 'g'), '*')
 
     return `${parsed.protocol}//${host}`
   } catch (err) {


### PR DESCRIPTION
Needs backend change to be merged first, but this will allow the CLI to add any protocol as CORS-origin.