### PR TITLE
[dashboard] Use observables for fetching, unsubscribe on unmount

### DIFF
--- a/packages/@sanity/dashboard/package.json
+++ b/packages/@sanity/dashboard/package.json
@@ -22,7 +22,8 @@
   ],
   "dependencies": {
     "lodash": "^4.17.15",
-    "react-icons": "^2.2.7"
+    "react-icons": "^2.2.7",
+    "rxjs": "^6.5.3"
   },
   "devDependencies": {
     "@sanity/base": "1.149.3",

--- a/packages/@sanity/dashboard/src/widgets/sanityTutorials/SanityTutorials.js
+++ b/packages/@sanity/dashboard/src/widgets/sanityTutorials/SanityTutorials.js
@@ -31,11 +31,17 @@ class SanityTutorials extends React.Component {
 
   componentDidMount() {
     const {templateRepoId} = this.props
-    getFeed(templateRepoId).then(response => {
+    this.subscription = getFeed(templateRepoId).subscribe(response => {
       this.setState({
         feedItems: response.items
       })
     })
+  }
+
+  componentWillUnmount() {
+    if (this.subscription) {
+      this.subscription.unsubscribe()
+    }
   }
 
   render() {

--- a/packages/@sanity/dashboard/src/widgets/sanityTutorials/dataAdapter.js
+++ b/packages/@sanity/dashboard/src/widgets/sanityTutorials/dataAdapter.js
@@ -12,7 +12,7 @@ export default {
     const uri = templateRepoId
       ? `/addons/dashboard?templateRepoId=${templateRepoId}`
       : '/addons/dashboard'
-    return client.request({uri, withCredentials: false})
+    return client.observable.request({uri, withCredentials: false})
   },
   urlBuilder: imageUrlBuilder(configuredClient)
 }

--- a/packages/@sanity/studio-hints/src/components/HintsPackage.js
+++ b/packages/@sanity/studio-hints/src/components/HintsPackage.js
@@ -4,10 +4,9 @@ import {isEmpty} from 'lodash'
 import Spinner from 'part:@sanity/components/loading/spinner'
 import studioHintsConfig from 'part:@sanity/default-layout/studio-hints-config'
 import WarningIcon from 'part:@sanity/base/warning-icon'
-import {locationSetting, getHints, updateLocation} from '../datastore'
+import {locationSetting, getHints} from '../datastore'
 import {resolveUrl} from './utils'
 import LinksList from './LinksList'
-// import HintPage from './HintPage'
 import styles from './HintsPackage.css'
 
 const removeHintsArticleSlug = 'remove-this-sidebar'
@@ -24,12 +23,15 @@ export default class HintsPackage extends React.PureComponent {
   subscription = null
 
   fetchHintsPackage(repoId) {
-    getHints(repoId, removeHintsArticleSlug)
-      .then(result => {
+    this.fetchSubscription = getHints(repoId, removeHintsArticleSlug).subscribe({
+      next: result => {
         const {hintsPackage, sidebarRemovalInstructions} = result
         this.setState({hintsPackage, sidebarRemovalInstructions, isLoading: false})
-      })
-      .catch(error => this.setState({error, isLoading: false}))
+      },
+      error: error => {
+        this.setState({error, isLoading: false})
+      }
+    })
   }
 
   componentDidMount() {
@@ -44,6 +46,10 @@ export default class HintsPackage extends React.PureComponent {
   componentWillUnmount() {
     if (this.subscription) {
       this.subscription.unsubscribe()
+    }
+
+    if (this.fetchSubscription) {
+      this.fetchSubscription.unsubscribe()
     }
   }
 

--- a/packages/@sanity/studio-hints/src/datastore.js
+++ b/packages/@sanity/studio-hints/src/datastore.js
@@ -15,5 +15,5 @@ export function updateLocation(locationObject) {
 
 export const getHints = (templateRepoId, removeHintsArticleSlug) => {
   const uri = `/addons/dashboard/hints?templateRepoId=${templateRepoId}&removeHintsArticleSlug=${removeHintsArticleSlug}`
-  return client.request({uri, withCredentials: false})
+  return client.observable.request({uri, withCredentials: false})
 }


### PR DESCRIPTION
**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

Dashboard and hints sidebar causes React warnings about using `setState` after unmount 

**Description**

This PR switches from promises to observables when fetching data in dashboard widgets and the studio hints package, and unsubscribes on unmount.  Needs a bit more testing before merging.

**Note for release**

- Fix bug where dashboard widgets sometimes would try to update state after unmount

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
