### PR TITLE
[server] Force transpiling of customProperties/css-variables syntax

### DIFF
--- a/packages/@sanity/server/src/configs/postcss.config.js
+++ b/packages/@sanity/server/src/configs/postcss.config.js
@@ -6,9 +6,7 @@ module.exports = {
     basePath: resolveProjectRoot({sync: true}),
     cssnext: {
       features: {
-        customProperties: {
-          preserve: false
-        }
+        customProperties: true
       }
     }
   })


### PR DESCRIPTION
This will ignore any browserslist config and always transpile customProperties/css variables syntax until we're on a webpack version that enables us to support a more up to date syntax.

See a description of the original issue in #1447 and the related PR #1462.