### PR TITLE
[eslint] Tweak ESLint rules for commonly ignored cases

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,24 +18,15 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'prettier/@typescript-eslint',
     'prettier',
-    'prettier/react'
+    'prettier/react',
+    './packages/eslint-config-sanity/typescript.js'
   ],
   rules: {
-    // --- causing parse errors with d.ts files, see https://github.com/typescript-eslint/typescript-eslint/issues/420
-    'no-useless-constructor': 'off',
-    '@typescript-eslint/no-useless-constructor': 'error',
-    // ---
-    '@typescript-eslint/no-use-before-define': 'off',
-    "@typescript-eslint/explicit-function-return-type": 'off',
-
-    '@typescript-eslint/no-var-requires': 'off', // covered by @typescript-eslint/no-var-requires
-    'react/jsx-filename-extension': ['error', {extensions: ['.tsx', '.js']}],
-
-    'import/no-extraneous-dependencies': 'off',
+    'import/no-extraneous-dependencies': 'off', // because of parts
     'import/no-unresolved': ['error', {ignore: ['.*:.*']}],
 
     'prettier/prettier': 'error',
-    'sort-imports': 'off'
+    'sort-imports': 'off' // prefer import/order
   },
   plugins: ['import', '@typescript-eslint', 'prettier', 'react']
 }

--- a/packages/eslint-config-sanity/index.js
+++ b/packages/eslint-config-sanity/index.js
@@ -25,7 +25,7 @@ module.exports = {
     'comma-dangle': 'off',
     'comma-spacing': ['error', {after: true, before: false}],
     'comma-style': ['error', 'last'],
-    complexity: ['warn', 9],
+    complexity: ['warn', 30],
     'computed-property-spacing': 'error',
     'consistent-return': 'error',
     'consistent-this': ['error', 'self'],
@@ -48,7 +48,7 @@ module.exports = {
     'guard-for-in': 'error',
     'handle-callback-err': 'error',
     'id-blacklist': 'off',
-    'id-length': ['warn', {exceptions: ['i', 'j', 'x', 'y', 'z'], min: 2}],
+    'id-length': 'off', // catch undescriptive names in code review
     'id-match': 'off',
     'implicit-arrow-linebreak': ['error', 'beside'],
     indent: ['error', 2, {SwitchCase: 1}],
@@ -60,8 +60,8 @@ module.exports = {
     'line-comment-position': 'off',
     'lines-around-comment': 'off',
     'lines-between-class-members': 'off', // turn on if supports methods only
-    'max-depth': ['error', 2],
-    'max-len': ['error', 150, 4],
+    'max-depth': ['error', 4],
+    'max-len': ['error', 150, 2],
     'max-lines': 'off',
     'max-nested-callbacks': ['error', 3],
     'max-params': ['error', 5],
@@ -74,7 +74,7 @@ module.exports = {
     'newline-per-chained-call': ['error', {ignoreChainWithDepth: 3}],
     'no-alert': 'error',
     'no-array-constructor': 'error',
-    'no-await-in-loop': 'error',
+    'no-await-in-loop': 'off', // should be caught in code reviews on dangerous usage
     'no-bitwise': 'error',
     'no-buffer-constructor': 'error',
     'no-caller': 'error',

--- a/packages/eslint-config-sanity/package.json
+++ b/packages/eslint-config-sanity/package.json
@@ -31,6 +31,8 @@
     "eslint": "^6.0.0"
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^2.10.0",
+    "@typescript-eslint/parser": "^2.10.0",
     "eslint": "^6.7.2",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-react": "^7.17.0",

--- a/packages/eslint-config-sanity/typescript.js
+++ b/packages/eslint-config-sanity/typescript.js
@@ -1,0 +1,37 @@
+// Use this for typescript projects
+module.exports = {
+  env: {
+    node: true,
+    browser: true
+  },
+  plugins: ['@typescript-eslint'],
+  parser: '@typescript-eslint/parser',
+  rules: {
+    // --- typescript types over prop types in typescript projects
+    'react/prop-types': 'off',
+    'react/require-default-props': 'off',
+    // ---
+
+    // --- causing parse errors with d.ts files, see https://github.com/typescript-eslint/typescript-eslint/issues/420
+    'no-useless-constructor': 'off',
+    '@typescript-eslint/no-useless-constructor': 'error',
+    // ---
+
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/no-use-before-define': 'off',
+    '@typescript-eslint/explicit-function-return-type': 'off',
+
+    '@typescript-eslint/no-var-requires': 'off', // covered by @typescript-eslint/no-var-requires
+
+    'react/jsx-filename-extension': ['error', {extensions: ['.tsx', '.js']}]
+  },
+  overrides: [
+    {
+      files: ['*.ts'],
+      rules: {
+        // Enable for TS files, but allow TSX (eg react components)
+        '@typescript-eslint/explicit-module-boundary-types': ['warn']
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Rationale for rule changes:

- `complexity` - Seems very low, very common to have large React components where breaking them into separate modules only leads to prop-drilling and unnecessarily deep trees. Also quite common to have readable but long validation/switch statements where adjusting to standard only makes code less readable rather than more. Depend on code reviews to catch hard-to-read code. If 30 is not enough for actual cases, ignore in-place.
- `id-length` - `itemA`/`itemB` and similar is not necessarily more readable than `a`, `b`. Lots of exceptions already in place. Commonly disabled. Catch in code reviews if variables are difficultly named.
- `max-depth` - Seems arbitrarily low. Quite common to have valid, deeper blocks than this. Again, catch exceptions in code-reviews rather than linting.
- `max-len` - Tab size seems to be set wrong. Have not seen this play out anywhere, but tweaked for consistency.
- `no-await-in-loop` - Lots of cases where this is useful and "correct" (retrying, for instance). Catch in code reviews if using it in cases where `Promise.all` or a concurrency limiter should be in place.
- `@typescript-eslint/explicit-module-boundary-types` - disable for tsx because defining `React.ReactElement` as return value is annoying. Still a good rule to ensure return values are what you expect in most other cases, however.
- `react/prop-types` - Disable for typescript because we want types, not runtime prop checks
- `react/require-default-props` - Disable for typescript because we want types, not runtime prop checks

Also exposed an `eslint-config-sanity/typescript` preset for easy use in other projects
