### PR TITLE
[base] Always disable native autocomplete on searchable selects

### DIFF
--- a/packages/@sanity/base/src/__legacy/@sanity/components/selects/StatelessSearchableSelect.tsx
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/selects/StatelessSearchableSelect.tsx
@@ -312,6 +312,7 @@ const StatelessSearchableSelect = forwardRef(
             selected={isInputSelected}
             disabled={disabled}
             ref={ref as any}
+            autoComplete="off"
             spellCheck="false"
             readOnly={readOnly}
           />


### PR DESCRIPTION
### Description

Tiny change to disable native auto complete for searchable selects.

### Notes for release
- Disabled native `autoComplete` for searchable selects used in studio search and reference search.
