### PR TITLE
[base] Use legacy theming for Sanity UI inputs

### DIFF
--- a/packages/@sanity/base/src/theme/color/index.ts
+++ b/packages/@sanity/base/src/theme/color/index.ts
@@ -1,0 +1,62 @@
+import {studioTheme as defaults, ThemeColorSchemes} from '@sanity/ui'
+import legacyTheme from 'sanity:css-custom-properties'
+import {input} from './input'
+
+// NOTE: This mapping is needed only in a transition period between legacy CSS custom properties,
+// and the new Theme API provided by Sanity UI.
+export const color: ThemeColorSchemes = {
+  ...defaults.color,
+  light: {
+    ...defaults.color.light,
+    default: {
+      ...defaults.color.light.default,
+      base: {
+        ...defaults.color.light.default.base,
+        bg: legacyTheme['--component-bg'],
+        fg: legacyTheme['--component-text-color'],
+        border: legacyTheme['--hairline-color'],
+      },
+      card: {
+        ...defaults.color.light.default.card,
+        enabled: {
+          ...defaults.color.light.default.card.enabled,
+          bg: legacyTheme['--component-bg'],
+          fg: legacyTheme['--component-text-color'],
+          border: legacyTheme['--hairline-color'],
+        },
+      },
+      input,
+      // @todo: button
+      // @todo: card
+      // @todo: spot
+      // @todo: syntax
+      // @todo: solid
+      // @todo: muted
+    },
+    transparent: {
+      ...defaults.color.light.transparent,
+      base: {
+        ...defaults.color.light.transparent.base,
+        bg: legacyTheme['--body-bg'],
+        fg: legacyTheme['--body-text'],
+        border: legacyTheme['--hairline-color'],
+      },
+      card: {
+        ...defaults.color.light.transparent.card,
+        enabled: {
+          ...defaults.color.light.transparent.card.enabled,
+          bg: legacyTheme['--body-bg'],
+          fg: legacyTheme['--body-text'],
+          border: legacyTheme['--hairline-color'],
+        },
+      },
+      input,
+      // @todo: button
+      // @todo: card
+      // @todo: spot
+      // @todo: syntax
+      // @todo: solid
+      // @todo: muted
+    },
+  },
+}

--- a/packages/@sanity/base/src/theme/color/input.ts
+++ b/packages/@sanity/base/src/theme/color/input.ts
@@ -1,0 +1,45 @@
+import {ThemeColorInput} from '@sanity/ui'
+import legacyTheme from 'sanity:css-custom-properties'
+
+export const input: ThemeColorInput = {
+  default: {
+    enabled: {
+      bg: legacyTheme['--input-bg'],
+      fg: legacyTheme['--input-color'],
+      border: legacyTheme['--input-border-color'],
+      placeholder: legacyTheme['--input-color-placeholder'],
+    },
+    disabled: {
+      bg: legacyTheme['--input-bg-disabled'],
+      fg: legacyTheme['--input-color-read-only'],
+      border: legacyTheme['--input-border-color'],
+      placeholder: legacyTheme['--input-color-placeholder'],
+    },
+    hovered: {
+      bg: legacyTheme['--input-bg'],
+      fg: legacyTheme['--input-color'],
+      border: legacyTheme['--input-border-color-hover'],
+      placeholder: legacyTheme['--input-color-placeholder'],
+    },
+  },
+  invalid: {
+    enabled: {
+      bg: legacyTheme['--input-bg-invalid'],
+      fg: legacyTheme['--input-color'],
+      border: legacyTheme['--input-border-color-invalid'],
+      placeholder: legacyTheme['--input-color-placeholder'],
+    },
+    disabled: {
+      bg: legacyTheme['--input-bg-invalid'],
+      fg: legacyTheme['--input-color'],
+      border: legacyTheme['--input-border-color-invalid'],
+      placeholder: legacyTheme['--input-color-placeholder'],
+    },
+    hovered: {
+      bg: legacyTheme['--input-bg-invalid'],
+      fg: legacyTheme['--input-color'],
+      border: legacyTheme['--input-border-color-invalid'],
+      placeholder: legacyTheme['--input-color-placeholder'],
+    },
+  },
+}

--- a/packages/@sanity/base/src/theme/index.ts
+++ b/packages/@sanity/base/src/theme/index.ts
@@ -1,5 +1,6 @@
-import {RootTheme, studioTheme as defaults, ThemeColorSchemes} from '@sanity/ui'
+import {RootTheme, studioTheme as defaults} from '@sanity/ui'
 import legacyTheme from 'sanity:css-custom-properties'
+import {color} from './color'
 
 // For debugging purposes
 declare global {
@@ -7,52 +8,8 @@ declare global {
     __sanityLegacyTheme: Record<string, string>
   }
 }
-window.__sanityLegacyTheme = legacyTheme
 
-// NOTE: This mapping is needed only in a transition period between legacy CSS custom properties,
-// and the new Theme API provided by Sanity UI.
-const color: ThemeColorSchemes = {
-  ...defaults.color,
-  light: {
-    ...defaults.color.light,
-    default: {
-      ...defaults.color.light.default,
-      base: {
-        ...defaults.color.light.default.base,
-        bg: legacyTheme['--component-bg'],
-        fg: legacyTheme['--component-text-color'],
-        border: legacyTheme['--hairline-color'],
-      },
-      card: {
-        ...defaults.color.light.default.card,
-        enabled: {
-          ...defaults.color.light.default.card.enabled,
-          bg: legacyTheme['--component-bg'],
-          fg: legacyTheme['--component-text-color'],
-          border: legacyTheme['--hairline-color'],
-        },
-      },
-    },
-    transparent: {
-      ...defaults.color.light.transparent,
-      base: {
-        ...defaults.color.light.transparent.base,
-        bg: legacyTheme['--body-bg'],
-        fg: legacyTheme['--body-text'],
-        border: legacyTheme['--hairline-color'],
-      },
-      card: {
-        ...defaults.color.light.transparent.card,
-        enabled: {
-          ...defaults.color.light.transparent.card.enabled,
-          bg: legacyTheme['--body-bg'],
-          fg: legacyTheme['--body-text'],
-          border: legacyTheme['--hairline-color'],
-        },
-      },
-    },
-  },
-}
+window.__sanityLegacyTheme = legacyTheme
 
 export const theme: RootTheme = {
   ...defaults,


### PR DESCRIPTION
This change adds mapping of color values from the legacy theming to the Sanity UI theme object, so that input elements get the correct colors.

### In order to test:

1. Open `examples/design-studio/themes/dev.css`
2. Change the `@import` to use `dark.css`
3. Start the Design Studio using `npm run design-studio`
4. Make sure all inputs have the expected color (defined in `dark.css`)