### PR TITLE
[import] Use unique tempdirs when unpacking archive for import

### DIFF
--- a/packages/@sanity/import/package.json
+++ b/packages/@sanity/import/package.json
@@ -38,6 +38,7 @@
     "peek-stream": "^1.1.2",
     "split2": "^2.1.1",
     "tar-fs": "^1.16.0",
+    "tempy": "^0.3.0",
     "whatwg-url": "^7.0.0"
   },
   "devDependencies": {

--- a/packages/@sanity/import/src/importFromStream.js
+++ b/packages/@sanity/import/src/importFromStream.js
@@ -6,6 +6,7 @@ const gunzipMaybe = require('gunzip-maybe')
 const peek = require('peek-stream')
 const isTar = require('is-tar')
 const tar = require('tar-fs')
+const tempy = require('tempy')
 const globby = require('globby')
 const debug = require('debug')('sanity:import:stream')
 const {noop} = require('lodash')
@@ -13,7 +14,7 @@ const getJsonStreamer = require('./util/getJsonStreamer')
 
 module.exports = (stream, options, importers) =>
   new Promise((resolve, reject) => {
-    const outputPath = path.join(os.tmpdir(), 'sanity-import')
+    const outputPath = path.join(tempy.directory(), 'sanity-import')
     debug('Importing from stream')
 
     let isTarStream = false


### PR DESCRIPTION
Previously `sanity import` reused the same tempdir when unpacking archives to be imported. This could leave the import folder in an unwanted state (e.g. including assets from previous imports). This patch ensures every run of `sanity import` gets assigned it's own unique tempdir.