### PR TITLE
[base] Fix history import to match new API

### DIFF
--- a/packages/@sanity/base/src/datastores/location/createLocationStore.js
+++ b/packages/@sanity/base/src/datastores/location/createLocationStore.js
@@ -2,11 +2,11 @@ import {Observable} from 'rxjs'
 import {map, share} from 'rxjs/operators'
 
 import Location from '../utils/Location'
-import createHistory from 'history/createBrowserHistory'
+import {createBrowserHistory} from 'history'
 import createActions from '../utils/createActions'
 
 const noop = () => {} // eslint-disable-line no-empty-function
-const history = createHistory()
+const history = createBrowserHistory()
 
 function readLocation() {
   return Location.parse(document.location.href)


### PR DESCRIPTION
Fixes this warning in the console:
> Please use `require("history").createBrowserHistory` instead of `require("history/createBrowserHistory")`. Support for the latter will be removed in the next major release.

