### PR TITLE
[components] fix errors disappearing too fast

### DIFF
--- a/packages/@sanity/base/src/components/ErrorHandler.js
+++ b/packages/@sanity/base/src/components/ErrorHandler.js
@@ -66,7 +66,8 @@ export default class ErrorHandler extends React.PureComponent {
         kind="error"
         onAction={this.handleClose}
         title={<strong>{message}</strong>}
-        subtitle={<div>Check browser javascript console for details</div>}
+        timeout={8000}
+        subtitle="Check your browser's JavaScript console for details."
       />
     )
   }

--- a/packages/@sanity/components/src/snackbar/SnackbarItem.js
+++ b/packages/@sanity/components/src/snackbar/SnackbarItem.js
@@ -43,7 +43,7 @@ export default class SnackbarItem extends React.Component {
 
   static defaultProps = {
     action: undefined,
-    autoDismissTimeout: 4000,
+    autoDismissTimeout: 5000,
     children: null,
     icon: null,
     isCloseable: true,


### PR DESCRIPTION
Currently some snackbars disappear too fast, particularly errors.
- Increased the default dismiss timeout (4s -> 5s)
- Increased the timeout for error snackbars (4s -> 8s)