### PR TITLE
[components] fix fieldsets without title layout (#2084)

### DIFF
--- a/packages/@sanity/components/src/fieldsets/DefaultFieldset.tsx
+++ b/packages/@sanity/components/src/fieldsets/DefaultFieldset.tsx
@@ -142,60 +142,67 @@ export default class Fieldset extends React.PureComponent<FieldsetProps, State> 
     const showSummary = isCollapsible && isCollapsed
     // Hide the tooltip if field is collapsible, but field is not collapsed
     const hideTooltip = isCollapsible && !isCollapsed
+
+    const showHeader = legend || fieldset.legend || description || fieldset.description
+    const labelPlaceholder = isCollapsible ? 'Untitled' : ''
     return (
       <div
         {...rest}
         onFocus={this.handleFocus}
-        tabIndex={tabIndex}
+        tabIndex={isCollapsible ? tabIndex : undefined}
         ref={this.setFocusElement}
         className={rootClassName}
       >
         <fieldset className={styles.fieldset}>
           <div className={styles.inner}>
-            <div className={styles.header}>
-              <div className={styles.headerMain}>
-                <legend
-                  className={`${styles.legend} ${isCollapsed ? '' : styles.isOpen}`}
-                  // Uses the tabIndex 0 and -1 here to avoid focus state on click
-                  tabIndex={isCollapsible ? 0 : undefined}
-                  onKeyDown={event => (event.key === 'Enter' ? this.handleToggle() : false)}
-                >
-                  <div
-                    className={styles.labelContainer}
-                    onClick={isCollapsible ? this.handleToggle : undefined}
-                    tabIndex={-1}
+            {(showHeader || isCollapsible) && (
+              <div className={styles.header}>
+                <div className={styles.headerMain}>
+                  <legend
+                    className={`${styles.legend} ${isCollapsed ? '' : styles.isOpen}`}
+                    // Uses the tabIndex 0 and -1 here to avoid focus state on click
+                    tabIndex={isCollapsible ? 0 : undefined}
+                    onKeyDown={event => (event.key === 'Enter' ? this.handleToggle() : false)}
                   >
-                    {isCollapsible && (
-                      <div className={`${styles.arrow} ${isCollapsed ? '' : styles.isOpen}`}>
-                        <ArrowDropDown />
-                      </div>
-                    )}
-                    <DefaultLabel className={styles.label} level={1}>
-                      {legend || fieldset.legend}
-                    </DefaultLabel>
-                  </div>
-                  <ValidationStatus
-                    className={styles.validationStatus}
-                    markers={
-                      showSummary
-                        ? validation.filter(marker => marker.path.length <= level)
-                        : validation.filter(marker => marker.path.length < 1)
-                    }
-                    showSummary={showSummary}
-                    hideTooltip={hideTooltip}
-                  />
-                </legend>
+                    <div
+                      className={styles.labelContainer}
+                      onClick={isCollapsible ? this.handleToggle : undefined}
+                      tabIndex={-1}
+                    >
+                      {isCollapsible && (
+                        <div className={`${styles.arrow} ${isCollapsed ? '' : styles.isOpen}`}>
+                          <ArrowDropDown />
+                        </div>
+                      )}
+                      <DefaultLabel className={styles.label} level={1}>
+                        {legend || fieldset.legend || labelPlaceholder}
+                      </DefaultLabel>
+                    </div>
+                    <ValidationStatus
+                      className={styles.validationStatus}
+                      markers={
+                        showSummary
+                          ? validation.filter(marker => marker.path.length <= level)
+                          : validation.filter(marker => marker.path.length < 1)
+                      }
+                      showSummary={showSummary}
+                      hideTooltip={hideTooltip}
+                    />
+                  </legend>
 
-                {(description || fieldset.description) && (
-                  <p className={`${styles.description} ${isCollapsed ? '' : styles.isOpen}`}>
-                    {description || fieldset.description}
-                  </p>
+                  {(description || fieldset.description) && (
+                    <p className={`${styles.description} ${isCollapsed ? '' : styles.isOpen}`}>
+                      {description || fieldset.description}
+                    </p>
+                  )}
+                </div>
+                {isCollapsible && (
+                  <FieldStatus>
+                    <FieldPresence maxAvatars={4} presence={presence} />
+                  </FieldStatus>
                 )}
               </div>
-              <FieldStatus>
-                <FieldPresence maxAvatars={4} presence={presence} />
-              </FieldStatus>
-            </div>
+            )}
 
             {isCollapsible && !isCollapsed && (
               <div className={styles.content}>


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Enhancement

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

#2084

Sometimes fieldsets don't have titles, but the div container is still rendered when there is no title.
We can't NOT render the header at all because it also includes markers and presence info, but this is pretty much only needed if the fieldset is can be collapsed.

The header now only shows if there's a field title or description AND the fieldset is collapsible. If it's collapsible and there's no title, the title fallbacks to `Untitled` in order to prevent buggy layouts:

_With `Untitled`:_
![Screenshot 2020-10-22 at 11 22 20](https://user-images.githubusercontent.com/25737281/96852213-26c4ab00-1459-11eb-9f8b-3ad7443e667c.png)

_Without:_
![Screenshot 2020-10-22 at 11 21 13](https://user-images.githubusercontent.com/25737281/96852220-27f5d800-1459-11eb-809e-2ac2e06a9c92.png)
![Screenshot 2020-10-22 at 11 21 56](https://user-images.githubusercontent.com/25737281/96852316-49ef5a80-1459-11eb-803e-ad27d5fb2873.png)

The before and after for the fix to the spacing when no title:

_Before:_
![Screenshot 2020-10-22 at 11 23 24](https://user-images.githubusercontent.com/25737281/96852275-39d77b00-1459-11eb-848c-94ab09819ec0.png)

_After:_
![Screenshot 2020-10-22 at 11 24 04](https://user-images.githubusercontent.com/25737281/96852295-4065f280-1459-11eb-8357-03da9ce2bffb.png)

**Notes**
If I've missed an edge case, let me know!


**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

- Fixed a layout issue in fieldsets without titles

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
