### PR TITLE
[form-builder] Fix crash on rendering unknown value warning for objects

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
@@ -233,7 +233,7 @@ export default class ArrayOfPrimitivesInput extends React.PureComponent<Props> {
                 onClick={() => this.handleRemoveItem(value.findIndex((v) => v === item.value))}
                 color="danger"
               >
-                Unset {item.value}
+                Unset {['string', 'number'].includes(typeof item.value) ? item.value : ''}
               </DefaultButton>
             )}
           </div>


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

If the array of primitives input contains an unknown type that is not renderable (say, an object), it will crash when React attempts to render the item/object.

**Description**

This PR checks if the value is a string or a number, and if not just renders "Unset" instead of "Unset <X>".

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
