### PR TITLE
[form-builder] Reference input: Don't show placeholder when input is readOnly

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.js
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.js
@@ -227,7 +227,7 @@ export default class ReferenceInput extends React.Component<Props, State> {
             </div>
           )}
           <SearchableSelect
-            placeholder={placeholder}
+            placeholder={readOnly ? '' : placeholder}
             title={
               isMissing && hasRef
                 ? `Document id: ${value._ref || 'unknown'}`


### PR DESCRIPTION
This fixes an issue with the reference input in `readOnly` mode, where it still displayed "Type to search…" as placeholder.