### PR TITLE
Fix mark bugs in the PTE

### DIFF
--- a/packages/@sanity/form-builder/package.json
+++ b/packages/@sanity/form-builder/package.json
@@ -26,7 +26,7 @@
     "@sanity/generate-help-url": "2.0.1",
     "@sanity/imagetool": "2.0.1",
     "@sanity/mutator": "2.0.1",
-    "@sanity/portable-text-editor": "0.1.17",
+    "@sanity/portable-text-editor": "0.1.19",
     "@sanity/types": "2.0.1",
     "@sanity/util": "2.0.1",
     "@sanity/uuid": "2.0.1",

--- a/packages/@sanity/form-builder/src/inputs/PortableText/Editor.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Editor.tsx
@@ -114,20 +114,20 @@ function PortableTextSanityEditor(props: Props) {
       ...(props.hotkeys || {}).custom
     }
   }
-  const defaultHotkeys = {}
+  const defaultHotkeys = {marks: {}}
   ptFeatures.decorators.forEach(dec => {
     switch (dec.value) {
       case 'strong':
-        defaultHotkeys['mod+b'] = dec.value
+        defaultHotkeys.marks['mod+b'] = dec.value
         break
       case 'em':
-        defaultHotkeys['mod+i'] = dec.value
+        defaultHotkeys.marks['mod+i'] = dec.value
         break
       case 'underline':
-        defaultHotkeys['mod+u'] = dec.value
+        defaultHotkeys.marks['mod+u'] = dec.value
         break
       case 'code':
-        defaultHotkeys["mod+'"] = dec.value
+        defaultHotkeys.marks["mod+'"] = dec.value
         break
       default:
       // Nothing
@@ -135,7 +135,7 @@ function PortableTextSanityEditor(props: Props) {
   })
   const marksFromProps: HotkeyOptions = {
     marks: {
-      ...defaultHotkeys,
+      ...defaultHotkeys.marks,
       ...(props.hotkeys || {}).marks
     }
   }


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Description**
Upgraded to latest `@sanity/portable-text-editor`. Fixes the following issues:
- Fixed a bug where marks where continued to the next block when pressing enter (splitting) on the end of a block text.
- Fixed a bug with undo/redo when using marks in portable text.

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

**Checklist** 

- [ ]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [ ]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [ ]  The code is linted
- [ ]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
