### PR TITLE
[mutator] Increase test timeout to 120 seconds

### DIFF
--- a/packages/@sanity/mutator/package.json
+++ b/packages/@sanity/mutator/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "clean": "rimraf lib",
-    "test": "tap test/*.test.ts",
+    "test": "tap -t120 test/*.test.ts",
     "perf": "node ./perf/run.js"
   },
   "keywords": [


### PR DESCRIPTION
The mutator uses quite a long time to "boot up" the tests, especially in a CI-environment, which leads to flakey tests when it sometimes goes over the 30s default timeout for tap.

~This PR adds the `-T` flag ("no timeout") to the mutator tests and should hopefully remove the flakey CI results.~
This PR increases the timeout to 2 minutes (120 seconds) through the `-t` flag ("timeout") for the mutator tests and should hopefully remove the flakey CI results.