### PR TITLE
[core] Use babel loader for ts/tsx files when generating GraphQL schema

### DIFF
--- a/packages/@sanity/core/src/actions/graphql/registerBabelLoader.js
+++ b/packages/@sanity/core/src/actions/graphql/registerBabelLoader.js
@@ -27,6 +27,7 @@ module.exports = basePath => {
         compact: false,
         root: basePath,
         ignore: [path.join(basePath, 'node_modules')],
+        extensions: ['.es6', '.es', '.jsx', '.js', '.mjs', '.ts', '.tsx'],
         test: /.*/,
         presets: [
           '@babel/preset-typescript',


### PR DESCRIPTION
**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

When running `sanity graphql deploy` and you have a require/import of a `.ts` or `.tsx` file as part of the schema, it will currently crash because it does not know how to resolve it, and if it does resolve, it won't be compiled with babel.

**Description**

This PR adds `.ts` and `.tsx` to the extensions that are ran through `@babel/register`, which fixes this issue.

**Note for release**

- Fix bug where using typescript in schema would crash `sanity graphql deploy`

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
