### PR TITLE
[eventsource] Use forked eventsource polyfill

### DIFF
--- a/packages/@sanity/eventsource/browser.js
+++ b/packages/@sanity/eventsource/browser.js
@@ -1,3 +1,4 @@
 /* eslint-disable no-var */
-var evs = require('eventsource-polyfill/dist/eventsource')
+var evs = require('@rexxars/eventsource-polyfill')
+
 module.exports = window.EventSource || evs.EventSource

--- a/packages/@sanity/eventsource/package.json
+++ b/packages/@sanity/eventsource/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://www.sanity.io/",
   "dependencies": {
-    "eventsource": "^1.0.6",
-    "eventsource-polyfill": "^0.9.6"
+    "@rexxars/eventsource-polyfill": "^1.0.0",
+    "eventsource": "^1.0.6"
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

When trying to use listeners in React Native, the current polyfill implementation crashes because it tries to access `window.location.origin`, which is not defined.

**Description**

This PR uses a forked version of the polyfill, which addresses this (and a few other) issues. Can't guarantee that this makes listener work in react native, but it will at least prevent _that_ error from happening.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
