### PR TITLE
[desk-tool] Fix deprecated part crashing on unpublished documents

### DIFF
--- a/packages/@sanity/desk-tool/src/pane/Editor/FormView.js
+++ b/packages/@sanity/desk-tool/src/pane/Editor/FormView.js
@@ -22,7 +22,7 @@ export default class FormView extends React.PureComponent {
     document: PropTypes.shape({
       draft: PropTypes.shape({_id: PropTypes.string, _type: PropTypes.string}),
       published: PropTypes.shape({_id: PropTypes.string, _type: PropTypes.string}),
-      displayed: PropTypes.shape({_type: PropTypes.string})
+      displayed: PropTypes.shape({_id: PropTypes.string, _type: PropTypes.string})
     }).isRequired,
     initialValue: PropTypes.shape({_type: PropTypes.string}),
     isReconnecting: PropTypes.bool,
@@ -98,6 +98,7 @@ export default class FormView extends React.PureComponent {
     const {focusPath, filterField} = this.state
     const value = draft || published
     const readOnly = this.isReadOnly()
+    const documentId = displayed && displayed._id && displayed._id.replace(/^drafts\./, '')
 
     const hasTypeMismatch = value && value._type && value._type !== schemaType.name
     if (hasTypeMismatch) {
@@ -135,7 +136,7 @@ export default class FormView extends React.PureComponent {
         )}
 
         {afterEditorComponents.map((AfterEditorComponent, i) => (
-          <AfterEditorComponent key={i} documentId={published._id} />
+          <AfterEditorComponent key={i} documentId={documentId} />
         ))}
       </div>
     )

--- a/packages/test-studio/sanity.json
+++ b/packages/test-studio/sanity.json
@@ -89,6 +89,10 @@
       "name": "part:@sanity/dashboard/widget/test-dummy",
       "implements": "part:@sanity/dashboard/widget",
       "path": "src/widgets/DummyWidget"
+    },
+    {
+      "implements": "part:@sanity/desk-tool/after-editor-component",
+      "path": "src/components/AfterEditorComponent.js"
     }
   ],
   "env": {

--- a/packages/test-studio/src/components/AfterEditorComponent.js
+++ b/packages/test-studio/src/components/AfterEditorComponent.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const AfterEditorComponent = () => (
+  <div style={{display: 'none'}}>This renders after the editor</div>
+)
+
+export default AfterEditorComponent


### PR DESCRIPTION
Fixes a bug where using the `part:@sanity/desk-tool/after-editor-component` part will crash the desk tool if the currently viewed document is not yet published.