### PR TITLE
[desk-tool] Fix incorrect schema type property for validation list

### DIFF
--- a/packages/@sanity/desk-tool/src/pane/Editor/Validation.tsx
+++ b/packages/@sanity/desk-tool/src/pane/Editor/Validation.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import {Tooltip} from 'react-tippy'
+import schema from 'part:@sanity/base/schema'
 import Button from 'part:@sanity/components/buttons/default'
 import ValidationList from 'part:@sanity/components/validation/list'
 import ChevronDown from 'part:@sanity/base/chevron-down-icon'
@@ -46,7 +47,7 @@ export function Validation(props: ValidationProps) {
           markers={validation}
           showLink
           isOpen={showValidationTooltip}
-          documentType={type}
+          documentType={schema.get(type)}
           onClose={onCloseValidationResults}
           onFocus={onFocus}
         />


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

A prop type warning is displayed, and validation list does not list the field names properly

**Description**

This PR fixes an error where the `Validation` component expects a schema type object, but receives a string.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
