### PR TITLE
[desk-tool] Prevent duplicate publish Snackbars when using split panes

### DIFF
--- a/packages/@sanity/base/src/components/DevServerStatus.js
+++ b/packages/@sanity/base/src/components/DevServerStatus.js
@@ -86,6 +86,7 @@ class DevServerStatus extends PureComponent {
           title={<strong>Reload required!</strong>}
           subtitle={<div>To see your latest changes, you need to reload the browser window.</div>}
           action={{title: 'Reload', callback: () => window.location.reload()}}
+          allowDuplicateSnackbarType
         />
       )
     }
@@ -104,6 +105,7 @@ class DevServerStatus extends PureComponent {
               </div>
             </Spinner>
           }
+          allowDuplicateSnackbarType
         />
       )
     }
@@ -135,6 +137,7 @@ class DevServerStatus extends PureComponent {
               project folder.
             </div>
           }
+          allowDuplicateSnackbarType
         />
       )
     }

--- a/packages/@sanity/components/src/snackbar/DefaultSnackbar.js
+++ b/packages/@sanity/components/src/snackbar/DefaultSnackbar.js
@@ -19,7 +19,7 @@ export default class DefaultSnackbar extends React.PureComponent {
     onAction: PropTypes.func,
     actionTitle: PropTypes.string,
     timeout: PropTypes.number,
-    preventDuplicate: PropTypes.bool
+    allowDuplicateSnackbarType: PropTypes.bool
   }
 
   static contextTypes = {
@@ -45,7 +45,7 @@ export default class DefaultSnackbar extends React.PureComponent {
       onAction,
       isPersisted,
       isCloseable,
-      preventDuplicate
+      allowDuplicateSnackbarType
     } = this.props
 
     return {
@@ -61,7 +61,7 @@ export default class DefaultSnackbar extends React.PureComponent {
       isPersisted,
       isCloseable,
       autoDismissTimeout: timeout,
-      preventDuplicate
+      allowDuplicateSnackbarType
     }
   }
 

--- a/packages/@sanity/components/src/snackbar/SnackbarProvider.js
+++ b/packages/@sanity/components/src/snackbar/SnackbarProvider.js
@@ -63,7 +63,7 @@ export default class SnackbarProvider extends React.Component {
       ...contextSnack
     }
 
-    if (newSnack.preventDuplicate) {
+    if (!newSnack.allowDuplicateSnackbarType) {
       const isInQueue = this.snackQueue.findIndex(snack => snack.kind === newSnack.kind) > -1
       const isInActive = activeSnacks.findIndex(snack => snack.kind === newSnack.kind) > -1
 

--- a/packages/@sanity/desk-tool/src/panes/documentPane/DocumentOperationResults.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/DocumentOperationResults.tsx
@@ -56,13 +56,12 @@ export const DocumentOperationResults = React.memo((props: Props) => {
             {event.error.message}
           </details>
         }
-        preventDuplicate
       />
     )
   }
 
   if (event && event.type === 'success' && !IGNORE_OPS.includes(event.op)) {
-    return <Snackbar key={Math.random()} kind="success" title={getOpSuccessTitle(event.op)} preventDuplicate />
+    return <Snackbar key={Math.random()} kind="success" title={getOpSuccessTitle(event.op)} />
   }
 
   return null

--- a/packages/@sanity/desk-tool/src/panes/documentPane/DocumentOperationResults.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/DocumentOperationResults.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import Snackbar from 'part:@sanity/components/snackbar/default'
 import {useDocumentOperationEvent} from '@sanity/react-hooks'
 
-function getOpErrorTitle(op) {
+function getOpErrorTitle(op: string): string {
   if (op === 'delete') {
     return `An error occurred while attempting to delete this document.
       This usually means that there are other documents that refers to it.`
@@ -14,7 +14,7 @@ function getOpErrorTitle(op) {
   return `An error occurred during ${op}`
 }
 
-function getOpSuccessTitle(op) {
+function getOpSuccessTitle(op: string): string {
   if (op === 'publish') {
     return `This document is now published.`
   }
@@ -32,7 +32,12 @@ function getOpSuccessTitle(op) {
 
 const IGNORE_OPS = ['patch', 'commit']
 
-export const DocumentOperationResults = React.memo((props: {id: string; type: string}) => {
+type Props = {
+  id: string
+  type: string
+}
+
+export const DocumentOperationResults = React.memo((props: Props) => {
   const event: any = useDocumentOperationEvent(props.id, props.type)
 
   if (!event) {
@@ -51,12 +56,13 @@ export const DocumentOperationResults = React.memo((props: {id: string; type: st
             {event.error.message}
           </details>
         }
+        preventDuplicate
       />
     )
   }
 
   if (event && event.type === 'success' && !IGNORE_OPS.includes(event.op)) {
-    return <Snackbar key={Math.random()} kind="success" title={getOpSuccessTitle(event.op)} />
+    return <Snackbar key={Math.random()} kind="success" title={getOpSuccessTitle(event.op)} preventDuplicate />
   }
 
   return null

--- a/packages/@sanity/desk-tool/src/panes/documentPane/DocumentPane.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/DocumentPane.tsx
@@ -865,7 +865,6 @@ export default class DocumentPane extends React.PureComponent<Props, State> {
               kind="warning"
               title="Connection lost. Reconnecting when online…"
               isPersisted
-              preventDuplicate
             />
           )}
           <DocumentOperationResults id={options.id} type={options.type} />


### PR DESCRIPTION
**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

When publishing a document when using split panes, you get _n_ amount of Snackbar messages based on how many panes are open.

**Description**

This PR uses the `preventDuplicate` functionality already available in the `SnackbarProvider` to prevent multiple instances of the same Snackbar type to appear.

Not sure if this was the intended solution for this, as it still generates multiple Snackbars when multiples panes are open. It kind of just swallows if it's of the same type in this PR. I saw other Snackbars which would also appear multiple times from what I can see, as they are rendered in each pane. A more robust way to fix this would be to move the connectionstate up in the hierarchy and have a common place for handling connectionstate Snackbars and document actions Snackbars. What do you think?

**Note for release**

Fix a problem where publishing a document when multiple panes are open would generate multiple Snackbars

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
