### PR TITLE
[chore] Provide repository subdirectory in package manifests

### DIFF
--- a/examples/blog-studio/package.json
+++ b/examples/blog-studio/package.json
@@ -35,6 +35,7 @@
   "homepage": "https://www.sanity.io/",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/blog-studio"
   }
 }

--- a/examples/clean-studio/package.json
+++ b/examples/clean-studio/package.json
@@ -35,6 +35,7 @@
   "homepage": "https://www.sanity.io/",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/clean-studio"
   }
 }

--- a/examples/design-studio/package.json
+++ b/examples/design-studio/package.json
@@ -10,7 +10,12 @@
     "start": "sanity start --port 4000"
   },
   "keywords": [
-    "sanity"
+    "sanity",
+    "cms",
+    "headless",
+    "realtime",
+    "content",
+    "design-studio"
   ],
   "dependencies": {
     "@sanity/base": "2.1.3",
@@ -31,5 +36,14 @@
   },
   "devDependencies": {
     "typescript-plugin-css-modules": "^2.4.0"
+  },
+  "bugs": {
+    "url": "https://github.com/sanity-io/sanity/issues"
+  },
+  "homepage": "https://www.sanity.io/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/design-studio"
   }
 }

--- a/examples/ecommerce-studio/package.json
+++ b/examples/ecommerce-studio/package.json
@@ -36,6 +36,7 @@
   "homepage": "https://www.sanity.io/",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/ecommerce-studio"
   }
 }

--- a/examples/example-studio/package.json
+++ b/examples/example-studio/package.json
@@ -50,6 +50,7 @@
   "homepage": "https://www.sanity.io/",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/example-studio"
   }
 }

--- a/examples/movies-studio/package.json
+++ b/examples/movies-studio/package.json
@@ -38,6 +38,7 @@
   "homepage": "https://www.sanity.io/",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/movies-studio"
   }
 }

--- a/examples/storybook/package.json
+++ b/examples/storybook/package.json
@@ -36,6 +36,7 @@
   "homepage": "https://www.sanity.io/",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/storybook"
   }
 }

--- a/examples/test-studio/package.json
+++ b/examples/test-studio/package.json
@@ -64,6 +64,7 @@
   "homepage": "https://www.sanity.io/",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/test-studio"
   }
 }

--- a/packages/@sanity/base/package.json
+++ b/packages/@sanity/base/package.json
@@ -10,7 +10,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/base"
   },
   "keywords": [
     "sanity",

--- a/packages/@sanity/block-tools/package.json
+++ b/packages/@sanity/block-tools/package.json
@@ -40,7 +40,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/block-tools"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -20,7 +20,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/cli"
   },
   "keywords": [
     "sanity",

--- a/packages/@sanity/client/package.json
+++ b/packages/@sanity/client/package.json
@@ -49,7 +49,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/client"
   },
   "keywords": [
     "sanity",

--- a/packages/@sanity/code-input/package.json
+++ b/packages/@sanity/code-input/package.json
@@ -31,6 +31,7 @@
   "homepage": "https://www.sanity.io/",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/code-input"
   }
 }

--- a/packages/@sanity/color-input/package.json
+++ b/packages/@sanity/color-input/package.json
@@ -31,7 +31,8 @@
   "homepage": "https://www.sanity.io/",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/color-input"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@sanity/components/package.json
+++ b/packages/@sanity/components/package.json
@@ -16,7 +16,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/components"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/packages/@sanity/core/package.json
+++ b/packages/@sanity/core/package.json
@@ -73,7 +73,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/core"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/packages/@sanity/dashboard/package.json
+++ b/packages/@sanity/dashboard/package.json
@@ -33,7 +33,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/dashboard"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/packages/@sanity/data-aspects/package.json
+++ b/packages/@sanity/data-aspects/package.json
@@ -26,7 +26,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/data-aspects"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/packages/@sanity/default-layout/package.json
+++ b/packages/@sanity/default-layout/package.json
@@ -10,7 +10,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/default-layout"
   },
   "keywords": [
     "sanity",

--- a/packages/@sanity/default-login/package.json
+++ b/packages/@sanity/default-login/package.json
@@ -27,7 +27,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/default-login"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/packages/@sanity/desk-tool/package.json
+++ b/packages/@sanity/desk-tool/package.json
@@ -85,7 +85,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/desk-tool"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/packages/@sanity/diff/package.json
+++ b/packages/@sanity/diff/package.json
@@ -35,7 +35,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/diff"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/packages/@sanity/eventsource/package.json
+++ b/packages/@sanity/eventsource/package.json
@@ -7,7 +7,8 @@
   "scripts": {},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/eventsource"
   },
   "keywords": [
     "sanity",

--- a/packages/@sanity/export/package.json
+++ b/packages/@sanity/export/package.json
@@ -46,7 +46,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/export"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/packages/@sanity/field/package.json
+++ b/packages/@sanity/field/package.json
@@ -18,6 +18,7 @@
     "headless",
     "realtime",
     "content",
+    "field",
     "diff"
   ],
   "publishConfig": {
@@ -42,7 +43,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/field"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/packages/@sanity/form-builder/package.json
+++ b/packages/@sanity/form-builder/package.json
@@ -80,7 +80,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/form-builder"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/packages/@sanity/generate-help-url/package.json
+++ b/packages/@sanity/generate-help-url/package.json
@@ -9,7 +9,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/generate-help-url"
   },
   "keywords": [
     "sanity",

--- a/packages/@sanity/google-maps-input/package.json
+++ b/packages/@sanity/google-maps-input/package.json
@@ -37,7 +37,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/google-maps-input"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/packages/@sanity/imagetool/package.json
+++ b/packages/@sanity/imagetool/package.json
@@ -42,7 +42,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/imagetool"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/packages/@sanity/import-cli/package.json
+++ b/packages/@sanity/import-cli/package.json
@@ -37,7 +37,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/import-cli"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/packages/@sanity/import/package.json
+++ b/packages/@sanity/import/package.json
@@ -56,7 +56,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/import"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/packages/@sanity/initial-value-templates/package.json
+++ b/packages/@sanity/initial-value-templates/package.json
@@ -44,7 +44,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/initial-value-templates"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/packages/@sanity/language-filter/package.json
+++ b/packages/@sanity/language-filter/package.json
@@ -29,7 +29,8 @@
   "homepage": "https://www.sanity.io/",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/language-filter"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@sanity/mutator/package.json
+++ b/packages/@sanity/mutator/package.json
@@ -34,7 +34,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/mutator"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/packages/@sanity/plugin-loader/package.json
+++ b/packages/@sanity/plugin-loader/package.json
@@ -12,7 +12,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/plugin-loader"
   },
   "keywords": [
     "sanity",

--- a/packages/@sanity/preview/package.json
+++ b/packages/@sanity/preview/package.json
@@ -47,6 +47,7 @@
   "homepage": "https://www.sanity.io/",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/preview"
   }
 }

--- a/packages/@sanity/production-preview/package.json
+++ b/packages/@sanity/production-preview/package.json
@@ -27,7 +27,8 @@
   "homepage": "https://www.sanity.io/",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/production-preview"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@sanity/react-hooks/package.json
+++ b/packages/@sanity/react-hooks/package.json
@@ -48,7 +48,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/react-hooks"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/packages/@sanity/resolver/package.json
+++ b/packages/@sanity/resolver/package.json
@@ -15,7 +15,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/resolver"
   },
   "keywords": [
     "sanity",

--- a/packages/@sanity/schema/package.json
+++ b/packages/@sanity/schema/package.json
@@ -44,6 +44,7 @@
   "homepage": "https://www.sanity.io/",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/schema"
   }
 }

--- a/packages/@sanity/server/package.json
+++ b/packages/@sanity/server/package.json
@@ -18,7 +18,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/server"
   },
   "keywords": [
     "sanity",

--- a/packages/@sanity/state-router/package.json
+++ b/packages/@sanity/state-router/package.json
@@ -50,7 +50,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/state-router"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/packages/@sanity/storybook/package.json
+++ b/packages/@sanity/storybook/package.json
@@ -8,7 +8,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/storybook"
   },
   "keywords": [
     "sanity",

--- a/packages/@sanity/structure/package.json
+++ b/packages/@sanity/structure/package.json
@@ -42,7 +42,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/structure"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/packages/@sanity/studio-hints/package.json
+++ b/packages/@sanity/studio-hints/package.json
@@ -30,7 +30,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/studio-hints"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/packages/@sanity/transaction-collator/package.json
+++ b/packages/@sanity/transaction-collator/package.json
@@ -41,7 +41,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/transaction-collator"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/packages/@sanity/types/package.json
+++ b/packages/@sanity/types/package.json
@@ -16,6 +16,7 @@
     "headless",
     "realtime",
     "content",
+    "types",
     "typescript"
   ],
   "dependencies": {
@@ -26,7 +27,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/types"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/packages/@sanity/util/package.json
+++ b/packages/@sanity/util/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/util"
   },
   "keywords": [
     "sanity",

--- a/packages/@sanity/validation/package.json
+++ b/packages/@sanity/validation/package.json
@@ -27,7 +27,8 @@
   "homepage": "https://www.sanity.io/",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/validation"
   },
   "devDependencies": {
     "jest": "^26.4.2"

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -42,7 +42,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/vision"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/packages/@sanity/webpack-integration/package.json
+++ b/packages/@sanity/webpack-integration/package.json
@@ -9,7 +9,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/webpack-integration"
   },
   "keywords": [
     "sanity",

--- a/packages/@sanity/webpack-loader/package.json
+++ b/packages/@sanity/webpack-loader/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/webpack-loader"
   },
   "keywords": [
     "sanity",

--- a/packages/create-sanity/package.json
+++ b/packages/create-sanity/package.json
@@ -25,6 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/create-sanity"
   }
 }

--- a/packages/groq/package.json
+++ b/packages/groq/package.json
@@ -16,19 +16,20 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/groq"
   },
   "keywords": [
-    "groq",
-    "tagged",
-    "template",
-    "literal",
-    "string",
     "sanity",
     "cms",
     "headless",
     "realtime",
-    "content"
+    "content",
+    "groq",
+    "tagged",
+    "template",
+    "literal",
+    "string"
   ],
   "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -24,6 +24,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity-io/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/sanity"
   }
 }

--- a/scripts/normalizePackageFields.js
+++ b/scripts/normalizePackageFields.js
@@ -12,7 +12,8 @@ transformPkgs((pkgManifest) => {
     engines.node = supportedNodeVersionRange
   }
 
-  return Object.assign({}, pkgManifest, {
+  return {
+    ...pkgManifest,
     engines,
     author: 'Sanity.io <hello@sanity.io>',
     bugs: {
@@ -24,6 +25,7 @@ transformPkgs((pkgManifest) => {
     repository: {
       type: 'git',
       url: 'git+https://github.com/sanity-io/sanity.git',
+      directory: `packages/${pkgManifest.name}`,
     },
-  })
+  }
 })


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [x]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

The npm package manifests link to the repository, but doesn't specify a subdirectory. This is a bit annoying when working with modules inside the monorepo - especially when listed on the npm website.

**Description**

This updates the package manifest normalization script, and adds the directory field to existing manifests.

**Note for release**

- Specify git monorepo subdirectory in package.json `repository` field

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
