### PR TITLE
[components] Spinner: Allow passing children instead of message

### DIFF
--- a/packages/@sanity/components/src/loading/Spinner.js
+++ b/packages/@sanity/components/src/loading/Spinner.js
@@ -10,15 +10,17 @@ export default class Spinner extends React.PureComponent {
     message: PropTypes.string,
     fullscreen: PropTypes.bool,
     center: PropTypes.bool,
+    children: PropTypes.node,
     delay: PropTypes.number // delay in ms
   }
 
   static defaultProps = {
-    delay: 300
+    delay: 300,
+    children: null
   }
 
   renderSpinner() {
-    const {inline, message, fullscreen, center, delay} = this.props
+    const {inline, message, fullscreen, center, delay, children} = this.props
     return (
       <div
         style={{animationDelay: `${delay}ms`}}
@@ -32,7 +34,8 @@ export default class Spinner extends React.PureComponent {
           <span className={styles.icon}>
             <SpinnerIcon />
           </span>
-          {message && <div className={styles.message}>{message}</div>}
+          {children}
+          {!children && message && <div className={styles.message}>{message}</div>}
         </div>
       </div>
     )

--- a/packages/@sanity/components/src/loading/story.js
+++ b/packages/@sanity/components/src/loading/story.js
@@ -2,6 +2,7 @@ import React from 'react'
 import {storiesOf} from 'part:@sanity/storybook'
 
 import Spinner from 'part:@sanity/components/loading/spinner'
+import styles from 'part:@sanity/components/loading/spinner-style'
 import AppLoadingScreen from 'part:@sanity/base/app-loading-screen'
 
 import {withKnobs, boolean, text} from 'part:@sanity/storybook/addons/knobs'
@@ -9,6 +10,15 @@ import Sanity from 'part:@sanity/storybook/addons/sanity'
 
 import CompanyLogo from 'part:@sanity/base/company-logo?'
 import SanityLogo from 'part:@sanity/base/sanity-logo'
+import SanityLogoIcon from 'part:@sanity/base/sanity-logo-icon'
+
+function renderCustomChildren() {
+  return (
+    <div className={styles.message}>
+      <SanityLogoIcon /> :wave:
+    </div>
+  )
+}
 
 storiesOf('Loading')
   .addDecorator(withKnobs)
@@ -20,7 +30,9 @@ storiesOf('Loading')
           message={text('Message', 'This is the message', 'props')}
           fullscreen={boolean('fullscreen', false, 'props')}
           center={boolean('center', false, 'props')}
-        />
+        >
+          {boolean('Custom children', false) && renderCustomChildren()}
+        </Spinner>
       </Sanity>
     )
   })


### PR DESCRIPTION
The `Spinner` component currently blindly renders `message`, but it does not accept anything but a string. I have a case where I want to render a message with `<strong>Some message</strong>`. Let me know if this is "bad behavior".