### PR TITLE
[components, form-builder] fix child presence on collapsed objects and fieldsets

### DIFF
--- a/packages/@sanity/components/src/fieldsets/DefaultFieldset.tsx
+++ b/packages/@sanity/components/src/fieldsets/DefaultFieldset.tsx
@@ -142,11 +142,12 @@ export default class Fieldset extends React.PureComponent<FieldsetProps, State> 
     const showSummary = isCollapsible && isCollapsed
     // Hide the tooltip if field is collapsible, but field is not collapsed
     const hideTooltip = isCollapsible && !isCollapsed
+    const childPresence = isCollapsible && isCollapsed ? presence : []
     return (
       <div
         {...rest}
         onFocus={this.handleFocus}
-        tabIndex={tabIndex}
+        tabIndex={isCollapsible && isCollapsed ? tabIndex : -1}
         ref={this.setFocusElement}
         className={rootClassName}
       >
@@ -192,9 +193,11 @@ export default class Fieldset extends React.PureComponent<FieldsetProps, State> 
                   </p>
                 )}
               </div>
-              <FieldStatus>
-                <FieldPresence maxAvatars={4} presence={presence} />
-              </FieldStatus>
+              {isCollapsible && (
+                <FieldStatus>
+                  <FieldPresence maxAvatars={4} presence={childPresence} />
+                </FieldStatus>
+              )}
             </div>
 
             {isCollapsible && !isCollapsed && (

--- a/packages/@sanity/form-builder/src/inputs/ObjectInput/ObjectInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ObjectInput/ObjectInput.tsx
@@ -152,7 +152,7 @@ export default class ObjectInput extends React.PureComponent<ObjectInputProps> {
           columns={columns}
           isCollapsible={collapsibleOpts.collapsible}
           isCollapsed={isCollapsed}
-          presence={isCollapsed ? childPresence : []}
+          presence={childPresence}
           onFocus={onFocus}
           changeIndicator={false}
           markers={markers}
@@ -243,7 +243,7 @@ export default class ObjectInput extends React.PureComponent<ObjectInputProps> {
           isCollapsible={collapsibleOpts.collapsible}
           isCollapsed={isCollapsed}
           markers={markers}
-          presence={presence.filter(item => item.path[0] === '$' || item.path.length === 0)}
+          presence={presence}
           onFocus={onFocus}
           changeIndicator={false}
         >

--- a/packages/test-studio/schemas/objects.js
+++ b/packages/test-studio/schemas/objects.js
@@ -67,7 +67,22 @@ export default {
         'This is a field of (anonymous, inline) object type. Values here should never get a `_type` property',
       fields: [
         {name: 'field1', type: 'string', description: 'This is a string field'},
-        {name: 'field2', type: 'string', description: 'This is a collapsed field'}
+        {name: 'field2', type: 'string', description: 'This is a collapsed field'},
+        {
+          name: 'field3',
+          type: 'object',
+          options: {collapsible: true, collapsed: true},
+          fields: [
+            {name: 'nested1', title: 'nested1', type: 'string'},
+            {
+              name: 'nested2',
+              title: 'nested2',
+              type: 'object',
+              fields: [{name: 'ge', title: 'hello', type: 'string'}],
+              options: {collapsible: true, collapsed: true}
+            }
+          ]
+        }
       ]
     },
     {


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

For some reason presence didn't show on collapsed objects and fieldsets. It didn't show when someone was inside a collapsed fields.

Issue was that presence wasn't passed down properly and filtered too early. This fixes that problem.
Also added objects to the schema for testing purposes.

I have tested it a lot, but if I missed something let me know!

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

- Fixed an issue where presence didn't display people inside collapsed objects or fieldsets

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
