### PR TITLE
Test for #1493 htmlToBlocks loses whitespace between two hyperlinks

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,3 +7,4 @@
 /packages/@sanity/*/lib
 /packages/@sanity/*/coverage
 /packages/@sanity/client/umd
+/packages/@sanity/cli/bin/sanity-cli.js

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "release-notes": "node scripts/printReleaseNotesTemplate.js",
     "versions": "node scripts/normalizeDependencyVersions.js",
     "normalize-pkgfields": "node scripts/normalizePackageFields.js",
-    "prettify": "lerna run clean && prettier --write \"**/*.js\""
+    "prettify": "lerna run clean && prettier --write \"**/*.js\"",
+    "postinstall": "lerna bootstrap"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "bootstrap": "lerna bootstrap && npm run package-yarn",
+    "rebuild": "gulp",
     "build": "lerna run clean && gulp && npm run package",
     "clean": "lerna run clean && lerna clean",
     "publish": "npm run build && lerna publish --exact",

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/whitespace2/input.html
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/whitespace2/input.html
@@ -7,5 +7,6 @@
 		<p>
 			I should have a space here: <a href="#lala">But none here</a>.<br>
 		</p>
+		<p>I should have a space between <a href="#lala">these</a> <a href="#lala">two</a> links.</p>
 	</body>
 </html>

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/whitespace2/output.json
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/whitespace2/output.json
@@ -76,5 +76,20 @@
       { "_type": "span", "marks": [], "text": "." },
       { "_type": "span", "marks": [], "text": "\n" }
     ]
+  },
+  {
+    "_type": "block",
+    "markDefs": [
+      { "_key": "randomKey2", "_type": "link", "href": "#lala" },
+      { "_key": "randomKey3", "_type": "link", "href": "#lala" }
+    ],
+    "style": "normal",
+    "children": [
+      { "_type": "span", "marks": [], "text": "I should have a space between " },
+      { "_type": "span", "marks": ["randomKey2"], "text": "these" },
+      { "_type": "span", "marks": [], "text": " " },
+      { "_type": "span", "marks": ["randomKey3"], "text": "two" },
+      { "_type": "span", "marks": [], "text": " links." }
+    ]
   }
 ]

--- a/packages/@sanity/dashboard/src/widgets/sanityTutorials/Tutorial.js
+++ b/packages/@sanity/dashboard/src/widgets/sanityTutorials/Tutorial.js
@@ -20,7 +20,7 @@ class Tutorial extends React.PureComponent {
     const {title, posterURL, showPlayIcon, href, presenterName, presenterSubtitle} = this.props
 
     return (
-      <a className={styles.root} href={href}>
+      <a className={styles.root} href={href} target="_blank" rel="noopener noreferrer">
         <div className={styles.posterContainer}>
           <img className={styles.poster} src={posterURL} />
           {showPlayIcon && (


### PR DESCRIPTION
A test case seemed like the simplest and clearest way to communicate the issue. See other notes in #1493. Test currently fails - on purpose!