### PR TITLE
[default-layout] Fix router state bug (NotFound component)

### DIFF
--- a/packages/@sanity/default-layout/src/components/NotFound.js
+++ b/packages/@sanity/default-layout/src/components/NotFound.js
@@ -1,12 +1,14 @@
 import React from 'react'
 import {withRouterHOC, StateLink} from 'part:@sanity/base/router'
 import {HAS_SPACES} from '../util/spaces'
+import styles from './styles/NotFound.css'
 
 export default withRouterHOC(function NotFound(props) {
   const router = props.router
-  const rootState = HAS_SPACES && router.state.space ? {space: router.state.space} : {}
+  const rootState =
+    HAS_SPACES && router.state && router.state.space ? {space: router.state.space} : {}
   return (
-    <div>
+    <div className={styles.root}>
       <h2>Page not found</h2>
       {props.children}
       <StateLink state={rootState}>Go to index</StateLink>

--- a/packages/@sanity/default-layout/src/components/styles/NotFound.css
+++ b/packages/@sanity/default-layout/src/components/styles/NotFound.css
@@ -1,0 +1,5 @@
+@import "part:@sanity/base/theme/variables-style";
+
+.root {
+  padding: var(--medium-padding);
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**
In some circumstances the `router.state` is null, and `router.state.space` will throw an error.

<!-- Reference/link the relevant issue and/or describe the behavior. -->

**Description**

Added a test for `router.state` before using it. Also added some padding to the NotFound component, because that page looked weird without.

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [ ]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
