### PR TITLE
[server] Only alias react-dom in development

### DIFF
--- a/packages/@sanity/server/src/configs/webpack.config.dev.js
+++ b/packages/@sanity/server/src/configs/webpack.config.dev.js
@@ -16,6 +16,7 @@ export default config => {
     }),
     resolve: {
       alias: Object.assign({}, baseConfig.resolve.alias, {
+        'react-dom': require.resolve('@hot-loader/react-dom'),
         'webpack-hot-middleware/client': require.resolve('webpack-hot-middleware/client')
       })
     },

--- a/packages/@sanity/server/src/configs/webpack.config.js
+++ b/packages/@sanity/server/src/configs/webpack.config.js
@@ -73,7 +73,7 @@ export default (config = {}) => {
     resolve: {
       alias: {
         react: path.dirname(reactPath),
-        'react-dom': '@hot-loader/react-dom',
+        'react-dom': path.dirname(reactDomPath),
         moment$: 'moment/moment.js',
         ...rxPaths()
       }
@@ -90,9 +90,7 @@ export default (config = {}) => {
                 resolve('@babel/preset-react'),
                 [resolve('@babel/preset-env'), require('./babel-env-config')]
               ],
-              plugins: [
-                resolve('@babel/plugin-proposal-class-properties'),
-              ].filter(Boolean),
+              plugins: [resolve('@babel/plugin-proposal-class-properties')].filter(Boolean),
               cacheDirectory: true
             }
           }


### PR DESCRIPTION
I should have caught this in the code review: https://travis-ci.org/sanity-io/sanity/jobs/570811472

We should only alias react-dom in development. In production, we want to use the regular react-dom.