### PR TITLE
Add installation instructions for Google Maps plugin

### DIFF
--- a/packages/@sanity/google-maps-input/README.md
+++ b/packages/@sanity/google-maps-input/README.md
@@ -1,10 +1,21 @@
 # @sanity/google-maps-input
 
-Sanity plugin providing input handlers for geo-related input types using Google Maps
+Plugin for [Sanity Studio](https://www.sanity.io) providing input handlers for geo-related input types using Google Maps.
+
+## Installation
+
+In your studio folder, run:
+
+```
+sanity install @sanity/google-maps-input
+```
+
+Then add a valid [Google Maps API key](https://developers.google.com/maps/documentation/javascript/get-api-key) into ``./example/config/@sanity/google-maps-input.json``.
+
+## Stuck? Get help
+
+[![Slack Community Button](https://slack.sanity.io/badge.svg)](https://slack.sanity.io/)
+
+Join [Sanity’s developer community](https://slack.sanity.io) or ping us [on twitter](https://twitter.com/sanity_io).
 
 
-## Example app
-
-First write a valid Google Maps API key into ``./example/config/@sanity/google-maps-input.json`` 
-
-Then ``npm start``


### PR DESCRIPTION
**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->

**Description**

This improves the README.md of the Google Maps input plugin with installation instructions, and to get the API key.

**Note for release**

This PR adds more helpful instructions for how to use this plugin.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [ ]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [x]  Corresponding changes to the documentation have been made
