### PR TITLE
[form-builder] Wrap BlockEditor in forwardRef

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/index.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/index.js
@@ -8,10 +8,11 @@ import SyncWrapper from './SyncWrapper'
 const keyGenerator = () => randomKey(12)
 KeyUtils.setGenerator(keyGenerator)
 
-const FormBuilderRoot = props => (
-  <FormBuilderErrorBoundary>
-    <SyncWrapper {...props} />
-  </FormBuilderErrorBoundary>
-)
-
-export default FormBuilderRoot
+// eslint-disable-next-line react/display-name
+export default React.forwardRef(function BlockEditorRoot(props, ref) {
+  return (
+    <FormBuilderErrorBoundary>
+      <SyncWrapper {...props} ref={ref} />
+    </FormBuilderErrorBoundary>
+  )
+})

--- a/packages/test-studio/schemas/blocks.js
+++ b/packages/test-studio/schemas/blocks.js
@@ -9,6 +9,12 @@ export default {
   icon,
   fields: [
     {
+      name: 'first',
+      title: 'Block array as first field',
+      type: 'array',
+      of: [{type: 'block'}]
+    },
+    {
       name: 'title',
       title: 'Title',
       type: 'string'


### PR DESCRIPTION
The change in #1450 wrapped the Block/Portable Text editor in a function component. Since function components can't be given refs, this caused the form builder to fail when trying to set focus on the portable text input component (see #1456).

I'm afraid we're going to see a lot more of these errors going forward, since the whole React community is shifting towards function components. So we should probably reconsider how we do the focus management in the form-builder (and align with the recent work/proposal to add declarative focus management to React).

I'll see if I can whip up a separate PR improving the error message to hint about this particular case, but this should at least fix the issue at hand.