### PR TITLE
[desk-tool] Plugin providers

### DIFF
--- a/packages/@sanity/default-layout/src/components/ComposedProvider.js
+++ b/packages/@sanity/default-layout/src/components/ComposedProvider.js
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+
+const Composed = ({wrappers, children}) => {
+  console.log(wrappers)
+  const Component = wrappers.reverse().reduce(
+    (Prev, {component, props}) => {
+      console.log(props)
+      const Outer = component
+      return () => (
+        <Outer {...props}>
+          <Prev />
+        </Outer>
+      )
+    },
+    () => <React.Fragment>{children}</React.Fragment>
+  )
+
+  return <Component>{children}</Component>
+}
+
+Composed.propTypes = {
+  children: PropTypes.element.isRequired,
+  wrappers: PropTypes.arrayOf(
+    PropTypes.shape({
+      component: PropTypes.element,
+      props: PropTypes.shape({})
+    })
+  )
+}
+
+Composed.defaultProps = {
+  wrappers: []
+}
+
+export default Composed

--- a/packages/@sanity/default-layout/src/components/ComposedProvider.js
+++ b/packages/@sanity/default-layout/src/components/ComposedProvider.js
@@ -1,17 +1,17 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
+/* eslint-disable react/no-multi-comp */
 const Composed = ({wrappers, children}) => {
-  console.log(wrappers)
-  const Component = wrappers.reverse().reduce(
+  const Component = wrappers.reduce(
     (Prev, {component, props}) => {
-      console.log(props)
       const Outer = component
-      return () => (
+      const Wrapped = () => (
         <Outer {...props}>
           <Prev />
         </Outer>
       )
+      return Wrapped
     },
     () => <React.Fragment>{children}</React.Fragment>
   )

--- a/packages/@sanity/default-layout/src/components/DefaultLayoutContainer.js
+++ b/packages/@sanity/default-layout/src/components/DefaultLayoutContainer.js
@@ -7,8 +7,16 @@ import getOrderedTools from '../util/getOrderedTools'
 import rootRouter, {maybeRedirectToBase} from '../defaultLayoutRouter'
 import DefaultLayout from './DefaultLayout'
 import NotFound from './NotFound'
+import ComposedProvider from './ComposedProvider'
 
 const handleNavigate = urlStateStore.navigate
+
+/* Extract all providers into an array */
+const getAllProviders = tools =>
+  tools.reduce((acc, tool) => {
+    if (!tool.providers || !tool.providers.length) return acc
+    return [...acc, ...tool.providers]
+  }, [])
 
 export default class DefaultLayoutContainer extends React.PureComponent {
   state = {}
@@ -30,7 +38,7 @@ export default class DefaultLayoutContainer extends React.PureComponent {
     this.urlStateSubscription.unsubscribe()
   }
 
-  render() {
+  renderInner() {
     const {intent, urlState, isNotFound} = this.state
     const tools = getOrderedTools()
 
@@ -58,5 +66,11 @@ export default class DefaultLayoutContainer extends React.PureComponent {
     ) : (
       router
     )
+  }
+
+  render() {
+    const tools = getOrderedTools()
+    const providers = getAllProviders(tools)
+    return <ComposedProvider wrappers={providers}>{this.renderInner()}</ComposedProvider>
   }
 }


### PR DESCRIPTION
Addresses #1272

Allows plugins to include custom wrappers. (See demo screengrabs in issue)

One problem: these components re-render whenever the user switches from tool to tool. This is implemented in `<DefaultLayoutContainer>` - I wasn't able to identify a better place for it. But, it would be simple to move elsewhere.

- [ ] - write tests
- [ ] - fix multiple renders

If you're into this, it would be super helpful when developing plugins!!