### PR TITLE
[client] Add effectFormat as allowed parameter to listener

### DIFF
--- a/packages/@sanity/client/sanityClient.d.ts
+++ b/packages/@sanity/client/sanityClient.d.ts
@@ -529,6 +529,7 @@ export type MutationEvent<R = any> = {
   resultRev?: string
   result?: SanityDocument<R>
   previous?: SanityDocument<R> | null
+  effects?: {apply: unknown[]; revert: unknown[]}
   timestamp: string
   transactionId: string
   transition: 'update' | 'appear' | 'disappear'
@@ -564,6 +565,7 @@ export interface ListenOptions {
   includePreviousRevision?: boolean
   visibility?: 'sync' | 'async' | 'query'
   events?: ListenEventName[]
+  effectFormat?: 'mendoza'
 }
 
 export type PreviousNextListenOptions = ListenOptions & {
@@ -1993,6 +1995,16 @@ export interface SanityClient {
    * @param options Request options
    */
   request(options: RawRequestOptions): Promise<any>
+
+  /**
+   * DEPRECATED: Perform an HTTP request a `/data` sub-endpoint
+   *
+   * @deprecated Use your own request library!
+   * @param endpoint Endpoint to hit (mutate, query etc)
+   * @param body Request body
+   * @param options Request options
+   */
+  dataRequest(endpoint: string, body: unknown, options?: BaseMutationOptions): Promise<any>
 }
 
 export interface ClientConstructor {

--- a/packages/@sanity/client/src/data/listen.js
+++ b/packages/@sanity/client/src/data/listen.js
@@ -19,7 +19,7 @@ const EventSource = isWindowEventSource
   ? window.EventSource // Native browser EventSource
   : polyfilledEventSource // Node.js, IE etc
 
-const possibleOptions = ['includePreviousRevision', 'includeResult', 'visibility']
+const possibleOptions = ['includePreviousRevision', 'includeResult', 'visibility', 'effectFormat']
 const defaultOptions = {
   includeResult: true
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Description**

This PR adds support to the sanity client for the `effectFormat` parameter on listeners, which will be used in upcoming features. It expresses the difference between the previous and the next revision as a minimal patch, and is an alternative to sending the entire previous/next versions.

**Note for release**

- Added support for `effectFormat` parameter on listeners

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
