### PR TITLE
[desk-tool] Remove the drafts prefix + warn when resolving intent links

### DIFF
--- a/packages/@sanity/desk-tool/src/tool/index.js
+++ b/packages/@sanity/desk-tool/src/tool/index.js
@@ -7,8 +7,8 @@ import Icon from 'part:@sanity/base/view-column-icon'
 import {route, useRouterState} from 'part:@sanity/base/router'
 import {parsePanesSegment, encodePanesSegment} from '../utils/parsePanesSegment'
 import IntentResolver from '../components/IntentResolver'
-import DeskTool from './DeskTool'
 import {EMPTY_PARAMS} from '../constants'
+import DeskTool from './DeskTool'
 
 function toState(pathSegment) {
   return parsePanesSegment(decodeURIComponent(pathSegment))


### PR DESCRIPTION
- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**
The issue with generating document links using draft ids from the document list dashboard-widget was fixed in https://github.com/sanity-io/dashboard-widget-document-list/commit/04f87b1e77cd9a7b313e117b14286b67b3cee15c. However, there are still studios out there with the older versions or that for some reason are still having intent links with draft id in them. This PR fixes this issue by rewriting intent links with draft prefix in the component that resolves intent links.

Closes #1865

**Note for release**
> Fixed an issue causing studio crash with different variations of "editOpsOf does not expect a draft id" and "useDocumentOperation(...) is null" (more details in #1865)
