### PR TITLE
[components] Wrap Tooltip children in div

### DIFF
--- a/packages/@sanity/components/src/tooltip/tooltip.tsx
+++ b/packages/@sanity/components/src/tooltip/tooltip.tsx
@@ -98,12 +98,13 @@ export function Tooltip(
   )
 
   return (
-    <>
+    <div
+      onBlur={handleBlur}
+      onFocus={handleFocus}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
       {React.cloneElement(children, {
-        onBlur: handleBlur,
-        onFocus: handleFocus,
-        onMouseEnter: handleMouseEnter,
-        onMouseLeave: handleMouseLeave,
         ref: setReferenceElement
       })}
 
@@ -113,6 +114,6 @@ export function Tooltip(
           {!portalProp && popperNode}
         </>
       )}
-    </>
+    </div>
   )
 }


### PR DESCRIPTION
Fixes a bug where the onHover didn't cover the whole element therefore
making it difficult to get the tooltip shown.

Probably because we attach the onMouseLeave and onMouseEnter onto the
individual child nodes instead of making it enclose all of them.

<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

Difficult to keep the tooltip open because the hover area is inconsistent.

**Description**

This change adds a div in order to nest the tooltip inside something so the hover area covers all children.

**Note for release**

n/a

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [x]  Corresponding changes to the documentation have been made
