### PR TITLE
[export] Retry assets on connection errors

### DIFF
--- a/packages/@sanity/export/src/requestStream.js
+++ b/packages/@sanity/export/src/requestStream.js
@@ -1,6 +1,34 @@
 const simpleGet = require('simple-get')
 
-module.exports = options =>
-  new Promise((resolve, reject) => {
+const MAX_RETRIES = 5
+
+// Just a promisified simpleGet
+function getStream(options) {
+  return new Promise((resolve, reject) => {
     simpleGet(options, (err, res) => (err ? reject(err) : resolve(res)))
   })
+}
+
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+/* eslint-disable no-await-in-loop, max-depth */
+module.exports = async options => {
+  let error
+  for (let i = 0; i < MAX_RETRIES; i++) {
+    try {
+      return await getStream(options)
+    } catch (err) {
+      error = err
+
+      if (err.statusCode && err.statusCode < 500) {
+        break
+      }
+
+      await delay(1500)
+    }
+  }
+
+  throw error
+}


### PR DESCRIPTION
Currently we are only retrying asset _download_ errors, not _connection_ errors.

In addition to this, the connection errors did not have any rejection handler, so the export would continue even if an asset failed to download, leading to potentially missing assets.

This PR fixes both of these issues.