### PR TITLE
[chore] Prevent lockfiles from being generated locally

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,8 @@
   "hoist": true,
   "concurrency": 8,
   "ci": false,
+  "npmClient": "npm",
+  "npmClientArgs": ["--no-package-lock"],
   "packages": [
     "packages/@sanity/*",
     "packages/blog-studio",


### PR DESCRIPTION
Lockfiles tends to get in our way when publishing packages and they are already ignored by `.gitignore`. There's not much value in having them generated locally anyways.

This adds an .npmrc that prevent lockfiles from being generated on `npm install` and adds the `--no-package-lock` flag when lerna installs dependencies using npm.

**Note for release**
N/A
