### PR TITLE
Fix block editor inline bug

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/plugins/InsertInlineObjectPlugin.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/plugins/InsertInlineObjectPlugin.js
@@ -1,9 +1,24 @@
 // @flow
 import {Inline} from 'slate'
 import {randomKey} from '@sanity/block-tools'
+import {editorValueToBlocks, blocksToEditorValue} from '@sanity/block-tools'
 import type {SlateEditor, Type} from '../typeDefs'
+import {VALUE_TO_JSON_OPTS} from '../utils/createOperationToPatches'
 
 export default function InsertInlineObjectPlugin(blockContentType: Type) {
+  function normalizeBlock(block) {
+    return blocksToEditorValue(
+      editorValueToBlocks(
+        {
+          document: {
+            nodes: [block.toJSON(VALUE_TO_JSON_OPTS)]
+          }
+        },
+        blockContentType
+      ),
+      blockContentType
+    ).document.nodes[0]
+  }
   return {
     onCommand(command: any, editor: SlateEditor, next: void => void) {
       if (command.type !== 'insertInlineObject') {
@@ -23,6 +38,12 @@ export default function InsertInlineObjectPlugin(blockContentType: Type) {
       }
       const inline = Inline.create(inlineProps)
       editor.insertInline(inline)
+
+      // Normalize the keys in the block nodes to match what is sent to gradient
+      const inlinePath = editor.value.selection.focus.path
+      const block = editor.value.focusBlock
+      editor.replaceNodeByKey(block.key, normalizeBlock(block))
+      editor.moveTo(inlinePath, 0)
       return editor
     }
   }

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/plugins/TogglePlaceHolderPlugin.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/plugins/TogglePlaceHolderPlugin.js
@@ -8,26 +8,38 @@
 
 import type {SlateEditor} from '../typeDefs'
 
-export default function TogglePlaceHolderAttributePlugin() {
-  return {
-    onKeyUp(event: any, editor: SlateEditor, next: void => void) {
-      if (editor.value.document.nodes.size === 1) {
-        const block = editor.value.document.nodes.first()
-        if (
-          block.type === 'contentBlock' &&
-          block.nodes.every(node => node.object === 'text') &&
-          block.text === ''
-        ) {
-          const newData = block.data.toObject()
-          newData.placeholder = true
-          editor.setNodeByKey(block.key, {data: newData})
-        } else if (block.type === 'contentBlock' && block.data.get('placeholder')) {
-          const newData = block.data.toObject()
-          delete newData.placeholder
-          editor.setNodeByKey(block.key, {data: newData})
-        }
-      }
+function toggle(event: any, editor: SlateEditor, next: void => void, isCommand = false) {
+  const block = editor.value.document.nodes.first()
+  if (isCommand) {
+    if (event.type !== 'insertInlineObject') {
       return next()
     }
+    const newData = block.data.toObject()
+    delete newData.placeholder
+    editor.setNodeByKey(block.key, {data: newData})
+    return next()
+  }
+  if (editor.value.document.nodes.size === 1) {
+    if (
+      block.type === 'contentBlock' &&
+      block.nodes.every(node => node.object === 'text') &&
+      block.text === ''
+    ) {
+      const newData = block.data.toObject()
+      newData.placeholder = true
+      editor.setNodeByKey(block.key, {data: newData})
+    } else if (block.type === 'contentBlock' && block.data.get('placeholder')) {
+      const newData = block.data.toObject()
+      delete newData.placeholder
+      editor.setNodeByKey(block.key, {data: newData})
+    }
+  }
+  return next()
+}
+
+export default function TogglePlaceHolderAttributePlugin() {
+  return {
+    onKeyUp: toggle,
+    onCommand: (command, editor, next) => toggle(command, editor, next, true)
   }
 }


### PR DESCRIPTION
Fixes two bugs where there would be deviations in the data in the editor and in the actual datastore, leading to crashes. Both are related to InlineObjects.

