### PR TITLE
[validation] Fix a performance issue when validating blocks

### DIFF
--- a/packages/@sanity/validation/src/Rule.js
+++ b/packages/@sanity/validation/src/Rule.js
@@ -251,6 +251,10 @@ class Rule {
     return this.cloneWithRules([{flag: 'reference'}])
   }
 
+  block(fn) {
+    return this.cloneWithRules([{flag: 'block', constraint: fn}])
+  }
+
   fields(rules) {
     if (this._type !== 'Object') {
       throw new Error('fields() can only be called on an object type')

--- a/packages/@sanity/validation/src/inferFromSchemaType.js
+++ b/packages/@sanity/validation/src/inferFromSchemaType.js
@@ -50,7 +50,7 @@ function inferFromSchemaType(typeDef, schema, visited = new Set()) {
   }
 
   if (type && type.name === 'block') {
-    base = base.custom(blockValidator)
+    base = base.block(blockValidator)
   }
 
   if (typeDef.annotations) {

--- a/packages/@sanity/validation/src/util/handleValidationResult.js
+++ b/packages/@sanity/validation/src/util/handleValidationResult.js
@@ -1,0 +1,29 @@
+/* eslint-disable complexity */
+const ValidationError = require('../ValidationError')
+const pathToString = require('./pathToString')
+
+module.exports = (result, message, options) => {
+  if (Array.isArray(result)) {
+    if (result.length === 0) {
+      return true
+    }
+    return result
+  }
+
+  if (result === true) {
+    return true
+  }
+
+  if (typeof result === 'string') {
+    return new ValidationError(message || result)
+  }
+
+  if (result && result.message && result.paths) {
+    return new ValidationError(message || result.message, {paths: result.paths})
+  }
+
+  const path = pathToString(options.path)
+  throw new Error(
+    `${path}: Validator must return 'true' if valid or an error message as a string on errors`
+  )
+}

--- a/packages/@sanity/validation/src/validators/blockValidator.js
+++ b/packages/@sanity/validation/src/validators/blockValidator.js
@@ -4,6 +4,10 @@ const {flatten} = require('lodash')
 
 // eslint-disable-next-line import/prefer-default-export
 export const blockValidator = async (value, options) => {
+  if (value.markDefs.length === 0) {
+    return []
+  }
+
   const {type} = options
   const childrenType = type.fields.find(field => field.name === 'children').type
   const spanType = childrenType.of.find(ofType => ofType.name === 'span')
@@ -21,12 +25,14 @@ export const blockValidator = async (value, options) => {
     })
     annotationValidations.push(validations)
   })
-  const result = await Promise.all(annotationValidations).then(flatten)
-  if (result.length) {
-    return result.map(res => {
+
+  const results = await Promise.all(annotationValidations).then(flatten)
+  if (results.length) {
+    return results.map(res => {
       res.item.paths = [res.path]
       return res.item
     })
   }
-  return true
+
+  return []
 }

--- a/packages/@sanity/validation/src/validators/genericValidator.js
+++ b/packages/@sanity/validation/src/validators/genericValidator.js
@@ -2,6 +2,7 @@ const Type = require('type-of-is')
 const {flatten} = require('lodash')
 const deepEquals = require('../util/deepEquals')
 const pathToString = require('../util/pathToString')
+const handleValidationResult = require('../util/handleValidationResult')
 const ValidationError = require('../ValidationError')
 
 const SLOW_VALIDATOR_TIMEOUT = 5000
@@ -87,29 +88,7 @@ const custom = async (fn, value, message, options) => {
 
   clearTimeout(slowTimer)
 
-  if (Array.isArray(result)) {
-    if (result.length === 0) {
-      return true
-    }
-    return result
-  }
-
-  if (result === true) {
-    return true
-  }
-
-  if (typeof result === 'string') {
-    return new ValidationError(message || result)
-  }
-
-  if (result && (result.message && result.paths)) {
-    return new ValidationError(message || result.message, {paths: result.paths})
-  }
-
-  const path = pathToString(options.path)
-  throw new Error(
-    `${path}: Validator must return 'true' if valid or an error message as a string on errors`
-  )
+  return handleValidationResult(result, message, options)
 }
 
 function formatValidationErrors(message, results, options = {}) {

--- a/packages/@sanity/validation/src/validators/objectValidator.js
+++ b/packages/@sanity/validation/src/validators/objectValidator.js
@@ -1,4 +1,6 @@
 const ValidationError = require('../ValidationError')
+const pathToString = require('../util/pathToString')
+const handleValidationResult = require('../util/handleValidationResult')
 const genericValidator = require('./genericValidator')
 
 const metaKeys = ['_key', '_type', '_weak']
@@ -28,6 +30,19 @@ const reference = (unused, value, message) => {
   return true
 }
 
+const block = async (validateBlock, value, message, options) => {
+  let result
+  try {
+    result = await validateBlock(value, options)
+  } catch (err) {
+    const path = pathToString(options.path)
+    err.message = `${path}: Error validating value: ${err.message}`
+    throw err
+  }
+
+  return handleValidationResult(result, message, options)
+}
+
 const assetRequired = (flag, value, message) => {
   if (!value || !value.asset || !value.asset._ref) {
     const assetType = flag.assetType || 'Asset'
@@ -40,5 +55,6 @@ const assetRequired = (flag, value, message) => {
 module.exports = Object.assign({}, genericValidator, {
   presence,
   reference,
+  block,
   assetRequired
 })

--- a/packages/@sanity/validation/test/strings.test.js
+++ b/packages/@sanity/validation/test/strings.test.js
@@ -116,14 +116,13 @@ describe('string', () => {
   })
 
   test('custom rule with string', async () => {
-    const rule = Rule.string().custom(
-      val =>
-        val
-          .split('')
-          .reverse()
-          .join('') === val
-          ? true
-          : 'Must be a palindrome!'
+    const rule = Rule.string().custom(val =>
+      val
+        .split('')
+        .reverse()
+        .join('') === val
+        ? true
+        : 'Must be a palindrome!'
     )
 
     await expect(rule.validate('hei')).resolves.toMatchSnapshot('not a palindrome')


### PR DESCRIPTION
**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

When validating the type `block`, it uses the `custom` validation function which spins up one or two `setTimeout`s which apparantly kills the browser.

**Description**

This PR changes the validation of a block to use it's own validation function. Earlier it used the 'custom' function which spins up one or two setTimeouts for each block. When working on huge documents that was too much for the browser (it seems, in Node it runs pretty good). This commit changes it to not use setTimeouts at all (if not the validation is overridden with an async validation function).

**Note for release**

Fix a performance issue when validating blocks

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
