### PR TITLE
[components] Remove unused canvas-to-blob dependency

### DIFF
--- a/packages/@sanity/components/package.json
+++ b/packages/@sanity/components/package.json
@@ -24,7 +24,6 @@
     "@sanity/imagetool": "0.140.0",
     "attr-accept": "^1.1.0",
     "boundless-arrow-key-navigation": "^1.1.0",
-    "canvas-to-blob": "^0.0.0",
     "chance": "^1.0.4",
     "circular-at": "^1.0.3",
     "classnames": "^2.2.5",


### PR DESCRIPTION
This dependency doesn't seem to be used anywhere within components