### PR TITLE
[form-builder] Display "no images found" text if no images are found

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ImageInput/SelectAsset.js
+++ b/packages/@sanity/form-builder/src/inputs/ImageInput/SelectAsset.js
@@ -99,6 +99,7 @@ export default class SelectAsset extends React.Component<Props, State> {
             />
           ))}
         </div>
+        {!isLoading && assets.length === 0 && <div>No images found</div>}
         <div className={styles.loadMore}>
           {!isLastPage && (
             <Button onClick={this.handleFetchNextPage} loading={isLoading}>


### PR DESCRIPTION
If no images are found, we just show an empty dialog with the title "Select image". This adds a (minimal) message to let you know what's going on.