### PR TITLE
[chore] Fix bug where CI tried to lint non-js files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install npm dependencies
         run: npm install
-      
+
       # Required for import lint rules to work - packages pointing to ex
       # `lib/index.js`, where `src/index.ts` gets compiled to `lib/index.js`
       - name: Build modules
@@ -49,8 +49,11 @@ jobs:
             printf "\nThese files have changed in $GITHUB_SHA:\n$CHANGED_FILES\n"
           fi
 
-          # Exclude files that were deleted with --diff-filter
-          CHANGED_FILES_SEPARATED_BY_SPACES=$(echo "$CHANGED_FILES" | sed ':a;N;$!ba;s/\n/ /g')
+          # Don't include files like LICENSE and css files
+          CHANGED_JS_FILES=$(echo "$CHANGED_FILES" | sed -e '/^.\+\(mjs\|tsx\|jsx\|js\|ts\)$/!d')
+
+          # Replace \n characters with a space
+          CHANGED_FILES_SEPARATED_BY_SPACES=$(echo "$CHANGED_JS_FILES" | sed ':a;N;$!ba;s/\n/ /g')
 
           echo "::set-output name=changedFiles::$( echo "$CHANGED_FILES_SEPARATED_BY_SPACES" )"
 


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [x]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->

Files like `LICENSE` and `.css`-files are being included in the `eslint` run in CI if they changed and would cause a failure.

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

This change includes an extra `sed` step which filters out all files that don't need to be run `eslint` on. Files that will be linted are:

* `.mjs`
* `.jsx`
* `.tsx`
* `.js`
* `.ts`

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
