### PR TITLE
[form-builder] Block editor: fix bug with dealing with placeholder onPaste

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/plugins/PastePlugin.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/plugins/PastePlugin.js
@@ -41,19 +41,13 @@ function handleHTML(html, editor, blockContentType, onProgress, pasteController)
     onProgress({status: 'blocks'})
     const value = deserialize(blocks, blockContentType)
     pasteController.setValue(value)
-    // If we have a placeholder block, we cant do insertFragment,
-    // because that may create a new placeholder block,
-    // because insertFragment may empty the document while operating
-    const placeHolderBlock = editor.value.document.nodes.find(
-      blk => blk.get('data').toObject().placeholder === true
-    )
-    if (placeHolderBlock) {
-      pasteController.value.document.nodes.forEach(blk => {
-        editor.insertBlock(blk)
-      })
-      editor.removeNodeByKey(placeHolderBlock.key)
-    } else {
-      editor.insertFragment(pasteController.value.document)
+    editor.insertFragment(pasteController.value.document)
+    // Remove placeholder status of first block
+    const firstBlock = editor.value.document.nodes.first()
+    if (firstBlock.type === 'contentBlock' && firstBlock.data.get('placeholder')) {
+      const newData = firstBlock.data.toObject()
+      delete newData.placeholder
+      editor.setNodeByKey(firstBlock.key, {data: newData})
     }
     pasteController.setValue(deserialize(null, blockContentType))
     onProgress({status: null})

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createOperationToPatches.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createOperationToPatches.js
@@ -320,12 +320,6 @@ export default function createOperationToPatches(
   function removeNodePatch(operation: Operation, beforeValue: SlateValue, afterValue: SlateValue) {
     const patches = []
     const block = toBlock(beforeValue, operation.path.get(0))
-    const oldNode = beforeValue.document.getNode(operation.path)
-    const isPlaceholder = oldNode && oldNode.data && oldNode.data.get('placeholder')
-    // Don't create any patches if this is a placeholder block that is removed.
-    if (isPlaceholder) {
-      return []
-    }
     if (operation.path.size === 1) {
       patches.push(unset([{_key: block._key}]))
     }

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createPatchToOperations.js
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createPatchToOperations.js
@@ -420,12 +420,13 @@ export default function createPatchesToChange(
     }
 
     const firstKey = patch.path[0] && patch.path[0]._key
+    const decendant = firstKey && editorValue.document.getDescendant(firstKey)
     const isVoidRootBlock =
-      firstKey &&
+      decendant &&
       editorValue &&
       editorValue.document &&
       editorValue.document.size > 0 &&
-      controller.query('isVoid', editorValue.document.getDescendant(firstKey))
+      controller.query('isVoid', decendant)
 
     const rootBlock = firstKey && editorValue.document.getDescendant(firstKey)
 


### PR DESCRIPTION
If the first action in the document is pasting, a unset patch for the placeholder block was made, and it should not unset it, but remove the placeholder status (set block patch) instead.

This removed the need for https://github.com/sanity-io/sanity/pull/1473/commits/b93fa935a481623e0d20f6e74a03c0cead0b7a70, which is reverted.
