### PR TITLE
[chore] Remove storybook from test-studio

### DIFF
--- a/packages/@sanity/storybook/package.json
+++ b/packages/@sanity/storybook/package.json
@@ -33,6 +33,6 @@
     "normalize.css": "^5.0.0",
     "react-addons-create-fragment": "^15.4.2",
     "shelljs": "^0.7.6",
-    "webpack": "^3.0.0"
+    "webpack": "^3.8.1"
   }
 }

--- a/packages/storybook/config/.checksums
+++ b/packages/storybook/config/.checksums
@@ -4,5 +4,6 @@
   "@sanity/data-aspects": "ba5c2649cc1b1c39ae92b7daf2661f95fa79d7325073ffd410245d2717b240e9",
   "@sanity/google-maps-input": "57ae3a403ce6a070b31ec6fa1f3c8339cafa66661eaddba1d4d5ee3cc2197ec2",
   "@sanity/storybook": "526dea3b461fda217e7150d12395d0ec639cba0155c05a084b85bcf2c44995a3",
-  "@sanity/default-login": "6fb6d3800aa71346e1b84d95bbcaa287879456f2922372bb0294e30b968cd37f"
+  "@sanity/default-login": "6fb6d3800aa71346e1b84d95bbcaa287879456f2922372bb0294e30b968cd37f",
+  "@sanity/form-builder": "b38478227ba5e22c91981da4b53436df22e48ff25238a55a973ed620be5068aa"
 }

--- a/packages/storybook/config/@sanity/form-builder.json
+++ b/packages/storybook/config/@sanity/form-builder.json
@@ -1,0 +1,5 @@
+{
+  "images": {
+    "directUploads": true
+  }
+}

--- a/packages/test-studio/package.json
+++ b/packages/test-studio/package.json
@@ -34,7 +34,6 @@
     "@sanity/production-preview": "1.149.0",
     "@sanity/react-hooks": "1.149.0",
     "@sanity/rich-date-input": "1.149.0",
-    "@sanity/storybook": "1.149.0",
     "@sanity/studio-hints": "1.149.0",
     "@sanity/vision": "1.149.0",
     "@turf/helpers": "^6.0.1",

--- a/packages/test-studio/sanity.json
+++ b/packages/test-studio/sanity.json
@@ -34,7 +34,6 @@
     "@sanity/color-input",
     "@sanity/dashboard",
     "@sanity/desk-tool",
-    "@sanity/storybook",
     "@sanity/google-maps-input",
     "@sanity/vision",
     "@sanity/production-preview",


### PR DESCRIPTION
This removes storybook from running in test studio by default. It can still be started using `npm run storybook`

**Note for release**
N/A