### PR TITLE
[default-login] Remove Safari login exception

### DIFF
--- a/packages/@sanity/default-login/src/LoginDialog.js
+++ b/packages/@sanity/default-login/src/LoginDialog.js
@@ -57,12 +57,12 @@ export default class LoginDialog extends React.Component {
   redirectToProvider(provider) {
     const {projectId} = this.props
     const currentUrl = encodeURIComponent(window.location.toString())
-    const ua = navigator.userAgent || ''
-    const isSafari = ua.includes('Safari') && !ua.includes('Chrome')
+    // const ua = navigator.userAgent || ''
+    // const isSafari = ua.includes('Safari') && !ua.includes('Chrome')
     const params = [
       `origin=${currentUrl}`,
-      projectId && `projectId=${projectId}`,
-      projectId && isSafari && `withSid=1`
+      projectId && `projectId=${projectId}`
+      // projectId && isSafari && `withSid=1`
     ].filter(Boolean)
 
     if (provider.custom && !provider.supported) {

--- a/packages/@sanity/default-login/src/LoginDialog.js
+++ b/packages/@sanity/default-login/src/LoginDialog.js
@@ -57,13 +57,7 @@ export default class LoginDialog extends React.Component {
   redirectToProvider(provider) {
     const {projectId} = this.props
     const currentUrl = encodeURIComponent(window.location.toString())
-    // const ua = navigator.userAgent || ''
-    // const isSafari = ua.includes('Safari') && !ua.includes('Chrome')
-    const params = [
-      `origin=${currentUrl}`,
-      projectId && `projectId=${projectId}`
-      // projectId && isSafari && `withSid=1`
-    ].filter(Boolean)
+    const params = [`origin=${currentUrl}`, projectId && `projectId=${projectId}`].filter(Boolean)
 
     if (provider.custom && !provider.supported) {
       this.setState({

--- a/packages/@sanity/default-login/src/LoginWrapper.js
+++ b/packages/@sanity/default-login/src/LoginWrapper.js
@@ -12,16 +12,6 @@ import UnauthorizedUser from './UnauthorizedUser'
 
 const isProjectLogin = client.config().useProjectHostname
 const projectId = isProjectLogin && client.config().projectId ? client.config().projectId : null
-
-const getSid = () => {
-  if (!window.location.hash.includes('sid=')) {
-    return false
-  }
-
-  const sid = window.location.hash.replace(/.*?sid=([^&]+)/, '$1')
-  return sid || false
-}
-
 export default class LoginWrapper extends React.PureComponent {
   static propTypes = {
     children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
@@ -44,56 +34,21 @@ export default class LoginWrapper extends React.PureComponent {
 
   userSubscription = null
 
-  componentDidMount() {
-    const sid = getSid()
-
-    if (sid) {
-      this.exchangeToken(sid)
-      const url = window.location.href.replace(`sid=${sid}`, '')
-      history.replaceState({}, document.title, url)
-    } else {
-      this.getUser()
-    }
-  }
-
-  getUser = () => {
+  constructor(props) {
+    super(props)
     this.userSubscription = userStore.currentUser.subscribe({
       next: evt => this.setState({user: evt.user, error: evt.error, isLoading: false}),
       error: error => this.setState({error, isLoading: false})
     })
   }
 
-  handleLoginError = err => {
-    this.setState({error: err, isLoading: false})
-    this.clearSid()
-  }
-
-  exchangeToken = sid => {
-    this.tokenExchange = client.observable
-      .request({
-        uri: '/auth/exchange',
-        withCredentials: true,
-        query: {sid}
-      })
-      .subscribe({
-        next: this.getUser,
-        error: this.handleLoginError
-      })
-  }
-
   componentWillUnmount() {
-    if (this.tokenExchange) {
-      this.tokenExchange.unsubscribe()
+    if (this.userSubscription) {
+      this.userSubscription.unsubscribe()
     }
-
-    this.userSubscription.unsubscribe()
   }
 
   handleRetry = () => {
-    if (!this.userSubscription) {
-      this.getUser()
-    }
-
     this.setState({error: null, isLoading: true})
     userStore.actions.retry()
   }


### PR DESCRIPTION
With the latest Mac OS release today, Safari was updated, and the workaround/exception we did for Safari is now broken (just returns to the login screen - even though it's not being hit by ITP). Resetting it to use the standard login flow while we work on a more permanent ITP solution.

Also removed code introduced by #1018