### PR TITLE
[form-builder] Block editor: fix paste controller bug

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/plugins/PastePlugin.ts
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/plugins/PastePlugin.ts
@@ -41,13 +41,13 @@ function handleHTML(html, editor, blockContentType, onProgress, pasteController)
     onProgress({status: 'blocks'})
     const value = deserialize(blocks, blockContentType)
     pasteController.setValue(value)
-    editor.insertFragment(pasteController.value.document)
     // Remove placeholder status of first block
     const firstBlock = editor.value.document.nodes.first()
     if (firstBlock.type === 'contentBlock' && firstBlock.data.get('placeholder')) {
       const newData = firstBlock.data.toObject()
       delete newData.placeholder
       editor.setNodeByKey(firstBlock.key, {data: newData})
+      editor.insertFragment(pasteController.value.document)
     }
     pasteController.setValue(deserialize(null, blockContentType))
     onProgress({status: null})


### PR DESCRIPTION
Fixes a bug where an error occurred pasting fragment into a placeholder block.