### PR TITLE
[form-builder] Fix bug where datetime popper would be hidden behind dialogs

### DIFF
--- a/cypress/integration/datetimeInput.js
+++ b/cypress/integration/datetimeInput.js
@@ -1,0 +1,28 @@
+describe('DatetimeInput react-datepicker popper', () => {
+  beforeEach(() => {
+    cy.visit(
+      '/test/desk/datetimeTest%2Ctemplate%3DdatetimeTest;b44f31f5-2cb0-431b-a912-aba0e1bf46cd'
+    )
+  })
+
+  it('should be rendered on top of array input dialog', () => {
+    cy.getField('inArray').within(($field) => {
+      cy.contains('Add').scrollIntoView().should('be.visible')
+      cy.contains('Add').click()
+    })
+
+    cy.getField('date').within(($dateField) => {
+      cy.get('button[title="Select date"]').click()
+    })
+
+    cy.get('.react-datepicker-popper').should('be.visible')
+  })
+
+  it('should be visible when clicking select date', () => {
+    cy.getField('justDefaults').within(($field) => {
+      cy.get('button[title="Select date"]').click()
+    })
+
+    cy.get('.react-datepicker-popper').should('be.visible')
+  })
+})

--- a/packages/@sanity/form-builder/src/inputs/DateInputs/BaseDateTimeInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/DateInputs/BaseDateTimeInput.tsx
@@ -2,7 +2,6 @@
 import 'react-datepicker/dist/react-datepicker-cssmodules.css'
 
 import React from 'react'
-import ReactDOM from 'react-dom'
 import moment from 'moment'
 import DatePicker from 'react-datepicker'
 import {isValidationErrorMarker, Marker} from '@sanity/types'
@@ -11,8 +10,9 @@ import TextInput from 'part:@sanity/components/textinputs/default'
 import Button from 'part:@sanity/components/buttons/default'
 import CalendarIcon from 'part:@sanity/base/calendar-icon'
 import {uniqueId} from 'lodash'
-import styles from './styles/BaseDateTimeInput.css'
 import {Layer} from '@sanity/ui'
+
+import styles from './styles/BaseDateTimeInput.css'
 
 type Props = {
   value: moment.Moment | null
@@ -26,11 +26,11 @@ type Props = {
   description: string | null
   placeholder: string | null
   readOnly: boolean | null
-  onFocus?: (event: any) => void
-  onBlur?: (event: any) => void
   onChange: (event: moment.Moment) => void
+  onFocus?: (event: unknown) => void
+  onBlur?: (event: unknown) => void
   level: number
-  presence: any
+  presence: unknown
 }
 
 const getFormat = (dateFormat, timeFormat) => dateFormat + (timeFormat ? ` ${timeFormat}` : '')
@@ -62,7 +62,7 @@ export default class BaseDateTimeInput extends React.Component<Props, State> {
     onChange(nextMoment)
     this.setState({inputValue: null})
   }
-  handleSetNow = (event) => {
+  handleSetNow = () => {
     this.handleDialogChange(moment())
   }
   focus() {
@@ -79,7 +79,7 @@ export default class BaseDateTimeInput extends React.Component<Props, State> {
     }
     return event
   }
-  handleButtonClick = (event) => {
+  handleButtonClick = () => {
     this.focus()
     this.handleOpen()
   }

--- a/packages/@sanity/form-builder/src/inputs/DateInputs/BaseDateTimeInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/DateInputs/BaseDateTimeInput.tsx
@@ -3,7 +3,7 @@ import 'react-datepicker/dist/react-datepicker-cssmodules.css'
 
 import React from 'react'
 import ReactDOM from 'react-dom'
-import moment, {Moment} from 'moment'
+import moment from 'moment'
 import DatePicker from 'react-datepicker'
 import {isValidationErrorMarker, Marker} from '@sanity/types'
 import FormField from 'part:@sanity/components/formfields/default'
@@ -15,7 +15,7 @@ import styles from './styles/BaseDateTimeInput.css'
 import {Layer} from '@sanity/ui'
 
 type Props = {
-  value: Moment | null
+  value: moment.Moment | null
   markers: Array<Marker>
   dateOnly?: boolean
   dateFormat: string
@@ -26,9 +26,9 @@ type Props = {
   description: string | null
   placeholder: string | null
   readOnly: boolean | null
-  onChange: (event: Moment) => void
   onFocus?: (event: any) => void
   onBlur?: (event: any) => void
+  onChange: (event: moment.Moment) => void
   level: number
   presence: any
 }
@@ -57,7 +57,7 @@ export default class BaseDateTimeInput extends React.Component<Props, State> {
       this.setState({inputValue: inputValue})
     }
   }
-  handleDialogChange = (nextMoment?: Moment) => {
+  handleDialogChange = (nextMoment?: moment.Moment) => {
     const {onChange} = this.props
     onChange(nextMoment)
     this.setState({inputValue: null})

--- a/packages/@sanity/form-builder/src/inputs/DateInputs/BaseDateTimeInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/DateInputs/BaseDateTimeInput.tsx
@@ -12,6 +12,7 @@ import Button from 'part:@sanity/components/buttons/default'
 import CalendarIcon from 'part:@sanity/base/calendar-icon'
 import {uniqueId} from 'lodash'
 import styles from './styles/BaseDateTimeInput.css'
+import {Layer} from '@sanity/ui'
 
 type Props = {
   value: Moment | null
@@ -106,9 +107,11 @@ export default class BaseDateTimeInput extends React.Component<Props, State> {
   }
   renderPopperContainer = ({children}) => {
     const {isDialogOpen} = this.state
-    return ReactDOM.createPortal(
-      <div className={isDialogOpen ? styles.portal : styles.portalClosed}>{children}</div>,
-      document.body
+
+    return (
+      <Layer>
+        <div className={isDialogOpen ? styles.portal : styles.portalClosed}>{children}</div>
+      </Layer>
     )
   }
   render() {


### PR DESCRIPTION
### Description
​
We use `react-datepicker`, it let's us specify the component that should wrap the datepicker. Previously we used `React.usePortal` directly to do this. But that doesn't work optimally with the new `Layer`-system of Sanity UI.

Change it to be wrapped inside a `Layer` so it's put on top.

This also adds an e2e-test which makes sure the datepicker is visible both on top of a dialog and without a dialog.
​
### What to review

Can we use `Layer` "naively" in this way or should we specify the z-index directly?

I also believe this changes where the datepicker is put into the DOM. Does that create some consequences for other inputs that I haven't noticed while testing?
​
### Notes for release
​
* Fixed a bug where datepicker was hidden behind dialogs
