### PR TITLE
[form-builder] Use shallow equality check on path property

### DIFF
--- a/packages/@sanity/form-builder/src/FormBuilderInput.tsx
+++ b/packages/@sanity/form-builder/src/FormBuilderInput.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable complexity */
 import React from 'react'
+import shallowEquals from 'shallow-equals'
 import {Path, PathSegment} from './typedefs/path'
 import PatchEvent from './PatchEvent'
 import generateHelpUrl from '@sanity/generate-help-url'
@@ -32,7 +33,7 @@ function trimChildPath(path, childPath) {
   return PathUtils.startsWith(path, childPath) ? PathUtils.trimLeft(path, childPath) : []
 }
 
-export class FormBuilderInput extends React.PureComponent<Props> {
+export class FormBuilderInput extends React.Component<Props> {
   scrollTimeout: number
   _element: HTMLDivElement | null
   static contextTypes = {
@@ -63,6 +64,16 @@ export class FormBuilderInput extends React.PureComponent<Props> {
     if (PathUtils.hasFocus(focusPath, path)) {
       this.focus()
     }
+  }
+
+  shouldComponentUpdate(nextProps) {
+    const {path: oldPath, ...oldProps} = this.props
+    const {path: newPath, ...newProps} = nextProps
+
+    const propsDiffer = !shallowEquals(oldProps, newProps)
+    const pathDiffer = !PathUtils.isEqual(oldPath, newPath)
+
+    return propsDiffer || pathDiffer
   }
 
   UNSAFE_componentWillReceiveProps(nextProps: Props) {


### PR DESCRIPTION
While doing some shallow profiling work, I discovered that the `path` property passed to the `FormBuilderInput` component was causing it to be re-rendered more often than necessary.

By comparing the path array using the path utils and the rest of the properties with a shallow equals function, we can significantly reduce the amount of re-renders.