### PR TITLE
[desk-tool] Fix issue where non-function `child` would fail to resolve

### DIFF
--- a/packages/@sanity/desk-tool/src/utils/resolvePanes.js
+++ b/packages/@sanity/desk-tool/src/utils/resolvePanes.js
@@ -58,7 +58,7 @@ function resolveForStructure(structure, ids, prevStructure, fromIndex) {
         return
       }
 
-      if (!parent || typeof parent.child !== 'function') {
+      if (!parent || !parent.child) {
         subscriber.complete()
         return
       }


### PR DESCRIPTION
The following structure fails to resolve the list:

```js
import S from '@sanity/desk-tool/structure-builder'

export default S.list()
  .title('Content')
  .items([
    S.listItem()
      .title('Posts')
      .schemaType('post')
      .child(
        S.documentTypeList('category')
          .title('Posts by category')
          .child(S.list().title('test'))
      ),

    ...S.documentTypeListItems()
  ])
```

The following works:
```js
import S from '@sanity/desk-tool/structure-builder'

export default S.list()
  .title('Content')
  .items([
    S.listItem()
      .title('Posts')
      .schemaType('post')
      .child(
        S.documentTypeList('category')
          .title('Posts by category')
          .child(() => S.list().title('test'))
      ),

    ...S.documentTypeListItems()
  ])
```

This was caused by us explicitly checking whether the `child` was a function, which it shouldn't have to be. Changed to only care about it being truthy or not.