### PR TITLE
[code-input] bugfix: Support groq and fallback in preview

### DIFF
--- a/packages/@sanity/code-input/src/CodeInput.js
+++ b/packages/@sanity/code-input/src/CodeInput.js
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types'
 import AceEditor from 'react-ace'
 import {get, has} from 'lodash'
 import {PatchEvent, set, insert, unset, setIfMissing} from 'part:@sanity/form-builder/patch-event'
-import styles from './CodeInput.css'
 import FormField from 'part:@sanity/components/formfields/default'
 import Fieldset from 'part:@sanity/components/fieldsets/default'
 import DefaultSelect from 'part:@sanity/components/selects/default'
 import TextInput from 'part:@sanity/components/textinputs/default'
 import createHighlightMarkers from './createHighlightMarkers'
+import styles from './CodeInput.css'
+
 import {
   LANGUAGE_ALIASES,
   ACE_EDITOR_PROPS,
@@ -84,7 +85,8 @@ export default class CodeInput extends PureComponent {
   }
 
   static defaultProps = {
-    onChange() {}
+    onChange() {},
+    value: undefined
   }
 
   focus() {
@@ -232,11 +234,11 @@ export default class CodeInput extends PureComponent {
   renderEditor = () => {
     const {value, type} = this.props
     const fixedLanguage = get(type, 'options.language')
-    const language = isSupportedLanguage((value && value.language) || fixedLanguage) || 'text'
+    const mode = isSupportedLanguage((value && value.language) || fixedLanguage) || 'text'
     return (
       <AceEditor
         className={styles.aceEditor}
-        mode={language}
+        mode={mode}
         theme={this.getTheme()}
         width="100%"
         onChange={this.handleCodeChange}

--- a/packages/@sanity/code-input/src/PreviewCode.css
+++ b/packages/@sanity/code-input/src/PreviewCode.css
@@ -12,6 +12,7 @@
   cursor: default;
   background-color: #272822;
   padding: 1rem;
+  pointer-events: none;
 }
 
 .aceWrapper :global(.ace_content) {

--- a/packages/@sanity/code-input/src/PreviewCode.js
+++ b/packages/@sanity/code-input/src/PreviewCode.js
@@ -22,15 +22,29 @@ import 'brace/theme/github'
 import 'brace/theme/monokai'
 import 'brace/theme/terminal'
 import 'brace/theme/tomorrow'
+import './groq'
 /* eslint-enable import/no-unassigned-import */
 
-import {SUPPORTED_LANGUAGES, ACE_EDITOR_PROPS, ACE_SET_OPTIONS} from './config'
+import {SUPPORTED_LANGUAGES, LANGUAGE_ALIASES, ACE_EDITOR_PROPS, ACE_SET_OPTIONS} from './config'
 import createHighlightMarkers from './createHighlightMarkers'
+
+function isSupportedLanguage(mode) {
+  const alias = LANGUAGE_ALIASES[mode]
+  if (alias) {
+    return alias
+  }
+
+  const isSupported = SUPPORTED_LANGUAGES.find(lang => lang.value === mode)
+  if (isSupported) {
+    return mode
+  }
+
+  return false
+}
 
 export default class PreviewCode extends PureComponent {
   static propTypes = {
     type: PropTypes.object,
-    layout: PropTypes.string,
     value: PropTypes.shape({
       _type: PropTypes.string,
       code: PropTypes.string,
@@ -53,14 +67,17 @@ export default class PreviewCode extends PureComponent {
   render() {
     const {value, type} = this.props
     const fixedLanguage = get(type, 'options.language')
+    const mode = isSupportedLanguage((value && value.language) || fixedLanguage) || 'text'
     return (
       <div className={styles.root}>
         <div className={styles.aceWrapper}>
           <AceEditor
             ref={this.ace}
-            mode={(value && value.language) || fixedLanguage || 'text'}
+            focus={false}
+            mode={mode}
             theme="monokai"
             width="100%"
+            onChange={() => undefined}
             height={null}
             maxLines={200}
             readOnly


### PR DESCRIPTION
- Fixes an issue where the code input preview tried to load an JS file that does not exist.
- Minor linting fixes
- pointer-events: none on the ace editor in preview, to prevent ace from triggering edits. Also makes it easier to drag the block around
