### PR TITLE
[export] Fix extensions with numbers not recognized as valid asset ID

### DIFF
--- a/packages/@sanity/export/src/AssetHandler.js
+++ b/packages/@sanity/export/src/AssetHandler.js
@@ -283,7 +283,7 @@ function getAssetType(item) {
 function isSanityAsset(assetId) {
   return (
     /^image-[a-f0-9]{40}-\d+x\d+-[a-z]+$/.test(assetId) ||
-    /^file-[a-f0-9]{40}-[a-z]+$/.test(assetId)
+    /^file-[a-f0-9]{40}-[a-z0-9]+$/.test(assetId)
   )
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

If exporting a dataset containing assets with a number in the extension (such as mp3, mp4), the export does not understand that it is a Sanity asset and skips it. This can lead to breaking imports when combined with the  `--no-assets` flag, as it will still be referencing excluded assets.

**Description**

This PR fixes the regular expression used to match the Sanity asset to also allow for numbers.

**Note for release**

- Fixed issue where exporting assets with numeric extensions (eg `mp3`) would not be recognized as valid Sanity assets

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
