### PR TITLE
[desk-tool] Implement naive, shallow, async intent resolver

### DIFF
--- a/packages/@sanity/desk-tool/package.json
+++ b/packages/@sanity/desk-tool/package.json
@@ -75,7 +75,11 @@
       "^part:@sanity/data-aspects/resolver$": "<rootDir>/test/mocks/dataAspects.js",
       "^part:@sanity/base/.*?-icon$": "<rootDir>/test/mocks/icon.js",
       "^part:@sanity/base/util/document-action-utils": "<rootDir>/test/mocks/documentActionUtils.js",
-      "^part:@sanity/base/router": "<rootDir>/test/mocks/router.js"
+      "^part:@sanity/base/router": "<rootDir>/test/mocks/router.js",
+      ".*\\.css$": "<rootDir>/test/mocks/styles.js"
+    },
+    "globals": {
+      "__DEV__": false
     }
   },
   "repository": {

--- a/packages/@sanity/desk-tool/src/components/IntentResolver.js
+++ b/packages/@sanity/desk-tool/src/components/IntentResolver.js
@@ -1,0 +1,112 @@
+/* eslint-disable react/no-multi-comp, react/prop-types */
+import React, {useEffect, useState} from 'react'
+import {of} from 'rxjs'
+import {map} from 'rxjs/operators'
+import client from 'part:@sanity/base/client'
+import {useRouter} from 'part:@sanity/base/router'
+import Spinner from 'part:@sanity/components/loading/spinner'
+import {useStructure} from '../utils/resolvePanes'
+import {LOADING_PANE} from '../../'
+import StructureError from './StructureError'
+import UUID from '@sanity/uuid'
+import {getTemplateById} from '@sanity/base/initial-value-templates'
+
+const FALLBACK_ID = '__fallback__'
+
+/**
+ * This is a *very naive* implementation of an intent resolver:
+ * - If type is missing from params, it'lltry to resolve from document
+ * - It manually builds a pane segment path: "<typeName>;<documentId>"
+ * - Tries to resolve that to a structure
+ * - Checks if the last pane segment is an editor, and if so; is it the right type/id?
+ *   - Yes: Resolves to "<typeName>;<documentId>"
+ *   - No : Resolves to fallback edit pane (context-less)
+ *
+ */
+const IntentResolver = React.memo(({params, payload}) => {
+  const {type: specifiedSchemaType, id, ...otherParams} = params || {}
+
+  const documentId = id || FALLBACK_ID
+  const schemaType = useDocumentType(documentId, specifiedSchemaType)
+  const paneSegments = schemaType
+    ? [[{id: schemaType, params: {}}], [{id: documentId, params: otherParams, payload}]]
+    : undefined
+
+  const {structure, error} = useStructure(paneSegments, {silent: true})
+
+  if (error) {
+    return <StructureError error={error} />
+  }
+
+  if (!schemaType) {
+    return <Spinner center message="Resolving document type…" delay={600} />
+  }
+
+  const isLoading = !structure || structure.some(item => item === LOADING_PANE)
+  if (isLoading) {
+    return <Spinner center message="Resolving structure…" delay={600} />
+  }
+
+  const panes = getNewRouterState({
+    structure,
+    schemaType,
+    params: otherParams,
+    payload,
+    paneSegments,
+    documentId
+  })
+
+  return <Redirect panes={panes} />
+})
+
+function getNewRouterState({structure, schemaType, params, payload, documentId, paneSegments}) {
+  const lastChild = structure[structure.length - 1] || {}
+  const lastGroup = paneSegments[paneSegments.length - 1]
+  const lastSibling = lastGroup[lastGroup.length - 1]
+  const terminatesInDocument = lastChild.type === 'document' && lastChild.options.id === documentId
+
+  const isTemplateCreate = params.template
+  const template = isTemplateCreate && getTemplateById(params.template)
+  const type = (template && template.schemaType) || schemaType
+  const fallbackParameters = {type, template: params.template}
+  const newDocumentId = documentId === FALLBACK_ID ? UUID() : documentId
+
+  return terminatesInDocument
+    ? paneSegments
+        .slice(0, -1)
+        .concat([lastGroup.slice(0, -1).concat({...lastSibling, id: newDocumentId})])
+    : [[{id: `__edit__${newDocumentId}`, params: fallbackParameters, payload}]]
+}
+
+// Navigates to passed router panes state on mount
+function Redirect({panes}) {
+  const router = useRouter()
+
+  useEffect(() => {
+    router.navigate({panes}, {replace: true})
+  })
+
+  return <Spinner center message="Redirecting…" delay={600} />
+}
+
+function useDocumentType(documentId, specifiedType) {
+  const [documentType, setDocumentType] = useState()
+  useEffect(() => {
+    const sub = resolveTypeForDocument(documentId, specifiedType).subscribe(setDocumentType)
+    return () => sub.unsubscribe()
+  })
+  return documentType
+}
+
+function resolveTypeForDocument(id, specifiedType) {
+  if (specifiedType) {
+    return of(specifiedType)
+  }
+
+  const query = '*[_id in [$documentId, $draftId]]._type'
+  const documentId = id.replace(/^drafts\./, '')
+  const draftId = `drafts.${documentId}`
+  return client.observable.fetch(query, {documentId, draftId}).pipe(map(types => types[0]))
+}
+
+export default IntentResolver

--- a/packages/@sanity/desk-tool/src/pane/DocumentPane.js
+++ b/packages/@sanity/desk-tool/src/pane/DocumentPane.js
@@ -1060,10 +1060,15 @@ export default withInitialValue(
         <div className={documentPaneStyles.unknownSchemaType}>
           <div className={documentPaneStyles.unknownSchemaTypeInner}>
             <h3>Unknown schema type</h3>
-            <p>
-              This document has the schema type <code>{typeName}</code>, which is not defined as a
-              type in the local content studio schema.
-            </p>
+            {typeName && (
+              <p>
+                This document has the schema type <code>{typeName}</code>, which is not defined as a
+                type in the local content studio schema.
+              </p>
+            )}
+            {!typeName && (
+              <p>This document does not exist, and no schema type was specified for it.</p>
+            )}
             {__DEV__ && doc && (
               <div>
                 <h4>Here is the JSON representation of the document:</h4>

--- a/packages/@sanity/desk-tool/src/utils/calculatePanesEquality.js
+++ b/packages/@sanity/desk-tool/src/utils/calculatePanesEquality.js
@@ -1,0 +1,33 @@
+import {isEqual} from 'lodash'
+
+// eslint-disable-next-line import/prefer-default-export
+export const calculatePanesEquality = (prev = [], next = []) => {
+  if (prev === next) {
+    return {ids: true, params: true}
+  }
+
+  if (prev.length !== next.length) {
+    return {ids: false, params: false}
+  }
+
+  let paramsDiffer = false
+  const idsEqual = prev.every((prevGroup, index) => {
+    const nextGroup = next[index]
+    if (prevGroup.length !== nextGroup.length) {
+      return false
+    }
+
+    return prevGroup.every((prevPane, paneIndex) => {
+      const nextPane = nextGroup[paneIndex]
+
+      paramsDiffer =
+        paramsDiffer ||
+        !isEqual(nextPane.params, prevPane.params) ||
+        !isEqual(nextPane.payload, prevPane.payload)
+
+      return nextPane.id === prevPane.id
+    })
+  })
+
+  return {ids: idsEqual, params: !paramsDiffer}
+}

--- a/packages/@sanity/desk-tool/test/mocks/styles.js
+++ b/packages/@sanity/desk-tool/test/mocks/styles.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/packages/@sanity/state-router/src/RouterContext.ts
+++ b/packages/@sanity/state-router/src/RouterContext.ts
@@ -1,4 +1,33 @@
-import React, {useContext} from 'react'
+import React, {useContext, useState, useEffect} from 'react'
+import {InternalRouter} from './components/types'
 
-export const RouterContext = React.createContext({})
+const missingContext = () => {
+  throw new Error('No router context provider found')
+}
+
+const missingRouter: InternalRouter = {
+  channel: {subscribe: missingContext, publish: missingContext},
+  getState: missingContext,
+  navigate: missingContext,
+  navigateIntent: missingContext,
+  navigateUrl: missingContext,
+  resolveIntentLink: missingContext,
+  resolvePathFromState: missingContext
+}
+
+export const RouterContext = React.createContext(missingRouter)
 export const useRouter = () => useContext(RouterContext)
+export const useRouterState = (deps?: string[]) => {
+  const router = useContext(RouterContext)
+  const [routerState, setState] = useState(router.getState())
+
+  let dependencies
+  if (deps) {
+    dependencies = deps.map(key => routerState[key])
+  }
+
+  // subscribe() returns an unsubscribe function, so this'll handle unmounting
+  useEffect(() => router.channel.subscribe(() => setState(router.getState())), dependencies)
+
+  return routerState
+}

--- a/packages/@sanity/state-router/src/RouterContext.ts
+++ b/packages/@sanity/state-router/src/RouterContext.ts
@@ -1,0 +1,4 @@
+import React, {useContext} from 'react'
+
+export const RouterContext = React.createContext({})
+export const useRouter = () => useContext(RouterContext)

--- a/packages/@sanity/state-router/src/components/RouteScope.tsx
+++ b/packages/@sanity/state-router/src/components/RouteScope.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import isEmpty from '../utils/isEmpty'
 
 import {InternalRouter, NavigateOptions, RouterProviderContext} from './types'
+import {RouterContext} from '../RouterContext'
 
 function addScope(routerState: Object, scope: string, scopedState: Object) {
   return (
@@ -72,6 +73,10 @@ export default class RouteScope extends React.Component<Props> {
   }
 
   render() {
-    return this.props.children
+    return (
+      <RouterContext.Provider value={this.__internalRouter}>
+        {this.props.children}
+      </RouterContext.Provider>
+    )
   }
 }

--- a/packages/@sanity/state-router/src/components/RouterProvider.tsx
+++ b/packages/@sanity/state-router/src/components/RouterProvider.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import pubsub from 'nano-pubsub'
 import {Router} from '../types'
+import {RouterContext} from '../RouterContext'
 import {
   InternalRouter,
   NavigateOptions,
@@ -81,6 +82,10 @@ export default class RouterProvider extends React.Component<Props> {
   }
 
   render() {
-    return this.props.children
+    return (
+      <RouterContext.Provider value={this.__internalRouter}>
+        {this.props.children}
+      </RouterContext.Provider>
+    )
   }
 }

--- a/packages/@sanity/state-router/src/components/types.ts
+++ b/packages/@sanity/state-router/src/components/types.ts
@@ -4,7 +4,6 @@ export type NavigateOptions = {
 
 type Channel<T> = {
   subscribe: (arg0: T) => () => void
-  get(): T
   publish(arg0: T): void
 }
 

--- a/packages/@sanity/state-router/src/index.ts
+++ b/packages/@sanity/state-router/src/index.ts
@@ -2,7 +2,7 @@ import resolveStateFromPath from './resolveStateFromPath'
 import resolvePathFromState from './resolvePathFromState'
 
 export {default as route} from './route'
-export {RouterContext, useRouter} from './RouterContext'
+export {RouterContext, useRouter, useRouterState} from './RouterContext'
 
 export {resolveStateFromPath}
 export {resolvePathFromState}

--- a/packages/@sanity/state-router/src/index.ts
+++ b/packages/@sanity/state-router/src/index.ts
@@ -2,6 +2,7 @@ import resolveStateFromPath from './resolveStateFromPath'
 import resolvePathFromState from './resolvePathFromState'
 
 export {default as route} from './route'
+export {RouterContext, useRouter} from './RouterContext'
 
 export {resolveStateFromPath}
 export {resolvePathFromState}


### PR DESCRIPTION
## Background

The desk tool uses a very basic approach in trying to figure out where an intent (edit/create) can be handled. Currently it looks at the open panes and recursively (depth first) calls  `canHandleIntent` on the structure nodes until it finds one that returns true. When it does, it navigates to it.

If no pane says it can handle the intent, we use a "fallback route" (`__edit__${documentId}`) which makes sure we can _always_ handle editing/creating a document, regardless of structure setup. 

What it fails to do is to look _upwards_, in other words: check structure nodes that _are not_ open. The reason for this is that the intent checker is on the _resolved_ child, which we can't statically analyze/get to without passing the child handler an ID and seeing what it returns, which could possibly be behind a promise/observable. 

## A naive solution

After some discussion with @simen and @evenwestvang, we decided that although far from perfect, we want to at least _attempt_ to find a better path to a document. 

This PR implements a very naive, shallow solution:

1. The intent resolving machinery expects a synchronously returned router state on intents, which we can't do for the _correct_ path. Instead, we resolve the intent to a _desk-tool_ specific intent resolving route.
2. The desk tool intent resolver displays a UI spinner (rarely seen) while fetching the configured structure, then attempts to resolve the structure for a (very naive) segmented path: `[documentType, documentId]`. While there are many cases where this won't match, for the vast majority of our users, it will match a document type list and a document ID.  If no document type is passed to the intent, we try to look up the document type by running a query. 
3. When the structure is resolved, we check if the last segment is an editor/document and if so, whether or not it was given the document ID we passed it. If so, we redirect to this route. Otherwise, we redirect to the fallback route as previously.

## Technical details

While implementing this, I created two new hooks (since we can now use those), for getting the router and the router state. I'm not super familiar with hooks yet, so please review these and see if they make sense. They can fairly easily be replaced with `withRouterHOC` if that is preferable.

