### PR TITLE
[chore] Remove Node 8 from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - '8'
   - '10'
   - '12'
 


### PR DESCRIPTION
Node.js 8 is out of LTS. Let's not spend CPU cycles on Travis CI: https://nodejs.org/en/about/releases/

**Note for release**
Since Node.js 8 is out of LTS we no longer run CI tests for it.