### PR TITLE
[base] Fix placement of SearchableSelect's result box

### DIFF
--- a/examples/test-studio/schemas/poppers.js
+++ b/examples/test-studio/schemas/poppers.js
@@ -1,0 +1,29 @@
+export default {
+  type: 'document',
+  name: 'poppers',
+  title: 'Poppers',
+  fields: [
+    {
+      type: 'string',
+      name: 'title',
+      title: 'Title',
+    },
+    {
+      type: 'array',
+      name: 'objectsWithReference',
+      title: 'Objects with reference',
+      of: [
+        {
+          type: 'object',
+          name: 'objectWithReference',
+          title: 'Object with reference',
+          fields: [
+            {type: 'string', name: 'title', title: 'Title'},
+            {type: 'text', name: 'description', title: 'Description', rows: 20},
+            {type: 'reference', name: 'reference', title: 'Reference', to: [{type: 'book'}]},
+          ],
+        },
+      ],
+    },
+  ],
+}

--- a/examples/test-studio/schemas/schema.js
+++ b/examples/test-studio/schemas/schema.js
@@ -2,6 +2,7 @@ import createSchema from 'part:@sanity/base/schema-creator'
 import codeInputType from 'part:@sanity/form-builder/input/code/schema'
 import schemaTypes from 'all:part:@sanity/base/schema-type'
 
+import poppers from './poppers'
 import simpleBlock from './simpleBlock'
 import simpleBlockNote from './simpleBlockNote'
 import simpleBlockNoteBody from './simpleBlockNoteBody'
@@ -64,6 +65,7 @@ import {customBlock, hoistedPt, hoistedPtDocument} from './hoistedPt'
 export default createSchema({
   name: 'test-examples',
   types: schemaTypes.concat([
+    poppers,
     objectWithNestedArray,
     book,
     author,

--- a/packages/@sanity/base/src/__legacy/@sanity/components/selects/StatelessSearchableSelect.tsx
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/selects/StatelessSearchableSelect.tsx
@@ -7,6 +7,7 @@ import {Layer, useLayer} from 'part:@sanity/components/layer'
 import Spinner from 'part:@sanity/components/loading/spinner'
 import DefaultTextInput from 'part:@sanity/components/textinputs/default'
 import CloseIcon from 'part:@sanity/base/close-icon'
+import {useBoundaryElement} from '../boundaryElement'
 import {useClickOutside} from '../hooks'
 import SelectMenu from './SelectMenu'
 
@@ -173,23 +174,38 @@ const StatelessSearchableSelect = forwardRef(
     } = props
 
     const itemsLen = items.length
-
+    const boundaryElement = useBoundaryElement()
     const [referenceElement, setReferenceElement] = useState<HTMLElement | null>(null)
     const [popperElement, setPopperElement] = useState<HTMLElement | null>(null)
+
     const popper = usePopper(referenceElement, popperElement, {
       placement: dropdownPosition as any,
       modifiers: [
         {
           name: 'preventOverflow',
           options: {
-            altAxis: true,
+            rootBoundary: boundaryElement ? undefined : 'viewport',
+            boundary: boundaryElement || 'clippingParents',
             padding: 8,
-            tether: false,
+          },
+        },
+        {
+          name: 'flip',
+          options: {
+            rootBoundary: boundaryElement ? undefined : 'viewport',
+            boundary: boundaryElement || 'clippingParents',
+            fallbackPlacements: ['top-start', 'bottom-start'],
           },
         },
         sameWidthModifier,
       ],
     })
+
+    const {forceUpdate} = popper
+
+    useEffect(() => {
+      if (forceUpdate) setTimeout(forceUpdate, 0)
+    }, [itemsLen, forceUpdate])
 
     const handleSelect = useCallback(
       (item: Item) => {


### PR DESCRIPTION
### Description

Code changes:
- The `SearchableSelect` now calls `popper.forceUpdate` whenever the height of the result items change.
- Replaces the [`altAxis`](https://popper.js.org/docs/v2/modifiers/prevent-overflow/#altaxis) and [`tether`](https://popper.js.org/docs/v2/modifiers/prevent-overflow/#tether) options in the `preventOverflow` modifier with using the `flip` modifier to fix situations in which the popper has insufficient room to expand below the reference element.

These changes solves the issue when a reference input is placed at the bottom of an array item, and the results box was cut off by the pane's scrollable element.

![image](https://user-images.githubusercontent.com/406933/105988503-016ebb00-60a0-11eb-8c38-42027c93cddb.png)

### What to review

- Make sure the reference input's search result box is placed correctly in all situations.

### Notes for release

- Fixes an issue with reference search results being cut off by the editor’s scrollable element.