### PR TITLE
[form-builder] Fix fieldset columns layout

### DIFF
--- a/packages/@sanity/components/src/fieldsets/styles/DefaultFieldset.css
+++ b/packages/@sanity/components/src/fieldsets/styles/DefaultFieldset.css
@@ -2,7 +2,7 @@
 @import 'part:@sanity/base/theme/variables-style';
 
 .root {
-  composes: root from "part:@sanity/components/formfields/default-style";
+  composes: root from 'part:@sanity/components/formfields/default-style';
   outline: none;
 }
 
@@ -14,6 +14,12 @@
 .root + .root {
   /* Margin between fieldsets */
   margin-top: var(--medium-padding);
+}
+
+.fieldWrapper {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-gap: var(--large-padding);
 }
 
 .fieldset {

--- a/packages/@sanity/form-builder/src/inputs/ObjectInput/ObjectInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ObjectInput/ObjectInput.tsx
@@ -7,6 +7,8 @@ import isEmpty from '../../utils/isEmpty'
 import UnknownFields from './UnknownFields'
 import fieldStyles from './styles/Field.css'
 
+import styles from './styles/ObjectInput.css'
+
 function getCollapsedWithDefaults(options: Record<string, any> = {}, level) {
   // todo: warn on "collapsable" and deprecate collapsible in favor of just "collapsed"
   //       --> relevant: https://github.com/sanity-io/sanity/issues/537
@@ -173,9 +175,11 @@ export default class ObjectInput extends React.PureComponent<ObjectInputProps, {
     const renderedUnknownFields = this.renderUnknownFields()
     if (level === 0) {
       return (
-        <div>
-          {renderedFields}
-          {renderedUnknownFields}
+        <div className={styles.root}>
+          <div className={styles.fieldWrapper}>
+            {renderedFields}
+            {renderedUnknownFields}
+          </div>
         </div>
       )
     }
@@ -183,17 +187,19 @@ export default class ObjectInput extends React.PureComponent<ObjectInputProps, {
     const isExpanded = focusPath.length > 0
     const columns = type.options && type.options.columns
     return (
-      <Fieldset
-        level={level}
-        legend={type.title}
-        description={type.description}
-        columns={columns}
-        isCollapsible={collapsibleOpts.collapsible}
-        isCollapsed={!isExpanded && collapsibleOpts.collapsed}
-      >
-        {renderedFields}
-        {renderedUnknownFields}
-      </Fieldset>
+      <div className={styles.root}>
+        <Fieldset
+          level={level}
+          legend={type.title}
+          description={type.description}
+          columns={columns}
+          isCollapsible={collapsibleOpts.collapsible}
+          isCollapsed={!isExpanded && collapsibleOpts.collapsed}
+        >
+          {renderedFields}
+          {renderedUnknownFields}
+        </Fieldset>
+      </div>
     )
   }
 }

--- a/packages/@sanity/form-builder/src/inputs/ObjectInput/styles/Field.css
+++ b/packages/@sanity/form-builder/src/inputs/ObjectInput/styles/Field.css
@@ -5,7 +5,3 @@
   width: 100%;
   box-sizing: border-box;
 }
-
-.root + .root {
-  margin-top: var(--large-padding);
-}

--- a/packages/@sanity/form-builder/src/inputs/ObjectInput/styles/ObjectInput.css
+++ b/packages/@sanity/form-builder/src/inputs/ObjectInput/styles/ObjectInput.css
@@ -1,0 +1,11 @@
+@import 'part:@sanity/base/theme/variables-style';
+
+.root {
+  /* empty */
+}
+
+.fieldWrapper {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-gap: var(--large-padding);
+}

--- a/packages/test-studio/schemas/fieldsets.js
+++ b/packages/test-studio/schemas/fieldsets.js
@@ -10,7 +10,18 @@ export default {
       title: 'myObject.first'
     }
   },
-  fieldsets: [{name: 'recursive', title: 'Recursive', options: {collapsable: true}}],
+  fieldsets: [
+    {
+      name: 'recursive',
+      title: 'Recursive',
+      options: {collapsable: true}
+    },
+    {
+      name: 'settings',
+      title: 'Settings',
+      options: {columns: 2}
+    }
+  ],
   fields: [
     {
       name: 'myObject',
@@ -18,6 +29,10 @@ export default {
       title: 'MyObject',
       description: 'The first field here should be the title'
     },
+    {type: 'number', name: 'x', title: 'X position', fieldset: 'settings'},
+    {type: 'number', name: 'y', title: 'Y position', fieldset: 'settings'},
+    {type: 'number', name: 'width', title: 'Width', fieldset: 'settings'},
+    {type: 'number', name: 'height', title: 'Height', fieldset: 'settings'},
     {
       name: 'person',
       type: 'object',


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->

- Fixes https://github.com/sanity-io/sanity/issues/1877
- Fixes https://github.com/sanity-io/sanity-priv/issues/2094
- https://github.com/sanity-io/sanity-priv/issues/2095
- https://sanity-io.slack.com/archives/CA9HS8MQQ/p1588948049459600?thread_ts=1588947505.455400&cid=CA9HS8MQQ

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

- Add an example of fieldset columns layout to the `fieldsetsTest` type in Test Studio
- Move responsibility of spacing fields away from `Field` to `ObjectField` and `DefaultFieldset`
- Add `ObjectField.css` with a `.fieldWrapper` to apply CSS grid

**Test script**

1. Start the Studio locally
1. Go to http://localhost:3333/test/desk/fieldsetsTest;b79acf77-6d67-482e-9a25-7c73a901980e
1. Make sure the "Settings" fieldset renders a grid of 2 columns, and that fields are spaced/aligned properly
1. Make sure all fields are spaced/aligned properly, as they used to be (since this change replaces the way regular fields were spaced)

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

- “Fixes a issue with rendering fieldset columns layout”

**Checklist** 

- [ ]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [ ] ~The test suite is passing~
- [ ] ~Corresponding changes to the documentation have been made~
