### PR TITLE
perf(util): optimize path utils functions to return memoized paths

### DIFF
--- a/packages/@sanity/util/src/pathUtils.ts
+++ b/packages/@sanity/util/src/pathUtils.ts
@@ -126,7 +126,7 @@ export function trimLeft(prefix: Path, path: Path): Path {
   if (!isSegmentEqual(prefixHead, pathHead)) {
     return path
   }
-  return trimLeft(prefixTail, pathTail)
+  return pathFor(trimLeft(prefixTail, pathTail))
 }
 
 export function trimRight(suffix: Path, path: Path): Path {
@@ -145,7 +145,7 @@ export function trimRight(suffix: Path, path: Path): Path {
     i++
   }
 
-  return path.slice(0, pathLen - i)
+  return pathFor(path.slice(0, pathLen - i))
 }
 
 export function trimChildPath(path: Path, childPath: Path): Path {


### PR DESCRIPTION
This builds on the utility introduced in #2307 and makes the trimLeft/trimRight utility functions pass the returned paths via the pathFor function to ensure referential equality with equal paths that has already been instantiated.

### Note for release
- Various performance optimizations