### PR TITLE
[cli] Ignore missing worker_threads module when building

### DIFF
--- a/packages/@sanity/cli/scripts/pack.js
+++ b/packages/@sanity/cli/scripts/pack.js
@@ -85,7 +85,11 @@ compiler.run((err, stats) => {
   }
 
   const filtered = stats.compilation.warnings.filter(warn => {
-    return !warn.origin || warn.origin.userRequest.indexOf('spawn-sync.js') === -1
+    return (
+      !warn.origin ||
+      (warn.origin.userRequest.indexOf('spawn-sync.js') === -1 &&
+        warn.origin.userRequest.indexOf('write-file-atomic') === -1)
+    )
   })
 
   if (filtered.length > 0) {


### PR DESCRIPTION
`write-file-atomic` is used by a dependency of ours, and tries to bundle `worked_threads`. It doesn't break anything, but the warning is kind of annoying every time I rebuild the CLI, so adding it to the ignore list.