### PR TITLE
[cli] fix default dataset settings crashing CLI on existing projects

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/promptForDatasetName.js
+++ b/packages/@sanity/cli/src/actions/init-project/promptForDatasetName.js
@@ -5,11 +5,15 @@ const datasetNameError =
   'numbers, underscores and dashes' +
   'and can be at most 20 characters.'
 
-export default function promptForDatasetName(prompt, options = {}) {
+export default function promptForDatasetName(prompt, options = {}, existingDatasets = []) {
   return prompt.single({
     type: 'input',
     message: 'Dataset name:',
     validate: name => {
+      if (existingDatasets.includes(name)) {
+        return `Dataset name already exists`
+      }
+
       if (!name || name.length < 2 || name.length > 20) {
         return 'Dataset name must be between 2 and 20 characters'
       }


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->
The CLI prompts for default dataset config in the wrong place when choosing an existing project, and crashes when using the default config because the dataset name already exists.

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->
This improves the DX by only prompting for default dataset config when creating a dataset for the first time, or when there are no datasets named "production". This PR also adds additional validation to check if a new dataset name already exists or not.

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->
- Fixed a bug where the CLI prompts for default dataset config in the wrong place and causes the CLI to crash when choosing the default config

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [x]  Corresponding changes to the documentation have been made
