### PR TITLE
[desk-tool] Make desk-tool/components/DraftStatus an implementable part (#1809)

### DIFF
--- a/packages/@sanity/desk-tool/sanity.json
+++ b/packages/@sanity/desk-tool/sanity.json
@@ -42,6 +42,14 @@
       "description": "An observable that emits a function to filter fields in form builder"
     },
     {
+      "name": "part:@sanity/desk-tool/components/draft-status",
+      "description": "A component that is displayed as a badge in the document list pane"
+    },
+    {
+      "implements": "part:@sanity/desk-tool/components/draft-status",
+      "path": "components/DraftStatus.js"
+    },
+    {
       "implements": "part:@sanity/base/component",
       "path": "components/story.js"
     }

--- a/packages/@sanity/desk-tool/src/components/DocumentPaneItemPreview.js
+++ b/packages/@sanity/desk-tool/src/components/DocumentPaneItemPreview.js
@@ -7,7 +7,7 @@ import {getDraftId, getPublishedId} from 'part:@sanity/base/util/draft-utils'
 import WarningIcon from 'part:@sanity/base/warning-icon'
 import {observeForPreview, SanityDefaultPreview} from 'part:@sanity/base/preview'
 import NotPublishedStatus from './NotPublishedStatus'
-import DraftStatus from './DraftStatus'
+import DraftStatus from 'part:@sanity/desk-tool/components/draft-status'
 
 const isLiveEditEnabled = schemaType => schemaType.liveEdit === true
 

--- a/packages/test-studio/sanity.json
+++ b/packages/test-studio/sanity.json
@@ -104,6 +104,10 @@
     {
       "implements": "part:@sanity/desk-tool/after-editor-component",
       "path": "src/components/AfterEditorComponent.js"
+    },
+    {
+      "implements": "part:@sanity/desk-tool/components/draft-status",
+      "path": "src/components/CustomDraftStatusInList.js"
     }
   ],
   "env": {

--- a/packages/test-studio/src/components/CustomDraftStatusInList.css
+++ b/packages/test-studio/src/components/CustomDraftStatusInList.css
@@ -1,0 +1,27 @@
+@import 'part:@sanity/base/theme/variables-style';
+
+.itemStatus {
+  z-index: 2;
+  position: relative;
+  opacity: 0.7;
+  transition: opacity 0.15s linear;
+
+  @nest &:hover {
+    opacity: 1;
+  }
+
+  @nest .selectedItem & {
+    color: var(--selected-item-color--inverted);
+  }
+
+  @nest & > i {
+    display: flex;
+    height: 100%;
+    align-items: center;
+  }
+}
+
+.draftBadge {
+  font-size: var(--font-size-tiny--relative);
+  opacity: 0.75;
+}

--- a/packages/test-studio/src/components/CustomDraftStatusInList.js
+++ b/packages/test-studio/src/components/CustomDraftStatusInList.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import styles from './CustomDraftStatusInList.css'
+import Badge from 'part:@sanity/components/badges/default'
+
+const DraftStatus = () => (
+  <div className={styles.draftBadge}>
+    <Badge inverted faded>
+      Custom Draft
+    </Badge>
+  </div>
+)
+
+export default DraftStatus


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

https://github.com/sanity-io/sanity/issues/1809

**Description**

Before this PR, DraftStatus is directly required from local source.
This PR makes it an implementable part so it can also be overwritten, which will introduce consistency with the custom badges API in case you want to override the draft badge entirely.

**Note for release**

Allow "DRAFT" badge in DocumentPaneItemPreview to be re-implemented as `part:@sanity/desk-tool/components/draft-status`

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
