### PR TITLE
Improve editor experience when disconnecting in the Studio

### DIFF
--- a/packages/@sanity/base/src/components/QueryContainer.js
+++ b/packages/@sanity/base/src/components/QueryContainer.js
@@ -14,7 +14,7 @@ import {
   refCount
 } from 'rxjs/operators'
 
-import {combineLatest, concat, merge, of} from 'rxjs'
+import {combineLatest, concat, merge, of, fromEvent} from 'rxjs'
 import deepEquals from 'react-fast-compare'
 import {createEventHandler, streamingComponent} from 'react-props-stream'
 import {listenQuery} from '../datastores/document/listenQuery'
@@ -59,7 +59,10 @@ export const getQueryResults = receivedProps$ => {
   return queryResults$.pipe(
     startWith(INITIAL_CHILD_PROPS),
     catchError((err, caught$) =>
-      concat(of(createErrorChildProps(err)), onRetry$.pipe(take(1), mergeMapTo(caught$)))
+      concat(
+        of(createErrorChildProps(err)),
+        merge(fromEvent(window, 'online'), onRetry$).pipe(take(1), mergeMapTo(caught$))
+      )
     ),
     scan((prev, next) => ({...prev, ...next, onRetry}))
   )

--- a/packages/@sanity/components/src/snackbar/DefaultSnackbar.js
+++ b/packages/@sanity/components/src/snackbar/DefaultSnackbar.js
@@ -18,7 +18,8 @@ export default class DefaultSnackbar extends React.PureComponent {
     // Legacy props
     onAction: PropTypes.func,
     actionTitle: PropTypes.string,
-    timeout: PropTypes.number
+    timeout: PropTypes.number,
+    preventDuplicate: PropTypes.bool
   }
 
   static contextTypes = {
@@ -43,7 +44,8 @@ export default class DefaultSnackbar extends React.PureComponent {
       onClose,
       onAction,
       isPersisted,
-      isCloseable
+      isCloseable,
+      preventDuplicate
     } = this.props
 
     return {
@@ -58,7 +60,8 @@ export default class DefaultSnackbar extends React.PureComponent {
       },
       isPersisted,
       isCloseable,
-      autoDismissTimeout: timeout
+      autoDismissTimeout: timeout,
+      preventDuplicate
     }
   }
 

--- a/packages/@sanity/desk-tool/src/panes/documentPane/DocumentPane.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/DocumentPane.tsx
@@ -861,7 +861,12 @@ export default class DocumentPane extends React.PureComponent<Props, State> {
             <InspectView value={value} onClose={this.handleHideInspector} />
           )}
           {connectionState === 'reconnecting' && (
-            <Snackbar kind="warning" isPersisted title="Connection lost. Reconnecting…" />
+            <Snackbar
+              kind="warning"
+              title="Connection lost. Reconnecting when online…"
+              isPersisted
+              preventDuplicate
+            />
           )}
           <DocumentOperationResults id={options.id} type={options.type} />
         </TabbedPane>


### PR DESCRIPTION
**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [x]  Other, please describe: Improvement

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

When disconnecting from the internet in the Studio, the document list pane throws an error snackbar because the listener crashes. A different component is also showing a connectivity indicator as well. So when disconnecting, you are getting hit in the face with multiple errors.

**Description**

This PR currently adds a retry when the browser send the `online` event. Basically when you get an internet connection back on your computer. It also removes a duplicate snackbar being generated when you lose the connection to the server.

What I want to do:
- Add a small delay to let the `online` event kick off before actually showing an error message. Let it try to recover within reasonable amount of time

**Note for release**

TBD.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [ ]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [ ]  The code is linted
- [ ]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
