### PR TITLE
[cli] install vision in CLI templates by default

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/createManifest.js
+++ b/packages/@sanity/cli/src/actions/init-project/createManifest.js
@@ -120,7 +120,8 @@ export function createSanityManifest(data, opts) {
         '@sanity/components',
         '@sanity/default-layout',
         '@sanity/default-login',
-        '@sanity/desk-tool'
+        '@sanity/desk-tool',
+        '@sanity/vision'
       ],
 
       parts: [

--- a/packages/@sanity/cli/src/actions/init-project/createManifest.js
+++ b/packages/@sanity/cli/src/actions/init-project/createManifest.js
@@ -120,9 +120,14 @@ export function createSanityManifest(data, opts) {
         '@sanity/components',
         '@sanity/default-layout',
         '@sanity/default-login',
-        '@sanity/desk-tool',
-        '@sanity/vision'
+        '@sanity/desk-tool'
       ],
+
+      env: {
+        development: {
+          plugins: ['@sanity/vision']
+        }
+      },
 
       parts: [
         {

--- a/packages/@sanity/cli/src/versionRanges.js
+++ b/packages/@sanity/cli/src/versionRanges.js
@@ -7,6 +7,7 @@ export default {
     '@sanity/default-layout': 'latest',
     '@sanity/default-login': 'latest',
     '@sanity/desk-tool': 'latest',
+    '@sanity/vision': 'latest',
     react: '^16.2',
     'react-dom': '^16.2',
     'prop-types': '^15.6'


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No 

Maybe?

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->
When creating a new project from a template in the CLI, the vision plugin is not installed by default.

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->
Makes the vision plugin be installed in templates by default

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If a new feature, remember to link to docs/blogpost, if bugfix please describe the bug in non-techincal terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->
- When creating a project from the CLI using a template, the vision plugin is now installed by default.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
