### PR TITLE
[form-builder] Block editor: Fix bug with editing annotated text

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createOperationToPatches.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createOperationToPatches.js
@@ -33,6 +33,17 @@ function findSpanTargetPath(
   const nodeInEditorValueParent = editorValue.document.getParent(nodeInEditorValue.key)
   let count = 0
   let targetKey
+  // If the parent is an inline, we must calculate a new start count,
+  // as inlines are not modelled in Portable Text, and the count will be off
+  if (nodeInEditorValueParent.object === 'inline') {
+    const texts = editorValue.document.getParent(nodeInEditorValueParent.key).getTexts()
+    const previousNumberOfTexts = texts.findIndex(node => node.key === nodeInEditorValue.key)
+    const previousTexts = texts.slice(0, previousNumberOfTexts)
+    const leavesCount = previousTexts.reduce((acc, current) => {
+      return acc + current.leaves.size
+    }, 0)
+    count = leavesCount
+  }
   // Note: do 'some' here so we can short circuit it when we reach our target
   // and don't have to loop through everything
   nodeInEditorValueParent.nodes.some(node => {

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createPatchToOperations.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createPatchToOperations.js
@@ -327,10 +327,12 @@ export default function createPatchesToChange(
     node: SlateNode,
     blockNode: SlateNode
   ) {
-    const textPath = editor.value.document.assertPath(node.key)
     const blockKey = patch.path[0]._key
     const childKey = findLastKey(patch.path)
-    const workTextNode = node.toJSON({preserveKeys: true})
+    const textNode = node.getFirstText()
+    const textPath = editor.value.document.assertPath(textNode.key)
+
+    let workTextNode = textNode.toJSON({preserveKeys: true})
     const blockIndex = getBlockTextIndex(blockNode, node)
     const leafIndex = workTextNode.leaves.findIndex(
       (leaf, index) => `${blockKey}${blockIndex + index}` === childKey
@@ -368,11 +370,11 @@ export default function createPatchesToChange(
       const valueIsString = isString(patch.value)
       const patchText = valueIsString ? patch.value : patch.value.text
       // If single leaf, we can just replace the text with the current marks
-      if (node.leaves.size === 1) {
+      if (textNode.leaves.size === 1) {
         let marks
         // eslint-disable-next-line max-depth
         if (valueIsString) {
-          marks = node.leaves.map(leaf => leaf.marks).get(0)
+          marks = textNode.leaves.map(leaf => leaf.marks).get(0)
         } else {
           marks = Mark.createSet(patch.value.marks.map(mark => ({type: mark})))
         }

--- a/packages/@sanity/form-builder/test/patching/blocks/tests/operationsToPatches/editLink1/input.json
+++ b/packages/@sanity/form-builder/test/patching/blocks/tests/operationsToPatches/editLink1/input.json
@@ -1,0 +1,36 @@
+[
+  {
+    "_key": "3b0b93b4bad7",
+    "_type": "block",
+    "children": [
+      {
+        "_key": "3b0b93b4bad70",
+        "_type": "span",
+        "marks": [],
+        "text": "It's a "
+      },
+      {
+        "_key": "3b0b93b4bad71",
+        "_type": "span",
+        "marks": [
+          "650fa5955287"
+        ],
+        "text": "link"
+      },
+      {
+        "_key": "3b0b93b4bad72",
+        "_type": "span",
+        "marks": [],
+        "text": " here"
+      }
+    ],
+    "markDefs": [
+      {
+        "_key": "650fa5955287",
+        "_type": "link",
+        "href": "123"
+      }
+    ],
+    "style": "normal"
+  }
+]

--- a/packages/@sanity/form-builder/test/patching/blocks/tests/operationsToPatches/editLink1/operations.json
+++ b/packages/@sanity/form-builder/test/patching/blocks/tests/operationsToPatches/editLink1/operations.json
@@ -1,0 +1,37 @@
+[
+  {
+    "object": "operation",
+    "type": "set_selection",
+    "properties": {
+      "focus": {
+        "object": "point",
+        "offset": 3,
+        "path": [
+          0,
+          1,
+          0
+        ]
+      }
+    },
+    "data": {}
+  },
+  {
+    "object": "operation",
+    "type": "insert_text",
+    "path": [
+      0,
+      1,
+      0
+    ],
+    "offset": 3,
+    "text": "1",
+    "marks": [
+      {
+        "object": "mark",
+        "type": "650fa5955287",
+        "data": {}
+      }
+    ],
+    "data": {}
+  }
+]

--- a/packages/@sanity/form-builder/test/patching/blocks/tests/operationsToPatches/editLink2/input.json
+++ b/packages/@sanity/form-builder/test/patching/blocks/tests/operationsToPatches/editLink2/input.json
@@ -1,0 +1,55 @@
+[
+  {
+    "_type": "block",
+    "_key": "3b0b93b4bad7",
+    "style": "normal",
+    "markDefs": [
+      {
+        "_type": "link",
+        "_key": "100a971c55df",
+        "href": "123"
+      },
+      {
+        "_type": "link",
+        "_key": "a112502ed498",
+        "href": "456"
+      }
+    ],
+    "children": [
+      {
+        "_type": "span",
+        "_key": "3b0b93b4bad70",
+        "text": "It's a ",
+        "marks": []
+      },
+      {
+        "_type": "span",
+        "_key": "3b0b93b4bad71",
+        "text": "link",
+        "marks": [
+          "100a971c55df"
+        ]
+      },
+      {
+        "_type": "span",
+        "_key": "3b0b93b4bad72",
+        "text": " here ",
+        "marks": []
+      },
+      {
+        "_type": "span",
+        "_key": "3b0b93b4bad73",
+        "text": "and",
+        "marks": [
+          "a112502ed498"
+        ]
+      },
+      {
+        "_type": "span",
+        "_key": "3b0b93b4bad74",
+        "text": " there",
+        "marks": []
+      }
+    ]
+  }
+]

--- a/packages/@sanity/form-builder/test/patching/blocks/tests/operationsToPatches/editLink2/operations.json
+++ b/packages/@sanity/form-builder/test/patching/blocks/tests/operationsToPatches/editLink2/operations.json
@@ -1,0 +1,37 @@
+[
+  {
+    "object": "operation",
+    "type": "set_selection",
+    "properties": {
+      "focus": {
+        "object": "point",
+        "offset": 2,
+        "path": [
+          0,
+          3,
+          0
+        ]
+      }
+    },
+    "data": {}
+  },
+  {
+    "object": "operation",
+    "type": "insert_text",
+    "path": [
+      0,
+      3,
+      0
+    ],
+    "offset": 2,
+    "text": "1",
+    "marks": [
+      {
+        "object": "mark",
+        "type": "a112502ed498",
+        "data": {}
+      }
+    ],
+    "data": {}
+  }
+]

--- a/packages/@sanity/form-builder/test/patching/blocks/tests/operationsToPatches/editLink3/input.json
+++ b/packages/@sanity/form-builder/test/patching/blocks/tests/operationsToPatches/editLink3/input.json
@@ -1,0 +1,63 @@
+[
+  {
+    "_type": "block",
+    "_key": "3b0b93b4bad7",
+    "style": "normal",
+    "markDefs": [
+      {
+        "_type": "link",
+        "_key": "366e03dab02d",
+        "href": "123"
+      },
+      {
+        "_type": "link",
+        "_key": "d586f10817f1",
+        "href": "456"
+      }
+    ],
+    "children": [
+      {
+        "_type": "span",
+        "_key": "3b0b93b4bad70",
+        "text": "It's a ",
+        "marks": []
+      },
+      {
+        "_type": "span",
+        "_key": "3b0b93b4bad71",
+        "text": "link",
+        "marks": [
+          "366e03dab02d"
+        ]
+      },
+      {
+        "_type": "span",
+        "_key": "3b0b93b4bad72",
+        "text": " here ",
+        "marks": []
+      },
+      {
+        "_type": "span",
+        "_key": "3b0b93b4bad73",
+        "text": "and ",
+        "marks": [
+          "strong"
+        ]
+      },
+      {
+        "_type": "span",
+        "_key": "3b0b93b4bad74",
+        "text": "there",
+        "marks": [
+          "d586f10817f1"
+        ]
+      },
+      {
+        "_type": "span",
+        "_key": "3b0b93b4bad75",
+        "text": " and here",
+        "marks": []
+      }
+    ]
+  }
+]

--- a/packages/@sanity/form-builder/test/patching/blocks/tests/operationsToPatches/editLink3/operations.json
+++ b/packages/@sanity/form-builder/test/patching/blocks/tests/operationsToPatches/editLink3/operations.json
@@ -1,0 +1,37 @@
+[
+  {
+    "object": "operation",
+    "type": "set_selection",
+    "properties": {
+      "focus": {
+        "object": "point",
+        "offset": 2,
+        "path": [
+          0,
+          3,
+          0
+        ]
+      }
+    },
+    "data": {}
+  },
+  {
+    "object": "operation",
+    "type": "insert_text",
+    "path": [
+      0,
+      3,
+      0
+    ],
+    "offset": 2,
+    "text": "1",
+    "marks": [
+      {
+        "object": "mark",
+        "type": "d586f10817f1",
+        "data": {}
+      }
+    ],
+    "data": {}
+  }
+]

--- a/packages/@sanity/form-builder/test/patching/blocks/tests/operationsToPatches/editLink4/input.json
+++ b/packages/@sanity/form-builder/test/patching/blocks/tests/operationsToPatches/editLink4/input.json
@@ -1,0 +1,94 @@
+[
+  {
+    "_key": "3b0b93b4bad7",
+    "_type": "block",
+    "children": [
+      {
+        "_key": "3b0b93b4bad70",
+        "_type": "span",
+        "marks": [],
+        "text": "It's a "
+      },
+      {
+        "_key": "3b0b93b4bad71",
+        "_type": "span",
+        "marks": [
+          "366e03dab02d"
+        ],
+        "text": "lin2k"
+      },
+      {
+        "_key": "3b0b93b4bad72",
+        "_type": "span",
+        "marks": [],
+        "text": " here "
+      },
+      {
+        "_key": "3b0b93b4bad73",
+        "_type": "span",
+        "marks": [
+          "strong",
+          "7a0384f34f56"
+        ],
+        "text": "aned"
+      },
+      {
+        "_key": "3b0b93b4bad74",
+        "_type": "span",
+        "marks": [
+          "strong"
+        ],
+        "text": " "
+      },
+      {
+        "_key": "3b0b93b4bad75",
+        "_type": "span",
+        "marks": [
+          "strong",
+          "em"
+        ],
+        "text": "ewrwerewr"
+      },
+      {
+        "_key": "3b0b93b4bad76",
+        "_type": "span",
+        "marks": [
+          "strong"
+        ],
+        "text": " "
+      },
+      {
+        "_key": "3b0b93b4bad77",
+        "_type": "span",
+        "marks": [
+          "d586f10817f1"
+        ],
+        "text": "th3e5re"
+      },
+      {
+        "_key": "3b0b93b4bad78",
+        "_type": "span",
+        "marks": [],
+        "text": " and here"
+      }
+    ],
+    "markDefs": [
+      {
+        "_key": "366e03dab02d",
+        "_type": "link",
+        "href": "123"
+      },
+      {
+        "_key": "7a0384f34f56",
+        "_type": "link",
+        "href": "sdfsdf"
+      },
+      {
+        "_key": "d586f10817f1",
+        "_type": "link",
+        "href": "456"
+      }
+    ],
+    "style": "normal"
+  }
+]

--- a/packages/@sanity/form-builder/test/patching/blocks/tests/operationsToPatches/editLink4/operations.json
+++ b/packages/@sanity/form-builder/test/patching/blocks/tests/operationsToPatches/editLink4/operations.json
@@ -1,0 +1,37 @@
+[
+  {
+    "object": "operation",
+    "type": "set_selection",
+    "properties": {
+      "focus": {
+        "object": "point",
+        "offset": 3,
+        "path": [
+          0,
+          5,
+          0
+        ]
+      }
+    },
+    "data": {}
+  },
+  {
+    "object": "operation",
+    "type": "insert_text",
+    "path": [
+      0,
+      5,
+      0
+    ],
+    "offset": 3,
+    "text": "e",
+    "marks": [
+      {
+        "object": "mark",
+        "type": "d586f10817f1",
+        "data": {}
+      }
+    ],
+    "data": {}
+  }
+]


### PR DESCRIPTION
This will fix an issue where editing the text for an annotation (i.e. the link text) would not send the correct patch paths.
