### PR TITLE
[base] Add missing @sanity/generate-help-url dependency

### DIFF
--- a/packages/@sanity/base/package.json
+++ b/packages/@sanity/base/package.json
@@ -28,6 +28,7 @@
   "homepage": "https://www.sanity.io/",
   "dependencies": {
     "@sanity/client": "1.148.3",
+    "@sanity/generate-help-url": "1.148.1",
     "@sanity/image-url": "0.140.15",
     "@sanity/initial-value-templates": "1.148.1",
     "@sanity/mutator": "1.148.5",


### PR DESCRIPTION
**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

Potentially crashes due to missing dependency (usually works because of hoisted dependencies)

**Description**

This PR adds a missing dependency on `@sanity/generate-help-url`.
It's used in https://github.com/sanity-io/sanity/blob/next/packages/@sanity/base/src/actions/utils/legacy_documentActionUtils.js#L2 but not declared as a dependency.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
