### PR TITLE
[preview] fix type icons not passed down to DefaultPreview for references

### DIFF
--- a/packages/@sanity/preview/src/components/RenderPreviewSnapshot.tsx
+++ b/packages/@sanity/preview/src/components/RenderPreviewSnapshot.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import customResolver from 'part:@sanity/base/preview-resolver?'
 import {get} from 'lodash'
-import SanityDefaultPreview from './SanityDefaultPreview'
 import {Type} from '../types'
+import SanityDefaultPreview from './SanityDefaultPreview'
 
 // Set this to true for debugging preview subscriptions
 const DEBUG = false
@@ -17,7 +17,7 @@ function resolvePreview(type) {
 }
 
 type Props = {
-  snapshot: object
+  snapshot: any
   type: Type
   isLive: boolean
   layout: string
@@ -28,13 +28,14 @@ export default function RenderPreviewSnapshot(props: Props) {
 
   // TODO: Bjoerge: Check for image type with "is()"
   const renderAsBlockImage = layout === 'block' && type && type.name === 'image'
-
+  const typeName = snapshot?._type
+  const icon = (type.to && type.to.find(t => t.name === typeName)?.icon) || type.icon
   const preview = (
     <PreviewComponent // Render media always until we have schema functionality for determining if there is media
       media={() => undefined}
       {...rest}
       value={snapshot}
-      icon={type && type.icon}
+      icon={icon}
       layout={layout}
       isPlaceholder={!snapshot}
       _renderAsBlockImage={renderAsBlockImage}


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->
If you have a reference to a type, it doesn't seem to be passed down to the DefaultPreview component.

Reported by the community:
> If I have a reference type field in a block array, how can I customize the icon to match the selected reference? For example, in this case I’d like the icon to use the configured pie chart icon if a pie chart is selected as the reference.

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->
This checks if it's a reference and tries to find the referenced type icon. Test it in `Array of named references` here: 
**This branch:** https://test-studio-git-type-icons-for-references-in-preview.sanity-io.now.sh/test/desk/arraysTest;4d7e9f30-20eb-4894-a4f1-c6a4eae2646a
**Current:** https://test-studio-git-current.sanity-io.now.sh/test/desk/arraysTest;4d7e9f30-20eb-4894-a4f1-c6a4eae2646a

Before and after
<img width="694" alt="Screenshot 2020-10-12 at 10 51 53" src="https://user-images.githubusercontent.com/25737281/95726490-4a2d7000-0c79-11eb-9e98-05a72e628b36.png">:


<img width="694" alt="Screenshot 2020-10-12 at 10 52 58" src="https://user-images.githubusercontent.com/25737281/95726481-4863ac80-0c79-11eb-8804-e876402ee4e0.png">


**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

- Fixed type icons not passed down in previews for references in the default preview component (and affecting previews in arrays)

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The code is linted
- [x]  The test suite is passing
