### PR TITLE
[core] Add "Document" query field, returning any document with given ID

### DIFF
--- a/packages/@sanity/core/src/actions/graphql/gen2/generateTypeQueries.js
+++ b/packages/@sanity/core/src/actions/graphql/gen2/generateTypeQueries.js
@@ -8,6 +8,27 @@ function generateTypeQueries(types, filters, sortings) {
 
   const isSortable = type => sortings.some(sorting => sorting.name === `${type.name}Sorting`)
 
+  // A document of any type
+  queries.push({
+    fieldName: 'Document',
+    type: 'Document',
+    constraints: [
+      {
+        field: '_id',
+        comparator: 'eq',
+        value: {kind: 'argumentValue', argName: 'id'}
+      }
+    ],
+    args: [
+      {
+        name: 'id',
+        description: 'Document ID',
+        type: 'ID',
+        isNullable: false
+      }
+    ]
+  })
+
   // Single ID-based result lookup queries
   queryable.forEach(type => {
     queries.push({


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

Currently you have to know which type a document is before querying for it with a `DocumentTypeName` query.

**Description**

This PR introduces a `Document` field (matches the interface name, is a reserved type for Sanity Studio, and matches the other `DocumentTypeName` queries). It has the same, single argument of a document ID, and has the return type of `Document`, which means you'll have to use conditional fragments to query on non-document properties.

In time we should also see if we can make some kind of psuedo-filter for all types, which would allow `allDocument(...)`, but that's a much larger task.

**Note for release**

- Introduce new `Document` field on GraphQL APIs for fetching any document by ID.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
