### PR TITLE
[validation] format dates in validation messages and support validations on date type

### DIFF
--- a/packages/@sanity/validation/package.json
+++ b/packages/@sanity/validation/package.json
@@ -35,7 +35,8 @@
   "dependencies": {
     "clone-deep": "^2.0.1",
     "es6-error": "^4.0.2",
-    "type-of-is": "^3.5.1"
+    "type-of-is": "^3.5.1",
+    "date-fns": "^1.29.0"
   },
   "jest": {
     "verbose": true,

--- a/packages/@sanity/validation/src/inferFromSchemaType.js
+++ b/packages/@sanity/validation/src/inferFromSchemaType.js
@@ -33,6 +33,10 @@ function inferFromSchemaType(typeDef, schema, visited = new Set()) {
     base = base.type('Date')
   }
 
+  if (type && type.name === 'date') {
+    base = base.type('Date')
+  }
+
   if (type && type.name === 'url') {
     base = base.uri()
   }

--- a/packages/@sanity/validation/src/validateDocument.js
+++ b/packages/@sanity/validation/src/validateDocument.js
@@ -131,7 +131,12 @@ function validatePrimitive(item, type, path, options) {
 
   const results = type.validation.map(rule =>
     rule
-      .validate(item, {parent: options.parent, document: options.document, path})
+      .validate(item, {
+        parent: options.parent,
+        document: options.document,
+        path,
+        type: {name: options.type.name, options: options.type.options}
+      })
       .then(currRuleResults => applyPath(currRuleResults, path))
   )
 

--- a/packages/@sanity/validation/src/validators/dateValidator.js
+++ b/packages/@sanity/validation/src/validators/dateValidator.js
@@ -1,4 +1,4 @@
-import moment from 'moment'
+import formatDate from 'date-fns/format'
 
 const ValidationError = require('../ValidationError')
 const genericValidator = require('./genericValidator')
@@ -12,7 +12,7 @@ const getFormattedDate = (type = '', value, options) => {
   }
   if (type === 'date') {
     // If the type is date only
-    return moment(value).format(format)
+    return formatDate(value, format)
   }
   // If the type is datetime
   if (options && options.timeFormat) {
@@ -20,7 +20,7 @@ const getFormattedDate = (type = '', value, options) => {
   } else {
     format += ' HH:mm'
   }
-  return moment(value).format(format)
+  return formatDate(value, format)
 }
 
 const type = (unused, value, message) => {


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->
When you have validation on date fields, the date isn't formatted when showing in the validation message, which makes it hard to read.

<img width="421" alt="Screenshot 2020-05-26 at 16 46 13" src="https://user-images.githubusercontent.com/25737281/83037744-733bc400-a03c-11ea-81f5-2d8f05ef496d.png">

Also, validation hasn't been possible on the `date` type.

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->
This gets the options from the field to be validated, and uses it in the validator to format the dates using either the default format, or the format specified in options.

This adds the same validation methods to the `date` type. 



**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->
- Fixed an issue where `date` wouldn't get the same built-in validation methods as `datetime`
- Fixed date formatting in validation messages

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
