### PR TITLE
[chore] Build modules before running lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,12 @@ jobs:
 
       - name: Install npm dependencies
         run: npm install
+      
+      # Required for import lint rules to work - packages pointing to ex
+      # `lib/index.js`, where `src/index.ts` gets compiled to `lib/index.js`
+      - name: Build modules
+        id: buildModules
+        run: npm run build
 
       - name: List which files changed
         id: listChangedFiles


### PR DESCRIPTION
The `import/no-unresolved` rule will fail if you depend on another module in the monorepo which hasn't yet been built. Thus; we need to actually build all modules before running the linter.

<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [x]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

eslints `import/no-unresolved` fails when depending on sibling module, since it points to a compiled version which is not yet available.

**Description**

This PR makes sure we build the modules prior to running the linter. Not ideal, but can't see a good workaround right now.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
