### PR TITLE
[chore] Remove extensions from sanity.json paths

### DIFF
--- a/packages/@sanity/base/sanity.json
+++ b/packages/@sanity/base/sanity.json
@@ -42,13 +42,13 @@
     },
     {
       "implements": "part:@sanity/base/version-checker",
-      "path": "components/VersionChecker.js"
+      "path": "components/VersionChecker"
     },
     {
       "name": "part:@sanity/base/asset-url-builder-default",
       "implements": "part:@sanity/base/asset-url-builder",
       "description": "Function that generates or modifies asset URLs for display in various contexts",
-      "path": "assets/asset-url-builder.js"
+      "path": "assets/asset-url-builder"
     },
     {
       "name": "part:@sanity/base/search",
@@ -152,11 +152,11 @@
     },
     {
       "implements": "part:@sanity/base/util/document-action-utils",
-      "path": "actions/utils/legacy_documentActionUtils.js"
+      "path": "actions/utils/legacy_documentActionUtils"
     },
     {
       "implements": "part:@sanity/base/actions/utils",
-      "path": "actions/utils/index.js"
+      "path": "actions/utils/index"
     },
     {
       "name": "part:@sanity/base/document-actions/resolver",
@@ -272,35 +272,35 @@
     },
     {
       "implements": "part:@sanity/base/sanity-root",
-      "path": "components/SanityRoot.js"
+      "path": "components/SanityRoot"
     },
     {
       "implements": "part:@sanity/base/app-loading-screen",
-      "path": "components/AppLoadingScreen.js"
+      "path": "components/AppLoadingScreen"
     },
     {
       "implements": "part:@sanity/base/root",
-      "path": "components/DefaultRootComponent.js"
+      "path": "components/DefaultRootComponent"
     },
     {
       "implements": "part:@sanity/base/schema-creator",
-      "path": "schema/createSchema.js"
+      "path": "schema/createSchema"
     },
     {
       "implements": "part:@sanity/base/search",
-      "path": "search/index.js"
+      "path": "search/index"
     },
     {
       "implements": "part:@sanity/base/search/weighted",
-      "path": "search/weighted/index.js"
+      "path": "search/weighted/index"
     },
     {
       "implements": "part:@sanity/base/util/draft-utils",
-      "path": "util/draftUtils.js"
+      "path": "util/draftUtils"
     },
     {
       "implements": "part:@sanity/base/util/search-utils",
-      "path": "util/searchUtils.js"
+      "path": "util/searchUtils"
     },
     {
       "implements": "part:@sanity/base/theme/variables-style",
@@ -396,7 +396,7 @@
     },
     {
       "name": "part:@sanity/base/settings",
-      "path": "datastores/settings/settingsStore.js"
+      "path": "datastores/settings/settingsStore"
     },
     {
       "name": "part:@sanity/base/router",
@@ -413,15 +413,15 @@
     },
     {
       "implements": "part:@sanity/base/language-resolver",
-      "path": "locale/languageResolver.js"
+      "path": "locale/languageResolver"
     },
     {
       "implements": "part:@sanity/base/locale-message-fetcher",
-      "path": "locale/messageFetcher.js"
+      "path": "locale/messageFetcher"
     },
     {
       "implements": "part:@sanity/base/locale/intl",
-      "path": "locale/intl.js"
+      "path": "locale/intl"
     },
     {
       "implements": "part:@sanity/base/sanity-intl-provider",
@@ -437,7 +437,7 @@
     },
     {
       "implements": "part:@sanity/base/locale/formatters",
-      "path": "components/IntlWrapper.js"
+      "path": "components/IntlWrapper"
     },
     {
       "implements": "part:@sanity/base/theme/layout/box-style",
@@ -697,7 +697,7 @@
     },
     {
       "implements": "part:@sanity/base/robot-icon",
-      "path": "components/icons/Robot.js"
+      "path": "components/icons/Robot"
     },
     {
       "name": "part:@sanity/base/trash-icon",
@@ -741,7 +741,7 @@
     },
     {
       "implements": "part:@sanity/base/preview",
-      "path": "preview/index.js"
+      "path": "preview/index"
     },
     {
       "implements": "part:@sanity/base/th-list-icon",
@@ -1045,15 +1045,15 @@
     },
     {
       "implements": "part:@sanity/base/sanity-logo",
-      "path": "components/logos/SanityLogo.js"
+      "path": "components/logos/SanityLogo"
     },
     {
       "implements": "part:@sanity/base/sanity-logo-alpha",
-      "path": "components/logos/SanityLogoAlpha.js"
+      "path": "components/logos/SanityLogoAlpha"
     },
     {
       "implements": "part:@sanity/base/sanity-studio-logo",
-      "path": "components/logos/SanityStudioLogo.js"
+      "path": "components/logos/SanityStudioLogo"
     },
     {
       "name": "part:@sanity/base/component",
@@ -1061,11 +1061,11 @@
     },
     {
       "implements": "part:@sanity/base/component",
-      "path": "styles/variables/story.js"
+      "path": "styles/variables/story"
     },
     {
       "implements": "part:@sanity/base/component",
-      "path": "components/story.js"
+      "path": "components/story"
     }
   ]
 }

--- a/packages/@sanity/cli/templates/ecommerce/plugins/barcode-input/sanity.json
+++ b/packages/@sanity/cli/templates/ecommerce/plugins/barcode-input/sanity.json
@@ -2,7 +2,7 @@
   "parts": [
     {
       "implements": "part:@sanity/base/schema-type",
-      "path": "./BarcodeType.js"
+      "path": "./BarcodeType"
     }
   ]
 }

--- a/packages/@sanity/code-input/sanity.json
+++ b/packages/@sanity/code-input/sanity.json
@@ -10,7 +10,7 @@
     },
     {
       "implements": "part:@sanity/form-builder/input/code",
-      "path": "CodeInput.js"
+      "path": "CodeInput"
     },
     {
       "name": "part:@sanity/form-builder/input/code/schema",
@@ -18,11 +18,11 @@
     },
     {
       "implements": "part:@sanity/base/schema-type",
-      "path": "schema.js"
+      "path": "schema"
     },
     {
       "implements": "part:@sanity/form-builder/input/code/schema",
-      "path": "deprecatedSchema.js"
+      "path": "deprecatedSchema"
     }
   ]
 }

--- a/packages/@sanity/color-input/sanity.json
+++ b/packages/@sanity/color-input/sanity.json
@@ -10,23 +10,23 @@
     },
     {
       "implements": "part:@sanity/form-builder/input/color",
-      "path": "ColorInput.js"
+      "path": "ColorInput"
     },
     {
       "implements": "part:@sanity/base/schema-type",
-      "path": "schemas/hslaColor.js"
+      "path": "schemas/hslaColor"
     },
     {
       "implements": "part:@sanity/base/schema-type",
-      "path": "schemas/hsvaColor.js"
+      "path": "schemas/hsvaColor"
     },
     {
       "implements": "part:@sanity/base/schema-type",
-      "path": "schemas/rgbaColor.js"
+      "path": "schemas/rgbaColor"
     },
     {
       "implements": "part:@sanity/base/schema-type",
-      "path": "schemas/color.js"
+      "path": "schemas/color"
     }
   ]
 }

--- a/packages/@sanity/dashboard/sanity.json
+++ b/packages/@sanity/dashboard/sanity.json
@@ -6,11 +6,11 @@
   "parts": [
     {
       "implements": "part:@sanity/base/tool",
-      "path": "DashboardTool.js"
+      "path": "DashboardTool"
     },
     {
       "implements": "part:@sanity/base/component",
-      "path": "components/story.js"
+      "path": "components/story"
     },
     {
       "name": "part:@sanity/dashboard/config",
@@ -18,7 +18,7 @@
     },
     {
       "implements": "part:@sanity/dashboard/config",
-      "path": "dashboardConfig.js"
+      "path": "dashboardConfig"
     },
     {
       "name": "part:@sanity/dashboard/widget",

--- a/packages/@sanity/data-aspects/sanity.json
+++ b/packages/@sanity/data-aspects/sanity.json
@@ -10,7 +10,7 @@
     },
     {
       "implements": "part:@sanity/data-aspects/resolver",
-      "path": "DataAspectsResolver.js"
+      "path": "DataAspectsResolver"
     }
   ]
 }

--- a/packages/@sanity/date-input/sanity.json
+++ b/packages/@sanity/date-input/sanity.json
@@ -2,7 +2,7 @@
   "parts": [
     {
       "implements": "part:@sanity/form-builder/input/rich-date",
-      "path": "./index.js"
+      "path": "./index"
     },
     {
       "implements": "part:@sanity/form-builder/input/legacy-date/schema",

--- a/packages/@sanity/default-layout/sanity.json
+++ b/packages/@sanity/default-layout/sanity.json
@@ -48,7 +48,7 @@
     },
     {
       "implements": "part:@sanity/base/component",
-      "path": "story.js"
+      "path": "story"
     }
   ]
 }

--- a/packages/@sanity/default-login/sanity.json
+++ b/packages/@sanity/default-login/sanity.json
@@ -11,19 +11,19 @@
     },
     {
       "implements": "part:@sanity/base/login-wrapper",
-      "path": "LoginWrapper.js"
+      "path": "LoginWrapper"
     },
     {
       "implements": "part:@sanity/base/login-dialog",
-      "path": "LoginDialog.js"
+      "path": "LoginDialog"
     },
     {
       "implements": "part:@sanity/base/login-dialog-content",
-      "path": "LoginDialogContent.js"
+      "path": "LoginDialogContent"
     },
     {
       "implements": "part:@sanity/base/authentication-fetcher",
-      "path": "authenticationFetcher.js"
+      "path": "authenticationFetcher"
     },
     {
       "implements": "part:@sanity/base/locale-messages",

--- a/packages/@sanity/desk-tool/sanity.json
+++ b/packages/@sanity/desk-tool/sanity.json
@@ -9,25 +9,25 @@
   "parts": [
     {
       "implements": "part:@sanity/base/tool",
-      "path": "tool/index.js"
+      "path": "tool/index"
     },
     {
       "implements": "part:@sanity/base/document-actions",
       "description": "The default document actions",
-      "path": "actions/defaultDocumentActions.js"
+      "path": "actions/defaultDocumentActions"
     },
     {
       "implements": "part:@sanity/base/document-actions/resolver",
-      "path": "actions/defaultResolveDocumentActions.js"
+      "path": "actions/defaultResolveDocumentActions"
     },
     {
       "implements": "part:@sanity/base/document-badges",
       "description": "The default document badges",
-      "path": "badges/defaultDocumentBadges.js"
+      "path": "badges/defaultDocumentBadges"
     },
     {
       "implements": "part:@sanity/base/document-badges/resolver",
-      "path": "badges/defaultResolveDocumentBadges.js"
+      "path": "badges/defaultResolveDocumentBadges"
     },
     {
       "name": "part:@sanity/desk-tool/after-editor-component",
@@ -43,7 +43,7 @@
     },
     {
       "implements": "part:@sanity/base/component",
-      "path": "components/story.js"
+      "path": "components/story"
     },
     {
       "implements": "part:@sanity/base/diff-resolver",

--- a/packages/@sanity/form-builder/sanity.json
+++ b/packages/@sanity/form-builder/sanity.json
@@ -97,40 +97,40 @@
     },
     {
       "implements": "part:@sanity/form-builder",
-      "path": "sanity/index.js"
+      "path": "sanity/index"
     },
     {
       "name": "part:@sanity/form-builder/patch-event",
-      "path": "PatchEvent.js"
+      "path": "PatchEvent"
     },
     {
       "name": "part:@sanity/form-builder/input/array/functions-default",
       "implements": "part:@sanity/form-builder/input/array/functions",
-      "path": "inputs/ArrayInput/ArrayFunctions.js"
+      "path": "inputs/ArrayInput/ArrayFunctions"
     },
     {
       "name": "part:@sanity/form-builder/input/block-editor/block-markers-default",
       "implements": "part:@sanity/form-builder/input/block-editor/block-markers",
-      "path": "inputs/PortableText/Markers.js"
+      "path": "inputs/PortableText/Markers"
     },
     {
       "name": "part:@sanity/form-builder/input/block-editor/block-extras-default",
       "implements": "part:@sanity/form-builder/input/block-editor/block-extras",
-      "path": "inputs/PortableText/BlockExtras.js"
+      "path": "inputs/PortableText/BlockExtras"
     },
     {
       "name": "part:@sanity/form-builder/input/block-editor/block-markers-custom-default",
       "implements": "part:@sanity/form-builder/input/block-editor/block-markers-custom",
-      "path": "inputs/PortableText/CustomMarkers.js"
+      "path": "inputs/PortableText/CustomMarkers"
     },
     {
       "name": "part:@sanity/form-builder/input/image/asset-source-default",
       "implements": "part:@sanity/form-builder/input/image/asset-source",
-      "path": "inputs/ImageInput/DefaultSource.js"
+      "path": "inputs/ImageInput/DefaultSource"
     },
     {
       "implements": "part:@sanity/base/component",
-      "path": "story.js"
+      "path": "story"
     }
   ]
 }

--- a/packages/@sanity/language-filter/sanity.json
+++ b/packages/@sanity/language-filter/sanity.json
@@ -6,11 +6,11 @@
   "parts": [
     {
       "implements": "part:@sanity/desk-tool/filter-fields-fn",
-      "path": "filter-fields.js"
+      "path": "filter-fields"
     },
     {
       "implements": "part:@sanity/desk-tool/language-select-component",
-      "path": "SelectLanguageProvider.js"
+      "path": "SelectLanguageProvider"
     }
   ]
 }

--- a/packages/@sanity/plugin-loader/test/fixture/plugins/better-date/sanity.json
+++ b/packages/@sanity/plugin-loader/test/fixture/plugins/better-date/sanity.json
@@ -2,7 +2,7 @@
   "parts": [
     {
       "implements": "part:date/timestamp",
-      "path": "./getBetterTimestamp.js"
+      "path": "./getBetterTimestamp"
     }
   ]
 }

--- a/packages/@sanity/plugin-loader/test/fixture/plugins/date/sanity.json
+++ b/packages/@sanity/plugin-loader/test/fixture/plugins/date/sanity.json
@@ -21,11 +21,11 @@
 
     {
       "implements": "part:date/timestamp",
-      "path": "./getTimestamp.js"
+      "path": "./getTimestamp"
     },
     {
       "implements": "part:date/iso-date",
-      "path": "./getIsoDate.js"
+      "path": "./getIsoDate"
     }
   ]
 }

--- a/packages/@sanity/plugin-loader/test/fixture/sanity.json
+++ b/packages/@sanity/plugin-loader/test/fixture/sanity.json
@@ -14,7 +14,7 @@
     {
       "name": "part:base/bar",
       "description": "Returns 'bar' when called",
-      "path": "./getBar.js"
+      "path": "./getBar"
     },
     {
       "name": "part:base/indexpart",

--- a/packages/@sanity/plugin-loader/test/loader.test.js
+++ b/packages/@sanity/plugin-loader/test/loader.test.js
@@ -74,7 +74,7 @@ test('should be able to include the sanity debug part', t => {
   const restore = pluginLoader({basePath: path.join(__dirname, 'fixture')})
   const debug = require('sanity:debug')
   t.is(debug.plugins[0].name, 'date')
-  t.is(debug.implementations['part:base/bar'][0], path.join(__dirname, 'fixture', 'getBar.js'))
+  t.is(debug.implementations['part:base/bar'][0], path.join(__dirname, 'fixture', 'getBar'))
   restore()
   t.end()
 })

--- a/packages/@sanity/production-preview/sanity.json
+++ b/packages/@sanity/production-preview/sanity.json
@@ -10,7 +10,7 @@
     },
     {
       "implements": "part:@sanity/transitional/production-preview/resolve-production-url",
-      "path": "resolveProductionUrl.js"
+      "path": "resolveProductionUrl"
     }
   ]
 }

--- a/packages/@sanity/rich-date-input/sanity.json
+++ b/packages/@sanity/rich-date-input/sanity.json
@@ -15,7 +15,7 @@
     },
     {
       "implements": "part:@sanity/base/component",
-      "path": "story.js"
+      "path": "story"
     }
   ]
 }

--- a/packages/@sanity/storybook/sanity.json
+++ b/packages/@sanity/storybook/sanity.json
@@ -8,44 +8,44 @@
     {
       "name": "part:@sanity/storybook",
       "description": "Sanity wrapped version of Kadira's React Storybook",
-      "path": "index.js"
+      "path": "index"
     },
     {
       "name": "part:@sanity/storybook/components",
-      "path": "components/index.js"
+      "path": "components/index"
     },
     {
       "name": "part:@sanity/storybook/decorators/center",
       "description": "Center decorator for storybook",
-      "path": "addons/Center.js"
+      "path": "addons/Center"
     },
     {
       "name": "part:@sanity/storybook/iframe",
       "description": "React component that renders a fullscreen iframe that shows the storybook",
-      "path": "tool/StorybookTool.js"
+      "path": "tool/StorybookTool"
     },
     {
       "name": "part:@sanity/storybook/addons/actions",
       "description": "Knobs addon for storybook",
-      "path": "addons/Actions.js"
+      "path": "addons/Actions"
     },
     {
       "name": "part:@sanity/storybook/addons/knobs",
       "description": "Knobs addon for storybook",
-      "path": "addons/Knobs.js"
+      "path": "addons/Knobs"
     },
     {
       "name": "part:@sanity/storybook/addons/sanity",
       "description": "Sanity addon for storybook",
-      "path": "addons/sanity/Sanity.js"
+      "path": "addons/sanity/Sanity"
     },
     {
       "implements": "part:@sanity/server/initializer",
-      "path": "server/fork.js"
+      "path": "server/fork"
     },
     {
       "implements": "part:@sanity/base/tool",
-      "path": "tool/index.js"
+      "path": "tool/index"
     }
   ]
 }

--- a/packages/@sanity/studio-hints/sanity.json
+++ b/packages/@sanity/studio-hints/sanity.json
@@ -10,7 +10,7 @@
     },
     {
       "implements": "part:@sanity/default-layout/sidecar",
-      "path": "StudioHints.js"
+      "path": "StudioHints"
     }
   ]
 }

--- a/packages/@sanity/vision/sanity.json
+++ b/packages/@sanity/vision/sanity.json
@@ -6,7 +6,7 @@
   "parts": [
     {
       "implements": "part:@sanity/base/tool",
-      "path": "VisionTool.js"
+      "path": "VisionTool"
     }
   ]
 }

--- a/packages/blog-studio/sanity.json
+++ b/packages/blog-studio/sanity.json
@@ -17,7 +17,7 @@
   "parts": [
     {
       "name": "part:@sanity/base/schema",
-      "path": "./schemas/schema.js"
+      "path": "./schemas/schema"
     }
   ],
   "env": {

--- a/packages/clean-studio/sanity.json
+++ b/packages/clean-studio/sanity.json
@@ -19,7 +19,7 @@
   "parts": [
     {
       "name": "part:@sanity/base/schema",
-      "path": "./schemas/schema.js"
+      "path": "./schemas/schema"
     }
   ]
 }

--- a/packages/ecommerce-studio/plugins/barcode-input/sanity.json
+++ b/packages/ecommerce-studio/plugins/barcode-input/sanity.json
@@ -2,7 +2,7 @@
   "parts": [
     {
       "implements": "part:@sanity/base/schema-type",
-      "path": "./BarcodeType.js"
+      "path": "./BarcodeType"
     }
   ]
 }

--- a/packages/ecommerce-studio/sanity.json
+++ b/packages/ecommerce-studio/sanity.json
@@ -18,7 +18,7 @@
   "parts": [
     {
       "name": "part:@sanity/base/schema",
-      "path": "./schemas/schema.js"
+      "path": "./schemas/schema"
     }
   ]
 }

--- a/packages/example-studio/sanity.json
+++ b/packages/example-studio/sanity.json
@@ -22,19 +22,19 @@
   "parts": [
     {
       "name": "part:@sanity/base/schema",
-      "path": "./schemas/schema.js"
+      "path": "./schemas/schema"
     },
     {
       "name": "part:@sanity/language-filter/config",
-      "path": "./parts/languageFilterConfig.js"
+      "path": "./parts/languageFilterConfig"
     },
     {
       "implements": "part:@sanity/base/brand-logo",
-      "path": "components/BrandLogo.js"
+      "path": "components/BrandLogo"
     },
     {
       "implements": "part:@sanity/form-builder/input-resolver",
-      "path": "./parts/inputResolver.js"
+      "path": "./parts/inputResolver"
     },
     {
       "implements": "part:@sanity/base/theme/variables/override-style",

--- a/packages/movies-studio/sanity.json
+++ b/packages/movies-studio/sanity.json
@@ -20,15 +20,15 @@
   "parts": [
     {
       "name": "part:@sanity/base/schema",
-      "path": "./schemas/schema.js"
+      "path": "./schemas/schema"
     },
     {
       "implements": "part:@sanity/base/brand-logo",
-      "path": "components/BrandLogo.js"
+      "path": "components/BrandLogo"
     },
     {
       "implements": "part:@sanity/production-preview/resolve-production-url",
-      "path": "./resolveProductionUrl.js"
+      "path": "./resolveProductionUrl"
     }
   ],
   "env": {

--- a/packages/storybook/sanity.json
+++ b/packages/storybook/sanity.json
@@ -19,15 +19,15 @@
   "parts": [
     {
       "name": "part:@sanity/base/schema",
-      "path": "./schema.js"
+      "path": "./schema"
     },
     {
       "implements": "part:@sanity/base/root",
-      "path": "./storybook.js"
+      "path": "./storybook"
     },
     {
       "implements": "part:@sanity/base/document",
-      "path": "./storybook.js"
+      "path": "./storybook"
     }
   ]
 }

--- a/packages/test-studio/sanity.json
+++ b/packages/test-studio/sanity.json
@@ -46,11 +46,11 @@
   "parts": [
     {
       "name": "part:@sanity/base/schema",
-      "path": "./schemas/schema.js"
+      "path": "./schemas/schema"
     },
     {
       "implements": "part:@sanity/base/schema-type",
-      "path": "src/components/PertEstimateSchema.js"
+      "path": "src/components/PertEstimateSchema"
     },
     {
       "implements": "part:@sanity/base/tool",
@@ -74,27 +74,27 @@
     },
     {
       "implements": "part:@sanity/form-builder/input/array/functions",
-      "path": "src/components/SearchableArrayFunctions.js"
+      "path": "src/components/SearchableArrayFunctions"
     },
     {
       "implements": "part:@sanity/dashboard/config",
-      "path": "src/dashboardConfig.js"
+      "path": "src/dashboardConfig"
     },
     {
       "name": "part:@sanity/desk-tool/structure",
-      "path": "src/deskStructure.js"
+      "path": "src/deskStructure"
     },
     {
       "implements": "part:@sanity/default-layout/studio-hints-config",
-      "path": "src/studioHintsConfig.js"
+      "path": "src/studioHintsConfig"
     },
     {
       "name": "part:@sanity/base/initial-value-templates",
-      "path": "src/templates.js"
+      "path": "src/templates"
     },
     {
       "name": "part:@sanity/base/new-document-structure",
-      "path": "src/newDocumentStructure.js"
+      "path": "src/newDocumentStructure"
     },
     {
       "name": "part:@sanity/dashboard/widget/test-dummy",
@@ -103,11 +103,11 @@
     },
     {
       "implements": "part:@sanity/desk-tool/after-editor-component",
-      "path": "src/components/AfterEditorComponent.js"
+      "path": "src/components/AfterEditorComponent"
     },
     {
       "implements": "part:@sanity/base/tool",
-      "path": "src/tools/css-variables/tool.js"
+      "path": "src/tools/css-variables/tool"
     }
   ],
   "env": {
@@ -120,7 +120,7 @@
       "parts": [
         {
           "implements": "part:@sanity/base/tool",
-          "path": "src/tools/long.js"
+          "path": "src/tools/long"
         }
       ]
     }


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [x]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Description**

Many paths specify an extension, eg ".js", where it's not strictly necessary for the resolving to work. By dropping the extension, we allow for the source paths to resolve to the typescript equivalent (eg `.ts`), while the compiled paths resolve to `.js`.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
