### PR TITLE
[components] Fix an issue where the BlockPreview extended outside its container

### DIFF
--- a/packages/@sanity/components/src/previews/styles/BlockPreview.css
+++ b/packages/@sanity/components/src/previews/styles/BlockPreview.css
@@ -8,7 +8,7 @@
 
 .header {
   display: flex;
-  width: 100%;
+  max-width: 100%;
   padding: 0.5em;
 }
 
@@ -33,6 +33,7 @@
   line-height: 1.2em;
   margin: 0;
   padding: 0;
+  white-space: inherit
 }
 
 .subtitle {


### PR DESCRIPTION
**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

When the block preview has a lot of text, it doesn't wrap and goes outside its container, effectively extending the container and makes the PTE very hard to use. 

**Description**

This PR fixes this by properly wrapping the text, so it doesn't extend outside its container.

**Note for release**

Fix an issue where the BlockPreview extended outside its container

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
