### PR TITLE
[form-builder] Block editor: fix focus bug

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Input.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Input.js
@@ -79,11 +79,10 @@ export default class BlockEditorInput extends React.Component<Props, State> {
   }
 
   focus = () => {
-    const {focusPath, onFocus, readOnly} = this.props
+    const {onFocus, readOnly} = this.props
     const blockEditor = this.blockEditor && this.blockEditor.current
     const editor = blockEditor && blockEditor.getEditor()
-    const shouldSetNewFocus = !focusPath || focusPath.length === 0
-    if (editor && !readOnly && shouldSetNewFocus) {
+    if (editor && !readOnly) {
       editor.command('ensurePlaceHolderBlock')
       editor.focus()
       const key = editor.value.focusBlock


### PR DESCRIPTION
There is some invalid logic here introduced in https://github.com/sanity-io/sanity/pull/1335/commits/aa93a906cbb302478cd680c347785d2b9a2a6f7d that prevents focus to be maintained between toggling fullscreen. This reverts that, and as far as I can tell there is no longer any issues by setting focus when the document is first openend which the invalid logic tried to deal with.