### PR TITLE
[core] Deploy: use passed SOURCE_DIR even when building

### DIFF
--- a/packages/@sanity/preview/src/createPathObserver.ts
+++ b/packages/@sanity/preview/src/createPathObserver.ts
@@ -42,7 +42,7 @@ function observePaths(value: Value, paths: Path[], observeFields: ObserveFieldsF
     if (isReference(value) || isDocument(value)) {
       const id = isRef ? (value as Reference)._ref : (value as Document)._id
       return observeFields(id, nextHeads).pipe(
-        switchMap(snapshot => {
+        switchMap((snapshot: object | null) => {
           if (snapshot === null) {
             return observableOf(null)
           }


### PR DESCRIPTION
This fixes two issues:

1. `sanity deploy graphql` vs `sanity graphql deploy`. I can't see someone actually wanting to deploy a `graphql` directory, so I decided to just error out when specifying that.
2. `sanity deploy somedir` wouldn't actually use `somedir` unless `--no-build` was passed. Very confusing.