### PR TITLE
[structure] Try to infer schema type from filter in document lists

### DIFF
--- a/packages/@sanity/structure/src/DocumentList.ts
+++ b/packages/@sanity/structure/src/DocumentList.ts
@@ -163,6 +163,10 @@ export class DocumentListBuilder extends GenericListBuilder<
       builder.spec.initialValueTemplates = inferInitialValueTemplates(builder.spec)
     }
 
+    if (!this.spec.schemaTypeName) {
+      builder.spec.schemaTypeName = inferTypeName(builder.spec)
+    }
+
     return builder
   }
 
@@ -194,6 +198,13 @@ function inferInitialValueTemplates(
       )
     )
   }, templateItems)
+}
+
+function inferTypeName(spec: PartialDocumentList): string | undefined {
+  const {options} = spec
+  const {filter, params} = options || {filter: '', params: {}}
+  const typeNames = getTypeNamesFromFilter(filter, params)
+  return typeNames.length === 1 ? typeNames[0] : undefined
 }
 
 export function getTypeNamesFromFilter(

--- a/packages/@sanity/structure/test/__snapshots__/DocumentList.test.ts.snap
+++ b/packages/@sanity/structure/test/__snapshots__/DocumentList.test.ts.snap
@@ -22,7 +22,7 @@ Object {
       "type": "book",
     },
   },
-  "schemaTypeName": undefined,
+  "schemaTypeName": "book",
   "title": "Books",
   "type": "documentList",
 }
@@ -50,7 +50,7 @@ Object {
       "type": "book",
     },
   },
-  "schemaTypeName": undefined,
+  "schemaTypeName": "book",
   "title": "Books",
   "type": "documentList",
 }
@@ -78,7 +78,7 @@ Object {
       "type": "book",
     },
   },
-  "schemaTypeName": undefined,
+  "schemaTypeName": "book",
   "title": "Books",
   "type": "documentList",
 }


### PR DESCRIPTION
As outlined in #1633, the following structure does not get a schema type set:

```js
S.documentList()
  .title('Unspecified books list')
  .menuItems(S.documentTypeList('book').getMenuItems())
  .filter('_type == $type')
  .params({type: 'book'})
```

While this shouldn't normally cause any problems, in this case we can actually infer it based on the filter/parameter, which saves us from having to resolve it further down the stack.
