### PR TITLE
[form-builder] support list option on number fields (#1858)

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/SelectInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/SelectInput.tsx
@@ -7,7 +7,9 @@ import {Type, Marker} from '../typedefs'
 import {uniqueId} from 'lodash'
 const EMPTY_ITEM = {title: '', value: undefined}
 function toSelectItems(list) {
-  return typeof list[0] === 'string' ? list.map(item => ({title: item, value: item})) : list
+  return typeof list[0] === 'string' || typeof list[0] === 'number'
+    ? list.map(item => ({title: item, value: item}))
+    : list
 }
 type Props = {
   type: Type
@@ -26,7 +28,9 @@ export default class StringSelect extends React.Component<Props> {
   }
   handleChange = (item: Record<string, any>) => {
     const {onChange} = this.props
-    onChange(PatchEvent.from(set(typeof item === 'string' ? item : item.value)))
+    onChange(
+      PatchEvent.from(set(typeof item === 'string' || typeof item === 'number' ? item : item.value))
+    )
   }
   focus() {
     if (this._input) {

--- a/packages/@sanity/form-builder/src/sanity/inputResolver/inputResolver.ts
+++ b/packages/@sanity/form-builder/src/sanity/inputResolver/inputResolver.ts
@@ -4,6 +4,7 @@ import * as is from '../../utils/is'
 import resolveReferenceInput from './resolveReferenceInput'
 import resolveArrayInput from './resolveArrayInput'
 import resolveStringInput from './resolveStringInput'
+import resolveNumberInput from './resolveNumberInput'
 
 function getExport(obj) {
   return obj && obj.__esModule ? obj.default : obj
@@ -30,6 +31,10 @@ function resolveTypeVariants(type) {
   // String input with a select
   if (is.type('string', type)) {
     return resolveStringInput(type)
+  }
+
+  if (is.type('number', type)) {
+    return resolveNumberInput(type)
   }
 
   return null

--- a/packages/@sanity/form-builder/src/sanity/inputResolver/resolveNumberInput.ts
+++ b/packages/@sanity/form-builder/src/sanity/inputResolver/resolveNumberInput.ts
@@ -1,0 +1,7 @@
+import NumberSelect from '../../inputs/SelectInput'
+import NumberInput from '../../inputs/NumberInput'
+import {getOption} from './resolveStringInput'
+
+export default function resolveNumberInput(type) {
+  return getOption(type, 'list') ? NumberSelect : NumberInput
+}


### PR DESCRIPTION
Hello Sanity 👋 very happy user of your products here hoping to make a small contribution 🙂!

<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [X]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Note: I do not believe this is a breaking change. I have done some manual testing, see below.**

**Does this change require a documentation update? (Check one)**

- [X]  Yes
- [ ]  No

I was not sure exactly where to update docs for this, but i am happy to make the update as well!

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->

**Description**

Number type fields currently accept a `list` option and perform validation using the `list` as expected, however the input component rendered does not reflect the valid options:

<img width="863" alt="Screen Shot 2020-04-27 at 9 18 52 PM" src="https://user-images.githubusercontent.com/29342769/80436259-bdf6de80-88cc-11ea-9581-82362e174d60.png">

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

This PR updates `number` type fields to behave the same way as `string` fields, when a `list` is provided in `options`.

<img width="770" alt="Screen Shot 2020-04-27 at 8 51 44 PM" src="https://user-images.githubusercontent.com/29342769/80435451-88e98c80-88ca-11ea-8c4a-5ae74757eef3.png">

<img width="470" alt="Screen Shot 2020-04-27 at 8 52 02 PM" src="https://user-images.githubusercontent.com/29342769/80435452-8ab35000-88ca-11ea-8cf6-254f75b80fd8.png">

Schema changes used to test:

```
+    {
+      name: 'testNumberNoList',
+      title: 'Test Number - No List',
+      type: 'number'
+    },
+    {
+      name: 'testNumberWithListObjects',
+      title: 'Test Number - List Objects',
+      type: 'number',
+      options: {
+        list: [
+          {value: 1, title: 'One'},
+          {value: 2, title: 'Two'}
+        ]
+      }
+    },
+    {
+      name: 'testNumberWithListValues',
+      title: 'Test Number - List Values',
+      type: 'number',
+      options: {
+        list: [1, 2]
+      }
+    },
```

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

Fields of type `number` with an `options.list` value will now render a select input, in the same way fields of type `string` do.

**Checklist** 

- [X]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue - N/A
- [X]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [X]  The code is linted - **Note:** There was a warning given about `missing return type` on `resolveNumberInput`, I left this out because there was no return type annotation in the other similar files, if it is desired i can add the annotation
- [X]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
