### PR TITLE
[chore] Upgrade image-url dependency

### DIFF
--- a/packages/@sanity/base/package.json
+++ b/packages/@sanity/base/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@sanity/client": "1.149.18",
     "@sanity/generate-help-url": "1.149.16",
-    "@sanity/image-url": "0.140.15",
+    "@sanity/image-url": "^0.140.19",
     "@sanity/initial-value-templates": "1.149.16",
     "@sanity/mutator": "1.149.18",
     "@sanity/observable": "1.149.16",

--- a/packages/@sanity/dashboard/package.json
+++ b/packages/@sanity/dashboard/package.json
@@ -21,6 +21,7 @@
     "sanity-tool"
   ],
   "dependencies": {
+    "@sanity/image-url": "^0.140.19",
     "lodash": "^4.17.15",
     "react-icons": "^2.2.7",
     "rxjs": "^6.5.3"

--- a/packages/@sanity/preview/package.json
+++ b/packages/@sanity/preview/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/sanity-io/sanity/issues"
   },
   "dependencies": {
-    "@sanity/image-url": "0.140.15",
+    "@sanity/image-url": "^0.140.19",
     "lodash": "^4.17.15",
     "observable-props": "^2.0.0",
     "react-props-stream": "^1.0.0",

--- a/packages/@sanity/studio-hints/package.json
+++ b/packages/@sanity/studio-hints/package.json
@@ -25,6 +25,7 @@
   ],
   "dependencies": {
     "@sanity/block-content-to-react": "^2.0.7",
+    "@sanity/image-url": "^0.140.19",
     "lodash": "^4.17.15",
     "next": "^9.1.3",
     "react-copy-to-clipboard": "^5.0.2",

--- a/packages/test-studio/package.json
+++ b/packages/test-studio/package.json
@@ -30,7 +30,7 @@
     "@sanity/desk-tool": "1.149.18",
     "@sanity/form-builder": "1.149.18",
     "@sanity/google-maps-input": "1.149.16",
-    "@sanity/image-url": "0.140.15",
+    "@sanity/image-url": "^0.140.19",
     "@sanity/production-preview": "1.149.0",
     "@sanity/react-hooks": "1.149.18",
     "@sanity/rich-date-input": "1.149.16",


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [x]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Description**

Upgrades the `@sanity/image-url` dependency, which fixes a few bugs. Also added it as dependency to some packages that were using it without declaring it as a dependency.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
