### PR TITLE
Collapsible button group in block editor

### DIFF
--- a/packages/@sanity/components/src/toggles/ToggleButton.js
+++ b/packages/@sanity/components/src/toggles/ToggleButton.js
@@ -20,20 +20,13 @@ export default class ToggleButton extends React.Component {
   }
 
   render() {
-    const {disabled, selected, icon, className, title} = this.props
+    const {selected, className} = this.props
     const buttonClasses = `
       ${selected ? styles.selected : styles.unSelected}
       ${className}
     `
     return (
-      <Button
-        className={buttonClasses}
-        icon={icon}
-        title={title}
-        disabled={disabled}
-        onClick={this.props.onClick}
-        kind="simple"
-      >
+      <Button {...this.props} className={buttonClasses} kind="simple">
         {this.props.children}
       </Button>
     )

--- a/packages/@sanity/form-builder/package.json
+++ b/packages/@sanity/form-builder/package.json
@@ -57,6 +57,7 @@
     "react-click-outside": "^3.0.0",
     "react-container-query": "^0.11.0",
     "react-datepicker": "^1.8.0",
+    "react-measure": "^2.3.0",
     "rxjs": "^6.1.0",
     "shallow-equals": "^1.0.0",
     "slate": "0.44.10",

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/AnnotationButtons.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/AnnotationButtons.js
@@ -12,6 +12,7 @@ import CustomIcon from './CustomIcon'
 import ToolbarClickAction from './ToolbarClickAction'
 
 import styles from './styles/AnnotationButtons.css'
+import CollapsibleButtonGroup from './CollapsibleButtonGroup';
 
 type AnnotationItem = BlockContentFeature & {
   active: boolean,
@@ -23,7 +24,8 @@ type Props = {
   editor: SlateEditor,
   editorValue: SlateValue,
   onFocus: Path => void,
-  userIsWritingText: boolean
+  userIsWritingText: boolean,
+  collapsed: boolean
 }
 
 function getIcon(type: string) {
@@ -126,7 +128,24 @@ export default class AnnotationButtons extends React.Component<Props> {
   }
 
   render() {
+    const {collapsed} = this.props
     const items = this.getItems()
+    let Icon
+    const icon = items[0].blockEditor ? items[0].blockEditor.icon : null
+    if (icon) {
+      if (typeof icon === 'string') {
+        Icon = () => <CustomIcon icon={icon} active={!!items[0].active} />
+      } else if (typeof icon === 'function') {
+        Icon = icon
+      }
+    }
+    if (items.length > 1 && collapsed) {
+      return (
+        <CollapsibleButtonGroup icon={Icon || getIcon(items[0].value)}>
+          <div className={styles.root}>{items.map(this.renderAnnotationButton)}</div>
+        </CollapsibleButtonGroup>
+      )
+    }
     return <div className={styles.root}>{items.map(this.renderAnnotationButton)}</div>
   }
 }

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/BlockStyleSelect.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/BlockStyleSelect.js
@@ -91,12 +91,13 @@ export default class BlockStyleSelect extends React.Component<Props> {
 
   render() {
     const {items, value} = this.getItemsAndValue()
-    if (!items || items.length === 0) {
+    if (!items || items.length < 2) {
       return null
     }
     const {editorValue, className} = this.props
     const {focusBlock} = editorValue
     const disabled = focusBlock ? focusBlock.isVoid : false
+
     return (
       <label className={className}>
         <span style={{display: 'none'}}>Text</span>

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/BlockStyleSelect.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/BlockStyleSelect.js
@@ -24,7 +24,8 @@ export type BlockStyleItem = {
 type Props = {
   blockContentFeatures: BlockContentFeatures,
   editor: SlateEditor,
-  editorValue: SlateValue
+  editorValue: SlateValue,
+  className: string
 }
 
 export default class BlockStyleSelect extends React.Component<Props> {
@@ -93,11 +94,11 @@ export default class BlockStyleSelect extends React.Component<Props> {
     if (!items || items.length === 0) {
       return null
     }
-    const {editorValue} = this.props
+    const {editorValue, className} = this.props
     const {focusBlock} = editorValue
     const disabled = focusBlock ? focusBlock.isVoid : false
     return (
-      <label>
+      <label className={className}>
         <span style={{display: 'none'}}>Text</span>
         <StyleSelect
           items={items}

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/CollapsibleButtonGroup.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/CollapsibleButtonGroup.js
@@ -3,6 +3,7 @@ import ChevronDown from 'part:@sanity/base/chevron-down-icon'
 import ToggleButton from 'part:@sanity/components/toggles/button'
 import styles from './styles/CollapsibleButtonGroup.css'
 import PropTypes from 'prop-types'
+import Poppable from 'part:@sanity/components/utilities/poppable'
 
 export default class CollapsibleButtonGroup extends React.Component {
   state = {
@@ -36,8 +37,10 @@ export default class CollapsibleButtonGroup extends React.Component {
         <ToggleButton onClick={this.handleToggle}>
           <Icon />
           <ChevronDown />
+          <Poppable onClickOutside={this.handleClose} onEscape={this.handleClose}>
+            {isOpen && <div className={styles.popup}>{children}</div>}
+          </Poppable>
         </ToggleButton>
-        {isOpen && <div className={styles.popup}>{children}</div>}
       </div>
     )
   }

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/CollapsibleButtonGroup.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/CollapsibleButtonGroup.js
@@ -1,0 +1,49 @@
+import React from 'react'
+import ChevronDown from 'part:@sanity/base/chevron-down-icon'
+import ToggleButton from 'part:@sanity/components/toggles/button'
+import styles from './styles/CollapsibleButtonGroup.css'
+import PropTypes from 'prop-types'
+
+export default class CollapsibleButtonGroup extends React.Component {
+  state = {
+    isOpen: false
+  }
+
+  handleOpen = () => {
+    this.setState({isOpen: true})
+  }
+
+  handleClose = () => {
+    this.setState({isOpen: false})
+  }
+
+  handleToggle = () => {
+    const {isOpen} = this.state
+    if (isOpen) {
+      this.handleClose()
+    } else {
+      this.handleOpen()
+    }
+  }
+
+  render() {
+    const {icon, children} = this.props
+    const {isOpen} = this.state
+    const Icon = icon
+
+    return (
+      <div className={styles.root}>
+        <ToggleButton onClick={this.handleToggle}>
+          <Icon />
+          <ChevronDown />
+        </ToggleButton>
+        {isOpen && <div className={styles.popup}>{children}</div>}
+      </div>
+    )
+  }
+}
+
+CollapsibleButtonGroup.propTypes = {
+  children: PropTypes.node,
+  icon: PropTypes.any
+}

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/DecoratorButtons.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/DecoratorButtons.js
@@ -15,13 +15,15 @@ import {keyMaps} from '../plugins/SetMarksOnKeyComboPlugin'
 import ToolbarClickAction from './ToolbarClickAction'
 
 import styles from './styles/DecoratorButtons.css'
+import CollapsibleButtonGroup from './CollapsibleButtonGroup';
 
 type DecoratorItem = BlockContentFeature & {active: boolean, disabled: boolean}
 
 type Props = {
   blockContentFeatures: BlockContentFeatures,
   editor: SlateEditor,
-  editorValue: SlateValue
+  editorValue: SlateValue,
+  collapsed: boolean
 }
 
 function getIcon(type: string) {
@@ -47,6 +49,9 @@ export default class DecoratorButtons extends React.Component<Props> {
   shouldComponentUpdate(nextProps: Props) {
     const nextMarks = nextProps.editorValue.marks.map(mrk => mrk.type)
     const currentMarks = this.props.editorValue.marks.map(mrk => mrk.type)
+    if (nextProps.collapsed != this.props.collapsed) {
+      return true
+    }
     if (isEqual(nextMarks, currentMarks)) {
       return false
     }
@@ -102,7 +107,17 @@ export default class DecoratorButtons extends React.Component<Props> {
   }
 
   render() {
+    const {collapsed} = this.props
     const items = this.getItems()
+    const icon = items[0].blockEditor ? items[0].blockEditor.icon : null
+
+    if (items.length > 0 && collapsed) {
+      return (
+        <CollapsibleButtonGroup icon={icon || getIcon(items[0].value)}>
+          {items.map(this.renderDecoratorButton)}
+        </CollapsibleButtonGroup>
+      )
+    }
     return <div className={styles.root}>{items.map(this.renderDecoratorButton)}</div>
   }
 }

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/InsertMenu.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/InsertMenu.js
@@ -54,9 +54,12 @@ export default class InsertMenu extends React.Component<Props> {
 
   renderButton = (item: BlockItem) => {
     return (
-      <Tooltip title={`Insert ${item.title}`} disabled={this.props.collapsed}>
+      <Tooltip
+        title={`Insert ${item.title}`}
+        disabled={this.props.collapsed}
+        key={`insertMenuItem_${item.key}`}
+      >
         <Button
-          key={`insertMenuItem_${item.title}`}
           onClick={() => this.handleOnAction(item)}
           title={`Insert ${item.title}`}
           icon={item.icon}
@@ -114,7 +117,7 @@ export default class InsertMenu extends React.Component<Props> {
     const items = this.getItems()
 
     if (!collapsed) {
-      return items.map(this.renderButton)
+      return items.map((item, key) => ({...item, key})).map(this.renderButton)
     }
 
     return (

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/InsertMenu.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/InsertMenu.js
@@ -2,8 +2,10 @@
 
 import React from 'react'
 import DropDownButton from 'part:@sanity/components/buttons/dropdown'
+import Button from 'part:@sanity/components/buttons/default'
 import BlockObjectIcon from 'part:@sanity/base/block-object-icon'
 import InlineObjectIcon from 'part:@sanity/base/inline-object-icon'
+import {Tooltip} from 'react-tippy'
 
 import type {Type, SlateValue, SlateEditor, Path} from '../typeDefs'
 import {FOCUS_TERMINATOR} from '@sanity/util/paths'
@@ -14,7 +16,8 @@ type Props = {
   editor: SlateEditor,
   editorValue: SlateValue,
   inlineTypes: Type[],
-  onFocus: Path => void
+  onFocus: Path => void,
+  collapsed: boolean
 }
 
 type BlockItem = {
@@ -28,6 +31,7 @@ type BlockItem = {
 export default class InsertMenu extends React.Component<Props> {
   shouldComponentUpdate(nextProps: Props) {
     return (
+      this.props.collapsed !== nextProps.collapsed ||
       this.props.blockTypes !== nextProps.blockTypes ||
       this.props.inlineTypes !== nextProps.inlineTypes ||
       this.props.editorValue.focusBlock !== nextProps.editorValue.focusBlock
@@ -45,6 +49,21 @@ export default class InsertMenu extends React.Component<Props> {
         )}
         {item.title}
       </div>
+    )
+  }
+
+  renderButton = (item: BlockItem) => {
+    return (
+      <Tooltip title={`Insert ${item.title}`} disabled={this.props.collapsed}>
+        <Button
+          key={`insertMenuItem_${item.title}`}
+          onClick={() => this.handleOnAction(item)}
+          title={`Insert ${item.title}`}
+          icon={item.icon}
+          kind="simple"
+          bleed
+        />
+      </Tooltip>
     )
   }
 
@@ -91,9 +110,16 @@ export default class InsertMenu extends React.Component<Props> {
   }
 
   render() {
+    const {collapsed} = this.props
+    const items = this.getItems()
+
+    if (!collapsed) {
+      return items.map(this.renderButton)
+    }
+
     return (
       <DropDownButton
-        items={this.getItems()}
+        items={items}
         renderItem={this.renderItem}
         onAction={this.handleOnAction}
         kind="simple"

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/InsertMenu.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/InsertMenu.js
@@ -6,6 +6,7 @@ import Button from 'part:@sanity/components/buttons/default'
 import BlockObjectIcon from 'part:@sanity/base/block-object-icon'
 import InlineObjectIcon from 'part:@sanity/base/inline-object-icon'
 import {Tooltip} from 'react-tippy'
+import {get} from 'lodash'
 
 import type {Type, SlateValue, SlateEditor, Path} from '../typeDefs'
 import {FOCUS_TERMINATOR} from '@sanity/util/paths'
@@ -17,7 +18,8 @@ type Props = {
   editorValue: SlateValue,
   inlineTypes: Type[],
   onFocus: Path => void,
-  collapsed: boolean
+  collapsed: boolean,
+  showLabels: boolean
 }
 
 type BlockItem = {
@@ -53,25 +55,31 @@ export default class InsertMenu extends React.Component<Props> {
   }
 
   renderButton = (item: BlockItem) => {
+    const {showLabels} = this.props
     return (
       <Tooltip
         title={`Insert ${item.title}`}
         disabled={this.props.collapsed}
         key={`insertMenuItem_${item.key}`}
+        style={showLabels ? {display: 'block', flexGrow: 1, minWidth: 'fit-content'} : {}}
       >
         <Button
           onClick={() => this.handleOnAction(item)}
           title={`Insert ${item.title}`}
+          aria-label={`Insert ${item.title}`}
           icon={item.icon}
           kind="simple"
           bleed
-        />
+        >
+          {showLabels && item.title}
+        </Button>
       </Tooltip>
     )
   }
 
   getIcon = (type, fallbackIcon) => {
-    return type.icon || (type.type && type.type.icon) || fallbackIcon
+    const referenceIcon = get(type, 'to[0].icon')
+    return type.icon || (type.type && type.type.icon) || referenceIcon || fallbackIcon
   }
 
   getItems() {

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/ListItemButtons.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/ListItemButtons.js
@@ -10,6 +10,7 @@ import ToggleButton from 'part:@sanity/components/toggles/button'
 import type {BlockContentFeature, BlockContentFeatures, SlateEditor, SlateValue} from '../typeDefs'
 import CustomIcon from './CustomIcon'
 import ToolbarClickAction from './ToolbarClickAction'
+import CollapsibleButtonGroup from './CollapsibleButtonGroup';
 
 import styles from './styles/ListItemButtons.css'
 
@@ -18,7 +19,8 @@ type ListItem = BlockContentFeature & {active: boolean, disabled: boolean}
 type Props = {
   blockContentFeatures: BlockContentFeatures,
   editor: SlateEditor,
-  editorValue: SlateValue
+  editorValue: SlateValue,
+  collapsed: boolean
 }
 
 function getIcon(type: string) {
@@ -40,6 +42,9 @@ export default class ListItemButtons extends React.Component<Props> {
     const currentFocusBlock = this.props.editorValue.focusBlock
     // Always update if we have selected more than one block
     if (nextProps.editorValue.blocks.size > 1) {
+      return true
+    }
+    if (nextProps.collapsed != this.props.collapsed) {
       return true
     }
     // Update if we have navigated to another block, or the block's data litItem prop is changed
@@ -107,7 +112,18 @@ export default class ListItemButtons extends React.Component<Props> {
   }
 
   render() {
+    const {collapsed} = this.props
     const items = this.getItems()
+    const icon = items[0].blockEditor ? items[0].blockEditor.icon : null
+
+    if (items.length > 0 && collapsed) {
+      return (
+        <CollapsibleButtonGroup icon={icon || getIcon(items[0].value)}>
+          {items.map(this.renderListItemButton)}
+        </CollapsibleButtonGroup>
+      )
+    }
+
     return <div className={styles.root}>{items.map(this.renderListItemButton)}</div>
   }
 }

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/PrimaryGroup.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/PrimaryGroup.js
@@ -1,0 +1,114 @@
+// @flow
+
+/* eslint-disable complexity */
+
+import React from 'react'
+import type {BlockContentFeatures, SlateValue, Path, SlateEditor, Type} from '../typeDefs'
+
+import AnnotationButtons from './AnnotationButtons'
+import BlockStyleSelect from './BlockStyleSelect'
+import DecoratorButtons from './DecoratorButtons'
+import InsertMenu from './InsertMenu'
+import ListItemButtons from './ListItemButtons'
+
+import styles from './styles/PrimaryGroup.css'
+
+type Props = {
+  blockContentFeatures: BlockContentFeatures,
+  editor: SlateEditor,
+  editorValue: SlateValue,
+  onFocus: Path => void,
+  style: {},
+  type: Type,
+  userIsWritingText: boolean,
+  collapsedGroups: array,
+  insertItems: array,
+  isPopped: boolean,
+  isMobile: boolean
+}
+
+type State = {
+  collapsePrimaryIsOpen: boolean,
+  showValidationTooltip: boolean,
+  collapsePrimary: boolean,
+  isMobile: boolean,
+  lastContentWidth: number
+}
+
+export default class PrimaryGroup extends React.PureComponent<Props, State> {
+  render() {
+    const {
+      blockContentFeatures,
+      editor,
+      editorValue,
+      onFocus,
+      type,
+      userIsWritingText,
+      collapsedGroups,
+      insertItems,
+      isMobile,
+      isPopped
+    } = this.props
+
+    if (!editor) {
+      return null
+    }
+    return (
+      <div className={isPopped ? styles.isPopped : styles.root}>
+        <div className={styles.blockStyleGroup}>
+          <BlockStyleSelect
+            className={styles.blockStyleSelect}
+            blockContentFeatures={blockContentFeatures}
+            editor={editor}
+            editorValue={editorValue}
+          />
+        </div>
+        {blockContentFeatures.decorators.length > 0 && (
+          <div className={styles.group}>
+            <DecoratorButtons
+              collapsed={collapsedGroups.indexOf('decoratorButtons') >= 0}
+              blockContentFeatures={blockContentFeatures}
+              editor={editor}
+              editorValue={editorValue}
+            />
+          </div>
+        )}
+        {blockContentFeatures.lists.length > 0 && (
+          <div className={styles.group}>
+            <ListItemButtons
+              collapsed={collapsedGroups.indexOf('listItemButtons') >= 0}
+              blockContentFeatures={blockContentFeatures}
+              editor={editor}
+              editorValue={editorValue}
+            />
+          </div>
+        )}
+        {blockContentFeatures.annotations.length > 0 && (
+          <div className={styles.group}>
+            <AnnotationButtons
+              collapsed={collapsedGroups.indexOf('annotationButtons') >= 0}
+              blockContentFeatures={blockContentFeatures}
+              editor={editor}
+              editorValue={editorValue}
+              onFocus={onFocus}
+              userIsWritingText={userIsWritingText}
+            />
+          </div>
+        )}
+        {insertItems.length > 0 && (
+          <div className={styles.group}>
+            <InsertMenu
+              collapsed={isMobile || collapsedGroups.indexOf('insertMenu') >= 0}
+              blockTypes={blockContentFeatures.types.blockObjects}
+              editor={editor}
+              editorValue={editorValue}
+              inlineTypes={blockContentFeatures.types.inlineObjects}
+              onFocus={onFocus}
+              type={type}
+            />
+          </div>
+        )}
+      </div>
+    )
+  }
+}

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/PrimaryGroup.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/PrimaryGroup.js
@@ -99,6 +99,11 @@ export default class PrimaryGroup extends React.PureComponent<Props, State> {
           <div className={styles.group}>
             <InsertMenu
               collapsed={isMobile || collapsedGroups.indexOf('insertMenu') >= 0}
+              showLabels={
+                blockContentFeatures.types.blockObjects.concat(
+                  blockContentFeatures.types.inlineObjects
+                ).length < 4
+              }
               blockTypes={blockContentFeatures.types.blockObjects}
               editor={editor}
               editorValue={editorValue}

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/Toolbar.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/Toolbar.js
@@ -3,11 +3,8 @@
 /* eslint-disable complexity */
 
 import React from 'react'
-import classnames from 'classnames'
-import enhanceWithClickOutside from 'react-click-outside'
-import {ContainerQuery} from 'react-container-query'
-import {Tooltip} from 'react-tippy'
-
+import Tooltip from 'react-tippy'
+import Measure from 'react-measure'
 import ArrowIcon from 'part:@sanity/base/angle-down-icon'
 import Button from 'part:@sanity/components/buttons/default'
 import ChevronDown from 'part:@sanity/base/chevron-down-icon'
@@ -15,18 +12,17 @@ import CloseIcon from 'part:@sanity/base/close-icon'
 import FullscreenIcon from 'part:@sanity/base/fullscreen-icon'
 import ValidationList from 'part:@sanity/components/validation/list'
 import WarningIcon from 'part:@sanity/base/warning-icon'
-
-import IS_MAC from '../utils/isMac'
+import Poppable from 'part:@sanity/components/utilities/poppable'
+import {debounce, xor} from 'lodash'
 
 import type {BlockContentFeatures, SlateValue, Path, SlateEditor, Type} from '../typeDefs'
 
-import AnnotationButtons from './AnnotationButtons'
-import BlockStyleSelect from './BlockStyleSelect'
-import DecoratorButtons from './DecoratorButtons'
-import InsertMenu from './InsertMenu'
-import ListItemButtons from './ListItemButtons'
-
+import IS_MAC from '../utils/isMac'
+import PrimaryGroup from './PrimaryGroup'
 import styles from './styles/Toolbar.css'
+
+const collapsibleGroups = ['insertMenu', 'annotationButtons', 'decoratorButtons', 'listItemButtons']
+const BREAKPOINT_SCREEN_MEDIUM = 512
 
 type Props = {
   blockContentFeatures: BlockContentFeatures,
@@ -42,37 +38,47 @@ type Props = {
 }
 
 type State = {
-  expanded: boolean,
-  showValidationTooltip: boolean
-}
-
-const query = {
-  [styles.largeContainer]: {
-    minWidth: 600
-  }
+  collapsePrimaryIsOpen: boolean,
+  showValidationTooltip: boolean,
+  collapsePrimary: boolean,
+  collapsedGroups: any,
+  isMobile: boolean,
+  lastContentWidth: number
 }
 
 class Toolbar extends React.PureComponent<Props, State> {
   state = {
-    expanded: false,
-    showValidationTooltip: false
+    collapsePrimaryIsOpen: false,
+    collapsePrimary: false,
+    showValidationTooltip: false,
+    collapsedGroups: [],
+    lastContentWidth: -1,
+    isMobile: false
   }
 
-  handleExpand = () => {
+  _primaryToolbar = React.createRef()
+
+  componentDidMount() {
+    if (window) {
+      this.setState({isMobile: window.innerWidth < BREAKPOINT_SCREEN_MEDIUM})
+    }
+  }
+
+  handleOpenPrimary = () => {
     this.setState({
-      expanded: true
+      collapsePrimaryIsOpen: true
     })
   }
 
-  handleContract = () => {
+  handleClosePrimary = () => {
     this.setState({
-      expanded: false
+      collapsePrimaryIsOpen: false
     })
   }
 
-  handleClickOutside = () => {
+  handleClickOutsidePrimary = () => {
     this.setState({
-      expanded: false
+      collapsePrimaryIsOpen: false
     })
   }
 
@@ -89,25 +95,60 @@ class Toolbar extends React.PureComponent<Props, State> {
     this.setState(prevState => ({showValidationTooltip: !prevState.showValidationTooltip}))
   }
 
+  handleResize = debounce(() => {
+    if (this.state.isMobile) return
+
+    const {_primaryToolbar} = this
+    const {collapsedGroups, lastContentWidth, collapsePrimary} = this.state
+
+    if (!_primaryToolbar || !_primaryToolbar.current) return
+
+    const width = _primaryToolbar.current.offsetWidth
+    const contentWidth = _primaryToolbar.current.scrollWidth
+    if (contentWidth > width && !collapsePrimary) {
+      const groupToCollapse = xor(collapsibleGroups, collapsedGroups)[0]
+      this.setState(
+        {collapsedGroups: [...collapsedGroups, groupToCollapse], lastContentWidth: contentWidth},
+        () => {
+          if (contentWidth > width && collapsedGroups.length != collapsibleGroups.length) {
+            this.handleResize()
+          } else if (collapsedGroups.length === collapsibleGroups.length && contentWidth > width) {
+            this.setState({collapsePrimary: true})
+          }
+        }
+      )
+    }
+
+    if (collapsePrimary && lastContentWidth < width) {
+      this.setState({
+        collapsePrimary: false,
+        collapsePrimaryIsOpen: false
+      })
+    }
+
+    if (width >= lastContentWidth && collapsedGroups.length != 0) {
+      this.setState({
+        collapsedGroups: []
+      })
+    }
+  }, 50)
+
   render() {
     const {
       blockContentFeatures,
       editor,
-      editorValue,
       fullscreen,
       markers,
-      onFocus,
       onToggleFullScreen,
       style,
-      type,
-      userIsWritingText
+      type
     } = this.props
 
     if (!editor) {
       return null
     }
 
-    const {expanded, showValidationTooltip} = this.state
+    const {showValidationTooltip, isMobile} = this.state
 
     const insertItems = blockContentFeatures.types.inlineObjects.concat(
       blockContentFeatures.types.blockObjects
@@ -117,80 +158,53 @@ class Toolbar extends React.PureComponent<Props, State> {
     const errors = validation.filter(marker => marker.level === 'error')
     const warnings = validation.filter(marker => marker.level === 'warning')
 
-    const hasMore =
-      blockContentFeatures.decorators.length > 0 ||
-      blockContentFeatures.annotations.length > 0 ||
-      blockContentFeatures.types.blockObjects.length > 0 ||
-      blockContentFeatures.types.inlineObjects.length > 0
+    const {collapsedGroups, collapsePrimary, collapsePrimaryIsOpen} = this.state
 
     return (
-      <ContainerQuery query={query}>
-        {params => (
+      <Measure offset scroll onResize={contentRect => this.handleResize(contentRect)}>
+        {({measureRef}) => (
           <div
+            ref={measureRef}
+            style={style}
             className={`
               ${styles.root}
-              ${classnames(params)}
               ${fullscreen ? ` ${styles.fullscreen}` : ''}
             `}
-            style={style}
           >
-            <div className={styles.primary}>
-              <div className={styles.blockFormatContainer} onClick={this.handleContract}>
-                <BlockStyleSelect
-                  blockContentFeatures={blockContentFeatures}
-                  editor={editor}
-                  editorValue={editorValue}
-                />
-              </div>
-              {hasMore && (
-                <Button className={styles.expandButton} onClick={this.handleExpand} kind="simple">
-                  More&nbsp;
+            <div className={styles.primary} ref={this._primaryToolbar}>
+              {collapsePrimary && (
+                <Button
+                  className={styles.showMoreButton}
+                  onClick={this.handleOpenPrimary}
+                  kind="simple"
+                >
+                  Show menu&nbsp;
                   <span className={styles.arrow}>
                     <ArrowIcon color="inherit" />
                   </span>
+                  <Poppable
+                    onClickOutside={this.handleClosePrimary}
+                    onEscape={this.handleClosePrimary}
+                  >
+                    {collapsePrimaryIsOpen && (
+                      <PrimaryGroup
+                        {...this.props}
+                        isPopped
+                        collapsedGroups={collapsedGroups}
+                        insertItems={insertItems}
+                      />
+                    )}
+                  </Poppable>
                 </Button>
               )}
-              <div className={`${styles.compactable} ${expanded ? styles.expanded : ''}`}>
-                {blockContentFeatures.decorators.length > 0 && (
-                  <div className={styles.decoratorButtonsContainer}>
-                    <DecoratorButtons
-                      blockContentFeatures={blockContentFeatures}
-                      editor={editor}
-                      editorValue={editorValue}
-                    />
-                  </div>
-                )}
-                {blockContentFeatures.lists.length > 0 && (
-                  <div className={styles.decoratorButtonsContainer}>
-                    <ListItemButtons
-                      blockContentFeatures={blockContentFeatures}
-                      editor={editor}
-                      editorValue={editorValue}
-                    />
-                  </div>
-                )}
-                {blockContentFeatures.annotations.length > 0 && (
-                  <div className={styles.annotationButtonsContainer}>
-                    <AnnotationButtons
-                      blockContentFeatures={blockContentFeatures}
-                      editor={editor}
-                      editorValue={editorValue}
-                      onFocus={onFocus}
-                      userIsWritingText={userIsWritingText}
-                    />
-                  </div>
-                )}
-                {insertItems.length > 0 && (
-                  <div className={styles.insertContainer}>
-                    <InsertMenu
-                      blockTypes={blockContentFeatures.types.blockObjects}
-                      editor={editor}
-                      editorValue={editorValue}
-                      inlineTypes={blockContentFeatures.types.inlineObjects}
-                      onFocus={onFocus}
-                      type={type}
-                    />
-                  </div>
+              <div className={styles.primaryInner}>
+                {!collapsePrimary && (
+                  <PrimaryGroup
+                    {...this.props}
+                    collapsedGroups={collapsedGroups}
+                    insertItems={insertItems}
+                    isMobile={isMobile}
+                  />
                 )}
               </div>
             </div>
@@ -231,7 +245,7 @@ class Toolbar extends React.PureComponent<Props, State> {
                   </Button>
                 </Tooltip>
               )}
-              <div className={styles.fullscreenButtonContainer} onClick={this.handleContract}>
+              <div className={styles.fullscreenButtonContainer}>
                 <Button
                   kind="simple"
                   onClick={onToggleFullScreen}
@@ -242,9 +256,9 @@ class Toolbar extends React.PureComponent<Props, State> {
             </div>
           </div>
         )}
-      </ContainerQuery>
+      </Measure>
     )
   }
 }
 
-export default enhanceWithClickOutside(Toolbar)
+export default Toolbar

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/Toolbar.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/Toolbar.js
@@ -3,7 +3,7 @@
 /* eslint-disable complexity */
 
 import React from 'react'
-import Tooltip from 'react-tippy'
+import {Tooltip} from 'react-tippy'
 import Measure from 'react-measure'
 import ArrowIcon from 'part:@sanity/base/angle-down-icon'
 import Button from 'part:@sanity/components/buttons/default'
@@ -251,6 +251,7 @@ class Toolbar extends React.PureComponent<Props, State> {
                   onClick={onToggleFullScreen}
                   title={`Open in fullscreen (${IS_MAC ? 'cmd' : 'ctrl'}+enter)`}
                   icon={fullscreen ? CloseIcon : FullscreenIcon}
+                  bleed
                 />
               </div>
             </div>

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/ToolbarClickAction.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/ToolbarClickAction.js
@@ -44,7 +44,7 @@ export default function ToolBarClickAction(props: Props) {
   }
 
   return (
-    <span onMouseDown={onMouseDown} onClick={onClick}>
+    <span onMouseDown={onMouseDown} onClick={onClick} style={{display: 'contents'}}>
       {props.children}
     </span>
   )

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/styles/AnnotationButtons.css
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/styles/AnnotationButtons.css
@@ -1,7 +1,4 @@
 .root {
-  display: inline-block;
-}
-
-.iconContainer {
-  transform: scale(1.5);
+  display: flex;
+  flex-wrap: nowrap;
 }

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/styles/CollapsibleButtonGroup.css
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/styles/CollapsibleButtonGroup.css
@@ -1,0 +1,16 @@
+@import "part:@sanity/base/theme/variables-style";
+
+.root {
+  display: flex;
+  height: 100%;
+  flex-wrap: nowrap;
+  align-items: stretch;
+}
+
+.popup {
+  composes: shadow-1dp from 'part:@sanity/base/theme/shadows-style';
+  top: 100%;
+  z-index: 1;
+  position: absolute;
+  background-color: var(--component-bg);
+}

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/styles/CollapsibleButtonGroup.css
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/styles/CollapsibleButtonGroup.css
@@ -9,8 +9,10 @@
 
 .popup {
   composes: shadow-1dp from 'part:@sanity/base/theme/shadows-style';
+  display: flex;
   top: 100%;
   z-index: 1;
   position: absolute;
   background-color: var(--component-bg);
+  padding: var(--small-padding);
 }

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/styles/DecoratorButtons.css
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/styles/DecoratorButtons.css
@@ -2,6 +2,7 @@
 
 .root {
   display: flex;
+  flex-wrap: nowrap;
 }
 
 .buttonWrapper + .buttonWrapper {

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/styles/ListItemButtons.css
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/styles/ListItemButtons.css
@@ -1,7 +1,4 @@
 .root {
-  display: inline-block;
-}
-
-.iconContainer {
-  transform: scale(1.5);
+  display: flex;
+  flex-wrap: nowrap;
 }

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/styles/PrimaryGroup.css
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/styles/PrimaryGroup.css
@@ -27,7 +27,7 @@
 .blockStyleGroup {
   composes: group;
 
-  @nest & + .group {
+  @nest &:not(:empty) + .group {
     border-left: none;
   }
 }

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/styles/PrimaryGroup.css
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/styles/PrimaryGroup.css
@@ -1,0 +1,33 @@
+@import "part:@sanity/base/theme/variables-style";
+
+.root {
+  display: flex;
+  flex-wrap: nowrap;
+  background-color: var(--component-bg);
+}
+
+.isPopped {
+  composes: root;
+  composes: shadow-6dp from 'part:@sanity/base/theme/shadows-style';
+  position: relative;
+  z-index: 20;
+  padding: var(--small-padding);
+  height: 2.5em;
+}
+
+.group {
+  composes: group from './Toolbar.css';
+}
+
+.blockStyleSelect {
+  min-width: 8em;
+  white-space: nowrap;
+}
+
+.blockStyleGroup {
+  composes: group;
+
+  @nest & + .group {
+    border-left: none;
+  }
+}

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/styles/Toolbar.css
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/styles/Toolbar.css
@@ -2,16 +2,11 @@
 
 .root {
   position: relative;
-  font-size: 0.8rem;
   display: flex;
   width: 100%;
-  justify-content: space-between;
+  justify-content: stretch;
   flex-wrap: nowrap;
   padding-bottom: var(--small-padding);
-
-  @media (--screen-medium) {
-    font-size: 0.8rem;
-  }
 
   @nest &.fullscreen {
     position: fixed;
@@ -22,8 +17,8 @@
     right: 0;
     z-index: 1;
     padding: var(--small-padding);
-    background-color: var(--input-bg);
-    box-shadow: 0 0 8px color(var(--input-border-color) a(35%));
+    background-color: var(--component-bg);
+    box-shadow: 0 0 8px color(var(--component-border-color) a(35%));
 
     @media (--screen-medium) {
       padding: var(--medium-padding--em);
@@ -32,62 +27,73 @@
 }
 
 .primary {
+  position: relative;
   display: flex;
-}
+  flex-grow: 1;
+  flex-wrap: nowrap;
+  overflow-x: scroll;
 
-.secondary {
-  margin-left: auto;
-  display: flex;
-}
-
-.compactable {
-  display: none;
-}
-
-.expanded {
-  composes: shadow-12dp from 'part:@sanity/base/theme/shadows-style';
-}
-
-.largeContainer .compactable {
-  display: flex;
-}
-
-.root:not(.largeContainer) .compactable.expanded {
-  display: flex;
-  flex-wrap: wrap;
-  z-index: var(--zindex-dropdown);
-  position: absolute;
-  max-width: calc(100% - var(--medium-padding) * 2);
-  top: 0;
-  left: 0;
-  background-color: var(--component-bg);
-  padding: var(--small-padding);
-  box-sizing: border-box;
-  margin: var(--medium-padding);
-}
-
-.largeContainer .expandButton {
-  display: none;
-}
-
-.blockFormatContainer {
-  max-width: 5em;
-  min-width: 4em;
-  padding-right: 0.5em;
+  @nest &::scrollbar {
+    display: none;
+  }
 
   @media (--screen-medium) {
-    max-width: none;
-    min-width: 8em;
-    padding-top: 0.2em;
+    overflow: hidden;
   }
 }
 
-.decoratorButtonsContainer {
-  padding-right: var(--medium-padding--em);
+.secondary::before {
+  position: absolute;
+  content: '';
+  right: 100%;
+  top: 0;
+  height: 100%;
+  width: 1em;
+  z-index: 10;
+  background: radial-gradient(var(--component-border-color), color(var(--component-border-color) a(0%)) 70%);
+  background-position: 0.5em 0;
+  background-repeat: no-repeat;
+  border-right: 1px solid color(var(--component-border-color) a(5%));
+
+  @media (--screen-medium) {
+    display: none;
+  }
 }
 
-.annotationButtonsContainer {
-  padding-right: var(--medium-padding--em);
+.primaryInner {
+  display: flex;
+}
+
+.primaryInnerCollapsed {
+  composes: primaryInner;
+  display: none;
+}
+
+.primaryInnerCollapsedOpen {
+  composes: shadow-12dp from 'part:@sanity/base/theme/shadows-style';
+  composes: primaryInner;
+  position: absolute;
+  top: 1em;
+  left: 1em;
+  z-index: 10;
+}
+
+.secondary {
+  display: flex;
+  flex-wrap: nowrap;
+  position: relative;
+}
+
+.group {
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
+}
+
+.group + .group {
+  border-left: 1px solid #eee;
+  padding-left: calc(var(--small-padding--em) / 2);
+  margin-left: calc(var(--small-padding--em) / 2);
 }
 
 .fullscreenButtonContainer {
@@ -97,4 +103,9 @@
   @nest & svg {
     transform: scale(1.5);
   }
+}
+
+.showMoreButton {
+  border: 1px solid green;
+  position: relative;
 }

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/styles/Toolbar.css
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/styles/Toolbar.css
@@ -94,7 +94,7 @@
   flex-wrap: nowrap;
 }
 
-.group + .group {
+.group:not(:empty) + .group {
   border-left: 1px solid #eee;
   padding-left: calc(var(--small-padding--em) / 2);
   margin-left: calc(var(--small-padding--em) / 2);

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/styles/Toolbar.css
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/styles/Toolbar.css
@@ -21,7 +21,6 @@
     background-color: var(--component-bg);
     box-shadow: 0 0 8px color(var(--component-border-color) a(35%));
 
-
     @media (--screen-medium) {
       padding: var(--small-padding);
       font-size: var(--font-size-base);
@@ -35,6 +34,7 @@
   flex-grow: 1;
   flex-wrap: nowrap;
   overflow-x: scroll;
+  -webkit-overflow-scrolling: touch;
 
   @nest &::scrollbar {
     display: none;

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/styles/Toolbar.css
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Toolbar/styles/Toolbar.css
@@ -7,6 +7,7 @@
   justify-content: stretch;
   flex-wrap: nowrap;
   padding-bottom: var(--small-padding);
+  font-size: var(--font-size-small);
 
   @nest &.fullscreen {
     position: fixed;
@@ -20,8 +21,10 @@
     background-color: var(--component-bg);
     box-shadow: 0 0 8px color(var(--component-border-color) a(35%));
 
+
     @media (--screen-medium) {
-      padding: var(--medium-padding--em);
+      padding: var(--small-padding);
+      font-size: var(--font-size-base);
     }
   }
 }
@@ -82,6 +85,7 @@
   display: flex;
   flex-wrap: nowrap;
   position: relative;
+  align-items: center;
 }
 
 .group {
@@ -98,6 +102,7 @@
 
 .fullscreenButtonContainer {
   margin-left: auto;
+  width: 2.5em;
   height: 100%;
 
   @nest & svg {

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/styles/BlockEditor.css
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/styles/BlockEditor.css
@@ -76,6 +76,7 @@
   width: 95vw;
   box-sizing: border-box;
   padding-bottom: 4rem;
+  margin-top: 5rem;
 
   @media (--screen-medium) {
     width: 90vw;

--- a/packages/test-studio/schemas/blocks.js
+++ b/packages/test-studio/schemas/blocks.js
@@ -1,4 +1,6 @@
 import icon from 'react-icons/lib/md/rate-review'
+import imageIcon from 'react-icons/lib/md/photo-library'
+import colorIcon from 'react-icons/lib/md/format-color-fill'
 
 export default {
   name: 'blocksTest',
@@ -17,7 +19,7 @@ export default {
       description: 'Profound description of what belongs here',
       type: 'array',
       of: [
-        {type: 'image', title: 'Image'},
+        {type: 'image', title: 'Image', icon: imageIcon},
         {
           type: 'reference',
           name: 'authorReference',
@@ -35,7 +37,8 @@ export default {
         {
           type: 'color',
           name: 'colorBlock',
-          title: 'Color (block)'
+          title: 'Color (block)',
+          icon: colorIcon
         },
         {
           type: 'object',


### PR DESCRIPTION
- Auto-collapsing groups in toolbar when needed
- Insert menu supports not being collapsed
- Display a "show menu" button when there is no room for all
- Touch scrolling in mobile with paper-cut-shadow™ to show scrollability