### PR TITLE
[schema] Validate file, image schema fields

### DIFF
--- a/packages/@sanity/schema/src/sanity/groupProblems.ts
+++ b/packages/@sanity/schema/src/sanity/groupProblems.ts
@@ -35,6 +35,8 @@ function createTypeWithMembersProblemsAccessor(
 const arrify = val => (Array.isArray(val) ? val : (typeof val === 'undefined' && []) || [val])
 
 const getObjectProblems = createTypeWithMembersProblemsAccessor('fields')
+const getImageProblems = createTypeWithMembersProblemsAccessor('fields')
+const getFileProblems = createTypeWithMembersProblemsAccessor('fields')
 const getArrayProblems = createTypeWithMembersProblemsAccessor('of')
 const getReferenceProblems = createTypeWithMembersProblemsAccessor('to', type => arrify(type.to))
 const getBlockAnnotationProblems = createTypeWithMembersProblemsAccessor('marks.annotations')
@@ -69,6 +71,12 @@ export function getTypeProblems(type, path = []): TypeWithProblems[] {
     }
     case 'block': {
       return getBlockProblems(type, path)
+    }
+    case 'image': {
+      return getImageProblems(type, path)
+    }
+    case 'file': {
+      return getFileProblems(type, path)
     }
     default: {
       return getDefaultProblems(type, path)

--- a/packages/@sanity/schema/src/sanity/validation/createValidationResult.ts
+++ b/packages/@sanity/schema/src/sanity/validation/createValidationResult.ts
@@ -12,6 +12,7 @@ export const HELP_IDS = {
   OBJECT_FIELDS_INVALID: 'schema-object-fields-invalid',
   OBJECT_FIELD_NOT_UNIQUE: 'schema-object-fields-invalid',
   OBJECT_FIELD_NAME_INVALID: 'schema-object-fields-invalid',
+  OBJECT_FIELD_DEFINITION_INVALID_TYPE: 'schema-object-fields-invalid',
   ARRAY_OF_ARRAY: 'schema-array-of-array',
   ARRAY_OF_INVALID: 'schema-array-of-invalid',
   ARRAY_OF_NOT_UNIQUE: 'schema-array-of-invalid',

--- a/packages/@sanity/schema/src/sanity/validation/types/file.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/file.ts
@@ -24,9 +24,9 @@ export default (typeDef, visitorContext) => {
 
   return {
     ...typeDef,
-    fields: (Array.isArray(fields) ? fields : []).map(field => {
+    fields: (Array.isArray(fields) ? fields : []).map((field, index) => {
       const {name, ...fieldTypeDef} = field
-      const {_problems, ...fieldType} = visitorContext.visit(fieldTypeDef, visitorContext)
+      const {_problems, ...fieldType} = visitorContext.visit(fieldTypeDef, index)
       return {
         name,
         ...fieldType,

--- a/packages/@sanity/schema/src/sanity/validation/types/file.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/file.ts
@@ -1,7 +1,13 @@
 import {error, HELP_IDS} from '../createValidationResult'
+import {validateFields, validateField} from './object'
 
 export default (typeDef, visitorContext) => {
   const problems = []
+  let fields = typeDef.fields
+
+  if (fields) {
+    problems.push(...validateFields(fields, {allowEmpty: true}))
+  }
 
   if (
     typeDef.options &&
@@ -18,6 +24,15 @@ export default (typeDef, visitorContext) => {
 
   return {
     ...typeDef,
+    fields: (Array.isArray(fields) ? fields : []).map(field => {
+      const {name, ...fieldTypeDef} = field
+      const {_problems, ...fieldType} = visitorContext.visit(fieldTypeDef, visitorContext)
+      return {
+        name,
+        ...fieldType,
+        _problems: validateField(field, visitorContext).concat(_problems || [])
+      }
+    }),
     _problems: problems
   }
 }

--- a/packages/@sanity/schema/src/sanity/validation/types/image.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/image.ts
@@ -24,9 +24,9 @@ export default (typeDef, visitorContext) => {
 
   return {
     ...typeDef,
-    fields: (Array.isArray(fields) ? fields : []).map(field => {
+    fields: (Array.isArray(fields) ? fields : []).map((field, index) => {
       const {name, ...fieldTypeDef} = field
-      const {_problems, ...fieldType} = visitorContext.visit(fieldTypeDef, visitorContext)
+      const {_problems, ...fieldType} = visitorContext.visit(fieldTypeDef, index)
       return {
         name,
         ...fieldType,

--- a/packages/@sanity/schema/src/sanity/validation/types/image.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/image.ts
@@ -1,7 +1,13 @@
 import {error, HELP_IDS} from '../createValidationResult'
+import {validateFields, validateField} from './object'
 
 export default (typeDef, visitorContext) => {
   const problems = []
+  let fields = typeDef.fields
+
+  if (fields) {
+    problems.push(...validateFields(fields, {allowEmpty: true}))
+  }
 
   if (
     typeDef.options &&
@@ -18,6 +24,15 @@ export default (typeDef, visitorContext) => {
 
   return {
     ...typeDef,
+    fields: (Array.isArray(fields) ? fields : []).map(field => {
+      const {name, ...fieldTypeDef} = field
+      const {_problems, ...fieldType} = visitorContext.visit(fieldTypeDef, visitorContext)
+      return {
+        name,
+        ...fieldType,
+        _problems: validateField(field, visitorContext).concat(_problems || [])
+      }
+    }),
     _problems: problems
   }
 }

--- a/packages/@sanity/schema/src/sanity/validation/types/object.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/object.ts
@@ -118,9 +118,9 @@ export default (typeDef, visitorContext) => {
 
   return {
     ...typeDef,
-    fields: (Array.isArray(typeDef.fields) ? typeDef.fields : []).map(field => {
+    fields: (Array.isArray(typeDef.fields) ? typeDef.fields : []).map((field, index) => {
       const {name, ...fieldTypeDef} = field
-      const {_problems, ...fieldType} = visitorContext.visit(fieldTypeDef, visitorContext)
+      const {_problems, ...fieldType} = visitorContext.visit(fieldTypeDef, index)
       return {
         name,
         ...fieldType,


### PR DESCRIPTION
There is currently no validation for an incorrectly defined `fields` property on file and image types. This PR reuses the fields validation from `object`, and also adds a type check for each field entry (ensuring it's an object before attempting to validate its properties).

I also fixed an issue where a `visitContext` was passed to the `visit()` method instead of an index, which resulted in field paths with `objectObject` in them 🤔 