### PR TITLE
[all] History UI fixes

### DIFF
--- a/packages/@sanity/base/src/styles/layout/selectable.css
+++ b/packages/@sanity/base/src/styles/layout/selectable.css
@@ -5,10 +5,12 @@
   color: var(--selectable-item-color--inverted);
   cursor: default;
 
-  @nest &:hover {
+  @media (hover: hover) {
     @media (--screen-medium) {
-      background-color: var(--selectable-item-color-hover);
-      color: var(--selectable-item-color-hover--inverted);
+      @nest &:hover {
+        background-color: var(--selectable-item-color-hover);
+        color: var(--selectable-item-color-hover--inverted);
+      }
     }
   }
 

--- a/packages/@sanity/components/src/history/ListItem.js
+++ b/packages/@sanity/components/src/history/ListItem.js
@@ -11,6 +11,21 @@ import styles from './styles/ListItem.modules.css'
 const noop = () => {} // eslint-disable-line no-empty-function
 const MAX_USERS = 3
 
+const DECIMALS = 2
+const DISTANCE_BETWEEN_POINTS = 5
+const offset = 100
+const radius = 50
+
+function makeClipPath() {
+  let p = ''
+  for (let i = 90; i <= 270; i += DISTANCE_BETWEEN_POINTS) {
+    const x = radius * Math.cos((i * Math.PI) / 180)
+    const y = radius * Math.sin((i * Math.PI) / 180)
+    p += `,${(offset + x).toFixed(DECIMALS)}% ${(50 + y).toFixed(DECIMALS)}%`
+  }
+  return `polygon(0 0,0 100%${p},0 0)`
+}
+
 export default class HistoryListItem extends React.PureComponent {
   static propTypes = {
     status: PropTypes.string,
@@ -138,16 +153,20 @@ export default class HistoryListItem extends React.PureComponent {
             duration={50}
           >
             <div className={styles.users}>
-              {users.slice(0, MAX_USERS).map(user => (
-                <div className={styles.user} key={user.id}>
-                  <PresenceCircle
-                    title={users.length === 1 ? undefined : user.displayName}
-                    showTooltip={false}
-                    imageUrl={user.imageUrl}
-                    color={colorHasher(user.id)}
-                  />
-                </div>
-              ))}
+              <div className={styles.userIcons}>
+                {users.slice(0, MAX_USERS).map((user, i) => (
+                  <div className={styles.user} key={user.id}>
+                    <div className={styles.userInner} style={{clipPath: makeClipPath()}}>
+                      <PresenceCircle
+                        title={users.length === 1 ? undefined : user.displayName}
+                        showTooltip={false}
+                        imageUrl={user.imageUrl}
+                        color={user.imageUrl ? undefined : colorHasher(user.id)}
+                      />
+                    </div>
+                  </div>
+                ))}
+              </div>
               {users.length === 1 && <div className={styles.userName}>{users[0].displayName}</div>}
               {users.length > 1 && (
                 <div className={styles.extraItems}>

--- a/packages/@sanity/components/src/history/styles/ListItem.modules.css
+++ b/packages/@sanity/components/src/history/styles/ListItem.modules.css
@@ -98,6 +98,10 @@
   position: relative;
 }
 
+.user + .user {
+  margin-left: 1px;
+}
+
 .userInner {
   position: absolute;
   top: 0;

--- a/packages/@sanity/components/src/history/styles/ListItem.modules.css
+++ b/packages/@sanity/components/src/history/styles/ListItem.modules.css
@@ -48,9 +48,10 @@
 }
 
 .endLine {
-  height: calc(
-    100% - var(--small-padding) - var(--history-circle-size) - var(--history-line-top) + 1px
-  );
+  height:
+    calc(
+      100% - var(--small-padding) - var(--history-circle-size) - var(--history-line-top) + 1px
+    );
   width: 0;
   position: absolute;
   top: calc(var(--small-padding) + var(--history-circle-size) + var(--history-line-top) - 1px);
@@ -87,17 +88,33 @@
   font-size: var(--font-size-large);
 }
 
+.userIcons {
+  display: flex;
+}
+
 .user {
   width: 0.5em;
   height: 0.5em;
   position: relative;
 }
 
-.user > * {
+.userInner {
   position: absolute;
   top: 0;
   left: 0;
   transform: translateY(-25%);
+}
+
+.userInner > * {
+  box-sizing: border-box;
+  border-radius: 50%;
+  background-clip: padding-box;
+  background-repeat: no-repeat;
+  background-position: 50% 50%;
+}
+
+.user:last-child .userInner {
+  clip-path: none !important;
 }
 
 .userName {

--- a/packages/@sanity/components/src/presence/PresenceCircle.js
+++ b/packages/@sanity/components/src/presence/PresenceCircle.js
@@ -35,7 +35,6 @@ export default class PresenceCircle extends React.PureComponent {
     const imgStyles = {
       display: 'block',
       backgroundColor: color,
-      borderColor: color,
       backgroundImage: imageUrl && `url(${imageUrl})`
     }
 
@@ -52,9 +51,7 @@ export default class PresenceCircle extends React.PureComponent {
         theme="light"
         distance="10"
         duration={50}
-        className={`${imageUrl ? styles.root : styles.noImage} ${
-          animateOnHover ? styles.animateOnHover : ''
-        }`}
+        className={`${styles.root} ${animateOnHover ? styles.animateOnHover : ''}`}
         style={imgStyles}
       >
         {imageUrl ? '' : <span className={styles.initials}>{text}</span>}

--- a/packages/@sanity/components/src/presence/story.js
+++ b/packages/@sanity/components/src/presence/story.js
@@ -28,6 +28,7 @@ storiesOf('Presence')
   .addDecorator(withKnobs)
   .add('Circles', () => {
     const showImage = boolean('show image', true, 'test')
+    const backgroundColor = color('background color', '#ccc', 'test')
     const newMarkers = markers.map(marker => {
       return {
         ...marker,
@@ -38,7 +39,7 @@ storiesOf('Presence')
       }
     })
     return (
-      <div style={{padding: '2em', backgroundColor: '#ccc', position: 'relative'}}>
+      <div style={{padding: '2em', backgroundColor, position: 'relative'}}>
         <PresenceCircles markers={newMarkers.slice(0, number('Number of markers', 10, 'test'))} />
       </div>
     )

--- a/packages/@sanity/components/src/presence/styles/PresenceCircle.css
+++ b/packages/@sanity/components/src/presence/styles/PresenceCircle.css
@@ -10,8 +10,8 @@
   box-sizing: border-box;
   border-radius: 50%;
   background-size: 100%;
-  border: calc(1em / 16) solid var(--text-color);
   background-color: var(--text-color);
+  border: calc(1em / 16) solid transparent;
   transition: transform 400ms cubic-bezier(0.075, 0.82, 0.165, 1), box-shadow 100ms ease;
   cursor: default;
   user-select: none;
@@ -20,12 +20,6 @@
 .root.hoverAnimation:hover {
   box-shadow: 1px 1px 10px #00000033;
   transform: scale(1.7);
-}
-
-.noImage {
-  composes: root;
-  border-width: calc(1em / 16);
-  border-color: var(--brand-primary--inverted) !important;
 }
 
 .initials {

--- a/packages/@sanity/desk-tool/src/components/InspectHistory.js
+++ b/packages/@sanity/desk-tool/src/components/InspectHistory.js
@@ -1,0 +1,41 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import InspectView from './InspectView'
+import Spinner from 'part:@sanity/components/loading/spinner'
+import historyStore from 'part:@sanity/base/datastore/history'
+
+export default class HistoryForm extends React.PureComponent {
+  static propTypes = {
+    event: PropTypes.object.isRequired,
+    onClose: PropTypes.func
+  }
+
+  state = {
+    document: undefined
+  }
+
+  componentDidMount() {
+    const {displayDocumentId, rev} = this.props.event
+    this.fetch(displayDocumentId, rev)
+  }
+
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    if (nextProps.event !== this.props.event) {
+      const {displayDocumentId, rev} = nextProps.event
+      this.fetch(displayDocumentId, rev)
+    }
+  }
+
+  fetch(id, rev) {
+    historyStore.getDocumentAtRevision(id, rev).then(document => {
+      this.setState({document})
+    })
+  }
+
+  render() {
+    if (this.state.document) {
+      return <InspectView value={this.state.document} onClose={this.props.onClose} />
+    }
+    return <Spinner />
+  }
+}

--- a/packages/@sanity/desk-tool/src/components/InspectHistory.js
+++ b/packages/@sanity/desk-tool/src/components/InspectHistory.js
@@ -4,7 +4,7 @@ import InspectView from './InspectView'
 import Spinner from 'part:@sanity/components/loading/spinner'
 import historyStore from 'part:@sanity/base/datastore/history'
 
-export default class HistoryForm extends React.PureComponent {
+export default class InspectHistory extends React.PureComponent {
   static propTypes = {
     event: PropTypes.object.isRequired,
     onClose: PropTypes.func

--- a/packages/@sanity/desk-tool/src/pane/Editor/Editor.js
+++ b/packages/@sanity/desk-tool/src/pane/Editor/Editor.js
@@ -31,6 +31,7 @@ import copyDocument from '../../utils/copyDocument'
 import ConfirmUnpublish from '../../components/ConfirmUnpublish'
 import ConfirmDelete from '../../components/ConfirmDelete'
 import InspectView from '../../components/InspectView'
+import InspectHistory from '../../components/InspectHistory'
 import DocTitle from '../../components/DocTitle'
 import History from '../History'
 import styles from '../styles/Editor.css'
@@ -54,39 +55,42 @@ function listen(target, eventType, callback, useCapture = false) {
   }
 }
 
-const getDuplicateItem = (draft, published) => ({
+const getDuplicateItem = (draft, published, isLiveEditEnabled, isHistoryEnabled) => ({
   action: 'duplicate',
   title: 'Duplicate',
   icon: ContentCopyIcon,
-  isDisabled: !draft && !published
+  isDisabled: isHistoryEnabled || (!draft && !published)
 })
 
-const getUnpublishItem = (draft, published, isLiveEditEnabled) =>
+const getUnpublishItem = (draft, published, isLiveEditEnabled, isHistoryEnabled) =>
   isLiveEditEnabled
     ? null
     : {
         action: 'unpublish',
         title: 'Unpublish…',
         icon: VisibilityOffIcon,
-        isDisabled: !published
+        isDisabled: isHistoryEnabled || !published
       }
 
-const getDeleteItem = (draft, published) => ({
+const getDeleteItem = (draft, published, isLiveEditEnabled, isHistoryEnabled) => ({
   group: 'danger',
   action: 'delete',
   title: 'Delete…',
   icon: TrashIcon,
   danger: true,
-  isDisabled: !draft && !published
+  isDisabled: isHistoryEnabled || (!draft && !published)
 })
 
-const getHistoryMenuItem = (draft, published) => {
+const getHistoryMenuItem = (draft, published, isLiveEditEnabled, isHistoryEnabled) => {
+  if (isLiveEditEnabled) {
+    return null
+  }
   if (window && window.innerWidth > BREAKPOINT_SCREEN_MEDIUM) {
     return {
       action: 'browseHistory',
       title: 'Browse history',
       icon: HistoryIcon,
-      isDisabled: !(draft || published)
+      isDisabled: isHistoryEnabled || !(draft || published)
     }
   }
   return null
@@ -106,14 +110,20 @@ const getInspectItem = (draft, published) => ({
   isDisabled: !(draft || published)
 })
 
-const getProductionPreviewItem = (draft, published) => {
+const getProductionPreviewItem = (
+  draft,
+  published,
+  liveEditEnable,
+  isHistoryEnabled,
+  selectedEvent
+) => {
   const snapshot = draft || published
   if (!snapshot || !resolveProductionPreviewUrl) {
     return null
   }
   let previewUrl
   try {
-    previewUrl = resolveProductionPreviewUrl(snapshot)
+    previewUrl = resolveProductionPreviewUrl(snapshot, selectedEvent && selectedEvent.rev)
   } catch (error) {
     error.message = `An error was thrown while trying to get production preview url: ${
       error.message
@@ -140,7 +150,15 @@ const getProductionPreviewItem = (draft, published) => {
   )
 }
 
-const getMenuItems = (enabledActions, draft, published, isLiveEditEnabled) =>
+// eslint-disable-next-line max-params
+const getMenuItems = (
+  enabledActions,
+  draft,
+  published,
+  isLiveEditEnabled,
+  isHistoryEnabled,
+  selectedEvent
+) =>
   [
     getProductionPreviewItem,
     enabledActions.includes('delete') && getUnpublishItem,
@@ -150,7 +168,7 @@ const getMenuItems = (enabledActions, draft, published, isLiveEditEnabled) =>
     enabledActions.includes('delete') && getDeleteItem
   ]
     .filter(Boolean)
-    .map(fn => fn(draft, published, isLiveEditEnabled))
+    .map(fn => fn(draft, published, isLiveEditEnabled, isHistoryEnabled, selectedEvent))
     .filter(Boolean)
 
 const isValidationError = marker => marker.type === 'validation' && marker.level === 'error'
@@ -748,11 +766,14 @@ export default withRouterHOC(
             index={this.props.index}
             title={this.getTitle(value)}
             onAction={this.handleMenuAction}
-            menuItems={
-              historyState.isOpen
-                ? []
-                : getMenuItems(enabledActions, draft, published, this.isLiveEditEnabled())
-            }
+            menuItems={getMenuItems(
+              enabledActions,
+              draft,
+              published,
+              this.isLiveEditEnabled(),
+              historyState.isOpen,
+              historyState.isOpen && this.findSelectedEvent()
+            )}
             renderActions={this.renderActions}
             onMenuToggle={this.handleMenuToggle}
             isSelected // last pane is always selected for now
@@ -767,7 +788,18 @@ export default withRouterHOC(
                 <AfterEditorComponent key={i} documentId={published._id} />
               ))}
 
-              {inspect && <InspectView value={value} onClose={this.handleHideInspector} />}
+              {inspect && historyState.isOpen && (
+                <InspectHistory
+                  id={value._id}
+                  event={this.findSelectedEvent()}
+                  onClose={this.handleHideInspector}
+                />
+              )}
+
+              {inspect && (!historyState || !historyState.isOpen) && (
+                <InspectView value={value} onClose={this.handleHideInspector} />
+              )}
+
               {showConfirmDelete && (
                 <ConfirmDelete
                   draft={draft}

--- a/packages/@sanity/desk-tool/src/pane/Editor/Editor.js
+++ b/packages/@sanity/desk-tool/src/pane/Editor/Editor.js
@@ -1,4 +1,4 @@
-/* eslint-disable complexity, camelcase */
+/* eslint-disable complexity, camelcase, max-params */
 // Connects the FormBuilder with various sanity roles
 import React from 'react'
 import PropTypes from 'prop-types'
@@ -150,7 +150,6 @@ const getProductionPreviewItem = (
   )
 }
 
-// eslint-disable-next-line max-params
 const getMenuItems = (
   enabledActions,
   draft,
@@ -212,7 +211,9 @@ export default withRouterHOC(
         })
       ),
       router: PropTypes.shape({
-        state: PropTypes.object
+        state: PropTypes.object,
+        navigate: PropTypes.func,
+        navigateIntent: PropTypes.func
       }).isRequired,
 
       onDelete: PropTypes.func,
@@ -220,7 +221,11 @@ export default withRouterHOC(
       onPublish: PropTypes.func,
       onRestore: PropTypes.func,
       onUnpublish: PropTypes.func,
-      transactionResult: PropTypes.shape({type: PropTypes.string}),
+      transactionResult: PropTypes.shape({
+        type: PropTypes.string,
+        error: PropTypes.object,
+        message: PropTypes.string
+      }),
       onClearTransactionResult: PropTypes.func,
 
       validationPending: PropTypes.bool,

--- a/packages/@sanity/desk-tool/src/pane/Editor/HistoryForm.js
+++ b/packages/@sanity/desk-tool/src/pane/Editor/HistoryForm.js
@@ -45,6 +45,7 @@ export default class HistoryForm extends React.PureComponent {
     this.fetch(displayDocumentId, rev)
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.event !== this.props.event) {
       const {displayDocumentId, rev} = nextProps.event

--- a/packages/@sanity/desk-tool/src/pane/History.js
+++ b/packages/@sanity/desk-tool/src/pane/History.js
@@ -13,12 +13,21 @@ const maybe = (val, fn) => val && fn(val)
 
 export default class History extends React.PureComponent {
   static propTypes = {
+    events: PropTypes.arrayOf(PropTypes.object),
     onClose: PropTypes.func,
     documentId: PropTypes.string,
     onItemSelect: PropTypes.func,
+    isLoading: PropTypes.bool,
     lastEdited: PropTypes.object,
     errorMessage: PropTypes.string,
-    selectedEvent: PropTypes.object
+    selectedEvent: PropTypes.object,
+    selectedRev: PropTypes.string,
+    historyValue: PropTypes.object,
+    error: PropTypes.object
+  }
+
+  static defaultProps = {
+    isLoading: true
   }
 
   state = {

--- a/packages/@sanity/desk-tool/src/pane/styles/History.css
+++ b/packages/@sanity/desk-tool/src/pane/styles/History.css
@@ -30,4 +30,5 @@
 .list {
   height: 100%;
   overflow: auto;
+  -webkit-overflow-scrolling: touch;
 }

--- a/packages/movies-studio/resolveProductionUrl.js
+++ b/packages/movies-studio/resolveProductionUrl.js
@@ -4,8 +4,13 @@ function stripDraftId(str) {
   return str.replace(/^drafts\./, '')
 }
 
-export default function resolveProductionUrl(document) {
+export default function resolveProductionUrl(document, rev) {
   const id = stripDraftId(document._id)
+
+  if (rev) {
+    // No support for historic revisions preview in movie frontend
+    return null
+  }
 
   if (document._type === 'movie') {
     return `${SITE_URL}/movie?id=${id}`

--- a/packages/test-studio/src/resolveProductionUrl.js
+++ b/packages/test-studio/src/resolveProductionUrl.js
@@ -1,5 +1,12 @@
 const PREVIEW_TYPES = ['book', 'author']
 
-export default function resolveProductionUrl(document) {
+export default function resolveProductionUrl(document, rev) {
+  if (rev) {
+    // Historic revision of the document exists
+    return (
+      PREVIEW_TYPES.includes(document._type) &&
+      `https://example.com/preview/${document._id}?rev=${rev}`
+    )
+  }
   return PREVIEW_TYPES.includes(document._type) && `https://example.com/preview/${document._id}`
 }


### PR DESCRIPTION
- Disabled hover on touch-devices
- Smooth overflow scroll on touch devices
- Removed colored border around avatars and make the border transparent with calculated clip-path to show the background color
- Enables as many context menu items as possible in history mode
- Send `_rev` to document preview
- 2px gap between user avatars
