### PR TITLE
[schema] Ensure "fields" property is not used on non-object types

### DIFF
--- a/packages/@sanity/schema/src/sanity/validation/types/common.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/common.ts
@@ -1,9 +1,12 @@
-import {warning} from '../createValidationResult'
+import {validateNonObjectFieldsProp} from '../utils/validateNonObjectFieldsProp'
 import {validateTypeName} from '../utils/validateTypeName'
 
 export default (typeDef, visitorContext) => {
   return {
     ...typeDef,
-    _problems: validateTypeName(typeDef.type, visitorContext).filter(Boolean),
+    _problems: [
+      ...validateTypeName(typeDef.type, visitorContext),
+      ...validateNonObjectFieldsProp(typeDef, visitorContext),
+    ].filter(Boolean),
   }
 }

--- a/packages/@sanity/schema/src/sanity/validation/utils/validateNonObjectFieldsProp.ts
+++ b/packages/@sanity/schema/src/sanity/validation/utils/validateNonObjectFieldsProp.ts
@@ -1,0 +1,18 @@
+import {error} from '../createValidationResult'
+
+export function validateNonObjectFieldsProp(typeDef, visitorContext) {
+  if (!typeDef.fields) {
+    return []
+  }
+
+  let type = typeDef
+  while (!type.jsonType && type) {
+    type = visitorContext.getType(type.type)
+  }
+
+  if (type && type.jsonType !== 'object') {
+    return [error(`Type has propery "fields", but is not an object/document type.`)]
+  }
+
+  return []
+}

--- a/packages/@sanity/validation/src/inferFromSchemaType.js
+++ b/packages/@sanity/validation/src/inferFromSchemaType.js
@@ -73,7 +73,7 @@ function inferFromSchemaType(typeDef, schema, visited = new Set()) {
 }
 
 function inferForFields(typeDef, schema, visited) {
-  if (!typeDef.fields) {
+  if (typeDef.jsonType !== 'object' || !typeDef.fields) {
     return
   }
 
@@ -98,7 +98,7 @@ function inferForMemberTypes(typeDef, schema, visited) {
 }
 
 function extractValueFromListOption(option) {
-  return option.value !== undefined ? option.value : option
+  return option.value === undefined ? option : option.value
 }
 
 function inferValidation(field, baseRule) {


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

If you make a schema type that is not of type `object` (or a type that inherits from it, eg `image`, `document`), providing a  `fields` property will silently be ignored, until you add a `validation` property - at which point the validation code will crash.

**Description**

This PR fixes these two issues separately:

- Skips the `fields` validation iteration if operating on a non-object type
- Validates that `fields` is only used on object types


Reported [in the community](https://sanity-io-land.slack.com/archives/C9Z7RC3V1/p1610841717279900)

**Note for release**

- Added check to ensure that `fields` is only used on object types

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
