### PR TITLE
[core] Disallow using aliases for studios

### DIFF
--- a/packages/@sanity/core/src/actions/start/startAction.js
+++ b/packages/@sanity/core/src/actions/start/startAction.js
@@ -130,6 +130,7 @@ async function ensureProjectConfig(context) {
   // If we're still missing information, prompt the user to provide them
   const configMissing = !projectId || !dataset
   if (!configMissing) {
+    validateAllowedDataset(dataset)
     return
   }
 
@@ -299,4 +300,10 @@ function createProject(apiClient, options) {
       projectId: response.projectId || response.id,
       displayName: options.displayName || '',
     }))
+}
+
+function validateAllowedDataset(datasetName) {
+  if (datasetName.startsWith('~')) {
+    throw new Error('Dataset aliases cannot be used in a studio context')
+  }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Description**

This PR prevents using dataset aliases in studios, as it will fail to perform mutations, asset uploads and connect to the presence layer.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
