### PR TITLE
[form-builder] Give popover in pt object renderer a medium content size

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/PortableText/Objects/renderers/PopoverObjectEditing.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Objects/renderers/PopoverObjectEditing.tsx
@@ -3,6 +3,7 @@ import React, {FunctionComponent, useMemo} from 'react'
 
 import Popover from 'part:@sanity/components/dialogs/popover'
 import Stacked from 'part:@sanity/components/utilities/stacked'
+import DialogContent from 'part:@sanity/components/dialogs/content'
 
 import {PortableTextBlock, PortableTextChild, Type} from '@sanity/portable-text-editor'
 import {PresenceOverlay} from '@sanity/base/presence'
@@ -53,21 +54,23 @@ export const PopoverObjectEditing: FunctionComponent<Props> = ({
           onClose={onClose}
           title={type.title}
         >
-          <PresenceOverlay>
-            <FormBuilderInput
-              type={type}
-              level={0}
-              readOnly={readOnly || type.readOnly}
-              value={object}
-              onChange={handleChange}
-              onFocus={onFocus}
-              onBlur={onBlur}
-              focusPath={focusPath}
-              path={path}
-              presence={presence}
-              markers={markers}
-            />
-          </PresenceOverlay>
+          <DialogContent size="small" padding="none">
+            <PresenceOverlay>
+              <FormBuilderInput
+                type={type}
+                level={0}
+                readOnly={readOnly || type.readOnly}
+                value={object}
+                onChange={handleChange}
+                onFocus={onFocus}
+                onBlur={onBlur}
+                focusPath={focusPath}
+                path={path}
+                presence={presence}
+                markers={markers}
+              />
+            </PresenceOverlay>
+          </DialogContent>
         </Popover>
       )}
     </Stacked>


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Maintenance

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

the url popover is not very wide. I’ve wrapped the popover content in the pt object rendderer in a `DialogContent` component and set the size to medium, then it will always have the same width as most other dialogs in the studio. Not sure if this is the desired look tho, so here's a PR

Screenshots: https://sanity-io.slack.com/archives/C011W8DMVH8/p1594290401004400
