### PR TITLE
[form-builder] Fix wrong invalid state in UrlInput

### DIFF
--- a/examples/test-studio/schemas/urls.js
+++ b/examples/test-studio/schemas/urls.js
@@ -16,6 +16,21 @@ export default {
       type: 'url',
       title: 'Plain url',
       description: 'A plain URL field',
+      // validation: (Rule) =>
+      //   Rule.uri({
+      //     scheme: ['http', 'https', 'mailto', 'tel'],
+      //   }),
+    },
+    {
+      name: 'relativeUri',
+      type: 'url',
+      title: 'Relative url',
+      description: 'A relative URL field',
+      validation: (Rule) =>
+        Rule.uri({
+          scheme: ['http', 'https', 'mailto', 'tel'],
+          allowRelative: true,
+        }),
     },
   ],
 }

--- a/packages/@sanity/form-builder/src/inputs/UrlInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/UrlInput.tsx
@@ -1,9 +1,11 @@
+import {get} from 'lodash'
 import React from 'react'
 import {StringSchemaType} from '@sanity/types'
 import {TextInput} from '@sanity/ui'
 import {useId} from '@reach/auto-id'
 import {FormField} from '@sanity/base/components'
 import PatchEvent, {set, unset} from '../PatchEvent'
+import {getValidationRule} from '../utils/getValidationRule'
 import {Props} from './types'
 
 const UrlInput = React.forwardRef(function UrlInput(
@@ -21,6 +23,8 @@ const UrlInput = React.forwardRef(function UrlInput(
     },
     [onChange]
   )
+  const uriRule = getValidationRule(type, 'uri')
+  const inputType = uriRule && get(uriRule, 'constraint.options.allowRelative') ? 'text' : 'url'
   return (
     <FormField
       level={level}
@@ -31,7 +35,7 @@ const UrlInput = React.forwardRef(function UrlInput(
       inputId={inputId}
     >
       <TextInput
-        type="url"
+        type={inputType}
         inputMode="url"
         id={inputId}
         customValidity={errors.length > 0 ? errors[0].item.message : ''}


### PR DESCRIPTION
### Description

- Fixes a bug where the URLInput was erroneously showing as `:invalid` when `allowRelative: true` was set in the URI validation.

Report:
> I have a standard URL field that is rather angry on the new version, but the same field with the same data is fine on the previous version. There are no validation errors on it in either version.

### How to test

- Go to the URLs test: http://localhost:3333/test/desk/urlsTest
- Check that plain URL fields and URL fields with `allowRelative` behave correctly.
