### PR TITLE
[base] Optimize and move drafts collate function to draft-utils

### DIFF
--- a/packages/@sanity/base/src/util/draftUtils.js
+++ b/packages/@sanity/base/src/util/draftUtils.js
@@ -42,15 +42,19 @@ export function createPublishedFrom(document) {
   }
 }
 
+// Takes a list of documents and collates draft/published pairs into single entries
+// {id: <published id>, draft?: <draft document>, published?: <published document>}
+export function collate(documents) {
+  const byId = documents.reduce((res, doc) => {
+    const id = getPublishedId(doc._id)
+    const entry = res[id] || (res[id] = {id})
+    entry[id === doc._id ? 'published' : 'draft'] = doc
+    return res
+  }, Object.create(null))
+  return Object.values(byId)
+}
+
 // Removes published documents that also has a draft
 export function removeDupes(documents) {
-  const drafts = documents.map(doc => doc._id).filter(isDraftId)
-
-  return documents.filter(doc => {
-    const draftId = getDraftId(doc._id)
-    const publishedId = getPublishedId(doc._id)
-    const hasDraft = drafts.includes(draftId)
-    const isPublished = doc._id === publishedId
-    return isPublished ? !hasDraft : true
-  })
+  return collate(documents).map(entry => entry.draft || entry.published)
 }

--- a/packages/@sanity/base/test/draftUtils.test.js
+++ b/packages/@sanity/base/test/draftUtils.test.js
@@ -1,0 +1,23 @@
+import {collate, removeDupes} from '../src/util/draftUtils'
+
+test('collate()', () => {
+  const foo = {_id: 'foo'}
+  const fooDraft = {_id: 'drafts.foo'}
+  const barDraft = {_id: 'drafts.bar'}
+  const baz = {_id: 'baz'}
+
+  expect(collate([foo, fooDraft, barDraft, baz])).toEqual([
+    {id: 'foo', draft: fooDraft, published: foo},
+    {id: 'bar', draft: barDraft},
+    {id: 'baz', published: baz}
+  ])
+})
+
+test('removeDupes()', () => {
+  const foo = {_id: 'foo'}
+  const fooDraft = {_id: 'drafts.foo'}
+  const barDraft = {_id: 'drafts.bar'}
+  const baz = {_id: 'baz'}
+
+  expect(removeDupes([foo, fooDraft, barDraft, baz])).toEqual([fooDraft, barDraft, baz])
+})


### PR DESCRIPTION
This optimizes how we collate drafts and published into a single entry for display in document lists. Also moved the collate function into the common draftUtils package so that we can re-use it anywhere else it's needed.

The numbers I got when collating a list of 10474 items locally (average of around 10 samples):

*Before*: 142.15 ms
*After*: 18.47 ms