### PR TITLE
[components] fix reference picker dropdown focus style

### DIFF
--- a/packages/@sanity/components/src/selects/SearchableSelect.css
+++ b/packages/@sanity/components/src/selects/SearchableSelect.css
@@ -40,8 +40,20 @@
   color: inherit;
   font-size: var(--font-size-large);
 
-  @nest &:hover, &:focus {
+  @nest &:hover {
     color: var(--link-color);
+
+    @nest & svg {
+      color: inherit;
+      opacity: 1;
+      transform: scale(1.1);
+    }
+  }
+
+  @nest &:focus {
+    box-shadow: var(--input-box-shadow--focus);
+    border-color: var(--input-border-color-focus);
+    border-radius: var(--input-border-radius);
 
     @nest & svg {
       color: inherit;


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Enhancement (non-breaking change which fixes an issue)

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

https://sanity-io.slack.com/archives/CAJ4KP63G/p1603355714097900

> The reference input dropdown button doesn’t have a clear focus state, it’s hard to see where the focus actually went when using keyboard only (it’s only thee arrow icon that becomes blue on focus)

Before:
<img width="341" alt="Screenshot 2020-10-22 at 11 09 35" src="https://user-images.githubusercontent.com/25737281/96850550-39d67b80-1457-11eb-9608-1e9eef928d80.png">

After:
<img width="338" alt="Screenshot 2020-10-22 at 11 08 36" src="https://user-images.githubusercontent.com/25737281/96850589-4529a700-1457-11eb-857b-f50dae198e3d.png">


To test, go to document at this path and tab through the document with the keyboard: `/test/desk/referenceTest;db7e9494-57d7-4f21-81b2-e5f916a13e83`

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

- N/A

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
