### PR TITLE
[components] Handle color hashing on non-transpiled css var() syntax

### DIFF
--- a/packages/@sanity/components/package.json
+++ b/packages/@sanity/components/package.json
@@ -28,6 +28,7 @@
     "circular-at": "^1.0.3",
     "classnames": "^2.2.5",
     "date-fns": "^1.29.0",
+    "chroma-js": "^2.0.4",
     "dom-scroll-into-view": "^1.2.1",
     "element-resize-detector": "^1.1.14",
     "exif-component": "^1.0.1",

--- a/packages/@sanity/components/src/presence/colorHasher.js
+++ b/packages/@sanity/components/src/presence/colorHasher.js
@@ -1,16 +1,32 @@
 import stringHash from 'string-hash'
 import palx from 'palx'
+import chroma from 'chroma-js'
+import {memoize} from 'lodash'
 import styles from './colorHasher.css'
 
-const brandPrimary = styles.brandPrimary || '#fcc'
+const readVar = varName =>
+  getComputedStyle(document.documentElement)
+    .getPropertyValue(varName)
+    .trim()
 
-const pal = palx(brandPrimary)
+const getBrandPrimary = memoize(() => {
+  if (chroma.valid(styles.brandPrimary)) {
+    return styles.brandPrimary
+  }
+  const fromVar = readVar('--brand-primary')
+  return fromVar && chroma.valid(fromVar) ? fromVar : '#fcc'
+})
+
+const getPalette = memoize(palx)
 
 // Picks strong colors from a palette created from the brand primary color
 function toColor(str) {
+  const brandPrimary = getBrandPrimary()
   if (!str) {
     return brandPrimary
   }
+
+  const pal = getPalette(brandPrimary)
   const hashFloat = stringHash(str) / Math.pow(2, 32)
   // ignore base and black from palx
   const hue = Object.keys(pal).slice(2)[Math.floor(hashFloat * (Object.keys(pal).length - 2))]


### PR DESCRIPTION
This provides a fix for #1447 by resolving the actual value of `var(--brand-primary)` at runtime if it isn't already transpiled to a valid color in css import.

For now I think we should also make sure you can't override browserslists in new studios, so that we make sure our css gets properly transpiled. Currently if you have a browserslists config saying e.g. latest chrome, the studio gets visually borked due to lack of support for `color(var(...))` syntax
