### PR TITLE
[form-builder] Support additional filter to reference input

### DIFF
--- a/packages/@sanity/base/src/search/weighted/createWeightedSearch.js
+++ b/packages/@sanity/base/src/search/weighted/createWeightedSearch.js
@@ -15,7 +15,7 @@ const toGroqParams = terms =>
   }, {})
 
 export function createWeightedSearch(types, client, options = {}) {
-  const {filter, filterParams} = options
+  const {filter, params} = options
   const searchSpec = types.map(type => {
     return {
       typeName: type.name,
@@ -56,7 +56,7 @@ export function createWeightedSearch(types, client, options = {}) {
         ...toGroqParams(terms),
         __types: searchSpec.map(spec => spec.typeName),
         __limit: 1000,
-        ...(filterParams || {})
+        ...(params || {})
       })
       .pipe(
         map(removeDupes),

--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
@@ -19,12 +19,16 @@ type PreviewSnapshot = {
   title: string
   description: string
 }
+type SearchOptions = {
+  filter?: string
+  filterParams?: {[key: string]: any}
+}
 export type Props = {
   value?: Reference
   type: Type
   markers: Array<Marker>
   readOnly?: boolean
-  onSearch: (query: string, type: Type) => ObservableI<Array<SearchHit>>
+  onSearch: (query: string, type: Type, options: SearchOptions) => ObservableI<Array<SearchHit>>
   getPreviewSnapshot: (Reference, Type) => ObservableI<PreviewSnapshot>
   onChange: (event: PatchEvent) => void
   level: number
@@ -117,12 +121,13 @@ export default class ReferenceInput extends React.Component<Props, State> {
   }
   search = (query: string) => {
     const {type, onSearch} = this.props
+    const options = type.options || {}
     this.setState({
       isFetching: true
     })
     this.subscriptions.replace(
       'search',
-      onSearch(query, type).subscribe((items: Array<SearchHit>) => {
+      onSearch(query, type, options).subscribe((items: Array<SearchHit>) => {
         const updatedCache = items.reduce((cache, item) => {
           cache[item._id] = item
           return cache

--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
@@ -1,16 +1,26 @@
 /* eslint-disable complexity */
 import React from 'react'
+import {get} from '@sanity/util/paths'
 import SearchableSelect from 'part:@sanity/components/selects/searchable'
 import FormField from 'part:@sanity/components/formfields/default'
 import Preview from '../../Preview'
 import subscriptionManager from '../../utils/subscriptionManager'
 import PatchEvent, {set, setIfMissing, unset} from '../../../PatchEvent'
 import {Reference, Type, Marker} from '../../typedefs'
+import {Path} from '../../typedefs/path'
 import {ObservableI} from '../../typedefs/observable'
 import LinkIcon from 'part:@sanity/base/link-icon'
 import {IntentLink} from 'part:@sanity/base/router'
 import styles from './styles/ReferenceInput.css'
 import Button from 'part:@sanity/components/buttons/default'
+import withDocument from '../../utils/withDocument'
+import withValuePath from '../../utils/withValuePath'
+
+type SanityDocument = {
+  _id: string
+  _type: string
+  [key: string]: any
+}
 type SearchHit = {
   _id: string
   _type: string
@@ -21,17 +31,40 @@ type PreviewSnapshot = {
 }
 type SearchOptions = {
   filter?: string
+  params?: {[key: string]: any}
+}
+type FilterResolver = (options: {
+  document: SanityDocument
+  parent?: object | object[]
+  parentPath: Path
+}) => SearchOptions
+type SearchTypeOptions = {
+  // Mutually exclusive if `filter` is a resolver (enforced in schema validation)
+  filter?: string | FilterResolver
   filterParams?: {[key: string]: any}
+}
+type SearchError = {
+  message: string
+  details?: {
+    type: string
+    description: string
+  }
 }
 export type Props = {
   value?: Reference
-  type: Type
+  type: Type & {options?: SearchTypeOptions}
   markers: Array<Marker>
   readOnly?: boolean
   onSearch: (query: string, type: Type, options: SearchOptions) => ObservableI<Array<SearchHit>>
   getPreviewSnapshot: (Reference, Type) => ObservableI<PreviewSnapshot>
   onChange: (event: PatchEvent) => void
   level: number
+
+  // From withDocument
+  document: SanityDocument
+
+  // From withValuePath
+  getValuePath: () => Path
 }
 
 type State = {
@@ -53,174 +86,211 @@ const getInitialState = (): State => {
   }
 }
 
-export default class ReferenceInput extends React.Component<Props, State> {
-  _lastQuery = ''
-  _input: SearchableSelect
-  state = getInitialState()
-  subscriptions = subscriptionManager('search', 'previewSnapshot')
-  componentWillUnmount() {
-    this.subscriptions.unsubscribeAll()
-  }
-  componentDidMount() {
-    this.getPreviewSnapshot(this.props.value)
-  }
-  UNSAFE_componentWillReceiveProps(nextProps: Props) {
-    if (nextProps.value !== this.props.value) {
-      this.setState(getInitialState())
-      this.getPreviewSnapshot(nextProps.value)
-    }
-  }
-  getPreviewSnapshot(value: Reference) {
-    if (!value || !value._ref) {
-      return
-    }
-    const {getPreviewSnapshot, type} = this.props
-    this.subscriptions.replace(
-      'previewSnapshot',
-      getPreviewSnapshot(value, type).subscribe(snapshot => {
-        this.setState({previewSnapshot: snapshot, isMissing: !snapshot})
-      })
-    )
-  }
-  getMemberTypeFor(typeName: string) {
-    const {type} = this.props
-    return type.to.find(ofType => ofType.type.name === typeName)
-  }
-  handleFocus = () => {
-    if (this._lastQuery) {
-      this.search(this._lastQuery)
-    }
-  }
-  handleChange = (item: SearchHit) => {
-    const {type} = this.props
-    this.props.onChange(
-      PatchEvent.from(
-        setIfMissing({
-          _type: type.name,
-          _ref: item._id
-        }),
-        type.weak === true ? set(true, ['_weak']) : unset(['_weak']),
-        set(item._id, ['_ref'])
-      )
-    )
-  }
-  handleFixWeak = () => {
-    const {type} = this.props
-    this.props.onChange(
-      PatchEvent.from(type.weak === true ? set(true, ['_weak']) : unset(['_weak']))
-    )
-  }
-  handleClear = () => {
-    this.props.onChange(PatchEvent.from(unset()))
-  }
-  handleSearch = (query: string) => {
-    this.search(query)
-  }
-  handleOpen = () => {
-    this.search('')
-  }
-  search = (query: string) => {
-    const {type, onSearch} = this.props
-    const options = type.options || {}
-    this.setState({
-      isFetching: true
-    })
-    this.subscriptions.replace(
-      'search',
-      onSearch(query, type, options).subscribe((items: Array<SearchHit>) => {
-        const updatedCache = items.reduce((cache, item) => {
-          cache[item._id] = item
-          return cache
-        }, Object.assign({}, this.state.refCache))
-        this.setState({
-          hits: items,
-          isFetching: false,
-          refCache: updatedCache
-        })
-      })
-    )
-  }
-  renderHit = (item: SearchHit) => {
-    const type = this.getMemberTypeFor(item._type)
-    return <Preview type={type} value={item} layout="default" />
-  }
-  renderOpenItemElement = () => {
-    const {value} = this.props
-    const {isMissing, previewSnapshot} = this.state
-    if (!value || !value._ref || isMissing) {
-      return null
-    }
-    return (
-      <IntentLink
-        title={previewSnapshot && `Open ${previewSnapshot.title}`}
-        intent="edit"
-        params={{id: value._ref}}
-      >
-        <LinkIcon />
-      </IntentLink>
-    )
-  }
-  focus() {
-    if (this._input) {
-      this._input.focus()
-    }
-  }
-  setInput = (input?: SearchableSelect) => {
-    this._input = input
-  }
-  render() {
-    const {type, value, level, markers, readOnly} = this.props
-    const {previewSnapshot, isFetching, isMissing, hits} = this.state
-    const valueFromHit = value && hits.find(hit => hit._id === value._ref)
-    const weakIs = value && value._weak ? 'weak' : 'strong'
-    const weakShouldBe = type.weak === true ? 'weak' : 'strong'
+export default withValuePath(
+  withDocument(
+    class ReferenceInput extends React.Component<Props, State> {
+      _lastQuery = ''
+      _input: SearchableSelect
+      state = getInitialState()
+      subscriptions = subscriptionManager('search', 'previewSnapshot')
+      componentWillUnmount() {
+        this.subscriptions.unsubscribeAll()
+      }
+      componentDidMount() {
+        this.getPreviewSnapshot(this.props.value)
+      }
+      UNSAFE_componentWillReceiveProps(nextProps: Props) {
+        if (nextProps.value !== this.props.value) {
+          this.setState(getInitialState())
+          this.getPreviewSnapshot(nextProps.value)
+        }
+      }
+      getPreviewSnapshot(value: Reference) {
+        if (!value || !value._ref) {
+          return
+        }
+        const {getPreviewSnapshot, type} = this.props
+        this.subscriptions.replace(
+          'previewSnapshot',
+          getPreviewSnapshot(value, type).subscribe(snapshot => {
+            this.setState({previewSnapshot: snapshot, isMissing: !snapshot})
+          })
+        )
+      }
+      getMemberTypeFor(typeName: string) {
+        const {type} = this.props
+        return type.to.find(ofType => ofType.type.name === typeName)
+      }
+      handleFocus = () => {
+        if (this._lastQuery) {
+          this.search(this._lastQuery)
+        }
+      }
+      handleChange = (item: SearchHit) => {
+        const {type} = this.props
+        this.props.onChange(
+          PatchEvent.from(
+            setIfMissing({
+              _type: type.name,
+              _ref: item._id
+            }),
+            type.weak === true ? set(true, ['_weak']) : unset(['_weak']),
+            set(item._id, ['_ref'])
+          )
+        )
+      }
+      handleFixWeak = () => {
+        const {type} = this.props
+        this.props.onChange(
+          PatchEvent.from(type.weak === true ? set(true, ['_weak']) : unset(['_weak']))
+        )
+      }
+      handleClear = () => {
+        this.props.onChange(PatchEvent.from(unset()))
+      }
+      handleSearch = (query: string) => {
+        this.search(query)
+      }
+      handleOpen = () => {
+        this.search('')
+      }
+      resolveUserDefinedFilter = (): SearchOptions => {
+        const {type, document, getValuePath} = this.props
+        const options = type.options
+        if (!options) {
+          return {}
+        }
 
-    const hasRef = value && value._ref
-    const hasWeakMismatch = hasRef && !isMissing && weakIs !== weakShouldBe
-    const validation = markers.filter(marker => marker.type === 'validation')
-    const errors = validation.filter(marker => marker.level === 'error')
-    let inputValue = value ? previewSnapshot && previewSnapshot.title : undefined
-    if (previewSnapshot && !previewSnapshot.title) {
-      inputValue = 'Untitled document'
-    }
-    const isLoadingSnapshot = value && value._ref && !previewSnapshot
-    const placeholder = isLoadingSnapshot ? 'Loading…' : 'Type to search…'
-    return (
-      <FormField markers={markers} label={type.title} level={level} description={type.description}>
-        <div className={hasWeakMismatch || isMissing ? styles.hasWarnings : ''}>
-          {hasWeakMismatch && (
-            <div className={styles.weakRefMismatchWarning}>
-              Warning: This reference is <em>{weakIs}</em>, but should be <em>{weakShouldBe}</em>{' '}
-              according to schema.
-              <div>
-                <Button onClick={this.handleFixWeak}>Convert to {weakShouldBe}</Button>
-              </div>
-            </div>
-          )}
-          <SearchableSelect
-            placeholder={readOnly ? '' : placeholder}
-            title={
-              isMissing && hasRef
-                ? `Referencing nonexistent document (id: ${value._ref || 'unknown'})`
-                : previewSnapshot && previewSnapshot.description
+        const {filter, filterParams: params} = options
+        if (typeof filter === 'function') {
+          const parentPath = getValuePath().slice(0, -1)
+          const parent = get(document, parentPath)
+          return filter({document, parentPath, parent})
+        }
+
+        return {filter, params}
+      }
+      search = (query: string) => {
+        const {type, onSearch} = this.props
+        const options = this.resolveUserDefinedFilter()
+
+        this.setState({
+          isFetching: true
+        })
+        this.subscriptions.replace(
+          'search',
+          onSearch(query, type, options).subscribe({
+            next: (items: Array<SearchHit>) => {
+              const updatedCache = items.reduce((cache, item) => {
+                cache[item._id] = item
+                return cache
+              }, Object.assign({}, this.state.refCache))
+              this.setState({
+                hits: items,
+                isFetching: false,
+                refCache: updatedCache
+              })
+            },
+            error: (err: SearchError) => {
+              const isQueryError = err.details && err.details.type === 'queryParseError'
+              if (!isQueryError || !this.resolveUserDefinedFilter().filter) {
+                throw err
+              }
+
+              err.message = 'Invalid reference filter, please check `filter`!'
+              throw err
             }
-            customValidity={errors.length > 0 ? errors[0].item.message : ''}
-            onOpen={this.handleOpen}
-            onFocus={this.handleFocus}
-            onSearch={this.handleSearch}
-            onChange={this.handleChange}
-            onClear={this.handleClear}
-            openItemElement={this.renderOpenItemElement}
-            value={valueFromHit || value}
-            inputValue={isMissing ? '<nonexistent reference>' : inputValue}
-            renderItem={this.renderHit}
-            isLoading={isFetching || isLoadingSnapshot}
-            items={hits}
-            ref={this.setInput}
-            readOnly={readOnly || isLoadingSnapshot}
-          />
-        </div>
-      </FormField>
-    )
-  }
-}
+          })
+        )
+      }
+      renderHit = (item: SearchHit) => {
+        const type = this.getMemberTypeFor(item._type)
+        return <Preview type={type} value={item} layout="default" />
+      }
+      renderOpenItemElement = () => {
+        const {value} = this.props
+        const {isMissing, previewSnapshot} = this.state
+        if (!value || !value._ref || isMissing) {
+          return null
+        }
+        return (
+          <IntentLink
+            title={previewSnapshot && `Open ${previewSnapshot.title}`}
+            intent="edit"
+            params={{id: value._ref}}
+          >
+            <LinkIcon />
+          </IntentLink>
+        )
+      }
+      focus() {
+        if (this._input) {
+          this._input.focus()
+        }
+      }
+      setInput = (input?: SearchableSelect) => {
+        this._input = input
+      }
+      render() {
+        const {type, value, level, markers, readOnly} = this.props
+        const {previewSnapshot, isFetching, isMissing, hits} = this.state
+        const valueFromHit = value && hits.find(hit => hit._id === value._ref)
+        const weakIs = value && value._weak ? 'weak' : 'strong'
+        const weakShouldBe = type.weak === true ? 'weak' : 'strong'
+
+        const hasRef = value && value._ref
+        const hasWeakMismatch = hasRef && !isMissing && weakIs !== weakShouldBe
+        const validation = markers.filter(marker => marker.type === 'validation')
+        const errors = validation.filter(marker => marker.level === 'error')
+        let inputValue = value ? previewSnapshot && previewSnapshot.title : undefined
+        if (previewSnapshot && !previewSnapshot.title) {
+          inputValue = 'Untitled document'
+        }
+        const isLoadingSnapshot = value && value._ref && !previewSnapshot
+        const placeholder = isLoadingSnapshot ? 'Loading…' : 'Type to search…'
+        return (
+          <FormField
+            markers={markers}
+            label={type.title}
+            level={level}
+            description={type.description}
+          >
+            <div className={hasWeakMismatch || isMissing ? styles.hasWarnings : ''}>
+              {hasWeakMismatch && (
+                <div className={styles.weakRefMismatchWarning}>
+                  Warning: This reference is <em>{weakIs}</em>, but should be{' '}
+                  <em>{weakShouldBe}</em> according to schema.
+                  <div>
+                    <Button onClick={this.handleFixWeak}>Convert to {weakShouldBe}</Button>
+                  </div>
+                </div>
+              )}
+              <SearchableSelect
+                placeholder={readOnly ? '' : placeholder}
+                title={
+                  isMissing && hasRef
+                    ? `Referencing nonexistent document (id: ${value._ref || 'unknown'})`
+                    : previewSnapshot && previewSnapshot.description
+                }
+                customValidity={errors.length > 0 ? errors[0].item.message : ''}
+                onOpen={this.handleOpen}
+                onFocus={this.handleFocus}
+                onSearch={this.handleSearch}
+                onChange={this.handleChange}
+                onClear={this.handleClear}
+                openItemElement={this.renderOpenItemElement}
+                value={valueFromHit || value}
+                inputValue={isMissing ? '<nonexistent reference>' : inputValue}
+                renderItem={this.renderHit}
+                isLoading={isFetching || isLoadingSnapshot}
+                items={hits}
+                ref={this.setInput}
+                readOnly={readOnly || isLoadingSnapshot}
+              />
+            </div>
+          </FormField>
+        )
+      }
+    }
+  )
+)

--- a/packages/@sanity/form-builder/src/sanity/inputs/client-adapters/reference.ts
+++ b/packages/@sanity/form-builder/src/sanity/inputs/client-adapters/reference.ts
@@ -7,8 +7,8 @@ export function getPreviewSnapshot(value, referenceType) {
   return observeForPreview(value, referenceType).pipe(map((result: any) => result.snapshot))
 }
 
-export function search(textTerm, referenceType) {
-  const doSearch = createWeightedSearch(referenceType.to, client)
+export function search(textTerm, referenceType, options) {
+  const doSearch = createWeightedSearch(referenceType.to, client, options)
   return doSearch(textTerm, {includeDrafts: false}).pipe(
     map((results: any[]) => results.map(res => res.hit))
   )

--- a/packages/@sanity/form-builder/src/utils/withValuePath.tsx
+++ b/packages/@sanity/form-builder/src/utils/withValuePath.tsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 export default function withValuePath(ComposedComponent: any) {
-  return class WithValuePath extends React.PureComponent {
+  return class WithValuePath<P> extends React.PureComponent<P> {
     _input: typeof ComposedComponent
     static displayName = `withValuePath(${ComposedComponent.displayName || ComposedComponent.name})`
     static contextTypes = {

--- a/packages/@sanity/schema/src/sanity/validation/createValidationResult.ts
+++ b/packages/@sanity/schema/src/sanity/validation/createValidationResult.ts
@@ -18,6 +18,9 @@ export const HELP_IDS = {
   ARRAY_OF_NOT_UNIQUE: 'schema-array-of-invalid',
   REFERENCE_TO_INVALID: 'schema-reference-to-invalid',
   REFERENCE_TO_NOT_UNIQUE: 'schema-reference-to-invalid',
+  REFERENCE_INVALID_OPTIONS: 'schema-reference-invalid-options',
+  REFERENCE_INVALID_OPTIONS_LOCATION: 'schema-reference-options-nesting',
+  REFERENCE_INVALID_FILTER_PARAMS_COMBINATION: 'schema-reference-filter-params-combination',
   SLUG_SLUGIFY_FN_RENAMED: 'slug-slugifyfn-renamed',
   ASSET_METADATA_FIELD_INVALID: 'asset-metadata-field-invalid'
 }

--- a/packages/@sanity/schema/src/sanity/validation/types/reference.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/reference.ts
@@ -1,6 +1,7 @@
 import {error, HELP_IDS} from '../createValidationResult'
 import {flatten, isPlainObject} from 'lodash'
 import {getDupes} from '../utils/getDupes'
+import {ValidationResult} from '../../typedefs'
 
 function normalizeToProp(typeDef) {
   if (Array.isArray(typeDef.to)) {
@@ -36,9 +37,73 @@ export default (typeDef, visitorContext) => {
     )
   }
 
+  problems.push(...getOptionErrors(typeDef))
+
   return {
     ...typeDef,
     to: (isValidTo ? normalizedTo : []).map(visitorContext.visit),
     _problems: problems
   }
+}
+
+function getOptionErrors(typeDef: any): ValidationResult[] {
+  const {options} = typeDef
+  const problems = [] as ValidationResult[]
+
+  problems.push(
+    ...['filter', 'filterParams']
+      .filter(key => key in typeDef)
+      .map(key =>
+        error(
+          `\`${key}\` is not allowed on a reference type definition - did you mean \`options.${key}\`?`,
+          HELP_IDS.REFERENCE_INVALID_OPTIONS_LOCATION
+        )
+      )
+  )
+
+  if (!options) {
+    return problems
+  }
+
+  if (!isPlainObject(options)) {
+    return problems.concat(
+      error(
+        'The reference type expects `options` to be an object',
+        HELP_IDS.REFERENCE_INVALID_OPTIONS
+      )
+    )
+  }
+
+  if (typeof options.filter === 'function' && typeof options.filterParams !== 'undefined') {
+    return problems.concat(
+      error(
+        '`filterParams` cannot be used if `filter` is a function. Either statically define `filter` as a string, or return `params` from the `filter`-function.',
+        HELP_IDS.REFERENCE_INVALID_FILTER_PARAMS_COMBINATION
+      )
+    )
+  }
+
+  if (typeof options.filter === 'function' || (!options.filter && !options.filterParams)) {
+    return problems
+  }
+
+  if (typeof options.filter !== 'string') {
+    return problems.concat(
+      error(`If set, \`filter\` must be a string. Got ${typeof options.filter}`)
+    )
+  }
+
+  if (typeof options.filterParams !== 'undefined' && !isPlainObject(options.filterParams)) {
+    return problems.concat(error(`If set, \`filterParams\` must be an object.`))
+  }
+
+  if (options.filterParams) {
+    return problems.concat(
+      Object.keys(options.filterParams)
+        .filter(key => key.startsWith('__') || key.startsWith('$'))
+        .map(key => error(`Filter parameter cannot be prefixed with "$" or "__". Got ${key}".`))
+    )
+  }
+
+  return problems
 }

--- a/packages/test-studio/schemas/references.js
+++ b/packages/test-studio/schemas/references.js
@@ -8,6 +8,51 @@ export default {
   icon,
   fields: [
     {name: 'title', type: 'string'},
+    {
+      title: 'Book with decade filter',
+      description: 'Reference will only search for books within given decade',
+      name: 'filtered',
+      type: 'object',
+      validation: Rule =>
+        Rule.custom(val => (!val || val.decade ? true : 'Must have decade defined')),
+      fields: [
+        {
+          title: 'Decade',
+          description: 'eg. 1980, 1990, 2000',
+          name: 'decade',
+          type: 'number',
+          validation: Rule =>
+            Rule.required()
+              .min(0)
+              .max(3000)
+              .custom(year => {
+                return year % 10 ? 'Must be a decade, eg use 1990 instead of 1994' : true
+              })
+        },
+        {
+          name: 'book',
+          title: 'Book reference',
+          type: 'reference',
+          to: {type: 'book'},
+          options: {
+            filter: options => {
+              const decade = options.parent && options.parent.decade
+              if (!decade) {
+                return {filter: 'false'} // && false always returns no results :)
+              }
+
+              const minYear = Math.floor(decade / 10) * 10
+              const maxYear = minYear + 9
+
+              return {
+                filter: 'publicationYear >= $minYear && publicationYear <= $maxYear',
+                params: {minYear, maxYear}
+              }
+            }
+          }
+        }
+      ]
+    },
     {name: 'selfRef', type: 'reference', to: {type: 'referenceTest'}},
     {
       name: 'refToTypeWithNoToplevelStrings',


### PR DESCRIPTION
Sometimes, you may want to be more specific about which documents to reference than just the document type. This is a basic implementation where you can pass a `filter` and an optional `filterParams` in the `options` object of reference fields.

Let the discussion commence!