### PR TITLE
fix(form-builder): hide slug generate button if field has no source

### DIFF
--- a/examples/test-studio/schemas/slugs.js
+++ b/examples/test-studio/schemas/slugs.js
@@ -32,7 +32,7 @@ export default {
     },
     {
       name: 'noSource',
-      title: 'Slug with not source',
+      title: 'Slug with no source',
       type: 'slug',
       options: {
         maxLength: 100,

--- a/packages/@sanity/form-builder/src/inputs/Slug/SlugInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/Slug/SlugInput.tsx
@@ -134,16 +134,18 @@ const SlugInput = React.forwardRef(function SlugInput(
                 </Card>
               )}
             </Box>
-            <Box marginLeft={1}>
-              <Button
-                mode="ghost"
-                type="button"
-                disabled={readOnly || isUpdating}
-                onClick={handleGenerateSlug}
-                onFocus={handleFocus}
-                text={generateState?.status === 'pending' ? 'Generating…' : 'Generate'}
-              />
-            </Box>
+            {sourceField && (
+              <Box marginLeft={1}>
+                <Button
+                  mode="ghost"
+                  type="button"
+                  disabled={readOnly || isUpdating}
+                  onClick={handleGenerateSlug}
+                  onFocus={handleFocus}
+                  text={generateState?.status === 'pending' ? 'Generating…' : 'Generate'}
+                />
+              </Box>
+            )}
           </Flex>
         </Stack>
       </FormField>


### PR DESCRIPTION
If a slug field has no `source` option, it shouldn't show a "Generate" button. Currently it does, and shows an error.
