### PR TITLE
[desk-tool] Allow description on document schema type

### DIFF
--- a/packages/@sanity/desk-tool/src/pane/Editor/EditForm.tsx
+++ b/packages/@sanity/desk-tool/src/pane/Editor/EditForm.tsx
@@ -66,6 +66,7 @@ export default class EditForm extends React.PureComponent<Props> {
           onSubmit={preventDefault}
           id="Sanity_Default_DeskTool_Editor_ScrollContainer"
         >
+          {type.description && <div className={styles.description}>{type.description}</div>}
           <FormBuilder
             schema={schema}
             patchChannel={this.patchChannel}

--- a/packages/@sanity/desk-tool/src/pane/styles/Editor.css
+++ b/packages/@sanity/desk-tool/src/pane/styles/Editor.css
@@ -140,6 +140,11 @@
   padding-bottom: 4em;
 }
 
+.description {
+  display: flex;
+  padding-bottom: 0.5em;
+}
+
 .syncStatus {
   display: block;
   opacity: 1;


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [X]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [X]  Yes
- [ ]  No

**Current behavior**
Addressing request described here https://github.com/sanity-io/sanity/issues/1714
At the moment, there is no way to have a description rendered without being attached to an input field.
<!-- Reference/link the relevant issue and/or describe the behavior. -->

**Description**
This PR utilises the fact that a description is already passed down from a document schema, and merely renders it at the top of the document pane, nested in the Edit Form, but outside of any form blocks.

As essentially it is a label for the form as a whole, it made more sense to nest it within the Edit Form, rather than anywhere else. Also due to the unknown length of a description - an assumption that it would fit within the DefaultPane header seemed too risky.
<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

**Note for release**
This PR enables a description value to be set on a document, to be rendered in the document editor pane above all other form items, not needing to be attached to a form input. 
<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

**Checklist** 

- [X]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [X]  The PR title includes a link to the relevant issue
- [X]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [X]  The code is linted
- [X]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
