### PR TITLE
Support overriding validation on array subtypes. Fixes #1774

### DIFF
--- a/packages/@sanity/schema/src/legacy/types/array.ts
+++ b/packages/@sanity/schema/src/legacy/types/array.ts
@@ -8,7 +8,8 @@ const OVERRIDABLE_FIELDS = [
   'title',
   'description',
   'options',
-  'fieldsets'
+  'fieldsets',
+  'validation'
 ]
 
 const ARRAY_CORE = {

--- a/packages/test-studio/schemas/schema.js
+++ b/packages/test-studio/schemas/schema.js
@@ -33,7 +33,7 @@ import geopoint from './geopoint'
 import fieldsets from './fieldsets'
 import empty from './empty'
 import readOnly from './readOnly'
-import validation from './validation'
+import validation, {validationArraySuperType} from './validation'
 import experiment from './experiment'
 import customInputs from './customInputs'
 import notitle from './notitle'
@@ -71,6 +71,7 @@ export default createSchema({
     datetime,
     date,
     richDateTest,
+    validationArraySuperType,
     validation,
     actions,
     topLevelArrayType,

--- a/packages/test-studio/schemas/validation.js
+++ b/packages/test-studio/schemas/validation.js
@@ -3,6 +3,18 @@ import {points, featureCollection} from '@turf/helpers'
 import pointsWithinPolygon from '@turf/points-within-polygon'
 import norway from '../data/norway'
 
+// "gallery" schema
+export const validationArraySuperType = {
+  name: 'gallery',
+  title: 'Gallery',
+  type: 'array',
+  of: [
+    {
+      type: 'image'
+    }
+  ]
+}
+
 export default {
   name: 'validationTest',
   type: 'document',
@@ -296,7 +308,12 @@ export default {
         ]
       }
     },
-
+    {
+      name: 'inheritedArray',
+      title: 'Inherited array type with custom validation',
+      type: 'gallery',
+      validation: Rule => [Rule.min(2), Rule.max(6).warning('too many images')]
+    },
     {
       name: 'location',
       type: 'geopoint',


### PR DESCRIPTION
This makes subtypes of array types override validation rules from its parent type, fixing the issue described in #1774.

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Note for release**
- Fixed an issue with subtypes of arrays not overriding validation rules from its parent type
