### PR TITLE
[form-builder] Update PTE module and fix modal saving bug

### DIFF
--- a/packages/@sanity/form-builder/package.json
+++ b/packages/@sanity/form-builder/package.json
@@ -26,7 +26,7 @@
     "@sanity/generate-help-url": "2.0.1",
     "@sanity/imagetool": "2.0.1",
     "@sanity/mutator": "2.0.1",
-    "@sanity/portable-text-editor": "0.1.14",
+    "@sanity/portable-text-editor": "0.1.15",
     "@sanity/types": "2.0.1",
     "@sanity/util": "2.0.1",
     "@sanity/uuid": "2.0.1",

--- a/packages/@sanity/form-builder/src/inputs/PortableText/Input.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Input.tsx
@@ -295,11 +295,8 @@ export default function PortableTextInput(props: Props) {
     )
   }
 
-  function renderEditObject() {
-    if (objectEditData === null) {
-      return null
-    }
-    const handleClose = () => {
+  function handleEditObjectClose() {
+    if (objectEditData) {
       const {editorPath} = objectEditData
       setObjectEditData(null)
       const sel = {
@@ -309,8 +306,11 @@ export default function PortableTextInput(props: Props) {
       onFocus(editorPath)
       PortableTextEditor.select(editor, sel)
       setInitialSelection(sel)
-      focus()
     }
+    focus()
+  }
+
+  function renderEditObject() {
     return (
       <EditObject
         focusPath={focusPath}
@@ -318,7 +318,7 @@ export default function PortableTextInput(props: Props) {
         markers={markers} // TODO: filter relevant
         onBlur={handleEditObjectFormBuilderBlur}
         onChange={handleFormBuilderEditObjectChange}
-        onClose={handleClose}
+        onClose={handleEditObjectClose}
         onFocus={handleEditObjectFormBuilderFocus}
         readOnly={readOnly}
         presence={presence}

--- a/packages/@sanity/form-builder/src/inputs/PortableText/Objects/EditObject.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Objects/EditObject.tsx
@@ -4,6 +4,7 @@ import {isKeySegment, Path, Marker} from '@sanity/types'
 import {FormFieldPresence} from '@sanity/base/presence'
 import {
   PortableTextBlock,
+  PortableTextChild,
   Type,
   PortableTextEditor,
   compactPatches,
@@ -52,66 +53,13 @@ export const EditObject = ({
 }: Props) => {
   const editor = usePortableTextEditor()
   const ptFeatures = PortableTextEditor.getPortableTextFeatures(editor)
-  const {formBuilderPath, editorPath, kind} = objectEditData
-
-  function findObjectAndType() {
-    let object
-    let type: Type
-
-    // Try finding the relevant block
-    const blockKey =
-      Array.isArray(formBuilderPath) && isKeySegment(formBuilderPath[0]) && formBuilderPath[0]._key
-
-    const block =
-      value && blockKey && Array.isArray(value) && value.find(blk => blk._key === blockKey)
-    const child =
-      block &&
-      block.children &&
-      block.children.find(cld => isKeySegment(editorPath[2]) && cld._key === editorPath[2]._key)
-
-    if (block) {
-      // Get object, type, and relevant editor element
-      switch (kind) {
-        case 'blockObject':
-          object = block
-          type = ptFeatures.types.blockObjects.find(t => t.name === block._type)
-          break
-        case 'inlineObject':
-          object = child
-          // eslint-disable-next-line max-depth
-          if (object) {
-            type = ptFeatures.types.inlineObjects.find(t => t.name === child._type)
-          }
-          break
-        case 'annotation':
-          // eslint-disable-next-line max-depth
-          if (child) {
-            const markDef =
-              child.marks &&
-              block.markDefs &&
-              block.markDefs.find(def => child.marks.includes(def._key))
-            // eslint-disable-next-line max-depth
-            if (markDef) {
-              type = ptFeatures.types.annotations.find(t => t.name === markDef._type)
-              object = markDef
-            }
-          }
-          break
-        default:
-        // Nothing
-      }
-    }
-    return [object, type]
-  }
-
-  const objectAndType = useMemo(findObjectAndType, [value])
-  const [object, setObject] = useState(objectAndType[0])
-  const type = objectAndType[1]
+  const [_object, type] = useMemo(() => findObjectAndType(objectEditData, value, ptFeatures), [
+    objectEditData,
+    ptFeatures,
+    value
+  ])
+  const [object, setObject] = useState(_object)
   const [timeoutInstance, setTimeoutInstance] = useState(undefined)
-
-  function handleClose(): void {
-    onClose()
-  }
 
   // Initialize weakmaps on mount, and send patches on unmount
   useEffect(() => {
@@ -125,8 +73,17 @@ export const EditObject = ({
   }, [])
 
   useLayoutEffect(() => {
-    setObject(objectAndType[0])
-  }, [value])
+    setObject(_object)
+  }, [_object])
+
+  if (!objectEditData) {
+    return null
+  }
+  const {formBuilderPath, kind} = objectEditData
+
+  function handleClose(): void {
+    onClose()
+  }
 
   const editModalLayout: ModalType = get(type, 'options.editModal')
 
@@ -218,4 +175,62 @@ export const EditObject = ({
       type={type}
     />
   )
+}
+
+function findObjectAndType(
+  objectEditData,
+  value,
+  ptFeatures
+): [PortableTextChild | undefined, Type | undefined] {
+  if (!objectEditData) {
+    return [undefined, undefined]
+  }
+  const {editorPath, formBuilderPath, kind} = objectEditData
+  let object: PortableTextChild
+  let type: Type
+
+  // Try finding the relevant block
+  const blockKey =
+    Array.isArray(formBuilderPath) && isKeySegment(formBuilderPath[0]) && formBuilderPath[0]._key
+
+  const block =
+    value && blockKey && Array.isArray(value) && value.find(blk => blk._key === blockKey)
+  const child =
+    block &&
+    block.children &&
+    block.children.find(cld => isKeySegment(editorPath[2]) && cld._key === editorPath[2]._key)
+
+  if (block) {
+    // Get object, type, and relevant editor element
+    switch (kind) {
+      case 'blockObject':
+        object = block
+        type = ptFeatures.types.blockObjects.find(t => t.name === block._type)
+        break
+      case 'inlineObject':
+        object = child
+        // eslint-disable-next-line max-depth
+        if (object) {
+          type = ptFeatures.types.inlineObjects.find(t => t.name === child._type)
+        }
+        break
+      case 'annotation':
+        // eslint-disable-next-line max-depth
+        if (child) {
+          const markDef =
+            child.marks &&
+            block.markDefs &&
+            block.markDefs.find(def => child.marks.includes(def._key))
+          // eslint-disable-next-line max-depth
+          if (markDef) {
+            type = ptFeatures.types.annotations.find(t => t.name === markDef._type)
+            object = markDef
+          }
+        }
+        break
+      default:
+      // Nothing
+    }
+  }
+  return [object, type]
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No


**Note for release**
- Fixed an issue where changes to portable text inside a modal would not be saved, if you closed the modal quickly after making changes. 
- Updated to the latest Portable Text Editor - fixes a normalization bug, and adds validation to markDefs and marks.
