### PR TITLE
[@sanity/client] Fixed the default return type of client.fetch

### DIFF
--- a/packages/@sanity/client/sanityClient.d.ts
+++ b/packages/@sanity/client/sanityClient.d.ts
@@ -569,11 +569,11 @@ export type FilteredResponseQueryOptions = RequestOptions & {
   filterResponse: true
 }
 
-export type UnfilteredReponseQueryOptions = RequestOptions & {
+export type UnfilteredResponseQueryOptions = RequestOptions & {
   filterResponse: false
 }
 
-export type QueryOptions = FilteredResponseQueryOptions | UnfilteredReponseQueryOptions
+export type QueryOptions = FilteredResponseQueryOptions | UnfilteredResponseQueryOptions
 
 type FirstDocumentMutationOptions = BaseMutationOptions & {
   returnFirst?: true
@@ -877,7 +877,7 @@ export class ObservableSanityClient {
   fetch<R = any>(
     query: string,
     params?: QueryParams,
-    options?: UnfilteredReponseQueryOptions
+    options?: UnfilteredResponseQueryOptions
   ): Observable<RawQueryResponse<R>>
 
   /**
@@ -1493,7 +1493,7 @@ export interface SanityClient {
   fetch<R = any>(
     query: string,
     params?: QueryParams,
-    options?: UnfilteredReponseQueryOptions
+    options?: UnfilteredResponseQueryOptions
   ): Promise<RawQueryResponse<R>>
 
   /**

--- a/packages/@sanity/client/sanityClient.d.ts
+++ b/packages/@sanity/client/sanityClient.d.ts
@@ -871,36 +871,42 @@ export class ObservableSanityClient {
    * Perform a GROQ-query against the configured dataset.
    *
    * @param query GROQ-query to perform
-   * @param params Optional query parameters
-   * @param options Request options
    */
-  fetch<R = any>(
-    query: string,
-    params?: QueryParams,
-    options?: UnfilteredResponseQueryOptions
-  ): Observable<RawQueryResponse<R>>
+  fetch<R = any>(query: string): Observable<R>
 
   /**
    * Perform a GROQ-query against the configured dataset.
    *
    * @param query GROQ-query to perform
-   * @param params Optional query parameters
+   * @param params Query parameters
+   */
+  fetch<R = any>(query: string, params: QueryParams): Observable<R>
+
+  /**
+   * Perform a GROQ-query against the configured dataset.
+   *
+   * @param query GROQ-query to perform
+   * @param params Query parameters
    * @param options Request options
    */
   fetch<R = any>(
     query: string,
-    params?: QueryParams,
-    options?: FilteredResponseQueryOptions
+    params: QueryParams | undefined,
+    options: FilteredResponseQueryOptions
   ): Observable<R>
 
   /**
    * Perform a GROQ-query against the configured dataset.
    *
    * @param query GROQ-query to perform
-   * @param params Optional query parameters
+   * @param params Query parameters
    * @param options Request options
    */
-  fetch<R = any>(query: string, params?: QueryParams): Observable<R>
+  fetch<R = any>(
+    query: string,
+    params: QueryParams | undefined,
+    options: UnfilteredResponseQueryOptions
+  ): Observable<RawQueryResponse<R>>
 
   /**
    * Fetch a single document with the given ID.
@@ -1487,14 +1493,16 @@ export interface SanityClient {
    * Perform a GROQ-query against the configured dataset.
    *
    * @param query GROQ-query to perform
-   * @param params Optional query parameters
-   * @param options Request options
    */
-  fetch<R = any>(
-    query: string,
-    params?: QueryParams,
-    options?: UnfilteredResponseQueryOptions
-  ): Promise<RawQueryResponse<R>>
+  fetch<R = any>(query: string): Promise<R>
+
+  /**
+   * Perform a GROQ-query against the configured dataset.
+   *
+   * @param query GROQ-query to perform
+   * @param params Optional query parameters
+   */
+  fetch<R = any>(query: string, params: QueryParams): Promise<R>
 
   /**
    * Perform a GROQ-query against the configured dataset.
@@ -1505,8 +1513,8 @@ export interface SanityClient {
    */
   fetch<R = any>(
     query: string,
-    params?: QueryParams,
-    options?: FilteredResponseQueryOptions
+    params: QueryParams | undefined,
+    options: FilteredResponseQueryOptions
   ): Promise<R>
 
   /**
@@ -1516,7 +1524,11 @@ export interface SanityClient {
    * @param params Optional query parameters
    * @param options Request options
    */
-  fetch<R = any>(query: string, params?: QueryParams): Promise<R>
+  fetch<R = any>(
+    query: string,
+    params: QueryParams | undefined,
+    options: UnfilteredResponseQueryOptions
+  ): Promise<RawQueryResponse<R>>
 
   /**
    * Fetch a single document with the given ID.


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

The default return type of `client.fetch` was returning unfiltered response which conflicts with the actual client.

**Description**

This PR fixes the problem for both typings - the Promise API & Observable API. I also made the typings more explicit.

Also fixed a typo in `UnfilteredResponseQueryOptions`.

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [ ]  The code is linted
- [ ]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
