### PR TITLE
[types] Add initial version of types package

### DIFF
--- a/packages/@sanity/types/.babelrc
+++ b/packages/@sanity/types/.babelrc
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../.babelrc",
+  "presets": ["@babel/react", "@babel/typescript"]
+}

--- a/packages/@sanity/types/.gitignore
+++ b/packages/@sanity/types/.gitignore
@@ -1,0 +1,15 @@
+# Logs
+logs
+*.log
+
+# Coverage directory used by tools like istanbul
+coverage
+
+# Grunt intermediate storage
+.grunt
+
+# Dependency directories
+node_modules
+
+# Compiled code
+lib

--- a/packages/@sanity/types/.npmignore
+++ b/packages/@sanity/types/.npmignore
@@ -1,0 +1,5 @@
+.babelrc
+.editorconfig
+.eslintignore
+.eslintrc
+test

--- a/packages/@sanity/types/LICENSE
+++ b/packages/@sanity/types/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 - 2020 Sanity.io
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/@sanity/types/package.json
+++ b/packages/@sanity/types/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@sanity/types",
+  "version": "1.150.7",
+  "description": "Type definitions for common Sanity data structures",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "author": "Sanity.io <hello@sanity.io>",
+  "license": "MIT",
+  "scripts": {
+    "clean": "rimraf lib",
+    "type-check": "tsc --noEmit"
+  },
+  "keywords": [
+    "sanity",
+    "cms",
+    "headless",
+    "realtime",
+    "content",
+    "typescript"
+  ],
+  "dependencies": {
+    "@types/react": "^16.9.49"
+  },
+  "devDependencies": {
+    "rimraf": "^2.7.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sanity-io/sanity.git"
+  },
+  "bugs": {
+    "url": "https://github.com/sanity-io/sanity/issues"
+  },
+  "homepage": "https://www.sanity.io/"
+}

--- a/packages/@sanity/types/src/assets/index.ts
+++ b/packages/@sanity/types/src/assets/index.ts
@@ -1,0 +1,1 @@
+export * from './types'

--- a/packages/@sanity/types/src/assets/types.ts
+++ b/packages/@sanity/types/src/assets/types.ts
@@ -1,0 +1,90 @@
+import {Reference, SanityDocument} from '../documents'
+
+export interface Image {
+  [key: string]: unknown
+  asset: Reference
+  crop?: ImageCrop
+  hotspot?: ImageHotspot
+}
+
+export interface Asset extends SanityDocument {
+  url: string
+  path: string
+  assetId: string
+  extension: string
+  mimeType: string
+  sha1hash: string
+  size: number
+  originalFilename?: string
+}
+
+export interface ImageAsset extends Asset {
+  _type: 'sanity.imageAsset'
+  metadata: ImageMetadata
+}
+
+export interface FileAsset extends Asset {
+  _type: 'sanity.fileAsset'
+  metadata: Record<string, unknown>
+}
+
+export interface ImageMetadata {
+  [key: string]: unknown
+  _type: 'sanity.imageMetadata'
+  dimensions: ImageDimensions
+  palette?: ImagePalette
+  lqip?: string
+  hasAlpha: boolean
+  isOpaque: boolean
+}
+
+export interface ImageDimensions {
+  _type: 'sanity.imageDimensions'
+  height: number
+  width: number
+  aspectRatio: number
+}
+
+export interface ImageCrop {
+  _type?: 'sanity.imageCrop'
+  left: number
+  bottom: number
+  right: number
+  top: number
+}
+
+export interface ImageHotspot {
+  _type: 'sanity.imageHotspot'
+  width: number
+  height: number
+  x: number
+  y: number
+}
+
+export interface ImagePalette {
+  _type: 'sanity.imagePalette'
+  darkMuted?: ImageSwatch
+  darkVibrant?: ImageSwatch
+  dominant?: ImageSwatch
+  lightMuted?: ImageSwatch
+  lightVibrant?: ImageSwatch
+  muted?: ImageSwatch
+  vibrant?: ImageSwatch
+}
+
+export interface ImageSwatch {
+  _type: 'sanity.imagePaletteSwatch'
+  background: string
+  foreground: string
+  population: number
+  title?: string
+}
+
+export type SwatchName =
+  | 'darkMuted'
+  | 'darkVibrant'
+  | 'dominant'
+  | 'lightMuted'
+  | 'lightVibrant'
+  | 'muted'
+  | 'vibrant'

--- a/packages/@sanity/types/src/documents/asserters.ts
+++ b/packages/@sanity/types/src/documents/asserters.ts
@@ -1,0 +1,23 @@
+import {KeyedObject, Reference, SanityDocument, TypedObject} from './types'
+
+function isObject(obj: unknown): obj is Record<string, unknown> {
+  return typeof obj === 'object' && obj !== null && !Array.isArray(obj)
+}
+
+export function isSanityDocument(document: unknown): document is SanityDocument {
+  return (
+    isObject(document) && typeof document._id === 'string' && typeof document._type === 'string'
+  )
+}
+
+export function isReference(reference: unknown): reference is Reference {
+  return isObject(reference) && typeof reference._ref === 'string'
+}
+
+export function isTypedObject(obj: unknown): obj is TypedObject {
+  return isObject(obj) && typeof obj._type === 'string'
+}
+
+export function isKeyedObject(obj: unknown): obj is KeyedObject {
+  return isObject(obj) && typeof obj._key === 'string'
+}

--- a/packages/@sanity/types/src/documents/index.ts
+++ b/packages/@sanity/types/src/documents/index.ts
@@ -1,0 +1,2 @@
+export * from './types'
+export * from './asserters'

--- a/packages/@sanity/types/src/documents/types.ts
+++ b/packages/@sanity/types/src/documents/types.ts
@@ -1,0 +1,28 @@
+export interface SanityDocument {
+  [key: string]: unknown
+  _id: string
+  _type: string
+  _createdAt: string
+  _updatedAt: string
+  _rev: string
+}
+
+export interface Reference {
+  _ref: string
+  _key?: string
+  _weak?: boolean
+}
+
+export interface WeakReference extends Reference {
+  _weak: true
+}
+
+export interface TypedObject {
+  [key: string]: unknown
+  _type: string
+}
+
+export interface KeyedObject {
+  [key: string]: unknown
+  _key: string
+}

--- a/packages/@sanity/types/src/index.ts
+++ b/packages/@sanity/types/src/index.ts
@@ -1,0 +1,6 @@
+export * from './slug'
+export * from './paths'
+export * from './schema'
+export * from './documents'
+export * from './portableText'
+export * from './assets'

--- a/packages/@sanity/types/src/paths/asserters.ts
+++ b/packages/@sanity/types/src/paths/asserters.ts
@@ -1,0 +1,29 @@
+import {PathSegment, KeyedSegment, IndexTuple} from './types'
+
+const reKeySegment = /_key\s*==\s*['"](.*)['"]/
+const reIndexTuple = /^\d*:\d*$/
+
+export function isIndexSegment(segment: PathSegment): segment is number {
+  return typeof segment === 'number' || (typeof segment === 'string' && /^\[\d+\]$/.test(segment))
+}
+
+export function isKeySegment(segment: PathSegment): segment is KeyedSegment {
+  if (typeof segment === 'string') {
+    return reKeySegment.test(segment.trim())
+  }
+
+  return typeof segment === 'object' && '_key' in segment
+}
+
+export function isIndexTuple(segment: PathSegment): segment is IndexTuple {
+  if (typeof segment === 'string' && reIndexTuple.test(segment)) {
+    return true
+  }
+
+  if (!Array.isArray(segment) || segment.length !== 2) {
+    return false
+  }
+
+  const [from, to] = segment
+  return (typeof from === 'number' || from === '') && (typeof to === 'number' || to === '')
+}

--- a/packages/@sanity/types/src/paths/index.ts
+++ b/packages/@sanity/types/src/paths/index.ts
@@ -1,0 +1,2 @@
+export * from './types'
+export * from './asserters'

--- a/packages/@sanity/types/src/paths/types.ts
+++ b/packages/@sanity/types/src/paths/types.ts
@@ -1,0 +1,7 @@
+/**
+ * Paths
+ */
+export type KeyedSegment = {_key: string}
+export type IndexTuple = [number | '', number | '']
+export type PathSegment = string | number | KeyedSegment | IndexTuple
+export type Path = PathSegment[]

--- a/packages/@sanity/types/src/portableText/index.ts
+++ b/packages/@sanity/types/src/portableText/index.ts
@@ -1,0 +1,1 @@
+export * from './types'

--- a/packages/@sanity/types/src/portableText/types.ts
+++ b/packages/@sanity/types/src/portableText/types.ts
@@ -1,0 +1,20 @@
+export interface Block<O = Span> {
+  _type: 'block'
+  _key: string
+  style: string
+  children: O[]
+  markDefs: MarkDefinition[]
+}
+
+export interface Span {
+  _type: 'span'
+  _key: string
+  marks: string[]
+  text: string
+}
+
+export interface MarkDefinition {
+  [key: string]: unknown
+  _type: string
+  _key: string
+}

--- a/packages/@sanity/types/src/schema/asserters.ts
+++ b/packages/@sanity/types/src/schema/asserters.ts
@@ -1,0 +1,5 @@
+import {ObjectSchemaType, SchemaType} from './types'
+
+export function isObjectSchemaType(type: SchemaType): type is ObjectSchemaType {
+  return type.jsonType === 'object'
+}

--- a/packages/@sanity/types/src/schema/index.ts
+++ b/packages/@sanity/types/src/schema/index.ts
@@ -1,0 +1,2 @@
+export * from './types'
+export * from './asserters'

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -1,0 +1,100 @@
+// Note: INCOMPLETE, but it's a start
+
+import {SlugOptions} from '../slug'
+
+export interface Schema {
+  name: string
+  get: (name: string) => SchemaType
+  has: (name: string) => boolean
+  getTypeNames: () => string[]
+}
+
+export interface BaseSchemaType {
+  name: string
+  title?: string
+  description?: string
+  type?: SchemaType
+}
+
+export interface StringSchemaType extends BaseSchemaType {
+  jsonType: 'string'
+  options?: {
+    list?: {title?: string; value: string}[]
+    layout?: 'radio' | 'dropdown'
+    direction?: 'horizontal' | 'vertical'
+
+    // Actually just part of date time, but can't find a good way to differentiate
+    dateFormat?: string
+    timeFormat?: string
+  }
+}
+
+export interface NumberSchemaType extends BaseSchemaType {
+  jsonType: 'number'
+}
+
+export interface BooleanSchemaType extends BaseSchemaType {
+  jsonType: 'boolean'
+  options?: {
+    layout: 'checkbox' | 'switch'
+  }
+}
+
+export interface ArraySchemaType extends BaseSchemaType {
+  jsonType: 'array'
+  of: Exclude<SchemaType, ArraySchemaType>[]
+}
+
+export interface BlockSchemaType extends ObjectSchemaType {
+  jsonType: 'object'
+  name: 'block'
+  of?: SchemaType[]
+}
+
+export interface SlugSchemaType extends ObjectSchemaType {
+  jsonType: 'object'
+  options?: SlugOptions
+}
+
+export interface ObjectField<T extends SchemaType = SchemaType> {
+  name: string
+  fieldset?: string
+  type: T
+}
+
+export interface ObjectSchemaType extends BaseSchemaType {
+  jsonType: 'object'
+  fields: ObjectField[]
+  fieldsets?: Fieldset[]
+}
+
+export interface SingleFieldSet {
+  single: true
+  field: ObjectField
+}
+
+export interface MultiFieldSet {
+  name: string
+  title?: string
+  description?: string
+  single?: false
+  options?: {
+    collapsible?: boolean
+    collapsed?: boolean
+    columns?: number
+  }
+  fields: ObjectField[]
+}
+
+export type Fieldset = SingleFieldSet | MultiFieldSet
+
+export interface ReferenceSchemaType extends ObjectSchemaType {
+  to: SchemaType[]
+}
+
+export type SchemaType =
+  | ArraySchemaType
+  | BooleanSchemaType
+  | NumberSchemaType
+  | ObjectSchemaType
+  | StringSchemaType

--- a/packages/@sanity/types/src/slug/index.ts
+++ b/packages/@sanity/types/src/slug/index.ts
@@ -1,0 +1,1 @@
+export * from './types'

--- a/packages/@sanity/types/src/slug/types.ts
+++ b/packages/@sanity/types/src/slug/types.ts
@@ -1,0 +1,42 @@
+import {SlugSchemaType} from '../schema'
+import {SanityDocument} from '../documents'
+import {Path} from '../paths'
+
+export interface Slug {
+  _type: 'slug'
+  current: string
+}
+
+export type SlugParent = Record<string, unknown> | Record<string, unknown>[]
+
+export interface SlugSourceOptions {
+  parentPath: Path
+  parent: SlugParent
+}
+
+export type SlugSourceFn = (
+  document: SanityDocument,
+  options: SlugSourceOptions
+) => string | Promise<string>
+
+export type SlugifierFn = (source: string, schemaType: SlugSchemaType) => string | Promise<string>
+
+export interface SlugUniqueOptions {
+  parent: SlugParent
+  type: SlugSchemaType
+  document: SanityDocument
+  defaultIsUnique: UniqueCheckerFn
+  path: Path
+}
+
+export type UniqueCheckerFn = (
+  slug: string,
+  options: SlugUniqueOptions
+) => boolean | Promise<boolean>
+
+export interface SlugOptions {
+  source?: string | Path | SlugSourceFn
+  maxLength?: number
+  slugify?: SlugifierFn
+  isUnique?: UniqueCheckerFn
+}

--- a/packages/@sanity/types/tsconfig.json
+++ b/packages/@sanity/types/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig",
+  "include": ["src/**/*.ts"],
+  "compilerOptions": {
+    "outDir": "./lib",
+    "jsx": "react",
+    "baseUrl": "./src"
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Description**

Now that we're starting to use TypeScript more actively, we often encounter cases where we'd like to share type declarations, but don't want to depend on one or more packages with a large number of dependencies. 

This PR exposes some initial, shared typings that we can build out over time. When adding types to this module, we should ensure that we never bring in any dependencies (except potentially from `@types`), and that actual _functionality_ is kept to a bare minimum. I've chosen to implement a few "type asserters" so far, making it easier to check whether or not something fulfils a given interface.

**Note for release**

- Added new `@sanity/types` module

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
