### PR TITLE
[cli] Add array of packages excluded from update

### DIFF
--- a/packages/@sanity/cli/src/actions/versions/findSanityModuleVersions.js
+++ b/packages/@sanity/cli/src/actions/versions/findSanityModuleVersions.js
@@ -7,6 +7,17 @@ import dynamicRequire from '../../util/dynamicRequire'
 import getLocalVersion from '../../util/getLocalVersion'
 import pkg from '../../../package.json'
 
+/*
+ * Some packages can introduce errors when updating. For example with Sanity UI
+ * we are at the moment dependant upon the version of @sanity/ui that
+ * @sanity/base imports to be the only version used since all imports of UI
+ * need to use the same context.
+ *
+ * Put them in this array to make sure the upgrade script doesn't upgrade
+ * them.
+ */
+const PACKAGES_TO_EXCLUDE = ['@sanity/ui']
+
 const defaultOptions = {
   includeCli: true,
 }
@@ -51,6 +62,7 @@ function filterSanityModules(manifest) {
 
   const sanityDeps = Object.keys(dependencies)
     .filter((mod) => mod.indexOf('@sanity/') === 0)
+    .filter((mod) => !PACKAGES_TO_EXCLUDE.includes(mod))
     .sort()
 
   return sanityDeps.reduce((versions, dependency) => {


### PR DESCRIPTION
## Description

### Context

We've had a lot of these:

```
useRootTheme(): missing context value
```

Which were caused by the `sanity upgrade` command also upgrading `@sanity/ui` for those few who've already installed it manually.

Problem is if a different version than the one `@sanity/base` is using is installed Studio will crash with that error.

### Changes

* Add a hardcoded array of package names to ignore when upgrading
* Add `@sanity/ui` to the array

This will make sure the upgrade command doesn't upgrade `@sanity/ui`.
​
## What to review

This is a very small change so shouldn't need a lot of review.

### How to test

1. Build the repo `npm run build`
2. `cd examples/test-studio`
3. `npm install`
4. Install an old version of Sanity UI: `npm install @sanity/ui@0.32.8`
5. Make sure it shows up in `package.json`
6. Make sure you run the built version of CLI: `../../packages/@sanity/cli/bin/sanity upgrade`
7. Observe that the script doesn't report any changes
​
## Notes for release
​
* Exclude `@sanity/ui` when running `sanity upgrade`
