### PR TITLE
Show warning when an array contains values with types not defined in the schema

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ArrayInput/ArrayInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ArrayInput/ArrayInput.tsx
@@ -2,22 +2,23 @@ import React from 'react'
 import ArrayFunctions from 'part:@sanity/form-builder/input/array/functions'
 import {map} from 'rxjs/operators'
 import {isPlainObject, get} from 'lodash'
+import {FOCUS_TERMINATOR, startsWith} from '@sanity/util/paths'
+import Button from 'part:@sanity/components/buttons/default'
+import Fieldset from 'part:@sanity/components/fieldsets/default'
+import formBuilderConfig from 'config:@sanity/form-builder'
 import {ResolvedUploader, Uploader} from '../../sanity/uploads/typedefs'
 import {Marker, Type} from '../../typedefs'
 import {Path} from '../../typedefs/path'
 import {Subscription} from '../../typedefs/observable'
 import {resolveTypeName} from '../../utils/resolveTypeName'
-import {FOCUS_TERMINATOR, startsWith} from '@sanity/util/paths'
 import UploadTargetFieldset from '../../utils/UploadTargetFieldset'
 import {insert, PatchEvent, set, setIfMissing, unset} from '../../PatchEvent'
+import Details from '../common/Details'
 import resolveListComponents from './resolveListComponents'
 import {ArrayType, ItemValue} from './typedefs'
 import RenderItemValue from './ItemValue'
 import randomKey from './randomKey'
-import Button from 'part:@sanity/components/buttons/default'
-import Fieldset from 'part:@sanity/components/fieldsets/default'
-import Details from '../common/Details'
-import formBuilderConfig from 'config:@sanity/form-builder'
+import UnknownValues from './UnknownValues'
 
 import styles from './styles/ArrayInput.css'
 
@@ -268,6 +269,20 @@ export default class ArrayInput extends React.Component<Props, ArrayInputState> 
     }
   }
 
+  renderUnknownValueTypes = () => {
+    const {value, type, readOnly} = this.props
+    const knownTypes = (type.of || []).map(t => t.name).filter(typeName => typeName !== 'object')
+    const unknownValues = (value || []).filter(v => v._type && !knownTypes.includes(v._type))
+    if (!unknownValues || unknownValues.length === 0) {
+      return null
+    }
+    return (
+      <div className={styles.unknownValueTypes}>
+        <UnknownValues values={unknownValues} onClick={this.handleRemoveItem} readOnly={readOnly} />
+      </div>
+    )
+  }
+
   render() {
     const {type, level, markers, readOnly, onChange, value, presence} = this.props
     const hasNonObjectValues = (value || []).some(item => !isPlainObject(item))
@@ -349,6 +364,7 @@ export default class ArrayInput extends React.Component<Props, ArrayInputState> 
       >
         <div>
           {value && value.length > 0 && this.renderList()}
+          {this.renderUnknownValueTypes()}
           <ArrayFunctions
             type={type}
             value={value}

--- a/packages/@sanity/form-builder/src/inputs/ArrayInput/ItemValue.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ArrayInput/ItemValue.tsx
@@ -11,17 +11,17 @@ import EditItemFold from 'part:@sanity/components/edititem/fold'
 import {createDragHandle} from 'part:@sanity/components/lists/sortable'
 import ValidationStatus from 'part:@sanity/components/validation/status'
 import DragHandleIcon from 'part:@sanity/base/drag-handle-icon'
+import * as PathUtils from '@sanity/util/paths'
+import {FieldPresence, Overlay as PresenceOverlay} from '@sanity/components/presence'
 import {FormBuilderInput} from '../../FormBuilderInput'
 import PatchEvent from '../../PatchEvent'
 import Preview from '../../Preview'
 import {resolveTypeName} from '../../utils/resolveTypeName'
 import {Path} from '../../typedefs/path'
 import {Presence, Marker, Type} from '../../typedefs'
-import * as PathUtils from '@sanity/util/paths'
 import ConfirmButton from './ConfirmButton'
 import styles from './styles/ItemValue.css'
 import {ArrayType, ItemValue} from './typedefs'
-import {FieldPresence, Overlay as PresenceOverlay} from '@sanity/components/presence'
 
 const DragHandle = createDragHandle(() => (
   <span className={styles.dragHandle}>
@@ -258,7 +258,10 @@ export default class RenderItemValue extends React.PureComponent<Props> {
       .filter(Boolean)
 
     const hasItemFocus = PathUtils.isExpanded(pathSegmentFrom(value), focusPath)
-
+    const memberType = this.getMemberType()
+    if (!memberType) {
+      return null
+    }
     return (
       <div className={styles.inner}>
         {!isGrid && isSortable && <DragHandle />}
@@ -275,7 +278,7 @@ export default class RenderItemValue extends React.PureComponent<Props> {
             onFocus={this.handleFocus}
           >
             {!value._key && <div className={styles.missingKeyMessage}>Missing key</div>}
-            <Preview layout={previewLayout} value={value} type={this.getMemberType()} />
+            <Preview layout={previewLayout} value={value} type={memberType} />
           </div>
         </div>
 

--- a/packages/@sanity/form-builder/src/inputs/ArrayInput/UnknownValues.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ArrayInput/UnknownValues.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import DefaultButton from 'part:@sanity/components/buttons/default'
+import ActivateOnFocus from 'part:@sanity/components/utilities/activate-on-focus'
+import Details from '../common/Details'
+import styles from '../ObjectInput/styles/UnknownFields.css'
+import {ItemValue} from './typedefs'
+
+type Props = {
+  values: ItemValue[]
+  onClick: (item: ItemValue) => void
+  readOnly?: boolean
+}
+
+export default class UnknownFields extends React.PureComponent<Props, {}> {
+  handleUnsetClick = value => {
+    this.props.onClick(value)
+  }
+
+  render() {
+    const {values = [], readOnly} = this.props
+    const len = values.length
+
+    return (
+      <div className={styles.root}>
+        <h2 className={styles.heading}>
+          Found {len === 1 ? <>a</> : len} {len === 1 ? <>value</> : <>values</>} with{' '}
+          {len === 1 && <>an</>} unknown {len === 1 ? <>type</> : <>types</>}
+        </h2>
+
+        <div className={styles.content}>
+          <Details>
+            These are not defined in the current schema as valid types for this array. This could
+            mean that the type has been removed, or that someone else has added it to their own
+            local schema that is not yet deployed.
+            {values.map(item => {
+              return (
+                <div key={item._type}>
+                  <h4>{item._type}</h4>
+                  <ActivateOnFocus>
+                    <pre className={styles.inspectValue}>{JSON.stringify(item, null, 2)}</pre>
+                  </ActivateOnFocus>
+                  {readOnly ? (
+                    <div>
+                      This array is <em>read only</em> according to its enclosing schema type and
+                      values cannot be unset. If you want to unset a value, make sure you remove the{' '}
+                      <strong>readOnly</strong> property from the enclosing type.
+                    </div>
+                  ) : (
+                    <DefaultButton onClick={() => this.handleUnsetClick(item)} color="danger">
+                      Unset {item._type}
+                    </DefaultButton>
+                  )}
+                </div>
+              )
+            })}
+          </Details>
+        </div>
+      </div>
+    )
+  }
+}

--- a/packages/@sanity/form-builder/src/inputs/ArrayInput/styles/ArrayInput.css
+++ b/packages/@sanity/form-builder/src/inputs/ArrayInput/styles/ArrayInput.css
@@ -85,3 +85,8 @@
 .removeNonObjectsButtonWrapper {
   composes: fixMissingKeysButtonWrapper;
 }
+
+.unknownValueTypes {
+  padding-top: var(--medium-padding);
+  padding-bottom: var(--large-padding);
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)

**Description**

When an array has values with types not defined in the schema, they're still rendered as items in the array with a broken preview, and when you try to open it, the desk tool crashes.

This adds the same time of warning with details that objects have when an object has unknown fields, and makes it possible to see the value and unset if needed, without crashing the desk tool.

**Before**
<img width="769" alt="Screenshot 2020-07-07 at 10 08 20" src="https://user-images.githubusercontent.com/25737281/87014182-0899ae80-c1cc-11ea-8abe-23c36a0bdf23.png">
![Screenshot 2020-07-09 at 10 13 30](https://user-images.githubusercontent.com/25737281/87014769-e05e7f80-c1cc-11ea-949d-9405c66e0645.png)


**After**
![Screenshot 2020-07-09 at 10 09 33](https://user-images.githubusercontent.com/25737281/87014357-52829480-c1cc-11ea-9c16-fa5859b753f3.png)

![Screenshot 2020-07-09 at 09 44 58](https://user-images.githubusercontent.com/25737281/87014235-21a25f80-c1cc-11ea-9eec-d210c60d7c38.png)

