### PR TITLE
[components] prevent tags from overflowing field width and not wrapping

### DIFF
--- a/packages/@sanity/components/src/tags/TextField.js
+++ b/packages/@sanity/components/src/tags/TextField.js
@@ -15,7 +15,8 @@ export default class TagsTextField extends React.Component {
     onBlur: PropTypes.func,
     readOnly: PropTypes.bool,
     markers: PropTypes.array,
-    value: PropTypes.arrayOf(PropTypes.string)
+    value: PropTypes.arrayOf(PropTypes.string),
+    inputId: PropTypes.string
   }
 
   static defaultProps = {
@@ -91,7 +92,7 @@ export default class TagsTextField extends React.Component {
 
   render() {
     const {inputValue} = this.state
-    const {onChange, value, readOnly, markers, ...rest} = this.props
+    const {onChange, value, readOnly, markers, inputId, ...rest} = this.props
 
     return (
       <div className={readOnly ? styles.rootReadOnly : styles.root}>
@@ -125,6 +126,7 @@ export default class TagsTextField extends React.Component {
                 onBlur={this.handleBlur}
                 ref={this.setInput}
                 autoComplete="off"
+                id={inputId}
               />
             </ul>
           </div>

--- a/packages/@sanity/components/src/tags/styles/TextField.css
+++ b/packages/@sanity/components/src/tags/styles/TextField.css
@@ -24,6 +24,8 @@
   display: flex;
   margin: 0;
   padding: 0; 
+  flex-wrap: wrap;
+  gap: var(--small-padding);
 }
 
 .tag {
@@ -33,7 +35,6 @@
   color: var(--gray-dark);
   border: 1px solid var(--gray-light);
   box-sizing: border-box;
-  margin-right: 0.25em;
   padding: 0 0.5em;
   font-size: 1em;
   line-height: 1.45em;


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->

![image (3)](https://user-images.githubusercontent.com/25737281/90861759-94d2f000-e38c-11ea-8889-154f9444dd4c.png)


**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

This fixes the layout issue in the tags input.
<img width="673" alt="Screenshot 2020-08-21 at 09 03 20" src="https://user-images.githubusercontent.com/25737281/90862085-2b071600-e38d-11ea-91aa-033d1f601621.png">


**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

- Fixed an issue where the tags input field would overflow and hide tags when many tags. This also caused tags to get the wrong height.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title is appropriately formatted: `[some-package] PR title`
- [x]  The code is linted
- [x]  The test suite is passing
