### PR TITLE
add check for prior __block

### DIFF
--- a/packages/@sanity/block-tools/src/HtmlDeserializer/helpers.ts
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/helpers.ts
@@ -172,7 +172,7 @@ export function ensureRootIsBlocks(blocks) {
       return memo
     }
 
-    if (i > 0 && original[i - 1]._type !== 'block') {
+    if (i > 0 && original[i - 1]._type !== 'block' && original[i - 1]._type !== '__block') {
       const block = memo[memo.length - 1]
       block.children.push(node)
       return memo


### PR DESCRIPTION
This prevents program from crashing when an image is not contained within a block, but parent is __block

![image](https://user-images.githubusercontent.com/3102249/65432052-8aa91a00-dde8-11e9-9b9f-2fcdc5ed3a33.png)
