### PR TITLE
[desk-tool] fix history pane background

### DIFF
--- a/packages/@sanity/desk-tool/src/pane/styles/History.css
+++ b/packages/@sanity/desk-tool/src/pane/styles/History.css
@@ -3,7 +3,7 @@
 .root {
   min-width: 260px;
   max-width: 320px;
-  background-color: var(--gray-lightest);
+  background-color: color(var(--component-bg) shade(2%));
   height: 100%;
   width: 100%;
   z-index: 1;


### PR DESCRIPTION
This makes the history pane background be calculated from the component background color, with a shade darker (2%) to match the previous gray light. This also makes it easier to customise and create themes for the Studio that look better.