### PR TITLE
[desk-tool] Fix error when duplicating document in fallback edit pane

### DIFF
--- a/packages/@sanity/desk-tool/src/pane/Editor.js
+++ b/packages/@sanity/desk-tool/src/pane/Editor.js
@@ -312,13 +312,22 @@ export default withRouterHOC(
 
       this.duplicate$ = documentStore.create(duplicatedDocument).subscribe(copied => {
         const copyDocId = getPublishedId(copied._id)
-        const newPanes = router.state.panes.map((prev, i) =>
-          i === paneIndex - 1 && prev === prevId ? copyDocId : prev
-        )
-        router.navigate({
-          ...router.state,
-          panes: newPanes
-        })
+        if (router.state.panes) {
+          const newPanes = router.state.panes.map((prev, i) =>
+            i === paneIndex - 1 && prev === prevId ? copyDocId : prev
+          )
+          router.navigate({
+            ...router.state,
+            panes: newPanes
+          })
+        } else if (router.state.editDocumentId) {
+          router.navigate({
+            ...router.state,
+            editDocumentId: copyDocId
+          })
+        } else {
+          throw new Error('Unknown router state')
+        }
       })
     }
 


### PR DESCRIPTION
When the desk tool is showing the "fallback" edit pane instead of a specific structure, the "duplicate" action tried to use the `panes` router state, which didn't exist. With this change, it will only reuse the last pane if present, and in the case of the fallback; replace the edited document ID with the new one.