### PR TITLE
Fix "Edit undefined" in title

### DIFF
--- a/packages/@sanity/components/src/dialogs/DefaultDialog.js
+++ b/packages/@sanity/components/src/dialogs/DefaultDialog.js
@@ -172,13 +172,11 @@ export default class DefaultDialog extends React.PureComponent {
                   onClickOutside={isActive ? onClickOutside : undefined}
                   className={styles.inner}
                 >
-                  {!title &&
-                    onClose &&
-                    showCloseButton && (
-                      <button className={styles.closeButtonOutside} onClick={onClose} type="button">
-                        <CloseIcon color="inherit" />
-                      </button>
-                    )}
+                  {!title && onClose && showCloseButton && (
+                    <button className={styles.closeButtonOutside} onClick={onClose} type="button">
+                      <CloseIcon color="inherit" />
+                    </button>
+                  )}
                   {title && (
                     <div className={styles.header}>
                       <h1 className={styles.title}>{title}</h1>
@@ -205,12 +203,11 @@ export default class DefaultDialog extends React.PureComponent {
                   >
                     {this.props.children}
                   </div>
-                  {actions &&
-                    actions.length > 0 && (
-                      <div className={contentHasOverflow ? styles.footerWithShadow : styles.footer}>
-                        {this.renderActions(actions)}
-                      </div>
-                    )}
+                  {actions && actions.length > 0 && (
+                    <div className={contentHasOverflow ? styles.footerWithShadow : styles.footer}>
+                      {this.renderActions(actions)}
+                    </div>
+                  )}
                 </CaptureOutsideClicks>
               </div>
             </div>

--- a/packages/@sanity/form-builder/src/inputs/ArrayInput/ItemValue.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ArrayInput/ItemValue.tsx
@@ -64,6 +64,7 @@ const IGNORE_KEYS = ['_key', '_type', '_weak']
 function isEmpty(value) {
   return Object.keys(value).every(key => IGNORE_KEYS.includes(key))
 }
+
 export default class RenderItemValue extends React.PureComponent<Props> {
   _focusArea: HTMLDivElement | null
   static defaultProps = {
@@ -113,7 +114,16 @@ export default class RenderItemValue extends React.PureComponent<Props> {
   getMemberType(): Type | null {
     const {value, type} = this.props
     const itemTypeName = resolveTypeName(value)
-    return type.of.find(memberType => memberType.name === itemTypeName)
+    const memberType = type.of.find(memberType => memberType.name === itemTypeName)
+    return memberType
+  }
+  getTitle(): string {
+    const {readOnly} = this.props
+    const memberType = this.getMemberType()
+    if (readOnly || memberType.readOnly) {
+      return memberType.title || ''
+    }
+    return memberType.title ? `Edit ${memberType.title}` : 'Edit'
   }
   setFocus(path: Path = []) {
     const {value, onFocus} = this.props
@@ -161,7 +171,9 @@ export default class RenderItemValue extends React.PureComponent<Props> {
     )
     // test focus issues by uncommenting the next line
     // return content
-    const title = readOnly || memberType.readOnly ? memberType.title : `Edit ${memberType.title}`
+
+    const title = this.getTitle()
+
     if (options.editModal === 'fullscreen') {
       return (
         <FullscreenDialog title={title} onClose={this.handleEditStop} isOpen>
@@ -200,11 +212,12 @@ export default class RenderItemValue extends React.PureComponent<Props> {
         </div>
       )
     }
+
     return (
       <DefaultDialog
         onClose={this.handleEditStop}
         key={item._key}
-        title={`Edit ${memberType.title}`}
+        title={title}
         actions={actions}
         onAction={this.handleDialogAction}
         showCloseButton={false}

--- a/packages/@sanity/schema/src/legacy/types/object.ts
+++ b/packages/@sanity/schema/src/legacy/types/object.ts
@@ -115,7 +115,10 @@ export const ObjectType = {
             throw new Error('Cannot override `fields` of subtypes of "object"')
           }
           const current = Object.assign({}, parent, pick(extensionDef, OVERRIDABLE_FIELDS), {
-            title: extensionDef.title || subTypeDef.title,
+            title:
+              extensionDef.title ||
+              subTypeDef.title ||
+              (subTypeDef.name ? startCase(subTypeDef.name) : ''),
             type: parent
           })
           lazyGetter(current, '__experimental_search', () => parent.__experimental_search)

--- a/packages/test-studio/schemas/book.js
+++ b/packages/test-studio/schemas/book.js
@@ -57,13 +57,39 @@ export default {
       description: 'ISBN-number of the book. Not shown in studio.',
       type: 'number',
       hidden: true
+    },
+    {
+      name: 'reviews',
+      title: 'Reviews',
+      type: 'array',
+      of: [
+        {
+          type: 'object',
+          name: 'review',
+          fields: [
+            {
+              name: 'title',
+              title: 'Title',
+              type: 'string'
+            },
+            {
+              name: 'body',
+              title: 'Body',
+              type: 'text'
+            }
+          ]
+        }
+      ]
     }
   ],
   orderings: [
     {
       title: 'Title',
       name: 'title',
-      by: [{field: 'title', direction: 'asc'}, {field: 'publicationYear', direction: 'asc'}]
+      by: [
+        {field: 'title', direction: 'asc'},
+        {field: 'publicationYear', direction: 'asc'}
+      ]
     },
     {
       title: 'Author name',
@@ -83,7 +109,10 @@ export default {
     {
       title: 'Swedish title',
       name: 'swedishTitle',
-      by: [{field: 'translations.se', direction: 'asc'}, {field: 'title', direction: 'asc'}]
+      by: [
+        {field: 'translations.se', direction: 'asc'},
+        {field: 'title', direction: 'asc'}
+      ]
     }
   ],
   preview: {

--- a/packages/test-studio/schemas/book.js
+++ b/packages/test-studio/schemas/book.js
@@ -62,6 +62,11 @@ export default {
       name: 'reviews',
       title: 'Reviews',
       type: 'array',
+      of: [{type: 'review'}]
+    },
+    {
+      name: 'reviewsInline',
+      type: 'array',
       of: [
         {
           type: 'object',
@@ -71,11 +76,6 @@ export default {
               name: 'title',
               title: 'Title',
               type: 'string'
-            },
-            {
-              name: 'body',
-              title: 'Body',
-              type: 'text'
             }
           ]
         }

--- a/packages/test-studio/schemas/review.js
+++ b/packages/test-studio/schemas/review.js
@@ -1,0 +1,11 @@
+export default {
+  name: 'review',
+  type: 'object',
+  fields: [
+    {
+      name: 'title',
+      title: 'Title',
+      type: 'string'
+    }
+  ]
+}

--- a/packages/test-studio/schemas/schema.js
+++ b/packages/test-studio/schemas/schema.js
@@ -49,6 +49,7 @@ import reservedFieldNames from './reservedFieldNames'
 import button from './button'
 import richTextObject from './richTextObject'
 import mux from './mux'
+import review from './review'
 
 export default createSchema({
   name: 'test-examples',
@@ -104,6 +105,7 @@ export default createSchema({
     empty,
     richTextObject,
     button,
-    mux
+    mux,
+    review
   ])
 })


### PR DESCRIPTION
If you had a field of type array and a member that array was defined in a separate file _and_ had no title key, the rendered title in the DefaultDialog would be `Edit undefined`. This PR solves this issue by:

- Falling back to use a human-friendly version of `name`, if `title` is missing
- Guarding against producing such titles in `ItemValue.tsx`

Fixes: https://github.com/sanity-io/sanity-priv/issues/2173