### PR TITLE
[client] Typings: Including missing SanityImagePalette definition

### DIFF
--- a/packages/@sanity/client/sanityClient.d.ts
+++ b/packages/@sanity/client/sanityClient.d.ts
@@ -641,6 +641,13 @@ export interface SanityAssetDocument extends SanityDocument {
   originalFilename?: string
 }
 
+export interface SanityImagePalette {
+  background: string
+  foreground: string
+  population: number
+  title: string
+}
+
 export interface SanityImageAssetDocument extends SanityAssetDocument {
   metadata: {
     _type: 'sanity.imageMetadata'


### PR DESCRIPTION
I seem to have forgotten to include the `SanityImagePalette` interface in the client definitions, which this PR fixes. Closes #1758.
