### PR TITLE
[language-filter] add defaultLanguage option

### DIFF
--- a/packages/@sanity/language-filter/README.md
+++ b/packages/@sanity/language-filter/README.md
@@ -34,10 +34,12 @@ export default {
     {id: 'pt', title: 'Portuguese'}
     //...
   ],
+  defaultLanguage: 'nb',
   filterField: (enclosingType, field, selectedLanguageIds) =>
     !enclosingType.name.startsWith('locale') || selectedLanguageIds.includes(field.name)
 }
 ```
 
 - `supportedLanguages` is an array of languages with `id` and `title`. If your localized fields are defined using our recommended way described here (https://www.sanity.io/docs/localization), you probably want to share this list of supported languages between this config and your schema. 
+- `defaultLanguage` is a string matching an `id` from the `supportedLanguages`.
 - `filterField` is a function that must return true if the field should be displayed. It is passed the enclosing type (e.g the object type containing the localized fields, the field, and an array of the currently selected language ids.

--- a/packages/@sanity/language-filter/src/SelectLanguage.js
+++ b/packages/@sanity/language-filter/src/SelectLanguage.js
@@ -1,14 +1,19 @@
 /* eslint-disable complexity */
-
-import React, {Fragment} from 'react'
+import React from 'react'
+import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import Poppable from 'part:@sanity/components/utilities/poppable'
 import Checkbox from 'part:@sanity/components/toggles/checkbox'
 import Button from 'part:@sanity/components/buttons/default'
+import ChevronDownIcon from 'part:@sanity/base/chevron-down-icon'
 import styles from './styles/SelectLanguage.css'
-import ChevronDown from 'part:@sanity/base/angle-down-icon'
 
-const LanguagePropType = PropTypes.shape({id: PropTypes.string, title: PropTypes.string})
+const LanguagePropType = PropTypes.shape({
+  id: PropTypes.string,
+  title: PropTypes.string,
+})
+
+const ACTION_LABEL = 'Filter languages'
 export default class SelectLanguage extends React.Component {
   static propTypes = {
     languages: PropTypes.arrayOf(LanguagePropType),
@@ -16,13 +21,34 @@ export default class SelectLanguage extends React.Component {
     onChange: PropTypes.func,
   }
 
-  state = {isOpen: false}
-  refElement = React.createRef()
+  state = {
+    isOpen: false,
+    id: Math.random().toString(36).substr(2, 6),
+  }
+  togglePoppableRef = React.createRef()
 
-  handleToggle = () => this.setState((prevState) => ({isOpen: !prevState.isOpen}))
-  handleOpen = () => this.setState({isOpen: true})
+  handleToggle = (event) => {
+    event.stopPropagation()
+    this.setState((prevState) => {
+      return {
+        isOpen: !prevState.isOpen,
+      }
+    })
+  }
+  handleOpen = () => {
+    this.setState({isOpen: true})
+    this.inputFocus.setFocus()
+  }
   handleClose = () => {
     this.setState({isOpen: false})
+  }
+  handleEsc = () => {
+    this.handleClose()
+  }
+  handleClickOutside = (event) => {
+    if (!event.target.textContent.includes(ACTION_LABEL)) {
+      this.handleClose()
+    }
   }
 
   selectLang = (langId) => {
@@ -35,13 +61,18 @@ export default class SelectLanguage extends React.Component {
     onChange(selected.filter((id) => id !== langId))
   }
 
+  isDefaultLang = (langId) => {
+    const {defaultLanguage} = this.props
+    return langId === defaultLanguage
+  }
+
   handleSelectAll = (event) => {
     const {languages, onChange} = this.props
     onChange(languages.map((l) => l.id))
   }
   handleSelectNone = (event) => {
-    const {onChange} = this.props
-    onChange([])
+    const {languages, onChange} = this.props
+    onChange(languages.map((l) => this.isDefaultLang(l.id) && l.id))
   }
   handleLangCheckboxChange = (event) => {
     const id = event.target.getAttribute('data-lang-id')
@@ -51,36 +82,45 @@ export default class SelectLanguage extends React.Component {
 
   render() {
     const {isOpen} = this.state
+    const {id} = this.state
     const {languages, selected} = this.props
     const allIsSelected = languages.length === selected.length
-    const refElement =
-      this.refElement && this.refElement.current && this.refElement.current._element
+    const toggleRef =
+      this.togglePoppableRef &&
+      this.togglePoppableRef.current &&
+      this.togglePoppableRef.current._element
 
     return (
-      <Fragment>
-        <div
-          className={styles.target}
+      <>
+        <button
+          type="button"
+          className={classNames(styles.target, isOpen && styles.targetSelected)}
           data-open={isOpen}
           onClick={this.handleToggle}
-          ref={this.refElement}
+          ref={this.togglePoppableRef}
           title={
             allIsSelected
               ? 'Filter language fields'
               : 'Displaying only fields for selected languages'
           }
+          aria-label="Menu"
+          aria-haspopup="menu"
+          aria-expanded={isOpen}
+          aria-controls={id}
         >
           <div className={styles.targetValue}>
-            Filter languages{allIsSelected ? '' : ` (${selected.length}/${languages.length})`}
+            {ACTION_LABEL} ({`${selected.length}/${languages.length}`})
           </div>
           <div className={styles.targetIcon}>
-            <ChevronDown />
+            <ChevronDownIcon />
           </div>
-        </div>
+        </button>
         <Poppable
-          onEscape={this.handleClose}
-          onClickOutside={this.handleClose}
+          onEscape={this.handleEsc}
+          onClickOutside={this.handleClickOutside}
           placement="bottom"
-          referenceElement={refElement}
+          referenceElement={toggleRef}
+          id={this.id}
         >
           {isOpen && (
             <div className={styles.root}>
@@ -88,26 +128,33 @@ export default class SelectLanguage extends React.Component {
                 <Button
                   inverted
                   onClick={allIsSelected ? this.handleSelectNone : this.handleSelectAll}
+                  kind="simple"
+                  padding="small"
+                  autoFocus
                 >
                   Select {allIsSelected ? 'none' : 'all'}
                 </Button>
               </div>
               <ul className={styles.list}>
-                {languages.map((lang) => (
-                  <li className={styles.item} key={lang.id}>
-                    <Checkbox
-                      onChange={this.handleLangCheckboxChange}
-                      data-lang-id={lang.id}
-                      checked={selected.includes(lang.id)}
-                      label={lang.title}
-                    />
-                  </li>
-                ))}
+                {languages.map((lang) => {
+                  const label = lang.title + (this.isDefaultLang(lang.id) ? ' (Default)' : '')
+                  return (
+                    <li className={styles.item} key={lang.id}>
+                      <Checkbox
+                        onChange={this.handleLangCheckboxChange}
+                        data-lang-id={lang.id}
+                        checked={selected.includes(lang.id)}
+                        label={label}
+                        disabled={this.isDefaultLang(lang.id)}
+                      />
+                    </li>
+                  )
+                })}
               </ul>
             </div>
           )}
         </Poppable>
-      </Fragment>
+      </>
     )
   }
 }

--- a/packages/@sanity/language-filter/src/SelectLanguageProvider.js
+++ b/packages/@sanity/language-filter/src/SelectLanguageProvider.js
@@ -1,7 +1,7 @@
 import React from 'react'
+import config from 'part:@sanity/language-filter/config'
 import {selectedLanguages$, setLangs} from './datastore'
 import SelectLanguage from './SelectLanguage'
-import config from 'part:@sanity/language-filter/config'
 
 export default class SelectLanguageProvider extends React.Component {
   state = {selected: []}
@@ -20,6 +20,7 @@ export default class SelectLanguageProvider extends React.Component {
     return (
       <SelectLanguage
         languages={config.supportedLanguages}
+        defaultLanguage={config.defaultLanguage}
         selected={selected}
         onChange={setLangs}
       />

--- a/packages/@sanity/language-filter/src/styles/SelectLanguage.css
+++ b/packages/@sanity/language-filter/src/styles/SelectLanguage.css
@@ -1,47 +1,70 @@
 @import 'part:@sanity/base/theme/variables-style';
 
+:root {
+  --dropdown-button-color: var(--default-button-color);
+
+  /* :enabled */
+  --dropdown-button-bg: transparent;
+  --dropdown-button-text: color(var(--dropdown-button-color) lightness(- 10%));
+
+  /* :hover */
+  --dropdown-button-hover-bg: color(var(--dropdown-button-color) alpha(10%));
+  --dropdown-button-hover-text: color(var(--dropdown-button-color) lightness(- 20%));
+
+  /* :selected */
+  --dropdown-button-selected-bg: color(var(--selected-item-color) alpha(15%));
+  --dropdown-button-selected-text: var(--selected-item-color);
+}
+
 .target {
-  display: flex;
-  align-items: center;
-  color: var(--default-button-color);
-  white-space: nowrap;
-  align-self: center;
-  border-radius: var(--button-border-radius);
+  appearance: none;
+  font: inherit;
+  border: 0;
   padding: var(--small-padding);
-  cursor: default;
+  border-radius: var(--border-radius-medium);
+  background: none;
+  display: inline-flex;
+  align-items: center;
+  outline: none;
+  background-color: var(--dropdown-button-bg);
+  color: var(--dropdown-button-text);
+  white-space: nowrap;
 
   @media (hover: hover) {
     @nest &:hover {
-      background: color(var(--default-button-color) a(10%));
-      color: color(var(--default-button-color) lightness(- 20%));
+      background-color: var(--dropdown-button-hover-bg);
+      color: var(--dropdown-button-hover-text);
     }
   }
 
-  @nest &[data-open='true'] {
-    background: color(var(--selected-item-color) alpha(15%));
-    color: var(--selected-item-color);
+  @nest &.targetSelected {
+    background-color: var(--dropdown-button-selected-bg);
+    color: var(--dropdown-button-selected-text);
+  }
+
+  @nest &:focus-visible {
+    box-shadow: 0 0 0 2px var(--focus-color);
   }
 }
 
 .targetValue {
+  display: block;
   font-size: var(--font-size-small);
   line-height: var(--line-height-small);
-
-  /* Optical alignment */
-  padding: 0 0 1px;
+  font-weight: 600;
+  margin: -3px 0.5em -2px 0;
 }
 
 .targetIcon {
-  margin-left: var(--extra-small-padding);
+  display: block;
+  margin: -5px;
 
-  @nest & svg {
-    display: block;
-    font-size: calc(15 / 16 * 1em);
-    margin: 1px 0;
+  @nest & > svg {
+    display: flex;
+    font-size: calc(21 / 16 * 1rem);
 
-    &[data-sanity-icon='true'] {
-      font-size: calc(21 / 16 * 1em);
-      margin: calc(2 / 21 * -1em);
+    @nest & path {
+      stroke-width: 1.5 !important;
     }
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x]  Documentation (fix or update to documentation)
- [ ]  Maintenance
- [ ]  Other, please describe:

**Does this change require a documentation update? (Check one)**

- [x]  Yes
- [ ]  No

**Current behavior**

Language filter hides/shows field level translation fields

**Description**

Added the option of a defaultLanguage that can't be be disabled/toggled. Also added minimal fixes to make toggle button keyboard accessible.

**Note for release**

Language filter has the added option of a `defaultLanguage` that can't be be disabled/toggled. Also added minimal fixes to make toggle button keyboard accessible.

**Checklist** 

- [x]  I have read the [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md)
- [x]  The PR title includes a link to the relevant issue
- [x]  The PR title is appropriately formatted: `[some-package] PR title (#123)`
- [x]  The code is linted
- [x]  The test suite is passing
- [x]  Corresponding changes to the documentation have been made
