### PR TITLE
[structure] Enforce unique IDs for views, add serializer tests

### DIFF
--- a/packages/@sanity/structure/src/Document.ts
+++ b/packages/@sanity/structure/src/Document.ts
@@ -1,4 +1,4 @@
-import {camelCase} from 'lodash'
+import {uniq, camelCase} from 'lodash'
 import {SerializeOptions, Serializable, Child, DocumentNode, EditorNode} from './StructureNodes'
 import {SerializeError, HELP_URL} from './SerializeError'
 import {SchemaType} from './parts/Schema'
@@ -141,9 +141,21 @@ export class DocumentBuilder implements Serializable {
       ).withHelpUrl(HELP_URL.DOCUMENT_ID_REQUIRED)
     }
 
-    const views = (this.spec.views && this.spec.views.length > 0 ? this.spec.views : [form()]).map(
-      (item, i) => maybeSerializeView(item, i, path)
-    )
+    const views = (this.spec.views && this.spec.views.length > 0
+      ? this.spec.views
+      : [form()]
+    ).map((item, i) => maybeSerializeView(item, i, path))
+
+    const viewIds = views.map(view => view.id)
+    const dupes = uniq(viewIds.filter((id, i) => viewIds.includes(id, i + 1)))
+    if (dupes.length > 0) {
+      throw new SerializeError(
+        `document node has views with duplicate IDs: ${dupes.join(',  ')}`,
+        path,
+        id,
+        hint
+      )
+    }
 
     return {
       ...this.spec,

--- a/packages/@sanity/structure/src/views/ComponentView.ts
+++ b/packages/@sanity/structure/src/views/ComponentView.ts
@@ -1,4 +1,4 @@
-import {View, ViewBuilder} from './View'
+import {View, GenericViewBuilder} from './View'
 import {SerializeOptions} from '../StructureNodes'
 import {SerializeError, HELP_URL} from '../SerializeError'
 
@@ -10,13 +10,16 @@ const isComponentSpec = (spec: any): spec is ComponentView => {
   return typeof spec === 'object'
 }
 
-export class ComponentViewBuilder extends ViewBuilder {
+export class ComponentViewBuilder extends GenericViewBuilder<
+  Partial<ComponentView>,
+  ComponentViewBuilder
+> {
   protected spec: Partial<ComponentView>
 
   constructor(componentOrSpec?: Function | Partial<ComponentView>) {
     const spec = isComponentSpec(componentOrSpec) ? componentOrSpec : {}
 
-    super(spec)
+    super()
     this.spec = spec
 
     const userComponent =

--- a/packages/@sanity/structure/src/views/FormView.ts
+++ b/packages/@sanity/structure/src/views/FormView.ts
@@ -1,13 +1,13 @@
-import {View, ViewBuilder} from './View'
+import {View, GenericViewBuilder} from './View'
 import {SerializeOptions} from '../StructureNodes'
 
 export interface FormView extends View {}
 
-export class FormViewBuilder extends ViewBuilder {
+export class FormViewBuilder extends GenericViewBuilder<Partial<View>, FormViewBuilder> {
   protected spec: Partial<FormView>
 
   constructor(spec?: Partial<FormView>) {
-    super(spec)
+    super()
     this.spec = {id: 'editor', title: 'Editor', ...(spec ? spec : {})}
   }
 

--- a/packages/@sanity/structure/test/ComponentView.test.ts
+++ b/packages/@sanity/structure/test/ComponentView.test.ts
@@ -1,0 +1,85 @@
+import {StructureBuilder as S} from '../src'
+
+test('throws on missing id', () => {
+  expect(() => S.view.component().serialize()).toThrowError(/`id` is required/)
+})
+
+test('throws on missing title', () => {
+  expect(() =>
+    S.view
+      .component()
+      .id('foo')
+      .serialize()
+  ).toThrowError(/`title` is required/)
+})
+
+test('throws on invalid id', () => {
+  expect(() =>
+    S.view
+      .component()
+      .id('foo bar')
+      .title('Foo bar')
+      .serialize()
+  ).toThrowError('Structure node id cannot contain character " "')
+})
+
+test('infers id from title if not set', () => {
+  expect(
+    S.view
+      .component()
+      .title('Foo bar')
+      .getId()
+  ).toEqual('foo-bar')
+})
+
+test('does not infer id from title if already set', () => {
+  expect(
+    S.view
+      .component()
+      .id('default-thing')
+      .title('Foo bar')
+      .getId()
+  ).toEqual('default-thing')
+})
+
+test('builds component view through component constructor', () => {
+  expect(
+    S.view
+      .component(() => null)
+      .id('custom')
+      .title('Custom')
+      .serialize()
+  ).toMatchSnapshot()
+})
+
+test('can override component set through constructor', () => {
+  const original = () => null
+  const changed = () => null
+  const builder = S.view
+    .component(original)
+    .id('custom')
+    .title('Custom')
+    .component(changed)
+
+  expect(builder.serialize()).toMatchSnapshot()
+  expect(builder.getComponent()).toBe(changed)
+})
+
+test('builder is immutable', () => {
+  const original = S.view.component()
+  expect(original.id('foo')).not.toEqual(original)
+  expect(original.title('foo')).not.toEqual(original)
+  expect(original.icon(() => null)).not.toEqual(original)
+  expect(original.component(() => null)).not.toEqual(original)
+})
+
+test('getters work', () => {
+  const original = S.view.component()
+  const icon = () => null
+  const component = () => null
+
+  expect(original.id('foo').getId()).toEqual('foo')
+  expect(original.title('title').getTitle()).toEqual('title')
+  expect(original.icon(icon).getIcon()).toEqual(icon)
+  expect(original.component(component).getComponent()).toEqual(component)
+})

--- a/packages/@sanity/structure/test/Document.test.ts
+++ b/packages/@sanity/structure/test/Document.test.ts
@@ -1,0 +1,110 @@
+import {StructureBuilder as S} from '../src'
+import {getDefaultSchema, SchemaType} from '../src/parts/Schema'
+
+test('builds document node through constructor', () => {
+  expect(
+    S.document({
+      id: 'foo',
+      options: {
+        id: 'docId',
+        type: 'book',
+        templateParameters: {
+          foo: 'bar'
+        }
+      }
+    }).serialize()
+  ).toMatchSnapshot()
+})
+
+test('throws on missing id', () => {
+  expect(() =>
+    S.document()
+      .schemaType('book')
+      .serialize()
+  ).toThrowError(/`id` is required/)
+})
+
+test('reuses pane ID if document ID is not set', () => {
+  expect(
+    S.document()
+      .id('id')
+      .schemaType('book')
+      .serialize()
+  ).toMatchObject({
+    id: 'id',
+    options: {id: 'id'}
+  })
+})
+
+test('can construct with schema type instead of schema type name', () => {
+  expect(
+    S.document()
+      .schemaType(getDefaultSchema().get('post') as SchemaType)
+      .id('yeah')
+      .documentId('wow')
+      .serialize()
+  ).toMatchSnapshot()
+})
+
+test('can construct using builder', () => {
+  expect(
+    S.document()
+      .id('yeah')
+      .documentId('wow')
+      .schemaType('book')
+      .initialValueTemplate('book-by-author', {authorId: 'grrm'})
+      .child(() => S.documentTypeList('post'))
+      .serialize()
+  ).toMatchSnapshot()
+})
+
+test('can construct using builder (alt)', () => {
+  expect(
+    S.document()
+      .schemaType('book')
+      .id('yeah')
+      .documentId('wow')
+      .views([])
+      .serialize()
+  ).toMatchSnapshot()
+})
+
+test('builder is immutable', () => {
+  const original = S.document()
+  expect(original.id('foo')).not.toEqual(original)
+  expect(original.views([])).not.toEqual(original)
+  expect(original.documentId('moo')).not.toEqual(original)
+  expect(original.schemaType('author')).not.toEqual(original)
+  expect(original.initialValueTemplate('book-by-author')).not.toEqual(original)
+  expect(original.child(() => S.documentTypeList('post'))).not.toEqual(original)
+})
+
+test('throws on duplicate view ids', () => {
+  expect(() =>
+    S.document()
+      .id('got')
+      .schemaType('book')
+      .views([S.view.form(), S.view.form(), S.view.component(() => null).title('Not editor')])
+      .serialize()
+  ).toThrowError(/document node has views with duplicate IDs: editor/)
+})
+
+test('getters work', () => {
+  const original = S.document()
+  const child = () => S.documentTypeList('post')
+  const views = [S.view.form()]
+
+  expect(original.id('foo').getId()).toEqual('foo')
+  expect(original.views(views).getViews()).toEqual(views)
+  expect(original.child(child).getChild()).toEqual(child)
+  expect(original.documentId('moo').getDocumentId()).toEqual('moo')
+  expect(original.schemaType('author').getSchemaType()).toEqual('author')
+  expect(original.initialValueTemplate('book-by-author').getInitalValueTemplate()).toEqual(
+    'book-by-author'
+  )
+  expect(
+    original
+      .initialValueTemplate('book-by-author', {authorId: 'grrm'})
+      .getInitialValueTemplateParameters()
+  ).toEqual({authorId: 'grrm'})
+})

--- a/packages/@sanity/structure/test/FormView.test.ts
+++ b/packages/@sanity/structure/test/FormView.test.ts
@@ -1,0 +1,32 @@
+import {StructureBuilder as S} from '../src'
+
+test('builds form view through constructor, with defaults', () => {
+  expect(S.view.form().serialize()).toMatchSnapshot()
+})
+
+test('can override defaults', () => {
+  expect(
+    S.view
+      .form()
+      .title('Custom editor')
+      .id('custom-editor')
+      .icon(() => null)
+      .serialize()
+  ).toMatchSnapshot()
+})
+
+test('builder is immutable', () => {
+  const original = S.view.form()
+  expect(original.id('foo')).not.toEqual(original)
+  expect(original.title('foo')).not.toEqual(original)
+  expect(original.icon(() => null)).not.toEqual(original)
+})
+
+test('getters work', () => {
+  const original = S.view.form()
+  const icon = () => null
+
+  expect(original.id('foo').getId()).toEqual('foo')
+  expect(original.title('title').getTitle()).toEqual('title')
+  expect(original.icon(icon).getIcon()).toEqual(icon)
+})

--- a/packages/@sanity/structure/test/__snapshots__/ComponentView.test.ts.snap
+++ b/packages/@sanity/structure/test/__snapshots__/ComponentView.test.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`builds component view through component constructor 1`] = `
+Object {
+  "component": [Function],
+  "icon": undefined,
+  "id": "custom",
+  "title": "Custom",
+  "type": "component",
+}
+`;
+
+exports[`can override component set through constructor 1`] = `
+Object {
+  "component": [Function],
+  "icon": undefined,
+  "id": "custom",
+  "title": "Custom",
+  "type": "component",
+}
+`;

--- a/packages/@sanity/structure/test/__snapshots__/Document.test.ts.snap
+++ b/packages/@sanity/structure/test/__snapshots__/Document.test.ts.snap
@@ -1,0 +1,88 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`builds document node through constructor 1`] = `
+Object {
+  "child": undefined,
+  "id": "foo",
+  "options": Object {
+    "id": "docId",
+    "templateParameters": Object {
+      "foo": "bar",
+    },
+    "type": "book",
+  },
+  "type": "document",
+  "views": Array [
+    Object {
+      "icon": undefined,
+      "id": "editor",
+      "title": "Editor",
+      "type": "form",
+    },
+  ],
+}
+`;
+
+exports[`can construct using builder (alt) 1`] = `
+Object {
+  "child": undefined,
+  "id": "yeah",
+  "options": Object {
+    "id": "wow",
+    "type": "book",
+  },
+  "type": "document",
+  "views": Array [
+    Object {
+      "icon": undefined,
+      "id": "editor",
+      "title": "Editor",
+      "type": "form",
+    },
+  ],
+}
+`;
+
+exports[`can construct using builder 1`] = `
+Object {
+  "child": [Function],
+  "id": "yeah",
+  "options": Object {
+    "id": "wow",
+    "template": "book-by-author",
+    "templateParameters": Object {
+      "authorId": "grrm",
+    },
+    "type": "book",
+  },
+  "type": "document",
+  "views": Array [
+    Object {
+      "icon": undefined,
+      "id": "editor",
+      "title": "Editor",
+      "type": "form",
+    },
+  ],
+}
+`;
+
+exports[`can construct with schema type instead of schema type name 1`] = `
+Object {
+  "child": undefined,
+  "id": "yeah",
+  "options": Object {
+    "id": "wow",
+    "type": "post",
+  },
+  "type": "document",
+  "views": Array [
+    Object {
+      "icon": undefined,
+      "id": "editor",
+      "title": "Editor",
+      "type": "form",
+    },
+  ],
+}
+`;

--- a/packages/@sanity/structure/test/__snapshots__/FormView.test.ts.snap
+++ b/packages/@sanity/structure/test/__snapshots__/FormView.test.ts.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`builds form view through constructor, with defaults 1`] = `
+Object {
+  "icon": undefined,
+  "id": "editor",
+  "title": "Editor",
+  "type": "form",
+}
+`;
+
+exports[`can override defaults 1`] = `
+Object {
+  "icon": [Function],
+  "id": "custom-editor",
+  "title": "Custom editor",
+  "type": "form",
+}
+`;


### PR DESCRIPTION
I discovered by chance that we did not validate the the ids for views were unique within it's parent document node. This has the unfortunate side-effect of not being able to select more than the first view which share the ID. 

This PR adds validation for this, along with tests to ensure that the serialization of structure view nodes work as intended.