### PR TITLE
[form-builder] Make canvas to blob polyfill node.js-safe

### DIFF
--- a/packages/@sanity/form-builder/package.json
+++ b/packages/@sanity/form-builder/package.json
@@ -38,7 +38,6 @@
     "@sanity/schema": "0.140.17",
     "@sanity/util": "0.140.3",
     "attr-accept": "^1.1.0",
-    "canvas-to-blob": "^0.0.0",
     "classnames": "^2.2.5",
     "date-fns": "^1.29.0",
     "debug": "^3.1.0",

--- a/packages/@sanity/form-builder/src/inputs/common/UploadTarget/canvasToBlob.js
+++ b/packages/@sanity/form-builder/src/inputs/common/UploadTarget/canvasToBlob.js
@@ -1,0 +1,41 @@
+// IE >= 10, most modern browsers
+// The Blob type can't be polyfilled, which is why there aren't any polyfills for TypedArrays for older IE's
+const supported =
+  typeof window !== 'undefined' &&
+  typeof window.HTMLCanvasElement !== 'undefined' &&
+  typeof window.atob !== 'undefined' &&
+  typeof window.Blob !== 'undefined' &&
+  typeof window.ArrayBuffer !== 'undefined' &&
+  typeof window.Uint8Array !== 'undefined'
+
+function toBlob(uri) {
+  const mime = uri
+    .split(',')[0]
+    .split(':')[1]
+    .split(';')[0]
+
+  const bytes = atob(uri.split(',')[1])
+  const len = bytes.length
+  const buffer = new window.ArrayBuffer(len)
+  const arr = new window.Uint8Array(buffer)
+
+  for (let i = 0; i < len; i++) {
+    arr[i] = bytes.charCodeAt(i)
+  }
+
+  return new Blob([arr], {type: mime})
+}
+
+export function polyfillCanvasToBlob() {
+  if (!supported) {
+    return
+  }
+
+  const CanvasPrototype = window.HTMLCanvasElement.prototype
+
+  if (!CanvasPrototype.toBlob && CanvasPrototype.toDataURL) {
+    CanvasPrototype.toBlob = function(callback, type, quality) {
+      callback(toBlob(this.toDataURL(type, quality)))
+    }
+  }
+}

--- a/packages/@sanity/form-builder/src/inputs/common/UploadTarget/imageUrlToBlob.js
+++ b/packages/@sanity/form-builder/src/inputs/common/UploadTarget/imageUrlToBlob.js
@@ -1,5 +1,7 @@
 // Loads an image, inserts it into a canvas and loads the canvas contents into a blob
-require('canvas-to-blob').init()
+import {polyfillCanvasToBlob} from './canvasToBlob'
+
+polyfillCanvasToBlob()
 
 export function imageUrlToBlob(imageUrl, format = 'image/jpeg', quality = 1): Promise<Blob> {
   if (imageUrl.match(/^webkit-fake-url:\/\//)) {

--- a/packages/@sanity/form-builder/src/sanity/uploads/image/orient.js
+++ b/packages/@sanity/form-builder/src/sanity/uploads/image/orient.js
@@ -2,8 +2,6 @@
 import {Observable} from 'rxjs'
 
 /* eslint-disable */
-// Polyfills HTMLCanvasElement.toBlob
-require('canvas-to-blob').init()
 
 /**
  * Check if we need to change dims.


### PR DESCRIPTION
The canvas-to-blob dependency has not been touched for 5 years and implicitly depends on `window`. Sometimes you end up requiring stuff in a node environment which includes dependant files in the dependency tree, which blows up. This PR moves the polyfill logic into our own repo, patches the `window` check and removes the dependency.
