### PR TITLE
[client] Typings: Use record as default document extension

### DIFF
--- a/packages/@sanity/client/sanityClient.d.ts
+++ b/packages/@sanity/client/sanityClient.d.ts
@@ -646,7 +646,7 @@ export interface RawQueryResponse<R> {
   result: R
 }
 
-export type SanityDocument<T extends Record<string, any> = {}> = {
+export type SanityDocument<T extends Record<string, any> = Record<string, any>> = {
   [P in keyof T]: T[P]
 } & {
   _id: string
@@ -656,13 +656,13 @@ export type SanityDocument<T extends Record<string, any> = {}> = {
   _updatedAt: string
 }
 
-export type SanityDocumentStub<T extends Record<string, any> = {}> = {
+export type SanityDocumentStub<T extends Record<string, any> = Record<string, any>> = {
   [P in keyof T]: T[P]
 } & {
   _type: string
 }
 
-export type IdentifiedSanityDocumentStub<T extends Record<string, any> = {}> = {
+export type IdentifiedSanityDocumentStub<T extends Record<string, any> = Record<string, any>> = {
   [P in keyof T]: T[P]
 } & {
   _id: string


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

If you don't specify a type for a document, you may end up with typescript errors like:
```
Type '{ _id: string; _type: string; title: string; }' is not assignable to type 'SanityDocument<{}>'.
  Object literal may only specify known properties, and 'title' does not exist in type 'SanityDocument<{}>' 
```

**Description**

The definition of `SanityDocument` declares that the provided document type should extend `Record<string, any>`, but then provides a default of `{}`, which _doesn't_ extend it (it has no key signature).

I believe that this PR should fix it by saying that the default type is a plain record of `<string, any>`, but correct me if I'm wrong here.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
