### PR TITLE
Normalize decorators

### DIFF
--- a/packages/@sanity/block-tools/README.md
+++ b/packages/@sanity/block-tools/README.md
@@ -164,7 +164,7 @@ const partialBlock = {
     }
   ]
 }
-normalizeBlock(partialBlock, {decorators: ['strong']})
+normalizeBlock(partialBlock, {alowedDecorators: ['strong']})
 ```
 Will produce
 ```

--- a/packages/@sanity/block-tools/README.md
+++ b/packages/@sanity/block-tools/README.md
@@ -149,7 +149,7 @@ blockTools.htmlToBlocks(
 
 ```
 
-### ``normalizeBlock(block, [decoratorMarks])``
+### ``normalizeBlock(block, [options={}])``
 Normalize a block object structure to make sure it has what it needs.
 
 ```js
@@ -164,7 +164,7 @@ const partialBlock = {
     }
   ]
 }
-normalizeBlock(partialBlock, ['strong'])
+normalizeBlock(partialBlock, {decorators: ['strong']})
 ```
 Will produce
 ```

--- a/packages/@sanity/block-tools/README.md
+++ b/packages/@sanity/block-tools/README.md
@@ -149,7 +149,7 @@ blockTools.htmlToBlocks(
 
 ```
 
-### ``normalizeBlock(block)``
+### ``normalizeBlock(block, [decoratorMarks])``
 Normalize a block object structure to make sure it has what it needs.
 
 ```js
@@ -159,11 +159,12 @@ const partialBlock = {
   children: [
     {
       _type: 'span',
-      text: 'Foobar'
+      text: 'Foobar',
+      marks: ['strong', 'df324e2qwe']
     }
   ]
 }
-normalizeBlock(partialBlock)
+normalizeBlock(partialBlock, ['strong'])
 ```
 Will produce
 ```
@@ -174,7 +175,7 @@ Will produce
     {
       _key: 'randomKey00',
       _type: 'span',
-      marks: [],
+      marks: ['strong'],
       text: 'Foobar'
     }
   ],

--- a/packages/@sanity/block-tools/changelog.md
+++ b/packages/@sanity/block-tools/changelog.md
@@ -1,1 +1,3 @@
 2018-12-13:  BREAKING: Changed params for `htmlToBlocks` from `(html, options={blockContentType})` to `(html, blockContentType, options={}` as blockContentType is now required.
+
+2019-10-16: `normalizeBlock` now takes a second parameter `options`. You can send in `options.decorators` which are the allowed decorator names. If you send in this, `normalizeBlock` will remove any span marks that are neither a decorator or exists in `block.markDefs`.

--- a/packages/@sanity/block-tools/src/converters/blocksToEditorValue.ts
+++ b/packages/@sanity/block-tools/src/converters/blocksToEditorValue.ts
@@ -134,7 +134,9 @@ function sanityBlockToRawNode(sanityBlock, blockContentFeatures, options: any = 
         : [EMPTY_TEXT_NODE]
   }
   if (options.normalize) {
-    return normalizeBlock(block)
+    return normalizeBlock(block, {
+      decorators: blockContentFeatures.decorators.map(decorator => decorator.value)
+    })
   }
   return block
 }

--- a/packages/@sanity/block-tools/src/converters/blocksToEditorValue.ts
+++ b/packages/@sanity/block-tools/src/converters/blocksToEditorValue.ts
@@ -135,7 +135,7 @@ function sanityBlockToRawNode(sanityBlock, blockContentFeatures, options: any = 
   }
   if (options.normalize) {
     return normalizeBlock(block, {
-      decorators: blockContentFeatures.decorators.map(decorator => decorator.value)
+      allowedDecorators: blockContentFeatures.decorators.map(decorator => decorator.value)
     })
   }
   return block

--- a/packages/@sanity/block-tools/src/converters/editorValueToBlocks.ts
+++ b/packages/@sanity/block-tools/src/converters/editorValueToBlocks.ts
@@ -124,5 +124,9 @@ export default function editorValueToBlocks(value, type, options = {}) {
   return nodes
     .map(node => toSanityBlock(node, blockContentFeatures, options))
     .filter(Boolean)
-    .map(normalizeBlock)
+    .map(block =>
+      normalizeBlock(block, {
+        decorators: blockContentFeatures.decorators.map(decorator => decorator.value)
+      })
+    )
 }

--- a/packages/@sanity/block-tools/src/converters/editorValueToBlocks.ts
+++ b/packages/@sanity/block-tools/src/converters/editorValueToBlocks.ts
@@ -126,7 +126,7 @@ export default function editorValueToBlocks(value, type, options = {}) {
     .filter(Boolean)
     .map(block =>
       normalizeBlock(block, {
-        decorators: blockContentFeatures.decorators.map(decorator => decorator.value)
+        allowedDecorators: blockContentFeatures.decorators.map(decorator => decorator.value)
       })
     )
 }

--- a/packages/@sanity/block-tools/src/util/normalizeBlock.ts
+++ b/packages/@sanity/block-tools/src/util/normalizeBlock.ts
@@ -2,7 +2,7 @@ import {isEqual} from 'lodash'
 import randomKey from './randomKey'
 
 // For a block with _type 'block' (text), join spans where possible
-export default function normalizeBlock(block) {
+export default function normalizeBlock(block, options: {decorators?: string[]} = {}) {
   let newIndex = 0
   if (!block._key) {
     block._key = randomKey(12)
@@ -30,6 +30,11 @@ export default function normalizeBlock(block) {
     return block
   }
   let usedMarkDefs = []
+  const allowedDecorators =
+    options.decorators &&
+    Array.isArray(options.decorators) &&
+    options.decorators.length > 0 &&
+    options.decorators
   block.children = block.children
     .reduce((acc, child) => {
       const previousChild = acc.slice(-1)[0]
@@ -52,6 +57,12 @@ export default function normalizeBlock(block) {
       child._key = `${block._key}${newIndex++}`
       if (child._type === 'span' && !child.marks) {
         child.marks = []
+      }
+      if (allowedDecorators && child._type === 'span') {
+        child.marks = child.marks.filter(
+          mark =>
+            allowedDecorators.includes(mark) || block.markDefs.map(def => def._key).includes(mark)
+        )
       }
       usedMarkDefs = usedMarkDefs.concat(child.marks)
       return child

--- a/packages/@sanity/block-tools/src/util/normalizeBlock.ts
+++ b/packages/@sanity/block-tools/src/util/normalizeBlock.ts
@@ -2,7 +2,7 @@ import {isEqual} from 'lodash'
 import randomKey from './randomKey'
 
 // For a block with _type 'block' (text), join spans where possible
-export default function normalizeBlock(block, options: {decorators?: string[]} = {}) {
+export default function normalizeBlock(block, options: {allowedDecorators?: string[]} = {}) {
   let newIndex = 0
   if (!block._key) {
     block._key = randomKey(12)
@@ -31,10 +31,9 @@ export default function normalizeBlock(block, options: {decorators?: string[]} =
   }
   let usedMarkDefs = []
   const allowedDecorators =
-    options.decorators &&
-    Array.isArray(options.decorators) &&
-    options.decorators.length > 0 &&
-    options.decorators
+    options.allowedDecorators &&
+    Array.isArray(options.allowedDecorators) &&
+    options.allowedDecorators
   block.children = block.children
     .reduce((acc, child) => {
       const previousChild = acc.slice(-1)[0]
@@ -60,8 +59,7 @@ export default function normalizeBlock(block, options: {decorators?: string[]} =
       }
       if (allowedDecorators && child._type === 'span') {
         child.marks = child.marks.filter(
-          mark =>
-            allowedDecorators.includes(mark) || block.markDefs.map(def => def._key).includes(mark)
+          mark => allowedDecorators.includes(mark) || block.markDefs.find(def => def._key)
         )
       }
       usedMarkDefs = usedMarkDefs.concat(child.marks)

--- a/packages/@sanity/block-tools/test/tests/util/normalizeBlock.test.ts
+++ b/packages/@sanity/block-tools/test/tests/util/normalizeBlock.test.ts
@@ -5,14 +5,32 @@ describe('normalizeBlock', () => {
   it('will normalize a block', () => {
     const block = {
       _type: 'block',
+      markDefs: [{
+        _key: '123123',
+        something: 'bogus'
+      }],
       children: [
         {
           _type: 'span',
-          text: 'Foobar'
+          text: 'Foobar',
+          marks: ['lala']
         }
       ]
     }
     assert.deepEqual(normalizeBlock(block), {
+      _key: 'randomKey0',
+      _type: 'block',
+      children: [
+        {
+          _key: 'randomKey00',
+          _type: 'span',
+          marks: ['lala'],
+          text: 'Foobar'
+        }
+      ],
+      markDefs: []
+    })
+    assert.deepEqual(normalizeBlock(block, {decorators: ['strong']}), {
       _key: 'randomKey0',
       _type: 'block',
       children: [

--- a/packages/@sanity/block-tools/test/tests/util/normalizeBlock.test.ts
+++ b/packages/@sanity/block-tools/test/tests/util/normalizeBlock.test.ts
@@ -30,7 +30,7 @@ describe('normalizeBlock', () => {
       ],
       markDefs: []
     })
-    assert.deepEqual(normalizeBlock(block, {decorators: ['strong']}), {
+    assert.deepEqual(normalizeBlock(block, {allowedDecorators: ['strong']}), {
       _key: 'randomKey0',
       _type: 'block',
       children: [

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/BlockExtrasOverlay.tsx
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/BlockExtrasOverlay.tsx
@@ -4,6 +4,7 @@ import BlockExtras from 'part:@sanity/form-builder/input/block-editor/block-extr
 import PatchEvent from '../../../PatchEvent'
 import createBlockActionPatchFn from './utils/createBlockActionPatchFn'
 import {
+  BlockContentFeatures,
   Marker,
   FormBuilderValue,
   SlateEditor,
@@ -15,6 +16,7 @@ import {
 import {Path} from '../../typedefs/path'
 import {getKey} from './utils/getKey'
 type Props = {
+  blockContentFeatures: BlockContentFeatures
   editor: SlateEditor | null
   editorValue: SlateValue | null
   fullscreen: boolean
@@ -59,6 +61,7 @@ export default class BlockExtrasOverlay extends React.Component<Props, State> {
   // eslint-disable-next-line complexity
   renderBlockExtras = (node: SlateNode) => {
     const {
+      blockContentFeatures,
       onFocus,
       renderCustomMarkers,
       renderBlockActions,
@@ -89,9 +92,9 @@ export default class BlockExtrasOverlay extends React.Component<Props, State> {
           <RenderComponent
             block={block}
             value={value}
-            set={createBlockActionPatchFn('set', block, onPatch)}
-            unset={createBlockActionPatchFn('unset', block, onPatch)}
-            insert={createBlockActionPatchFn('insert', block, onPatch)}
+            set={createBlockActionPatchFn('set', block, onPatch, blockContentFeatures)}
+            unset={createBlockActionPatchFn('unset', block, onPatch, blockContentFeatures)}
+            insert={createBlockActionPatchFn('insert', block, onPatch, blockContentFeatures)}
           />
         )
       }

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Editor.tsx
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Editor.tsx
@@ -481,6 +481,7 @@ export default class Editor extends React.Component<Props, {}> {
   }
   render() {
     const {
+      blockContentFeatures,
       editorValue,
       fullscreen,
       markers,
@@ -526,6 +527,7 @@ export default class Editor extends React.Component<Props, {}> {
         />
         <div className={styles.blockExtras}>
           <BlockExtrasOverlay
+            blockContentFeatures={blockContentFeatures}
             fullscreen={fullscreen}
             editor={this.editor}
             editorValue={editorValue}

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createBlockActionPatchFn.ts
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createBlockActionPatchFn.ts
@@ -1,22 +1,37 @@
-import {FormBuilderValue, Block} from '../typeDefs'
+import {FormBuilderValue, Block, BlockContentFeatures} from '../typeDefs'
 import PatchEvent, {insert, unset, set} from '../../../../PatchEvent'
 import {normalizeBlock} from '@sanity/block-tools'
 
 export default function createBlockActionPatchFn(
   type: string,
   block: FormBuilderValue,
-  onPatch: (arg0: PatchEvent) => void
+  onPatch: (arg0: PatchEvent) => void,
+  blockContentFeatures: BlockContentFeatures
 ) {
   let toInsert
   return (givenBlock: Block) => {
+    const decorators = blockContentFeatures.decorators.map(item => item.value)
     switch (type) {
       case 'set':
-        return onPatch(PatchEvent.from(set(normalizeBlock(givenBlock), [{_key: block._key}])))
+        return onPatch(
+          PatchEvent.from(
+            set(
+              normalizeBlock(givenBlock, {
+                decorators
+              }),
+              [{_key: block._key}]
+            )
+          )
+        )
       case 'unset':
         return onPatch(PatchEvent.from(unset([{_key: block._key}])))
       case 'insert':
         toInsert = Array.isArray(givenBlock) ? givenBlock : [givenBlock]
-        toInsert = toInsert.map(blk => normalizeBlock(blk))
+        toInsert = toInsert.map(blk =>
+          normalizeBlock(blk, {
+            decorators
+          })
+        )
         return onPatch(PatchEvent.from(insert(toInsert, 'after', [{_key: block._key}])))
       default:
         throw new Error(`Patch type ${type} not supported`)

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createBlockActionPatchFn.ts
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createBlockActionPatchFn.ts
@@ -10,14 +10,14 @@ export default function createBlockActionPatchFn(
 ) {
   let toInsert
   return (givenBlock: Block) => {
-    const decorators = blockContentFeatures.decorators.map(item => item.value)
+    const allowedDecorators = blockContentFeatures.decorators.map(item => item.value)
     switch (type) {
       case 'set':
         return onPatch(
           PatchEvent.from(
             set(
               normalizeBlock(givenBlock, {
-                decorators
+                allowedDecorators
               }),
               [{_key: block._key}]
             )
@@ -29,7 +29,7 @@ export default function createBlockActionPatchFn(
         toInsert = Array.isArray(givenBlock) ? givenBlock : [givenBlock]
         toInsert = toInsert.map(blk =>
           normalizeBlock(blk, {
-            decorators
+            allowedDecorators
           })
         )
         return onPatch(PatchEvent.from(insert(toInsert, 'after', [{_key: block._key}])))

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createEmptyBlock.ts
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createEmptyBlock.ts
@@ -21,6 +21,6 @@ export default function createEmptyBlock(blockContentFeatures, options: Opts = {
     ],
     style: options.style || 'normal'
   }
-  const decorators = blockContentFeatures.decorators.map(item => item.value)
-  return deserialize([normalizeBlock(raw, {decorators})], blockContentFeatures.types.block).document.nodes.first()
+  const allowedDecorators = blockContentFeatures.decorators.map(item => item.value)
+  return deserialize([normalizeBlock(raw, {allowedDecorators})], blockContentFeatures.types.block).document.nodes.first()
 }

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createEmptyBlock.ts
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/utils/createEmptyBlock.ts
@@ -21,5 +21,6 @@ export default function createEmptyBlock(blockContentFeatures, options: Opts = {
     ],
     style: options.style || 'normal'
   }
-  return deserialize([normalizeBlock(raw)], blockContentFeatures.types.block).document.nodes.first()
+  const decorators = blockContentFeatures.decorators.map(item => item.value)
+  return deserialize([normalizeBlock(raw, {decorators})], blockContentFeatures.types.block).document.nodes.first()
 }


### PR DESCRIPTION
The block normalization function should normalize span marks and remove those who aren't allowed by the schema. This includes both decorator marks and annotation marks.

In order to differentiate between decorator marks and annotation marks, we need to know which decorator names are allowed in the schema.

Fixes https://github.com/sanity-io/sanity-priv/issues/1632