### PR TITLE
[desk-tool] Scroll to nearest block if on focus path change

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/views/editForm.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/views/editForm.tsx
@@ -53,7 +53,7 @@ export const EditForm = memo((props: Props) => {
   useEffect(() => {
     const el = document.querySelector(`[data-focus-path="${startSegment}"]`)
     if (el) {
-      scrollIntoView(el, {scrollMode: 'if-needed', block: 'start'})
+      scrollIntoView(el, {scrollMode: 'if-needed', block: 'nearest'})
     }
   }, [startSegment])
 


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

Scrolls to _top_ of the element containing the first segment of the focus path.

**Description**

When you have a portable text field at the bottom of object and have not yet focused any element in the form, then click the "activate" handler on it, it scrolls to the top of the form. This is caused by the editor attempting to scroll to the top of the first segment in the focus path (the object). Previously we scrolled to the _center_, which meant we sometime scrolled _past_ the field (such as with a large form and clicking the first field). This PR scrolls to the _nearest_ point, which seems more correct at least.

I'm still not sure I feel this is the right solution, but I can't quite remember why we wanted to scroll in the first place. 

**Note for release**

- Fix bug where form would scroll to top when first focusing a child of a nested field

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
