### PR TITLE
fix: strip special characters from studio search

### DIFF
--- a/packages/@sanity/base/src/search/common/tokenize.js
+++ b/packages/@sanity/base/src/search/common/tokenize.js
@@ -1,4 +1,4 @@
-const pattern = /([^\s,-])+/g
+const pattern = /([^!@#$%^&*(),.?":{}|[\]+<>\s-])+/g
 
 export function tokenize(string) {
   return string.match(pattern) || []

--- a/packages/@sanity/base/src/search/common/tokenize.js
+++ b/packages/@sanity/base/src/search/common/tokenize.js
@@ -1,4 +1,4 @@
-const pattern = /([^!@#$%^&*(),.?":{}|[\]+<>\s-])+/g
+const pattern = /([^!@#$%^&*(),\\/?":{}|[\]+<>\s-])+/g
 
 export function tokenize(string) {
   return string.match(pattern) || []

--- a/packages/@sanity/base/src/search/common/tokenize.js
+++ b/packages/@sanity/base/src/search/common/tokenize.js
@@ -1,5 +1,6 @@
-const pattern = /([^!@#$%^&*(),\\/?":{}|[\]+<>\s-])+/g
+const SPECIAL_CHARS = /([^!@#$%^&*(),\\/?":{}|[\]+<>\s-])+/g
+const STRIP_EDGE_CHARS = /(^[.]+)|([.]+$)/
 
 export function tokenize(string) {
-  return string.match(pattern) || []
+  return (string.match(SPECIAL_CHARS) || []).map((token) => token.replace(STRIP_EDGE_CHARS, ''))
 }

--- a/packages/@sanity/base/test/search-tokenize.test.js
+++ b/packages/@sanity/base/test/search-tokenize.test.js
@@ -13,9 +13,15 @@ const tests = [
   ['1 2 3', ['1', '2', '3']],
   ['foo, bar, baz', ['foo', 'bar', 'baz']],
   ['foo   , bar   , baz', ['foo', 'bar', 'baz']],
-  ['a.b.c', ['a', 'b', 'c']],
+  ['a.b.c', ['a.b.c']],
+  ['sanity.io', ['sanity.io']],
   ['fourty-two', ['fourty', 'two']],
   ['abc -23 def', ['abc', '23', 'def']],
+  ['banana&[friends]\\/ barnåler', ['banana', 'friends', 'barnåler']],
+  ['banana&friends barnåler', ['banana', 'friends', 'barnåler']],
+  ['ban*ana*', ['ban', 'ana']],
+  ['한국인은 banana 동의하지 않는다', ['한국인은', 'banana', '동의하지', '않는다']],
+  ['한국인은    동의2하지', ['한국인은', '동의2하지']],
 ]
 
 tests.forEach(([input, expected]) => {

--- a/packages/@sanity/base/test/search-tokenize.test.js
+++ b/packages/@sanity/base/test/search-tokenize.test.js
@@ -16,6 +16,8 @@ const tests = [
   ['a.b.c', ['a.b.c']],
   ['sanity.io', ['sanity.io']],
   ['fourty-two', ['fourty', 'two']],
+  ['full stop. Then new beginning', ['full', 'stop', 'Then', 'new', 'beginning']],
+  ['about .io domains', ['about', 'io', 'domains']],
   ['abc -23 def', ['abc', '23', 'def']],
   ['banana&[friends]\\/ barnåler', ['banana', 'friends', 'barnåler']],
   ['banana&friends barnåler', ['banana', 'friends', 'barnåler']],

--- a/packages/@sanity/base/test/search-tokenize.test.js
+++ b/packages/@sanity/base/test/search-tokenize.test.js
@@ -13,7 +13,7 @@ const tests = [
   ['1 2 3', ['1', '2', '3']],
   ['foo, bar, baz', ['foo', 'bar', 'baz']],
   ['foo   , bar   , baz', ['foo', 'bar', 'baz']],
-  ['a.b.c', ['a.b.c']],
+  ['a.b.c', ['a', 'b', 'c']],
   ['fourty-two', ['fourty', 'two']],
   ['abc -23 def', ['abc', '23', 'def']],
 ]


### PR DESCRIPTION
Previously we'd only strip whitespace, comma and dash. This PR makes sure we ignore more special characters from the search string when doing a search from the Studio.

*Note for release*
Studio search will now strip special characters from the search string before searching