### PR TITLE
[base] Add typescript definitions for structure, initial value templates

### DIFF
--- a/packages/@sanity/base/initial-value-template-builder.d.ts
+++ b/packages/@sanity/base/initial-value-template-builder.d.ts
@@ -1,0 +1,3 @@
+import {TemplateBuilder} from '@sanity/initial-value-templates'
+
+export = TemplateBuilder

--- a/packages/@sanity/base/initial-value-templates.d.ts
+++ b/packages/@sanity/base/initial-value-templates.d.ts
@@ -1,0 +1,3 @@
+import * as InitialValueTemplates from '@sanity/initial-value-templates'
+
+export = InitialValueTemplates

--- a/packages/@sanity/base/structure-builder.d.ts
+++ b/packages/@sanity/base/structure-builder.d.ts
@@ -1,0 +1,3 @@
+import {StructureBuilder} from '@sanity/structure'
+
+export = StructureBuilder


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [x]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Description**

Adds "proxy" typescript definitions for things in `@sanity/base` that just re-export the upstream definitions. 

**Note for release**

- Added typescript definitions for structure builder and initial value templates

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
