### PR TITLE
[form-builder] Normalize blocks received from custom paste handler

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/Editor.tsx
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/Editor.tsx
@@ -54,7 +54,7 @@ import Decorator from './nodes/Decorator'
 import InlineObject from './nodes/InlineObject'
 import Span from './nodes/Span'
 import styles from './styles/Editor.css'
-import {EDITOR_DEFAULT_BLOCK_TYPE, editorValueToBlocks} from '@sanity/block-tools'
+import {EDITOR_DEFAULT_BLOCK_TYPE, editorValueToBlocks, normalizeBlock} from '@sanity/block-tools'
 import {getKey} from './utils/getKey'
 import {Path} from '../../typedefs/path'
 type PasteProgressResult = {
@@ -293,11 +293,13 @@ export default class Editor extends React.Component<Props, {}> {
           throw result
         }
         if (result && result.insert) {
+          const allowedDecorators = this.props.blockContentFeatures.decorators.map(item => item.value)
+          const blocksToInsertNormalized = result.insert.map(block => normalizeBlock(block, {allowedDecorators}))
           const patches = [
-            setIfMissing(result.insert),
+            setIfMissing(blocksToInsertNormalized),
             this.props.value && this.props.value.length !== 0
-              ? insert(result.insert, 'after', result.path || focusPath)
-              : set(result.insert, [])
+              ? insert(blocksToInsertNormalized, 'after', result.path || focusPath)
+              : set(blocksToInsertNormalized, [])
           ]
           onPatch(PatchEvent.from(patches))
           onLoading({paste: null})


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**
Blocks returned from a custom paste handler is not normalized. This can lead to errors (missing keys etc). We should totally normalize them, before inserting them into the block array.

<!-- Reference/link the relevant issue and/or describe the behavior. -->

**Description**
Blocks are now normalized so that they are always "right", and the end user doesn't have to worry about it.

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

**Note for release**
Fix a bug where blocks returned from a custom paste handler in the portable text editor was not normalized.

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [x]  Corresponding changes to the documentation have been made
