### PR TITLE
[base] Fix: make the new FormField behave the same way as DefaultFormField

### DIFF
--- a/examples/test-studio/schemas/arrays.js
+++ b/examples/test-studio/schemas/arrays.js
@@ -254,6 +254,13 @@ export default {
       ],
     },
     {
+      name: 'arrayOfStrings',
+      title: 'Array of strings',
+      description: 'This array contains only strings, with no title',
+      type: 'array',
+      of: [{type: 'string'}],
+    },
+    {
       name: 'arrayOfPrimitives',
       title: 'Array with primitive types',
       description: 'This array contains only strings, values and booleans',

--- a/packages/@sanity/base/src/components/formField/FormField.tsx
+++ b/packages/@sanity/base/src/components/formField/FormField.tsx
@@ -58,13 +58,20 @@ export function FormField(
 
   return (
     <Stack {...restProps} data-level={level} space={1}>
-      <FormFieldHeader
-        __unstable_markers={markers}
-        __unstable_presence={presence}
-        description={description}
-        inputId={inputId}
-        title={title}
-      />
+      {/*
+        NOTE: It’s not ideal to hide validation, presence and description when there's no `title`.
+        So we might want to separate the concerns of input vs formfield components later on.
+      */}
+      {title && (
+        <FormFieldHeader
+          __unstable_markers={markers}
+          __unstable_presence={presence}
+          description={description}
+          inputId={inputId}
+          title={title}
+        />
+      )}
+
       <div>{content}</div>
     </Stack>
   )


### PR DESCRIPTION
### Description

This change makes the new `FormField` component behave the same way as the legacy `DefaultFormField` component with regards to the `title` (previously `label`) property.

The `DefaultFormField` hides the entire form field header when no `title` is provided. Although this is not ideal in all scenarios, this is something we will continue to do for backwards compatibility.

### What to review

This change affects mainly arrays with primitive types, but may affect all fields using the new `FormField` component.

**How to test:**
- Start the test studio: `npm run test-studio`
- Open the arrays test: http://localhost:3333/test/desk/arraysTest
- Make sure the items in **Array with primitive types** have a header title
- Make sure the items in **Array of strings** have no header title

### Notes for release

- Fixes a visual regression that affected rendering of form field headers in primitive array values.