### PR TITLE
[structure] Remove auto-inferring of ID based on function name

### DIFF
--- a/packages/@sanity/structure/src/Component.ts
+++ b/packages/@sanity/structure/src/Component.ts
@@ -26,14 +26,6 @@ export interface BuildableComponent extends Partial<StructureNode> {
   menuItemGroups?: (MenuItemGroup | MenuItemGroupBuilder)[]
 }
 
-interface ReactComponent extends Function {
-  displayName?: string
-}
-
-function getFunctionName(fn: ReactComponent) {
-  return typeof fn.displayName === 'string' ? fn.displayName : fn.name
-}
-
 export class ComponentBuilder implements Serializable {
   protected spec: BuildableComponent
 
@@ -66,7 +58,7 @@ export class ComponentBuilder implements Serializable {
   }
 
   component(component: Function) {
-    return this.clone({component, id: this.spec.id || getFunctionName(component)})
+    return this.clone({component})
   }
 
   getComponent() {

--- a/packages/@sanity/structure/src/views/ComponentView.ts
+++ b/packages/@sanity/structure/src/views/ComponentView.ts
@@ -1,15 +1,6 @@
-import {kebabCase} from 'lodash'
 import {View, ViewBuilder} from './View'
 import {SerializeOptions} from '../StructureNodes'
 import {SerializeError, HELP_URL} from '../SerializeError'
-
-interface ReactComponent extends Function {
-  displayName?: string
-}
-
-function getFunctionName(fn: ReactComponent) {
-  return typeof fn.displayName === 'string' ? fn.displayName : fn.name
-}
 
 export interface ComponentView extends View {
   component: Function
@@ -38,11 +29,7 @@ export class ComponentViewBuilder extends ViewBuilder {
   }
 
   component(component: Function) {
-    return this.clone({
-      component,
-      id: this.spec.id || kebabCase(getFunctionName(component)),
-      title: this.spec.title || getFunctionName(component)
-    })
+    return this.clone({component})
   }
 
   getComponent() {

--- a/packages/@sanity/structure/test/Component.test.ts
+++ b/packages/@sanity/structure/test/Component.test.ts
@@ -48,27 +48,6 @@ test('infers ID from title if not specified', () => {
   ).toEqual('blah')
 })
 
-test('infers ID from function name if not specified', () => {
-  const FooBar = () => null
-  expect(
-    S.component()
-      .component(FooBar)
-      .getId()
-  ).toEqual('FooBar')
-  expect(
-    S.component()
-      .id('zing')
-      .component(FooBar)
-      .getId()
-  ).toEqual('zing')
-  expect(
-    S.component()
-      .component(FooBar)
-      .id('blah')
-      .getId()
-  ).toEqual('blah')
-})
-
 test('throws on missing component', () => {
   expect(() =>
     S.component()


### PR DESCRIPTION
The `S.component()` and  `S.view.component()` methods tried to be smart and infer the title/id from the component display name. What I had not factored into the equation is that when minifying the javascript bundle, these display names becomes absolutely useless (`SomeAwesomePreview` becomes `n`, for instance).

This PR removes this inferring logic and instead relies on users explicitly specifying a stable ID, which seems like a better choice anyway.