### PR TITLE
[form-builder] Round device pixel ratio, avoiding float dimensions for images

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ImageInput/Asset.js
+++ b/packages/@sanity/form-builder/src/inputs/ImageInput/Asset.js
@@ -108,7 +108,7 @@ export default class Asset extends React.PureComponent {
     const dpi =
       typeof window === 'undefined' || !window.devicePixelRatio
         ? 1
-        : Math.ceil(window.devicePixelRatio)
+        : Math.round(window.devicePixelRatio)
 
     const imgH = 100 * Math.max(1, dpi)
     const width = get(asset, 'metadata.dimensions.width') || 100

--- a/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.js
+++ b/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.js
@@ -68,7 +68,7 @@ const getDevicePixelRatio = () => {
     return 1
   }
 
-  return Math.max(1, window.devicePixelRatio)
+  return Math.round(Math.max(1, window.devicePixelRatio))
 }
 
 export default class ImageInput extends React.PureComponent<Props, State> {


### PR DESCRIPTION
Prevents a case where some browsers report a DPR of things like 1.005 or something along those lines.