### PR TITLE
[components] Support tabIndex from props for buttons and StyleSelect

### DIFF
--- a/packages/@sanity/components/src/buttons/DropDownButton.js
+++ b/packages/@sanity/components/src/buttons/DropDownButton.js
@@ -54,7 +54,8 @@ export default class DropDownButton extends React.PureComponent {
     className: PropTypes.string,
     renderItem: PropTypes.func,
     placement: PropTypes.string,
-    showArrow: PropTypes.bool
+    showArrow: PropTypes.bool,
+    tabIndex: PropTypes.number
   }
 
   static defaultProps = {
@@ -71,7 +72,8 @@ export default class DropDownButton extends React.PureComponent {
       return <div>{item.title}</div>
     },
     showArrow: true,
-    placement: 'bottom-start'
+    placement: 'bottom-start',
+    tabIndex: 0
   }
 
   firstItemElement = React.createRef()
@@ -151,7 +153,7 @@ export default class DropDownButton extends React.PureComponent {
   }
 
   render() {
-    const {items, renderItem, children, kind, className, placement, showArrow, ...rest} = omit(
+    const {items, renderItem, children, kind, placement, showArrow, tabIndex, ...rest} = omit(
       this.props,
       'onAction'
     )
@@ -170,6 +172,7 @@ export default class DropDownButton extends React.PureComponent {
           onKeyDown={this.handleButtonKeyDown}
           onBlur={this.handleButtonBlur}
           ref={this.buttonElement}
+          tabIndex={tabIndex}
         >
           {(showArrow || children) && (
             <div className={styles.inner}>
@@ -210,7 +213,7 @@ export default class DropDownButton extends React.PureComponent {
                         onClick={event => this.handleItemClick(event, item)} //eslint-disable-line react/jsx-no-bind
                         onKeyPress={event => this.handleItemKeyPress(event, item)} //eslint-disable-line react/jsx-no-bind
                         item={item}
-                        tabIndex={0}
+                        tabIndex={tabIndex}
                         ref={i === 0 && this.firstItemElement}
                       >
                         {renderItem(item)}
@@ -219,7 +222,7 @@ export default class DropDownButton extends React.PureComponent {
                   })}
                 </ArrowKeyNavigation>
               </List>
-              <div tabIndex={0} onFocus={this.handleMenuBlur} />
+              <div tabIndex={tabIndex} onFocus={this.handleMenuBlur} />
             </>
           )}
         </Poppable>

--- a/packages/@sanity/components/src/buttons/createButtonLike.js
+++ b/packages/@sanity/components/src/buttons/createButtonLike.js
@@ -38,6 +38,7 @@ export default function createButtonLike(Component, {displayName, defaultProps =
       bleed: false,
       padding: 'default',
       selected: false,
+      tabIndex: 0,
       ...defaultProps
     }
 
@@ -82,6 +83,7 @@ export default function createButtonLike(Component, {displayName, defaultProps =
         padding,
         bleed,
         selected,
+        tabIndex,
         ...rest
       } = this.props
 
@@ -103,7 +105,7 @@ export default function createButtonLike(Component, {displayName, defaultProps =
           className={style}
           disabled={disabled || loading}
           ref={this.setRootElement}
-          tabIndex={0}
+          tabIndex={tabIndex}
           onBlur={this.handleBlur}
         >
           {/*

--- a/packages/@sanity/components/src/selects/StyleSelect.js
+++ b/packages/@sanity/components/src/selects/StyleSelect.js
@@ -62,7 +62,8 @@ class StyleSelect extends React.PureComponent {
       })
     ),
     padding: PropTypes.oneOf(['large', 'default', 'small', 'none']),
-    transparent: PropTypes.bool
+    transparent: PropTypes.bool,
+    tabIndex: PropTypes.number
   }
 
   static defaultProps = {
@@ -74,6 +75,7 @@ class StyleSelect extends React.PureComponent {
     padding: 'default',
     placeholder: undefined,
     transparent: false,
+    tabIndex: 0,
     value: undefined
   }
 
@@ -173,7 +175,8 @@ class StyleSelect extends React.PureComponent {
       padding,
       placeholder,
       renderItem,
-      transparent
+      transparent,
+      tabIndex
     } = this.props
     const {showList} = this.state
     const className = classNames(
@@ -191,7 +194,12 @@ class StyleSelect extends React.PureComponent {
         onKeyPress={this.handleButtonKeyDown}
         tabIndex={0}
       >
-        <button className={styles.button} disabled={disabled} ref={this.buttonElement}>
+        <button
+          type="button"
+          className={styles.button}
+          disabled={disabled}
+          ref={this.buttonElement}
+        >
           <div className={styles.buttonInner}>
             <span className={styles.title}>
               {value && value.length > 1 && 'Multiple'}
@@ -216,7 +224,7 @@ class StyleSelect extends React.PureComponent {
                 {items.map((item, index) => {
                   const isSemiSelected = value && value.length > 1 && value.includes(item)
                   const isSelected = value && value.length === 1 && value[0].key == item.key
-                  const classNames = `
+                  const itemClassNames = `
                         ${isSelected ? styles.itemSelected : styles.item}
                         ${isSemiSelected ? styles.itemSemiSelected : ''}
                       `
@@ -226,7 +234,8 @@ class StyleSelect extends React.PureComponent {
                         title={item.title}
                         data-index={index}
                         onClick={this.handleSelect}
-                        className={classNames}
+                        className={itemClassNames}
+                        tabIndex={0}
                         onKeyPress={this.handleItemKeyPress} //eslint-disable-line react/jsx-no-bind
                         ref={index === 0 && this.firstItemElement}
                       >
@@ -241,7 +250,7 @@ class StyleSelect extends React.PureComponent {
                 })}
               </ArrowKeyNavigation>
 
-              <div tabIndex={0} onFocus={this.handleMenuBlur} />
+              <div tabIndex={tabIndex} onFocus={this.handleMenuBlur} />
             </>
           )}
         </Poppable>


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->

I discovered that it's not possible to control `tabIndex` on our buttons and the StyleSelect component. This will add that support, while defaulting to what it was originally.

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

**Note for release**

Support tabIndex from props on various components.

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
