### PR TITLE
[form-builder] Constrain rendered images to a reasonable size

### DIFF
--- a/packages/@sanity/imagetool/src/index.js
+++ b/packages/@sanity/imagetool/src/index.js
@@ -16,7 +16,11 @@ export default function ImageToolWrapper(props) {
         }
         if (image) {
           return (
-            <Resize image={image} maxHeight={500} maxWidth={1000}>
+            <Resize
+              image={image}
+              maxHeight={ImageToolWrapper.maxHeight}
+              maxWidth={ImageToolWrapper.maxWidth}
+            >
               {canvas => <ImageTool image={canvas} {...props} />}
             </Resize>
           )
@@ -30,3 +34,6 @@ export default function ImageToolWrapper(props) {
 ImageToolWrapper.propTypes = {
   src: PropTypes.string.isRequired
 }
+
+ImageToolWrapper.maxHeight = 500
+ImageToolWrapper.maxWidth = 1000


### PR DESCRIPTION
The image input renders the full-size image, which can be quite expensive in terms of both bandwidth and CPU/memory usage.

While the optimal thing to do may be to constrain it to the size of the container, that can quickly yield a myriad of different variations based on the client. Instead, we constrain it to the max size that the image tool (the crop/hotspot editor) will use, currently 1000px in width. We also factor in the DPR, scaling it up if the device supports it.

It's a bit convoluted, but I think this is the best I can come up with within a reasonable timeframe. Better than 20 MB jpegs, I guess? ;)