### PR TITLE
[structure] Add divider builder method

### DIFF
--- a/packages/@sanity/components/src/lists/styles/DefaultList.css
+++ b/packages/@sanity/components/src/lists/styles/DefaultList.css
@@ -1,5 +1,17 @@
+@import 'part:@sanity/base/theme/variables-style';
+
 .root {
   display: block;
   margin: 0;
   padding: 0;
+}
+
+.divider {
+  width: 100%;
+  height: 0;
+  padding: 0;
+  margin: 0;
+  background: none;
+  border-top: 1px solid var(--hairline-color);
+  border-bottom: none;
 }

--- a/packages/@sanity/desk-tool/src/pane/ListPane.js
+++ b/packages/@sanity/desk-tool/src/pane/ListPane.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import {withRouterHOC} from 'part:@sanity/base/router'
 import DefaultPane from 'part:@sanity/components/panes/default'
+import listStyles from 'part:@sanity/components/lists/default-style'
 import PaneItem from './PaneItem'
 import ListView from './ListView'
 
@@ -114,7 +115,7 @@ export default withRouterHOC(
           <ListView layout={defaultLayout}>
             {items.map(item =>
               item.type === 'divider' ? (
-                <hr key={item.id} />
+                <hr key={item.id} className={listStyles.divider} />
               ) : (
                 <PaneItem
                   key={item.id}

--- a/packages/@sanity/desk-tool/src/pane/ListPane.js
+++ b/packages/@sanity/desk-tool/src/pane/ListPane.js
@@ -22,6 +22,7 @@ export default withRouterHOC(
       items: PropTypes.arrayOf(
         PropTypes.shape({
           id: PropTypes.string.isRequired,
+          type: PropTypes.string.isRequired,
           schemaType: PropTypes.shape({name: PropTypes.string})
         })
       ),
@@ -111,19 +112,23 @@ export default withRouterHOC(
           menuItemGroups={menuItemGroups}
         >
           <ListView layout={defaultLayout}>
-            {items.map(item => (
-              <PaneItem
-                key={item.id}
-                id={item.id}
-                index={index}
-                value={item}
-                icon={this.shouldShowIconForItem(item)}
-                layout={defaultLayout}
-                isSelected={this.itemIsSelected(item)}
-                getLinkState={this.getLinkStateForItem}
-                schemaType={item.schemaType}
-              />
-            ))}
+            {items.map(item =>
+              item.type === 'divider' ? (
+                <hr key={item.id} />
+              ) : (
+                <PaneItem
+                  key={item.id}
+                  id={item.id}
+                  index={index}
+                  value={item}
+                  icon={this.shouldShowIconForItem(item)}
+                  layout={defaultLayout}
+                  isSelected={this.itemIsSelected(item)}
+                  getLinkState={this.getLinkStateForItem}
+                  schemaType={item.schemaType}
+                />
+              )
+            )}
           </ListView>
         </DefaultPane>
       )

--- a/packages/@sanity/structure/src/StructureNodes.ts
+++ b/packages/@sanity/structure/src/StructureNodes.ts
@@ -22,6 +22,11 @@ export interface EditorNode extends StructureNode {
   }
 }
 
+export interface Divider {
+  id: string
+  type: 'divider'
+}
+
 export type SerializePath = (string | number)[]
 
 export interface SerializeOptions {

--- a/packages/@sanity/structure/src/index.ts
+++ b/packages/@sanity/structure/src/index.ts
@@ -1,3 +1,4 @@
+import {uniqueId} from 'lodash'
 import {ListBuilder, ListInput} from './List'
 import {
   getDocumentTypeListItems,
@@ -14,7 +15,7 @@ import {ListItemBuilder, ListItemInput} from './ListItem'
 import {MenuItemGroup, MenuItemGroupBuilder} from './MenuItemGroup'
 import {DocumentListBuilder, DocumentListInput} from './DocumentList'
 import {EditorBuilder} from './Editor'
-import {EditorNode} from './StructureNodes'
+import {EditorNode, Divider} from './StructureNodes'
 import {SerializeError} from './SerializeError'
 import {ComponentInput, ComponentBuilder} from './Component'
 import {DocumentListItemBuilder, DocumentListItemInput} from './DocumentListItem'
@@ -42,7 +43,9 @@ const StructureBuilder = {
     return typeof spec === 'function'
       ? new ComponentBuilder().component(spec)
       : new ComponentBuilder(spec)
-  }
+  },
+
+  divider: (): Divider => ({id: uniqueId('__divider__'), type: 'divider'})
 }
 
 export {StructureBuilder, SerializeError}

--- a/packages/test-studio/src/deskStructure.js
+++ b/packages/test-studio/src/deskStructure.js
@@ -16,6 +16,8 @@ export default () =>
         .title('Singleton author')
         .schemaType('author'),
 
+      S.divider(),
+
       S.listItem()
         .title('Anything with a title')
         .icon(() => <span style={{fontSize: '2em'}}>T</span>)
@@ -103,6 +105,8 @@ export default () =>
                 )
             ])
         ),
+
+      S.divider(),
 
       ...S.documentTypeListItems()
     ])


### PR DESCRIPTION
Usage:

```js
import S from '@sanity/desk-tool/structure-builder'

export default
  S.list()
    .id('content')
    .title('Content')
    .items([
      S.listItem().title('Foo'),
      S.divider(),
      S.listItem().title('Bar'),
    ])
```

Currently just renders a `<hr />`:

![image](https://user-images.githubusercontent.com/48200/58252976-a384be80-7d67-11e9-897d-902c132bde7b.png)

Needs some design work, I assume. Open for discussion.