### PR TITLE
[components] Make snackbar items updateable

### DIFF
--- a/packages/@sanity/components/src/snackbar/DefaultSnackbar.js
+++ b/packages/@sanity/components/src/snackbar/DefaultSnackbar.js
@@ -7,6 +7,7 @@ export default class DefaultSnackbar extends React.PureComponent {
     title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     isPersisted: PropTypes.bool,
+    isCloseable: PropTypes.bool,
     children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     onClose: PropTypes.func,
     action: PropTypes.shape({
@@ -22,10 +23,15 @@ export default class DefaultSnackbar extends React.PureComponent {
 
   static contextTypes = {
     addToSnackQueue: PropTypes.func,
-    handleDismissSnack: PropTypes.func
+    handleDismissSnack: PropTypes.func,
+    updateSnack: PropTypes.func
   }
 
   componentDidMount() {
+    this.snackId = this.context.addToSnackQueue(this.getSnackOptions())
+  }
+
+  getSnackOptions() {
     const {
       action,
       actionTitle,
@@ -36,10 +42,11 @@ export default class DefaultSnackbar extends React.PureComponent {
       children,
       onClose,
       onAction,
-      isPersisted
+      isPersisted,
+      isCloseable
     } = this.props
 
-    this.snackId = this.context.addToSnackQueue({
+    return {
       kind,
       title,
       subtitle,
@@ -50,15 +57,20 @@ export default class DefaultSnackbar extends React.PureComponent {
         callback: onAction || (action && action.callback)
       },
       isPersisted,
+      isCloseable,
       autoDismissTimeout: timeout
-    })
+    }
   }
 
   componentWillUnmount() {
     this.context.handleDismissSnack(this.snackId)
   }
 
+  componentDidUpdate() {
+    this.context.updateSnack(this.snackId, this.getSnackOptions())
+  }
+
   render() {
-    return <div />
+    return null
   }
 }

--- a/packages/@sanity/components/src/snackbar/SnackbarProvider.js
+++ b/packages/@sanity/components/src/snackbar/SnackbarProvider.js
@@ -10,7 +10,8 @@ export default class SnackbarProvider extends React.Component {
 
   static childContextTypes = {
     addToSnackQueue: PropTypes.func,
-    handleDismissSnack: PropTypes.func
+    handleDismissSnack: PropTypes.func,
+    updateSnack: PropTypes.func
   }
 
   constructor(props, context) {
@@ -66,6 +67,19 @@ export default class SnackbarProvider extends React.Component {
     this.snackQueue.push(newSnack)
     this.handleMaxSnackDisplay()
     return newSnack.id
+  }
+
+  updateSnack = (snackId, contextSnack) => {
+    const indexInQueue = this.snackQueue.findIndex(snack => snack.id === snackId)
+    if (indexInQueue > -1) {
+      this.snackQueue[indexInQueue] = {...this.snackQueue[indexInQueue], ...contextSnack}
+    } else {
+      this.setState(({activeSnacks}) => ({
+        activeSnacks: activeSnacks.map(snack =>
+          snack.id === snackId ? {...snack, ...contextSnack} : snack
+        )
+      }))
+    }
   }
 
   /*
@@ -124,7 +138,7 @@ export default class SnackbarProvider extends React.Component {
   }
 
   /*
-    Dismiss the snack from the view, 
+    Dismiss the snack from the view,
     then call to remove it from activeSnacks in order to
     transition it out
   */
@@ -144,7 +158,7 @@ export default class SnackbarProvider extends React.Component {
     Remove the snack from the state
     The removal is delayed in order to transition the snack out first
   */
-  handleRemoveSnack = (id) => {
+  handleRemoveSnack = id => {
     this._removeTimer = setTimeout(() => {
       this.setState(({activeSnacks}) => ({
         activeSnacks: activeSnacks.filter(snack => snack.id !== id)
@@ -158,14 +172,15 @@ export default class SnackbarProvider extends React.Component {
 
   getChildContext = () => ({
     addToSnackQueue: this.addToSnackQueue,
-    handleDismissSnack: this.handleDismissSnack
+    handleDismissSnack: this.handleDismissSnack,
+    updateSnack: this.updateSnack
   })
 
   render() {
     const {activeSnacks} = this.state
     const {children} = this.props
     return (
-      <div>
+      <>
         {children}
         <Portal>
           <div role="region" aria-label="notifications" tabIndex="-1">
@@ -180,7 +195,7 @@ export default class SnackbarProvider extends React.Component {
             ))}
           </div>
         </Portal>
-      </div>
+      </>
     )
   }
 }


### PR DESCRIPTION
I have a case where I'm rendering a snackbar item and later want to update the message while it's being displayed. Currently, nothing happens if you send new properties to the snackbar component.

With this change, the new properties are reflected in the providers state/queue.

I also took the liberty of:
- Rendering `null` and/or fragments instead of `<div />`, to cut down on the number of DOM-elements actually being generated
- Lifting `isCloseable` property through to the snackbar item