### PR TITLE
[components] Add back deprecated presence export path

### DIFF
--- a/packages/@sanity/components/src/presence/index.ts
+++ b/packages/@sanity/components/src/presence/index.ts
@@ -1,0 +1,9 @@
+// Since we're not bundling this module in our internals,
+// this warning will only appear if third-party developers have imported it
+
+// eslint-disable-next-line no-console
+console.warn(
+  'Importing from `@sanity/components/lib/presence` is deprecated - please import from `@sanity/base/presence` instead'
+)
+
+export * from '@sanity/base/lib/presence'


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

When you follow the old presence documentation, it tells (told) you to import paths from `@sanity/components/lib/presence`. This is currently breaking, because we moved the presence pieces into `@sanity/base`. 

**Description**

This PR adds back the path to the source tree with a deprecation warning. We can probably deprecate this in 3.0.

**Note for release**

- Add back (deprecated) presence components in `@sanity/components`

**Checklist** 

- [ ]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [x]  Corresponding changes to the documentation have been made
