### PR TITLE
[form-builder] Unset empty object when removing asset

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.tsx
@@ -4,6 +4,7 @@ import {Observable} from 'rxjs'
 import HotspotImage from '@sanity/imagetool/HotspotImage'
 import ImageTool from '@sanity/imagetool'
 import React from 'react'
+import PropTypes from 'prop-types'
 
 // Parts
 import assetSources from 'all:part:@sanity/form-builder/input/image/asset-source'
@@ -70,7 +71,7 @@ export interface Value {
 
 export type Props = {
   value?: Value
-  document?: Value,
+  document?: Value
   type: Type
   level: number
   onChange: (arg0: PatchEvent) => void
@@ -100,6 +101,10 @@ type ImageInputState = {
 const globalAssetSources = userDefinedAssetSources ? userDefinedAssetSources : assetSources
 
 export default class ImageInput extends React.PureComponent<Props, ImageInputState> {
+  static contextTypes = {
+    getValuePath: PropTypes.func
+  }
+
   _focusArea: any
   uploadSubscription: any
   state = {
@@ -217,7 +222,32 @@ export default class ImageInput extends React.PureComponent<Props, ImageInputSta
   }
 
   handleRemoveButtonClick = (event: React.SyntheticEvent<any>) => {
-    this.props.onChange(PatchEvent.from(unset(['asset'])))
+    const {getValuePath} = this.context
+    const {value} = this.props
+    const parentPathSegment = getValuePath().slice(-1)[0]
+
+    // String path segment mean an object path, while a number or a
+    // keyed segment means we're a direct child of an array
+    const isArrayElement = typeof parentPathSegment !== 'string'
+
+    // When removing the image, we should also remove any crop and hotspot
+    // _type and _key are "meta"-properties and are not significant unless
+    // other properties are present. Thus, we want to remove the entire
+    // "container" object if these are the only properties present, BUT
+    // only if we're not an array element, as removing the array element
+    // will close the selection dialog. Instead, when closing the dialog,
+    // the array logic will check for an "empty" value and remove it for us
+    const allKeys = Object.keys(value)
+    const remainingKeys = allKeys.filter(
+      key => !['_type', '_key', '_upload', 'asset', 'crop', 'hotspot'].includes(key)
+    )
+
+    const isEmpty = remainingKeys.length === 0
+    const removeKeys = ['asset']
+      .concat(allKeys.filter(key => ['crop', 'hotspot', '_upload'].includes(key)))
+      .map(key => unset([key]))
+
+    this.props.onChange(PatchEvent.from(isEmpty && !isArrayElement ? unset() : removeKeys))
   }
 
   handleFieldChange = (event: PatchEvent, field: FieldT) => {


### PR DESCRIPTION
Currently, if you have a file or an image field with a selected asset, then click the "remove" button, the only thing that is unset is the `asset` property. This leads to a dangling `_type` property, which results in weird results in frontends that assume it'll also have an `asset`.

In addition to this, the image input does not currently clear the `crop` and `hotspot` properties (though they are cleared when selecting a new asset, luckily).

This PR checks whether or not the "container" object is "empty" after unsetting the asset: in other words, does it have any properties that are not `_type`, `_key`, `_upload`? For the image type we also consider  `crop` and `hotspot` to be unset, as they don't make sense for the next asset to be selected. If there are no other properties present on the object, we unset the entire "container".

An unfortunate side-effect of this change is that when you unset the container on an array element, the selection dialog is closed, since the path no longer exists. To work around this, I'm checking if the field path terminates on an array element and resort to just unsetting the `asset`/`crop`/`hotspot` properties. There seems to be some logic elsewhere that handles removal of the container when you close the dialog, which leads to the optimal user experience.

I'm not super happy with all the edge-casing for arrays, but for now this is the best I could come up with - feel free to suggest better approaches if you know of any!
