### PR TITLE
[schema] Allow file + image to extend validation

### DIFF
--- a/packages/@sanity/schema/src/legacy/types/file.js
+++ b/packages/@sanity/schema/src/legacy/types/file.js
@@ -15,7 +15,8 @@ const OVERRIDABLE_FIELDS = [
   'title',
   'description',
   'options',
-  'fieldsets'
+  'fieldsets',
+  'validation'
 ]
 
 const FILE_CORE = {

--- a/packages/@sanity/schema/src/legacy/types/image.js
+++ b/packages/@sanity/schema/src/legacy/types/image.js
@@ -10,7 +10,8 @@ const OVERRIDABLE_FIELDS = [
   'title',
   'description',
   'options',
-  'fieldsets'
+  'fieldsets',
+  'validation'
 ]
 
 const IMAGE_CORE = {


### PR DESCRIPTION
If you extend an image or file type by adding custom fields, validation no longer kicked in. This PR fixes that by allowing the specification of the `validation` property on subtypes.