### PR TITLE
Fix presence in advanced image edit dialogs and replace fullscreen dialog

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.css
+++ b/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.css
@@ -76,6 +76,10 @@
 
 .advancedEditFields {
   margin-bottom: var(--medium-padding);
+
+  @nest & .field {
+    padding-bottom: var(--large-padding);
+  }
 }
 
 .selectDropDownAssetSourceItem {

--- a/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.tsx
@@ -12,7 +12,9 @@ import PropTypes from 'prop-types'
 import assetSources from 'all:part:@sanity/form-builder/input/image/asset-source'
 import Button from 'part:@sanity/components/buttons/default'
 import ButtonGrid from 'part:@sanity/components/buttons/button-grid'
-import Dialog from 'part:@sanity/components/dialogs/fullscreen'
+import Dialog from 'part:@sanity/components/dialogs/default'
+import DialogContent from 'part:@sanity/components/dialogs/content'
+import {Overlay as PresenceOverlay} from '@sanity/components/presence'
 import DropDownButton from 'part:@sanity/components/buttons/dropdown'
 import EditIcon from 'part:@sanity/base/edit-icon'
 import Fieldset from 'part:@sanity/components/fieldsets/default'
@@ -365,6 +367,8 @@ export default class ImageInput extends React.PureComponent<Props, ImageInputSta
     const {value, level, type, onChange, readOnly, materialize} = this.props
     return (
       <Dialog title="Edit details" onClose={this.handleStopAdvancedEdit} isOpen>
+        <PresenceOverlay>
+          <DialogContent size="medium">
         {this.isImageToolEnabled() && value && value.asset && (
           <WithMaterializedReference materialize={materialize} reference={value.asset}>
             {imageAsset => (
@@ -381,6 +385,8 @@ export default class ImageInput extends React.PureComponent<Props, ImageInputSta
         )}
         <div className={styles.advancedEditFields}>{this.renderFields(fields)}</div>
         <Button onClick={this.handleStopAdvancedEdit}>Close</Button>
+          </DialogContent>
+        </PresenceOverlay>
       </Dialog>
     )
   }


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->
Advanced image edit dialogs used a fullscreen dialog which made the field stretch and look weird. This replaced the fullscreen dialog with a default one with medium sized content. Presence also didn't know where to place avatars when someone enters an advanced image edit dialog, so a `PresenceOverlay` was also added to fix this.

**Before**
<img width="1440" alt="Screenshot 2020-07-06 at 14 41 35" src="https://user-images.githubusercontent.com/25737281/86735943-72328500-c033-11ea-8024-3d0247532a29.png">

**After**
<img width="1552" alt="Screenshot 2020-07-07 at 09 25 47" src="https://user-images.githubusercontent.com/25737281/86736486-db19fd00-c033-11ea-8d15-b3a02223b1aa.png">

