### PR TITLE
[form-builder] Add error boundary around portable text editor

### DIFF
--- a/packages/@sanity/form-builder/src/FormBuilderErrorBoundary.js
+++ b/packages/@sanity/form-builder/src/FormBuilderErrorBoundary.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Details from './inputs/common/Details'
+import styles from './styles/FormBuilderErrorBoundary.css'
+
+// eslint-disable-next-line react/require-optimization
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {error: false}
+  }
+
+  static getDerivedStateFromError(error) {
+    return {error}
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  componentDidCatch(error) {
+    // eslint-disable-next-line no-console
+    console.error('Input component crashed:', error)
+  }
+
+  render() {
+    const error = this.state.error
+    if (!error) {
+      return this.props.children
+    }
+
+    return (
+      <div className={styles.root} tabIndex={0} ref={this.setElement}>
+        <h3>Rats! The input component crashed.</h3>
+        <Details>
+          <pre>{error.message}</pre>
+          <em>(check developer tools console for details)</em>
+        </Details>
+      </div>
+    )
+  }
+}
+
+ErrorBoundary.propTypes = {
+  children: PropTypes.node.isRequired
+}
+
+export default ErrorBoundary

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/SyncWrapper.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/SyncWrapper.js
@@ -61,7 +61,7 @@ function isDeprecatedBlockValue(value: ?(FormBuilderValue[])) {
   if (!value || !Array.isArray(value)) {
     return false
   }
-  const block = value.find(item => item._type === 'block')
+  const block = value.find(item => item && item._type === 'block')
   if (block && Object.keys(block).includes('spans')) {
     return true
   }

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/index.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/index.js
@@ -1,8 +1,17 @@
 import {KeyUtils} from 'slate'
+import React from 'react'
 import {randomKey} from '@sanity/block-tools'
+import FormBuilderErrorBoundary from '../../FormBuilderErrorBoundary'
+import SyncWrapper from './SyncWrapper'
 
 // Set our own key generator for Slate (as early as possible)
 const keyGenerator = () => randomKey(12)
 KeyUtils.setGenerator(keyGenerator)
 
-export {default} from './SyncWrapper'
+const FormBuilderRoot = props => (
+  <FormBuilderErrorBoundary>
+    <SyncWrapper {...props} />
+  </FormBuilderErrorBoundary>
+)
+
+export default FormBuilderRoot

--- a/packages/@sanity/form-builder/src/styles/FormBuilderErrorBoundary.css
+++ b/packages/@sanity/form-builder/src/styles/FormBuilderErrorBoundary.css
@@ -1,0 +1,13 @@
+@import 'part:@sanity/base/theme/variables-style';
+
+.root {
+  composes: root from 'part:@sanity/components/fieldsets/default-style';
+  padding: var(--large-padding);
+  background-color: var(--state-warning-color);
+  color: var(--state-warning-color--inverted);
+
+  @nest & h3 {
+    margin: 0;
+    padding: 0;
+  }
+}


### PR DESCRIPTION
Currently, if something goes wrong during the rendering of the portable text editor, the whole desk tool crashes. Because this happens in the case outlined in #1449, we need something to prevent it from fully crashing so the user can still restore other versions of the document, for instance.

What I ended up with was a very minimal but possibly reusable error boundary that is _currently_ only wrapped around the PT editor, but could potentially be included by default on the FormBuilderInput level (unless it has drawbacks in terms of performance and the like). 

## Screenshot 

![image](https://user-images.githubusercontent.com/48200/63191782-b1499780-c069-11e9-84dd-a6b2b497573b.png)
