### PR TITLE
[server] Make react/react-dom alias to folders, not files

### DIFF
--- a/packages/@sanity/server/package.json
+++ b/packages/@sanity/server/package.json
@@ -61,6 +61,7 @@
     "postcss-loader": "^2.0.6",
     "querystring": "^0.2.0",
     "react-hot-loader": "^4.12.11",
+    "read-pkg-up": "^7.0.1",
     "require-uncached": "^1.0.3",
     "resolve": "^1.3.3",
     "resolve-from": "^4.0.0",

--- a/packages/@sanity/server/src/configs/getModulePath.js
+++ b/packages/@sanity/server/src/configs/getModulePath.js
@@ -1,0 +1,8 @@
+import path from 'path'
+import readPkgUp from 'read-pkg-up'
+
+export function getModulePath(mod) {
+  const modulePath = require.resolve(mod)
+  const pkg = readPkgUp.sync({cwd: path.dirname(modulePath)})
+  return pkg ? path.dirname(pkg.path) : modulePath
+}

--- a/packages/@sanity/server/src/configs/webpack.config.dev.js
+++ b/packages/@sanity/server/src/configs/webpack.config.dev.js
@@ -2,6 +2,7 @@ import webpack from 'webpack'
 import applyStaticLoaderFix from '../util/applyStaticLoaderFix'
 import getBaseConfig from './webpack.config'
 import {getMonorepoAliases} from './monorepoAliases'
+import {getModulePath} from './getModulePath'
 
 export default (config) => {
   const baseConfig = getBaseConfig(config)
@@ -20,7 +21,7 @@ export default (config) => {
         {},
         baseConfig.resolve.alias,
         {
-          'react-dom': require.resolve('@hot-loader/react-dom'),
+          'react-dom': getModulePath('@hot-loader/react-dom'),
           'webpack-hot-middleware/client': require.resolve('../browser/hot-client'),
         },
         config.isSanityMonorepo ? getMonorepoAliases() : {}

--- a/packages/@sanity/server/src/configs/webpack.config.js
+++ b/packages/@sanity/server/src/configs/webpack.config.js
@@ -6,6 +6,7 @@ import webpackIntegration from '@sanity/webpack-integration/v3'
 import ExtractTextPlugin from 'extract-text-webpack-plugin'
 import rxPaths from 'rxjs/_esm5/path-mapping'
 import getStaticBasePath from '../util/getStaticBasePath'
+import {getModulePath} from './getModulePath'
 
 const resolve = (mod) => require.resolve(mod)
 
@@ -78,8 +79,8 @@ export default (config = {}) => {
     },
     resolve: {
       alias: {
-        react: path.dirname(reactPath),
-        'react-dom': path.dirname(reactDomPath),
+        react: getModulePath('react'),
+        'react-dom': getModulePath('react-dom'),
         moment$: 'moment/moment.js',
         ...rxPaths(),
       },


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

When attempting to import say `react-dom/server`, the webpack alias prevents this as we're resolving it to a specific file. 

**Description**

This PR changes the resolving of the react/react-dom aliases: it first resolves using `require.resolve`, then looks up the directory tree for the closest `package.json` and uses that folder as the alias target. This ensures both the entry/root will resolve correctly, _and_ subpaths.

**Note for release**

- Fix bug where importing `react-dom/server` would not work 

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
