### PR TITLE
Fix a few TS issues

### DIFF
--- a/examples/design-studio/package.json
+++ b/examples/design-studio/package.json
@@ -30,7 +30,6 @@
     "sanity-plugin-asset-source-unsplash": "^0.1.3"
   },
   "devDependencies": {
-    "typescript": "^4.0.2",
     "typescript-plugin-css-modules": "^2.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "stylelint": "^13.4.1",
     "stylelint-config-prettier": "^8.0.1",
     "stylelint-prettier": "^1.1.2",
-    "typescript": "^4.0.2",
+    "typescript": "^4.1.3",
     "yarn": "^1.3.2"
   },
   "husky": {

--- a/packages/@sanity/base/src/__legacy/@sanity/components/snackbar/SnackbarItem.tsx
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/snackbar/SnackbarItem.tsx
@@ -40,8 +40,8 @@ interface State {
 }
 
 export default class SnackbarItem extends React.Component<SnackbarItemProps> {
-  _dismissTimer?: number
-  _enterTimer?: number
+  _dismissTimer?: ReturnType<typeof setTimeout>
+  _enterTimer?: ReturnType<typeof setTimeout>
   _snackRef: React.RefObject<HTMLDivElement> = React.createRef()
 
   state: State = {

--- a/packages/@sanity/base/src/__legacy/@sanity/components/snackbar/SnackbarProvider.tsx
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/snackbar/SnackbarProvider.tsx
@@ -30,7 +30,7 @@ export default class SnackbarProvider extends React.Component<SnackbarProviderPr
   maxStack = 3
   snackQueue: SnackbarItemType[] = []
 
-  _removeTimer?: number
+  _removeTimer?: ReturnType<typeof setTimeout>
 
   get offsets() {
     const {activeSnacks} = this.state

--- a/packages/@sanity/base/src/__legacy/@sanity/components/tabs/Tab.tsx
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/tabs/Tab.tsx
@@ -20,7 +20,7 @@ interface State {
 // @todo: refactor to functional component
 export default class Tab extends React.PureComponent<TabProps, State> {
   element: HTMLButtonElement | null = null
-  focusTimeout?: number
+  focusTimeout?: ReturnType<typeof setTimeout>
 
   constructor(props: TabProps) {
     super(props)

--- a/packages/@sanity/diff/package.json
+++ b/packages/@sanity/diff/package.json
@@ -31,8 +31,7 @@
     "@types/jest": "^24.0.23",
     "jest": "^26.4.2",
     "rimraf": "^2.7.1",
-    "ts-jest": "^26.3.0",
-    "typescript": "^4.0.2"
+    "ts-jest": "^26.3.0"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/field/package.json
+++ b/packages/@sanity/field/package.json
@@ -35,8 +35,7 @@
   },
   "devDependencies": {
     "react": "17.0.1",
-    "rimraf": "^2.7.1",
-    "typescript": "^4.0.2"
+    "rimraf": "^2.7.1"
   },
   "peerDependencies": {
     "react": "^16.2.0 || ^17"

--- a/packages/@sanity/google-maps-input/package.json
+++ b/packages/@sanity/google-maps-input/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@sanity/base": "2.1.3",
-    "@types/googlemaps": "^3.39.11",
+    "@types/googlemaps": "^3.43.0",
     "lodash": "^4.17.15",
     "rimraf": "^2.7.1"
   },

--- a/packages/@sanity/google-maps-input/src/input/GeopointSelect.tsx
+++ b/packages/@sanity/google-maps-input/src/input/GeopointSelect.tsx
@@ -37,11 +37,11 @@ export class GeopointSelect extends React.PureComponent<SelectProps> {
     this.setValue(place.geometry.location)
   }
 
-  handleMarkerDragEnd = (event: google.maps.MouseEvent) => {
+  handleMarkerDragEnd = (event: google.maps.MapMouseEvent) => {
     this.setValue(event.latLng)
   }
 
-  handleMapClick = (event: google.maps.MouseEvent) => {
+  handleMapClick = (event: google.maps.MapMouseEvent) => {
     this.setValue(event.latLng)
   }
 

--- a/packages/@sanity/google-maps-input/src/map/Arrow.tsx
+++ b/packages/@sanity/google-maps-input/src/map/Arrow.tsx
@@ -10,7 +10,7 @@ interface Props {
   color?: {background: string; border: string; text: string}
   zIndex?: number
   arrowRef?: React.MutableRefObject<google.maps.Polyline | undefined>
-  onClick?: (event: google.maps.MouseEvent) => void
+  onClick?: (event: google.maps.MapMouseEvent) => void
 }
 
 export class Arrow extends React.PureComponent<Props> {

--- a/packages/@sanity/google-maps-input/src/map/Map.tsx
+++ b/packages/@sanity/google-maps-input/src/map/Map.tsx
@@ -11,7 +11,7 @@ interface MapProps {
   mapTypeControl?: boolean
   scrollWheel?: boolean
   controlSize?: number
-  onClick?: (event: google.maps.MouseEvent) => void
+  onClick?: (event: google.maps.MapMouseEvent) => void
   children?: (map: google.maps.Map) => React.ReactElement
 }
 

--- a/packages/@sanity/google-maps-input/src/map/Marker.tsx
+++ b/packages/@sanity/google-maps-input/src/map/Marker.tsx
@@ -8,10 +8,10 @@ const markerPath =
 interface Props {
   api: typeof window.google.maps
   map: google.maps.Map
-  onMove?: (event: google.maps.MouseEvent) => void
-  onClick?: (event: google.maps.MouseEvent) => void
-  onMouseOver?: (event: google.maps.MouseEvent) => void
-  onMouseOut?: (event: google.maps.MouseEvent) => void
+  onMove?: (event: google.maps.MapMouseEvent) => void
+  onClick?: (event: google.maps.MapMouseEvent) => void
+  onMouseOver?: (event: google.maps.MapMouseEvent) => void
+  onMouseOut?: (event: google.maps.MapMouseEvent) => void
   position: LatLng | google.maps.LatLng
   zIndex?: number
   opacity?: number

--- a/packages/@sanity/initial-value-templates/package.json
+++ b/packages/@sanity/initial-value-templates/package.json
@@ -40,8 +40,7 @@
     "jest": "^26.4.2",
     "rimraf": "^2.7.1",
     "rxjs": "^6.5.3",
-    "ts-jest": "^26.3.0",
-    "typescript": "^4.0.2"
+    "ts-jest": "^26.3.0"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/react-hooks/package.json
+++ b/packages/@sanity/react-hooks/package.json
@@ -41,8 +41,7 @@
     "react": "17.0.1",
     "rimraf": "^2.7.1",
     "rxjs": "^6.5.3",
-    "ts-jest": "^26.3.0",
-    "typescript": "^4.0.2"
+    "ts-jest": "^26.3.0"
   },
   "peerDependencies": {
     "react": "^16.9 || ^17"

--- a/packages/@sanity/structure/package.json
+++ b/packages/@sanity/structure/package.json
@@ -38,8 +38,7 @@
     "jest": "^26.4.2",
     "rimraf": "^2.7.1",
     "rxjs": "^6.5.3",
-    "ts-jest": "^26.3.0",
-    "typescript": "^4.0.2"
+    "ts-jest": "^26.3.0"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/transaction-collator/package.json
+++ b/packages/@sanity/transaction-collator/package.json
@@ -37,8 +37,7 @@
     "rimraf": "^2.7.1",
     "rxjs": "^6.5.3",
     "ts-jest": "^26.3.0",
-    "tslint": "^5.18.0",
-    "typescript": "^4.0.2"
+    "tslint": "^5.18.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This adds three commits that can be reviewed individually:

### 8de684a [base] Fix typing issues with setTimeout
There was suddenly build errors on setTimeout return values which I suspect was due to a new minor/patch release of TypeScript. This fixes the issue by using `ReturnType<typeof setTimeout>` as type for timer id where applicable.

### 973f89b [google-maps-input] Upgrade @types/googlemaps
Looks like there has been some changes to the type definitions in @types/googlemaps recently that broke the google-maps-input package

### bfea836a5 [chore] Upgrade typescript and remove as dependency from individual packages

This upgrades typescript in the monorepo to latest (4.1.3) and at the same time removes typescript as dev dependency from some individual packages that still had it around)

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [x]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No
