### PR TITLE
[components] Fix use of undeclared react-icons dependency in story

### DIFF
--- a/packages/@sanity/components/src/tabs/stories/withIcons.js
+++ b/packages/@sanity/components/src/tabs/stories/withIcons.js
@@ -8,7 +8,7 @@ import React from 'react'
 // Import icons
 import EyeIcon from 'part:@sanity/base/eye-icon'
 import EditIcon from 'part:@sanity/base/edit-icon'
-import FaCalendarIcon from 'react-icons/lib/fa/calendar'
+import CalendarIcon from 'part:@sanity/base/calendar-icon'
 
 export function WithIconsStory() {
   const currentTabId = select(
@@ -19,7 +19,7 @@ export function WithIconsStory() {
   )
   const tabs = [
     {icon: EditIcon, id: 'tab-edit', label: 'Content'},
-    {icon: FaCalendarIcon, id: 'tab-seo', label: 'SEO'},
+    {icon: CalendarIcon, id: 'tab-seo', label: 'SEO'},
     {icon: EyeIcon, id: 'tab-preview', label: 'Preview'}
   ]
   return (


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

Breaks if `react-icons` is installed in project at a non-2x version range.

**Description**

A file inside of `@sanity/components` is requiring something from `react-icons` without `@sanity/components/package.json` having declared react-icons as a dependency.

This usually works because of hoisting - `@react/base` has a dependency on `react-icons`, and usually lifts this dependency up to the root, which means `@sanity/components` can find it and use it.

However, when the user installs `react-icons` in their project and the version range does not match ours (2.x), `react-icons` will be installed two places: inside of `@sanity/base/node_modules` (2x) and inside of the studio `node_modules` (3x/4x/whatever range they specified)

Given that this is just a use inside of a story for storybook, the easy option was to use a different icon in this case.

**Note for release**

- Fixed incorrect path for icon in a storybook story

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
