### PR TITLE
fix(form-builder): make sure document prop is passed to imported asset source components

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ImageInput/ImageInput.tsx
@@ -104,7 +104,12 @@ type ImageInputState = {
   selectedAssetSource?: any
   hasFocus: boolean
 }
-const globalAssetSources = userDefinedAssetSources ? userDefinedAssetSources : assetSources
+const globalAssetSources = (userDefinedAssetSources ? userDefinedAssetSources : assetSources).map(
+  (source) => ({
+    ...source,
+    component: withDocument(source.component),
+  })
+)
 
 function ImageInputField(props: any) {
   const {onChange, ...restProps} = props


### PR DESCRIPTION
closes #2316

### Notes for release

- Fixed a regression introduced in `v2.3.8` that didn't pass the document to imported asset source components