### PR TITLE
[validation] Fix bug on object type with "value" field + "list" option

### DIFF
--- a/examples/test-studio/schemas/validation.js
+++ b/examples/test-studio/schemas/validation.js
@@ -1,6 +1,7 @@
 import client from 'part:@sanity/base/client'
 import {points, featureCollection} from '@turf/helpers'
 import pointsWithinPolygon from '@turf/points-within-polygon'
+import {CustomObjectSelectInput} from '../src/components/CustomObjectSelectInput'
 import norway from '../data/norway'
 
 export const validationArraySuperType = {
@@ -505,6 +506,30 @@ export default {
           ],
         },
       ],
+    },
+    {
+      name: 'objectList',
+      title: 'Object field with custom input supporting `list` option',
+      type: 'object',
+      validation: (Rule) => Rule.required(),
+      fields: [
+        {
+          name: 'title',
+          type: 'string',
+        },
+        {
+          name: 'value',
+          type: 'string',
+        },
+      ],
+      options: {
+        list: [
+          {title: 'Red', value: '#f00'},
+          {title: 'Green', value: '#0f0'},
+          {title: 'Blue', value: '#00f'},
+        ],
+      },
+      inputComponent: CustomObjectSelectInput,
     },
   ],
 }

--- a/examples/test-studio/src/components/CustomObjectSelectInput.tsx
+++ b/examples/test-studio/src/components/CustomObjectSelectInput.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import {Marker, ObjectSchemaType} from '@sanity/types'
+import {PatchEvent, set, unset} from 'part:@sanity/form-builder/patch-event'
+import {FormField} from '@sanity/base/components'
+import {Select} from '@sanity/ui'
+
+type Value = {title: string; value: string}
+
+type Props = {
+  type: ObjectSchemaType & {options?: {list?: Value[]}}
+  level: number
+  value: Value | null | undefined
+  readOnly: boolean | null
+  onChange: (patchEvent: unknown) => void
+  markers: Marker[]
+  presence: unknown[]
+}
+
+const EMPTY_ARRAY: Value[] = []
+
+let objectSelectInputIdx = 0
+export const CustomObjectSelectInput = React.forwardRef(function CustomObjectSelectInput(
+  props: Props,
+  forwardedRef: React.ForwardedRef<HTMLSelectElement | HTMLInputElement>
+) {
+  const {value, readOnly, markers, type, level, onChange, presence} = props
+  const items = (type.options && type.options.list) || EMPTY_ARRAY
+  const validation = markers.filter((marker) => marker.type === 'validation')
+  const errors = validation.filter((marker) => marker.level === 'error')
+  const [inputId] = React.useState(() => ++objectSelectInputIdx)
+
+  const handleChange = React.useCallback(
+    (evt) => {
+      onChange(
+        PatchEvent.from(
+          evt.target.value ? set(items.find((item) => item.value === evt.target.value)) : unset()
+        )
+      )
+    },
+    [onChange, items]
+  )
+  return (
+    <FormField
+      inputId={inputId}
+      level={level}
+      title={type.title}
+      description={type.description}
+      __unstable_markers={markers}
+      __unstable_presence={presence}
+    >
+      <Select
+        onChange={handleChange}
+        id={inputId}
+        ref={forwardedRef}
+        readOnly={readOnly}
+        customValidity={errors?.[0]?.item.message}
+        value={value && value.value}
+      >
+        {[{title: '', value: undefined}, ...items].map((item, i) => (
+          <option key={i} value={item.value}>
+            {item.title}
+          </option>
+        ))}
+      </Select>
+    </FormField>
+  )
+})

--- a/packages/@sanity/validation/package.json
+++ b/packages/@sanity/validation/package.json
@@ -31,6 +31,7 @@
     "directory": "packages/@sanity/validation"
   },
   "devDependencies": {
+    "@sanity/schema": "2.2.0",
     "jest": "^26.4.2"
   },
   "dependencies": {

--- a/packages/@sanity/validation/src/validators/arrayValidator.js
+++ b/packages/@sanity/validation/src/validators/arrayValidator.js
@@ -53,7 +53,7 @@ const valid = (allowedValues, values, message) => {
 
   return paths.length === 0
     ? true
-    : new ValidationError(message || 'Value did not match any of allowed values', {paths})
+    : new ValidationError(message || 'Value did not match any allowed values', {paths})
 }
 
 const unique = (flag, value, message) => {

--- a/packages/@sanity/validation/src/validators/genericValidator.js
+++ b/packages/@sanity/validation/src/validators/genericValidator.js
@@ -59,8 +59,8 @@ const valid = (allowedValues, actual, message) => {
   const strValue = value && value.length > 30 ? `${value.slice(0, 30)}…` : value
 
   const defaultMessage = value
-    ? `Value "${strValue}" did not match any of allowed values`
-    : 'Value did not match any of allowed values'
+    ? `Value "${strValue}" did not match any allowed values`
+    : 'Value did not match any allowed values'
 
   return allowedValues.some((expected) => deepEquals(expected, actual))
     ? true

--- a/packages/@sanity/validation/test/infer.test.js
+++ b/packages/@sanity/validation/test/infer.test.js
@@ -1,0 +1,75 @@
+const Schema = require('@sanity/schema').default
+const inferFromSchema = require('../src/inferFromSchema')
+
+describe('schema validation inference', () => {
+  describe('object with `options.list` and `value` field', () => {
+    const listOptions = [
+      {value: '#f00', title: 'Red'},
+      {value: '#0f0', title: 'Green'},
+      {value: '#00f', title: 'Blue'},
+    ]
+
+    const schema = Schema.compile({
+      types: [
+        {
+          name: 'colorList',
+          type: 'object',
+          fields: [
+            {name: 'value', type: 'string'},
+            {name: 'title', type: 'string'},
+          ],
+          options: {
+            list: listOptions,
+          },
+        },
+      ],
+    })
+
+    test('allowed value', async () => {
+      const type = inferFromSchema(schema).get('colorList')
+      await expectNoError(type.validation, listOptions[0])
+    })
+
+    test('disallowed value', async () => {
+      const type = inferFromSchema(schema).get('colorList')
+      await expectError(
+        type.validation,
+        {value: '#ccc', title: 'Gray'},
+        'Value did not match any allowed value'
+      )
+    })
+  })
+})
+
+async function expectNoError(validations, value) {
+  const errors = (await Promise.all(validations.map((rule) => rule.validate(value)))).flat()
+  if (errors.length === 0) {
+    // This shouldn't actually be needed, but counts against an assertion in jest-terms
+    expect(errors).toHaveLength(0)
+    return
+  }
+
+  const messages = errors.map((err) => err.item && err.item.message).join('\n\n- ')
+  throw new Error(`Expected no errors, but found ${errors.length}:\n- ${messages}`)
+}
+
+async function expectError(validations, value, message, level = 'error') {
+  const errors = (await Promise.all(validations.map((rule) => rule.validate(value)))).flat()
+  if (!errors.length) {
+    throw new Error(`Expected error matching "${message}", but no errors were returned.`)
+  }
+
+  const matches = errors.filter((err) => err.item && err.item.message.includes(message))
+  if (matches.length === 0) {
+    const messages = errors.map((err) => err.item && err.item.message).join('\n\n- ')
+    throw new Error(`Expected error matching "${message}" not found. Errors found:\n- ${messages}`)
+  }
+
+  const levelMatch = matches.find((err) => err.level === level)
+  if (!levelMatch) {
+    throw new Error(`Expected error to have level "${level}", got ${matches[0].level}`)
+  }
+
+  // This shouldn't actually be needed, but counts against an assertion in jest-terms
+  expect(levelMatch.item.message).toMatch(message)
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

Note: This is quite an edge-case, but be patient with me:

If you...
1. Have an object type that defines the field `value`
2. Add the (non-standard) `options.list` configuration (generally seen in `string` and `number` types) on the field/type
3. Set a (valid) value on the field 

... when the validation inference runs on the schema types, it will incorrectly grab the value of the `value` field, instead of the object itself. When comparing the value of the object field (`{value: 'foo', other: 'props'}`) against the "allowed" values, it will never find a match, since it's comparing the nested value of the `value` prop instead of the root object.

This results in a "Value does not match allowed values" error.

This particular case was uncovered by the [color-list](https://github.com/KimPaow/sanity-color-list) plugin.

**Description**

This PR changes the logic of the `extractValueFromListOption` method in the validation module to look for a defined `value` field on the object. If defined, it will use the root-level object as the value - otherwise it will assume you wanted the nested `value`.

While this technically is an edge case, I figured it's not too far-fetched that we will support an object select in the same way we support string/number selects, so this will come in handy in that case. 

I also added an example input component mirroring the behavior of the color list plugin (but without the fancy UI logic), which lets us reproduce the issue.

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

- Fix bug when object type has a `value` field and is paired with the (unsupported) `options.list` schema type option

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
