### PR TITLE
[schema] Add blockEditor to list of overridable fields

### DIFF
--- a/packages/@sanity/schema/src/legacy/types/object.ts
+++ b/packages/@sanity/schema/src/legacy/types/object.ts
@@ -9,6 +9,7 @@ const OVERRIDABLE_FIELDS = [
   ...DEFAULT_OVERRIDEABLE_FIELDS,
   'orderings',
   '__experimental_search',
+  'blockEditor',
   'icon',
 ]
 


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**
Currently, given the `marks` configuration below, Sanity Studio won't apply the custom icons to the `color` annotation. It'll display the Sanity Logo:

![image](https://user-images.githubusercontent.com/13774309/106391793-5e93a500-63ef-11eb-8df3-a020ba72d1bb.png)

<details>
  <summary>Click to see the configuration</summary>
  
```
marks: {
  annotations: [
    {
      title: 'URL',
      name: 'link',
      type: 'object',
      fields: [
        {
          title: 'URL',
          name: 'href',
          type: 'url',
        },
      ],
      blockEditor: {
        icon: () => '🔗',
      },
    },
    {
      title: 'Color',
      name: 'color',
      type: 'color',
      blockEditor: {
        icon: () => '🎨',
      },
    },
  ],
},
```
</details>

<!-- Reference/link the relevant issue and/or describe the behavior. -->

**Description**
With the changes in this PR, the annotation will have the provided icon:

![image](https://user-images.githubusercontent.com/13774309/106391826-7ff49100-63ef-11eb-8617-4195895ecf31.png)

This PR closes #1917.

<!-- Please include a summary of the changes this PR introduces and/or which issue is fixed. Please also include relevant motivation and context of why this PR is necessary. -->

**Note for release**

<!-- Please include a high level summary of the changes this PR introduce. The intended audience is both editors and developers. If it's introducing a new feature, remember to link to docs/blogpost, if it's a bugfix, please describe the bug in non-technical terms (e.g. how a user/developer may have experienced it).
For inspiration, check out the release notes from an earlier release: https://github.com/sanity-io/sanity/releases/tag/v0.142.0 -->

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [x]  Corresponding changes to the documentation have been made
