### PR TITLE
[all] New layers and portals

### DIFF
--- a/cypress/integration/default-layout/navbar.test.js
+++ b/cypress/integration/default-layout/navbar.test.js
@@ -1,0 +1,19 @@
+describe('@sanity/default-layout: Navbar', () => {
+  it('should render ActionModal on top of Desk Tool’s pane headers', () => {
+    cy.visit('/test/desk')
+
+    cy.get('[data-test="default-layout-global-create-button"]').click()
+
+    cy.get('[data-test="default-layout-global-create-dialog"]').should(
+      'have.css',
+      'z-index',
+      '500401'
+    )
+
+    cy.get('[data-test="desk-tool-list-pane"] [data-test="components-default-pane-header"]').should(
+      'have.css',
+      'z-index',
+      '101'
+    )
+  })
+})

--- a/examples/test-studio/schemas/poppers.js
+++ b/examples/test-studio/schemas/poppers.js
@@ -1,3 +1,61 @@
+const objectsWithReference = {
+  type: 'array',
+  name: 'objectsWithReference',
+  title: 'Objects with reference',
+  of: [
+    {
+      type: 'object',
+      name: 'objectWithReference',
+      title: 'Object with reference',
+      fields: [
+        {type: 'string', name: 'title', title: 'Title'},
+        {type: 'array', name: 'primitives', title: 'Primitives', of: [{type: 'string'}]},
+        {type: 'text', name: 'description', title: 'Description', rows: 20},
+        {type: 'reference', name: 'reference', title: 'Reference', to: [{type: 'book'}]},
+      ],
+    },
+  ],
+}
+
+const arraysInArrays = {
+  type: 'array',
+  name: 'arraysInArrays',
+  title: 'Arrays in arrays',
+  of: [
+    {
+      type: 'object',
+      name: 'object',
+      title: 'Object',
+      fields: [
+        {
+          type: 'string',
+          name: 'title',
+          title: 'Title',
+        },
+        {
+          type: 'array',
+          name: 'array',
+          title: 'Arrays in arrays',
+          of: [
+            {
+              type: 'object',
+              name: 'object',
+              title: 'Object',
+              fields: [
+                {
+                  type: 'string',
+                  name: 'title',
+                  title: 'Title',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
 export default {
   type: 'document',
   name: 'poppers',
@@ -8,22 +66,8 @@ export default {
       name: 'title',
       title: 'Title',
     },
-    {
-      type: 'array',
-      name: 'objectsWithReference',
-      title: 'Objects with reference',
-      of: [
-        {
-          type: 'object',
-          name: 'objectWithReference',
-          title: 'Object with reference',
-          fields: [
-            {type: 'string', name: 'title', title: 'Title'},
-            {type: 'text', name: 'description', title: 'Description', rows: 20},
-            {type: 'reference', name: 'reference', title: 'Reference', to: [{type: 'book'}]},
-          ],
-        },
-      ],
-    },
+    {type: 'array', name: 'primitives', title: 'Primitives', of: [{type: 'string'}]},
+    objectsWithReference,
+    arraysInArrays,
   ],
 }

--- a/packages/@sanity/base/src/__legacy/@sanity/components/dialogs/DefaultDialog.css
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/dialogs/DefaultDialog.css
@@ -29,12 +29,12 @@
   position: absolute;
   top: 0;
   left: 0;
+  right: 0;
   bottom: 0;
   outline: none;
 
   @media (--max-screen-medium) {
     position: fixed;
-    bottom: auto;
   }
 }
 

--- a/packages/@sanity/base/src/__legacy/@sanity/components/dialogs/DefaultDialog.tsx
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/dialogs/DefaultDialog.tsx
@@ -1,13 +1,14 @@
 /* eslint-disable react/no-unused-prop-types */
 
+import {Portal, useLayer} from '@sanity/ui'
 import classNames from 'classnames'
 import CloseIcon from 'part:@sanity/base/close-icon'
 import Button from 'part:@sanity/components/buttons/default'
 import {ContainerQuery} from 'part:@sanity/components/container-query'
 import styles from 'part:@sanity/components/dialogs/default-style'
-import {Layer, useLayer} from 'part:@sanity/components/layer'
 import {ScrollContainer} from 'part:@sanity/components/scroll'
-import React, {createElement, useCallback, useEffect, useState} from 'react'
+import React, {useCallback, useEffect, useState} from 'react'
+import {LegacyLayerProvider} from '../../../../components'
 import {useClickOutside} from '../hooks'
 import {DefaultDialogActions} from './DefaultDialogActions'
 import {DialogAction, DialogColor} from './types'
@@ -29,7 +30,13 @@ interface DefaultDialogProps {
 }
 
 function DefaultDialog(props: DefaultDialogProps) {
-  return <Layer>{createElement(DefaultDialogChildren, props)}</Layer>
+  return (
+    <Portal>
+      <LegacyLayerProvider zOffset="portal">
+        <DefaultDialogChildren {...props} />
+      </LegacyLayerProvider>
+    </Portal>
+  )
 }
 
 export default DefaultDialog
@@ -51,8 +58,7 @@ function DefaultDialogChildren(props: DefaultDialogProps) {
     title,
   } = props
 
-  const layer = useLayer()
-  const isTopLayer = layer.depth === layer.size
+  const {isTopLayer, zIndex} = useLayer()
   const [cardElement, setCardElement] = useState<HTMLDivElement | null>(null)
   const renderCloseButton = onClose && showCloseButton
   const renderFloatingCloseButton = !title && renderCloseButton
@@ -96,6 +102,7 @@ function DefaultDialogChildren(props: DefaultDialogProps) {
       data-dialog-color={color}
       data-dialog-padding={padding}
       data-dialog-size={size}
+      style={{zIndex}}
     >
       <div className={styles.overlay} />
 

--- a/packages/@sanity/base/src/__legacy/@sanity/components/dialogs/DefaultDialog.tsx
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/dialogs/DefaultDialog.tsx
@@ -56,6 +56,7 @@ function DefaultDialogChildren(props: DefaultDialogProps) {
     showCloseButton = true,
     size = 'medium',
     title,
+    ...restProps
   } = props
 
   const {isTopLayer, zIndex} = useLayer()
@@ -98,6 +99,7 @@ function DefaultDialogChildren(props: DefaultDialogProps) {
 
   return (
     <ContainerQuery
+      {...restProps}
       className={classNames(styles.root, hasActions && styles.hasFunctions, classNameProp)}
       data-dialog-color={color}
       data-dialog-padding={padding}

--- a/packages/@sanity/base/src/__legacy/@sanity/components/dialogs/FullscreenDialog.css
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/dialogs/FullscreenDialog.css
@@ -3,9 +3,9 @@
 .root {
   position: absolute;
   top: 0;
-  bottom: 0;
   left: 0;
   right: 0;
+  bottom: 0;
   background: var(--backdrop-color);
   color: var(--component-text-color);
   padding: var(--large-padding);
@@ -13,6 +13,10 @@
   display: flex;
   align-items: center;
   justify-content: center;
+
+  @media (--max-screen-medium) {
+    position: fixed;
+  }
 }
 
 .card {

--- a/packages/@sanity/base/src/__legacy/@sanity/components/dialogs/FullscreenDialog.tsx
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/dialogs/FullscreenDialog.tsx
@@ -44,15 +44,19 @@ export default FullscreenDialog
 
 function FullscreenDialogChildren(props: FullScreenDialogProps) {
   const {
+    children,
+    color,
     title,
     cardClassName,
     className,
+    isOpen = true,
     onAction,
     onClickOutside,
     onClose,
     onEscape,
-    isOpen = true,
+    padding,
     actions,
+    ...restProps
   } = props
   const {isTopLayer, zIndex} = useLayer()
   const [secondary, primary] = partition(actions, (action) => action.secondary)
@@ -85,6 +89,7 @@ function FullscreenDialogChildren(props: FullScreenDialogProps) {
 
   return (
     <div
+      {...restProps}
       className={classNames(styles.root, isOpen ? styles.isOpen : styles.isClosed, className)}
       style={{zIndex}}
     >
@@ -107,9 +112,7 @@ function FullscreenDialogChildren(props: FullScreenDialogProps) {
           </header>
         )}
 
-        {props.children && (
-          <ScrollContainer className={styles.content}>{props.children}</ScrollContainer>
-        )}
+        {children && <ScrollContainer className={styles.content}>{children}</ScrollContainer>}
 
         {actions && actions.length > 0 && (
           <div className={styles.actionsWrapper}>

--- a/packages/@sanity/base/src/__legacy/@sanity/components/dialogs/FullscreenDialog.tsx
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/dialogs/FullscreenDialog.tsx
@@ -1,14 +1,15 @@
 /* eslint-disable react/no-unused-prop-types */
 
+import {Portal, useLayer} from '@sanity/ui'
 import classNames from 'classnames'
 import {partition} from 'lodash'
 import CloseIcon from 'part:@sanity/base/close-icon'
 import Button from 'part:@sanity/components/buttons/default'
 import ButtonGrid from 'part:@sanity/components/buttons/button-grid'
 import styles from 'part:@sanity/components/dialogs/fullscreen-style'
-import {Layer, useLayer} from 'part:@sanity/components/layer'
 import {ScrollContainer} from 'part:@sanity/components/scroll'
-import React, {createElement, useCallback, useEffect, useState} from 'react'
+import React, {useCallback, useEffect, useState} from 'react'
+import {LegacyLayerProvider} from '../../../../components'
 import {useClickOutside} from '../hooks'
 import {DialogAction} from './types'
 
@@ -30,7 +31,13 @@ interface FullScreenDialogProps {
 }
 
 function FullscreenDialog(props: FullScreenDialogProps) {
-  return <Layer>{createElement(FullscreenDialogChildren, props)}</Layer>
+  return (
+    <Portal>
+      <LegacyLayerProvider zOffset="portal">
+        <FullscreenDialogChildren {...props} />
+      </LegacyLayerProvider>
+    </Portal>
+  )
 }
 
 export default FullscreenDialog
@@ -47,10 +54,7 @@ function FullscreenDialogChildren(props: FullScreenDialogProps) {
     isOpen = true,
     actions,
   } = props
-
-  const layer = useLayer()
-  const isTopLayer = layer.depth === layer.size
-
+  const {isTopLayer, zIndex} = useLayer()
   const [secondary, primary] = partition(actions, (action) => action.secondary)
 
   useEffect(() => {
@@ -80,7 +84,10 @@ function FullscreenDialogChildren(props: FullScreenDialogProps) {
   )
 
   return (
-    <div className={classNames(styles.root, isOpen ? styles.isOpen : styles.isClosed, className)}>
+    <div
+      className={classNames(styles.root, isOpen ? styles.isOpen : styles.isClosed, className)}
+      style={{zIndex}}
+    >
       <div className={classNames(styles.card, cardClassName)} ref={setCardElement}>
         {(title || onClose) && (
           <header className={styles.header}>

--- a/packages/@sanity/base/src/__legacy/@sanity/components/dialogs/FullscreenMessageDialog.css
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/dialogs/FullscreenMessageDialog.css
@@ -2,7 +2,6 @@
 
 .root {
   position: fixed;
-  z-index: var(--zindex-portal);
   top: 0;
   left: 0;
   right: 0;

--- a/packages/@sanity/base/src/__legacy/@sanity/components/dialogs/FullscreenMessageDialog.tsx
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/dialogs/FullscreenMessageDialog.tsx
@@ -1,6 +1,8 @@
+import {Portal, useLayer} from '@sanity/ui'
 import classNames from 'classnames'
 import CloseIcon from 'part:@sanity/base/close-icon'
 import React from 'react'
+import {LegacyLayerProvider} from '../../../../components'
 
 import styles from './FullscreenMessageDialog.css'
 
@@ -13,10 +15,21 @@ interface Props {
 }
 
 function FullscreenMessageDialog(props: Props) {
+  return (
+    <Portal>
+      <LegacyLayerProvider zOffset="portal">
+        <FullscreenMessageDialogChildren {...props} />
+      </LegacyLayerProvider>
+    </Portal>
+  )
+}
+
+function FullscreenMessageDialogChildren(props: Props) {
+  const {zIndex} = useLayer()
   const className = classNames(styles.root, props.color && styles[`color_${props.color}`])
 
   return (
-    <div className={className}>
+    <div className={className} style={{zIndex}}>
       <div className={styles.card}>
         <div className={styles.cardHeader}>
           <h2 className={styles.cardTitle}>{props.title}</h2>

--- a/packages/@sanity/base/src/__legacy/@sanity/components/dialogs/PanePopover.css
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/dialogs/PanePopover.css
@@ -8,7 +8,6 @@
   position: absolute;
   top: 0;
   box-shadow: 0 0 0 9999px var(--broken-backdrop);
-  z-index: var(--zindex-portal);
   max-width: 100%;
   line-height: 1.3125;
   outline: 0;

--- a/packages/@sanity/base/src/__legacy/@sanity/components/dialogs/PanePopover.tsx
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/dialogs/PanePopover.tsx
@@ -1,8 +1,10 @@
-import React from 'react'
+import {useLayer} from '@sanity/ui'
+import React, {useMemo} from 'react'
 import CheckCircleIcon from 'part:@sanity/base/circle-check-icon'
 import WarningIcon from 'part:@sanity/base/warning-icon'
 import InfoIcon from 'part:@sanity/base/info-icon'
 import classNames from 'classnames'
+import {LegacyLayerProvider} from '../../../../components'
 import styles from './PanePopover.css'
 
 interface PanePopoverProps {
@@ -21,41 +23,48 @@ const DEFAULT_ICONS = {
   error: <WarningIcon />,
 }
 
-// @todo: refactor to functional component
-export default class PanePopover extends React.PureComponent<PanePopoverProps> {
-  iconKind = () => {
-    const {icon, kind = 'info'} = this.props
+function PanePopoverDialog(props: PanePopoverProps) {
+  return (
+    <LegacyLayerProvider zOffset="portal">
+      <PanePopoverDialogChildren {...props} />
+    </LegacyLayerProvider>
+  )
+}
+
+function PanePopoverDialogChildren(props: PanePopoverProps) {
+  const {children, icon, id, kind = 'info', title, subtitle} = props
+  const {zIndex} = useLayer()
+
+  const iconNode = useMemo(() => {
     if (kind && typeof icon === 'boolean' && icon) return DEFAULT_ICONS[kind]
     if (typeof icon === 'object') return icon
     return undefined
-  }
+  }, [icon, kind])
 
-  render() {
-    const {children, icon, id, kind = 'info', title, subtitle} = this.props
-    const iconNode = this.iconKind()
-
-    return (
-      <div
-        aria-label={kind}
-        aria-describedby={`popoverTitle-${kind}-${id}`}
-        className={classNames(styles.root, styles.dialog)}
-        data-kind={kind}
-      >
-        <div className={styles.inner}>
-          <div className={styles.content}>
-            <div id={`popoverTitle-${kind}-${id}`} className={styles.title}>
-              {icon && (
-                <div role="img" aria-hidden className={styles.icon}>
-                  {iconNode}
-                </div>
-              )}
-              {title}
-            </div>
-            {subtitle && <div className={styles.subtitle}>{subtitle}</div>}
-            {children && <div className={styles.children}>{children}</div>}
+  return (
+    <div
+      aria-label={kind}
+      aria-describedby={`popoverTitle-${kind}-${id}`}
+      className={classNames(styles.root, styles.dialog)}
+      data-kind={kind}
+      style={{zIndex}}
+    >
+      <div className={styles.inner}>
+        <div className={styles.content}>
+          <div id={`popoverTitle-${kind}-${id}`} className={styles.title}>
+            {icon && (
+              <div role="img" aria-hidden className={styles.icon}>
+                {iconNode}
+              </div>
+            )}
+            {title}
           </div>
+          {subtitle && <div className={styles.subtitle}>{subtitle}</div>}
+          {children && <div className={styles.children}>{children}</div>}
         </div>
       </div>
-    )
-  }
+    </div>
+  )
 }
+
+export default PanePopoverDialog

--- a/packages/@sanity/base/src/__legacy/@sanity/components/dialogs/PopoverDialog.css
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/dialogs/PopoverDialog.css
@@ -35,7 +35,6 @@
   width: 100%;
   background-color: var(--backdrop-color);
   opacity: 0.75;
-  z-index: var(--zindex-portal);
   pointer-events: none;
   animation-name: popoverDialogBackgroundFadeIn;
   animation-duration: 0.2s;
@@ -45,6 +44,9 @@
 
 .root {
   width: calc(100% - 16px);
+  max-height: 50vh;
+  display: flex;
+  flex-direction: column;
 
   @nest &:not([data-size]), &[data-size='auto'] {
     width: auto;
@@ -77,8 +79,6 @@
 }
 
 .card {
-  max-height: 50vh;
-
   @nest .root[data-color='danger'] & {
     background-color: var(--state-danger-color);
     color: var(--state-danger-color--inverted);
@@ -122,6 +122,8 @@
 
 .content {
   overflow: auto;
+  flex: 1;
+  min-height: 0;
 }
 
 .contentWrapper {

--- a/packages/@sanity/base/src/__legacy/@sanity/components/dialogs/PopoverDialog.tsx
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/dialogs/PopoverDialog.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable react/no-unused-prop-types */
 
+import {useLayer} from '@sanity/ui'
 import classNames from 'classnames'
 import {partition} from 'lodash'
 import CloseIcon from 'part:@sanity/base/close-icon'
 import styles from 'part:@sanity/components/dialogs/popover-style'
 import Button from 'part:@sanity/components/buttons/default'
 import ButtonGrid from 'part:@sanity/components/buttons/button-grid'
-import {useLayer} from 'part:@sanity/components/layer'
 import {Popover} from 'part:@sanity/components/popover'
 import React, {useCallback, useEffect, useState} from 'react'
 import {useClickOutside} from '../hooks'
@@ -89,7 +89,7 @@ export default PopoverDialog
 function PopoverDialogChildren(props: PopoverDialogChildrenProps) {
   const {actions = [], children, onAction, onClickOutside, onClose, onEscape, title} = props
 
-  const layer = useLayer()
+  const {isTopLayer} = useLayer()
 
   const [primary, secondary] = partition(actions, (action) => action.primary)
 
@@ -102,8 +102,6 @@ function PopoverDialogChildren(props: PopoverDialogChildrenProps) {
     // eslint-disable-next-line react/no-array-index-key
     <PopoverDialogActionButton action={action} key={actionIndex} onAction={onAction} />
   ))
-
-  const isTopLayer = layer.depth === layer.size
 
   useEffect(() => {
     if (!isTopLayer) return undefined

--- a/packages/@sanity/base/src/__legacy/@sanity/components/dialogs/stories/fullscreen.tsx
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/dialogs/stories/fullscreen.tsx
@@ -1,9 +1,9 @@
+import {LayerProvider, useLayer} from '@sanity/ui'
 import Chance from 'chance'
 import {range} from 'lodash'
 import {action} from 'part:@sanity/storybook/addons/actions'
 import {text, select, boolean} from 'part:@sanity/storybook/addons/knobs'
 import FullscreenDialog from 'part:@sanity/components/dialogs/fullscreen'
-import {LayerProvider, useLayer} from 'part:@sanity/components/layer'
 import Sanity from 'part:@sanity/storybook/addons/sanity'
 import React from 'react'
 
@@ -91,7 +91,7 @@ function DialogExampleChildren({children}: {children: React.ReactNode}) {
 
   return (
     <>
-      <pre>depth={layer.depth}</pre>
+      <pre>zIndex={layer.zIndex}</pre>
       <div>{children}</div>
     </>
   )

--- a/packages/@sanity/base/src/__legacy/@sanity/components/edititem/EditItemFoldOut.tsx
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/edititem/EditItemFoldOut.tsx
@@ -1,8 +1,8 @@
 import {Modifier} from '@popperjs/core'
+import {Layer, useLayer} from '@sanity/ui'
 import CloseIcon from 'part:@sanity/base/close-icon'
 import DefaultButton from 'part:@sanity/components/buttons/default'
 import styles from 'part:@sanity/components/edititem/fold-style'
-import {Layer, useLayer} from 'part:@sanity/components/layer'
 import {Portal} from 'part:@sanity/components/portal'
 import React, {forwardRef, useEffect, useState} from 'react'
 import {usePopper} from 'react-popper'
@@ -33,8 +33,7 @@ const EditItemFoldOutChildren = forwardRef(
     ref
   ) => {
     const {children, onClose, title, ...restProps} = props
-    const layer = useLayer()
-    const isTopLayer = layer.depth === layer.size
+    const {isTopLayer} = useLayer()
 
     useEffect(() => {
       if (!isTopLayer) return undefined

--- a/packages/@sanity/base/src/__legacy/@sanity/components/menuButton/menuButton.tsx
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/menuButton/menuButton.tsx
@@ -1,5 +1,5 @@
+import {useLayer} from '@sanity/ui'
 import Button from 'part:@sanity/components/buttons/default'
-import {useLayer} from 'part:@sanity/components/layer'
 import {Popover} from 'part:@sanity/components/popover'
 import React, {forwardRef, useCallback, useEffect, useState} from 'react'
 import {ButtonProps} from '../buttons'
@@ -20,8 +20,7 @@ interface MenuButtonProps {
 const MenuButtonChildren = forwardRef(
   (props: {onClose: () => void} & React.HTMLProps<HTMLDivElement>, ref) => {
     const {children, onClose, ...restProps} = props
-    const layer = useLayer()
-    const isTopLayer = layer.depth === layer.size
+    const {isTopLayer} = useLayer()
     const [rootElement, setRootElement] = useState<HTMLDivElement | null>(null)
 
     const setRef = useCallback(
@@ -82,7 +81,6 @@ export const MenuButton = forwardRef(
       setOpen,
       ...restProps
     } = props
-
     const handleClose = useCallback(() => setOpen(false), [setOpen])
     const handleButtonClick = useCallback(() => setOpen(!open), [open, setOpen])
 

--- a/packages/@sanity/base/src/__legacy/@sanity/components/panes/DefaultPane.css
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/panes/DefaultPane.css
@@ -66,7 +66,6 @@
 .header {
   background: var(--component-bg);
   position: relative;
-  z-index: var(--zindex-pane);
 
   @nest .isCollapsed & {
     width: 100%;
@@ -263,7 +262,6 @@
   box-sizing: border-box;
   background-color: var(--component-bg);
   color: var(--text-color-secondary);
-  z-index: var(--zindex-pane);
 
   @supports (padding-bottom: env(safe-area-inset-bottom)) {
     padding-bottom: env(safe-area-inset-bottom);

--- a/packages/@sanity/base/src/__legacy/@sanity/components/panes/DefaultPane.tsx
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/panes/DefaultPane.tsx
@@ -1,3 +1,4 @@
+import {Layer} from '@sanity/ui'
 import {StructureBuilder as S} from '@sanity/structure'
 import {InitialValueTemplateItem} from '@sanity/structure/lib/InitialValueTemplateItem'
 import classNames from 'classnames'
@@ -15,6 +16,7 @@ import {childrenToElementArray} from '../helpers'
 import {MenuItem, MenuItemGroup} from '../menus/types'
 import Styleable from '../utilities/Styleable'
 
+import {LegacyLayerProvider} from '../../../../components'
 import defaultStyles from './DefaultPane.css'
 
 interface DefaultPaneProps {
@@ -352,15 +354,25 @@ class DefaultPane extends React.PureComponent<DefaultPaneProps, State> {
       title,
       children,
       hasTabs,
+      index,
+      initialValueTemplates,
       isCollapsed,
       isLoading,
       isScrollable,
       isSelected,
       hasSiblings,
+      menuItems,
+      menuItemGroups,
+      onAction,
+      onCollapse,
+      onExpand,
+      renderActions,
+      renderHeaderViewMenu,
       styles = {},
       footer,
       tabIdPrefix,
       viewId,
+      ...restProps
     } = this.props
 
     const mainChildren = isScrollable ? (
@@ -374,49 +386,54 @@ class DefaultPane extends React.PureComponent<DefaultPaneProps, State> {
     const headerViewMenuNode = this.props.renderHeaderViewMenu && this.props.renderHeaderViewMenu()
 
     return (
-      <div
-        className={classNames(
-          styles.root,
-          isCollapsed && styles.isCollapsed,
-          isSelected ? styles.isActive : styles.isDisabled
-        )}
-        data-pane-color={color}
-        data-pane-loading={isLoading}
-        onClick={this.handleRootClick}
-        ref={this.setRootElement}
-      >
-        <div className={styles.header}>
-          <div className={styles.headerContent}>
-            <div className={styles.titleContainer}>
-              <h2 className={styles.title} onClick={this.handleTitleClick}>
-                {title}
-              </h2>
+      <LegacyLayerProvider zOffset="pane">
+        <div
+          {...restProps}
+          className={classNames(
+            styles.root,
+            isCollapsed && styles.isCollapsed,
+            isSelected ? styles.isActive : styles.isDisabled
+          )}
+          data-pane-color={color}
+          data-pane-loading={isLoading}
+          onClick={this.handleRootClick}
+          ref={this.setRootElement}
+        >
+          <Layer className={styles.header} data-test="components-default-pane-header">
+            <div className={styles.headerContent}>
+              <div className={styles.titleContainer}>
+                <h2 className={styles.title} onClick={this.handleTitleClick}>
+                  {title}
+                </h2>
+              </div>
+              <div className={styles.headerTools}>{this.renderHeaderTools()}</div>
             </div>
-            <div className={styles.headerTools}>{this.renderHeaderTools()}</div>
-          </div>
 
-          {/* To render tabs and similar */}
-          {headerViewMenuNode && <div className={styles.headerViewMenu}>{headerViewMenuNode}</div>}
+            {/* To render tabs and similar */}
+            {headerViewMenuNode && (
+              <div className={styles.headerViewMenu}>{headerViewMenuNode}</div>
+            )}
+          </Layer>
+
+          {hasTabs ? (
+            <TabPanel
+              aria-labelledby={`${tabIdPrefix}tab-${viewId}`}
+              className={styles.main}
+              id={`${tabIdPrefix}tabpanel`}
+            >
+              {mainChildren}
+            </TabPanel>
+          ) : (
+            <div className={styles.main}>{mainChildren}</div>
+          )}
+
+          {footer && (
+            <Layer className={hasTabs && hasSiblings ? styles.hoverFooter : styles.stickyFooter}>
+              {footer}
+            </Layer>
+          )}
         </div>
-
-        {hasTabs ? (
-          <TabPanel
-            aria-labelledby={`${tabIdPrefix}tab-${viewId}`}
-            className={styles.main}
-            id={`${tabIdPrefix}tabpanel`}
-          >
-            {mainChildren}
-          </TabPanel>
-        ) : (
-          <div className={styles.main}>{mainChildren}</div>
-        )}
-
-        {footer && (
-          <div className={hasTabs && hasSiblings ? styles.hoverFooter : styles.stickyFooter}>
-            {footer}
-          </div>
-        )}
-      </div>
+      </LegacyLayerProvider>
     )
   }
 }

--- a/packages/@sanity/base/src/__legacy/@sanity/components/panes/SplitController.css
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/panes/SplitController.css
@@ -52,7 +52,7 @@
 
 .resizer {
   position: relative;
-  z-index: 1000;
+  z-index: var(--zindex-pane-resizer);
   box-sizing: border-box;
   background-clip: padding-box;
   width: 11px;

--- a/packages/@sanity/base/src/__legacy/@sanity/components/popover/popover.css
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/popover/popover.css
@@ -1,12 +1,7 @@
 @import 'part:@sanity/base/theme/variables-style';
 
-.layer {
-  pointer-events: none;
-}
-
 .root {
   pointer-events: all;
-  z-index: var(--zindex-popover);
   display: flex;
 }
 

--- a/packages/@sanity/base/src/__legacy/@sanity/components/selects/StatelessSearchableSelect.tsx
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/selects/StatelessSearchableSelect.tsx
@@ -1,9 +1,9 @@
 import {Modifier} from '@popperjs/core'
+import {Layer, useLayer} from '@sanity/ui'
 import React, {forwardRef, useCallback, useEffect, useState} from 'react'
 import {usePopper} from 'react-popper'
 import styles from 'part:@sanity/components/selects/searchable-style'
 import FaAngleDown from 'part:@sanity/base/angle-down-icon'
-import {Layer, useLayer} from 'part:@sanity/components/layer'
 import Spinner from 'part:@sanity/components/loading/spinner'
 import DefaultTextInput from 'part:@sanity/components/textinputs/default'
 import CloseIcon from 'part:@sanity/base/close-icon'
@@ -70,8 +70,7 @@ const StatelessSearchableSelectResults = forwardRef(
       value,
       ...restProps
     } = props
-    const layer = useLayer()
-    const isTopLayer = layer.depth === layer.size
+    const {isTopLayer} = useLayer()
     const itemsLen = items.length
 
     const renderItem = useCallback(

--- a/packages/@sanity/base/src/__legacy/@sanity/components/tooltip/tooltip.css
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/tooltip/tooltip.css
@@ -1,7 +1,6 @@
 @import 'part:@sanity/base/theme/variables-style';
 
 .root {
-  z-index: var(--zindex-popover + 1);
   pointer-events: none;
 }
 

--- a/packages/@sanity/base/src/__legacy/@sanity/components/utilities/ActivateOnFocus.tsx
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/utilities/ActivateOnFocus.tsx
@@ -1,3 +1,4 @@
+import {Layer} from '@sanity/ui'
 import classNames from 'classnames'
 import React from 'react'
 import enhanceWithClickOutside from 'react-click-outside'
@@ -62,7 +63,7 @@ class ActivateOnFocus extends React.Component<ActivateOnFocusProps> {
     const overlayClassName = classNames(styles.overlay, overlayClassNameProp)
 
     return (
-      <div className={className} id={inputId}>
+      <Layer className={className} id={inputId}>
         {!isActive && (
           <div className={styles.eventHandler} onClick={this.handleClick}>
             <div className={overlayClassName}>
@@ -72,7 +73,7 @@ class ActivateOnFocus extends React.Component<ActivateOnFocusProps> {
           </div>
         )}
         <div className={styles.content}>{children}</div>
-      </div>
+      </Layer>
     )
   }
 }

--- a/packages/@sanity/base/src/__legacy/@sanity/components/utilities/Poppable.tsx
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/utilities/Poppable.tsx
@@ -1,8 +1,8 @@
 import classNames from 'classnames'
 import {Modifier} from '@popperjs/core'
+import {Layer, useLayer} from '@sanity/ui'
 import React, {forwardRef, useCallback, useEffect, useState} from 'react'
 import {usePopper} from 'react-popper'
-import {Layer, useLayer} from 'part:@sanity/components/layer'
 import {Portal} from 'part:@sanity/components/portal'
 import {useClickOutside} from '../hooks'
 import {Placement} from '../types'
@@ -44,8 +44,7 @@ const PoppableChildren = forwardRef(
     ref
   ) => {
     const {children, onEscape, onClickOutside, popperClassName, ...restProps} = props
-    const layer = useLayer()
-    const isTopLayer = layer.depth === layer.size
+    const {isTopLayer} = useLayer()
     const [rootElement, setRootElement] = useState<HTMLDivElement | null>(null)
 
     const setRef = useCallback(

--- a/packages/@sanity/base/src/change-indicators/ChangeIndicator.tsx
+++ b/packages/@sanity/base/src/change-indicators/ChangeIndicator.tsx
@@ -1,3 +1,4 @@
+import {useLayer} from '@sanity/ui'
 import React from 'react'
 import deepCompare from 'react-fast-compare'
 import * as PathUtils from '@sanity/util/paths'
@@ -33,6 +34,7 @@ const ChangeBarWrapper = (
     children: React.ReactNode
   }
 ) => {
+  const layer = useLayer()
   const [hasHover, setHover] = React.useState(false)
   const onMouseEnter = React.useCallback(() => setHover(true), [])
   const onMouseLeave = React.useCallback(() => setHover(false), [])
@@ -46,6 +48,7 @@ const ChangeBarWrapper = (
       isChanged: props.isChanged,
       hasFocus: props.hasFocus,
       hasHover: hasHover,
+      zIndex: layer.zIndex,
     }),
     // note: deepCompare should be ok here since we're not comparing deep values
     deepCompare

--- a/packages/@sanity/base/src/change-indicators/overlay/ConnectorsOverlay.css
+++ b/packages/@sanity/base/src/change-indicators/overlay/ConnectorsOverlay.css
@@ -1,7 +1,6 @@
 @import 'part:@sanity/base/theme/variables-style';
 
 .svg {
-  z-index: calc(var(--zindex-portal) - 1);
   pointer-events: none;
   position: absolute;
   left: 0;

--- a/packages/@sanity/base/src/change-indicators/overlay/ConnectorsOverlay.tsx
+++ b/packages/@sanity/base/src/change-indicators/overlay/ConnectorsOverlay.tsx
@@ -8,11 +8,11 @@ import {getElementGeometry} from '../helpers/getElementGeometry'
 import isChangeBar from '../helpers/isChangeBar'
 import scrollIntoView from '../helpers/scrollIntoView'
 import {DEBUG_LAYER_BOUNDS} from '../constants'
+import {resizeObserver} from '../../util/resizeObserver'
 import {Connector} from './Connector'
 
 import styles from './ConnectorsOverlay.css'
 import {DebugLayers} from './DebugLayers'
-import {resizeObserver} from '../../util/resizeObserver'
 
 export interface Rect {
   height: number
@@ -89,7 +89,10 @@ export const ConnectorsOverlay = React.memo(function ConnectorsOverlay(props: Pr
 
   return (
     <ScrollMonitor onScroll={forceUpdate}>
-      <svg className={styles.svg}>
+      <svg
+        className={styles.svg}
+        style={{zIndex: visibleConnectors[0] && visibleConnectors[0].field.zIndex}}
+      >
         {visibleConnectors.map(({field, change, hasFocus, hasHover, hasRevertHover}) => {
           const onConnectorClick = () => {
             scrollIntoView(field)

--- a/packages/@sanity/base/src/change-indicators/tracker.tsx
+++ b/packages/@sanity/base/src/change-indicators/tracker.tsx
@@ -10,6 +10,7 @@ export interface TrackedChange {
   hasFocus: boolean
   hasHover: boolean
   hasRevertHover: boolean
+  zIndex: number
 }
 
 export interface TrackedArea {

--- a/packages/@sanity/base/src/components/SanityRoot.tsx
+++ b/packages/@sanity/base/src/components/SanityRoot.tsx
@@ -1,8 +1,13 @@
-import {Card, ThemeColorProvider, ThemeProvider, useRootTheme} from '@sanity/ui'
+import {
+  Card,
+  LayerProvider,
+  PortalProvider,
+  ThemeColorProvider,
+  ThemeProvider,
+  useRootTheme,
+} from '@sanity/ui'
 import config from 'config:sanity'
 import RootComponent from 'part:@sanity/base/root'
-import {LayerProvider} from 'part:@sanity/components/layer'
-import {PortalProvider} from 'part:@sanity/components/portal'
 import SnackbarProvider from 'part:@sanity/components/snackbar/provider'
 import React, {useState} from 'react'
 import Refractor from 'react-refractor'
@@ -75,8 +80,8 @@ function AppProvider() {
               <ErrorHandler onUIError={setUIError} />
               <RootComponent />
               <VersionChecker />
+              <div data-portal="" ref={setPortalElement} />
             </Root>
-            <div data-portal="" ref={setPortalElement} />
           </SnackbarProvider>
         </LayerProvider>
       </PortalProvider>

--- a/packages/@sanity/base/src/components/ZIndexProvider.tsx
+++ b/packages/@sanity/base/src/components/ZIndexProvider.tsx
@@ -1,0 +1,30 @@
+import React, {createContext, useContext} from 'react'
+import vars from 'sanity:css-custom-properties'
+
+const defaults = {
+  pane: parseInt(vars['--zindex-pane'], 10) || 900,
+  navbar: parseInt(vars['--zindex-navbar'], 10) || 1000,
+  navbarFixed: parseInt(vars['--zindex-navbar-fixed'], 10) || 1010,
+  dropdown: parseInt(vars['--zindex-dropdown'], 10) || 1010,
+  fullscreenEdit: parseInt(vars['--zindex-fullscreen-edit'], 10) || 1050,
+  portal: parseInt(vars['--zindex-portal'], 10) || 1060,
+  popoverBackground: parseInt(vars['--zindex-popover-background'], 10) || 1060,
+  popover: parseInt(vars['--zindex-popover'], 10) || 1070,
+  tooltip: parseInt(vars['--zindex-tooltip'], 10) || 1100,
+  modalBackground: parseInt(vars['--zindex-modal-background'], 10) || 2000,
+  modal: parseInt(vars['--zindex-modal'], 10) || 2010,
+  movingItem: parseInt(vars['--zindex-moving-item'], 10) || 3000,
+  spinner: parseInt(vars['--zindex-spinner'], 10) || 3000,
+  drawershade: parseInt(vars['--zindex-drawershade'], 10) || 4000,
+  drawer: parseInt(vars['--zindex-drawer'], 10) || 4001,
+}
+
+const ZIndexContext = createContext(defaults)
+
+export function useZIndex() {
+  return useContext(ZIndexContext)
+}
+
+export function ZIndexProvider({children}: {children?: React.ReactNode}) {
+  return <ZIndexContext.Provider value={defaults}>{children}</ZIndexContext.Provider>
+}

--- a/packages/@sanity/base/src/components/ZIndexProvider.tsx
+++ b/packages/@sanity/base/src/components/ZIndexProvider.tsx
@@ -2,21 +2,70 @@ import React, {createContext, useContext} from 'react'
 import vars from 'sanity:css-custom-properties'
 
 const defaults = {
-  pane: parseInt(vars['--zindex-pane'], 10) || 900,
-  navbar: parseInt(vars['--zindex-navbar'], 10) || 1000,
+  /*
+    used by
+    - Navbar
+  */
+  navbar: parseInt(vars['--zindex-navbar'], 10) || 200,
+  navbarPopover: parseInt(vars['--zindex-navbar-popover'], 10) || 500000,
+  navbarDialog: parseInt(vars['--zindex-navbar-dialog'], 10) || 500001,
+
+  /*
+    used by:
+    - DefaultPane
+  */
+  pane: parseInt(vars['--zindex-pane'], 10) || 100,
+
+  /*
+    used by:
+    - DefaultPane
+  */
+  paneResizer: parseInt(vars['--zindex-pane-resizer'], 10) || 150,
+
+  /*
+    used by:
+    - EditItemFoldOut
+    - Spinner
+    - ConnectorsOverlay
+    - tippy.css
+    - BaseDateTimeInput
+  */
+  portal: parseInt(vars['--zindex-portal'], 10) || 200,
+
+  /*
+    used by tooltip
+  */
+  popover: parseInt(vars['--zindex-popover'], 10) || 200,
+
+  /*
+    used by google-maps-input
+  */
+  modal: parseInt(vars['--zindex-modal'], 10) || 200,
+
+  /*
+    used for movingItem in:
+    packages/@sanity/base/src/styles/layout/helpers.css
+  */
+  movingItem: parseInt(vars['--zindex-moving-item'], 10) || 10000,
+
+  /*
+    used for shadow behind the navbar search, and behind sidemenu
+  */
+  drawershade: parseInt(vars['--zindex-drawershade'], 10) || 1000000,
+
+  /*
+    used for snackbar
+  */
+  drawer: parseInt(vars['--zindex-drawer'], 10) || 1000001,
+
+  // NOT IN USE
+  dropdown: parseInt(vars['--zindex-dropdown'], 10) || 200,
   navbarFixed: parseInt(vars['--zindex-navbar-fixed'], 10) || 1010,
-  dropdown: parseInt(vars['--zindex-dropdown'], 10) || 1010,
   fullscreenEdit: parseInt(vars['--zindex-fullscreen-edit'], 10) || 1050,
-  portal: parseInt(vars['--zindex-portal'], 10) || 1060,
   popoverBackground: parseInt(vars['--zindex-popover-background'], 10) || 1060,
-  popover: parseInt(vars['--zindex-popover'], 10) || 1070,
-  tooltip: parseInt(vars['--zindex-tooltip'], 10) || 1100,
+  tooltip: parseInt(vars['--zindex-tooltip'], 10) || 200,
   modalBackground: parseInt(vars['--zindex-modal-background'], 10) || 2000,
-  modal: parseInt(vars['--zindex-modal'], 10) || 2010,
-  movingItem: parseInt(vars['--zindex-moving-item'], 10) || 3000,
   spinner: parseInt(vars['--zindex-spinner'], 10) || 3000,
-  drawershade: parseInt(vars['--zindex-drawershade'], 10) || 4000,
-  drawer: parseInt(vars['--zindex-drawer'], 10) || 4001,
 }
 
 const ZIndexContext = createContext(defaults)

--- a/packages/@sanity/base/src/components/index.ts
+++ b/packages/@sanity/base/src/components/index.ts
@@ -1,3 +1,4 @@
 export * from './formField'
+export * from './transitional'
 export * from './UserAvatar'
 export * from './ZIndexProvider'

--- a/packages/@sanity/base/src/components/index.ts
+++ b/packages/@sanity/base/src/components/index.ts
@@ -1,2 +1,3 @@
 export * from './formField'
 export * from './UserAvatar'
+export * from './ZIndexProvider'

--- a/packages/@sanity/base/src/components/transitional/LegacyLayerProvider.tsx
+++ b/packages/@sanity/base/src/components/transitional/LegacyLayerProvider.tsx
@@ -1,0 +1,39 @@
+import {LayerProvider} from '@sanity/ui'
+import React from 'react'
+import {useZIndex} from '../ZIndexProvider'
+
+export type LegacyLayerZIndexKey =
+  | 'pane'
+  | 'paneResizer'
+  | 'navbar'
+  | 'navbarPopover'
+  | 'navbarDialog'
+  | 'navbarFixed'
+  | 'dropdown'
+  | 'fullscreenEdit'
+  | 'portal'
+  | 'popoverBackground'
+  | 'popover'
+  | 'tooltip'
+  | 'modalBackground'
+  | 'modal'
+  | 'movingItem'
+  | 'spinner'
+  | 'drawershade'
+  | 'drawer'
+
+/**
+ * @internal This component should only be used by core Sanity packages.
+ */
+export function LegacyLayerProvider({
+  children,
+  zOffset: zOffsetKey,
+}: {
+  children: React.ReactNode
+  zOffset: LegacyLayerZIndexKey
+}) {
+  const zIndex = useZIndex()
+  const zOffset = zIndex[zOffsetKey]
+
+  return <LayerProvider zOffset={zOffset}>{children}</LayerProvider>
+}

--- a/packages/@sanity/base/src/components/transitional/index.ts
+++ b/packages/@sanity/base/src/components/transitional/index.ts
@@ -1,0 +1,1 @@
+export * from './LegacyLayerProvider'

--- a/packages/@sanity/base/src/styles/variables/layers.css
+++ b/packages/@sanity/base/src/styles/variables/layers.css
@@ -1,17 +1,32 @@
+/*
+  NOTE: most browsers operate with a max. z-index of 2147483647
+  – the maximum positive value for a 32-bit signed binary integer.
+  NOTE: Safari 0–3 operate with a max. z-index of 16777271
+*/
+
 :root {
-  --zindex-pane: 900;
-  --zindex-navbar: 1000;
+  --zindex-navbar: 200;
+  --zindex-navbar-popover: 500000;
+  --zindex-navbar-dialog: 500001;
+
+  --zindex-pane: 100;
+  --zindex-pane-resizer: 150;
+
+  --zindex-portal: 200;
+  --zindex-popover: 200;
+  --zindex-modal: 200;
+
+  --zindex-moving-item: 10000;
+
+  --zindex-drawershade: 1000000;
+  --zindex-drawer: 1000001;
+
+  /* NOT IN USE */
+  --zindex-dropdown: 200;
   --zindex-navbar-fixed: 1010;
-  --zindex-dropdown: 1010;
   --zindex-fullscreen-edit: 1050;
-  --zindex-portal: 1060;
   --zindex-popover-background: 1060;
-  --zindex-popover: 1070;
-  --zindex-tooltip: 1100;
+  --zindex-tooltip: 200;
   --zindex-modal-background: 2000;
-  --zindex-modal: 2010;
-  --zindex-moving-item: 3000;
   --zindex-spinner: 3000;
-  --zindex-drawershade: 4000;
-  --zindex-drawer: 4001;
 }

--- a/packages/@sanity/default-layout/package.json
+++ b/packages/@sanity/default-layout/package.json
@@ -31,13 +31,15 @@
   "dependencies": {
     "@sanity/base": "2.2.6",
     "@sanity/generate-help-url": "2.2.6",
+    "@sanity/ui": "^0.33.0",
     "@sanity/util": "2.2.6",
     "classnames": "^2.2.5",
     "is-hotkey": "^0.1.4",
     "lodash": "^4.17.15",
     "react-click-outside": "^3.0.0",
     "react-props-stream": "^1.0.0",
-    "rxjs": "^6.5.3"
+    "rxjs": "^6.5.3",
+    "styled-components": "^5.2.1"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/packages/@sanity/default-layout/src/DefaultLayout.css
+++ b/packages/@sanity/default-layout/src/DefaultLayout.css
@@ -16,26 +16,6 @@
   display: flex;
   flex-direction: column;
 
-  @nest &::before {
-    content: '';
-    display: block;
-    z-index: var(--zindex-drawershade);
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: var(--backdrop-color);
-    pointer-events: none;
-    opacity: 0;
-    transition: 150ms opacity ease-in-out;
-  }
-
-  @nest &.isOverlayVisible::before {
-    pointer-events: all;
-    opacity: 1;
-  }
-
   @media (--screen-medium) {
     overflow: hidden;
     width: 100%;
@@ -43,32 +23,22 @@
   }
 }
 
-.navbar {
-  position: relative;
-  background-color: var(--main-navigation-color);
-  color: var(--main-navigation-color--inverted);
-  padding-left: env(safe-area-inset-left);
-  padding-right: env(safe-area-inset-right);
-
-  @nest &::after {
-    content: '';
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    border-bottom: 1px solid var(--hairline-color);
-  }
-}
-
 .loadingScreen {
+  /*
+    NOTE: The reason for the double selector here, is to be able to override
+    `@sanity/ui`’s CSS for the `Layer` component. Since `styled-components`
+    applies class names to the element, we need to provide a more specific
+    CSS selector to make sure this property is not overriden.
+  */
+  @nest &.loadingScreen {
+    position: fixed;
+  }
+
   display: block;
-  position: fixed;
   top: 0;
   left: 0;
   opacity: 1;
   transition: opacity 0.5s linear;
-  z-index: 5000;
   animation-name: loadingScreen;
   animation-duration: 1s;
   animation-delay: 1s;
@@ -90,9 +60,9 @@
 }
 
 .toolContainer {
+  position: relative;
   flex: 1;
   min-width: 0;
-  position: relative;
   height: 100%;
   margin-top: 0;
   margin-left: env(safe-area-inset-left);

--- a/packages/@sanity/default-layout/src/DefaultLayout.tsx
+++ b/packages/@sanity/default-layout/src/DefaultLayout.tsx
@@ -1,9 +1,12 @@
+import {Layer} from '@sanity/ui'
+import classNames from 'classnames'
 import React from 'react'
 import {Subscription} from 'rxjs'
 import AppLoadingScreen from 'part:@sanity/base/app-loading-screen'
 import {RouteScope, withRouterHOC} from 'part:@sanity/base/router'
 import absolutes from 'all:part:@sanity/base/absolutes'
 import userStore from 'part:@sanity/base/user'
+import {LegacyLayerProvider} from '@sanity/base/components'
 import Sidecar from './addons/Sidecar'
 import RenderTool from './main/RenderTool'
 import ActionModal from './actionModal/ActionModal'
@@ -134,41 +137,44 @@ class DefaultLayout extends React.PureComponent<Props, State> {
   renderContent = () => {
     const {tools, router} = this.props
     const {createMenuIsOpen, menuIsOpen, searchIsOpen} = this.state
-
     const isOverlayVisible = menuIsOpen || searchIsOpen
-    let className = styles.root
-    if (isOverlayVisible) className += ` ${styles.isOverlayVisible}`
 
     return (
-      <div className={className} onClickCapture={this.handleClickCapture}>
+      <div
+        className={classNames(styles.root, isOverlayVisible && styles.isOverlayVisible)}
+        onClickCapture={this.handleClickCapture}
+      >
         {this.state.showLoadingScreen && (
-          <div
+          <Layer
             className={
               this.state.loaded || document.visibilityState == 'hidden'
                 ? styles.loadingScreenLoaded
                 : styles.loadingScreen
             }
+            zOffset={5000}
             ref={this.setLoadingScreenElement}
           >
             <AppLoadingScreen text="Restoring Sanity" />
-          </div>
+          </Layer>
         )}
 
-        <div className={styles.navbar}>
-          <NavbarContainer
-            tools={tools}
-            createMenuIsOpen={createMenuIsOpen}
-            onCreateButtonClick={this.handleCreateButtonClick}
-            onToggleMenu={this.handleToggleMenu}
-            onSwitchTool={this.handleSwitchTool}
-            router={router}
-            searchIsOpen={searchIsOpen}
-            /* eslint-disable-next-line react/jsx-handler-names */
-            onUserLogout={userStore.actions.logout}
-            onSearchOpen={this.handleSearchOpen}
-            onSearchClose={this.handleSearchClose}
-          />
-        </div>
+        <LegacyLayerProvider zOffset="navbar">
+          <div className={styles.navbar}>
+            <NavbarContainer
+              tools={tools}
+              createMenuIsOpen={createMenuIsOpen}
+              onCreateButtonClick={this.handleCreateButtonClick}
+              onToggleMenu={this.handleToggleMenu}
+              onSwitchTool={this.handleSwitchTool}
+              router={router}
+              searchIsOpen={searchIsOpen}
+              /* eslint-disable-next-line react/jsx-handler-names */
+              onUserLogout={userStore.actions.logout}
+              onSearchOpen={this.handleSearchOpen}
+              onSearchClose={this.handleSearchClose}
+            />
+          </div>
+        </LegacyLayerProvider>
 
         <div className={styles.sideMenuContainer}>
           <SideMenu
@@ -197,10 +203,12 @@ class DefaultLayout extends React.PureComponent<Props, State> {
         </div>
 
         {createMenuIsOpen && (
-          <ActionModal
-            onClose={this.handleActionModalClose}
-            actions={getNewDocumentModalActions()}
-          />
+          <LegacyLayerProvider zOffset="navbar">
+            <ActionModal
+              onClose={this.handleActionModalClose}
+              actions={getNewDocumentModalActions()}
+            />
+          </LegacyLayerProvider>
         )}
 
         {absolutes.map((Abs, i) => (

--- a/packages/@sanity/default-layout/src/actionModal/ActionModal.tsx
+++ b/packages/@sanity/default-layout/src/actionModal/ActionModal.tsx
@@ -1,10 +1,11 @@
-import React from 'react'
+import {LegacyLayerProvider} from '@sanity/base/components'
+import FileIcon from 'part:@sanity/base/file-icon'
 import DefaultDialog from 'part:@sanity/components/dialogs/default'
 import CreateDocumentList from 'part:@sanity/components/lists/create-document'
-import FileIcon from 'part:@sanity/base/file-icon'
+import React from 'react'
 
 interface Props {
-  actions: {icon?: React.ComponentType<{}>; key: string}[]
+  actions: {icon?: React.ComponentType; key: string}[]
   onClose: () => void
 }
 
@@ -12,24 +13,27 @@ function ActionModal(props: Props) {
   const {actions, onClose} = props
 
   return (
-    <DefaultDialog
-      onClickOutside={onClose}
-      onClose={onClose}
-      size="large"
-      title="Create new document"
-    >
-      {actions.length > 0 ? (
-        <CreateDocumentList
-          items={actions.map((action) => ({
-            ...action,
-            icon: action.icon || FileIcon,
-            onClick: onClose,
-          }))}
-        />
-      ) : (
-        <h3>No initial value templates are configured.</h3>
-      )}
-    </DefaultDialog>
+    <LegacyLayerProvider zOffset="navbarDialog">
+      <DefaultDialog
+        data-test="default-layout-global-create-dialog"
+        onClickOutside={onClose}
+        onClose={onClose}
+        size="large"
+        title="Create new document"
+      >
+        {actions.length > 0 ? (
+          <CreateDocumentList
+            items={actions.map((action) => ({
+              ...action,
+              icon: action.icon || FileIcon,
+              onClick: onClose,
+            }))}
+          />
+        ) : (
+          <h3>No initial value templates are configured.</h3>
+        )}
+      </DefaultDialog>
+    </LegacyLayerProvider>
   )
 }
 

--- a/packages/@sanity/default-layout/src/addons/Sidecar.css
+++ b/packages/@sanity/default-layout/src/addons/Sidecar.css
@@ -11,7 +11,6 @@
     left: 0;
     right: 0;
     bottom: 0;
-    z-index: var(--zindex-pane);
   }
 }
 

--- a/packages/@sanity/default-layout/src/addons/Sidecar.tsx
+++ b/packages/@sanity/default-layout/src/addons/Sidecar.tsx
@@ -1,8 +1,11 @@
+import {LegacyLayerProvider} from '@sanity/base/components'
+import {Layer} from '@sanity/ui'
 import classNames from 'classnames'
 import React from 'react'
 import {Subscription} from 'rxjs'
 import * as sidecar from 'part:@sanity/default-layout/sidecar?'
 import {isSidecarOpenSetting} from 'part:@sanity/default-layout/sidecar-datastore'
+
 import styles from './Sidecar.css'
 
 let isSidecarEnabled: () => boolean | null = null
@@ -17,6 +20,7 @@ interface State {
   isVisible: boolean
 }
 
+// eslint-disable-next-line @typescript-eslint/ban-types
 class Sidecar extends React.PureComponent<{}, State> {
   state = {
     isOpen: true,
@@ -68,9 +72,11 @@ class Sidecar extends React.PureComponent<{}, State> {
     }
 
     return (
-      <div className={classNames(styles.root, isOpen && styles.isOpen)}>
-        {isVisible && <SidecarLayout />}
-      </div>
+      <LegacyLayerProvider zOffset="pane">
+        <Layer className={classNames(styles.root, isOpen && styles.isOpen)}>
+          {isVisible && <SidecarLayout />}
+        </Layer>
+      </LegacyLayerProvider>
     )
   }
 }

--- a/packages/@sanity/default-layout/src/navbar/Navbar.css
+++ b/packages/@sanity/default-layout/src/navbar/Navbar.css
@@ -1,6 +1,10 @@
 @import 'part:@sanity/base/theme/variables-style';
 
 .root {
+  background-color: var(--main-navigation-color);
+  color: var(--main-navigation-color--inverted);
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
   display: grid;
   box-sizing: border-box;
   /* prettier-ignore */
@@ -20,6 +24,16 @@
       /* prettier-ignore */
       grid-template-columns: max-content max-content   min-content  minmax(180px, 400px)  auto         max-content max-content  min-content max-content min-content;
     }
+  }
+
+  @nest &::after {
+    content: '';
+    display: block;
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    border-bottom: 1px solid var(--hairline-color);
   }
 }
 
@@ -126,15 +140,18 @@
     position: absolute;
     z-index: var(--zindex-drawer);
     width: 100%;
+    height: 100%;
+    pointer-events: none;
+    opacity: 0;
+    background-color: var(--body-bg);
+    color: var(--gray-base);
 
-    @nest & > div {
-      display: none;
-      background: var(--body-bg);
-      color: var(--gray-base);
-    }
+    @nest &.searchIsOpen {
+      opacity: 1;
 
-    @nest &.searchIsOpen > div {
-      display: block;
+      @nest & > div {
+        pointer-events: all;
+      }
     }
   }
 

--- a/packages/@sanity/default-layout/src/navbar/Navbar.tsx
+++ b/packages/@sanity/default-layout/src/navbar/Navbar.tsx
@@ -9,6 +9,7 @@ import Button from 'part:@sanity/components/buttons/default'
 import {Tooltip} from 'part:@sanity/components/tooltip'
 import * as sidecar from 'part:@sanity/default-layout/sidecar?'
 import ToolMenu from 'part:@sanity/default-layout/tool-switcher'
+import {LegacyLayerProvider} from '@sanity/base/components'
 import {DatasetSelect} from '../components'
 import {HAS_SPACES} from '../util/spaces'
 import {Router, Tool} from '../types'
@@ -86,25 +87,30 @@ export default function Navbar(props: Props) {
         </div>
       )}
       <div className={styles.createButton}>
-        <Tooltip
-          disabled={TOUCH_DEVICE}
-          content={
-            (<span className={styles.createButtonTooltipContent}>Create new document</span>) as any
-          }
-          tone="navbar"
-        >
-          <div>
-            <Button
-              aria-label="Create"
-              icon={ComposeIcon}
-              kind="simple"
-              onClick={onCreateButtonClick}
-              padding="small"
-              selected={createMenuIsOpen}
-              tone="navbar"
-            />
-          </div>
-        </Tooltip>
+        <LegacyLayerProvider zOffset="navbarPopover">
+          <Tooltip
+            disabled={TOUCH_DEVICE}
+            content={
+              (
+                <span className={styles.createButtonTooltipContent}>Create new document</span>
+              ) as any
+            }
+            tone="navbar"
+          >
+            <div>
+              <Button
+                aria-label="Create"
+                data-test="default-layout-global-create-button"
+                icon={ComposeIcon}
+                kind="simple"
+                onClick={onCreateButtonClick}
+                padding="small"
+                selected={createMenuIsOpen}
+                tone="navbar"
+              />
+            </div>
+          </Tooltip>
+        </LegacyLayerProvider>
       </div>
       <div className={searchClassName} ref={onSetSearchElement}>
         <div>

--- a/packages/@sanity/default-layout/src/navbar/loginStatus/LoginStatus.tsx
+++ b/packages/@sanity/default-layout/src/navbar/loginStatus/LoginStatus.tsx
@@ -1,4 +1,4 @@
-import {UserAvatar} from '@sanity/base/components'
+import {LegacyLayerProvider, UserAvatar} from '@sanity/base/components'
 import ChevronDownIcon from 'part:@sanity/base/chevron-down-icon'
 import IconSignOut from 'part:@sanity/base/sign-out-icon'
 import {ClickOutside} from 'part:@sanity/components/click-outside'
@@ -68,15 +68,17 @@ export default class LoginStatus extends React.PureComponent<LoginStatusProps, L
             type="button"
           >
             <div className={styles.inner} tabIndex={-1}>
-              <Popover
-                content={popoverContent as any}
-                open={this.state.isOpen}
-                placement="bottom-end"
-              >
-                <div className={styles.avatarContainer}>
-                  <UserAvatar size="medium" tone="navbar" userId="me" />
-                </div>
-              </Popover>
+              <LegacyLayerProvider zOffset="navbarPopover">
+                <Popover
+                  content={popoverContent as any}
+                  open={this.state.isOpen}
+                  placement="bottom-end"
+                >
+                  <div className={styles.avatarContainer}>
+                    <UserAvatar size="medium" tone="navbar" userId="me" />
+                  </div>
+                </Popover>
+              </LegacyLayerProvider>
 
               <div className={styles.iconContainer}>
                 <ChevronDownIcon />

--- a/packages/@sanity/default-layout/src/navbar/presenceMenu/PresenceMenu.tsx
+++ b/packages/@sanity/default-layout/src/navbar/presenceMenu/PresenceMenu.tsx
@@ -1,5 +1,5 @@
 import client from 'part:@sanity/base/client'
-import {UserAvatar} from '@sanity/base/components'
+import {LegacyLayerProvider, UserAvatar} from '@sanity/base/components'
 import {useGlobalPresence} from '@sanity/base/hooks'
 import CogIcon from 'part:@sanity/base/cog-icon'
 import UsersIcon from 'part:@sanity/base/users-icon'
@@ -61,39 +61,41 @@ export function PresenceMenu() {
     <ClickOutside onClickOutside={handleClose}>
       {(ref) => (
         <div className={styles.root} ref={ref as React.Ref<HTMLDivElement>}>
-          <Popover content={popoverContent as any} open={open}>
-            <div>
-              <Button
-                className={styles.narrowButton}
-                icon={UsersIcon}
-                iconStatus={presence.length > 0 ? 'success' : undefined}
-                kind="simple"
-                onClick={handleToggle}
-                padding="small"
-                selected={open}
-                tone="navbar"
-              />
+          <LegacyLayerProvider zOffset="navbarPopover">
+            <Popover content={popoverContent as any} open={open}>
+              <div>
+                <Button
+                  className={styles.narrowButton}
+                  icon={UsersIcon}
+                  iconStatus={presence.length > 0 ? 'success' : undefined}
+                  kind="simple"
+                  onClick={handleToggle}
+                  padding="small"
+                  selected={open}
+                  tone="navbar"
+                />
 
-              <Button
-                className={styles.wideButton}
-                kind="simple"
-                onClick={handleToggle}
-                padding="small"
-                selected={open}
-                tone="navbar"
-              >
-                <AvatarStack
-                  className={styles.avatarStack}
-                  maxLength={MAX_AVATARS_GLOBAL}
+                <Button
+                  className={styles.wideButton}
+                  kind="simple"
+                  onClick={handleToggle}
+                  padding="small"
+                  selected={open}
                   tone="navbar"
                 >
-                  {presence.map((item) => (
-                    <UserAvatar key={item.user.id} user={item.user} />
-                  ))}
-                </AvatarStack>
-              </Button>
-            </div>
-          </Popover>
+                  <AvatarStack
+                    className={styles.avatarStack}
+                    maxLength={MAX_AVATARS_GLOBAL}
+                    tone="navbar"
+                  >
+                    {presence.map((item) => (
+                      <UserAvatar key={item.user.id} user={item.user} />
+                    ))}
+                  </AvatarStack>
+                </Button>
+              </div>
+            </Popover>
+          </LegacyLayerProvider>
 
           {open && <Escapable onEscape={handleClose} />}
         </div>

--- a/packages/@sanity/default-layout/src/navbar/search/SearchField.css
+++ b/packages/@sanity/default-layout/src/navbar/search/SearchField.css
@@ -3,6 +3,7 @@
 .root {
   position: relative;
   color: var(--main-navigation-color--inverted-muted);
+  height: 100%;
 
   @nest &:not(.isBleeding) {
     background: color(
@@ -127,7 +128,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  min-width: 33px;
+  min-width: 41px;
 
   & > svg {
     font-size: 1.5625em;

--- a/packages/@sanity/default-layout/src/navbar/search/SearchField.tsx
+++ b/packages/@sanity/default-layout/src/navbar/search/SearchField.tsx
@@ -3,6 +3,8 @@ import CloseIcon from 'part:@sanity/base/close-icon'
 import SearchIcon from 'part:@sanity/base/search-icon'
 import Hotkeys from 'part:@sanity/components/typography/hotkeys'
 
+import {Layer} from '@sanity/ui'
+import {LegacyLayerProvider} from '@sanity/base/components'
 import styles from './SearchField.css'
 
 interface Props {
@@ -66,37 +68,39 @@ class SearchField extends React.PureComponent<Props> {
     if (value.length) className += ` ${styles.hasValue}`
 
     return (
-      <div className={className} onMouseDown={onMouseDown}>
-        <div className={styles.inputField}>
-          <label className={styles.label}>
-            <SearchIcon />
-          </label>
-          <input
-            className={styles.input}
-            type="text"
-            value={value}
-            onChange={onChange}
-            onBlur={onBlur}
-            onFocus={onFocus}
-            onKeyDown={onKeyDown}
-            placeholder={placeholder}
-            ref={this.setInputElement}
-          />
-          {hotkeys && (
-            <div className={styles.hotkeys}>
-              <Hotkeys keys={hotkeys} />
+      <LegacyLayerProvider zOffset="navbarDialog">
+        <div className={className} onMouseDown={onMouseDown}>
+          <Layer className={styles.inputField}>
+            <label className={styles.label}>
+              <SearchIcon />
+            </label>
+            <input
+              className={styles.input}
+              type="text"
+              value={value}
+              onChange={onChange}
+              onBlur={onBlur}
+              onFocus={onFocus}
+              onKeyDown={onKeyDown}
+              placeholder={placeholder}
+              ref={this.setInputElement}
+            />
+            {hotkeys && (
+              <div className={styles.hotkeys}>
+                <Hotkeys keys={hotkeys} />
+              </div>
+            )}
+            <div
+              className={value ? styles.clearButtonWithValue : styles.clearButton}
+              onClick={onClear}
+              title="Clear search"
+            >
+              <CloseIcon />
             </div>
-          )}
-          <div
-            className={value ? styles.clearButtonWithValue : styles.clearButton}
-            onClick={onClear}
-            title="Clear search"
-          >
-            <CloseIcon />
-          </div>
+          </Layer>
+          <div className={styles.results}>{results}</div>
         </div>
-        <div className={styles.results}>{results}</div>
-      </div>
+      </LegacyLayerProvider>
     )
   }
 }

--- a/packages/@sanity/default-layout/src/navbar/studioStatus/CurrentVersionsDialog.tsx
+++ b/packages/@sanity/default-layout/src/navbar/studioStatus/CurrentVersionsDialog.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import Dialog from 'part:@sanity/components/dialogs/default'
+import DefaultDialog from 'part:@sanity/components/dialogs/default'
 
+import {LegacyLayerProvider} from '@sanity/base/components'
 import styles from './UpdateNotifierDialog.css'
 
 interface Props {
@@ -39,17 +40,20 @@ class CurrentVersionsDialog extends React.PureComponent<Props> {
 
   render() {
     const {onClose} = this.props
+
     return (
-      <Dialog onClose={onClose} onClickOutside={onClose} size="medium">
-        <div className={styles.content}>
-          <h2 className={styles.dialogHeading}>This Studio is up to date</h2>
-          <p>It was built using the latest versions of all packages.</p>
-          <details className={styles.details}>
-            <summary className={styles.summary}>List all installed packages</summary>
-            {this.renderTable()}
-          </details>
-        </div>
-      </Dialog>
+      <LegacyLayerProvider zOffset="navbarDialog">
+        <DefaultDialog onClose={onClose} onClickOutside={onClose} size="medium">
+          <div className={styles.content}>
+            <h2 className={styles.dialogHeading}>This Studio is up to date</h2>
+            <p>It was built using the latest versions of all packages.</p>
+            <details className={styles.details}>
+              <summary className={styles.summary}>List all installed packages</summary>
+              {this.renderTable()}
+            </details>
+          </div>
+        </DefaultDialog>
+      </LegacyLayerProvider>
     )
   }
 }

--- a/packages/@sanity/default-layout/src/navbar/studioStatus/UpdateNotifierDialog.tsx
+++ b/packages/@sanity/default-layout/src/navbar/studioStatus/UpdateNotifierDialog.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import Dialog from 'part:@sanity/components/dialogs/default'
+import DefaultDialog from 'part:@sanity/components/dialogs/default'
+import {LegacyLayerProvider} from '@sanity/base/components'
 import {Package} from './types'
 
 import styles from './UpdateNotifierDialog.css'
@@ -91,26 +92,28 @@ class UpdateNotifierDialog extends React.PureComponent<Props> {
     const {severity, onClose} = this.props
 
     return (
-      <Dialog
-        onClose={onClose}
-        onClickOutside={onClose}
-        title={severity === 'low' ? 'Upgrades available' : 'Studio is outdated'}
-      >
-        {__DEV__ && (
-          <>
-            <div className={styles.textContent}>
-              <p>
-                This Studio is no longer up to date{' '}
-                {severity === 'high' ? 'and should be upgraded.' : 'and can be upgraded.'}
-              </p>
-            </div>
+      <LegacyLayerProvider zOffset="navbarDialog">
+        <DefaultDialog
+          onClose={onClose}
+          onClickOutside={onClose}
+          title={severity === 'low' ? 'Upgrades available' : 'Studio is outdated'}
+        >
+          {__DEV__ && (
+            <>
+              <div className={styles.textContent}>
+                <p>
+                  This Studio is no longer up to date{' '}
+                  {severity === 'high' ? 'and should be upgraded.' : 'and can be upgraded.'}
+                </p>
+              </div>
 
-            {this.renderTable()}
-          </>
-        )}
+              {this.renderTable()}
+            </>
+          )}
 
-        {!__DEV__ && this.renderContactDeveloper()}
-      </Dialog>
+          {!__DEV__ && this.renderContactDeveloper()}
+        </DefaultDialog>
+      </LegacyLayerProvider>
     )
   }
 }

--- a/packages/@sanity/default-layout/src/navbar/toolMenu/ToolMenu.tsx
+++ b/packages/@sanity/default-layout/src/navbar/toolMenu/ToolMenu.tsx
@@ -1,3 +1,4 @@
+import {LegacyLayerProvider} from '@sanity/base/components'
 import StateButton from 'part:@sanity/components/buttons/state'
 import {Tooltip} from 'part:@sanity/components/tooltip'
 import React from 'react'
@@ -40,30 +41,32 @@ function ToolMenu(props: Props) {
 
         return (
           <li key={tool.name}>
-            <Tooltip
-              content={tooltipContent as any}
-              disabled={showLabel}
-              placement="bottom"
-              title={showLabel ? '' : title}
-              tone={tone}
-            >
-              <div>
-                <StateButton
-                  icon={tool.icon}
-                  key={tool.name}
-                  kind="simple"
-                  onClick={onSwitchTool}
-                  padding={direction === 'horizontal' ? 'small' : 'medium'}
-                  selected={activeToolName === tool.name}
-                  state={{...router.state, tool: tool.name, [tool.name]: undefined}}
-                  title={title}
-                  tabIndex={isVisible ? 0 : -1}
-                  tone={tone}
-                >
-                  {tool.title}
-                </StateButton>
-              </div>
-            </Tooltip>
+            <LegacyLayerProvider zOffset="navbarPopover">
+              <Tooltip
+                content={tooltipContent as any}
+                disabled={showLabel}
+                placement="bottom"
+                title={showLabel ? '' : title}
+                tone={tone}
+              >
+                <div>
+                  <StateButton
+                    icon={tool.icon}
+                    key={tool.name}
+                    kind="simple"
+                    onClick={onSwitchTool}
+                    padding={direction === 'horizontal' ? 'small' : 'medium'}
+                    selected={activeToolName === tool.name}
+                    state={{...router.state, tool: tool.name, [tool.name]: undefined}}
+                    title={title}
+                    tabIndex={isVisible ? 0 : -1}
+                    tone={tone}
+                  >
+                    {tool.title}
+                  </StateButton>
+                </div>
+              </Tooltip>
+            </LegacyLayerProvider>
           </li>
         )
       })}

--- a/packages/@sanity/default-layout/src/sideMenu/SideMenu.css
+++ b/packages/@sanity/default-layout/src/sideMenu/SideMenu.css
@@ -7,8 +7,16 @@
 }
 
 .root {
-  position: fixed;
-  z-index: var(--zindex-drawer);
+  /*
+    NOTE: The reason for the double selector here, is to be able to override
+    `@sanity/ui`’s CSS for the `Layer` component. Since `styled-components`
+    applies class names to the element, we need to provide a more specific
+    CSS selector to make sure this property is not overriden.
+  */
+  @nest &.root {
+    position: fixed;
+  }
+
   top: 0;
   left: 0;
   width: 100%;
@@ -16,7 +24,22 @@
   pointer-events: none;
 }
 
-.root > div {
+.backdrop {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--backdrop-color);
+  opacity: 0;
+  transition: 200ms opacity ease-in-out;
+
+  @nest .root.isOpen & {
+    opacity: 1;
+  }
+}
+
+.inner {
   position: relative;
   min-width: 200px;
   max-width: 280px;
@@ -30,10 +53,8 @@
   pointer-events: all;
   padding-left: env(safe-area-inset-left);
   margin-right: var(--side-menu-margin-right);
-}
 
-.root.isOpen {
-  @nest & > div {
+  @nest .root.isOpen & {
     transform: translate(0);
   }
 }

--- a/packages/@sanity/default-layout/src/sideMenu/SideMenu.tsx
+++ b/packages/@sanity/default-layout/src/sideMenu/SideMenu.tsx
@@ -1,4 +1,5 @@
-import {UserAvatar} from '@sanity/base/components'
+import {UserAvatar, useZIndex} from '@sanity/base/components'
+import {Layer} from '@sanity/ui'
 import React from 'react'
 import CloseIcon from 'part:@sanity/base/close-icon'
 import SignOutIcon from 'part:@sanity/base/sign-out-icon'
@@ -23,13 +24,16 @@ interface Props {
 
 function SideMenu(props: Props) {
   const {activeToolName, isOpen, onClose, onSignOut, onSwitchTool, router, tools, user} = props
+  const zindex = useZIndex()
   let className = styles.root
   if (isOpen) className += ` ${styles.isOpen}`
   const tabIndex = isOpen ? 0 : -1
 
   return (
-    <div className={className}>
-      <div>
+    <Layer className={className} zOffset={zindex.drawer}>
+      <div className={styles.backdrop} />
+
+      <div className={styles.inner}>
         <div className={styles.header}>
           <div className={styles.headerMain}>
             <div className={styles.userProfile}>
@@ -77,7 +81,7 @@ function SideMenu(props: Props) {
           </div>
         </div>
       </div>
-    </div>
+    </Layer>
   )
 }
 

--- a/packages/@sanity/desk-tool/src/panes/documentPane/documentPane.css
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/documentPane.css
@@ -20,9 +20,22 @@
 }
 
 .footerContainer {
-  position: relative;
+  /*
+    NOTE: The reason for the double selector here, is to be able to override
+    `@sanity/ui`’s CSS for the `Layer` component. Since `styled-components`
+    applies class names to the element, we need to provide a more specific
+    CSS selector to make sure this property is not overriden.
+  */
+  @nest &.footerContainer {
+    position: relative;
+
+    @media (--max-screen-medium) {
+      position: sticky;
+      bottom: 0;
+    }
+  }
+
   background: var(--component-bg);
-  z-index: var(--zindex-pane);
 
   @nest &:before {
     content: '';
@@ -40,11 +53,6 @@
 
   @nest .isCollapsed & {
     display: none;
-  }
-
-  @media (--max-screen-medium) {
-    position: sticky;
-    bottom: 0;
   }
 }
 
@@ -73,7 +81,6 @@
 .documentContainer {
   flex: 3;
   min-width: 334px;
-  position: relative;
 }
 
 .changesContainer {

--- a/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/documentPanel.css
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/documentPanel.css
@@ -5,15 +5,28 @@
   height: 100%;
   flex-direction: column;
 
-  /* override @sanity/ui */
+  /*
+    NOTE: The reason for the double selector here, is to be able to override
+    `@sanity/ui`’s CSS for the `Layer` component. Since `styled-components`
+    applies class names to the element, we need to provide a more specific
+    CSS selector to make sure this property is not overriden.
+  */
   @nest &.root:not([hidden]) {
     display: flex;
   }
 }
 
 .headerContainer {
-  z-index: var(--zindex-pane);
-  position: relative;
+  /*
+    NOTE: The reason for the double selector here, is to be able to override
+    `@sanity/ui`’s CSS for the `Layer` component. Since `styled-components`
+    applies class names to the element, we need to provide a more specific
+    CSS selector to make sure this property is not overriden.
+  */
+  @nest &.headerContainer {
+    position: relative;
+  }
+
   background: var(--component-bg);
 
   @nest .root:not(.isCollapsed) &::after {
@@ -58,7 +71,6 @@
 }
 
 .portalContainer {
-  z-index: calc(var(--zindex-pane) - 1);
   position: absolute;
   top: 0;
   left: 0;

--- a/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/documentPanel.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/documentPanel.tsx
@@ -1,10 +1,10 @@
-import {MenuItemGroup, BoundaryElementProvider} from '@sanity/base/__legacy/@sanity/components'
-import {Card} from '@sanity/ui'
+import {MenuItemGroup} from '@sanity/base/__legacy/@sanity/components'
+import {BoundaryElementProvider, Card, Layer, PortalProvider, usePortal} from '@sanity/ui'
 import classNames from 'classnames'
-import {PortalProvider, usePortal} from 'part:@sanity/components/portal'
 import {ScrollContainer} from 'part:@sanity/components/scroll'
 import React, {createElement, useCallback, useMemo, useRef, useState} from 'react'
 import {Path} from '@sanity/types'
+import {useZIndex} from '@sanity/base/components'
 import {useDeskToolFeatures} from '../../../features'
 import {useDocumentHistory} from '../documentHistory'
 import {Doc, DocumentView} from '../types'
@@ -56,11 +56,14 @@ interface DocumentPanelProps {
 
 export function DocumentPanel(props: DocumentPanelProps) {
   const {toggleInspect, isHistoryOpen, views, activeViewId} = props
-
+  const zindex = useZIndex()
   const parentPortal = usePortal()
   const features = useDeskToolFeatures()
-  const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null)
   const portalRef = useRef<HTMLDivElement | null>(null)
+  const [
+    documentViewerContainerElement,
+    setDocumentViewerContainerElement,
+  ] = useState<HTMLDivElement | null>(null)
   const {displayed, historyController, open: openHistory} = useDocumentHistory()
   const activeView = views.find((view) => view.id === activeViewId) || views[0] || {type: 'form'}
 
@@ -100,7 +103,7 @@ export function DocumentPanel(props: DocumentPanelProps) {
   )
 
   // Use a local portal container when split panes is supported
-  const portalElement: HTMLElement = features.splitPanes
+  const portalElement: HTMLElement | null = features.splitPanes
     ? portalRef.current || parentPortal.element
     : parentPortal.element
 
@@ -114,7 +117,7 @@ export function DocumentPanel(props: DocumentPanelProps) {
 
   return (
     <Card className={classNames(styles.root, props.isCollapsed && styles.isCollapsed)}>
-      <div className={styles.headerContainer}>
+      <Layer className={styles.headerContainer} zOffset={zindex.pane}>
         <DocumentPanelHeader
           activeViewId={props.activeViewId}
           idPrefix={props.idPrefix}
@@ -147,12 +150,12 @@ export function DocumentPanel(props: DocumentPanelProps) {
           rev={revTime}
           isHistoryOpen={isHistoryOpen}
         />
-      </div>
+      </Layer>
 
       <PortalProvider element={portalElement}>
-        <BoundaryElementProvider element={scrollElement}>
-          <div className={styles.documentViewerContainer}>
-            <ScrollContainer className={styles.documentScroller} ref={setScrollElement}>
+        <BoundaryElementProvider element={documentViewerContainerElement}>
+          <div className={styles.documentViewerContainer} ref={setDocumentViewerContainerElement}>
+            <ScrollContainer className={styles.documentScroller}>
               {activeView.type === 'form' && (
                 <FormView
                   id={props.documentId}

--- a/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/header/contextMenu.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/header/contextMenu.tsx
@@ -59,6 +59,7 @@ export function DocumentPanelContextMenu(props: DocumentPanelContextMenuProps) {
       }
       open={open}
       placement="bottom"
+      portal
       setOpen={setOpen}
     />
   )

--- a/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/header/header.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/header/header.tsx
@@ -2,6 +2,7 @@ import {useTimeAgo} from '@sanity/base/hooks'
 import {MenuItem, MenuItemGroup} from '@sanity/base/__legacy/@sanity/components'
 import {Chunk} from '@sanity/field/diff'
 import {Path} from '@sanity/types'
+import {Layer} from '@sanity/ui'
 import classNames from 'classnames'
 import {negate, upperFirst} from 'lodash'
 import CloseIcon from 'part:@sanity/base/close-icon'
@@ -97,7 +98,7 @@ export function DocumentPanelHeader(props: DocumentPanelHeaderProps) {
   const menuOpen = isTimelineOpen && timelineMode === 'rev'
 
   return (
-    <div className={classNames(styles.root, isCollapsed && styles.isCollapsed)}>
+    <Layer className={classNames(styles.root, isCollapsed && styles.isCollapsed)}>
       <div className={styles.mainNav}>
         <div className={styles.title} onClick={handleTitleClick}>
           <strong>{title}</strong>
@@ -198,7 +199,7 @@ export function DocumentPanelHeader(props: DocumentPanelHeaderProps) {
           )}
         </div>
       )}
-    </div>
+    </Layer>
   )
 }
 

--- a/packages/@sanity/desk-tool/src/panes/documentPane/statusBar/actionMenu.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/statusBar/actionMenu.tsx
@@ -105,7 +105,7 @@ export function ActionMenu({actionStates, onOpen, onClose, disabled, isOpen}: Pr
 
   return (
     <div className={styles.actionsDropDown} ref={clickOutsideRef} onKeyDown={handleKeyDown}>
-      <Popover content={popoverContent} open={isOpen} placement="top-end">
+      <Popover content={popoverContent} open={isOpen} placement="top-end" portal>
         <div>
           <Button
             aria-controls={`${idPrefix}-menu`}

--- a/packages/@sanity/desk-tool/src/panes/listPane/ListPane.js
+++ b/packages/@sanity/desk-tool/src/panes/listPane/ListPane.js
@@ -89,6 +89,7 @@ export default class ListPane extends React.PureComponent {
 
     return (
       <DefaultPane
+        data-test="desk-tool-list-pane"
         index={index}
         title={title}
         styles={styles}

--- a/packages/@sanity/desk-tool/src/tool/DeskToolPanes.css
+++ b/packages/@sanity/desk-tool/src/tool/DeskToolPanes.css
@@ -1,6 +1,7 @@
 @import 'part:@sanity/base/theme/variables-style';
 
 .root {
+  position: relative;
   height: 100%;
 
   @media (--screen-medium) {

--- a/packages/@sanity/desk-tool/src/tool/DeskToolPanes.js
+++ b/packages/@sanity/desk-tool/src/tool/DeskToolPanes.js
@@ -8,6 +8,7 @@ import {mapTo, delay, distinctUntilChanged} from 'rxjs/operators'
 import SplitController from 'part:@sanity/components/panes/split-controller'
 import SplitPaneWrapper from 'part:@sanity/components/panes/split-pane-wrapper'
 import {resizeObserver} from '@sanity/base/lib/util/resizeObserver'
+import {PortalProvider} from '@sanity/ui'
 import {DeskToolPane, LoadingPane} from '../panes'
 import windowWidth$ from '../utils/windowWidth'
 import isNarrowScreen from '../utils/isNarrowScreen'
@@ -259,18 +260,25 @@ export default class DeskToolPanes extends React.Component {
     }, [])
   }
 
+  setPortalElement = (portalElement) => {
+    this.portalElement = portalElement
+  }
+
   render() {
     const {hasNarrowScreen} = this.state
     return (
       <div ref={this._rootElement} className={styles.root}>
-        <SplitController
-          isMobile={hasNarrowScreen}
-          autoCollapse={this.props.autoCollapse}
-          collapsedWidth={COLLAPSED_WIDTH}
-          onCheckCollapse={this.handleCheckCollapse}
-        >
-          {this.renderPanes()}
-        </SplitController>
+        <PortalProvider element={this.portalElement || null}>
+          <SplitController
+            isMobile={hasNarrowScreen}
+            autoCollapse={this.props.autoCollapse}
+            collapsedWidth={COLLAPSED_WIDTH}
+            onCheckCollapse={this.handleCheckCollapse}
+          >
+            {this.renderPanes()}
+          </SplitController>
+          <div data-portal="" ref={this.setPortalElement} />
+        </PortalProvider>
       </div>
     )
   }

--- a/packages/@sanity/field/package.json
+++ b/packages/@sanity/field/package.json
@@ -30,9 +30,11 @@
     "@sanity/diff": "2.2.6",
     "@sanity/react-hooks": "2.2.6",
     "@sanity/types": "2.2.6",
+    "@sanity/ui": "^0.33.0",
     "@sanity/util": "2.2.6",
     "date-fns": "^2.16.1",
-    "sanity-diff-patch": "^1.0.9"
+    "sanity-diff-patch": "^1.0.9",
+    "styled-components": "^5.2.1"
   },
   "devDependencies": {
     "react": "17.0.1",

--- a/packages/@sanity/field/src/diff/components/ChangeList.tsx
+++ b/packages/@sanity/field/src/diff/components/ChangeList.tsx
@@ -1,4 +1,5 @@
 import {DialogAction} from '@sanity/base/__legacy/@sanity/components'
+import {LegacyLayerProvider} from '@sanity/base/components'
 import {useDocumentOperation} from '@sanity/react-hooks'
 import UndoIcon from 'part:@sanity/base/undo-icon'
 import Button from 'part:@sanity/components/buttons/default'
@@ -119,6 +120,7 @@ export function ChangeList({diff, fields, schemaType}: Props): React.ReactElemen
                 },
               ]}
               onAction={handleConfirmDialogAction}
+              onClickOutside={closeRevertAllChangesConfirmDialog}
               referenceElement={revertAllContainerElement}
               size="small"
             >

--- a/packages/@sanity/field/src/diff/components/FieldChange.tsx
+++ b/packages/@sanity/field/src/diff/components/FieldChange.tsx
@@ -1,4 +1,5 @@
 import {DialogAction} from '@sanity/base/__legacy/@sanity/components'
+import {LegacyLayerProvider} from '@sanity/base/components'
 import {useDocumentOperation} from '@sanity/react-hooks'
 import classNames from 'classnames'
 import PopoverDialog from 'part:@sanity/components/dialogs/popover'
@@ -92,7 +93,6 @@ export function FieldChange({change}: {change: FieldChangeNode}) {
 
               {confirmRevertOpen && (
                 <PopoverDialog
-                  portal
                   actions={[
                     {
                       color: 'danger',
@@ -106,7 +106,8 @@ export function FieldChange({change}: {change: FieldChangeNode}) {
                     },
                   ]}
                   onAction={handleConfirmDialogAction}
-                  // portal
+                  onClickOutside={closeRevertChangesConfirmDialog}
+                  portal
                   referenceElement={revertButtonElement}
                   size="small"
                 >

--- a/packages/@sanity/field/src/types/portableText/diff/components/Annotation.tsx
+++ b/packages/@sanity/field/src/types/portableText/diff/components/Annotation.tsx
@@ -1,3 +1,4 @@
+import {useClickOutside} from '@sanity/ui'
 import {toString} from '@sanity/util/paths'
 import classNames from 'classnames'
 import {isKeySegment, Path} from '@sanity/types'
@@ -5,7 +6,6 @@ import ChevronDownIcon from 'part:@sanity/base/chevron-down-icon'
 import {Popover} from 'part:@sanity/components/popover'
 import React, {useCallback, useEffect, useState} from 'react'
 import {ConnectorContext, useReportedValues} from '@sanity/base/lib/change-indicators'
-import {useClickOutside} from '@sanity/base/__legacy/@sanity/components'
 import {
   ChangeList,
   DiffContext,

--- a/packages/@sanity/field/src/types/portableText/diff/components/InlineObject.tsx
+++ b/packages/@sanity/field/src/types/portableText/diff/components/InlineObject.tsx
@@ -1,10 +1,9 @@
 import {FOCUS_TERMINATOR, toString} from '@sanity/util/paths'
 import classNames from 'classnames'
 import {isKeySegment, Path} from '@sanity/types'
+import {useClickOutside, useLayer} from '@sanity/ui'
 import ChevronDownIcon from 'part:@sanity/base/chevron-down-icon'
 import SanityPreview from 'part:@sanity/base/preview'
-import {useClickOutside} from '@sanity/base/__legacy/@sanity/components'
-import {useLayer} from 'part:@sanity/components/layer'
 import {Popover} from 'part:@sanity/components/popover'
 import React, {useCallback, useState, useEffect} from 'react'
 import {ConnectorContext, useReportedValues} from '@sanity/base/lib/change-indicators'
@@ -154,16 +153,14 @@ function PopoverContent({
   schemaType: ObjectSchemaType
 }) {
   const [popoverElement, setPopoverElement] = useState<HTMLDivElement | null>(null)
-  const layer = useLayer()
-  const isTopLayer = layer.depth === layer.size
+  const {isTopLayer} = useLayer()
 
-  useClickOutside(
-    useCallback(() => {
-      if (!isTopLayer) return
-      onClose()
-    }, [isTopLayer, onClose]),
-    [popoverElement]
-  )
+  const handleClickOutside = useCallback(() => {
+    if (!isTopLayer) return
+    onClose()
+  }, [isTopLayer, onClose])
+
+  useClickOutside(handleClickOutside, [popoverElement])
 
   return (
     <div className={styles.popoverContent} ref={setPopoverElement}>

--- a/packages/@sanity/form-builder/src/inputs/ArrayInput/ArrayInput.css
+++ b/packages/@sanity/form-builder/src/inputs/ArrayInput/ArrayInput.css
@@ -47,6 +47,10 @@
   padding-bottom: var(--extra-small-padding);
 }
 
+:global(.ArrayInput__moving) {
+  z-index: var(--zindex-moving-item);
+}
+
 .gridItem {
 }
 

--- a/packages/@sanity/form-builder/src/inputs/ArrayInput/item/ArrayInputGridItem.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ArrayInput/item/ArrayInputGridItem.tsx
@@ -9,7 +9,7 @@ import Button from 'part:@sanity/components/buttons/default'
 import IntentButton from 'part:@sanity/components/buttons/intent'
 import DefaultDialog from 'part:@sanity/components/dialogs/default'
 import FullscreenDialog from 'part:@sanity/components/dialogs/fullscreen'
-import Popover from 'part:@sanity/components/dialogs/popover'
+import PopoverDialog from 'part:@sanity/components/dialogs/popover'
 import EditItemFold from 'part:@sanity/components/edititem/fold'
 import {createDragHandle} from 'part:@sanity/components/lists/sortable'
 import ValidationStatus from 'part:@sanity/components/validation/status'
@@ -205,15 +205,15 @@ export class ArrayInputGridItem extends React.PureComponent<ArrayInputGridItemPr
     if (options.editModal === 'popover') {
       return (
         <div className={styles.popupAnchor}>
-          <Popover
+          <PopoverDialog
             title={title}
             onClose={this.handleEditStop}
             onEscape={this.handleEditStop}
             onClickOutside={this.handleEditStop}
-            placement="auto"
+            placement="bottom"
           >
             <PresenceOverlay margins={[0, 0, 1, 0]}>{content}</PresenceOverlay>
-          </Popover>
+          </PopoverDialog>
         </div>
       )
     }

--- a/packages/@sanity/form-builder/src/inputs/ArrayInput/item/ArrayInputListItem.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ArrayInput/item/ArrayInputListItem.tsx
@@ -212,7 +212,7 @@ export class ArrayInputListItem extends React.PureComponent<ArrayInputListItemPr
           onClose={this.handleEditStop}
           onEscape={this.handleEditStop}
           onClickOutside={this.handleEditStop}
-          placement="auto"
+          placement="bottom"
           referenceElement={this.innerElement}
         >
           <PresenceOverlay margins={[0, 0, 1, 0]}>{content}</PresenceOverlay>

--- a/packages/@sanity/form-builder/src/inputs/PortableText/BlockExtras.css
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/BlockExtras.css
@@ -5,7 +5,6 @@
   box-sizing: border-box;
   position: relative;
   overflow: hidden;
-  z-index: var(--zindex-portal);
 }
 
 .content {
@@ -78,7 +77,6 @@
 }
 
 .hasFocus {
-  
 }
 
 .changeIndicator {

--- a/packages/@sanity/form-builder/src/inputs/PortableText/BlockExtras.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/BlockExtras.tsx
@@ -1,3 +1,5 @@
+import {useZIndex} from '@sanity/base/components'
+import {Layer} from '@sanity/ui'
 import React from 'react'
 import classNames from 'classnames'
 import {ChangeIndicatorWithProvidedFullPath} from '@sanity/base/lib/change-indicators'
@@ -22,6 +24,7 @@ type Props = {
 }
 export default function BlockExtras(props: Props) {
   const editor = usePortableTextEditor()
+  const zindex = useZIndex()
   const {block, blockActions, height, isFullscreen, markers, onFocus, renderCustomMarkers} = props
   const blockValidation = getValidationMarkers(markers)
   const errors = blockValidation.filter((mrkr) => mrkr.level === 'error')
@@ -62,7 +65,7 @@ export default function BlockExtras(props: Props) {
       content
     )
   return (
-    <div
+    <Layer
       className={classNames([
         styles.root,
         hasFocus && styles.hasFocus,
@@ -70,9 +73,10 @@ export default function BlockExtras(props: Props) {
         errors.length > 0 && styles.withError,
         warnings.length > 0 && !errors.length && styles.withWarning,
       ])}
+      zOffset={zindex.portal}
     >
       {returned}
-    </div>
+    </Layer>
   )
 }
 

--- a/packages/@sanity/form-builder/src/inputs/PortableText/Editor.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Editor.tsx
@@ -14,8 +14,8 @@ import {
   usePortableTextEditor,
 } from '@sanity/portable-text-editor'
 import {Marker} from '@sanity/types'
+import {useLayer} from '@sanity/ui'
 import {FOCUS_TERMINATOR} from '@sanity/util/paths'
-import {useLayer} from 'part:@sanity/components/layer'
 import {ScrollContainer} from 'part:@sanity/components/scroll'
 import React, {useMemo, useCallback, useEffect, useState} from 'react'
 import PatchEvent from '../../PatchEvent'
@@ -44,6 +44,7 @@ type Props = {
   renderBlockActions?: RenderBlockActions
   renderChild: RenderChildFunction
   renderCustomMarkers?: RenderCustomMarkers
+  setPortalElement?: (el: HTMLDivElement | null) => void
   setScrollContainerElement: (el: HTMLElement | null) => void
   value: PortableTextBlock[] | undefined
 }
@@ -68,14 +69,14 @@ function PortableTextSanityEditor(props: Props) {
     renderBlockActions,
     renderChild,
     renderCustomMarkers,
+    setPortalElement,
     setScrollContainerElement,
     value,
   } = props
 
   const editor = usePortableTextEditor()
   const ptFeatures = useMemo(() => PortableTextEditor.getPortableTextFeatures(editor), [])
-  const layer = useLayer()
-  const isTopLayer = layer.depth === layer.size
+  const {isTopLayer} = useLayer()
 
   const handleOpenObjectHotkey = (
     event: React.BaseSyntheticEvent,
@@ -215,25 +216,28 @@ function PortableTextSanityEditor(props: Props) {
           </div>
         </div>
 
-        <ScrollContainer className={scClassNames} ref={setScrollContainerElement}>
-          <div className={editorWrapperClassNames}>
-            <div className={styles.blockExtras}>{blockExtras()}</div>
-            <div className={editorClassNames}>
-              <PortableTextEditable
-                hotkeys={hotkeys}
-                onCopy={onCopy}
-                onPaste={onPaste}
-                placeholderText={value ? undefined : 'Empty'}
-                renderAnnotation={renderAnnotation}
-                renderBlock={renderBlock}
-                renderChild={renderChild}
-                renderDecorator={renderDecorator}
-                selection={initialSelection}
-                spellCheck
-              />
+        <div className={styles.editorBoxContent}>
+          <ScrollContainer className={scClassNames} ref={setScrollContainerElement}>
+            <div className={editorWrapperClassNames}>
+              <div className={styles.blockExtras}>{blockExtras()}</div>
+              <div className={editorClassNames}>
+                <PortableTextEditable
+                  hotkeys={hotkeys}
+                  onCopy={onCopy}
+                  onPaste={onPaste}
+                  placeholderText={value ? undefined : 'Empty'}
+                  renderAnnotation={renderAnnotation}
+                  renderBlock={renderBlock}
+                  renderChild={renderChild}
+                  renderDecorator={renderDecorator}
+                  selection={initialSelection}
+                  spellCheck
+                />
+              </div>
             </div>
-          </div>
-        </ScrollContainer>
+          </ScrollContainer>
+          <div data-portal="" ref={setPortalElement} />
+        </div>
       </div>
     ),
     [initialSelection, isFullscreen, value, readOnly, forceUpdate]

--- a/packages/@sanity/form-builder/src/inputs/PortableText/Input.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Input.tsx
@@ -375,7 +375,7 @@ export default function PortableTextInput(props: Props) {
             <BoundaryElementProvider element={scrollContainerElement}>
               <Layer
                 className={classNames(styles.fullscreenPortal, readOnly && styles.readOnly)}
-                zOffset={zindex.pane - 2}
+                zOffset={zindex.portal}
               >
                 {ptEditor}
               </Layer>

--- a/packages/@sanity/form-builder/src/inputs/PortableText/Objects/renderers/PopoverObjectEditing.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Objects/renderers/PopoverObjectEditing.tsx
@@ -45,7 +45,6 @@ export const PopoverObjectEditing: FunctionComponent<Props> = ({
   readOnly,
   type,
 }) => {
-  const boundaryElement = useBoundaryElement()
   const editor = usePortableTextEditor()
   const handleChange = (patchEvent: PatchEvent): void => onChange(patchEvent, path)
   const getEditorElement = () => {
@@ -60,14 +59,14 @@ export const PopoverObjectEditing: FunctionComponent<Props> = ({
 
   return (
     <PopoverDialog
-      boundaryElement={boundaryElement}
       fallbackPlacements={['top', 'bottom']}
       placement="bottom"
-      portal
       referenceElement={refElement}
       onClickOutside={onClose}
       onEscape={onClose}
       onClose={onClose}
+      preventOverflow
+      portal
       title={type.title}
       size="small"
     >

--- a/packages/@sanity/form-builder/src/inputs/PortableText/PortableTextInput.css
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/PortableTextInput.css
@@ -2,16 +2,19 @@
 
 /* The fullscreen editor renders in a portal element */
 .fullscreenPortal {
-  position: absolute;
+  /* Override Sanity UI */
+  &.fullscreenPortal {
+    position: absolute;
+
+    @media (--max-screen-medium) {
+      position: fixed;
+    }
+  }
+
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-
-  @media (--max-screen-medium) {
-    position: fixed;
-    z-index: var(--zindex-portal);
-  }
 }
 
 .root {
@@ -101,21 +104,28 @@
   }
 }
 
-.scrollContainer {
-  composes: scrollY from 'part:@sanity/base/theme/layout/scrolling-style';
-  background-color: var(--body-bg);
-  display: block;
+.editorBoxContent {
   height: 15rem;
-  box-sizing: border-box;
-  overflow-y: overlay;
-  flex-direction: column;
-  flex-grow: 1;
   position: relative;
 
   @nest .fullscreenPortal & {
     min-height: 0;
     flex: 1;
     height: 100%;
+  }
+}
+
+.scrollContainer {
+  composes: scrollY from 'part:@sanity/base/theme/layout/scrolling-style';
+  background-color: var(--body-bg);
+  display: block;
+  height: 100%;
+  box-sizing: border-box;
+  overflow-y: overlay;
+  flex-direction: column;
+  flex-grow: 1;
+
+  @nest .fullscreenPortal & {
     overflow: auto;
 
     @media (--screen-medium) {

--- a/packages/@sanity/form-builder/src/inputs/PortableText/PortableTextInput.css
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/PortableTextInput.css
@@ -2,19 +2,24 @@
 
 /* The fullscreen editor renders in a portal element */
 .fullscreenPortal {
-  /* Override Sanity UI */
+  /*
+    NOTE: The reason for the double selector here, is to be able to override
+    `@sanity/ui`’s CSS for the `Layer` component. Since `styled-components`
+    applies class names to the element, we need to provide a more specific
+    CSS selector to make sure this property is not overriden.
+  */
   &.fullscreenPortal {
     position: absolute;
+    top: 1px;
+    left: 0;
+    right: 0;
+    bottom: 0;
 
     @media (--max-screen-medium) {
       position: fixed;
+      top: 0;
     }
   }
-
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
 }
 
 .root {
@@ -282,9 +287,9 @@
   @nest .fullscreenPortal & {
     width: calc(100% - var(--block-extras-width));
     /* This is needed for the change connectors to render properly in fullscreen mode */
-    border: 1px solid transparent;
     box-sizing: border-box;
   }
+
   @nest .fullscreenPortal .hasNoBlockExtras & {
     width: 100%;
   }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

- This change implements the use of `Layer`, `LayerProvider` and `Portal` from `@sanity/ui`, where we prior to this were using part-based components for these (`part:@sanity/components/layer` and `part:@sanity/components/portal`).
- This change introduces a `useZIndex()` hook exported from `@sanity/base/components` which returns a map of all the z-indexes that are defined in CSS variables, to make it easier to transition to `@sanity/ui` gradually.

The affected packages and components:
- `@sanity/base`
  - `DefaultDialog` (legacy)
  - `FullscreenDialog` (legacy)
  - `PopoverDialog` (legacy)
  - `EditItemFoldOut` (legacy)
  - `MenuButton` (legacy)
  - `Popover` (legacy)
  - `StatelessSearchableSelect` (legacy)
  - `Poppable` (legacy)
  - `SanityRoot`
- `@sanity/default-layout`
  - `DefaultLayout`
  - `ActionModal`
  - `Sidecard`
  - `LoginStatus`
  - `PresenceMenu`
  - `SideMenu`
- `@sanity/desk-tool`
  - `DocumentPane`
- `@sanity/field`
  - `ChangeList`
  - `FieldChange`
  - `Annotation`
  - `InlineObject`
- `@sanity/form-builder`
  - `ArrayInputGridItem`
  - `ArrayInputListItem`
  - `PortableTextInput`
- `@sanity/storybook`

### What to review

- Make sure everything that renders on top of something else is rendered with the right `z-index`, and are not covering something that should be in the front.

### Notes for release

- Migrated to using `Layer` and `Portal` from `@sanity/ui` for dialogs, popovers, overlays, and the like.