### PR TITLE
Fix editor on paste patch bug

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Editor.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Editor.js
@@ -321,13 +321,12 @@ export default class Editor extends React.Component<Props> {
           throw result
         }
         if (result && result.insert) {
-          const patches =
+          const patches = [
+            setIfMissing(result.insert),
             this.props.value && this.props.value.length !== 0
-              ? [
-                  setIfMissing(result.insert),
-                  insert(result.insert, 'after', result.path || focusPath)
-                ]
-              : [setIfMissing(result.insert), set(result.insert, [])]
+              ? insert(result.insert, 'after', result.path || focusPath)
+              : set(result.insert, [])
+          ]
           onPatch(PatchEvent.from(patches))
           onLoading({paste: null})
           return result.insert

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Editor.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Editor.js
@@ -13,7 +13,7 @@ import insertBlockOnEnter from 'slate-insert-block-on-enter'
 import onPasteFromPart from 'part:@sanity/form-builder/input/block-editor/on-paste?'
 import onCopy from 'part:@sanity/form-builder/input/block-editor/on-copy?'
 
-import PatchEvent, {insert} from '../../../PatchEvent'
+import PatchEvent, {insert, set, setIfMissing} from '../../../PatchEvent'
 import type {
   BlockContentFeatures,
   FormBuilderValue,
@@ -321,7 +321,14 @@ export default class Editor extends React.Component<Props> {
           throw result
         }
         if (result && result.insert) {
-          onPatch(PatchEvent.from([insert(result.insert, 'after', result.path || focusPath)]))
+          const patches =
+            this.props.value && this.props.value.length !== 0
+              ? [
+                  setIfMissing(result.insert),
+                  insert(result.insert, 'after', result.path || focusPath)
+                ]
+              : [setIfMissing(result.insert), set(result.insert, [])]
+          onPatch(PatchEvent.from(patches))
           onLoading({paste: null})
           return result.insert
         }

--- a/packages/example-studio/package.json
+++ b/packages/example-studio/package.json
@@ -18,6 +18,7 @@
     "example-studio"
   ],
   "dependencies": {
+    "@sanity/block-tools": "0.140.17",
     "@sanity/base": "0.140.17",
     "@sanity/cli": "0.140.17",
     "@sanity/code-input": "0.140.12",


### PR DESCRIPTION
The custom paste handler must take into account that the field can now be empty (it was always populated by a block before)