### PR TITLE
[form-builder] Fix invalid unset patch

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createOperationToPatches.ts
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createOperationToPatches.ts
@@ -318,8 +318,12 @@ export default function createOperationToPatches(
 
   function removeNodePatch(operation: Operation, beforeValue: SlateValue, afterValue: SlateValue) {
     const patches = []
+    const isPlaceholder = beforeValue.document.nodes
+      .get(operation.path.get(0))
+      .data.get('placeholder')
     const block = toBlock(beforeValue, operation.path.get(0))
-    if (operation.path.size === 1) {
+    // Send unset patch unless is it is a placeholder
+    if (operation.path.size === 1 && !isPlaceholder) {
       patches.push(unset([{_key: block._key}]))
     }
     if (operation.path.size > 1) {

--- a/packages/@sanity/form-builder/src/patch/primitive.ts
+++ b/packages/@sanity/form-builder/src/patch/primitive.ts
@@ -34,7 +34,9 @@ export default function apply(value, patch) {
     throw new Error(
       `Cannot apply deep operations on primitive values. Received patch with type "${
         patch.type
-      }" and path "${patch.path.join('.')} that targeted the value "${JSON.stringify(value)}"`
+      }" and path "${patch.path
+        .map(path => JSON.stringify(path))
+        .join('.')} that targeted the value "${JSON.stringify(value)}"`
     )
   }
 


### PR DESCRIPTION
Is the block trying to be unset is a placeholder block in the editor, it should not produce unset patches (because it's not really there).