### PR TITLE
[client] Fix `withCredentials` override not being applied

### DIFF
--- a/packages/@sanity/client/src/http/requestOptions.js
+++ b/packages/@sanity/client/src/http/requestOptions.js
@@ -14,11 +14,17 @@ module.exports = (config, overrides = {}) => {
     headers[projectHeader] = config.projectId
   }
 
+  const withCredentials = Boolean(
+    typeof overrides.withCredentials === 'undefined'
+      ? config.token || config.withCredentials
+      : overrides.withCredentials
+  )
+
   const timeout = typeof overrides.timeout === 'undefined' ? config.timeout : overrides.timeout
   return assign({}, overrides, {
     headers: assign({}, headers, overrides.headers || {}),
     timeout: typeof timeout === 'undefined' ? 5 * 60 * 1000 : timeout,
     json: true,
-    withCredentials: Boolean(config.token || config.withCredentials)
+    withCredentials
   })
 }


### PR DESCRIPTION
If you have a client globally configured to use credentials (such as in the studio), then do a request using the client where you explicitly tell it not to use credentials (`client.request({uri: '/ping', withCredentials: false})`), the client does not currently respect this.

This breaks the CORS-check we do when a network failure happens during the login phase, which can be confusing for users.

This PR fixes this by always honoring the `withCredentials` override first, then falling back to token/globally configured `withCredentials` option.