### PR TITLE
[language-filter] Add missing labels for languages

### DIFF
--- a/packages/@sanity/language-filter/src/SelectLanguage.js
+++ b/packages/@sanity/language-filter/src/SelectLanguage.js
@@ -99,9 +99,8 @@ export default class SelectLanguage extends React.Component {
                       onChange={this.handleLangCheckboxChange}
                       data-lang-id={lang.id}
                       checked={selected.includes(lang.id)}
-                    >
-                      {lang.title}
-                    </Checkbox>
+                      label={lang.title}
+                    />
                   </li>
                 ))}
               </ul>


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

The language filter doesn't show a label for the available options in the dropdown:

![image](https://user-images.githubusercontent.com/48200/101888632-aab82b00-3b9e-11eb-9ba6-ba98dcb42bb5.png)

**Description**

This PR fixes the use of the `Checkbox` component so the labels are rendered:
![image](https://user-images.githubusercontent.com/48200/101888758-ddfaba00-3b9e-11eb-8126-499d82a49c96.png)

Ideally we'd migrate this to `@sanity/ui`, but will leave that for another time.

**Note for release**

- Fixed language labels not appearing in the language-filter plugin

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
