### PR TITLE
[base] Improve scheduling of document action state updates

### DIFF
--- a/packages/@sanity/base/src/actions/utils/GetHookCollectionState.tsx
+++ b/packages/@sanity/base/src/actions/utils/GetHookCollectionState.tsx
@@ -1,0 +1,101 @@
+import React from 'react'
+import {HookStateContainer} from './HookStateContainer'
+import {throttle} from 'lodash'
+import {cancelIdleCallback, requestIdleCallback} from './requestIdleCallback'
+
+const actionIds = new WeakMap()
+
+let counter = 0
+const getHookId = action => {
+  if (actionIds.has(action)) {
+    return actionIds.get(action)
+  }
+  const id = `${action.name || action.displayName || '<anonymous>'}-${counter++}`
+  actionIds.set(action, id)
+  return id
+}
+
+interface Props<T, K> {
+  hooks: ((args: T) => K)[]
+  args: T
+  component: React.ComponentProps<any> & React.Component<{state: K[]}>
+  onReset?: () => void
+}
+
+function useThrottled(callback, wait, options) {
+  const throttled = React.useCallback(throttle(callback, wait, options), [callback])
+  React.useEffect(
+    () => () => {
+      throttled.flush()
+    },
+    []
+  )
+  return throttled
+}
+
+export function GetHookCollectionState<T, K>(props: Props<T, K>) {
+  const {hooks, args, component: Component, onReset: propsOnReset, ...rest} = props
+
+  const statesRef = React.useRef({})
+  const [, setTick] = React.useState(0)
+
+  const [keys, setKeys] = React.useState({})
+
+  const ricHandle = React.useRef(null)
+  const onRequestUpdate = useThrottled(
+    () => {
+      if (ricHandle.current) {
+        cancelIdleCallback(ricHandle.current)
+      }
+      requestIdleCallback(() => {
+        ricHandle.current = null
+        setTick(t => t + 1)
+      })
+    },
+    60,
+    {trailing: true}
+  )
+
+  const onNext = React.useCallback((id, hookState) => {
+    if (hookState === null) {
+      delete statesRef.current[id]
+    } else {
+      const current = statesRef.current[id]
+      statesRef.current[id] = {...current, value: hookState}
+    }
+  }, [])
+
+  const onReset = React.useCallback(id => {
+    setKeys(currentKeys => ({...currentKeys, [id]: (currentKeys[id] || 0) + 1}))
+    if (propsOnReset) {
+      propsOnReset()
+    }
+  }, [])
+
+  const hookIds = hooks.map(hook => getHookId(hook))
+
+  return (
+    <>
+      {hooks.map(hook => {
+        const id = getHookId(hook)
+        const key = keys[id] || 0
+        return (
+          <HookStateContainer
+            key={`${id}-${key}`}
+            hook={hook}
+            id={id}
+            args={args}
+            onNext={onNext}
+            onRequestUpdate={onRequestUpdate}
+            onReset={onReset}
+          />
+        )
+      })}
+
+      <Component
+        {...rest}
+        states={hookIds.map(id => statesRef.current[id]?.value).filter(Boolean)}
+      />
+    </>
+  )
+}

--- a/packages/@sanity/base/src/actions/utils/HookStateContainer.ts
+++ b/packages/@sanity/base/src/actions/utils/HookStateContainer.ts
@@ -1,0 +1,39 @@
+import React from 'react'
+import shallowEquals from 'shallow-equals'
+
+function useShallowCompareMemoize(value) {
+  const ref = React.useRef()
+  if (!shallowEquals(value, ref.current)) {
+    ref.current = value
+  }
+  return [ref.current]
+}
+
+function useShallowCompareEffect(callback, dependencies) {
+  React.useEffect(callback, useShallowCompareMemoize(dependencies))
+}
+
+export const HookStateContainer = React.memo(
+  function HookStateContainer(props: any) {
+    const {hook, args, id, onNext, onReset, onRequestUpdate} = props
+
+    const hookState = hook({
+      ...args,
+      onComplete: () => {
+        onReset(id)
+      }
+    })
+
+    useShallowCompareEffect(() => {
+      onNext(id, hookState)
+      onRequestUpdate()
+      return () => {
+        onNext(id, null)
+        onRequestUpdate()
+      }
+    }, hookState)
+
+    return null
+  },
+  (prev, next) => prev.args === next.args
+)

--- a/packages/@sanity/base/src/actions/utils/RenderActionCollectionState.tsx
+++ b/packages/@sanity/base/src/actions/utils/RenderActionCollectionState.tsx
@@ -1,83 +1,28 @@
 /* eslint-disable react/no-multi-comp */
 import * as React from 'react'
-import {ActionDescription} from './types'
+import {ActionDescription, DocumentActionProps} from './types'
+import {GetHookCollectionState} from './GetHookCollectionState'
 
-interface RenderActionCollectionProps {
-  actions: any[]
-  actionProps: any
-  onActionComplete: () => void
-  component: (args: {actionStates: ActionDescription[]}) => React.ReactNode
+interface Action<Args, Description> {
+  (args: Args): Description
 }
 
-const actionIds = new WeakMap()
-
-let counter = 0
-const getActionId = action => {
-  if (actionIds.has(action)) {
-    return actionIds.get(action)
-  }
-  const id = `${action.name || action.displayName || '<anonymous>'}-${counter++}`
-  actionIds.set(action, id)
-  return id
+interface RenderActionCollectionProps {
+  actions: Action<DocumentActionProps, ActionDescription>[]
+  actionProps: DocumentActionProps
+  onActionComplete: () => void
+  component: (args: {states: ActionDescription[]}) => React.ReactNode
 }
 
 export function RenderActionCollectionState(props: RenderActionCollectionProps) {
-  const [actionsWithStates, setActionsWithState] = React.useState([])
-  const [keys, setKey] = React.useState({})
-  const handleComplete = React.useCallback(
-    id => {
-      setKey(keys => ({...keys, [id]: (keys[id] || 0) + 1}))
-      props.onActionComplete()
-    },
-    [props.actions]
-  )
-
-  const onStateChange = React.useCallback(
-    stateUpdate => {
-      setActionsWithState(prevState => {
-        return props.actions.map((action: any) => {
-          const id = getActionId(action)
-          return stateUpdate[0] === id
-            ? [id, stateUpdate[1]]
-            : prevState.find(prev => prev[0] === id) || [id]
-        })
-      })
-    },
-    [props.actions]
-  )
-
-  const {actions: _, actionProps, component, ...rest} = props
-
+  const {actions, component, actionProps, onActionComplete, ...rest} = props
   return (
-    <>
-      {component({
-        actionStates: actionsWithStates
-          .map(([id, state]) => state && {...state, actionId: id})
-          .filter(Boolean),
-        ...rest
-      })}
-
-      {props.actions.map(action => {
-        const actionId = getActionId(action)
-        return (
-          <ActionStateContainer
-            key={`${actionId}-${keys[actionId] || '0'}`}
-            action={action}
-            id={actionId}
-            actionProps={props.actionProps}
-            onUpdate={onStateChange}
-            onComplete={handleComplete}
-          />
-        )
-      })}
-    </>
+    <GetHookCollectionState
+      {...rest}
+      onReset={onActionComplete}
+      hooks={actions}
+      args={actionProps}
+      component={component}
+    />
   )
 }
-
-const ActionStateContainer = React.memo(function ActionStateContainer(props: any) {
-  const {id, action, onUpdate, onComplete, actionProps} = props
-
-  const state = action({...actionProps, onComplete: () => onComplete(id)})
-  onUpdate([id, state ? state : null])
-  return null
-})

--- a/packages/@sanity/base/src/actions/utils/RenderBadgeCollectionState.tsx
+++ b/packages/@sanity/base/src/actions/utils/RenderBadgeCollectionState.tsx
@@ -1,0 +1,21 @@
+/* eslint-disable react/no-multi-comp */
+import * as React from 'react'
+import {GetHookCollectionState} from './GetHookCollectionState'
+
+export interface Badge {
+  label: string
+  title: string
+  color: 'success' | 'failure' | 'warning'
+}
+
+interface RenderBadgeCollectionProps {
+  badges: any[]
+  badgeProps: any
+  onActionComplete: () => void
+  component: (args: {states: Badge[]}) => React.ReactNode
+}
+
+export function RenderBadgeCollectionState(props: RenderBadgeCollectionProps) {
+  const {badges, component, badgeProps, ...rest} = props
+  return <GetHookCollectionState {...rest} hooks={badges} args={badgeProps} component={component} />
+}

--- a/packages/@sanity/base/src/actions/utils/index.ts
+++ b/packages/@sanity/base/src/actions/utils/index.ts
@@ -1,1 +1,2 @@
 export {RenderActionCollectionState} from './RenderActionCollectionState'
+export {RenderBadgeCollectionState} from './RenderBadgeCollectionState'

--- a/packages/@sanity/base/src/actions/utils/requestIdleCallback.ts
+++ b/packages/@sanity/base/src/actions/utils/requestIdleCallback.ts
@@ -1,0 +1,27 @@
+function requestIdleCallbackShim(callback) {
+  return setTimeout(() => {
+    const start = Date.now()
+    callback({
+      didTimeout: false,
+      timeRemaining: function() {
+        return Math.max(0, 50 - (Date.now() - start))
+      }
+    })
+  }, 1)
+}
+
+function cancelIdleCallbackShim(callback) {
+  return setTimeout(() => {
+    const start = Date.now()
+    callback({
+      didTimeout: false,
+      timeRemaining: function() {
+        return Math.max(0, 50 - (Date.now() - start))
+      }
+    })
+  }, 1)
+}
+
+const win: any = window
+export const requestIdleCallback = win.requestIdleCallback || requestIdleCallbackShim
+export const cancelIdleCallback = win.cancelIdleCallback || cancelIdleCallbackShim

--- a/packages/@sanity/base/src/actions/utils/types.ts
+++ b/packages/@sanity/base/src/actions/utils/types.ts
@@ -9,7 +9,7 @@ interface Document {
   _type: string
 }
 
-interface DocumentActionProps {
+export interface DocumentActionProps {
   id: string
   type: string
   draft: null | Document

--- a/packages/@sanity/desk-tool/src/actions/DiscardChangesAction.tsx
+++ b/packages/@sanity/desk-tool/src/actions/DiscardChangesAction.tsx
@@ -8,12 +8,12 @@ const DISABLED_REASON_TITLE = {
 }
 
 export function DiscardChangesAction({id, type, published, liveEdit, onComplete}) {
+  const {discardChanges}: any = useDocumentOperation(id, type)
+  const [isConfirmDialogOpen, setConfirmDialogOpen] = React.useState(false)
+
   if (!published || liveEdit) {
     return null
   }
-
-  const {discardChanges}: any = useDocumentOperation(id, type)
-  const [isConfirmDialogOpen, setConfirmDialogOpen] = React.useState(false)
 
   return {
     icon: CloseIcon,

--- a/packages/@sanity/desk-tool/src/actions/PublishAction.tsx
+++ b/packages/@sanity/desk-tool/src/actions/PublishAction.tsx
@@ -85,6 +85,14 @@ export function PublishAction(props) {
       publish.disabled
   )
 
+  const onHandle = React.useCallback(() => {
+    if (syncState.isSyncing || validationStatus.isValidating) {
+      setPublishScheduled(true)
+    } else {
+      doPublish()
+    }
+  }, [syncState.isSyncing, validationStatus.isValidating])
+
   return {
     disabled,
     label:
@@ -105,12 +113,6 @@ export function PublishAction(props) {
       ? null
       : title,
     shortcut: disabled || publishScheduled ? null : 'Ctrl+Alt+P',
-    onHandle: () => {
-      if (syncState.isSyncing || validationStatus.isValidating) {
-        setPublishScheduled(true)
-      } else {
-        doPublish()
-      }
-    }
+    onHandle: onHandle
   }
 }

--- a/packages/@sanity/desk-tool/src/components/DocumentStatusBar/DocumentStatusBarActions.tsx
+++ b/packages/@sanity/desk-tool/src/components/DocumentStatusBar/DocumentStatusBarActions.tsx
@@ -18,9 +18,10 @@ const TOUCH_SUPPORT = 'ontouchstart' in document.documentElement
 interface Props {
   id: string
   type: string
-  actionStates: any
+  states: any[]
   disabled: boolean
   isMenuOpen: boolean
+  showMenu: boolean
   onMenuOpen: () => void
   onMenuClose: () => void
 }
@@ -33,8 +34,8 @@ function ConditionalTooltip(
 }
 
 function DocumentStatusBarActionsInner(props: Props) {
-  const [firstActionState, ...rest] = props.actionStates
-  const hasMoreActions = rest.length > 0
+  const {states, showMenu} = props
+  const [firstActionState, ...menuActionStates] = states
 
   return (
     <div className={props.isMenuOpen ? styles.isMenuOpen : styles.root}>
@@ -62,7 +63,7 @@ function DocumentStatusBarActionsInner(props: Props) {
           >
             <Button
               className={
-                hasMoreActions ? styles.mainActionButtonWithMoreActions : styles.mainActionButton
+                showMenu ? styles.mainActionButtonWithMoreActions : styles.mainActionButton
               }
               icon={firstActionState.icon}
               color={firstActionState.disabled ? undefined : firstActionState.color || 'primary'}
@@ -76,9 +77,9 @@ function DocumentStatusBarActionsInner(props: Props) {
           {firstActionState.dialog && <ActionStateDialog dialog={firstActionState.dialog} />}
         </div>
       )}
-      {hasMoreActions && (
+      {showMenu && (
         <ActionMenu
-          actionStates={rest}
+          actionStates={menuActionStates}
           isOpen={props.isMenuOpen}
           onOpen={props.onMenuOpen}
           onClose={props.onMenuClose}
@@ -90,7 +91,7 @@ function DocumentStatusBarActionsInner(props: Props) {
 }
 
 export function DocumentStatusBarActions(props: {id: string; type: string}) {
-  const editState = useEditState(props.id, props.type)
+  const editState: any = useEditState(props.id, props.type)
   const connectionState = useConnectionState(props.id, props.type)
 
   const [isMenuOpen, setMenuOpen] = React.useState(false)
@@ -101,10 +102,11 @@ export function DocumentStatusBarActions(props: {id: string; type: string}) {
     <RenderActionCollectionState
       component={DocumentStatusBarActionsInner}
       isMenuOpen={isMenuOpen}
+      showMenu={actions.length > 1}
       onMenuOpen={() => setMenuOpen(true)}
       onMenuClose={() => setMenuOpen(false)}
       onActionComplete={() => setMenuOpen(false)}
-      actions={actions}
+      actions={isMenuOpen ? actions : actions.slice(0, 1)}
       actionProps={editState}
       disabled={connectionState !== 'connected'}
     />
@@ -135,9 +137,6 @@ export function HistoryStatusBarActions(props: HistoryStatusBarActionsProps) {
       component={DocumentStatusBarActionsInner}
       actions={historyActions}
       actionProps={actionProps}
-      onActionComplete={() => {
-        /*todo: make optional*/
-      }}
       disabled={connectionState !== 'connected' || Boolean(disabled)}
     />
   )

--- a/packages/@sanity/desk-tool/src/components/DocumentStatusBar/DocumentStatusBarBadges.tsx
+++ b/packages/@sanity/desk-tool/src/components/DocumentStatusBar/DocumentStatusBarBadges.tsx
@@ -5,6 +5,7 @@ import Badge from 'part:@sanity/components/badges/default'
 
 import styles from './DocumentStatusBarBadges.css'
 import resolveDocumentBadges from 'part:@sanity/base/document-badges/resolver'
+import {RenderBadgeCollectionState} from 'part:@sanity/base/actions/utils'
 
 export interface Badge {
   label: string
@@ -13,16 +14,16 @@ export interface Badge {
 }
 
 interface Props {
-  badgeStates: Badge[]
+  states: Badge[]
 }
 
 function DocumentStatusBarBadgesInner(props: Props) {
-  if (props.badgeStates.length === 0) {
+  if (props.states.length === 0) {
     return null
   }
   return (
     <div className={styles.statusBadges}>
-      {props.badgeStates.map((badge, i) => (
+      {props.states.map((badge, i) => (
         <Badge key={i} color={badge.color} title={badge.title}>
           {badge.label}
         </Badge>
@@ -33,82 +34,14 @@ function DocumentStatusBarBadgesInner(props: Props) {
 
 export function DocumentStatusBarBadges(props: {id: string; type: string}) {
   const editState = useEditState(props.id, props.type)
+
   const badges = editState ? resolveDocumentBadges(editState) : null
+
   return badges ? (
-    <RenderDocumentBadgeState
+    <RenderBadgeCollectionState
       component={DocumentStatusBarBadgesInner}
       badges={badges}
       badgeProps={editState}
     />
   ) : null
 }
-
-interface RenderBadgeCollectionProps {
-  badges: any[]
-  badgeProps: any
-  component: (args: {badgeStates: any[]}) => React.ReactNode
-}
-
-const badgeIds = new WeakMap()
-
-let counter = 0
-const getBadgeId = badge => {
-  if (badgeIds.has(badge)) {
-    return badgeIds.get(badge)
-  }
-  const id = `${badge.name || badge.displayName || '<anonymous>'}-${counter++}`
-  badgeIds.set(badge, id)
-  return id
-}
-
-export function RenderDocumentBadgeState(props: RenderBadgeCollectionProps) {
-  const [badgesWithStates, setBadgesWithState] = React.useState<[string, Badge | null][]>([])
-
-  const onStateChange = React.useCallback(
-    stateUpdate => {
-      setBadgesWithState(prevState => {
-        return props.badges.map((badge: Badge) => {
-          const id = getBadgeId(badge)
-          return stateUpdate[0] === id
-            ? [id, stateUpdate[1]]
-            : prevState.find(prev => prev[0] === id) || [id, null]
-        })
-      })
-    },
-    [props.badges]
-  )
-
-  const {badges: _, badgeProps, component, ...rest} = props
-
-  return (
-    <>
-      {component({
-        badgeStates: badgesWithStates
-          .map(([id, state]) => state && {...state, badgeId: id})
-          .filter(Boolean),
-        ...rest
-      })}
-
-      {props.badges.map(badge => {
-        const badgeId = getBadgeId(badge)
-        return (
-          <BadgeStateContainer
-            key={badgeId}
-            badge={badge}
-            id={badgeId}
-            badgeProps={props.badgeProps}
-            onUpdate={onStateChange}
-          />
-        )
-      })}
-    </>
-  )
-}
-
-const BadgeStateContainer = React.memo(function BadgeStateContainer(props: any) {
-  const {id, badge, onUpdate, badgeProps} = props
-
-  const state = badge(badgeProps)
-  onUpdate([id, state ? state : null])
-  return null
-})

--- a/packages/test-studio/src/resolveDocumentActions.js
+++ b/packages/test-studio/src/resolveDocumentActions.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import defaultResolve from 'part:@sanity/base/document-actions'
 
 import {
@@ -6,19 +7,45 @@ import {
   PopoverDialogAction
 } from './test-action-tool/actions/DialogActions'
 
-function TestAction() {
+const useInterval = ms => {
+  const [tick, setTick] = React.useState(0)
+  React.useEffect(() => {
+    const intervalId = setInterval(() => setTick(t => t + 1), ms)
+    return () => clearInterval(intervalId)
+  }, [ms])
+  return tick
+}
+
+function TickAction() {
+  const tick = useInterval(10)
   return {
-    label: 'A custom action',
+    label: `A custom action / ${tick}`,
     title: `An action that doesn't do anything particular`
   }
 }
 
+function StaticAction() {
+  return {
+    label: `A custom static action`,
+    title: `An action that doesn't do anything particular`
+  }
+}
+
+function OnlyWhenPublishedAction(props) {
+  return {
+    label: `Document is published`
+  }
+}
+
 export default function resolveDocumentActions(props) {
+  // return defaultResolve(props)
   return [
     ...defaultResolve(props),
-    TestAction,
+    // StaticAction,
+    // TestAction,
+    props.published ? OnlyWhenPublishedAction : null,
     PopoverDialogAction,
     ModalDialogAction,
     ConfirmDialogAction
-  ]
+  ].filter(Boolean)
 }


### PR DESCRIPTION
This is an internal rewrite of how we get the state out of the document action components. Previously we would call a function from within the render function of a state containing component. This caused a lot of warnings being spewed out into the console in React 16.13 (and possibly breakage in future React versions).

This patch switches to another approach which schedules updates to the action component renderer at most every 60ms, and in a requestIdleCallback to avoid updates from blocking more critical tasks.

**Note for release**
Fixed an issue that triggered a flood of console warnings in Studios using in React 16.13.