### PR TITLE
[cli] Clarify tsconfig role in studios

### DIFF
--- a/packages/@sanity/cli/templates/blog/tsconfig.json
+++ b/packages/@sanity/cli/templates/blog/tsconfig.json
@@ -1,3 +1,6 @@
 {
+  // Note: This config is only used to help editors like VS Code understand/resolve
+  // parts, the actual transpilation is done by babel. Any compiler configuration in
+  // here will be ignored.
   "include": ["./node_modules/@sanity/base/types/**/*.ts", "./**/*.ts", "./**/*.tsx"]
 }

--- a/packages/@sanity/cli/templates/clean/tsconfig.json
+++ b/packages/@sanity/cli/templates/clean/tsconfig.json
@@ -1,3 +1,6 @@
 {
+  // Note: This config is only used to help editors like VS Code understand/resolve
+  // parts, the actual transpilation is done by babel. Any compiler configuration in
+  // here will be ignored.
   "include": ["./node_modules/@sanity/base/types/**/*.ts", "./**/*.ts", "./**/*.tsx"]
 }

--- a/packages/@sanity/cli/templates/ecommerce/tsconfig.json
+++ b/packages/@sanity/cli/templates/ecommerce/tsconfig.json
@@ -1,3 +1,6 @@
 {
+  // Note: This config is only used to help editors like VS Code understand/resolve
+  // parts, the actual transpilation is done by babel. Any compiler configuration in
+  // here will be ignored.
   "include": ["./node_modules/@sanity/base/types/**/*.ts", "./**/*.ts", "./**/*.tsx"]
 }

--- a/packages/@sanity/cli/templates/moviedb/tsconfig.json
+++ b/packages/@sanity/cli/templates/moviedb/tsconfig.json
@@ -1,3 +1,6 @@
 {
+  // Note: This config is only used to help editors like VS Code understand/resolve
+  // parts, the actual transpilation is done by babel. Any compiler configuration in
+  // here will be ignored.
   "include": ["./node_modules/@sanity/base/types/**/*.ts", "./**/*.ts", "./**/*.tsx"]
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

As mentioned in #2035, the tsconfig.json file in bootstrapped studios is not used for transpilation, but only serves to help editors understand parts and such. There is nothing that's indicating that fact, however, which can lead you to believe that modifying the config will yield different results.

**Description**

This PR adds a few comments to the tsconfig explaining the fact that it's only there for editors sake, and that babel is the brains behind the transpilation.

**Note for release**

- Clarify role of tsconfig in new studios

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [x]  Corresponding changes to the documentation have been made
