### PR TITLE
[chore] Make `sanity start` build from source paths within monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "sanity",
   "private": true,
+  "isSanityMonorepo": true,
   "scripts": {
     "bootstrap": "lerna bootstrap && npm run package-yarn",
     "dev": "npm start",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ecommerce-studio": "gulp ecommerce-studio",
     "test-studio": "gulp test-studio",
     "clean-studio": "gulp clean-studio",
-    "design-studio": "gulp design-studio",
+    "design-studio": "cd packages/design-studio && npm start",
     "example-studio": "gulp example-studio",
     "movies-studio": "gulp movies-studio",
     "blog-studio": "gulp blog-studio",

--- a/packages/@sanity/server/package.json
+++ b/packages/@sanity/server/package.json
@@ -72,6 +72,7 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "cross-env": "^5.0.5",
+    "find-config": "^1.0.0",
     "prop-types": "^15.6.0",
     "react": "17.0.1",
     "react-dom": "17.0.1",

--- a/packages/@sanity/server/src/baseServer.js
+++ b/packages/@sanity/server/src/baseServer.js
@@ -23,8 +23,9 @@ const assetify = (assetPath, hashes) => ({
   hash: hashes[assetPath],
 })
 
-const getDocumentComponent = (basePath) =>
-  resolveParts({basePath}).then((res) => {
+const getDocumentComponent = basePath => {
+  // Explicitly pass false here to not use uncompiled JSX etc
+  return resolveParts({basePath, isSanityMonorepo: false}).then(res => {
     const part = res.implementations[docPart]
     if (!part) {
       throw new Error(
@@ -34,6 +35,7 @@ const getDocumentComponent = (basePath) =>
 
     return getDefaultModule(requireUncached(part[0].path))
   })
+}
 
 export function getBaseServer() {
   return express()
@@ -86,7 +88,7 @@ export function applyStaticRoutes(app, config = {}) {
 }
 
 export function callInitializers(config) {
-  resolveParts({config}).then((res) => {
+  resolveParts(config).then(res => {
     const parts = res.implementations[initPart]
     if (!parts) {
       return

--- a/packages/@sanity/server/src/configs/isSanityMonorepo.js
+++ b/packages/@sanity/server/src/configs/isSanityMonorepo.js
@@ -1,0 +1,21 @@
+const path = require('path')
+const findConfig = require('find-config')
+
+module.exports = function isSanityMonorepo(basePath) {
+  const configPath = findConfig('package.json', {home: false, cwd: basePath})
+  if (!configPath) {
+    return false
+  }
+
+  try {
+    // eslint-disable-next-line import/no-dynamic-require
+    const pkg = require(configPath)
+    if (pkg.isSanityMonorepo) {
+      return true
+    }
+  } catch (err) {
+    return false
+  }
+
+  return isSanityMonorepo(path.dirname(path.dirname(configPath)))
+}

--- a/packages/@sanity/server/src/configs/postcss.config.js
+++ b/packages/@sanity/server/src/configs/postcss.config.js
@@ -1,9 +1,13 @@
 const resolveProjectRoot = require('@sanity/resolver').resolveProjectRoot
 const webpackIntegration = require('@sanity/webpack-integration/v3')
+const isSanityMonorepo = require('./isSanityMonorepo')
+
+const basePath = resolveProjectRoot({sync: true})
 
 module.exports = {
   plugins: webpackIntegration.getPostcssPlugins({
-    basePath: resolveProjectRoot({sync: true}),
+    basePath,
+    isSanityMonorepo: isSanityMonorepo(basePath),
     cssnext: {
       features: {
         customProperties: true,

--- a/packages/@sanity/server/src/configs/webpack.config.js
+++ b/packages/@sanity/server/src/configs/webpack.config.js
@@ -6,6 +6,7 @@ import webpackIntegration from '@sanity/webpack-integration/v3'
 import ExtractTextPlugin from 'extract-text-webpack-plugin'
 import rxPaths from 'rxjs/_esm5/path-mapping'
 import getStaticBasePath from '../util/getStaticBasePath'
+import isSanityMonorepo from './isSanityMonorepo'
 
 const resolve = (mod) => require.resolve(mod)
 
@@ -13,7 +14,14 @@ const resolve = (mod) => require.resolve(mod)
 export default (config = {}) => {
   const staticPath = getStaticBasePath(config)
   const env = config.env || 'development'
-  const wpIntegrationOptions = {basePath: config.basePath, env: config.env, webpack}
+  const inSanityMonorepo = isSanityMonorepo(config.basePath)
+  const wpIntegrationOptions = {
+    basePath: config.basePath,
+    env: config.env,
+    webpack,
+    isSanityMonorepo: inSanityMonorepo
+  }
+
   const basePath = config.basePath || process.cwd()
   const skipMinify = config.skipMinify || false
 

--- a/packages/@sanity/server/src/configs/webpack.config.js
+++ b/packages/@sanity/server/src/configs/webpack.config.js
@@ -83,7 +83,7 @@ export default (config = {}) => {
       rules: [
         {
           test: /(\.jsx?|\.tsx?)/,
-          exclude: /(packages\/@sanity|node_modules|bower_components)/,
+          exclude: /(node_modules|bower_components)/,
           use: {
             loader: resolve('babel-loader'),
             options: babelConfig || {

--- a/packages/@sanity/server/src/devServer.js
+++ b/packages/@sanity/server/src/devServer.js
@@ -5,8 +5,10 @@ import webpackHotMiddleware from 'webpack-hot-middleware'
 import {getBaseServer, applyStaticRoutes, callInitializers} from './baseServer'
 import getWebpackDevConfig from './configs/webpack.config.dev'
 import getStaticBasePath from './util/getStaticBasePath'
+import isSanityMonorepo from './configs/isSanityMonorepo'
 
 export default function getDevServer(config = {}) {
+  config.isSanityMonorepo = isSanityMonorepo(config.basePath)
   const staticPath = getStaticBasePath(config)
   const app = getBaseServer(config)
   const webpackConfig = config.webpack || getWebpackDevConfig(config)

--- a/packages/@sanity/storybook/src/config/webpack.config.js
+++ b/packages/@sanity/storybook/src/config/webpack.config.js
@@ -3,8 +3,9 @@ const sanityServer = require('@sanity/server')
 const wpIntegration = require('@sanity/webpack-integration/v3')
 const genDefaultConfig = require('@storybook/react/dist/server/config/defaults/webpack.config.js')
 
-const skipCssLoader = (rule) => !rule.test || (rule.test && !rule.test.toString().includes('.css'))
-const isCssLoader = (rule) => rule.test && rule.test.toString().includes('.css')
+const skipCssLoader = rule => !rule.test || (rule.test && !rule.test.toString().includes('.css'))
+const isCssLoader = rule => rule.test && rule.test.toString().includes('.css')
+const isJsxLoader = rule => rule.test && rule.test.toString().includes('jsx')
 
 // This is very hacky, but I couldn't figure out a way to pass config from
 // the parent task onto this configuration, which we need to infer the base
@@ -33,14 +34,14 @@ function getWebpackConfig(baseConfig, env) {
   config.module.rules = config.module.rules.filter(skipCssLoader)
   config.module.rules.unshift(sanityWpConfig.module.rules.find(isCssLoader))
 
-  const jsonLoaderAt = config.module.rules.findIndex((rule) =>
+  const jsonLoaderAt = config.module.rules.findIndex(rule =>
     (rule.loader || '').includes('json-loader')
   )
 
   const jsonHackLoader = {
     test: /\.json$/,
     resourceQuery: /sanityPart=/,
-    loader: require.resolve('./jsonHackLoader.js'),
+    loader: require.resolve('./jsonHackLoader.js')
   }
 
   if (jsonLoaderAt !== -1) {
@@ -48,12 +49,23 @@ function getWebpackConfig(baseConfig, env) {
   }
 
   config.resolve = Object.assign({}, config.resolve, sanityWpConfig.resolve, {
-    alias: Object.assign({}, config.resolve.alias || {}, sanityWpConfig.resolve.alias || {}),
+    alias: Object.assign({}, config.resolve.alias || {}, sanityWpConfig.resolve.alias || {})
   })
+
+  const storybookJsxLoader = config.module.rules.find(isJsxLoader)
+  const sanityJsxLoader = sanityWpConfig.module.rules.find(isJsxLoader)
+
+  if (storybookJsxLoader && sanityJsxLoader) {
+    const jsxLoaderIndex = config.module.rules.indexOf(storybookJsxLoader)
+
+    // replace with Sanity's JSX/TSX loader
+    config.module.rules.splice(jsxLoaderIndex, 1, sanityJsxLoader)
+  }
+
   return config
 }
 
-getWebpackConfig.setSanityContext = (context) => {
+getWebpackConfig.setSanityContext = context => {
   sanityContext = context
 }
 

--- a/packages/@sanity/webpack-integration/src/v3/extractCssCustomProperties.js
+++ b/packages/@sanity/webpack-integration/src/v3/extractCssCustomProperties.js
@@ -13,9 +13,9 @@ const readFile = util.promisify(fs.readFile)
 
 const VAR_RE = /var\([\s+]?(--[A-Za-z0-9-]+)[\s+]?\)/
 
-async function extractCssCustomProperties(basePath, entryPath) {
+async function extractCssCustomProperties(basePath, entryPath, isSanityMonorepo) {
   const processor = postcss([
-    getPostcssImportPlugin({basePath}),
+    getPostcssImportPlugin({basePath, isSanityMonorepo}),
     postcssCustomProperties({preserve: true}),
     postcssCalc(),
     postcssColorFunction({preserveCustomProps: true}),

--- a/packages/@sanity/webpack-integration/src/v3/postcss.js
+++ b/packages/@sanity/webpack-integration/src/v3/postcss.js
@@ -3,7 +3,10 @@ const postcssCssnext = require('postcss-cssnext')
 const resolveStyleImport = require('./resolveStyleImport')
 
 function getStyleResolver(options) {
-  return resolveStyleImport({from: options.basePath})
+  return resolveStyleImport({
+    from: options.basePath,
+    isSanityMonorepo: options.isSanityMonorepo
+  })
 }
 
 function getPostcssImportPlugin(options) {

--- a/packages/@sanity/webpack-integration/src/v3/resolveStyleImport.js
+++ b/packages/@sanity/webpack-integration/src/v3/resolveStyleImport.js
@@ -18,16 +18,16 @@ const nodeCache = new PAC({
   maxAge: 1000,
 })
 
-function resolvePartsForPath(basePath) {
-  return resolveParts({basePath})
+function resolvePartsForPath(basePath, isSanityMonorepo) {
+  return resolveParts({basePath, isSanityMonorepo})
 }
 
 function resolveNodeImport(moduleId, basedir) {
   return resolveModule(moduleId, {basedir})
 }
 
-function resolveSanityImport(id, basePath) {
-  return partsCache.get(basePath).then((cached) => {
+function resolveSanityImport(id, basePath, isSanityMonorepo) {
+  return partsCache.get(basePath, isSanityMonorepo).then(cached => {
     const parts = cached.value
     const loadAll = id.indexOf('all:') === 0
     const partName = loadAll ? id.substr(4) : id
@@ -73,10 +73,11 @@ function realPath(path) {
 }
 
 function getStyleResolver(opts) {
+  const isSanityMonorepo = opts.isSanityMonorepo || false
   return function resolveStyleProxy(moduleId, basedir) {
     const id = moduleId.replace(/^\.\/(part|all:)/, '$1')
     const resolveStyleImport = isSanityPart(id)
-      ? sanityCache.get(id, opts.from)
+      ? sanityCache.get(id, opts.from, isSanityMonorepo)
       : nodeCache.get(id, basedir)
 
     return resolveStyleImport.then((res) => res.value)

--- a/packages/@sanity/webpack-loader/src/PartResolverPlugin.js
+++ b/packages/@sanity/webpack-loader/src/PartResolverPlugin.js
@@ -23,6 +23,7 @@ const PartResolverPlugin = function (options) {
   this.additionalPlugins = options.additionalPlugins || []
   this.configPath = path.join(this.basePath, 'config')
   this.extractCssCustomProperties = options.extractCssCustomProperties
+  this.isSanityMonorepo = options.isSanityMonorepo
 }
 
 PartResolverPlugin.prototype.apply = function (compiler) {
@@ -30,6 +31,7 @@ PartResolverPlugin.prototype.apply = function (compiler) {
   const basePath = this.basePath
   const additionalPlugins = this.additionalPlugins
   const configPath = this.configPath
+  const isSanityMonorepo = this.isSanityMonorepo
   const extractCssCustomProperties = this.extractCssCustomProperties
 
   compiler.plugin('watch-run', (watcher, cb) => {
@@ -44,7 +46,7 @@ PartResolverPlugin.prototype.apply = function (compiler) {
     const instance = params.compiler || params
     instance.sanity = compiler.sanity || {basePath: basePath}
     return partResolver
-      .resolveParts({env, basePath, additionalPlugins, useSourcePaths: true})
+      .resolveParts({env, basePath, additionalPlugins, isSanityMonorepo})
       .then(parts => {
         instance.sanity.parts = parts
         return {instance, parts}
@@ -57,9 +59,11 @@ PartResolverPlugin.prototype.apply = function (compiler) {
       return Promise.resolve()
     }
 
-    return extractCssCustomProperties(basePath, impl[0].path).then((cssCustomProperties) => {
-      instance.sanity.cssCustomProperties = cssCustomProperties
-    })
+    return extractCssCustomProperties(basePath, impl[0].path, isSanityMonorepo).then(
+      cssCustomProperties => {
+        instance.sanity.cssCustomProperties = cssCustomProperties
+      }
+    )
   }
 
   compiler.plugin('compilation', () => {

--- a/packages/@sanity/webpack-loader/src/PartResolverPlugin.js
+++ b/packages/@sanity/webpack-loader/src/PartResolverPlugin.js
@@ -43,10 +43,12 @@ PartResolverPlugin.prototype.apply = function (compiler) {
   function cacheParts(params) {
     const instance = params.compiler || params
     instance.sanity = compiler.sanity || {basePath: basePath}
-    return partResolver.resolveParts({env, basePath, additionalPlugins}).then((parts) => {
-      instance.sanity.parts = parts
-      return {instance, parts}
-    })
+    return partResolver
+      .resolveParts({env, basePath, additionalPlugins, useSourcePaths: true})
+      .then(parts => {
+        instance.sanity.parts = parts
+        return {instance, parts}
+      })
   }
 
   function resolveCssCustomProperties({instance, parts}) {


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [x]  Maintenance
- [x]  Other, please describe: improves dev server performance in the monorepo.

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->

Before this change, the dev server is slow since it:

- Uses gulp to watch all `@sanity/*` packages
- Runs the webpack dev server (`sanity start`)

After this change, the `npm run design-studio` command only:

- Runs the webpack dev server.

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

Instead of compiling the app from the compiled package files, `sanity start` (when run within the monorepo) now compiles the source files from all the @sanity/*. This eliminates the need for babel-watching all the source files in the monorepo.

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

- Internal: increased monorepo tooling performance.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [ ]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
