### PR TITLE
test(form-builder): give all inputs a data-testid with their given path

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -22,8 +22,7 @@ Cypress.Commands.add('login', (sanitySessionToken) => {
 })
 
 Cypress.Commands.add('getField', (fieldName) => {
-  // TODO(@benedicteb, 2021-01-26) Add <data-qa=..." /> or something to html to make select super robust
-  return cy.get(`[data-focus-path=${fieldName}]`)
+  return cy.get(`[data-testid="input-${fieldName}"]`)
 })
 
 Cypress.Commands.add('getFieldInput', (fieldName) => {

--- a/packages/@sanity/form-builder/src/FormBuilderInput.tsx
+++ b/packages/@sanity/form-builder/src/FormBuilderInput.tsx
@@ -316,7 +316,7 @@ function FormBuilderInputInner(props: FormBuilderInputInnerProps & Props) {
   )
 
   return (
-    <div data-focus-path={PathUtils.toString(path)}>
+    <div data-testid={path.length === 0 ? 'input-$root' : `input-${PathUtils.toString(path)}`}>
       <FormFieldPresenceContext.Provider value={childPresenceInfo}>
         <ChangeIndicatorProvider
           path={path}

--- a/perf/typingSpeed/typingSpeed.ts
+++ b/perf/typingSpeed/typingSpeed.ts
@@ -22,7 +22,7 @@ export async function testTypingSpeed({userToken}: Options) {
     timeout: 1000 * 60 * 5,
   })
 
-  const input = await page.waitForSelector('[data-focus-path="rootStringField"] input')
+  const input = await page.waitForSelector('[data-testid="input-rootStringField"] input')
 
   // clear the input value first
   await input.evaluate((el: HTMLInputElement) => {


### PR DESCRIPTION
This adds a `data-test-id` attribute around every input component in the sanity studio in order to provide a stable way of selecting inputs in e2e tests.

In addition, this PR also removes the `data-focus-path` attribute that we no longer use after merging #2329.

Based on #2367 