### PR TITLE
[form-builder] Reuse empty markers array if none are present

### DIFF
--- a/packages/@sanity/form-builder/src/FormBuilderInput.tsx
+++ b/packages/@sanity/form-builder/src/FormBuilderInput.tsx
@@ -4,7 +4,9 @@ import {Path, PathSegment} from './typedefs/path'
 import PatchEvent from './PatchEvent'
 import generateHelpUrl from '@sanity/generate-help-url'
 import * as PathUtils from '@sanity/util/paths.js'
-import {Type} from './typedefs'
+import {Type, Marker} from './typedefs'
+
+const NO_MARKERS: Marker[] = []
 
 type Props = {
   value: any
@@ -14,7 +16,7 @@ type Props = {
   onBlur: () => void
   readOnly: boolean
   focusPath: Path
-  markers: Array<any>
+  markers: Marker[]
   level: number
   isRoot?: boolean
   path: Array<PathSegment>
@@ -45,7 +47,7 @@ export class FormBuilderInput extends React.PureComponent<Props> {
   static defaultProps = {
     focusPath: [],
     path: [],
-    markers: []
+    markers: NO_MARKERS
   }
   _input: FormBuilderInput | HTMLDivElement | null
   getValuePath = () => {
@@ -203,7 +205,7 @@ export class FormBuilderInput extends React.PureComponent<Props> {
           {...leafProps}
           value={value}
           readOnly={readOnly || type.readOnly}
-          markers={childMarkers}
+          markers={childMarkers.length === 0 ? NO_MARKERS : childMarkers}
           type={type}
           onChange={this.handleChange}
           onFocus={this.handleFocus}

--- a/packages/@sanity/form-builder/src/inputs/ArrayInput/ArrayInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ArrayInput/ArrayInput.tsx
@@ -20,6 +20,7 @@ import Fieldset from 'part:@sanity/components/fieldsets/default'
 import Details from '../common/Details'
 import formBuilderConfig from 'config:@sanity/form-builder'
 
+const NO_MARKERS: Marker[] = []
 const SUPPORT_DIRECT_UPLOADS = get(formBuilderConfig, 'images.directUploads')
 
 function createProtoValue(type: Type): ItemValue {
@@ -179,6 +180,8 @@ export default class ArrayInput extends React.Component<Props, ArrayInputState> 
         {value.map((item, index) => {
           const isChildMarker = marker =>
             startsWith([index], marker.path) || startsWith([{_key: item && item._key}], marker.path)
+          const childMarkers = markers.filter(isChildMarker)
+
           const itemProps = isSortable ? {index} : {}
           return (
             <Item
@@ -190,7 +193,7 @@ export default class ArrayInput extends React.Component<Props, ArrayInputState> 
                 type={type}
                 value={item}
                 level={level}
-                markers={markers.filter(isChildMarker)}
+                markers={childMarkers.length === 0 ? NO_MARKERS : childMarkers}
                 onRemove={this.handleRemoveItem}
                 onChange={this.handleItemChange}
                 focusPath={focusPath}

--- a/packages/@sanity/form-builder/src/inputs/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
@@ -14,6 +14,8 @@ import styles from './styles/ArrayOfPrimitivesInput.css'
 import getEmptyValue from './getEmptyValue'
 import Item from './Item'
 
+const NO_MARKERS: Marker[] = []
+
 function move(arr, from, to) {
   const copy = arr.slice()
   const val = copy[from]
@@ -127,7 +129,7 @@ export default class ArrayOfPrimitivesInput extends React.PureComponent<Props> {
           index={index}
           value={item}
           readOnly={readOnly}
-          markers={filteredMarkers}
+          markers={filteredMarkers.length === 0 ? NO_MARKERS : filteredMarkers}
           isSortable={isSortable}
           type={itemMemberType}
           focusPath={focusPath}

--- a/packages/@sanity/form-builder/src/inputs/ObjectInput/ObjectInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ObjectInput/ObjectInput.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Field from './Field'
+import {Marker} from '../../typedefs'
 import Fieldset from 'part:@sanity/components/fieldsets/default'
 import PatchEvent, {set, setIfMissing, unset} from '../../PatchEvent'
 import isEmpty from '../../utils/isEmpty'
@@ -35,7 +36,7 @@ type ObjectInputProps = {
   onChange?: (...args: any[]) => any
   onFocus: (...args: any[]) => any
   focusPath?: any[]
-  markers?: any[]
+  markers?: Marker[]
   onBlur: (...args: any[]) => any
   level?: number
   readOnly?: boolean


### PR DESCRIPTION
It's quite common that after filtering an array of markers, you are left with an empty array. Two empty arrays doesn't mean they are strictly equal, however.

To make it easier for `React.PureComponent` and other shallow equality checks, this PR implements a basic "is the markers array empty" check and uses a constant in this case. Should hopefully prevent some unnecessary re-renders.