### PR TITLE
[client] Fix typings for constructor options (useProjectHostname)

### DIFF
--- a/packages/@sanity/client/sanityClient.d.ts
+++ b/packages/@sanity/client/sanityClient.d.ts
@@ -480,10 +480,11 @@ type ProjectlessClientConfig = BaseClientConfig & {
   dataset?: string
 }
 
-type ProjectClientConfig = {
+type ProjectClientConfig = BaseClientConfig & {
+  useProjectHostname?: true
   projectId: string
   dataset?: string
-} & BaseClientConfig
+}
 
 export type ClientConfig = ProjectClientConfig | ProjectlessClientConfig
 


### PR DESCRIPTION
**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Description**

For some reason, typescript was having issues resolving the constructor options for this call:
```ts
const client = new SanityClient({
  projectId: 'foo',
  dataset: 'bar',
  token: 'baz',
  useCdn: false
})
```

It seemed to infer that it should be a `ProjectlessClientConfig`, which requires `useProjectHostname` to be set to  `false`. It seems like introducing `useProjectHostname` as an optional, `true` value in the `ProjectClientConfig`, it resolves correctly.

**Note for release**

- Fixed bug where typescript resolved incorrect option signature for client constructor

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
