### PR TITLE
[default-layout] Decouple default layout from desk tool

### DIFF
--- a/packages/@sanity/default-layout/src/components/SideMenu.js
+++ b/packages/@sanity/default-layout/src/components/SideMenu.js
@@ -74,7 +74,7 @@ function SideMenu(props) {
 }
 
 SideMenu.propTypes = {
-  activeToolName: PropTypes.string.isRequired,
+  activeToolName: PropTypes.string,
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   onSignOut: PropTypes.func.isRequired,
@@ -88,6 +88,10 @@ SideMenu.propTypes = {
     profileImage: PropTypes.string,
     name: PropTypes.string.isRequired
   }).isRequired
+}
+
+SideMenu.defaultProps = {
+  activeToolName: ''
 }
 
 export default SideMenu

--- a/packages/@sanity/default-layout/src/datastores/urlState.js
+++ b/packages/@sanity/default-layout/src/datastores/urlState.js
@@ -14,11 +14,13 @@ function resolveUrlStateWithDefaultSpace(state) {
 }
 
 function resolveUrlStateWithDefaultTool(state) {
-  if (!state || state.tool) {
+  const defaultTool = getOrderedTools()[0]
+  if (!state || state.tool || !defaultTool) {
     return state
   }
+
   return Object.assign({}, state, {
-    tool: getOrderedTools()[0].name
+    tool: defaultTool.name
   })
 }
 


### PR DESCRIPTION
The default layout currently crashes if desk tool is not installed as a tool, because it uses the data-aspects resolver to infer which items to display in the "New" dialog. I also discovered a few issues where the layout would crash if no tools were installed, which I also fixed. 

I think we intend to deprecate/remove data aspects at some point, but leaving that for a different PR.