### PR TITLE
Fix bug where BooleanInput had too much padding-bottom

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/BooleanInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/BooleanInput.tsx
@@ -14,6 +14,10 @@ const CenterAlignedBox = styled(Box)`
   align-self: center;
 `
 
+const ZeroLineHeightBox = styled(Box)`
+  line-height: 0;
+`
+
 const BooleanInput = React.forwardRef(function BooleanInput(
   props: Props<boolean, BooleanSchemaType>,
   ref: React.ForwardedRef<HTMLInputElement>
@@ -39,7 +43,7 @@ const BooleanInput = React.forwardRef(function BooleanInput(
     <ChangeIndicator>
       <Card as="label" border radius={1}>
         <Flex>
-          <Box style={{lineHeight: 0}}>
+          <ZeroLineHeightBox padding={3}>
             <LayoutSpecificInput
               id={inputId}
               ref={ref}
@@ -51,7 +55,7 @@ const BooleanInput = React.forwardRef(function BooleanInput(
               checked={checked}
               style={{margin: -4}}
             />
-          </Box>
+          </ZeroLineHeightBox>
           <Box marginLeft={3} flex={1} padding={3}>
             <FormFieldHeaderText
               description={type.description}

--- a/packages/@sanity/form-builder/src/inputs/BooleanInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/BooleanInput.tsx
@@ -1,4 +1,5 @@
 import React, {useCallback} from 'react'
+import styled from 'styled-components'
 import {useId} from '@reach/auto-id'
 import {Box, Card, Checkbox, Flex, Switch} from '@sanity/ui'
 import {BooleanSchemaType} from '@sanity/types'
@@ -8,6 +9,10 @@ import {ChangeIndicator} from '@sanity/base/lib/change-indicators'
 import {FieldPresence} from '@sanity/base/presence'
 import PatchEvent, {set} from '../PatchEvent'
 import {Props} from './types'
+
+const CenterAlignedBox = styled(Box)`
+  align-self: center;
+`
 
 const BooleanInput = React.forwardRef(function BooleanInput(
   props: Props<boolean, BooleanSchemaType>,
@@ -32,7 +37,7 @@ const BooleanInput = React.forwardRef(function BooleanInput(
 
   return (
     <ChangeIndicator>
-      <Card as="label" border radius={1} padding={3}>
+      <Card as="label" border radius={1}>
         <Flex>
           <Box style={{lineHeight: 0}}>
             <LayoutSpecificInput
@@ -47,18 +52,18 @@ const BooleanInput = React.forwardRef(function BooleanInput(
               style={{margin: -4}}
             />
           </Box>
-          <Box marginLeft={3} flex={1}>
+          <Box marginLeft={3} flex={1} padding={3}>
             <FormFieldHeaderText
               description={type.description}
               __unstable_markers={markers}
               title={type.title}
             />
           </Box>
-          <Box>
+          <CenterAlignedBox paddingX={3} paddingY={1}>
             <FieldStatus maxAvatars={1} position="top">
               <FieldPresence maxAvatars={1} presence={presence} />
             </FieldStatus>
-          </Box>
+          </CenterAlignedBox>
         </Flex>
       </Card>
     </ChangeIndicator>

--- a/packages/@sanity/form-builder/src/inputs/BooleanInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/BooleanInput.tsx
@@ -41,7 +41,7 @@ const BooleanInput = React.forwardRef(function BooleanInput(
 
   return (
     <ChangeIndicator>
-      <Card as="label" border radius={1}>
+      <Card border radius={1}>
         <Flex>
           <ZeroLineHeightBox padding={3}>
             <LayoutSpecificInput
@@ -56,9 +56,10 @@ const BooleanInput = React.forwardRef(function BooleanInput(
               style={{margin: -4}}
             />
           </ZeroLineHeightBox>
-          <Box marginLeft={3} flex={1} padding={3}>
+          <Box flex={1} paddingY={3}>
             <FormFieldHeaderText
               description={type.description}
+              inputId={inputId}
               __unstable_markers={markers}
               title={type.title}
             />


### PR DESCRIPTION
## Description

### Context

A bug was reported where `BooleanInput` had too much bottom padding. It's not supposed to look like that.

![screenshot_2021-01-27-09:01:06](https://user-images.githubusercontent.com/3595094/105963019-c4df9700-6080-11eb-8262-afb39513509f.png)

### Changes

* Move the `BooleanInput` padding from the surrounding `Card` to the individual boxes making up the component in order to reduce the padding around the `Presence` field which has a certain height and what was caused the whitespace
* Move a `line-height` css prop to a styled component

![screenshot_2021-01-27-09:00:35](https://user-images.githubusercontent.com/3595094/105962993-bf824c80-6080-11eb-9dcb-fd3236008425.png)
​
## What to review
​
This is very visual so shouldn't require too much reviewing.

### How to review

1. Remove `readonly: true` from `switchIndeterminate2` in `examples/test-studio/schemas/booleans.js`
1. Navigate to `http://localhost:3333/test/desk/booleansTest;bd99e58a-845f-4d52-b54a-56a9b7af3be1` and look at the check box
​
## Notes for release
​
* Fixed a bug where `BooleanInput`s without description text had unwanted bottom whitespace