### PR TITLE
[form-builder] Fix typings for resolveArrayInput

### DIFF
--- a/packages/@sanity/form-builder/src/sanity/inputResolver/resolveArrayInput.ts
+++ b/packages/@sanity/form-builder/src/sanity/inputResolver/resolveArrayInput.ts
@@ -1,39 +1,42 @@
+import {ComponentType} from 'react'
+import {ArraySchemaType} from '@sanity/types'
+import * as is from '../../utils/is'
 import OptionsArray from '../../inputs/OptionsArrayInput'
 import PortableTextInput from '../../inputs/PortableText/PortableTextInput'
 import ArrayOfPrimitivesInput from '../../inputs/ArrayOfPrimitivesInput'
 import TagsArrayInput from '../../inputs/TagsArrayInput'
-import * as is from '../../utils/is'
-import {get} from 'lodash'
 import SanityArrayInput from '../inputs/SanityArrayInput'
 
 const PRIMITIVES = ['string', 'number', 'boolean']
 
-export function isArrayOfPrimitives(type) {
+export function isArrayOfPrimitives(type: ArraySchemaType): boolean {
   return type.of.every((ofType) => PRIMITIVES.includes(ofType.jsonType))
 }
 
-function isTagsArray(type) {
-  return (
-    get(type.options, 'layout') === 'tags' && type.of.length === 1 && is.type('string', type.of[0])
-  )
+function isStringArray(type: ArraySchemaType): type is ArraySchemaType<string> {
+  return type.of.length === 1 && is.type('string', type.of[0])
 }
 
-function isPortableText(type) {
+function isTagsArray(type: ArraySchemaType<string>): boolean {
+  return type.options?.layout === 'tags'
+}
+
+function isPortableText(type: ArraySchemaType): boolean {
   // TODO: better testing here, not only for type 'block' !
   return type.of.some((memberType) => is.type('block', memberType))
 }
 
-export function hasOptionsList(type) {
-  return get(type.options, 'list')
+export function hasOptionsList(type: ArraySchemaType): boolean {
+  return Boolean(type.options?.list)
 }
 
-export default function resolveArrayInput(type) {
+export default function resolveArrayInput(type: ArraySchemaType): ComponentType {
   // Schema provides predefines list
   if (hasOptionsList(type)) {
     return OptionsArray
   }
 
-  if (isTagsArray(type)) {
+  if (isStringArray(type) && isTagsArray(type)) {
     return TagsArrayInput
   }
 
@@ -43,7 +46,6 @@ export default function resolveArrayInput(type) {
   }
 
   // Use Portable Text editor if portable text.
-
   if (isPortableText(type)) {
     return PortableTextInput
   }


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

Currently fails to build when attempting to infer return type for `resolveArrayInput`

**Description**

This PR introduces proper typings for the  `resolveArrayInput` module. Also replaces lodash.get usage with optional chaining syntax.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
