### PR TITLE
[form-builder] Handle async rendering in ImageToolInput

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ImageToolInput/ImageToolInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ImageToolInput/ImageToolInput.tsx
@@ -67,13 +67,14 @@ export default class ImageToolInput extends React.Component<Props, ImageToolInpu
         : value.hotspot
       onChange(PatchEvent.from([set(crop, ['crop']), set(hotspot, ['hotspot'])]))
     }
-    this.setState({value: this.props.value})
   }
   handleChange = (nextValue: Value) => {
     this.setState({value: nextValue})
   }
   UNSAFE_componentWillReceiveProps(nextProps) {
-    this.setState({value: nextProps.value})
+    if (nextProps.value !== this.props.value) {
+      this.setState({value: nextProps.value})
+    }
   }
   render() {
     const {imageUrl, level, readOnly} = this.props


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->

In certain situations (depending on the scheduler of React and/or event handling in our mutator) the ImageTool could glitch where it would briefly show the previous hotspot. There is no indication that this has occurred any current releases.

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

ImageToolInput called onChange with the assumption that it would cause a synchronous re-rendering so that the following `setState({value: props.value})` would use the _updated_ value. This turns out to not be universally true.

The following change removes the extra setState and instead handles state updates only when the value-props is being updated from the outside.

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

This PR fixes a case where the image input component was depending on a particular behavior of React (which is not guaranteed) to work correctly. We haven't seen any reports that this has caused any problems in any releases.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [x]  Corresponding changes to the documentation have been made
