### PR TITLE
[chore] CI: Skip puppeteer download on non-perf workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,8 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
 
       - name: Install npm dependencies
+        env:
+         PUPPETEER_SKIP_DOWNLOAD: 'true'
         run: npm install
 
       # Required for import lint rules to work - packages pointing to ex

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
 
       - name: Install npm dependencies
+        env:
+         PUPPETEER_SKIP_DOWNLOAD: 'true'
         run: npm install
 
       - name: Build modules

--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -27,6 +27,8 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
 
       - name: Install npm dependencies
+        env:
+         PUPPETEER_SKIP_DOWNLOAD: 'true'
         run: npm install
 
       - name: Run cypress

--- a/.github/workflows/verify_format.yml
+++ b/.github/workflows/verify_format.yml
@@ -25,6 +25,8 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
 
       - name: Install npm dependencies
+        env:
+         PUPPETEER_SKIP_DOWNLOAD: 'true'
         # --ignore-scripts disables postinstall because it's not needed
         # in this CI step and takes a long time
         run: npm install --ignore-scripts


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [x]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

When installing dependencies for our GitHub actions to run, we download a chromium build through puppeteer, which is currently only necessary for the perf suite to run (as far as I can tell). This provides another point of failure (tests in a PR of mine stopped because the download server was giving a 503) and slows down the runs.

**Description**

This PR sets the `PUPPETEER_SKIP_DOWNLOAD` environment variable to `true` on non-perf workflows, which should apparently stop the download from happening.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
