### PR TITLE
[components] fix various minor boolean visuals

### DIFF
--- a/packages/@sanity/components/src/toggles/Checkbox.css
+++ b/packages/@sanity/components/src/toggles/Checkbox.css
@@ -13,7 +13,6 @@
 .root {
   position: relative;
   display: flex;
-  margin-bottom: var(--small-padding);
 }
 
 .input {
@@ -40,7 +39,6 @@
   border: 1px solid var(--checkbox-off-color);
   border-radius: 3px;
   margin-top: 1px;
-  margin-right: var(--small-padding);
   line-height: 1;
 
   @nest & .mark {

--- a/packages/@sanity/components/src/toggles/Checkbox.tsx
+++ b/packages/@sanity/components/src/toggles/Checkbox.tsx
@@ -70,7 +70,8 @@ export default React.forwardRef(function Checkbox(
           <path d="M0.0799561 1.5H8.91996" stroke="currentColor" strokeWidth="2" />
         </svg>
       </div>
-      <div>
+      {label && (
+      <div className={sharedStyles.label}>
         <div className={sharedStyles.titleWrapper}>
           <label className={sharedStyles.title} htmlFor={`checkbox-${elementId}-input`}>
             {label}
@@ -83,6 +84,7 @@ export default React.forwardRef(function Checkbox(
           </div>
         )}
       </div>
+      )}
     </div>
   )
 })

--- a/packages/@sanity/components/src/toggles/Switch.css
+++ b/packages/@sanity/components/src/toggles/Switch.css
@@ -44,7 +44,6 @@
 .switchWrapper {
   flex-shrink: 0;
   position: relative;
-  margin-right: var(--small-padding);
   height: var(--track-height);
   width: var(--track-width);
   border-radius: var(--track-height);

--- a/packages/@sanity/components/src/toggles/Switch.tsx
+++ b/packages/@sanity/components/src/toggles/Switch.tsx
@@ -45,7 +45,8 @@ export default React.forwardRef(function Switch(
         <div className={styles.track} />
         <div className={styles.thumb} />
       </div>
-      <div>
+      {label && (
+      <div className={sharedStyles.label}>
         <div className={sharedStyles.titleWrapper}>
           <label className={sharedStyles.title} htmlFor={`switch-${elementId}-input`}>
             {label}
@@ -58,6 +59,7 @@ export default React.forwardRef(function Switch(
           </div>
         )}
       </div>
+      )}
     </div>
   )
 })

--- a/packages/@sanity/components/src/toggles/shared.css
+++ b/packages/@sanity/components/src/toggles/shared.css
@@ -6,7 +6,15 @@
   z-index: 1;
 }
 
+.label {
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  margin-left: var(--small-padding);
+}
+
 .title {
+  composes: label from 'part:@sanity/base/theme/typography/forms-style';
   padding-right: var(--small-padding);
 }
 

--- a/packages/@sanity/form-builder/src/inputs/OptionsArrayInput/OptionsArrayInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/OptionsArrayInput/OptionsArrayInput.tsx
@@ -123,7 +123,7 @@ export default class OptionsArrayInput extends React.PureComponent<OptionsArrayI
               }
               const checked = inArray(value, resolveValueWithLegacyOptionsSupport(option))
               return (
-                <div key={option._key || index}>
+                <div className={styles.item} key={option._key || index}>
                   <Item
                     type={optionType}
                     readOnly={readOnly}

--- a/packages/@sanity/form-builder/src/inputs/OptionsArrayInput/styles/OptionsArrayInput.css
+++ b/packages/@sanity/form-builder/src/inputs/OptionsArrayInput/styles/OptionsArrayInput.css
@@ -2,6 +2,10 @@
 
 .itemWrapperVertical {
   display: block;
+
+  @nest & .item {
+    margin-bottom: var(--small-padding);
+  }
 }
 
 .itemWrapperHorizontal {


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

Some visual fixes to the boolean inputs, most notably the labels

**Before:**
![Screenshot 2020-08-25 at 15 17 48](https://user-images.githubusercontent.com/25737281/91179185-77808780-e6e6-11ea-9d63-db93c34e1973.png)
**After:**
![Screenshot 2020-08-25 at 15 16 11](https://user-images.githubusercontent.com/25737281/91179193-78b1b480-e6e6-11ea-89f0-b28f2a420594.png)


**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

- Fixed styling of boolean input labels

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
