### PR TITLE
[default-login] Treat official provider URLs as non-custom

### DIFF
--- a/packages/@sanity/default-login/src/LoginDialog.js
+++ b/packages/@sanity/default-login/src/LoginDialog.js
@@ -59,18 +59,22 @@ export default class LoginDialog extends React.Component {
     const currentUrl = encodeURIComponent(window.location.toString())
     const params = [`origin=${currentUrl}`, projectId && `projectId=${projectId}`].filter(Boolean)
 
-    if (provider.custom && !provider.supported) {
+    if (provider.custom && !provider.supported && !this.state.error) {
       this.setState({
         error: {
           message:
             'This project is missing the required "thirdPartyLogin" ' +
             'feature to support custom logins.',
-          link: generateHelpUrl('third-party-login')
+          link: generateHelpUrl('third-party-login'),
+          hideClose: true
         }
       })
       return
     }
-    window.location = `${provider.url}?${params.join('&')}`
+
+    if (!this.state.error) {
+      window.location = `${provider.url}?${params.join('&')}`
+    }
   }
 
   handleLoginButtonClicked = (provider, evnt) => {
@@ -93,7 +97,7 @@ export default class LoginDialog extends React.Component {
           title="Error"
           isOpen
           centered
-          onClose={this.handleErrorDialogClosed}
+          onClose={error.hideClose ? undefined : this.handleErrorDialogClosed}
         >
           <div className={styles.error}>
             {error.message}

--- a/packages/@sanity/default-login/src/util/getProviders.js
+++ b/packages/@sanity/default-login/src/util/getProviders.js
@@ -10,17 +10,27 @@ export default function getProviders() {
     })
     .then(res => {
       const {providers, thirdPartyLogin} = res
-      const customProviders = (config.providers && config.providers.entries
-        ? config.providers.entries
-        : []
-      ).map(provider => {
-        provider.custom = true
-        provider.supported = thirdPartyLogin
-        return provider
-      })
-      if (customProviders.length && config.providers && config.providers.mode === 'replace') {
-        return Promise.resolve(customProviders)
+      const customProviders = (config.providers && config.providers.entries) || []
+      if (customProviders.length === 0) {
+        return providers
       }
-      return providers.concat(customProviders)
+
+      const custom = customProviders.map(provider => {
+        // A user may want to remove certain login options (eg GitHub) and thus provide "official"
+        // login options through the config. These shouldn't be treated as custom login providers
+        // which require the third-party login feature, but as the official provider
+        const isOfficial = providers.some(official => official.url === provider.url)
+        return {...provider, custom: !isOfficial, supported: isOfficial || thirdPartyLogin}
+      })
+
+      if (config.providers.mode === 'replace') {
+        return custom
+      }
+
+      // Append to the list of official providers, but replace any provider that has
+      // the same URL with the custom one (allows customizing the title, name)
+      return providers
+        .filter(official => custom.some(provider => provider.url !== official.url))
+        .concat(custom)
     })
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

Sometimes you may want to limit the available login providers for a studio. A common example is when users log in with their Google account and later try to log in with their GitHub and get confused when they don't have access. To prevent this confusion, a developer may choose to only allow logins through one provider, and update their default login configuration to reflect this:

```json
{
  "providers": {
    "mode": "replace",
    "redirectOnSingle": true,
    "entries": [
      {
        "name": "sanity",
        "title": "Sanity ",
        "url": "https://api.sanity.io/v1/auth/login/sanity"
      }
    ]
  }
}
```

The problem is that all entries in the configuration are treated as "custom", which require the third-party login feature. 

**Description**

This PR checks the configured provider URLs against the official providers and only treats them as custom if there is no corresponding official provider.

I'm not 100% sure if we all agree on this behavior, so I'm including multiple reviewers. 

**Note for release**

- Fixed bug where configuring official login providers would require the third-party login feature for the project

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
