### PR TITLE
[chore] Remove unnecessary internal dependency

### DIFF
--- a/packages/@sanity/dashboard/package.json
+++ b/packages/@sanity/dashboard/package.json
@@ -6,9 +6,7 @@
   "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",
   "scripts": {
-    "clean": "rimraf lib",
-    "start": "npm run example-testbed",
-    "test": "#todo: jest"
+    "clean": "rimraf lib"
   },
   "keywords": [
     "sanity",
@@ -26,8 +24,6 @@
     "rxjs": "^6.5.3"
   },
   "devDependencies": {
-    "@sanity/base": "2.0.5",
-    "@sanity/check": "2.0.1",
     "prop-types": "^15.6.0",
     "rimraf": "^2.7.1"
   },

--- a/packages/@sanity/react-hooks/package.json
+++ b/packages/@sanity/react-hooks/package.json
@@ -30,7 +30,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@sanity/base": "2.0.5",
     "@sanity/types": "2.0.1",
     "lodash": "^4.17.15",
     "rxjs": "^6.5.3",

--- a/packages/@sanity/studio-hints/package.json
+++ b/packages/@sanity/studio-hints/package.json
@@ -9,9 +9,7 @@
     "access": "public"
   },
   "scripts": {
-    "clean": "rimraf lib",
-    "start": "npm run example-testbed",
-    "test": "#todo: jest"
+    "clean": "rimraf lib"
   },
   "keywords": [
     "sanity",
@@ -24,8 +22,6 @@
     "sanity-plugin"
   ],
   "devDependencies": {
-    "@sanity/base": "2.0.5",
-    "@sanity/check": "2.0.1",
     "rimraf": "^2.7.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

These three modules are explicitly listing `@sanity/base` as a dependency, when they're actually only using the parts system to import. That means the additional dependency is a potential for version mismatches, which has been happening now and then.

**Description**

This PR removes the direct dependency on `@sanity/base`, hopefully solving the problem where the modules would not get a bumped version of `@sanity/base` when publishing new versions, and reducing cross-dependency chatter.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
