### PR TITLE
[preview] Use visibility query when setting up listener

### DIFF
--- a/packages/@sanity/client/src/data/listen.js
+++ b/packages/@sanity/client/src/data/listen.js
@@ -19,7 +19,7 @@ const EventSource = isWindowEventSource
   ? window.EventSource // Native browser EventSource
   : polyfilledEventSource // Node.js, IE etc
 
-const possibleOptions = ['includePreviousRevision', 'includeResult']
+const possibleOptions = ['includePreviousRevision', 'includeResult', 'visibility']
 const defaultOptions = {
   includeResult: true
 }

--- a/packages/@sanity/preview/src/observeFields.js
+++ b/packages/@sanity/preview/src/observeFields.js
@@ -34,7 +34,7 @@ const getGlobalEvents = () => {
       client.listen(
         '*[!(_id in path("_.**"))]',
         {},
-        {events: ['welcome', 'mutation'], includeResult: false}
+        {events: ['welcome', 'mutation'], includeResult: false, visibility: 'query'}
       )
     ).pipe(share())
 
@@ -82,7 +82,7 @@ const fetchDocumentPathsSlow = debounceCollect(fetchAllDocumentPaths, 1000)
 function listenFields(id: Id, fields: FieldName[]) {
   return listen(id).pipe(
     switchMap(event => {
-      if (event.type === 'welcome') {
+      if (event.type === 'welcome' || event.visibility === 'query') {
         return fetchDocumentPathsFast(id, fields).pipe(
           mergeMap(result => {
             return concat(


### PR DESCRIPTION
This adds support for specifying the `visibility`-parameter to `@sanity/client`. (Described here: https://www.sanity.io/docs/listening#parameters)

It also modifies the preview observer so that it re-fetches a previewed document immediately when receiving a mutation event with `visibility: query` (https://www.sanity.io/docs/realtime-updates#object-object-events)
