### PR TITLE
[components] fix link color in selected item (#1429)

### DIFF
--- a/packages/@sanity/components/src/history/styles/ListItem.modules.css
+++ b/packages/@sanity/components/src/history/styles/ListItem.modules.css
@@ -143,4 +143,8 @@
     font-size: var(--font-size-xsmall, 0.75rem);
     margin: 0 0 var(--small-padding);
   }
+
+  @nest .selected & a {
+    color: inherit;
+  }
 }


### PR DESCRIPTION
- Fix #1429: unreadable link in selected truncated history pane item