### PR TITLE
[groq] Don't use arrow functions - fixes IE11 compatibility

### DIFF
--- a/packages/groq/src/groq.js
+++ b/packages/groq/src/groq.js
@@ -2,7 +2,8 @@
 module.exports = function groq(strings, ...keys) {
   const lastIndex = strings.length - 1
   return (
-    strings.slice(0, lastIndex).reduce((acc, str, i) => acc + str + keys[i], '') +
-    strings[lastIndex]
+    strings.slice(0, lastIndex).reduce(function(acc, str, i) {
+      return acc + str + keys[i]
+    }, '') + strings[lastIndex]
   )
 }


### PR DESCRIPTION
We should probably add a specific  babel config here soon, but for now this should do the trick.