### PR TITLE
[cli] Reject template download if statusCode is not 2xx

### DIFF
--- a/packages/@sanity/cli/src/actions/init-plugin/bootstrapFromTemplate.js
+++ b/packages/@sanity/cli/src/actions/init-plugin/bootstrapFromTemplate.js
@@ -149,6 +149,12 @@ function getZip(url) {
         return
       }
 
+      if (res.statusCode > 299) {
+        const httpErr = ['HTTP', res.statusCode, res.statusMessage].filter(Boolean).join(' ')
+        reject(new Error(`${httpErr} trying to download ${url}`))
+        return
+      }
+
       resolve(decompress(data))
     })
   })


### PR DESCRIPTION
When bootstrapping a plugin from a template URL,  we were only checking for network errors, not HTTP errors. This makes it hard to debug problems such as a 404 response from the server, since it would end up with the hopeless error message of:

> Error: Could not find `package.json` in template

This adds rejection logic based on the HTTP status code.