### PR TITLE
[core] Add support for typescript in studio

### DIFF
--- a/packages/@sanity/base/types/parts.d.ts
+++ b/packages/@sanity/base/types/parts.d.ts
@@ -11,11 +11,7 @@ declare module 'config:*' {
   export default pluginConfig
 }
 
-declare module 'part:*' {
-  const any: any
-
-  export default any
-}
+declare module 'part:*'
 
 declare module '*.css' {
   const cssModule: {[key: string]: string}

--- a/packages/@sanity/base/types/parts.d.ts
+++ b/packages/@sanity/base/types/parts.d.ts
@@ -1,0 +1,24 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+declare module 'all:*' {
+  const anyArray: any[]
+
+  export default anyArray
+}
+
+declare module 'config:*' {
+  const pluginConfig: {[key: string]: any}
+
+  export default pluginConfig
+}
+
+declare module 'part:*' {
+  const any: any
+
+  export default any
+}
+
+declare module '*.css' {
+  const cssModule: {[key: string]: string}
+
+  export default cssModule
+}

--- a/packages/@sanity/cli/templates/blog/tsconfig.json
+++ b/packages/@sanity/cli/templates/blog/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "include": ["./node_modules/@sanity/base/types/**/*.ts", "./**/*.ts", "./**/*.tsx"]
+}

--- a/packages/@sanity/cli/templates/clean/tsconfig.json
+++ b/packages/@sanity/cli/templates/clean/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "include": ["./node_modules/@sanity/base/types/**/*.ts", "./**/*.ts", "./**/*.tsx"]
+}

--- a/packages/@sanity/cli/templates/ecommerce/tsconfig.json
+++ b/packages/@sanity/cli/templates/ecommerce/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "include": ["./node_modules/@sanity/base/types/**/*.ts", "./**/*.ts", "./**/*.tsx"]
+}

--- a/packages/@sanity/cli/templates/moviedb/tsconfig.json
+++ b/packages/@sanity/cli/templates/moviedb/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "include": ["./node_modules/@sanity/base/types/**/*.ts", "./**/*.ts", "./**/*.tsx"]
+}

--- a/packages/@sanity/core/package.json
+++ b/packages/@sanity/core/package.json
@@ -23,6 +23,7 @@
     "@babel/plugin-proposal-class-properties": "^7.7.4",
     "@babel/preset-env": "^7.7.4",
     "@babel/preset-react": "^7.7.4",
+    "@babel/preset-typescript": "^7.7.4",
     "@babel/register": "^7.7.4",
     "@sanity/check": "0.147.0",
     "@sanity/export": "0.147.8",

--- a/packages/@sanity/core/src/actions/exec/babel.js
+++ b/packages/@sanity/core/src/actions/exec/babel.js
@@ -10,6 +10,7 @@ function getConfig() {
   } catch (err) {
     return {
       presets: [
+        require.resolve('@babel/preset-typescript'),
         require.resolve('@babel/preset-react'),
         [
           require.resolve('@babel/preset-env'),
@@ -20,7 +21,8 @@ function getConfig() {
           }
         ]
       ],
-      plugins: [require.resolve('@babel/plugin-proposal-class-properties')]
+      plugins: [require.resolve('@babel/plugin-proposal-class-properties')],
+      extensions: ['.js', '.jsx', '.es6', '.es', '.mjs', '.ts', '.tsx']
     }
   }
 }

--- a/packages/@sanity/core/src/actions/graphql/registerBabelLoader.js
+++ b/packages/@sanity/core/src/actions/graphql/registerBabelLoader.js
@@ -29,6 +29,7 @@ module.exports = basePath => {
         ignore: [path.join(basePath, 'node_modules')],
         test: /.*/,
         presets: [
+          '@babel/preset-typescript',
           '@babel/preset-react',
           [
             '@babel/preset-env',

--- a/packages/@sanity/server/package.json
+++ b/packages/@sanity/server/package.json
@@ -38,6 +38,7 @@
     "@babel/plugin-proposal-class-properties": "^7.7.4",
     "@babel/preset-env": "^7.7.4",
     "@babel/preset-react": "^7.7.4",
+    "@babel/preset-typescript": "^7.7.4",
     "@babel/register": "^7.7.4",
     "@hot-loader/react-dom": "^16.9.0-4.12.11",
     "@sanity/css-loader": "^0.28.12",

--- a/packages/@sanity/server/src/configs/webpack.config.dev.js
+++ b/packages/@sanity/server/src/configs/webpack.config.dev.js
@@ -18,7 +18,8 @@ export default config => {
       alias: Object.assign({}, baseConfig.resolve.alias, {
         'react-dom': require.resolve('@hot-loader/react-dom'),
         'webpack-hot-middleware/client': require.resolve('../browser/hot-client')
-      })
+      }),
+      extensions: baseConfig.resolve.extensions
     },
     plugins: (baseConfig.plugins || []).concat([
       new webpack.HotModuleReplacementPlugin(),

--- a/packages/@sanity/server/src/configs/webpack.config.js
+++ b/packages/@sanity/server/src/configs/webpack.config.js
@@ -81,12 +81,13 @@ export default (config = {}) => {
     module: {
       rules: [
         {
-          test: /\.jsx?/,
+          test: /(\.jsx?|\.tsx?)/,
           exclude: /(packages\/@sanity|node_modules|bower_components)/,
           use: {
             loader: resolve('babel-loader'),
             options: babelConfig || {
               presets: [
+                resolve('@babel/preset-typescript'),
                 resolve('@babel/preset-react'),
                 [resolve('@babel/preset-env'), require('./babel-env-config')]
               ],

--- a/packages/@sanity/server/src/configs/webpack.config.js
+++ b/packages/@sanity/server/src/configs/webpack.config.js
@@ -76,7 +76,8 @@ export default (config = {}) => {
         'react-dom': path.dirname(reactDomPath),
         moment$: 'moment/moment.js',
         ...rxPaths()
-      }
+      },
+      extensions: ['.js', '.jsx', '.es6', '.es', '.mjs', '.ts', '.tsx']
     },
     module: {
       rules: [


### PR DESCRIPTION
This PR adds support for using typescript in the studio. It uses the babel preset.

To work around parts not being resolvable, I've added an ambient module which defines the `part:*`, `all:*`, `config:*` patters as basically just `any` (`all` returns array of `any`, `config` returns an object). Since we're using CSS modules, I also added `*.css` as an object of class name mappings.

Unfortunately I could not find any way for the definitions to be automatically picked up without adding a `tsconfig` in each studio - I tried a bunch of different approaches to no avail. Thus, I've added the `tsconfig.json` file to all the CLI templates, and we should probably also add it to any of our other templates when we've verified that it works.
