### PR TITLE
[core] Initialize plugin configs before resolving GraphQL schema

### DIFF
--- a/packages/@sanity/core/src/actions/graphql/deployApiAction.js
+++ b/packages/@sanity/core/src/actions/graphql/deployApiAction.js
@@ -1,3 +1,4 @@
+const {tryInitializePluginConfigs} = require('../config/reinitializePluginConfigs')
 const getSanitySchema = require('./getSanitySchema')
 const extractFromSanitySchema = require('./extractFromSanitySchema')
 const generateTypeQueries = require('./generateTypeQueries')
@@ -6,6 +7,9 @@ const SchemaError = require('./SchemaError')
 
 module.exports = async function deployApiActions(args, context) {
   const {apiClient, workDir, output, prompt} = context
+
+  await tryInitializePluginConfigs({workDir, output, env: 'production'})
+
   const flags = args.extOptions
 
   const client = apiClient({


### PR DESCRIPTION
If a plugin config is missing and you try to run `sanity graphql deploy`, you might end up with a crash if something in the runtime path tries to load the configuration. This PR ensures we initialize the plugins before the deploy command is run.