### PR TITLE
Make base font-size overridable

### DIFF
--- a/packages/@sanity/base/src/styles/body.css
+++ b/packages/@sanity/base/src/styles/body.css
@@ -2,6 +2,10 @@
 @import 'part:@sanity/base/theme/variables/fonts-style';
 @import './layout/tippy.css';
 
+:global(html, body) {
+  font-size: var(--font-size-base);
+}
+
 :global(a) {
   color: var(--link-color);
 }

--- a/packages/@sanity/base/src/styles/variables/typography.css
+++ b/packages/@sanity/base/src/styles/variables/typography.css
@@ -11,7 +11,7 @@
   --font-family-serif: Georgia, "Times New Roman", Times, serif;
   --font-family-monospace: "SF Mono", Menlo, Monaco, Consolas, "Courier New", monospace;
   --font-family-base: var(--font-family-sans-serif);
-  --font-size-base: 1rem;
+  --font-size-base: 16px;
   --font-size-huge: 2rem;
   --font-size-large: 1.25rem;
   --font-size-small: 0.875rem;


### PR DESCRIPTION
- Sets the base font-size to 16px
- Makes it possible to override the base font-size for the studio