### PR TITLE
[form-builder] Handle focus when passed a path instead of an event

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/common/UploadTarget/createUploadTarget.tsx
+++ b/packages/@sanity/form-builder/src/inputs/common/UploadTarget/createUploadTarget.tsx
@@ -77,11 +77,10 @@ export function createUploadTarget<T>(Component: any): React.ComponentType<any> 
       rejected: [],
       ambiguous: [],
     }
-    handleFocus = (event: FocusEvent) => {
+    handleFocus = (path: Path) => {
       const {onFocus} = this.props
-      event.stopPropagation()
       if (onFocus) {
-        onFocus(['$'])
+        onFocus(Array.isArray(path) ? path : ['$'])
       }
     }
     handleKeyPress = (event: KeyboardEvent) => {


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

With the change in 636bb79d1a7cfd694909fa941c43b6bd1e9f7ee4 we are now passing a path to the `onFocus` method of the input, which apparently was expecting an event in the upload target for images/files. Thus, calling  `stopPropagation` on it would crash. 

**Description**

This PR changes it to expect a Path. I haven't seen any side-effects of this change, but I wasn't 100% sure if there were still cases where an event would be passed and expecting the focus terminator to be passed down, so I added a ternary just in case, to maintain the old behavior (apart from the `stopPropagation` call)


**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
