### PR TITLE
[base] Fix references in arrays being nulled when restoring

### DIFF
--- a/packages/@sanity/base/jest.config.js
+++ b/packages/@sanity/base/jest.config.js
@@ -1,7 +1,8 @@
 module.exports = {
-  testRegex: 'test\\/.*\\.test\\.js',
+  testRegex: 'test\\/.*\\.test\\.js$',
   testURL: 'http://localhost/',
   moduleNameMapper: {
-    '^part:@sanity/base/schema?': '<rootDir>/test/mocks/schema.js'
+    '^part:@sanity/base/schema?': '<rootDir>/test/mocks/schema.js',
+    '^part:@sanity/base/client': '<rootDir>/test/mocks/client.js'
   }
 }

--- a/packages/@sanity/base/test/__snapshots__/history.test.js.snap
+++ b/packages/@sanity/base/test/__snapshots__/history.test.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`removeMissingReferences removes references to missing docs, deeply 1`] = `
+Object {
+  "_id": "foo",
+  "_type": "test",
+  "arrayOfObjects": Array [
+    Object {
+      "_type": "foo",
+      "prop": "yes",
+    },
+    Object {
+      "_type": "foo",
+      "prop": "no",
+    },
+  ],
+  "arrayOfStrings": Array [
+    "a",
+    "b",
+    "c",
+  ],
+  "bool": true,
+  "number": 123,
+  "string": "value",
+  "subObject": Object {
+    "_type": "sub",
+    "nested": Object {
+      "array": Array [
+        "contents",
+        Object {
+          "_ref": "abc123",
+          "_type": "reference",
+        },
+        Object {
+          "_type": "nonref",
+          "someProp": "yes-it-exists",
+        },
+      ],
+      "prop": true,
+    },
+  },
+}
+`;

--- a/packages/@sanity/base/test/history.test.js
+++ b/packages/@sanity/base/test/history.test.js
@@ -1,0 +1,35 @@
+import {removeMissingReferences} from '../src/datastores/history/createHistoryStore'
+
+const testDoc = {
+  _id: 'foo',
+  _type: 'test',
+  string: 'value',
+  number: 123,
+  bool: true,
+  subObject: {
+    _type: 'sub',
+    nested: {
+      prop: true,
+      array: [
+        'contents',
+        {_type: 'reference', _ref: 'abc123'},
+        {_type: 'nonref', someProp: 'yes-it-exists'}
+      ]
+    }
+  },
+  arrayOfStrings: ['a', 'b', 'c'],
+  arrayOfObjects: [
+    {_type: 'foo', prop: 'yes'},
+    {_type: 'reference', _ref: 'random'},
+    {_type: 'foo', prop: 'no'},
+    {_type: 'reference', _ref: 'd987abc'}
+  ]
+}
+
+describe('removeMissingReferences', () => {
+  test('removes references to missing docs, deeply', () => {
+    const existingIds = {abc123: true, d987abc: false}
+    const mapped = removeMissingReferences(testDoc, existingIds)
+    expect(mapped).toMatchSnapshot()
+  })
+})

--- a/packages/@sanity/base/test/mocks/client.js
+++ b/packages/@sanity/base/test/mocks/client.js
@@ -1,0 +1,1 @@
+module.exports = {}


### PR DESCRIPTION
#1423 seems to have broken restoring of documents which included arrays. The culprit was in a tiny typo: `map(item)` vs `jsonMap(item)`.

While pursuing the issue, I refactored slightly to be able to test the method/functionality in question.  I also added a minor change which to me makes the code/result slightly more readable: instead of including `undefined` array elements and object values and relying on the JSON implementation to remove these, I explicitly filter them out.
