### PR TITLE
[desk-tool] Redirect old edit URLs to new fallback edit route

### DIFF
--- a/packages/@sanity/desk-tool/src/DeskTool.js
+++ b/packages/@sanity/desk-tool/src/DeskTool.js
@@ -14,6 +14,7 @@ import isNarrowScreen from './utils/isNarrowScreen'
 import windowWidth$ from './utils/windowWidth'
 import defaultStructure from './defaultStructure'
 import {LOADING_PANE} from './index'
+import {getTemplateById} from '@sanity/base/initial-value-templates'
 
 const EMPTY_PANE_KEYS = []
 
@@ -96,6 +97,10 @@ export default withRouterHOC(
               })
             )
           ),
+          params: PropTypes.shape({
+            template: PropTypes.string
+          }),
+          editDocumentId: PropTypes.string,
           legacyEditDocumentId: PropTypes.string,
           type: PropTypes.string,
           action: PropTypes.string
@@ -242,9 +247,28 @@ export default withRouterHOC(
 
     maybeHandleOldUrl() {
       const {navigate} = this.props.router
-      const {panes, action, legacyEditDocumentId} = this.props.router.state
+      const {
+        action,
+        legacyEditDocumentId,
+        type: schemaType,
+        editDocumentId,
+        params = {}
+      } = this.props.router.state
+
+      const {template: templateName, ...payload} = params
+      const template = getTemplateById(templateName)
+      const type = (template && template.schemaType) || schemaType
+      const parameters = {type, template: templateName}
+
       if (action === 'edit' && legacyEditDocumentId) {
-        navigate({panes: panes.concat([{id: legacyEditDocumentId}])}, {replace: true})
+        navigate({panes: [[{id: `__edit__${legacyEditDocumentId}`}]]}, {replace: true})
+      }
+
+      if (type && editDocumentId) {
+        navigate(
+          {panes: [[{id: `__edit__${editDocumentId}`, params: parameters, payload}]]},
+          {replace: true}
+        )
       }
     }
 

--- a/packages/@sanity/desk-tool/src/tool.js
+++ b/packages/@sanity/desk-tool/src/tool.js
@@ -15,6 +15,20 @@ function toPath(panes) {
   return encodePanesSegment(panes)
 }
 
+function legacyEditParamsToState(params) {
+  try {
+    return JSON.parse(decodeURIComponent(params))
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn('Failed to parse JSON parameters')
+    return {}
+  }
+}
+
+function legacyEditParamsToPath(params) {
+  return JSON.stringify(params)
+}
+
 const state = {activePanes: []}
 
 function setActivePanes(panes) {
@@ -60,6 +74,14 @@ function getFallbackIntentState({documentId, intentName, params, payload}) {
 
 export default {
   router: route('/', [
+    // Legacy fallback route, will be redirected to new format
+    route('/edit/:type/:editDocumentId', [
+      route({
+        path: '/:params',
+        transform: {params: {toState: legacyEditParamsToState, toPath: legacyEditParamsToPath}}
+      })
+    ]),
+
     // The regular path - when the intent can be resolved to a specific pane
     route({
       path: '/:panes',


### PR DESCRIPTION
The "fallback editor" URL and pane handling changes significantly in 0.145.0, but it seems I forgot to account for the old fallback URLs potentially being bookmarked/integrated somewhere.

With this PR, we handle the `/edit/type/documentId` route and redirect to the new format.