### PR TITLE
[form-builder] Cleanup isEmpty function

### DIFF
--- a/packages/@sanity/form-builder/src/utils/isEmpty.ts
+++ b/packages/@sanity/form-builder/src/utils/isEmpty.ts
@@ -13,9 +13,7 @@ function isEmptyObject(value: {[key: string]: any}): boolean {
 }
 
 function isEmptyArray(value: Array<any>): boolean {
-  if (value === undefined) {
-    return true
-  }
+
 
   for (let i = 0; i < value.length; i++) {
     if (isEmpty(value[i])) {
@@ -25,20 +23,16 @@ function isEmptyArray(value: Array<any>): boolean {
   return false
 }
 
-function isEmptyPrimitive(value: any) {
-  return value === undefined
-}
-
 export default function isEmpty(value: any): boolean {
-  if (value === undefined) {
+  if (value === undefined || value === null) {
     return true
   }
   const type = typeof value
-  if (type === 'object' && type !== null) {
+  if (type === 'object') {
     return isEmptyObject(value)
   }
   if (Array.isArray(value)) {
     return isEmptyArray(value)
   }
-  return isEmptyPrimitive(value)
+  return false
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [x]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**
Same, but with a bunch of redundant stuff.

**Description**
`null` values were going down the isEmptyObject code path. There was a check that type !== null (but it never will be, I think the intent was to check the value not the type).
Just exit early for null cases and stop worrying about them later on in the function.

isEmptyArray was checking if the value was undefined, which we already know its not.

Same with isEmptyPrimative; we already know its not undefined, why check again.
**Note for release**

Tidy up isEmpty function.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
