### PR TITLE
[base] Use ellipsis for long error messages

### DIFF
--- a/packages/@sanity/base/src/components/ErrorHandler.js
+++ b/packages/@sanity/base/src/components/ErrorHandler.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import Snackbar from 'part:@sanity/components/snackbar/default'
+import styles from './styles/ErrorHandler.css'
 
 const SANITY_ERROR_HANDLER = Symbol.for('SANITY_ERROR_HANDLER')
 
@@ -62,7 +63,7 @@ export default class ErrorHandler extends React.PureComponent {
 
     return (
       <Snackbar kind="error" action={{title: 'Close'}} onAction={this.handleClose} timeout={2500}>
-        <div>
+        <div className={styles.errorMessageHeader}>
           <strong>{message}</strong>
         </div>
         <div>Check browser javascript console for details</div>

--- a/packages/@sanity/base/src/components/styles/ErrorHandler.css
+++ b/packages/@sanity/base/src/components/styles/ErrorHandler.css
@@ -1,0 +1,5 @@
+.errorMessageHeader {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}


### PR DESCRIPTION
Fixes the case where a really long error message would fill the whole screen (at least partly).
Might be worth changing the snackbar to have some sort of max-height as well, but this at least partly addresses the issue.
