### PR TITLE
[core] Specify target/source dataset in copy prompt

### DIFF
--- a/packages/@sanity/core/src/commands/dataset/copyDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/copyDatasetCommand.js
@@ -75,14 +75,16 @@ export default {
       .list()
       .then((datasets) => datasets.map((ds) => ds.name))
 
-    const sourceDatasetName = await (sourceDataset || promptForDatasetName(prompt))
+    const sourceDatasetName = await (sourceDataset ||
+      promptForDatasetName(prompt, {message: 'Source dataset name:'}))
     if (!existingDatasets.includes(sourceDatasetName)) {
-      throw new Error(`Dataset "${sourceDatasetName}" doesn't exist`)
+      throw new Error(`Source dataset "${sourceDatasetName}" doesn't exist`)
     }
 
-    const targetDatasetName = await (targetDataset || promptForDatasetName(prompt))
+    const targetDatasetName = await (targetDataset ||
+      promptForDatasetName(prompt, {message: 'Target dataset name:'}))
     if (existingDatasets.includes(targetDatasetName)) {
-      throw new Error(`Dataset "${targetDatasetName}" already exists`)
+      throw new Error(`Target dataset "${targetDatasetName}" already exists`)
     }
 
     const err = validateDatasetName(targetDatasetName)


### PR DESCRIPTION
Without this users have no way of knowing which dataset is prompted for
in interactive mode.

<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->

There is no difference between the interactive prompts for source and target dataset when initiating a Cloud Copy.

![screenshot_2020-11-26-08:43:39](https://user-images.githubusercontent.com/3595094/100321776-81ef3d80-2fc3-11eb-99c5-48e9edc1edd2.png)

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

This fix customises the prompt so they're different.

![screenshot_2020-11-26-08:33:52](https://user-images.githubusercontent.com/3595094/100321403-e958bd80-2fc2-11eb-97a5-6c68a71879bc.png)

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [x]  Corresponding changes to the documentation have been made
