### PR TITLE
[cli] Add codemod command with react-icons migration

### DIFF
--- a/packages/@sanity/cli/.babelrc
+++ b/packages/@sanity/cli/.babelrc
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "8"
+          "node": "10"
         }
       }
     ]

--- a/packages/@sanity/cli/codemods/reactIconsV3.js
+++ b/packages/@sanity/cli/codemods/reactIconsV3.js
@@ -1,0 +1,110 @@
+const splitRegexp = [/([a-z0-9])([A-Z])/g, /([A-Z])([A-Z][a-z])/g]
+const stripRegexp = /[^A-Z0-9]+/gi
+
+fixIcons.parser = 'tsx'
+module.exports = fixIcons
+
+function fixIcons(fileInfo, api) {
+  const j = api.jscodeshift
+  const root = j(fileInfo.source)
+
+  // Imports
+  // from: import {MdPerson} from 'react-icons/lib/md'
+  //   to: import {MdPerson} from 'react-icons/md'
+  //
+  // from: import PersonIcon from 'react-icons/lib/md/person'
+  //   to: import {MdPerson as PersonIcon} from 'react-icons/md'
+  root
+    .find(api.jscodeshift.ImportDeclaration, node => node.source.value.startsWith('react-icons/'))
+    .filter(path => isLegacyPath(path.node.source.value))
+    .forEach(path => {
+      const node = path.value
+      const icon = iconSpecFromPath(node.source.value)
+
+      if (!icon) {
+        // import {MdPerson} from 'react-icons/lib/md' => import {MdPerson} from 'react-icons/md'
+        node.source.value = node.source.value.replace(/react-icons\/lib/, 'react-icons')
+        return
+      }
+
+      // import MdPerson from 'react-icons/lib/md/person' => import {MdPerson} from 'react-icons/md'
+      const oldName = path.value.specifiers[0].local.name
+      j(path).replaceWith(
+        j.importDeclaration(
+          [j.importSpecifier(j.identifier(icon.name), j.identifier(oldName))],
+          j.literal(`react-icons/${icon.pack}`)
+        )
+      )
+    })
+
+  // Requires
+  // from: const PersonIcon = require('react-icons/lib/md/person'
+  //   to: const {MdPerson: PersonIcon} = require('react-icons/md')
+  //
+  // from: const {MdPerson} = require('react-icons/lib/md')
+  //   to: const {MdPerson} = require('react-icons/md')
+  root
+    .find(j.VariableDeclarator, {
+      id: {type: 'Identifier'},
+      init: {callee: {name: 'require'}}
+    })
+    .filter(path => isLegacyPath(path.value.init.arguments[0].value))
+    .forEach(path => {
+      const oldName = path.value.id.name
+      const filePath = path.value.init.arguments[0].value
+      const icon = iconSpecFromPath(filePath)
+      const prop = j.objectProperty(j.identifier(icon.name), j.identifier(oldName), false, true)
+      if (oldName === icon.name) {
+        prop.shorthand = true
+      }
+
+      j(path).replaceWith(
+        j.variableDeclarator(
+          j.objectPattern([prop]),
+          j.callExpression(j.identifier('require'), [j.stringLiteral(`react-icons/${icon.pack}`)])
+        )
+      )
+    })
+
+  return root.toSource()
+}
+
+function pascalCase(input) {
+  const inner = replace(input, splitRegexp, '$1\0$2')
+  const result = replace(inner, stripRegexp, '\0')
+  return result
+    .slice(0, result.length)
+    .split('\0')
+    .map(pascalCaseTransform)
+    .join('')
+}
+
+function replace(input, re, value) {
+  if (re instanceof RegExp) return input.replace(re, value)
+  return re.reduce((str, pattern) => str.replace(pattern, value), input)
+}
+
+function pascalCaseTransform(input) {
+  const firstChar = input.charAt(0)
+  const lowerChars = input.substr(1).toLowerCase()
+  return `${firstChar.toUpperCase()}${lowerChars}`
+}
+
+function iconSpecFromPath(path) {
+  const [, pack, icon] =
+    path.match(/(ai|bi|bs|cg|di|fa|fc|fi|gi|go|gr|hi|im|io|md|ri|si|src|ti|vsc|wi)\/(.*)/) || []
+
+  if (!pack) {
+    return undefined
+  }
+
+  const prefix = pack[0].toUpperCase() + pack.slice(1)
+  const suffix = pascalCase(icon.replace(/\.jsx?$/, ''))
+  return {pack, name: prefix + suffix}
+}
+
+function isLegacyPath(path) {
+  return /^react-icons\/(lib\/)?(ai|bi|bs|cg|di|fa|fc|fi|gi|go|gr|hi|im|io|md|ri|si|src|ti|vsc|wi)/.test(
+    path
+  )
+}

--- a/packages/@sanity/cli/src/actions/codemod/mods/index.js
+++ b/packages/@sanity/cli/src/actions/codemod/mods/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  reactIconsV3: require('./reactIconsV3')
+}

--- a/packages/@sanity/cli/src/actions/codemod/mods/reactIconsV3.js
+++ b/packages/@sanity/cli/src/actions/codemod/mods/reactIconsV3.js
@@ -1,0 +1,48 @@
+const path = require('path')
+const {readJson} = require('fs-extra')
+const resolveFrom = require('resolve-from')
+const semverCompare = require('semver-compare')
+
+const purpose = 'Transform react-icons v2 imports to v3 form'
+const description = `
+Modifies all found react-icons import and require statements from their v2 form
+to the path structure used in react-icons v3. For instance:
+
+from: import {MdPerson} from 'react-icons/lib/md'
+  to: import {MdPerson} from 'react-icons/md'
+
+from: import PersonIcon from 'react-icons/lib/md/person'
+  to: import {MdPerson as PersonIcon} from 'react-icons/md'
+`.trim()
+
+module.exports = {
+  purpose,
+  description,
+  verify: async context => {
+    const {workDir} = context
+    const iconPkgPath = resolveFrom.silent(workDir, 'react-icons/package.json')
+    const iconPkg = iconPkgPath && (await maybeReadJson(iconPkgPath))
+    const studioPkg = await maybeReadJson(path.join(workDir, 'package.json'))
+    if (iconPkg && semverCompare(iconPkg.version, '3.0.0') < 0) {
+      throw new Error('The installed version of react-icon seems to be < 3.0.0')
+    }
+
+    const dependencies = (studioPkg && studioPkg.dependencies) || {}
+    const dependencyVersion = (dependencies['react-icons'] || '').replace(/^[\^~]/, '')
+    if (!dependencyVersion) {
+      throw new Error('Could not find react-icons declared as dependency in package.json')
+    }
+
+    if (semverCompare(dependencyVersion, '3.0.0') < 0) {
+      throw new Error('react-icons declared in package.json dependencies is lower than 3.0.0')
+    }
+  }
+}
+
+async function maybeReadJson(jsonPath) {
+  try {
+    return await readJson(jsonPath)
+  } catch (err) {
+    return null
+  }
+}

--- a/packages/@sanity/cli/src/commands/codemod/codemodCommand.js
+++ b/packages/@sanity/cli/src/commands/codemod/codemodCommand.js
@@ -1,0 +1,116 @@
+/* eslint-disable no-process-exit, no-sync */
+const childProcess = require('child_process')
+const path = require('path')
+const fs = require('fs')
+const mods = require('../../actions/codemod/mods')
+
+const helpText = `
+Runs a given code modification script on the current studio folder.
+Running the command without a specified codemod name will list available transformations.
+
+Options
+  --dry Dry run (no changes are made to files)
+  --extensions=EXT Transform files with these file extensions (comma separated list)
+                   (default: js,ts,tsx)
+
+Examples
+  # Show available code mods
+  sanity codemod
+
+  # Run codemod to transform react-icons imports from v2 style to v3 style,
+  # but only as a dry-run (do not write the files)
+  sanity codemod reactIconsV3 --dry
+
+`
+
+export default {
+  name: 'codemod',
+  signature: '[CODEMOD_NAME]',
+  description: 'Runs a code modification script',
+  helpText,
+  async action(args, context) {
+    const {output, cliRoot, workDir} = context
+    const [name] = args.argsWithoutOptions
+    const cliFlags = args.extOptions
+    if (!name) {
+      printMods(output)
+      return
+    }
+
+    const modNames = Object.keys(mods).reduce((lowercased, orgName) => {
+      lowercased[orgName.toLowerCase()] = orgName
+      return lowercased
+    }, {})
+
+    const modName = modNames[name.toLowerCase()]
+    if (!modName) {
+      throw new Error(`Codemod with name "${name}" not found`)
+    }
+
+    const mod = mods[modName]
+    if (typeof mod.verify === 'function') {
+      await mod.verify(context)
+    }
+
+    const exts = cliFlags.extensions
+      ? cliFlags.extensions.split(',').map(ext => ext.trim().replace(/^\./, ''))
+      : ['js', 'ts', 'tsx']
+
+    const dryRun = Boolean(typeof cliFlags.dry === 'undefined' ? false : cliFlags.dry)
+
+    ensureNpx()
+
+    const hasGitIgnore = fs.existsSync(path.join(workDir, '.gitignore'))
+
+    const modPath = path.resolve(path.join(cliRoot, 'codemods', `${modName}.js`))
+    const cmdArgs = [
+      'jscodeshift',
+      '--ignore-pattern',
+      'node_modules',
+      '--ignore-pattern',
+      'dist',
+      hasGitIgnore && '--ignore-config',
+      hasGitIgnore && '.gitignore',
+      '-t',
+      modPath,
+      '--extensions',
+      exts.join(','),
+      dryRun && '--dry',
+      workDir
+    ].filter(Boolean)
+
+    const child = childProcess.spawn('npx', cmdArgs, {
+      stdio: 'inherit'
+    })
+
+    process.on('SIGINT', () => {
+      child.kill(2)
+    })
+
+    child.on('close', code => {
+      process.exit(code)
+    })
+  }
+}
+
+function printMods(output) {
+  output.print('Available code modifications:\n')
+
+  Object.keys(mods).forEach(modName => {
+    const mod = mods[modName]
+    output.print(`${modName} - ${mod.purpose}`)
+  })
+}
+
+function ensureNpx() {
+  try {
+    const npxHelp = childProcess.execSync('npx --help', {encoding: 'utf8'})
+    if (!npxHelp.includes('npm')) {
+      throw new Error('Not the npx we expected')
+    }
+  } catch (err) {
+    throw new Error(
+      `Failed to run "npx" - required to run codemods. Do you have a recent version of npm installed?`
+    )
+  }
+}

--- a/packages/@sanity/cli/src/commands/index.js
+++ b/packages/@sanity/cli/src/commands/index.js
@@ -10,6 +10,7 @@ import listProjectsCommand from './projects/listProjectsCommand'
 import manageCommand from './manage/manageCommand'
 import upgradeCommand from './upgrade/upgradeCommand'
 import versionsCommand from './versions/versionsCommand'
+import codemodCommand from './codemod/codemodCommand'
 
 export default [
   initCommand,
@@ -23,5 +24,6 @@ export default [
   debugCommand,
   helpCommand,
   projectsGroup,
-  listProjectsCommand
+  listProjectsCommand,
+  codemodCommand
 ]


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [x]  Yes
- [ ]  No

**Description**

Every once in a while we find ourselves in a situation where doing changes to a studio is either required or is encouraged. For instance, we've for a while been encountering issues with people inadvertently depending on `react-icons` as a side-effect of `@sanity/base` using it, as well as our documentation having examples encouraging the usage of it without perhaps clearly stating that you should be adding it as a dependency of the studio.

This PR introduces a new CLI command, "codemod", which allows us to run certain code modifications using  [jscodeshift](https://github.com/facebook/jscodeshift). For now, the only included codemod is one that fixes the import/require statements people might have in their studio to use syntax and paths compatible with react-icons v3. 

Ideally we should be bundling jscodeshift with the CLI and using its programatic API, but because of how it's built (and certain time constraints on our part), I took the cheap route and instead spawn `jscodeshift` through `npx`. We can always clean this up in the future, given that the CLI command remains the same.

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

- Add `sanity codemod` CLI command

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
