### PR TITLE
[client] Add dataset alias support in client

### DIFF
--- a/packages/@sanity/client/src/validators.js
+++ b/packages/@sanity/client/src/validators.js
@@ -2,7 +2,7 @@ const VALID_ASSET_TYPES = ['image', 'file']
 const VALID_INSERT_LOCATIONS = ['before', 'after', 'replace']
 
 exports.dataset = name => {
-  if (!/^[~][a-z0-9][-\w]{2,20}$|^[a-z0-9][-\w]{1,20}$/.test(name)) {
+  if (!/^(~[a-z0-9]{1}[-\w]{0,25}|[a-z0-9]{1}[-\w]{0,19})$/.test(name)) {
     throw new Error(
       'Datasets can only contain lowercase characters, numbers, underscores and dashes, and start with tilde, and be maximum 20 characters'
     )

--- a/packages/@sanity/client/src/validators.js
+++ b/packages/@sanity/client/src/validators.js
@@ -2,9 +2,9 @@ const VALID_ASSET_TYPES = ['image', 'file']
 const VALID_INSERT_LOCATIONS = ['before', 'after', 'replace']
 
 exports.dataset = name => {
-  if (!/^[-\w]{1,128}$/.test(name)) {
+  if (!/^[~][a-z0-9][-\w]{2,20}$|^[a-z0-9][-\w]{1,20}$/.test(name)) {
     throw new Error(
-      'Datasets can only contain lowercase characters, numbers, underscores and dashes'
+      'Datasets can only contain lowercase characters, numbers, underscores and dashes, and start with tilde, and be maximum 20 characters'
     )
   }
 }

--- a/packages/@sanity/client/test/client.test.js
+++ b/packages/@sanity/client/test/client.test.js
@@ -108,6 +108,14 @@ test('throws on invalid dataset names', t => {
   t.end()
 })
 
+test('accepts alias in dataset field', t => {
+  t.doesNotThrow(
+    () => sanityClient({projectId: 'abc123', dataset: '~alias'}),
+    /Datasets can only contain/i
+  )
+  t.end()
+})
+
 test('can use request() for API-relative requests', t => {
   nock(projectHost())
     .get('/v1/ping')

--- a/packages/@sanity/client/test/client.test.js
+++ b/packages/@sanity/client/test/client.test.js
@@ -376,7 +376,10 @@ test('can query for multiple documents', t => {
     .get('/v1/data/doc/foo/abc123,abc321')
     .reply(200, {
       ms: 123,
-      documents: [{_id: 'abc123', mood: 'lax'}, {_id: 'abc321', mood: 'tense'}]
+      documents: [
+        {_id: 'abc123', mood: 'lax'},
+        {_id: 'abc321', mood: 'tense'}
+      ]
     })
 
   getClient()
@@ -394,7 +397,10 @@ test('preserves the position of requested documents', t => {
     .get('/v1/data/doc/foo/abc123,abc321,abc456')
     .reply(200, {
       ms: 123,
-      documents: [{_id: 'abc456', mood: 'neutral'}, {_id: 'abc321', mood: 'tense'}]
+      documents: [
+        {_id: 'abc456', mood: 'neutral'},
+        {_id: 'abc321', mood: 'tense'}
+      ]
     })
 
   getClient()
@@ -1525,7 +1531,11 @@ test('uploads images with progress events', t => {
   getClient()
     .observable.assets.upload('image', fs.createReadStream(fixturePath))
     .pipe(filter(event => event.type === 'progress'))
-    .subscribe(event => t.equal(event.type, 'progress'), ifError(t), () => t.end())
+    .subscribe(
+      event => t.equal(event.type, 'progress'),
+      ifError(t),
+      () => t.end()
+    )
 })
 
 test('uploads images with custom label', t => {


### PR DESCRIPTION
**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [x]  Yes
- [ ]  No

**Current behavior**

The Sanity JS client currently crashes when using an alias in the `dataset` field.

**Description**

This PR let's the alias format through the dataset validator. Aliases starts with the `~` character, and isn't currently allowed.

**Note for release**

Add support for using aliases in the Sanity JS client

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
