### PR TITLE
[form-builder] Fix slug source not supporting asynchronous resolving

### DIFF
--- a/packages/test-studio/schemas/slugs.js
+++ b/packages/test-studio/schemas/slugs.js
@@ -123,6 +123,14 @@ export default {
           }
         }
       ]
+    },
+    {
+      name: 'async',
+      type: 'slug',
+      title: 'Async slug resolving',
+      options: {
+        source: doc => new Promise(resolve => setTimeout(resolve, 1000, doc.title))
+      }
     }
   ]
 }


### PR DESCRIPTION
**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

According to the documentation, the slug `source` property should be allowed to return a promise. The code does not actually reflect this, so it simply doesn't set a new value.

**Description**

This PR ensures that the slug `source` property _can_ return a promise. I also made sure that the `source` property was not called on every render if it is a function, to prevent sending needless API requests/asynchronous calls.

**Note for release**

- Fix slug `source` property not allowing asynchronous resolving of value

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [x]  Corresponding changes to the documentation have been made
