### PR TITLE
[export] Recusively rewrite additional fields on image/file fields

### DIFF
--- a/packages/@sanity/export/src/AssetHandler.js
+++ b/packages/@sanity/export/src/AssetHandler.js
@@ -146,13 +146,19 @@ class AssetHandler {
       if (isModernAsset(assetId)) {
         const assetType = getAssetType(item)
         const filePath = `${assetType}s/${generateFilename(assetId)}`
-        return {_sanityAsset: `${assetType}@file://./${filePath}`, ...other}
+        return {
+          _sanityAsset: `${assetType}@file://./${filePath}`,
+          ...(await this.findAndModify(other, action))
+        }
       }
 
       // Legacy asset
       const type = this.assetsSeen.get(assetId) || (await this.lookupAssetType(assetId))
       const filePath = `${type}s/${generateFilename(assetId)}`
-      return {_sanityAsset: `${type}@file://./${filePath}`, ...other}
+      return {
+        _sanityAsset: `${type}@file://./${filePath}`,
+        ...(await this.findAndModify(other, action))
+      }
     }
 
     const newItem = {}

--- a/packages/@sanity/export/test/AssetHandler.test.js
+++ b/packages/@sanity/export/test/AssetHandler.test.js
@@ -15,7 +15,7 @@ describe('asset handler', () => {
   test('can rewrite documents / queue downloads', done => {
     // prettier-ignore
     const docs = [
-      {_id: 'doc1', _type: 'bike', name: 'Scooter', image: {_type: 'image', caption: 'Scooter bike', asset: {_ref: 'image-idx_abc123-3360x840-png'}}},
+      {_id: 'doc1', _type: 'bike', name: 'Scooter', image: {_type: 'image', caption: 'Scooter bike', asset: {_ref: 'image-idx_abc123-3360x840-png'}, nested: {_type: 'image', asset: {_ref: 'image-idx_abc123-3360x840-png'}}}},
       {_id: 'doc2', _type: 'bike', name: 'Dupe', image: {_type: 'image', asset: {_ref: 'image-idx_abc123-3360x840-png'}}},
       {_id: 'doc3', _type: 'bike', name: 'Tandem', image: {_type: 'image', asset: {_ref: 'image-idx_abc456-310x282-jpg'}}},
       {_id: 'old4', _type: 'bike', name: 'Cool', image: {asset: {_ref: 'mzFgq1cvHSEeGscxBsRFoqKG'}}},

--- a/packages/@sanity/export/test/__snapshots__/AssetHandler.test.js.snap
+++ b/packages/@sanity/export/test/__snapshots__/AssetHandler.test.js.snap
@@ -56,6 +56,10 @@ Object {
     "_sanityAsset": "image@file://./images/idx_abc123-3360x840.png",
     "_type": "image",
     "caption": "Scooter bike",
+    "nested": Object {
+      "_sanityAsset": "image@file://./images/idx_abc123-3360x840.png",
+      "_type": "image",
+    },
   },
   "name": "Scooter",
 }


### PR DESCRIPTION
This fixes an issue with `sanity export` that affected asset fields that had additional fields that also included assets.