### PR TITLE
feat(client): add support for patch/delete with query and params

### DIFF
--- a/packages/@sanity/client/src/util/getSelection.js
+++ b/packages/@sanity/client/src/util/getSelection.js
@@ -4,7 +4,7 @@ module.exports = function getSelection(sel) {
   }
 
   if (sel && sel.query) {
-    return {query: sel.query}
+    return 'params' in sel ? {query: sel.query, params: sel.params} : {query: sel.query}
   }
 
   const selectionOpts = [

--- a/packages/@sanity/client/test/client.test.js
+++ b/packages/@sanity/client/test/client.test.js
@@ -822,6 +822,20 @@ test('delete() can use request tag', (t) => {
     .then(() => t.end())
 })
 
+test('delete() can use query with params', (t) => {
+  const query = '*[_type == "beer" && title == $beerName]'
+  const params = {beerName: 'Headroom Double IPA'}
+  const expectedBody = {mutations: [{delete: {query: query, params: params}}]}
+  nock(projectHost())
+    .post('/v1/data/mutate/foo?returnIds=true&returnDocuments=true&visibility=sync', expectedBody)
+    .reply(200, {transactionId: 'abc123'})
+
+  getClient()
+    .delete({query: query, params: params})
+    .catch(t.ifError)
+    .then(() => t.end())
+})
+
 test('delete() can be told not to return documents', (t) => {
   const expectedBody = {mutations: [{delete: {id: 'abc123'}}]}
   nock(projectHost())
@@ -996,8 +1010,18 @@ test('patch() can take an array of IDs', (t) => {
 })
 
 test('patch() can take a query', (t) => {
-  const patch = getClient().patch({query: 'beerfiesta.beer'}).inc({count: 1}).serialize()
-  t.deepEqual(patch, {query: 'beerfiesta.beer', inc: {count: 1}})
+  const patch = getClient().patch({query: '*[_type == "beer]'}).inc({count: 1}).serialize()
+  t.deepEqual(patch, {query: '*[_type == "beer]', inc: {count: 1}})
+  t.end()
+})
+
+test('patch() can take a query and params', (t) => {
+  const patch = getClient()
+    .patch({query: '*[_type == $type]', params: {type: 'beer'}})
+    .inc({count: 1})
+    .serialize()
+
+  t.deepEqual(patch, {query: '*[_type == $type]', params: {type: 'beer'}, inc: {count: 1}})
   t.end()
 })
 


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [x]  Yes
- [ ]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->
The javascript client getSelection (used in patch and delete) accepts an object with a query, but not params for that query

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->
I've added the option to pass params in adition to the query that was already accepted. I added a test for this as well, but I'm not 100% sure if the test is helpful?
Running the tests works fine, and testing this feature in my own project also worked fine 
(This example isn't extremely useful since I could have just used the document id, but the intention is to use the query to check the author for example)
```
sanity
    .delete({
      query: `*[_type == 'submission' && _id == $submissionId]`,
      params: { submissionId: id },
    })
    .then((sanityRes) => res.sendStatus(200))
    .catch((err) => {
      return res.json(err);
    });
```
Not sure if this counts as a feature or a bug (or maybe it's even intended? 😮) - also I don't think passing a query to the delete function is documented at all.

**Note for release**
Allow passing params when using a query instead of just a document id in the delete and patch functions of the javascript client.
<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
