### PR TITLE
[base] Maintain order of documents when collating drafts/published

### DIFF
--- a/packages/@sanity/base/src/util/draftUtils.js
+++ b/packages/@sanity/base/src/util/draftUtils.js
@@ -47,11 +47,17 @@ export function createPublishedFrom(document) {
 export function collate(documents) {
   const byId = documents.reduce((res, doc) => {
     const id = getPublishedId(doc._id)
-    const entry = res[id] || (res[id] = {id})
+    let entry = res.get(id)
+    if (!entry) {
+      entry = {id}
+      res.set(id, entry)
+    }
+
     entry[id === doc._id ? 'published' : 'draft'] = doc
     return res
-  }, Object.create(null))
-  return Object.values(byId)
+  }, new Map())
+
+  return Array.from(byId.values())
 }
 
 // Removes published documents that also has a draft


### PR DESCRIPTION
#1422 introduced a change of behavior in `collate()`, where the order of the passed documents would not be maintained anymore.

I'm not sure if this was intentional, but there is code that depends on the order currently - the desk tool, when showing a list of documents ordered by a specific field, for instance.

This PR switches from using an object (which does not guarantee order) + Object.values, to using a Map - which is guaranteed to maintain order.