### PR TITLE
[components] Make DefaultPreview more resilient to being placed within CSS grids

### DIFF
--- a/packages/@sanity/base/src/styles/variables/globals.css
+++ b/packages/@sanity/base/src/styles/variables/globals.css
@@ -4,7 +4,7 @@
   --body-text: color(var(--body-bg) contrast(57%));
   --component-bg: #fff;
   --component-text-color: color(var(--component-bg) contrast(80%));
-  --preview-placeholder-color: color(var(--component-bg) contrast(80%) alpha(10%));
+  --preview-placeholder-color: var(--gray-lightest);
   --component-border-color: color(var(--component-bg) contrast(80%) a(20%));
   --backdrop-color: color(var(--brand-darkest) a(12%));
   --main-navigation-color: color(var(--brand-primary) shade(70%) saturation(20%));

--- a/packages/@sanity/components/src/previews/DefaultPreview.js
+++ b/packages/@sanity/components/src/previews/DefaultPreview.js
@@ -1,4 +1,5 @@
 /* eslint-disable complexity */
+
 import PropTypes from 'prop-types'
 import React from 'react'
 import defaultStyles from 'part:@sanity/components/previews/default-style'
@@ -20,16 +21,21 @@ class DefaultPreview extends React.PureComponent {
     media: fieldProp,
     isPlaceholder: PropTypes.bool,
     children: PropTypes.node,
+    // eslint-disable-next-line react/forbid-prop-types
     styles: PropTypes.object,
     progress: PropTypes.number
   }
 
   static defaultProps = {
+    children: undefined,
     title: 'Untitled',
     subtitle: undefined,
     progress: undefined,
+    isPlaceholder: undefined,
     media: undefined,
-    mediaDimensions: {width: 80, height: 80, aspect: 1, fit: 'crop'}
+    mediaDimensions: {width: 80, height: 80, aspect: 1, fit: 'crop'},
+    status: undefined,
+    styles: undefined
   }
 
   render() {
@@ -48,10 +54,12 @@ class DefaultPreview extends React.PureComponent {
     if (isPlaceholder) {
       return (
         <div className={styles.placeholder}>
-          {media !== false && <div className={styles.media} />}
-          <div className={styles.heading}>
-            <h2 className={styles.title}>Loading…</h2>
-            <h3 className={styles.subtitle}>Loading…</h3>
+          <div className={styles.inner}>
+            {media !== false && <div className={styles.media} />}
+            <div className={styles.heading}>
+              <h2 className={styles.title}>Loading…</h2>
+              <h3 className={styles.subtitle}>Loading…</h3>
+            </div>
           </div>
         </div>
       )
@@ -64,37 +72,45 @@ class DefaultPreview extends React.PureComponent {
           ${subtitle ? styles.hasSubtitle : ''}
         `}
       >
-        {media !== false && (
-          <div className={styles.media}>
-            {typeof media === 'function' && media({dimensions: mediaDimensions, layout: 'default'})}
-            {typeof media === 'string' && <div className={styles.mediaString}>{media}</div>}
-            {React.isValidElement(media) && media}
-          </div>
-        )}
+        <div className={styles.inner}>
+          {media !== false && (
+            <div className={styles.media}>
+              {typeof media === 'function' &&
+                media({dimensions: mediaDimensions, layout: 'default'})}
 
-        <div className={styles.heading}>
-          <h2 className={styles.title}>
-            {typeof title !== 'function' && title}
-            {typeof title === 'function' && title({layout: 'default'})}
-          </h2>
-          {subtitle && (
-            <h3 className={styles.subtitle}>
-              {(typeof subtitle === 'function' && subtitle({layout: 'default'})) || subtitle}
-            </h3>
+              {typeof media === 'string' && <div className={styles.mediaString}>{media}</div>}
+
+              {React.isValidElement(media) && media}
+            </div>
           )}
-        </div>
-        {status && (
-          <div className={styles.status}>
-            {(typeof status === 'function' && status({layout: 'default'})) || status}
+
+          <div className={styles.heading}>
+            <h2 className={styles.title}>
+              {typeof title !== 'function' && title}
+              {typeof title === 'function' && title({layout: 'default'})}
+            </h2>
+
+            {subtitle && (
+              <h3 className={styles.subtitle}>
+                {(typeof subtitle === 'function' && subtitle({layout: 'default'})) || subtitle}
+              </h3>
+            )}
           </div>
-        )}
-        {children && <div className={styles.children}>{children}</div>}
-        {typeof progress === 'number' &&
-          progress > -1 && (
+
+          {status && (
+            <div className={styles.status}>
+              {(typeof status === 'function' && status({layout: 'default'})) || status}
+            </div>
+          )}
+
+          {children && <div className={styles.children}>{children}</div>}
+
+          {typeof progress === 'number' && progress > -1 && (
             <div className={styles.progress}>
               <div className={styles.progressBar} style={{width: `${progress}%`}} />
             </div>
           )}
+        </div>
       </div>
     )
   }

--- a/packages/@sanity/components/src/previews/styles/DefaultPreview.css
+++ b/packages/@sanity/components/src/previews/styles/DefaultPreview.css
@@ -17,14 +17,22 @@
 }
 
 .root {
-  display: flex;
-  justify-content: space-between;
+  position: relative;
   width: 100%;
   padding: 0;
   user-select: none;
-  height: 2.5em;
-  position: relative;
   clear: both;
+  height: 2.5em;
+}
+
+.inner {
+  position: absolute;
+  display: flex;
+  justify-content: space-between;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2.5em;
 }
 
 .hasSubtitle {
@@ -115,20 +123,24 @@
   @nest & .heading {
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
     height: 100%;
+    padding-top: 0.25rem;
   }
 
   @nest & .title {
     width: 80%;
+    height: 12px;
     color: transparent;
     background-color: var(--preview-placeholder-color);
   }
 
   @nest & .subtitle {
     width: 40%;
+    height: 8px;
     color: transparent;
     background-color: var(--preview-placeholder-color);
+    margin-top: 0.5rem;
+    padding: 0;
   }
 
   @nest & .media {


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->

The recent release that placed form fields in a vertical grid, caused the rendering of DefaultPreview to behave differently. Specifically, there was an issue with text-overflow not working, and forcing the width of all other field elements to exceed their bounds.

See report here: https://sanity-io.slack.com/archives/CAJ4KP63G/p1589363595001100

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

This change adds a container (`.inner`) in DefaultPreview that has `position: absolute`. This caused `text-overflow` to behave in a much more resilient manner.

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [ ] ~The test suite is passing~
- [ ] ~Corresponding changes to the documentation have been made~
