### PR TITLE
perf(form-builder): include path and focusPath in FormBuilderInput's shouldComponentUpdate check

### DIFF
--- a/packages/@sanity/form-builder/src/FormBuilderInput.tsx
+++ b/packages/@sanity/form-builder/src/FormBuilderInput.tsx
@@ -80,13 +80,15 @@ export class FormBuilderInput extends React.Component<Props> {
   }
 
   shouldComponentUpdate(nextProps) {
-    const {path: oldPath, ...oldProps} = this.props
-    const {path: newPath, ...newProps} = nextProps
+    const {path: oldPath, focusPath: oldFocusPath, markers: oldMarkers, ...oldProps} = this.props
+    const {path: newPath, focusPath: newFocusPath, markers: newMarkers, ...newProps} = nextProps
 
-    const propsDiffer = !shallowEquals(oldProps, newProps)
-    const pathDiffer = !PathUtils.isEqual(oldPath, newPath)
-
-    return propsDiffer || pathDiffer
+    return (
+      !shallowEquals(oldProps, newProps) ||
+      !shallowEquals(oldPath, newPath) ||
+      !shallowEquals(oldFocusPath, newFocusPath) ||
+      !shallowEquals(oldMarkers, newMarkers)
+    )
   }
 
   // eslint-disable-next-line camelcase


### PR DESCRIPTION
This includes a shallow equality check of `path` and `focusPath` in the FormBuilderInput. These props rarely change, and doing this check should be fairly cheap (especially when using the pathFor utility introduced in #2307 for the passed `path`/`focusPath` props)

### Note for release
- Various performance optimizations