### PR TITLE
[default-layout] fix brand logo sizing

### DIFF
--- a/packages/@sanity/base/src/styles/variables/globals.css
+++ b/packages/@sanity/base/src/styles/variables/globals.css
@@ -62,5 +62,6 @@
   --block-extras-background-color: #eee;
 
   /* Others */
-  --pane-header-height: 3.4375rem; /* 55px */
+  --pane-header-height: 3.4375rem;
+  --nav-bar-box: 3.0625em; /* 55px */
 }

--- a/packages/@sanity/default-layout/src/components/Branding.js
+++ b/packages/@sanity/default-layout/src/components/Branding.js
@@ -15,7 +15,7 @@ function Branding(props) {
         </div>
       )}
       {!Logo && (
-        <div>
+        <div className={styles.projectNameContainer}>
           <h1 className={styles.projectName}>{projectName}</h1>
         </div>
       )}

--- a/packages/@sanity/default-layout/src/components/styles/Branding.css
+++ b/packages/@sanity/default-layout/src/components/styles/Branding.css
@@ -1,50 +1,52 @@
 @import "part:@sanity/base/theme/variables-style";
 
 .root {
+  display: flex;
   text-decoration: none;
   color: inherit;
   font-weight: 400;
-  width: 100%;
+  height: 100%;
   outline: none;
-  padding: 1em;
+  padding: var(--extra-small-padding) var(--medium-padding);
+  padding-right: var(--extra-small-padding);
   box-sizing: border-box;
   position: relative;
+  max-height: var(--nav-bar-box);
+}
 
-  @media (--screen-medium) {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
+.projectNameContainer {
+  display: flex;
+  align-items: center;
 }
 
 .projectName {
-  display: block;
   color: inherit;
   font-size: inherit;
   margin: 0;
-  padding: 0;
-  line-height: calc(17 / 16);
   font-weight: 600;
   white-space: nowrap;
   text-overflow: ellipsis;
   width: 100%;
   overflow: hidden;
-
-  @media (--screen-medium) {
-    width: unset;
-    max-width: 12em;
-  }
 }
 
 .brandLogoContainer {
-  display: block;
+  display: flex;
+  align-items: center;
   cursor: pointer;
   color: inherit;
+  flex-grow: 1;
 
-  @nest & svg {
-    display: block;
-    fill: currentColor;
-    height: 1em;
+  @nest & * {
+    max-height: 100%;
+    height: 100%;
     width: auto;
+    max-width: 12em;
+    min-width: var(--nav-bar-box);
+    flex-grow: 1;
+  }
+
+  @nest & img {
+    height: auto;
   }
 }

--- a/packages/@sanity/default-layout/src/components/styles/NavBar.css
+++ b/packages/@sanity/default-layout/src/components/styles/NavBar.css
@@ -7,7 +7,7 @@
 .root {
   display: grid;
   grid-template-areas:   "hamburger         createButton       branding     extras   searchButton";
-  grid-template-columns: var(--nav-bar-box) var(--nav-bar-box) auto         auto     var(--nav-bar-box);
+  grid-template-columns: var(--nav-bar-box) var(--nav-bar-box) min-content  auto     var(--nav-bar-box);
   grid-template-rows: var(--nav-bar-box);
   box-sizing: border-box;
   align-items: stretch;
@@ -19,7 +19,7 @@
 
     @nest &.withToolSwitcher {
       grid-template-areas: " branding    createButton       search               spaceSwitcher toolSwitcher extras      sanityStatus loginStatus";
-      grid-template-columns: max-content var(--nav-bar-box) minmax(240px, 400px) max-content   auto         max-content max-content  calc(var(--nav-bar-box) + 1em);
+      grid-template-columns: min-content var(--nav-bar-box) minmax(240px, 400px) max-content   auto         max-content max-content  calc(var(--nav-bar-box) + 1em);
     }
   }
 
@@ -34,12 +34,6 @@
   position: relative;
   box-sizing: border-box;
   overflow: hidden;
-
-  @media (--screen-medium) {
-    display: flex;
-    align-items: stretch;
-    overflow: visible;
-  }
 }
 
 a.branding {


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->
When using a custom brand logo component that returns an image or SVG, the sizing is botched.

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->
This makes images and SVGs display correctly in terms of size and how they take up space. Works when returning an img and svgs  in a custom brand logo component, as well as anything else.

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If a new feature, remember to link to docs/blogpost, if bugfix please describe the bug in non-techincal terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->
- Improved styling and sizing when using a custom logo

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [x]  Corresponding changes to the documentation have been made

**Other comments**

There seem to be a chrome glitch when it comes to SVGs and the height property. The SVG won't fill the space as it should if the logo is long (compared to round or squared), but when you toggle on and off the height in dev tools, it works as expected. Not sure how this will be in production, but the glitchy behaviour is the same as the current behaviour so it shouldn't have a big impact.
