### PR TITLE
[cli] Remove explicit .js extension from path of schema part in new projects

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/createManifest.js
+++ b/packages/@sanity/cli/src/actions/init-project/createManifest.js
@@ -132,7 +132,7 @@ export function createSanityManifest(data, opts) {
       parts: [
         {
           name: 'part:@sanity/base/schema',
-          path: './schemas/schema.js'
+          path: './schemas/schema'
         }
       ]
     }


### PR DESCRIPTION
Currently if you rename the schema from `.js` to `.ts` after initialising a new project using `sanity init` will fail because the path of the implementation for `part:@sanity/base/schema` ships with an explicit `.js` extension. (See https://github.com/sanity-io/sanity/issues/1799)

This fixes the issue by removing the explicit `.js` extension when we generate sanity.json manifests in during `sanity init`.

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Note for release**
Removed explicit `.js` extension from schema file in new projects initialised using `sanity init`.
