### PR TITLE
[form-builder] Text inputs should be resizable and have a larger default height

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/TextInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/TextInput.tsx
@@ -1,9 +1,8 @@
 import React, {ForwardedRef} from 'react'
+import {useId} from '@reach/auto-id'
+import {FormField} from '@sanity/base/components'
 import {TextSchemaType} from '@sanity/types'
 import {TextArea} from '@sanity/ui'
-import {useId} from '@reach/auto-id'
-
-import {FormField} from '@sanity/base/components'
 import PatchEvent, {set, unset} from '../PatchEvent'
 import {Props} from './types'
 
@@ -43,7 +42,7 @@ const TextInput = React.forwardRef(function TextInput(
         onChange={handleChange}
         onFocus={onFocus}
         onBlur={onBlur}
-        rows={type.rows}
+        rows={type.rows || 10}
         ref={forwardedRef}
       />
     </FormField>

--- a/packages/@sanity/form-builder/src/inputs/TextInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/TextInput.tsx
@@ -3,8 +3,15 @@ import {useId} from '@reach/auto-id'
 import {FormField} from '@sanity/base/components'
 import {TextSchemaType} from '@sanity/types'
 import {TextArea} from '@sanity/ui'
+import styled from 'styled-components'
 import PatchEvent, {set, unset} from '../PatchEvent'
 import {Props} from './types'
+
+const StyledTextArea = styled(TextArea)`
+  &[data-as='textarea'] {
+    resize: vertical;
+  }
+`
 
 const TextInput = React.forwardRef(function TextInput(
   props: Props<string, TextSchemaType>,
@@ -33,7 +40,7 @@ const TextInput = React.forwardRef(function TextInput(
       __unstable_presence={presence}
       inputId={inputId}
     >
-      <TextArea
+      <StyledTextArea
         id={inputId}
         customValidity={errors && errors.length > 0 ? errors[0].item.message : ''}
         value={value || ''}


### PR DESCRIPTION
- Fixes issue with the `rows` property’s default value being different than before.
- Fixes issue with the `textarea` missing its resize affordance.