### PR TITLE
fix(base): export `theme` so Storybook can import it and run

### DIFF
--- a/packages/@sanity/base/src/index.ts
+++ b/packages/@sanity/base/src/index.ts
@@ -1,2 +1,3 @@
 export {default as DefaultRootComponent} from './components/DefaultRootComponent'
 export {UserStore} from './datastores/user/types'
+export * from './theme'

--- a/packages/@sanity/storybook/.babelrc
+++ b/packages/@sanity/storybook/.babelrc
@@ -1,3 +1,4 @@
 {
-  presets: ['@babel/react']
+  "extends": "../../../.babelrc",
+  "presets": ["@babel/react"]
 }

--- a/packages/@sanity/storybook/package.json
+++ b/packages/@sanity/storybook/package.json
@@ -4,6 +4,7 @@
   "description": "Sanity plugin for running react-storybook in a Sanity studio",
   "main": "./lib/index.js",
   "scripts": {
+    "build": "babel src --copy-files --out-dir lib",
     "clean": "rimraf lib"
   },
   "repository": {
@@ -26,6 +27,7 @@
   },
   "homepage": "https://www.sanity.io/",
   "dependencies": {
+    "@sanity/base": "2.4.3",
     "@sanity/server": "2.4.0",
     "@sanity/ui": "^0.33.6",
     "@sanity/webpack-integration": "2.4.0",

--- a/packages/@sanity/storybook/src/decorators/root.js
+++ b/packages/@sanity/storybook/src/decorators/root.js
@@ -1,7 +1,7 @@
-const {theme: baseTheme} = require('@sanity/base')
-const {Card, ThemeProvider} = require('@sanity/ui')
-const React = require('react')
-const {css, createGlobalStyle} = require('styled-components')
+import {theme as baseTheme} from '@sanity/base'
+import {Card, LayerProvider, ThemeProvider, ToastProvider} from '@sanity/ui'
+import React from 'react'
+import {css, createGlobalStyle} from 'styled-components'
 
 const GlobalStyle = createGlobalStyle(({theme}) => {
   const base = theme.sanity.color.base
@@ -31,11 +31,17 @@ const GlobalStyle = createGlobalStyle(({theme}) => {
   `
 })
 
-module.exports = function RootDecorator(story) {
+function RootDecorator(story) {
   return (
     <ThemeProvider scheme="light" theme={baseTheme}>
-      <GlobalStyle />
-      <Card style={{height: '100%'}}>{story()}</Card>
+      <ToastProvider zOffset={12000}>
+        <LayerProvider>
+          <GlobalStyle />
+          <Card height="fill">{story()}</Card>
+        </LayerProvider>
+      </ToastProvider>
     </ThemeProvider>
   )
 }
+
+export default RootDecorator

--- a/packages/@sanity/storybook/src/index.js
+++ b/packages/@sanity/storybook/src/index.js
@@ -3,7 +3,7 @@ const storyBook = require('@storybook/react')
 const sortByName = (storyA, storyB) => (storyB.name || '').localeCompare(storyA.name || '')
 const registerStoryKind = storyBook.storiesOf
 
-const rootDecorator = require('./decorators/root')
+const rootDecorator = require('./decorators/root').default
 
 const storybookApi = Object.assign({}, storyBook, {
   declaredStories: [],

--- a/packages/@sanity/storybook/src/server/fork.js
+++ b/packages/@sanity/storybook/src/server/fork.js
@@ -28,6 +28,7 @@ module.exports = (config) => {
   })
 
   proc.stderr.on('data', (data) => {
+    // eslint-disable-next-line no-control-regex
     const msg = data.toString().replace(/\x08/g, '').trim()
 
     // Skip empty messages

--- a/packages/@sanity/storybook/src/server/server.js
+++ b/packages/@sanity/storybook/src/server/server.js
@@ -5,6 +5,7 @@ const path = require('path')
 const express = require('express')
 const middleware = require('@storybook/react/dist/server/middleware')
 const webpackConfig = require('../config/webpack.config')
+
 const storybook = middleware.default || middleware
 
 let app = null
@@ -50,6 +51,7 @@ function unhandledMessage(msg) {
 
 function tryLoadConfig(basePath) {
   try {
+    // eslint-disable-next-line import/no-dynamic-require
     return require(path.join(basePath, 'config', '@sanity', 'storybook.json'))
   } catch (err) {
     return {}


### PR DESCRIPTION
**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)

**Does this change require a documentation update? (Check one)**

- [x]  No

**Current behavior**

Storybook crashes on boot, because it’s using `undefined` as theme object.

**Description**

This change makes `@sanity/base` export its `theme` object, as well as adding some code style updates to `@sanity/storybook`.