### PR TITLE
[base] Prevent printing warnings when importing ZIndexProvider

### DIFF
--- a/packages/@sanity/base/src/components/ZIndexProvider.tsx
+++ b/packages/@sanity/base/src/components/ZIndexProvider.tsx
@@ -1,5 +1,28 @@
-import React, {createContext, useContext} from 'react'
+import React, {createContext, useContext, useMemo} from 'react'
 import cssCustomProperties from 'sanity:css-custom-properties'
+
+interface ZIndexContextValue {
+  navbar: number
+  navbarPopover: number
+  navbarDialog: number
+  pane: number
+  paneResizer: number
+  portal: number
+  popover: number
+  modal: number
+  movingItem: number
+  drawershade: number
+  drawer: number
+
+  // NOT IN USE
+  dropdown: number
+  navbarFixed: number
+  fullscreenEdit: number
+  popoverBackground: number
+  tooltip: number
+  modalBackground: number
+  spinner: number
+}
 
 function getCustomCSSPropertyNumber(key: string): number | undefined {
   const rawValue = cssCustomProperties[key]
@@ -21,79 +44,109 @@ function getCustomCSSPropertyNumber(key: string): number | undefined {
   return value
 }
 
-const defaults = {
-  /*
-    used by
-    - Navbar
-  */
-  navbar: getCustomCSSPropertyNumber('--zindex-navbar') || 200,
-  navbarPopover: getCustomCSSPropertyNumber('--zindex-navbar-popover') || 500000,
-  navbarDialog: getCustomCSSPropertyNumber('--zindex-navbar-dialog') || 500001,
-
-  /*
-    used by:
-    - DefaultPane
-  */
-  pane: getCustomCSSPropertyNumber('--zindex-pane') || 100,
-
-  /*
-    used by:
-    - DefaultPane
-  */
-  paneResizer: getCustomCSSPropertyNumber('--zindex-pane-resizer') || 150,
-
-  /*
-    used by:
-    - EditItemFoldOut
-    - Spinner
-    - ConnectorsOverlay
-    - tippy.css
-    - BaseDateTimeInput
-  */
-  portal: getCustomCSSPropertyNumber('--zindex-portal') || 200,
-
-  /*
-    used by tooltip
-  */
-  popover: getCustomCSSPropertyNumber('--zindex-popover') || 200,
-
-  /*
-    used by google-maps-input
-  */
-  modal: getCustomCSSPropertyNumber('--zindex-modal') || 200,
-
-  /*
-    used for `movingItem` in:
-    packages/@sanity/base/src/styles/layout/helpers.css
-  */
-  movingItem: getCustomCSSPropertyNumber('--zindex-moving-item') || 10000,
-
-  /*
-    used for shadow behind the navbar search, and behind sidemenu
-  */
-  drawershade: getCustomCSSPropertyNumber('--zindex-drawershade') || 1000000,
-
-  /*
-    used for snackbar
-  */
-  drawer: getCustomCSSPropertyNumber('--zindex-drawer') || 1000001,
+const defaults: ZIndexContextValue = {
+  navbar: 200,
+  navbarPopover: 500000,
+  navbarDialog: 500001,
+  pane: 100,
+  paneResizer: 150,
+  portal: 200,
+  popover: 200,
+  modal: 200,
+  movingItem: 10000,
+  drawershade: 1000000,
+  drawer: 1000001,
 
   // NOT IN USE
-  dropdown: getCustomCSSPropertyNumber('--zindex-dropdown') || 200,
-  navbarFixed: getCustomCSSPropertyNumber('--zindex-navbar-fixed') || 1010,
-  fullscreenEdit: getCustomCSSPropertyNumber('--zindex-fullscreen-edit') || 1050,
-  popoverBackground: getCustomCSSPropertyNumber('--zindex-popover-background') || 1060,
-  tooltip: getCustomCSSPropertyNumber('--zindex-tooltip') || 200,
-  modalBackground: getCustomCSSPropertyNumber('--zindex-modal-background') || 2000,
-  spinner: getCustomCSSPropertyNumber('--zindex-spinner') || 3000,
+  dropdown: 200,
+  navbarFixed: 1010,
+  fullscreenEdit: 1050,
+  popoverBackground: 1060,
+  tooltip: 200,
+  modalBackground: 2000,
+  spinner: 3000,
 }
 
-const ZIndexContext = createContext(defaults)
+function getLegacyZIndexes(): ZIndexContextValue {
+  return {
+    /*
+      used by
+      - Navbar
+    */
+    navbar: getCustomCSSPropertyNumber('--zindex-navbar') || defaults.navbar,
+    navbarPopover: getCustomCSSPropertyNumber('--zindex-navbar-popover') || defaults.navbarPopover,
+    navbarDialog: getCustomCSSPropertyNumber('--zindex-navbar-dialog') || defaults.navbarDialog,
 
-export function useZIndex() {
+    /*
+      used by:
+      - DefaultPane
+    */
+    pane: getCustomCSSPropertyNumber('--zindex-pane') || defaults.pane,
+
+    /*
+      used by:
+      - DefaultPane
+    */
+    paneResizer: getCustomCSSPropertyNumber('--zindex-pane-resizer') || defaults.paneResizer,
+
+    /*
+      used by:
+      - EditItemFoldOut
+      - Spinner
+      - ConnectorsOverlay
+      - tippy.css
+      - BaseDateTimeInput
+    */
+    portal: getCustomCSSPropertyNumber('--zindex-portal') || defaults.portal,
+
+    /*
+      used by tooltip
+    */
+    popover: getCustomCSSPropertyNumber('--zindex-popover') || defaults.popover,
+
+    /*
+      used by google-maps-input
+    */
+    modal: getCustomCSSPropertyNumber('--zindex-modal') || defaults.modal,
+
+    /*
+      used for `movingItem` in:
+      packages/@sanity/base/src/styles/layout/helpers.css
+    */
+    movingItem: getCustomCSSPropertyNumber('--zindex-moving-item') || defaults.movingItem,
+
+    /*
+      used for shadow behind the navbar search, and behind sidemenu
+    */
+    drawershade: getCustomCSSPropertyNumber('--zindex-drawershade') || defaults.drawershade,
+
+    /*
+      used for snackbar
+    */
+    drawer: getCustomCSSPropertyNumber('--zindex-drawer') || defaults.drawer,
+
+    // NOT IN USE
+    dropdown: getCustomCSSPropertyNumber('--zindex-dropdown') || defaults.dropdown,
+    navbarFixed: getCustomCSSPropertyNumber('--zindex-navbar-fixed') || defaults.navbarFixed,
+    fullscreenEdit:
+      getCustomCSSPropertyNumber('--zindex-fullscreen-edit') || defaults.fullscreenEdit,
+    popoverBackground:
+      getCustomCSSPropertyNumber('--zindex-popover-background') || defaults.popoverBackground,
+    tooltip: getCustomCSSPropertyNumber('--zindex-tooltip') || defaults.tooltip,
+    modalBackground:
+      getCustomCSSPropertyNumber('--zindex-modal-background') || defaults.modalBackground,
+    spinner: getCustomCSSPropertyNumber('--zindex-spinner') || defaults.spinner,
+  }
+}
+
+const ZIndexContext = createContext<ZIndexContextValue>(defaults)
+
+export function useZIndex(): ZIndexContextValue {
   return useContext(ZIndexContext)
 }
 
-export function ZIndexProvider({children}: {children?: React.ReactNode}) {
-  return <ZIndexContext.Provider value={defaults}>{children}</ZIndexContext.Provider>
+export function ZIndexProvider({children}: {children?: React.ReactNode}): React.ReactElement {
+  const zIndexes = useMemo(() => getLegacyZIndexes(), [])
+
+  return <ZIndexContext.Provider value={zIndexes}>{children}</ZIndexContext.Provider>
 }


### PR DESCRIPTION
This change prevents console warnings from being printed when importing `ZIndexProvider`, by wrapping the conversion in a function.