### PR TITLE
[default-layout] Prettier styling of broken avatar image

### DIFF
--- a/packages/@sanity/default-layout/src/components/LoginStatus.js
+++ b/packages/@sanity/default-layout/src/components/LoginStatus.js
@@ -64,7 +64,7 @@ class LoginStatus extends React.PureComponent {
                 src={user.profileImage}
                 className={styles.userImage}
                 alt={`${user.name}'s profile image`}
-                data-initials={user.name ? user.name.charAt(0) : user.email.charAt(0)}
+                data-initials={(user.name || user.email || '?').charAt(0)}
               />
             ) : (
               <div className={styles.userImageMissing}>

--- a/packages/@sanity/default-layout/src/components/LoginStatus.js
+++ b/packages/@sanity/default-layout/src/components/LoginStatus.js
@@ -64,6 +64,7 @@ class LoginStatus extends React.PureComponent {
                 src={user.profileImage}
                 className={styles.userImage}
                 alt={`${user.name}'s profile image`}
+                data-initials={user.name ? user.name.charAt(0) : user.email.charAt(0)}
               />
             ) : (
               <div className={styles.userImageMissing}>

--- a/packages/@sanity/default-layout/src/components/SideMenu.js
+++ b/packages/@sanity/default-layout/src/components/SideMenu.js
@@ -33,6 +33,7 @@ function SideMenu(props) {
               className={styles.userProfileImage}
               src={user.profileImage}
               alt={`${user.name}'s profile image`}
+              data-initials={user.name ? user.name.charAt(0) : user.email.charAt(0)}
             />
           ) : (
             <div className={styles.userProfileImageMissing}>

--- a/packages/@sanity/default-layout/src/components/styles/LoginStatus.css
+++ b/packages/@sanity/default-layout/src/components/styles/LoginStatus.css
@@ -49,6 +49,18 @@
   height: 2.0625em;
   width: 2.0625em;
   border-radius: 50%;
+  overflow: hidden;
+  background-color: var(--preview-placeholder-color);
+
+  @nest &:before {
+    content: attr(data-initials);
+    text-align: center;
+    display: block;
+    line-height: 2em;
+    margin-bottom: 10px;
+    text-transform: uppercase;
+    background-color: var(--preview-placeholder-color);
+  }
 }
 
 .userImageMissing {

--- a/packages/@sanity/default-layout/src/components/styles/SideMenu.css
+++ b/packages/@sanity/default-layout/src/components/styles/SideMenu.css
@@ -68,6 +68,17 @@
   width: 2.0625em;
   height: 2.0625em;
   border-radius: 50%;
+  overflow: hidden;
+  background-color: var(--preview-placeholder-color);
+
+  @nest &:before {
+    content: attr(data-initials);
+    text-align: center;
+    display: block;
+    line-height: 2em;
+    margin-bottom: 10px;
+    text-transform: uppercase;
+  }
 }
 
 .userProfileImageMissing {


### PR DESCRIPTION
In some cases the avatar image is broken, and the `alt` text is no very pretty. Uses a CSS-trick to show the initials of the user in the avatar circle instead.