### PR TITLE
[desk-tool] Handle permission errors from database

### DIFF
--- a/packages/@sanity/document-store/src/createObservableBufferedDocument.js
+++ b/packages/@sanity/document-store/src/createObservableBufferedDocument.js
@@ -43,6 +43,14 @@ export const createObservableBufferedDocument = (serverEvents$, doCommit) => {
       })
     }
 
+    bufferedDocument.onError = error => {
+      // If this is a permission error from Gradient, we should error the stream.
+      // Other errors might be tried recovered.
+      if (error && error.message && error.message.match(/permissions/gi)) {
+        updates$.error(error)
+      }
+    }
+
     bufferedDocument.onRebase = edge => {
       updates$.next({type: 'rebase', document: edge})
     }


### PR DESCRIPTION
**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**
If you have set up custom access control and get a permission error trying to do something with the document, the studio will break with an ugly technical error message.

<!-- Reference/link the relevant issue and/or describe the behavior. -->

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->
The error handling in `DocumentPane` has been streamlined and is always written to state.error by the various subscriptions. By a common error handler function, we now can test if it is a permission error, and if it is, output an own Snackbar error message for it.

What complicated this was that permission errors that happened when trying to create a document, happened another place (formBuilderValueStore) which gets a rebase event with a null document. In order to fix this, I added an `onError` callback function for  `BufferedDocument`. Then document store's `createObservableBufferedDocument` can register it's `onError` callback, and if it is called and the error is a permission error, it can error the stream (`updates$.error(error)`). Then we are able to catch the original error inside `DocumentPane`.

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [ ]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
