### PR TITLE
[desk-tool] Wrap EditorPane and use document id as key to force reload

### DIFF
--- a/packages/@sanity/desk-tool/src/pane/Pane.js
+++ b/packages/@sanity/desk-tool/src/pane/Pane.js
@@ -10,7 +10,7 @@ import ListPane from './ListPane'
 const paneMap = {
   list: ListPane,
   documentList: DocumentsListPane,
-  document: EditorPane,
+  document: props => <EditorPane key={props.options.id} {...props} />,
   component: UserComponentPane
 }
 


### PR DESCRIPTION
**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**
When switching between documents from the search bar (and with no document list panes open), the portable text editor retains the value from the previous document.

**Description**
I wasn't able to figure out the root cause, but this PR at least provides a quickfix by changing the key for EditorPane, triggering an unmount + remount with new id.

**Note for release**

This provides a fix for a bug that affected portable text fields: When switching between documents from the search bar (and with no document list panes open), the portable text editor would retain the value from the previous document.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [ ]  The code is linted
- [ ]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
