### PR TITLE
Make sure all environments use the same version of prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "minimist": "^1.2.0",
     "path-exists-cli": "^1.0.0",
     "pre-commit": "^1.2.2",
-    "prettier": "^2.1.2",
+    "prettier": "2.1.2",
     "rimraf": "^2.7.1",
     "semver": "^6.1.2",
     "stylelint": "^13.4.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prettify": "lerna run clean && npm run prettier -- --write",
     "prettier": "node_modules/.bin/prettier '**/*.{ts,js,tsx,jsx}'",
     "lint-next": "npm run eslint -- `git diff --name-only next --diff-filter ACMRTUXB`",
-    "verify-format": "npm run prettier -- -c",
+    "verify-format": "lerna run clean && npm run prettier -- -c",
     "postinstall": "npm run bootstrap",
     "vercel-build": "npm run build && cd examples/test-studio && npm run build -- -y",
     "type-check": "tsc -b ./packages --force"

--- a/packages/@sanity/base/src/__legacy/@sanity/components/previews/DefaultPreview.tsx
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/previews/DefaultPreview.tsx
@@ -114,7 +114,6 @@ class DefaultPreview extends React.PureComponent<DefaultPreviewProps> {
   }
 }
 
-export default Styleable(
-  DefaultPreview as any,
-  defaultStyles
-) as React.ComponentType<DefaultPreviewProps>
+export default Styleable(DefaultPreview as any, defaultStyles) as React.ComponentType<
+  DefaultPreviewProps
+>

--- a/packages/@sanity/base/src/datastores/document/document-pair/checkoutPair.ts
+++ b/packages/@sanity/base/src/datastores/document/document-pair/checkoutPair.ts
@@ -50,9 +50,9 @@ export function checkoutPair(idPair: IdPair): Pair {
 
   const listenerEvents$ = getPairListener(client, idPair).pipe(share())
 
-  const reconnect$ = listenerEvents$.pipe(
-    filter((ev) => ev.type === 'reconnect')
-  ) as Observable<ReconnectEvent>
+  const reconnect$ = listenerEvents$.pipe(filter((ev) => ev.type === 'reconnect')) as Observable<
+    ReconnectEvent
+  >
 
   const draft = createBufferedDocument(
     draftId,

--- a/packages/@sanity/core/src/actions/graphql/SchemaError.js
+++ b/packages/@sanity/core/src/actions/graphql/SchemaError.js
@@ -5,9 +5,7 @@ const generateHelpUrl = require('@sanity/generate-help-url')
 // eslint-disable-next-line no-console
 const consoleOutputter = {error: (...args) => console.error(...args)}
 
-module.exports = class SchemaError extends (
-  Error
-) {
+module.exports = class SchemaError extends Error {
   constructor(problemGroups) {
     super('Schema errors encountered')
     this.problemGroups = problemGroups

--- a/packages/@sanity/preview/src/components/ObserveForPreview.tsx
+++ b/packages/@sanity/preview/src/components/ObserveForPreview.tsx
@@ -95,17 +95,16 @@ type ReceivedProps<T = unknown> = {
   error?: Error
   children: (props: any) => React.ReactElement
 }
-export default withPropsStream<OuterProps, ReceivedProps>(
-  connect,
-  function ObserveForPreview(props: ReceivedProps) {
-    const {snapshot, type, error, isLoading, children} = props
-    return children({
-      error,
-      isLoading,
-      result: {
-        type,
-        snapshot: snapshot === INVALID_PREVIEW_CONFIG ? INVALID_PREVIEW_FALLBACK : snapshot,
-      },
-    })
-  }
-)
+export default withPropsStream<OuterProps, ReceivedProps>(connect, function ObserveForPreview(
+  props: ReceivedProps
+) {
+  const {snapshot, type, error, isLoading, children} = props
+  return children({
+    error,
+    isLoading,
+    result: {
+      type,
+      snapshot: snapshot === INVALID_PREVIEW_CONFIG ? INVALID_PREVIEW_FALLBACK : snapshot,
+    },
+  })
+})


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [x]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->

Since we clamp the prettier version in `package.json` with `^2.1.2` we will automatically pull in all upgrades as long as the major version is 2. However this might produce different formatting conventions depending on "when" you ran `npm install`. CI always being the one running the newest since they always run install before running format.

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

This change clamps the version on `2.1.2`. Producing consistent formatting. However we should make sure to update `prettier` now and then by upping the version in the string. Although that might mean changes to the whole code base so it's nice to have control over.

This could also be solved by having a more expressive `.prettierrc` which conserves our options regardless of `prettier` defaults. However as we've discussed before that might also mean we diverge from the "norm".

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [x]  Corresponding changes to the documentation have been made
