### PR TITLE
[base, desk-tool] Update useTimeAgo hook to make trailing `ago` optional, and update sparkline to use minimal timestamp

### DIFF
--- a/packages/@sanity/base/src/time/useTimeAgo.ts
+++ b/packages/@sanity/base/src/time/useTimeAgo.ts
@@ -22,25 +22,26 @@ const ONE_HOUR = ONE_MINUTE * 60
 
 interface TimeAgoOpts {
   minimal?: boolean
+  agoSuffix?: boolean
 }
 
-export function useTimeAgo(time: Date | string, {minimal}: TimeAgoOpts = {}): string {
-  const [resolved, setResolved] = useState(() => formatRelativeTime(time, {minimal}))
+export function useTimeAgo(time: Date | string, {minimal, agoSuffix}: TimeAgoOpts = {}): string {
+  const [resolved, setResolved] = useState(() => formatRelativeTime(time, {minimal, agoSuffix}))
 
   useEffect(() => {
-    setResolved(formatRelativeTime(time, {minimal}))
-  }, [time, minimal])
+    setResolved(formatRelativeTime(time, {minimal, agoSuffix}))
+  }, [time, minimal, agoSuffix])
 
   useEffect(() => {
     const id: number | undefined = Number.isFinite(resolved.refreshInterval)
       ? window.setInterval(
-          () => setResolved(formatRelativeTime(time, {minimal})),
+          () => setResolved(formatRelativeTime(time, {minimal, agoSuffix})),
           resolved.refreshInterval
         )
       : undefined
 
     return () => clearInterval(id)
-  }, [time, minimal, resolved.refreshInterval])
+  }, [time, minimal, resolved.refreshInterval, agoSuffix])
 
   return resolved.timestamp
 }
@@ -77,23 +78,30 @@ function formatRelativeTime(date: Date | string, opts: TimeAgoOpts = {}): TimeSp
   const diffWeeks = differenceInWeeks(now, parsedDate)
   if (diffWeeks) {
     if (opts.minimal) {
-      return {timestamp: `${diffWeeks}w`, refreshInterval: ONE_HOUR}
-    }
-
-    return {timestamp: `${diffWeeks} weeks ago`, refreshInterval: ONE_HOUR}
-  }
-
-  const diffDays = differenceInDays(now, parsedDate)
-  if (diffDays) {
-    if (opts.minimal) {
       return {
-        timestamp: diffDays === 1 ? 'yesterday' : `${diffDays}d`,
+        timestamp: opts.agoSuffix ? `${diffWeeks}w ago` : `${diffWeeks}w`,
         refreshInterval: ONE_HOUR
       }
     }
 
     return {
-      timestamp: diffDays === 1 ? 'yesterday' : `${diffDays} days ago`,
+      timestamp: opts.agoSuffix ? `${diffWeeks} weeks ago` : `${diffWeeks} weeks`,
+      refreshInterval: ONE_HOUR
+    }
+  }
+
+  const diffDays = differenceInDays(now, parsedDate)
+  if (diffDays) {
+    if (opts.minimal) {
+      const daysSince = opts.agoSuffix ? `${diffDays}d ago` : `${diffDays}d`
+      return {
+        timestamp: diffDays === 1 ? 'yesterday' : daysSince,
+        refreshInterval: ONE_HOUR
+      }
+    }
+    const daysSince = opts.agoSuffix ? `${diffDays} days ago` : `${diffDays} days`
+    return {
+      timestamp: diffDays === 1 ? 'yesterday' : daysSince,
       refreshInterval: ONE_HOUR
     }
   }
@@ -101,28 +109,44 @@ function formatRelativeTime(date: Date | string, opts: TimeAgoOpts = {}): TimeSp
   const diffHours = differenceInHours(now, parsedDate)
   if (diffHours) {
     if (opts.minimal) {
-      return {timestamp: `${diffHours}h`, refreshInterval: ONE_MINUTE}
+      return {
+        timestamp: opts.agoSuffix ? `${diffHours}h ago` : `${diffHours}h`,
+        refreshInterval: ONE_MINUTE
+      }
     }
-
-    return {timestamp: `${diffHours} hours ago`, refreshInterval: ONE_MINUTE}
+    return {
+      timestamp: opts.agoSuffix ? `${diffHours} hours ago` : `${diffHours} hours`,
+      refreshInterval: ONE_MINUTE
+    }
   }
 
   const diffMins = differenceInMinutes(now, parsedDate)
   if (diffMins) {
     if (opts.minimal) {
-      return {timestamp: `${diffMins}m`, refreshInterval: TWENTY_SECONDS}
+      return {
+        timestamp: opts.agoSuffix ? `${diffMins}m ago` : `${diffMins}m`,
+        refreshInterval: TWENTY_SECONDS
+      }
     }
-
-    return {timestamp: `${diffMins} minutes ago`, refreshInterval: TWENTY_SECONDS}
+    return {
+      timestamp: opts.agoSuffix ? `${diffMins} minutes ago` : `${diffMins} minutes`,
+      refreshInterval: TWENTY_SECONDS
+    }
   }
 
   const diffSeconds = differenceInSeconds(now, parsedDate)
   if (diffSeconds > 10) {
     if (opts.minimal) {
-      return {timestamp: `${diffSeconds}s`, refreshInterval: FIVE_SECONDS}
+      return {
+        timestamp: opts.agoSuffix ? `${diffSeconds}s ago` : `${diffSeconds}s`,
+        refreshInterval: FIVE_SECONDS
+      }
     }
 
-    return {timestamp: `${diffSeconds} seconds ago`, refreshInterval: FIVE_SECONDS}
+    return {
+      timestamp: opts.agoSuffix ? `${diffSeconds} seconds ago` : `${diffSeconds} seconds`,
+      refreshInterval: FIVE_SECONDS
+    }
   }
 
   return {timestamp: 'just now', refreshInterval: FIVE_SECONDS}

--- a/packages/@sanity/desk-tool/src/panes/documentPane/changesPanel/changesPanel.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/changesPanel/changesPanel.tsx
@@ -174,7 +174,7 @@ function Content({
 }
 
 function SinceText({since}: {since: Chunk}): React.ReactElement {
-  const timeAgo = useTimeAgo(since.endTimestamp)
+  const timeAgo = useTimeAgo(since.endTimestamp, {agoSuffix: true})
 
   return (
     <>

--- a/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/header/header.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/header/header.tsx
@@ -203,7 +203,7 @@ export function DocumentPanelHeader(props: DocumentPanelHeaderProps) {
 }
 
 function TimelineButtonLabel({rev}: {rev: Chunk}) {
-  const timeAgo = useTimeAgo(rev.endTimestamp)
+  const timeAgo = useTimeAgo(rev.endTimestamp, {agoSuffix: true})
 
   return (
     <>

--- a/packages/@sanity/desk-tool/src/panes/documentPane/statusBar/documentSparkline.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/statusBar/documentSparkline.tsx
@@ -62,8 +62,12 @@ export function DocumentSparkline({badges, lastUpdated, editState}: DocumentSpar
   const lastUnpublishOrPublishSession = chunks.find(
     chunk => chunk.type === 'unpublish' || chunk.type === 'publish'
   )
-  const lastPublishedTimeAgo = useTimeAgo(lastUnpublishOrPublishSession?.endTimestamp || '')
-  const lastUpdatedTimeAgo = useTimeAgo(lastUpdated || '')
+
+  const lastPublishedTimeAgo = useTimeAgo(lastUnpublishOrPublishSession?.endTimestamp || '', {
+    minimal: true,
+    agoSuffix: true
+  })
+  const lastUpdatedTimeAgo = useTimeAgo(lastUpdated || '', {minimal: true, agoSuffix: true})
 
   // Make sure we only show editDraft sessions (and count the unpublish as a draft session)
   const filteredSessions = lastUnpublishOrPublishSession


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

Noticed that the sparkline doesn't currently use the minimal timestamp format, which sometimes makes it hard to read + causing layout issues when document was only published or updated a while ago. Also didn't match the Figma sketch.

This uses the minimal format for the timestamp in the sparkline, but also adds an option called `useAgo` to the `useTimeAgo` hook to make it possible to use both the default and minimal format with and without a trailing `ago`. 

The components using the `useTimeAgo` hook with the minimal format have been updated to use the appropriate `ago` as well.

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
