### PR TITLE
[core] Add `require.context` hook for schema generation, script exec

### DIFF
--- a/packages/@sanity/core/package.json
+++ b/packages/@sanity/core/package.json
@@ -52,6 +52,7 @@
     "jsdom-global": "^3.0.2",
     "json-lexer": "^1.1.1",
     "json5": "^1.0.1",
+    "klaw-sync": "^4.0.0",
     "lodash": "^4.17.15",
     "log-symbols": "^2.2.0",
     "oneline": "^1.0.3",

--- a/packages/@sanity/core/src/actions/exec/execScript.js
+++ b/packages/@sanity/core/src/actions/exec/execScript.js
@@ -24,7 +24,8 @@ module.exports = async args => {
 
   const babel = require.resolve('./babel')
   const loader = require.resolve('./pluginLoader')
-  const nodeArgs = ['-r', babel, '-r', loader]
+  const requireContext = require.resolve('./requireContext')
+  const nodeArgs = ['-r', babel, '-r', loader, '-r', requireContext]
     .concat(withToken ? ['-r', require.resolve('./configClient')] : [])
     .concat(scriptPath)
     .concat(args.extraArguments || [])

--- a/packages/@sanity/core/src/actions/exec/requireContext.js
+++ b/packages/@sanity/core/src/actions/exec/requireContext.js
@@ -1,0 +1,3 @@
+const requireContext = require('../../util/requireContext')
+
+requireContext.register()

--- a/packages/@sanity/core/src/actions/graphql/getSanitySchema.js
+++ b/packages/@sanity/core/src/actions/graphql/getSanitySchema.js
@@ -1,6 +1,7 @@
 const pirates = require('pirates')
 const jsdomGlobal = require('jsdom-global')
 const pluginLoader = require('@sanity/plugin-loader')
+const requireContext = require('../../util/requireContext')
 const registerBabelLoader = require('./registerBabelLoader')
 
 const getFakeGlobals = () => ({
@@ -30,6 +31,7 @@ function provideFakeGlobals() {
 function getSanitySchema(basePath) {
   const domCleanup = jsdomGlobal()
   const globalCleanup = provideFakeGlobals()
+  const contextCleanup = requireContext.register()
   const cleanupFileLoader = pirates.addHook(
     (code, filename) => `module.exports = ${JSON.stringify(filename)}`,
     {
@@ -45,6 +47,7 @@ function getSanitySchema(basePath) {
   const schema = schemaMod.default || schemaMod
 
   cleanupFileLoader()
+  contextCleanup()
   globalCleanup()
   domCleanup()
 

--- a/packages/@sanity/core/src/util/requireContext.js
+++ b/packages/@sanity/core/src/util/requireContext.js
@@ -1,0 +1,141 @@
+/* eslint-disable import/no-dynamic-require, max-depth, no-inner-declarations */
+
+/**
+ * This file exposes a "register" function which hacks in a `require.context` function,
+ * mirroring webpacks version (https://webpack.js.org/guides/dependency-management/#requirecontext)
+ *
+ * Basically allows you to do `require.context('./types', true, /\.js$/)` to import multiple
+ * files at the same time. While generally not advised (given it's a webpack-only thing),
+ * people are already using it in the wild, so it breaks when trying to deploy GraphQL APIs,
+ * or when running scripts using `sanity exec`.
+ *
+ * We have to inject the `require.context` function to each required file, which is done by
+ * overriding the `module.constructor.wrap` method, with a stringified version of `requireContext`
+ * injected to the top of the file, assigned to `require.context`.
+ *
+ * To make things worse, knowing where the require call was performed from is harder than it
+ * ought to be, so we have to use an approach where we get the calling path name from an
+ * error stacktrace. This is required to resolve `./types` to `/some/studio/path/schemas/types`,
+ * for instance.
+ */
+
+const klawPath = require.resolve('klaw-sync')
+const resolvePath = require.resolve('resolve-from')
+const hookPath = __dirname
+
+let registered = false
+
+const requireContext = (directory, recursive, regExp) => {
+  // This whole thing is kind of sketchy, so let's wrap it to prevent any breakage
+  // if node should change it's APIs in any way
+  try {
+    // Has to be required from within function because of wrapping
+    const path = require('path')
+    const klaw = require(klawPath)
+    const resolveFrom = require(resolvePath)
+
+    // We need to resolve `./foo` from where the _caller_ is situated
+    function getCallerDirName() {
+      const originalFunc = Error.prepareStackTrace
+
+      let callerFile
+      let currentFile
+      try {
+        const err = new Error()
+
+        Error.prepareStackTrace = function prepareStackTrace(error, stack) {
+          return stack
+        }
+
+        currentFile = err.stack.shift().getFileName()
+        if (currentFile === hookPath) {
+          while (err.stack.length) {
+            callerFile = err.stack.shift().getFileName()
+
+            if (currentFile !== callerFile) {
+              break
+            }
+          }
+        } else {
+          callerFile = currentFile
+        }
+      } catch (err) {
+        // noop
+      }
+
+      Error.prepareStackTrace = originalFunc
+
+      return path.dirname(callerFile)
+    }
+
+    // Assume absolute path by default
+    let basePath = directory
+
+    if (directory[0] === '.') {
+      // Relative path
+      basePath = path.join(getCallerDirName(), directory)
+    } else if (!path.isAbsolute(directory)) {
+      // Module path, resolve the module from the caller
+      basePath = resolveFrom(getCallerDirName(), directory)
+    }
+
+    // Fix any trailing slashes and similar
+    basePath = path.resolve(basePath)
+
+    const keys = klaw(basePath, {depthLimit: recursive ? 30 : 0, nodir: false})
+      // Make sure we only match the provided regexp (or use the default (.json/.js))
+      .filter(file => file.path.match(regExp || /\.(json|js)$/))
+      // Use relative paths for the keys
+      .map(file => path.join('.', file.path.slice(basePath.length + 1)))
+
+    const context = key => require(context.resolve(key))
+    context.resolve = key => path.resolve(basePath, key)
+    context.keys = () => keys
+
+    return context
+  } catch (contextErr) {
+    contextErr.message = `Error running require.context():\n\n${contextErr.message}`
+    throw contextErr
+  }
+}
+
+const wrap = module.constructor.wrap
+const restore = () => {
+  module.constructor.wrap = wrap
+}
+
+function register() {
+  if (registered) {
+    return restore
+  }
+
+  try {
+    module.constructor.wrap = script => {
+      const requireContextScript = requireContext
+        .toString()
+        .replace(/hookPath/g, JSON.stringify(hookPath))
+        .replace(/klawPath/g, JSON.stringify(klawPath))
+        .replace(/resolvePath/g, JSON.stringify(resolvePath))
+
+      // Assigning the function may very well crash in an upcoming version,
+      // so try to catch and warn if this is the case
+      return wrap(`try {
+        require.context = ${requireContextScript}
+      } catch (err) {
+        console.warn('Error assigning require.context function:\\n' + err.message)
+      }\n\n${script}`)
+    }
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(`Error assigning module wrapper for require.context hook:\n${err.message}`)
+  }
+
+  registered = true
+
+  // There isn't a good way to clean this up
+  return restore
+}
+
+module.exports = {
+  register
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

If you're using `require.context` in the studio (for instance, to load all schema type files without having to specify them all), this works fine until you try to deploy a GraphQL API or running a script with `sanity exec`, at which point it'll crash because `require.context` does not exist in the node APIs. 

**Description**

This PR injects a "polyfill" for `require.context` into the node environment when running `sanity graphql deploy` and `sanity exec`. It's a bit of a hairy beast, so it comes with a set of pessimistic try/catch clauses, warning should it fail to register itself. 

To try it out, here's a sample `schema.js` file which requires all `.js` files in the same folder (recursively):

```js
import createSchema from 'part:@sanity/base/schema-creator'
import schemaTypes from 'all:part:@sanity/base/schema-type'

const context = require.context('./', true, /^(?!.*schema\.js$).*\.js$/)
const types = context
  .keys()
  .map((filename) => context(filename))
  .map((mod) => (mod.__esModule && mod.default) || mod)

export default createSchema({
  name: 'default',
  types: schemaTypes.concat(types),
})
```

**Note for release**

- Implemented polyfill for `require.context` in node.js environment, preventing `sanity graphql deploy` and `sanity exec` from crashing if used.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
