### PR TITLE
[base] Don't call onFocus when toggling fieldsets

### DIFF
--- a/packages/@sanity/base/src/__legacy/@sanity/components/fieldsets/DefaultFieldset.tsx
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/fieldsets/DefaultFieldset.tsx
@@ -74,12 +74,6 @@ export default class Fieldset extends React.PureComponent<FieldsetProps, State> 
       isCollapsed: !prevState.isCollapsed,
       hasBeenToggled: true,
     }))
-
-    // Let parent know field has been toggled
-    const {onFocus} = this.props
-    if (onFocus) {
-      onFocus([FOCUS_TERMINATOR])
-    }
   }
 
   handleFocus = (event: React.FocusEvent<HTMLDivElement>) => {


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

When opening fieldsets, the editor scrolls to the top (of the form, not the fieldset), focusing the first input.

**Description**

This PR attempts to address the issue, but I'm not 100% sure it's the right approach since I don't know the focus subsystem all too well. I had another approach where I instead passed a custom `onFocus` to the fieldset, which checked for a terminator path and instead focused the first field within the fieldset. This _felt_ right, but it was inconsistent with how collapsed objects functioned. In other words: please let me know if there is a better solution to this.

Fixes #2094

**Note for release**

- Fix issue where opening fieldsets would scroll to the top of the form

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
