### PR TITLE
[server] Add missing dependencies

### DIFF
--- a/packages/@sanity/server/package.json
+++ b/packages/@sanity/server/package.json
@@ -52,6 +52,7 @@
     "eventsource-polyfill": "^0.9.6",
     "express": "^4.16.1",
     "extract-text-webpack-plugin": "^3.0.0",
+    "find-config": "^1.0.0",
     "file-loader": "^1.1.4",
     "json-loader": "^0.5.4",
     "lodash": "^4.17.15",
@@ -66,6 +67,7 @@
     "strip-ansi": "^5.2.0",
     "style-loader": "^0.20.1",
     "symbol-observable": "^1.2.0",
+    "tsconfig": "^7.0.0",
     "webpack": "^3.8.1",
     "webpack-dev-middleware": "^2.0.5",
     "webpack-hot-middleware": "2.25.0"


### PR DESCRIPTION

**Type of change (check at least one)**
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [x]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**
When upgrading sanity packages released from `next` you'll get an error saying that the `tsconfig` and `find-config` modules cannot be found.

**Description**
This adds `tsconfig` and `find-config` as dependencies to `@sanity/server`

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

**Note for release**
N/A
