### PR TITLE
[form-builder] Pass on markers from asset inputs to fieldset

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/FileInput/FileInput.js
+++ b/packages/@sanity/form-builder/src/inputs/FileInput/FileInput.js
@@ -15,7 +15,7 @@ import styles from './styles/FileInput.css'
 import Dialog from 'part:@sanity/components/dialogs/fullscreen'
 import {ObservableI} from '../../typedefs/observable'
 
-import type {Reference, Type} from '../../typedefs'
+import type {Reference, Type, Marker} from '../../typedefs'
 import type {Uploader, UploaderResolver} from '../../sanity/uploads/typedefs'
 
 import WithMaterializedReference from '../../utils/WithMaterializedReference'
@@ -46,7 +46,8 @@ type Props = {
   onBlur: () => void,
   onFocus: () => void,
   readOnly: ?boolean,
-  focusPath: Array<*>
+  focusPath: Array<*>,
+  markers: Array<Marker>
 }
 
 type State = {
@@ -283,7 +284,7 @@ export default class FileInput extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const {type, value, level, readOnly} = this.props
+    const {type, value, level, markers, readOnly} = this.props
 
     const {isAdvancedEditOpen, uploadError} = this.state
 
@@ -296,6 +297,7 @@ export default class FileInput extends React.PureComponent<Props, State> {
 
     return (
       <UploadTargetFieldset
+        markers={markers}
         legend={type.title}
         description={type.description}
         level={level}

--- a/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.js
+++ b/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.js
@@ -15,7 +15,7 @@ import Dialog from 'part:@sanity/components/dialogs/fullscreen'
 import {ObservableI} from '../../typedefs/observable'
 import ButtonGrid from 'part:@sanity/components/buttons/button-grid'
 
-import type {Reference, Type} from '../../typedefs'
+import type {Reference, Type, Marker} from '../../typedefs'
 import type {Uploader, UploaderResolver} from '../../sanity/uploads/typedefs'
 
 import WithMaterializedReference from '../../utils/WithMaterializedReference'
@@ -49,7 +49,8 @@ type Props = {
   onBlur: () => void,
   onFocus: () => void,
   readOnly: ?boolean,
-  focusPath: Array<*>
+  focusPath: Array<*>,
+  markers: Array<Marker>
 }
 
 type State = {
@@ -327,7 +328,7 @@ export default class ImageInput extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const {type, value, level, materialize, readOnly} = this.props
+    const {type, value, level, materialize, markers, readOnly} = this.props
 
     const {isAdvancedEditOpen, isSelectAssetOpen, uploadError, hasFocus} = this.state
 
@@ -342,6 +343,7 @@ export default class ImageInput extends React.PureComponent<Props, State> {
 
     return (
       <UploadTargetFieldset
+        markers={markers}
         legend={type.title}
         description={type.description}
         level={level}


### PR DESCRIPTION
Image and file fields were not getting their markers displayed because they were not passed down to the fieldset. This fixes that, making validation status more prominent.