### PR TITLE
[form-builder] Pass accepted mime types to input

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/FileInput/FileInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/FileInput/FileInput.tsx
@@ -275,6 +275,7 @@ export default class FileInput extends React.PureComponent<Props, FileInputState
       type.fields.filter(field => !HIDDEN_FIELDS.includes(field.name)),
       'type.options.isHighlighted'
     )
+    const accept = get(type, 'options.accept', '')
     const hasAsset = value && value.asset
     return (
       <UploadTargetFieldset
@@ -311,7 +312,7 @@ export default class FileInput extends React.PureComponent<Props, FileInputState
         </div>
         <div className={styles.functions}>
           {!readOnly && (
-            <FileInputButton icon={UploadIcon} onSelect={this.handleSelectFile} accept={''}>
+            <FileInputButton icon={UploadIcon} onSelect={this.handleSelectFile} accept={accept}>
               Upload
             </FileInputButton>
           )}

--- a/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.tsx
@@ -329,6 +329,7 @@ export default class ImageInput extends React.PureComponent<Props, ImageInputSta
       type.fields.filter(field => !HIDDEN_FIELDS.includes(field.name)),
       'type.options.isHighlighted'
     )
+    const accept = get(type, 'options.accept', 'image/*')
     const hasAsset = value && value.asset
     const showAdvancedEditButton =
       value && (otherFields.length > 0 || (hasAsset && this.isImageToolEnabled()))
@@ -377,7 +378,7 @@ export default class ImageInput extends React.PureComponent<Props, ImageInputSta
                 icon={UploadIcon}
                 inverted
                 onSelect={this.handleSelectFile}
-                accept={''}
+                accept={accept}
               >
                 Upload
               </FileInputButton>


### PR DESCRIPTION
For file and image inputs, we seem to somewhere in the stack reject files that do not match the configured `accept` value, but we don't actually pass the accept value to the underlying file input.

This is confusing, as you'll be able to select files of any type, but they are silently ignored if they do not match. It also creates a less than ideal selection of files, especially on mobile devices.

This PR passes the configured accept value down to the file input, and also defaults to `image/*` for the image input - this will make mobile devices (at least Android) use a different mode.