### PR TITLE
Various PTE  enhancements

### DIFF
--- a/packages/@sanity/form-builder/package.json
+++ b/packages/@sanity/form-builder/package.json
@@ -25,7 +25,7 @@
     "@sanity/generate-help-url": "1.149.16",
     "@sanity/imagetool": "1.149.18",
     "@sanity/mutator": "1.149.18",
-    "@sanity/portable-text-editor": "0.1.3",
+    "@sanity/portable-text-editor": "0.1.4",
     "@sanity/util": "1.149.16",
     "@sanity/uuid": "1.149.16",
     "attr-accept": "^1.1.0",

--- a/packages/@sanity/form-builder/src/inputs/PortableText/Editor.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Editor.tsx
@@ -9,7 +9,6 @@ import {
   RenderBlockFunction,
   RenderChildFunction,
   RenderDecoratorFunction,
-  Type,
   EditorSelection,
   OnPasteFn,
   OnCopyFn
@@ -30,6 +29,7 @@ type Props = {
   initialSelection?: EditorSelection
   isFullscreen: boolean
   markers: Array<Marker>
+  hotkeys: HotkeyOptions
   onBlur: () => void
   onCopy?: OnCopyFn
   onCloseValidationResults: () => void
@@ -56,15 +56,23 @@ const renderDecorator: RenderDecoratorFunction = (mark, mType, attributes, defau
 // eslint-disable-next-line complexity
 function PortableTextSanityEditor(props: Props) {
   const {value, showValidationTooltip, markers, readOnly, isFullscreen} = props
-  const hotkeys: HotkeyOptions = {
+  const customFromProps: HotkeyOptions = {
+    custom: {
+      'mod+enter': props.onToggleFullscreen,
+      ...(props.hotkeys || {}).custom
+    }
+  }
+  const marksFromProps: HotkeyOptions = {
     marks: {
       'mod+b': 'strong',
       'mod+i': 'em',
-      'mod+´': 'code'
-    },
-    custom: {
-      'mod+enter': props.onToggleFullscreen
+      'mod+´': 'code',
+      ...(props.hotkeys || {}).marks
     }
+  }
+  const hotkeys: HotkeyOptions = {
+    ...marksFromProps,
+    ...customFromProps
   }
   const {
     initialSelection,

--- a/packages/@sanity/form-builder/src/inputs/PortableText/Input.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Input.tsx
@@ -138,12 +138,12 @@ export default function PortableTextInput(props: Props) {
     }
   }, [focusPath])
 
-  // Set as active whenever we have a focusPath inside the editor.
+  // Set as active whenever we have focus inside the editor.
   useEffect(() => {
-    if (focusPath && focusPath.length > 1) {
+    if (hasFocus) {
       setIsActive(true)
     }
-  }, [focusPath])
+  }, [hasFocus])
 
   // Update the FormBuilder focusPath as we get a new selection from the editor
   // This will also set presence on that path

--- a/packages/@sanity/form-builder/src/inputs/PortableText/Input.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Input.tsx
@@ -10,7 +10,8 @@ import {
   PortableTextEditor,
   Type,
   usePortableTextEditor,
-  usePortableTextEditorSelection
+  usePortableTextEditorSelection,
+  HotkeyOptions
 } from '@sanity/portable-text-editor'
 import {uniqueId, isEqual} from 'lodash'
 import ActivateOnFocus from 'part:@sanity/components/utilities/activate-on-focus'
@@ -34,6 +35,7 @@ import PortableTextSanityEditor from './Editor'
 type Props = {
   focusPath: Path
   hasFocus: boolean
+  hotkeys: HotkeyOptions
   isFullscreen: boolean
   markers: Array<Marker>
   onBlur: () => void
@@ -55,6 +57,7 @@ export default function PortableTextInput(props: Props) {
   const {
     focusPath,
     hasFocus,
+    hotkeys,
     isFullscreen,
     markers,
     onBlur,
@@ -314,6 +317,7 @@ export default function PortableTextInput(props: Props) {
 
   const ptEditor = (
     <PortableTextSanityEditor
+      hotkeys={hotkeys}
       initialSelection={initialSelection}
       isFullscreen={isFullscreen}
       markers={markers}

--- a/packages/@sanity/form-builder/src/inputs/PortableText/Input.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Input.tsx
@@ -138,6 +138,13 @@ export default function PortableTextInput(props: Props) {
     }
   }, [focusPath])
 
+  // Set as active whenever we have a focusPath inside the editor.
+  useEffect(() => {
+    if (focusPath && focusPath.length > 1) {
+      setIsActive(true)
+    }
+  }, [focusPath])
+
   // Update the FormBuilder focusPath as we get a new selection from the editor
   // This will also set presence on that path
   useEffect(() => {

--- a/packages/@sanity/form-builder/src/inputs/PortableText/PortableTextInput.css
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/PortableTextInput.css
@@ -264,3 +264,26 @@
     width: calc(100% - var(--block-extras-width));
   }
 }
+
+.focusSkipper {
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  margin: 0;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+  padding: 0.2em;
+  background-color: var(--component-bg);
+  border: var(--input-border-size) solid var(--input-border-color);
+  border-radius: var(--input-border-radius);
+
+  @nest &:focus {
+    z-index: 20;
+    width: auto;
+    height: auto;
+    clip: auto;
+    outline: none;
+    box-shadow: var(--input-box-shadow--focus);
+    border-color: var(--input-border-color-focus);
+  }
+}

--- a/packages/@sanity/form-builder/src/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/PortableTextInput.tsx
@@ -126,7 +126,10 @@ export default withPatchSubscriber(function PortableTextInput(props: Props) {
   function handleEditorChange(change: EditorChange): void {
     switch (change.type) {
       case 'mutation':
-        onChange(PatchEvent.from(change.patches))
+        // Don't wait for the result
+        setTimeout(() => {
+          onChange(PatchEvent.from(change.patches))
+        })
         break
       case 'focus':
         setHasFocus(true)

--- a/packages/@sanity/form-builder/src/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/PortableTextInput.tsx
@@ -234,6 +234,7 @@ export default withPatchSubscriber(function PortableTextInput(props: Props) {
   return (
     <>
       {editorErrorNotification && (
+        // Display intended editor errors to the user
         <Snackbar
           kind={editorErrorNotification.level}
           isPersisted

--- a/packages/@sanity/form-builder/src/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/PortableTextInput.tsx
@@ -9,7 +9,8 @@ import {
   Patch as EditorPatch,
   PortableTextBlock,
   PortableTextEditor,
-  Type
+  Type,
+  HotkeyOptions
 } from '@sanity/portable-text-editor'
 import {Subject} from 'rxjs'
 import {Patch} from '../../typedefs/patch'
@@ -28,6 +29,7 @@ export type PatchWithOrigin = Patch & {
 
 type Props = {
   focusPath: Path
+  hotkeys: HotkeyOptions
   level: number
   markers: Array<Marker>
   onBlur: () => void
@@ -47,6 +49,7 @@ type Props = {
 export default withPatchSubscriber(function PortableTextInput(props: Props) {
   const {
     focusPath,
+    hotkeys,
     level,
     markers,
     onBlur,
@@ -204,6 +207,7 @@ export default withPatchSubscriber(function PortableTextInput(props: Props) {
         <Input
           focusPath={focusPath}
           hasFocus={hasFocus}
+          hotkeys={hotkeys}
           isFullscreen={isFullscreen}
           markers={markers}
           onBlur={onBlur}

--- a/packages/@sanity/form-builder/src/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/PortableTextInput.tsx
@@ -68,8 +68,7 @@ export default withPatchSubscriber(function PortableTextInput(props: Props) {
   // The PortableTextEditor will not re-render unless the value is changed (which is good).
   // But, we want to re-render it when the markers changes too,
   // (we render error indicators directly in the editor nodes)
-  const validation = markers.filter(marker => marker.type === 'validation')
-  const validationHash = validation
+  const validationHash = markers
     .map(marker =>
       JSON.stringify(marker.path)
         .concat(marker.type)

--- a/packages/@sanity/form-builder/src/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/PortableTextInput.tsx
@@ -103,9 +103,10 @@ export default withPatchSubscriber(function PortableTextInput(props: Props) {
     }
   }, [])
 
+  // Memoized patch stream
+  const patche$: Subject<EditorPatch> = useMemo(() => new Subject(), [])
+
   // Handle incoming patches from withPatchSubscriber HOC
-  let incoming: PatchWithOrigin[] = []
-  const patche$: Subject<EditorPatch> = new Subject()
   function handleDocumentPatches({
     patches
   }: {
@@ -115,7 +116,6 @@ export default withPatchSubscriber(function PortableTextInput(props: Props) {
     const patchSelection =
       patches && patches.length > 0 && patches.filter(patch => patch.origin !== 'local')
     if (patchSelection) {
-      incoming = incoming.concat(patchSelection)
       patchSelection.map(patch => patche$.next(patch))
     }
   }

--- a/packages/@sanity/form-builder/src/inputs/PortableText/Toolbar/OverflowMenu.css
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Toolbar/OverflowMenu.css
@@ -9,7 +9,6 @@
   flex: 1;
   min-width: 0;
   white-space: nowrap;
-  overflow: hidden;
 }
 
 .actionButton {


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

* Re-implemented the focus-skipper button for easy access to the editor without tabbing through all the toolbar-buttons.
* Export a React class as the outmost component with `focus` and `blur` class methods. The FormBuilder expects this.
* Optimize when props.value is deserialized in regard to not updating the value while the user is actively selecting text. The editor value will not be updated unless the actual props.value is changed while selecting.
* Fix focus ring cutoff for overflow menu buttons in the PTE toolbar.
* Don't wait for the onChange result from the FormBuilder - we will update the value when a new prop comes in anyway.
* Set the editor active when the editor has focus. There was a problem with this state when tabbing into the editor.
* Upgrade to latest PTE core module.
* Hash value on not just validation markers, but all markers
* Allow customizing hotkeys via outside props
* Memoize patches stream