### PR TITLE
[server] Prevent build error on symlinked modules

### DIFF
--- a/packages/@sanity/server/src/configs/webpack.config.js
+++ b/packages/@sanity/server/src/configs/webpack.config.js
@@ -75,6 +75,7 @@ export default (config = {}) => {
       alias: {
         react: path.dirname(reactPath),
         'react-dom': path.dirname(reactDomPath),
+        'react-hot-loader': path.dirname(resolve('react-hot-loader')),
         moment$: 'moment/moment.js',
         ...rxPaths()
       }


### PR DESCRIPTION
Fixes react-hot-loader not resolving in symlinked modules
