### PR TITLE
[cli] Add spinner for dataset creation

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.js
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.js
@@ -115,10 +115,10 @@ export default async function initSanity(args, context) {
   debug('Prompting user to select or create a dataset')
   const {datasetName} = await getOrCreateDataset(
     {
-    projectId,
-    displayName,
-    dataset: flags.dataset,
-    aclMode: flags.visibility
+      projectId,
+      displayName,
+      dataset: flags.dataset,
+      aclMode: flags.visibility
     },
     context
   )
@@ -359,7 +359,8 @@ export default async function initSanity(args, context) {
       debug('User wants to create a new project, prompting for name')
       return createProject(apiClient, {
         displayName: await prompt.single({
-          message: 'Informal name for your project'
+          message: 'Your project name:',
+          default: 'My Sanity Project'
         })
       }).then(response => ({
         ...response,
@@ -402,6 +403,9 @@ export default async function initSanity(args, context) {
       if (unattended || !privateDatasetsAllowed) {
         return 'public'
       } else if (privateDatasetsAllowed) {
+        output.print(
+          'A dataset can be public or private, depending on if you want to query content with or without authentication.\nSee docs for more info: https://sanity.io/docs/data-store/keeping-your-data-safe'
+        )
         return promptForAclMode(prompt, output)
       }
 
@@ -450,6 +454,9 @@ export default async function initSanity(args, context) {
 
     if (selected === 'new') {
       debug('User wants to create a new dataset, prompting for name')
+      output.print(
+        'Your content will be stored in a dataset. We name your first \ndataset "production" by default, but you are free to rename it.'
+      )
       const newDatasetName = await promptForDatasetName(prompt, {
         message: 'Name your dataset:',
         default: 'production'
@@ -521,7 +528,7 @@ export default async function initSanity(args, context) {
         specifiedPath ||
         (await prompt.single({
           type: 'input',
-          message: 'Output path:',
+          message: 'Project output path:',
           default: workDirIsEmpty ? workDir : path.join(workDir, sluggedName),
           validate: validateEmptyPath,
           filter: absolutify
@@ -642,7 +649,7 @@ async function promptForAclMode(prompt, output) {
       },
       {
         value: 'private',
-        name: 'Private (Authenticated user or token needed for API requests)'
+        name: 'Private (authenticated requests only)'
       }
     ]
   })

--- a/packages/@sanity/cli/src/actions/init-project/initProject.js
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.js
@@ -113,12 +113,15 @@ export default async function initSanity(args, context) {
 
   // Now let's pick or create a dataset
   debug('Prompting user to select or create a dataset')
-  const {datasetName} = await getOrCreateDataset({
+  const {datasetName} = await getOrCreateDataset(
+    {
     projectId,
     displayName,
     dataset: flags.dataset,
     aclMode: flags.visibility
-  })
+    },
+    context
+  )
 
   debug(`Dataset with name ${datasetName} selected`)
 
@@ -426,7 +429,9 @@ export default async function initSanity(args, context) {
       })
 
       const aclMode = await getAclMode()
+      const spinner = context.output.spinner('Creating dataset...').start()
       await client.datasets.create(name, {aclMode})
+      spinner.succeed()
       return {datasetName: name}
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->
After choosing options for creating a dataset, it can feel like the CLI stopped working because there is no indicator of what is happening (dataset is being created).

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->
This adds a spinner and a message to let you know that your dataset is being created.
Also improved some of the prompts with clearer messaging and a default project name to avoid ugly `displayName` error message.

![cli-dataset-spinner](https://user-images.githubusercontent.com/25737281/66298924-d680b680-e8f2-11e9-8908-fedbf78947f7.gif)

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If a new feature, remember to link to docs/blogpost, if bugfix please describe the bug in non-techincal terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->
N/A

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [x]  Corresponding changes to the documentation have been made
