### PR TITLE
[form-builder] Fix bug where SelectInput sent the wrong update patch

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/SelectInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/SelectInput.tsx
@@ -33,7 +33,7 @@ const SelectInput = React.forwardRef(function SelectInput(
   }
 
   const optionValueFromItem = (item) => {
-    return items.indexOf(item)
+    return String(items.indexOf(item))
   }
 
   const inputId = useId()

--- a/packages/@sanity/form-builder/src/inputs/SelectInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/SelectInput.tsx
@@ -49,9 +49,12 @@ const SelectInput = React.forwardRef(function SelectInput(
   const handleSelectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const nextItem = itemFromOptionValue(event.currentTarget.value)
 
-    if (nextItem) {
-      handleChange(nextItem)
+    if (!nextItem) {
+      handleChange(EMPTY_ITEM)
+      return
     }
+
+    handleChange(nextItem)
   }
 
   return (

--- a/packages/@sanity/form-builder/src/inputs/SelectInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/SelectInput.tsx
@@ -26,15 +26,34 @@ const SelectInput = React.forwardRef(function SelectInput(
   const validation = markers.filter((marker) => marker.type === 'validation')
   const errors = validation.filter((marker) => marker.level === 'error')
 
+  const itemFromOptionValue = (optionValue) => {
+    const index = Number(optionValue)
+
+    return items[index]
+  }
+
+  const optionValueFromItem = (item) => {
+    return items.indexOf(item)
+  }
+
   const inputId = useId()
   const handleChange = React.useCallback(
-    (nextItem) => {
+    (nextItem: TitledListValue<string | number>) => {
       onChange(
         PatchEvent.from(typeof nextItem.value === 'undefined' ? unset() : set(nextItem.value))
       )
     },
     [onChange]
   )
+
+  const handleSelectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const nextItem = itemFromOptionValue(event.currentTarget.value)
+
+    if (nextItem) {
+      handleChange(nextItem)
+    }
+  }
+
   return (
     <FormField
       inputId={inputId}
@@ -56,14 +75,15 @@ const SelectInput = React.forwardRef(function SelectInput(
         />
       ) : (
         <Select
-          onChange={handleChange}
+          onChange={handleSelectChange}
           id={inputId}
           ref={forwardedRef as React.ForwardedRef<HTMLSelectElement>}
           readOnly={readOnly}
           customValidity={errors?.[0]?.item.message}
+          value={optionValueFromItem(currentItem)}
         >
           {[EMPTY_ITEM, ...items].map((item, i) => (
-            <option key={i} value={item.value}>
+            <option key={`${i - 1}`} value={i - 1}>
               {item.title}
             </option>
           ))}


### PR DESCRIPTION
* Fixed a typo in the value where we should have used `-` instead of `+`. Other than that the idea is the same - use index to map between value and item
* Added `value` to the select so that it'll have the right value selected on for example undo from review changes