### PR TITLE
[validation] Fix unnamed object type matching incorrect array member

### DIFF
--- a/packages/@sanity/validation/src/validateDocument.js
+++ b/packages/@sanity/validation/src/validateDocument.js
@@ -142,13 +142,14 @@ function resolveTypeForArrayItem(item, candidates) {
   const primitive =
     typeof item === 'undefined' || item === null || (!item._type && Type.string(item).toLowerCase())
 
-  if (primitive) {
+  if (primitive && primitive !== 'object') {
     return candidates.find(candidate => candidate.jsonType === primitive)
   }
 
   return (
     candidates.find(candidate => candidate.type.name === item._type) ||
-    candidates.find(candidate => candidate.name === item._type)
+    candidates.find(candidate => candidate.name === item._type) ||
+    candidates.find(candidate => candidate.name === 'object' && primitive === 'object')
   )
 }
 


### PR DESCRIPTION
If you have an array with multiple object types where _one of them_ does not have a `name` property, the validator incorrectly picks the first declared object member of the array and uses it's validation rules.

This PR fixes this by using a more specific check and matching the first candidate without a name. This is safe because we don't allow more than a single unnamed object member within an array, since they can't be told apart.

Fixes #813