### PR TITLE
[components] DefaultDialog: Actually hide close button when 'showCloseButton' is falsy

### DIFF
--- a/packages/@sanity/components/src/dialogs/DefaultDialog.js
+++ b/packages/@sanity/components/src/dialogs/DefaultDialog.js
@@ -180,7 +180,7 @@ export default class DefaultDialog extends React.PureComponent {
                   {title && (
                     <div className={styles.header}>
                       <h1 className={styles.title}>{title}</h1>
-                      {onClose && (
+                      {onClose && showCloseButton && (
                         <button
                           className={styles.closeButton}
                           onClick={onClose}


### PR DESCRIPTION
**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**
If you currently pass both a `title` and `showCloseButton={false}` to DefaultDialog, the close button will still appear:

![image](https://user-images.githubusercontent.com/876086/77315977-d5a8d900-6d08-11ea-91eb-70f8145d6898.png)

This PR actually disables close button even when a title is passed.

**Note for release**
Fix an issue with `DefaultDialog` causing the close button to appear if `showCloseButton` is passed along with a `title`.
