### PR TITLE
[form-builder] Don't wrap Details content in a button

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/common/Details.css
+++ b/packages/@sanity/form-builder/src/inputs/common/Details.css
@@ -1,22 +1,22 @@
 @import 'part:@sanity/base/theme/variables-style';
 
 .root {
-  padding: 0;
-  background: none;
-  display: block;
-  width: 100%;
-  text-align: left;
   border: 1px solid var(--state-warning-color);
   border-radius: var(--input-border-radius);
+}
+
+.headerButton {
+  background: none;
+  width: 100%;
+  text-align: left;
+  border: 0;
 }
 
 .header {
   display: flex;
   align-items: center;
   cursor: default;
-  userselect: none;
   user-select: none;
-  outline: none;
   padding: calc(var(--small-padding) - 1px);
   line-height: 0;
 

--- a/packages/@sanity/form-builder/src/inputs/common/Details.tsx
+++ b/packages/@sanity/form-builder/src/inputs/common/Details.tsx
@@ -34,15 +34,17 @@ export default class Details extends React.Component<DetailsProps, DetailsState>
     const {isOpen} = this.state
 
     return (
-      <button type="button" className={styles.root} data-open={isOpen} onClick={this.handleToggle}>
-        <div className={styles.header} tabIndex={0}>
-          <span className={styles.iconContainer} aria-hidden="true" role="img">
-            <ChevronDownIcon />
-          </span>
-          <span className={styles.summary}>{title}</span>
-        </div>
+      <div className={styles.root} data-open={isOpen}>
+        <button type="button" className={styles.headerButton} onClick={this.handleToggle}>
+          <div className={styles.header}>
+            <span className={styles.iconContainer}>
+              <ChevronDownIcon />
+            </span>
+            <span className={styles.summary}>{title}</span>
+          </div>
+        </button>
         <div className={styles.content}>{children}</div>
-      </button>
+      </div>
     )
   }
 }


### PR DESCRIPTION
**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**
Currently the root element of the `Details`-component that we use to support expandable/collapsable content in the form builder is a button element. This causes several issues, but the most notable one is that any click inside it will collapse it. For example, the "unknown field" warning no longer accepts clicks on it's content, and instead collapses when clicking on anything inside:
![image](https://user-images.githubusercontent.com/876086/103558299-bd2f3700-4eb4-11eb-8850-681b6bd7baae.png)

(reproducible at the bottom of the page here: https://test-studio-git-current.sanity-io.vercel.app/test/desk/book;f4d76e3b-1d8b-4321-b79a-87f7e6b84446%2Ctemplate%3Dbook)

In cases where it was used to contain buttons and other interactive elements it also produced a console warning complaining about invalid dom nesting, e.g: `Warning: validateDOMNesting(...): <button> cannot appear as a descendant of <button>.`

<!-- Reference/link the relevant issue and/or describe the behavior. -->

**Description**
This PR fixes the issue by wrapping the header element in a button instead of the root element.

**Note for release**
Fixed an issue making collapsable elements collapse when clicking on content inside.
