### PR TITLE
Fix serialization issues

### DIFF
--- a/packages/@sanity/block-tools/src/HtmlDeserializer/preprocessors/html.ts
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/preprocessors/html.ts
@@ -6,6 +6,8 @@ export default (html, doc) => {
     '/html/text()',
     '/html/head/text()',
     '/html/body/text()',
+    '/html/body/ul/text()',
+    '/html/body/ol/text()',
     '//comment()',
     '//style',
     '//xml',
@@ -25,6 +27,5 @@ export default (html, doc) => {
     const unwanted = unwantedNodes.snapshotItem(i)
     unwanted.parentNode.removeChild(unwanted)
   }
-
   return doc
 }

--- a/packages/@sanity/block-tools/src/HtmlDeserializer/rules/html.ts
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/rules/html.ts
@@ -31,12 +31,18 @@ export default function createHTMLRules(blockContentType, options: any = {}) {
     // Text nodes
     {
       deserialize(el) {
-        const isValidText = el.textContent !== ' ' && tagName(el.parentNode) !== 'body'
+        const isValidWhiteSpace =
+          el.nodeType === 3 &&
+          el.textContent.replace(/[\r\n]/g, ' ').replace(/\s\s+/g, ' ') === ' ' &&
+          el.nextSibling && el.nextSibling.nodeType !== 3 &&
+          el.previousSibling && el.previousSibling.nodeType !== 3
+        const isValidText =
+          (isValidWhiteSpace || el.textContent !== ' ') && tagName(el.parentNode) !== 'body'
         if (el.nodeName === '#text' && isValidText) {
           return {
             ...DEFAULT_SPAN,
             marks: [],
-            text: el.value || el.nodeValue
+            text: el.textContent.replace(/\s\s+/g, ' ')
           }
         }
         return undefined

--- a/packages/@sanity/block-tools/src/util/normalizeBlock.ts
+++ b/packages/@sanity/block-tools/src/util/normalizeBlock.ts
@@ -29,9 +29,10 @@ export default function normalizeBlock(block) {
     ]
     return block
   }
+  let usedMarkDefs = []
   block.children = block.children
-    .filter((child, index) => {
-      const previousChild = block.children[index - 1]
+    .reduce((acc, child) => {
+      const previousChild = acc.slice(-1)[0]
       if (
         previousChild &&
         child._type === 'span' &&
@@ -39,19 +40,23 @@ export default function normalizeBlock(block) {
         isEqual(previousChild.marks, child.marks)
       ) {
         if (lastChild && lastChild === child && child.text === '' && block.children.length > 1) {
-          return false
+          return acc
         }
         previousChild.text += child.text
-        return false
+        return acc
       }
-      return child
-    })
+      acc.push(child)
+      return acc
+    }, [])
     .map(child => {
       child._key = `${block._key}${newIndex++}`
       if (child._type === 'span' && !child.marks) {
         child.marks = []
       }
+      usedMarkDefs = usedMarkDefs.concat(child.marks)
       return child
     })
+  // Remove leftover markDefs
+  block.markDefs = block.markDefs.filter(markDef => usedMarkDefs.includes(markDef._key))
   return block
 }

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/annotations/output.json
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/annotations/output.json
@@ -10,6 +10,7 @@
         "text": "strong"
       },
       { "_type": "span", "marks": ["randomKey0"], "text": " link" },
+      { "_type": "span", "marks": [], "text": " " },
       { "_type": "span", "marks": ["em"], "text": "and " },
       {
         "_type": "span",

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/decorators/input.html
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/decorators/input.html
@@ -3,7 +3,7 @@
     <p>
       <strong>Strong text but
         <em>this is also emphasized and
-          <strike>striked</strike></strike>
+          <strike>striked</strike>
         </em>
       </strong>
       <em>Just emphasized</em>

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/decorators/output.json
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/decorators/output.json
@@ -5,6 +5,7 @@
       {"_type": "span", "marks": ["strong"], "text": "Strong text but "},
       {"_type": "span", "marks": ["strong", "em"], "text": "this is also emphasized and "},
       {"_type": "span", "marks": ["strong", "em", "strike-through"], "text": "striked"},
+      { "_type": "span", "marks": [], "text": " " },
       {"_type": "span", "marks": ["em"], "text": "Just emphasized"}
     ],
     "markDefs": [],

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/githubIssue/output.json
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/githubIssue/output.json
@@ -3,18 +3,24 @@
     "_type": "block",
     "children": [
       {"_type": "span", "marks": ["randomKey0"], "text": "The preview API seems broken"},
+      {"_type": "span", "marks": [], "text": " "},
       {"_type": "span", "marks": ["randomKey1"], "text": "bug/major"},
       {"_type": "span", "marks": [], "text": " #783 opened "},
       {"_type": "span", "marks": [], "text": "3 hours ago"},
       {"_type": "span", "marks": [], "text": " by "},
       {"_type": "span", "marks": ["randomKey2"], "text": "kmelve"},
+      {"_type": "span", "marks": [], "text": " "},
+      {"_type": "span", "marks": [], "text": " "},
       {"_type": "span", "marks": ["randomKey3"], "text": "2"},
+      {"_type": "span", "marks": [], "text": " "},
       {"_type": "span", "marks": ["randomKey4"], "text": "Elasticsearch broke"},
+      {"_type": "span", "marks": [], "text": " "},
       {"_type": "span", "marks": ["randomKey5"], "text": "ops"},
       {"_type": "span", "marks": [], "text": " #782 opened "},
       {"_type": "span", "marks": [], "text": "5 hours ago"},
       {"_type": "span", "marks": [], "text": " by "},
-      {"_type": "span", "marks": ["randomKey6"], "text": "nicholasklem"}
+      {"_type": "span", "marks": ["randomKey6"], "text": "nicholasklem"},
+      {"_type": "span", "marks": [], "text": " "}
     ],
     "markDefs": [
       {"_key": "randomKey0", "_type": "link", "href": "/sanity-io/sanity-priv/issues/783"},

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/whitespace2/input.html
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/whitespace2/input.html
@@ -7,5 +7,7 @@
 		<p>
 			I should have a space here: <a href="#lala">But none here</a>.<br>
 		</p>
+		<p>I should have a space between <a href="#lala">these</a> <a href="#lala">two</a> links.</p>
+		<p>I should have a space between <em>these</em> <em>two</em> words.</p>
 	</body>
 </html>

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/whitespace2/output.json
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/whitespace2/output.json
@@ -1,62 +1,60 @@
 [
   {
     "_type": "block",
-    "markDefs": [],
-    "style": "normal",
     "children": [
       {
         "_type": "span",
         "marks": [],
-        "text":
-          "I should not have any whitepace in the start, and none in the end"
+        "text": "I should not have any whitepace in the start, and none in the end"
       }
-    ]
+    ],
+    "markDefs": [],
+    "style": "normal"
   },
   {
     "_type": "block",
-    "markDefs": [],
-    "style": "normal",
     "children": [
       {
         "_type": "span",
         "marks": [],
-        "text":
-          "I should not have any whitepace in the start, and none in the end"
+        "text": "I should not have any whitepace in the start, and none in the end"
       }
-    ]
+    ],
+    "markDefs": [],
+    "style": "normal"
   },
   {
     "_type": "block",
-    "markDefs": [],
-    "style": "normal",
     "children": [
       {
         "_type": "span",
         "marks": [],
-        "text":
-          "I should not have any whitepace in the start, and none in the end"
+        "text": "I should not have any whitepace in the start, and none in the end"
       },
       {
         "_type": "span",
-        "marks": ["em"],
+        "marks": [
+          "em"
+        ],
         "text": " I have one in the beginning but none in the end"
       }
-    ]
+    ],
+    "markDefs": [],
+    "style": "normal"
   },
   {
     "_type": "block",
-    "markDefs": [{ "_key": "randomKey0", "_type": "link", "href": "#foo" }],
-    "style": "normal",
     "children": [
       {
         "_type": "span",
         "marks": [],
-        "text":
-          "I should not have any whitepace in the start, and one in the end "
+        "text": "I should not have any whitepace in the start, and one in the end "
       },
       {
         "_type": "span",
-        "marks": ["randomKey0"],
+        "marks": [
+          "randomKey0"
+        ],
         "text": "I have none in the beginning and none in the end"
       },
       {
@@ -64,17 +62,132 @@
         "marks": [],
         "text": " But I have one in the beginning"
       }
-    ]
+    ],
+    "markDefs": [
+      {
+        "_key": "randomKey0",
+        "_type": "link",
+        "href": "#foo"
+      }
+    ],
+    "style": "normal"
   },
   {
     "_type": "block",
-    "markDefs": [{ "_key": "randomKey1", "_type": "link", "href": "#lala" }],
-    "style": "normal",
     "children": [
-      { "_type": "span", "marks": [], "text": "I should have a space here: " },
-      { "_type": "span", "marks": ["randomKey1"], "text": "But none here" },
-      { "_type": "span", "marks": [], "text": "." },
-      { "_type": "span", "marks": [], "text": "\n" }
-    ]
+      {
+        "_type": "span",
+        "marks": [],
+        "text": "I should have a space here: "
+      },
+      {
+        "_type": "span",
+        "marks": [
+          "randomKey1"
+        ],
+        "text": "But none here"
+      },
+      {
+        "_type": "span",
+        "marks": [],
+        "text": "."
+      },
+      {
+        "_type": "span",
+        "marks": [],
+        "text": "\n"
+      }
+    ],
+    "markDefs": [
+      {
+        "_key": "randomKey1",
+        "_type": "link",
+        "href": "#lala"
+      }
+    ],
+    "style": "normal"
+  },
+  {
+    "_type": "block",
+    "children": [
+      {
+        "_type": "span",
+        "marks": [],
+        "text": "I should have a space between "
+      },
+      {
+        "_type": "span",
+        "marks": [
+          "randomKey2"
+        ],
+        "text": "these"
+      },
+      {
+        "_type": "span",
+        "marks": [],
+        "text": " "
+      },
+      {
+        "_type": "span",
+        "marks": [
+          "randomKey3"
+        ],
+        "text": "two"
+      },
+      {
+        "_type": "span",
+        "marks": [],
+        "text": " links."
+      }
+    ],
+    "markDefs": [
+      {
+        "_key": "randomKey2",
+        "_type": "link",
+        "href": "#lala"
+      },
+      {
+        "_key": "randomKey3",
+        "_type": "link",
+        "href": "#lala"
+      }
+    ],
+    "style": "normal"
+  },
+  {
+    "_type": "block",
+    "children": [
+      {
+        "_type": "span",
+        "marks": [],
+        "text": "I should have a space between "
+      },
+      {
+        "_type": "span",
+        "marks": [
+          "em"
+        ],
+        "text": "these"
+      },
+      {
+        "_type": "span",
+        "marks": [],
+        "text": " "
+      },
+      {
+        "_type": "span",
+        "marks": [
+          "em"
+        ],
+        "text": "two"
+      },
+      {
+        "_type": "span",
+        "marks": [],
+        "text": " words."
+      }
+    ],
+    "markDefs": [],
+    "style": "normal"
   }
 ]

--- a/packages/@sanity/block-tools/test/tests/converters/editorValueToBlocks/leafNode/index.ts
+++ b/packages/@sanity/block-tools/test/tests/converters/editorValueToBlocks/leafNode/index.ts
@@ -1,0 +1,8 @@
+import defaultSchema from '../../../../fixtures/defaultSchema'
+
+const blockContentType = defaultSchema.get('blogPost').fields.find(field => field.name === 'body')
+  .type
+
+export default (slateJsonToBlocks, input) => {
+  return slateJsonToBlocks(input, blockContentType)
+}

--- a/packages/@sanity/block-tools/test/tests/converters/editorValueToBlocks/leafNode/input.json
+++ b/packages/@sanity/block-tools/test/tests/converters/editorValueToBlocks/leafNode/input.json
@@ -1,0 +1,71 @@
+{
+  "object": "value",
+  "document": {
+    "object": "document",
+    "data": {},
+    "nodes": [
+      {
+        "object": "block",
+        "type": "contentBlock",
+        "data": {
+          "_type": "block",
+          "_key": "a7b5dedee2dc",
+          "style": "h1"
+        },
+        "nodes": [
+          {
+            "object": "text",
+            "leaves": [
+              {
+                "object": "leaf",
+                "text": "This is a ",
+                "marks": []
+              }
+            ]
+          },
+          {
+            "object": "text",
+            "leaves": [
+              {
+                "object": "leaf",
+                "text": "link",
+                "marks": [
+                  {
+                    "object": "mark",
+                    "type": "f939a1f16082",
+                    "data": {}
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "object": "inline",
+            "type": "span",
+            "data": {
+              "_key": "a7b5dedee2dc1",
+              "annotations": {
+                "link": {
+                  "_key": "f939a1f16082",
+                  "_type": "link",
+                  "href": "1234"
+                }
+              }
+            },
+            "nodes": []
+          },
+          {
+            "object": "text",
+            "leaves": [
+              {
+                "object": "leaf",
+                "text": " test",
+                "marks": []
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/@sanity/block-tools/test/tests/converters/editorValueToBlocks/leafNode/output.json
+++ b/packages/@sanity/block-tools/test/tests/converters/editorValueToBlocks/leafNode/output.json
@@ -1,0 +1,16 @@
+[
+  {
+    "_key": "randomKey0",
+    "_type": "block",
+    "children": [
+      {
+        "_key": "randomKey00",
+        "_type": "span",
+        "marks": [],
+        "text": "This is a link test"
+      }
+    ],
+    "markDefs": [],
+    "style": "h1"
+  }
+]

--- a/packages/@sanity/form-builder/test/patching/blocks/tests/operationsToPatches/removeLink/input.json
+++ b/packages/@sanity/form-builder/test/patching/blocks/tests/operationsToPatches/removeLink/input.json
@@ -1,0 +1,36 @@
+[
+  {
+    "_key": "a7b5dedee2dc",
+    "_type": "block",
+    "children": [
+      {
+        "_key": "a7b5dedee2dc0",
+        "_type": "span",
+        "marks": [],
+        "text": "This is a "
+      },
+      {
+        "_key": "a7b5dedee2dc1",
+        "_type": "span",
+        "marks": [
+          "f939a1f16082"
+        ],
+        "text": "link"
+      },
+      {
+        "_key": "a7b5dedee2dc2",
+        "_type": "span",
+        "marks": [],
+        "text": " test"
+      }
+    ],
+    "markDefs": [
+      {
+        "_key": "f939a1f16082",
+        "_type": "link",
+        "href": "1234"
+      }
+    ],
+    "style": "h1"
+  }
+]

--- a/packages/@sanity/form-builder/test/patching/blocks/tests/operationsToPatches/removeLink/operations.json
+++ b/packages/@sanity/form-builder/test/patching/blocks/tests/operationsToPatches/removeLink/operations.json
@@ -1,0 +1,41 @@
+[
+  {
+    "object": "operation",
+    "type": "set_selection",
+    "properties": {
+      "anchor": {
+        "object": "point",
+        "offset": 2,
+        "path": [
+          0,
+          1,
+          0
+        ]
+      },
+      "focus": {
+        "object": "point",
+        "offset": 2,
+        "path": [
+          0,
+          1,
+          0
+        ]
+      }
+    },
+    "data": {}
+  },
+  {
+    "object": "operation",
+    "type": "move_node",
+    "path": [
+      0,
+      1,
+      0
+    ],
+    "newPath": [
+      0,
+      1
+    ],
+    "data": {}
+  }
+]


### PR DESCRIPTION
This will a couple of HTML deserialization and PT normalization issues.

* Keep space between links https://github.com/sanity-io/sanity/issues/1493
* Remove leftover markDefs (https://github.com/sanity-io/sanity-priv/issues/1632)
* Fix bug where trailing text after an annotation got lost in the remove link operation.