### PR TITLE
[cli] Require node version 8.6 or higher

### DIFF
--- a/packages/@sanity/cli/bin/sanity
+++ b/packages/@sanity/cli/bin/sanity
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-/* eslint-disable no-var, no-console, no-process-exit, prefer-template */
+/* eslint-disable no-var, no-console, no-process-exit, prefer-template, import/no-unassigned-import */
 /**
  * ┌────────────────┐
  * │                │
@@ -10,16 +10,15 @@
  */
 
 var err = '\u001b[31m\u001b[1mERROR:\u001b[22m\u001b[39m '
-var nodeVersion = Number(process.version.replace(/^v/i, '').split('.', 2)[0])
-if (nodeVersion < 8) {
-  console.error(err + 'Node.js version 8 or higher required. You are running ' + process.version)
-  console.error('')
-  process.exit(1)
-}
+var nodeVersionParts = process.version
+  .replace(/^v/i, '')
+  .split('.')
+  .map(Number)
 
-if (process.version === 'v8.1.0' || process.version === 'v8.1.1') {
-  console.error(err + 'Node.js v8.1.0 and v8.1.1 has a bug that prevents the Sanity CLI')
-  console.error('from receiving input. Please upgrade to a newer version of Node.js.')
+var majorVersion = nodeVersionParts[0]
+var minorVersion = nodeVersionParts[1]
+if (majorVersion < 8 || (majorVersion === 8 && minorVersion < 6)) {
+  console.error(err + 'Node.js version 8.6 or higher required. You are running ' + process.version)
   console.error('')
   process.exit(1)
 }
@@ -28,7 +27,7 @@ try {
   // Default, unpackaged version for development
   require('./entry')
   return
-} catch (err) {
+} catch (error) {
   // Probably in "production", flow through to pre-packaged
 }
 


### PR DESCRIPTION
Apparently some of our upstream dependencies have started using object rest spread, which is only supported in node 8.6 and higher. While we would ideally use a different dependency, it's getting progressively harder to find alternatives with a better engine support.

Given that node 8 will be out of maintenance in a month and a half, I feel like it's OK to raise the minimum version requirement to 8.6 or higher (we'll bump to v10 in January, I suspect). Thoughts?