### PR TITLE
[desk-tool] Add missing `setPayload` method to pane router context

### DIFF
--- a/packages/@sanity/desk-tool/src/contexts/PaneRouterContext.js
+++ b/packages/@sanity/desk-tool/src/contexts/PaneRouterContext.js
@@ -58,6 +58,9 @@ export const PaneRouterContext = React.createContext({
   // Set the parameters for the current pane
   setParams: params => missingContext(),
 
+  // Set the payload for the current pane
+  setPayload: payload => missingContext(),
+
   // Proxied navigation to a given intent. Consider just exposing `router` instead?
   navigateIntent: (intentName, params, options = {}) => missingContext()
 })
@@ -130,6 +133,14 @@ export function getPaneRouterContextFactory(instance) {
       const newRouterState = {...router.state, panes: newPanes}
       router.navigate(newRouterState)
       return newRouterState
+    }
+
+    const setPayload = payload => {
+      modifyCurrentGroup((siblings, item) => {
+        const newGroup = siblings.slice()
+        newGroup[siblingIndex] = {...item, payload}
+        return newGroup
+      })
     }
 
     const setParams = (params, setOptions = {}) => {
@@ -241,6 +252,9 @@ export function getPaneRouterContextFactory(instance) {
 
       // Set the parameters for the current pane
       setParams,
+
+      // Set the payload for the current pane
+      setPayload,
 
       // Proxied navigation to a given intent. Consider just exposing `router` instead?
       navigateIntent: instance.props.router.navigateIntent

--- a/packages/test-studio/src/previews/developer/DeveloperPreview.js
+++ b/packages/test-studio/src/previews/developer/DeveloperPreview.js
@@ -1,14 +1,20 @@
 /* eslint-disable react/prop-types */
 
-import React from 'react'
+import React, {useContext} from 'react'
 import JSONPretty from 'react-json-pretty'
 import monikai from 'react-json-pretty/dist/monikai'
 import styles from './DeveloperPreview.module.css'
+import {PaneRouterContext} from '@sanity/desk-tool'
 
 function DeveloperPreview(props) {
+  const pane = useContext(PaneRouterContext)
+  const payload = {count: 0, ...pane.payload}
   const {displayed} = props.document
   return (
     <div className={styles.root}>
+      <button type="button" onClick={() => pane.setPayload({count: payload.count + 1})}>
+        + {payload.count}
+      </button>
       <JSONPretty data={displayed} theme={monikai} mainStyle="white-space: pre-wrap" />
     </div>
   )


### PR DESCRIPTION
There is currently no way to set the payload of a pane. This PR adds the missing  `setPayload` method. Note that payloads are undefined by default, and can be any JSON value; thus you should always make sure the payload _exists_ before attempting to use it.

Also added an example of how to use the method in the test-studio.