### PR TITLE
[desk-tool] Fix an issue with disappearing document action button

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/documentPane/DocumentStatusBar/DocumentStatusBarActions.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/DocumentStatusBar/DocumentStatusBarActions.tsx
@@ -77,7 +77,7 @@ function DocumentStatusBarActionsInner(props: Props) {
           {firstActionState.dialog && <ActionStateDialog dialog={firstActionState.dialog} />}
         </div>
       )}
-      {showMenu && (
+      {showMenu && menuActionStates.length > 0 && (
         <ActionMenu
           actionStates={menuActionStates}
           isOpen={props.isMenuOpen}
@@ -106,7 +106,7 @@ export function DocumentStatusBarActions(props: {id: string; type: string}) {
       onMenuOpen={() => setMenuOpen(true)}
       onMenuClose={() => setMenuOpen(false)}
       onActionComplete={() => setMenuOpen(false)}
-      actions={isMenuOpen ? actions : actions.slice(0, 1)}
+      actions={actions}
       actionProps={editState}
       disabled={connectionState !== 'connected'}
     />


### PR DESCRIPTION
This fixes a regression introduced in 6da6802, causing the issue described in #1830

Also made sure to display the dropdown button *only* if there's more than one available action

Closes #1830

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Note for release**
Fixed an issue that could sometimes make a document action button disappear.
