### PR TITLE
[@sanity/core] Allow startup with env without api settings

### DIFF
--- a/packages/@sanity/cli/src/util/clientWrapper.js
+++ b/packages/@sanity/cli/src/util/clientWrapper.js
@@ -39,15 +39,12 @@ export default function clientWrapper(manifest, configPath) {
   return function(opts = {}) {
     const {requireUser, requireProject, api} = {...defaults, ...opts}
     const userConfig = getUserConfig()
-    const userApiConf = userConfig.get('api')
     const token = envAuthToken || userConfig.get('authToken')
     const apiHost = apiHosts[sanityEnv]
-    const apiConfig = Object.assign(
-      {},
-      userApiConf || {},
-      (manifest && manifest.api) || {},
-      api || {}
-    )
+    const apiConfig = {
+      ...((manifest && manifest.api) || {}),
+      ...(api || {})
+    }
 
     if (apiHost) {
       apiConfig.apiHost = apiHost
@@ -66,7 +63,7 @@ export default function clientWrapper(manifest, configPath) {
 
     return client({
       ...apiConfig,
-      dataset: apiConfig.dataset || 'dummy',
+      dataset: apiConfig.dataset || '_dummy_',
       token: token,
       useProjectHostname: requireProject,
       requester: requester,

--- a/packages/@sanity/core/src/actions/start/startAction.js
+++ b/packages/@sanity/core/src/actions/start/startAction.js
@@ -111,8 +111,13 @@ async function ensureProjectConfig(context) {
 
   let displayName = projectManifest.project && projectManifest.project.displayName
   let {projectId, dataset} = apiConfig || {}
-  const configMissing = !projectId || !dataset
-  if (!configMissing) {
+
+  const sanityConfigPresent =
+    context.apiClient().clientConfig.projectId && context.apiClient().clientConfig.dataset
+  if (sanityConfigPresent) {
+    if (!projectId && !dataset) {
+      output.print('Using project id and dataset from .env file instead of sanity.json file.')
+    }
     return
   }
 

--- a/packages/@sanity/core/src/actions/start/startAction.js
+++ b/packages/@sanity/core/src/actions/start/startAction.js
@@ -1,7 +1,7 @@
 import path from 'path'
 import chalk from 'chalk'
 import fse from 'fs-extra'
-import {isPlainObject} from 'lodash'
+import {get, isPlainObject} from 'lodash'
 import {promisify} from 'es6-promisify'
 import {getDevServer} from '@sanity/server'
 import getConfig from '@sanity/util/lib/getConfig'
@@ -104,25 +104,39 @@ async function ensureProjectConfig(context) {
   const {workDir, output} = context
   const manifestPath = path.join(workDir, 'sanity.json')
   const projectManifest = await fse.readJson(manifestPath)
-  const apiConfig = projectManifest.api
-  if (typeof apiConfig !== 'undefined' && !isPlainObject(apiConfig)) {
+  const apiConfig = projectManifest.api || {}
+  if (!isPlainObject(apiConfig)) {
     throw new Error('Invalid `api` property in `sanity.json` - should be an object')
   }
 
-  let displayName = projectManifest.project && projectManifest.project.displayName
-  let {projectId, dataset} = apiConfig || {}
+  // The API client wrapper extracts information from environment variables,
+  // which means it could potentially hold any missing project ID / dataset
+  let {projectId, dataset} = context.apiClient({requireProject: false}).config()
 
-  const sanityConfigPresent =
-    context.apiClient().clientConfig.projectId && context.apiClient().clientConfig.dataset
-  if (sanityConfigPresent) {
-    if (!projectId && !dataset) {
-      output.print('Using project id and dataset from .env file instead of sanity.json file.')
-    }
+  // The client wrapper returns `_dummy_` in the case where no dataset is configured,
+  // to be able to do non-dataset requests without having the client complain.
+  // We obviously don't want to use this as an actual value
+  dataset = dataset === '_dummy_' ? undefined : dataset
+
+  // Let the user know why these values are being used
+  if (projectId && projectId !== apiConfig.projectId) {
+    output.print(`Using project ID from environment config (${projectId})`)
+  }
+
+  if (dataset && dataset !== apiConfig.dataset) {
+    output.print(`Using dataset from environment config (${dataset})`)
+  }
+
+  // If we're still missing information, prompt the user to provide them
+  const configMissing = !projectId || !dataset
+  if (!configMissing) {
     return
   }
 
   output.print('Project configuration required before starting studio')
   output.print('')
+
+  let displayName = get(projectManifest, 'project.displayName')
 
   if (!projectId) {
     const selected = await getOrCreateProject(context)
@@ -145,7 +159,7 @@ async function ensureProjectConfig(context) {
   const newProps = {
     root: true,
     api: {
-      ...(projectManifest.api || {}),
+      ...apiConfig,
       projectId,
       dataset
     },
@@ -156,10 +170,11 @@ async function ensureProjectConfig(context) {
     }
   }
 
-  // Ensure root, api and project keys are at top to follow sanity.json key order convention
   await fse.outputJSON(
     manifestPath,
     {
+      // We're listing `newProps` twice to ensure root, api and project keys
+      // are at top to follow sanity.json key order convention
       ...newProps,
       ...projectManifest,
       ...newProps
@@ -167,7 +182,7 @@ async function ensureProjectConfig(context) {
     {spaces: 2}
   )
 
-  output.print('Project ID / dataset configured')
+  output.print(`Project ID + dataset written to "${manifestPath}"`)
 }
 
 function resolveStaticPath(rootDir, config) {


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [x]  Yes
- [ ]  No

**Current behavior**

`ensureProjectConfig()` in startAction.js fails when there are no values in `sanity.json`'s `api.project_id` and `api.dataset`, while with the recent addtion of dotenv (`.env`) functionality, `.env.[development|productions|etc.]` can be used to set these values. There should be no values in `sanity.json` in this case for these since it would confuse someone who reads through the configuration. Also, it is easy to configure these values through `.env` in cases where `gatsby-source-sanity` is used and the same values need to be set there as well.

<!-- Reference/link the relevant issue and/or describe the behavior. -->

**Description**

This code change checks `context.apiClient().clientConfig.projectId` and `context.apiClient().clientConfig.dataset`, since the values for `projectId` and `dataset` are present both when there are values set in either the `sanity.json` file OR the `.env` file.

`SANITY_STUDIO_API_PROJECT_ID=adsfasdf`
`SANITY_STUDIO_API_DATASET=123123123`


- A message "Using project id and dataset from .env file instead of sanity.json file" is displayed to show that the values are being overridden by the `.env` file. (Even better would be detecting when both values are present in both the sanity.json file AND the `.env` file, since the `.env` values are used in this case.
- Instead of using an or to check for values not present and then a return if not present (confusing), an `and` is used to make this clearer (if config values present, then return).
 
<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

This change allows for Sanity project id and dataset values to be set through the dotenv files and not through the sanity.json configuration file. 

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [ ]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
