### PR TITLE
[core] Check for breaking changes when deploying GraphQL API

### DIFF
--- a/packages/@sanity/core/src/actions/graphql/deleteApiAction.js
+++ b/packages/@sanity/core/src/actions/graphql/deleteApiAction.js
@@ -10,7 +10,7 @@ module.exports = async function deleteApiAction(args, context) {
   if (
     !(await prompt.single({
       type: 'confirm',
-      message: `Are you absolutely sure you want to delete the current GraphQL API?`,
+      message: 'Are you absolutely sure you want to delete the current GraphQL API?',
       default: false
     }))
   ) {

--- a/packages/@sanity/core/src/actions/graphql/deleteApiAction.js
+++ b/packages/@sanity/core/src/actions/graphql/deleteApiAction.js
@@ -7,18 +7,24 @@ module.exports = async function deleteApiAction(args, context) {
     requireProject: true
   })
 
+  const dataset = flags.dataset || client.config().dataset
+  const tag = flags.tag || 'default'
+
+  const confirmMessage =
+    tag === 'default'
+      ? 'Are you absolutely sure you want to delete the current GraphQL API?'
+      : `Are you absolutely sure you want to delete the GraphQL API tagged "${tag}"?`
+
   if (
     !(await prompt.single({
       type: 'confirm',
-      message: 'Are you absolutely sure you want to delete the current GraphQL API?',
+      message: confirmMessage,
       default: false
     }))
   ) {
     return
   }
 
-  const dataset = flags.dataset || client.config().dataset
-  const tag = flags.tag || 'default'
   try {
     await client.request({
       url: `/apis/graphql/${dataset}/${tag}`,

--- a/packages/@sanity/core/src/commands/graphql/deployGraphQLAPICommand.js
+++ b/packages/@sanity/core/src/commands/graphql/deployGraphQLAPICommand.js
@@ -6,12 +6,14 @@ Options
   --tag <tag> Deploy API to given tag (defaults to 'default')
   --playground Deploy a GraphQL playground for easily testing queries (public)
   --no-playground Skip playground prompt (do not deploy a playground)
+  --force Deploy API without confirming breaking changes
 
 Examples
   sanity graphql deploy
   sanity graphql deploy --playground
   sanity graphql deploy --dataset staging --no-playground
   sanity graphql deploy --dataset staging --tag next --no-playground
+  sanity graphql deploy --no-playground --force
 `
 
 export default {


### PR DESCRIPTION
This adds validation logic to the GraphQL API deployment, ensuring that the user is made aware of any dangerous or breaking changes. 

If any dangerous changes are found, a confirmation dialog is shown. A new flag,  `--force` can be used to blindly overwrite the API (useful for CI flows etc).
