### PR TITLE
[desk-tool] Omit _createdAt, _updatedAt when creating duplicate document

### DIFF
--- a/packages/@sanity/desk-tool/src/pane/Editor.js
+++ b/packages/@sanity/desk-tool/src/pane/Editor.js
@@ -305,10 +305,11 @@ export default withRouterHOC(
     handleCreateCopy = () => {
       const {router, draft, published, paneIndex} = this.props
       const prevId = getPublishedId((draft || published)._id)
+      const omit = ['_createdAt', '_updatedAt']
 
       const duplicatedDocument = this.isLiveEditEnabled()
-        ? copyDocument(published)
-        : newDraftFrom(copyDocument(draft || published))
+        ? copyDocument(published, {omit})
+        : newDraftFrom(copyDocument(draft || published, {omit}))
 
       this.duplicate$ = documentStore.create(duplicatedDocument).subscribe(copied => {
         const copyDocId = getPublishedId(copied._id)

--- a/packages/@sanity/desk-tool/src/utils/copyDocument.js
+++ b/packages/@sanity/desk-tool/src/utils/copyDocument.js
@@ -47,5 +47,6 @@ function copyAny(value, options) {
 }
 
 export default function copyDocument(doc, options = {}) {
-  return copyAny(omit(doc, '_id'), options)
+  const omitProps = ['_id'].concat(options.omit)
+  return copyAny(omit(doc, omitProps), options)
 }


### PR DESCRIPTION
When you duplicate a document using the desk tool, the timestamps (`_createdAt`, `_updatedAt`) are kept as-is. Whether or not this is a bug or a feature is up for discussion, I guess, but it feels odd to me. I was expecting to see my new duplicate document at the top of the list when ordering by updated date.

This PR omits these timestamps from the cloned document.