### PR TITLE
[form-builder] Block editor: fix decorator horiz. padding

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/nodes/styles/Decorator.css
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/nodes/styles/Decorator.css
@@ -26,5 +26,5 @@
   font-family: monospace;
   background-color: #eee;
   color: #333;
-  padding: 0.1em 0.3em;
+  padding: 0.1em 0em;
 }


### PR DESCRIPTION
Code decorator has horizontal padding that in some situations seems like whitespace which is not really there.