### PR TITLE
[core] When copying a dataset, the check for existing source datasets was wrong

### DIFF
--- a/packages/@sanity/core/src/commands/dataset/copyDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/copyDatasetCommand.js
@@ -71,7 +71,7 @@ export default {
       throw new Error(nameError)
     }
 
-    const [existingDatasets] = await client.datasets
+    const existingDatasets = await client.datasets
       .list()
       .then(datasets => datasets.map(ds => ds.name))
 


### PR DESCRIPTION
**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

The copy dataset command only checks against the first item in the dataset list response, instead of the whole list of datasets.

**Description**

This PR fixes ☝️ by actually checking against the whole list instead of the first item in the response.

**Note for release**

Fix a problem with the copy dataset command where it didn't correctly check that the source dataset actually exists.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
