### PR TITLE
[validation] Short-circuit to avoid failed coercion of `undefined` to string

### DIFF
--- a/packages/@sanity/validation/src/validators/numberValidator.js
+++ b/packages/@sanity/validation/src/validators/numberValidator.js
@@ -12,6 +12,8 @@ const integer = (unused, value, message) => {
 }
 
 const precision = (limit, value, message) => {
+  if (typeof value === "undefined") return true
+  
   const places = value.toString().match(precisionRx)
   const decimals = Math.max(
     (places[1] ? places[1].length : 0) - (places[2] ? parseInt(places[2], 10) : 0),


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [X]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [X]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->

When a field using `validation: Rule => Rule.precision(limit)` has an empty value, the `precision` validator will fail with the error message “Cannot read property 'toString' of undefined”. This error message subsequently overrides the validation failure messages for the field. 

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

This PR short-circuits the function by returning `true` early when the field value is undefined.

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->
Improved handling of empty values when using precision validation on number fields

**Checklist** 

- [X]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [X]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [ ]  The code is linted
- [ ]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
