### PR TITLE
[desk-tool] Optimize loading of large lists

### DIFF
--- a/packages/@sanity/desk-tool/src/pane/DocumentsListPane.js
+++ b/packages/@sanity/desk-tool/src/pane/DocumentsListPane.js
@@ -16,7 +16,7 @@ import InfiniteList from './InfiniteList'
 import PaneItem from './PaneItem'
 
 const PARTIAL_PAGE_LIMIT = 100
-const FULL_PAGE_LIMIT = 5000
+const FULL_LIST_LIMIT = 2000
 
 const DEFAULT_ORDERING = [{field: '_createdAt', direction: 'desc'}]
 
@@ -271,7 +271,7 @@ export default class DocumentsListPane extends React.PureComponent {
     const projectionFields = ['_id', '_type']
     const finalProjection = projectionFields.join(', ')
     const sortBy = (sortOrder && sortOrder.by) || defaultOrdering || []
-    const limit = fullList ? FULL_PAGE_LIMIT : PARTIAL_PAGE_LIMIT
+    const limit = fullList ? FULL_LIST_LIMIT : PARTIAL_PAGE_LIMIT
     const sort = sortBy.length > 0 ? sortBy : DEFAULT_ORDERING
 
     if (extendedProjection) {
@@ -330,7 +330,7 @@ export default class DocumentsListPane extends React.PureComponent {
             getItemKey={getDocumentKey}
             renderItem={this.renderItem}
             onScroll={this.handleScroll}
-            hasMoreItems={items.length === FULL_PAGE_LIMIT}
+            hasMoreItems={items.length === FULL_LIST_LIMIT}
             isLoadingMore={isLoadingMore}
           />
         )}

--- a/packages/@sanity/desk-tool/src/pane/DocumentsListPane.js
+++ b/packages/@sanity/desk-tool/src/pane/DocumentsListPane.js
@@ -122,7 +122,7 @@ export default class DocumentsListPane extends React.PureComponent {
     }
   }
 
-  state = {scrollTop: 0, sortOrder: null, layout: null}
+  state = {sortOrder: null, layout: null}
 
   constructor(props) {
     super()
@@ -192,10 +192,6 @@ export default class DocumentsListPane extends React.PureComponent {
     return true
   }
 
-  handleScroll = scrollTop => {
-    this.setState({scrollTop})
-  }
-
   buildListQuery() {
     const {options} = this.props
     const {filter, defaultOrdering} = options
@@ -252,7 +248,6 @@ export default class DocumentsListPane extends React.PureComponent {
         className={className}
         styles={this.props.styles}
         index={this.props.index}
-        scrollTop={this.state.scrollTop}
         menuItems={menuItems}
         menuItemGroups={menuItemGroups}
         initialValueTemplates={initialValueTemplates}
@@ -311,7 +306,6 @@ export default class DocumentsListPane extends React.PureComponent {
                 {items && (
                   <InfiniteList
                     className={listStyles.scroll}
-                    onScroll={this.handleScroll}
                     items={items}
                     layout={layout}
                     getItemKey={getDocumentKey}

--- a/packages/@sanity/desk-tool/src/pane/InfiniteList.js
+++ b/packages/@sanity/desk-tool/src/pane/InfiniteList.js
@@ -77,6 +77,14 @@ export default enhanceWithAvailHeight(
       )
     }
 
+    handleScroll = scrollTop => {
+      if (!this.props.onScroll) {
+        return
+      }
+
+      this.props.onScroll(scrollTop, this.state.itemSize)
+    }
+
     render() {
       const {layout, height, items, className, renderItem, hasMoreItems, isLoadingMore} = this.props
       const {triggerUpdate, itemSize} = this.state
@@ -94,7 +102,7 @@ export default enhanceWithAvailHeight(
         <VirtualList
           key={layout} // forcefully re-render the whole list when layout changes
           data-trigger-update-hack={triggerUpdate} // see componentWillReceiveProps above
-          onScroll={this.props.onScroll}
+          onScroll={this.handleScroll}
           className={className || ''}
           height={height}
           itemCount={addExtraItem ? items.length + 1 : items.length}

--- a/packages/@sanity/desk-tool/src/pane/InfiniteList.js
+++ b/packages/@sanity/desk-tool/src/pane/InfiniteList.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import VirtualList from 'react-tiny-virtual-list'
 import enhanceWithAvailHeight from './enhanceWithAvailHeight'
+import styles from './styles/InfiniteList.css'
 
 export default enhanceWithAvailHeight(
   class InfiniteList extends React.PureComponent {
@@ -61,10 +62,12 @@ export default enhanceWithAvailHeight(
       const {renderItem, getItemKey, items, isLoadingMore} = this.props
       if (index === items.length) {
         return (
-          <div key="more-items" style={style}>
-            {isLoadingMore
-              ? 'Loading additional documents…'
-              : 'There are more documents than are currently shown.'}
+          <div
+            key="more-items"
+            style={{...style, height: style.height - 1, lineHeight: `${style.height - 1}px`}}
+            className={styles.bottomMetaInfo}
+          >
+            {isLoadingMore ? 'Loading…' : 'This list contains more documents'}
           </div>
         )
       }

--- a/packages/@sanity/desk-tool/src/pane/InfiniteList.js
+++ b/packages/@sanity/desk-tool/src/pane/InfiniteList.js
@@ -8,6 +8,8 @@ export default enhanceWithAvailHeight(
     static propTypes = {
       height: PropTypes.number,
       items: PropTypes.array, // eslint-disable-line react/forbid-prop-types
+      hasMoreItems: PropTypes.bool,
+      isLoadingMore: PropTypes.bool,
       renderItem: PropTypes.func,
       className: PropTypes.string,
       getItemKey: PropTypes.func,
@@ -16,6 +18,8 @@ export default enhanceWithAvailHeight(
     }
 
     static defaultProps = {
+      hasMoreItems: false,
+      isLoadingMore: false,
       layout: 'default',
       items: [],
       height: 250
@@ -54,7 +58,17 @@ export default enhanceWithAvailHeight(
     }
 
     renderItem = ({index, style}) => {
-      const {renderItem, getItemKey, items} = this.props
+      const {renderItem, getItemKey, items, isLoadingMore} = this.props
+      if (index === items.length) {
+        return (
+          <div key="more-items" style={style}>
+            {isLoadingMore
+              ? 'Loading additional documents…'
+              : 'There are more documents than are currently shown.'}
+          </div>
+        )
+      }
+
       const item = items[index]
       return (
         <div key={getItemKey(item)} style={style}>
@@ -64,8 +78,9 @@ export default enhanceWithAvailHeight(
     }
 
     render() {
-      const {layout, height, items, className, renderItem} = this.props
+      const {layout, height, items, className, renderItem, hasMoreItems, isLoadingMore} = this.props
       const {triggerUpdate, itemSize} = this.state
+      const addExtraItem = hasMoreItems || isLoadingMore
 
       if (!items || items.length === 0) {
         return <div />
@@ -82,7 +97,7 @@ export default enhanceWithAvailHeight(
           onScroll={this.props.onScroll}
           className={className || ''}
           height={height}
-          itemCount={items.length}
+          itemCount={addExtraItem ? items.length + 1 : items.length}
           itemSize={itemSize}
           renderItem={this.renderItem}
           overscanCount={50}

--- a/packages/@sanity/desk-tool/src/pane/styles/InfiniteList.css
+++ b/packages/@sanity/desk-tool/src/pane/styles/InfiniteList.css
@@ -1,0 +1,5 @@
+.bottomMetaInfo {
+  border-top: 1px solid #d1d7e0;
+  text-align: center;
+  color: #758097;
+}


### PR DESCRIPTION
Document lists with a large number of documents are currently pretty slow to load. At some point we want to provide a scrolling window implementation that we've talked about for a while.

This is a temporary workaround until we can get around to that implementation, however. In essence, it:

- Loads only the 100 first documents matching the query
- Waits for the user to scroll half way down in that list
- Starts loading the "full" list (without clearing the list while loading)
- Re-renders the list with the "full" document set, which should usually be an add-only operation

I'm putting "full" in quotes because we were previously loading up to 50 000 document IDs, while we're now stopping at 2000. Even this seems excessive, as I/we can't see a legitimate reason for using such an enormous list to find anything - you're much better off using the search or providing a more fine-grained navigation using the structure builder if you've got that amount of documents. 

If you _do_ scroll to the bottom of the 2000 documents, we'll show a message saying that more documents _do_ exist, but are not loaded.