### PR TITLE
[base] Fix wrong typeof check

### DIFF
--- a/packages/@sanity/base/src/datastores/history/createHistoryStore.js
+++ b/packages/@sanity/base/src/datastores/history/createHistoryStore.js
@@ -146,7 +146,7 @@ function jsonMap(value, mapFn) {
 
 const mapRefNodes = (doc, mapFn) =>
   jsonMap(doc, node => {
-    return typeof node && typeof node === 'object' && typeof node._ref === 'string'
+    return node && typeof node === 'object' && typeof node._ref === 'string'
       ? mapFn(node)
       : node
   })


### PR DESCRIPTION
Currently, when restoring a document from the revision history we look through the restored version for references to check if they still exist. Due to an erroneous typeof check, which should have been a falsey check, any null values in the restored version would throw an error saying `Cannot read property _ref of null`.

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Note for release**
Fixed a bug that would cause an error when trying to restore a document that has `null` values.
