### PR TITLE
[form-builder] Send document to asset source plugin

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.tsx
@@ -20,6 +20,7 @@ import ProgressCircle from 'part:@sanity/components/progress/circle'
 import UploadIcon from 'part:@sanity/base/upload-icon'
 import userDefinedAssetSources from 'part:@sanity/form-builder/input/image/asset-sources?'
 import VisibilityIcon from 'part:@sanity/base/visibility-icon'
+import {withDocument} from 'part:@sanity/form-builder'
 
 // Package files
 import {FormBuilderInput} from '../../FormBuilderInput'
@@ -70,6 +71,7 @@ export interface Value {
 
 export type Props = {
   value?: Value
+  document?: Value,
   type: Type
   level: number
   onChange: (arg0: PatchEvent) => void
@@ -98,7 +100,7 @@ type ImageInputState = {
 }
 const globalAssetSources = userDefinedAssetSources ? userDefinedAssetSources : assetSources
 
-export default class ImageInput extends React.PureComponent<Props, ImageInputState> {
+export default withDocument(class ImageInput extends React.PureComponent<Props, ImageInputState> {
   _focusArea: any
   uploadSubscription: any
   state = {
@@ -460,7 +462,7 @@ export default class ImageInput extends React.PureComponent<Props, ImageInputSta
 
   renderAssetSource() {
     const {selectedAssetSource} = this.state
-    const {value, materialize} = this.props
+    const {value, materialize, document} = this.props
     if (!selectedAssetSource) {
       return null
     }
@@ -471,6 +473,7 @@ export default class ImageInput extends React.PureComponent<Props, ImageInputSta
           {imageAsset => {
             return (
               <Component
+                document={document}
                 selectedAssets={[imageAsset]}
                 selectionType="single"
                 onClose={this.handleAssetSourceClosed}
@@ -483,6 +486,7 @@ export default class ImageInput extends React.PureComponent<Props, ImageInputSta
     }
     return (
       <Component
+        document={document}
         selectedAssets={[]}
         selectionType="single"
         onClose={this.handleAssetSourceClosed}
@@ -581,4 +585,4 @@ export default class ImageInput extends React.PureComponent<Props, ImageInputSta
       </FieldSetComponent>
     )
   }
-}
+})


### PR DESCRIPTION
**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [x]  Yes
- [ ]  No

**Current behavior**
The asset source plugin would not know about the document. 

**Description**
This will send in the document as prop to the asset source plugins, which can enable some additional functionality.

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

**Note for release**
Asset source plugins now will receive the document as prop.

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
