### PR TITLE
[components] Fix propType depending on window global

### DIFF
--- a/packages/@sanity/components/src/utilities/Poppable.js
+++ b/packages/@sanity/components/src/utilities/Poppable.js
@@ -15,7 +15,8 @@ export default class Poppable extends React.Component {
     target: PropTypes.node,
     children: PropTypes.node,
     referenceClassName: PropTypes.string,
-    referenceElement: PropTypes.instanceOf(Element),
+    // When requiring this file in node, Element is undefined (since it's a window global)
+    referenceElement: typeof window === 'undefined' ? PropTypes.any : PropTypes.instanceOf(Element),
     placement: PropTypes.string,
     positionFixed: PropTypes.bool,
     popperClassname: PropTypes.string,


### PR DESCRIPTION
The `Poppable` utility is referencing the `window.Element` global implicitly, which does not work in Node.js.

This PR makes it return `PropTypes.any` for that property in non-browser environments.