### PR TITLE
[form-builder] Don't show 'Load more'-button if reached known end

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ImageInput/SelectAsset.js
+++ b/packages/@sanity/form-builder/src/inputs/ImageInput/SelectAsset.js
@@ -45,7 +45,7 @@ export default class SelectAsset extends React.Component<Props, State> {
     this.setState({isLoading: true})
     return client.fetch(createQuery(start, end)).then(result => {
       this.setState(prevState => ({
-        isLastPage: result.length === 0,
+        isLastPage: result.length < PER_PAGE,
         assets: prevState.assets.concat(result),
         isLoading: false
       }))


### PR DESCRIPTION
If we request 200 items and receive less than this amount, we can assume we're at the end. This doesn't solve the case where there is exactly `PER_PAGE` items to load, but should at least provide a better UX 99% of the time.