### PR TITLE
[form-builder] Emit onFocus from select + radio select inputs

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/SelectInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/SelectInput.tsx
@@ -19,7 +19,7 @@ const SelectInput = React.forwardRef(function SelectInput(
   props: Props<string | number>,
   forwardedRef: React.ForwardedRef<HTMLSelectElement | HTMLInputElement>
 ) {
-  const {value, readOnly, markers, type, level, onChange, presence} = props
+  const {value, readOnly, markers, type, level, onChange, onFocus, presence} = props
   const items = ((type.options?.list || []) as unknown[]).map(toSelectItem)
   const currentItem = items.find((item) => item.value === value)
   const isRadio = type.options && type.options.layout === 'radio'
@@ -57,6 +57,10 @@ const SelectInput = React.forwardRef(function SelectInput(
     handleChange(nextItem)
   }
 
+  const handleFocus = React.useCallback(() => {
+    onFocus()
+  }, [onFocus])
+
   return (
     <FormField
       inputId={inputId}
@@ -75,11 +79,13 @@ const SelectInput = React.forwardRef(function SelectInput(
           direction={type.options.direction || 'vertical'}
           ref={forwardedRef as React.ForwardedRef<HTMLInputElement>}
           readOnly={readOnly}
+          onFocus={handleFocus}
           customValidity={errors?.[0]?.item.message}
         />
       ) : (
         <Select
           onChange={handleSelectChange}
+          onFocus={handleFocus}
           id={inputId}
           ref={forwardedRef as React.ForwardedRef<HTMLSelectElement>}
           readOnly={readOnly}
@@ -106,12 +112,13 @@ const RadioSelect = React.forwardRef(function RadioSelect(
     direction: 'horizontal' | 'vertical'
     readOnly: boolean
     onChange: (value: TitledListValue<string | number> | null) => void
+    onFocus: (event: React.FocusEvent<HTMLElement>) => void
     customValidity?: string
     inputId?: string
   },
   forwardedRef: React.ForwardedRef<HTMLInputElement>
 ) {
-  const {items, value, onChange, readOnly, customValidity, direction, inputId} = props
+  const {items, value, onChange, onFocus, readOnly, customValidity, direction, inputId} = props
 
   const Layout = direction === 'horizontal' ? Inline : Stack
   return (
@@ -123,6 +130,7 @@ const RadioSelect = React.forwardRef(function RadioSelect(
               ref={index === 0 ? forwardedRef : null}
               checked={value === item}
               onChange={() => onChange(item)}
+              onFocus={onFocus}
               readOnly={readOnly}
               customValidity={customValidity}
               name={inputId}

--- a/packages/@sanity/form-builder/src/inputs/types.ts
+++ b/packages/@sanity/form-builder/src/inputs/types.ts
@@ -4,6 +4,7 @@ import {
   Marker,
   NumberSchemaType,
   ObjectSchemaType,
+  Path,
   SchemaType,
   StringSchemaType,
 } from '@sanity/types'
@@ -29,7 +30,9 @@ export type Props<
   value: T | null | undefined
   readOnly: boolean | null
   onChange: (patchEvent: PatchEvent) => void
-  onFocus: () => void
+  // Note: we should allow implementors of custom inputs to forward the passed onFocus to native element's onFocus handler,
+  // but use Path consistently on internal inputs
+  onFocus: (path?: Path | React.FocusEvent<any>) => void
   onBlur?: () => void
   markers: Marker[]
   presence: FormFieldPresence[]


### PR DESCRIPTION
This makes sure we emit onFocus from Select Input (including radio select). Had to modify the signature of Input component Props type to better reflect the reality (in the future, allowing `React.FocusEvent<any>` should go into a convenience wrapper for custom inputs so we can avoid having to verify/normalized the passed event at different steps).

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)

**Does this change require a documentation update? (Check one)**

- [x]  No
