### PR TITLE
[cli] inform about /create when init new project

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.js
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.js
@@ -81,8 +81,11 @@ export default async function initSanity(args, context) {
     print(`You're setting up a new project!`)
     print(`We'll make sure you have an account with Sanity.io. Then we'll`)
     print('install an open-source JS content editor that connects to')
-    print('the real-time hosted API on Sanity.io. Hang on.')
+    print('the real-time hosted API on Sanity.io. Hang on.\n')
     print('Press ctrl + C at any time to quit.\n')
+    print('Prefer web interfaces to terminals?')
+    print('You can also set up best practice Sanity projects with')
+    print('your favorite frontends on https://sanity.io/create\n')
   }
 
   // If the user isn't already authenticated, make it so


### PR DESCRIPTION
(sorry about this, the other one closed and I can't reopen it)

Inform about /create when running `sanity init` and creating a new project.

```
print('Prefer web interfaces to terminals?')
print('You can also set up best practice Sanity projects with')
print('your favorite frontends on https://sanity.io/create\n')
```

<img width="594" alt="image" src="https://user-images.githubusercontent.com/25737281/64327434-f9563d00-cfcb-11e9-812e-c869ef14370f.png">