### PR TITLE
[core] Add dataset alias support

### DIFF
--- a/packages/@sanity/core/src/actions/dataset/alias/datasetAliasNamePrompt.js
+++ b/packages/@sanity/core/src/actions/dataset/alias/datasetAliasNamePrompt.js
@@ -1,0 +1,17 @@
+import validateDatasetAliasName from './validateDatasetAliasName'
+
+export default function promptForAliasName(prompt, options = {}) {
+  return prompt.single({
+    type: 'input',
+    message: 'Alias name:',
+    validate: (name) => {
+      const err = validateDatasetAliasName(name)
+      if (err) {
+        return err
+      }
+
+      return true
+    },
+    ...options,
+  })
+}

--- a/packages/@sanity/core/src/actions/dataset/alias/validateDatasetAliasName.js
+++ b/packages/@sanity/core/src/actions/dataset/alias/validateDatasetAliasName.js
@@ -1,0 +1,33 @@
+module.exports = (datasetName) => {
+  if (!datasetName) {
+    return 'Alias name is missing'
+  }
+
+  const name = `${datasetName}`
+
+  if (name.toLowerCase() !== name) {
+    return 'Alias name must be all lowercase characters'
+  }
+
+  if (name.length < 2) {
+    return 'Alias name must be at least two characters long'
+  }
+
+  if (name.length > 20) {
+    return 'Alias name must be at most 20 characters'
+  }
+
+  if (!/^[a-z0-9~]/.test(name)) {
+    return 'Alias name must start with a letter or a number'
+  }
+
+  if (!/^[a-z0-9~][-_a-z0-9]+$/.test(name)) {
+    return 'Alias name must only contain letters, numbers, dashes and underscores'
+  }
+
+  if (/[-_]$/.test(name)) {
+    return 'Alias name must not end with a dash or an underscore'
+  }
+
+  return false
+}

--- a/packages/@sanity/core/src/commands/dataset/alias/aliasCommands.js
+++ b/packages/@sanity/core/src/commands/dataset/alias/aliasCommands.js
@@ -1,0 +1,60 @@
+import oneline from 'oneline'
+import createAliasHandler from './createAliasHandler'
+import deleteAliasHandler from './deleteAliasHandler'
+import unlinkAliasHandler from './unlinkAliasHandler'
+import linkAliasHandler from './linkAliasHandler'
+
+const helpText = `
+Below are examples of the alias subcommand
+
+Create Alias
+  sanity dataset alias create
+  sanity dataset alias create <alias-name>
+  sanity dataset alias create <alias-name> <target-dataset>
+
+Delete Alias
+  sanity dataset alias delete <alias-name>
+
+Link Alias
+  Options
+    --force Skips security prompt and forces link command
+
+  Usage
+    sanity dataset alias link
+    sanity dataset alias link <alias-name>
+    sanity dataset alias link <alias-name> <target-dataset>
+
+Un-link Alias
+  sanity dataset alias unlink
+  sanity dataset alias unlink <alias-name>
+`
+
+export default {
+  name: 'alias',
+  group: 'dataset',
+  signature: 'SUBCOMMAND [ALIAS_NAME, TARGET_DATASET]',
+  helpText,
+  description: 'You can manage your dataset alias using this command.',
+  action: async (args, context) => {
+    const [verb] = args.argsWithoutOptions
+    switch (verb) {
+      case 'create':
+        await createAliasHandler(args, context)
+        break
+      case 'delete':
+        await deleteAliasHandler(args, context)
+        break
+      case 'unlink':
+        await unlinkAliasHandler(args, context)
+        break
+      case 'link':
+        await linkAliasHandler(args, context)
+        break
+      default:
+        throw new Error(oneline`
+          Invalid command provided. Available commands are: create, delete, link and unlink.
+          For more guide run the help command 'sanity dataset alias --help'
+        `)
+    }
+  },
+}

--- a/packages/@sanity/core/src/commands/dataset/alias/createAliasHandler.js
+++ b/packages/@sanity/core/src/commands/dataset/alias/createAliasHandler.js
@@ -1,0 +1,64 @@
+import promptForDatasetName from '../../../actions/dataset/datasetNamePrompt'
+import promptForDatasetAliasName from '../../../actions/dataset/alias/datasetAliasNamePrompt'
+import validateDatasetAliasName from '../../../actions/dataset/alias/validateDatasetAliasName'
+import validateDatasetName from '../../../actions/dataset/validateDatasetName'
+import * as aliasClient from './datasetAliasesClient'
+import {ALIAS_PREFIX} from './datasetAliasesClient'
+
+export default async (args, context) => {
+  const {apiClient, output, prompt} = context
+  const [, alias, targetDataset] = args.argsWithoutOptions
+  const client = apiClient()
+
+  const nameError = alias && validateDatasetAliasName(alias)
+  if (nameError) {
+    throw new Error(nameError)
+  }
+
+  const [datasets, aliases, projectFeatures] = await Promise.all([
+    client.datasets.list().then((sets) => sets.map((ds) => ds.name)),
+    aliasClient.listAliases(client).then((sets) => sets.map((ds) => ds.name)),
+    client.request({uri: '/features'}),
+  ])
+
+  let aliasName = await (alias || promptForDatasetAliasName(prompt))
+  let aliasOutputName = aliasName
+
+  if (aliasName.startsWith(ALIAS_PREFIX)) {
+    aliasName = aliasName.substring(1)
+  } else {
+    aliasOutputName = `${ALIAS_PREFIX}${aliasName}`
+  }
+
+  if (aliases.includes(aliasName)) {
+    throw new Error(`Dataset alias "${aliasOutputName}" already exists`)
+  }
+
+  if (targetDataset) {
+    const datasetErr = validateDatasetName(targetDataset)
+    if (datasetErr) {
+      throw new Error(datasetErr)
+    }
+  }
+
+  const datasetName = await (targetDataset || promptForDatasetName(prompt))
+  if (datasetName && !datasets.includes(datasetName)) {
+    throw new Error(`Dataset "${datasetName}" does not exist `)
+  }
+
+  const canCreateAlias = projectFeatures.includes('advancedDatasetManagement')
+  if (!canCreateAlias) {
+    throw new Error(`This project cannot create a dataset alias`)
+  }
+
+  try {
+    await aliasClient.createAlias(client, aliasName, datasetName)
+    output.print(
+      `Dataset alias ${aliasOutputName} created ${
+        datasetName && `and linked to ${datasetName}`
+      } successfully`
+    )
+  } catch (err) {
+    throw new Error(`Dataset alias creation failed:\n${err.message}`)
+  }
+}

--- a/packages/@sanity/core/src/commands/dataset/alias/datasetAliasesClient.js
+++ b/packages/@sanity/core/src/commands/dataset/alias/datasetAliasesClient.js
@@ -1,0 +1,28 @@
+import validateAlias from '../../../actions/dataset/alias/validateDatasetAliasName'
+
+export const ALIAS_PREFIX = '~'
+
+export function listAliases(client) {
+  return client.request({uri: '/aliases'})
+}
+
+export function createAlias(client, name, datasetName) {
+  return modify(client, 'PUT', name, datasetName ? {datasetName} : null)
+}
+
+export function modify(client, method, name, body) {
+  return client.request({method, uri: `/aliases/${name}`, body})
+}
+
+export function updateAlias(client, name, datasetName) {
+  return modify(client, 'PATCH', name, datasetName ? {datasetName} : null)
+}
+
+export function unlinkAlias(client, name) {
+  validateAlias(name)
+  return modify(client, 'PATCH', `${name}/unlink`, {}, true)
+}
+
+export function removeAlias(client, name) {
+  return modify(client, 'DELETE', name)
+}

--- a/packages/@sanity/core/src/commands/dataset/alias/deleteAliasHandler.js
+++ b/packages/@sanity/core/src/commands/dataset/alias/deleteAliasHandler.js
@@ -1,0 +1,42 @@
+import validateDatasetAliasName from '../../../actions/dataset/alias/validateDatasetAliasName'
+import * as aliasClient from './datasetAliasesClient'
+import {ALIAS_PREFIX} from './datasetAliasesClient'
+
+export default async (args, context) => {
+  const {apiClient, prompt, output} = context
+  const [, ds] = args.argsWithoutOptions
+  const client = apiClient()
+  if (!ds) {
+    throw new Error('Dataset alias name must be provided')
+  }
+
+  let aliasName = `${ds}`
+  const dsError = validateDatasetAliasName(aliasName)
+  if (dsError) {
+    throw dsError
+  }
+  aliasName = aliasName.startsWith(ALIAS_PREFIX) ? aliasName.substring(1) : aliasName
+
+  const [fetchedAliases] = await Promise.all([aliasClient.listAliases(client)])
+  const linkedAlias = fetchedAliases.find((elem) => elem.name === aliasName)
+  const message =
+    linkedAlias && linkedAlias.datasetName
+      ? `This dataset alias is linked to ${linkedAlias.datasetName}. `
+      : ''
+
+  await prompt.single({
+    type: 'input',
+    message: `${message}Are you ABSOLUTELY sure you want to delete this dataset alias?\n  Type the name of the dataset alias to confirm delete: `,
+    filter: (input) => `${input}`.trim(),
+    validate: (input) => {
+      return input === aliasName || 'Incorrect dataset alias name. Ctrl + C to cancel delete.'
+    },
+  })
+
+  // Strip out alias prefix if it exist in the string
+  aliasName = aliasName.startsWith(ALIAS_PREFIX) ? aliasName.substring(1) : aliasName
+
+  return aliasClient.removeAlias(client, aliasName).then(() => {
+    output.print('Dataset alias deleted successfully')
+  })
+}

--- a/packages/@sanity/core/src/commands/dataset/alias/linkAliasHandler.js
+++ b/packages/@sanity/core/src/commands/dataset/alias/linkAliasHandler.js
@@ -1,0 +1,74 @@
+import promptForDatasetName from '../../../actions/dataset/datasetNamePrompt'
+import promptForDatasetAliasName from '../../../actions/dataset/alias/datasetAliasNamePrompt'
+import validateDatasetAliasName from '../../../actions/dataset/alias/validateDatasetAliasName'
+import validateDatasetName from '../../../actions/dataset/validateDatasetName'
+import * as aliasClient from './datasetAliasesClient'
+import {ALIAS_PREFIX} from './datasetAliasesClient'
+
+export default async (args, context) => {
+  const {apiClient, output, prompt} = context
+  const [, alias, targetDataset] = args.argsWithoutOptions
+  const flags = args.extOptions
+  const client = apiClient()
+
+  const nameError = alias && validateDatasetAliasName(alias)
+  if (nameError) {
+    throw new Error(nameError)
+  }
+
+  const [datasets, fetchedAliases] = await Promise.all([
+    client.datasets.list().then((sets) => sets.map((ds) => ds.name)),
+    aliasClient.listAliases(client),
+  ])
+  const aliases = fetchedAliases.map((da) => da.name)
+
+  let aliasName = await (alias || promptForDatasetAliasName(prompt))
+  let aliasOutputName = aliasName
+
+  if (aliasName.startsWith(ALIAS_PREFIX)) {
+    aliasName = aliasName.substring(1)
+  } else {
+    aliasOutputName = `${ALIAS_PREFIX}${aliasName}`
+  }
+
+  if (!aliases.includes(aliasName)) {
+    throw new Error(`Dataset alias "${aliasOutputName}" does not exist `)
+  }
+
+  const datasetName = await (targetDataset || promptForDatasetName(prompt))
+  const datasetErr = validateDatasetName(datasetName)
+  if (datasetErr) {
+    throw new Error(datasetErr)
+  }
+
+  if (!datasets.includes(datasetName)) {
+    throw new Error(`Dataset "${datasetName}" does not exist `)
+  }
+
+  const linkedAlias = fetchedAliases.find((elem) => elem.name === aliasName)
+
+  if (linkedAlias && linkedAlias.datasetName) {
+    if (linkedAlias.datasetName === datasetName) {
+      throw new Error(`Dataset alias ${aliasOutputName} already linked to ${datasetName}`)
+    }
+
+    if (!flags.force) {
+      await prompt.single({
+        type: 'input',
+        message: `This alias is linked to dataset <${linkedAlias.datasetName}>. Are you ABSOLUTELY sure you want to link this dataset alias to this dataset?
+        \n  Type YES/NO: `,
+        filter: (input) => `${input}`.toLowerCase(),
+        validate: (input) => {
+          return input === 'yes' || 'Ctrl + C to cancel dataset alias link.'
+        },
+      })
+    }
+  }
+
+  try {
+    await aliasClient.updateAlias(client, aliasName, datasetName)
+    output.print(`Dataset alias ${aliasOutputName} linked to ${datasetName} successfully`)
+  } catch (err) {
+    throw new Error(`Dataset alias link failed:\n${err.message}`)
+  }
+}

--- a/packages/@sanity/core/src/commands/dataset/alias/listAliasesHandler.js
+++ b/packages/@sanity/core/src/commands/dataset/alias/listAliasesHandler.js
@@ -1,0 +1,14 @@
+import * as aliasClient from './datasetAliasesClient'
+import {ALIAS_PREFIX} from './datasetAliasesClient'
+
+export default async (args, context) => {
+  const {apiClient, output} = context
+  const client = apiClient()
+
+  const aliases = await aliasClient.listAliases(client)
+  output.print(
+    aliases
+      .map((set) => `${ALIAS_PREFIX}${set.name} -> ${set.datasetName || '<unlinked>'}`)
+      .join('\n')
+  )
+}

--- a/packages/@sanity/core/src/commands/dataset/alias/unlinkAliasHandler.js
+++ b/packages/@sanity/core/src/commands/dataset/alias/unlinkAliasHandler.js
@@ -1,0 +1,55 @@
+import promptForDatasetAliasName from '../../../actions/dataset/alias/datasetAliasNamePrompt'
+import validateDatasetAliasName from '../../../actions/dataset/alias/validateDatasetAliasName'
+import * as aliasClient from './datasetAliasesClient'
+import {ALIAS_PREFIX} from './datasetAliasesClient'
+
+export default async (args, context) => {
+  const {apiClient, output, prompt} = context
+  const [, alias] = args.argsWithoutOptions
+  const client = apiClient()
+
+  const nameError = alias && validateDatasetAliasName(alias)
+  if (nameError) {
+    throw new Error(nameError)
+  }
+
+  const fetchedAliases = await aliasClient.listAliases(client)
+
+  let aliasName = await (alias || promptForDatasetAliasName(prompt))
+  let aliasOutputName = aliasName
+
+  if (aliasName.startsWith(ALIAS_PREFIX)) {
+    aliasName = aliasName.substring(1)
+  } else {
+    aliasOutputName = `${ALIAS_PREFIX}${aliasName}`
+  }
+
+  // get the current alias from the remote alias list
+  const linkedAlias = fetchedAliases.find((elem) => elem.name === aliasName)
+  if (!linkedAlias) {
+    throw new Error(`Dataset alias "${aliasOutputName}" does not exist`)
+  }
+
+  if (!linkedAlias.datasetName) {
+    throw new Error(`Dataset alias "${aliasOutputName}" is not linked to a dataset`)
+  }
+
+  await prompt.single({
+    type: 'input',
+    message: `Are you ABSOLUTELY sure you want to unlink this alias from the "${linkedAlias.datasetName}" dataset?
+      \n  Type YES/NO: `,
+    filter: (input) => `${input}`.toLowerCase(),
+    validate: (input) => {
+      return input === 'yes' || 'Ctrl + C to cancel dataset alias unlink.'
+    },
+  })
+
+  try {
+    const result = await aliasClient.unlinkAlias(client, aliasName)
+    output.print(
+      `Dataset alias ${aliasOutputName} unlinked from ${result.datasetName} successfully`
+    )
+  } catch (err) {
+    throw new Error(`Dataset alias unlink failed:\n${err.message}`)
+  }
+}

--- a/packages/@sanity/core/src/commands/dataset/listDatasetsCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/listDatasetsCommand.js
@@ -1,3 +1,5 @@
+import listAliasesHandler from './alias/listAliasesHandler'
+
 export default {
   name: 'list',
   group: 'dataset',
@@ -8,5 +10,8 @@ export default {
     const client = apiClient()
     const datasets = await client.datasets.list()
     output.print(datasets.map((set) => set.name).join('\n'))
+
+    // Print alias list
+    await listAliasesHandler(args, context)
   },
 }

--- a/packages/@sanity/core/src/commands/index.js
+++ b/packages/@sanity/core/src/commands/index.js
@@ -11,6 +11,7 @@ import deleteDatasetCommand from './dataset/deleteDatasetCommand'
 import exportDatasetCommand from './dataset/exportDatasetCommand'
 import importDatasetCommand from './dataset/importDatasetCommand'
 import copyDatasetCommand from './dataset/copyDatasetCommand'
+import aliasDatasetCommand from './dataset/alias/aliasCommands'
 import documentsGroup from './documents/documentsGroup'
 import getDocumentsCommand from './documents/getDocumentsCommand'
 import queryDocumentsCommand from './documents/queryDocumentsCommand'
@@ -52,6 +53,7 @@ export default [
   importDatasetCommand,
   deleteDatasetCommand,
   copyDatasetCommand,
+  aliasDatasetCommand,
   corsGroup,
   listCorsOriginsCommand,
   addCorsOriginCommand,


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [x] Yes
- [ ]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->

**Description**
This PR adds support for `dataset` `alias` in the sanity CLI. It provides the interface to interact and manage `dataset` `alias`


**Note for release**

Added support for the following sub commands to dataset
```bash
  $ sanity dataset alias create <alias-name> <target-dataset>

  $ sanity dataset alias delete <alias-name>

  $ sanity dataset alias link <alias-name> <target-dataset>

  $ sanity dataset alias unlink <alias-name>
```

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
