### PR TITLE
[base] Switch to a warning instead of hard failure on missing tracker context

### DIFF
--- a/packages/@sanity/base/src/components/react-track-elements/createScope.tsx
+++ b/packages/@sanity/base/src/components/react-track-elements/createScope.tsx
@@ -2,24 +2,54 @@ import * as React from 'react'
 import {TrackerContext} from './types'
 import {createUseReporter, IsEqualFunction} from './createUseReporter'
 import {createStore} from './createStore'
+import {Reported} from './index'
 
-const useReporterGuard = (id: string) => {
-  throw new Error(
-    `No context provided for reporter. Make sure that the component calling "useReporter(${id}, ...)", is wrapped in a <Tracker> element`
-  )
+// Todo: consider memozing individual functions or move the context assertion/guard to a separate step.
+let didWarn = false
+const useReporterGuard = (id: string): void => {
+  if (!didWarn) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      new Error(
+        `No context provided for reporter. Make sure that the component calling "useReporter(${id}, ...)", is wrapped in a <Tracker> element`
+      )
+    )
+  }
+  didWarn = true
 }
 
-const useReportedValueGuard = () => {
-  throw new Error(
-    'No context provided for reporter. Make sure that the component calling "useReportedValues()", is wrapped inside a <Tracker> element'
-  )
+function useReportedValueGuard(): Reported<unknown>[] {
+  if (!didWarn) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      new Error(
+        'No context provided for reporter. Make sure that the component calling "useReportedValues()", is wrapped inside a <Tracker> element'
+      )
+    )
+  }
+  didWarn = true
+  return []
+}
+
+const useSubscribeGuard = () => {
+  if (!didWarn) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      new Error(
+        'No context provided for reporter. Make sure that the component calling "useReportedValues()", is wrapped inside a <Tracker> element'
+      )
+    )
+  }
+  didWarn = true
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  return () => {}
 }
 
 const DEFAULT_CONTEXT: TrackerContext<unknown> = {
   add: useReporterGuard,
   update: useReporterGuard,
   remove: useReporterGuard,
-  subscribe: useReportedValueGuard,
+  subscribe: useSubscribeGuard,
   read: useReportedValueGuard
 }
 

--- a/packages/@sanity/base/src/components/react-track-elements/createStore.ts
+++ b/packages/@sanity/base/src/components/react-track-elements/createStore.ts
@@ -11,6 +11,7 @@ export function createStore<Value>() {
 
   function add(id: string, value: Value) {
     if (reportedValues.has(id)) {
+      // eslint-disable-next-line no-console
       console.error(
         new Error(
           `Invalid call to useReporter(${id}): A component reporting on "${id}" is already mounted in the subtree. Make sure that all reporters within the same <Tracker> subtree have unique ids.`


### PR DESCRIPTION
Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**
When using the `useReporter()` or `useReportedValues()` hook outside of a Tracker element context we currently throw an error which makes the studio crash. Since this is currently used for non-critical features like the change connectors and presence we should hard fail when it happens.

<!-- Reference/link the relevant issue and/or describe the behavior. -->

**Description**
 This PR issues a console warning instead of crashing the studio. A future improvement would be to make the failure mode configurable on a per-tracker basis, since there might be situations where it's used for more critical features.

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

**Note for release**
Added a more graceful handling of cases where no tracker context could be found by issuing a console warning instead of throwing an error, causing studio crash.
