### PR TITLE
[client] Typings: Fix patch() signature not accepting patch instance

### DIFF
--- a/packages/@sanity/client/sanityClient.d.ts
+++ b/packages/@sanity/client/sanityClient.d.ts
@@ -390,13 +390,21 @@ export class Transaction {
   delete(documentId: string): this
 
   /**
-   * Performs a patch on the given document ID. Can either be a builder function, a prepared Patch instance or an object of patch operations.
+   * Performs a patch on the given document ID. Can either be a builder function or an object of patch operations.
    * The operation is added to the current transaction, ready to be commited by `commit()`
    *
    * @param documentId Document ID to perform the patch operation on
    * @param patchOps Operations to perform, or a builder function
    */
-  patch(documentId: string, patchOps?: PatchBuilder | Patch | PatchOperations): this
+  patch(documentId: string, patchOps?: PatchBuilder | PatchOperations): this
+
+  /**
+   * Adds the given patch instance to the transaction.
+   * The operation is added to the current transaction, ready to be commited by `commit()`
+   *
+   * @param patch Patch to execute
+   */
+  patch(patch: Patch): this
 
   /**
    * Set or gets the ID of this transaction.


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

You're currently not allowed by the typescript definitions to pass a `Patch` instance to a `Transaction`, eg `trx.patch(somePatchInstance)`

**Description**

This PR declares a separate method overload for the case where you pass it a patch instance instead of a document ID + patch builder/patch operations bundle.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
