### PR TITLE
[form-builder] Send document to asset source plugin (restore #1628)

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.tsx
@@ -70,6 +70,7 @@ export interface Value {
 
 export type Props = {
   value?: Value
+  document?: Value,
   type: Type
   level: number
   onChange: (arg0: PatchEvent) => void
@@ -460,7 +461,7 @@ export default class ImageInput extends React.PureComponent<Props, ImageInputSta
 
   renderAssetSource() {
     const {selectedAssetSource} = this.state
-    const {value, materialize} = this.props
+    const {value, materialize, document} = this.props
     if (!selectedAssetSource) {
       return null
     }
@@ -471,6 +472,7 @@ export default class ImageInput extends React.PureComponent<Props, ImageInputSta
           {imageAsset => {
             return (
               <Component
+                document={document}
                 selectedAssets={[imageAsset]}
                 selectionType="single"
                 onClose={this.handleAssetSourceClosed}
@@ -483,6 +485,7 @@ export default class ImageInput extends React.PureComponent<Props, ImageInputSta
     }
     return (
       <Component
+        document={document}
         selectedAssets={[]}
         selectionType="single"
         onClose={this.handleAssetSourceClosed}

--- a/packages/@sanity/form-builder/src/sanity/inputs/SanityImageInput.tsx
+++ b/packages/@sanity/form-builder/src/sanity/inputs/SanityImageInput.tsx
@@ -2,7 +2,9 @@ import React from 'react'
 import ImageInput, {Props} from '../../inputs/ImageInput'
 import {materializeReference} from './client-adapters/assets'
 import resolveUploader from '../uploads/resolveUploader'
-export default class SanityImageInput extends React.Component<Props> {
+import withDocument from '../../utils/withDocument'
+
+export default withDocument(class SanityImageInput extends React.Component<Props> {
   _input: any
   focus() {
     if (this._input) {
@@ -22,4 +24,4 @@ export default class SanityImageInput extends React.Component<Props> {
       />
     )
   }
-}
+})


### PR DESCRIPTION
**Type of change (check at least one)**

This is restoring #1628  which was reverted due to a circular import issue.

In this PR `withDocument` is wrapped around `SanityImageInput` (the root) and not the `ImageInput` itself, which does not lead to the previous issues.

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

It's already written.

**Current behavior**

Was reverted due to bug.

<!-- Reference/link the relevant issue and/or describe the behavior. -->

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [x]  Corresponding changes to the documentation have been made
