### PR TITLE
feat(cli): load `.env` files before running any command

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -48,6 +48,7 @@
     "debug": "^3.1.0",
     "decompress": "^4.2.0",
     "deep-sort-object": "^1.0.1",
+    "dotenv": "^8.2.0",
     "es6-promisify": "^6.0.0",
     "eventsource": "^1.0.6",
     "execa": "^1.0.0",

--- a/packages/@sanity/cli/src/cli.js
+++ b/packages/@sanity/cli/src/cli.js
@@ -2,6 +2,7 @@
 // eslint-disable-next-line import/no-unassigned-import
 import path from 'path'
 import chalk from 'chalk'
+import dotenv from 'dotenv'
 import fse from 'fs-extra'
 import neatStack from 'neat-stack'
 import resolveFrom from 'resolve-from'
@@ -23,6 +24,11 @@ module.exports = async function runCli(cliRoot) {
   const isInit = args.groupOrCommand === 'init' && args.argsWithoutOptions[0] !== 'plugin'
   const cwd = checkCwdPresence()
   const workDir = isInit ? process.cwd() : resolveRootDir(cwd)
+
+  // Try to load .env files from the sanity studio directory
+  // eslint-disable-next-line no-process-env
+  const env = process.env.SANITY_ACTIVE_ENV || process.env.NODE_ENV || 'development'
+  dotenv.config({path: path.join(workDir, `.env.${env}`)})
 
   await updateNotifier({pkg, cwd, workDir}).notify()
 

--- a/packages/@sanity/cli/src/util/clientWrapper.js
+++ b/packages/@sanity/cli/src/util/clientWrapper.js
@@ -1,11 +1,6 @@
+import client from '@sanity/client'
 import generateHelpUrl from '@sanity/generate-help-url'
 import getUserConfig from './getUserConfig'
-import client from '@sanity/client'
-
-/* eslint-disable no-process-env */
-const envAuthToken = process.env.SANITY_AUTH_TOKEN
-const sanityEnv = process.env.SANITY_INTERNAL_ENV || 'production'
-/* eslint-enable no-process-env */
 
 const apiHosts = {
   staging: 'https://api.sanity.work',
@@ -37,6 +32,13 @@ export default function clientWrapper(manifest, configPath) {
   requester.use(authErrors())
 
   return function (opts = {}) {
+    // Read these environment variables "late" to allow `.env` files
+
+    /* eslint-disable no-process-env */
+    const envAuthToken = process.env.SANITY_AUTH_TOKEN
+    const sanityEnv = process.env.SANITY_INTERNAL_ENV || 'production'
+    /* eslint-enable no-process-env */
+
     const {requireUser, requireProject, api} = {...defaults, ...opts}
     const userConfig = getUserConfig()
     const token = envAuthToken || userConfig.get('authToken')


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Current behavior**

When running CLI commands, any environment variables set in `.env`-files are not respected. For instance, running `sanity graphql deploy`, `sanity deploy` and `sanity users list` uses the values defined in `sanity.json` instead of respecting any `.env` file overrides.

**Description**

This PR ensures any `.env`-file is read and used before running any CLI commands.

Fixes #2318

**Note for release**

- `.env` files will now be loaded before running any Sanity CLI command

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [ ]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [ ]  Corresponding changes to the documentation have been made
