### PR TITLE
[field] PT: tolerate missing .markDefs on block

### DIFF
--- a/packages/@sanity/field/src/types/portableText/diff/helpers.ts
+++ b/packages/@sanity/field/src/types/portableText/diff/helpers.ts
@@ -391,12 +391,15 @@ export function escapeRegExp(text: string): string {
 }
 
 export function getAllMarkDefs(diff: ObjectDiff): PortableTextChild[] {
-  const allDefs = [...(diff.toValue ? diff.toValue.markDefs : [])]
-  const oldDefs = diff.fromValue ? diff.fromValue.markDefs : []
+  const allDefs: PortableTextChild[] = [
+    ...(diff.toValue && diff.toValue.markDefs ? diff.toValue.markDefs : [])
+  ]
+  const oldDefs: PortableTextChild[] =
+    diff.fromValue && diff.fromValue.markDefs ? diff.fromValue.markDefs : []
   oldDefs.forEach(oDef => {
     if (!allDefs.some(def => oDef._key === def._key)) {
       allDefs.push(oDef)
     }
   })
-  return orderBy(allDefs, ['_key'], ['asc']) as PortableTextChild[]
+  return orderBy(allDefs, ['_key'], ['asc'])
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Description**

Just tolerate that the block might be missing the `.markDefs` property.

**Note for release**
Doesn't need to be mentioned.