### PR TITLE
[code-input] add JAVA to dropdown list of language in Code-Input

### DIFF
--- a/packages/@sanity/code-input/src/CodeInput.js
+++ b/packages/@sanity/code-input/src/CodeInput.js
@@ -1,9 +1,9 @@
 import classNames from 'classnames'
-import React, {PureComponent} from 'react'
+import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import AceEditor from 'react-ace'
-import {get, has} from 'lodash'
-import {PatchEvent, set, insert, unset, setIfMissing} from 'part:@sanity/form-builder/patch-event'
+import { get, has } from 'lodash'
+import { PatchEvent, set, insert, unset, setIfMissing } from 'part:@sanity/form-builder/patch-event'
 import FormField from 'part:@sanity/components/formfields/default'
 import Fieldset from 'part:@sanity/components/fieldsets/default'
 import DefaultSelect from 'part:@sanity/components/selects/default'
@@ -25,6 +25,7 @@ import {
 import 'brace/mode/batchfile'
 import 'brace/mode/css'
 import 'brace/mode/html'
+import 'brace/mode/java'
 import 'brace/mode/javascript'
 import 'brace/mode/json'
 import 'brace/mode/jsx'
@@ -101,25 +102,25 @@ export default class CodeInput extends PureComponent {
   }
 
   handleCodeChange = code => {
-    const {type, onChange} = this.props
+    const { type, onChange } = this.props
     const path = ['code']
     const fixedLanguage = get(type, 'options.language')
 
     onChange(
       PatchEvent.from([
-        setIfMissing({_type: type.name, language: fixedLanguage}),
+        setIfMissing({ _type: type.name, language: fixedLanguage }),
         code ? set(code, path) : unset(path)
       ])
     )
   }
 
   handleToggleSelectLine = lineNumber => {
-    const {type, onChange, value} = this.props
+    const { type, onChange, value } = this.props
     const path = ['highlightedLines']
     const highlightedLines = (value && value.highlightedLines) || []
 
     let position = highlightedLines.indexOf(lineNumber)
-    const patches = [setIfMissing({_type: type.name}), setIfMissing([], ['highlightedLines'])]
+    const patches = [setIfMissing({ _type: type.name }), setIfMissing([], ['highlightedLines'])]
     const addLine = position === -1
 
     if (addLine) {
@@ -137,13 +138,13 @@ export default class CodeInput extends PureComponent {
       // (https://github.com/securingsincity/react-ace/issues/229)
       const editor = this.editor
 
-      // Remove all markers from editor
-      ;[true, false].forEach(inFront => {
-        const currentMarkers = editor.getSession().getMarkers(inFront)
-        Object.keys(currentMarkers).forEach(marker => {
-          editor.getSession().removeMarker(currentMarkers[marker].id)
+        // Remove all markers from editor
+        ;[true, false].forEach(inFront => {
+          const currentMarkers = editor.getSession().getMarkers(inFront)
+          Object.keys(currentMarkers).forEach(marker => {
+            editor.getSession().removeMarker(currentMarkers[marker].id)
+          })
         })
-      })
     } else {
       // Removed, but not the last element, remove single item
       patches.push(unset(path.concat(position)))
@@ -167,23 +168,23 @@ export default class CodeInput extends PureComponent {
   }
 
   handleLanguageChange = item => {
-    const {type, onChange} = this.props
+    const { type, onChange } = this.props
     const path = ['language']
     onChange(
       PatchEvent.from([
-        setIfMissing({_type: type.name}),
+        setIfMissing({ _type: type.name }),
         item ? set(item.value, path) : unset(path)
       ])
     )
   }
 
   handleFilenameChange = item => {
-    const {type, onChange} = this.props
+    const { type, onChange } = this.props
     const path = ['filename']
 
     onChange(
       PatchEvent.from([
-        setIfMissing({_type: type.name}),
+        setIfMissing({ _type: type.name }),
         item ? set(item.target.value, path) : unset(path)
       ])
     )
@@ -201,7 +202,7 @@ export default class CodeInput extends PureComponent {
       )
     }
 
-    return languageAlternatives.reduce((acc, {title, value}) => {
+    return languageAlternatives.reduce((acc, { title, value }) => {
       const alias = LANGUAGE_ALIASES[value]
       if (alias) {
         // eslint-disable-next-line no-console
@@ -212,7 +213,7 @@ export default class CodeInput extends PureComponent {
           alias
         )
 
-        return acc.concat({title, value: alias})
+        return acc.concat({ title, value: alias })
       }
 
       if (!SUPPORTED_LANGUAGES.find(lang => lang.value === value)) {
@@ -223,7 +224,7 @@ export default class CodeInput extends PureComponent {
         )
       }
 
-      return acc.concat({title, value})
+      return acc.concat({ title, value })
     }, [])
   }
 
@@ -237,7 +238,7 @@ export default class CodeInput extends PureComponent {
   renderEditor = () => {
     // console.log('CodeInput', this.props)
 
-    const {readOnly, value, type} = this.props
+    const { readOnly, value, type } = this.props
     const fixedLanguage = get(type, 'options.language')
     const mode = isSupportedLanguage((value && value.language) || fixedLanguage) || 'text'
     return (
@@ -264,7 +265,7 @@ export default class CodeInput extends PureComponent {
   }
 
   render() {
-    const {value, type, level, readOnly} = this.props
+    const { value, type, level, readOnly } = this.props
     const languages = this.getLanguageAlternatives().slice()
 
     if (has(type, 'options.language')) {
@@ -279,7 +280,7 @@ export default class CodeInput extends PureComponent {
       value && value.language ? languages.find(item => item.value === value.language) : undefined
 
     if (!selectedLanguage) {
-      languages.unshift({title: 'Select language'})
+      languages.unshift({ title: 'Select language' })
     }
 
     const languageField = type.fields.find(field => field.name === 'language')

--- a/packages/@sanity/code-input/src/PreviewCode.js
+++ b/packages/@sanity/code-input/src/PreviewCode.js
@@ -1,13 +1,14 @@
-import React, {PureComponent} from 'react'
+import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import AceEditor from 'react-ace'
-import {get} from 'lodash'
+import { get } from 'lodash'
 import styles from './PreviewCode.css'
 
 /* eslint-disable import/no-unassigned-import */
 import 'brace/mode/batchfile'
 import 'brace/mode/css'
 import 'brace/mode/html'
+import 'brace/mode/java'
 import 'brace/mode/javascript'
 import 'brace/mode/json'
 import 'brace/mode/jsx'
@@ -25,7 +26,7 @@ import 'brace/theme/tomorrow'
 import './groq'
 /* eslint-enable import/no-unassigned-import */
 
-import {SUPPORTED_LANGUAGES, LANGUAGE_ALIASES, ACE_EDITOR_PROPS, ACE_SET_OPTIONS} from './config'
+import { SUPPORTED_LANGUAGES, LANGUAGE_ALIASES, ACE_EDITOR_PROPS, ACE_SET_OPTIONS } from './config'
 import createHighlightMarkers from './createHighlightMarkers'
 
 function isSupportedLanguage(mode) {
@@ -65,7 +66,7 @@ export default class PreviewCode extends PureComponent {
   }
 
   render() {
-    const {value, type} = this.props
+    const { value, type } = this.props
     const fixedLanguage = get(type, 'options.language')
     const mode = isSupportedLanguage((value && value.language) || fixedLanguage) || 'text'
     return (

--- a/packages/@sanity/code-input/src/config.js
+++ b/packages/@sanity/code-input/src/config.js
@@ -1,21 +1,22 @@
 export const SUPPORTED_LANGUAGES = [
-  {title: 'Batch file', value: 'batchfile'},
-  {title: 'CSS', value: 'css'},
-  {title: 'SASS', value: 'sass'},
-  {title: 'SCSS', value: 'scss'},
-  {title: 'HTML', value: 'html'},
-  {title: 'JavaScript', value: 'javascript'},
-  {title: 'JSON', value: 'json'},
-  {title: 'JSX', value: 'jsx'},
-  {title: 'Markdown', value: 'markdown'},
-  {title: 'PHP', value: 'php'},
-  {title: 'Python', value: 'python'},
-  {title: 'sh', value: 'sh'},
-  {title: 'Plain text', value: 'text'},
-  {title: 'GROQ', value: 'groq'}
+  { title: 'Batch file', value: 'batchfile' },
+  { title: 'CSS', value: 'css' },
+  { title: 'SASS', value: 'sass' },
+  { title: 'SCSS', value: 'scss' },
+  { title: 'HTML', value: 'html' },
+  { title: 'JAVA', value: 'java' },
+  { title: 'JavaScript', value: 'javascript' },
+  { title: 'JSON', value: 'json' },
+  { title: 'JSX', value: 'jsx' },
+  { title: 'Markdown', value: 'markdown' },
+  { title: 'PHP', value: 'php' },
+  { title: 'Python', value: 'python' },
+  { title: 'sh', value: 'sh' },
+  { title: 'Plain text', value: 'text' },
+  { title: 'GROQ', value: 'groq' }
 ]
 
-export const LANGUAGE_ALIASES = {js: 'javascript'}
+export const LANGUAGE_ALIASES = { js: 'javascript' }
 
 export const SUPPORTED_THEMES = ['github', 'monokai', 'terminal', 'tomorrow']
 
@@ -26,4 +27,4 @@ export const ACE_SET_OPTIONS = {
   navigateWithinSoftTabs: true /* note only supported by ace v1.2.7 or higher */
 }
 
-export const ACE_EDITOR_PROPS = {$blockScrolling: true}
+export const ACE_EDITOR_PROPS = { $blockScrolling: true }


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

The code-input dropdown does not have a JAVA option.

**Description**

This provides JAVA as an option in the dropdown list. So, the JAVA code can also be highlighted now.

**Note for release**

Added JAVA option in the dropdown list for code-input.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
