### PR TITLE
Make a couple of stability improvements to gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -88,13 +88,7 @@ function buildTypeScript(packageDir) {
   const project = ts.createProject(path.join(packageDir, 'tsconfig.json'))
   return withDisplayName(compileTaskName('dts', packageDir), () => {
     const compilation = project.src().pipe(project())
-    return compilation.dts
-      .pipe(
-        changed(DEST_DIR, {
-          cwd: packageDir
-        })
-      )
-      .pipe(dest(project.options.outDir))
+    return compilation.dts.pipe(dest(project.options.outDir))
   })
 }
 

--- a/scripts/utils/getPackagesOrderedByTopology.js
+++ b/scripts/utils/getPackagesOrderedByTopology.js
@@ -1,0 +1,30 @@
+const PackageGraph = require('@lerna/package-graph')
+const {getFilteredPackages} = require('@lerna/filter-options')
+const Project = require('@lerna/project')
+const {toposort} = require('@lerna/query-graph')
+const {spawnSync} = require('child_process')
+
+// When used as a module, this script exports a function that, when called, will invoke itself through
+// child_process.spawnSync and return the JSON parsed stdout. When called as a script, it will retrieve
+// (async) the monorepo packages sorted by topology and write the list of packages as a JSON string to stdout.
+//
+// (who says you can't make asynchronous APIs synchronous? :p)
+
+async function getLernaTopology(dir) {
+  const packages = await new Project(dir).getPackages()
+  const pkgs = await getFilteredPackages(new PackageGraph(packages))
+  return toposort(pkgs, {graphType: 'allDependencies'}).map(pkg => pkg.name)
+}
+
+if (require.main === module) {
+  getLernaTopology(process.cwd()).then(topology => process.stdout.write(JSON.stringify(topology)))
+}
+
+exports.getPackagesOrderedByTopology = function getPackagesOrderedByTopology() {
+  const {stderr, stdout} = spawnSync('node', [__filename], {encoding: 'utf8'})
+  if (stderr) {
+    // eslint-disable-next-line no-console
+    console.log('[package topology] %s ', stderr)
+  }
+  return JSON.parse(stdout)
+}


### PR DESCRIPTION
**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [x]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**
Currently the gulpfile uses a hand written list of TypeScript modules that depends on each other so that they can be compiled in order. This was brittle and easily got out of hand. This PR instead retrieves the list of packages ordered by toplology (e.g. their interdependencies - leaves first) from lerna. This makes sure all packages gets compiled in order.

This probably increases the build time for release a bit since it now builds all TypeScript modules serially, but I guess reliability trumps performance in this regard. On the bright side I didn't notice any significant differences in startup time for the test studios compared to before.

Sneaking in 44eb047 into this PR also, which removes piping typescript files to `changed()`, since this, for some reason didn't trigger a recompile.

**Note for release**
(n/a)

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [x]  Corresponding changes to the documentation have been made
