### PR TITLE
[core] Add a CLI command for listing out deployed GraphQL endpoints

### DIFF
--- a/packages/@sanity/core/src/actions/graphql/listApisAction.js
+++ b/packages/@sanity/core/src/actions/graphql/listApisAction.js
@@ -13,11 +13,7 @@ module.exports = async function listApisAction(args, context) {
       method: 'GET'
     })
   } catch (err) {
-    if (err.statusCode === 404) {
-      endpoints = []
-    } else {
-      throw err
-    }
+    throw err
   }
 
   if (endpoints && endpoints.length > 0) {

--- a/packages/@sanity/core/src/actions/graphql/listApisAction.js
+++ b/packages/@sanity/core/src/actions/graphql/listApisAction.js
@@ -1,0 +1,35 @@
+module.exports = async function listApisAction(args, context) {
+  const {apiClient, output} = context
+
+  const client = apiClient({
+    requireUser: true,
+    requireProject: true
+  })
+
+  let endpoints
+  try {
+    endpoints = await client.request({
+      url: `/apis/graphql`,
+      method: 'GET'
+    })
+  } catch (err) {
+    if (err.statusCode === 404) {
+      endpoints = []
+    } else {
+      throw err
+    }
+  }
+
+  if (endpoints && endpoints.length > 0) {
+    output.print('Here are the GraphQL endpoints deployed for this project:')
+    endpoints.forEach((endpoint, index) => {
+      output.print(`* [${index + 1}] `)
+      output.print(`  ** Dataset:     ${endpoint.dataset}`)
+      output.print(`  ** Tag:         ${endpoint.tag}`)
+      output.print(`  ** Generation:  ${endpoint.generation}`)
+      output.print(`  ** Playground:  ${endpoint.playgroundEnabled}\n`)
+    })
+  }
+
+  output.print("This project doesn't have any GraphQL endpoints deployed.")
+}

--- a/packages/@sanity/core/src/actions/graphql/listApisAction.js
+++ b/packages/@sanity/core/src/actions/graphql/listApisAction.js
@@ -20,18 +20,6 @@ module.exports = async function listApisAction(args, context) {
     }
   }
 
-  endpoints = [{
-    dataset: 'production',
-    tag: 'default',
-    generation: 'gen1',
-    playgroundEnabled: false
-  }, {
-    dataset: 'staging',
-    tag: 'next',
-    generation: 'gen2',
-    playgroundEnabled: true
-  }]
-
   if (endpoints && endpoints.length > 0) {
     output.print('Here are the GraphQL endpoints deployed for this project:')
     endpoints.forEach((endpoint, index) => {

--- a/packages/@sanity/core/src/actions/graphql/listApisAction.js
+++ b/packages/@sanity/core/src/actions/graphql/listApisAction.js
@@ -28,7 +28,7 @@ module.exports = async function listApisAction(args, context) {
       output.print(`    ${chalk.bold('Generation:')}  ${endpoint.generation}`)
       output.print(`    ${chalk.bold('Playground:')}  ${endpoint.playgroundEnabled}\n`)
     })
+  } else {
+    output.print("This project doesn't have any GraphQL endpoints deployed.")
   }
-
-  output.print("This project doesn't have any GraphQL endpoints deployed.")
 }

--- a/packages/@sanity/core/src/actions/graphql/listApisAction.js
+++ b/packages/@sanity/core/src/actions/graphql/listApisAction.js
@@ -1,5 +1,5 @@
 module.exports = async function listApisAction(args, context) {
-  const {apiClient, output} = context
+  const {apiClient, output, chalk} = context
 
   const client = apiClient({
     requireUser: true,
@@ -20,14 +20,25 @@ module.exports = async function listApisAction(args, context) {
     }
   }
 
+  endpoints = [{
+    dataset: 'production',
+    tag: 'default',
+    generation: 'gen1',
+    playgroundEnabled: false
+  }, {
+    dataset: 'staging',
+    tag: 'next',
+    generation: 'gen2',
+    playgroundEnabled: true
+  }]
+
   if (endpoints && endpoints.length > 0) {
     output.print('Here are the GraphQL endpoints deployed for this project:')
     endpoints.forEach((endpoint, index) => {
-      output.print(`* [${index + 1}] `)
-      output.print(`  ** Dataset:     ${endpoint.dataset}`)
-      output.print(`  ** Tag:         ${endpoint.tag}`)
-      output.print(`  ** Generation:  ${endpoint.generation}`)
-      output.print(`  ** Playground:  ${endpoint.playgroundEnabled}\n`)
+      output.print(`${index + 1}.  ${chalk.bold('Dataset:')}     ${endpoint.dataset}`)
+      output.print(`    ${chalk.bold('Tag:')}         ${endpoint.tag}`)
+      output.print(`    ${chalk.bold('Generation:')}  ${endpoint.generation}`)
+      output.print(`    ${chalk.bold('Playground:')}  ${endpoint.playgroundEnabled}\n`)
     })
   }
 

--- a/packages/@sanity/core/src/commands/graphql/listGraphQLAPIsCommand.js
+++ b/packages/@sanity/core/src/commands/graphql/listGraphQLAPIsCommand.js
@@ -1,9 +1,6 @@
 import lazyRequire from '@sanity/util/lib/lazyRequire'
 
 const helpText = `
-Options
-  N/A
-
 Examples
   sanity graphql list
 `

--- a/packages/@sanity/core/src/commands/graphql/listGraphQLAPIsCommand.js
+++ b/packages/@sanity/core/src/commands/graphql/listGraphQLAPIsCommand.js
@@ -1,0 +1,18 @@
+import lazyRequire from '@sanity/util/lib/lazyRequire'
+
+const helpText = `
+Options
+  N/A
+
+Examples
+  sanity graphql list
+`
+
+export default {
+  name: 'list',
+  signature: '',
+  group: 'graphql',
+  description: 'Lists all the GraphQL endpoints deployed for this project',
+  action: lazyRequire(require.resolve('../../actions/graphql/listApisAction')),
+  helpText
+}

--- a/packages/@sanity/core/src/commands/index.js
+++ b/packages/@sanity/core/src/commands/index.js
@@ -30,6 +30,7 @@ import addCorsOriginCommand from './cors/addCorsOriginCommand'
 import listCorsOriginsCommand from './cors/listCorsOriginsCommand'
 import deleteCorsOriginCommand from './cors/deleteCorsOriginCommand'
 import graphqlGroup from './graphql/graphqlGroup'
+import listGraphQLAPIsCommand from './graphql/listGraphQLAPIsCommand'
 import deployGraphQLAPICommand from './graphql/deployGraphQLAPICommand'
 import deleteGraphQLAPICommand from './graphql/deleteGraphQLAPICommand'
 import usersGroup from './users/usersGroup'
@@ -68,6 +69,7 @@ export default [
   deleteDocumentsCommand,
   createDocumentsCommand,
   graphqlGroup,
+  listGraphQLAPIsCommand,
   deployGraphQLAPICommand,
   deleteGraphQLAPICommand,
   installCommand,


### PR DESCRIPTION
**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [x]  Yes
- [ ]  No

**Current behavior**

After we introduced multiple GraphQL endpoints, there are currently no way of knowing what you already deployed (unless you take notes).

**Description**

This PR adds functionality for listing out currently deployed GraphQL endpoints.

**Note for release**

Add a CLI GraphQL sub-command for listing out deployed GraphQL endpoints.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
