### PR TITLE
[form-builder] Fix crash on array items missing `_key`

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ArrayInput/ArrayInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ArrayInput/ArrayInput.tsx
@@ -223,13 +223,14 @@ export default class ArrayInput extends React.Component<Props, ArrayInputState> 
           return (
             <Item
               className={isGrid ? styles.gridItem : styles.listItem}
-              key={item._key}
+              key={item._key || index}
               {...itemProps}
             >
               <ArrayInputItem
                 compareValue={compareValue}
                 filterField={filterField}
                 focusPath={focusPath}
+                index={index}
                 level={level}
                 markers={childMarkers.length === 0 ? NO_MARKERS : childMarkers}
                 onBlur={onBlur}

--- a/packages/@sanity/form-builder/src/inputs/ArrayInput/item/ArrayInputGridItem.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ArrayInput/item/ArrayInputGridItem.tsx
@@ -28,6 +28,7 @@ import styles from './ArrayInputGridItem.css'
 interface ArrayInputGridItemProps {
   type: ArraySchemaType
   value: ItemValue
+  index: number
   compareValue?: any[]
   level: number
   markers: Array<Marker>
@@ -150,6 +151,7 @@ export class ArrayInputGridItem extends React.PureComponent<ArrayInputGridItemPr
       focusPath,
       onFocus,
       onBlur,
+      index,
       readOnly,
       filterField,
       presence,
@@ -171,7 +173,7 @@ export class ArrayInputGridItem extends React.PureComponent<ArrayInputGridItemPr
         focusPath={focusPath}
         readOnly={readOnly || memberType.readOnly}
         markers={childMarkers}
-        path={[{_key: item._key}]}
+        path={[item._key ? {_key: item._key} : index]}
         filterField={filterField}
         presence={childPresence}
       />
@@ -217,14 +219,14 @@ export class ArrayInputGridItem extends React.PureComponent<ArrayInputGridItemPr
     }
 
     return (
-      <DefaultDialog onClose={this.handleEditStop} key={item._key} title={title}>
+      <DefaultDialog onClose={this.handleEditStop} key={item._key || index} title={title}>
         <PresenceOverlay margins={[0, 0, 1, 0]}>{content}</PresenceOverlay>
       </DefaultDialog>
     )
   }
 
   renderItem() {
-    const {value, markers, type, readOnly, presence, focusPath} = this.props
+    const {value, markers, type, index, readOnly, presence, focusPath} = this.props
     const options = type.options || {}
     const isSortable = !readOnly && !type.readOnly && options.sortable !== false
     const validation = markers.filter(isValidationMarker)
@@ -247,7 +249,7 @@ export class ArrayInputGridItem extends React.PureComponent<ArrayInputGridItemPr
     }
 
     return (
-      <ChangeIndicatorScope path={[{_key: value._key}]}>
+      <ChangeIndicatorScope path={[value._key ? {_key: value._key} : index]}>
         <ContextProvidedChangeIndicator compareDeep disabled={hasItemFocus}>
           <div className={styles.inner}>
             <div

--- a/packages/@sanity/form-builder/src/inputs/ArrayInput/item/ArrayInputItem.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ArrayInput/item/ArrayInputItem.tsx
@@ -10,6 +10,7 @@ interface ArrayInputItemProps {
   compareValue?: any[]
   layout?: 'media' | 'default'
   level: number
+  index: number
   markers: Marker[]
   type: ArraySchemaType
   value: ItemValue

--- a/packages/@sanity/form-builder/src/inputs/ArrayInput/item/ArrayInputListItem.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ArrayInput/item/ArrayInputListItem.tsx
@@ -34,6 +34,7 @@ const DragHandle = createDragHandle(() => (
 interface ArrayInputListItemProps {
   type: ArraySchemaType
   value: ItemValue
+  index: number
   compareValue?: any[]
   level: number
   markers: Marker[]
@@ -153,6 +154,7 @@ export class ArrayInputListItem extends React.PureComponent<ArrayInputListItemPr
       focusPath,
       onFocus,
       onBlur,
+      index,
       readOnly,
       filterField,
       presence,
@@ -174,7 +176,7 @@ export class ArrayInputListItem extends React.PureComponent<ArrayInputListItemPr
         focusPath={focusPath}
         readOnly={readOnly || memberType.readOnly}
         markers={childMarkers}
-        path={[{_key: item._key}]}
+        path={[item._key ? {_key: item._key} : index]}
         filterField={filterField}
         presence={childPresence}
       />
@@ -230,7 +232,7 @@ export class ArrayInputListItem extends React.PureComponent<ArrayInputListItemPr
   }
 
   renderItem() {
-    const {value, markers, type, readOnly, presence, focusPath} = this.props
+    const {value, markers, type, index, readOnly, presence, focusPath} = this.props
     const options = type.options || {}
     const isSortable = !readOnly && !type.readOnly && options.sortable !== false
     const validation = markers.filter(isValidationMarker)
@@ -250,7 +252,7 @@ export class ArrayInputListItem extends React.PureComponent<ArrayInputListItemPr
     }
 
     return (
-      <ChangeIndicatorScope path={[{_key: value._key}]}>
+      <ChangeIndicatorScope path={[value._key ? {_key: value._key} : index]}>
         <ContextProvidedChangeIndicator compareDeep disabled={hasItemFocus}>
           <div className={styles.inner} ref={this.setInnerElement}>
             {isSortable && <DragHandle />}


### PR DESCRIPTION
**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

Object arrays with items missing a `_key` will crash the desk tool

**Description**
 
Some refactoring in the array input has lead to it crashing the desk tool because it always assumes that items will have a `_key`. This PR checks whether or not it does and uses the array index if the key is not present. I spotted some focus path checking that I think also assumes a `_key`, so this might not be the only fix required for change bars/indicators/connectors to work on keyless items, but it at least prevents the tool from crashing.

**Note for release**

- Fixed a bug where array items without a `_key` would crash the desk tool

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
