### PR TITLE
[desk-tool] Resolve document type from template if available

### DIFF
--- a/packages/@sanity/desk-tool/src/utils/withInitialValue.js
+++ b/packages/@sanity/desk-tool/src/utils/withInitialValue.js
@@ -46,10 +46,8 @@ const withInitialValue = Pane => {
           switchMap(document => {
             const {templateName, parameters} = getInitialValueProps(document, props, paneContext)
             const shouldResolve = Boolean(templateName)
-            const documentType = options.type || (document && document._type)
-
-            // If we were not passed a schema type, use the resolved value if available
-            const paneOptions = options.type ? options : {...options, type: documentType}
+            const paneOptions = resolvePaneOptions(props, templateName, document)
+            const documentType = paneOptions.type
 
             if (!shouldResolve) {
               // Wrap in broken references component to prevent "reload"
@@ -158,6 +156,20 @@ function resolveInitialValueWithParameters(templateName, parameters) {
   return from(resolveInitialValue(getTemplateById(templateName), parameters)).pipe(
     map(initialValue => ({isResolving: false, initialValue}))
   )
+}
+
+function resolvePaneOptions(props, templateName, document) {
+  const {options} = props
+  const hasDefinedType = options.type && options.type !== '*'
+  const typeFromOptions = hasDefinedType ? options.type : undefined
+  let documentType = typeFromOptions || (document && document._type)
+  if (!documentType && templateName) {
+    const template = getTemplateById(templateName)
+    documentType = template && template.schemaType
+  }
+
+  // If we were not passed a schema type, use the resolved value if available
+  return hasDefinedType ? options : {...options, type: documentType}
 }
 
 export default withInitialValue

--- a/packages/test-studio/src/deskStructure.js
+++ b/packages/test-studio/src/deskStructure.js
@@ -158,6 +158,16 @@ export default () =>
 
       ...S.documentTypeListItems(),
 
+      S.listItem()
+        .title('Custom books list')
+        .child(
+          S.documentList()
+            .title('Unspecified books list')
+            .menuItems(S.documentTypeList('book').getMenuItems())
+            .filter('_type == $type')
+            .params({type: 'book'})
+        ),
+
       S.documentTypeListItem('sanity.imageAsset')
         .title('Images')
         .icon(MdImage)


### PR DESCRIPTION
Given the following structure:

```js
S.documentList()
  .title('Unspecified books list')
  .menuItems(S.documentTypeList('book').getMenuItems())
  .filter('_type == $type')
  .params({type: 'book'})
```

You may end up in a situation where the automatically generated editor has the schema type value `*`, which should be resolved by the desk tool to the correct type (structure doesn't figure out that this pane holds a specific schema type, since it's not set using `schemaType(someTypeName)`/`documentTypeList(someTypeName)`.

With this PR, we use the template parameter to resolve the schema type to use if none is explicitly defined. 