### PR TITLE
fix(google-maps-input): make search results visible by raising z-index

### DIFF
--- a/examples/blog-studio/config/@sanity/google-maps-input.json
+++ b/examples/blog-studio/config/@sanity/google-maps-input.json
@@ -1,5 +1,5 @@
 {
-  "apiKey": "AIzaSyDwxpdp6WJwj9VjoVCjEudljhkR1inzhSE",
+  "apiKey": "AIzaSyDDO2FFi5wXaQdk88S1pQUa70bRtWuMhkI",
   "defaultZoom": 11,
   "defaultLocation": {
     "lat": 40.7058254,

--- a/examples/design-studio/config/@sanity/google-maps-input.json
+++ b/examples/design-studio/config/@sanity/google-maps-input.json
@@ -1,5 +1,5 @@
 {
-  "apiKey": "AIzaSyDwxpdp6WJwj9VjoVCjEudljhkR1inzhSE",
+  "apiKey": "AIzaSyDDO2FFi5wXaQdk88S1pQUa70bRtWuMhkI",
   "defaultZoom": 11,
   "defaultLocation": {
     "lat": 40.7058254,

--- a/examples/movies-studio/config/@sanity/google-maps-input.json
+++ b/examples/movies-studio/config/@sanity/google-maps-input.json
@@ -1,5 +1,5 @@
 {
-  "apiKey": "AIzaSyC1J6PVAOELsy1vyTh-x38GadFv70g2Qcc",
+  "apiKey": "AIzaSyDDO2FFi5wXaQdk88S1pQUa70bRtWuMhkI",
   "defaultZoom": 11,
   "defaultLocation": {
     "lat": 40.7058254,

--- a/examples/test-studio/config/@sanity/google-maps-input.json
+++ b/examples/test-studio/config/@sanity/google-maps-input.json
@@ -1,5 +1,5 @@
 {
-  "apiKey": "AIzaSyDwxpdp6WJwj9VjoVCjEudljhkR1inzhSE",
+  "apiKey": "AIzaSyDDO2FFi5wXaQdk88S1pQUa70bRtWuMhkI",
   "defaultZoom": 11,
   "defaultLocation": {
     "lat": 40.7058254,

--- a/packages/@sanity/google-maps-input/src/input/GeopointSelect.css
+++ b/packages/@sanity/google-maps-input/src/input/GeopointSelect.css
@@ -23,5 +23,14 @@
 }
 
 :global(.pac-container) {
-  z-index: calc(var(--zindex-modal) + 1);
+  /**
+   * Google maps renders the "search results" container at the root of the body,
+   * and we can't control the placement, so we need to just assume a high z-index works.
+   * Because modals can be nested and adds to the z-index, we need a fairly high number
+   * to be sure. Important to note that the search results dialog closes automatically
+   * (with display: none) once the input loses focus, so it _shouldn't_ cause any
+   * "bleed through" issues. In a future version we may consider handling the
+   * search/rendering ourselves, which would solve this in a more coherent fashion.
+   */
+  z-index: calc(var(--zindex-modal) + 10000);
 }


### PR DESCRIPTION
The search results for the google maps input falls behind the modal because of z-index changes. This PR adds a high number to the z-index in order to fix it - the rationale behind simply increasing the z-index is mentioned in the CSS file.

Also replaces the API key used in examples to allow it to work on `*.sanity.build`