### PR TITLE
[structure] Allow passing object spec to documentTypeList()

### DIFF
--- a/packages/@sanity/structure/src/DocumentTypeList.ts
+++ b/packages/@sanity/structure/src/DocumentTypeList.ts
@@ -1,6 +1,12 @@
 import {DocumentListBuilder, DocumentListInput, PartialDocumentList} from './DocumentList'
 import {Child} from './StructureNodes'
 import {DEFAULT_INTENT_HANDLER} from './Intent'
+import {GenericListInput} from './GenericList'
+import {SchemaType} from './parts/Schema'
+
+export interface DocumentTypeListInput extends Partial<GenericListInput> {
+  schemaType: SchemaType | string
+}
 
 export class DocumentTypeListBuilder extends DocumentListBuilder {
   protected spec: PartialDocumentList

--- a/packages/@sanity/structure/test/DocumentTypeList.test.ts
+++ b/packages/@sanity/structure/test/DocumentTypeList.test.ts
@@ -1,0 +1,164 @@
+import {StructureBuilder as S} from '../src'
+import serializeStructure from './util/serializeStructure'
+import {getDefaultSchema, SchemaType} from '../src/parts/Schema'
+
+test('builds document type lists with only required properties', () => {
+  expect(
+    S.documentTypeList({
+      id: 'custom-id',
+      title: 'Custom author title',
+      schemaType: 'author'
+    }).serialize({
+      path: []
+    })
+  ).toMatchSnapshot()
+})
+
+test('builds document type lists with schema type as string', () => {
+  expect(
+    S.documentTypeList('author').serialize({
+      path: []
+    })
+  ).toMatchSnapshot()
+})
+
+test('builds document type lists with schema type name + schema', () => {
+  expect(
+    S.documentTypeList('author', getDefaultSchema()).serialize({
+      path: []
+    })
+  ).toMatchSnapshot()
+})
+
+test('builds document type lists with schema type instance', () => {
+  expect(
+    S.documentTypeList({
+      schemaType: getDefaultSchema().get('author') as SchemaType
+    }).serialize({
+      path: []
+    })
+  ).toMatchSnapshot()
+})
+
+test('throws if no filter is set', () => {
+  expect(() =>
+    S.documentTypeList('author')
+      .id('foo')
+      .filter('')
+      .serialize()
+  ).toThrowErrorMatchingSnapshot()
+})
+
+test('builds document type lists through setters', () => {
+  expect(
+    S.documentTypeList('author')
+      .id('authors')
+      .title('authors')
+      .filter('_type == $type')
+      .params({type: 'author'})
+      .defaultLayout('card')
+      .defaultOrdering([{field: 'title', direction: 'asc'}])
+      .serialize()
+  ).toMatchSnapshot()
+})
+
+test('builds document type lists through setters (alt order)', () => {
+  expect(
+    S.documentTypeList('author')
+      .defaultOrdering([{field: 'title', direction: 'desc'}])
+      .id('authors')
+      .title('authors')
+      .filter('_type == $type')
+      .params({type: 'author'})
+      .serialize()
+  ).toMatchSnapshot()
+})
+
+test('builds document type lists through setters (alt order #2)', () => {
+  expect(
+    S.documentTypeList('author')
+      .params({type: 'author'})
+      .defaultOrdering([{field: 'title', direction: 'desc'}])
+      .id('authors')
+      .title('authors')
+      .filter('_type == $type')
+      .serialize()
+  ).toMatchSnapshot()
+})
+
+test('default child resolver resolves to editor', done => {
+  const list = S.documentTypeList('author').serialize()
+
+  const context = {parent: list, index: 1}
+  serializeStructure(list.child, context, ['asoiaf-wow', context]).subscribe(child => {
+    expect(child).toEqual({
+      child: undefined,
+      id: 'editor',
+      type: 'document',
+      options: {
+        id: 'asoiaf-wow',
+        type: 'author'
+      },
+      views: [
+        {
+          id: 'editor',
+          title: 'Editor',
+          type: 'form',
+          icon: undefined
+        }
+      ]
+    })
+    done()
+  })
+})
+
+test('builder is immutable', () => {
+  const original = S.documentTypeList('author')
+  expect(original.id('foo')).not.toEqual(original)
+  expect(original.title('foo')).not.toEqual(original)
+  expect(original.filter('foo == "bar"')).not.toEqual(original)
+  expect(original.params({foo: 'bar'})).not.toEqual(original)
+  expect(original.menuItems([])).not.toEqual(original)
+  expect(original.showIcons(false)).not.toEqual(original)
+  expect(original.menuItemGroups([])).not.toEqual(original)
+  expect(original.defaultLayout('card')).not.toEqual(original)
+  expect(original.child(() => undefined)).not.toEqual(original)
+  expect(original.canHandleIntent(() => false)).not.toEqual(original)
+  expect(original.defaultOrdering([{field: 'title', direction: 'asc'}])).not.toEqual(original)
+})
+
+test('getters work', () => {
+  const original = S.documentTypeList('author')
+  const child = () => undefined
+  const canHandleIntent = () => false
+  const field = 'title'
+  const direction = 'asc'
+  expect(original.id('foo').getId()).toEqual('foo')
+  expect(original.title('bar').getTitle()).toEqual('bar')
+  expect(original.filter('foo == "bar"').getFilter()).toEqual('foo == "bar"')
+  expect(original.params({foo: 'bar'}).getParams()).toEqual({foo: 'bar'})
+  expect(original.menuItems([]).getMenuItems()).toEqual([])
+  expect(original.menuItemGroups([]).getMenuItemGroups()).toEqual([])
+  expect(original.defaultLayout('card').getDefaultLayout()).toEqual('card')
+  expect(original.child(child).getChild()).toEqual(child)
+  expect(original.showIcons(false).getShowIcons()).toEqual(false)
+  expect(original.canHandleIntent(canHandleIntent).getCanHandleIntent()).toEqual(canHandleIntent)
+  expect(original.defaultOrdering([{field, direction}]).getDefaultOrdering()).toEqual([
+    {field, direction}
+  ])
+})
+
+test('can disable icons from being displayed', () => {
+  const list = S.documentTypeList('author')
+    .id('blamuggost')
+    .title('Blåmuggost')
+    .filter('_type == "bluecheese"')
+    .showIcons(false)
+
+  expect(list.serialize()).toMatchObject({
+    id: 'blamuggost',
+    displayOptions: {showIcons: false}
+  })
+
+  expect(list.getShowIcons()).toBe(false)
+})

--- a/packages/@sanity/structure/test/__snapshots__/DocumentTypeList.test.ts.snap
+++ b/packages/@sanity/structure/test/__snapshots__/DocumentTypeList.test.ts.snap
@@ -1,0 +1,647 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`builds document type lists through setters (alt order #2) 1`] = `
+Object {
+  "canHandleIntent": [Function],
+  "child": [Function],
+  "defaultLayout": undefined,
+  "displayOptions": Object {
+    "showIcons": true,
+  },
+  "id": "authors",
+  "initialValueTemplates": Array [],
+  "menuItemGroups": Array [
+    Object {
+      "id": "sorting",
+      "title": "Sort",
+    },
+    Object {
+      "id": "layout",
+      "title": "Layout",
+    },
+    Object {
+      "id": "actions",
+      "title": "Actions",
+    },
+  ],
+  "menuItems": Array [
+    Object {
+      "action": "setSortOrder",
+      "group": "sorting",
+      "icon": [Function],
+      "params": Object {
+        "by": Array [
+          Object {
+            "direction": "desc",
+            "field": "_updatedAt",
+          },
+        ],
+        "extendedProjection": "",
+      },
+      "title": "Sort by Last edited",
+    },
+    Object {
+      "action": "setSortOrder",
+      "group": "sorting",
+      "icon": [Function],
+      "params": Object {
+        "by": Array [
+          Object {
+            "direction": "desc",
+            "field": "_createdAt",
+          },
+        ],
+        "extendedProjection": "",
+      },
+      "title": "Sort by Created",
+    },
+    Object {
+      "action": "setLayout",
+      "group": "layout",
+      "icon": [Function],
+      "params": Object {
+        "layout": "default",
+      },
+      "title": "List",
+    },
+    Object {
+      "action": "setLayout",
+      "group": "layout",
+      "icon": [Function],
+      "params": Object {
+        "layout": "detail",
+      },
+      "title": "Details",
+    },
+  ],
+  "options": Object {
+    "defaultOrdering": Array [
+      Object {
+        "direction": "desc",
+        "field": "title",
+      },
+    ],
+    "filter": "_type == $type",
+    "params": Object {
+      "type": "author",
+    },
+  },
+  "schemaTypeName": "author",
+  "title": "authors",
+  "type": "documentList",
+}
+`;
+
+exports[`builds document type lists through setters (alt order) 1`] = `
+Object {
+  "canHandleIntent": [Function],
+  "child": [Function],
+  "defaultLayout": undefined,
+  "displayOptions": Object {
+    "showIcons": true,
+  },
+  "id": "authors",
+  "initialValueTemplates": Array [],
+  "menuItemGroups": Array [
+    Object {
+      "id": "sorting",
+      "title": "Sort",
+    },
+    Object {
+      "id": "layout",
+      "title": "Layout",
+    },
+    Object {
+      "id": "actions",
+      "title": "Actions",
+    },
+  ],
+  "menuItems": Array [
+    Object {
+      "action": "setSortOrder",
+      "group": "sorting",
+      "icon": [Function],
+      "params": Object {
+        "by": Array [
+          Object {
+            "direction": "desc",
+            "field": "_updatedAt",
+          },
+        ],
+        "extendedProjection": "",
+      },
+      "title": "Sort by Last edited",
+    },
+    Object {
+      "action": "setSortOrder",
+      "group": "sorting",
+      "icon": [Function],
+      "params": Object {
+        "by": Array [
+          Object {
+            "direction": "desc",
+            "field": "_createdAt",
+          },
+        ],
+        "extendedProjection": "",
+      },
+      "title": "Sort by Created",
+    },
+    Object {
+      "action": "setLayout",
+      "group": "layout",
+      "icon": [Function],
+      "params": Object {
+        "layout": "default",
+      },
+      "title": "List",
+    },
+    Object {
+      "action": "setLayout",
+      "group": "layout",
+      "icon": [Function],
+      "params": Object {
+        "layout": "detail",
+      },
+      "title": "Details",
+    },
+  ],
+  "options": Object {
+    "defaultOrdering": Array [
+      Object {
+        "direction": "desc",
+        "field": "title",
+      },
+    ],
+    "filter": "_type == $type",
+    "params": Object {
+      "type": "author",
+    },
+  },
+  "schemaTypeName": "author",
+  "title": "authors",
+  "type": "documentList",
+}
+`;
+
+exports[`builds document type lists through setters 1`] = `
+Object {
+  "canHandleIntent": [Function],
+  "child": [Function],
+  "defaultLayout": "card",
+  "displayOptions": Object {
+    "showIcons": true,
+  },
+  "id": "authors",
+  "initialValueTemplates": Array [],
+  "menuItemGroups": Array [
+    Object {
+      "id": "sorting",
+      "title": "Sort",
+    },
+    Object {
+      "id": "layout",
+      "title": "Layout",
+    },
+    Object {
+      "id": "actions",
+      "title": "Actions",
+    },
+  ],
+  "menuItems": Array [
+    Object {
+      "action": "setSortOrder",
+      "group": "sorting",
+      "icon": [Function],
+      "params": Object {
+        "by": Array [
+          Object {
+            "direction": "desc",
+            "field": "_updatedAt",
+          },
+        ],
+        "extendedProjection": "",
+      },
+      "title": "Sort by Last edited",
+    },
+    Object {
+      "action": "setSortOrder",
+      "group": "sorting",
+      "icon": [Function],
+      "params": Object {
+        "by": Array [
+          Object {
+            "direction": "desc",
+            "field": "_createdAt",
+          },
+        ],
+        "extendedProjection": "",
+      },
+      "title": "Sort by Created",
+    },
+    Object {
+      "action": "setLayout",
+      "group": "layout",
+      "icon": [Function],
+      "params": Object {
+        "layout": "default",
+      },
+      "title": "List",
+    },
+    Object {
+      "action": "setLayout",
+      "group": "layout",
+      "icon": [Function],
+      "params": Object {
+        "layout": "detail",
+      },
+      "title": "Details",
+    },
+  ],
+  "options": Object {
+    "defaultOrdering": Array [
+      Object {
+        "direction": "asc",
+        "field": "title",
+      },
+    ],
+    "filter": "_type == $type",
+    "params": Object {
+      "type": "author",
+    },
+  },
+  "schemaTypeName": "author",
+  "title": "authors",
+  "type": "documentList",
+}
+`;
+
+exports[`builds document type lists with only required properties 1`] = `
+Object {
+  "canHandleIntent": [Function],
+  "child": [Function],
+  "defaultLayout": undefined,
+  "displayOptions": Object {
+    "showIcons": true,
+  },
+  "id": "custom-id",
+  "initialValueTemplates": Array [],
+  "menuItemGroups": Array [
+    Object {
+      "id": "sorting",
+      "title": "Sort",
+    },
+    Object {
+      "id": "layout",
+      "title": "Layout",
+    },
+    Object {
+      "id": "actions",
+      "title": "Actions",
+    },
+  ],
+  "menuItems": Array [
+    Object {
+      "action": "setSortOrder",
+      "group": "sorting",
+      "icon": [Function],
+      "params": Object {
+        "by": Array [
+          Object {
+            "direction": "desc",
+            "field": "_updatedAt",
+          },
+        ],
+        "extendedProjection": "",
+      },
+      "title": "Sort by Last edited",
+    },
+    Object {
+      "action": "setSortOrder",
+      "group": "sorting",
+      "icon": [Function],
+      "params": Object {
+        "by": Array [
+          Object {
+            "direction": "desc",
+            "field": "_createdAt",
+          },
+        ],
+        "extendedProjection": "",
+      },
+      "title": "Sort by Created",
+    },
+    Object {
+      "action": "setLayout",
+      "group": "layout",
+      "icon": [Function],
+      "params": Object {
+        "layout": "default",
+      },
+      "title": "List",
+    },
+    Object {
+      "action": "setLayout",
+      "group": "layout",
+      "icon": [Function],
+      "params": Object {
+        "layout": "detail",
+      },
+      "title": "Details",
+    },
+  ],
+  "options": Object {
+    "defaultOrdering": Array [
+      Object {
+        "direction": "desc",
+        "field": "_updatedAt",
+      },
+    ],
+    "filter": "_type == $type",
+    "params": Object {
+      "type": "author",
+    },
+  },
+  "schemaTypeName": "author",
+  "title": "Custom author title",
+  "type": "documentList",
+}
+`;
+
+exports[`builds document type lists with schema type as string 1`] = `
+Object {
+  "canHandleIntent": [Function],
+  "child": [Function],
+  "defaultLayout": undefined,
+  "displayOptions": Object {
+    "showIcons": true,
+  },
+  "id": "author",
+  "initialValueTemplates": Array [],
+  "menuItemGroups": Array [
+    Object {
+      "id": "sorting",
+      "title": "Sort",
+    },
+    Object {
+      "id": "layout",
+      "title": "Layout",
+    },
+    Object {
+      "id": "actions",
+      "title": "Actions",
+    },
+  ],
+  "menuItems": Array [
+    Object {
+      "action": "setSortOrder",
+      "group": "sorting",
+      "icon": [Function],
+      "params": Object {
+        "by": Array [
+          Object {
+            "direction": "desc",
+            "field": "_updatedAt",
+          },
+        ],
+        "extendedProjection": "",
+      },
+      "title": "Sort by Last edited",
+    },
+    Object {
+      "action": "setSortOrder",
+      "group": "sorting",
+      "icon": [Function],
+      "params": Object {
+        "by": Array [
+          Object {
+            "direction": "desc",
+            "field": "_createdAt",
+          },
+        ],
+        "extendedProjection": "",
+      },
+      "title": "Sort by Created",
+    },
+    Object {
+      "action": "setLayout",
+      "group": "layout",
+      "icon": [Function],
+      "params": Object {
+        "layout": "default",
+      },
+      "title": "List",
+    },
+    Object {
+      "action": "setLayout",
+      "group": "layout",
+      "icon": [Function],
+      "params": Object {
+        "layout": "detail",
+      },
+      "title": "Details",
+    },
+  ],
+  "options": Object {
+    "defaultOrdering": Array [
+      Object {
+        "direction": "desc",
+        "field": "_updatedAt",
+      },
+    ],
+    "filter": "_type == $type",
+    "params": Object {
+      "type": "author",
+    },
+  },
+  "schemaTypeName": "author",
+  "title": "Author",
+  "type": "documentList",
+}
+`;
+
+exports[`builds document type lists with schema type instance 1`] = `
+Object {
+  "canHandleIntent": [Function],
+  "child": [Function],
+  "defaultLayout": undefined,
+  "displayOptions": Object {
+    "showIcons": true,
+  },
+  "id": "author",
+  "initialValueTemplates": Array [],
+  "menuItemGroups": Array [
+    Object {
+      "id": "sorting",
+      "title": "Sort",
+    },
+    Object {
+      "id": "layout",
+      "title": "Layout",
+    },
+    Object {
+      "id": "actions",
+      "title": "Actions",
+    },
+  ],
+  "menuItems": Array [
+    Object {
+      "action": "setSortOrder",
+      "group": "sorting",
+      "icon": [Function],
+      "params": Object {
+        "by": Array [
+          Object {
+            "direction": "desc",
+            "field": "_updatedAt",
+          },
+        ],
+        "extendedProjection": "",
+      },
+      "title": "Sort by Last edited",
+    },
+    Object {
+      "action": "setSortOrder",
+      "group": "sorting",
+      "icon": [Function],
+      "params": Object {
+        "by": Array [
+          Object {
+            "direction": "desc",
+            "field": "_createdAt",
+          },
+        ],
+        "extendedProjection": "",
+      },
+      "title": "Sort by Created",
+    },
+    Object {
+      "action": "setLayout",
+      "group": "layout",
+      "icon": [Function],
+      "params": Object {
+        "layout": "default",
+      },
+      "title": "List",
+    },
+    Object {
+      "action": "setLayout",
+      "group": "layout",
+      "icon": [Function],
+      "params": Object {
+        "layout": "detail",
+      },
+      "title": "Details",
+    },
+  ],
+  "options": Object {
+    "defaultOrdering": Array [
+      Object {
+        "direction": "desc",
+        "field": "_updatedAt",
+      },
+    ],
+    "filter": "_type == $type",
+    "params": Object {
+      "type": "author",
+    },
+  },
+  "schemaTypeName": "author",
+  "title": "Author",
+  "type": "documentList",
+}
+`;
+
+exports[`builds document type lists with schema type name + schema 1`] = `
+Object {
+  "canHandleIntent": [Function],
+  "child": [Function],
+  "defaultLayout": undefined,
+  "displayOptions": Object {
+    "showIcons": true,
+  },
+  "id": "author",
+  "initialValueTemplates": Array [],
+  "menuItemGroups": Array [
+    Object {
+      "id": "sorting",
+      "title": "Sort",
+    },
+    Object {
+      "id": "layout",
+      "title": "Layout",
+    },
+    Object {
+      "id": "actions",
+      "title": "Actions",
+    },
+  ],
+  "menuItems": Array [
+    Object {
+      "action": "setSortOrder",
+      "group": "sorting",
+      "icon": [Function],
+      "params": Object {
+        "by": Array [
+          Object {
+            "direction": "desc",
+            "field": "_updatedAt",
+          },
+        ],
+        "extendedProjection": "",
+      },
+      "title": "Sort by Last edited",
+    },
+    Object {
+      "action": "setSortOrder",
+      "group": "sorting",
+      "icon": [Function],
+      "params": Object {
+        "by": Array [
+          Object {
+            "direction": "desc",
+            "field": "_createdAt",
+          },
+        ],
+        "extendedProjection": "",
+      },
+      "title": "Sort by Created",
+    },
+    Object {
+      "action": "setLayout",
+      "group": "layout",
+      "icon": [Function],
+      "params": Object {
+        "layout": "default",
+      },
+      "title": "List",
+    },
+    Object {
+      "action": "setLayout",
+      "group": "layout",
+      "icon": [Function],
+      "params": Object {
+        "layout": "detail",
+      },
+      "title": "Details",
+    },
+  ],
+  "options": Object {
+    "defaultOrdering": Array [
+      Object {
+        "direction": "desc",
+        "field": "_updatedAt",
+      },
+    ],
+    "filter": "_type == $type",
+    "params": Object {
+      "type": "author",
+    },
+  },
+  "schemaTypeName": "author",
+  "title": "Author",
+  "type": "documentList",
+}
+`;
+
+exports[`throws if no filter is set 1`] = `"\`filter\` is required for document lists"`;


### PR DESCRIPTION
While most structure nodes accept an object form specification, the  `documentTypeList()` method does not - instead it accepts a string. This is fine for most cases, but sometimes you may want to override certain aspects of the default setup without using the "builder" approach (`.child(differentChildResolver)`). 

With this PR, the method now accepts _either_ a string _or_ an object specification. 