### PR TITLE
[chore] Fix issues with multiple versions of Sanity UI

### DIFF
--- a/packages/@sanity/base/package.json
+++ b/packages/@sanity/base/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "clean": "rimraf lib",
     "coverage": "nyc --report=lcov --report=text _mocha -- test/**/*.test.js",
+    "prepublishOnly": "node scripts/writeRequiredUIVersion.js",
     "test": "jest"
   },
   "repository": {

--- a/packages/@sanity/base/scripts/writeRequiredUIVersion.js
+++ b/packages/@sanity/base/scripts/writeRequiredUIVersion.js
@@ -1,0 +1,18 @@
+// This overwrites the compiled ./lib/requiredSanityUiVersion.js with a the actual version we currently depend on in @sanity/base
+const pkg = require('../package.json')
+const fs = require('fs')
+
+const template = (version) => `exports.REQUIRED_UI_VERSION = '${version}'`
+
+let builtFile
+try {
+  builtFile = require.resolve('../lib/requiredSanityUiVersion.js')
+} catch (error) {
+  // eslint-disable-next-line no-console
+  console.error(
+    'Error: Unable to resolve "requiredSanityUiVersion.js" in ./lib. Please make sure the project has been successfully built.'
+  )
+  process.exit(1)
+}
+
+fs.writeFileSync(builtFile, template(pkg.dependencies['@sanity/ui'] || 'latest'))

--- a/packages/@sanity/base/src/components/SanityRoot.tsx
+++ b/packages/@sanity/base/src/components/SanityRoot.tsx
@@ -8,7 +8,7 @@ import React, {useState} from 'react'
 import Refractor from 'react-refractor'
 import jsx from 'refractor/lang/jsx'
 import styled from 'styled-components'
-import pkg from '../../package.json'
+import {REQUIRED_UI_VERSION} from '../requiredSanityUiVersion'
 import {theme} from '../theme'
 import {userColorManager, UserColorManagerProvider} from '../user-color'
 import ErrorHandler from './ErrorHandler'
@@ -44,7 +44,7 @@ function AppProvider() {
         </p>
 
         <pre style={{padding: 20, background: '#000', color: '#fff'}}>
-          <code>npm install @sanity/ui@{pkg.dependencies['@sanity/ui']}</code>
+          <code>npm install @sanity/ui@"{REQUIRED_UI_VERSION}"</code>
         </pre>
       </div>
     )

--- a/packages/@sanity/base/src/components/SanityRoot.tsx
+++ b/packages/@sanity/base/src/components/SanityRoot.tsx
@@ -1,4 +1,4 @@
-import {Card, ThemeColorProvider, ThemeProvider} from '@sanity/ui'
+import {Card, ThemeColorProvider, ThemeProvider, useRootTheme} from '@sanity/ui'
 import config from 'config:sanity'
 import RootComponent from 'part:@sanity/base/root'
 import {LayerProvider} from 'part:@sanity/components/layer'
@@ -8,6 +8,7 @@ import React, {useState} from 'react'
 import Refractor from 'react-refractor'
 import jsx from 'refractor/lang/jsx'
 import styled from 'styled-components'
+import pkg from '../../package.json'
 import {theme} from '../theme'
 import {userColorManager, UserColorManagerProvider} from '../user-color'
 import ErrorHandler from './ErrorHandler'
@@ -22,10 +23,57 @@ const Root = styled(Card).attrs({tone: 'transparent'})`
   height: 100%;
 `
 
+function AppProvider() {
+  const [portalElement, setPortalElement] = useState(() => document.createElement('div'))
+
+  try {
+    useRootTheme()
+  } catch (_) {
+    return (
+      <div style={{padding: 20, margin: '0 auto', maxWidth: '40rem'}}>
+        <h1>Error: Missing theme context</h1>
+
+        <p>
+          This problem is usually caused by multiple versions of <code>@sanity/ui</code> in the same
+          application.
+        </p>
+
+        <p>
+          Make sure to install the same version of <code>@sanity/ui</code> as{' '}
+          <code>@sanity/base</code>:
+        </p>
+
+        <pre style={{padding: 20, background: '#000', color: '#fff'}}>
+          <code>npm install @sanity/ui@{pkg.dependencies['@sanity/ui']}</code>
+        </pre>
+      </div>
+    )
+  }
+
+  return (
+    <UserColorManagerProvider manager={userColorManager}>
+      <PortalProvider element={portalElement}>
+        <LayerProvider>
+          <SnackbarProvider>
+            <ThemeColorProvider tone="transparent">
+              <GlobalStyle />
+            </ThemeColorProvider>
+            <Root scheme="light">
+              <DevServerStatus />
+              <ErrorHandler />
+              <RootComponent />
+              <VersionChecker />
+            </Root>
+            <div data-portal="" ref={setPortalElement} />
+          </SnackbarProvider>
+        </LayerProvider>
+      </PortalProvider>
+    </UserColorManagerProvider>
+  )
+}
+
 function SanityRoot() {
   const {projectId, dataset} = config.api || {}
-  const [portalElement, setPortalElement] = useState(() => document.createElement('div'))
-  const colorScheme = 'light'
 
   if (!projectId || !dataset) {
     return <MissingProjectConfig />
@@ -33,24 +81,7 @@ function SanityRoot() {
 
   return (
     <ThemeProvider theme={theme}>
-      <UserColorManagerProvider manager={userColorManager}>
-        <PortalProvider element={portalElement}>
-          <LayerProvider>
-            <SnackbarProvider>
-              <ThemeColorProvider tone="transparent">
-                <GlobalStyle />
-              </ThemeColorProvider>
-              <Root scheme={colorScheme}>
-                <DevServerStatus />
-                <ErrorHandler />
-                <RootComponent />
-                <VersionChecker />
-              </Root>
-              <div data-portal="" ref={setPortalElement} />
-            </SnackbarProvider>
-          </LayerProvider>
-        </PortalProvider>
-      </UserColorManagerProvider>
+      <AppProvider />
     </ThemeProvider>
   )
 }

--- a/packages/@sanity/base/src/requiredSanityUiVersion.ts
+++ b/packages/@sanity/base/src/requiredSanityUiVersion.ts
@@ -1,0 +1,3 @@
+// Note: This file is overwritten on prepublish - see `scripts/writeRequiredUIVersion.js`
+// The version here is only read in development
+export const REQUIRED_UI_VERSION = '^0.0.0'


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)

**Does this change require a documentation update? (Check one)**

- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->

Since `@sanity/base` depends on `@sanity/ui`, users who install `@sanity/ui` themselves may end up with multiple versions of `@sanity/ui` in their project. This causes the application to throw the error:

```
Error: useRootTheme(): missing context value
```

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

- This change includes calling `useRootTheme` in the application root, and catching it if it fails.
- When `useRootTheme` fails, we instead render a helpful message.

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

- Renders an improved error message when experiencing issues with multiple versions of `@sanity/ui`.
