### PR TITLE
[core] Make `sanity exec` use same babel config as studio

### DIFF
--- a/packages/@sanity/core/src/actions/exec/babel.js
+++ b/packages/@sanity/core/src/actions/exec/babel.js
@@ -1,14 +1,28 @@
+import fs from 'fs'
+import path from 'path'
 import registerBabel from '@babel/register'
 
-registerBabel({
-  presets: [
-    [
-      '@babel/preset-env',
-      {
-        targets: {
-          node: 'current'
-        }
-      }
-    ]
-  ]
-})
+function getConfig() {
+  try {
+    // eslint-disable-next-line no-sync
+    const content = fs.readFileSync(path.join(process.cwd(), '.babelrc'))
+    return JSON.parse(content)
+  } catch (err) {
+    return {
+      presets: [
+        require.resolve('@babel/preset-react'),
+        [
+          require.resolve('@babel/preset-env'),
+          {
+            targets: {
+              node: 'current'
+            }
+          }
+        ]
+      ],
+      plugins: [require.resolve('@babel/plugin-proposal-class-properties')]
+    }
+  }
+}
+
+registerBabel(getConfig())

--- a/packages/@sanity/core/src/actions/exec/execScript.js
+++ b/packages/@sanity/core/src/actions/exec/execScript.js
@@ -1,5 +1,5 @@
-const path = require('path')
 const spawn = require('child_process').spawn
+const path = require('path')
 const fse = require('fs-extra')
 
 module.exports = async args => {
@@ -17,7 +17,7 @@ module.exports = async args => {
   }
 
   const babel = require.resolve('./babel')
-  const loader = require.resolve('@sanity/plugin-loader/register')
+  const loader = require.resolve('./pluginLoader')
   const nodeArgs = ['-r', babel, '-r', loader]
     .concat(withToken ? ['-r', require.resolve('./configClient')] : [])
     .concat(scriptPath)

--- a/packages/@sanity/core/src/actions/exec/pluginLoader.js
+++ b/packages/@sanity/core/src/actions/exec/pluginLoader.js
@@ -1,0 +1,3 @@
+const registerLoader = require('@sanity/plugin-loader')
+
+registerLoader({basePath: process.cwd(), stubCss: true})


### PR DESCRIPTION
Currently, if you have JSX or class properties in any files required when doing `sanity exec` on a script, it'll fail because the only loaded plugin is the env plugin. This brings the default babel config in line with the studio.

Also makes the plugin loader stub the CSS to speed up the sanity exec process a bit.