### PR TITLE
fix(desk-tool): fix position of pane header and presence avatars

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/constants.ts
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/constants.ts
@@ -2,5 +2,4 @@ type Margins = [number, number, number, number]
 
 export const DEFAULT_MARGINS: Margins = [0, 0, 1, 0]
 
-export const MARGINS_NARROW_SCREEN_WITH_TABS: Margins = [74, 0, 64, 0]
-export const MARGINS_NARROW_SCREEN_WITHOUT_TABS: Margins = [49, 0, 64, 0]
+export const MARGINS_NARROW_SCREEN_WITH_TABS: Margins = [76, 0, 64, 0]

--- a/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/documentPanel.css
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/documentPanel.css
@@ -41,7 +41,9 @@
   }
 
   @media (--max-screen-medium) {
-    position: sticky;
+    @nest &.headerContainer {
+      position: sticky;
+    }
     top: 0;
   }
 }

--- a/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/documentPanel.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/documentPanel.tsx
@@ -14,11 +14,7 @@ import {getMenuItems} from './menuItems'
 import {FormView} from './views'
 
 import styles from './documentPanel.css'
-import {
-  DEFAULT_MARGINS,
-  MARGINS_NARROW_SCREEN_WITH_TABS,
-  MARGINS_NARROW_SCREEN_WITHOUT_TABS,
-} from './constants'
+import {DEFAULT_MARGINS, MARGINS_NARROW_SCREEN_WITH_TABS} from './constants'
 
 interface DocumentPanelProps {
   activeViewId: string
@@ -110,12 +106,8 @@ export function DocumentPanel(props: DocumentPanelProps) {
     : parentPortal.element
 
   // Calculate the height of the header
-  const hasTabs = views.length > 1
-  const narrowScreenMargins = hasTabs
-    ? MARGINS_NARROW_SCREEN_WITH_TABS
-    : MARGINS_NARROW_SCREEN_WITHOUT_TABS
   const screenIsNarrow = !features.splitPanes
-  const margins = screenIsNarrow ? narrowScreenMargins : DEFAULT_MARGINS
+  const margins = screenIsNarrow ? MARGINS_NARROW_SCREEN_WITH_TABS : DEFAULT_MARGINS
 
   return (
     <Card className={classNames(styles.root, props.isCollapsed && styles.isCollapsed)}>


### PR DESCRIPTION
- Fixes an issue that made the document pane header not have `position: sticky`. 
- Fixes the positioning of the presence avatars on narrow screens.