### PR TITLE
[desk-tool] Allow publishing on validation warnings

### DIFF
--- a/packages/@sanity/desk-tool/src/actions/PublishAction.tsx
+++ b/packages/@sanity/desk-tool/src/actions/PublishAction.tsx
@@ -42,7 +42,7 @@ export function PublishAction(props) {
   const validationStatus = useValidationStatus(id, type)
   const syncState = useSyncState(id, type)
 
-  const hasValidationErrors = validationStatus.markers.length > 0
+  const hasValidationErrors = validationStatus.markers.some(marker => marker.level === 'error')
 
   // we use this to "schedule" publish after pending tasks (e.g. validation and sync) has completed
   const [publishScheduled, setPublishScheduled] = React.useState<boolean>(false)

--- a/packages/@sanity/desk-tool/src/pane/Editor/Validation.tsx
+++ b/packages/@sanity/desk-tool/src/pane/Editor/Validation.tsx
@@ -53,13 +53,13 @@ export function Validation(props: ValidationProps) {
       }
     >
       <Button
-        color="danger"
+        color={errors.length > 0 ? 'danger' : 'warning'}
         bleed
         icon={WarningIcon}
         padding="small"
         onClick={onToggleValidationResults}
       >
-        {errors.length}
+        {errors.length + warnings.length}
         <span style={{paddingLeft: '0.5em', display: 'flex'}}>
           <ChevronDown />
         </span>

--- a/packages/test-studio/schemas/validation.js
+++ b/packages/test-studio/schemas/validation.js
@@ -291,8 +291,8 @@ export default {
       options: {
         direction: 'vertical',
         list: [
-          {_type: 'reference', _key: 'espen', _ref: 'espen'},
-          {_type: 'reference', _key: 'bjoerge', _ref: 'bjoerge'}
+          {_type: 'reference', _key: 'grrm', _ref: 'grrm'},
+          {_type: 'reference', _key: 'jrr-tolkien', _ref: 'jrr-tolkien'}
         ]
       }
     },
@@ -318,22 +318,27 @@ export default {
     {
       name: 'body',
       title: 'Block content',
-      description: 'Requires',
       type: 'array',
       of: [
-        {type: 'image', title: 'Image', options: {inline: true}},
         {type: 'author', title: 'Author'},
         {
           type: 'block',
+          of: [{type: 'image', title: 'Image', options: {inline: true}}],
           styles: [
             {title: 'Normal', value: 'normal'},
             {title: 'H1', value: 'h1'},
             {title: 'H2', value: 'h2'},
             {title: 'Quote', value: 'blockquote'}
           ],
-          lists: [{title: 'Bullet', value: 'bullet'}, {title: 'Numbered', value: 'number'}],
+          lists: [
+            {title: 'Bullet', value: 'bullet'},
+            {title: 'Numbered', value: 'number'}
+          ],
           marks: {
-            decorators: [{title: 'Strong', value: 'strong'}, {title: 'Emphasis', value: 'em'}],
+            decorators: [
+              {title: 'Strong', value: 'strong'},
+              {title: 'Emphasis', value: 'em'}
+            ],
             annotations: [
               {name: 'Author', title: 'Author', type: 'reference', to: {type: 'author'}}
             ]


### PR DESCRIPTION
This PR fixes a few issues with validation _warnings_:

- Fixes an issue where publishing would not be allowed on warnings (only errors should block)
- Fixes an issue where the validation error indicator would show a red button with the count of `0` when warnings were present. With this change, the count now correctly includes warnings, as well as changing the color of the button to a yellow warning color when no errors are present.