### PR TITLE
[core] Deploy to sanity.studio without basePath

### DIFF
--- a/packages/@sanity/core/src/actions/build/buildStaticAssets.js
+++ b/packages/@sanity/core/src/actions/build/buildStaticAssets.js
@@ -14,6 +14,7 @@ const rimraf = promisify(rimTheRaf)
 const absoluteMatch = /^https?:\/\//i
 
 export default async (args, context) => {
+  const overrides = args.overrides || {}
   const {output, prompt, workDir} = context
   const flags = Object.assign(
     {minify: true, profile: false, stats: false, 'source-maps': false},
@@ -32,7 +33,7 @@ export default async (args, context) => {
     sourceMaps: flags['source-maps'],
     skipMinify: !flags.minify,
     profile: flags.profile,
-    project: config.get('project')
+    project: Object.assign({}, config.get('project'), overrides.project)
   }
 
   await tryInitializePluginConfigs({workDir, output})

--- a/packages/@sanity/core/src/actions/deploy/deployAction.js
+++ b/packages/@sanity/core/src/actions/deploy/deployAction.js
@@ -39,8 +39,9 @@ export default async (args, context) => {
   // Always build the project, unless --no-build is passed
   const shouldBuild = flags.build
   if (shouldBuild) {
+    const overrides = {project: {basePath: undefined}}
     const buildStaticAssets = lazyRequire(require.resolve('../build/buildStaticAssets'))
-    await buildStaticAssets({extOptions: flags, argsWithoutOptions: []}, context)
+    await buildStaticAssets({extOptions: flags, argsWithoutOptions: [], overrides}, context)
   }
 
   // Ensure that the directory exists, is a directory and seems to have valid content


### PR DESCRIPTION
When you set a `basePath` for a studio, this information is not carried over to the `sanity.studio` hosting. The result is that the `index.html` file references paths that do not exist, which obviously fails.

For now, let's ignore any base path when using `sanity deploy`, but obviously keep support for it when using `sanity build`.
