### PR TITLE
[base] New form field components

### DIFF
--- a/packages/@sanity/base/src/components/formField/FormField.tsx
+++ b/packages/@sanity/base/src/components/formField/FormField.tsx
@@ -1,0 +1,71 @@
+/* eslint-disable camelcase */
+
+import {Marker} from '@sanity/types'
+import {Stack} from '@sanity/ui'
+import React from 'react'
+import {ChangeIndicator, ChangeIndicatorContextProvidedProps} from '../../change-indicators'
+import {FormFieldPresence} from '../../presence'
+import {FormFieldHeader} from './FormFieldHeader'
+
+export interface FormFieldProps {
+  /**
+   * @beta
+   */
+  __unstable_changeIndicator?: ChangeIndicatorContextProvidedProps | boolean
+  /**
+   * @beta
+   */
+  __unstable_markers?: Marker[]
+  /**
+   * @beta
+   */
+  __unstable_presence?: FormFieldPresence[]
+  children: React.ReactNode
+  description?: React.ReactNode
+  /**
+   * The unique ID used to target the actual input element
+   */
+  inputId?: string
+  /**
+   * The nesting level of the form field
+   */
+  level?: number
+  title?: React.ReactNode
+}
+
+export function FormField(
+  props: FormFieldProps & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'height' | 'ref'>
+) {
+  const {
+    __unstable_changeIndicator: changeIndicator = true,
+    __unstable_markers: markers,
+    __unstable_presence: presence,
+    children,
+    description,
+    inputId,
+    level,
+    title,
+    ...restProps
+  } = props
+
+  let content = children
+
+  if (changeIndicator) {
+    const changeIndicatorProps = typeof changeIndicator === 'object' ? changeIndicator : {}
+
+    content = <ChangeIndicator {...changeIndicatorProps}>{children}</ChangeIndicator>
+  }
+
+  return (
+    <Stack {...restProps} data-level={level} space={1}>
+      <FormFieldHeader
+        __unstable_markers={markers}
+        __unstable_presence={presence}
+        description={description}
+        inputId={inputId}
+        title={title}
+      />
+      <div>{content}</div>
+    </Stack>
+  )
+}

--- a/packages/@sanity/base/src/components/formField/FormFieldHeader.tsx
+++ b/packages/@sanity/base/src/components/formField/FormFieldHeader.tsx
@@ -1,0 +1,53 @@
+/* eslint-disable camelcase */
+
+import React from 'react'
+import {Box, Flex} from '@sanity/ui'
+import {Marker} from '@sanity/types'
+import {FieldPresence, FormFieldPresence} from '../../presence'
+import {FormFieldHeaderText} from './FormFieldHeaderText'
+
+export interface FormFieldHeaderProps {
+  /**
+   * @beta
+   */
+  __unstable_markers?: Marker[]
+  /**
+   * @beta
+   */
+  __unstable_presence?: FormFieldPresence[]
+  description?: React.ReactNode
+  /**
+   * The unique ID used to target the actual input element
+   */
+  inputId?: string
+  title?: React.ReactNode
+}
+
+export function FormFieldHeader(props: FormFieldHeaderProps) {
+  const {
+    __unstable_markers: markers,
+    __unstable_presence: presence,
+    description,
+    inputId,
+    title,
+  } = props
+
+  return (
+    <Flex align="flex-end">
+      <Box flex={1} paddingY={2}>
+        <FormFieldHeaderText
+          __unstable_markers={markers}
+          description={description}
+          inputId={inputId}
+          title={title}
+        />
+      </Box>
+
+      {presence && presence.length > 0 && (
+        <Box>
+          <FieldPresence maxAvatars={4} presence={presence} />
+        </Box>
+      )}
+    </Flex>
+  )
+}

--- a/packages/@sanity/base/src/components/formField/FormFieldHeaderText.tsx
+++ b/packages/@sanity/base/src/components/formField/FormFieldHeaderText.tsx
@@ -1,0 +1,47 @@
+/* eslint-disable camelcase */
+
+import {isValidationMarker, Marker} from '@sanity/types'
+import {Box, Flex, Stack, Text} from '@sanity/ui'
+import React from 'react'
+import {FormFieldValidationStatus} from './FormFieldValidationStatus'
+
+export interface FormFieldHeaderTextProps {
+  /**
+   * @beta
+   */
+  __unstable_markers?: Marker[]
+  description?: React.ReactNode
+  /**
+   * The unique ID used to target the actual input element
+   */
+  inputId?: string
+  title?: React.ReactNode
+}
+
+export function FormFieldHeaderText(props: FormFieldHeaderTextProps) {
+  const {description, inputId, title, __unstable_markers: markers = []} = props
+  const validationMarkers = markers.filter(isValidationMarker)
+  const hasValidations = validationMarkers.length > 0
+
+  return (
+    <Stack space={2}>
+      <Flex>
+        <Text as="label" htmlFor={inputId} weight="semibold" size={1}>
+          {title || <em>Untitled</em>}
+        </Text>
+
+        {hasValidations && (
+          <Box marginLeft={2}>
+            <FormFieldValidationStatus fontSize={1} __unstable_markers={markers} />
+          </Box>
+        )}
+      </Flex>
+
+      {description && (
+        <Text muted size={1}>
+          {description}
+        </Text>
+      )}
+    </Stack>
+  )
+}

--- a/packages/@sanity/base/src/components/formField/FormFieldSet.tsx
+++ b/packages/@sanity/base/src/components/formField/FormFieldSet.tsx
@@ -1,0 +1,191 @@
+/* eslint-disable camelcase */
+
+import {Path, Marker} from '@sanity/types'
+import {Box, Flex, Grid, rem, Stack, Text, Theme, useForwardedRef} from '@sanity/ui'
+import {FOCUS_TERMINATOR} from '@sanity/util/paths'
+import React, {forwardRef, useState, useCallback, useEffect} from 'react'
+import styled, {css} from 'styled-components'
+import {ChangeIndicator, ChangeIndicatorContextProvidedProps} from '../../change-indicators'
+import {FieldPresence, FormFieldPresence} from '../../presence'
+import {FormFieldValidationStatus} from './FormFieldValidationStatus'
+import {FormFieldSetLegend} from './FormFieldSetLegend'
+import {markersToValidationList} from './helpers'
+import {focusRingStyle} from './styles'
+
+export interface FormFieldSetProps {
+  /**
+   * @beta
+   */
+  __unstable_changeIndicator?: ChangeIndicatorContextProvidedProps | boolean
+  /**
+   * @beta
+   */
+  __unstable_markers?: Marker[]
+  /**
+   * @beta
+   */
+  __unstable_presence?: FormFieldPresence[]
+  children: React.ReactNode
+  collapsed?: boolean
+  collapsible?: boolean
+  columns?: number
+  description?: React.ReactNode
+  /**
+   * The nesting level of the form field set
+   */
+  level?: number
+  onFocus?: (path: Path) => void
+  onToggle?: (collapsed: boolean) => void
+  title?: React.ReactNode
+}
+
+const FOCUS_PATH = [FOCUS_TERMINATOR]
+
+const Root = styled(Box).attrs({forwardedAs: 'fieldset'})`
+  border: none;
+
+  /* See: https://thatemil.com/blog/2015/01/03/reset-your-fieldset/ */
+  body:not(:-moz-handler-blocked) & {
+    display: table-cell;
+  }
+`
+
+const Content = styled(Box)<{
+  /**
+   * @note: The dollar sign ($) prefix is a `styled-components` convention for
+   * denoting transient props. See:
+   * https://styled-components.com/docs/api#transient-props
+   */
+  $borderLeft: boolean
+  theme: Theme
+}>((props) => {
+  const {$borderLeft, theme} = props
+  const {focusRing, radius} = theme.sanity
+  const {base} = theme.sanity.color
+
+  return css`
+    outline: none;
+    border-left: ${$borderLeft ? '1px solid var(--card-border-color)' : undefined};
+    border-radius: ${rem(radius[1])};
+
+    &:focus {
+      box-shadow: ${focusRingStyle({base, focusRing})};
+    }
+
+    &:focus:not(:focus-visible) {
+      box-shadow: none;
+    }
+  `
+})
+
+export const FormFieldSet = forwardRef(
+  (
+    props: FormFieldSetProps &
+      Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'height' | 'onFocus' | 'ref'>,
+    ref
+  ) => {
+    const {
+      __unstable_changeIndicator: changeIndicator = false,
+      __unstable_markers: markers = [],
+      __unstable_presence: presence = [],
+      children,
+      collapsed: collapsedProp = false,
+      collapsible,
+      columns,
+      description,
+      level = 0,
+      onFocus,
+      onToggle,
+      tabIndex,
+      title,
+      ...restProps
+    } = props
+    const [collapsed, setCollapsed] = useState(collapsedProp)
+    const validation = markersToValidationList(markers)
+    const hasValidations = validation.length > 0
+    const forwardedRef = useForwardedRef(ref)
+
+    const handleFocus = useCallback(
+      (event: React.FocusEvent<HTMLDivElement>) => {
+        const element = forwardedRef.current
+
+        if (element === event.target) {
+          if (onFocus) onFocus(FOCUS_PATH)
+        }
+      },
+      [forwardedRef, onFocus]
+    )
+
+    const handleToggleCollapse = useCallback(() => {
+      setCollapsed(!collapsed)
+      if (onToggle) onToggle(!collapsed)
+    }, [collapsed, onToggle])
+
+    let content = (
+      <Grid columns={columns} gapX={4} gapY={5}>
+        {children}
+      </Grid>
+    )
+
+    if (changeIndicator) {
+      const changeIndicatorProps = typeof changeIndicator === 'object' ? changeIndicator : {}
+
+      content = <ChangeIndicator {...changeIndicatorProps}>{children}</ChangeIndicator>
+    }
+
+    useEffect(() => {
+      setCollapsed(collapsedProp)
+    }, [collapsedProp])
+
+    return (
+      <Root data-level={level} {...restProps}>
+        <Flex align="flex-end">
+          <Box flex={1} paddingY={2}>
+            <Stack space={2}>
+              <Flex>
+                <FormFieldSetLegend
+                  collapsed={collapsed}
+                  collapsible={collapsible}
+                  onClick={collapsible ? handleToggleCollapse : undefined}
+                  title={title}
+                />
+
+                {hasValidations && (
+                  <Box marginLeft={2}>
+                    <FormFieldValidationStatus fontSize={1} __unstable_markers={markers} />
+                  </Box>
+                )}
+              </Flex>
+
+              {description && (
+                <Text muted size={1}>
+                  {description}
+                </Text>
+              )}
+            </Stack>
+          </Box>
+
+          {presence.length > 0 && (
+            <Box>
+              <FieldPresence maxAvatars={4} presence={presence} />
+            </Box>
+          )}
+        </Flex>
+
+        <Content
+          $borderLeft={level > 0}
+          hidden={collapsed}
+          marginTop={1}
+          paddingLeft={level === 0 ? 0 : 3}
+          onFocus={handleFocus}
+          ref={forwardedRef}
+          tabIndex={tabIndex}
+        >
+          {!collapsed && content}
+        </Content>
+      </Root>
+    )
+  }
+)
+
+FormFieldSet.displayName = 'FormFieldSet'

--- a/packages/@sanity/base/src/components/formField/FormFieldSetLegend.tsx
+++ b/packages/@sanity/base/src/components/formField/FormFieldSetLegend.tsx
@@ -1,0 +1,89 @@
+import {Box, Flex, rem, Text, Theme} from '@sanity/ui'
+import React from 'react'
+import {ToggleArrowRightIcon} from '@sanity/icons'
+import styled, {css} from 'styled-components'
+import {focusRingStyle} from './styles'
+
+export interface FormFieldSetLegendProps {
+  collapsed: boolean
+  collapsible?: boolean
+  onClick?: () => void
+  title: React.ReactNode
+}
+
+const Root = styled.legend`
+  /* See: https://thatemil.com/blog/2015/01/03/reset-your-fieldset/ */
+  padding: 0;
+  display: table;
+`
+
+const ToggleButton = styled(Flex).attrs({forwardedAs: 'button'})((props: {theme: Theme}) => {
+  const {theme} = props
+  const {focusRing, radius} = theme.sanity
+  const {base} = theme.sanity.color
+
+  return css`
+    appearance: none;
+    border: 0;
+    background: none;
+    color: inherit;
+    -webkit-font-smoothing: inherit;
+    font: inherit;
+    outline: none;
+    border-radius: ${rem(radius[1])};
+
+    &:not([hidden]) {
+      display: flex;
+    }
+
+    &:focus {
+      box-shadow: ${focusRingStyle({base, focusRing})};
+    }
+
+    &:focus:not(:focus-visible) {
+      box-shadow: none;
+    }
+  `
+})
+
+const ToggleIconBox = styled(Box)`
+  width: 9px;
+  height: 9px;
+  margin-right: 3px;
+
+  & svg {
+    transition: transform 100ms;
+  }
+`
+
+export function FormFieldSetLegend(props: FormFieldSetLegendProps) {
+  const {collapsed, collapsible, onClick, title} = props
+
+  const text = (
+    <Text weight="semibold" size={1}>
+      {title || <em>Untitled</em>}
+    </Text>
+  )
+
+  if (!collapsible) {
+    return <Root>{text}</Root>
+  }
+
+  return (
+    <Root>
+      <ToggleButton onClick={onClick}>
+        <ToggleIconBox>
+          <Text muted size={1}>
+            <ToggleArrowRightIcon
+              style={{
+                transform: `rotate(${collapsed ? '0' : '90deg'}) translate3d(0, 0, 0)`,
+              }}
+            />
+          </Text>
+        </ToggleIconBox>
+
+        {text}
+      </ToggleButton>
+    </Root>
+  )
+}

--- a/packages/@sanity/base/src/components/formField/FormFieldValidationStatus.tsx
+++ b/packages/@sanity/base/src/components/formField/FormFieldValidationStatus.tsx
@@ -1,0 +1,115 @@
+/* eslint-disable camelcase */
+
+import {color} from '@sanity/color'
+import {ErrorOutlineIcon, WarningOutlineIcon} from '@sanity/icons'
+import {
+  isValidationErrorMarker,
+  isValidationMarker,
+  isValidationWarningMarker,
+  Marker,
+  ValidationMarker,
+} from '@sanity/types'
+import {Box, Flex, Placement, Stack, Text, Tooltip} from '@sanity/ui'
+import React, {createElement} from 'react'
+import {markersToValidationList} from './helpers'
+import {FormFieldValidation} from './types'
+
+export interface FormFieldValidationStatusProps {
+  /**
+   * @beta
+   */
+  __unstable_markers?: Marker[]
+  /**
+   * @beta
+   */
+  __unstable_showSummary?: boolean
+  fontSize?: number | number
+  placement?: Placement
+}
+
+export function FormFieldValidationStatus(props: FormFieldValidationStatusProps) {
+  const {
+    __unstable_markers: markers = [],
+    __unstable_showSummary: showSummary,
+    fontSize,
+    placement = 'top',
+  } = props
+  const validationMarkers = markers.filter(isValidationMarker)
+  const validation = markersToValidationList(validationMarkers)
+  const errors = validation.filter((v) => v.type === 'error')
+  const hasErrors = errors.length > 0
+  const statusIcon = hasErrors ? ErrorOutlineIcon : WarningOutlineIcon
+  const statusColor = hasErrors ? color.red[500].hex : color.yellow[500].hex
+
+  return (
+    <Tooltip
+      content={
+        <Stack padding={3} space={3}>
+          {showSummary && <FormFieldValidationSummary markers={validationMarkers} />}
+
+          {!showSummary && (
+            <>
+              {validation.map((item, itemIndex) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <FormFieldValidationStatusItem item={item} key={itemIndex} />
+              ))}
+            </>
+          )}
+        </Stack>
+      }
+      placement={placement}
+      fallbackPlacements={['bottom', 'right', 'left']}
+    >
+      <div>
+        <Text muted size={fontSize} weight="semibold" style={{color: statusColor}}>
+          {createElement(statusIcon)}
+        </Text>
+      </div>
+    </Tooltip>
+  )
+}
+
+function FormFieldValidationStatusItem(props: {item: FormFieldValidation}) {
+  const {item} = props
+  const statusIcon = item.type === 'error' ? ErrorOutlineIcon : WarningOutlineIcon
+  const statusColor = item.type === 'error' ? color.red[500].hex : color.yellow[500].hex
+
+  return (
+    <Flex>
+      <Box marginRight={2}>
+        <Text size={1} style={{color: statusColor}}>
+          {createElement(statusIcon)}
+        </Text>
+      </Box>
+      <Box flex={1}>
+        <Text muted size={1}>
+          {item.label}
+        </Text>
+      </Box>
+    </Flex>
+  )
+}
+
+function FormFieldValidationSummary({markers}: {markers: ValidationMarker[]}) {
+  const errorMarkers = markers.filter(isValidationErrorMarker)
+  const warningMarkers = markers.filter(isValidationWarningMarker)
+  const errorLen = errorMarkers.length
+  const warningLen = warningMarkers.length
+
+  const errorsStr = `error${errorLen === 1 ? '' : 's'}`
+  const warningsStr = `warning${warningLen === 1 ? '' : 's'}`
+  const errorText = errorLen && `${errorLen} ${errorsStr}`
+  const warningText = warningLen && `${warningLen} ${warningsStr}`
+
+  const hasErrors = errorLen > 0
+  const hasWarnings = warningLen > 0
+  const hasBoth = hasErrors && hasWarnings
+
+  return (
+    <Text muted size={1}>
+      {errorText || ''}
+      {hasBoth && <> and </>}
+      {warningText || ''}
+    </Text>
+  )
+}

--- a/packages/@sanity/base/src/components/formField/helpers.ts
+++ b/packages/@sanity/base/src/components/formField/helpers.ts
@@ -1,0 +1,13 @@
+import {isValidationMarker, ValidationMarker} from '@sanity/types'
+import {FormFieldValidation} from './types'
+
+export function markersToValidationList(markers: ValidationMarker[]): FormFieldValidation[] {
+  const validationMarkers = markers.filter(isValidationMarker)
+
+  return validationMarkers.map((marker) => {
+    return {
+      type: marker.level === 'error' ? 'error' : 'warning',
+      label: marker.item.message,
+    }
+  })
+}

--- a/packages/@sanity/base/src/components/formField/index.ts
+++ b/packages/@sanity/base/src/components/formField/index.ts
@@ -1,0 +1,4 @@
+export * from './FormField'
+export * from './FormFieldHeaderText'
+export * from './FormFieldSet'
+export * from './FormFieldValidationStatus'

--- a/packages/@sanity/base/src/components/formField/styles.ts
+++ b/packages/@sanity/base/src/components/formField/styles.ts
@@ -1,0 +1,23 @@
+function focusRingBorderStyle(border: {color: string; width: number}): string {
+  return `inset 0 0 0 ${border.width}px ${border.color}`
+}
+
+export function focusRingStyle(opts: {
+  base?: {bg: string}
+  border?: {color: string; width: number}
+  focusRing: {offset: number; width: number}
+}): string {
+  const {base, border, focusRing} = opts
+  const focusRingOutsetWidth = focusRing.offset + focusRing.width
+  const focusRingInsetWidth = 0 - focusRing.offset
+  const bgColor = base ? base.bg : 'var(--card-bg-color)'
+
+  return [
+    focusRingInsetWidth > 0 && `inset 0 0 0 ${focusRingInsetWidth}px var(--card-focus-ring-color)`,
+    border && focusRingBorderStyle(border),
+    focusRingInsetWidth < 0 && `0 0 0 ${0 - focusRingInsetWidth}px ${bgColor}`,
+    focusRingOutsetWidth > 0 && `0 0 0 ${focusRingOutsetWidth}px var(--card-focus-ring-color)`,
+  ]
+    .filter(Boolean)
+    .join(',')
+}

--- a/packages/@sanity/base/src/components/formField/types.ts
+++ b/packages/@sanity/base/src/components/formField/types.ts
@@ -1,0 +1,11 @@
+interface FormFieldValidationWarning {
+  type: 'warning'
+  label: string
+}
+
+interface FormFieldValidationError {
+  type: 'error'
+  label: string
+}
+
+export type FormFieldValidation = FormFieldValidationWarning | FormFieldValidationError

--- a/packages/@sanity/base/src/components/index.ts
+++ b/packages/@sanity/base/src/components/index.ts
@@ -1,1 +1,2 @@
+export * from './formField'
 export * from './UserAvatar'

--- a/packages/@sanity/base/src/theme/index.ts
+++ b/packages/@sanity/base/src/theme/index.ts
@@ -57,6 +57,10 @@ const color: ThemeColorSchemes = {
 export const theme: RootTheme = {
   ...defaults,
   color,
+  focusRing: {
+    offset: -1,
+    width: 2,
+  },
   media: [
     parseInt(legacyTheme['--screen-medium-break'], 10) || 512,
     parseInt(legacyTheme['--screen-default-break'], 10) || 640,


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  New feature (non-breaking change which adds functionality)

**Does this change require a documentation update? (Check one)**

- [x]  No (but it will soon)

**Description**

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

This change introduces 4 new public components for building form field components:

```tsx
import {
  FormField,
  FormFieldHeaderText,
  FormFieldSet,
  FormFieldValidationStatus,
} from '@sanity/base/components'
```

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

- New building blocks for composing form fields, that will be used by `@sanity/form-builder` and to create custom input components.