### PR TITLE
[all] Allow setting studio environment variables

### DIFF
--- a/packages/@sanity/cli/src/CommandRunner.js
+++ b/packages/@sanity/cli/src/CommandRunner.js
@@ -65,7 +65,9 @@ export default class CommandRunner {
     debug(`Reading "${manifestPath}"`)
 
     const baseManifest = await loadJson(manifestPath)
-    const manifest = reduceConfig(baseManifest || {}, environment)
+    const manifest = reduceConfig(baseManifest || {}, environment, {
+      studioRootPath: options.workDir
+    })
     const apiClient = clientWrapper(manifest, manifestPath)
 
     const context = {

--- a/packages/@sanity/cli/src/CommandRunner.js
+++ b/packages/@sanity/cli/src/CommandRunner.js
@@ -16,7 +16,7 @@ import {
 } from './util/generateCommandsDocumentation'
 
 /* eslint-disable no-process-env */
-const sanityEnv = process.env.SANITY_ENV
+const sanityEnv = process.env.SANITY_INTERNAL_ENV
 const environment = sanityEnv ? sanityEnv : process.env.NODE_ENV
 /* eslint-enable no-process-env */
 

--- a/packages/@sanity/cli/src/actions/init-project/initProject.js
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.js
@@ -692,7 +692,9 @@ async function doDatasetImport(options) {
   const {outputPath, coreCommands, template, datasetName, context} = options
   const manifestPath = path.join(outputPath, 'sanity.json')
   const baseManifest = await loadJson(manifestPath)
-  const manifest = reduceConfig(baseManifest || {}, environment)
+  const manifest = reduceConfig(baseManifest || {}, environment, {
+    studioRootPath: outputPath
+  })
 
   const importCmd = coreCommands.find(cmd => cmd.name === 'import' && cmd.group === 'dataset')
   return importCmd.action(

--- a/packages/@sanity/cli/src/actions/init-project/initProject.js
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.js
@@ -20,7 +20,7 @@ import templates from './templates'
 
 /* eslint-disable no-process-env */
 const isCI = process.env.CI
-const sanityEnv = process.env.SANITY_ENV
+const sanityEnv = process.env.SANITY_INTERNAL_ENV
 const environment = sanityEnv ? sanityEnv : process.env.NODE_ENV
 /* eslint-enable no-process-env */
 

--- a/packages/@sanity/cli/src/cli.js
+++ b/packages/@sanity/cli/src/cli.js
@@ -13,7 +13,7 @@ import mergeCommands from './util/mergeCommands'
 import {getCliRunner} from './CommandRunner'
 import baseCommands from './commands'
 
-const sanityEnv = process.env.SANITY_ENV || 'production' // eslint-disable-line no-process-env
+const sanityEnv = process.env.SANITY_INTERNAL_ENV || 'production' // eslint-disable-line no-process-env
 const knownEnvs = ['development', 'staging', 'production']
 
 module.exports = async function runCli(cliRoot) {

--- a/packages/@sanity/cli/src/util/clientWrapper.js
+++ b/packages/@sanity/cli/src/util/clientWrapper.js
@@ -3,7 +3,7 @@ import getUserConfig from './getUserConfig'
 
 /* eslint-disable no-process-env */
 const envAuthToken = process.env.SANITY_AUTH_TOKEN
-const sanityEnv = process.env.SANITY_ENV || 'production'
+const sanityEnv = process.env.SANITY_INTERNAL_ENV || 'production'
 /* eslint-enable no-process-env */
 
 const apiHosts = {

--- a/packages/@sanity/cli/src/util/getUserConfig.js
+++ b/packages/@sanity/cli/src/util/getUserConfig.js
@@ -1,6 +1,6 @@
 import ConfigStore from 'configstore'
 
-const sanityEnv = (process.env.SANITY_ENV || '').toLowerCase() // eslint-disable-line no-process-env
+const sanityEnv = (process.env.SANITY_INTERNAL_ENV || '').toLowerCase() // eslint-disable-line no-process-env
 const defaults = {}
 let config = null
 

--- a/packages/@sanity/core/package.json
+++ b/packages/@sanity/core/package.json
@@ -40,6 +40,7 @@
     "configstore": "^3.0.0",
     "debug": "^3.1.0",
     "deep-sort-object": "^1.0.1",
+    "dotenv": "^8.2.0",
     "es6-promisify": "^6.0.0",
     "execa": "^1.0.0",
     "filesize": "^3.5.6",

--- a/packages/@sanity/core/package.json
+++ b/packages/@sanity/core/package.json
@@ -35,6 +35,7 @@
     "@sanity/server": "0.146.0",
     "@sanity/util": "0.146.0",
     "@sanity/uuid": "0.146.0",
+    "@sanity/webpack-integration": "0.146.0",
     "batch-stream-operation": "^1.0.2",
     "chokidar": "^2.0.3",
     "configstore": "^3.0.0",

--- a/packages/@sanity/core/src/actions/build/buildStaticAssets.js
+++ b/packages/@sanity/core/src/actions/build/buildStaticAssets.js
@@ -24,7 +24,7 @@ export default async (args, context) => {
   const unattendedMode = flags.yes || flags.y
   const defaultOutputDir = path.resolve(path.join(workDir, 'dist'))
   const outputDir = path.resolve(args.argsWithoutOptions[0] || defaultOutputDir)
-  const config = getConfig(workDir)
+  const config = getConfig(workDir, {env: 'production'})
   const compilationConfig = {
     env: 'production',
     staticPath: resolveStaticPath(workDir, config.get('server')),
@@ -36,7 +36,7 @@ export default async (args, context) => {
     project: Object.assign({}, config.get('project'), overrides.project)
   }
 
-  await tryInitializePluginConfigs({workDir, output})
+  await tryInitializePluginConfigs({workDir, output, env: 'production'})
 
   checkStudioDependencyVersions(workDir)
 

--- a/packages/@sanity/core/src/actions/build/buildStaticAssets.js
+++ b/packages/@sanity/core/src/actions/build/buildStaticAssets.js
@@ -3,6 +3,7 @@ import fse from 'fs-extra'
 import rimTheRaf from 'rimraf'
 import filesize from 'filesize'
 import {promisify} from 'es6-promisify'
+import webpackIntegration from '@sanity/webpack-integration/v3'
 import getConfig from '@sanity/util/lib/getConfig'
 import {getWebpackCompiler, getDocumentElement, ReactDOM} from '@sanity/server'
 import sortModulesBySize from '../../stats/sortModulesBySize'
@@ -39,6 +40,16 @@ export default async (args, context) => {
   await tryInitializePluginConfigs({workDir, output, env: 'production'})
 
   checkStudioDependencyVersions(workDir)
+
+  const envVars = webpackIntegration.getSanityEnvVars({env: 'production', basePath: workDir})
+  const envVarKeys = Object.keys(envVars)
+  if (envVarKeys.length > 0) {
+    output.print(
+      '\nIncluding the following environment variables as part of the JavaScript bundle:'
+    )
+    envVarKeys.forEach(key => output.print(`- ${key}`))
+    output.print('')
+  }
 
   const compiler = getWebpackCompiler(compilationConfig)
   const compile = promisify(compiler.run.bind(compiler))

--- a/packages/@sanity/core/src/actions/config/reinitializePluginConfigs.js
+++ b/packages/@sanity/core/src/actions/config/reinitializePluginConfigs.js
@@ -7,10 +7,10 @@ import generateConfigChecksum from '../../util/generateConfigChecksum'
 import {getChecksums, setChecksums, localConfigExists} from '../../util/pluginChecksumManifest'
 
 async function reinitializePluginConfigs(options, flags = {}) {
-  const {workDir, output} = options
+  const {workDir, output, env} = options
 
   const localChecksums = await getChecksums(workDir)
-  const allPlugins = await resolveTree({basePath: workDir})
+  const allPlugins = await resolveTree({basePath: workDir, env})
   const pluginsWithDistConfig = (await Promise.all(allPlugins.map(pluginHasDistConfig))).filter(
     Boolean
   )

--- a/packages/@sanity/core/src/actions/exec/configClient.js
+++ b/packages/@sanity/core/src/actions/exec/configClient.js
@@ -6,7 +6,7 @@ if (!client) {
 }
 
 // eslint-disable-next-line no-process-env
-const sanityEnv = (process.env.SANITY_ENV || '').toLowerCase()
+const sanityEnv = (process.env.SANITY_INTERNAL_ENV || '').toLowerCase()
 const defaults = {}
 const config = new ConfigStore(
   sanityEnv && sanityEnv !== 'production' ? `sanity-${sanityEnv}` : 'sanity',

--- a/packages/@sanity/core/src/actions/exec/execScript.js
+++ b/packages/@sanity/core/src/actions/exec/execScript.js
@@ -1,6 +1,12 @@
 const spawn = require('child_process').spawn
 const path = require('path')
+const dotenv = require('dotenv')
 const fse = require('fs-extra')
+
+// Try to load .env files from the current directory
+// eslint-disable-next-line no-process-env
+const env = process.env.NODE_ENV || 'development'
+dotenv.config({path: path.join(process.cwd(), `.env.${env}`)})
 
 module.exports = async args => {
   // In case of specifying --with-user-token <file.js>, use the "token" as the script

--- a/packages/@sanity/core/src/actions/exec/execScript.js
+++ b/packages/@sanity/core/src/actions/exec/execScript.js
@@ -5,7 +5,7 @@ const fse = require('fs-extra')
 
 // Try to load .env files from the current directory
 // eslint-disable-next-line no-process-env
-const env = process.env.NODE_ENV || 'development'
+const env = process.env.SANITY_ACTIVE_ENV || process.env.NODE_ENV || 'development'
 dotenv.config({path: path.join(process.cwd(), `.env.${env}`)})
 
 module.exports = async args => {

--- a/packages/@sanity/core/src/actions/start/startAction.js
+++ b/packages/@sanity/core/src/actions/start/startAction.js
@@ -36,7 +36,7 @@ export default async (args, context) => {
 
   let compileSpinner
   const configSpinner = output.spinner('Checking configuration files...')
-  await tryInitializePluginConfigs({workDir, output})
+  await tryInitializePluginConfigs({workDir, output, env: 'development'})
   configSpinner.succeed()
 
   const server = getDevServer(serverOptions)

--- a/packages/@sanity/plugin-loader/loader.js
+++ b/packages/@sanity/plugin-loader/loader.js
@@ -9,7 +9,7 @@ const reduceConfig = util.reduceConfig
 const getSanityVersions = util.getSanityVersions
 
 /* eslint-disable no-process-env */
-const sanityEnv = process.env.SANITY_ENV
+const sanityEnv = process.env.SANITY_INTERNAL_ENV
 const env = typeof sanityEnv === 'undefined' ? process.env.NODE_ENV : sanityEnv
 /* eslint-enable no-process-env */
 

--- a/packages/@sanity/plugin-loader/loader.js
+++ b/packages/@sanity/plugin-loader/loader.js
@@ -81,7 +81,12 @@ function registerLoader(options) {
       const configFor = configMatch[1]
       if (configFor === 'sanity') {
         const sanityConfig = require(path.join(basePath, 'sanity.json'))
-        require.cache[request] = getModule(request, reduceConfig(sanityConfig, env))
+        require.cache[request] = getModule(
+          request,
+          reduceConfig(sanityConfig, env, {
+            studioRootPath: basePath
+          })
+        )
         return request
       }
 

--- a/packages/@sanity/resolver/src/readManifest.js
+++ b/packages/@sanity/resolver/src/readManifest.js
@@ -31,13 +31,13 @@ function parseManifest(rawData, options) {
   const parsedManifest = JSON.parse(rawData)
   const manifest = validateManifest(parsedManifest)
   const reduced = reduceConfig(manifest, options.env, {
-    studioRootPath: options.manifestDir || options.basePath || process.cwd()
+    studioRootPath: options.basePath || process.cwd()
   })
   return reduced
 }
 
 function readManifest(opts = {}) {
-  const env = process.env.NODE_ENV || 'development'
+  const env = process.env.NODE_ENV || opts.env || 'development'
   const options = Object.assign({env}, opts)
   const basePath = options.basePath || process.cwd()
   const manifestPath = path.join(options.manifestDir || basePath, 'sanity.json')

--- a/packages/@sanity/resolver/src/readManifest.js
+++ b/packages/@sanity/resolver/src/readManifest.js
@@ -30,7 +30,9 @@ function handleManifestReadError(err, options) {
 function parseManifest(rawData, options) {
   const parsedManifest = JSON.parse(rawData)
   const manifest = validateManifest(parsedManifest)
-  const reduced = reduceConfig(manifest, options.env)
+  const reduced = reduceConfig(manifest, options.env, {
+    studioRootPath: options.manifestDir || options.basePath || process.cwd()
+  })
   return reduced
 }
 

--- a/packages/@sanity/resolver/src/resolvePlugins.js
+++ b/packages/@sanity/resolver/src/resolvePlugins.js
@@ -16,7 +16,7 @@ export function resolvePlugins(pluginNames, options) {
 }
 
 export function resolvePlugin(options) {
-  const {name, basePath, parentPluginPath, sync} = options
+  const {name, basePath, parentPluginPath, sync, env} = options
   const resolver = sync ? dir => dir : dir => Promise.resolve(dir)
   const parentDir = parentPluginPath || basePath
   const isDirPlugin = dirMatcher.test(name)
@@ -40,6 +40,7 @@ export function resolvePlugin(options) {
       manifest,
       path: manifestDir,
       plugins: resolvePlugins(manifest.plugins || [], {
+        env,
         sync,
         basePath,
         parentPluginPath: manifestDir
@@ -55,16 +56,18 @@ export function resolvePlugin(options) {
 
   return dirResolver.then(manifestDir => {
     const plugin = {name: pluginName, path: manifestDir}
-    return readManifest({basePath, manifestDir: plugin.path, plugin: pluginName}).then(manifest =>
-      promiseProps(
-        Object.assign(plugin, {
-          manifest,
-          plugins: resolvePlugins(manifest.plugins || [], {
-            basePath,
-            parentPluginPath: plugin.path
+    return readManifest({basePath, manifestDir: plugin.path, plugin: pluginName, env}).then(
+      manifest =>
+        promiseProps(
+          Object.assign(plugin, {
+            manifest,
+            plugins: resolvePlugins(manifest.plugins || [], {
+              env,
+              basePath,
+              parentPluginPath: plugin.path
+            })
           })
-        })
-      )
+        )
     )
   })
 }

--- a/packages/@sanity/util/package.json
+++ b/packages/@sanity/util/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://www.sanity.io/",
   "dependencies": {
+    "dotenv": "^8.2.0",
     "fs-extra": "^6.0.1",
     "get-random-values": "^1.2.0",
     "lodash": "^4.17.4",

--- a/packages/@sanity/util/src/getConfig.ts
+++ b/packages/@sanity/util/src/getConfig.ts
@@ -15,11 +15,11 @@ const configContainer = values => ({
   get: (dotPath, defaultValue) => get(values, dotPath, defaultValue)
 })
 
-const getConfig = rootDir => {
+const getConfig = (rootDir, options: {env?: string} = {}) => {
   const localConfig = rootDir && loadJsonSync(path.join(rootDir, 'sanity.json'))
   const config = reduceConfig(
     localConfig ? merge({}, defaults, localConfig) : defaults,
-    process.env.NODE_ENV || 'development', // eslint-disable-line no-process-env
+    options.env || process.env.NODE_ENV || 'development', // eslint-disable-line no-process-env
     {studioRootPath: rootDir}
   )
 

--- a/packages/@sanity/util/src/getConfig.ts
+++ b/packages/@sanity/util/src/getConfig.ts
@@ -19,7 +19,8 @@ const getConfig = rootDir => {
   const localConfig = rootDir && loadJsonSync(path.join(rootDir, 'sanity.json'))
   const config = reduceConfig(
     localConfig ? merge({}, defaults, localConfig) : defaults,
-    process.env.NODE_ENV || 'development' // eslint-disable-line no-process-env
+    process.env.NODE_ENV || 'development', // eslint-disable-line no-process-env
+    {studioRootPath: rootDir}
   )
 
   return configContainer(config)

--- a/packages/@sanity/util/src/reduceConfig.ts
+++ b/packages/@sanity/util/src/reduceConfig.ts
@@ -6,7 +6,7 @@ import dotenv from 'dotenv'
 
 const readEnvFile = memoize(tryReadEnvFile)
 const sanityEnv = process.env.SANITY_ENV || 'production'
-const basePath = process.env.SANITY_STUDIO_BASEPATH || process.env.STUDIO_BASEPATH
+const basePath = process.env.SANITY_STUDIO_PROJECT_BASEPATH || process.env.STUDIO_BASEPATH
 const apiHosts = {
   staging: 'https://api.sanity.work',
   development: 'http://api.sanity.wtf'
@@ -58,8 +58,8 @@ export default (rawConfig, env = 'development', options: {studioRootPath?: strin
     envVars = {...envVars, ...tryReadDotEnv(studioRootPath, env)}
   }
 
-  const projectId = envVars.SANITY_STUDIO_PROJECT_ID
-  const dataset = envVars.SANITY_STUDIO_DATASET
+  const projectId = envVars.SANITY_STUDIO_API_PROJECT_ID
+  const dataset = envVars.SANITY_STUDIO_API_DATASET
 
   const apiHost = apiHosts[sanityEnv]
   const api = clean({apiHost, projectId, dataset})

--- a/packages/@sanity/util/src/reduceConfig.ts
+++ b/packages/@sanity/util/src/reduceConfig.ts
@@ -2,13 +2,21 @@
 import {mergeWith} from 'lodash'
 
 const sanityEnv = process.env.SANITY_ENV || 'production'
+const basePath = process.env.SANITY_STUDIO_BASEPATH || process.env.STUDIO_BASEPATH
 const apiHosts = {
   staging: 'https://api.sanity.work',
   development: 'http://api.sanity.wtf'
 }
 
+const projectId = process.env.SANITY_STUDIO_PROJECT_ID || undefined
+const dataset = process.env.SANITY_STUDIO_DATASET || undefined
+
 const processEnvConfig = {
-  project: process.env.STUDIO_BASEPATH ? {basePath: process.env.STUDIO_BASEPATH} : {}
+  project: basePath ? {basePath} : {}
+}
+
+function clean(obj) {
+  return Object.keys(obj).reduce((acc, key) => (obj[key] ? {...acc, [key]: obj[key]} : acc), {})
 }
 
 function merge(objValue, srcValue, key) {
@@ -22,7 +30,8 @@ function merge(objValue, srcValue, key) {
 
 export default (rawConfig, env = 'development') => {
   const apiHost = apiHosts[sanityEnv]
-  const sanityConf = apiHost ? {api: {apiHost}} : {}
+  const api = clean({apiHost, projectId, dataset})
+  const sanityConf = {api}
   const envConfig = (rawConfig.env || {})[env] || {}
   const config = mergeWith({}, rawConfig, envConfig, sanityConf, processEnvConfig, merge)
   delete config.env

--- a/packages/@sanity/util/src/reduceConfig.ts
+++ b/packages/@sanity/util/src/reduceConfig.ts
@@ -45,7 +45,7 @@ function tryReadEnvFile(pathName: string): {[key: string]: string} {
 }
 
 function tryReadDotEnv(studioRootPath: string, fallbackEnv?: string) {
-  const configEnv = process.env.NODE_ENV || fallbackEnv || 'development'
+  const configEnv = process.env.SANITY_ACTIVE_ENV || fallbackEnv || 'development'
   const envFile = path.join(studioRootPath, `.env.${configEnv}`)
   return readEnvFile(envFile)
 }

--- a/packages/@sanity/util/src/reduceConfig.ts
+++ b/packages/@sanity/util/src/reduceConfig.ts
@@ -28,7 +28,7 @@ function merge(objValue, srcValue, key) {
   return undefined
 }
 
-export default (rawConfig, env = 'development') => {
+export default (rawConfig, env = 'development', options: {studioRootPath?: string} = {}) => {
   const apiHost = apiHosts[sanityEnv]
   const api = clean({apiHost, projectId, dataset})
   const sanityConf = {api}

--- a/packages/@sanity/util/src/reduceConfig.ts
+++ b/packages/@sanity/util/src/reduceConfig.ts
@@ -5,7 +5,7 @@ import {mergeWith, memoize} from 'lodash'
 import dotenv from 'dotenv'
 
 const readEnvFile = memoize(tryReadEnvFile)
-const sanityEnv = process.env.SANITY_ENV || 'production'
+const sanityEnv = process.env.SANITY_INTERNAL_ENV || 'production'
 const basePath = process.env.SANITY_STUDIO_PROJECT_BASEPATH || process.env.STUDIO_BASEPATH
 const apiHosts = {
   staging: 'https://api.sanity.work',

--- a/packages/@sanity/webpack-integration/package.json
+++ b/packages/@sanity/webpack-integration/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@sanity/resolver": "0.146.0",
     "@sanity/webpack-loader": "0.146.0",
+    "dotenv": "^8.2.0",
     "fs.realpath": "^1.0.0",
     "p-async-cache": "^1.0.2",
     "postcss-cssnext": "^3.0.2",

--- a/packages/@sanity/webpack-integration/src/v3/index.js
+++ b/packages/@sanity/webpack-integration/src/v3/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-process-env */
 const postcssImport = require('postcss-import')
 const postcssCssnext = require('postcss-cssnext')
 const PartResolverPlugin = require('@sanity/webpack-loader')
@@ -9,13 +10,30 @@ function getPartResolverPlugin(options) {
   return new PartResolverPlugin(options)
 }
 
+function getEnvVars(isProd) {
+  return Object.keys(process.env).reduce(
+    (acc, key) => {
+      if (key.startsWith('SANITY_STUDIO_')) {
+        acc[`process.env.${key}`] = JSON.stringify(process.env[key])
+      }
+      return acc
+    },
+    {
+      'process.env.NODE_ENV': JSON.stringify(isProd ? 'production' : 'development'),
+      'process.env': JSON.stringify({})
+    }
+  )
+}
+
 function getEnvPlugin(options) {
-  // eslint-disable-next-line no-process-env
   const bundleEnv = options.bundleEnv || process.env.BUNDLE_ENV || 'development'
   const env = options.env || 'development'
   const isProd = env === 'production'
   const webpack = options.webpack || require('webpack')
-  return new webpack.DefinePlugin({__DEV__: !isProd && bundleEnv === 'development'})
+  return new webpack.DefinePlugin({
+    __DEV__: !isProd && bundleEnv === 'development',
+    ...getEnvVars(isProd)
+  })
 }
 
 function getPlugins(options) {

--- a/packages/@sanity/webpack-integration/src/v3/index.js
+++ b/packages/@sanity/webpack-integration/src/v3/index.js
@@ -31,7 +31,7 @@ function tryReadDotEnv(studioRootPath, configEnv) {
 }
 
 function getSanityEnvVars({env, basePath}) {
-  const configEnv = process.env.BUNDLE_ENV || env || process.env.NODE_ENV || 'development'
+  const configEnv = process.env.SANITY_ACTIVE_ENV || env || 'development'
   const dotEnvVars = tryReadDotEnv(basePath, configEnv)
   const allEnvVars = {...dotEnvVars, ...process.env}
   return Object.keys(allEnvVars).reduce((acc, key) => {

--- a/packages/@sanity/webpack-loader/src/partLoader.js
+++ b/packages/@sanity/webpack-loader/src/partLoader.js
@@ -6,7 +6,7 @@ const reduceConfig = sanityUtil.reduceConfig
 const getSanityVersions = sanityUtil.getSanityVersions
 
 /* eslint-disable no-process-env */
-const sanityEnv = process.env.SANITY_ENV
+const sanityEnv = process.env.SANITY_INTERNAL_ENV
 const env = typeof sanityEnv === 'undefined' ? process.env.NODE_ENV : sanityEnv
 /* eslint-enable no-process-env */
 

--- a/packages/@sanity/webpack-loader/src/partLoader.js
+++ b/packages/@sanity/webpack-loader/src/partLoader.js
@@ -35,7 +35,7 @@ function sanityPartLoader(input) {
   if (request.indexOf('config:') === 0) {
     const config = JSON.parse(input)
     const indent = buildEnv === 'production' ? 0 : 2
-    const reduced = reduceConfig(config, buildEnv)
+    const reduced = reduceConfig(config, buildEnv, {studioRootPath: basePath})
     return `module.exports = ${JSON.stringify(reduced, null, indent)}\n`
   }
 


### PR DESCRIPTION
# Environment variable support

## Overriding project ID / dataset

There are many cases where you might want to override the Sanity project ID and dataset which is defined in `sanity.json`. Common use cases is having a different dataset for development/staging/production, building the same studio for many different project IDs in a CI-workflow etc. The common way people want this to work is to defined environment variables.

With this PR, this is now possible by defining `SANITY_STUDIO_API_DATASET` and `SANITY_STUDIO_API_PROJECT_ID`. 

## Passing variables to the JS-environment

We currently have no way of passing environment variables to the javascript bundle. For instance, an agency might want to provide the same base schema and studio for many different clients, but alter both the project ID / dataset as well as things inside the bundle. 

With this PR, all environment variables starting with `SANITY_STUDIO_` is exposed to the Webpack bundle environment, so you can do things like `SANITY_STUDIO_CLIENT_NAME="Acme Inc"` and use that inside your own plugins/schemas/studio code as `process.env.SANITY_STUDIO_CLIENT_NAME`.

## Environment-specific configurations

In many cases you might want to define "static" environment variables for different environments in a `.env`-file alongside the studio. For instance, you could use a different dataset name for development and production by setting  `SANITY_STUDIO_API_DATASET=development` in a `.env.development` file.

With this PR, these environment files are now automatically loaded on studio startup (and on `sanity build`/`sanity deploy`). The environment name is fetched from the `NODE_ENV` environment variable - if it has not been set, it defaults to `development` when running `sanity start` or `sanity exec`, and `production` when using `sanity build`/`sanity deploy`.

I'm a little unsure as to whether we should automatically use `production` for `build`/`deploy` or if we should just fall back to development. Thoughts welcome.

## Related issues

_Partially_ solves #859 (this PR doesn't allow injecting configuration _post-build_). 
