### PR TITLE
[export] Catch errors in JSON stream without a statusCode property

### DIFF
--- a/packages/@sanity/export/src/export.js
+++ b/packages/@sanity/export/src/export.js
@@ -15,6 +15,7 @@ const filterSystemDocuments = require('./filterSystemDocuments')
 const filterDocumentTypes = require('./filterDocumentTypes')
 const filterDrafts = require('./filterDrafts')
 const logFirstChunk = require('./logFirstChunk')
+const tryParseJson = require('./tryParseJson')
 
 const noop = () => null
 
@@ -97,7 +98,7 @@ function exportDataset(opts) {
     const jsonStream = miss.pipeline(
       inputStream,
       logFirstChunk(),
-      split(JSON.parse),
+      split(tryParseJson),
       rejectOnApiError(),
       filterSystemDocuments(),
       assetStreamHandler,

--- a/packages/@sanity/export/src/rejectOnApiError.js
+++ b/packages/@sanity/export/src/rejectOnApiError.js
@@ -7,5 +7,10 @@ module.exports = () =>
       return
     }
 
+    if (!doc._id && doc.error) {
+      callback(new Error(doc.error.description || doc.error.message || JSON.stringify(doc)))
+      return
+    }
+
     callback(null, doc)
   })

--- a/packages/@sanity/export/src/tryParseJson.js
+++ b/packages/@sanity/export/src/tryParseJson.js
@@ -1,0 +1,20 @@
+module.exports = line => {
+  try {
+    return JSON.parse(line)
+  } catch (err) {
+    // Catch half-done lines with an error at the end
+    const errorPosition = line.lastIndexOf('{"error":')
+    if (errorPosition === -1) {
+      throw err
+    }
+
+    const errorJson = line.slice(errorPosition)
+    const errorLine = JSON.parse(errorJson)
+    const error = errorLine && errorLine.error
+    if (error && error.description) {
+      throw new Error(`Error streaming dataset: ${error.description}\n\n${errorJson}\n`)
+    }
+
+    throw err
+  }
+}


### PR DESCRIPTION
**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

If the export stream (ndjson) terminates with a JSON error without a `statusCode` property, the export doesn't throw. In the same way, if the stream is terminated mid-stream with a JSON error, there is nothing that gives any clear indication of what the actual error message was.

Consider the following cases:

```ndjson
{"_id":"valid","_type":"document"}
{"error":{"description":"Operation timed out"}}
```

```ndjson
{"_id":"valid","_type":"document"}
{"_id":"start-of{"error":{"description":"Operation timed out"}}
```

**Description**

With this change, we pick up both "whole line"-errors (such as the first example) and "mid-line" errors such as the second, and throw an error based on the contents.

**Note for release**

- Fix error where CLI export operations would not throw an error if API/database yields error during export

**Checklist**  

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
