### PR TITLE
[cli] Add build script to template package.json

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/createManifest.js
+++ b/packages/@sanity/cli/src/actions/init-project/createManifest.js
@@ -48,6 +48,7 @@ export function createPackageManifest(data) {
       scripts: {
         start: 'sanity start',
         test: 'sanity check',
+        build: 'sanity build',
       },
     },
     deps


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  New feature (non-breaking change which adds functionality)

**Does this change require a documentation update? (Check one)**

- [x]  No

**Current behavior**

CLI templates include only the npm scripts `start` and `test`.

**Description**

If you're making a template starter for /create with a CLI bootstrapped studio, you have to remember to add a `build` script to the package.json. This seems like something we could've just include from the get-go. 

I tried to figure out how we could add the `@sanity/cli` to dev-dependencies too with no avail. This is also needed (or the npx equivalent) to run the build script in a CI environment.

**Note for release**

Add build script to template studios to make them more easily deployable on other hosting platforms.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
