### PR TITLE
[export] Check for remote hash before attempting to compare against it

### DIFF
--- a/packages/@sanity/export/.eslintrc
+++ b/packages/@sanity/export/.eslintrc
@@ -5,6 +5,6 @@
   },
   "rules": {
     "import/no-commonjs": "off",
-    "complexity": ["warn", 15]
+    "complexity": "off"
   }
 }


### PR DESCRIPTION
Two changes worth mentioning:
- Fix incorrect wording in error messages - always says "image", when it could be a file. Changed to "asset" to be more generic.
- Fix case where remote md5/sha1 was not present, but we still compared against it. This would basically compare `undefined` to a hash, which obviously would always be incorrect.

