### PR TITLE
[form-builder] Show warning for array items without `_type`

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ArrayInput/InvalidItem.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ArrayInput/InvalidItem.tsx
@@ -1,33 +1,24 @@
 import React from 'react'
-import {resolveTypeName} from '../../utils/resolveTypeName'
-import InvalidValue from '../InvalidValueInput'
 import PatchEvent from '../../PatchEvent'
-type Type = {
-  name: string
-  of: Array<Type>
+import {resolveTypeName} from '../../utils/resolveTypeName'
+import InvalidValueInput from '../InvalidValueInput'
+import {ArrayType, ItemValue} from './typedefs'
+
+interface Props {
+  type: ArrayType
+  value: unknown
+  onChange: (event: PatchEvent, valueOverride?: ItemValue) => void
 }
-export default class Item extends React.PureComponent<{}, {}> {
-  props: {
-    // note: type here is the *array* type
-    type: Type
-    value: any
-    onChange: (arg0: PatchEvent, value: any) => void
-  }
-  handleChange = (event: PatchEvent) => {
-    const {onChange, value} = this.props
-    onChange(event, value)
-  }
-  render() {
-    const {type, value} = this.props
-    const actualType = resolveTypeName(value)
-    const validTypes = type.of.map(ofType => ofType.name)
-    return (
-      <InvalidValue
-        actualType={actualType}
-        validTypes={validTypes}
-        onChange={this.handleChange}
-        value={value}
-      />
-    )
-  }
+
+export default function InvalidItem({value, type, onChange}: Props) {
+  const actualType = resolveTypeName(value)
+  const validTypes = type.of.map(ofType => ofType.name)
+  return (
+    <InvalidValueInput
+      actualType={actualType}
+      validTypes={validTypes}
+      onChange={onChange}
+      value={value}
+    />
+  )
 }

--- a/packages/@sanity/form-builder/src/inputs/InvalidValueInput/UntypedValueInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/InvalidValueInput/UntypedValueInput.tsx
@@ -1,0 +1,93 @@
+import React from 'react'
+import schema from 'part:@sanity/base/schema'
+import DefaultButton from 'part:@sanity/components/buttons/default'
+import PatchEvent, {setIfMissing, unset} from '../../PatchEvent'
+import styles from '../ObjectInput/styles/UnknownFields.css'
+import Warning from '../Warning'
+
+type Props = {
+  validTypes?: string[]
+  value?: Record<string, unknown>
+  onChange?: (event: PatchEvent, value?: Record<string, unknown>) => void
+}
+
+function SetMissingTypeButton({
+  value,
+  targetType,
+  onChange
+}: {
+  value: Record<string, unknown>
+  targetType: string
+  onChange: Props['onChange']
+}) {
+  const itemValue = {...value, _type: targetType}
+  return (
+    <DefaultButton
+      onClick={() => onChange(PatchEvent.from(setIfMissing(targetType, ['_type'])), itemValue)}
+      color="primary"
+    >
+      Set <code>_type</code> to <code>{targetType}</code>
+    </DefaultButton>
+  )
+}
+
+function UnsetItemButton({
+  value,
+  onChange,
+  validTypes
+}: {
+  value: Record<string, unknown>
+  validTypes: string[]
+  onChange: Props['onChange']
+}) {
+  // Doesn't matter which `_type` we use as long as it's allowed by the array
+  const itemValue = {...value, _type: validTypes[0]}
+  return (
+    <DefaultButton onClick={() => onChange(PatchEvent.from(unset()), itemValue)} color="danger">
+      Remove value
+    </DefaultButton>
+  )
+}
+
+/**
+ * When the value does not have an `_type` property,
+ * but the schema has a named type
+ */
+export function UntypedValueInput({validTypes, value, onChange}: Props) {
+  const isSingleValidType = validTypes.length === 1
+  const isHoistedType = schema.has(validTypes[0])
+  const fix = isSingleValidType ? (
+    <SetMissingTypeButton onChange={onChange} targetType={validTypes[0]} value={value} />
+  ) : null
+
+  const message = (
+    <>
+      Encountered an object value without a <code>_type</code> property.
+      {isSingleValidType && !isHoistedType && (
+        <div>
+          Either remove the <code>name</code> property of the object declaration, or set{' '}
+          <code>_type</code> property on items.
+        </div>
+      )}
+      {!isSingleValidType && (
+        <div>
+          The following types are valid here according to schema:{' '}
+          <ul>
+            {validTypes.map(validType => (
+              <li key={validType}>
+                <code>{validType}</code>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <h4>object</h4>
+      <pre className={styles.inspectValue}>{JSON.stringify(value, null, 2)}</pre>
+      {fix}
+      {fix && ' '}
+      <UnsetItemButton onChange={onChange} validTypes={validTypes} value={value} />
+    </>
+  )
+
+  return <Warning heading="Content is missing _type" message={message} />
+}

--- a/packages/@sanity/form-builder/src/utils/resolveTypeName.ts
+++ b/packages/@sanity/form-builder/src/utils/resolveTypeName.ts
@@ -1,6 +1,11 @@
 import {resolveJSType} from './resolveJSType'
 
-export function resolveTypeName(value) {
+export function resolveTypeName(value: unknown): string {
   const jsType = resolveJSType(value)
-  return (jsType === 'object' && '_type' in value && value._type) || jsType
+  if (jsType !== 'object') {
+    return jsType
+  }
+
+  const obj = value as Record<string, unknown> & {_type?: string}
+  return ('_type' in obj && obj._type) || jsType
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

If an array member type has a `name`, but array items exist that do not have a `_type`, they are silently hidden.

Example: https://test-studio-git-next.sanity-io.now.sh/test/desk/arraysTest;untyped-objects

- "Array of multiple types" actually has one array item, but is not displayed

**Description**

This PR checks for the case when a member type cannot be found.

- If there is only a single member type that is valid, it renders an option to set the type name
- If there are multiple member types that are valid, it renders the possible types and an option to remove the item

Example: https://test-studio-git-fix-array-missing-type.sanity-io.now.sh/test/desk/arraysTest;untyped-objects

**Note for release**

- Fixed bug where objects in arrays without a `_type` property would not be displayed

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
