### PR TITLE
[form-builder] TextInput: Only apply default when type.rows is not a number

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/TextInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/TextInput.tsx
@@ -49,7 +49,7 @@ const TextInput = React.forwardRef(function TextInput(
         onChange={handleChange}
         onFocus={onFocus}
         onBlur={onBlur}
-        rows={type.rows || 10}
+        rows={typeof type.rows === 'number' ? type.rows : 10}
         ref={forwardedRef}
       />
     </FormField>


### PR DESCRIPTION
### Description

Fixes #2258

### Notes for release
Fixed an issue with text areas getting default (10) rows when using `rows: 0` on the schema type