### PR TITLE
[preview] Add support for extracting text from portable text

### DIFF
--- a/packages/@sanity/preview/src/prepareForPreview.ts
+++ b/packages/@sanity/preview/src/prepareForPreview.ts
@@ -1,6 +1,7 @@
 // @flow
 import {debounce, flatten, get, isPlainObject, pick, uniqBy} from 'lodash'
 import {INVALID_PREVIEW_CONFIG} from './constants'
+import {isPortableTextArray, extractTextFromBlocks} from './utils/portableText'
 
 const PRESERVE_KEYS = ['_id', '_type', '_upload']
 const EMPTY = []
@@ -190,6 +191,17 @@ function validateReturnedPreview(result: PrepareInvocationResult) {
   }
 }
 
+function defaultPrepare(value: SelectedValue): {[key: string]: any} {
+  return Object.keys(value).reduce((acc: {[key: string]: any}, fieldName: string) => {
+    return {
+      ...acc,
+      [fieldName]: isPortableTextArray(value[fieldName])
+        ? extractTextFromBlocks(value[fieldName])
+        : value[fieldName]
+    }
+  }, {})
+}
+
 export function invokePrepare(
   type: Type,
   value: SelectedValue,
@@ -198,7 +210,7 @@ export function invokePrepare(
   const prepare = type.preview.prepare
   try {
     return {
-      returnValue: prepare ? prepare(value, viewOptions) : value,
+      returnValue: prepare ? prepare(value, viewOptions) : defaultPrepare(value),
       errors: EMPTY
     }
   } catch (error) {

--- a/packages/@sanity/preview/src/utils/portableText.ts
+++ b/packages/@sanity/preview/src/utils/portableText.ts
@@ -1,0 +1,39 @@
+type Span = {
+  _type: 'span'
+  _key: string
+  text: string
+  marks: string[]
+}
+
+type MarkDef = {_key: string; _type: string}
+
+type Block = {
+  _type: string
+  _key: string
+  children: Span[]
+  markDefs: MarkDef[]
+}
+
+function isBlock(block: Block): block is Block {
+  return block && Array.isArray(block.markDefs) && Array.isArray(block.children)
+}
+
+function isSpan(span: Span): span is Span {
+  return span && span._type === 'span' && typeof span.text === 'string'
+}
+
+export function isPortableTextArray(blocks: Block[]): blocks is Block[] {
+  return Array.isArray(blocks) && (blocks.length === 0 || blocks.some(isBlock))
+}
+
+export function extractTextFromBlocks(blocks: Block[]): string {
+  const firstBlock = blocks.find(isBlock)
+  if (!firstBlock || !firstBlock.children) {
+    return ''
+  }
+
+  return firstBlock.children
+    .filter(isSpan)
+    .map(span => span.text)
+    .join('')
+}

--- a/packages/@sanity/schema/src/legacy/preview/guessPreviewConfig.ts
+++ b/packages/@sanity/schema/src/legacy/preview/guessPreviewConfig.ts
@@ -1,6 +1,7 @@
 import {omitBy, isUndefined} from 'lodash'
 import arrify from 'arrify'
 import {createFallbackPrepare} from './fallbackPrepare'
+import {isBlockField} from './portableText'
 
 const TITLE_CANDIDATES = ['title', 'name', 'label', 'heading', 'header', 'caption']
 const DESCRIPTION_CANDIDATES = ['description', ...TITLE_CANDIDATES]
@@ -47,18 +48,24 @@ export default function guessPreviewFields(rawObjectTypeDef) {
     .filter(field => field.type === 'string')
     .map(field => field.name)
 
+  const blockFieldNames = objectTypeDef.fields.filter(isBlockField).map(field => field.name)
+
   // Check if we have fields with names that is listed in candidate fields
-  let titleField = TITLE_CANDIDATES.find(candidate => stringFieldNames.includes(candidate))
+  let titleField = TITLE_CANDIDATES.find(
+    candidate => stringFieldNames.includes(candidate) || blockFieldNames.includes(candidate)
+  )
 
   let descField = DESCRIPTION_CANDIDATES.find(
-    candidate => candidate !== titleField && stringFieldNames.includes(candidate)
+    candidate =>
+      candidate !== titleField &&
+      (stringFieldNames.includes(candidate) || blockFieldNames.includes(candidate))
   )
 
   if (!titleField) {
     // Pick first defined string field
-    titleField = stringFieldNames[0]
+    titleField = stringFieldNames[0] || blockFieldNames[0]
     // Pick next as desc
-    descField = stringFieldNames[1]
+    descField = stringFieldNames[1] || blockFieldNames[1]
   }
 
   const mediaField = objectTypeDef.fields.find(field => field.type === 'image')

--- a/packages/@sanity/schema/src/legacy/preview/portableText.ts
+++ b/packages/@sanity/schema/src/legacy/preview/portableText.ts
@@ -1,0 +1,9 @@
+type FieldDef = {
+  type: string
+  name: string
+  of?: {type: string}[]
+}
+
+export function isBlockField(field: FieldDef): boolean {
+  return field.type === 'array' && field.of && field.of.some(member => member.type === 'block')
+}


### PR DESCRIPTION
If a schema type does not contain any string fields, it falls back to using an object representation for the previews. I find that a quite common scenario is to have a portable text field with a title or description, and while you _could_ create a snippet and set up a prepare function yourself, this is a bit tedious.

This PR adds support for:
- Guessing the title and description fields based on whether or not the schema type is a portable text array (strings still preferred if available)
- Extracting the text from all spans within the first portable text block of matched arrays

Jury is still out on whether or not this is a good idea - potentially we may want to just select `someBlockField.0` to cut down on the amount of data returned and hope that the first entry in the array is a text block.
 