### PR TITLE
[core] Cast document IDs to string for document commands

### DIFF
--- a/packages/@sanity/core/src/commands/documents/createDocumentsCommand.js
+++ b/packages/@sanity/core/src/commands/documents/createDocumentsCommand.js
@@ -2,10 +2,10 @@ const os = require('os')
 const path = require('path')
 const fse = require('fs-extra')
 const json5 = require('json5')
-const uuid = require('@sanity/uuid')
 const execa = require('execa')
 const chokidar = require('chokidar')
 const {isPlainObject, isEqual, noop} = require('lodash')
+const uuid = require('@sanity/uuid')
 
 const helpText = `
 Options

--- a/packages/@sanity/core/src/commands/documents/deleteDocumentsCommand.js
+++ b/packages/@sanity/core/src/commands/documents/deleteDocumentsCommand.js
@@ -19,9 +19,9 @@ export default {
   helpText,
   description: 'Delete a document by ID',
   action: async (args, context) => {
-    const {apiClient, output} = context
+    const {apiClient, output, chalk} = context
     const {dataset} = args.extOptions
-    const [id] = args.argsWithoutOptions
+    const [id] = args.argsWithoutOptions.map(str => `${str}`)
 
     if (!id) {
       throw new Error('Document ID must be specified')
@@ -38,7 +38,7 @@ export default {
       if (results.length > 0 && results[0].operation === 'delete') {
         output.print('Document deleted')
       } else {
-        output.print(`Document with ID "${id}" not found`)
+        output.error(chalk.red(`Document with ID "${id}" not found`))
       }
     } catch (err) {
       throw new Error(`Failed to delete document:\n${err.message}`)

--- a/packages/@sanity/core/src/commands/documents/getDocumentsCommand.js
+++ b/packages/@sanity/core/src/commands/documents/getDocumentsCommand.js
@@ -24,7 +24,7 @@ export default {
   action: async (args, context) => {
     const {apiClient, output, chalk} = context
     const {pretty, dataset} = args.extOptions
-    const [docId] = args.argsWithoutOptions
+    const [docId] = args.argsWithoutOptions.map(str => `${str}`)
 
     if (!docId) {
       throw new Error('Document ID must be specified')


### PR DESCRIPTION
This fixes an issue where `sanity documents delete 123` and `sanity documents get 123` would not work because the CLI would automatically cast the argument to a number, where the client expects a string.