### PR TITLE
[dashboard] Update design

### DIFF
--- a/packages/@sanity/dashboard/src/widget.css
+++ b/packages/@sanity/dashboard/src/widget.css
@@ -21,7 +21,7 @@
 }
 
 .title {
-  composes: heading4 from "part:@sanity/base/theme/typography/headings-style";
+  composes: heading4 from 'part:@sanity/base/theme/typography/headings-style';
   padding: var(--small-padding) var(--medium-padding) !important;
 }
 
@@ -34,7 +34,6 @@
 
   @media (--screen-medium) {
     height: stretch;
-    max-height: 30rem;
     overflow-y: auto;
   }
 }

--- a/packages/@sanity/dashboard/src/widgets/sanityTutorials/SanityTutorials.css
+++ b/packages/@sanity/dashboard/src/widgets/sanityTutorials/SanityTutorials.css
@@ -6,27 +6,34 @@
 }
 
 .header {
-  composes: header from "part:@sanity/dashboard/widget-styles";
+  composes: header from 'part:@sanity/dashboard/widget-styles';
 }
 
 .title {
-  composes: title from "part:@sanity/dashboard/widget-styles";
+  composes: title from 'part:@sanity/dashboard/widget-styles';
 }
 
 .grid {
   list-style: none;
   margin: 0;
-  padding: 0 var(--small-padding) var(--small-padding);
-  display: grid;
+  padding: 0 0 var(--small-padding);
+  display: flex;
   overflow-x: auto;
-  grid-template-columns: repeat(5, minmax(200px, 350px));
 
   @nest & li {
+    flex: 0 0 27.5%;
+    width: 30%;
+    min-width: 272px;
     display: flex;
     align-items: stretch;
+    padding-left: var(--small-padding);
 
     @nest & > * {
       flex: 1;
+    }
+
+    @nest &:last-child {
+      padding-right: var(--small-padding);
     }
   }
 }

--- a/packages/@sanity/dashboard/src/widgets/sanityTutorials/SanityTutorials.js
+++ b/packages/@sanity/dashboard/src/widgets/sanityTutorials/SanityTutorials.js
@@ -26,10 +26,11 @@ class SanityTutorials extends React.Component {
 
   render() {
     const {feedItems} = this.state
+    const title = 'Learn about Sanity'
     return (
       <div className={styles.root}>
         <header className={styles.header}>
-          <h1 className={styles.title}>Guides & tutorials</h1>
+          <h1 className={styles.title}>{title}</h1>
         </header>
         <ul className={styles.grid}>
           {feedItems.map(feedItem => {
@@ -47,7 +48,7 @@ class SanityTutorials extends React.Component {
                   presenterSubtitle={`${distanceInWords(new Date(date), new Date())} ago`}
                   posterURL={urlBuilder
                     .image(feedItem.poster)
-                    .height(240)
+                    .height(360)
                     .url()}
                 />
               </li>

--- a/packages/@sanity/dashboard/src/widgets/sanityTutorials/Tutorial.css
+++ b/packages/@sanity/dashboard/src/widgets/sanityTutorials/Tutorial.css
@@ -9,6 +9,21 @@
   flex-direction: column;
   padding: var(--small-padding);
   border-radius: 2px;
+
+  @nest li:first-child & {
+    background-color: var(--main-navigation-color);
+    color: var(--main-navigation-color--inverted);
+
+    @nest &:hover {
+      background: var(--selected-item-color);
+      color: var(--selected-item-color--inverted);
+    }
+
+    @nest &:active {
+      background: var(--selected-item-color-hover);
+      color: var(--selected-item-color-hover--inverted);
+    }
+  }
 }
 
 .byLine {
@@ -62,5 +77,29 @@
 
   @nest &:not([src]) {
     display: none;
+  }
+}
+
+.playIcon {
+  position: absolute;
+  top: calc(50% - 1.375em);
+  left: calc(50% - 1.375em);
+  background: color(var(--component-bg) alpha(90%));
+  width: 2.75em;
+  height: 2.75em;
+  border-radius: 50%;
+
+  @nest & > span {
+    position: absolute;
+    left: 1em;
+    top: calc(50% - 10px);
+    border-left: 15px solid #000;
+    border-top: 10px solid transparent;
+    border-bottom: 10px solid transparent;
+    display: block;
+  }
+
+  @nest .root:hover & {
+    background: var(--component-bg);
   }
 }

--- a/packages/@sanity/dashboard/src/widgets/sanityTutorials/Tutorial.js
+++ b/packages/@sanity/dashboard/src/widgets/sanityTutorials/Tutorial.js
@@ -21,6 +21,9 @@ class Tutorial extends React.PureComponent {
       <a className={styles.root} href={href}>
         <div className={styles.posterContainer}>
           <img className={styles.poster} src={posterURL} />
+          <div className={styles.playIcon}>
+            <span />
+          </div>
         </div>
         <h3 className={styles.title}>{title}</h3>
         <div className={styles.byLine}>

--- a/packages/test-studio/src/dashboardConfig.js
+++ b/packages/test-studio/src/dashboardConfig.js
@@ -33,6 +33,7 @@ export default {
         ]
       }
     },
-    {name: 'cats'}
+    {name: 'cats'},
+    {name: 'document-list', options: {limit: 100}}
   ]
 }


### PR DESCRIPTION
Updates the tutorials stream to use flex box (to allow for cut-off of the last item, for discoverability).

![image](https://user-images.githubusercontent.com/406933/56797936-1f95f000-6816-11e9-8698-3d7a2521b29b.png)

Changes the max-height logic to fix weird overflow scrolling.

Adds play icon to tutorial items.