### PR TITLE
[base] Fix setState after unmount in hook collection state

### DIFF
--- a/packages/@sanity/base/src/actions/utils/GetHookCollectionState.tsx
+++ b/packages/@sanity/base/src/actions/utils/GetHookCollectionState.tsx
@@ -40,6 +40,13 @@ export function GetHookCollectionState<T, K>(props: Props<T, K>) {
   const [, setTick] = React.useState(0)
 
   const [keys, setKeys] = React.useState({})
+  const mountedRef = React.useRef(true)
+
+  React.useEffect(() => {
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
 
   const ricHandle = React.useRef(null)
   const onRequestUpdate = useThrottled(
@@ -47,9 +54,12 @@ export function GetHookCollectionState<T, K>(props: Props<T, K>) {
       if (ricHandle.current) {
         cancelIdleCallback(ricHandle.current)
       }
-      requestIdleCallback(() => {
+      ricHandle.current = requestIdleCallback(() => {
         ricHandle.current = null
-        setTick(t => t + 1)
+
+        if (mountedRef.current) {
+          setTick(tick => tick + 1)
+        }
       })
     },
     60,


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

When developing on the studio, the "Hook collection state" utility sometimes re-renders, and some logic is calling a `setTick` method, which attempts to set state on a now unmounted component. This results in the following error in the console:

```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
    in GetHookCollectionState (created by RenderActionCollectionState)
    in RenderActionCollectionState
    in Unknown (created by DocumentPane)
    in Popover (created by DocumentPane)
    in DocumentPane
    in DocumentHistoryProvider
```

**Description**

This PR does a hack to work around the bug. I attempted to find the actual source of the issue, but with the amount of throttling, idle callbacks and re-renders, I couldn't figure out what exactly in the dependency chain was causing issues.

By setting a "mounted" flag to true in a mutable ref (and setting to false on unmount), we can check that value before calling the state setter, which seems to fix the issue.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
