### PR TITLE
Connectors redraw on resize

### DIFF
--- a/packages/@sanity/base/package.json
+++ b/packages/@sanity/base/package.json
@@ -65,6 +65,7 @@
     "shallow-equals": "^1.0.0"
   },
   "devDependencies": {
+    "@types/resize-observer-browser": "^0.1.4",
     "jest": "^26.4.2",
     "prop-types": "^15.6.0",
     "react": "16.9.0",

--- a/packages/@sanity/base/src/change-indicators/overlay/ConnectorsOverlay.tsx
+++ b/packages/@sanity/base/src/change-indicators/overlay/ConnectorsOverlay.tsx
@@ -12,6 +12,7 @@ import {Connector} from './Connector'
 
 import styles from './ConnectorsOverlay.css'
 import {DebugLayers} from './DebugLayers'
+import {resizeObserver} from '../../util/resizeObserver'
 
 export interface Rect {
   height: number
@@ -25,6 +26,12 @@ interface Props {
   onSetFocus: (nextFocusPath: Path) => void
 }
 
+function useResizeObserver(
+  element: HTMLDivElement,
+  onResize: (event: ResizeObserverEntry) => void
+) {
+  React.useEffect(() => resizeObserver.observe(element, onResize), [element, onResize])
+}
 export const ConnectorsOverlay = React.memo(function ConnectorsOverlay(props: Props) {
   const {rootRef, onSetFocus} = props
 
@@ -32,6 +39,9 @@ export const ConnectorsOverlay = React.memo(function ConnectorsOverlay(props: Pr
 
   const allReportedValues = useReportedValues()
   const [, forceUpdate] = React.useReducer(n => n + 1, 0)
+
+  useResizeObserver(rootRef, forceUpdate)
+
   const byId = new Map(allReportedValues)
 
   const changeBarsWithHover: Reported<TrackedChange>[] = []

--- a/packages/@sanity/base/src/util/resizeObserver.ts
+++ b/packages/@sanity/base/src/util/resizeObserver.ts
@@ -1,0 +1,40 @@
+import {ResizeObserver as Polyfill, ResizeObserverEntry} from '@juggle/resize-observer'
+
+import createPubSub, {Subscriber} from 'nano-pubsub'
+
+const ResizeObserver: typeof Polyfill = (window as any).ResizeObserver || Polyfill
+
+export interface SharedResizeObserver {
+  observe: (
+    element: Element,
+    observer: Subscriber<ResizeObserverEntry>,
+    options?: ResizeObserverOptions
+  ) => () => void
+}
+
+export const createSharedResizeObserver = (): SharedResizeObserver => {
+  const event = createPubSub<ResizeObserverEntry[]>()
+  const resizeObserver = new ResizeObserver((entries: ResizeObserverEntry[]) =>
+    event.publish(entries)
+  )
+  return {
+    observe: (
+      element: Element,
+      observer: Subscriber<ResizeObserverEntry>,
+      options?: ResizeObserverOptions
+    ) => {
+      const unsubscribe = event.subscribe(entries => {
+        const entry = entries.find(e => e.target === element)
+        if (entry) {
+          observer(entry)
+        }
+      })
+      resizeObserver.observe(element, options)
+      return () => {
+        unsubscribe()
+        resizeObserver.unobserve(element)
+      }
+    }
+  }
+}
+export const resizeObserver = createSharedResizeObserver()

--- a/packages/@sanity/desk-tool/package.json
+++ b/packages/@sanity/desk-tool/package.json
@@ -21,7 +21,6 @@
     "sanity-tool"
   ],
   "dependencies": {
-    "@juggle/resize-observer": "^3.2.0",
     "@popperjs/core": "^2.4.4",
     "@reach/auto-id": "^0.10.5",
     "@sanity/base": "2.0.4",

--- a/packages/@sanity/desk-tool/src/tool/resize-observer.ts
+++ b/packages/@sanity/desk-tool/src/tool/resize-observer.ts
@@ -1,3 +1,0 @@
-// Todo: this can be safely removed at some point
-import {ResizeObserver as Polyfill} from '@juggle/resize-observer'
-export const ResizeObserver = (window as any).ResizeObserver || Polyfill


### PR DESCRIPTION
**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

Currently the connector lines are not redrawn/recalculated on resize.

**Description**
This makes sure the connector lines are being redrawn properly on window resize.

There are three separate commits that can be reviewed individually:
- a9718b8 Exports a single resizeObserver instance that can be shared across different studio components (there are performance gains to be had from using a single instance instead of creating multiple). It's also exported with a bit nicer API that fits React hooks a bit better than the native ResizeObserver API.
- 4825c6c Makes desk-tool import the shared resizeObserver instance from base instead of creating its own.
- 55e0e5f Makes use of the same resizeObserver instance to force redraw the connector lines on resize.

**Note for release**
Fixes an issue with lines connecting a change with it's corresponding input not being redrawn on window/pane resize.

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

**Checklist** 

- [ ]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [ ]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [ ]  The code is linted
- [ ]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
