### PR TITLE
[core] Close JSDOM window after schema is resolved

### DIFF
--- a/packages/@sanity/core/src/actions/graphql/getSanitySchema.js
+++ b/packages/@sanity/core/src/actions/graphql/getSanitySchema.js
@@ -30,6 +30,7 @@ function provideFakeGlobals() {
 
 function getSanitySchema(basePath) {
   const domCleanup = jsdomGlobal()
+  const windowCleanup = () => global.window.close()
   const globalCleanup = provideFakeGlobals()
   const contextCleanup = requireContext.register()
   const cleanupFileLoader = pirates.addHook(
@@ -49,6 +50,7 @@ function getSanitySchema(basePath) {
   cleanupFileLoader()
   contextCleanup()
   globalCleanup()
+  windowCleanup()
   domCleanup()
 
   return schema


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

This is an odd one, so hang tight:

- In order to evaluate and get hold of the Sanity schema within a Node.js context, we have to provide a fake browser environment. This is because of input components and such that are imported and assume a browser environment, which tends to crash. We use JSDom for this.
- That's not always enough. JSDom is missing a few globals, such as `requestAnimationFrame`, `InputEvent` and a few other oddities that some plugins feature detect or call. So we explicitly put these things onto the global, if not already there, and remove them again once  the schema is resolved. Pain.
- Some components add _events_ or event set _timers_ - `DOMReady` being one such. In certain cases, there is a race condition where a timer or event is fired _after_ the schema has been resolved. By then, we've done our best to "clean up" the JSDOM context. If that event or timer tries to access, say... `document`: boom 💥.

**Description**

This PR adds a missing piece of the puzzle! When we do the cleanup, by calling `window.close()`, JSDOM will remove all registered timers and events. Hurray! 

**Note for release**

- Fix bug where a `document is not defined` error might be thrown while attempting to deploy a GraphQL API

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
