### PR TITLE
[form-builder] Check for focus method before calling it

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ObjectInput/Field.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ObjectInput/Field.tsx
@@ -33,7 +33,9 @@ export default class Field extends React.PureComponent<FieldProps> {
     }
   }
   focus() {
-    this._input.focus()
+    if (this._input && typeof this._input.focus === 'function') {
+      this._input.focus()
+    }
   }
   setInput = input => {
     this._input = input


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

When the "InvalidValueInput" component is rendered, the form builder crashes because it's trying to call `focus()` on it, which does not exist.

Crashing example: https://test-studio-git-next.sanity-io.now.sh/test/desk/book;f7101679-9b44-4dbf-824d-1b8b03a4068f

**Description**

This PR makes sure we check for a `focus` method before attempting to call it. 

Fixed example: https://test-studio-git-fix-schema-type-change.sanity-io.vercel.app/test/desk/book;f7101679-9b44-4dbf-824d-1b8b03a4068f

**Note for release**

- Fixed crash when displaying "invalid value" dialog

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
