### PR TITLE
[base] Restore typing stubs

### DIFF
--- a/packages/@sanity/base/types/parts.d.ts
+++ b/packages/@sanity/base/types/parts.d.ts
@@ -1,0 +1,25 @@
+/**
+ * These are used by studios, not internals.
+ * Please do not remove this, as it'll break people's studios.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+declare module 'all:*' {
+  const anyArray: any[]
+
+  export default anyArray
+}
+
+declare module 'config:*' {
+  const pluginConfig: {[key: string]: any}
+
+  export default pluginConfig
+}
+
+declare module 'part:*'
+
+declare module '*.css' {
+  const cssModule: {[key: string]: string}
+
+  export default cssModule
+}


### PR DESCRIPTION
**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Description**
The PR #2150 accidentally removed a file that studios using TypeScript relies on and that our official docs refers to. This patch restores it.

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

**Note for release**
- Fixed an issue causing part imports to produce a compile error in studios using TypeScript
