### PR TITLE
[form-builder] Fix bug where radio was missing onChange

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/SelectInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/SelectInput.tsx
@@ -46,6 +46,7 @@ const SelectInput = React.forwardRef(function SelectInput(
     >
       {isRadio ? (
         <RadioSelect
+          inputId={inputId}
           items={items}
           value={currentItem}
           onChange={handleChange}
@@ -83,10 +84,11 @@ const RadioSelect = React.forwardRef(function RadioSelect(
     readOnly: boolean
     onChange: (value: TitledListValue<string | number> | null) => void
     customValidity?: string
+    inputId?: string
   },
   forwardedRef: React.ForwardedRef<HTMLInputElement>
 ) {
-  const {items, value, onChange, readOnly, customValidity, direction} = props
+  const {items, value, onChange, readOnly, customValidity, direction, inputId} = props
 
   const Layout = direction === 'horizontal' ? Inline : Stack
   return (
@@ -100,6 +102,7 @@ const RadioSelect = React.forwardRef(function RadioSelect(
               onChange={() => onChange(item)}
               readOnly={readOnly}
               customValidity={customValidity}
+              name={inputId}
             />
             <Box marginLeft={3}>
               <Text>{item.title}</Text>

--- a/packages/@sanity/form-builder/src/inputs/SelectInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/SelectInput.tsx
@@ -97,7 +97,7 @@ const RadioSelect = React.forwardRef(function RadioSelect(
             <Radio
               ref={index === 0 ? forwardedRef : null}
               checked={value === item}
-              onClick={() => onChange(item)}
+              onChange={() => onChange(item)}
               readOnly={readOnly}
               customValidity={customValidity}
             />


### PR DESCRIPTION
## Context

This change should fix the warning in console complaining about that you can't have a `checked` prop without having `onChange`.

## Summary

* Rename `onClick` to `onChange` in the usage of `Radio` from `Sanity-UI` (the `onChange` as far as I can see should work since we send the item itself)
* Send `inputId` which is sent to `FormField` to `RadioInput` as well to give the radios a name which should fix tabbed navigation