### PR TITLE
[cli] add error message when plugin name is invalid

### DIFF
--- a/packages/@sanity/cli/src/actions/init-plugin/bootstrapFromTemplate.js
+++ b/packages/@sanity/cli/src/actions/init-plugin/bootstrapFromTemplate.js
@@ -83,9 +83,9 @@ module.exports = async (context, url) => {
     message: 'Plugin name:',
     default: tplVars.suggestedName || '',
     validate: async pkgName => {
-      const {validForNewPackages, errors} = validateNpmPackageName(pkgName)
+      const {validForNewPackages} = validateNpmPackageName(pkgName)
       if (!validForNewPackages) {
-        return errors[0]
+        return 'Name must be a valid npm package name (https://docs.npmjs.com/files/package.json#name)'
       }
 
       const outputPath = path.join(workDir, 'plugins', pkgName)


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->
When you try to create a plugin with the CLI, the name is validated against npm package naming rules, and when the name you give is invalid, the CLI crashes instead of showing a helpful error message.

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

This adds a message that says the name needs to be a valid npm package name and includes a link to the npm package naming rules.

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

- Fixed a bug where the CLI would crash if trying to create a plugin with an invalid name

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [x]  Corresponding changes to the documentation have been made
