### PR TITLE
[components] add dev server status snackbar

### DIFF
--- a/packages/@sanity/base/src/components/DevServerStatus.js
+++ b/packages/@sanity/base/src/components/DevServerStatus.js
@@ -7,15 +7,16 @@ const EventSource = isWindowEventSource
   ? window.EventSource // Native browser EventSource
   : polyfilledEventSource // Node.js, IE, Edge etc
 
-const STATE_CLOSED = 0
+const STATE_CONNECTING = 0
 const STATE_OPEN = 1
+const STATE_CLOSED = 2
 
 class DevServerStatus extends PureComponent {
   constructor(...args) {
     super(...args)
     this.enabled = __DEV__ && EventSource
     this.state = {
-      connectionState: STATE_CLOSED,
+      connectionState: STATE_OPEN,
       hasHadConnection: false
     }
   }
@@ -65,8 +66,11 @@ class DevServerStatus extends PureComponent {
       return null
     }
 
-    // We are disconnected, show snackbar
-    if (this.state.connectionState === STATE_CLOSED) {
+    // We are disconnected
+    if (
+      this.state.connectionState === STATE_CLOSED ||
+      this.state.connectionState === STATE_CONNECTING
+    ) {
       return (
         <Snackbar
           id="__dev-server-status"
@@ -76,8 +80,10 @@ class DevServerStatus extends PureComponent {
           title={<strong>Disconnected from the dev server!</strong>}
           subtitle={
             <div>
-              To see your latest changes, restart the Studio with <code>sanity start</code> from
-              your project folder.
+              {this.state.connectionState === STATE_CLOSED
+                ? 'To see your latest changes,'
+                : 'We are trying to reconnect you, but you can also'}{' '}
+              restart the Studio with <code>sanity start</code> in your project folder.
             </div>
           }
         />

--- a/packages/@sanity/base/src/components/DevServerStatus.js
+++ b/packages/@sanity/base/src/components/DevServerStatus.js
@@ -16,7 +16,7 @@ class DevServerStatus extends PureComponent {
     super(...args)
     this.enabled = __DEV__ && EventSource
     this.state = {
-      connectionState: STATE_OPEN,
+      connectionState: STATE_CONNECTING,
       hasHadConnection: false
     }
   }
@@ -67,10 +67,7 @@ class DevServerStatus extends PureComponent {
     }
 
     // We are disconnected
-    if (
-      this.state.connectionState === STATE_CLOSED ||
-      this.state.connectionState === STATE_CONNECTING
-    ) {
+    if (this.state.hasHadConnection) {
       return (
         <Snackbar
           id="__dev-server-status"
@@ -80,10 +77,8 @@ class DevServerStatus extends PureComponent {
           title={<strong>Disconnected from the dev server!</strong>}
           subtitle={
             <div>
-              {this.state.connectionState === STATE_CLOSED
-                ? 'To see your latest changes,'
-                : 'We are trying to reconnect you, but you can also'}{' '}
-              restart the Studio with <code>sanity start</code> in your project folder.
+              To see your latest changes, restart the Studio with <code>sanity start</code> in your
+              project folder.
             </div>
           }
         />

--- a/packages/@sanity/base/src/components/DevServerStatus.js
+++ b/packages/@sanity/base/src/components/DevServerStatus.js
@@ -1,0 +1,90 @@
+import React, {PureComponent} from 'react'
+import polyfilledEventSource from '@sanity/eventsource'
+import Snackbar from 'part:@sanity/components/snackbar/default'
+
+const isWindowEventSource = Boolean(typeof window !== 'undefined' && window.EventSource)
+const EventSource = isWindowEventSource
+  ? window.EventSource // Native browser EventSource
+  : polyfilledEventSource // Node.js, IE, Edge etc
+
+const STATE_CLOSED = 0
+const STATE_OPEN = 1
+
+class DevServerStatus extends PureComponent {
+  constructor(...args) {
+    super(...args)
+    this.enabled = __DEV__ && EventSource
+    this.state = {
+      connectionState: STATE_CLOSED,
+      hasHadConnection: false
+    }
+  }
+
+  componentDidMount() {
+    if (!this.enabled) {
+      return
+    }
+
+    this.es = new EventSource('/__webpack_hmr')
+    this.es.onerror = this.handleReadyChange
+    this.es.onopen = this.handleOpen
+  }
+
+  componentWillUnmount() {
+    if (this.es) {
+      this.es.close()
+    }
+  }
+
+  handleOpen = () => {
+    this.handleReadyChange()
+
+    if (this.state.hasHadConnection) {
+      // We reconnected after being disconnected.
+      // Hot-reloading won't be applied automatically.
+      // We should consider showing a message telling the user to reload,
+      // or just programatically reload the page:
+      window.location.reload()
+    } else {
+      this.setState({hasHadConnection: true})
+    }
+  }
+
+  handleReadyChange = () => {
+    this.setState({connectionState: this.es.readyState})
+  }
+
+  render() {
+    // We're in production, or eventsource is not supported by the browser (Edge)
+    if (!this.enabled) {
+      return null
+    }
+
+    // We're connected, don't show anything
+    if (this.state.connectionState === STATE_OPEN) {
+      return null
+    }
+
+    // We are disconnected, show snackbar
+    if (this.state.connectionState === STATE_CLOSED) {
+      return (
+        <Snackbar
+          id="__dev-server-status"
+          kind="warning"
+          isPersisted
+          isCloseable={false}
+          title={<strong>Disconnected from the dev server!</strong>}
+          subtitle={
+            <div>
+              To see your latest changes, restart the Studio with <code>sanity start</code> from
+              your project folder.
+            </div>
+          }
+        />
+      )
+    }
+    return null
+  }
+}
+
+export default DevServerStatus

--- a/packages/@sanity/base/src/components/SanityRoot.js
+++ b/packages/@sanity/base/src/components/SanityRoot.js
@@ -6,6 +6,7 @@ import ErrorHandler from './ErrorHandler'
 import VersionChecker from './VersionChecker'
 import MissingProjectConfig from './MissingProjectConfig'
 import styles from './styles/SanityRoot.css'
+import DevServerStatus from './DevServerStatus'
 
 function SanityRoot() {
   const {projectId, dataset} = config.api || {}
@@ -16,6 +17,7 @@ function SanityRoot() {
   return (
     <div className={styles.root}>
       <SnackbarProvider>
+        <DevServerStatus />
         <ErrorHandler />
         <RootComponent />
         <VersionChecker />


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->
When the dev server disconnects, there is no way of knowing this happened by looking at the Studio in the browser. Can be confusing, if changes are being made and you don't understand why the Studio isn't updating.

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->
This adds a snackbar to show that the dev server was disconnected and needs to be restarted to see any changes made to the Studio.

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If a new feature, remember to link to docs/blogpost, if bugfix please describe the bug in non-techincal terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->
- If your development server is disconnected/stops working, the Studio will now show you a notification to let you know that you should restart with `sanity start` to see your latest changes.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [x]  Corresponding changes to the documentation have been made
