### PR TITLE
[base] Add less intrusive error handler

### DIFF
--- a/packages/@sanity/base/src/components/ErrorHandler.js
+++ b/packages/@sanity/base/src/components/ErrorHandler.js
@@ -1,0 +1,72 @@
+import React from 'react'
+import Snackbar from 'part:@sanity/components/snackbar/default'
+
+const SANITY_ERROR_HANDLER = Symbol.for('SANITY_ERROR_HANDLER')
+
+export default class ErrorHandler extends React.PureComponent {
+  state = {error: null}
+
+  constructor(props) {
+    super(props)
+
+    this.handleGlobalError = this.handleGlobalError.bind(this)
+    this.handleGlobalError.identity = SANITY_ERROR_HANDLER
+  }
+
+  componentDidMount() {
+    // Only store the original error handler if it wasn't a copy of _this_ error handler
+    if (window.onerror && window.onerror.identity !== SANITY_ERROR_HANDLER) {
+      this.originalErrorHandler = window.onerror
+    }
+
+    window.onerror = this.handleGlobalError
+  }
+
+  componentWillUnmount() {
+    window.onerror = this.originalErrorHandler || window.onerror
+  }
+
+  handleGlobalError = (msg, url, lineNo, columnNo, err) => {
+    // Certain events (ResizeObserver max loop threshold, for instance)
+    // only gives a _message_. We choose to ignore these events since
+    // they are usually not _fatal_
+    if (!err) {
+      return
+    }
+
+    // Certain errors should be ignored
+    if (
+      [
+        /unexpected token <$/i // Trying to load HTML as JS
+      ].some(item => item.test(err.message))
+    ) {
+      return
+    }
+
+    // eslint-disable-next-line no-console
+    console.error(err)
+    this.setState({error: err})
+  }
+
+  handleClose = () => {
+    this.setState({error: null})
+  }
+
+  render() {
+    const {error} = this.state
+    if (!error) {
+      return null
+    }
+
+    const message = __DEV__ ? `An error occured: ${error.message}` : 'An error occured'
+
+    return (
+      <Snackbar kind="error" action={{title: 'Close'}} onAction={this.handleClose} timeout={2500}>
+        <div>
+          <strong>{message}</strong>
+        </div>
+        <div>Check browser javascript console for details</div>
+      </Snackbar>
+    )
+  }
+}

--- a/packages/@sanity/base/src/components/SanityRoot.js
+++ b/packages/@sanity/base/src/components/SanityRoot.js
@@ -1,11 +1,13 @@
 import React from 'react'
 import RootComponent from 'part:@sanity/base/root'
 import VersionChecker from './VersionChecker'
+import ErrorHandler from './ErrorHandler'
 import styles from './styles/SanityRoot.css'
 
 function SanityRoot() {
   return (
     <div className={styles.root}>
+      <ErrorHandler />
       <RootComponent />
       <VersionChecker />
     </div>

--- a/packages/@sanity/base/src/util/uncaughtErrorHandler.js
+++ b/packages/@sanity/base/src/util/uncaughtErrorHandler.js
@@ -9,13 +9,6 @@ function errHandler(msg, url, lineNo, columnNo, err) {
     return
   }
 
-  // Certain errors should be ignored
-  if ([
-    /unexpected token <$/i // Trying to load HTML as JS
-  ].some(item => item.test(err.message))) {
-    return
-  }
-
   var container = document.getElementById('sanity')
   var wrapper = document.createElement('div')
   wrapper.style.position = 'absolute'
@@ -69,4 +62,4 @@ export default () => `window.onerror = ${errHandler.toString()}`
 */
 
 export default () =>
-  '/* Global error handler */ window.onerror = function(e,t,n,o,r){if(r&&![/unexpected token <$/i].some(e=>e.test(r.message))){var a=document.getElementById("sanity"),l=document.createElement("div");l.style.position="absolute",l.style.top="50%",l.style.left="50%",l.style.transform="translate(-50%, -50%)";var s=document.createElement("h1");s.innerText="Uncaught error";var d=document.createElement("pre"),i=document.createElement("code");d.style.fontSize="0.8em",d.style.opacity="0.7",d.style.overflow="auto",d.style.whiteSpace="pre-wrap",d.style.maxHeight="70vh";var c=r.stack&&r.stack.replace(r.message,"").replace(/^error: *\\n?/i,""),m=(r.stack?r.message:r.toString())+(r.stack?"\\n\\nStack:\\n\\n"+c:"")+"\\n\\n(Your browsers Developer Tools may contain more info)";i.textContent=m;var p=document.createElement("button");for(p.style.padding="0.8em 1em",p.style.marginTop="1em",p.style.border="none",p.style.backgroundColor="#303030",p.style.color="#fff",p.style.borderRadius="4px",p.onclick=function(){window.location.reload()},p.textContent="Reload",d.appendChild(i),l.appendChild(s),l.appendChild(d),l.appendChild(p);a.firstChild;)a.removeChild(a.firstChild);a.appendChild(l)}}'
+  '/* Global error handler */ window.onerror = function(e,t,n,o,r){if(r){var a=document.getElementById("sanity"),l=document.createElement("div");l.style.position="absolute",l.style.top="50%",l.style.left="50%",l.style.transform="translate(-50%, -50%)";var s=document.createElement("h1");s.innerText="Uncaught error";var d=document.createElement("pre"),i=document.createElement("code");d.style.fontSize="0.8em",d.style.opacity="0.7",d.style.overflow="auto",d.style.whiteSpace="pre-wrap",d.style.maxHeight="70vh";var c=r.stack&&r.stack.replace(r.message,"").replace(/^error: *\\n?/i,""),m=(r.stack?r.message:r.toString())+(r.stack?"\\n\\nStack:\\n\\n"+c:"")+"\\n\\n(Your browsers Developer Tools may contain more info)";i.textContent=m;var p=document.createElement("button");for(p.style.padding="0.8em 1em",p.style.marginTop="1em",p.style.border="none",p.style.backgroundColor="#303030",p.style.color="#fff",p.style.borderRadius="4px",p.onclick=function(){window.location.reload()},p.textContent="Reload",d.appendChild(i),l.appendChild(s),l.appendChild(d),l.appendChild(p);a.firstChild;)a.removeChild(a.firstChild);a.appendChild(l)}}'


### PR DESCRIPTION
The full-screen global error handler is quite intrusive. Sometimes this is necessary, because the error that occurs actually crashes the app in a way it cannot recover. However, a lot of the time the errors are fairly innocent, where most of the app continues to work as expected despite the error.

To allow for these errors not to fully block the studio from functioning, this change introduces a _second_ error handler, which takes over as quickly as React has been mounted. This makes sure that any low-level errors that prevents React from rendering will still use the full-screen error handler. Any errors after this point will render a "Snackbar" error that prompts the user to take a peek at their browsers devtools to figure out the error.

In development, it shows the first line of the error message, while in production it only shows "An error occured, check browser javascript console for details".

Looks something like the following:

![image](https://user-images.githubusercontent.com/48200/59436483-fc3bfa00-8def-11e9-8ae6-c57d466088ad.png)
