### PR TITLE
[block-tools] Add info about running sanity scripts

### DIFF
--- a/packages/@sanity/block-tools/README.md
+++ b/packages/@sanity/block-tools/README.md
@@ -2,6 +2,12 @@
 
 Various tools for processing Sanity block content. Mostly used internally in the Studio code, but it got some nice functions (especially `htmlToBlocks`) which is handy when you are importing data from HTML into your dataset as block text.
 
+**NOTE:** If you want to use `@sanity/block-tools` in a Node.js script, make sure to run it with `sanity exec` (see [docs](https://www.sanity.io/docs/cli/exec)):
+
+```sh
+sanity exec path/to/script.js
+```
+
 ## Example
 
 Let's start with a complete example:


### PR DESCRIPTION
A user was having issues with running a script using `@sanity/block-tools`.

> Hei, jeg prøver å bruke @sanity/block-tools i et eksternt node-script i vårt sanity-prosjekt til å konvertere html. Men jeg får aldri kjørt scriptet. Hvis jeg kjører med modules-støtte så fungerer ikke referansen til @sanity/schema. Hvis jeg bruker require så kommer jeg et skritt lenger, men det stopper i schema.js på import av part:@sanity/base/schema-creator.

> Hva er det jeg gjør galt?

Which is understandable, because `sanity exec` is not mentioned anywhere in the README.