### PR TITLE
[desk-tool] Fix issue with path segments getting stripped out of from ids containing `.`

### DIFF
--- a/packages/@sanity/desk-tool/src/utils/parsePanesSegment.js
+++ b/packages/@sanity/desk-tool/src/utils/parsePanesSegment.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/prefer-default-export */
-const panePattern = /^([a-z0-9_-]+),?({.*?})?(?:(;|$))/i
+const panePattern = /^([.a-z0-9_-]+),?({.*?})?(?:(;|$))/i
 
 export function parsePanesSegment(str) {
   const chunks = []


### PR DESCRIPTION
This fixes a regression introduced in v0.144.0 that broke editing of a document that had an `_id` that included a dot character (`.`)

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

**Note for release**

This fixes a regression introduced in v0.144.0 that broke editing of a document that had an `_id` that included a dot character (`.`)

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
