### PR TITLE
perf(form-builder): wrap the asset source plugin components in withDocument instead of the image input

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.tsx
@@ -52,6 +52,7 @@ import PatchEvent, {set, setIfMissing, unset} from '../../PatchEvent'
 import UploadPlaceholder from '../common/UploadPlaceholder'
 import UploadTargetFieldset from '../../utils/UploadTargetFieldset'
 import WithMaterializedReference from '../../utils/WithMaterializedReference'
+import withDocument from '../../utils/withDocument'
 import {urlToFile, base64ToFile} from './utils/image'
 
 import styles from './ImageInput.css'
@@ -126,7 +127,10 @@ export default class ImageInput extends React.PureComponent<Props, ImageInputSta
     // Allow overriding sources set directly on type.options
     const sourcesFromType = get(props.type, 'options.sources')
     if (Array.isArray(sourcesFromType) && sourcesFromType.length > 0) {
-      this.assetSources = sourcesFromType
+      this.assetSources = sourcesFromType.map((source) => ({
+        ...source,
+        component: withDocument(source.component),
+      }))
     } else if (sourcesFromType) {
       this.assetSources = null
     }
@@ -528,7 +532,7 @@ export default class ImageInput extends React.PureComponent<Props, ImageInputSta
 
   renderAssetSource() {
     const {selectedAssetSource} = this.state
-    const {value, materialize, document} = this.props
+    const {value, materialize} = this.props
     if (!selectedAssetSource) {
       return null
     }
@@ -539,7 +543,6 @@ export default class ImageInput extends React.PureComponent<Props, ImageInputSta
           {(imageAsset) => {
             return (
               <Component
-                document={document}
                 selectedAssets={[imageAsset]}
                 selectionType="single"
                 onClose={this.handleAssetSourceClosed}
@@ -552,7 +555,6 @@ export default class ImageInput extends React.PureComponent<Props, ImageInputSta
     }
     return (
       <Component
-        document={document}
         selectedAssets={[]}
         selectionType="single"
         onClose={this.handleAssetSourceClosed}

--- a/packages/@sanity/form-builder/src/sanity/inputs/SanityImageInput.tsx
+++ b/packages/@sanity/form-builder/src/sanity/inputs/SanityImageInput.tsx
@@ -1,29 +1,26 @@
 import React from 'react'
 import ImageInput, {Props} from '../../inputs/ImageInput'
 import resolveUploader from '../uploads/resolveUploader'
-import withDocument from '../../utils/withDocument'
 import {materializeReference} from './client-adapters/assets'
 
-export default withDocument(
-  class SanityImageInput extends React.Component<Props> {
-    _input: any
-    focus() {
-      if (this._input) {
-        this._input.focus()
-      }
-    }
-    setInput = (input) => {
-      this._input = input
-    }
-    render() {
-      return (
-        <ImageInput
-          {...this.props}
-          resolveUploader={resolveUploader}
-          materialize={materializeReference}
-          ref={this.setInput}
-        />
-      )
+export default class SanityImageInput extends React.Component<Props> {
+  _input: any
+  focus() {
+    if (this._input) {
+      this._input.focus()
     }
   }
-)
+  setInput = (input) => {
+    this._input = input
+  }
+  render() {
+    return (
+      <ImageInput
+        {...this.props}
+        resolveUploader={resolveUploader}
+        materialize={materializeReference}
+        ref={this.setInput}
+      />
+    )
+  }
+}


### PR DESCRIPTION
Previously the ImageInput was wrapped by the `withDocument` HOC that provided it with the current document as a prop. This was then passed to the asset source plugin for convenience. This meant that whenever the document changed the image input would then receive a new `document` prop. Since it only forwarded the document to the asset source plugin, this patch instead wraps the asset source plugin in `withDocument`.

This should improve the render performance of the ImageInput since it no longer receives the enclosing `document` as a prop, which changes on every keystroke.

### Note for release
- Skip uneccessary re-rendring of image input when the edited document is changed