### PR TITLE
[structure] Improve error when promise is passed in list items

### DIFF
--- a/packages/@sanity/structure/src/List.ts
+++ b/packages/@sanity/structure/src/List.ts
@@ -11,6 +11,14 @@ import {
 } from './GenericList'
 
 const getArgType = (thing: ListItem) => {
+  if (thing instanceof ListBuilder) {
+    return 'ListBuilder'
+  }
+
+  if (isPromise<ListItem>(thing)) {
+    return 'Promise'
+  }
+
   return Array.isArray(thing) ? 'array' : typeof thing
 }
 
@@ -45,6 +53,10 @@ function maybeSerializeListItem(
   }
 
   return item
+}
+
+function isPromise<T>(thing: any): thing is Promise<T> {
+  return thing && typeof thing.then === 'function'
 }
 
 export interface List extends GenericList {


### PR DESCRIPTION
```js
S.list().title('Things').items([Promise.resolve(thing)])
```

Gives something along the lines of "Expected _listItem_, got _object_"

With this change, it gives "Expected _listItem_, got _Promise_"

The documentation link that follows it gives some helpful information on how to deal with cases where you actually want to use a promise for building list items.