### PR TITLE
[import] Don't override _type for imported assets

### DIFF
--- a/packages/@sanity/import/src/uploadAssets.js
+++ b/packages/@sanity/import/src/uploadAssets.js
@@ -236,13 +236,16 @@ function getAssetType(assetId) {
 
 function reducePatch(trx, task) {
   return trx.patch(task.documentId, patch =>
-    patch.setIfMissing({[task.path]: {}}).set({
-      [`${task.path}._type`]: getAssetType(task.assetId),
-      [`${task.path}.asset`]: {
-        _type: 'reference',
-        _ref: task.assetId
-      }
-    })
+    patch
+      .setIfMissing({
+        [task.path]: {_type: getAssetType(task.assetId)}
+      })
+      .set({
+        [`${task.path}.asset`]: {
+          _type: 'reference',
+          _ref: task.assetId
+        }
+      })
   )
 }
 

--- a/packages/@sanity/import/test/__snapshots__/uploadAssets.test.js.snap
+++ b/packages/@sanity/import/test/__snapshots__/uploadAssets.test.js.snap
@@ -12,14 +12,15 @@ Object {
       "patch": Object {
         "id": "movie_1",
         "set": Object {
-          "metadata.poster._type": "someAssetI",
           "metadata.poster.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "metadata.poster": Object {},
+          "metadata.poster": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -34,14 +35,15 @@ Object {
       "patch": Object {
         "id": "movie_1",
         "set": Object {
-          "metadata.poster._type": "newAssetI",
           "metadata.poster.asset": Object {
             "_ref": "newAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "metadata.poster": Object {},
+          "metadata.poster": Object {
+            "_type": "newAssetI",
+          },
         },
       },
     },
@@ -56,14 +58,15 @@ Object {
       "patch": Object {
         "id": "doc_1",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -71,14 +74,15 @@ Object {
       "patch": Object {
         "id": "doc_2",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -86,14 +90,15 @@ Object {
       "patch": Object {
         "id": "doc_3",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -101,14 +106,15 @@ Object {
       "patch": Object {
         "id": "doc_4",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -116,14 +122,15 @@ Object {
       "patch": Object {
         "id": "doc_5",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -131,14 +138,15 @@ Object {
       "patch": Object {
         "id": "doc_6",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -146,14 +154,15 @@ Object {
       "patch": Object {
         "id": "doc_7",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -161,14 +170,15 @@ Object {
       "patch": Object {
         "id": "doc_8",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -176,14 +186,15 @@ Object {
       "patch": Object {
         "id": "doc_9",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -191,14 +202,15 @@ Object {
       "patch": Object {
         "id": "doc_10",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -206,14 +218,15 @@ Object {
       "patch": Object {
         "id": "doc_11",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -221,14 +234,15 @@ Object {
       "patch": Object {
         "id": "doc_12",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -236,14 +250,15 @@ Object {
       "patch": Object {
         "id": "doc_13",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -251,14 +266,15 @@ Object {
       "patch": Object {
         "id": "doc_14",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -266,14 +282,15 @@ Object {
       "patch": Object {
         "id": "doc_15",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -281,14 +298,15 @@ Object {
       "patch": Object {
         "id": "doc_16",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -296,14 +314,15 @@ Object {
       "patch": Object {
         "id": "doc_17",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -311,14 +330,15 @@ Object {
       "patch": Object {
         "id": "doc_18",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -326,14 +346,15 @@ Object {
       "patch": Object {
         "id": "doc_19",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -341,14 +362,15 @@ Object {
       "patch": Object {
         "id": "doc_20",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -356,14 +378,15 @@ Object {
       "patch": Object {
         "id": "doc_21",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -371,14 +394,15 @@ Object {
       "patch": Object {
         "id": "doc_22",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -386,14 +410,15 @@ Object {
       "patch": Object {
         "id": "doc_23",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -401,14 +426,15 @@ Object {
       "patch": Object {
         "id": "doc_24",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -416,14 +442,15 @@ Object {
       "patch": Object {
         "id": "doc_25",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -431,14 +458,15 @@ Object {
       "patch": Object {
         "id": "doc_26",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -446,14 +474,15 @@ Object {
       "patch": Object {
         "id": "doc_27",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -461,14 +490,15 @@ Object {
       "patch": Object {
         "id": "doc_28",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -476,14 +506,15 @@ Object {
       "patch": Object {
         "id": "doc_29",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -491,14 +522,15 @@ Object {
       "patch": Object {
         "id": "doc_30",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -506,14 +538,15 @@ Object {
       "patch": Object {
         "id": "doc_31",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -521,14 +554,15 @@ Object {
       "patch": Object {
         "id": "doc_32",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -536,14 +570,15 @@ Object {
       "patch": Object {
         "id": "doc_33",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -551,14 +586,15 @@ Object {
       "patch": Object {
         "id": "doc_34",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -566,14 +602,15 @@ Object {
       "patch": Object {
         "id": "doc_35",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -581,14 +618,15 @@ Object {
       "patch": Object {
         "id": "doc_36",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -596,14 +634,15 @@ Object {
       "patch": Object {
         "id": "doc_37",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -611,14 +650,15 @@ Object {
       "patch": Object {
         "id": "doc_38",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -626,14 +666,15 @@ Object {
       "patch": Object {
         "id": "doc_39",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -641,14 +682,15 @@ Object {
       "patch": Object {
         "id": "doc_40",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -656,14 +698,15 @@ Object {
       "patch": Object {
         "id": "doc_41",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -671,14 +714,15 @@ Object {
       "patch": Object {
         "id": "doc_42",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -686,14 +730,15 @@ Object {
       "patch": Object {
         "id": "doc_43",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -701,14 +746,15 @@ Object {
       "patch": Object {
         "id": "doc_44",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -716,14 +762,15 @@ Object {
       "patch": Object {
         "id": "doc_45",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -731,14 +778,15 @@ Object {
       "patch": Object {
         "id": "doc_46",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -746,14 +794,15 @@ Object {
       "patch": Object {
         "id": "doc_47",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -761,14 +810,15 @@ Object {
       "patch": Object {
         "id": "doc_48",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -776,14 +826,15 @@ Object {
       "patch": Object {
         "id": "doc_49",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -791,14 +842,15 @@ Object {
       "patch": Object {
         "id": "doc_50",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -813,14 +865,15 @@ Object {
       "patch": Object {
         "id": "doc_51",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -828,14 +881,15 @@ Object {
       "patch": Object {
         "id": "doc_52",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -843,14 +897,15 @@ Object {
       "patch": Object {
         "id": "doc_53",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -858,14 +913,15 @@ Object {
       "patch": Object {
         "id": "doc_54",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -873,14 +929,15 @@ Object {
       "patch": Object {
         "id": "doc_55",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -888,14 +945,15 @@ Object {
       "patch": Object {
         "id": "doc_56",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -903,14 +961,15 @@ Object {
       "patch": Object {
         "id": "doc_57",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -918,14 +977,15 @@ Object {
       "patch": Object {
         "id": "doc_58",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -933,14 +993,15 @@ Object {
       "patch": Object {
         "id": "doc_59",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },
@@ -948,14 +1009,15 @@ Object {
       "patch": Object {
         "id": "doc_60",
         "set": Object {
-          "some.path._type": "someAssetI",
           "some.path.asset": Object {
             "_ref": "someAssetId",
             "_type": "reference",
           },
         },
         "setIfMissing": Object {
-          "some.path": Object {},
+          "some.path": Object {
+            "_type": "someAssetI",
+          },
         },
       },
     },


### PR DESCRIPTION
If you have the following in an exported dataset dump:
```js
{
  _id: 'foo',
  _type: 'someDocument',
  coverImage: {
    _type: 'myCustomImage',
    _sanityAsset: 'image@some-path.jpg'
  }
}
```

The `_type` property will be overwritten:
```js
{
  _id: 'foo',
  _type: 'someDocument',
  coverImage: {
    _type: 'image',
    asset: {_ref: 'some-ref'}
  }
}
```

This PR fixes this by using a `setIfMissing` patch instead.