### PR TITLE
[components] fix fieldsets columns with nested fieldwrappers

### DIFF
--- a/packages/@sanity/components/src/fieldsets/DefaultFieldset.css
+++ b/packages/@sanity/components/src/fieldsets/DefaultFieldset.css
@@ -7,8 +7,11 @@
 
 .fieldWrapper {
   display: grid;
-  grid-template-columns: minmax(0, 1fr);
   grid-gap: 2rem var(--medium-padding);
+
+  @nest &[data-columns='true'] {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 .fieldset {
@@ -41,15 +44,15 @@
 }
 
 @media (--screen-medium) {
-  .columns4 .fieldWrapper {
+  .columns4 .fieldWrapper[data-columns='true'] {
     grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
-  .columns3 .fieldWrapper {
+  .columns3 .fieldWrapper[data-columns='true'] {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
-  .columns2 .fieldWrapper {
+  .columns2 .fieldWrapper[data-columns='true'] {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }

--- a/packages/@sanity/components/src/fieldsets/DefaultFieldset.tsx
+++ b/packages/@sanity/components/src/fieldsets/DefaultFieldset.tsx
@@ -199,7 +199,7 @@ export default class Fieldset extends React.PureComponent<FieldsetProps, State> 
 
             {isCollapsible && !isCollapsed && (
               <div className={styles.content}>
-                <div className={styles.fieldWrapper}>
+                <div className={styles.fieldWrapper} data-columns={columns && columns > 1}>
                   {(hasBeenToggled || !isCollapsed) && children}
                 </div>
               </div>
@@ -209,10 +209,14 @@ export default class Fieldset extends React.PureComponent<FieldsetProps, State> 
               <div className={styles.content}>
                 {changeIndicator ? (
                   <ChangeIndicator {...changeIndicator}>
-                    <div className={styles.fieldWrapper}>{children}</div>
+                    <div className={styles.fieldWrapper} data-columns={columns && columns > 1}>
+                      {children}
+                    </div>
                   </ChangeIndicator>
                 ) : (
-                  <div className={styles.fieldWrapper}>{children}</div>
+                  <div className={styles.fieldWrapper} data-columns={columns && columns > 1}>
+                    {children}
+                  </div>
                 )}
               </div>
             )}


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Descriptioin**

<!-- Reference/link the relevant issue and/or describe the behavior. -->
The field wrappers would also get columns when nested, causing incorrect layouts:

![Screenshot 2020-10-12 at 17 05 53](https://user-images.githubusercontent.com/25737281/95761942-54696180-0cad-11eb-87a9-bdac25a54907.png)

This only applies columns to the field wrapper if there are one or more columns:
![Screenshot 2020-10-12 at 17 06 43](https://user-images.githubusercontent.com/25737281/95762028-706d0300-0cad-11eb-88a7-30f32a7c0d08.png)


**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

- Fixed column layout not working properly in fieldsets with certain content types

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing