### PR TITLE
[components] Vertical align switch button to middle

### DIFF
--- a/packages/@sanity/components/src/toggles/Switch.js
+++ b/packages/@sanity/components/src/toggles/Switch.js
@@ -2,6 +2,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import styles from 'part:@sanity/components/toggles/switch-style'
+import classNames from 'classnames'
 
 export default class Switch extends React.Component {
   static propTypes = {
@@ -62,12 +63,12 @@ export default class Switch extends React.Component {
 
     return (
       <label
-        className={`
-          ${disabled || readOnly ? styles.isDisabled : styles.isEnabled}
-          ${typeof checked === 'undefined' ? styles.indeterminate : styles.root}
-          ${checked ? styles.isChecked : styles.unChecked}
-          ${hasFocus ? styles.hasFocus : ''}
-        `}
+        className={classNames([
+          styles.root,
+          (disabled || readOnly) && styles.isDisabled,
+          checked ? styles.isChecked : styles.unChecked,
+          hasFocus && styles.hasFocus
+        ])}
         onBlur={this.handleBlur}
       >
         <div className={styles.inner}>

--- a/packages/@sanity/components/src/toggles/styles/Switch.css
+++ b/packages/@sanity/components/src/toggles/styles/Switch.css
@@ -29,7 +29,6 @@
 
 .root {
   composes: root from 'part:@sanity/components/formfields/default-style';
-  display: inline-block !important;
   user-select: none;
   position: relative;
 }
@@ -38,12 +37,9 @@
   display: flex;
 }
 
-.indeterminate {
-  composes: root;
-}
-
 .switchWrapper {
   position: relative;
+  vertical-align: center;
   min-width: 2.5em;
 }
 
@@ -51,7 +47,7 @@
   background: var(--switch-off-track-color);
   position: absolute;
   left: 0;
-  top: var(--switch-track-top);
+  top: 50%;
   height: var(--switch-track-height);
   width: var(--switch-track-length);
   border-radius: var(--switch-track-height);
@@ -93,7 +89,7 @@
   background: var(--switch-off-thumb-color);
   position: absolute;
   left: 0;
-  top: var(--switch-thumb-top);
+  top: calc(50% - var(--switch-thumb-size) / 2);
   height: var(--switch-thumb-size);
   width: var(--switch-thumb-size);
   border-radius: 50%;
@@ -181,7 +177,7 @@
   background: var(--switch-off-track-color);
   position: absolute;
   left: 0;
-  top: var(--switch-track-top);
+  top: calc(50% - var(--switch-track-height) / 2);
   height: var(--switch-track-height);
   width: var(--switch-track-length);
   border-radius: var(--switch-track-height);


### PR DESCRIPTION
This makes the switch button align vertically
Before:
![image](https://user-images.githubusercontent.com/876086/76631392-ed7ea100-6541-11ea-95cd-28b28e057bb4.png)
After:
![image](https://user-images.githubusercontent.com/876086/76631443-012a0780-6542-11ea-9818-8fcd35105329.png)

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Note for release**
Fixed an issue with Switch buttons not getting proper vertical alignment.
