### PR TITLE
[imagetool] When limiting, use default crop if none specified

### DIFF
--- a/packages/@sanity/imagetool/src/ImageTool.js
+++ b/packages/@sanity/imagetool/src/ImageTool.js
@@ -32,7 +32,7 @@ function checkCropBoundaries(value, delta) {
 }
 
 function limitToBoundaries(value, delta) {
-  const {top, right, bottom, left} = value.crop
+  const {top, right, bottom, left} = value.crop || DEFAULT_CROP
 
   const newValue = {...value}
 


### PR DESCRIPTION
On an image without any hotspot/crop, if you attempt to move the crop area, it'll crash with `cannot read "top" of undefined`.

This PR makes it fall back to using the default crop area if none is specified, which fixes the issue.