### PR TITLE
[base] Fix keyboard accessibility in change bars

### DIFF
--- a/packages/@sanity/base/src/change-indicators/ChangeBar.css
+++ b/packages/@sanity/base/src/change-indicators/ChangeBar.css
@@ -105,6 +105,12 @@
 }
 
 .hitArea {
+  appearance: none;
+  border: 0;
+  outline: 0;
+  display: block;
+  padding: 0;
+  background: 0;
   position: absolute;
   left: calc(0 - var(--extra-small-padding));
   width: calc(var(--extra-small-padding) + var(--medium-padding));

--- a/packages/@sanity/base/src/change-indicators/ChangeBar.tsx
+++ b/packages/@sanity/base/src/change-indicators/ChangeBar.tsx
@@ -76,7 +76,10 @@ export const ChangeBar = React.forwardRef(
               <EditIconSmall className={styles.badge__icon} />
             </div>
 
-            <div
+            <button
+              tabIndex={isReviewChangesOpen ? -1 : 0}
+              type="button"
+              aria-label="Review changes"
               onClick={isReviewChangesOpen ? null : onOpenReviewChanges}
               className={styles.hitArea}
               onMouseEnter={handleMouseEnter}


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Description**
<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->
It's currently not possible to open the changes panel from a field when using a keyboard only.

This makes the hit area in `ChangeBar` a button so that it is possible to get to it with keyboard only, and giving it a negative tab index when the changes panel is open to keep correct focus order of the fields 

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

- Fixed accessibility in field change bar to make it possible to open changes panel with keyboard only from a field

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
