### PR TITLE
[core] Fix missing eventsource dependency

### DIFF
--- a/packages/@sanity/core/package.json
+++ b/packages/@sanity/core/package.json
@@ -26,6 +26,7 @@
     "@babel/preset-typescript": "^7.10.4",
     "@babel/register": "^7.7.4",
     "@sanity/check": "2.0.1",
+    "@sanity/eventsource": "2.0.1",
     "@sanity/export": "2.0.1",
     "@sanity/generate-help-url": "2.0.1",
     "@sanity/import": "2.0.1",

--- a/packages/@sanity/core/src/commands/dataset/copyDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/copyDatasetCommand.js
@@ -1,4 +1,4 @@
-import EventSource from 'eventsource'
+import EventSource from '@sanity/eventsource'
 import Observable from '@sanity/observable/minimal'
 import chalk from 'chalk'
 import promptForDatasetName from '../../actions/dataset/datasetNamePrompt'


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

Currently the dataset copy command crashes unless the `eventsource` dependency happens to be hoisted by a sibling.

**Description**

This adds `@sanity/eventsource` as a direct dependency and uses that internally. Fixes #2102

**Note for release**

- Fixed missing dependency in `@sanity/core` sometimes causing `sanity dataset copy` to crash

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
