### PR TITLE
[core] Add a tag option when interacting with GraphQL endpoints

### DIFF
--- a/packages/@sanity/core/src/actions/graphql/deleteApiAction.js
+++ b/packages/@sanity/core/src/actions/graphql/deleteApiAction.js
@@ -1,5 +1,6 @@
 module.exports = async function deleteApiAction(args, context) {
   const {apiClient, output, prompt} = context
+  const flags = args.extOptions
 
   const client = apiClient({
     requireUser: true,
@@ -16,10 +17,11 @@ module.exports = async function deleteApiAction(args, context) {
     return
   }
 
-  const dataset = client.config().dataset
+  const dataset = flags.dataset || client.config().dataset
+  const tag = flags.tag || 'default'
   try {
     await client.request({
-      url: `/apis/graphql/${dataset}/default`,
+      url: `/apis/graphql/${dataset}/${tag}`,
       method: 'DELETE'
     })
   } catch (err) {

--- a/packages/@sanity/core/src/actions/graphql/deployApiAction.js
+++ b/packages/@sanity/core/src/actions/graphql/deployApiAction.js
@@ -18,6 +18,7 @@ module.exports = async function deployApiActions(args, context) {
   })
 
   const dataset = flags.dataset || client.config().dataset
+  const tag = flags.tag || 'default'
   const enablePlayground =
     typeof flags.playground === 'undefined'
       ? await prompt.single({
@@ -53,7 +54,7 @@ module.exports = async function deployApiActions(args, context) {
 
   try {
     const response = await client.request({
-      url: `/apis/graphql/${dataset}/default`,
+      url: `/apis/graphql/${dataset}/${tag}`,
       method: 'PUT',
       body: {enablePlayground, schema},
       maxRedirects: 0

--- a/packages/@sanity/core/src/commands/graphql/deleteGraphQLAPICommand.js
+++ b/packages/@sanity/core/src/commands/graphql/deleteGraphQLAPICommand.js
@@ -1,8 +1,20 @@
 import lazyRequire from '@sanity/util/lib/lazyRequire'
 
+const helpText = `
+Options
+  --dataset <dataset> Delete GraphQL API for the given dataset
+  --tag <tag> Delete GraphQL API for the given tag (defaults to 'default')
+
+Examples
+  sanity graphql undeploy
+  sanity graphql undeploy --dataset staging
+  sanity graphql undeploy --dataset staging --tag next
+`
+
 export default {
   name: 'undeploy',
   group: 'graphql',
   description: 'Remove a deployed GraphQL API',
-  action: lazyRequire(require.resolve('../../actions/graphql/deleteApiAction'))
+  action: lazyRequire(require.resolve('../../actions/graphql/deleteApiAction')),
+  helpText
 }

--- a/packages/@sanity/core/src/commands/graphql/deployGraphQLAPICommand.js
+++ b/packages/@sanity/core/src/commands/graphql/deployGraphQLAPICommand.js
@@ -3,6 +3,7 @@ import lazyRequire from '@sanity/util/lib/lazyRequire'
 const helpText = `
 Options
   --dataset <dataset> Deploy API for the given dataset
+  --tag <tag> Deploy API to given tag (defaults to 'default')
   --playground Deploy a GraphQL playground for easily testing queries (public)
   --no-playground Skip playground prompt (do not deploy a playground)
 
@@ -10,6 +11,7 @@ Examples
   sanity graphql deploy
   sanity graphql deploy --playground
   sanity graphql deploy --dataset staging --no-playground
+  sanity graphql deploy --dataset staging --tag next --no-playground
 `
 
 export default {


### PR DESCRIPTION
**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [x]  Yes
- [ ]  No

**Current behavior**

The CLI defaults to use the `default` tag when deploying GraphQL endpoints.

**Description**

When migrating schemas, it's very useful to specify a custom tag and not break the existing endpoint.

This PR only merges to the `gql-tag-option` as there's more to do in regards to handle error messages from the GraphQL service.

**Note for release**

This change makes it possible for developers to provide a custom tag when deploying their GraphQL endpoints. This to either migrating to a new endpoint if the new schema contains breaking changes.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [ ]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
