### PR TITLE
[core] Dynamically generate type sortings

### DIFF
--- a/packages/@sanity/core/src/actions/graphql/deployApiAction.js
+++ b/packages/@sanity/core/src/actions/graphql/deployApiAction.js
@@ -3,6 +3,7 @@ const getSanitySchema = require('./getSanitySchema')
 const extractFromSanitySchema = require('./extractFromSanitySchema')
 const generateTypeQueries = require('./generateTypeQueries')
 const generateTypeFilters = require('./generateTypeFilters')
+const generateTypeSortings = require('./generateTypeSortings')
 const SchemaError = require('./SchemaError')
 
 module.exports = async function deployApiActions(args, context) {
@@ -36,9 +37,10 @@ module.exports = async function deployApiActions(args, context) {
     const sanitySchema = getSanitySchema(workDir)
     const extracted = extractFromSanitySchema(sanitySchema)
     const filters = generateTypeFilters(extracted.types)
-    const queries = generateTypeQueries(extracted.types, filters)
-    const types = extracted.types.concat(filters)
-    schema = {types, queries, interfaces: extracted.interfaces}
+    const sortings = generateTypeSortings(extracted.types)
+    const queries = generateTypeQueries(extracted.types, filters, sortings)
+    const types = extracted.types.concat(filters).concat(sortings)
+    schema = {types, queries, interfaces: extracted.interfaces, generation: 'v2'}
   } catch (err) {
     spinner.fail()
 

--- a/packages/@sanity/core/src/actions/graphql/generateTypeSortings.js
+++ b/packages/@sanity/core/src/actions/graphql/generateTypeSortings.js
@@ -1,0 +1,69 @@
+const builtInTypes = ['ID', 'String', 'Url', 'Float', 'Integer', 'Boolean', 'Datetime', 'Date']
+
+const builtInSortingEnum = {
+  name: 'SortOrder',
+  kind: 'Enum',
+  values: [
+    {
+      name: 'ASC',
+      description: 'Sorts on the value in ascending order.',
+      value: 1
+    },
+    {
+      name: 'DESC',
+      description: 'Sorts on the value in descending order.',
+      value: 2
+    }
+  ]
+}
+
+function generateTypeSortings(types) {
+  const objectTypes = types.filter(
+    type =>
+      type.type === 'Object' &&
+      !['Block', 'Span'].includes(type.name) && // TODO: What do we do with blocks?
+      !type.interfaces &&
+      !builtInTypes.includes(type.name)
+  )
+  const documentTypes = types.filter(
+    type => type.type === 'Object' && type.interfaces && type.interfaces.includes('Document')
+  )
+
+  const objectTypeSortings = createObjectTypeSortings(objectTypes)
+  const documentTypeSortings = createDocumentTypeSortings(documentTypes)
+
+  return objectTypeSortings.concat(documentTypeSortings).concat(builtInSortingEnum)
+}
+
+function createObjectTypeSortings(objectTypes) {
+  return objectTypes.map(objectType => {
+    return {
+      name: `${objectType.name}Sorting`,
+      kind: 'InputObject',
+      fields: objectType.fields
+        .filter(field => field.type !== 'JSON' && field.kind !== 'List')
+        .map(field => ({
+          fieldName: field.fieldName,
+          type: builtInTypes.includes(field.type) ? builtInSortingEnum.name : `${field.type}Sorting`
+        }))
+    }
+  })
+}
+
+function createDocumentTypeSortings(documentTypes) {
+  return documentTypes.map(documentType => {
+    const fields = documentType.fields
+      .filter(field => field.type !== 'JSON' && field.kind !== 'List')
+      .map(field => ({
+        fieldName: field.fieldName,
+        type: builtInTypes.includes(field.type) ? builtInSortingEnum.name : `${field.type}Sorting`
+      }))
+    return {
+      name: `${documentType.name}Sorting`,
+      kind: 'InputObject',
+      fields
+    }
+  })
+}
+
+module.exports = generateTypeSortings


### PR DESCRIPTION
**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [x]  Yes
- [ ]  No

**Description**

Currently, there's no way to sort in the GraphQL API. This generates all the types required in order to do that.

**Note for release**

Dynamically generate sorting types for possibility to sort on documents, objects and fields.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
