### PR TITLE
[desk-tool] Fix loading indicator being cut at top

### DIFF
--- a/packages/@sanity/desk-tool/src/pane/LoadingPane.js
+++ b/packages/@sanity/desk-tool/src/pane/LoadingPane.js
@@ -72,6 +72,7 @@ export default class LoadingPane extends React.PureComponent {
     return (
       <DefaultPane
         title={'\u00a0'} // Non-breaking space
+        isScrollable={false}
         isSelected={isSelected}
         isCollapsed={isCollapsed}
         onCollapse={onCollapse}
@@ -79,7 +80,7 @@ export default class LoadingPane extends React.PureComponent {
         index={this.props.index}
       >
         {/* div wrapper to match styling of documents list pane - prevents spinner
-          * from jumping to new position when pane definition is loaded */}
+         * from jumping to new position when pane definition is loaded */}
         <div className={styles.root}>
           <Spinner center message={message} />
         </div>


### PR DESCRIPTION
When the "loading" indicator is shown, it is cut at the top, so spinner is not actually visible. Text also cut in certain cases. This fixes the issue by cutting an intermediary div, which aligns the loading indicator to the vertical center.