### PR TITLE
[cli] Add `sanity init --bare` flag

### DIFF
--- a/packages/@sanity/cli/src/actions/init-bare/initBareProject.js
+++ b/packages/@sanity/cli/src/actions/init-bare/initBareProject.js
@@ -1,0 +1,231 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import fse from 'fs-extra'
+import deburr from 'lodash/deburr'
+import noop from 'lodash/noop'
+import debug from '../../debug'
+import login from '../login/login'
+import getUserConfig from '../../util/getUserConfig'
+import resolveLatestVersions from '../../util/resolveLatestVersions'
+import prepareFlags from '../init-project/prepareFlags'
+import getOrCreateProject from '../init-project/getOrCreateProject'
+import getOrCreateDataset from '../init-project/getOrCreateDataset'
+
+// eslint-disable-next-line max-statements, complexity
+export default async function initBare(args, context) {
+  const {output, prompt, workDir, apiClient, chalk} = context
+  const cliFlags = args.extOptions
+  const unattended = cliFlags.y || cliFlags.yes
+  const print = unattended ? noop : output.print
+  const specifiedOutputPath = cliFlags['output-path']
+
+  print(`You're setting up a new, bare project!`)
+  print(`We'll make sure you have an account with Sanity.io. Then we'll`)
+  print('install a few dependencies needed to use the CLI in a project')
+  print('context to communicate with the real-time hosted API on Sanity.io.')
+  print('Press ctrl + C at any time to quit.\n')
+  print('Prefer web interfaces to terminals?')
+  print('You can also set up best practice Sanity projects with')
+  print('your favorite frontends on https://sanity.io/create\n')
+
+  // If the user isn't already authenticated, make it so
+  const userConfig = getUserConfig()
+  const hasToken = userConfig.get('authToken')
+
+  debug(hasToken ? 'User already has a token' : 'User has no token')
+
+  if (hasToken) {
+    print('Looks like you already have a Sanity-account. Sweet!\n')
+  } else if (!unattended) {
+    await getOrCreateUser()
+  }
+
+  const flags = await prepareFlags(cliFlags, {apiClient, output})
+
+  // We're authenticated, now lets select or create a project
+  debug('Prompting user to select or create a project')
+  const {projectId, displayName, isFirstProject} = await getOrCreateProject({
+    apiClient,
+    unattended,
+    flags,
+    prompt
+  })
+
+  const sluggedName = deburr(displayName.toLowerCase())
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9]/g, '')
+
+  debug(`Project with name ${displayName} selected`)
+
+  // Does the user want a dataset?
+  let configureDataset = true
+  if (!flags.dataset && !flags.visibility && !flags.datasetDefault) {
+    configureDataset = await prompt.single({
+      type: 'confirm',
+      message: 'Do you want to select or create a dataset?',
+      default: true
+    })
+  }
+
+  // Now let's pick or create a dataset
+  let datasetName
+  if (configureDataset) {
+    debug('Prompting user to select or create a dataset')
+    datasetName = (
+      await getOrCreateDataset({
+        dataset: flags.dataset,
+        useDefaultConfig: cliFlags['dataset-default'],
+        aclMode: flags.visibility,
+        client: apiClient({api: {projectId}}),
+        unattended,
+        prompt,
+        output
+      })
+    ).datasetName
+
+    debug(`Dataset with name ${datasetName} selected`)
+  }
+
+  // Does the user want a sanity.json/package.json?
+  let outputPath
+  const createFiles =
+    specifiedOutputPath ||
+    (await prompt.single({
+      type: 'confirm',
+      message:
+        'Do you want to create a project folder with a sanity.json? This will allow you to run CLI commands interacting with your project.',
+      default: true
+    }))
+
+  if (createFiles) {
+    // Prompt the user for output path
+    const specifiedPath = specifiedOutputPath && path.resolve(specifiedOutputPath)
+    const workDirIsEmpty = (await fse.readdir(workDir)).length === 0
+    outputPath = specifiedPath || workDir
+    if (!unattended && (!workDirIsEmpty || !outputPath)) {
+      outputPath = await prompt.single({
+        type: 'input',
+        message: 'Project output path:',
+        default: workDirIsEmpty ? workDir : path.join(workDir, sluggedName),
+        validate: validateEmptyPath,
+        filter: absolutify
+      })
+    }
+
+    // Ensure directory exists
+    await fse.mkdirp(outputPath)
+
+    // Write a sanity.json
+    await fse.writeJson(
+      path.join(outputPath, 'sanity.json'),
+      {
+        root: true,
+        project: {name: displayName},
+        api: {projectId, dataset: datasetName},
+        plugins: [],
+        parts: []
+      },
+      {spaces: 2}
+    )
+
+    // And a package.json, for `@sanity/core`
+    await fse.writeJson(
+      path.join(outputPath, 'package.json'),
+      {
+        name: sluggedName,
+        version: '0.0.1',
+        private: true,
+        dependencies: await resolveLatestVersions(['@sanity/core'], {asRange: true})
+      },
+      {spaces: 2}
+    )
+  }
+
+  print(`\n${chalk.green('Success!')}`)
+  print(`Project ID: ${chalk.green(projectId)}`)
+
+  if (datasetName) {
+    print(`Dataset:    ${chalk.green(datasetName)}`)
+  }
+
+  if (createFiles) {
+    print(`\nNow what?\n`)
+
+    const isCurrentDir = outputPath === process.cwd()
+    if (!isCurrentDir) {
+      print(`▪ ${chalk.cyan(`cd ${outputPath}`)}, then:`)
+    }
+
+    print(`▪ ${chalk.cyan('npm i')} or ${chalk.cyan('yarn')} to install CLI dependencies`)
+    print(`▪ ${chalk.cyan('sanity docs')} to open the documentation in a browser`)
+    print(`▪ ${chalk.cyan('sanity manage')} to open the project settings in a browser`)
+    print(`▪ ${chalk.cyan('sanity help')} to explore the CLI manual\n`)
+  }
+
+  const sendInvite =
+    isFirstProject &&
+    (await prompt.single({
+      type: 'confirm',
+      message:
+        'We have an excellent developer community, would you like us to send you an invitation to join?',
+      default: true
+    }))
+
+  if (sendInvite) {
+    apiClient({requireProject: false})
+      .request({
+        uri: '/invitations/community',
+        method: 'POST'
+      })
+      .catch(noop)
+  }
+
+  async function getOrCreateUser() {
+    print(`We can't find any auth credentials in your Sanity config`)
+    print('- log in or create a new account\n')
+
+    // Provide login options (`sanity login`)
+    await login(args, context)
+
+    print("Good stuff, you're now authenticated.")
+  }
+}
+
+function validateEmptyPath(dir) {
+  const checkPath = absolutify(dir)
+  return pathIsEmpty(checkPath) ? true : 'Given path is not empty'
+}
+
+function pathIsEmpty(dir) {
+  // We are using fs instead of fs-extra because it silently, weirdly, crashes on windows
+  try {
+    // eslint-disable-next-line no-sync
+    const content = fs.readdirSync(dir)
+    return content.length === 0
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return true
+    }
+
+    throw err
+  }
+}
+
+function expandHome(filePath) {
+  if (filePath.charCodeAt(0) === 126 /* ~ */) {
+    if (filePath.charCodeAt(1) === 43 /* + */) {
+      return path.join(process.cwd(), filePath.slice(2))
+    }
+
+    const home = os.homedir()
+    return home ? path.join(home, filePath.slice(1)) : filePath
+  }
+
+  return filePath
+}
+
+function absolutify(dir) {
+  const pathName = expandHome(dir)
+  return path.isAbsolute(pathName) ? pathName : path.resolve(process.cwd(), pathName)
+}

--- a/packages/@sanity/cli/src/actions/init-project/getOrCreateDataset.js
+++ b/packages/@sanity/cli/src/actions/init-project/getOrCreateDataset.js
@@ -1,0 +1,173 @@
+import debug from '../../debug'
+import promptForDatasetName from './promptForDatasetName'
+
+// eslint-disable-next-line no-process-env
+const isCI = process.env.CI
+const allowedAclModes = ['public', 'private']
+const datasetInfoMessage = `
+Your content will be stored in a dataset that can be public or private, depending on
+whether you want to query your content with or without authentication.
+The default dataset configuration has a public dataset named "production".`.trim()
+
+export default async function getOrCreateDataset(options) {
+  const {dataset, client, unattended, prompt, output} = options
+
+  if (dataset && isCI) {
+    return {datasetName: dataset}
+  }
+
+  const existingDatasets = await client.datasets.list()
+  const useDefaultConfig = Boolean(options.useDefaultConfig)
+  const showDefaultConfigPrompt = !(dataset || options.aclMode || unattended)
+  const aclMode = useDefaultConfig || unattended ? 'public' : options.aclMode
+
+  if (aclMode && !allowedAclModes.includes(aclMode)) {
+    throw new Error(`Visibility mode "${aclMode}" not allowed`)
+  }
+
+  // If user has specified dataset through CLI flag
+  if (dataset) {
+    return useSpecifiedDataset({dataset, existingDatasets, output, client, aclMode, prompt})
+  }
+
+  // If nothing is specified and this is the first dataset in the project
+  if (existingDatasets.length === 0) {
+    return promptForNewDataset({
+      aclMode,
+      showDefaultConfigPrompt,
+      useDefaultConfig,
+      prompt,
+      output,
+      client,
+      existingDatasets
+    })
+  }
+
+  // When there are choices to select from
+  return promptFromAvailableDatasets({
+    dataset,
+    existingDatasets,
+    output,
+    client,
+    aclMode,
+    prompt,
+    showDefaultConfigPrompt
+  })
+}
+
+async function promptForAclMode(prompt, output) {
+  const mode = await prompt.single({
+    type: 'list',
+    message: 'Choose dataset visibility – this can be changed later',
+    choices: [
+      {
+        value: 'public',
+        name: 'Public (world readable)'
+      },
+      {
+        value: 'private',
+        name: 'Private (authenticated requests only)'
+      }
+    ]
+  })
+
+  if (mode === 'private') {
+    output.print(
+      'Please note that while documents are private, assets (files and images) are still public\n'
+    )
+  }
+
+  return mode
+}
+
+async function useSpecifiedDataset({aclMode, client, dataset, existingDatasets, output, prompt}) {
+  debug('User has specified dataset through a flag (%s)', dataset)
+  const existing = existingDatasets.find(ds => ds.name === dataset)
+
+  if (!existing) {
+    debug('Specified dataset not found, creating it')
+    const wantedAclMode = aclMode || (await promptForAclMode(prompt, output))
+    const spinner = output.spinner('Creating dataset').start()
+    await client.datasets.create(dataset, {aclMode: wantedAclMode})
+    spinner.succeed()
+  }
+
+  return {datasetName: dataset}
+}
+
+async function promptForNewDataset({
+  aclMode,
+  showDefaultConfigPrompt,
+  useDefaultConfig,
+  prompt,
+  output,
+  client,
+  existingDatasets = []
+}) {
+  debug('No datasets found for project, prompting for name')
+
+  let useDefaultDatasetConfig = useDefaultConfig
+  if (showDefaultConfigPrompt) {
+    output.print(datasetInfoMessage)
+    useDefaultDatasetConfig = await prompt.single({
+      type: 'confirm',
+      message: 'Use the default dataset configuration?',
+      default: true
+    })
+  }
+
+  const name = useDefaultDatasetConfig
+    ? 'production'
+    : await promptForDatasetName(
+        prompt,
+        {message: 'Dataset name:'},
+        existingDatasets.map(ds => ds.name)
+      )
+
+  const wantedAclMode = useDefaultDatasetConfig
+    ? 'public'
+    : aclMode || (await promptForAclMode(prompt, output))
+
+  const spinner = output.spinner('Creating dataset').start()
+  await client.datasets.create(name, {aclMode: wantedAclMode})
+  spinner.succeed()
+  return {datasetName: name}
+}
+
+async function promptFromAvailableDatasets({
+  aclMode,
+  showDefaultConfigPrompt,
+  useDefaultConfig,
+  prompt,
+  output,
+  client,
+  existingDatasets = []
+}) {
+  debug(`User has ${existingDatasets.length} dataset(s) already, showing list of choices`)
+  const datasetChoices = existingDatasets.map(existing => ({value: existing.name}))
+
+  const selected = await prompt.single({
+    message: 'Select dataset to use',
+    type: 'list',
+    choices: [
+      {value: '__new__', name: 'Create new dataset'},
+      new prompt.Separator(),
+      ...datasetChoices
+    ]
+  })
+
+  if (selected === '__new__') {
+    return promptForNewDataset({
+      aclMode,
+      showDefaultConfigPrompt,
+      useDefaultConfig,
+      prompt,
+      output,
+      client,
+      existingDatasets
+    })
+  }
+
+  debug(`Returning selected dataset (${selected})`)
+  return {datasetName: selected}
+}

--- a/packages/@sanity/cli/src/actions/init-project/getOrCreateProject.js
+++ b/packages/@sanity/cli/src/actions/init-project/getOrCreateProject.js
@@ -1,0 +1,77 @@
+import debug from '../../debug'
+import createProject from '../project/createProject'
+
+export default async function getOrCreateProject({apiClient, unattended, flags, prompt}) {
+  let projects
+  try {
+    projects = await apiClient({requireProject: false}).projects.list()
+  } catch (err) {
+    if (unattended) {
+      return {projectId: flags.project, displayName: 'Unknown project', isFirstProject: false}
+    }
+
+    throw new Error(`Failed to communicate with the Sanity API:\n${err.message}`)
+  }
+
+  if (projects.length === 0 && unattended) {
+    throw new Error('No projects found for current user')
+  }
+
+  if (flags.project) {
+    const project = projects.find(proj => proj.id === flags.project)
+    if (!project && !unattended) {
+      throw new Error(
+        `Given project ID (${flags.project}) not found, or you do not have access to it`
+      )
+    }
+
+    return {
+      projectId: flags.project,
+      displayName: project ? project.displayName : 'Unknown project',
+      isFirstProject: false
+    }
+  }
+
+  const isUsersFirstProject = projects.length === 0
+  if (isUsersFirstProject) {
+    debug('No projects found for user, prompting for name')
+    const projectName = await prompt.single({message: 'Project name'})
+    return createProject(apiClient, {displayName: projectName}).then(response => ({
+      ...response,
+      isFirstProject: isUsersFirstProject
+    }))
+  }
+
+  debug(`User has ${projects.length} project(s) already, showing list of choices`)
+
+  const projectChoices = projects.map(project => ({
+    value: project.id,
+    name: `${project.displayName} [${project.id}]`
+  }))
+
+  const selected = await prompt.single({
+    message: 'Select project to use',
+    type: 'list',
+    choices: [{value: 'new', name: 'Create new project'}, new prompt.Separator(), ...projectChoices]
+  })
+
+  if (selected === 'new') {
+    debug('User wants to create a new project, prompting for name')
+    return createProject(apiClient, {
+      displayName: await prompt.single({
+        message: 'Your project name:',
+        default: 'My Sanity Project'
+      })
+    }).then(response => ({
+      ...response,
+      isFirstProject: isUsersFirstProject
+    }))
+  }
+
+  debug(`Returning selected project (${selected})`)
+  return {
+    projectId: selected,
+    displayName: projects.find(proj => proj.id === selected).displayName,
+    isFirstProject: isUsersFirstProject
+  }
+}

--- a/packages/@sanity/cli/src/actions/init-project/prepareFlags.js
+++ b/packages/@sanity/cli/src/actions/init-project/prepareFlags.js
@@ -1,0 +1,57 @@
+import debug from '../../debug'
+import createProject from '../project/createProject'
+
+export default async function prepareFlags(flags, {apiClient, output}) {
+  const unattended = flags.y || flags.yes
+  const createProjectName = flags['create-project']
+  const newFlags = {...flags}
+
+  if (flags.project && createProjectName) {
+    throw new Error('Both `--project` and `--create-project` specified, only a single is supported')
+  }
+
+  if (createProjectName === true) {
+    throw new Error('Please specify a project name (`--create-project <name>`)')
+  }
+
+  if (typeof createProjectName === 'string' && createProjectName.trim().length === 0) {
+    throw new Error('Please specify a project name (`--create-project <name>`)')
+  }
+
+  if (unattended) {
+    debug('Unattended mode, validating required options')
+    const requiredForUnattended = ['dataset', 'output-path']
+    requiredForUnattended.forEach(flag => {
+      if (!flags[flag]) {
+        throw new Error(`\`--${flag}\` must be specified in unattended mode`)
+      }
+    })
+
+    if (!flags.project && !createProjectName) {
+      throw new Error(
+        '`--project <id>` or `--create-project <name>` must be specified in unattended mode'
+      )
+    }
+  }
+
+  if (createProjectName) {
+    debug('--create-project specified, creating a new project')
+    const createdProject = await createProject(apiClient, {
+      displayName: createProjectName.trim()
+    })
+    debug('Project with ID %s created', createdProject.projectId)
+
+    if (flags.dataset) {
+      debug('--dataset specified, creating dataset (%s)', flags.dataset)
+      const client = apiClient({api: {projectId: createdProject.projectId}})
+      const spinner = output.spinner('Creating dataset').start()
+      await client.datasets.create(flags.dataset)
+      spinner.succeed()
+    }
+
+    newFlags.project = createdProject.projectId
+    delete newFlags['create-project']
+  }
+
+  return flags
+}

--- a/packages/@sanity/cli/src/commands/init/initCommand.js
+++ b/packages/@sanity/cli/src/commands/init/initCommand.js
@@ -1,5 +1,6 @@
 import initProject from '../../actions/init-project/initProject'
 import initPlugin from '../../actions/init-plugin/initPlugin'
+import initBareProject from '../../actions/init-bare/initBareProject'
 
 const helpText = `
 Options
@@ -12,6 +13,7 @@ Options
   --visibility <mode> Visibility mode for dataset (public/private)
   --create-project <name> Create a new project with the given name
   --reconfigure Reconfigure Sanity studio in current folder with new project/dataset
+  --bare Do not create any studio files, only sanity.json/package.json
 
 Examples
   # Initialize a new project, prompt for required information along the way
@@ -30,6 +32,9 @@ Examples
   # template to the given path
   sanity init -y --project abc123 --dataset staging --template moviedb --output-path .
 
+  # Initialize a "bare" project, only creating sanity.json and package.json
+  sanity init --bare
+
   # Create a brand new project with name "Movies Unlimited"
   sanity init -y \\
     --create-project "Movies Unlimited" \\
@@ -46,6 +51,11 @@ export default {
   helpText,
   action: (args, context) => {
     const [type] = args.argsWithoutOptions
+    const {bare} = args.extOptions
+
+    if (bare) {
+      return initBareProject(args, context)
+    }
 
     if (!type) {
       return initProject(args, context)

--- a/packages/@sanity/cli/src/commands/init/initCommand.js
+++ b/packages/@sanity/cli/src/commands/init/initCommand.js
@@ -32,7 +32,7 @@ Examples
   # template to the given path
   sanity init -y --project abc123 --dataset staging --template moviedb --output-path .
 
-  # Initialize a "bare" project, only creating sanity.json and package.json
+  # Initialize a project without Sanity Studio, only creating sanity.json and package.json
   sanity init --bare
 
   # Create a brand new project with name "Movies Unlimited"

--- a/packages/@sanity/cli/src/commands/init/initCommand.js
+++ b/packages/@sanity/cli/src/commands/init/initCommand.js
@@ -13,7 +13,7 @@ Options
   --visibility <mode> Visibility mode for dataset (public/private)
   --create-project <name> Create a new project with the given name
   --reconfigure Reconfigure Sanity studio in current folder with new project/dataset
-  --bare Do not create any studio files, only sanity.json/package.json
+  --bare Create a project without a studio, only sanity.json and package.json
 
 Examples
   # Initialize a new project, prompt for required information along the way


### PR DESCRIPTION
**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [x]  Yes
- [ ]  No

**Description**

This PR allows a user to run `sanity init --bare` and only create a project and (optionally) a dataset. If the user chooses to, it will also create a folder with a `sanity.json` (containing project ID and dataset) and a `package.json` (containing `@sanity/core` as a dependency).

I didn't want to create even more "branches" in the init project code which is already a bit unwieldy, so I separated some logic into their own files for reuse between the "init bare" method and the "regular" init.

**Note for release**

Add `--bare` flag to CLI `sanity init` command, for cases where a studio is not needed.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
