### PR TITLE
[default-layout] improve studio module update indicator

### DIFF
--- a/packages/@sanity/default-layout/src/components/SanityStatus.js
+++ b/packages/@sanity/default-layout/src/components/SanityStatus.js
@@ -45,7 +45,7 @@ export default function SanityStatus(props) {
               <span className={styles.updateIcon}>
                 <div
                   className={styles.updateIndicator}
-                  data-severity={"notice"}
+                  data-severity={severity}
                   aria-label={`${severity} severity level.`} />
                 <PackageIcon />
               </span>

--- a/packages/@sanity/default-layout/src/components/SanityStatus.js
+++ b/packages/@sanity/default-layout/src/components/SanityStatus.js
@@ -24,11 +24,10 @@ export default function SanityStatus(props) {
   } = props
   const currentLevel = outdated.length ? level : 'notice'
   const severity = isSupported ? currentLevel : 'high'
-  const className = `${styles.root} ${styles[severity]}`
   const Dialog = isUpToDate ? CurrentVersionsDialog : UpdateNotifierDialog
 
   return (
-    <div className={className}>
+    <div className={styles.root}>
       {showDialog && (
         <Dialog
           severity={severity}
@@ -42,9 +41,16 @@ export default function SanityStatus(props) {
           {isUpToDate ? (
             <span>Up to date</span>
           ) : (
-            <span>
-              <PackageIcon /> {formatUpdateLabel(outdated.length)}
-            </span>
+            <div className={styles.hasUpdates}>
+              <span className={styles.updateIcon}>
+                <div
+                  className={styles.updateIndicator}
+                  data-severity={"notice"}
+                  aria-label={`${severity} severity level.`} />
+                <PackageIcon />
+              </span>
+              <span className={styles.updateLabel}>{formatUpdateLabel(outdated.length)}</span>
+            </div>
           )}
         </div>
       </button>

--- a/packages/@sanity/default-layout/src/components/styles/SanityStatus.css
+++ b/packages/@sanity/default-layout/src/components/styles/SanityStatus.css
@@ -6,7 +6,7 @@
 
   @nest & span {
     font-size: var(--font-size-small);
-    line-height: 25px;
+    line-height: calc(25 / 14);
   }
 
   @nest & span > svg {
@@ -64,16 +64,16 @@
   height: 0.5em;
   width: 0.5em;
   border-radius: 50%;
-  border: 1px solid var(--main-navigation-color--inverted);
+  border: 1px solid currentColor;
   box-sizing: border-box;
 }
 
 .updateIndicator[data-severity="notice"] {
-  background: var(--main-navigation-color--inverted);
+  background: currentColor;
 }
 
 .updateIndicator[data-severity="low"] {
-  background: #6cb8ff;
+  background: currentColor;
 }
 
 .updateIndicator[data-severity="medium"] {

--- a/packages/@sanity/default-layout/src/components/styles/SanityStatus.css
+++ b/packages/@sanity/default-layout/src/components/styles/SanityStatus.css
@@ -5,7 +5,7 @@
   align-items: center;
 
   @nest & span {
-    font-size: 14px;
+    font-size: var(--font-size-small);
     line-height: 25px;
   }
 
@@ -48,18 +48,42 @@
   padding: 0.75em;
 }
 
-.notice {
-  /* empty */
+.hasUpdates {
+  display: flex;
+  align-items: center;
 }
 
-.low {
-  color: #6cb8ff;
+.updateIcon {
+  position: relative;
 }
 
-.medium {
-  color: var(--state-warning-color);
+.updateIndicator {
+  position: absolute;
+  top: 0.2em;
+  right: 0.15em;
+  height: 0.5em;
+  width: 0.5em;
+  border-radius: 50%;
+  border: 1px solid var(--main-navigation-color--inverted);
+  box-sizing: border-box;
 }
 
-.high {
-  color: var(--state-danger-color);
+.updateIndicator[data-severity="notice"] {
+  background: var(--main-navigation-color--inverted);
+}
+
+.updateIndicator[data-severity="low"] {
+  background: #6cb8ff;
+}
+
+.updateIndicator[data-severity="medium"] {
+  background: var(--state-warning-color);
+}
+
+.updateIndicator[data-severity="high"] {
+  background: var(--state-danger-color);
+}
+
+.updateLabel {
+  margin-left: 0.25em;
 }


### PR DESCRIPTION
Improvements to the way we indicate that the Studio has available updates:
- Font size is now relative instead of fixed to 14px
- Package icon uses a colored circle to indicate severity level, and is labeled for accessibility
- A more accessible approach regardless of severity level and navigation bar background color (like when using custom Studio themes)

Further possible improvements to these changes:
- Position and size of indicator on package icon
- Colors indicating severity level

Examples, current vs. proposed changes:

<img width="998" alt="update indicator old vs proposal" src="https://user-images.githubusercontent.com/25737281/64079066-04b31b00-cce3-11e9-982a-ed1ff95b3b5d.png">