### PR TITLE
[mutator] Fixes the problem where diff-match-patch and inc-dec would y…

### DIFF
--- a/packages/@sanity/mutator/src/patch/DiffMatchPatch.ts
+++ b/packages/@sanity/mutator/src/patch/DiffMatchPatch.ts
@@ -2,6 +2,12 @@ import * as DMP from 'diff-match-patch'
 
 const dmp = new DMP.diff_match_patch()
 
+function applyPatch(patch, oldValue) {
+  // Silently avoid patching if the value type is not string
+  if (typeof oldValue !== 'string') return oldValue
+  return dmp.patch_apply(patch, oldValue)[0]
+}
+
 export default class DiffMatchPatch {
   path: string
   dmpPatch: DMP.patch_obj[]
@@ -13,16 +19,23 @@ export default class DiffMatchPatch {
   }
   apply(targets, accessor) {
     let result = accessor
+    // The target must be a container type
+    if (result.containerType() == 'primitive') {
+      return result
+    }
     targets.forEach(target => {
       if (target.isIndexReference()) {
         target.toIndicies(accessor).forEach(i => {
-          const oldValue = result.getIndex(i).get()
-          const nextValue = dmp.patch_apply(this.dmpPatch, oldValue)[0]
-          result = result.setIndex(i, nextValue)
+          // Skip patching unless the index actually currently exists
+          if (result.getIndex(i)) {
+            const oldValue = result.getIndex(i).get()
+            const nextValue = applyPatch(this.dmpPatch, oldValue)
+            result = result.setIndex(i, nextValue)
+          }
         })
-      } else if (target.isAttributeReference()) {
+      } else if (target.isAttributeReference() && result.hasAttribute(target.name())) {
         const oldValue = result.getAttribute(target.name()).get()
-        const nextValue = dmp.patch_apply(this.dmpPatch, oldValue)[0]
+        const nextValue = applyPatch(this.dmpPatch, oldValue)
         result = result.setAttribute(target.name(), nextValue)
       } else {
         throw new Error(`Unable to apply diffMatchPatch to target ${target.toString()}`)

--- a/packages/@sanity/mutator/src/patch/IncPatch.ts
+++ b/packages/@sanity/mutator/src/patch/IncPatch.ts
@@ -1,3 +1,8 @@
+function performIncrement(previousValue, delta) {
+  if (!Number.isFinite(previousValue)) return previousValue
+  return previousValue + delta
+}
+
 export default class IncPatch {
   path: string
   value: number
@@ -9,15 +14,22 @@ export default class IncPatch {
   }
   apply(targets, accessor) {
     let result = accessor
+    // The target must be a container type
+    if (result.containerType() == 'primitive') {
+      return result
+    }
     targets.forEach(target => {
       if (target.isIndexReference()) {
         target.toIndicies(accessor).forEach(i => {
-          const previousValue = result.getIndex(i).get()
-          result = result.setIndex(i, previousValue + this.value)
+          // Skip patching unless the index actually currently exists
+          if (result.getIndex(i)) {
+            const previousValue = result.getIndex(i).get()
+            result = result.setIndex(i, performIncrement(previousValue, this.value))
+          }
         })
-      } else if (target.isAttributeReference()) {
+      } else if (target.isAttributeReference() && result.hasAttribute(target.name())) {
         const previousValue = result.getAttribute(target.name()).get()
-        result = result.setAttribute(target.name(), previousValue + this.value)
+        result = result.setAttribute(target.name(), performIncrement(previousValue, this.value))
       } else {
         throw new Error(`Unable to apply to target ${target.toString()}`)
       }

--- a/packages/@sanity/mutator/test/patchExamples/diffMatchPatch.ts
+++ b/packages/@sanity/mutator/test/patchExamples/diffMatchPatch.ts
@@ -28,5 +28,48 @@ export default [
     after: {
       a: ['The nice dog']
     }
+  },
+  {
+    name: 'Diff match patch missing array element',
+    before: {
+      a: ['The rabid dog']
+    },
+    patch: {
+      diffMatchPatch: {
+        'a[1]': '@@ -1,13 +1,12 @@\n The \n-rabid\n+nice\n  dog\n'
+      }
+    },
+    after: {
+      a: ['The rabid dog']
+    }
+  },
+  {
+    name: 'Diff match patch null value',
+    before: {
+      a: null
+    },
+    patch: {
+      diffMatchPatch: {
+        'a': '@@ -1,13 +1,12 @@\n The \n-rabid\n+nice\n  dog\n'
+      }
+    },
+    after: {
+      a: null
+    }
+  },
+  {
+    name: 'Diff match patch null container',
+    before: {
+      a: null
+    },
+    patch: {
+      diffMatchPatch: {
+        'a.b': '@@ -1,13 +1,12 @@\n The \n-rabid\n+nice\n  dog\n'
+      }
+    },
+    after: {
+      a: null
+    }
   }
+
 ]


### PR DESCRIPTION
Fixes a problem where diff-match-patch and inc/dec patches could yield exceptions when targetting array indicies or attributes that were missing. This is almost impossible to experience except under very laggy network conditions when more than one user is battle-editing the same fields.