### PR TITLE
[chore] Improve handling of TypeScript compile errors during dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "gulp-changed": "^4.0.2",
     "gulp-filter": "^6.0.0",
     "gulp-newer": "^1.4.0",
+    "gulp-notify": "^3.2.0",
     "gulp-plumber": "^1.2.1",
     "gulp-sourcemaps": "^2.6.5",
     "gulp-typescript": "^5.0.1",


### PR DESCRIPTION
Currently, if there are compile errors when you start the dev server the gulp script will just crash and the process will exit, leaving the dev server running and occupying the port.

This PR adds graceful handling of TS compile errors during both startup and later on if introducing compile errors during development. It also pops a notification when a compile error appears during development.

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [x]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Note for release**
N/A
