### PR TITLE
[client] Add client.getDocuments

### DIFF
--- a/packages/@sanity/client/README.md
+++ b/packages/@sanity/client/README.md
@@ -32,10 +32,18 @@ const client = sanityClient({
 
 Initializes a new Sanity Client. Required options are `projectId` and `dataset`.
 
-### Fetch a single document
+### Fetch an entire single document
 
 ```js
 client.getDocument('bike-123').then(bike => {
+  console.log(`${bike.name} (${bike.seats} seats)`)
+})
+```
+
+### Fetch multiple entire documents in one go
+
+```js
+client.getDocuments(['bike123', 'bike345']).then(([bike123, bike345]) => {
   console.log(`${bike.name} (${bike.seats} seats)`)
 })
 ```

--- a/packages/@sanity/client/README.md
+++ b/packages/@sanity/client/README.md
@@ -32,22 +32,6 @@ const client = sanityClient({
 
 Initializes a new Sanity Client. Required options are `projectId` and `dataset`.
 
-### Fetch an entire single document
-
-```js
-client.getDocument('bike-123').then(bike => {
-  console.log(`${bike.name} (${bike.seats} seats)`)
-})
-```
-
-### Fetch multiple entire documents in one go
-
-```js
-client.getDocuments(['bike123', 'bike345']).then(([bike123, bike345]) => {
-  console.log(`${bike.name} (${bike.seats} seats)`)
-})
-```
-
 ### Performing queries
 
 ```js
@@ -90,6 +74,35 @@ The update events which are emitted always contain `mutation`, which is an objec
 By default, the emitted update event will also contain a `result` property, which contains the document with the mutation applied to it. In case of a delete mutation, this property will not be present, however. You can also tell the client not to return the document (to save bandwidth, or in cases where the mutation or the document ID is the only relevant factor) by setting the `includeResult` property to `false` in the options.
 
 Likewise, you can also have the client return the document *before* the mutation was applied, by setting`includePreviousRevision` to `true` in the options, which will include a `previous` property in each emitted object.
+
+### Fetch a single document
+This will fetch a document from the [DOC endpoint](https://www.sanity.io/docs/http-query#the-doc-endpoint). Should be used sparingly and performing a query is usually a better option.
+
+```js
+client.getDocument('bike-123').then(bike => {
+  console.log(`${bike.name} (${bike.seats} seats)`)
+})
+```
+
+### Fetch multiple documents in one go
+This will fetch multiple documents in one request from the [DOC endpoint](https://www.sanity.io/docs/http-query#the-doc-endpoint). Should be used sparingly and performing a query is usually a better option.
+
+```js
+client.getDocuments(['bike123', 'bike345']).then(([bike123, bike345]) => {
+  console.log(`Bike 123: ${bike123.name} (${bike123.seats} seats)`)
+  console.log(`Bike 345: ${bike345.name} (${bike345.seats} seats)`)
+})
+```
+
+Note: Unlike in the HTTP API, the order/position of documents is _preserved_ based on the original array of IDs. If a any of the documents are missing, they will be replaced by a `null` entry in the returned array:
+
+```js
+const ids = ['bike123', 'nonexistent-document', 'bike345']
+client.getDocuments(ids).then(docs => {
+  // the docs array will be:
+  // [{_id: 'bike123', ...}, null, {_id: 'bike345', ...}]
+})
+```
 
 ### Creating documents
 

--- a/packages/@sanity/client/test/client.test.js
+++ b/packages/@sanity/client/test/client.test.js
@@ -363,6 +363,43 @@ test('can query for single document', t => {
     .then(t.end)
 })
 
+test('can query for multiple documents', t => {
+  nock(projectHost())
+    .get('/v1/data/doc/foo/abc123,abc321')
+    .reply(200, {
+      ms: 123,
+      documents: [{_id: 'abc123', mood: 'lax'}, {_id: 'abc321', mood: 'tense'}]
+    })
+
+  getClient()
+    .getDocuments(['abc123', 'abc321'])
+    .then(([abc123, abc321]) => {
+      t.equal(abc123.mood, 'lax', 'data should match')
+      t.equal(abc321.mood, 'tense', 'data should match')
+    })
+    .catch(t.ifError)
+    .then(t.end)
+})
+
+
+test('preserves the position of requested documents', t => {
+  nock(projectHost())
+    .get('/v1/data/doc/foo/abc123,abc321')
+    .reply(200, {
+      ms: 123,
+      documents: [{_id: 'abc321', mood: 'tense'}]
+    })
+
+  getClient()
+    .getDocuments(['abc123', 'abc321'])
+    .then(([abc123, abc321]) => {
+      t.equal(abc123, null, 'first item should be null')
+      t.equal(abc321.mood, 'tense', 'data should match')
+    })
+    .catch(t.ifError)
+    .then(t.end)
+})
+
 test('gives http statuscode as error if no body is present on errors', t => {
   nock(projectHost())
     .get('/v1/data/doc/foo/abc123')

--- a/packages/@sanity/client/test/client.test.js
+++ b/packages/@sanity/client/test/client.test.js
@@ -381,20 +381,20 @@ test('can query for multiple documents', t => {
     .then(t.end)
 })
 
-
 test('preserves the position of requested documents', t => {
   nock(projectHost())
-    .get('/v1/data/doc/foo/abc123,abc321')
+    .get('/v1/data/doc/foo/abc123,abc321,abc456')
     .reply(200, {
       ms: 123,
-      documents: [{_id: 'abc321', mood: 'tense'}]
+      documents: [{_id: 'abc456', mood: 'neutral'}, {_id: 'abc321', mood: 'tense'}]
     })
 
   getClient()
-    .getDocuments(['abc123', 'abc321'])
-    .then(([abc123, abc321]) => {
+    .getDocuments(['abc123', 'abc321', 'abc456'])
+    .then(([abc123, abc321, abc456]) => {
       t.equal(abc123, null, 'first item should be null')
       t.equal(abc321.mood, 'tense', 'data should match')
+      t.equal(abc456.mood, 'neutral', 'data should match')
     })
     .catch(t.ifError)
     .then(t.end)


### PR DESCRIPTION
This adds a client method for fetching multiple _entire_ documents in one go, using the `/doc` endpoint.

Usage: `client.getDocuments(['foo', 'bar']) => [{_id: 'foo', ...}, {_id: 'bar', ...}]`

Note: This adds a workaround for an issue with the `/doc` HTTP endpoint not yielding `null` values for nonexsting documents in the resulting array. This can lead to nasty bugs, e.g.:

`const [draft, published] = await client.getDocuments([draftId, publishedId])`

Without the workaround, this will assign the published document to the `draft` variable if the draft does not exists.