### PR TITLE
[schema] Guard against multidimensional arrays

### DIFF
--- a/packages/@sanity/schema/src/sanity/validation/createValidationResult.ts
+++ b/packages/@sanity/schema/src/sanity/validation/createValidationResult.ts
@@ -12,6 +12,7 @@ export const HELP_IDS = {
   OBJECT_FIELDS_INVALID: 'schema-object-fields-invalid',
   OBJECT_FIELD_NOT_UNIQUE: 'schema-object-fields-invalid',
   OBJECT_FIELD_NAME_INVALID: 'schema-object-fields-invalid',
+  ARRAY_OF_ARRAY: 'schema-array-of-array',
   ARRAY_OF_INVALID: 'schema-array-of-invalid',
   ARRAY_OF_NOT_UNIQUE: 'schema-array-of-invalid',
   REFERENCE_TO_INVALID: 'schema-reference-to-invalid',

--- a/packages/@sanity/schema/src/sanity/validation/types/array.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/array.ts
@@ -8,6 +8,15 @@ export default (typeDef, visitorContext) => {
 
   if (ofIsArray) {
     const invalid = typeDef.of.reduce((errs, def, idx) => {
+      if (def.type === 'array') {
+        return errs.concat(
+          error(
+            `Found array member declaration of type "array" - multidimensional arrays are not currently supported by Sanity`,
+            HELP_IDS.ARRAY_OF_ARRAY
+          )
+        )
+      }
+
       if (def) {
         return errs
       }


### PR DESCRIPTION
We currently don't give a good, meaningful error message when you model multidimensional arrays in your schemas.

This PR introduces a basic check for this case. Help article has been written to explain how you might go about remodelling your schema (wrap it in an object).

Fixes #452
