### PR TITLE
[base] Remove nonexistent references when restoring to an earlier revision

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.js
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.js
@@ -230,7 +230,7 @@ export default class ReferenceInput extends React.Component<Props, State> {
             placeholder={readOnly ? '' : placeholder}
             title={
               isMissing && hasRef
-                ? `Document id: ${value._ref || 'unknown'}`
+                ? `Referencing nonexistent document (id: ${value._ref || 'unknown'})`
                 : previewSnapshot && previewSnapshot.description
             }
             customValidity={errors.length > 0 ? errors[0].item.message : ''}
@@ -241,7 +241,7 @@ export default class ReferenceInput extends React.Component<Props, State> {
             onClear={this.handleClear}
             openItemElement={this.renderOpenItemElement}
             value={valueFromHit || value}
-            inputValue={isMissing ? '<Unpublished or missing document>' : inputValue}
+            inputValue={isMissing ? '<nonexistent reference>' : inputValue}
             renderItem={this.renderHit}
             isLoading={isFetching || isLoadingSnapshot}
             items={hits}


### PR DESCRIPTION
When restoring a document to an earlier revision, it may have references to documents that no longer exists. This adds a check that removes any references to documents that no longer exists right before the restore is performed.

Moved most of the restore logic over into a `restore` method in the revision history store and cleaned up some frontend code as well.