### PR TITLE
[initial-value-templates] Allow resolving initial value using observable

### DIFF
--- a/packages/@sanity/initial-value-templates/package.json
+++ b/packages/@sanity/initial-value-templates/package.json
@@ -34,7 +34,8 @@
     "@types/node": "^8.0.0",
     "lodash": "^4.17.15",
     "memoize-one": "^3.1.1",
-    "oneline": "^1.0.3"
+    "oneline": "^1.0.3",
+    "rxjs": "^6.5.2"
   },
   "devDependencies": {
     "@types/jest": "^24.0.23",

--- a/packages/@sanity/initial-value-templates/src/index.ts
+++ b/packages/@sanity/initial-value-templates/src/index.ts
@@ -1,5 +1,5 @@
 export {default as TemplateBuilder} from './builder'
-export {resolveInitialValue, isBuilder} from './resolve'
+export {resolveInitialValue, isBuilder, isProgressEvent, createProgressEvent} from './resolve'
 export {validateTemplates} from './validate'
 export {
   templateExists,

--- a/packages/@sanity/initial-value-templates/src/resolve.ts
+++ b/packages/@sanity/initial-value-templates/src/resolve.ts
@@ -1,5 +1,5 @@
 import {Observable, from, of} from 'rxjs'
-import {map} from 'rxjs/operators'
+import {map, takeWhile} from 'rxjs/operators'
 import {isPlainObject} from 'lodash'
 import {Template, TemplateBuilder} from './Template'
 import {validateInitialValue} from './validate'
@@ -71,14 +71,10 @@ export function resolveInitialValue(
   const subscribable = isSubscribable(initial) ? from(initial) : of(initial)
 
   return subscribable.pipe(
-    map(event => {
-      if (isProgressEvent(event)) {
-        return event
-      }
-
-      const value = validateInitialValue(event, template)
-      return createCompleteEvent(value)
-    })
+    takeWhile(event => isProgressEvent(event), true),
+    map(event =>
+      isProgressEvent(event) ? event : createCompleteEvent(validateInitialValue(event, template))
+    )
   )
 }
 

--- a/packages/test-studio/src/templates.js
+++ b/packages/test-studio/src/templates.js
@@ -1,4 +1,7 @@
+import {createProgressEvent} from '@sanity/base/initial-value-templates'
 import T from '@sanity/base/initial-value-template-builder'
+import {of, from, concat} from 'rxjs'
+import {delay, concatMap} from 'rxjs/operators'
 
 export default [
   ...T.defaults(),
@@ -20,5 +23,25 @@ export default [
     value: params => ({
       author: {_type: 'reference', _ref: params.authorId}
     })
+  }),
+
+  T.template({
+    id: 'slow-color-promise',
+    title: 'Slow color (promise)',
+    schemaType: 'colorTest',
+    value: () => new Promise(resolve => setTimeout(resolve, 5000, {title: 'Really slow color!'}))
+  }),
+
+  T.template({
+    id: 'slow-color-observable',
+    title: 'Slow color (observable)',
+    schemaType: 'colorTest',
+    value: () =>
+      concat(
+        from([5, 4, 3, 2, 1, 0]).pipe(
+          concatMap(num => of(createProgressEvent(`Resolving in... ${num}`)).pipe(delay(1000)))
+        ),
+        of({title: 'Wow, that took a while.'})
+      )
   })
 ]

--- a/packages/test-studio/src/templates.js
+++ b/packages/test-studio/src/templates.js
@@ -1,7 +1,7 @@
 import {createProgressEvent} from '@sanity/base/initial-value-templates'
 import T from '@sanity/base/initial-value-template-builder'
-import {of, from, concat} from 'rxjs'
-import {delay, concatMap} from 'rxjs/operators'
+import {of, from, concat, timer} from 'rxjs'
+import {map, delay, concatMap} from 'rxjs/operators'
 
 export default [
   ...T.defaults(),
@@ -43,5 +43,13 @@ export default [
         ),
         of({title: 'Wow, that took a while.'})
       )
+  }),
+
+  T.template({
+    id: 'changing-color',
+    title: 'Changing color (observable)',
+    schemaType: 'colorTest',
+    value: () =>
+      timer(0, 1000).pipe(map((_, num) => ({title: `First resolved ${num} seconds ago`})))
   })
 ]


### PR DESCRIPTION
We currently allow promises to be used when resolving initial values, but using observables allows us to do things like provide a stream of updates about what the asynchronous process is up to. 

This PR implements support for observable for just that reason.

In theory it could deliver a stream of updated values, but I'm not sure it's a good idea - it would at the very least have to report back to the resolving machinery that the initial value is no longer needed once it has been persisted to a draft.
