### PR TITLE
fix: date input emit value on right format

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/DateInputs/CommonDateTimeInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/DateInputs/CommonDateTimeInput.tsx
@@ -4,7 +4,6 @@ import {FormField} from '@sanity/base/components'
 import {Marker} from '@sanity/types'
 import {useId} from '@reach/auto-id'
 import {useForwardedRef, TextInput} from '@sanity/ui'
-import PatchEvent, {set, unset} from '../../PatchEvent'
 import {DateTimeInput} from './base/DateTimeInput'
 import {format, parse} from './legacy'
 import {CommonProps} from './types'
@@ -13,6 +12,7 @@ type Props = CommonProps & {
   title: string
   description: string
   inputFormat: string
+  onChange: (nextDate: Date | null) => void
   selectTime: boolean
   placeholder?: string
   timeStep?: number
@@ -49,12 +49,12 @@ export const CommonDateTimeInput = React.forwardRef(function CommonDateTimeInput
       setParseError(undefined)
       setInputValue(undefined)
       if (!nextInputValue) {
-        onChange(PatchEvent.from([unset()]))
+        onChange(null)
         return
       }
       const result = parse(nextInputValue, inputFormat)
       if (result.isValid) {
-        onChange(PatchEvent.from([set(result.date.toISOString())]))
+        onChange(result.date)
       } else {
         setParseError(result.error)
         // keep the input value floating around as long as it's invalid so that the
@@ -67,7 +67,7 @@ export const CommonDateTimeInput = React.forwardRef(function CommonDateTimeInput
 
   const handleDatePickerChange = React.useCallback(
     (nextDate: Date) => {
-      onChange(PatchEvent.from([set(nextDate.toISOString())]))
+      onChange(nextDate)
       setParseError(undefined)
       setInputValue(undefined)
     },

--- a/packages/@sanity/form-builder/src/inputs/DateInputs/DateInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/DateInputs/DateInput.tsx
@@ -1,4 +1,6 @@
-import React from 'react'
+import React, {useCallback} from 'react'
+import PatchEvent, {set, unset} from '../../PatchEvent'
+import {format} from './legacy'
 
 import {CommonDateTimeInput} from './CommonDateTimeInput'
 import {CommonProps} from './types'
@@ -18,6 +20,7 @@ const VALUE_FORMAT = 'YYYY-MM-DD'
 const DEFAULT_DATE_FORMAT = VALUE_FORMAT
 
 type Props = CommonProps & {
+  onChange: (event: PatchEvent) => void
   type: {
     name: string
     title: string
@@ -38,14 +41,22 @@ export const DateInput = React.forwardRef(function DateInput(
   props: Props,
   forwardedRef: React.ForwardedRef<HTMLInputElement>
 ) {
-  const {type, ...rest} = props
+  const {type, onChange, ...rest} = props
   const {title, description, placeholder} = type
 
   const {dateFormat} = parseOptions(type.options)
 
+  const handleChange = useCallback(
+    (nextDate: Date | null) => {
+      onChange(PatchEvent.from([nextDate === null ? unset() : set(format(nextDate, VALUE_FORMAT))]))
+    },
+    [onChange]
+  )
+
   return (
     <CommonDateTimeInput
       {...rest}
+      onChange={handleChange}
       ref={forwardedRef}
       selectTime={false}
       title={title}

--- a/packages/@sanity/form-builder/src/inputs/DateInputs/DateTimeInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/DateInputs/DateTimeInput.tsx
@@ -1,5 +1,6 @@
-import React from 'react'
+import React, {useCallback} from 'react'
 
+import PatchEvent, {set, unset} from '../../PatchEvent'
 import {CommonDateTimeInput} from './CommonDateTimeInput'
 import {CommonProps} from './types'
 
@@ -18,6 +19,7 @@ type SchemaOptions = {
 const DEFAULT_DATE_FORMAT = 'YYYY-MM-DD'
 const DEFAULT_TIME_FORMAT = 'HH:mm'
 type Props = CommonProps & {
+  onChange: (event: PatchEvent) => void
   type: {
     name: string
     title: string
@@ -40,14 +42,22 @@ export const DateTimeInput = React.forwardRef(function DateTimeInput(
   props: Props,
   forwardedRef: React.ForwardedRef<HTMLInputElement>
 ) {
-  const {type, ...rest} = props
+  const {type, onChange, ...rest} = props
   const {title, description, placeholder} = type
 
   const {dateFormat, timeFormat, timeStep} = parseOptions(type.options)
 
+  const handleChange = useCallback(
+    (nextDate: Date | null) => {
+      onChange(PatchEvent.from([nextDate === null ? unset() : set(nextDate.toISOString())]))
+    },
+    [onChange]
+  )
+
   return (
     <CommonDateTimeInput
       {...rest}
+      onChange={handleChange}
       ref={forwardedRef}
       selectTime
       timeStep={timeStep}

--- a/packages/@sanity/form-builder/src/inputs/DateInputs/types.ts
+++ b/packages/@sanity/form-builder/src/inputs/DateInputs/types.ts
@@ -1,6 +1,5 @@
 import {Marker} from '@sanity/types'
 import {FormFieldPresence} from '@sanity/base/presence'
-import PatchEvent from '../../PatchEvent'
 
 export type ParseResult = {isValid: boolean; date?: Date; error?: string} & (
   | {isValid: true; date: Date}
@@ -10,7 +9,6 @@ export type CommonProps = {
   value: string
   markers: Marker[]
   readOnly: boolean | null
-  onChange: (event: PatchEvent) => void
   level: number
   onFocus: () => void
   presence: FormFieldPresence[]


### PR DESCRIPTION
This fixes an accidental breaking change we shipped with the new date inputs released in [v2.6.3](https://github.com/sanity-io/sanity/releases/tag/v2.6.3) that made the input for `date` fields emit the full ISO string instead of an `YYYY-MM-DD`-formatted string. We should ship this as soon as possible.

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)

**Does this change require a documentation update? (Check one)**

- [ ]  Yes
- [x]  No

**Note for release**
Fix a regression introduced in v2.6.3 that caused values coming from `date` inputs to be stored on the same format as `datetime` fields.
