### PR TITLE
[export] Use SHA1 for validation if MD5 is not available

### DIFF
--- a/packages/@sanity/export/.eslintrc
+++ b/packages/@sanity/export/.eslintrc
@@ -4,6 +4,7 @@
     "node": true
   },
   "rules": {
-    "import/no-commonjs": "off"
+    "import/no-commonjs": "off",
+    "complexity": ["warn", 15]
   }
 }


### PR DESCRIPTION
Because _mistakes were made_ ™️ , we don't always have an md5 sum available for uploaded assets, but we _do_ have a SHA1 sum. With this change;

- If no etag (md5) or sha1 header is present, assume the download is valid
- If no etag (md5) is present but a sha1 header _is_, use sha1 for validation
- If both etag (md5) _and_ sha1 header is available, use md5 for validation

A bit messy, but we can phase out one approach in the future.
