### PR TITLE
[components] Tweak avatar component

### DIFF
--- a/packages/@sanity/components/src/presence/AvatarCircle.css
+++ b/packages/@sanity/components/src/presence/AvatarCircle.css
@@ -8,6 +8,11 @@
   pointer-events: auto;
   display: flex;
   user-select: none;
+  box-shadow: 0 0 0 1px var(--component-bg);
+
+  &[data-tone='navbar'] {
+    box-shadow: 0 0 0 1px var(--main-navigation-color);
+  }
 }
 
 .avatar {
@@ -46,19 +51,19 @@
   }
 }
 
-.avatar[data-size="xsmall"] {
+.avatar[data-size='xsmall'] {
   font-size: calc(var(--avatar-height) * 0.8);
   width: calc(var(--avatar-height) * 0.8);
   height: calc(var(--avatar-height) * 0.8);
 }
 
-.avatar[data-size="small"] {
+.avatar[data-size='small'] {
   font-size: var(--avatar-height);
   width: var(--avatar-height);
   height: var(--avatar-height);
 }
 
-.avatar[data-size="medium"] {
+.avatar[data-size='medium'] {
   font-size: calc(var(--avatar-height) * 1.3);
   width: calc(var(--avatar-height) * 1.3);
   height: calc(var(--avatar-height) * 1.3);
@@ -86,6 +91,23 @@
   }
 }
 
+.border {
+  fill: var(--component-bg);
+
+  @nest .root[data-tone='navbar'] & {
+    fill: var(--main-navigation-color);
+  }
+}
+
+.backgroundFill {
+  stroke-width: 1;
+  stroke: var(--component-bg);
+
+  @nest .root[data-tone='navbar'] & {
+    stroke: var(--main-navigation-color);
+  }
+}
+
 .arrow {
   position: absolute;
   width: 100%;
@@ -98,11 +120,11 @@
   transform: rotate(-90deg) translate3d(0, 5px, 0);
 
   @nest & > svg {
-    width: 0.3em;
-    height: 0.3em;
+    width: 11px;
+    height: 7px;
     position: absolute;
-    top: -0.25em;
-    left: calc((100% - 0.3em) / 2);
+    top: -4px;
+    left: calc(50% - 5.5px);
   }
 }
 
@@ -112,15 +134,11 @@
 }
 
 .arrow[data-dock='top'] {
-  display: block;
-  top: 1px;
   opacity: 1;
   transform: rotate(0deg);
 }
 
 .arrow[data-dock='bottom'] {
-  bottom: 1px;
-  display: block;
   opacity: 1;
   transform: rotate(-180deg);
 }

--- a/packages/@sanity/components/src/presence/AvatarCircle.tsx
+++ b/packages/@sanity/components/src/presence/AvatarCircle.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import React, {useState, useEffect} from 'react'
 import {useId} from '@reach/auto-id'
 import styles from './AvatarCircle.css'
@@ -5,8 +6,6 @@ import {Position, Status, Size} from './types'
 
 type Props = {
   borderColor: string
-  fillColor?: string
-  showFill?: boolean
   imageUrl?: string
   label: string
   isAnimating?: boolean
@@ -15,12 +14,14 @@ type Props = {
   position?: Position
   status?: Status
   size?: Size
+  tone?: 'navbar'
 }
+
+const W = 21
+const H = 21
 
 export default function AvatarCircle({
   borderColor = 'currentColor',
-  fillColor = 'white',
-  showFill = true,
   imageUrl,
   label,
   isAnimating = false,
@@ -28,7 +29,8 @@ export default function AvatarCircle({
   onImageLoadError,
   position = 'inside',
   status = 'online',
-  size = 'small'
+  size = 'small',
+  tone
 }: Props) {
   const elementId = useId()
   const [arrowPosition, setArrowPosition] = useState('inside')
@@ -43,37 +45,50 @@ export default function AvatarCircle({
   }, [])
 
   return (
-    <div className={styles.root} data-dock={arrowPosition} aria-label={label} title={label}>
-      <div className={`${styles.avatar}`} data-status={status} data-size={size}>
+    <div
+      className={styles.root}
+      data-dock={arrowPosition}
+      data-tone={tone}
+      aria-label={label}
+      title={label}
+    >
+      <div className={styles.avatar} data-status={status} data-size={size}>
+        <div className={styles.arrow} data-dock={arrowPosition}>
+          <svg viewBox="0 0 11 7" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path
+              d="M6.67948 1.50115L11 7L0 7L4.32052 1.50115C4.92109 0.736796 6.07891 0.736795 6.67948 1.50115Z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
         <div className={styles.avatarInner}>
-          <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <svg viewBox={`0 0 ${W} ${H}`} fill="none" xmlns="http://www.w3.org/2000/svg">
             <ellipse
               data-avatar-border
-              cx="16"
-              cy="16"
-              rx="15"
-              ry="15"
-              transform="rotate(90 16 16)"
+              cx={W / 2}
+              cy={H / 2}
+              rx={W / 2 - 1}
+              ry={H / 2 - 1}
+              transform={`rotate(90 ${W / 2} ${H / 2})`}
               stroke={borderColor}
-              className={`
-                ${styles.border}
-                ${isAnimating && styles.isAnimating}
-              `}
+              className={classNames(styles.border, isAnimating && styles.isAnimating)}
             />
-            <ellipse
-              data-avatar-fill
-              cx="16"
-              cy="16"
-              rx="14"
-              ry="14"
-              transform="rotate(-90 16 16)"
-              fill={fillColor}
-            />
+            {imageUrl && (
+              <ellipse
+                className={styles.backgroundFill}
+                data-avatar-fill
+                cx={W / 2}
+                cy={H / 2}
+                rx={W / 2 - 2}
+                ry={H / 2 - 2}
+                transform={`rotate(90 ${W / 2} ${H / 2})`}
+              />
+            )}
             <circle
               data-avatar-image
-              cx="16"
-              cy="16"
-              r={showFill ? 13 : 14.2}
+              cx={W / 2}
+              cy={H / 2}
+              r={W / 2 - 2}
               fill={imageUrl ? `url(#${elementId}-image-url)` : 'currentColor'}
             />
             <defs>
@@ -95,14 +110,6 @@ export default function AvatarCircle({
             </defs>
           </svg>
           {children && <div className={styles.avatarInitials}>{children}</div>}
-        </div>
-        <div className={styles.arrow} data-dock={arrowPosition}>
-          <svg viewBox="0 0 10 7" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path
-              d="M0 6.4H9.6L5.44 0.853333C5.12 0.426666 4.48 0.426666 4.16 0.853333L0 6.4Z"
-              fill="currentColor"
-            />
-          </svg>
         </div>
       </div>
     </div>

--- a/packages/@sanity/components/src/presence/GlobalStatus.tsx
+++ b/packages/@sanity/components/src/presence/GlobalStatus.tsx
@@ -61,10 +61,10 @@ export function GlobalStatus({projectId, presence}: Props) {
           </div>
           {/* Show avatars laid out like on a field */}
           <div className={styles.avatars}>
-            {showCounter && <StackCounter count={hiddenUsers.length} />}
+            {showCounter && <StackCounter count={hiddenUsers.length} tone="navbar" />}
             {visibleUsers.map(presentUser => (
               <div className={styles.avatarOverlap} key={presentUser.user.id}>
-                <UserAvatar user={presentUser.user} fillColor="currentColor" color="#ea5fb1" />
+                <UserAvatar user={presentUser.user} tone="navbar" />
               </div>
             ))}
           </div>

--- a/packages/@sanity/components/src/presence/StackCounter.css
+++ b/packages/@sanity/components/src/presence/StackCounter.css
@@ -5,22 +5,25 @@
 }
 
 .counter {
+  color: inherit;
   align-self: center;
-  background: var(--white);
-  min-height: calc(var(--avatar-height) - 1px);
-  min-width: calc(var(--avatar-height) - 1px);
+  background: var(--component-bg);
+  min-height: var(--avatar-height);
+  min-width: var(--avatar-height);
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 2rem;
-  border: 1px solid var(--text-color);
-  color: var(--text-color);
+  border-radius: calc(var(--avatar-height) / 2);
+  box-shadow: inset 0 0 0 1.5px var(--gray);
   font-size: var(--font-size-tiny);
-  padding: 0 var(--extra-small-padding);
+  padding: 0 calc(var(--small-padding) - 2px);
   box-sizing: border-box;
-  margin-right: 3px;
   font-weight: 600;
   user-select: none;
+
+  @nest .root[data-tone='navbar'] & {
+    background: var(--main-navigation-color);
+  }
 }
 
 .isGlobal {
@@ -28,5 +31,4 @@
   color: var(--main-navigation-color--inverted);
   font-size: var(--font-size-tiny--relative);
   background: var(--main-navigation-color);
-  margin-right: -6px;
 }

--- a/packages/@sanity/components/src/presence/StackCounter.tsx
+++ b/packages/@sanity/components/src/presence/StackCounter.tsx
@@ -4,11 +4,12 @@ import styles from './StackCounter.css'
 type Props = {
   count: number
   isGlobal?: boolean
+  tone?: 'navbar'
 }
 
-export default function StackCounter({count, isGlobal = false}: Props) {
+export default function StackCounter({count, isGlobal = false, tone}: Props) {
   return (
-    <div className={styles.root} key="counter">
+    <div className={styles.root} data-tone={tone} key="counter">
       <div className={`${styles.counter} ${isGlobal ? styles.isGlobal : ''}`}>{count}</div>
     </div>
   )

--- a/packages/@sanity/components/src/presence/UserAvatar.tsx
+++ b/packages/@sanity/components/src/presence/UserAvatar.tsx
@@ -6,11 +6,10 @@ import {User} from './types'
 export type Props = {
   user: User
   color?: string
-  fillColor?: string
   position?: Position
   status?: Status
   size?: Size
-  showFill?: boolean
+  tone?: 'navbar'
 }
 
 function nameToInitials(fullName: string) {
@@ -19,15 +18,7 @@ function nameToInitials(fullName: string) {
   return `${namesArray[0].charAt(0)}${namesArray[namesArray.length - 1].charAt(0)}`
 }
 
-export default function UserAvatar({
-  user,
-  position,
-  color,
-  fillColor,
-  showFill,
-  status = 'online',
-  size
-}: Props) {
+export default function UserAvatar({user, position, color, status = 'online', size, tone}: Props) {
   const [imageLoadError, setImageLoadError] = useState<null | Error>(null)
   // Decide whether the avatar border should animate
   const isAnimating = !position && status === 'editing'
@@ -42,9 +33,8 @@ export default function UserAvatar({
       size={size}
       label={user?.displayName}
       borderColor={userColor}
-      fillColor={fillColor}
       onImageLoadError={error => setImageLoadError(error)}
-      showFill={showFill}
+      tone={tone}
     >
       {!imageUrl && user?.displayName && nameToInitials(user.displayName)}
     </AvatarCircle>


### PR DESCRIPTION
- Adds property `tone` to the AvatarCircle component. This is used to tell the component whether it is rendered in the navbar or not (and some colors are based on that)
- Removes `showFill` property. Uses instead `imageUrl` to tell whether or not to render the thin "transparent" border between the image and the border of the avatar.
- Bases size values in the SVG on constants `W` and `H` (which are set to 21px for now). This is to avoid the SVG scaling leading to unwanted stroke widths and such.