### PR TITLE
[server] Fix potential crash when attempting to normalize module path

### DIFF
--- a/packages/@sanity/server/src/browser/process-update.js
+++ b/packages/@sanity/server/src/browser/process-update.js
@@ -176,6 +176,10 @@ module.exports = function processUpdate(hash, moduleMap, callbacks = {}) {
   }
 
   function normalizeModulePath(pathName) {
+    if (!pathName) {
+      return {path: '<unknown>'}
+    }
+
     const [path, partName] = pathName.split('?sanityPart=')
     return {path, partName: partName && decodeURIComponent(partName)}
   }


### PR DESCRIPTION
Sometimes the hot module reloading cannot find a module in it's module map - when this happens the `process-update` script fails because it tries to split a string which is actually `undefined`. We only use this to display which modules have been updated,  so it's non-critical that the path is correct.

This PR checks for this case and returns `<unknown>` should we not be passed a path name.