### PR TITLE
[desk-tool] Prevent showing document inspector on no snapshot

### DIFF
--- a/packages/@sanity/desk-tool/src/pane/DocumentPane.js
+++ b/packages/@sanity/desk-tool/src/pane/DocumentPane.js
@@ -564,6 +564,12 @@ export default withInitialValue(
     }
 
     handleToggleInspect = () => {
+      const {draft, published} = this.state
+      const value = draft.snapshot || published.snapshot
+      if (!value) {
+        return
+      }
+
       this.setState(prevState => ({inspect: !prevState.inspect}))
     }
 
@@ -1521,10 +1527,10 @@ export default withInitialValue(
           >
             {this.renderHistorySpinner()}
             {this.renderCurrentView()}
-            {inspect && this.historyIsOpen() && (
+            {inspect && this.historyIsOpen() && historical && (
               <InspectHistory document={historical} onClose={this.handleHideInspector} />
             )}
-            {inspect && !this.historyIsOpen() && (
+            {inspect && !this.historyIsOpen() && value && (
               <InspectView value={value} onClose={this.handleHideInspector} />
             )}
             {showConfirmDelete && (


### PR DESCRIPTION
When you use the keyboard shortcut for toggling the inspector on an empty (non-existent) document, it crashes when attempting to access the `_type` property of a snapshot that is  `null`.

This PR adds a check that prevents the inspect flag from being toggled when there is no snapshot.

Fixes #1559