### PR TITLE
[cli] Use more fool-proof status code check for auth errors

### DIFF
--- a/packages/@sanity/cli/src/util/clientWrapper.js
+++ b/packages/@sanity/cli/src/util/clientWrapper.js
@@ -24,8 +24,8 @@ const defaults = {
 
 const authErrors = () => ({
   onError: err => {
-    const body = err.response.body
-    if (body.statusCode === 401) {
+    const statusCode = err.response && err.response.body && err.response.body.statusCode
+    if (statusCode === 401) {
       err.message = `${err.message}. For more information, see ${generateHelpUrl('cli-errors')}.`
     }
     return err


### PR DESCRIPTION
#1741 introduced a regression where the `response` property was not present on errors but would blindly be checked. This adds a more fool-proof check for it.
