### PR TITLE
[base] Improve theme errors originating in @sanity/ui

### DIFF
--- a/examples/test-studio/sanity.json
+++ b/examples/test-studio/sanity.json
@@ -102,6 +102,10 @@
     {
       "implements": "part:@sanity/base/tool",
       "path": "src/tools/css-variables/tool"
+    },
+    {
+      "implements": "part:@sanity/base/tool",
+      "path": "src/tools/test-ui-error/tool"
     }
   ],
   "env": {

--- a/examples/test-studio/src/tools/test-ui-error/tool.js
+++ b/examples/test-studio/src/tools/test-ui-error/tool.js
@@ -1,0 +1,21 @@
+import React, {useCallback} from 'react'
+
+export default {
+  title: 'Test UI error',
+  name: 'test-ui-error',
+  component: TestUIErrorTool,
+}
+
+function TestUIErrorTool() {
+  const handleThrowUIError = useCallback(() => {
+    throw new Error('useRootTheme(): missing context value')
+  }, [])
+
+  return (
+    <div style={{padding: 16}}>
+      <button onClick={handleThrowUIError} type="button">
+        Throw UI error
+      </button>
+    </div>
+  )
+}

--- a/packages/@sanity/base/scripts/writeRequiredUIVersion.js
+++ b/packages/@sanity/base/scripts/writeRequiredUIVersion.js
@@ -1,6 +1,6 @@
 // This overwrites the compiled ./lib/requiredSanityUiVersion.js with a the actual version we currently depend on in @sanity/base
-const pkg = require('../package.json')
 const fs = require('fs')
+const pkg = require('../package.json')
 
 const template = (version) => `exports.REQUIRED_UI_VERSION = '${version}'`
 
@@ -15,4 +15,10 @@ try {
   process.exit(1)
 }
 
-fs.writeFileSync(builtFile, template(pkg.dependencies['@sanity/ui'] || 'latest'))
+let version = pkg.dependencies['@sanity/ui']
+
+if (typeof version === 'string' && version.startsWith('^')) {
+  version = version.slice(1)
+}
+
+fs.writeFileSync(builtFile, template(version || 'latest'))

--- a/packages/@sanity/base/src/components/ErrorHandler.js
+++ b/packages/@sanity/base/src/components/ErrorHandler.js
@@ -44,6 +44,13 @@ export default class ErrorHandler extends React.PureComponent {
       return
     }
 
+    // NOTE: This checks if the error is the common "missing theme content value"
+    // error thrown by `@sanity/ui`, in order to take steps to render a helpful error message.
+    if (err.message.includes('useRootTheme():')) {
+      this.props.onUIError(err)
+      return
+    }
+
     // eslint-disable-next-line no-console
     console.error(err)
     this.setState({error: err})

--- a/packages/@sanity/base/src/components/SanityRoot.tsx
+++ b/packages/@sanity/base/src/components/SanityRoot.tsx
@@ -7,6 +7,7 @@ import SnackbarProvider from 'part:@sanity/components/snackbar/provider'
 import React, {useState} from 'react'
 import Refractor from 'react-refractor'
 import jsx from 'refractor/lang/jsx'
+import cssVars from 'sanity:css-custom-properties'
 import styled from 'styled-components'
 import {REQUIRED_UI_VERSION} from '../requiredSanityUiVersion'
 import {theme} from '../theme'
@@ -23,31 +24,42 @@ const Root = styled(Card).attrs({tone: 'transparent'})`
   height: 100%;
 `
 
+function UIErrorMessage() {
+  return (
+    <div
+      style={{WebkitFontSmoothing: 'antialiased', padding: 20, margin: '0 auto', maxWidth: '40rem'}}
+    >
+      <h1>Error: Missing theme context</h1>
+
+      <p>
+        This problem is usually caused by the existence of multiple versions of{' '}
+        <code>@sanity/ui</code> in the same application.
+      </p>
+
+      <p>
+        Make sure to install the same version of <code>@sanity/ui</code> as{' '}
+        <code>@sanity/base</code>:
+      </p>
+
+      <pre style={{padding: 20, background: cssVars['--black'], color: cssVars['--white']}}>
+        <code>npm install @sanity/ui@{REQUIRED_UI_VERSION}</code>
+      </pre>
+    </div>
+  )
+}
+
 function AppProvider() {
   const [portalElement, setPortalElement] = useState(() => document.createElement('div'))
+  const [uiError, setUIError] = useState<Error | null>(null)
 
   try {
     useRootTheme()
   } catch (_) {
-    return (
-      <div style={{padding: 20, margin: '0 auto', maxWidth: '40rem'}}>
-        <h1>Error: Missing theme context</h1>
+    return <UIErrorMessage />
+  }
 
-        <p>
-          This problem is usually caused by multiple versions of <code>@sanity/ui</code> in the same
-          application.
-        </p>
-
-        <p>
-          Make sure to install the same version of <code>@sanity/ui</code> as{' '}
-          <code>@sanity/base</code>:
-        </p>
-
-        <pre style={{padding: 20, background: '#000', color: '#fff'}}>
-          <code>npm install @sanity/ui@"{REQUIRED_UI_VERSION}"</code>
-        </pre>
-      </div>
-    )
+  if (uiError) {
+    return <UIErrorMessage />
   }
 
   return (
@@ -60,7 +72,7 @@ function AppProvider() {
             </ThemeColorProvider>
             <Root scheme="light">
               <DevServerStatus />
-              <ErrorHandler />
+              <ErrorHandler onUIError={setUIError} />
               <RootComponent />
               <VersionChecker />
             </Root>

--- a/packages/@sanity/base/src/requiredSanityUiVersion.ts
+++ b/packages/@sanity/base/src/requiredSanityUiVersion.ts
@@ -1,3 +1,3 @@
 // Note: This file is overwritten on prepublish - see `scripts/writeRequiredUIVersion.js`
 // The version here is only read in development
-export const REQUIRED_UI_VERSION = '^0.0.0'
+export const REQUIRED_UI_VERSION = '0.0.0'

--- a/packages/@sanity/base/src/util/uncaughtErrorHandler.js
+++ b/packages/@sanity/base/src/util/uncaughtErrorHandler.js
@@ -5,7 +5,9 @@ function errHandler(msg, url, lineNo, columnNo, err) {
   // Certain events (ResizeObserver max loop threshold, for instance)
   // only gives a _message_. We choose to ignore these events since
   // they are usually not _fatal_
-  if (!err) {
+  // NOTE: This checks if the error is the common "missing theme content value"
+  // error thrown by `@sanity/ui`, in order to take steps to render a helpful error message.
+  if (!err || err.message.includes('useRootTheme():')) {
     return
   }
 
@@ -62,4 +64,4 @@ export default () => `window.onerror = ${errHandler.toString()}`
 */
 
 export default () =>
-  '/* Global error handler */ window.onerror = function(e,t,n,o,r){if(r){var a=document.getElementById("sanity"),l=document.createElement("div");l.style.position="absolute",l.style.top="50%",l.style.left="50%",l.style.transform="translate(-50%, -50%)";var s=document.createElement("h1");s.innerText="Uncaught error";var d=document.createElement("pre"),i=document.createElement("code");d.style.fontSize="0.8em",d.style.opacity="0.7",d.style.overflow="auto",d.style.whiteSpace="pre-wrap",d.style.maxHeight="70vh";var c=r.stack&&r.stack.replace(r.message,"").replace(/^error: *\\n?/i,""),m=(r.stack?r.message:r.toString())+(r.stack?"\\n\\nStack:\\n\\n"+c:"")+"\\n\\n(Your browsers Developer Tools may contain more info)";i.textContent=m;var p=document.createElement("button");for(p.style.padding="0.8em 1em",p.style.marginTop="1em",p.style.border="none",p.style.backgroundColor="#303030",p.style.color="#fff",p.style.borderRadius="4px",p.onclick=function(){window.location.reload()},p.textContent="Reload",d.appendChild(i),l.appendChild(s),l.appendChild(d),l.appendChild(p);a.firstChild;)a.removeChild(a.firstChild);a.appendChild(l)}}'
+  '/* Global error handler */ window.onerror = function(e,t,n,o,r){if(r&&!r.message.includes("useRootTheme():")){var a=document.getElementById("sanity"),l=document.createElement("div");l.style.position="absolute",l.style.top="50%",l.style.left="50%",l.style.transform="translate(-50%, -50%)";var s=document.createElement("h1");s.innerText="Uncaught error";var d=document.createElement("pre"),i=document.createElement("code");d.style.fontSize="0.8em",d.style.opacity="0.7",d.style.overflow="auto",d.style.whiteSpace="pre-wrap",d.style.maxHeight="70vh";var c=r.stack&&r.stack.replace(r.message,"").replace(/^error: *\\n?/i,""),m=(r.stack?r.message:r.toString())+(r.stack?"\\n\\nStack:\\n\\n"+c:"")+"\\n\\n(Your browsers Developer Tools may contain more info)";i.textContent=m;var p=document.createElement("button");for(p.style.padding="0.8em 1em",p.style.marginTop="1em",p.style.border="none",p.style.backgroundColor="#303030",p.style.color="#fff",p.style.borderRadius="4px",p.onclick=function(){window.location.reload()},p.textContent="Reload",d.appendChild(i),l.appendChild(s),l.appendChild(d),l.appendChild(p);a.firstChild;)a.removeChild(a.firstChild);a.appendChild(l)}}'


### PR DESCRIPTION
### Description

- Test Studio: Adds a tool called `Test UI error` (http://localhost:3333/test/test-ui-error)
- Removes the `^` from the version string written by `packages/@sanity/base/scripts/writeRequiredUIVersion.js`
- Ignore errors containing `useRootTheme():` in the global error handler `packages/@sanity/base/src/util/uncaughtErrorHandler.js`
- Introduces a `onUIError` callback in `ErrorHandler`, so that the theme error is caught and stored in `SanityRoot`’s react state.
- Now renders the theme error message when the error was uncaught.
- Renders the install command as `npm install @sanity/ui@0.32.8` instead of `npm install @sanity/ui@"^0.32.8"` (which was causing issues, and would actually set `"@sanity/ui": "^0.32.9"` in the user’s package.json)

### What to review

- Make sure uncaught exceptions containing `useRootTheme():` makes the Studio render a helpful error message.

### Notes for release

- Uncaught exceptions containing `useRootTheme():` now makes the Studio render a helpful error message.