### PR TITLE
[chore] Make @sanity/ui and styled components peerDependencies instead of direct dependencies

### DIFF
--- a/examples/blog-studio/package.json
+++ b/examples/blog-studio/package.json
@@ -26,8 +26,10 @@
     "@sanity/desk-tool": "2.1.4",
     "@sanity/google-maps-input": "2.1.4",
     "@sanity/vision": "2.1.4",
+    "@sanity/ui": "^0.28",
     "react": "17.0.1",
-    "react-dom": "17.0.1"
+    "react-dom": "17.0.1",
+    "styled-components": "^5.2"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/examples/clean-studio/package.json
+++ b/examples/clean-studio/package.json
@@ -26,8 +26,10 @@
     "@sanity/desk-tool": "2.1.4",
     "@sanity/google-maps-input": "2.1.4",
     "@sanity/vision": "2.1.4",
+    "@sanity/ui": "^0.28",
     "react": "17.0.1",
-    "react-dom": "17.0.1"
+    "react-dom": "17.0.1",
+    "styled-components": "^5.2"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/examples/design-studio/package.json
+++ b/examples/design-studio/package.json
@@ -28,11 +28,13 @@
     "@sanity/react-hooks": "2.1.4",
     "@sanity/types": "2.1.4",
     "@sanity/vision": "2.1.4",
+    "@sanity/ui": "^0.28",
     "prop-types": "^15.6.0",
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "react-jason": "^1.1.2",
-    "sanity-plugin-asset-source-unsplash": "^0.1.3"
+    "sanity-plugin-asset-source-unsplash": "^0.1.3",
+    "styled-components": "^5.2"
   },
   "devDependencies": {
     "typescript-plugin-css-modules": "^2.4.0"

--- a/examples/ecommerce-studio/package.json
+++ b/examples/ecommerce-studio/package.json
@@ -26,9 +26,11 @@
     "@sanity/default-login": "2.1.4",
     "@sanity/desk-tool": "2.1.4",
     "@sanity/vision": "2.1.4",
+    "@sanity/ui": "^0.28",
     "react": "17.0.1",
     "react-barcode": "^1.3.2",
-    "react-dom": "17.0.1"
+    "react-dom": "17.0.1",
+    "styled-components": "^5.2"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/examples/example-studio/package.json
+++ b/examples/example-studio/package.json
@@ -30,6 +30,7 @@
     "@sanity/language-filter": "2.1.4",
     "@sanity/storybook": "2.1.4",
     "@sanity/vision": "2.1.4",
+    "@sanity/ui": "^0.28",
     "bio-pv": "^1.8.1",
     "date-fns": "^2.16.1",
     "fetch": "^1.1.0",
@@ -39,7 +40,8 @@
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "react-icons": "^3.11.0",
-    "react-tooltip": "^3.5.0"
+    "react-tooltip": "^3.5.0",
+    "styled-components": "^5.2"
   },
   "devDependencies": {
     "rimraf": "^2.7.1"

--- a/examples/movies-studio/package.json
+++ b/examples/movies-studio/package.json
@@ -28,9 +28,11 @@
     "@sanity/google-maps-input": "2.1.4",
     "@sanity/production-preview": "2.1.4",
     "@sanity/vision": "2.1.4",
+    "@sanity/ui": "0.28",
     "react": "17.0.1",
     "react-dom": "17.0.1",
-    "react-icons": "^3.11.0"
+    "react-icons": "^3.11.0",
+    "styled-components": "^5.2"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/examples/test-studio/package.json
+++ b/examples/test-studio/package.json
@@ -35,6 +35,7 @@
     "@sanity/react-hooks": "2.1.4",
     "@sanity/studio-hints": "2.1.4",
     "@sanity/types": "2.1.4",
+    "@sanity/ui": "^0.28",
     "@sanity/util": "2.1.4",
     "@sanity/vision": "2.1.4",
     "@turf/helpers": "^6.0.1",
@@ -53,7 +54,8 @@
     "sanity-plugin-dashboard-widget-cats": "^0.0.2",
     "sanity-plugin-dashboard-widget-document-count": "^0.0.1",
     "sanity-plugin-dashboard-widget-document-list": "^0.0.11",
-    "sanity-plugin-mux-input": "^0.1.11"
+    "sanity-plugin-mux-input": "^0.1.11",
+    "styled-components": "^5.2"
   },
   "devDependencies": {
     "rimraf": "^2.7.1"

--- a/packages/@sanity/base/package.json
+++ b/packages/@sanity/base/package.json
@@ -44,7 +44,6 @@
     "@sanity/structure": "2.1.4",
     "@sanity/transaction-collator": "2.1.4",
     "@sanity/types": "2.1.4",
-    "@sanity/ui": "^0.28.0",
     "@sanity/util": "2.1.4",
     "@sanity/validation": "2.1.4",
     "boundless-arrow-key-navigation": "^1.1.0",
@@ -75,10 +74,10 @@
     "react-split-pane": "^0.1.84",
     "rxjs": "^6.5.3",
     "semver-compare": "^1.0.0",
-    "shallow-equals": "^1.0.0",
-    "styled-components": "^5.2.1"
+    "shallow-equals": "^1.0.0"
   },
   "devDependencies": {
+    "@sanity/ui": "^0.28.0",
     "@types/chance": "^1.1.0",
     "@types/element-resize-detector": "1.1.2",
     "@types/refractor": "^3.0.0",
@@ -88,11 +87,14 @@
     "prop-types": "^15.6.0",
     "react": "17.0.1",
     "react-dom": "17.0.1",
-    "rimraf": "^2.7.1"
+    "rimraf": "^2.7.1",
+    "styled-components": "^5.2.1"
   },
   "peerDependencies": {
     "prop-types": "^15.6 || ^16",
     "react": "^16.9 || ^17",
-    "react-dom": "^16.9 || ^17"
+    "react-dom": "^16.9 || ^17",
+    "@sanity/ui": ">=0.28 <= 0.32",
+    "styled-components": "^5.2"
   }
 }

--- a/packages/@sanity/cli/src/versionRanges.js
+++ b/packages/@sanity/cli/src/versionRanges.js
@@ -8,9 +8,11 @@ export default {
     '@sanity/default-login': 'latest',
     '@sanity/desk-tool': 'latest',
     '@sanity/vision': 'latest',
+    '@sanity/ui': '^0.32',
     react: '^17.0',
     'react-dom': '^17.0',
     'prop-types': '^15.7',
+    'styled-components': '^5.2',
   },
 
   // Only used for Sanity-style plugins (eg, the ones we build at Sanity.io)

--- a/packages/@sanity/form-builder/package.json
+++ b/packages/@sanity/form-builder/package.json
@@ -26,7 +26,6 @@
     "@sanity/mutator": "2.1.4",
     "@sanity/portable-text-editor": "0.1.25",
     "@sanity/types": "2.1.4",
-    "@sanity/ui": "^0.28.0",
     "@sanity/util": "2.1.4",
     "@sanity/uuid": "^3.0.1",
     "attr-accept": "^1.1.0",
@@ -55,6 +54,7 @@
     "speakingurl": "^13.0.0"
   },
   "devDependencies": {
+    "@sanity/ui": "^0.28.0",
     "@types/diff-match-patch": "^1.0.32",
     "@types/moment": "^2.13.0",
     "@types/react": "^17",
@@ -73,7 +73,8 @@
   "peerDependencies": {
     "prop-types": "^15.6 || ^16",
     "react": "^16.9 || ^17",
-    "react-dom": "^16.9 || ^17"
+    "react-dom": "^16.9 || ^17",
+    "@sanity/ui": ">=0.28 <= 0.32"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
This should help address issues with multiple versions of both @sanity/ui  and styled-components (e.g. #2190).

**Type of change (check at least one)**

- [x]  Maintenance

**Does this change require a documentation update? (Check one)**

- [x]  No

**Current behavior**

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

**Note for release**
- In this release we made `@sanity/ui` and `styled-components` peer dependencies instead of direct dependencies of Studio packages. After this update, Studio projects need to depend on @sanity/ui explicitly.