### PR TITLE
[validation] Exclude meta fields from object emptiness check

### DIFF
--- a/packages/@sanity/validation/src/validators/objectValidator.js
+++ b/packages/@sanity/validation/src/validators/objectValidator.js
@@ -1,12 +1,15 @@
 const ValidationError = require('../ValidationError')
 const genericValidator = require('./genericValidator')
 
+const metaKeys = ['_key', '_type', '_weak']
+
 const presence = (expected, value, message) => {
   if (expected !== 'required') {
     return true
   }
 
-  if (typeof value === 'undefined' || Object.keys(value).length === 0) {
+  const keys = value && Object.keys(value).filter(key => !metaKeys.includes(key))
+  if (typeof value === 'undefined' || (keys && keys.length === 0)) {
     return new ValidationError(message || 'Required')
   }
 


### PR DESCRIPTION
Currently, if you have an object type with an object only consisting of meta fields, for instance:
```
{_type: 'foo'}
```

...it is treated as having a value, and the `required()` validation does not kick in.

This PR changes the semantics to exclude the following meta keys: `_key`, `_type`, `_weak`.
