### PR TITLE
[core] GraphQL: Allow types to be present both as a reference and as an inline object in an array

### DIFF
--- a/packages/@sanity/core/src/actions/graphql/extractFromSanitySchema.js
+++ b/packages/@sanity/core/src/actions/graphql/extractFromSanitySchema.js
@@ -369,31 +369,31 @@ function extractFromSanitySchema(sanitySchema) {
       {
         fieldName: '_id',
         type: 'ID',
-        isNullable: false,
+        isNullable: true,
         description: 'Document ID'
       },
       {
         fieldName: '_type',
         type: 'String',
-        isNullable: false,
+        isNullable: true,
         description: 'Document type'
       },
       {
         fieldName: '_createdAt',
         type: 'Datetime',
-        isNullable: false,
+        isNullable: true,
         description: 'Date the document was created'
       },
       {
         fieldName: '_updatedAt',
         type: 'Datetime',
-        isNullable: false,
+        isNullable: true,
         description: 'Date the document was last modified'
       },
       {
         fieldName: '_rev',
         type: 'String',
-        isNullable: false,
+        isNullable: true,
         description: 'Current document revision'
       }
     ]

--- a/packages/@sanity/core/src/actions/graphql/extractFromSanitySchema.js
+++ b/packages/@sanity/core/src/actions/graphql/extractFromSanitySchema.js
@@ -322,8 +322,11 @@ function extractFromSanitySchema(sanitySchema) {
 
       const interfaces = allCandidatesAreDocuments ? ['Document'] : undefined
       const refs = flattened.filter(type => type.isReference).map(ref => ref.type)
-      const possibleTypes = flattened.map(type => (type.isReference ? type.type : type.name)).sort()
-
+      const inlineObjs = flattened.filter(type => !type.isReference).map(ref => ref.name)
+      // Here we remove duplicates, as they might appear twice due to in-line usage of types as well as references
+      const possibleTypes = [
+        ...new Set(flattened.map(type => (type.isReference ? type.type : type.name)))
+      ].sort()
       const name = possibleTypes.join('Or')
 
       if (!unionTypes.some(item => item.name === name)) {
@@ -336,7 +339,8 @@ function extractFromSanitySchema(sanitySchema) {
       }
 
       const references = refs.length > 0 ? refs : undefined
-      return {type: name, references}
+      const inlineObjects = inlineObjs.length > 0 ? inlineObjs : undefined
+      return {type: name, references, inlineObjects}
     } finally {
       const parentIndex = unionRecursionGuards.indexOf(parent)
       if (parentIndex !== -1) {

--- a/packages/@sanity/core/src/actions/graphql/extractFromSanitySchema.js
+++ b/packages/@sanity/core/src/actions/graphql/extractFromSanitySchema.js
@@ -340,7 +340,9 @@ function extractFromSanitySchema(sanitySchema) {
 
       const references = refs.length > 0 ? refs : undefined
       const inlineObjects = inlineObjs.length > 0 ? inlineObjs : undefined
-      return {type: name, references, inlineObjects}
+      return isReference(parent)
+        ? {type: name, references}
+        : {type: name, references, inlineObjects}
     } finally {
       const parentIndex = unionRecursionGuards.indexOf(parent)
       if (parentIndex !== -1) {


### PR DESCRIPTION
**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

When deploying a GraphQL endpoint with a schema that contains an array definition with the same type both in the `references` array and the `to` array, the `sanity graphql deploy` command fails.

**Description**

This change fixes a problem where deploying a GraphQL endpoint with a schema that contains an array definition with the same type both in the `references` array and the `to` array, the `sanity graphql deploy` command fails.

**Note for release**

Fix an issue where deploying a GraphQL endpoint with a schema that contains an array definition with the same type both in the `references` array and the `to` array, the `sanity graphql deploy` command fails.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made

---

Before merging this, we need changes in the backend that accepts the new parameter.
