### PR TITLE
[form-builder] Don't put placeholder operation into undo step

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/SyncWrapper.tsx
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/SyncWrapper.tsx
@@ -22,7 +22,8 @@ import {
   SlateSelection,
   SlateValue,
   Type,
-  UndoRedoStack, UndoRedoStackItem
+  UndoRedoStack,
+  UndoRedoStackItem
 } from './typeDefs'
 import createEditorController from './utils/createEditorController'
 import Input from './Input'
@@ -222,7 +223,14 @@ export default withPatchSubscriber(
         !isRemote &&
         !operations.some(op => op.__isUndoRedo) &&
         !operations.every(op => op.type === 'set_selection') &&
-        !operations.every(op => op.type === 'set_value')
+        !operations.every(op => op.type === 'set_value') &&
+        !operations.every(
+          op =>
+            op.type === 'set_node' &&
+            op.properties &&
+            op.properties.data &&
+            op.properties.data.get('placeholder')
+        )
       ) {
         this._undoRedoStack.undo.push({
           operations,

--- a/packages/@sanity/form-builder/src/inputs/BlockEditor/plugins/UndoRedoPlugin.ts
+++ b/packages/@sanity/form-builder/src/inputs/BlockEditor/plugins/UndoRedoPlugin.ts
@@ -40,6 +40,9 @@ function recalculateOperations(item: UndoRedoStackItem) {
       if (!checkedOp || !checkedOp.path) {
         return
       }
+      if (!remoteOp || !remoteOp.path) {
+        return
+      }
       const pAbove = remoteOp.path.get(0) < checkedOp.path.get(0)
       const pEqual = remoteOp.path.get(0) == checkedOp.path.get(0)
       switch (remoteOp.type) {


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**
When the editor is emptied, we delete the value from the document, but the editor still needs to have a placeholder block in order to have something to write into. The creation and removal of this placeholderblock should not be included in the undo/redo history, because it makes an extra step there that is unexecpted (you have to undo twice when deleting everything in the editor to get it back).

<!-- Reference/link the relevant issue and/or describe the behavior. -->

**Description**
This makes the placeholder operations not to be included in the undo/redo stack.

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

Related issue: https://github.com/sanity-io/sanity/issues/1730

**Note for release**
Avoid redundant undo step related to deleting all content in the PTE.

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
