### PR TITLE
[chore] Make linting in CI handle changes with many files better

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
         id: buildModules
         run: npm run build
 
-      - name: List which files changed
+      - name: Lint changed files
         id: listChangedFiles
         run: |
           # Is this a pull request?
@@ -52,10 +52,7 @@ jobs:
           # Don't include files like LICENSE and css files
           CHANGED_JS_FILES=$(echo "$CHANGED_FILES" | sed -e '/^.\+\(mjs\|tsx\|jsx\|js\|ts\)$/!d')
 
-          # Replace \n characters with a space
-          CHANGED_FILES_SEPARATED_BY_SPACES=$(echo "$CHANGED_JS_FILES" | sed ':a;N;$!ba;s/\n/ /g')
-
-          echo "::set-output name=changedFiles::$( echo "$CHANGED_FILES_SEPARATED_BY_SPACES" )"
-
-      - name: Run eslint for changed files
-        run: npm run eslint -- ${{ steps.listChangedFiles.outputs.changedFiles }}
+          for FILE_NAME in $CHANGED_JS_FILES
+          do
+            npm run eslint -- $FILE_NAME
+          done


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [x]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->

For cases where there are many hundred changed files in a PR the shell will break because of too long a command.

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

This change alters the behaviour of the lint CI action to lint each file individually. This will take longer, however in most cases the slowdown won't be noticed.

If it's a problem over time we can look into chunking.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [x]  Corresponding changes to the documentation have been made
