### PR TITLE
[core] Upgrade to Terser 4.4, execute out-of-process

### DIFF
--- a/packages/@sanity/client/package.json
+++ b/packages/@sanity/client/package.json
@@ -43,7 +43,7 @@
     "rimraf": "^2.6.2",
     "sse-channel": "^2.0.6",
     "tape": "^4.8.0",
-    "terser": "^3.10.11",
+    "terser": "^4.4.0",
     "uglifyify": "^5.0.1"
   },
   "repository": {

--- a/packages/@sanity/core/package.json
+++ b/packages/@sanity/core/package.json
@@ -56,12 +56,13 @@
     "pirates": "^4.0.0",
     "pluralize": "^7.0.0",
     "pretty-ms": "^3.2.0",
+    "resolve-bin": "^0.4.0",
     "resolve-from": "^4.0.0",
     "rimraf": "^2.6.2",
     "semver": "^6.1.2",
     "simple-get": "^3.0.2",
     "tar-fs": "^1.16.0",
-    "terser": "^3.10.11"
+    "terser": "^4.4.0"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/core/src/actions/build/compressJavascript.js
+++ b/packages/@sanity/core/src/actions/build/compressJavascript.js
@@ -1,60 +1,20 @@
+import path from 'path'
+import execa from 'execa'
 import fse from 'fs-extra'
-import Terser, {minify as minifyJs} from 'terser'
+import resolveBin from 'resolve-bin'
 
 export default async inputFile => {
-  const content = await fse.readFile(inputFile, 'utf8')
-  const minified = await minify(content, inputFile)
-  await fse.outputFile(inputFile, minified)
-}
-
-function minify(content, fileName) {
-  return new Promise((resolve, reject) => {
-    // Terser introduced a breaking API change in a patch version
-    // In case they revert or people are using an older version,
-    // try both combinations
-    let result
-    if (minifyJs) {
-      result = minifyJs(content)
-    } else if (Terser.minify) {
-      result = Terser.minify(content)
-    } else {
-      return reject(new Error('Breaking change in Terser - `minify` function not found'))
-    }
-
-    if (result.error) {
-      reject(formatError(result.error, fileName, content))
-    } else {
-      resolve(result.code)
-    }
-  })
-}
-
-function formatError(err, fileName, content) {
-  let msg = `Parse error at ${fileName}:${err.line},${err.col}`
-
-  const limit = 70
-  const lines = content.split(/\r?\n/)
-  let col = err.col
-  let line = lines[err.line - 1]
-
-  if (!line && !col) {
-    line = lines[err.line - 2]
-    col = line.length
+  const terserBin = resolveBin.sync('terser')
+  if (!terserBin) {
+    throw new Error(`Can't find terser binary, cannot compress bundles`)
   }
 
-  if (line) {
-    if (col > limit) {
-      line = line.slice(col - limit)
-      col = limit
-    }
-
-    msg += '\n\n'
-    msg += line.slice(0, 80)
-    msg += '\n'
-    msg += line.slice(0, col).replace(/\S/g, ' ')
-    msg += '^'
+  const outPath = `${inputFile}.min`
+  const {stderr, stdout, code} = await execa(terserBin, ['-c', '-m', '-o', outPath, inputFile])
+  if (code > 0) {
+    throw new Error(`Failed to minify bundle (${path.basename(inputFile)}):\n\n${stderr || stdout}`)
   }
 
-  err.message = msg
-  return err
+  await fse.unlink(inputFile)
+  await fse.move(outPath, inputFile)
 }


### PR DESCRIPTION
Terser has had a bunch of fixes and performance improvements since we last upgraded, so it makes sense to try and follow along.

In addition to this, when minifying javascript for `sanity build`/`sanity deploy`, we currently do the minification in-process, which blocks the "minifying" spinner in the CLI. This PR changes this to simply spawn the terser binary out-of-process.
