### PR TITLE
[export] Fix incorrectly handled rewriting of non-sanity assets

### DIFF
--- a/packages/@sanity/export/test/AssetHandler.test.js
+++ b/packages/@sanity/export/test/AssetHandler.test.js
@@ -15,13 +15,14 @@ describe('asset handler', () => {
   test('can rewrite documents / queue downloads', done => {
     // prettier-ignore
     const docs = [
-      {_id: 'doc1', _type: 'bike', name: 'Scooter', image: {_type: 'image', caption: 'Scooter bike', asset: {_ref: 'image-idx_abc123-3360x840-png'}, nested: {_type: 'image', asset: {_ref: 'image-idx_abc123-3360x840-png'}}}},
-      {_id: 'doc2', _type: 'bike', name: 'Dupe', image: {_type: 'image', asset: {_ref: 'image-idx_abc123-3360x840-png'}}},
-      {_id: 'doc3', _type: 'bike', name: 'Tandem', image: {_type: 'image', asset: {_ref: 'image-idx_abc456-310x282-jpg'}}},
-      {_id: 'old4', _type: 'bike', name: 'Cool', image: {asset: {_ref: 'mzFgq1cvHSEeGscxBsRFoqKG'}}},
+      {_id: 'doc1', _type: 'bike', name: 'Scooter', image: {_type: 'image', caption: 'Scooter bike', asset: {_ref: 'image-6dcdb82c282dbe0a09ff7a6b58b639732f2fb8de-3360x840-png'}, nested: {_type: 'image', asset: {_ref: 'image-6dcdb82c282dbe0a09ff7a6b58b639732f2fb8de-3360x840-png'}}}},
+      {_id: 'doc2', _type: 'bike', name: 'Dupe', image: {_type: 'image', asset: {_ref: 'image-6dcdb82c282dbe0a09ff7a6b58b639732f2fb8de-3360x840-png'}}},
+      {_id: 'doc3', _type: 'bike', name: 'Tandem', image: {_type: 'image', asset: {_ref: 'image-31befc6dfa0315d6c535b8a57e34f86c18eb5f20-310x282-jpg'}}},
+      {_id: 'datMuxAsset', _type: 'mux.videoAsset', assetId: 'someAssetId'},
+      {_id: 'refsDatMuxAsset', _type: 'bike', video: {_type: 'mux.video', asset: {_ref: 'datMuxAsset'}}},
       {_id: 'mzFgq1cvHSEeGscxBsRFoqKG', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/mzFgq1cvHSEeGscxBsRFoqKG-2048x1364.jpg'},
-      {_id: 'image-idx_abc123-dads3360x840-png', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/idx_abc123-3360x840.png'},
-      {_id: 'image-idx_abc456-310x282-jpg', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/idx_abc456-310x282.jpg'},
+      {_id: 'image-54e9595477915230501dfec656c8e86235bb470a-dads3360x840-png', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/6dcdb82c282dbe0a09ff7a6b58b639732f2fb8de-3360x840.png'},
+      {_id: 'image-31befc6dfa0315d6c535b8a57e34f86c18eb5f20-310x282-jpg', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/31befc6dfa0315d6c535b8a57e34f86c18eb5f20-310x282.jpg'},
       {_id: 'plain', _type: 'bike', name: 'Broom'}
     ]
 
@@ -32,12 +33,14 @@ describe('asset handler', () => {
       .pipe(miss.concat(onComplete))
 
     async function onComplete(newDocs) {
-      expect(newDocs).toHaveLength(5)
+      expect(newDocs).toHaveLength(6)
       expect(docById(newDocs, 'doc1')).toMatchSnapshot('Rewritten asset for doc1')
       expect(docById(newDocs, 'doc2')).toMatchSnapshot('Rewritten asset for doc2')
       expect(docById(newDocs, 'doc3')).toMatchSnapshot('Rewritten asset for doc3')
-      expect(docById(newDocs, 'old4')).toMatchSnapshot('Rewritten asset for old4')
       expect(docById(newDocs, 'plain')).toMatchSnapshot('Nothing rewritten in assetless doc')
+      expect(docById(newDocs, 'refsDatMuxAsset')).toMatchSnapshot(
+        'Nothing rewritten if pattern doesnt match Sanity asset'
+      )
 
       await assetHandler.finish()
       expect(assetHandler.filesWritten).toEqual(3)
@@ -48,13 +51,12 @@ describe('asset handler', () => {
   test('can remove asset documents', done => {
     // prettier-ignore
     const docs = [
-      {_id: 'doc1', _type: 'bike', name: 'Scooter', image: {_type: 'image', caption: 'Scooter bike', asset: {_ref: 'image-idx_abc123-3360x840-png'}}},
-      {_id: 'doc2', _type: 'bike', name: 'Dupe', image: {_type: 'image', asset: {_ref: 'image-idx_abc123-3360x840-png'}}},
-      {_id: 'doc3', _type: 'bike', name: 'Tandem', image: {_type: 'image', asset: {_ref: 'image-idx_abc456-310x282-jpg'}}},
-      {_id: 'old4', _type: 'bike', name: 'Cool', image: {asset: {_ref: 'mzFgq1cvHSEeGscxBsRFoqKG'}}},
+      {_id: 'doc1', _type: 'bike', name: 'Scooter', image: {_type: 'image', caption: 'Scooter bike', asset: {_ref: 'image-6dcdb82c282dbe0a09ff7a6b58b639732f2fb8de-3360x840-png'}}},
+      {_id: 'doc2', _type: 'bike', name: 'Dupe', image: {_type: 'image', asset: {_ref: 'image-6dcdb82c282dbe0a09ff7a6b58b639732f2fb8de-3360x840-png'}}},
+      {_id: 'doc3', _type: 'bike', name: 'Tandem', image: {_type: 'image', asset: {_ref: 'image-31befc6dfa0315d6c535b8a57e34f86c18eb5f20-310x282-jpg'}}},
       {_id: 'mzFgq1cvHSEeGscxBsRFoqKG', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/mzFgq1cvHSEeGscxBsRFoqKG-2048x1364.jpg'},
-      {_id: 'image-idx_abc123-3360x840-png', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/idx_abc123-3360x840.png'},
-      {_id: 'image-idx_abc456-310x282-jpg', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/idx_abc456-310x282.jpg'},
+      {_id: 'image-6dcdb82c282dbe0a09ff7a6b58b639732f2fb8de-3360x840-png', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/6dcdb82c282dbe0a09ff7a6b58b639732f2fb8de-3360x840.png'},
+      {_id: 'image-31befc6dfa0315d6c535b8a57e34f86c18eb5f20-310x282-jpg', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/31befc6dfa0315d6c535b8a57e34f86c18eb5f20-310x282.jpg'},
       {_id: 'plain', _type: 'bike', name: 'Broom'}
     ]
 
@@ -65,11 +67,10 @@ describe('asset handler', () => {
       .pipe(miss.concat(onComplete))
 
     async function onComplete(newDocs) {
-      expect(newDocs).toHaveLength(5)
+      expect(newDocs).toHaveLength(4)
       expect(docById(newDocs, 'doc1')).toMatchSnapshot('doc1 with no image asset')
       expect(docById(newDocs, 'doc2')).toMatchSnapshot('doc2 with no image asset')
       expect(docById(newDocs, 'doc3')).toMatchSnapshot('doc3 with no image asset')
-      expect(docById(newDocs, 'old4')).toMatchSnapshot('old4 with no image asset')
       expect(docById(newDocs, 'plain')).toMatchSnapshot('Nothing removed in assetless doc')
 
       await assetHandler.finish()
@@ -81,7 +82,7 @@ describe('asset handler', () => {
   test('downloads assets that are not referenced by documents', done => {
     // prettier-ignore
     const docs = [
-      {_id: 'image-idx_abc123-3360x840-png', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/idx_abc123-3360x840.png'},
+      {_id: 'image-6dcdb82c282dbe0a09ff7a6b58b639732f2fb8de-3360x840-png', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/6dcdb82c282dbe0a09ff7a6b58b639732f2fb8de-3360x840.png'},
       {_id: 'mzFgq1cvHSEeGscxBsRFoqKG', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/mzFgq1cvHSEeGscxBsRFoqKG-2048x1364.jpg'},
       {_id: 'plain', _type: 'bike', name: 'Broom'}
     ]
@@ -105,12 +106,12 @@ describe('asset handler', () => {
   test('can skip asset documents', done => {
     // prettier-ignore
     const docs = [
-      {_id: 'doc1', _type: 'bike', name: 'Scooter', image: {_type: 'image', caption: 'Scooter bike', asset: {_ref: 'image-idx_abc123-3360x840-png'}}},
-      {_id: 'doc2', _type: 'bike', name: 'Dupe', image: {_type: 'image', asset: {_ref: 'image-idx_abc123-3360x840-png'}}},
-      {_id: 'doc3', _type: 'bike', name: 'Tandem', image: {_type: 'image', asset: {_ref: 'image-idx_abc456-310x282-jpg'}}},
+      {_id: 'doc1', _type: 'bike', name: 'Scooter', image: {_type: 'image', caption: 'Scooter bike', asset: {_ref: 'image-6dcdb82c282dbe0a09ff7a6b58b639732f2fb8de-3360x840-png'}}},
+      {_id: 'doc2', _type: 'bike', name: 'Dupe', image: {_type: 'image', asset: {_ref: 'image-6dcdb82c282dbe0a09ff7a6b58b639732f2fb8de-3360x840-png'}}},
+      {_id: 'doc3', _type: 'bike', name: 'Tandem', image: {_type: 'image', asset: {_ref: 'image-31befc6dfa0315d6c535b8a57e34f86c18eb5f20-310x282-jpg'}}},
       {_id: 'mzFgq1cvHSEeGscxBsRFoqKG', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/mzFgq1cvHSEeGscxBsRFoqKG-2048x1364.jpg'},
-      {_id: 'image-idx_abc123-3360x840-png', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/idx_abc123-3360x840.png'},
-      {_id: 'image-idx_abc456-310x282-jpg', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/idx_abc456-310x282.jpg'},
+      {_id: 'image-6dcdb82c282dbe0a09ff7a6b58b639732f2fb8de-3360x840-png', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/6dcdb82c282dbe0a09ff7a6b58b639732f2fb8de-3360x840.png'},
+      {_id: 'image-31befc6dfa0315d6c535b8a57e34f86c18eb5f20-310x282-jpg', _type: 'sanity.imageAsset', url: 'https://cdn.sanity.io/images/__fixtures__/__test__/31befc6dfa0315d6c535b8a57e34f86c18eb5f20-310x282.jpg'},
       {_id: 'plain', _type: 'bike', name: 'Broom'}
     ]
 

--- a/packages/@sanity/export/test/__snapshots__/AssetHandler.test.js.snap
+++ b/packages/@sanity/export/test/__snapshots__/AssetHandler.test.js.snap
@@ -32,11 +32,16 @@ Object {
 }
 `;
 
-exports[`asset handler can remove asset documents: old4 with no image asset 1`] = `
+exports[`asset handler can rewrite documents / queue downloads: Nothing rewritten if pattern doesnt match Sanity asset 1`] = `
 Object {
-  "_id": "old4",
+  "_id": "refsDatMuxAsset",
   "_type": "bike",
-  "name": "Cool",
+  "video": Object {
+    "_type": "mux.video",
+    "asset": Object {
+      "_ref": "datMuxAsset",
+    },
+  },
 }
 `;
 
@@ -53,11 +58,11 @@ Object {
   "_id": "doc1",
   "_type": "bike",
   "image": Object {
-    "_sanityAsset": "image@file://./images/idx_abc123-3360x840.png",
+    "_sanityAsset": "image@file://./images/6dcdb82c282dbe0a09ff7a6b58b639732f2fb8de-3360x840.png",
     "_type": "image",
     "caption": "Scooter bike",
     "nested": Object {
-      "_sanityAsset": "image@file://./images/idx_abc123-3360x840.png",
+      "_sanityAsset": "image@file://./images/6dcdb82c282dbe0a09ff7a6b58b639732f2fb8de-3360x840.png",
       "_type": "image",
     },
   },
@@ -70,7 +75,7 @@ Object {
   "_id": "doc2",
   "_type": "bike",
   "image": Object {
-    "_sanityAsset": "image@file://./images/idx_abc123-3360x840.png",
+    "_sanityAsset": "image@file://./images/6dcdb82c282dbe0a09ff7a6b58b639732f2fb8de-3360x840.png",
     "_type": "image",
   },
   "name": "Dupe",
@@ -82,20 +87,9 @@ Object {
   "_id": "doc3",
   "_type": "bike",
   "image": Object {
-    "_sanityAsset": "image@file://./images/idx_abc456-310x282.jpg",
+    "_sanityAsset": "image@file://./images/31befc6dfa0315d6c535b8a57e34f86c18eb5f20-310x282.jpg",
     "_type": "image",
   },
   "name": "Tandem",
-}
-`;
-
-exports[`asset handler can rewrite documents / queue downloads: Rewritten asset for old4 1`] = `
-Object {
-  "_id": "old4",
-  "_type": "bike",
-  "image": Object {
-    "_sanityAsset": "image@file://./images/mzFgq1cvHSEeGscxBsRFoqKG.bin",
-  },
-  "name": "Cool",
 }
 `;


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->
If encountering documents with an `asset` property which happens to be a reference, but is not a reference to a sanity image or file asset, the export potentially crashes  because it assumes it's a Sanity asset and tries to download the asset.


**Description**

This PR introduces more strict checking of the referenced ID, to make sure it matches the image or file ID pattern. In the future we should probably check that the dataset actually exports the referenced asset, as _theoretically_ someone could make a document with the same asset shape.

I also took the liberty of removing handling of (very) legacy assets, which has the side benefit of removing an async hot path, which should speed things up a bit.

And I finally identified the cause of the max listeners warning (sockets were reused because of keepAlive agent, which made it reapply the timeout listener many times on the same socket)

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
