### PR TITLE
[types] Relax titled list option check, allow additional attributes

### DIFF
--- a/examples/test-studio/schemas/strings.js
+++ b/examples/test-studio/schemas/strings.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import {MdTextFormat as icon} from 'react-icons/md'
 import {HooksBasedStringInput} from '../src/components/HooksBasedStringInput'
 
@@ -106,6 +107,35 @@ export default {
           {
             title: 'Three (3)',
             value: 'three',
+          },
+        ],
+      },
+    },
+    {
+      name: 'listWithKeys',
+      title: 'Select (with `_key`)',
+      type: 'string',
+      options: {
+        list: [
+          // Note: "icon" is not used for anything, but was brought up as an example
+          // of a regression on the community slack (it was used in a custom input)
+          {
+            _key: 'red',
+            title: 'Red',
+            value: 'red',
+            icon: <div style={{width: '1em', height: '1em', background: 'red'}} />,
+          },
+          {
+            _key: 'green',
+            title: 'Green',
+            value: 'green',
+            icon: <div style={{width: '1em', height: '1em', background: 'green'}} />,
+          },
+          {
+            _key: 'blue',
+            title: 'Blue',
+            value: 'blue',
+            icon: <div style={{width: '1em', height: '1em', background: 'blue'}} />,
           },
         ],
       },

--- a/packages/@sanity/types/src/schema/asserters.ts
+++ b/packages/@sanity/types/src/schema/asserters.ts
@@ -11,11 +11,5 @@ export function isReferenceSchemaType(
 }
 
 export function isTitledListValue(item: unknown): item is TitledListValue {
-  return (
-    typeof item === 'object' &&
-    item !== null &&
-    'title' in item &&
-    'value' in item &&
-    Object.keys(item).length === 2
-  )
+  return typeof item === 'object' && item !== null && 'title' in item && 'value' in item
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

As #2088 describes - if you have additional attributes aside from `value` and `title` in the `options.list` configuration, we'll incorrectly try to use the entire object as the title, which results in a dropdown of `[object Object]`.

**Description**

The validation seems a little over-eager to me. There isn't really any good reason (that I can see) why we have to enforce that `value` and `title` are the only two properties in the object. 

I've removed the check for `Object.keys(item).length === 2`, but we still check that both `value` and `title` is present.  Also added an example schema that reproduces the error. 

Fixes #2088

**Note for release**

- Fix error where inputs with `options.list` option would render `[object Object]` in certain cases

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
