### PR TITLE
[form-builder] Hide image edit button if no fields and no asset

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.js
+++ b/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.js
@@ -338,7 +338,8 @@ export default class ImageInput extends React.PureComponent<Props, State> {
 
     const hasAsset = value && value.asset
 
-    const showAdvancedEditButton = value && (otherFields.length > 0 || this.isImageToolEnabled())
+    const showAdvancedEditButton =
+      value && (otherFields.length > 0 || (hasAsset && this.isImageToolEnabled()))
 
     return (
       <UploadTargetFieldset


### PR DESCRIPTION
If you have an image field where all the fields are "hoisted"/"highlighted" to always be shown and the hotspot tool is enabled, the edit button is shown. If however the field does not have any asset, the dialog shows nothing but a header.

With this PR, we only show the edit button if the image has non-hoisted fields, _OR_ the image field both has an asset _and_ has hotspot enabled.