### PR TITLE
[base] Check for missing projectId/dataset on startup

### DIFF
--- a/packages/@sanity/base/src/client/index.js
+++ b/packages/@sanity/base/src/client/index.js
@@ -1,6 +1,6 @@
-import sanityClient from '@sanity/client'
 import config from 'config:sanity'
 import configureClient from 'part:@sanity/base/configure-client?'
+import sanityClient from '@sanity/client'
 
 const deprecationMessage = `[deprecation] The Sanity client is now exposed in CommonJS format.
 
@@ -11,7 +11,8 @@ To the following:
   \`const client = require('part:@sanity/base/client')\`
 `
 
-const apiConfig = {...config.api, withCredentials: true, useCdn: false}
+const fallbackConfig = {projectId: 'UNSPECIFIED', dataset: 'UNSPECIFIED'}
+const apiConfig = {...fallbackConfig, ...config.api, withCredentials: true, useCdn: false}
 const client = sanityClient(apiConfig)
 
 const configuredClient = configureClient ? configureClient(sanityClient(apiConfig)) : client
@@ -26,4 +27,5 @@ Object.defineProperty(configuredClient, 'default', {
 })
 
 // Expose as CJS to allow Node scripts to consume it without `.default`
+// eslint-disable-next-line import/no-commonjs
 module.exports = configuredClient

--- a/packages/@sanity/base/src/components/MissingProjectConfig.js
+++ b/packages/@sanity/base/src/components/MissingProjectConfig.js
@@ -1,0 +1,44 @@
+import React from 'react'
+import config from 'config:sanity'
+import DialogContent from 'part:@sanity/components/dialogs/content?'
+import FullscreenDialog from 'part:@sanity/components/dialogs/fullscreen?'
+
+export default function MissingProjectConfig() {
+  const {root, project, plugins} = config
+  const {dataset, projectId} = config.api || {}
+  const api = {projectId: projectId || 'myProjectId', dataset: dataset || 'myDatasetName'}
+  const desiredConfig = {root, project, api, plugins}
+  const missing = [!projectId && '"projectId"', !dataset && '"dataset"'].filter(Boolean)
+  return (
+    <FullscreenDialog color="default" title="Project details missing" isOpen centered>
+      <DialogContent size="medium" padding="none">
+        <p>
+          The <code>sanity.json</code> file in your studio folder seems to be missing the{' '}
+          {missing.join(' and ')} configuration {missing.length > 1 ? 'options ' : 'option '}
+          under the <code>api</code> key.
+        </p>
+        <p>
+          A valid <code>sanity.json</code> file looks something like the following:
+        </p>
+        <pre>
+          <code>{highlightMissing(JSON.stringify(desiredConfig, null, 2))}</code>
+        </pre>
+      </DialogContent>
+    </FullscreenDialog>
+  )
+}
+
+// eslint-disable-next-line react/no-multi-comp
+function highlightMissing(jsonConfig) {
+  const parts = jsonConfig
+    .split(/("dataset": "myDatasetName"|"projectId": "myProjectId")/)
+    .reduce((els, part, i) => {
+      if (i % 2 === 0) {
+        return els.concat(part)
+      }
+
+      return els.concat(<strong key={part}>{part}</strong>)
+    }, [])
+
+  return <>{parts}</>
+}

--- a/packages/@sanity/base/src/components/SanityRoot.js
+++ b/packages/@sanity/base/src/components/SanityRoot.js
@@ -1,10 +1,17 @@
 import React from 'react'
+import config from 'config:sanity'
 import RootComponent from 'part:@sanity/base/root'
-import VersionChecker from './VersionChecker'
 import ErrorHandler from './ErrorHandler'
+import VersionChecker from './VersionChecker'
+import MissingProjectConfig from './MissingProjectConfig'
 import styles from './styles/SanityRoot.css'
 
 function SanityRoot() {
+  const {projectId, dataset} = config.api || {}
+  if (!projectId || !dataset) {
+    return <MissingProjectConfig />
+  }
+
   return (
     <div className={styles.root}>
       <ErrorHandler />

--- a/packages/@sanity/default-login/src/ErrorDialog.js
+++ b/packages/@sanity/default-login/src/ErrorDialog.js
@@ -25,7 +25,7 @@ export default function ErrorDialog(props) {
 
 ErrorDialog.propTypes = {
   error: PropTypes.shape({
-    isNetworkError: PropTypes.boolean,
+    isNetworkError: PropTypes.bool,
     message: PropTypes.string.isRequired
   }).isRequired,
   onRetry: PropTypes.func.isRequired


### PR DESCRIPTION
When running `sanity build` without having specified a project ID or dataset in  `sanity.json`, the studio currently crashes when trying to initialize the studio client with a missing configuration.

There is some value in being able to build a Sanity project without specifying these credentials, for instance when shipping examples/templates that is deployable to a provider.

This PR adds a new dialog that lets you know what the error is:

![image](https://user-images.githubusercontent.com/48200/60264104-b2b8d800-98e2-11e9-8f1a-3f12aae54a1f.png)
