### PR TITLE
fix(form-builder): fix an issue that caused focus handler to be triggered by unfocusable fieldsets

### DIFF
--- a/packages/@sanity/base/src/__legacy/@sanity/components/fieldsets/DefaultFieldset.tsx
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/fieldsets/DefaultFieldset.tsx
@@ -136,7 +136,7 @@ export default class Fieldset extends React.PureComponent<FieldsetProps, State> 
     return (
       <div
         {...rest}
-        onFocus={this.handleFocus}
+        onFocus={isCollapsible && isCollapsed ? this.handleFocus : null}
         tabIndex={isCollapsible && isCollapsed ? tabIndex : -1}
         ref={this.setFocusElement}
         className={rootClassName}


### PR DESCRIPTION

### Notes for release
- Fixed an issue that caused clicks on labels within fieldsets to set focus in the wrong field