### PR TITLE
[client] Raise default timeout, allow overriding per-request

### DIFF
--- a/packages/@sanity/client/src/data/dataMethods.js
+++ b/packages/@sanity/client/src/data/dataMethods.js
@@ -42,7 +42,7 @@ module.exports = {
   fetch(query, params, options = {}) {
     const mapResponse = options.filterResponse === false ? res => res : res => res.result
 
-    const observable = this._dataRequest('query', {query, params}).pipe(map(mapResponse))
+    const observable = this._dataRequest('query', {query, params}, options).pipe(map(mapResponse))
     return this.isPromiseAPI() ? toPromise(observable) : observable
   },
 
@@ -108,6 +108,7 @@ module.exports = {
     const useGet = !isMutation && strQuery.length < getQuerySizeLimit
     const stringQuery = useGet ? strQuery : ''
     const returnFirst = options.returnFirst
+    const {timeout, token} = options
 
     const uri = this.getDataUrl(endpoint, stringQuery)
 
@@ -116,7 +117,9 @@ module.exports = {
       uri: uri,
       json: true,
       body: useGet ? undefined : body,
-      query: isMutation && getMutationQuery(options)
+      query: isMutation && getMutationQuery(options),
+      timeout,
+      token
     }
 
     return this._requestObservable(reqOptions).pipe(

--- a/packages/@sanity/client/src/http/requestOptions.js
+++ b/packages/@sanity/client/src/http/requestOptions.js
@@ -13,7 +13,7 @@ module.exports = config => {
 
   return {
     headers: headers,
-    timeout: 'timeout' in config ? config.timeout : 30000,
+    timeout: 'timeout' in config ? config.timeout : 5 * 60 * 1000,
     json: true,
     withCredentials: Boolean(config.token || config.withCredentials)
   }

--- a/packages/@sanity/client/src/http/requestOptions.js
+++ b/packages/@sanity/client/src/http/requestOptions.js
@@ -1,20 +1,24 @@
+const assign = require('object-assign')
+
 const projectHeader = 'X-Sanity-Project-ID'
 
-module.exports = config => {
+module.exports = (config, overrides = {}) => {
   const headers = {}
 
-  if (config.token) {
-    headers.Authorization = `Bearer ${config.token}`
+  const token = overrides.token || config.token
+  if (token) {
+    headers.Authorization = `Bearer ${token}`
   }
 
   if (!config.useProjectHostname && config.projectId) {
     headers[projectHeader] = config.projectId
   }
 
-  return {
-    headers: headers,
-    timeout: 'timeout' in config ? config.timeout : 5 * 60 * 1000,
+  const timeout = typeof overrides.timeout === 'undefined' ? config.timeout : overrides.timeout
+  return assign({}, overrides, {
+    headers: assign({}, headers, overrides.headers || {}),
+    timeout: typeof timeout === 'undefined' ? 5 * 60 * 1000 : timeout,
     json: true,
     withCredentials: Boolean(config.token || config.withCredentials)
-  }
+  })
 }

--- a/packages/@sanity/client/src/sanityClient.js
+++ b/packages/@sanity/client/src/sanityClient.js
@@ -70,12 +70,14 @@ assign(SanityClient.prototype, {
       ['GET', 'HEAD'].indexOf(options.method || 'GET') >= 0 &&
       uri.indexOf('/data/') === 0
 
-    return httpRequest(
-      mergeOptions(getRequestOptions(this.clientConfig), options, {
+    const reqOptions = getRequestOptions(
+      this.clientConfig,
+      assign({}, options, {
         url: this.getUrl(uri, canUseCdn)
-      }),
-      this.clientConfig.requester
+      })
     )
+
+    return httpRequest(reqOptions, this.clientConfig.requester)
   },
 
   request(options) {
@@ -87,17 +89,6 @@ assign(SanityClient.prototype, {
     return this.isPromiseAPI() ? toPromise(observable) : observable
   }
 })
-
-// Merge http options and headers
-function mergeOptions(...opts) {
-  const headers = opts.reduce((merged, options) => {
-    if (!merged && !options.headers) {
-      return null
-    }
-    return assign(merged || {}, options.headers || {})
-  }, null)
-  return assign(...opts, headers ? {headers} : {})
-}
 
 SanityClient.Patch = Patch
 SanityClient.Transaction = Transaction


### PR DESCRIPTION
This PR ensures that the default timeout is above the technical limits (5 minutes, vs 3 minute mutation and 1 minute query timeout). This will lead to more understandable error messages on timeouts, and being able to more easily differentiate between _client_ and _server_ timeouts.

Also added the ability to override timeout and token on a per-request basis, which can be quite useful in a lot of situations.