### PR TITLE
[base, schema] Added support for exact number searching

### DIFF
--- a/packages/@sanity/base/src/search/weighted/createWeightedSearch.js
+++ b/packages/@sanity/base/src/search/weighted/createWeightedSearch.js
@@ -1,32 +1,72 @@
 import {map} from 'rxjs/operators'
-import {joinPath} from '../../util/searchUtils'
+import {joinPath, getMatchingOperatorForType, getTypedTermValue, getUsedTermTypes} from '../../util/searchUtils'
 import {compact, toLower, flatten, uniq, flow, sortBy, union} from 'lodash'
 import {removeDupes} from '../../util/draftUtils'
 import {applyWeights} from './applyWeights'
 import {tokenize} from '../common/tokenize'
 
 const combinePaths = flow([flatten, union, compact])
+const combineTermTypes = flow([flatten, uniq])
 
-const toGroqParams = terms =>
+// "t" is short for term
+const typedTerm = (term, type) => `t${term}${type.charAt(0)}`
+
+const toGroqParams = (terms, termTypes) =>
   terms.reduce((acc, term, i) => {
-    acc[`t${i}`] = `${term}*` // "t" is short for term
+    termTypes[term].forEach(type => {
+      acc[typedTerm(i, type)] = getTypedTermValue(term, type)
+    })
     return acc
   }, {})
 
 export function createWeightedSearch(types, client) {
-  const searchSpec = types.map(type => {
-    return {
-      typeName: type.name,
-      paths: type.__experimental_search.map(config => ({
+  const searchSpec = []
+  const operatorMap = {}
+
+  types.forEach(type => {
+    const typePaths = []
+
+    // Extract operators and add path to spec
+    type.__experimental_search.forEach(config => {
+      const path = joinPath(config.path)
+      const valueType = config.type || 'string'
+
+      if (!(path in operatorMap)) {
+        operatorMap[path] = []
+      }
+
+      const operator = getMatchingOperatorForType(valueType)
+
+      // Add operator for path and guard against duplicates
+      if (!operatorMap[path].some(o => o.type === valueType && o.operator === operator)) {
+        operatorMap[path].push({type: valueType, operator})
+      }
+
+      // Add path to spec
+      typePaths.push({
         weight: config.weight,
-        path: joinPath(config.path)
-      }))
-    }
+        path
+      })
+    })
+
+    // Commit spec
+    searchSpec.push({
+      typeName: type.name,
+      paths: typePaths
+    })
   })
 
   const combinedSearchPaths = combinePaths(
     searchSpec.map(configForType => configForType.paths.map(opt => opt.path))
   )
+
+  const searchPathsWithOptions = combinedSearchPaths.reduce((accumulation, joinedPath) => {
+    operatorMap[joinedPath].forEach(operator => accumulation.push({joinedPath, ...operator}))
+    return accumulation
+  }, [])
+  
+  // Collect all types available to search
+  const termTypes = combineTermTypes(Object.keys(operatorMap).map(path => operatorMap[path].map(operator => operator.type)))
 
   const selections = searchSpec.map(
     spec => `_type == "${spec.typeName}" => {${spec.paths.map((cfg, i) => `"w${i}": ${cfg.path}`)}}`
@@ -35,8 +75,13 @@ export function createWeightedSearch(types, client) {
   // this is the actual search function that takes the search string and returns the hits
   return function search(queryString, opts = {}) {
     const terms = uniq(compact(tokenize(toLower(queryString))))
+    const usedTermTypes = getUsedTermTypes(terms, termTypes)
     const constraints = terms
-      .map((term, i) => combinedSearchPaths.map(joinedPath => `${joinedPath} match $t${i}`))
+      .map((term, i) =>
+        searchPathsWithOptions
+          .filter(({ type }) => usedTermTypes[term].includes(type))
+          .map(({joinedPath, operator, type}) => `${joinedPath} ${operator} $${typedTerm(i, type)}`)
+      )
       .filter(constraint => constraint.length > 0)
 
     const filters = [
@@ -50,7 +95,7 @@ export function createWeightedSearch(types, client) {
 
     return client.observable
       .fetch(query, {
-        ...toGroqParams(terms),
+        ...toGroqParams(terms, usedTermTypes),
         types: searchSpec.map(spec => spec.typeName),
         limit: 1000
       })

--- a/packages/@sanity/base/src/util/searchUtils.js
+++ b/packages/@sanity/base/src/util/searchUtils.js
@@ -1,4 +1,4 @@
-import { compact, difference } from 'lodash'
+import { compact } from 'lodash'
 
 const GROQ_KEYWORDS = ['match', 'in', 'asc', 'desc', 'true', 'false', 'null']
 const VALID_FIELD = /^[a-zA-Z_][a-zA-Z0-9_]*$/

--- a/packages/@sanity/base/src/util/searchUtils.js
+++ b/packages/@sanity/base/src/util/searchUtils.js
@@ -1,3 +1,5 @@
+import { compact, difference } from 'lodash'
+
 const GROQ_KEYWORDS = ['match', 'in', 'asc', 'desc', 'true', 'false', 'null']
 const VALID_FIELD = /^[a-zA-Z_][a-zA-Z0-9_]*$/
 
@@ -21,3 +23,30 @@ export const joinPath = pathArray =>
     }
     return isFirst ? pathSegment : `${prev}.${pathSegment}`
   }, '')
+
+export const getMatchingOperatorForType = type => {
+  switch (type) {
+    case 'number':
+      return '=='
+
+    default:
+      return 'match'
+  }
+}
+
+export const getTypedTermValue = (value, type) => {
+  switch (type) {
+    case 'number':
+      return parseFloat(value)
+
+    default:
+      return `${value}*`
+  }
+}
+
+export const getUsedTermTypes = (terms, types) => {
+  return terms.reduce((accumulation, term) => {
+    accumulation[term] = compact(types.map(type => !!getTypedTermValue(term, type) && type))
+    return accumulation
+  }, {})
+}

--- a/packages/@sanity/schema/src/legacy/resolveSearchConfig.ts
+++ b/packages/@sanity/schema/src/legacy/resolveSearchConfig.ts
@@ -31,7 +31,7 @@ function reduceObject(objectType, reducer, accumulator, path, maxDepth) {
   }, accumulator)
 }
 
-const BASE_WEIGHTS = [{weight: 1, path: ['_id']}, {weight: 1, path: ['_type']}]
+const BASE_WEIGHTS = [{weight: 1, path: ['_id'], type: 'string'}, {weight: 1, path: ['_type'], type: 'string'}]
 
 const PREVIEW_FIELD_WEIGHT_MAP = {
   title: 10,
@@ -45,7 +45,8 @@ function deriveFromPreview(type) {
     .filter(fieldName => fieldName in PREVIEW_FIELD_WEIGHT_MAP)
     .map(fieldName => ({
       weight: PREVIEW_FIELD_WEIGHT_MAP[fieldName],
-      path: select[fieldName].split('.')
+      path: select[fieldName].split('.'),
+      type: 'string'
     }))
 }
 
@@ -55,7 +56,7 @@ function getCachedStringFieldPaths(type, maxDepth) {
       [
         ...BASE_WEIGHTS,
         ...deriveFromPreview(type),
-        ...getStringFieldPaths(type, maxDepth).map(path => ({weight: 1, path}))
+        ...getStringFieldPaths(type, maxDepth).map(path => ({weight: 1, path, type: 'string'}))
       ],
       spec => spec.path.join('.')
     )

--- a/packages/@sanity/schema/src/legacy/types/object.ts
+++ b/packages/@sanity/schema/src/legacy/types/object.ts
@@ -31,14 +31,17 @@ const normalizeSearchConfig = configs => {
       return conf
     }
     if (!isPlainObject(conf)) {
-      throw new Error('Search config must be an object of {path: string, weight: number}')
+      throw new Error('Search config must be an object of {path: string, weight: number, type?: string}')
     }
     if (typeof conf.path !== 'string') {
       throw new Error('The path property of the search field declaration must be a string')
     }
     return {
       weight: 'weight' in conf ? conf.weight : 1,
-      path: toPath(conf.path)
+      path: toPath(conf.path),
+      // TODO: Warn-guard against unsupported types.
+      // TODO: Automagically infer type for path from schema?
+      type: conf.type || 'string'
     }
   })
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [x]  Yes
- [ ]  No

**Current behavior**

If numeric type is exposed to search (via `preview` or `__experimental_search`), there is no possibility to search for it, because by default, the search uses `match` operator, which works on strings only.

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

🔢 This PR adds partial support for exact number searches.

It is done by adding extra `type` parameter to `__experimental_search` specification which is then consumed by `createWeightedSearch` to change the search operator and provide the search term value accordingly.

Partial, because the type is also added to default search configuration (base and previews and strings), but it's currently hardcoded to string in all scenarios, to be backwards compatible with previous solution. Because otherwise, type inferring has to be setup.

⛲️ The design of the PR is such that there is already a foundation to support other types too.

📈 Currently the operator is inferred from the provided type, but the feature could be extended to also provide user-land configurable operator to use for the field.

🔬 It would also be possible to infer type from schema, but that's too much effort for now to support properly - so I have skipped it for now, adding a TODO pointer instead. This should be also built in for search setup that's being inferred from preview setup.

🧹 Search conditions and terms have been heavily sanitized so that they support string searching together with number. Otherwise GROQ error got thrown: `No function match() defined for arguments (float, string)`. That happened in cases when term for number would resolve to `null` in case a non-numeric term got provided.

I need this (and actually a lot more, but that appears to be impossible for now due to GROQ) for a customer project, that have LOADS of imported/generated documents, that are mostly referenced by numbers. Browsing for them is helluva slow, when one could simply search for the necessary entity by number/code. The number type is necessary for other filtering, so transforming the field to a string was not an option. This implementation, though, acts as a good enough MVP.

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

- Added exact search support for numeric fields via `type: number` specification
  - Document with:  
    ```
    __experimental_search: [{ weight: 5, path: 'numberField', type: 'number' }]
    ```
  - Will allow searches for:  
    ![Exact number now matches](https://user-images.githubusercontent.com/1030080/67910420-4ea56980-fb8b-11e9-9db5-47435d45a4a4.png)
  - INEXACT NUMBER, THOUGH, WON'T BE FOUND:  
    ![Inexact number still don't match](https://user-images.githubusercontent.com/1030080/67910467-7b598100-fb8b-11e9-82b4-571a84602ab9.png)


**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [ ]  The code is linted
- [ ]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
