### PR TITLE
[search/weighted] Sort search results alphabetically before applying weights

### DIFF
--- a/packages/@sanity/base/src/search/weighted/createWeightedSearch.js
+++ b/packages/@sanity/base/src/search/weighted/createWeightedSearch.js
@@ -61,6 +61,7 @@ export function createWeightedSearch(types, client, options = {}) {
       })
       .pipe(
         map(removeDupes),
+        map((hits) => sortBy(hits, (hit) => hit.w2)),
         map((hits) => applyWeights(searchSpec, hits, terms)),
         map((hits) => sortBy(hits, (hit) => -hit.score)),
         map((hits) => hits.slice(0, 100))


### PR DESCRIPTION
by sorting the results alphabetically before applying the weights the results are ordered in a visually logical way. 

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

The weighted searches (like navbar search and reference dropdown) are sorted by type and within their type seemingly random, when an empty query is given. This happens when clicking the reference dropdown arrow with no query, or by typing a space inside the navbar search.

<img src="https://user-images.githubusercontent.com/580312/102311008-621cbb00-3f6c-11eb-9822-15adbf9eee84.png" width="400" />

<details>
<summary>More examples with no input</summary>

Example: No query inside navbar search
![Screenshot 2020-12-10 at 10 37 08](https://user-images.githubusercontent.com/580312/101754625-3b760480-3ad4-11eb-92a1-fea249eb0c73.png)

Example: No query inside reference input with single ref type
![Screenshot 2020-12-10 at 10 37 38](https://user-images.githubusercontent.com/580312/101754629-3ca73180-3ad4-11eb-8bf8-895e60493ad6.png)

Example: No query inside reference input with multiple ref types
![Screenshot 2020-12-10 at 10 38 17](https://user-images.githubusercontent.com/580312/101754631-3d3fc800-3ad4-11eb-964f-1f30b18e44b1.png)

</details>

When an input value is given, the ordering seems random, within type and with weights applied. 

![Screenshot 2020-12-10 at 11 15 03](https://user-images.githubusercontent.com/580312/101779169-2f4e6f00-3af5-11eb-84db-3da4eb54390b.png)

<details>
<summary>More examples with input value</summary>

Example: Query inside navbar search
![Screenshot 2020-12-10 at 10 44 31](https://user-images.githubusercontent.com/580312/101755113-c8b95900-3ad4-11eb-8641-814ca7549195.png)

Example: Query inside reference input with single ref type
![Screenshot 2020-12-10 at 10 43 42](https://user-images.githubusercontent.com/580312/101755135-cf47d080-3ad4-11eb-8739-c60d744c8b86.png)

Example: Query inside reference input with multiple ref types
![Screenshot 2020-12-10 at 10 43 04](https://user-images.githubusercontent.com/580312/101755149-d7077500-3ad4-11eb-90dc-16581ce5b25e.png)

</details>

**Description**

This behaviour is probably due to how GROQ returns the results and how [Lodash preserves the original sort order of equal elements](https://lodash.com/docs/4.17.15#sortBy).

By sorting the results alphabetically first and then applying weights and sorting by hit, the original order is changed and results are sorted alphabetically when weights are equal.

![Screenshot 2020-12-10 at 11 20 03](https://user-images.githubusercontent.com/580312/101759292-afff7200-3ad9-11eb-8198-9cddda2edfad.png)

<details>
<summary>More examples</summary>

Example: No query inside navbar search
![Screenshot 2020-12-10 at 10 55 17](https://user-images.githubusercontent.com/580312/101756833-bdffc380-3ad6-11eb-97b5-f14f9fcb46e0.png)

Example: No query inside reference input with single ref type
![Screenshot 2020-12-10 at 10 55 31](https://user-images.githubusercontent.com/580312/101756846-c1934a80-3ad6-11eb-9b62-ca022f794a56.png)

Example: No query inside reference input with multiple ref types
![Screenshot 2020-12-10 at 10 56 04](https://user-images.githubusercontent.com/580312/101756864-c5bf6800-3ad6-11eb-84fa-0ac0bfa31a2a.png)

Example: Query inside navbar search
![Screenshot 2020-12-10 at 10 57 57](https://user-images.githubusercontent.com/580312/101756889-cce67600-3ad6-11eb-8378-be59555b7c2c.png)

Example: Query inside reference input with single ref type
![Screenshot 2020-12-10 at 10 56 50](https://user-images.githubusercontent.com/580312/101756912-d243c080-3ad6-11eb-94e6-93ee6703eae8.png)

Example: Query inside reference input with multiple ref types
![Screenshot 2020-12-10 at 10 57 21](https://user-images.githubusercontent.com/580312/101756937-d96ace80-3ad6-11eb-8021-b4f07e2682c6.png)

</details>

I'm not sure about using the `result.w2` key, but it seems to consistently be a title or name of a document. 

**Note for release**

Added default alphabetical sort to weighted searches like reference input and navbar search for results with equal weights

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [ ]  The code is linted
- [ ]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
