### PR TITLE
[default-login] Fix synchronous setState in constructor

### DIFF
--- a/packages/@sanity/default-login/src/LoginWrapper.js
+++ b/packages/@sanity/default-login/src/LoginWrapper.js
@@ -12,6 +12,7 @@ import UnauthorizedUser from './UnauthorizedUser'
 
 const isProjectLogin = client.config().useProjectHostname
 const projectId = isProjectLogin && client.config().projectId ? client.config().projectId : null
+
 export default class LoginWrapper extends React.PureComponent {
   static propTypes = {
     children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
@@ -36,10 +37,25 @@ export default class LoginWrapper extends React.PureComponent {
 
   constructor(props) {
     super(props)
+
+    let sync = true
+
     this.userSubscription = userStore.currentUser.subscribe({
-      next: evt => this.setState({user: evt.user, error: evt.error, isLoading: false}),
+      next: evt => {
+        // Because observables _can_ be syncronous, it's not safe to call `setState` as it is a noop
+        // We must therefore explicitly check whether or not we were call syncronously
+        const newState = {user: evt.user, error: evt.error, isLoading: false}
+        if (sync) {
+          // eslint-disable-next-line react/no-direct-mutation-state
+          this.state = {...this.state, ...newState}
+        } else {
+          this.setState(newState)
+        }
+      },
       error: error => this.setState({error, isLoading: false})
     })
+
+    sync = false
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Issue introduced in #1263 - I should have spotted this in code review, sorry.
On first mount, the auth store does not have any state, so resolves asynchronously and works as expected.
On subsequent mounts (in hot reload mode), we already have the user so it resolves synchronously. This makes it call `setState` inside of the constructor, which is a noop. It's therefore stuck in a loading state until you manually reload.

This PR fixes that by introducing the ugly but functional sync check - I'm sure we could make a better fix at some point, this is 🔥 🚒 