### PR TITLE
[form-builder] disable onclickoutside to prevent dialogs from closing in nested PTEs

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/PortableText/Objects/renderers/DefaultObjectEditing.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Objects/renderers/DefaultObjectEditing.tsx
@@ -43,7 +43,7 @@ export function DefaultObjectEditing(props: Props) {
       {(): JSX.Element => (
         <DefaultDialog
           isOpen
-          onClickOutside={onClose}
+          // onClickOutside={onClose} /* disabled to fix dialogs closing in nested PTEs */
           onClose={onClose}
           showCloseButton
           title={type.title}


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

Disabled the click outside as you said @mariuslundgard, is this right? Or should this instead wait and be solved with the other dialog improvements?

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

- Fixed an issue where dialogs in nested portable text wouldn't open

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
