### PR TITLE
[eslint-config-sanity] Allow unescaped quotes in JSX

### DIFF
--- a/packages/eslint-config-sanity/react.js
+++ b/packages/eslint-config-sanity/react.js
@@ -76,7 +76,7 @@ module.exports = {
     'react/no-string-refs': 'warn',
     'react/no-this-in-sfc': 'error',
     'react/no-typos': 'error',
-    'react/no-unescaped-entities': 'error',
+    'react/no-unescaped-entities': ['error', {forbid: ['>', '}']}],
     'react/no-unknown-property': 'error',
     'react/no-unused-prop-types': 'error',
     'react/no-unused-state': 'error',


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [x]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

```jsx
<div>It's a "thing"</div>
```

has to be written as either

```jsx
<div>It&apos;s a &quot;thing&quot;</div>
```

or

```jsx
<div>It{"'"}s a {'"'}thing{'"'}</div>
```

...making the code hard to read. I've rarely (if ever) encountered this warning in cases where it legitimately was an error on my part. 

**Description**

This changes the eslint rule to allow quotes, but still disallow unescaped `}` and `>`, as those are rarely used in normal text flow.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title is appropriately formatted: `[some-package] PR title`
- [x]  The code is linted
- [x]  The test suite is passing
