### PR TITLE
[server] Implement custom HMR client for in-studio build status

### DIFF
--- a/packages/@sanity/base/package.json
+++ b/packages/@sanity/base/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "@sanity/client": "0.144.0",
     "@sanity/document-store": "0.144.0",
-    "@sanity/eventsource": "0.144.0",
     "@sanity/image-url": "0.140.15",
     "@sanity/initial-value-templates": "0.144.0",
     "@sanity/observable": "0.144.0",

--- a/packages/@sanity/base/src/components/DevServerStatus.js
+++ b/packages/@sanity/base/src/components/DevServerStatus.js
@@ -1,22 +1,23 @@
 import React, {PureComponent} from 'react'
-import polyfilledEventSource from '@sanity/eventsource'
 import Snackbar from 'part:@sanity/components/snackbar/default'
+import Spinner from 'part:@sanity/components/loading/spinner'
 
-const isWindowEventSource = Boolean(typeof window !== 'undefined' && window.EventSource)
-const EventSource = isWindowEventSource
-  ? window.EventSource // Native browser EventSource
-  : polyfilledEventSource // Node.js, IE, Edge etc
+const eventBus = window.__webpack_hot_middleware_eventbus__
+const events = eventBus ? eventBus.eventTypes : {}
 
 const STATE_CONNECTING = 0
 const STATE_OPEN = 1
+const STATE_CLOSED = 2
 
 class DevServerStatus extends PureComponent {
   constructor(...args) {
     super(...args)
-    this.enabled = __DEV__ && EventSource
+    this.enabled = __DEV__ && eventBus
     this.state = {
       connectionState: STATE_CONNECTING,
-      hasHadConnection: false
+      hasHadConnection: false,
+      buildState: events.EVENT_UP_TO_DATE,
+      reloadRequired: false
     }
   }
 
@@ -25,19 +26,40 @@ class DevServerStatus extends PureComponent {
       return
     }
 
-    this.es = new EventSource('/__webpack_hmr')
-    this.es.onerror = this.handleReadyChange
-    this.es.onopen = this.handleOpen
+    this.hmrUnsubscribe = eventBus.subscribe(this.handleEvent)
   }
 
   componentWillUnmount() {
-    if (this.es) {
-      this.es.close()
+    if (this.hmrUnsubscribe) {
+      this.hmrUnsubscribe()
     }
   }
 
-  handleOpen = () => {
-    this.handleReadyChange()
+  handleEvent = evt => {
+    switch (evt.type) {
+      case events.EVENT_DISCONNECTED:
+        return this.setState({connectionState: STATE_CLOSED})
+      case events.EVENT_CONNECTING:
+        return this.setState({connectionState: STATE_CONNECTING})
+      case events.EVENT_CONNECTED:
+        return this.handleConnected()
+      case events.EVENT_BUILDING:
+      case events.EVENT_UP_TO_DATE:
+        return this.setState(({reloadRequired: reloadWasRequired}) => ({
+          buildState: evt.type,
+          reloadRequired: reloadWasRequired || evt.requiresReload || false
+        }))
+      default:
+        if (evt.requiresReload && !this.state.reloadRequired) {
+          this.setState({buildState: events.EVENT_BUILT, reloadRequired: true})
+        }
+    }
+
+    return null
+  }
+
+  handleConnected = () => {
+    this.setState({connectionState: STATE_OPEN})
 
     if (this.state.hasHadConnection) {
       // We reconnected after being disconnected.
@@ -50,23 +72,48 @@ class DevServerStatus extends PureComponent {
     }
   }
 
-  handleReadyChange = () => {
-    this.setState({connectionState: this.es.readyState})
+  renderBuildStatus() {
+    const {reloadRequired, buildState} = this.state
+    if (reloadRequired) {
+      return (
+        <Snackbar
+          id="__dev-server-status"
+          kind="warning"
+          isPersisted
+          isCloseable={false}
+          title={<strong>Reload required!</strong>}
+          subtitle={<div>To see your latest changes, you need to reload the browser window.</div>}
+          action={{title: 'Reload', callback: () => window.location.reload()}}
+        />
+      )
+    }
+
+    if (buildState === events.EVENT_BUILDING) {
+      return (
+        <Snackbar
+          id="__dev-server-status"
+          kind="warning"
+          isPersisted
+          isCloseable={false}
+          title={<Spinner inline message={<strong>Rebuilding bundle…</strong>} />}
+        />
+      )
+    }
+
+    return null
   }
 
   render() {
-    // We're in production, or eventsource is not supported by the browser (Edge)
+    // We're in production or missing the HMR event bus
     if (!this.enabled) {
       return null
     }
 
-    // We're connected, don't show anything
-    if (this.state.connectionState === STATE_OPEN) {
-      return null
-    }
+    const {connectionState, hasHadConnection} = this.state
+    const isDisconnected = connectionState === STATE_CONNECTING || connectionState === STATE_CLOSED
 
     // We are disconnected
-    if (this.state.hasHadConnection) {
+    if (isDisconnected && hasHadConnection) {
       return (
         <Snackbar
           id="__dev-server-status"
@@ -83,7 +130,14 @@ class DevServerStatus extends PureComponent {
         />
       )
     }
-    return null
+
+    // We're still trying to connect for the first time
+    if (!hasHadConnection) {
+      return null
+    }
+
+    // We're connected, show build status if we have anything worthwhile
+    return this.renderBuildStatus()
   }
 }
 

--- a/packages/@sanity/base/src/components/DevServerStatus.js
+++ b/packages/@sanity/base/src/components/DevServerStatus.js
@@ -1,6 +1,7 @@
 import React, {PureComponent} from 'react'
 import Snackbar from 'part:@sanity/components/snackbar/default'
 import Spinner from 'part:@sanity/components/loading/spinner'
+import spinnerStyles from 'part:@sanity/components/loading/spinner-style'
 
 const eventBus = window.__webpack_hot_middleware_eventbus__
 const events = eventBus ? eventBus.eventTypes : {}
@@ -43,6 +44,7 @@ class DevServerStatus extends PureComponent {
         return this.setState({connectionState: STATE_CONNECTING})
       case events.EVENT_CONNECTED:
         return this.handleConnected()
+      case events.EVENT_BUILT:
       case events.EVENT_BUILDING:
       case events.EVENT_UP_TO_DATE:
         return this.setState(({reloadRequired: reloadWasRequired}) => ({
@@ -95,7 +97,13 @@ class DevServerStatus extends PureComponent {
           kind="warning"
           isPersisted
           isCloseable={false}
-          title={<Spinner inline message={<strong>Rebuilding bundle…</strong>} />}
+          title={
+            <Spinner inline>
+              <div className={spinnerStyles.message}>
+                <strong>Rebuilding bundle…</strong>
+              </div>
+            </Spinner>
+          }
         />
       )
     }

--- a/packages/@sanity/server/package.json
+++ b/packages/@sanity/server/package.json
@@ -41,6 +41,7 @@
     "@babel/register": "^7.6.0",
     "@hot-loader/react-dom": "^16.9.0-4.12.11",
     "@sanity/css-loader": "^0.28.12",
+    "@sanity/eventsource": "0.144.0",
     "@sanity/resolver": "0.144.0",
     "@sanity/webpack-integration": "0.144.0",
     "@sanity/webpack-loader": "0.144.0",
@@ -54,16 +55,18 @@
     "lodash": "^4.17.4",
     "normalize.css": "^5.0.0",
     "postcss-loader": "^2.0.6",
+    "querystring": "^0.2.0",
     "react-hot-loader": "^4.12.11",
     "require-uncached": "^1.0.3",
     "resolve": "^1.3.3",
     "resolve-from": "^4.0.0",
     "rxjs": "^6.5.2",
+    "strip-ansi": "^5.2.0",
     "style-loader": "^0.20.1",
     "symbol-observable": "^1.2.0",
     "webpack": "^3.8.1",
     "webpack-dev-middleware": "^2.0.5",
-    "webpack-hot-middleware": "^2.17.1"
+    "webpack-hot-middleware": "2.25.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/packages/@sanity/server/src/browser/hot-client.js
+++ b/packages/@sanity/server/src/browser/hot-client.js
@@ -1,0 +1,256 @@
+/* eslint-env browser */
+/* eslint-disable complexity, no-console, camelcase, no-case-declarations, max-depth */
+const strip = require('strip-ansi')
+const clientOverlay = require('webpack-hot-middleware/client-overlay')
+const processUpdate = require('./process-update')
+const polyfilledEventSource = require('@sanity/eventsource')
+
+const TIMEOUT = 20 * 1000
+const RECONNECT_TIMEOUT = 2500
+const HEARTBEAT = '\uD83D\uDC93'
+const HMR_PATH = '/__webpack_hmr'
+const REPORTER_KEY = '__webpack_hot_middleware_reporter__'
+const EVENTBUS_KEY = '__webpack_hot_middleware_eventbus__'
+
+const EVENT_CONNECTED = 'connected'
+const EVENT_CONNECTING = 'connecting'
+const EVENT_DISCONNECTED = 'disconnected'
+const EVENT_BUILDING = 'building'
+const EVENT_BUILT = 'built'
+const EVENT_SYNC = 'sync'
+const EVENT_CHECKING_FOR_UPDATES = 'checking-for-updates'
+const EVENT_NOTHING_UPDATED = 'nothing-updated'
+const EVENT_APPLY_ERROR = 'apply-error'
+const EVENT_UNACCEPTED = 'unaccepted'
+const EVENT_UPDATE_CHECK_FAILED = 'update-check-failed'
+const EVENT_UPDATED = 'updated'
+const EVENT_UPDATE_NOT_FOUND = 'update-not-found'
+const EVENT_UP_TO_DATE = 'up-to-date'
+
+const REQUIRES_RELOAD = [
+  EVENT_UPDATE_NOT_FOUND,
+  EVENT_UNACCEPTED,
+  EVENT_APPLY_ERROR,
+  EVENT_UPDATE_CHECK_FAILED
+]
+
+const REPORTER_STYLES = {
+  errors: 'color: #ff0000;',
+  warnings: 'color: #999933;'
+}
+
+;(function hotMiddlewareClient() {
+  if (typeof window === 'undefined') {
+    // Do nothing if not in a browser context
+    return
+  }
+
+  let es
+  let isConnected = false
+  let lastActivity = new Date()
+  let timeoutCheckTimer
+
+  window[EVENTBUS_KEY] = window[EVENTBUS_KEY] || createEventBus({isConnected: () => isConnected})
+  window[REPORTER_KEY] = window[REPORTER_KEY] || createReporter()
+  const reporter = window[REPORTER_KEY]
+  const eventBus = window[EVENTBUS_KEY]
+
+  const getEventPublisher = type => (evt = {}) => {
+    eventBus.publish({...evt, type, requiresReload: REQUIRES_RELOAD.includes(type)})
+  }
+
+  const hmrHandlers = {
+    handleCheckUpdate: getEventPublisher(EVENT_CHECKING_FOR_UPDATES),
+    handleError: getEventPublisher(EVENT_APPLY_ERROR),
+    handleNothingUpdated: getEventPublisher(EVENT_NOTHING_UPDATED),
+    handleUnaccepted: getEventPublisher(EVENT_UNACCEPTED),
+    handleUpdateCheckFailed: getEventPublisher(EVENT_UPDATE_CHECK_FAILED),
+    handleUpdated: getEventPublisher(EVENT_UPDATED),
+    handleUpdateNotFound: getEventPublisher(EVENT_UPDATE_NOT_FOUND),
+    handleUpToDate: getEventPublisher(EVENT_UP_TO_DATE)
+  }
+
+  connect()
+
+  function connect() {
+    eventBus.publish({type: EVENT_CONNECTING})
+
+    const EventSource = window.EventSource || polyfilledEventSource
+    es = new EventSource(HMR_PATH)
+    es.onopen = handleOnline
+    es.onerror = handleDisconnect
+    es.onmessage = handleMessage
+
+    timeoutCheckTimer = setInterval(handleCheckTimeout, TIMEOUT / 2)
+  }
+
+  function handleOnline() {
+    console.log('[HMR] connected')
+    eventBus.publish({type: EVENT_CONNECTED})
+    lastActivity = new Date()
+    isConnected = true
+  }
+
+  function handleMessage(event) {
+    lastActivity = new Date()
+
+    if (event.data === HEARTBEAT) {
+      return
+    }
+
+    processMessage(parseMessage(event))
+  }
+
+  function handleCheckTimeout() {
+    if (new Date() - lastActivity > TIMEOUT) {
+      handleDisconnect()
+    }
+  }
+
+  function handleDisconnect() {
+    clearInterval(timeoutCheckTimer)
+    es.close()
+    isConnected = false
+    eventBus.publish({type: EVENT_DISCONNECTED})
+    setTimeout(connect, RECONNECT_TIMEOUT)
+  }
+
+  function parseMessage(event) {
+    try {
+      return JSON.parse(event.data)
+    } catch (ex) {
+      console.warn(`Invalid HMR message: ${event.data}\n${ex}`)
+    }
+
+    return false
+  }
+
+  function processMessage(evt) {
+    if (!evt) {
+      return
+    }
+
+    eventBus.publish({...evt, type: evt.action})
+
+    switch (evt.action) {
+      case EVENT_BUILDING:
+        console.log(`[HMR] bundle rebuilding`)
+        break
+      case EVENT_BUILT:
+        console.log(`[HMR] bundle rebuilt in ${evt.time} ms`)
+      // fall through
+      case EVENT_SYNC:
+        let applyUpdate = true
+        const hasWarnings = evt.warnings.length > 0
+        const hasErrors = evt.errors.length > 0
+        if (hasErrors) {
+          reporter.problems('errors', evt)
+          applyUpdate = false
+        } else if (hasWarnings) {
+          const overlayShown = reporter.problems('warnings', evt)
+          applyUpdate = overlayShown
+        } else if (!hasWarnings) {
+          reporter.cleanProblemsCache()
+          reporter.success()
+        }
+
+        if (applyUpdate) {
+          processUpdate(evt.hash, evt.modules, hmrHandlers)
+        }
+
+        break
+      default:
+    }
+  }
+})()
+
+function createReporter() {
+  const overlay = clientOverlay({
+    ansiColors: {},
+    overlayStyles: {}
+  })
+
+  function formatProblems(type, obj) {
+    return obj[type].map(msg => strip(msg)).join('\n')
+  }
+
+  let previousProblems = null
+  function log(type, obj) {
+    const newProblems = formatProblems(type, obj)
+
+    if (previousProblems === newProblems) {
+      return
+    }
+
+    previousProblems = newProblems
+
+    const style = REPORTER_STYLES[type]
+    const title = `[HMR] bundle has ${obj[type].length} ${type}`
+    // NOTE: console.warn or console.error will print the stack trace
+    // which isn't helpful here, so using console.log to escape it.
+    if (console.group && console.groupEnd) {
+      console.group(`%c${title}`, style)
+      console.log(`%c${newProblems}`, style)
+      console.groupEnd()
+    } else {
+      console.log(
+        `%c${title}\n\t%c${newProblems.replace(/\n/g, '\n\t')}`,
+        `${style}font-aweight: bold;`,
+        `${style}font-weight: normal;`
+      )
+    }
+  }
+
+  return {
+    cleanProblemsCache() {
+      previousProblems = null
+    },
+    problems(type, obj) {
+      log(type, obj)
+
+      if (overlay) {
+        if (type === 'errors') {
+          overlay.showProblems(type, obj[type])
+          return false
+        }
+        overlay.clear()
+      }
+      return true
+    },
+    success() {
+      if (overlay) {
+        overlay.clear()
+      }
+    }
+  }
+}
+
+function createEventBus({isConnected}) {
+  const listeners = []
+  return {
+    publish: msg => listeners.forEach(listener => listener(msg)),
+    subscribe: fn => {
+      listeners.push(fn)
+      if (isConnected()) {
+        fn({type: EVENT_CONNECTED})
+      }
+      return () => listeners.splice(listeners.indexOf(fn), 1)
+    },
+    eventTypes: {
+      EVENT_CONNECTED,
+      EVENT_CONNECTING,
+      EVENT_DISCONNECTED,
+      EVENT_BUILDING,
+      EVENT_BUILT,
+      EVENT_SYNC,
+      EVENT_CHECKING_FOR_UPDATES,
+      EVENT_NOTHING_UPDATED,
+      EVENT_APPLY_ERROR,
+      EVENT_UNACCEPTED,
+      EVENT_UPDATE_CHECK_FAILED,
+      EVENT_UPDATED,
+      EVENT_UPDATE_NOT_FOUND,
+      EVENT_UP_TO_DATE
+    }
+  }
+}

--- a/packages/@sanity/server/src/browser/process-update.js
+++ b/packages/@sanity/server/src/browser/process-update.js
@@ -1,0 +1,182 @@
+/**
+ * Based heavily on https://github.com/webpack/webpack/blob/
+ *  c0afdf9c6abc1dd70707c594e473802a566f7b6e/hot/only-dev-server.js
+ * Original copyright Tobias Koppers @sokra (MIT license)
+ */
+
+/* eslint-disable complexity, no-console, camelcase, no-case-declarations, max-depth */
+/* global __webpack_hash__ */
+
+if (!module.hot) {
+  throw new Error('[HMR] Hot Module Replacement is disabled.')
+}
+
+let lastHash
+const failureStatuses = {abort: 1, fail: 1}
+const applyOptions = {
+  ignoreUnaccepted: true,
+  ignoreDeclined: true,
+  ignoreErrored: true,
+  onUnaccepted(data) {
+    console.warn(`Ignored an update to unaccepted module ${data.chain.join(' -> ')}`)
+  },
+  onDeclined(data) {
+    console.warn(`Ignored an update to declined module ${data.chain.join(' -> ')}`)
+  },
+  onErrored(data) {
+    console.warn(
+      `Ignored an error while updating module ${data.moduleId} (${data.type}): ${data.error.message}`
+    )
+  }
+}
+
+function isUpToDate(hash) {
+  if (hash) {
+    lastHash = hash
+  }
+
+  return lastHash === __webpack_hash__
+}
+
+module.exports = function processUpdate(hash, moduleMap, callbacks = {}) {
+  if (!isUpToDate(hash) && module.hot.status() === 'idle') {
+    callbacks.handleCheckUpdate()
+    check()
+  }
+
+  function check() {
+    const cb = (err, updatedModules) => {
+      if (err) {
+        return handleError(err)
+      }
+
+      if (!updatedModules) {
+        callbacks.handleUpdateNotFound()
+        return null
+      }
+
+      const applyCallback = (applyErr, renewedModules) => {
+        if (applyErr) {
+          handleError(applyErr)
+          return
+        }
+
+        if (!isUpToDate()) {
+          check()
+        }
+
+        logUpdates(updatedModules, renewedModules)
+        triggerCallbacks(updatedModules, renewedModules)
+      }
+
+      const options = {
+        ...applyOptions,
+        onErrored: (...args) => {
+          applyOptions.onErrored(...args)
+          callbacks.handleError(...args)
+        },
+        onDeclined: (...args) => {
+          applyOptions.onDeclined(...args)
+          callbacks.handleError(...args)
+        },
+        onUnaccepted: (...args) => {
+          applyOptions.onUnaccepted(...args)
+          callbacks.handleUnaccepted(...args)
+        }
+      }
+
+      const applyResult = module.hot.apply(options, applyCallback)
+      // webpack 2 promise
+      if (applyResult && applyResult.then) {
+        // HotModuleReplacement.runtime.js refers to the result as `outdatedModules`
+        applyResult.then(outdatedModules => applyCallback(null, outdatedModules))
+        applyResult.catch(applyCallback)
+      }
+
+      return undefined
+    }
+
+    const result = module.hot.check(false, cb)
+    // webpack 2 promise
+    if (result && result.then) {
+      result.then(updatedModules => cb(null, updatedModules))
+      result.catch(cb)
+    }
+  }
+
+  function logUpdates(updatedModules, renewedModules) {
+    const unacceptedModules = updatedModules.filter(
+      moduleId => renewedModules && renewedModules.indexOf(moduleId) < 0
+    )
+
+    if (unacceptedModules.length > 0) {
+      console.warn(
+        "[HMR] The following modules couldn't be hot updated: " +
+          '(Full reload needed)\n' +
+          'This is usually because the modules which have changed ' +
+          '(and their parents) do not know how to hot reload themselves. '
+      )
+      unacceptedModules.forEach(moduleId => {
+        console.warn(`[HMR]  - ${normalizeModulePath(moduleMap[moduleId] || moduleId).path}`)
+      })
+
+      return
+    }
+
+    if (!renewedModules || renewedModules.length === 0) {
+      console.log('[HMR] Nothing hot updated.')
+    } else {
+      console.log('[HMR] Updated modules:')
+      renewedModules.forEach(moduleId => {
+        console.log(`[HMR]  - ${normalizeModulePath(moduleMap[moduleId] || moduleId).path}`)
+      })
+    }
+
+    if (isUpToDate()) {
+      console.log('[HMR] App is up to date.')
+    }
+  }
+
+  function triggerCallbacks(updatedModules, renewedModules) {
+    const unacceptedModules = updatedModules.filter(
+      moduleId => renewedModules && renewedModules.indexOf(moduleId) < 0
+    )
+
+    if (unacceptedModules.length > 0) {
+      callbacks.handleUnaccepted({
+        modules: unacceptedModules.map(moduleId =>
+          normalizeModulePath(moduleMap[moduleId] || moduleId)
+        )
+      })
+      return
+    }
+
+    if (!renewedModules || renewedModules.length === 0) {
+      callbacks.handleNothingUpdated()
+    } else {
+      callbacks.handleUpdated({
+        modules: renewedModules.map(moduleId =>
+          normalizeModulePath(moduleMap[moduleId] || moduleId)
+        )
+      })
+    }
+
+    if (isUpToDate()) {
+      callbacks.handleUpToDate()
+    }
+  }
+
+  function handleError(err) {
+    if (module.hot.status() in failureStatuses) {
+      callbacks.handleError({error: err})
+      return
+    }
+
+    callbacks.handleUpdateCheckFailed({error: err})
+  }
+
+  function normalizeModulePath(pathName) {
+    const [path, partName] = pathName.split('?sanityPart=')
+    return {path, partName: partName && decodeURIComponent(partName)}
+  }
+}

--- a/packages/@sanity/server/src/configs/webpack.config.dev.js
+++ b/packages/@sanity/server/src/configs/webpack.config.dev.js
@@ -11,13 +11,13 @@ export default config => {
     entry: Object.assign({}, baseConfig.entry, {
       vendor: [
         require.resolve('eventsource-polyfill'),
-        require.resolve('webpack-hot-middleware/client')
+        require.resolve('../browser/hot-client')
       ].concat(baseConfig.entry.vendor)
     }),
     resolve: {
       alias: Object.assign({}, baseConfig.resolve.alias, {
         'react-dom': require.resolve('@hot-loader/react-dom'),
-        'webpack-hot-middleware/client': require.resolve('webpack-hot-middleware/client')
+        'webpack-hot-middleware/client': require.resolve('../browser/hot-client')
       })
     },
     plugins: (baseConfig.plugins || []).concat([


### PR DESCRIPTION
I liked the "you are disconnected" dev server status message so much that I wanted to also allow it to show  messages based on the current build status. When you save a file,  there is currently no indication that the server is building a new bundle until it's completed. Also, sometimes it cannot hot-reload the changes and you need to open up the dev console to actually see what's going on.

Unfortunately, the events I needed to subscribe to were not exposed by the webpack hot middleware client, so I've reimplemented the client and exposed a thin "eventbus" on the window when in development mode, which you can use to subscribe to events.

With this change, the dev server status will show a "Building..."-spinner in a snackbar item while it's working, which is removed when the build completes. If the patch cannot be applied and the user needs a full reload of the studio, we also show a message letting the user know about this (potentially we could auto-reload, but that may not always be what you want).
