### PR TITLE
[form-builder] Fix ESC key behavior in nested dialogs

### DIFF
--- a/packages/@sanity/base/src/__legacy/@sanity/components/utilities/ActivateOnFocus.tsx
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/utilities/ActivateOnFocus.tsx
@@ -1,4 +1,3 @@
-import {Layer} from '@sanity/ui'
 import classNames from 'classnames'
 import React from 'react'
 import enhanceWithClickOutside from 'react-click-outside'
@@ -63,7 +62,7 @@ class ActivateOnFocus extends React.Component<ActivateOnFocusProps> {
     const overlayClassName = classNames(styles.overlay, overlayClassNameProp)
 
     return (
-      <Layer className={className} id={inputId}>
+      <div className={className} id={inputId}>
         {!isActive && (
           <div className={styles.eventHandler} onClick={this.handleClick}>
             <div className={overlayClassName}>
@@ -73,7 +72,7 @@ class ActivateOnFocus extends React.Component<ActivateOnFocusProps> {
           </div>
         )}
         <div className={styles.content}>{children}</div>
-      </Layer>
+      </div>
     )
   }
 }

--- a/packages/@sanity/form-builder/src/inputs/PortableText/BlockExtras.css
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/BlockExtras.css
@@ -5,6 +5,7 @@
   box-sizing: border-box;
   position: relative;
   overflow: hidden;
+  z-index: var(--zindex-portal);
 }
 
 .content {

--- a/packages/@sanity/form-builder/src/inputs/PortableText/BlockExtras.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/BlockExtras.tsx
@@ -1,5 +1,3 @@
-import {useZIndex} from '@sanity/base/components'
-import {Layer} from '@sanity/ui'
 import React from 'react'
 import classNames from 'classnames'
 import {ChangeIndicatorWithProvidedFullPath} from '@sanity/base/lib/change-indicators'
@@ -24,7 +22,6 @@ type Props = {
 }
 export default function BlockExtras(props: Props) {
   const editor = usePortableTextEditor()
-  const zindex = useZIndex()
   const {block, blockActions, height, isFullscreen, markers, onFocus, renderCustomMarkers} = props
   const blockValidation = getValidationMarkers(markers)
   const errors = blockValidation.filter((mrkr) => mrkr.level === 'error')
@@ -65,7 +62,7 @@ export default function BlockExtras(props: Props) {
       content
     )
   return (
-    <Layer
+    <div
       className={classNames([
         styles.root,
         hasFocus && styles.hasFocus,
@@ -73,10 +70,9 @@ export default function BlockExtras(props: Props) {
         errors.length > 0 && styles.withError,
         warnings.length > 0 && !errors.length && styles.withWarning,
       ])}
-      zOffset={zindex.portal}
     >
       {returned}
-    </Layer>
+    </div>
   )
 }
 


### PR DESCRIPTION
### Description

This bug was caused by using `Layer` within the dialogs (in `ActivateOnFocus` and `BlockExtras`), causing the `isTopLayer` property of the layer context of `Dialog` to be false (and hence blocking closing dialogs on ESC).

Report:
> The esc key doesn’t close dialogs/modals reliably on the new version. E.g. when nesting in multiple levels, it’s frequently not possible to dismiss them all back to the document with escape key on v2.2.6/2.3.2.