### PR TITLE
[core] Prevent throwing on missing static folder when building

### DIFF
--- a/packages/@sanity/core/src/actions/build/buildStaticAssets.js
+++ b/packages/@sanity/core/src/actions/build/buildStaticAssets.js
@@ -155,7 +155,14 @@ export default async (args, context) => {
     }
 
     // Copy static assets (from /static folder) to output dir
-    await fse.copy(path.join(workDir, 'static'), path.join(outputDir, 'static'), {overwrite: false})
+    await fse
+      .copy(path.join(workDir, 'static'), path.join(outputDir, 'static'), {overwrite: false})
+      .catch(err => {
+        // Allow missing static folder
+        if (err.code !== 'ENOENT') {
+          throw err
+        }
+      })
   } catch (err) {
     spin.fail()
     throw err


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

If you delete the `static` folder, the `sanity build` command fails to run because it attempts to copy it.

**Description**

This PR checks for `ENOENT` errors and allows these. Other errors are still thrown.

**Note for release**

- Fixed `sanity build` crashing if `static` folder does not exist

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
