### PR TITLE
[chore] Fail build script on TS compile errors + smaller improvements

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -115,6 +115,6 @@ const watchJSAndAssets = parallel(
 )
 
 exports.ts = buildTS
-exports.build = parallel(buildJSAndAssets, buildTS)
-exports.watch = series(parallel(buildJSAndAssets, buildTS), parallel(watchJSAndAssets, watchTS))
+exports.build = series(buildJSAndAssets, buildTS)
+exports.watch = series(buildJSAndAssets, parallel(watchJSAndAssets, watchTS))
 exports.clean = () => del(PACKAGE_PATHS.map((pth) => path.join(pth, DEST_DIR)))

--- a/scripts/runTsc.js
+++ b/scripts/runTsc.js
@@ -16,13 +16,21 @@ const getProjectEnv = (projectPath) => {
 exports.runTsc = function runTsc(projectPath, watch) {
   const proc = childProcess.spawn(
     'tsc',
-    ['-b', './packages', '--force', ...(watch ? ['--watch'] : [])],
+    ['-b', './packages', '--pretty', '--force', ...(watch ? ['--watch'] : [])],
     {
       shell: isWindows,
       cwd: projectPath,
       env: getProjectEnv(projectPath),
     }
   )
+
+  if (!watch) {
+    proc.on('close', (code) => {
+      if (code !== 0) {
+        throw new Error(`Process exited with code ${code}`)
+      }
+    })
+  }
 
   return mergeStream([
     proc.stdout.pipe(


### PR DESCRIPTION
**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [x]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**
Currently `npm run build` doesn't fail on TypeScript compile errors.

**Description**
This PR makes sure "npm run build" fails on TypeScript compile errors. Also runs tsc after babel to make sure the path aliases actually gets resolved, And improves console output of TS compile errors.
