### PR TITLE
[preview] Insert a nonbreaking space initially to workaround chromium bug

### DIFF
--- a/packages/@sanity/preview/src/components/WithVisibility.js
+++ b/packages/@sanity/preview/src/components/WithVisibility.js
@@ -77,7 +77,8 @@ export default class WithVisibility extends React.Component<Props, State> {
         style: {...STYLE, ...style},
         ...rest
       },
-      children(isVisible)
+      // Render a nonbreaking space here because of https://bugs.chromium.org/p/chromium/issues/detail?id=972196
+      isVisible ? children(isVisible) : '\u00A0' // &nbsp
     )
   }
 }


### PR DESCRIPTION
This is a workaround for a bug recently introduced in Chromium, released in Chrome 75 which is causing the `IntersectionObserverEntry.isIntersecting` to report `false` on empty elements. This again affected list previews in the Sanity Studio (see full description here:  #1375)

See also https://bugs.chromium.org/p/chromium/issues/detail?id=972196

Fixes #1375