### PR TITLE
[block-tools] Fix test to be in line with new schema changes

### DIFF
--- a/packages/@sanity/block-tools/test/fixtures/customFeatures.json
+++ b/packages/@sanity/block-tools/test/fixtures/customFeatures.json
@@ -102,6 +102,7 @@
               }
             },
             "name": "author",
+            "title": "Author",
             "fields": [
               {
                 "name": "name",
@@ -158,21 +159,15 @@
             "__experimental_search": [
               {
                 "weight": 1,
-                "path": [
-                  "_id"
-                ]
+                "path": ["_id"]
               },
               {
                 "weight": 1,
-                "path": [
-                  "_type"
-                ]
+                "path": ["_type"]
               },
               {
                 "weight": 10,
-                "path": [
-                  "name"
-                ]
+                "path": ["name"]
               }
             ]
           }
@@ -379,6 +374,7 @@
                               }
                             },
                             "name": "author",
+                            "title": "Author",
                             "fields": [
                               {
                                 "name": "name",
@@ -435,21 +431,15 @@
                             "__experimental_search": [
                               {
                                 "weight": 1,
-                                "path": [
-                                  "_id"
-                                ]
+                                "path": ["_id"]
                               },
                               {
                                 "weight": 1,
-                                "path": [
-                                  "_type"
-                                ]
+                                "path": ["_type"]
                               },
                               {
                                 "weight": 10,
-                                "path": [
-                                  "name"
-                                ]
+                                "path": ["name"]
                               }
                             ]
                           }
@@ -694,6 +684,7 @@
                 }
               },
               "name": "author",
+              "title": "Author",
               "fields": [
                 {
                   "name": "name",
@@ -750,21 +741,15 @@
               "__experimental_search": [
                 {
                   "weight": 1,
-                  "path": [
-                    "_id"
-                  ]
+                  "path": ["_id"]
                 },
                 {
                   "weight": 1,
-                  "path": [
-                    "_type"
-                  ]
+                  "path": ["_type"]
                 },
                 {
                   "weight": 10,
-                  "path": [
-                    "name"
-                  ]
+                  "path": ["name"]
                 }
               ]
             }


### PR DESCRIPTION
[This commit](https://github.com/sanity-io/sanity/pull/1778/commits/a02066646c2fa4a86f1c85c0612d46944fe01336) changed some behavior that make the block-tools tests fail.

Preferably the test should be more specific on what it expects, but this will at least fix the tests for now.