### PR TITLE
[components, default-layout, desk-tool] Fix peer dependencies

### DIFF
--- a/packages/@sanity/components/package.json
+++ b/packages/@sanity/components/package.json
@@ -54,7 +54,7 @@
     "rimraf": "^2.7.1"
   },
   "peerDependencies": {
-    "@sanity/base": "^0.147.0",
+    "@sanity/base": "^0.147.0 || ^1.148.0",
     "prop-types": "^15.6 || ^16",
     "react": "^16.9",
     "react-dom": "^16.9"

--- a/packages/@sanity/default-layout/package.json
+++ b/packages/@sanity/default-layout/package.json
@@ -48,7 +48,7 @@
     "rimraf": "^2.7.1"
   },
   "peerDependencies": {
-    "@sanity/base": "^0.147.0",
+    "@sanity/base": "^0.147.0 || ^1.148.0",
     "prop-types": "^15.6 || ^16",
     "react": "^16.9",
     "react-dom": "^16.9"

--- a/packages/@sanity/desk-tool/package.json
+++ b/packages/@sanity/desk-tool/package.json
@@ -59,7 +59,7 @@
     "rimraf": "^2.7.1"
   },
   "peerDependencies": {
-    "@sanity/base": "^0.147.0",
+    "@sanity/base": "^0.147.0 || ^1.148.0",
     "prop-types": "^15.6 || ^16",
     "react": "^16.9"
   },


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**
npm install generates following warnings: 
```
@sanity/components@1.149.15 requires a peer of @sanity/base@^0.147.0 but none is installed.
@sanity/default-layout@1.149.15 requires a peer of @sanity/base@^0.147.0
@sanity/desk-tool@1.149.15 requires a peer of @sanity/base@^0.147.0 but none is installed.
```
<!-- Reference/link the relevant issue and/or describe the behavior. -->

**Description**
Include latest major version in peer dependency.
Fixes warning when running npm install.
<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

**Note for release**
I assume peer dependencies should include the current major version of the package, but the caret ^ only includes the major version 0.X.X. Using >= in front of the version would include all future releases (1.X.X, 2.X.X), but tried to make the change as minor as possible, so included only 0.X.X and 1.X.X instead. 

I'm a novice to development but would consider removing 0.147.0 as peer dependency.
<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [ ]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
