### PR TITLE
[base] Make sure restoring from history takes liveEdit into account

### DIFF
--- a/packages/@sanity/base/src/datastores/document/document-pair/operations/restore.ts
+++ b/packages/@sanity/base/src/datastores/document/document-pair/operations/restore.ts
@@ -1,9 +1,11 @@
 import {OperationArgs} from '../../types'
 import historyStore from 'part:@sanity/base/datastore/history'
+import {isLiveEditEnabled} from '../utils/isLiveEditEnabled'
 
 export const restore = {
   disabled: (): false => false,
-  execute: ({idPair}: OperationArgs, fromRevision: string) => {
-    return historyStore.restore(idPair.publishedId, fromRevision)
+  execute: ({idPair, typeName}: OperationArgs, fromRevision: string) => {
+    const targetId = isLiveEditEnabled(typeName) ? idPair.publishedId : idPair.draftId
+    return historyStore.restore(idPair.publishedId, targetId, fromRevision)
   }
 }

--- a/packages/@sanity/base/src/datastores/history/createHistoryStore.js
+++ b/packages/@sanity/base/src/datastores/history/createHistoryStore.js
@@ -157,7 +157,7 @@ export const removeMissingReferences = (doc, existingIds) =>
     return documentExists ? refNode : undefined
   })
 
-function restore(id, rev) {
+function restore(id, targetId, rev) {
   return from(getDocumentAtRevision(id, rev)).pipe(
     mergeMap(documentAtRevision => {
       const existingIdsQuery = getAllRefIds(documentAtRevision)
@@ -172,7 +172,7 @@ function restore(id, rev) {
       // Remove _updatedAt and create a new draft from the document at given revision
       ({
         ...omit(documentAtRevision, '_updatedAt'),
-        _id: getDraftId(id)
+        _id: targetId
       })
     ),
     mergeMap(restoredDraft =>


### PR DESCRIPTION
This patch ensures we restore to the published document instead of creating a new draft when restoring a document from history that has `liveEdit` enabled.