### PR TITLE
[default-layout] Vertically center searching spinner

### DIFF
--- a/packages/@sanity/default-layout/src/navbar/search/SearchResults.css
+++ b/packages/@sanity/default-layout/src/navbar/search/SearchResults.css
@@ -8,6 +8,9 @@
 
 .root.isLoading {
   height: 8em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .root.noResults {


### PR DESCRIPTION
**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<img width="569" alt="Screenshot 2020-10-12 at 15 16 01" src="https://user-images.githubusercontent.com/48200/95751016-4233f700-0c9e-11eb-8e8a-1f8ed3c74af2.png">

**Description**

Vertically centers the loading spinner while it's loading:

<img width="569" alt="Screenshot 2020-10-12 at 15 16 56" src="https://user-images.githubusercontent.com/48200/95751053-50821300-0c9e-11eb-82fb-92002263b0bd.png">


**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
