### PR TITLE
[form-builder] Add setIfMissing patch to createInitialUploadEvent

### DIFF
--- a/packages/@sanity/form-builder/src/sanity/uploads/utils.ts
+++ b/packages/@sanity/form-builder/src/sanity/uploads/utils.ts
@@ -1,6 +1,6 @@
 import {UploadEvent} from './typedefs'
 import {UPLOAD_STATUS_KEY} from './constants'
-import {set, unset} from '../../utils/patches'
+import {set, unset, setIfMissing} from '../../utils/patches'
 
 const UNSET_UPLOAD_PATCH = unset([UPLOAD_STATUS_KEY])
 
@@ -14,14 +14,13 @@ export function createUploadEvent(patches = []): UploadEvent {
 export const CLEANUP_EVENT = createUploadEvent([UNSET_UPLOAD_PATCH])
 
 export function createInitialUploadEvent(file: File) {
+  const value = {
+    progress: 2,
+    initiated: new Date().toISOString(),
+    file: {name: file.name, type: file.type}
+  }
   return createUploadEvent([
-    set(
-      {
-        progress: 2,
-        initiated: new Date().toISOString(),
-        file: {name: file.name, type: file.type}
-      },
-      [UPLOAD_STATUS_KEY]
-    )
+    setIfMissing({[UPLOAD_STATUS_KEY]: value}, []),
+    set(value, [UPLOAD_STATUS_KEY])
   ])
 }


### PR DESCRIPTION
If you have a nested object inside the PTE which you upload images to, there will be an error because the _upload key is not set yet. This ensures that key is always set.
