### PR TITLE
[structure] Reintroduce title attribute to document node

### DIFF
--- a/packages/@sanity/structure/src/Document.ts
+++ b/packages/@sanity/structure/src/Document.ts
@@ -1,3 +1,4 @@
+import {camelCase} from 'lodash'
 import {SerializeOptions, Serializable, Child, DocumentNode, EditorNode} from './StructureNodes'
 import {SerializeError, HELP_URL} from './SerializeError'
 import {SchemaType} from './parts/Schema'
@@ -17,6 +18,7 @@ interface DocumentOptions {
 
 export type PartialDocumentNode = {
   id?: string
+  title?: string
   child?: Child
   views?: (View | ViewBuilder)[]
   options?: Partial<DocumentOptions>
@@ -35,6 +37,14 @@ export class DocumentBuilder implements Serializable {
 
   getId() {
     return this.spec.id
+  }
+
+  title(title: string) {
+    return this.clone({title, id: this.spec.id || camelCase(title)})
+  }
+
+  getTitle() {
+    return this.spec.title
   }
 
   child(child: Child) {

--- a/packages/test-studio/src/deskStructure.js
+++ b/packages/test-studio/src/deskStructure.js
@@ -39,7 +39,13 @@ export default () =>
 
       S.listItem()
         .title('Singleton?')
-        .child(delay(S.editor({id: 'editor', options: {id: 'circular', type: 'referenceTest'}})))
+        .child(
+          delay(
+            S.editor({id: 'editor', options: {id: 'circular', type: 'referenceTest'}}).title(
+              'Specific title!'
+            )
+          )
+        )
         .showIcon(false),
 
       S.documentListItem()


### PR DESCRIPTION
Regression in v0.145.0: the `title` attribute was removed from the editor/document node.
