### PR TITLE
[desk-tool] Style broken references errors and warnings

### DIFF
--- a/packages/@sanity/components/sanity.json
+++ b/packages/@sanity/components/sanity.json
@@ -291,6 +291,10 @@
       "description": "Popover styling"
     },
     {
+      "name": "part:@sanity/components/dialogs/pane-popover",
+      "description": "A pane popover dialog"
+    },
+    {
       "name": "part:@sanity/components/snackbar/default",
       "description": "Deprecated snackbar."
     },
@@ -511,35 +515,35 @@
       "path": "radiobutton/RadioButtonDefault.js"
     },
     {
-      "implements":  "part:@sanity/components/toggles/button",
+      "implements": "part:@sanity/components/toggles/button",
       "path": "toggles/ToggleButton.js"
     },
     {
-      "implements":  "part:@sanity/components/formfields/default",
+      "implements": "part:@sanity/components/formfields/default",
       "path": "formfields/DefaultFormField.js"
     },
     {
-      "implements":  "part:@sanity/components/labels/default",
+      "implements": "part:@sanity/components/labels/default",
       "path": "labels/DefaultLabel.js"
     },
     {
-      "implements":  "part:@sanity/components/textareas/default",
+      "implements": "part:@sanity/components/textareas/default",
       "path": "textareas/DefaultTextArea.js"
     },
     {
-      "implements":  "part:@sanity/components/textinputs/default",
+      "implements": "part:@sanity/components/textinputs/default",
       "path": "textinputs/DefaultTextInput.js"
     },
     {
-      "implements":  "part:@sanity/components/textfields/default",
+      "implements": "part:@sanity/components/textfields/default",
       "path": "textfields/DefaultTextField.js"
     },
     {
-      "implements":  "part:@sanity/components/textfields/search",
+      "implements": "part:@sanity/components/textfields/search",
       "path": "textfields/SearchField.js"
     },
     {
-      "implements":  "part:@sanity/components/tags/textfield",
+      "implements": "part:@sanity/components/tags/textfield",
       "path": "tags/TextField.js"
     },
     {
@@ -591,29 +595,34 @@
       "path": "selects/styles/StyleSelect.css"
     },
     {
-      "implements":  "part:@sanity/components/dialogs/default",
+      "implements": "part:@sanity/components/dialogs/default",
       "path": "dialogs/DefaultDialog.js"
     },
     {
-      "implements":  "part:@sanity/components/dialogs/content",
+      "implements": "part:@sanity/components/dialogs/content",
       "path": "dialogs/DialogContent.js"
     },
     {
-      "implements":  "part:@sanity/components/dialogs/confirm",
+      "implements": "part:@sanity/components/dialogs/confirm",
       "path": "dialogs/ConfirmDialog.js"
     },
     {
-      "implements":  "part:@sanity/components/dialogs/fullscreen",
+      "implements": "part:@sanity/components/dialogs/fullscreen",
       "path": "dialogs/FullscreenDialog.js"
     },
     {
-      "implements":  "part:@sanity/components/dialogs/popover",
+      "implements": "part:@sanity/components/dialogs/popover",
       "path": "dialogs/PopOver.js"
     },
     {
-      "implements":  "part:@sanity/components/dialogs/popover-style",
+      "implements": "part:@sanity/components/dialogs/pane-popover",
+      "path": "dialogs/PanePopover.js"
+    },
+    {
+      "implements": "part:@sanity/components/dialogs/popover-style",
       "path": "dialogs/styles/PopOver.css"
     },
+
     {
       "implements": "part:@sanity/components/fieldsets/default",
       "path": "fieldsets/DefaultFieldset.js"
@@ -625,6 +634,10 @@
     {
       "implements": "part:@sanity/components/snackbar/item",
       "path": "snackbar/SnackbarItem.js"
+    },
+    {
+      "implements": "part:@sanity/components/snackbar/dialog",
+      "path": "snackbar/SnackbarDialog.js"
     },
     {
       "implements": "part:@sanity/components/snackbar/provider",
@@ -779,15 +792,15 @@
       "path": "tags/styles/TextField.css"
     },
     {
-      "implements":  "part:@sanity/components/dialogs/fullscreen-style",
+      "implements": "part:@sanity/components/dialogs/fullscreen-style",
       "path": "dialogs/styles/FullscreenDialog.css"
     },
     {
-      "implements":  "part:@sanity/components/dialogs/default-style",
+      "implements": "part:@sanity/components/dialogs/default-style",
       "path": "dialogs/styles/DefaultDialog.css"
     },
     {
-      "implements":  "part:@sanity/components/dialogs/content-style",
+      "implements": "part:@sanity/components/dialogs/content-style",
       "path": "dialogs/styles/DialogContent.css"
     },
     {

--- a/packages/@sanity/components/src/dialogs/PanePopover.js
+++ b/packages/@sanity/components/src/dialogs/PanePopover.js
@@ -1,0 +1,75 @@
+/* eslint-disable complexity */
+import React from 'react'
+import PropTypes from 'prop-types'
+import CheckCircleIcon from 'part:@sanity/base/circle-check-icon'
+import WarningIcon from 'part:@sanity/base/warning-icon'
+import ErrorIcon from 'part:@sanity/base/error-icon'
+import InfoIcon from 'part:@sanity/base/info-icon'
+import classNames from 'classnames'
+import styles from './styles/PanePopover.css'
+
+export default class PanePopover extends React.PureComponent {
+  static propTypes = {
+    children: PropTypes.node,
+    icon: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.bool]),
+    kind: PropTypes.oneOf(['info', 'warning', 'error', 'success', 'neutral']),
+    title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+    subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired
+  }
+
+  static defaultProps = {
+    children: null,
+    icon: null,
+    kind: 'info',
+    title: 'Pane Popover',
+    subtitle: 'Popover content'
+  }
+
+  DEFAULT_ICONS = {
+    info: <InfoIcon />,
+    success: <CheckCircleIcon />,
+    warning: <WarningIcon />,
+    error: <WarningIcon />
+  }
+
+  snackIcon = () => {
+    const {icon, kind} = this.props
+    if (typeof icon === 'boolean' && icon) return this.DEFAULT_ICONS[kind]
+    if (typeof icon === 'object' || typeof icon === 'string') return icon
+    return undefined
+  }
+
+  render() {
+    const {children, icon, id, kind, title, subtitle} = this.props
+
+    const role = () => {
+      if (kind === 'success') return 'status'
+      if (kind === 'info') return 'log'
+      return 'alert'
+    }
+    return (
+      <div
+        aria-label={kind}
+        aria-describedby={`snackbarTitle-${kind}-${id}`}
+        className={classNames([styles.root, styles.dialog])}
+        data-kind={kind}
+      >
+        <div className={styles.inner}>
+          <div className={styles.content}>
+            <div id={`snackbarTitle-${kind}-${id}`} className={styles.title}>
+              {icon && (
+                <div role="img" aria-hidden className={styles.icon}>
+                  {this.snackIcon()}
+                </div>
+              )}
+              {title}
+            </div>
+            {subtitle && <div className={styles.subtitle}>{subtitle}</div>}
+            {children && <div className={styles.children}>{children}</div>}
+          </div>
+        </div>
+      </div>
+    )
+  }
+}

--- a/packages/@sanity/components/src/dialogs/PanePopover.js
+++ b/packages/@sanity/components/src/dialogs/PanePopover.js
@@ -1,9 +1,7 @@
-/* eslint-disable complexity */
 import React from 'react'
 import PropTypes from 'prop-types'
 import CheckCircleIcon from 'part:@sanity/base/circle-check-icon'
 import WarningIcon from 'part:@sanity/base/warning-icon'
-import ErrorIcon from 'part:@sanity/base/error-icon'
 import InfoIcon from 'part:@sanity/base/info-icon'
 import classNames from 'classnames'
 import styles from './styles/PanePopover.css'
@@ -11,9 +9,9 @@ import styles from './styles/PanePopover.css'
 export default class PanePopover extends React.PureComponent {
   static propTypes = {
     children: PropTypes.node,
-    icon: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.bool]),
+    icon: PropTypes.oneOfType([PropTypes.node, PropTypes.bool]),
     kind: PropTypes.oneOf(['info', 'warning', 'error', 'success', 'neutral']),
-    title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+    title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
     subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired
   }
@@ -21,9 +19,7 @@ export default class PanePopover extends React.PureComponent {
   static defaultProps = {
     children: null,
     icon: null,
-    kind: 'info',
-    title: 'Pane Popover',
-    subtitle: 'Popover content'
+    kind: 'info'
   }
 
   DEFAULT_ICONS = {
@@ -33,34 +29,30 @@ export default class PanePopover extends React.PureComponent {
     error: <WarningIcon />
   }
 
-  snackIcon = () => {
+  iconKind = () => {
     const {icon, kind} = this.props
     if (typeof icon === 'boolean' && icon) return this.DEFAULT_ICONS[kind]
-    if (typeof icon === 'object' || typeof icon === 'string') return icon
+    if (typeof icon === 'object') return icon
     return undefined
   }
 
   render() {
     const {children, icon, id, kind, title, subtitle} = this.props
+    const Icon = this.iconKind()
 
-    const role = () => {
-      if (kind === 'success') return 'status'
-      if (kind === 'info') return 'log'
-      return 'alert'
-    }
     return (
       <div
         aria-label={kind}
-        aria-describedby={`snackbarTitle-${kind}-${id}`}
+        aria-describedby={`popoverTitle-${kind}-${id}`}
         className={classNames([styles.root, styles.dialog])}
         data-kind={kind}
       >
         <div className={styles.inner}>
           <div className={styles.content}>
-            <div id={`snackbarTitle-${kind}-${id}`} className={styles.title}>
+            <div id={`popoverTitle-${kind}-${id}`} className={styles.title}>
               {icon && (
                 <div role="img" aria-hidden className={styles.icon}>
-                  {this.snackIcon()}
+                  {Icon}
                 </div>
               )}
               {title}

--- a/packages/@sanity/components/src/dialogs/styles/PanePopover.css
+++ b/packages/@sanity/components/src/dialogs/styles/PanePopover.css
@@ -8,7 +8,7 @@
   position: absolute;
   top: 0;
   box-shadow: 0 0 0 9999px var(--broken-backdrop);
-  z-index: var(--zindex-modal);
+  z-index: var(--zindex-portal);
   max-width: 100%;
   line-height: 1.3125;
   outline: 0;

--- a/packages/@sanity/components/src/dialogs/styles/PanePopover.css
+++ b/packages/@sanity/components/src/dialogs/styles/PanePopover.css
@@ -1,0 +1,75 @@
+@import 'part:@sanity/base/theme/variables-style';
+
+:root {
+  --broken-backdrop: color(var(--gray-base) lightness(+ 70%) a(50%));
+}
+
+.root {
+  position: absolute;
+  top: 0;
+  box-shadow: 0 0 0 9999px var(--broken-backdrop);
+  z-index: var(--zindex-modal);
+  max-width: 100%;
+  line-height: 1.3125;
+  outline: 0;
+  margin: var(--medium-padding) var(--extra-large-padding);
+  border-radius: var(--border-radius-large);
+}
+
+.inner {
+  composes: shadow-1dp from 'part:@sanity/base/theme/shadows-style';
+  position: relative;
+  border-radius: var(--border-radius-large);
+  line-height: inherit;
+}
+
+.title {
+  display: flex;
+  align-items: center;
+  font-weight: bold;
+  margin-bottom: var(--small-padding);
+}
+
+.icon {
+  margin-right: calc(var(--small-padding) - 2px);
+  align-self: center;
+  line-height: 0;
+  font-size: 1.2rem;
+}
+
+.subtitle {
+  margin-bottom: var(--small-padding);
+}
+
+.root[data-kind='info'] .inner {
+  background-color: var(--state-info-color);
+  color: var(--state-info-color--inverted);
+}
+
+.root[data-kind='warning'] .inner {
+  background-color: var(--state-warning-color);
+  color: var(--state-warning-color--inverted);
+}
+
+.root[data-kind='success'] .inner {
+  background-color: var(--state-success-color);
+  color: var(--state-success-color--inverted);
+}
+
+.root[data-kind='error'] .inner {
+  background-color: var(--state-danger-color);
+  color: var(--state-danger-color--inverted);
+}
+
+.root[data-kind='neutral'] .inner {
+  background-color: var(--component-bg);
+  color: var(--text-color);
+}
+
+.content {
+  padding: var(--medium-padding) calc(var(--medium-padding) - 2px) var(--medium-padding);
+}
+
+.children:not(:empty) {
+  padding-top: 0.5em;
+}

--- a/packages/@sanity/components/src/snackbar/styles/SnackbarItem.css
+++ b/packages/@sanity/components/src/snackbar/styles/SnackbarItem.css
@@ -1,4 +1,4 @@
-@import "part:@sanity/base/theme/variables-style";
+@import 'part:@sanity/base/theme/variables-style';
 
 .root {
   position: fixed;
@@ -21,26 +21,26 @@
 .inner {
   position: relative;
   border-radius: var(--border-radius-large);
-  composes: shadow-1dp from "part:@sanity/base/theme/shadows-style";
+  composes: shadow-1dp from 'part:@sanity/base/theme/shadows-style';
   line-height: 1.3125;
 }
 
-.root[data-kind="info"] .inner {
+.root[data-kind='info'] .inner {
   background-color: var(--state-info-color);
   color: var(--state-info-color--inverted);
 }
 
-.root[data-kind="warning"] .inner {
+.root[data-kind='warning'] .inner {
   background-color: var(--state-warning-color);
   color: var(--state-warning-color--inverted);
 }
 
-.root[data-kind="success"] .inner {
+.root[data-kind='success'] .inner {
   background-color: var(--state-success-color);
   color: var(--state-success-color--inverted);
 }
 
-.root[data-kind="error"] .inner {
+.root[data-kind='error'] .inner {
   background-color: var(--state-danger-color);
   color: var(--state-danger-color--inverted);
 }
@@ -92,20 +92,20 @@
 }
 
 @media (hover: hover) {
-  .buttonContainer [class^="DefaultButton_root"]:hover {
+  .buttonContainer [class^='DefaultButton_root']:hover {
     background-color: transparent !important;
   }
 }
 
-.actionButtonContainer [class^="DefaultButton_inner"] {
+.actionButtonContainer [class^='DefaultButton_inner'] {
   padding: var(--medium-padding) var(--small-padding);
 }
 
-.closeButtonContainer [class^="DefaultButton_inner"] {
+.closeButtonContainer [class^='DefaultButton_inner'] {
   padding: calc(var(--medium-padding) - 2px);
 }
 
-.actionButtonContainer:first-child [class*=inner] {
+.actionButtonContainer:first-child [class*='inner'] {
   padding: var(--medium-padding) calc(var(--medium-padding) - 2px);
 }
 

--- a/packages/@sanity/desk-tool/src/components/BrokenReferences.js
+++ b/packages/@sanity/desk-tool/src/components/BrokenReferences.js
@@ -12,7 +12,6 @@ import PanePopover from 'part:@sanity/components/dialogs/pane-popover'
 import styles from './styles/BrokenReferences.css'
 import ReferringDocumentsList from './ReferringDocumentsList'
 
-// @todo get some designers to pretty this up (and reword it)
 function BrokenRefs(props) {
   const {documents, type, schema} = props
   const schemaType = schema.get(type)
@@ -106,9 +105,7 @@ const BrokenReferences = streamingComponent(props$ =>
         map(docs => docs.filter(isMissingPublished)),
         map(broken =>
           broken.length > 0 ? (
-            <BrokenRefs documents={broken} type={type} schema={schema}>
-              eek
-            </BrokenRefs>
+            <BrokenRefs documents={broken} type={type} schema={schema} />
           ) : (
             props.children
           )

--- a/packages/@sanity/desk-tool/src/components/BrokenReferences.js
+++ b/packages/@sanity/desk-tool/src/components/BrokenReferences.js
@@ -7,12 +7,15 @@ import {uniq, uniqBy} from 'lodash'
 import DefaultPane from 'part:@sanity/components/panes/default'
 import {observePaths} from 'part:@sanity/base/preview'
 import {getDraftId, getPublishedId} from 'part:@sanity/base/util/draft-utils'
+import FormBuilder from 'part:@sanity/form-builder'
+import PanePopover from 'part:@sanity/components/dialogs/pane-popover'
+import styles from './styles/BrokenReferences.css'
 import ReferringDocumentsList from './ReferringDocumentsList'
 
 // @todo get some designers to pretty this up (and reword it)
 function BrokenRefs(props) {
-  const {documents} = props
-
+  const {documents, type, schema} = props
+  const schemaType = schema.get(type)
   const {unpublished, nonExistent} = documents.reduce(
     (groups, doc) => {
       const group = doc.hasDraft ? groups.unpublished : groups.nonExistent
@@ -22,50 +25,62 @@ function BrokenRefs(props) {
     {unpublished: [], nonExistent: []}
   )
 
-  const isMultiDoc = documents.length > 1
-  const documentsText = isMultiDoc ? 'other documents' : 'another document'
-  const actionDocText = isMultiDoc ? 'these other documents' : 'the other document'
-  let missingText = 'do not exist'
-  let actionText = 'must be created'
-  if (unpublished.length > 0 && nonExistent.length > 0) {
-    missingText = 'do not exist and/or are not published'
-    actionText = 'must first be created and published'
-  } else if (unpublished.length > 0) {
-    missingText = `${isMultiDoc ? 'are' : 'is'} not published`
-    actionText = 'must first be published'
-  }
-
+  const renderNonExisting = nonExistent.length > 0
+  const renderUnpublished = !renderNonExisting
   return (
-    <DefaultPane title="Broken references">
-      <p>
-        The initial value for this document references {documentsText} that {missingText}. In order
-        to create <em>this</em> document, {actionDocText} {actionText}.
-      </p>
-
-      {unpublished.length > 0 && (
-        <>
-          <h2>Unpublished documents:</h2>
-          <ReferringDocumentsList
-            documents={unpublished.map(({id, type}) => ({_id: `drafts.${id}`, _type: type}))}
-          />
-        </>
-      )}
-
-      {nonExistent.length > 0 && (
-        <>
-          <h2>Non-existent document IDs:</h2>
-          <ul>
-            {nonExistent.map(doc => (
-              <li key={doc.id}>{doc.id}</li>
-            ))}
-          </ul>
-        </>
-      )}
+    <DefaultPane title={`New ${type}`} contentMaxWidth={672} isScrollable={false}>
+      <div className={styles.brokenReferences}>
+        {renderNonExisting && (
+          <PanePopover
+            icon
+            kind="error"
+            id="missing-references"
+            title="Missing references"
+            subtitle={`The new document can only reference existing documents. ${
+              nonExistent.length === 1 ? 'A document' : 'Documents'
+            } with the following ID${nonExistent.length === 1 ? ' was' : 's were'} not found:`}
+          >
+            <ul className={styles.tagList}>
+              {nonExistent.map(doc => (
+                <li className={styles.tagItem} key={doc.id}>
+                  {doc.id}
+                </li>
+              ))}
+            </ul>
+          </PanePopover>
+        )}
+        {renderUnpublished && (
+          <PanePopover
+            icon
+            kind="warning"
+            id="unpublished-documents"
+            title="Unpublished references"
+            subtitle={`A document can only refer to published documents. Publish the following ${
+              unpublished.length === 1 ? 'draft' : 'drafts'
+            } before creating
+            a new document.`}
+          >
+            <ReferringDocumentsList
+              documents={unpublished.map(({id, type, hasDraft}) => ({
+                _id: `drafts.${id}`,
+                _type: type,
+                _hasDraft: hasDraft
+              }))}
+            />
+          </PanePopover>
+        )}
+      </div>
+      <form className={styles.editor}>
+        <FormBuilder readOnly type={schemaType} schema={schema} />
+      </form>
     </DefaultPane>
   )
 }
 
 BrokenRefs.propTypes = {
+  schema: PropTypes.any,
+  type: PropTypes.any,
+  document: PropTypes.any,
   documents: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,
@@ -79,7 +94,7 @@ const BrokenReferences = streamingComponent(props$ =>
   props$.pipe(
     switchMap(props => {
       const ids = findReferences(props.document)
-
+      const {type, schema} = props
       if (!ids.length) {
         return of(props.children)
       }
@@ -90,7 +105,13 @@ const BrokenReferences = streamingComponent(props$ =>
         filter(docs => docs.length === ids.length),
         map(docs => docs.filter(isMissingPublished)),
         map(broken =>
-          broken.length > 0 ? <BrokenRefs documents={broken}>eek</BrokenRefs> : props.children
+          broken.length > 0 ? (
+            <BrokenRefs documents={broken} type={type} schema={schema}>
+              eek
+            </BrokenRefs>
+          ) : (
+            props.children
+          )
         )
       )
     })

--- a/packages/@sanity/desk-tool/src/components/ReferringDocumentsList.js
+++ b/packages/@sanity/desk-tool/src/components/ReferringDocumentsList.js
@@ -1,10 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {List as DefaultList, Item as DefaultItem} from 'part:@sanity/components/lists/default'
-import styles from './styles/ReferringDocumentsList.css'
 import Preview from 'part:@sanity/base/preview'
 import {IntentLink} from 'part:@sanity/base/router'
 import schema from 'part:@sanity/base/schema'
+import styles from './styles/ReferringDocumentsList.css'
+import DraftStatus from './DraftStatus'
 
 export default function ReferringDocumentsList(props) {
   const {documents} = props
@@ -21,6 +22,7 @@ export default function ReferringDocumentsList(props) {
                 params={{id: document._id, type: document._type}}
               >
                 <Preview value={document} type={schemaType} />
+                {document._hasDraft && <DraftStatus />}
               </IntentLink>
             ) : (
               <div>

--- a/packages/@sanity/desk-tool/src/components/styles/BrokenReferences.css
+++ b/packages/@sanity/desk-tool/src/components/styles/BrokenReferences.css
@@ -1,0 +1,19 @@
+@import 'part:@sanity/base/theme/variables-style';
+
+.editor {
+  padding: 0 var(--medium-padding);
+}
+
+.tagList {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+}
+
+.tagItem {
+  margin-right: var(--small-padding);
+  padding: var(--extra-small-padding) var(--small-padding);
+  background: color(var(--state-danger-color) shade(15%));
+  border-radius: var(--border-radius-base);
+}

--- a/packages/@sanity/desk-tool/src/components/styles/ReferringDocumentsList.css
+++ b/packages/@sanity/desk-tool/src/components/styles/ReferringDocumentsList.css
@@ -1,3 +1,4 @@
+@import 'part:@sanity/base/theme/variables-style';
 
 .root {
   composes: root from 'part:@sanity/components/lists/default-style';
@@ -5,9 +6,17 @@
 
 .item {
   composes: lineBetween from 'part:@sanity/components/lists/default-item-style';
-  padding: 1px 0;
+  background: var(--white);
+  padding: var(--medium-padding);
+  border-radius: var(--border-radius-base);
+  color: inherit;
+  margin-bottom: var(--medium-padding);
 }
 
 .link {
   color: inherit;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }

--- a/packages/@sanity/desk-tool/src/utils/withInitialValue.js
+++ b/packages/@sanity/desk-tool/src/utils/withInitialValue.js
@@ -161,7 +161,11 @@ export default function withInitialValue(Pane) {
             return isResolving ? (
               <LoadingPane {...this.props} title={title} message="Resolving initial value…" />
             ) : (
-              <BrokenReferences document={initialValue}>
+              <BrokenReferences
+                document={initialValue}
+                type={this.props.options.type}
+                schema={schema}
+              >
                 <Pane {...this.props} initialValue={initialValue} />
               </BrokenReferences>
             )


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->
![64277456-3acce680-ceff-11e9-854a-91ec0734f92b](https://user-images.githubusercontent.com/25737281/66035833-2edb4100-e50c-11e9-9d7d-577c8c288e21.png)


**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->
Styled error dialogs that appear when document template references unpublished or missing documents.

<img width="1440" alt="65834536-36b49e80-e2dc-11e9-9ad3-e8225dda5a0c" src="https://user-images.githubusercontent.com/25737281/66035884-49adb580-e50c-11e9-8572-4387df2a4259.png">
<img width="1440" alt="65834537-36b49e80-e2dc-11e9-87e7-fdf49550bba5" src="https://user-images.githubusercontent.com/25737281/66035886-49adb580-e50c-11e9-905d-44f9564762a0.png">

**Comments**

Some color changes may still be coming, depending on what @mariuslundgard says.

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If a new feature, remember to link to docs/blogpost, if bugfix please describe the bug in non-techincal terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->
- Styled error dialogs that appear when document template references unpublished or missing documents

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [x]  Corresponding changes to the documentation have been made