### PR TITLE
test: use data-testid instead of data-test

### DIFF
--- a/cypress/integration/default-layout/navbar.test.js
+++ b/cypress/integration/default-layout/navbar.test.js
@@ -2,15 +2,15 @@ describe('@sanity/default-layout: Navbar', () => {
   it('should render ActionModal on top of Desk Tool’s pane headers', () => {
     cy.visit('/test/desk')
 
-    cy.get('[data-test="default-layout-global-create-button"]').click()
+    cy.get('[data-testid="default-layout-global-create-button"]').click()
 
-    cy.get('[data-test="default-layout-global-create-dialog"]').should(
+    cy.get('[data-testid="default-layout-global-create-dialog"]').should(
       'have.css',
       'z-index',
       '500401'
     )
 
-    cy.get('[data-test="desk-tool-list-pane"] [data-test="components-default-pane-header"]').should(
+    cy.get('[data-testid="desk-tool-list-pane"] [data-test="components-default-pane-header"]').should(
       'have.css',
       'z-index',
       '101'

--- a/packages/@sanity/default-layout/src/actionModal/ActionModal.tsx
+++ b/packages/@sanity/default-layout/src/actionModal/ActionModal.tsx
@@ -15,7 +15,7 @@ function ActionModal(props: Props) {
   return (
     <LegacyLayerProvider zOffset="navbarDialog">
       <DefaultDialog
-        data-test="default-layout-global-create-dialog"
+        data-testid="default-layout-global-create-dialog"
         onClickOutside={onClose}
         onClose={onClose}
         size="large"

--- a/packages/@sanity/default-layout/src/navbar/Navbar.tsx
+++ b/packages/@sanity/default-layout/src/navbar/Navbar.tsx
@@ -100,7 +100,7 @@ export default function Navbar(props: Props) {
             <div>
               <Button
                 aria-label="Create"
-                data-test="default-layout-global-create-button"
+                data-testid="default-layout-global-create-button"
                 icon={ComposeIcon}
                 kind="simple"
                 onClick={onCreateButtonClick}

--- a/packages/@sanity/desk-tool/src/panes/listPane/ListPane.js
+++ b/packages/@sanity/desk-tool/src/panes/listPane/ListPane.js
@@ -92,7 +92,7 @@ export default class ListPane extends React.PureComponent {
 
     return (
       <DefaultPane
-        data-test="desk-tool-list-pane"
+        data-testid="desk-tool-list-pane"
         index={index}
         title={title}
         styles={styles}


### PR DESCRIPTION
This changes the attribute we use to target elements in e2e tests from `data-test` to `data-testid`, which seems like the more widespread convention.