### PR TITLE
[desk-tool] Fix unhandled experimental actions

### DIFF
--- a/packages/@sanity/desk-tool/src/pane/Editor/FormView.js
+++ b/packages/@sanity/desk-tool/src/pane/Editor/FormView.js
@@ -9,6 +9,8 @@ import styles from '../styles/Editor.css'
 import EditForm from './EditForm'
 import HistoryForm from './HistoryForm'
 
+const noop = () => undefined
+
 const INITIAL_STATE = {
   focusPath: [],
   filterField: () => true
@@ -95,6 +97,7 @@ export default class FormView extends React.PureComponent {
     const {draft, published, displayed} = document
     const {focusPath, filterField} = this.state
     const value = draft || published
+    const readOnly = this.isReadOnly()
 
     const hasTypeMismatch = value && value._type && value._type !== schemaType.name
     if (hasTypeMismatch) {
@@ -121,11 +124,11 @@ export default class FormView extends React.PureComponent {
             initialValue={initialValue}
             markers={markers}
             onBlur={this.handleBlur}
-            onChange={this.props.onChange}
+            onChange={readOnly ? noop : this.props.onChange}
             onFocus={this.handleFocus}
             patchChannel={patchChannel}
             published={published}
-            readOnly={this.isReadOnly()}
+            readOnly={readOnly}
             schema={schema}
             type={schemaType}
           />

--- a/packages/@sanity/desk-tool/src/pane/Editor/FormView.js
+++ b/packages/@sanity/desk-tool/src/pane/Editor/FormView.js
@@ -78,17 +78,20 @@ export default class FormView extends React.PureComponent {
     return selectedSchemaType.liveEdit === true
   }
 
-  render() {
-    const {
-      document,
-      history,
-      schemaType,
-      markers,
-      patchChannel,
-      initialValue,
-      isReconnecting
-    } = this.props
+  isReadOnly() {
+    const {document, schemaType, isReconnecting} = this.props
+    const {draft, published} = document
+    const isNonExistent = !draft && !published
 
+    return (
+      isReconnecting ||
+      !isActionEnabled(schemaType, 'update') ||
+      (isNonExistent && !isActionEnabled(schemaType, 'create'))
+    )
+  }
+
+  render() {
+    const {document, history, schemaType, markers, patchChannel, initialValue} = this.props
     const {draft, published, displayed} = document
     const {focusPath, filterField} = this.state
     const value = draft || published
@@ -122,7 +125,7 @@ export default class FormView extends React.PureComponent {
             onFocus={this.handleFocus}
             patchChannel={patchChannel}
             published={published}
-            readOnly={isReconnecting || !isActionEnabled(schemaType, 'update')}
+            readOnly={this.isReadOnly()}
             schema={schema}
             type={schemaType}
           />

--- a/packages/@sanity/desk-tool/src/pane/documentPaneFooterActions.js
+++ b/packages/@sanity/desk-tool/src/pane/documentPaneFooterActions.js
@@ -20,7 +20,7 @@ export function getDocumentPaneFooterActions(props) {
   const isNonexistent = !draft && !published
 
   const actions = [
-    {
+    enabledActions.includes('publish') && {
       color: 'primary',
       disabled:
         isCreatingDraft ||

--- a/packages/@sanity/structure/src/DocumentList.ts
+++ b/packages/@sanity/structure/src/DocumentList.ts
@@ -1,5 +1,6 @@
 import {getParameterlessTemplatesBySchemaType} from '@sanity/initial-value-templates'
-import {SchemaType} from './parts/Schema'
+import {SchemaType, getDefaultSchema} from './parts/Schema'
+import {isActionEnabled} from './parts/documentActionUtils'
 import {client} from './parts/Client'
 import {SortItem} from './Sort'
 import {SerializeError, HELP_URL} from './SerializeError'
@@ -178,6 +179,7 @@ export class DocumentListBuilder extends GenericListBuilder<
 function inferInitialValueTemplates(
   spec: PartialDocumentList
 ): InitialValueTemplateItem[] | undefined {
+  const schema = getDefaultSchema()
   const {schemaTypeName, options} = spec
   const {filter, params} = options || {filter: '', params: {}}
   const typeNames = schemaTypeName ? [schemaTypeName] : getTypeNamesFromFilter(filter, params)
@@ -188,6 +190,11 @@ function inferInitialValueTemplates(
 
   let templateItems: InitialValueTemplateItem[] = []
   return typeNames.reduce((items, typeName) => {
+    const schemaType = schema.get(typeName)
+    if (!isActionEnabled(schemaType, 'create')) {
+      return items
+    }
+
     return items.concat(
       getParameterlessTemplatesBySchemaType(typeName).map(
         (tpl): InitialValueTemplateItem => ({


### PR DESCRIPTION
After the editor => document + pane refactoring work in v0.145.0, certain of the experimental action affordances were not accounted for.

This PR addresses these points:
- Initial value templates were listed in panes even when the `create` action was disabled
- Publish button was shown even when `publish` action was disabled
- Publish action could be triggered through hotkey even when `publish` action was disabled
- Form was not set to read-only for new documents even with `create` action disabled
- Creating new documents could (theoretically) be done by triggering `onChange` in an input component even when `create` action was disabled

There may be more edge-cases that are unaccounted for, but given that this is an _experimental_ feature, I think this should at least address the _regressions_. 

Fixes #1605.

---

Sidenote: I'll be on vacation until Tuesday, so feel free to do any necessary changes to this PR and merge/release before that time if deemed necessary.
