### PR TITLE
[form-builder] Make asset upload options optional

### DIFF
--- a/packages/@sanity/form-builder/src/sanity/inputs/client-adapters/assets.ts
+++ b/packages/@sanity/form-builder/src/sanity/inputs/client-adapters/assets.ts
@@ -7,7 +7,7 @@ import {UploadOptions} from '../../uploads/typedefs'
 
 const MAX_CONCURRENT_UPLOADS = 4
 
-function uploadSanityAsset(assetType, file, options: UploadOptions) {
+function uploadSanityAsset(assetType, file, options: UploadOptions = {}) {
   const extract = options.metadata
   const preserveFilename = options.storeOriginalFilename
   return observableFrom(hashFile(file)).pipe(


### PR DESCRIPTION
If you drag and drop a bunch of images to an array input, it currently breaks because the `withMaxConcurrency` function doesn't pass any options to the asset uploader, which causes it to crash when attempting to access `metadata` on the options.

This defaults the options to an empty object.