### PR TITLE
[components, field] fix diff tooltip placement when close to top or bottom of panel

### DIFF
--- a/packages/@sanity/components/src/tooltip/tooltip.tsx
+++ b/packages/@sanity/components/src/tooltip/tooltip.tsx
@@ -16,6 +16,8 @@ export interface TooltipProps {
   placement?: TooltipPlacement
   portal?: boolean
   tone?: 'navbar'
+  allowedAutoPlacements?: TooltipPlacement[]
+  fallbackPlacements?: TooltipPlacement[]
 }
 
 export function Tooltip(
@@ -56,6 +58,13 @@ export function Tooltip(
       {
         name: 'offset',
         options: {offset: [0, 3]}
+      },
+      {
+        name: 'flip',
+        options: {
+          allowedAutoPlacements: props.allowedAutoPlacements,
+          fallbackPlacements: props.fallbackPlacements
+        }
       }
     ]
   })

--- a/packages/@sanity/field/src/diff/components/DiffTooltip.tsx
+++ b/packages/@sanity/field/src/diff/components/DiffTooltip.tsx
@@ -36,7 +36,7 @@ export function DiffTooltip(props: DiffTooltipProps | DiffTooltipWithAnnotations
 }
 
 function DiffTooltipWithAnnotation(props: DiffTooltipWithAnnotationsProps) {
-  const {annotations, children, description = 'Changed', placement = 'top'} = props
+  const {annotations, children, description = 'Changed', placement = 'auto'} = props
 
   if (!annotations) {
     return children
@@ -52,7 +52,12 @@ function DiffTooltipWithAnnotation(props: DiffTooltipWithAnnotationsProps) {
   )
 
   return (
-    <Tooltip content={content} placement={placement} portal>
+    <Tooltip
+      content={content}
+      placement={placement}
+      portal
+      allowedAutoPlacements={['top', 'bottom']}
+    >
       {children}
     </Tooltip>
   )


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->
When a diff is hovered and it's close to the top or bottom of the change panel, the tooltip will cover the content instead of positioning itself correctly.

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->
This will make the tooltip place itself where there's enough space, with placement auto and fallback to top and bottom if needed.

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->
- Fixed an issue where tooltips in diff components had the wrong placement when close to top or bottom of the changes panel 

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title`
- [x]  The code is linted


