### PR TITLE
perf(utils): introduce a memoized pathFor function that always resolves to the same path instance

### DIFF
--- a/packages/@sanity/util/src/pathUtils.ts
+++ b/packages/@sanity/util/src/pathUtils.ts
@@ -52,6 +52,19 @@ export function get(obj: unknown, path: Path | string, defaultVal?: unknown): un
   return acc
 }
 
+const pathsMemo = new Map<string, Path>()
+export function pathFor(path: Path): Path {
+  if (path.length === 0) {
+    return EMPTY_PATH
+  }
+  const asString = toString(path)
+  if (pathsMemo.has(asString)) {
+    return pathsMemo.get(asString)!
+  }
+  pathsMemo.set(asString, path)
+  return path
+}
+
 export function isEqual(path: Path, otherPath: Path): boolean {
   return (
     path.length === otherPath.length &&


### PR DESCRIPTION
In studio forms we use arrays to denote paths within documents. We do quite a lot of passing paths props where paths hardly ever change, and most of the times these path arrays are created inline in render functions, and even though they hardly ever change, they will break React.memo's shallow compare. This PR adds a small util named `pathFor()` that, for any given path, always returns the same array instance, so that `pathFor(['some', 'property']) === pathFor(['some', 'property'])` holds true. This provides us with a handy utility to avoid unnecessary re-renders.

Considerations: Currently there's no invalidation and the memo array will hold an ever-growing array of path references. I'm not sure how big issue this will be in practice, but it sure def is a memory leak. We could consider using a LRU cache here instead. Thoughts?

### Notes for release
N/A