### PR TITLE
[form-builder] Update @sanity/portable-text-editor

### DIFF
--- a/packages/@sanity/form-builder/package.json
+++ b/packages/@sanity/form-builder/package.json
@@ -25,7 +25,7 @@
     "@sanity/generate-help-url": "1.150.1",
     "@sanity/imagetool": "1.150.1",
     "@sanity/mutator": "1.150.1",
-    "@sanity/portable-text-editor": "0.1.6",
+    "@sanity/portable-text-editor": "0.1.8",
     "@sanity/util": "1.150.1",
     "@sanity/uuid": "1.150.1",
     "attr-accept": "^1.1.0",


### PR DESCRIPTION
This is an update of `@sanity/portable-text-editor` in `form-builder` which fixes a couple of issues with hoisted block types.

- Fixed an issue where an hoisted block type, would wrongly be included in the insert menu.
- Fixed an issue with hoisted block type and pasting of HTML (unknown type 'block').
