### PR TITLE
[code-input] Only render editor on supported languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "sanity",
+  "//": "Note: The actual “@sanity/client” package is located under “./packages/@sanity/client”. The “name” field below is there to get the GitHub's “Used by” number right",
+  "name": "@sanity/client",
   "private": true,
   "scripts": {
     "bootstrap": "lerna bootstrap && npm run package-yarn && npm run install-husky",

--- a/packages/@sanity/code-input/src/config.js
+++ b/packages/@sanity/code-input/src/config.js
@@ -14,6 +14,8 @@ export const SUPPORTED_LANGUAGES = [
   {title: 'Plain text', value: 'text'}
 ]
 
+export const LANGUAGE_ALIASES = {js: 'javascript'}
+
 export const SUPPORTED_THEMES = ['github', 'monokai', 'terminal', 'tomorrow']
 
 export const DEFAULT_THEME = 'tomorrow'


### PR DESCRIPTION
If you specify a language that there is no corresponding ace mode registered for, it'll currently crash the studio. With this PR, it'll warn and fall back to text mode instead. Unknown modes will also be removed from the dropdown and a warning will be logged.

I also took the time to add basic aliasing support with warning for `js` instead of `javascript`