### PR TITLE
[chore] Upgrade get-it dependency

### DIFF
--- a/packages/@sanity/client/package.json
+++ b/packages/@sanity/client/package.json
@@ -26,7 +26,7 @@
     "@sanity/generate-help-url": "1.149.0",
     "@sanity/observable": "1.149.0",
     "deep-assign": "^2.0.0",
-    "get-it": "^5.0.0",
+    "get-it": "^5.0.3",
     "make-error": "^1.3.0",
     "object-assign": "^4.1.1"
   },

--- a/packages/@sanity/import/package.json
+++ b/packages/@sanity/import/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@sanity/client": "1.149.7",
-    "get-it": "^5.0.0",
+    "get-it": "^5.0.3",
     "jest": "^24.9.0",
     "nock": "^9.0.5",
     "rimraf": "^2.7.1"


### PR DESCRIPTION
**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [x]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Description**

Upgrades the `get-it` dependency in the client + import to the latest version, which fixes a bug where error middlewares would be called with `null`/`undefined` if errors were handled by a previous middleware. When the `retry` middleware successfully retried a request, it would flag the error as being handled, but any following error handers would still be called with `null` as the first argument, often crashing because they were expecting an `Error`.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
