### PR TITLE
[core] Ensure dataset name is a string before validating

### DIFF
--- a/packages/@sanity/core/src/actions/dataset/validateDatasetName.js
+++ b/packages/@sanity/core/src/actions/dataset/validateDatasetName.js
@@ -1,7 +1,9 @@
-module.exports = name => {
-  if (!name) {
+module.exports = datasetName => {
+  if (!datasetName) {
     return 'Dataset name is missing'
   }
+
+  const name = `${datasetName}`
 
   if (name.toLowerCase() !== name) {
     return 'Dataset name must be all lowercase characters'


### PR DESCRIPTION
Fixes a bug where `sanity dataset create 2019` would fail because the CLI auto-converts the argument to a number