### PR TITLE
[default-layoyt] Hide toolswitcher when no choices

### DIFF
--- a/packages/@sanity/default-layout/src/components/ToolSwitcher.js
+++ b/packages/@sanity/default-layout/src/components/ToolSwitcher.js
@@ -35,6 +35,7 @@ class ToolSwitcher extends React.PureComponent {
 
   render() {
     const {tools} = this.props
+    if (!tools || tools.length <= 1) return null
     return <ToolSwitcherWidget {...this.props} renderItem={this.renderItem} tools={tools} />
   }
 }


### PR DESCRIPTION
No need to show the tool-switcher when there is only one tool.