### PR TITLE
fix(default-layout): adjust the z-index of `AppLoadingScreen`

### DIFF
--- a/packages/@sanity/default-layout/src/DefaultLayout.tsx
+++ b/packages/@sanity/default-layout/src/DefaultLayout.tsx
@@ -151,7 +151,7 @@ class DefaultLayout extends React.PureComponent<Props, State> {
                 ? styles.loadingScreenLoaded
                 : styles.loadingScreen
             }
-            zOffset={5000}
+            zOffset={600000}
             ref={this.setLoadingScreenElement}
           >
             <AppLoadingScreen text="Restoring Sanity" />


### PR DESCRIPTION
**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)

**Does this change require a documentation update? (Check one)**

- [x]  No

**Current behavior**

The global search is visible (flash) on the loading screen.

**Description**

This change fixes the issue by increasing the `z-index` of the loading screen to be larger than the navbar’s `z-index`.