### PR TITLE
[form-builder] add checkered background for assets

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ImageInput/styles/Asset.css
+++ b/packages/@sanity/form-builder/src/inputs/ImageInput/styles/Asset.css
@@ -6,7 +6,14 @@
   width: 100%;
   vertical-align: bottom;
   box-sizing: border-box;
-  background-color: var(--component-bg);
+  background-color: var(--body-bg);
+  background-image:
+    linear-gradient(45deg, var(--checkerboard-color) 25%, transparent 25%),
+    linear-gradient(-45deg, var(--checkerboard-color) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, var(--checkerboard-color) 75%),
+    linear-gradient(-45deg, transparent 75%, var(--checkerboard-color) 75%);
+  background-size: 20px 20px;
+  background-position: 0 0, 0 10px, 10px -10px, -10px 0;
 }
 
 .item {


### PR DESCRIPTION
To make images/assets easier to see (and to see if an image is actually transparent) in the browse assets dialog, this adds the same white/grey checkered background to assets as the image input (fixes #1487).

Before:

<img width="896" alt="image" src="https://user-images.githubusercontent.com/25737281/64539669-2f265900-d31f-11e9-9d99-7cafe75c5e35.png">

After:

<img width="896" alt="image" src="https://user-images.githubusercontent.com/25737281/64539620-1a49c580-d31f-11e9-9486-ea50ad3190bc.png">