### PR TITLE
[mutator] Use strict equals when comparing equality

### DIFF
--- a/packages/@sanity/mutator/src/jsonpath/Expression.js
+++ b/packages/@sanity/mutator/src/jsonpath/Expression.js
@@ -198,7 +198,7 @@ function testBinaryOperator(lhsValue, operator, rhsValue) {
     case '<=':
       return lhsValue <= rhsValue
     case '==':
-      return lhsValue == rhsValue
+      return lhsValue === rhsValue
     case '!=':
       return lhsValue != rhsValue
     default:

--- a/packages/@sanity/mutator/test/Expression.test.js
+++ b/packages/@sanity/mutator/test/Expression.test.js
@@ -42,6 +42,20 @@ test('Expression constraints', tap => {
   tap.equal(true, attrCompare.testConstraint(new PlainProbe({banana: 'rotten'})))
   tap.equal(false, attrCompare.testConstraint(new PlainProbe(7)))
 
+  const numCompare = new Expression(parse('[number == 123]').nodes[0])
+  tap.equal(false, numCompare.constraintTargetIsSelf())
+  tap.equal(true, numCompare.constraintTargetIsAttribute())
+  tap.equal(false, numCompare.testConstraint(new PlainProbe({number: '123'})))
+  tap.equal(true, numCompare.testConstraint(new PlainProbe({number: 123})))
+  tap.equal(false, numCompare.testConstraint(new PlainProbe(7)))
+
+  const strNumCompare = new Expression(parse('[number == "123"]').nodes[0])
+  tap.equal(false, strNumCompare.constraintTargetIsSelf())
+  tap.equal(true, strNumCompare.constraintTargetIsAttribute())
+  tap.equal(false, strNumCompare.testConstraint(new PlainProbe({number: 123})))
+  tap.equal(true, strNumCompare.testConstraint(new PlainProbe({number: '123'})))
+  tap.equal(false, strNumCompare.testConstraint(new PlainProbe(7)))
+
   tap.end()
 })
 

--- a/packages/@sanity/mutator/test/patchExamples/unset.js
+++ b/packages/@sanity/mutator/test/patchExamples/unset.js
@@ -130,5 +130,20 @@ export default [
     after: {
       a: [{key: 'two'}]
     }
+  },
+
+  {
+    name: 'Numeric key for string value',
+    before: {
+      a: [{key: '123'}],
+      b: [{key: 123}, {key: '123'}]
+    },
+    patch: {
+      unset: ['a[key==123]', 'b[key==123]']
+    },
+    after: {
+      a: [{key: '123'}],
+      b: [{key: '123'}]
+    }
   }
 ]


### PR DESCRIPTION
Given the object:
`{attr: "123"}`

The following expression matches in the mutators JSONPath implementation:
`[attr==123]`

While in the Sanity DB, it does not (should be `[attr=="123"]`).

The error was simply not using a strict equality check when evaluating the expression.
This PR fixes this and adds tests for this case.

Over-the-shoulder, IRL-approved by @simen