### PR TITLE
[cli] Fix inverted visibility allowed check

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.js
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.js
@@ -369,7 +369,7 @@ export default async function initSanity(args, context) {
     const privateDatasetsAllowed = projectFeatures.includes('privateDataset')
     const allowedModes = privateDatasetsAllowed ? ['public', 'private'] : ['public']
 
-    if (opts.aclMode && allowedModes.includes(opts.aclMode)) {
+    if (opts.aclMode && !allowedModes.includes(opts.aclMode)) {
       throw new Error(`Visibility mode "${opts.aclMode}" not allowed`)
     }
 


### PR DESCRIPTION
Fixes a bug where `sanity init --visibility private` would yield "visibility mode not allowed" (a check had mistakenly been inverted).

Also took the liberty of adding a check for whether a different output path is given and skipping the reconfiguration prompts if such is the case.