### PR TITLE
[desk-tool] Scroll to top of input instead of center

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/views/editForm.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/views/editForm.tsx
@@ -35,13 +35,27 @@ export const EditForm = memo((props: Props) => {
   const presence = useDocumentPresence(props.id)
   const subscriptionRef = useRef<Subscription | null>(null)
   const patchChannel = useMemo(() => FormBuilder.createPatchChannel(), [])
+  const {
+    filterField,
+    focusPath,
+    markers,
+    value,
+    onBlur,
+    onFocus,
+    onChange,
+    compareValue,
+    readOnly,
+    schema,
+    type
+  } = props
 
+  const startSegment = focusPath[0]
   useEffect(() => {
-    const el = document.querySelector(`[data-focus-path="${focusPath[0]}"]`)
+    const el = document.querySelector(`[data-focus-path="${startSegment}"]`)
     if (el) {
-      scrollIntoView(el, {scrollMode: 'if-needed'})
+      scrollIntoView(el, {scrollMode: 'if-needed', block: 'start'})
     }
-  }, [props.focusPath[0]])
+  }, [startSegment])
 
   useEffect(() => {
     subscriptionRef.current = documentStore.pair
@@ -60,20 +74,6 @@ export const EditForm = memo((props: Props) => {
       }
     }
   }, [])
-
-  const {
-    filterField,
-    focusPath,
-    markers,
-    value,
-    onBlur,
-    onFocus,
-    onChange,
-    compareValue,
-    readOnly,
-    schema,
-    type
-  } = props
 
   return (
     <form onSubmit={preventDefault}>


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

When the first segment of the focus path is larger than the viewport, the form scrolls to the center of that element instead of to its top.

**Description**

This PR specifies an option that makes sure we scroll to the top, not the center of the target element.

**Note for release**

- Fix issue where the form would scroll to the center of the focused element instead of the top of it

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [x]  Corresponding changes to the documentation have been made
