### PR TITLE
[chore] Replace in-publish with prepublishOnly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,3 @@
-
 Want to file an issue? [Jump to _How to file an issue_ ⏬](#how-to-file-an-issue)
 
 # Contributing
@@ -9,7 +8,7 @@ Contributions are always welcome, no matter how large or small.
 
 Before contributing, please read our [code of conduct](https://github.com/sanity-io/sanity/blob/master/CODE_OF_CONDUCT.md).
 
-Then make sure you have *Node.js version 4 or newer* and *npm version 5 or newer*.
+Then make sure you have _Node.js version 4 or newer_ and _npm version 5 or newer_.
 
 ```sh
 git clone git@github.com:sanity-io/sanity.git
@@ -28,7 +27,7 @@ npm start
 - Rebase your feature branch regularly against `next`. Make sure its even with `next` before merging.
 - Once its done, open a pull request to merge your feature branch into `next`
 - After someone else has reviewed and signed off on the pull request, you can merge it into `next`.
-- Everything except minor *trivial* changes should go through pull-requests. If you're unsure whether it's a trivial change or not, submit a pull request just to be sure.
+- Everything except minor _trivial_ changes should go through pull-requests. If you're unsure whether it's a trivial change or not, submit a pull request just to be sure.
 - Pull requests should be as ready as possible for merge. Unless stated otherwise, it should be safe to assume that:
 
   - The changes/feature are reviewed and tested by you
@@ -93,7 +92,10 @@ If you run into build issues, you might want to run `npm run init`, which will d
 
 # Testing
 
+Some tests are based on compiled files, so you will need to build the repository first before running the tests:
+
 ```sh
+npm run build
 npm test
 ```
 

--- a/packages/@sanity/block-tools/package.json
+++ b/packages/@sanity/block-tools/package.json
@@ -30,7 +30,6 @@
   "devDependencies": {
     "@sanity/schema": "0.144.0",
     "assert": "^1.4.1",
-    "in-publish": "^2.0.0",
     "jest": "^24.9.0",
     "jsdom": "^12.0.0",
     "ts-jest": "^24.0.2",

--- a/packages/@sanity/check/package.json
+++ b/packages/@sanity/check/package.json
@@ -12,7 +12,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "prepublish": "in-publish && ./src/bin.js || not-in-publish",
+    "prepublishOnly": "./src/bin.js",
     "clean": "rimraf lib"
   },
   "keywords": [
@@ -29,7 +29,6 @@
     "@sanity/resolver": "0.144.0",
     "chalk": "^2.3.0",
     "fs-extra": "^6.0.1",
-    "in-publish": "^2.0.0",
     "promise-props-recursive": "^1.0.0"
   },
   "devDependencies": {

--- a/packages/@sanity/check/src/bin.js
+++ b/packages/@sanity/check/src/bin.js
@@ -3,7 +3,6 @@
 const path = require('path')
 const fse = require('fs-extra')
 const chalk = require('chalk')
-const publish = require('in-publish')
 const sanityCheck = require('./sanityCheck')
 const pkg = require('../package.json')
 
@@ -16,10 +15,7 @@ const manifestDir = path.join(dir, 'sanity.json')
 const showHelp = includes(args, '-h') || includes(args, '--help')
 const showVersion = includes(args, '-v') || includes(args, '--version')
 const productionMode =
-  process.env.NODE_ENV === 'production' ||
-  publish.inPublish() ||
-  includes(args, '-p') ||
-  includes(args, '--production')
+  process.env.NODE_ENV === 'production' || includes(args, '-p') || includes(args, '--production')
 
 if (showHelp) {
   console.log('Usage: sanity-check [DIRECTORY]')

--- a/packages/@sanity/cli/src/versionRanges.js
+++ b/packages/@sanity/cli/src/versionRanges.js
@@ -27,9 +27,6 @@ export default {
       'eslint-config-sanity': '^1.1.3',
       'eslint-plugin-react': '^6.3.0',
       rimraf: '^2.5.2'
-    },
-    prod: {
-      'in-publish': '^2.0.0'
     }
   }
 }

--- a/packages/@sanity/components/package.json
+++ b/packages/@sanity/components/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "scripts": {
     "clean": "rimraf lib",
-    "prepublish": "in-publish && sanity-check || not-in-publish",
+    "prepublishOnly": "sanity-check",
     "start": "cd demo && sanity start -d"
   },
   "keywords": [
@@ -32,7 +32,6 @@
     "dom-scroll-into-view": "^1.2.1",
     "element-resize-detector": "^1.1.14",
     "exif-component": "^1.0.1",
-    "in-publish": "^2.0.0",
     "lodash": "^4.17.4",
     "nano-pubsub": "^1.0.2",
     "palx": "^1.0.3",

--- a/packages/@sanity/data-aspects/package.json
+++ b/packages/@sanity/data-aspects/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "scripts": {
     "clean": "rimraf lib",
-    "prepublish": "in-publish && sanity-check || not-in-publish"
+    "prepublishOnly": "sanity-check"
   },
   "keywords": [
     "sanity",
@@ -20,7 +20,6 @@
   ],
   "dependencies": {
     "@sanity/generate-help-url": "0.144.0",
-    "in-publish": "^2.0.0",
     "lodash": "^4.17.4"
   },
   "devDependencies": {

--- a/packages/@sanity/default-layout/package.json
+++ b/packages/@sanity/default-layout/package.json
@@ -7,7 +7,7 @@
     "start": "cd example && sanity start",
     "coverage": "nyc --report=lcov --report=text _mocha -- test/**/*.test.js",
     "clean": "rimraf lib .nyc_output coverage",
-    "prepublish": "in-publish && sanity-check || not-in-publish"
+    "prepublishOnly": "sanity-check"
   },
   "repository": {
     "type": "git",
@@ -47,7 +47,6 @@
     "@sanity/schema": "0.144.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
-    "in-publish": "^2.0.0",
     "mocha": "^5.0.1",
     "nyc": "^11.0.3",
     "prop-types": "^15.6.0",

--- a/packages/@sanity/default-login/package.json
+++ b/packages/@sanity/default-login/package.json
@@ -7,8 +7,7 @@
   "license": "MIT",
   "scripts": {
     "clean": "rimraf lib",
-    "prepublish": "in-publish && sanity-check || not-in-publish",
-    "test": "sanity-check"
+    "prepublishOnly": "sanity-check"
   },
   "keywords": [
     "sanity",
@@ -21,7 +20,6 @@
   ],
   "dependencies": {
     "@sanity/generate-help-url": "0.144.0",
-    "in-publish": "^2.0.0",
     "prop-types": "^15.6.0",
     "rxjs": "^6.5.2"
   },

--- a/packages/@sanity/form-builder/package.json
+++ b/packages/@sanity/form-builder/package.json
@@ -72,7 +72,6 @@
     "@types/diff-match-patch": "^1.0.32",
     "@types/moment": "^2.13.0",
     "assert": "^1.4.1",
-    "in-publish": "^2.0.0",
     "jest": "^24.9.0",
     "json-markup": "^1.1.0",
     "prop-types": "^15.6.0",

--- a/packages/@sanity/google-maps-input/package.json
+++ b/packages/@sanity/google-maps-input/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "clean": "rimraf lib",
     "start": "cd example && sanity start",
-    "prepublish": "in-publish && sanity-check || not-in-publish"
+    "prepublishOnly": "sanity-check"
   },
   "keywords": [
     "sanity",
@@ -19,9 +19,6 @@
     "google-maps-input",
     "sanity-plugin"
   ],
-  "dependencies": {
-    "in-publish": "^2.0.0"
-  },
   "devDependencies": {
     "@sanity/base": "0.144.1",
     "@sanity/check": "0.144.0",

--- a/packages/@sanity/rich-date-input/package.json
+++ b/packages/@sanity/rich-date-input/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "scripts": {
     "clean": "rimraf lib",
-    "prepublish": "in-publish && sanity-check || not-in-publish"
+    "prepublishOnly": "sanity-check"
   },
   "keywords": [
     "sanity",
@@ -28,7 +28,6 @@
   },
   "devDependencies": {
     "@sanity/check": "0.144.0",
-    "in-publish": "^2.0.0",
     "rimraf": "^2.6.2"
   },
   "repository": {

--- a/packages/@sanity/server/package.json
+++ b/packages/@sanity/server/package.json
@@ -50,7 +50,6 @@
     "express": "^4.16.1",
     "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^1.1.4",
-    "in-publish": "^2.0.0",
     "json-loader": "^0.5.4",
     "lodash": "^4.17.4",
     "normalize.css": "^5.0.0",

--- a/packages/@sanity/state-router/package.json
+++ b/packages/@sanity/state-router/package.json
@@ -32,7 +32,6 @@
     "error-capture-middleware": "0.0.2",
     "express": "^4.16.1",
     "history": "^4.6.3",
-    "in-publish": "^2.0.0",
     "jest": "^24.9.0",
     "object-inspect": "^1.6.0",
     "prop-types": "^15.6.0",


### PR DESCRIPTION
**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [x]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

The `npm run test-all` is a little flaky due to a dependency in `in-publish`. It doesn't say anywhere that you also need to build the repository before running tests.

**Description**

This PR completely removes the usage of the `in-publish` package in favor for `prepublishOnly`, as that's what was missing a while back.

**Note for release**

- Replace `in-publish` package with `prepublishOnly` NPM step
- Reflect that `npm run build` must be run before running the tests as some tests are running against compiled assets

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ] The PR title includes a link to the relevant issue
- [x] The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x] The code is linted
- [x] The test suite is passing
- [x] Corresponding changes to the documentation have been made
