### PR TITLE
[desk-tool] Fix bug where pane options would be passed to view

### DIFF
--- a/packages/@sanity/desk-tool/src/pane/DocumentPane.js
+++ b/packages/@sanity/desk-tool/src/pane/DocumentPane.js
@@ -1396,7 +1396,7 @@ export default withInitialValue(
 
         // Other stuff
         documentId: this.getPublishedId(),
-        options,
+        options: activeView.options,
         schemaType,
         markers: markers || []
       }

--- a/packages/test-studio/src/deskStructure.js
+++ b/packages/test-studio/src/deskStructure.js
@@ -15,6 +15,7 @@ export const getDefaultDocumentNode = () => {
     S.view.form().icon(EditIcon),
     S.view
       .component(DeveloperPreview)
+      .options({some: 'option'})
       .icon(EyeIcon)
       .title('Preview')
   ])
@@ -64,6 +65,7 @@ export default () =>
         .child(
           S.component(JsonDocumentDump)
             .id('json-dump')
+            .options({pass: 'through'})
             .menuItems([
               S.menuItem()
                 .title('Reload')
@@ -136,18 +138,6 @@ export default () =>
             .filter('_type == $type && role == $role')
             .params({type: 'author', role: 'developer'})
             .initialValueTemplates(S.initialValueTemplateItem('author-developer'))
-            .child(documentId =>
-              S.document()
-                .documentId(documentId)
-                .schemaType('author')
-                .views([
-                  S.view.form().icon(EditIcon),
-                  S.view
-                    .component(DeveloperPreview)
-                    .icon(EyeIcon)
-                    .title('Preview')
-                ])
-            )
       }),
 
       S.listItem({


### PR DESCRIPTION
The component view was being passed the options of the _pane_ instead of the _view_. This fixes that.