### PR TITLE
[base] use base font-family variable for body

### DIFF
--- a/packages/@sanity/base/src/styles/body.css
+++ b/packages/@sanity/base/src/styles/body.css
@@ -19,7 +19,7 @@
 }
 
 :global(body#sanityBody) {
-  font-family: var(--font-family-sans-serif);
+  font-family: var(--font-family-base);
   line-height: var(--line-height-base);
   color: var(--text-color);
   background-color: var(--body-bg);

--- a/packages/@sanity/form-builder/src/inputs/DateInputs/styles/BaseDateTimeInput.css
+++ b/packages/@sanity/form-builder/src/inputs/DateInputs/styles/BaseDateTimeInput.css
@@ -107,7 +107,7 @@
 
 .datepicker {
   composes: shadow-12dp from 'part:@sanity/base/theme/shadows-style';
-  font-family: var(--font-family-sans-serif);
+  font-family: var(--font-family-base);
   border: 0;
 
   @nest & :global(.react-datepicker__current-month) {


### PR DESCRIPTION
- Make body use the font-family-base variable instead of the sans-serif variable for clearer and easier Studio customization