### PR TITLE
[selects/searchable-style] add `pointer-events: none` to noResultTextHidden to fix it blocking the scrollbar

### DIFF
--- a/packages/@sanity/components/src/selects/SearchableSelect.css
+++ b/packages/@sanity/components/src/selects/SearchableSelect.css
@@ -101,6 +101,7 @@
   composes: noResultText;
   transition: none;
   opacity: 0;
+  pointer-events: none;
 }
 
 .spinner {


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

The top part of the searchable select scrollbar is unusable with the mouse because of an overlaying hidden div with the 'no results' message. 

![Screenshot 2020-11-18 at 08 26 30](https://user-images.githubusercontent.com/580312/99498771-41b30e00-2978-11eb-8f58-69481a8feae7.png)

![searchable-dropdown-not-scrollable](https://user-images.githubusercontent.com/580312/99498775-42e43b00-2978-11eb-95f1-3ca7ba31324f.gif)

<!-- Reference/link the relevant issue and/or describe the behavior. -->

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

The hidden text should either be made unusable with `pointer-events: none` or completely hidden and out of the way (other than with opacity), for example with a `transform: scale(0)`. 

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

Fixed a bug where the top part of the searchable select dropdown scrollbar was being blocked by a hidden div.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [ ]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
