### PR TITLE
test(webpack-integration): make 'broken css' fixture more broken

### DIFF
--- a/packages/@sanity/webpack-integration/test/fixtures/broken.css
+++ b/packages/@sanity/webpack-integration/test/fixtures/broken.css
@@ -1,4 +1,5 @@
 :root {
+  // this aint valid css
   --missing-semi: var(--color)
   --not-missing-semi: #bf1942;
 }


### PR DESCRIPTION
It looks like the postcss parser has become more lenient/accepting of invalid CSS. This caused one of our tests to fail, as it was expecting postcss to throw an error, where it instead gave a warning. This PR makes the test fixture even more broken, making the tests pass again.