### PR TITLE
Various fixes to the PTE

### DIFF
--- a/packages/@sanity/components/src/validation/ValidationList.tsx
+++ b/packages/@sanity/components/src/validation/ValidationList.tsx
@@ -42,13 +42,17 @@ export default class ValidationList extends React.PureComponent<Props> {
 
     if (element) {
       element.scrollIntoView({behavior: 'smooth', inline: 'center'})
+      if (this.scrollTimeout) {
+        clearTimeout(this.scrollTimeout)
+      }
       this.scrollTimeout = setTimeout(() => {
         onFocus(path)
+        onClose()
       }, 300)
     } else {
       onFocus(path)
+      onClose()
     }
-    onClose()
   }
 
   resolvePathTitle(path) {

--- a/packages/@sanity/form-builder/package.json
+++ b/packages/@sanity/form-builder/package.json
@@ -25,7 +25,7 @@
     "@sanity/generate-help-url": "1.150.1",
     "@sanity/imagetool": "1.150.1",
     "@sanity/mutator": "1.150.1",
-    "@sanity/portable-text-editor": "0.1.5",
+    "@sanity/portable-text-editor": "0.1.6",
     "@sanity/util": "1.150.1",
     "@sanity/uuid": "1.150.1",
     "attr-accept": "^1.1.0",

--- a/packages/@sanity/form-builder/src/inputs/PortableText/Input.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Input.tsx
@@ -133,7 +133,8 @@ export default function PortableTextInput(props: Props) {
           focus: {path, offset: 0},
           anchor: {path, offset: 0}
         })
-        setObjectEditData({editorPath: path, formBuilderPath: path, kind})
+        // Make it go to selection first, then load  the editing interface
+        setTimeout(() => setObjectEditData({editorPath: path, formBuilderPath: path, kind}))
       }
     }
   }, [focusPath])

--- a/packages/@sanity/form-builder/src/inputs/PortableText/Objects/BlockObject.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Objects/BlockObject.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React, {FunctionComponent, SyntheticEvent} from 'react'
+import React, {FunctionComponent, SyntheticEvent, useMemo} from 'react'
 import classNames from 'classnames'
 import {
   PortableTextEditor,
@@ -66,19 +66,23 @@ export const BlockObject: FunctionComponent<Props> = ({
     )
     PortableTextEditor.focus(editor)
   }
-
+  const blockPreview = useMemo(() => {
+    return (
+      <BlockObjectPreview
+        type={type}
+        value={value}
+        path={path}
+        readOnly={readOnly}
+        onFocus={onFocus}
+        onClickingDelete={handleDelete}
+        onClickingEdit={handleEdit}
+      />
+    )
+  }, [value, readOnly])
   return (
     <div className={classnames} onDoubleClick={handleClickToOpen}>
       <div className={styles.previewContainer} style={readOnly ? {cursor: 'default'} : {}}>
-        <BlockObjectPreview
-          type={type}
-          value={value}
-          path={path}
-          readOnly={readOnly}
-          onFocus={onFocus}
-          onClickingDelete={handleDelete}
-          onClickingEdit={handleEdit}
-        />
+        {blockPreview}
       </div>
     </div>
   )

--- a/packages/@sanity/form-builder/src/inputs/PortableText/Toolbar/helpers.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Toolbar/helpers.tsx
@@ -109,8 +109,7 @@ function getPTEListActions(
   const focusBlock = PortableTextEditor.focusBlock(editor)
 
   return features.lists.map((listItem: PortableTextFeature) => {
-    const active = focusBlock ? focusBlock.listItem === listItem.value : false
-
+    const active = PortableTextEditor.hasListStyle(editor, listItem.value)
     return {
       active,
       key: listItem.value,
@@ -122,6 +121,7 @@ function getPTEListActions(
   })
 }
 
+// eslint-disable-next-line complexity
 function getAnnotationIcon(item: PortableTextFeature, active: boolean): React.ComponentType {
   let Icon: React.ComponentType
 

--- a/packages/test-studio/schemas/simpleBlock.js
+++ b/packages/test-studio/schemas/simpleBlock.js
@@ -23,7 +23,11 @@ export default {
           },
           of: [
             {type: 'image', name: 'image'},
-            {type: 'object', name: 'test', fields: [{type: 'string', name: 'mystring'}]},
+            {
+              type: 'object',
+              name: 'test',
+              fields: [{type: 'string', name: 'mystring', validation: Rule => Rule.required()}]
+            },
             {
               type: 'reference',
               name: 'strongAuthorRef',
@@ -33,7 +37,11 @@ export default {
           ]
         },
         {type: 'image', name: 'image'},
-        {type: 'object', name: 'test', fields: [{type: 'string', name: 'mystring'}]}
+        {
+          type: 'object',
+          name: 'test',
+          fields: [{type: 'string', name: 'mystring', validation: Rule => Rule.required()}]
+        }
       ]
     },
     {


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

Changes:

* Updated the core Portable Text Editor to latest version
   - Fixes reversed selection issues
   - Fixes clunky scrollIntoView behaviour on block objects (will now only scroll if focused and totally out of the scroll area)
   - Adds functionality to strip formatting inside the selection (select anything and click bold to remove everything bold in that selection)
    - Fixes unnecessary renders of block object previews (keep object equality)
* Fixes an issue where clicking items in the root validation list would not scroll and set focus correctly
* Memoize the block preview on the value inside the Studio code
