### PR TITLE
[base] Fix broken search on no document types

### DIFF
--- a/packages/@sanity/default-layout/src/components/SearchContainer.js
+++ b/packages/@sanity/default-layout/src/components/SearchContainer.js
@@ -128,29 +128,20 @@ class SearchContainer extends React.Component {
     this.setState({isFocused: false})
   }
 
-  /* eslint-disable-next-line complexity */
   handleKeyDown = event => {
     const {results, activeIndex} = this.state
     const isArrowKey = ['ArrowUp', 'ArrowDown'].includes(event.key)
     const lastIndex = results.length - 1
 
     if (event.key === 'Enter') {
-      const hitEl = this.resultsRef.current.element.querySelector(
-        `[data-hit-index="${activeIndex}"]`
-      )
+      const resultsEl = this.resultsRef.current.element
+      const hitEl = resultsEl && resultsEl.querySelector(`[data-hit-index="${activeIndex}"]`)
       if (hitEl) hitEl.click()
     }
 
     if (event.key === 'Escape') {
-      // this.handleClear()
       this.fieldRef.current.inputElement.blur()
     }
-
-    // TODO: is it safe to remove this?
-    // if (!isFocused && isArrowKey) {
-    //   this.handleFocus()
-    //   return
-    // }
 
     if (isArrowKey) {
       event.preventDefault()


### PR DESCRIPTION
If you have no document types in your schema (for instance in the case of the clean template) and try to do a search, two bugs are surfaced:

1. An invalid query is generated. In essence, it looks like this: `*[_type in $types && ()] {...select()}` - an empty parentheses is not allowed, so it fails. Also, the `select()` function needs a body.
2. When pressing Enter in the search input, the studio crashes because it tries to use `querySelector` on a non-existing element. 

This PR fixes both of these issues. To reproduce/test this issue, remove all document types from your `types` array and try to search.
