### PR TITLE
Fix: Make useObservable resubscribe when receiving new observables

### DIFF
--- a/packages/@sanity/react-hooks/src/useConnectionState.ts
+++ b/packages/@sanity/react-hooks/src/useConnectionState.ts
@@ -1,7 +1,8 @@
 import documentStore from 'part:@sanity/base/datastore/document'
-import {toObservable, useObservable} from './utils/use-observable'
-import {distinctUntilChanged, map, switchMap, mapTo} from 'rxjs/operators'
-import {Observable, of, timer} from 'rxjs'
+import {useObservable} from './utils/use-observable'
+import {distinctUntilChanged, map, mapTo, switchMap} from 'rxjs/operators'
+import {of, timer} from 'rxjs'
+import React from 'react'
 
 type ConnectionState = 'connecting' | 'reconnecting' | 'connected'
 
@@ -9,22 +10,17 @@ const INITIAL: ConnectionState = 'connecting'
 
 export function useConnectionState(publishedId, typeName): ConnectionState {
   return useObservable<ConnectionState>(
-    toObservable({publishedId, typeName}, props$ =>
-      props$.pipe(
-        distinctUntilChanged((curr, next) => curr.publishedId === next.publishedId),
-        switchMap(
-          ({publishedId, typeName}): Observable<ConnectionState> => {
-            return documentStore.pair.documentEvents(publishedId, typeName).pipe(
-              map((ev: {type: string}) => ev.type),
-              map(eventType => eventType !== 'reconnect'),
-              switchMap(isConnected =>
-                isConnected ? of('connected') : timer(200).pipe(mapTo('reconnecting'))
-              ),
-              distinctUntilChanged()
-            )
-          }
-        )
-      )
+    React.useMemo(
+      () =>
+        documentStore.pair.documentEvents(publishedId, typeName).pipe(
+          map((ev: {type: string}) => ev.type),
+          map(eventType => eventType !== 'reconnect'),
+          switchMap(isConnected =>
+            isConnected ? of('connected') : timer(200).pipe(mapTo('reconnecting'))
+          ),
+          distinctUntilChanged()
+        ),
+      [publishedId, typeName]
     ),
     INITIAL
   )

--- a/packages/@sanity/react-hooks/src/useDocumentOperation.ts
+++ b/packages/@sanity/react-hooks/src/useDocumentOperation.ts
@@ -1,16 +1,12 @@
+import React from 'react'
 import documentStore from 'part:@sanity/base/datastore/document'
-import {toObservable, useObservable} from './utils/use-observable'
-import {distinctUntilChanged, switchMap} from 'rxjs/operators'
+import {useObservable} from './utils/use-observable'
 
 export function useDocumentOperation(publishedId, typeName) {
   return useObservable(
-    toObservable({publishedId, typeName}, props$ =>
-      props$.pipe(
-        distinctUntilChanged((curr, next) => curr.publishedId === next.publishedId),
-        switchMap(({publishedId, typeName}) =>
-          documentStore.pair.editOperations(publishedId, typeName)
-        )
-      )
-    )
+    React.useMemo(() => documentStore.pair.editOperations(publishedId, typeName), [
+      publishedId,
+      typeName
+    ])
   )
 }

--- a/packages/@sanity/react-hooks/src/useDocumentOperationEvent.ts
+++ b/packages/@sanity/react-hooks/src/useDocumentOperationEvent.ts
@@ -1,17 +1,12 @@
 import documentStore from 'part:@sanity/base/datastore/document'
-import {toObservable, useObservable} from './utils/use-observable'
-import {distinctUntilChanged, switchMap} from 'rxjs/operators'
+import {useObservable} from './utils/use-observable'
+import React from 'react'
 
 export function useDocumentOperationEvent(publishedId, typeName) {
   return useObservable(
-    toObservable({publishedId, typeName}, props$ =>
-      props$.pipe(
-        distinctUntilChanged((curr, next) => curr.publishedId === next.publishedId),
-        switchMap(({publishedId, typeName}) =>
-          documentStore.pair.operationEvents(publishedId, typeName)
-        ),
-        distinctUntilChanged()
-      )
-    )
+    React.useMemo(() => documentStore.pair.operationEvents(publishedId, typeName), [
+      publishedId,
+      typeName
+    ])
   )
 }

--- a/packages/@sanity/react-hooks/src/useEditState.ts
+++ b/packages/@sanity/react-hooks/src/useEditState.ts
@@ -1,14 +1,12 @@
 import documentStore from 'part:@sanity/base/datastore/document'
-import {toObservable, useObservable} from './utils/use-observable'
-import {switchMap, distinctUntilChanged} from 'rxjs/operators'
+import {useObservable} from './utils/use-observable'
+import React from 'react'
 
 export function useEditState(publishedId, typeName) {
   return useObservable(
-    toObservable({publishedId, typeName}, props$ =>
-      props$.pipe(
-        distinctUntilChanged((curr, next) => curr.publishedId === next.publishedId),
-        switchMap(({publishedId, typeName}) => documentStore.pair.editState(publishedId, typeName))
-      )
-    )
+    React.useMemo(() => documentStore.pair.editState(publishedId, typeName), [
+      publishedId,
+      typeName
+    ])
   )
 }

--- a/packages/@sanity/react-hooks/src/useSyncState.ts
+++ b/packages/@sanity/react-hooks/src/useSyncState.ts
@@ -1,7 +1,7 @@
 import documentStore from 'part:@sanity/base/datastore/document'
-import {toObservable, useObservable} from './utils/use-observable'
-import {map, switchMap, distinctUntilChanged} from 'rxjs/operators'
-import {Observable} from 'rxjs'
+import {useObservable} from './utils/use-observable'
+import {map} from 'rxjs/operators'
+import React from 'react'
 
 interface SyncState {
   isSyncing: boolean
@@ -12,17 +12,12 @@ const NOT_SYNCING = {isSyncing: false}
 
 export function useSyncState(publishedId, typeName): SyncState {
   return useObservable<SyncState>(
-    toObservable(publishedId, props$ =>
-      props$.pipe(
-        distinctUntilChanged(),
-        switchMap(
-          (publishedId): Observable<SyncState> => {
-            return documentStore.pair
-              .consistencyStatus(publishedId)
-              .pipe(map(isConsistent => (isConsistent ? NOT_SYNCING : SYNCING)))
-          }
-        )
-      )
+    React.useMemo(
+      () =>
+        documentStore.pair
+          .consistencyStatus(publishedId)
+          .pipe(map(isConsistent => (isConsistent ? NOT_SYNCING : SYNCING))),
+      [publishedId]
     ),
     NOT_SYNCING
   )

--- a/packages/@sanity/react-hooks/src/useValidationStatus.ts
+++ b/packages/@sanity/react-hooks/src/useValidationStatus.ts
@@ -1,7 +1,6 @@
 import documentStore from 'part:@sanity/base/datastore/document'
-import {toObservable, useObservable} from './utils/use-observable'
-import {switchMap, distinctUntilChanged} from 'rxjs/operators'
-import {Observable} from 'rxjs'
+import {useObservable} from './utils/use-observable'
+import React from 'react'
 
 interface Marker {
   level: string
@@ -17,15 +16,10 @@ const INITIAL: ValidationStatus = {markers: [], isValidating: false}
 
 export function useValidationStatus(publishedId, typeName): ValidationStatus {
   return useObservable(
-    toObservable({publishedId, typeName}, props$ =>
-      props$.pipe(
-        distinctUntilChanged((curr, next) => curr.publishedId === next.publishedId),
-        switchMap(
-          ({publishedId, typeName}): Observable<ValidationStatus> =>
-            documentStore.pair.validation(publishedId, typeName)
-        )
-      )
-    ),
+    React.useMemo(() => documentStore.pair.validation(publishedId, typeName), [
+      publishedId,
+      typeName
+    ]),
     INITIAL
   )
 }

--- a/packages/@sanity/react-hooks/src/utils/use-observable.ts
+++ b/packages/@sanity/react-hooks/src/utils/use-observable.ts
@@ -33,13 +33,22 @@ export function toObservable<T, K>(
   return setup ? setup(o) : o
 }
 
-export function useObservable<T>(observable$: Observable<T>): T | null
+const isCallable = (val: any): val is (...args: unknown[]) => unknown => typeof val === 'function'
+
+function getValue<T>(value: T): T
+function getValue<T>(value: T | (() => T)): T {
+  return isCallable(value) ? value() : value
+}
+
+export function useObservable<T>(observable$: Observable<T>): T | undefined
 export function useObservable<T>(observable$: Observable<T>, initialValue: T): T
-export function useObservable<T>(observable$: Observable<T>, initialValue?: T): T | null {
+export function useObservable<T>(observable$: Observable<T>, initialValue: () => T): T
+export function useObservable<T>(observable$: Observable<T>, initialValue?: T): T | undefined {
   const subscription = React.useRef<Subscription>()
-  const [value, setState] = React.useState<T | null>(() => {
+  const isInitial = React.useRef(true)
+  const [value, setState] = React.useState<T | undefined>(() => {
     let isSync = true
-    let syncVal = typeof initialValue === 'undefined' ? null : initialValue
+    let syncVal = getValue(initialValue)
     subscription.current = observable$.subscribe(nextVal => {
       if (isSync) {
         syncVal = nextVal
@@ -51,14 +60,18 @@ export function useObservable<T>(observable$: Observable<T>, initialValue?: T): 
     return syncVal
   })
 
-  React.useEffect(
-    () => () => {
+  React.useEffect(() => {
+    // when the observable$ changes after initial (possibly sync render)
+    if (!isInitial.current) {
+      subscription.current = observable$.subscribe(nextVal => setState(nextVal))
+    }
+    isInitial.current = false
+    return () => {
       if (subscription.current) {
         subscription.current.unsubscribe()
       }
-    },
-    []
-  )
+    }
+  }, [observable$])
 
   return value
 }


### PR DESCRIPTION
The change in 2f34d6a makes sure the `useObservable` utility function in @sanity/react-hooks resubscribe whenever it receives a new observable.

Additionally, in 5148c37 we avoid creating new observables on every render by memoizing them by the given parameters.

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Note for release**
N/A

