### PR TITLE
[core] Include GraphQL commands in CLI help output

### DIFF
--- a/packages/@sanity/core/src/commands/graphql/deleteGraphQLAPICommand.js
+++ b/packages/@sanity/core/src/commands/graphql/deleteGraphQLAPICommand.js
@@ -4,6 +4,5 @@ export default {
   name: 'undeploy',
   group: 'graphql',
   description: 'Remove a deployed GraphQL API',
-  action: lazyRequire(require.resolve('../../actions/graphql/deleteApiAction')),
-  hideFromHelp: true
+  action: lazyRequire(require.resolve('../../actions/graphql/deleteApiAction'))
 }

--- a/packages/@sanity/core/src/commands/graphql/deployGraphQLAPICommand.js
+++ b/packages/@sanity/core/src/commands/graphql/deployGraphQLAPICommand.js
@@ -18,6 +18,5 @@ export default {
   group: 'graphql',
   description: 'Deploy a GraphQL API from the current Sanity schema',
   action: lazyRequire(require.resolve('../../actions/graphql/deployApiAction')),
-  helpText,
-  hideFromHelp: true
+  helpText
 }

--- a/packages/@sanity/core/src/commands/graphql/graphqlGroup.js
+++ b/packages/@sanity/core/src/commands/graphql/graphqlGroup.js
@@ -2,6 +2,5 @@ export default {
   name: 'graphql',
   signature: '[COMMAND]',
   isGroupRoot: true,
-  description: 'Interact with GraphQL APIs',
-  hideFromHelp: true
+  description: 'Interact with GraphQL APIs'
 }


### PR DESCRIPTION
Since the GraphQL API is in open beta, it doesn't make sense to hide the commands from the help output anymore.
