### PR TITLE
fix(desk-tool): make sure there's a valid selection state before opening the review changes panel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
       "@babel/env",
       {
         "targets": {
-          "node": "8",
+          "node": "10",
           "chrome": "59",
           "safari": "10",
           "firefox": "56",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -113,6 +113,7 @@ const watchJSAndAssets = parallel(
   )
 )
 
+exports.js = buildJSAndAssets
 exports.ts = buildTS
 exports.watchTS = series(buildTS, watchTS)
 exports.build = series(buildJSAndAssets, buildTS)

--- a/packages/@sanity/desk-tool/src/panes/documentPane/documentHistory/history/controller.ts
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/documentHistory/history/controller.ts
@@ -122,7 +122,7 @@ export class Controller {
 
   /** Returns true when the changes panel should be active. */
   changesPanelActive(): boolean {
-    return Boolean(this._since) && this.selectionState !== 'invalid'
+    return Boolean(this._since) && this.selectionState === 'range'
   }
 
   findRangeForNewRev(rev: Chunk): [string | null, string | null] {


### PR DESCRIPTION


<!-- Thank you for contributing to Sanity. Please read our [Code of Conduct](https://github.com/sanity-io/sanity/blob/next/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/sanity-io/sanity/blob/next/CONTRIBUTING.md) before submitting a PR.

To help us review your Pull Request, please make sure you follow the steps and guidelines below.

It's OK to open a Pull Request to start a discussion/ask for help, but it should then be created as a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). 

Do not delete the instructional comments. -->

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Description**

This fixes an issue that would sometimes make the studio crash with an error saying "start required". This would in some rare cases happen when history controller's selectionState was in a loading state. This patch fixes this by instead checking against `selectionState=="range"`, which is the only state where we are guaranteed to have the start document.

**Note for release**
- Fixes an issue that could cause an error saying "start required" during review changes
