### PR TITLE
[schema] Catch and display errors for falsey/incorrectly imported type defs

### DIFF
--- a/packages/@sanity/schema/src/core/traverseSchema.js
+++ b/packages/@sanity/schema/src/core/traverseSchema.js
@@ -40,7 +40,7 @@ export default function traverseSchema(
 
   const reservedTypeNames = FUTURE_RESERVED.concat(coreTypeNames)
 
-  const typeNames = types.map(typeDef => typeDef.name).filter(Boolean)
+  const typeNames = types.map(typeDef => typeDef && typeDef.name).filter(Boolean)
 
   coreTypes.forEach(coreType => {
     coreTypesRegistry[coreType.name] = coreType
@@ -48,7 +48,7 @@ export default function traverseSchema(
 
   types.forEach((type, i) => {
     // Allocate a placeholder for each type
-    registry[type.name || `__unnamed_${i}`] = {}
+    registry[(type && type.name) || `__unnamed_${i}`] = {}
   })
 
   function getType(typeName) {
@@ -69,14 +69,15 @@ export default function traverseSchema(
     return typeName === 'type' || reservedTypeNames.includes(typeName)
   }
 
-  const visitType = isRoot => typeDef => {
+  const visitType = isRoot => (typeDef, index) => {
     return visitor(typeDef, {
       visit: visitType(false),
       isRoot,
       getType,
       getTypeNames,
       isReserved,
-      isDuplicate
+      isDuplicate,
+      index
     })
   }
 
@@ -85,7 +86,10 @@ export default function traverseSchema(
   })
 
   types.forEach((typeDef, i) => {
-    Object.assign(registry[typeDef.name || `__unnamed_${i}`], visitType(true)(typeDef))
+    Object.assign(
+      registry[(typeDef && typeDef.name) || `__unnamed_${i}`],
+      visitType(true)(typeDef, i)
+    )
   })
 
   return {

--- a/packages/@sanity/schema/src/sanity/validateSchema.js
+++ b/packages/@sanity/schema/src/sanity/validateSchema.js
@@ -20,7 +20,8 @@ const typeVisitors = {
   reference: reference
 }
 
-const NOOP_VISITOR = schemaDef => ({
+const getNoopVisitor = visitorContext => schemaDef => ({
+  name: `<unnamed_type_@_index_${visitorContext.index}>`,
   ...schemaDef,
   _problems: []
 })
@@ -45,10 +46,14 @@ function combine(...visitors) {
 // Clean up the api
 export default function validateSchema(schemaTypes) {
   return traverseSchema(schemaTypes, (schemaDef, visitorContext) => {
-    const typeVisitor = (schemaDef.type && typeVisitors[schemaDef.type]) || NOOP_VISITOR
+    const typeVisitor =
+      (schemaDef && schemaDef.type && typeVisitors[schemaDef.type]) ||
+      getNoopVisitor(visitorContext)
+
     if (visitorContext.isRoot) {
       return combine(rootType, common, typeVisitor)(schemaDef, visitorContext)
     }
+
     return combine(common, typeVisitor)(schemaDef, visitorContext)
   })
 }

--- a/packages/@sanity/schema/src/sanity/validation/createValidationResult.js
+++ b/packages/@sanity/schema/src/sanity/validation/createValidationResult.js
@@ -3,6 +3,8 @@ import type {Severity, ValidationResult} from '../typedefs'
 
 // Temporary solution to ensure we have a central registry over used helpIds
 export const HELP_IDS = {
+  TYPE_INVALID: 'schema-type-invalid',
+  TYPE_IS_ESM_MODULE: 'schema-type-is-esm-module',
   TYPE_NAME_RESERVED: 'schema-type-name-reserved',
   TYPE_MISSING_NAME: 'schema-type-missing-name-or-type',
   TYPE_MISSING_TYPE: 'schema-type-missing-name-or-type',

--- a/packages/@sanity/schema/src/sanity/validation/types/rootType.js
+++ b/packages/@sanity/schema/src/sanity/validation/types/rootType.js
@@ -1,8 +1,29 @@
 import {error, HELP_IDS, warning} from '../createValidationResult'
 
 export default (typeDef, visitorContext) => {
+  const hasName = Boolean(typeDef.name)
+  if (!hasName && Object.keys(typeDef).length === 1) {
+    // Short-circuit on obviously invalid types (only key is _problems)
+    return {
+      ...typeDef,
+      _problems: [
+        error(
+          'Invalid/undefined type declaration, check declaration or the import/export of the schema type.',
+          HELP_IDS.TYPE_INVALID
+        )
+      ]
+    }
+  }
+
   const problems = []
-  if (!typeDef.name) {
+  if (looksLikeEsmModule(typeDef)) {
+    problems.push(
+      error(
+        'Type appears to be an ES6 module imported through CommonJS require - use an import statement or access the `.default` property',
+        HELP_IDS.TYPE_IS_ESM_MODULE
+      )
+    )
+  } else if (!hasName) {
     problems.push(error('Missing type name', HELP_IDS.TYPE_MISSING_NAME))
   } else if (visitorContext.isReserved(typeDef.name)) {
     problems.push(
@@ -32,4 +53,8 @@ export default (typeDef, visitorContext) => {
     ...typeDef,
     _problems: problems
   }
+}
+
+function looksLikeEsmModule(typeDef) {
+  return !typeDef.name && typeDef.default && (typeDef.default.name || typeDef.default.title)
 }


### PR DESCRIPTION
This PR makes sure that if you include a `null`, `undefined` or `false` in your `types` array, instead of crashing the studio you will get a descriptive error back. It also catches the case where you import an ES module through `require` and end up with an object with a `default` property.

Help articles have also been written to cover these cases.
