### PR TITLE
[form-builder] Pass parent object to slug source function

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/Slug/SlugInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/Slug/SlugInput.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import speakingurl from 'speakingurl'
-import {get} from 'lodash'
+import {get} from '@sanity/util/paths'
 import Button from 'part:@sanity/components/buttons/default'
 import FormField from 'part:@sanity/components/formfields/default'
 import TextInput from 'part:@sanity/components/textinputs/default'
@@ -71,7 +71,7 @@ export default withValuePath(
           return Promise.resolve(sourceValue)
         }
         const {type} = this.props
-        const slugify = get(type, 'options.slugify', defaultSlugify)
+        const slugify = get(type, ['options', 'slugify'], defaultSlugify)
         return Promise.resolve(slugify(sourceValue, type))
       }
       UNSAFE_componentWillReceiveProps(nextProps) {
@@ -99,7 +99,7 @@ export default withValuePath(
       }
       handleGenerateSlug = () => {
         const {type} = this.props
-        const source = get(type, 'options.source')
+        const source = get(type, ['options', 'source'])
         if (!source) {
           // eslint-disable-next-line no-console
           console.error(`Source is missing. Check source on type "${type.name}" in schema`)
@@ -120,8 +120,11 @@ export default withValuePath(
       getNewFromSource = () => {
         const {getValuePath, type, document} = this.props
         const parentPath = getValuePath().slice(0, -1)
-        const source = get(type, 'options.source')
-        return typeof source === 'function' ? source(document, {parentPath}) : get(document, source)
+        const parent = get(document, parentPath)
+        const source = get(type, ['options', 'source'])
+        return typeof source === 'function'
+          ? source(document, {parentPath, parent})
+          : get(document, source)
       }
       render() {
         const {value, type, level, markers, readOnly} = this.props

--- a/packages/@sanity/util/paths.d.ts
+++ b/packages/@sanity/util/paths.d.ts
@@ -3,7 +3,7 @@ type PathSegment = string | number | KeyedSegment
 type Path = PathSegment[]
 
 export declare const FOCUS_TERMINATOR: string
-export declare function get(obj: any, path: Path | string, defaultVal: any): any
+export declare function get(obj: any, path: Path | string, defaultVal?: any): any
 export declare function isEqual(path: Path, otherPath: Path): boolean
 export declare function isSegmentEqual(
   pathSegment: PathSegment,

--- a/packages/test-studio/schemas/experiment.js
+++ b/packages/test-studio/schemas/experiment.js
@@ -1,21 +1,3 @@
-const equals = (itemA, itemB) => Object.keys(itemA).every(key => itemA[key] === itemB[key])
-
-const get = (doc, path, defValue) => {
-  const result = path.reduce((item, segment) => {
-    if (!item) {
-      return item
-    }
-
-    if (typeof segment !== 'object') {
-      return item[segment]
-    }
-
-    return Array.isArray(item) ? item.find(curr => equals(segment, curr)) : undefined
-  }, doc)
-
-  return typeof result === 'undefined' ? defValue : result
-}
-
 export default {
   name: 'experiment',
   type: 'object',
@@ -30,7 +12,7 @@ export default {
       title: 'Slug',
       type: 'slug',
       options: {
-        source: (doc, {parentPath}) => get(doc, parentPath, {}).title
+        source: (doc, {parent}) => parent && parent.title
       }
     }
   ]


### PR DESCRIPTION
Quite often you'll want to reference a property on the parent of the slug, especially when it is nested. Right now, we only pass the parent path and the document, which requires a user to look up the parent using something like lodash's `_.get()`. The issue is that we also pass keyed path segments (`{_key: 'abc123'}`) which makes it needlessly complicated to do inside of arrays.

With this PR, we pass both `parent` and `parentPath` to the `source` function.