### PR TITLE
[core] GraphQL: Add --non-null-document-fields flag

### DIFF
--- a/packages/@sanity/cli/src/util/parseArguments.js
+++ b/packages/@sanity/cli/src/util/parseArguments.js
@@ -27,6 +27,7 @@ module.exports = function parseArguments(argv = process.argv) {
       v, version,
     },
 
+    argv, // forwarded to commands that want to be more explicit about parsing
     extOptions, // forwarded to commands
     argsWithoutOptions, // remaining arguments
     extraArguments, // arguments after the ended argument list (--)

--- a/packages/@sanity/core/package.json
+++ b/packages/@sanity/core/package.json
@@ -69,7 +69,8 @@
     "semver": "^6.1.2",
     "simple-get": "^4.0.0",
     "tar-fs": "^1.16.0",
-    "terser": "4.6.7"
+    "terser": "4.6.7",
+    "yargs": "^16.2.0"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/core/src/actions/graphql/extractFromSanitySchema.js
+++ b/packages/@sanity/core/src/actions/graphql/extractFromSanitySchema.js
@@ -62,7 +62,8 @@ function isReference(typeDef) {
   return false
 }
 
-function extractFromSanitySchema(sanitySchema) {
+function extractFromSanitySchema(sanitySchema, extractOptions = {}) {
+  const {nonNullDocumentFields} = extractOptions
   const unionRecursionGuards = []
   const hasErrors =
     sanitySchema._validation &&
@@ -374,35 +375,36 @@ function extractFromSanitySchema(sanitySchema) {
   }
 
   function getDocumentInterfaceFields() {
+    const isNullable = typeof nonNullDocumentFields === 'boolean' ? !nonNullDocumentFields : true
     return [
       {
         fieldName: '_id',
         type: 'ID',
-        isNullable: true,
+        isNullable,
         description: 'Document ID',
       },
       {
         fieldName: '_type',
         type: 'String',
-        isNullable: true,
+        isNullable,
         description: 'Document type',
       },
       {
         fieldName: '_createdAt',
         type: 'Datetime',
-        isNullable: true,
+        isNullable,
         description: 'Date the document was created',
       },
       {
         fieldName: '_updatedAt',
         type: 'Datetime',
-        isNullable: true,
+        isNullable,
         description: 'Date the document was last modified',
       },
       {
         fieldName: '_rev',
         type: 'String',
-        isNullable: true,
+        isNullable,
         description: 'Current document revision',
       },
     ]

--- a/packages/@sanity/core/src/commands/graphql/deployGraphQLAPICommand.js
+++ b/packages/@sanity/core/src/commands/graphql/deployGraphQLAPICommand.js
@@ -5,6 +5,7 @@ Options
   --dataset <dataset> Deploy API for the given dataset
   --tag <tag> Deploy API to given tag (defaults to 'default')
   --generation <generation> API generation to deploy (defaults to 'gen3')
+  --non-null-document-fields Set document interface fields (_id, _type etc) as non-null
   --playground Deploy a GraphQL playground for easily testing queries (public)
   --no-playground Skip playground prompt (do not deploy a playground)
   --force Deploy API without confirming breaking changes
@@ -16,6 +17,7 @@ Examples
   sanity graphql deploy --dataset staging --no-playground
   sanity graphql deploy --dataset staging --tag next --no-playground
   sanity graphql deploy --no-playground --force
+  sanity graphql deploy --playground --non-null-document-fields
 `
 
 export default {


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [x]  Yes
- [ ]  No

**Current behavior**

In a previous release, we set the document interface fields (`_id`, `_type`, `_createdAt` and such) to be nullable, because you can use a document type as an (unreferenced) object in a document field or array. In these situations, `_createdAt` would not be present - so flagging it as non-nullable was incorrect.

**Description**

In many cases this is not something that you actually use, however - you usually create objects for things you want to inline and documents for things you want to reference. Having these fields be non-null can greatly enhance the development experience.

This PR adds a flag you can use to opt-in for non-nullable document fields. This way the technically correct behavior is the default, while the user (who knows their schema best) can _choose_ to opt in.

I've added yargs and explicit argv parsing within the action because these boolean flags gets unwieldy if not parsed correctly. We should find the time to improve the general flags parsing in the CLI soon, but leaving that for another time.

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

- Add `--non-null-document-fields` flag to the `sanity graphql deploy` command. Use it to force fields like `_id`, `_type` and `_createdAt` to be marked as non-nullable fields in GraphQL APIs.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [x]  Corresponding changes to the documentation have been made _(staged)_
