### PR TITLE
[client] Fix incorrect return value type for transaction.serialize()

### DIFF
--- a/packages/@sanity/client/sanityClient.d.ts
+++ b/packages/@sanity/client/sanityClient.d.ts
@@ -396,14 +396,14 @@ export class Transaction {
   transactionId<T extends string | undefined>(id: T): T extends string ? this : string | undefined
 
   /**
-   * Return a plain JSON representation of the patch
+   * Return a plain JSON representation of the transaction
    */
-  serialize(): PatchMutationOperation
+  serialize(): Mutation[]
 
   /**
    * Return a plain JSON representation of the transaction
    */
-  toJSON(): PatchMutationOperation
+  toJSON(): Mutation[]
 
   /**
    * Commit the transaction, returning a promise that resolves to the first mutated document


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Description**

When calling `transaction.serialize()` or `transaction.toJSON()`, an array of mutations is returned, but typescript definitions says it will return a patch. This is a copy+paste bug from `Patch`.

This PR fixes the definitions.

**Note for release**

- Fixed typescript definition for client having incorrect return value type for `transaction.serialize()` and  `transaction.toJSON()`

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
