### PR TITLE
[form-builder] Use loading state for reference input while loading initial value

### DIFF
--- a/packages/@sanity/components/src/selects/SearchableSelect.js
+++ b/packages/@sanity/components/src/selects/SearchableSelect.js
@@ -141,7 +141,7 @@ export default class SearchableSelect extends React.PureComponent {
         <StatelessSearchableSelect
           {...rest}
           {...changeHandlers}
-          placeholder={readOnly ? 'No value' : placeholder}
+          placeholder={placeholder}
           onFocus={this.handleFocus}
           onBlur={this.handleBlur}
           onHighlightIndexChange={this.handleHighlightIndexChange}

--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.js
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.js
@@ -190,16 +190,7 @@ export default class ReferenceInput extends React.Component<Props, State> {
   }
 
   render() {
-    const {
-      type,
-      value,
-      level,
-      markers,
-      readOnly,
-      onSearch,
-      getPreviewSnapshot,
-      ...rest
-    } = this.props
+    const {type, value, level, markers, readOnly} = this.props
 
     const {previewSnapshot, isFetching, hits} = this.state
     const valueFromHit = value && hits.find(hit => hit._id === value._ref)
@@ -220,6 +211,9 @@ export default class ReferenceInput extends React.Component<Props, State> {
       inputValue = 'Untitled document'
     }
 
+    const isLoadingSnapshot = value && value._ref && !previewSnapshot
+    const placeholder = isLoadingSnapshot ? 'Loading…' : 'Type to search…'
+
     return (
       <FormField markers={markers} label={type.title} level={level} description={type.description}>
         <div className={hasWeakMismatch || isMissing ? styles.hasWarnings : ''}>
@@ -233,7 +227,7 @@ export default class ReferenceInput extends React.Component<Props, State> {
             </div>
           )}
           <SearchableSelect
-            placeholder="Type to search…"
+            placeholder={placeholder}
             title={
               isMissing && hasRef
                 ? `Document id: ${value._ref || 'unknown'}`
@@ -249,10 +243,10 @@ export default class ReferenceInput extends React.Component<Props, State> {
             value={valueFromHit || value}
             inputValue={isMissing ? '<Unpublished or missing document>' : inputValue}
             renderItem={this.renderHit}
-            isLoading={isFetching}
+            isLoading={isFetching || isLoadingSnapshot}
             items={hits}
             ref={this.setInput}
-            readOnly={readOnly}
+            readOnly={readOnly || isLoadingSnapshot}
           />
         </div>
       </FormField>


### PR DESCRIPTION
When you are on a slow connection, the reference input will simply show an empty input with the placeholder "Type to search" while it is loading the preview snapshot. This fixes this issue by checking for this state and changing the placeholder to "Loading..." as well as putting the input into read-only mode. The loading state is also passed down to the underlying searchable select.

In order to make this work, I had to remove a special-cased check for the placeholder in SearchableSelect, where if the input was in read-only mode, it would show "No value". I'm not sure why this was chosen as a behavior, so please correct me/this PR if this has to be done differently.
