### PR TITLE
Add support for Sanity UI toasts in studio

### DIFF
--- a/packages/@sanity/base/src/components/DevServerStatus.js
+++ b/packages/@sanity/base/src/components/DevServerStatus.js
@@ -1,148 +1,115 @@
-import React, {PureComponent} from 'react'
-import Snackbar from 'part:@sanity/components/snackbar/default'
-import Spinner from 'part:@sanity/components/loading/spinner'
+import {useToast} from '@sanity/ui'
+import {useCallback, useEffect, useState} from 'react'
 
 const eventBus = window.__webpack_hot_middleware_eventbus__
 const events = eventBus ? eventBus.eventTypes : {}
+
+const CONNECTION_TOAST_ID = 'dev-server-status'
+const BUNDLE_EVENT_TOAST_ID = 'dev-server-bundle-event'
 
 const STATE_CONNECTING = 0
 const STATE_OPEN = 1
 const STATE_CLOSED = 2
 
-class DevServerStatus extends PureComponent {
-  constructor(...args) {
-    super(...args)
-    this.enabled = __DEV__ && eventBus
-    this.state = {
-      connectionState: STATE_CONNECTING,
-      hasHadConnection: false,
-      buildState: events.EVENT_UP_TO_DATE,
-      reloadRequired: false,
+function DevServerStatus() {
+  const [connectionState, setConnectionState] = useState(STATE_CONNECTING)
+  const [hasHadConnection, setHasHadConnection] = useState(false)
+  const {push} = useToast()
+
+  const handleBuilding = useCallback(() => {
+    push({
+      closable: true,
+      id: BUNDLE_EVENT_TOAST_ID,
+      status: 'info',
+      title: 'Rebuilding bundle…',
+    })
+  }, [push])
+
+  const handleBuilt = useCallback(() => {
+    push({
+      closable: true,
+      id: BUNDLE_EVENT_TOAST_ID,
+      status: 'success',
+      title: 'Rebuilt bundle',
+    })
+  }, [push])
+
+  const handleConnecting = useCallback(() => {
+    if (connectionState === STATE_CONNECTING) return
+    setConnectionState(STATE_CONNECTING)
+  }, [connectionState])
+
+  const handleConnected = useCallback(() => {
+    if (connectionState === STATE_OPEN) return
+    setConnectionState(STATE_OPEN)
+    push({
+      closable: true,
+      id: CONNECTION_TOAST_ID,
+      status: 'success',
+      title: 'Connected to dev server',
+    })
+  }, [connectionState, push])
+
+  const handleDisconnected = useCallback(() => {
+    if (connectionState === STATE_CLOSED) return
+    setConnectionState(STATE_CLOSED)
+    push({
+      closable: true,
+      id: CONNECTION_TOAST_ID,
+      status: 'warning',
+      title: 'Disconnected from dev server',
+      timeout: Infinity,
+    })
+  }, [connectionState, push])
+
+  const handleEvent = useCallback(
+    (evt) => {
+      if (evt.type === events.EVENT_BUILT) {
+        handleBuilt(evt)
+      }
+
+      if (evt.type === events.EVENT_BUILDING) {
+        handleBuilding(evt)
+      }
+
+      if (evt.type === events.EVENT_CONNECTING) {
+        handleConnecting(evt)
+      }
+
+      if (evt.type === events.EVENT_CONNECTED) {
+        handleConnected(evt)
+      }
+
+      if (evt.type === events.EVENT_DISCONNECTED) {
+        handleDisconnected(evt)
+      }
+    },
+    [handleBuilding, handleBuilt, handleConnected, handleConnecting, handleDisconnected]
+  )
+
+  // Handle reconnected
+  useEffect(() => {
+    if (connectionState === STATE_OPEN) {
+      if (hasHadConnection) {
+        // @todo
+        // We reconnected after being disconnected.
+        // Hot-reloading won't be applied automatically.
+        // We should consider showing a message telling the user to reload,
+        // or just programatically reload the page:
+        // window.location.reload()
+      } else {
+        setHasHadConnection(true)
+      }
     }
-  }
+  }, [connectionState, hasHadConnection])
 
-  componentDidMount() {
-    if (!this.enabled) {
-      return
-    }
+  // Subscribe to events
+  useEffect(() => {
+    if (!__DEV__ || !eventBus) return undefined
+    return eventBus.subscribe(handleEvent)
+  }, [handleEvent])
 
-    this.hmrUnsubscribe = eventBus.subscribe(this.handleEvent)
-  }
-
-  componentWillUnmount() {
-    if (this.hmrUnsubscribe) {
-      this.hmrUnsubscribe()
-    }
-  }
-
-  handleEvent = (evt) => {
-    switch (evt.type) {
-      case events.EVENT_DISCONNECTED:
-        return this.setState({connectionState: STATE_CLOSED})
-      case events.EVENT_CONNECTING:
-        return this.setState({connectionState: STATE_CONNECTING})
-      case events.EVENT_CONNECTED:
-        return this.handleConnected()
-      case events.EVENT_BUILT:
-      case events.EVENT_BUILDING:
-      case events.EVENT_UP_TO_DATE:
-        return this.setState(({reloadRequired: reloadWasRequired}) => ({
-          buildState: evt.type,
-          reloadRequired: reloadWasRequired || evt.requiresReload || false,
-        }))
-      default:
-        if (evt.requiresReload && !this.state.reloadRequired) {
-          this.setState({buildState: events.EVENT_BUILT, reloadRequired: true})
-        }
-    }
-
-    return null
-  }
-
-  handleConnected = () => {
-    this.setState({connectionState: STATE_OPEN})
-
-    if (this.state.hasHadConnection) {
-      // We reconnected after being disconnected.
-      // Hot-reloading won't be applied automatically.
-      // We should consider showing a message telling the user to reload,
-      // or just programatically reload the page:
-      window.location.reload()
-    } else {
-      this.setState({hasHadConnection: true})
-    }
-  }
-
-  renderBuildStatus() {
-    const {reloadRequired, buildState} = this.state
-    if (reloadRequired) {
-      return (
-        <Snackbar
-          id="__dev-server-status"
-          kind="warning"
-          isPersisted
-          isCloseable={false}
-          title={<strong>Reload required!</strong>}
-          subtitle={<div>To see your latest changes, you need to reload the browser window.</div>}
-          action={{title: 'Reload', callback: () => window.location.reload()}}
-          allowDuplicateSnackbarType
-        />
-      )
-    }
-
-    if (buildState === events.EVENT_BUILDING) {
-      return (
-        <Snackbar
-          id="__dev-server-status"
-          kind="warning"
-          isPersisted
-          isCloseable={false}
-          title={<Spinner delay={0} inline message="Rebuilding bundle…" />}
-          allowDuplicateSnackbarType
-        />
-      )
-    }
-
-    return null
-  }
-
-  render() {
-    // We're in production or missing the HMR event bus
-    if (!this.enabled) {
-      return null
-    }
-
-    const {connectionState, hasHadConnection} = this.state
-    const isDisconnected = connectionState === STATE_CONNECTING || connectionState === STATE_CLOSED
-
-    // We are disconnected
-    if (isDisconnected && hasHadConnection) {
-      return (
-        <Snackbar
-          id="__dev-server-status"
-          kind="warning"
-          isPersisted
-          isCloseable={false}
-          title={<strong>Disconnected from the dev server!</strong>}
-          subtitle={
-            <div>
-              To see your latest changes, restart the Studio with <code>sanity start</code> in your
-              project folder.
-            </div>
-          }
-          allowDuplicateSnackbarType
-        />
-      )
-    }
-
-    // We're still trying to connect for the first time
-    if (!hasHadConnection) {
-      return null
-    }
-
-    // We're connected, show build status if we have anything worthwhile
-    return this.renderBuildStatus()
-  }
+  return null
 }
 
 export default DevServerStatus

--- a/packages/@sanity/base/src/components/ErrorHandler.js
+++ b/packages/@sanity/base/src/components/ErrorHandler.js
@@ -1,81 +1,68 @@
-import React from 'react'
-import Snackbar from 'part:@sanity/components/snackbar/default'
-import styles from './styles/ErrorHandler.css'
+import {useToast} from '@sanity/ui'
+import {useCallback, useEffect} from 'react'
 
 const SANITY_ERROR_HANDLER = Symbol.for('SANITY_ERROR_HANDLER')
 
-export default class ErrorHandler extends React.PureComponent {
-  state = {error: null}
+function ErrorHandler({onUIError}) {
+  const {push} = useToast()
 
-  constructor(props) {
-    super(props)
+  const handleGlobalError = useCallback(
+    (msg, url, lineNo, columnNo, err) => {
+      // Certain events (ResizeObserver max loop threshold, for instance)
+      // only gives a _message_. We choose to ignore these events since
+      // they are usually not _fatal_
+      if (!err) {
+        return
+      }
 
-    this.handleGlobalError = this.handleGlobalError.bind(this)
-    this.handleGlobalError.identity = SANITY_ERROR_HANDLER
-  }
+      // Certain errors should be ignored
+      if (
+        [
+          /unexpected token <$/i, // Trying to load HTML as JS
+        ].some((item) => item.test(err.message))
+      ) {
+        return
+      }
 
-  componentDidMount() {
+      // NOTE: This checks if the error is the common "missing theme content value"
+      // error thrown by `@sanity/ui`, in order to take steps to render a helpful error message.
+      if (err.message.includes('useRootTheme():')) {
+        onUIError(err)
+        return
+      }
+
+      // eslint-disable-next-line no-console
+      console.error(err)
+
+      push({
+        closable: true,
+        status: 'error',
+        title: __DEV__ ? `Error: ${err.message}` : 'An error occured',
+        description: "Check your browser's JavaScript console for details.",
+        timeout: 8000,
+      })
+    },
+    [onUIError, push]
+  )
+
+  handleGlobalError.identity = SANITY_ERROR_HANDLER
+
+  useEffect(() => {
+    let originalErrorHandler
+
     // Only store the original error handler if it wasn't a copy of _this_ error handler
     if (window.onerror && window.onerror.identity !== SANITY_ERROR_HANDLER) {
-      this.originalErrorHandler = window.onerror
+      originalErrorHandler = window.onerror
     }
 
-    window.onerror = this.handleGlobalError
-  }
+    window.onerror = handleGlobalError
 
-  componentWillUnmount() {
-    window.onerror = this.originalErrorHandler || window.onerror
-  }
-
-  handleGlobalError = (msg, url, lineNo, columnNo, err) => {
-    // Certain events (ResizeObserver max loop threshold, for instance)
-    // only gives a _message_. We choose to ignore these events since
-    // they are usually not _fatal_
-    if (!err) {
-      return
+    return () => {
+      window.onerror = originalErrorHandler
     }
+  }, [handleGlobalError])
 
-    // Certain errors should be ignored
-    if (
-      [
-        /unexpected token <$/i, // Trying to load HTML as JS
-      ].some((item) => item.test(err.message))
-    ) {
-      return
-    }
-
-    // NOTE: This checks if the error is the common "missing theme content value"
-    // error thrown by `@sanity/ui`, in order to take steps to render a helpful error message.
-    if (err.message.includes('useRootTheme():')) {
-      this.props.onUIError(err)
-      return
-    }
-
-    // eslint-disable-next-line no-console
-    console.error(err)
-    this.setState({error: err})
-  }
-
-  handleClose = () => {
-    this.setState({error: null})
-  }
-
-  render() {
-    const {error} = this.state
-    if (!error) {
-      return null
-    }
-
-    const message = __DEV__ ? `An error occured: ${error.message}` : 'An error occured'
-
-    return (
-      <Snackbar
-        kind="error"
-        onAction={this.handleClose}
-        title={<strong>{message}</strong>}
-        timeout={8000}
-        subtitle="Check your browser's JavaScript console for details."
-      />
-    )
-  }
+  return null
 }
+
+export default ErrorHandler

--- a/packages/@sanity/base/src/components/ErrorHandler.js
+++ b/packages/@sanity/base/src/components/ErrorHandler.js
@@ -1,13 +1,23 @@
 import {useToast} from '@sanity/ui'
-import {useCallback, useEffect} from 'react'
+import {useCallback, useEffect, useRef} from 'react'
 
 const SANITY_ERROR_HANDLER = Symbol.for('SANITY_ERROR_HANDLER')
 
 function ErrorHandler({onUIError}) {
   const {push} = useToast()
 
+  const prevErrorRef = useRef(null)
+
   const handleGlobalError = useCallback(
     (msg, url, lineNo, columnNo, err) => {
+      // Workaround for issue triggering two errors in a row in DEV (https://github.com/facebook/react/issues/10474)
+      // We store a ref to the previous error and checks if it's equal to the current
+      if (prevErrorRef.current === err) {
+        prevErrorRef.current = null
+        return
+      }
+      prevErrorRef.current = err
+
       // Certain events (ResizeObserver max loop threshold, for instance)
       // only gives a _message_. We choose to ignore these events since
       // they are usually not _fatal_

--- a/packages/@sanity/base/src/components/SanityRoot.tsx
+++ b/packages/@sanity/base/src/components/SanityRoot.tsx
@@ -86,7 +86,7 @@ function AppProvider() {
     <UserColorManagerProvider manager={userColorManager}>
       <PortalProvider element={portalElement}>
         <LayerProvider>
-          <ToastProvider>
+          <ToastProvider paddingY={7} zOffset={10000}>
             <SnackbarProvider>
               <ThemeColorProvider tone="transparent">
                 <GlobalStyle />

--- a/packages/@sanity/base/src/components/SanityRoot.tsx
+++ b/packages/@sanity/base/src/components/SanityRoot.tsx
@@ -27,6 +27,7 @@ import DevServerStatus from './DevServerStatus'
 import {GlobalStyle} from './GlobalStyle'
 import MissingProjectConfig from './MissingProjectConfig'
 import VersionChecker from './VersionChecker'
+import {useZIndex, ZIndexProvider} from './zOffsets'
 
 Refractor.registerLanguage(bash)
 Refractor.registerLanguage(javascript)
@@ -71,6 +72,7 @@ function UIErrorMessage() {
 function AppProvider() {
   const [portalElement, setPortalElement] = useState(() => document.createElement('div'))
   const [uiError, setUIError] = useState<Error | null>(null)
+  const zIndex = useZIndex()
 
   try {
     useRootTheme()
@@ -86,7 +88,7 @@ function AppProvider() {
     <UserColorManagerProvider manager={userColorManager}>
       <PortalProvider element={portalElement}>
         <LayerProvider>
-          <ToastProvider paddingY={7} zOffset={10000}>
+          <ToastProvider paddingY={7} zOffset={zIndex.toast}>
             <SnackbarProvider>
               <ThemeColorProvider tone="transparent">
                 <GlobalStyle />
@@ -114,9 +116,11 @@ function SanityRoot() {
   }
 
   return (
-    <ThemeProvider theme={theme}>
-      <AppProvider />
-    </ThemeProvider>
+    <ZIndexProvider>
+      <ThemeProvider theme={theme}>
+        <AppProvider />
+      </ThemeProvider>
+    </ZIndexProvider>
   )
 }
 

--- a/packages/@sanity/base/src/components/transitional/ImperativeToast.ts
+++ b/packages/@sanity/base/src/components/transitional/ImperativeToast.ts
@@ -1,0 +1,21 @@
+import {useToast} from '@sanity/ui'
+import React, {forwardRef, useImperativeHandle} from 'react'
+
+export interface ToastParams {
+  closable?: boolean
+  description?: React.ReactNode
+  duration?: number
+  onClose?: () => void
+  title?: React.ReactNode
+  status?: 'error' | 'warning' | 'success' | 'info'
+}
+
+export const ImperativeToast = forwardRef((_, ref) => {
+  const {push} = useToast()
+
+  useImperativeHandle(ref, () => ({push}))
+
+  return null
+})
+
+ImperativeToast.displayName = 'ImperativeToast'

--- a/packages/@sanity/base/src/components/transitional/index.ts
+++ b/packages/@sanity/base/src/components/transitional/index.ts
@@ -1,1 +1,2 @@
+export * from './ImperativeToast'
 export * from './LegacyLayerProvider'

--- a/packages/@sanity/base/src/components/zOffsets/defaults.ts
+++ b/packages/@sanity/base/src/components/zOffsets/defaults.ts
@@ -18,6 +18,7 @@ export const defaults: ZIndexContextValue = {
   drawershade: 1000000,
   drawer: 1000001,
   fullscreen: 1200000,
+  toast: 11000,
 
   // NOT IN USE
   dropdown: 200,

--- a/packages/@sanity/base/src/components/zOffsets/legacyZIndexes.ts
+++ b/packages/@sanity/base/src/components/zOffsets/legacyZIndexes.ts
@@ -21,6 +21,7 @@ export function getLegacyZIndexes(): ZIndexContextValue {
     drawershade: getCustomCSSPropertyNumber('--zindex-drawershade') || defaults.drawershade,
     drawer: getCustomCSSPropertyNumber('--zindex-drawer') || defaults.drawer,
     fullscreen: defaults.fullscreen,
+    toast: defaults.toast,
 
     // THESE ARE NOT IN USE:
     dropdown: getCustomCSSPropertyNumber('--zindex-dropdown') || defaults.dropdown,

--- a/packages/@sanity/base/src/components/zOffsets/types.ts
+++ b/packages/@sanity/base/src/components/zOffsets/types.ts
@@ -36,6 +36,9 @@ export interface ZIndexContextValue {
   /** Used for UI that sits on top of the entire application */
   fullscreen: number
 
+  /** Used for toasts */
+  toast: number
+
   // THESE ARE NOT IN USE:
   dropdown: number
   navbarFixed: number

--- a/packages/@sanity/desk-tool/src/panes/documentPane/documentOperationResults.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/documentOperationResults.tsx
@@ -1,6 +1,6 @@
 import {useDocumentOperationEvent} from '@sanity/react-hooks'
-import Snackbar from 'part:@sanity/components/snackbar/default'
-import React from 'react'
+import {useToast} from '@sanity/ui'
+import React, {useEffect} from 'react'
 
 function getOpErrorTitle(op: string): string {
   if (op === 'delete') {
@@ -38,31 +38,34 @@ type Props = {
 }
 
 export const DocumentOperationResults = React.memo((props: Props) => {
+  const {push} = useToast()
   const event: any = useDocumentOperationEvent(props.id, props.type)
 
-  if (!event) {
-    return null
-  }
+  useEffect(() => {
+    if (!event) return
 
-  if (event && event.type === 'error') {
-    return (
-      <Snackbar
-        kind="error"
-        key={Math.random()}
-        title={getOpErrorTitle(event.op)}
-        subtitle={
+    if (event.type === 'error') {
+      push({
+        closable: true,
+        status: 'error',
+        title: getOpErrorTitle(event.op),
+        description: (
           <details>
             <summary>Details</summary>
             {event.error.message}
           </details>
-        }
-      />
-    )
-  }
+        ),
+      })
+    }
 
-  if (event && event.type === 'success' && !IGNORE_OPS.includes(event.op)) {
-    return <Snackbar key={Math.random()} kind="success" title={getOpSuccessTitle(event.op)} />
-  }
+    if (event.type === 'success' && !IGNORE_OPS.includes(event.op)) {
+      push({
+        closable: true,
+        status: 'success',
+        title: getOpSuccessTitle(event.op),
+      })
+    }
+  }, [event, push])
 
   return null
 })

--- a/packages/@sanity/desk-tool/src/panes/documentPane/statusBar/actionStateDialog.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/statusBar/actionStateDialog.tsx
@@ -1,8 +1,8 @@
 import {ButtonColor, DialogAction} from '@sanity/base/__legacy/@sanity/components'
-import React, {useCallback} from 'react'
+import {useToast} from '@sanity/ui'
+import React, {useCallback, useEffect} from 'react'
 import Dialog from 'part:@sanity/components/dialogs/default'
 import PopoverDialog from 'part:@sanity/components/dialogs/popover'
-import Snackbar from 'part:@sanity/components/snackbar/default'
 
 // Todo: move these to action spec/core types
 interface ConfirmDialogProps {
@@ -61,6 +61,7 @@ interface Props {
 
 export function ActionStateDialog(props: Props) {
   const {dialog, referenceElement} = props
+  const {push} = useToast()
 
   const handleDialogAction = useCallback(
     (action: DialogAction) => {
@@ -76,6 +77,28 @@ export function ActionStateDialog(props: Props) {
     },
     [dialog]
   )
+
+  useEffect(() => {
+    if (dialog.type === 'success') {
+      push({
+        closable: true,
+        status: 'success',
+        title: dialog.title,
+        description: dialog.content,
+        onClose: dialog.onClose,
+      })
+    }
+
+    if (dialog.type === 'error') {
+      push({
+        closable: true,
+        status: 'error',
+        onClose: dialog.onClose,
+        title: dialog.title,
+        description: dialog.content,
+      })
+    }
+  }, [dialog, push])
 
   if (dialog.type === 'legacy') {
     return <>{dialog.content}</>
@@ -140,26 +163,11 @@ export function ActionStateDialog(props: Props) {
   }
 
   if (dialog.type === 'success') {
-    return (
-      <Snackbar
-        kind="success"
-        isPersisted={false}
-        isCloseable
-        timeout={2000}
-        onClose={dialog.onClose}
-        title={dialog.title}
-      >
-        {dialog.content}
-      </Snackbar>
-    )
+    return null
   }
 
   if (dialog.type === 'error') {
-    return (
-      <Snackbar isCloseable kind="error" onClose={dialog.onClose} title={dialog.title}>
-        {dialog.content}
-      </Snackbar>
-    )
+    return null
   }
 
   const unknownDialog: any = dialog

--- a/packages/@sanity/desk-tool/src/panes/documentsListPane/DocumentsListPane.js
+++ b/packages/@sanity/desk-tool/src/panes/documentsListPane/DocumentsListPane.js
@@ -1,9 +1,9 @@
+import {Box, Button, Container, Heading, Stack, Text} from '@sanity/ui'
 import React from 'react'
 import PropTypes from 'prop-types'
 import schema from 'part:@sanity/base/schema'
 import DefaultPane from 'part:@sanity/components/panes/default'
 import {getQueryResults} from 'part:@sanity/base/query-container'
-import Snackbar from 'part:@sanity/components/snackbar/default'
 import Spinner from 'part:@sanity/components/loading/spinner'
 import {collate, getPublishedId} from 'part:@sanity/base/util/draft-utils'
 import {isEqual} from 'lodash'
@@ -301,6 +301,10 @@ export default class DocumentsListPane extends React.PureComponent {
     return `*[${filter}] | order(${toOrderClause(sort)}) [0...${limit}] {${finalProjection}}`
   }
 
+  setToast = (toast) => {
+    this.toast = toast
+  }
+
   renderResults() {
     const {queryResult, isLoadingMore} = this.state
     const {result} = queryResult
@@ -352,14 +356,19 @@ export default class DocumentsListPane extends React.PureComponent {
 
     if (error) {
       return (
-        <Snackbar
-          kind="error"
-          isPersisted
-          actionTitle="Retry"
-          onAction={onRetry}
-          title="An error occurred while loading items:"
-          subtitle={<div>{error.message}</div>}
-        />
+        <div className={styles[`layout__${layout}`]}>
+          <Container width={1}>
+            <Stack paddingX={4} paddingY={5} space={4}>
+              <Heading>Could not fetch list items</Heading>
+              <Text>
+                Error: <code>{error.message}</code>
+              </Text>
+              <Box>
+                <Button onClick={onRetry} text="Retry" tone="primary" />
+              </Box>
+            </Stack>
+          </Container>
+        </div>
       )
     }
 


### PR DESCRIPTION
Builds on #2345

### Description
This PR adds support for Sanity UI based toasts in the studio, and also replaces a few snackbars that relied on them.

### What to review
Snackbars in the studio.
​

### Notes for release
Added support for using [Sanity UI](https://www.sanity.io/ui/) based [Toasts](https://www.sanity.io/ui/docs/component/toast) in the Studio.