### PR TITLE
[components] Add maxSize modifier to StyleSelect

### DIFF
--- a/packages/@sanity/components/src/selects/StyleSelect.tsx
+++ b/packages/@sanity/components/src/selects/StyleSelect.tsx
@@ -51,14 +51,19 @@ const modifiers = [
     }
   },
   {
-    name: 'sameWidth',
+    name: 'maxHeight',
     enabled: true,
     phase: 'beforeWrite',
     requires: ['computeStyles'],
-    fn({state}) {
-      state.styles.popper.maxHeight = `${window.innerHeight - 6 * 16}px`
+    fn(params) {
+      const {state} = params
+      const refElement = state.scrollParents.reference[0]
+      if (refElement && (refElement as Node).nodeType === Node.ELEMENT_NODE) {
+        const offsetHeight = (refElement as HTMLElement).offsetHeight
+        state.styles.popper.maxHeight = `${offsetHeight - 3 * 16}px`
+      }
     }
-  } as Modifier<'sameWidth', any>
+  } as Modifier<'maxHeight', any>
 ]
 
 const StyleSelectList = React.forwardRef(


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->

The StyleSelect menu is unreachable in certain conditions (small screens, or when PTE is nested in a dialog).

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

This fix adds a custom Popper modifier that checks the size of the scroll parent (PTE container) and constrains the height based on that.

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

- Fix overflow issue with StyleSelect menu.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [ ]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
