### PR TITLE
[form-builder] prevent slate-react built in scrolling

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/plugins/OnFocusPlugin.ts
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/plugins/OnFocusPlugin.ts
@@ -1,13 +1,22 @@
 // This plugin runs when the editor receives focus
 // Ensures that an empty block is inserted when the editor gets focus and it's empty.
 
+// It also prevents default onFocus actions in slate-react being triggered as we
+// abort the plugin chain. The version of slate-react we are currently using (0.21.16)
+// has a terrible scrolling bug which will be prevented by canceling the plugin chain here.
+
+// TODO: remove this and continue once we have upgraded slate-react
+// (where the bug is fixed - see https://github.com/ianstormtaylor/slate/commit/d28f78c0607ad147f85ff4a363fa65d7ddfa7c8c)
+
 import {SlateEditor} from '../typeDefs'
 
 export default function OnFocusPlugin() {
   return {
     onFocus(event: any, editor: SlateEditor, next: (arg0: void) => void) {
       editor.command('ensurePlaceHolderBlock')
-      return next()
+      editor.focus()
+      // Cancel slate-react's 'after' plugin chain to prevent built in scrolling bug.
+      return true
     }
   }
 }


### PR DESCRIPTION
There is a very annoying bug in the version of `slate-react` we are using that tries to scroll to focus in invalid situations. Typically where focus is set programatically. By aborting the `onFocus` plugin chain the built in onFocus functions in `slate-react` doesn't kick in.

This was recently fixed in `slate-react`: https://github.com/ianstormtaylor/slate/pull/3019 and we should upgrade the Slate version when time.

I'm still not 100% certain where we are in the plugin chain by setting onFocus as prop on the component, as opposed to the `onFocus` plugins we are running ourselves  *This needs to be checked up upon before merging.*

<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

**Note for release**

Fix portable text editor scroll bug where the editor scrolled to top after acquiring focus.

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

**Checklist** 

- [x ]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [x]  Corresponding changes to the documentation have been made
