### PR TITLE
[form-builder] prevent date picker from closing before selecting a time

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/DateInputs/BaseDateTimeInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/DateInputs/BaseDateTimeInput.tsx
@@ -56,7 +56,7 @@ export default class BaseDateTimeInput extends React.Component<Props, State> {
   handleDialogChange = (nextMoment?: Moment) => {
     const {onChange} = this.props
     onChange(nextMoment)
-    this.setState({inputValue: null, isDialogOpen: false})
+    this.setState({inputValue: null})
   }
   handleSetNow = event => {
     this.handleDialogChange(moment())


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->

> Right now, the date picker closes when selecting a date. If the user also wants to change the time, they have to reopen the date picker.

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->
This prevents the date picker closing before it's supposed to. The datepicker library handles closing it.

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

- Fixed an issue where the date and time picker closed when choosing a date and had to reopened to choose a time

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
