### PR TITLE
[structure] Improve type inference from filters

### DIFF
--- a/packages/@sanity/structure/src/GenericList.ts
+++ b/packages/@sanity/structure/src/GenericList.ts
@@ -48,6 +48,7 @@ export interface GenericListInput extends StructureNode {
   title: string
   menuItems?: (MenuItem | MenuItemBuilder)[]
   menuItemGroups?: (MenuItemGroup | MenuItemGroupBuilder)[]
+  initialValueTemplates?: (InitialValueTemplateItem | InitialValueTemplateItemBuilder)[]
   defaultLayout?: Layout
   canHandleIntent?: IntentChecker
   child?: Child
@@ -55,6 +56,7 @@ export interface GenericListInput extends StructureNode {
 
 export abstract class GenericListBuilder<L extends BuildableGenericList, ConcreteImpl>
   implements Serializable {
+  protected initialValueTemplatesSpecified = false
   protected spec: L = {} as L
 
   id(id: string) {
@@ -124,6 +126,7 @@ export abstract class GenericListBuilder<L extends BuildableGenericList, Concret
   }
 
   initialValueTemplates(templates: InitialValueTemplateItem | InitialValueTemplateItem[]) {
+    this.initialValueTemplatesSpecified = true
     return this.clone({initialValueTemplates: Array.isArray(templates) ? templates : [templates]})
   }
 

--- a/packages/@sanity/structure/src/Intent.ts
+++ b/packages/@sanity/structure/src/Intent.ts
@@ -1,4 +1,4 @@
-import {PartialDocumentList, getTypeNameFromSingleTypeFilter} from './DocumentList'
+import {PartialDocumentList, getTypeNamesFromFilter} from './DocumentList'
 import {StructureNode} from './StructureNodes'
 
 type JsonParams = {[key: string]: any}
@@ -29,8 +29,9 @@ export const defaultIntentChecker: IntentChecker = (intentName, params, {pane}):
   const typedSpec = pane as PartialDocumentList
   const paneFilter = (typedSpec.options && typedSpec.options.filter) || ''
   const paneParams = (typedSpec.options && typedSpec.options.params) || {}
-  const typeName =
-    typedSpec.schemaTypeName || getTypeNameFromSingleTypeFilter(paneFilter, paneParams)
+  const typeNames = typedSpec.schemaTypeName
+    ? [typedSpec.schemaTypeName]
+    : getTypeNamesFromFilter(paneFilter, paneParams)
 
   const initialValueTemplates = typedSpec.initialValueTemplates || []
 
@@ -38,7 +39,10 @@ export const defaultIntentChecker: IntentChecker = (intentName, params, {pane}):
     return initialValueTemplates.some(tpl => tpl.templateId === params.template)
   }
 
-  return (isEdit && params.id && params.type === typeName) || (isCreate && params.type === typeName)
+  return (
+    (isEdit && params.id && typeNames.includes(params.type)) ||
+    (isCreate && typeNames.includes(params.type))
+  )
 }
 
 defaultIntentChecker.identity = DEFAULT_INTENT_HANDLER

--- a/packages/@sanity/structure/src/List.ts
+++ b/packages/@sanity/structure/src/List.ts
@@ -87,6 +87,7 @@ export class ListBuilder extends GenericListBuilder<BuildableList, ListBuilder> 
   constructor(spec?: ListInput) {
     super()
     this.spec = spec ? spec : {}
+    this.initialValueTemplatesSpecified = Boolean(spec && spec.initialValueTemplates)
   }
 
   items(items: (ListItemBuilder | ListItem | Divider)[]): ListBuilder {

--- a/packages/@sanity/structure/test/__snapshots__/documentTypeListItems.test.ts.snap
+++ b/packages/@sanity/structure/test/__snapshots__/documentTypeListItems.test.ts.snap
@@ -4,6 +4,7 @@ exports[`generates correct document type list item for specific type 1`] = `
 ListItemBuilder {
   "spec": Object {
     "child": DocumentTypeListBuilder {
+      "initialValueTemplatesSpecified": false,
       "spec": Object {
         "canHandleIntent": [Function],
         "child": [Function],
@@ -145,6 +146,7 @@ exports[`generates correct document type list item for specific type 2`] = `
 ListItemBuilder {
   "spec": Object {
     "child": DocumentTypeListBuilder {
+      "initialValueTemplatesSpecified": false,
       "spec": Object {
         "canHandleIntent": [Function],
         "child": [Function],
@@ -287,6 +289,7 @@ Array [
   ListItemBuilder {
     "spec": Object {
       "child": DocumentTypeListBuilder {
+        "initialValueTemplatesSpecified": false,
         "spec": Object {
           "canHandleIntent": [Function],
           "child": [Function],
@@ -425,6 +428,7 @@ Array [
   ListItemBuilder {
     "spec": Object {
       "child": DocumentTypeListBuilder {
+        "initialValueTemplatesSpecified": false,
         "spec": Object {
           "canHandleIntent": [Function],
           "child": [Function],
@@ -688,6 +692,7 @@ Array [
   ListItemBuilder {
     "spec": Object {
       "child": DocumentTypeListBuilder {
+        "initialValueTemplatesSpecified": false,
         "spec": Object {
           "canHandleIntent": [Function],
           "child": [Function],
@@ -826,6 +831,7 @@ Array [
   ListItemBuilder {
     "spec": Object {
       "child": DocumentTypeListBuilder {
+        "initialValueTemplatesSpecified": false,
         "spec": Object {
           "canHandleIntent": [Function],
           "child": [Function],


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

When you use filters for document lists such as `_type in [$foo]`, the inferring of schema type fails, which makes intent handlers fail to recognize they can handle the intent, as well as initial value templates from appearing automatically. 

**Description**

This PR picks up on  type filters using the `in` operator, and also expands to match all specified types. This enables document lists with filters such as  `_type == "foo" || _type == "bar"` to pick up initial value templates from both `foo` and  `bar`, as well as allowing both schema types to be recognized by the intent handler. 

Fixes #1567 

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

Improve type inference for document list filters

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
