### PR TITLE
[chore] Set root package name to '@sanity/client'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "sanity",
+  "//": "Note: The actual “@sanity/client” package is located under “./packages/@sanity/client”. The “name” field below is there to get the GitHub's “Used by” number right",
+  "name": "@sanity/client",
   "private": true,
   "scripts": {
     "bootstrap": "lerna bootstrap && npm run package-yarn && npm run install-husky",


### PR DESCRIPTION
GitHub recently introduced the "Used by"-feature, which displays usage numbers based on the package `name` in the repo's root level `package.json`. This has initially been just `sanity`, but I think it makes more sense (and better reflects real-world usage) if we change this to `@sanity/client` instead.

This change may introduce some confusion for people coming looking for the actual `@santiy/client`-package, so I added a comment about where to find it (who says you can't have comments in JSON).