### PR TITLE
[cli] Fix duplicated word in the comments of cli/schema.JS

### DIFF
--- a/packages/@sanity/cli/templates/blog/schemas/schema.js
+++ b/packages/@sanity/cli/templates/blog/schemas/schema.js
@@ -14,7 +14,7 @@ import author from './author'
 export default createSchema({
   // We name our schema
   name: 'default',
-  // Then proceed to concatenate our our document type
+  // Then proceed to concatenate our document type
   // to the ones provided by any plugins that are installed
   types: schemaTypes.concat([
     // The following are document types which will appear

--- a/packages/@sanity/cli/templates/clean/schemas/schema.js
+++ b/packages/@sanity/cli/templates/clean/schemas/schema.js
@@ -6,8 +6,9 @@ import schemaTypes from 'all:part:@sanity/base/schema-type'
 
 // Then we give our schema to the builder and provide the result to Sanity
 export default createSchema({
+  // We name our schema
   name: 'default',
-  // Then proceed to concatenate our our document type
+  // Then proceed to concatenate our document type
   // to the ones provided by any plugins that are installed
   types: schemaTypes.concat([
     /* Your types here! */

--- a/packages/@sanity/cli/templates/ecommerce/schemas/schema.js
+++ b/packages/@sanity/cli/templates/ecommerce/schemas/schema.js
@@ -18,7 +18,7 @@ import localeBlockContent from './locale/BlockContent'
 export default createSchema({
   // We name our schema
   name: 'default',
-  // Then proceed to concatenate our our document type
+  // Then proceed to concatenate our document type
   // to the ones provided by any plugins that are installed
   types: schemaTypes.concat([
     // The following are document types which will appear

--- a/packages/@sanity/cli/templates/moviedb/schemas/schema.js
+++ b/packages/@sanity/cli/templates/moviedb/schemas/schema.js
@@ -17,7 +17,7 @@ import plotSummaries from './plotSummaries'
 export default createSchema({
   // We name our schema
   name: 'default',
-  // Then proceed to concatenate our our document type
+  // Then proceed to concatenate our document type
   // to the ones provided by any plugins that are installed
   types: schemaTypes.concat([
     // The following are document types which will appear


### PR DESCRIPTION
A simple fix to the comment: // Then proceed to concatenate our our document type