### PR TITLE
[base] Export PresenceScope as part of the public API

### DIFF
--- a/packages/@sanity/base/src/presence/index.ts
+++ b/packages/@sanity/base/src/presence/index.ts
@@ -10,3 +10,4 @@ export {FormFieldPresence}
 export {FormFieldPresenceContext}
 export {PresenceOverlay} from './overlay/PresenceOverlay'
 export {FieldPresence} from './FieldPresence'
+export {PresenceScope} from './PresenceScope'


### PR DESCRIPTION
**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Description**
The export of the PresenceScope component which is a part of the public presence API seems to have been accidentally removed in 2.0. This patch adds it back.

**Note for release**
Added back export of the PresenceScope component that got accidentally removed in the 2.0 release.
