### PR TITLE
[default-layout] Reload window when switching spaces

### DIFF
--- a/packages/@sanity/default-layout/src/components/NavBar.js
+++ b/packages/@sanity/default-layout/src/components/NavBar.js
@@ -45,6 +45,8 @@ function NavBar(props) {
   let className = styles.root
   if (showToolSwitcher) className += ` ${styles.withToolSwitcher}`
 
+  const rootState = HAS_SPACES && router.state.space ? {space: router.state.space} : {}
+
   return (
     <div className={className} data-search-open={searchIsOpen}>
       <div className={styles.hamburger}>
@@ -59,7 +61,7 @@ function NavBar(props) {
           </div>
         </button>
       </div>
-      <StateLink toIndex className={styles.branding}>
+      <StateLink state={rootState} className={styles.branding}>
         <Branding projectName={config && config.project.name} />
       </StateLink>
       <button className={styles.createButton} onClick={onCreateButtonClick} type="button">
@@ -147,7 +149,7 @@ NavBar.propTypes = {
   onSetLoginStatusElement: PropTypes.func,
   onSetSearchElement: PropTypes.func,
   router: PropTypes.shape({
-    state: PropTypes.shape({tool: PropTypes.string}),
+    state: PropTypes.shape({tool: PropTypes.string, space: PropTypes.string}),
     navigate: PropTypes.func
   }).isRequired,
   tools: PropTypes.arrayOf(

--- a/packages/@sanity/default-layout/src/components/NotFound.js
+++ b/packages/@sanity/default-layout/src/components/NotFound.js
@@ -1,12 +1,15 @@
 import React from 'react'
-import {StateLink} from 'part:@sanity/base/router'
+import {withRouterHOC, StateLink} from 'part:@sanity/base/router'
+import {HAS_SPACES} from '../util/spaces'
 
-export default function NotFound(props) {
+export default withRouterHOC(function NotFound(props) {
+  const router = props.router
+  const rootState = HAS_SPACES && router.state.space ? {space: router.state.space} : {}
   return (
     <div>
       <h2>Page not found</h2>
       {props.children}
-      <StateLink toIndex>Go to index</StateLink>
+      <StateLink state={rootState}>Go to index</StateLink>
     </div>
   )
-}
+})

--- a/packages/@sanity/default-layout/src/components/SpaceSwitcher.js
+++ b/packages/@sanity/default-layout/src/components/SpaceSwitcher.js
@@ -45,7 +45,9 @@ class SpaceSwitcher extends React.PureComponent {
 
   handleChange = item => {
     this.props.router.navigate({space: item.name})
-    this.setState({menuOpen: false})
+    this.setState({menuOpen: false}, () => {
+      window.location.reload()
+    })
   }
 
   render() {


### PR DESCRIPTION
Because we can't guarantee that all code in the studio will respect the "new" space when switching, a "quick-fix" which this PR implements simply reloads the studio after the URL has changed.

In addition, I've fixed the "root" links within the default layout to include a space if present. This makes sure it doesn't reset when clicking on the studio logo, for instance.
