### PR TITLE
[preview] Fetch all fields specified in preview.select even when requesting only a specific preview field

### DIFF
--- a/packages/@sanity/preview/src/observeForPreview.ts
+++ b/packages/@sanity/preview/src/observeForPreview.ts
@@ -44,11 +44,7 @@ export default function observeForPreview(
 
   const selection = type.preview.select
   if (selection) {
-    const configFields = Object.keys(selection)
-    const targetFields = fields
-      ? configFields.filter(fieldName => fields.includes(fieldName))
-      : configFields
-    const paths = targetFields.map(key => selection[key].split('.'))
+    const paths = Object.keys(selection).map(key => selection[key].split('.'))
     return observePaths(value, paths).pipe(
       map(snapshot => ({
         type: type,


### PR DESCRIPTION
This fixes an issue caused by an optimization in the preview package that excluded other preview fields than the one that should be displayed. This caused problems in cases where the `preview.prepare` method would put together a title by combining values from other fields.

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

**Note for release**
Fixed an issue that would under some circumstances caused problems in cases with preview configs that put together a title by combining values from other fields.
