### PR TITLE
docs(code-input): example usage in react frontend

### DIFF
--- a/packages/@sanity/code-input/README.md
+++ b/packages/@sanity/code-input/README.md
@@ -22,8 +22,8 @@ Use it in your schema types:
     {
       name: 'exampleUsage',
       title: 'Example usage',
-      type: 'code'
-    }
+      type: 'code',
+    },
   ]
 }
 ```
@@ -68,6 +68,42 @@ Note that the above only works if you import and use the `all:part:@sanity/base/
   code: 'const foo = "bar"\nconsole.log(foo.toUpperCase())\n// BAR'
 }
 ```
+
+## Example usage in frontend (React)
+
+You can use any syntax highlighter you want - but not all of them might support highlighted lines or the syntax you've defined.
+
+As outlined above, the actual code is stored in a `code` property, so if your schema has a field called `codeExample` of type `code`, the property you'd want to pass to the highlighter would be `codeExample.code`.
+
+Here's an example using [react-refractor](https://github.com/rexxars/react-refractor):
+
+```jsx
+import React from 'react'
+import Refractor from 'react-refractor'
+import js from 'refractor/lang/javascript'
+
+Refractor.registerLanguage(js)
+
+export function Code(props) {
+  return (
+    <Refractor
+      // In this example, `props` is the value of a `code` field
+      language={props.language}
+      value={props.code}
+      markers={props.highlightedLines}
+    />
+  )
+}
+
+export default Code
+```
+
+Other syntax highlighters include:
+
+- [react-lowlight](https://github.com/rexxars/react-lowlight)
+- [react-syntax-highlighter](https://github.com/react-syntax-highlighter/react-syntax-highlighter)
+- [highlight.js](https://github.com/highlightjs/highlight.js)
+- [prism](https://github.com/PrismJS/prism)
 
 ## License
 


### PR DESCRIPTION
I spent quite some time researching a good way to display this in my frontend-app, thought an example usage in the docs might be useful for the next user ;-)

<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

<!-- Reference/link the relevant issue and/or describe the behavior. -->

**Description**

Example usage of data from the code-input in a React app

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

**Checklist** 

- [ ]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [ ]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [ ]  The code is linted
- [ ]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
