### PR TITLE
[structure] Allow setting options on component, component view

### DIFF
--- a/packages/@sanity/desk-tool/src/pane/DocumentPane.js
+++ b/packages/@sanity/desk-tool/src/pane/DocumentPane.js
@@ -1396,6 +1396,7 @@ export default withInitialValue(
 
         // Other stuff
         documentId: this.getPublishedId(),
+        options,
         schemaType,
         markers: markers || []
       }

--- a/packages/@sanity/desk-tool/src/pane/UserComponentPane.js
+++ b/packages/@sanity/desk-tool/src/pane/UserComponentPane.js
@@ -15,6 +15,7 @@ export default class UserComponentPane extends React.PureComponent {
     index: PropTypes.number.isRequired,
     type: PropTypes.string.isRequired,
     component: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
+    options: PropTypes.object, // eslint-disable-line react/forbid-prop-types
     isSelected: PropTypes.bool.isRequired,
     isCollapsed: PropTypes.bool.isRequired,
     onExpand: PropTypes.func,
@@ -34,6 +35,7 @@ export default class UserComponentPane extends React.PureComponent {
 
   static defaultProps = {
     title: '',
+    options: {},
     menuItems: [],
     menuItemGroups: [],
     styles: undefined,

--- a/packages/@sanity/structure/src/Component.ts
+++ b/packages/@sanity/structure/src/Component.ts
@@ -10,11 +10,13 @@ export interface Component extends StructureNode {
   child?: Child
   menuItems: MenuItem[]
   menuItemGroups: MenuItemGroup[]
+  options: {[key: string]: any}
 }
 
 export interface ComponentInput extends StructureNode {
   component: Function
   child?: Child
+  options?: {[key: string]: any}
   menuItems?: (MenuItem | MenuItemBuilder)[]
   menuItemGroups?: (MenuItemGroup | MenuItemGroupBuilder)[]
 }
@@ -22,6 +24,7 @@ export interface ComponentInput extends StructureNode {
 export interface BuildableComponent extends Partial<StructureNode> {
   component?: Function
   child?: Child
+  options?: {[key: string]: any}
   menuItems?: (MenuItem | MenuItemBuilder)[]
   menuItemGroups?: (MenuItemGroup | MenuItemGroupBuilder)[]
 }
@@ -30,7 +33,7 @@ export class ComponentBuilder implements Serializable {
   protected spec: BuildableComponent
 
   constructor(spec?: ComponentInput) {
-    this.spec = spec ? spec : {}
+    this.spec = {options: {}, ...(spec ? spec : {})}
   }
 
   id(id: string) {
@@ -65,6 +68,14 @@ export class ComponentBuilder implements Serializable {
     return this.spec.component
   }
 
+  options(options: {[key: string]: any}) {
+    return this.clone({options})
+  }
+
+  getOptions() {
+    return this.spec.options || {}
+  }
+
   menuItems(menuItems: (MenuItem | MenuItemBuilder)[]) {
     return this.clone({menuItems})
   }
@@ -82,7 +93,7 @@ export class ComponentBuilder implements Serializable {
   }
 
   serialize(options: SerializeOptions = {path: []}): Component {
-    const {id, title, child, component} = this.spec
+    const {id, title, child, options: componentOptions, component} = this.spec
     if (!id) {
       throw new SerializeError(
         '`id` is required for `component` structure item',
@@ -105,6 +116,7 @@ export class ComponentBuilder implements Serializable {
       type: 'component',
       child,
       component,
+      options: componentOptions || {},
       menuItems: (this.spec.menuItems || []).map((item, i) =>
         maybeSerializeMenuItem(item, i, options.path)
       ),

--- a/packages/@sanity/structure/src/views/ComponentView.ts
+++ b/packages/@sanity/structure/src/views/ComponentView.ts
@@ -4,6 +4,7 @@ import {SerializeError, HELP_URL} from '../SerializeError'
 
 export interface ComponentView extends View {
   component: Function
+  options: {[key: string]: any}
 }
 
 const isComponentSpec = (spec: any): spec is ComponentView => {
@@ -17,7 +18,7 @@ export class ComponentViewBuilder extends GenericViewBuilder<
   protected spec: Partial<ComponentView>
 
   constructor(componentOrSpec?: Function | Partial<ComponentView>) {
-    const spec = isComponentSpec(componentOrSpec) ? componentOrSpec : {}
+    const spec = isComponentSpec(componentOrSpec) ? {...componentOrSpec} : {options: {}}
 
     super()
     this.spec = spec
@@ -39,6 +40,14 @@ export class ComponentViewBuilder extends GenericViewBuilder<
     return this.spec.component
   }
 
+  options(options: {[key: string]: any}) {
+    return this.clone({options})
+  }
+
+  getOptions() {
+    return this.spec.options || {}
+  }
+
   serialize(options: SerializeOptions = {path: []}): ComponentView {
     const base = super.serialize(options)
 
@@ -54,6 +63,7 @@ export class ComponentViewBuilder extends GenericViewBuilder<
     return {
       ...base,
       component,
+      options: this.spec.options || {},
       type: 'component'
     }
   }

--- a/packages/@sanity/structure/test/Component.test.ts
+++ b/packages/@sanity/structure/test/Component.test.ts
@@ -2,6 +2,7 @@ import {StructureBuilder as S} from '../src'
 
 const noop = () => null
 const component = () => null
+const options = {foo: 'bar'}
 const childResolver = () => undefined
 
 test('builds component node through constructor', () => {
@@ -10,6 +11,7 @@ test('builds component node through constructor', () => {
       id: 'foo',
       title: 'some title',
       child: childResolver,
+      options,
       component
     }).serialize()
   ).toMatchSnapshot()
@@ -63,6 +65,7 @@ test('can construct using builder', () => {
       .id('yeah')
       .title('Yeah')
       .component(component)
+      .options(options)
       .child(childResolver)
       .serialize()
   ).toMatchSnapshot()
@@ -125,12 +128,13 @@ test('can set menu items groups with builder', () => {
 
 test('builder is immutable', () => {
   const original = S.component()
-  expect(original.id('foo')).not.toEqual(original)
-  expect(original.title('foo')).not.toEqual(original)
-  expect(original.component(component)).not.toEqual(original)
-  expect(original.child(childResolver)).not.toEqual(original)
-  expect(original.menuItems([])).not.toEqual(original)
-  expect(original.menuItemGroups([])).not.toEqual(original)
+  expect(original.id('foo')).not.toBe(original)
+  expect(original.title('foo')).not.toBe(original)
+  expect(original.component(component)).not.toBe(original)
+  expect(original.options(options)).not.toBe(original)
+  expect(original.child(childResolver)).not.toBe(original)
+  expect(original.menuItems([])).not.toBe(original)
+  expect(original.menuItemGroups([])).not.toBe(original)
 })
 
 test('getters work', () => {
@@ -138,6 +142,7 @@ test('getters work', () => {
   expect(original.id('foo').getId()).toEqual('foo')
   expect(original.title('bar').getTitle()).toEqual('bar')
   expect(original.component(component).getComponent()).toEqual(component)
+  expect(original.options(options).getOptions()).toEqual(options)
   expect(original.menuItems([]).getMenuItems()).toEqual([])
   expect(original.menuItemGroups([]).getMenuItemGroups()).toEqual([])
   expect(original.child(childResolver).getChild()).toEqual(childResolver)

--- a/packages/@sanity/structure/test/ComponentView.test.ts
+++ b/packages/@sanity/structure/test/ComponentView.test.ts
@@ -48,6 +48,7 @@ test('builds component view through component constructor', () => {
       .component(() => null)
       .id('custom')
       .title('Custom')
+      .options({foo: 'bar'})
       .serialize()
   ).toMatchSnapshot()
 })
@@ -67,19 +68,22 @@ test('can override component set through constructor', () => {
 
 test('builder is immutable', () => {
   const original = S.view.component()
-  expect(original.id('foo')).not.toEqual(original)
-  expect(original.title('foo')).not.toEqual(original)
-  expect(original.icon(() => null)).not.toEqual(original)
-  expect(original.component(() => null)).not.toEqual(original)
+  expect(original.id('foo')).not.toBe(original)
+  expect(original.title('foo')).not.toBe(original)
+  expect(original.icon(() => null)).not.toBe(original)
+  expect(original.options({})).not.toBe(original)
+  expect(original.component(() => null)).not.toBe(original)
 })
 
 test('getters work', () => {
   const original = S.view.component()
   const icon = () => null
   const component = () => null
+  const options = {foo: 'bar'}
 
   expect(original.id('foo').getId()).toEqual('foo')
   expect(original.title('title').getTitle()).toEqual('title')
   expect(original.icon(icon).getIcon()).toEqual(icon)
+  expect(original.options(options).getOptions()).toEqual(options)
   expect(original.component(component).getComponent()).toEqual(component)
 })

--- a/packages/@sanity/structure/test/Document.test.ts
+++ b/packages/@sanity/structure/test/Document.test.ts
@@ -71,12 +71,12 @@ test('can construct using builder (alt)', () => {
 
 test('builder is immutable', () => {
   const original = S.document()
-  expect(original.id('foo')).not.toEqual(original)
-  expect(original.views([])).not.toEqual(original)
-  expect(original.documentId('moo')).not.toEqual(original)
-  expect(original.schemaType('author')).not.toEqual(original)
-  expect(original.initialValueTemplate('book-by-author')).not.toEqual(original)
-  expect(original.child(() => S.documentTypeList('post'))).not.toEqual(original)
+  expect(original.id('foo')).not.toBe(original)
+  expect(original.views([])).not.toBe(original)
+  expect(original.documentId('moo')).not.toBe(original)
+  expect(original.schemaType('author')).not.toBe(original)
+  expect(original.initialValueTemplate('book-by-author')).not.toBe(original)
+  expect(original.child(() => S.documentTypeList('post'))).not.toBe(original)
 })
 
 test('throws on duplicate view ids', () => {

--- a/packages/@sanity/structure/test/DocumentList.test.ts
+++ b/packages/@sanity/structure/test/DocumentList.test.ts
@@ -111,17 +111,17 @@ test('default child resolver resolves to editor', done => {
 
 test('builder is immutable', () => {
   const original = S.documentList()
-  expect(original.id('foo')).not.toEqual(original)
-  expect(original.title('foo')).not.toEqual(original)
-  expect(original.filter('foo == "bar"')).not.toEqual(original)
-  expect(original.params({foo: 'bar'})).not.toEqual(original)
-  expect(original.menuItems([])).not.toEqual(original)
-  expect(original.showIcons(false)).not.toEqual(original)
-  expect(original.menuItemGroups([])).not.toEqual(original)
-  expect(original.defaultLayout('card')).not.toEqual(original)
-  expect(original.child(() => undefined)).not.toEqual(original)
-  expect(original.canHandleIntent(() => false)).not.toEqual(original)
-  expect(original.defaultOrdering([{field: 'title', direction: 'asc'}])).not.toEqual(original)
+  expect(original.id('foo')).not.toBe(original)
+  expect(original.title('foo')).not.toBe(original)
+  expect(original.filter('foo == "bar"')).not.toBe(original)
+  expect(original.params({foo: 'bar'})).not.toBe(original)
+  expect(original.menuItems([])).not.toBe(original)
+  expect(original.showIcons(false)).not.toBe(original)
+  expect(original.menuItemGroups([])).not.toBe(original)
+  expect(original.defaultLayout('card')).not.toBe(original)
+  expect(original.child(() => undefined)).not.toBe(original)
+  expect(original.canHandleIntent(() => false)).not.toBe(original)
+  expect(original.defaultOrdering([{field: 'title', direction: 'asc'}])).not.toBe(original)
 })
 
 test('getters work', () => {

--- a/packages/@sanity/structure/test/DocumentListItem.test.ts
+++ b/packages/@sanity/structure/test/DocumentListItem.test.ts
@@ -84,9 +84,9 @@ test('builds list items with child defined through builder', () => {
 
 test('builder is immutable', () => {
   const original = S.documentListItem()
-  expect(original.id('foo')).not.toEqual(original)
-  expect(original.title('foo')).not.toEqual(original)
-  expect(original.child(() => undefined)).not.toEqual(original)
+  expect(original.id('foo')).not.toBe(original)
+  expect(original.title('foo')).not.toBe(original)
+  expect(original.child(() => undefined)).not.toBe(original)
 })
 
 test('getters work', () => {

--- a/packages/@sanity/structure/test/DocumentTypeList.test.ts
+++ b/packages/@sanity/structure/test/DocumentTypeList.test.ts
@@ -114,17 +114,17 @@ test('default child resolver resolves to editor', done => {
 
 test('builder is immutable', () => {
   const original = S.documentTypeList('author')
-  expect(original.id('foo')).not.toEqual(original)
-  expect(original.title('foo')).not.toEqual(original)
-  expect(original.filter('foo == "bar"')).not.toEqual(original)
-  expect(original.params({foo: 'bar'})).not.toEqual(original)
-  expect(original.menuItems([])).not.toEqual(original)
-  expect(original.showIcons(false)).not.toEqual(original)
-  expect(original.menuItemGroups([])).not.toEqual(original)
-  expect(original.defaultLayout('card')).not.toEqual(original)
-  expect(original.child(() => undefined)).not.toEqual(original)
-  expect(original.canHandleIntent(() => false)).not.toEqual(original)
-  expect(original.defaultOrdering([{field: 'title', direction: 'asc'}])).not.toEqual(original)
+  expect(original.id('foo')).not.toBe(original)
+  expect(original.title('foo')).not.toBe(original)
+  expect(original.filter('foo == "bar"')).not.toBe(original)
+  expect(original.params({foo: 'bar'})).not.toBe(original)
+  expect(original.menuItems([])).not.toBe(original)
+  expect(original.showIcons(false)).not.toBe(original)
+  expect(original.menuItemGroups([])).not.toBe(original)
+  expect(original.defaultLayout('card')).not.toBe(original)
+  expect(original.child(() => undefined)).not.toBe(original)
+  expect(original.canHandleIntent(() => false)).not.toBe(original)
+  expect(original.defaultOrdering([{field: 'title', direction: 'asc'}])).not.toBe(original)
 })
 
 test('getters work', () => {

--- a/packages/@sanity/structure/test/FormView.test.ts
+++ b/packages/@sanity/structure/test/FormView.test.ts
@@ -17,9 +17,9 @@ test('can override defaults', () => {
 
 test('builder is immutable', () => {
   const original = S.view.form()
-  expect(original.id('foo')).not.toEqual(original)
-  expect(original.title('foo')).not.toEqual(original)
-  expect(original.icon(() => null)).not.toEqual(original)
+  expect(original.id('foo')).not.toBe(original)
+  expect(original.title('foo')).not.toBe(original)
+  expect(original.icon(() => null)).not.toBe(original)
 })
 
 test('getters work', () => {

--- a/packages/@sanity/structure/test/List.test.ts
+++ b/packages/@sanity/structure/test/List.test.ts
@@ -224,14 +224,14 @@ test('can disable icons from being displayed', () => {
 
 test('builder is immutable', () => {
   const original = S.list()
-  expect(original.id('foo')).not.toEqual(original)
-  expect(original.title('foo')).not.toEqual(original)
-  expect(original.items([])).not.toEqual(original)
-  expect(original.menuItems([])).not.toEqual(original)
-  expect(original.menuItemGroups([])).not.toEqual(original)
-  expect(original.defaultLayout('card')).not.toEqual(original)
-  expect(original.child(() => undefined)).not.toEqual(original)
-  expect(original.canHandleIntent(() => false)).not.toEqual(original)
+  expect(original.id('foo')).not.toBe(original)
+  expect(original.title('foo')).not.toBe(original)
+  expect(original.items([])).not.toBe(original)
+  expect(original.menuItems([])).not.toBe(original)
+  expect(original.menuItemGroups([])).not.toBe(original)
+  expect(original.defaultLayout('card')).not.toBe(original)
+  expect(original.child(() => undefined)).not.toBe(original)
+  expect(original.canHandleIntent(() => false)).not.toBe(original)
 })
 
 test('getters work', () => {

--- a/packages/@sanity/structure/test/ListItem.test.ts
+++ b/packages/@sanity/structure/test/ListItem.test.ts
@@ -101,11 +101,11 @@ test('builds list items with display options (show icon)', () => {
 
 test('builder is immutable', () => {
   const original = S.listItem()
-  expect(original.id('foo')).not.toEqual(original)
-  expect(original.title('foo')).not.toEqual(original)
-  expect(original.child(() => undefined)).not.toEqual(original)
-  expect(original.schemaType('foo')).not.toEqual(original)
-  expect(original.showIcon(true)).not.toEqual(original)
+  expect(original.id('foo')).not.toBe(original)
+  expect(original.title('foo')).not.toBe(original)
+  expect(original.child(() => undefined)).not.toBe(original)
+  expect(original.schemaType('foo')).not.toBe(original)
+  expect(original.showIcon(true)).not.toBe(original)
 })
 
 test('getters work', () => {

--- a/packages/@sanity/structure/test/MenuItem.test.ts
+++ b/packages/@sanity/structure/test/MenuItem.test.ts
@@ -73,13 +73,13 @@ test('throws if building menu item group without title', () => {
 
 test('builder is immutable', () => {
   const original = S.menuItem()
-  expect(original.title('foo')).not.toEqual(original)
-  expect(original.params({foo: 'bar'})).not.toEqual(original)
-  expect(original.action('doSomething')).not.toEqual(original)
-  expect(original.intent({type: 'create'})).not.toEqual(original)
-  expect(original.group('create')).not.toEqual(original)
-  expect(original.icon(() => null)).not.toEqual(original)
-  expect(original.showAsAction(false)).not.toEqual(original)
+  expect(original.title('foo')).not.toBe(original)
+  expect(original.params({foo: 'bar'})).not.toBe(original)
+  expect(original.action('doSomething')).not.toBe(original)
+  expect(original.intent({type: 'create'})).not.toBe(original)
+  expect(original.group('create')).not.toBe(original)
+  expect(original.icon(() => null)).not.toBe(original)
+  expect(original.showAsAction(false)).not.toBe(original)
 })
 
 test('getters work', () => {

--- a/packages/@sanity/structure/test/__snapshots__/Component.test.ts.snap
+++ b/packages/@sanity/structure/test/__snapshots__/Component.test.ts.snap
@@ -7,6 +7,7 @@ Object {
   "id": "foo",
   "menuItemGroups": Array [],
   "menuItems": Array [],
+  "options": Object {},
   "title": undefined,
   "type": "component",
 }
@@ -19,6 +20,9 @@ Object {
   "id": "foo",
   "menuItemGroups": Array [],
   "menuItems": Array [],
+  "options": Object {
+    "foo": "bar",
+  },
   "title": "some title",
   "type": "component",
 }
@@ -31,6 +35,9 @@ Object {
   "id": "yeah",
   "menuItemGroups": Array [],
   "menuItems": Array [],
+  "options": Object {
+    "foo": "bar",
+  },
   "title": "Yeah",
   "type": "component",
 }
@@ -54,6 +61,7 @@ Object {
       "title": "Print",
     },
   ],
+  "options": Object {},
   "title": undefined,
   "type": "component",
 }
@@ -71,6 +79,7 @@ Object {
       "title": "Print",
     },
   ],
+  "options": Object {},
   "title": undefined,
   "type": "component",
 }
@@ -94,6 +103,7 @@ Object {
       "title": "Print",
     },
   ],
+  "options": Object {},
   "title": undefined,
   "type": "component",
 }
@@ -111,6 +121,7 @@ Object {
       "title": "Purge",
     },
   ],
+  "options": Object {},
   "title": undefined,
   "type": "component",
 }

--- a/packages/@sanity/structure/test/__snapshots__/ComponentView.test.ts.snap
+++ b/packages/@sanity/structure/test/__snapshots__/ComponentView.test.ts.snap
@@ -5,6 +5,9 @@ Object {
   "component": [Function],
   "icon": undefined,
   "id": "custom",
+  "options": Object {
+    "foo": "bar",
+  },
   "title": "Custom",
   "type": "component",
 }
@@ -15,6 +18,7 @@ Object {
   "component": [Function],
   "icon": undefined,
   "id": "custom",
+  "options": Object {},
   "title": "Custom",
   "type": "component",
 }


### PR DESCRIPTION
This PR introduces the `options()` method on `S.component()` and `S.view.component()` - allowing you to pass arbitrary options through to the view layer from the structure definition.

Example:
```js
function MyReactComponent(props) {
  return <div>{props.options.arb}</div>
}

S.component(MyReactComponent)
  .id('that-custom-thing')
  .title('My custom thing')
  .options({arb: 'itrary'})
```

Also discovered that the tests were not doing a good job at testing immutability of setter methods, so I fixed those within this PR as well.