### PR TITLE
[core] Do not require authed user for `sanity start`

### DIFF
--- a/packages/@sanity/core/src/actions/start/startAction.js
+++ b/packages/@sanity/core/src/actions/start/startAction.js
@@ -111,7 +111,7 @@ async function ensureProjectConfig(context) {
 
   // The API client wrapper extracts information from environment variables,
   // which means it could potentially hold any missing project ID / dataset
-  let {projectId, dataset} = context.apiClient({requireProject: false}).config()
+  let {projectId, dataset} = context.apiClient({requireProject: false, requireUser: false}).config()
 
   // The client wrapper returns `_dummy_` in the case where no dataset is configured,
   // to be able to do non-dataset requests without having the client complain.


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

When you run `sanity start` without being authenticated in the CLI, it'll tell you: 
> Error: You must login first - run "sanity login"

...which is weird, as there are no API interactions to start up a development server


**Description**

This PR passes a flag to the client wrapper telling it that the command does not require an authenticated user.

**Note for release**

- Fixed `sanity start` giving error if CLI had no locally authenticated user

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
