### PR TITLE
[form-builder] PTE: Fix issues with rendering object edit under some conditions

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/PortableText/Input.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Input.tsx
@@ -350,7 +350,7 @@ export default function PortableTextInput(props: Props) {
 
   const editObject = useMemo(() => {
     return renderEditObject()
-  }, [focusPath, markers, presence, value])
+  }, [focusPath, markers, objectEditData, presence, value])
 
   const activationId = useMemo(() => uniqueId('PortableTextInput'), [])
   const fullscreenToggledEditor = (


### PR DESCRIPTION
This will fix an issue where the edit objects in the PTE would not open and render correctly whenever we had a Websocket error. 