### PR TITLE
Add default ArrayInput implementation

### DIFF
--- a/packages/@sanity/form-builder/sanity.json
+++ b/packages/@sanity/form-builder/sanity.json
@@ -24,6 +24,11 @@
       "description": "Input component for the core array type"
     },
     {
+      "name": "part:@sanity/form-builder/input/array-default",
+      "implements": "part:@sanity/form-builder/input/array",
+      "path": "inputs/ArrayInput/ArrayInput"
+    },
+    {
       "name": "part:@sanity/form-builder/input/array/functions",
       "description": "React component defining array functions such as add item"
     },


### PR DESCRIPTION
## About

Related to https://github.com/sanity-io/sanity/issues/2376

Uses approach documented in the [parts docs](https://www.sanity.io/docs/parts#de2ed8f04eba).

> This allows other plugins to compose from the original implementation, extending it as need be.

## Usage

```tsx
import ArrayInput from 'part:@sanity/form-builder/input/array-default';
```