### PR TITLE
[export/import] Improve asset performance

### DIFF
--- a/packages/@sanity/core/src/commands/dataset/exportDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/exportDatasetCommand.js
@@ -10,12 +10,13 @@ const noop = () => null
 
 const helpText = `
 Options
-  --raw         Extract only documents, without rewriting asset references
-  --no-assets   Export only non-asset documents and remove references to image assets
-  --no-drafts   Export only published versions of documents
-  --no-compress Skips compressing tarball entries (still generates a gzip file)
-  --types       Defines which document types to export
-  --overwrite   Overwrite any file with the same name
+  --raw                Extract only documents, without rewriting asset references
+  --no-assets          Export only non-asset documents and remove references to image assets
+  --no-drafts          Export only published versions of documents
+  --no-compress        Skips compressing tarball entries (still generates a gzip file)
+  --types              Defines which document types to export
+  --overwrite          Overwrite any file with the same name
+  --concurrency <field> Concurrent downloads of assets
 
 Examples
   sanity dataset export moviedb localPath.tar.gz

--- a/packages/@sanity/core/src/commands/dataset/exportDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/exportDatasetCommand.js
@@ -10,13 +10,13 @@ const noop = () => null
 
 const helpText = `
 Options
-  --raw                Extract only documents, without rewriting asset references
-  --no-assets          Export only non-asset documents and remove references to image assets
-  --no-drafts          Export only published versions of documents
-  --no-compress        Skips compressing tarball entries (still generates a gzip file)
-  --types              Defines which document types to export
-  --overwrite          Overwrite any file with the same name
-  --concurrency <field> Concurrent downloads of assets
+  --raw               Extract only documents, without rewriting asset references
+  --no-assets         Export only non-asset documents and remove references to image assets
+  --no-drafts         Export only published versions of documents
+  --no-compress       Skips compressing tarball entries (still generates a gzip file)
+  --types             Defines which document types to export
+  --overwrite         Overwrite any file with the same name
+  --concurrency <num> Concurrent number of asset downloads
 
 Examples
   sanity dataset export moviedb localPath.tar.gz

--- a/packages/@sanity/core/src/commands/dataset/exportDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/exportDatasetCommand.js
@@ -10,13 +10,13 @@ const noop = () => null
 
 const helpText = `
 Options
-  --raw               Extract only documents, without rewriting asset references
-  --no-assets         Export only non-asset documents and remove references to image assets
-  --no-drafts         Export only published versions of documents
-  --no-compress       Skips compressing tarball entries (still generates a gzip file)
-  --types             Defines which document types to export
-  --overwrite         Overwrite any file with the same name
-  --concurrency <num> Concurrent number of asset downloads
+  --raw                     Extract only documents, without rewriting asset references
+  --no-assets               Export only non-asset documents and remove references to image assets
+  --no-drafts               Export only published versions of documents
+  --no-compress             Skips compressing tarball entries (still generates a gzip file)
+  --types                   Defines which document types to export
+  --overwrite               Overwrite any file with the same name
+  --asset-concurrency <num> Concurrent number of asset downloads
 
 Examples
   sanity dataset export moviedb localPath.tar.gz
@@ -40,6 +40,10 @@ export default {
 
     if (flags.types) {
       flags.types = `${flags.types}`.split(',')
+    }
+
+    if (flags['asset-concurrency']) {
+      flags.assetConcurrency = parseInt(flags['asset-concurrency'], 10)
     }
 
     let dataset = targetDataset ? `${targetDataset}` : null

--- a/packages/@sanity/core/src/commands/dataset/importDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/importDatasetCommand.js
@@ -43,6 +43,7 @@ export default {
     const {apiClient, output, chalk, fromInitCommand} = context
 
     const allowFailingAssets = args.extOptions['allow-failing-assets']
+    const assetConcurrency = args.extOptions['asset-concurrency']
     const operation = getMutationOperation(args.extOptions)
     const client = apiClient()
 
@@ -148,7 +149,8 @@ export default {
         client: importClient,
         operation,
         onProgress,
-        allowFailingAssets
+        allowFailingAssets,
+        assetConcurrency
       })
 
       endTask({success: true})

--- a/packages/@sanity/export/README.md
+++ b/packages/@sanity/export/README.md
@@ -38,7 +38,10 @@ exportDataset({
 
   // Export only given document types (`_type`)
   // Optional, default: all types
-  types: ['products', 'shops']
+  types: ['products', 'shops'],
+
+  // Run 12 concurrent asset downloads
+  concurrency: 12
 })
 ```
 

--- a/packages/@sanity/export/README.md
+++ b/packages/@sanity/export/README.md
@@ -41,14 +41,14 @@ exportDataset({
   types: ['products', 'shops'],
 
   // Run 12 concurrent asset downloads
-  concurrency: 12
+  assetConcurrency: 12
 })
 ```
 
 ## Future improvements
 
-* Restore original filenames, keep track of duplicates, increase counter (`filename (<num>).ext`)
-* Skip archiving on raw/no-asset mode?
+- Restore original filenames, keep track of duplicates, increase counter (`filename (<num>).ext`)
+- Skip archiving on raw/no-asset mode?
 
 ## CLI-tool
 

--- a/packages/@sanity/export/package.json
+++ b/packages/@sanity/export/package.json
@@ -22,6 +22,7 @@
     "ndjson"
   ],
   "dependencies": {
+    "agentkeepalive": "^4.1.0",
     "archiver": "^2.1.1",
     "debug": "^3.1.0",
     "fs-extra": "^6.0.1",

--- a/packages/@sanity/export/src/AssetHandler.js
+++ b/packages/@sanity/export/src/AssetHandler.js
@@ -16,6 +16,9 @@ const ASSET_DOWNLOAD_CONCURRENCY = 8
 
 class AssetHandler {
   constructor(options) {
+    const concurrency = options.concurrency || ASSET_DOWNLOAD_CONCURRENCY
+    debug('Using asset download concurrency of %d', concurrency)
+
     this.client = options.client
     this.tmpDir = options.tmpDir
     this.assetDirsCreated = false
@@ -24,7 +27,8 @@ class AssetHandler {
     this.assetMap = {}
     this.filesWritten = 0
     this.queueSize = 0
-    this.queue = options.queue || new PQueue({concurrency: options.concurrency || ASSET_DOWNLOAD_CONCURRENCY})
+    this.queue = options.queue || new PQueue({concurrency})
+
     this.rejectedError = null
     this.reject = err => {
       this.rejectedError = err
@@ -171,7 +175,7 @@ class AssetHandler {
     }
 
     if (differs && attemptNum < 3) {
-      debug('%s does not match downloaded asset, retrying (#%d)', method, attemptNum + 1)
+      debug('%s does not match downloaded asset, retrying (#%d) [%s]', method, attemptNum + 1, url)
       return this.downloadAsset(assetDoc, dstPath, attemptNum + 1)
     } else if (differs) {
       const details = [

--- a/packages/@sanity/export/src/AssetHandler.js
+++ b/packages/@sanity/export/src/AssetHandler.js
@@ -23,6 +23,7 @@ class AssetHandler {
     this.tmpDir = options.tmpDir
     this.assetDirsCreated = false
 
+    this.downloading = []
     this.assetsSeen = new Map()
     this.assetMap = {}
     this.filesWritten = 0
@@ -101,6 +102,7 @@ class AssetHandler {
 
     debug('Adding download task for %s (destination: %s)', assetDoc._id, dstPath)
     this.queueSize++
+    this.downloading.push(assetDoc.url)
     this.queue.add(() => this.downloadAsset(assetDoc, dstPath))
   }
 
@@ -212,6 +214,11 @@ class AssetHandler {
     if (Object.keys(metaProps).length > 0) {
       this.assetMap[id] = metaProps
     }
+
+    this.downloading.splice(
+      this.downloading.findIndex(datUrl => datUrl === url),
+      1
+    )
 
     this.filesWritten++
     return true

--- a/packages/@sanity/export/src/AssetHandler.js
+++ b/packages/@sanity/export/src/AssetHandler.js
@@ -12,6 +12,7 @@ const debug = require('./debug')
 const EXCLUDE_PROPS = ['_id', '_type', 'assetId', 'extension', 'mimeType', 'path', 'url']
 const ACTION_REMOVE = 'remove'
 const ACTION_REWRITE = 'rewrite'
+const ASSET_DOWNLOAD_CONCURRENCY = 8
 
 class AssetHandler {
   constructor(options) {
@@ -23,7 +24,7 @@ class AssetHandler {
     this.assetMap = {}
     this.filesWritten = 0
     this.queueSize = 0
-    this.queue = options.queue || new PQueue({concurrency: 3})
+    this.queue = options.queue || new PQueue({concurrency: options.concurrency || ASSET_DOWNLOAD_CONCURRENCY})
     this.rejectedError = null
     this.reject = err => {
       this.rejectedError = err

--- a/packages/@sanity/export/src/export.js
+++ b/packages/@sanity/export/src/export.js
@@ -41,7 +41,8 @@ function exportDataset(opts) {
   const assetHandler = new AssetHandler({
     client: options.client,
     tmpDir,
-    prefix
+    prefix,
+    concurrency: options.concurrency
   })
 
   debug('Outputting assets (temporarily) to %s', tmpDir)

--- a/packages/@sanity/export/src/export.js
+++ b/packages/@sanity/export/src/export.js
@@ -125,7 +125,9 @@ function exportDataset(opts) {
 
       let prevCompleted = 0
       const progressInterval = setInterval(() => {
-        const completed = assetHandler.queueSize - assetHandler.queue.size
+        const completed =
+          assetHandler.queueSize - assetHandler.queue.size - assetHandler.queue.pending
+
         if (prevCompleted === completed) {
           return
         }
@@ -142,6 +144,15 @@ function exportDataset(opts) {
       debug('Waiting for asset handler to complete downloads')
       try {
         const assetMap = await assetHandler.finish()
+
+        // Make sure we mark the progress as done (eg 100/100 instead of 99/100)
+        onProgress({
+          step: 'Downloading assets...',
+          current: assetHandler.queueSize,
+          total: assetHandler.queueSize,
+          update: true
+        })
+
         archive.append(JSON.stringify(assetMap), {name: 'assets.json', prefix})
         clearInterval(progressInterval)
       } catch (assetErr) {

--- a/packages/@sanity/export/src/export.js
+++ b/packages/@sanity/export/src/export.js
@@ -42,7 +42,7 @@ function exportDataset(opts) {
     client: options.client,
     tmpDir,
     prefix,
-    concurrency: options.concurrency
+    concurrency: options.assetConcurrency
   })
 
   debug('Outputting assets (temporarily) to %s', tmpDir)
@@ -165,11 +165,7 @@ function exportDataset(opts) {
     })
 
     archive.append(jsonStream, {name: 'data.ndjson', prefix})
-    miss.pipe(
-      archive,
-      outputStream,
-      onComplete
-    )
+    miss.pipe(archive, outputStream, onComplete)
 
     async function onComplete(err) {
       onProgress({step: 'Clearing temporary files...'})

--- a/packages/@sanity/export/src/requestStream.js
+++ b/packages/@sanity/export/src/requestStream.js
@@ -1,5 +1,11 @@
 const simpleGet = require('simple-get')
+const HttpAgent = require('agentkeepalive')
 
+const HttpsAgent = HttpAgent.HttpsAgent
+const httpAgent = new HttpAgent()
+const httpsAgent = new HttpsAgent()
+
+const RESPONSE_TIMEOUT = 15000
 const MAX_RETRIES = 5
 
 // Just a promisified simpleGet
@@ -15,10 +21,14 @@ function delay(ms) {
 
 /* eslint-disable no-await-in-loop, max-depth */
 module.exports = async options => {
+  const agent = options.url.startsWith('https:') ? httpsAgent : httpAgent
+  const reqOptions = {...options, followRedirects: false, agent}
   let error
   for (let i = 0; i < MAX_RETRIES; i++) {
     try {
-      return await getStream(options)
+      const response = await getStream(reqOptions)
+      response.setTimeout(RESPONSE_TIMEOUT)
+      return response
     } catch (err) {
       error = err
 

--- a/packages/@sanity/export/src/requestStream.js
+++ b/packages/@sanity/export/src/requestStream.js
@@ -1,5 +1,6 @@
 const simpleGet = require('simple-get')
 const HttpAgent = require('agentkeepalive')
+const debug = require('./debug')
 
 const HttpsAgent = HttpAgent.HttpsAgent
 const httpAgent = new HttpAgent()
@@ -36,6 +37,7 @@ module.exports = async options => {
         break
       }
 
+      debug('Error, retrying after 1500ms: %s', err.message)
       await delay(1500)
     }
   }

--- a/packages/@sanity/export/src/validateOptions.js
+++ b/packages/@sanity/export/src/validateOptions.js
@@ -46,6 +46,10 @@ function validateOptions(opts) {
     throw new Error('outputPath must be specified (- for stdout)')
   }
 
+  if (options.concurrency && options.concurrency > 24) {
+    throw new Error('`concurrency` must be <= 24')
+  }
+
   return options
 }
 

--- a/packages/@sanity/export/src/validateOptions.js
+++ b/packages/@sanity/export/src/validateOptions.js
@@ -46,8 +46,8 @@ function validateOptions(opts) {
     throw new Error('outputPath must be specified (- for stdout)')
   }
 
-  if (options.concurrency && options.concurrency > 24) {
-    throw new Error('`concurrency` must be <= 24')
+  if (options.concurrency && options.concurrency < 1 && options.concurrency > 24) {
+    throw new Error('`concurrency` must be between 1 and 24')
   }
 
   return options

--- a/packages/@sanity/export/src/validateOptions.js
+++ b/packages/@sanity/export/src/validateOptions.js
@@ -46,8 +46,8 @@ function validateOptions(opts) {
     throw new Error('outputPath must be specified (- for stdout)')
   }
 
-  if (options.concurrency && options.concurrency < 1 && options.concurrency > 24) {
-    throw new Error('`concurrency` must be between 1 and 24')
+  if (options.assetConcurrency && (options.assetConcurrency < 1 || options.assetConcurrency > 24)) {
+    throw new Error('`assetConcurrency` must be between 1 and 24')
   }
 
   return options

--- a/packages/@sanity/import-cli/README.md
+++ b/packages/@sanity/import-cli/README.md
@@ -20,7 +20,7 @@ npm install -g @sanity/import-cli
     -p, --project <projectId> Project ID to import to
     -d, --dataset <dataset> Dataset to import to
     -t, --token <token> Token to authenticate with
-    --concurrency <concurrency> Number of parallel asset imports
+    --asset-concurrency <concurrency> Number of parallel asset imports
     --replace Replace documents with the same IDs
     --missing Skip documents that already exist
     --help Show this help

--- a/packages/@sanity/import-cli/README.md
+++ b/packages/@sanity/import-cli/README.md
@@ -20,6 +20,7 @@ npm install -g @sanity/import-cli
     -p, --project <projectId> Project ID to import to
     -d, --dataset <dataset> Dataset to import to
     -t, --token <token> Token to authenticate with
+    --concurrency <concurrency> Number of parallel asset imports
     --replace Replace documents with the same IDs
     --missing Skip documents that already exist
     --help Show this help

--- a/packages/@sanity/import-cli/src/sanity-import.js
+++ b/packages/@sanity/import-cli/src/sanity-import.js
@@ -22,6 +22,7 @@ const cli = meow(
     -p, --project <projectId> Project ID to import to
     -d, --dataset <dataset> Dataset to import to
     -t, --token <token> Token to authenticate with
+    --concurrency <concurrency> Number of parallel asset imports
     --replace Replace documents with the same IDs
     --missing Skip documents that already exist
     --allow-failing-assets Skip assets that cannot be fetched/uploaded
@@ -42,7 +43,8 @@ const cli = meow(
     alias: {
       p: 'project',
       d: 'dataset',
-      t: 'token'
+      t: 'token',
+      c: 'concurrency'
     }
   }
 )
@@ -51,6 +53,7 @@ const {flags, input, showHelp} = cli
 const {dataset, allowFailingAssets} = flags
 const token = flags.token || process.env.SANITY_IMPORT_TOKEN
 const projectId = flags.project
+const concurrency = flags.concurrency
 const source = input[0]
 
 if (!projectId) {
@@ -96,7 +99,9 @@ const client = sanityClient({
 })
 
 getStream()
-  .then(stream => sanityImport(stream, {client, operation, onProgress, allowFailingAssets}))
+  .then(stream =>
+    sanityImport(stream, {client, operation, onProgress, allowFailingAssets, concurrency})
+  )
   .then(({numDocs, warnings}) => {
     const timeSpent = prettyMs(Date.now() - stepStart, {secDecimalDigits: 2})
     currentProgress.text = `[100%] ${currentStep} (${timeSpent})`

--- a/packages/@sanity/import-cli/src/sanity-import.js
+++ b/packages/@sanity/import-cli/src/sanity-import.js
@@ -22,7 +22,7 @@ const cli = meow(
     -p, --project <projectId> Project ID to import to
     -d, --dataset <dataset> Dataset to import to
     -t, --token <token> Token to authenticate with
-    --concurrency <concurrency> Number of parallel asset imports
+    --asset-concurrency <concurrency> Number of parallel asset imports
     --replace Replace documents with the same IDs
     --missing Skip documents that already exist
     --allow-failing-assets Skip assets that cannot be fetched/uploaded
@@ -44,7 +44,7 @@ const cli = meow(
       p: 'project',
       d: 'dataset',
       t: 'token',
-      c: 'concurrency'
+      c: 'asset-concurrency'
     }
   }
 )
@@ -53,7 +53,7 @@ const {flags, input, showHelp} = cli
 const {dataset, allowFailingAssets} = flags
 const token = flags.token || process.env.SANITY_IMPORT_TOKEN
 const projectId = flags.project
-const concurrency = flags.concurrency
+const assetConcurrency = flags.assetConcurrency
 const source = input[0]
 
 if (!projectId) {
@@ -100,7 +100,7 @@ const client = sanityClient({
 
 getStream()
   .then(stream =>
-    sanityImport(stream, {client, operation, onProgress, allowFailingAssets, concurrency})
+    sanityImport(stream, {client, operation, onProgress, allowFailingAssets, assetConcurrency})
   )
   .then(({numDocs, warnings}) => {
     const timeSpent = prettyMs(Date.now() - stepStart, {secDecimalDigits: 2})

--- a/packages/@sanity/import/src/uploadAssets.js
+++ b/packages/@sanity/import/src/uploadAssets.js
@@ -45,7 +45,7 @@ async function uploadAssets(assets, options) {
     : ensureAssetExists
 
   // Loop over all unique URLs and ensure they exist, and if not, upload them
-  const mapOptions = {concurrency: ASSET_UPLOAD_CONCURRENCY}
+  const mapOptions = {concurrency: options.concurrency || ASSET_UPLOAD_CONCURRENCY}
   const assetIds = await pMap(assetRefMap.keys(), ensureMethod, mapOptions)
 
   // Extract a list of all failures so we may report them and possibly retry them later

--- a/packages/@sanity/import/src/uploadAssets.js
+++ b/packages/@sanity/import/src/uploadAssets.js
@@ -11,6 +11,9 @@ const ASSET_PATCH_CONCURRENCY = 1
 const ASSET_PATCH_BATCH_SIZE = 50
 
 async function uploadAssets(assets, options) {
+  const concurrency = options.assetConcurrency || ASSET_UPLOAD_CONCURRENCY
+  debug('Uploading assets with a concurrency of %d', concurrency)
+
   // Build a Map where the keys are `type#url` and the value is an array of all
   // objects containing document id and path to inject asset reference to.
   // `assets` is an array of objects with shape: {documentId, path, url, type}
@@ -45,7 +48,7 @@ async function uploadAssets(assets, options) {
     : ensureAssetExists
 
   // Loop over all unique URLs and ensure they exist, and if not, upload them
-  const mapOptions = {concurrency: options.concurrency || ASSET_UPLOAD_CONCURRENCY}
+  const mapOptions = {concurrency}
   const assetIds = await pMap(assetRefMap.keys(), ensureMethod, mapOptions)
 
   // Extract a list of all failures so we may report them and possibly retry them later

--- a/packages/@sanity/import/src/uploadAssets.js
+++ b/packages/@sanity/import/src/uploadAssets.js
@@ -6,7 +6,7 @@ const progressStepper = require('./util/progressStepper')
 const getHashedBufferForUri = require('./util/getHashedBufferForUri')
 const retryOnFailure = require('./util/retryOnFailure')
 
-const ASSET_UPLOAD_CONCURRENCY = 3
+const ASSET_UPLOAD_CONCURRENCY = 8
 const ASSET_PATCH_CONCURRENCY = 1
 const ASSET_PATCH_BATCH_SIZE = 50
 

--- a/packages/@sanity/import/src/validateOptions.js
+++ b/packages/@sanity/import/src/validateOptions.js
@@ -39,8 +39,8 @@ function validateOptions(input, opts) {
     throw new Error(`Operation "${options.operation}" is not supported`)
   }
 
-  if (options.concurrency && options.concurrency > 12) {
-    throw new Error('`concurrency` must be <= 12')
+  if (options.assetConcurrency && options.assetConcurrency > 12) {
+    throw new Error('`assetConcurrency` must be <= 12')
   }
 
   return options

--- a/packages/@sanity/import/src/validateOptions.js
+++ b/packages/@sanity/import/src/validateOptions.js
@@ -39,8 +39,8 @@ function validateOptions(input, opts) {
     throw new Error(`Operation "${options.operation}" is not supported`)
   }
 
-  if (options.concurrency && options.concurrency > 24) {
-    throw new Error('`concurrency` must be <= 24')
+  if (options.concurrency && options.concurrency > 12) {
+    throw new Error('`concurrency` must be <= 12')
   }
 
   return options

--- a/packages/@sanity/import/src/validateOptions.js
+++ b/packages/@sanity/import/src/validateOptions.js
@@ -39,6 +39,10 @@ function validateOptions(input, opts) {
     throw new Error(`Operation "${options.operation}" is not supported`)
   }
 
+  if (options.concurrency && options.concurrency > 24) {
+    throw new Error('`concurrency` must be <= 24')
+  }
+
   return options
 }
 


### PR DESCRIPTION
Exporting and importing assets is currently quite slow. The assumption was that we would be able to saturate a clients connection and should thus keep the number of parallel downloads/uploads to a minimum.

This isn't the case, however, so by increasing the number of concurrent downloads and uploads, we greatly increase the speed of the process.

Exporting a large number of assets is improved by a factor of ~300%
Imports greatly vary based on the size of the assets, but should see benefits too.
