### PR TITLE
chore(deps): upgrade @reach/auto-id

### DIFF
--- a/packages/@sanity/base/package.json
+++ b/packages/@sanity/base/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://www.sanity.io/",
   "dependencies": {
     "@popperjs/core": "^2.5.4",
-    "@reach/auto-id": "^0.10.5",
+    "@reach/auto-id": "^0.13.2",
     "@sanity/bifur-client": "^0.0.7",
     "@sanity/client": "2.2.6",
     "@sanity/color": "^1.0.0",

--- a/packages/@sanity/default-layout/package.json
+++ b/packages/@sanity/default-layout/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://www.sanity.io/",
   "dependencies": {
+    "@reach/auto-id": "^0.13.2",
     "@sanity/base": "2.6.0",
     "@sanity/generate-help-url": "2.2.6",
     "@sanity/ui": "^0.33.6",

--- a/packages/@sanity/desk-tool/package.json
+++ b/packages/@sanity/desk-tool/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "@popperjs/core": "^2.5.4",
-    "@reach/auto-id": "^0.10.5",
+    "@reach/auto-id": "^0.13.2",
     "@sanity/base": "2.6.0",
     "@sanity/data-aspects": "2.2.6",
     "@sanity/diff": "2.2.6",

--- a/packages/@sanity/form-builder/package.json
+++ b/packages/@sanity/form-builder/package.json
@@ -18,6 +18,7 @@
   "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",
   "dependencies": {
+    "@reach/auto-id": "^0.13.2",
     "@sanity/base": "2.6.0",
     "@sanity/block-tools": "2.5.0",
     "@sanity/color": "^2.0.14",


### PR DESCRIPTION
The old version we were depending on did not specify that it allowed react 17 as a peer dependency.
Also added it as a dependency to a few packages that were implicitly depending on it 😬 

Does not seem to have been any meaningful changes to the module apart from that.
