### PR TITLE
[field, form-builder] fix text overflow issue in diff component and field overflow modals

### DIFF
--- a/packages/@sanity/field/src/diff/components/DiffFromTo.css
+++ b/packages/@sanity/field/src/diff/components/DiffFromTo.css
@@ -2,4 +2,5 @@
   flex: 1;
   min-width: 0;
   display: block;
+  white-space: break-spaces;
 }

--- a/packages/@sanity/form-builder/src/inputs/ObjectInput/styles/Field.css
+++ b/packages/@sanity/form-builder/src/inputs/ObjectInput/styles/Field.css
@@ -4,4 +4,5 @@
   display: block;
   width: 100%;
   box-sizing: border-box;
+  min-width: 0;
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

Content in a field overflows the fieldset width:
<img width="721" alt="Screenshot 2020-10-19 at 16 12 26" src="https://user-images.githubusercontent.com/25737281/96462468-e3cec180-1225-11eb-9082-59fb3aefc249.png">

Content in a field overflows the diff component:
<img width="344" alt="Screenshot 2020-10-19 at 16 12 53" src="https://user-images.githubusercontent.com/25737281/96462520-f21cdd80-1225-11eb-9a92-a606b25c8eb5.png">


**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

This fixes the overflow issue in both cases. Path to test it in  `/test/desk/blocksTest;6f5befe8-d84a-4b2a-95f3-eae63bbce31f%2Csince%3D%40lastPublished` under recursive blocks and in the changes panel.


**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
