### PR TITLE
[core] GraphQL: Only use field description if type is string

### DIFF
--- a/packages/@sanity/core/src/actions/graphql/extractFromSanitySchema.js
+++ b/packages/@sanity/core/src/actions/graphql/extractFromSanitySchema.js
@@ -421,7 +421,8 @@ function extractFromSanitySchema(sanitySchema) {
   }
 
   function getDescription(type) {
-    return (type.type && type.type.description) || undefined
+    const description = type.type && type.type.description
+    return typeof description === 'string' ? description : undefined
   }
 
   function gatherAllFields(type, field = 'fields') {


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

If a field has a description set to a React element (`description: <span>Foo</span>`), it gets serialized and sent to the server as the object description of the element, and is rejected by the validation.

**Description**

This PR silently ignores any non-string description fields. I don't see any reason for adding a flag or a warning as I think this is an edge-case (in an upcoming "editor declaration" implementation, we'll have better ways of achieving rich "descriptions" for fields while keeping the schema definition "pure".

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

- Fixed bug where non-string field descriptions would prevent GraphQL APIs from being deployed

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
