### PR TITLE
[chore] Require node 10 across packages

### DIFF
--- a/packages/@sanity/check/package.json
+++ b/packages/@sanity/check/package.json
@@ -8,7 +8,7 @@
   },
   "author": "Sanity.io <hello@sanity.io>",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "license": "MIT",
   "scripts": {

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -14,7 +14,7 @@
     "prepublishOnly": "npm run build"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/core/package.json
+++ b/packages/@sanity/core/package.json
@@ -9,7 +9,7 @@
     "clean": "rimraf lib"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "keywords": [
     "sanity",

--- a/packages/@sanity/export/package.json
+++ b/packages/@sanity/export/package.json
@@ -4,7 +4,7 @@
   "description": "Export Sanity documents and assets",
   "main": "lib/export.js",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",

--- a/packages/@sanity/import-cli/package.json
+++ b/packages/@sanity/import-cli/package.json
@@ -7,7 +7,7 @@
     "sanity-import": "./lib/sanity-import.js"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",

--- a/packages/@sanity/import/package.json
+++ b/packages/@sanity/import/package.json
@@ -4,7 +4,7 @@
   "description": "Import documents to a Sanity dataset",
   "main": "lib/import.js",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",

--- a/packages/@sanity/initial-value-templates/package.json
+++ b/packages/@sanity/initial-value-templates/package.json
@@ -6,7 +6,7 @@
   "types": "./lib/index.d.ts",
   "author": "Sanity.io <hello@sanity.io>",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "license": "MIT",
   "scripts": {
@@ -20,6 +20,7 @@
     "headless",
     "realtime",
     "content",
+    "initial-value-templates",
     "initial-values",
     "check"
   ],

--- a/packages/@sanity/plugin-loader/package.json
+++ b/packages/@sanity/plugin-loader/package.json
@@ -8,7 +8,7 @@
     "coverage": "nyc --reporter=html ava"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/react-hooks/package.json
+++ b/packages/@sanity/react-hooks/package.json
@@ -6,7 +6,7 @@
   "types": "./lib/index.d.ts",
   "author": "Sanity.io <hello@sanity.io>",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "license": "MIT",
   "scripts": {
@@ -21,6 +21,7 @@
     "headless",
     "realtime",
     "content",
+    "react-hooks",
     "structure",
     "api"
   ],

--- a/packages/@sanity/resolver/package.json
+++ b/packages/@sanity/resolver/package.json
@@ -9,7 +9,7 @@
     "test": "#todo: mocha test/**/*.test.js"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/server/package.json
+++ b/packages/@sanity/server/package.json
@@ -12,7 +12,7 @@
     "sanity-server": "./bin/sanity-server.js"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/structure/package.json
+++ b/packages/@sanity/structure/package.json
@@ -6,7 +6,7 @@
   "types": "./lib/index.d.ts",
   "author": "Sanity.io <hello@sanity.io>",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "license": "MIT",
   "scripts": {

--- a/packages/@sanity/studio-hints/package.json
+++ b/packages/@sanity/studio-hints/package.json
@@ -19,6 +19,7 @@
     "headless",
     "realtime",
     "content",
+    "studio-hints",
     "hints",
     "sanity-plugin"
   ],

--- a/packages/@sanity/transaction-collator/package.json
+++ b/packages/@sanity/transaction-collator/package.json
@@ -6,7 +6,7 @@
   "types": "./lib/index.d.ts",
   "author": "Sanity.io <hello@sanity.io>",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "license": "MIT",
   "scripts": {
@@ -20,6 +20,7 @@
     "headless",
     "realtime",
     "content",
+    "transaction-collator",
     "mutations",
     "history"
   ],

--- a/packages/@sanity/util/package.json
+++ b/packages/@sanity/util/package.json
@@ -8,7 +8,7 @@
     "test": "tap -j1"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/webpack-integration/package.json
+++ b/packages/@sanity/webpack-integration/package.json
@@ -20,7 +20,7 @@
     "webpack"
   ],
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",

--- a/packages/@sanity/webpack-loader/package.json
+++ b/packages/@sanity/webpack-loader/package.json
@@ -7,7 +7,7 @@
     "clean": "rimraf lib"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/create-sanity/package.json
+++ b/packages/create-sanity/package.json
@@ -4,7 +4,7 @@
   "description": "Initialize a new Sanity project",
   "bin": "index.js",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "keywords": [
     "sanity",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -18,7 +18,7 @@
     "content"
   ],
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "homepage": "https://www.sanity.io/",
   "license": "MIT",

--- a/scripts/normalizePackageFields.js
+++ b/scripts/normalizePackageFields.js
@@ -2,7 +2,7 @@ const uniq = require('lodash/uniq')
 const transformPkgs = require('./utils/transformPkgs')
 
 const COMMON_KEYWORDS = ['sanity', 'cms', 'headless', 'realtime', 'content']
-const supportedNodeVersionRange = '>=8.0.0'
+const supportedNodeVersionRange = '>=10.0.0'
 
 transformPkgs(pkgManifest => {
   const name = pkgManifest.name.split('/').slice(-1)[0]


### PR DESCRIPTION
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [x]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

We currently say that we support node 8 and up, while our tests are (since a few days ago) only run on node 10 and up. 

**Description**

This PR sets the engines field to require node 10 for all packages.

**Note for release**

- Require node v10 and up to run Sanity

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
