### PR TITLE
[form-builder] Add octet-stream asset source uploader (#2266)

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ImageInput/utils/image.ts
+++ b/packages/@sanity/form-builder/src/inputs/ImageInput/utils/image.ts
@@ -1,17 +1,40 @@
 import UUID from '@sanity/uuid'
 
+function extFromData(string: string): string | undefined {
+  let ext: string
+
+  if (string.match(/^data:application\/octet-stream/)) {
+    ext = 'bin'
+  }
+
+  if (string.match(/^data:image/)) {
+    ext = string.substring('data:image/'.length, string.indexOf(';base64'))
+  }
+
+  return ext
+}
+
 export function urlToFile(url: string, filename?: string): Promise<File> {
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest()
     xhr.onload = () => {
       const reader = new FileReader()
       reader.onloadend = () => {
+        // Return early if we have a filename for this this file data
+        if (filename) {
+          return resolve(dataURLtoFile(reader.result, filename))
+        }
+
+        // Otherwise we need to dig into the string representation of the data to
+        // determine what extension to use when constructing a filename
         const string = reader.result.toString()
-        const ext = string.substring('data:image/'.length, string.indexOf(';base64'))
-        if (!ext && !filename) {
+        const ext = extFromData(string)
+
+        if (!ext) {
           return reject(new Error('Could not find mime type for image'))
         }
-        resolve(dataURLtoFile(reader.result, filename || `${UUID()}.${ext}`))
+
+        resolve(dataURLtoFile(reader.result, `${UUID()}.${ext}`))
       }
       reader.readAsDataURL(xhr.response)
     }
@@ -26,15 +49,21 @@ export function urlToFile(url: string, filename?: string): Promise<File> {
 
 export function base64ToFile(base64Data: string | ArrayBuffer, filename?: string): Promise<File> {
   return new Promise((resolve, reject) => {
+    // Return early if we have a filename for this this file data
+    if (filename) {
+      return resolve(dataURLtoFile(base64Data, filename))
+    }
     const string = base64Data.toString()
-    const ext = string.substring('data:image/'.length, string.indexOf(';base64'))
-    if (!ext && !filename) {
+    const ext = extFromData(string)
+    if (!ext) {
       return reject(new Error('Could not find mime type for image'))
     }
-    resolve(dataURLtoFile(base64Data, filename || `${UUID()}.${ext}`))
+    resolve(dataURLtoFile(base64Data, `${UUID()}.${ext}`))
   })
 }
 
+// FIXME: What happens if ArrayBuffer  is passed into here as dataurl?
+// (base64Data in function base64ToFile is passed into dataurl param)
 function dataURLtoFile(dataurl, filename) {
   const arr = dataurl.split(',')
   const mime = arr[0].match(/:(.*?);/)[1]

--- a/packages/@sanity/form-builder/src/sanity/uploads/typedefs.ts
+++ b/packages/@sanity/form-builder/src/sanity/uploads/typedefs.ts
@@ -25,13 +25,13 @@ export type UploadOptions = {
 
 export type UploaderDef = {
   type: string
-  accepts: string
+  accepts: string[]
   upload: (file: File, type: Type) => Observable<UploadEvent>
 }
 
 export type Uploader = {
   type: string
-  accepts: string
+  accepts: string[]
   upload: (file: File, type: Type, options?: UploadOptions) => Observable<UploadEvent>
   priority: number
 }

--- a/packages/@sanity/form-builder/src/sanity/uploads/typedefs.ts
+++ b/packages/@sanity/form-builder/src/sanity/uploads/typedefs.ts
@@ -25,13 +25,13 @@ export type UploadOptions = {
 
 export type UploaderDef = {
   type: string
-  accepts: string[]
+  accepts: string | string[]
   upload: (file: File, type: Type) => Observable<UploadEvent>
 }
 
 export type Uploader = {
   type: string
-  accepts: string[]
+  accepts: string | string[]
   upload: (file: File, type: Type, options?: UploadOptions) => Observable<UploadEvent>
   priority: number
 }

--- a/packages/@sanity/form-builder/src/sanity/uploads/uploaders.ts
+++ b/packages/@sanity/form-builder/src/sanity/uploads/uploaders.ts
@@ -13,13 +13,13 @@ const UPLOAD_IMAGE: UploaderDef = {
 
 const UPLOAD_FILE: UploaderDef = {
   type: 'file',
-  accepts: [],
+  accepts: '',
   upload: (file: File, type: Type, options?: UploadOptions) => uploadFile(file, options)
 }
 
 const UPLOAD_TEXT: UploaderDef = {
   type: 'string',
-  accepts: ['text/*'],
+  accepts: 'text/*',
   upload: (file: File, type: Type, options?: UploadOptions) =>
     uploadFile(file, options).pipe(
       map(content => ({

--- a/packages/@sanity/form-builder/src/sanity/uploads/uploaders.ts
+++ b/packages/@sanity/form-builder/src/sanity/uploads/uploaders.ts
@@ -5,27 +5,21 @@ import {Type} from '../../typedefs'
 import {set} from '../../utils/patches'
 import {map} from 'rxjs/operators'
 
-const UPLOAD_BLOB: UploaderDef = {
-  type: 'image',
-  accepts: 'application/octet-stream',
-  upload: (file: File, type?: Type, options?: UploadOptions) => uploadImage(file, options)
-}
-
 const UPLOAD_IMAGE: UploaderDef = {
   type: 'image',
-  accepts: 'image/*',
+  accepts: ['image/*', 'application/octet-stream'],
   upload: (file: File, type?: Type, options?: UploadOptions) => uploadImage(file, options)
 }
 
 const UPLOAD_FILE: UploaderDef = {
   type: 'file',
-  accepts: '',
+  accepts: [],
   upload: (file: File, type: Type, options?: UploadOptions) => uploadFile(file, options)
 }
 
 const UPLOAD_TEXT: UploaderDef = {
   type: 'string',
-  accepts: 'text/*',
+  accepts: ['text/*'],
   upload: (file: File, type: Type, options?: UploadOptions) =>
     uploadFile(file, options).pipe(
       map(content => ({
@@ -37,11 +31,9 @@ const UPLOAD_TEXT: UploaderDef = {
   // and make it possible to register custom uploaders
 }
 
-const uploaders: Array<Uploader> = [UPLOAD_IMAGE, UPLOAD_TEXT, UPLOAD_FILE, UPLOAD_BLOB].map(
-  (uploader, i) => ({
-    ...uploader,
-    priority: i
-  })
-)
+const uploaders: Array<Uploader> = [UPLOAD_IMAGE, UPLOAD_TEXT, UPLOAD_FILE].map((uploader, i) => ({
+  ...uploader,
+  priority: i
+}))
 
 export default uploaders

--- a/packages/@sanity/form-builder/src/sanity/uploads/uploaders.ts
+++ b/packages/@sanity/form-builder/src/sanity/uploads/uploaders.ts
@@ -5,6 +5,12 @@ import {Type} from '../../typedefs'
 import {set} from '../../utils/patches'
 import {map} from 'rxjs/operators'
 
+const UPLOAD_BLOB: UploaderDef = {
+  type: 'image',
+  accepts: 'application/octet-stream',
+  upload: (file: File, type?: Type, options?: UploadOptions) => uploadImage(file, options)
+}
+
 const UPLOAD_IMAGE: UploaderDef = {
   type: 'image',
   accepts: 'image/*',
@@ -31,9 +37,11 @@ const UPLOAD_TEXT: UploaderDef = {
   // and make it possible to register custom uploaders
 }
 
-const uploaders: Array<Uploader> = [UPLOAD_IMAGE, UPLOAD_TEXT, UPLOAD_FILE].map((uploader, i) => ({
-  ...uploader,
-  priority: i
-}))
+const uploaders: Array<Uploader> = [UPLOAD_IMAGE, UPLOAD_TEXT, UPLOAD_FILE, UPLOAD_BLOB].map(
+  (uploader, i) => ({
+    ...uploader,
+    priority: i
+  })
+)
 
 export default uploaders


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->


**Type of change (check at least one)**

- [X]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [X]  No

**Current behavior**
Asset source upload silently fails (error in console) when asset is served as `application/octet-stream`.

<!-- Reference/link the relevant issue and/or describe the behavior. -->

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->
This PR introduces an uploader which will resolve for `application/octet-stream` and also provides a fallback for filenames when mime type is not of `image/*`

**Note for release**
Support `application/octet-stream` in custom asset sources

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

**Checklist** 

- [X]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [X]  The PR title includes a link to the relevant issue
- [X]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [X]  The code is linted
- [X]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
