### PR TITLE
[schema] Provide fallback for preview select if none is given

### DIFF
--- a/packages/@sanity/schema/src/legacy/preview/createPreviewGetter.ts
+++ b/packages/@sanity/schema/src/legacy/preview/createPreviewGetter.ts
@@ -13,7 +13,7 @@ function parsePreview(preview) {
   if (!preview) {
     return preview
   }
-  const select = preview.select || preview.fields
+  const select = preview.select || preview.fields || {}
   if (Array.isArray(select)) {
     return {
       ...pick(preview, ['prepare', 'component']),


### PR DESCRIPTION
This does not yield `Static title`:
```js
export default {
  name: 'noTitleField',
  type: 'document',
  title: 'No title field',
  preview: {
    prepare: () => ({title: 'Static title'})
  },
  fields: [
    {
      name: 'isChecked',
      type: 'boolean',
      title: 'Is checked?'
    }
  ]
}
```

This works:
```js
export default {
  name: 'noTitleField',
  type: 'document',
  title: 'No title field',
  preview: {
    select: {},
    prepare: () => ({title: 'Static title'})
  },
  fields: [
    {
      name: 'isChecked',
      type: 'boolean',
      title: 'Is checked?'
    }
  ]
}
```

With this PR, the first example also works :)