### PR TITLE
[components] support type icons in insert array element menu list

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ArrayInput/ArrayFunctions.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ArrayInput/ArrayFunctions.tsx
@@ -6,6 +6,7 @@ import {Type} from '../../typedefs'
 import styles from './styles/ArrayInput.css'
 import {ArrayType, ItemValue} from './typedefs'
 import PatchEvent from '../../PatchEvent'
+import PlusIcon from 'part:@sanity/base/plus-icon'
 type Props = {
   type: ArrayType
   children: Node | null
@@ -30,10 +31,16 @@ export default class ArrayFunctions extends React.Component<Props, {}> {
     onAppendItem(item)
   }
   renderSelectType() {
-    const items = this.props.type.of.map(memberDef => ({
-      title: memberDef.title || memberDef.type.name,
-      type: memberDef
-    }))
+    const items = this.props.type.of.map(memberDef => {
+      // Use reference icon if reference is to one type only
+      const referenceIcon = (memberDef.to || []).length === 1 && memberDef.to[0].icon
+      const icon = memberDef.icon || memberDef.type.icon || referenceIcon || PlusIcon
+      return {
+        title: memberDef.title || memberDef.type.name,
+        type: memberDef,
+        icon
+      }
+    })
     return (
       <DropDownButton inverted items={items} onAction={this.handleDropDownAction}>
         Add


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  New feature (non-breaking change which adds functionality)

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->

Menu does not include type icons and it can't be customized

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

This adds icons to the insert array item dropdown menu. Supports custom icons, fallback is type icon, icon for reference (if ref is to one type only), or plus icon

<img width="768" alt="Screenshot 2020-07-29 at 08 10 49" src="https://user-images.githubusercontent.com/25737281/88779913-942eab80-d18a-11ea-8738-48b21dccb582.png">

Edit: primitives also get an icon now, which is always the plus icon. Might look a little weird.. :/ 


**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

- Dropdown menu for adding array items now include type icons, and they can also be overridden

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
