### PR TITLE
[components] fix spacing between certain field wrappers (#1984)

### DIFF
--- a/packages/@sanity/components/src/fieldsets/styles/DefaultFieldset.css
+++ b/packages/@sanity/components/src/fieldsets/styles/DefaultFieldset.css
@@ -9,10 +9,6 @@
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   grid-gap: var(--large-padding) var(--medium-padding);
-
-  @media (--screen-medium) {
-    grid-gap: var(--extra-large-padding) var(--medium-padding);
-  }
 }
 
 .fieldset {

--- a/packages/@sanity/components/src/fieldsets/styles/DefaultFieldset.css
+++ b/packages/@sanity/components/src/fieldsets/styles/DefaultFieldset.css
@@ -125,7 +125,7 @@
   vertical-align: middle;
   transition: transform 0.1s linear;
   transform: rotate(-90deg);
-  margin-top: -0.1em;
+  margin-top: 1px;
 
   @nest &.isOpen {
     transform: rotate(0);


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->

Fieldsets uses extra large padding, making the spacing between certain fields inside objects too large in comparison to fields at the root of the editor.

Also the arrow on collapsible objects is slightly misaligned.

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

This removes the extra large padding and uses the same large padding as other field wrappers, and fixes arrow alignment on collapsible objects.

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

- Fixed an issue where the spacing between fields would be too large in some cases

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
