### PR TITLE
feat(base): add `altText` field to asset types

### DIFF
--- a/packages/@sanity/base/src/schema/types/fileAsset.js
+++ b/packages/@sanity/base/src/schema/types/fileAsset.js
@@ -32,6 +32,11 @@ export default {
       title: 'Description',
     },
     {
+      name: 'altText',
+      type: 'string',
+      title: 'Alternative text',
+    },
+    {
       name: 'sha1hash',
       type: 'string',
       title: 'SHA1 hash',

--- a/packages/@sanity/base/src/schema/types/imageAsset.js
+++ b/packages/@sanity/base/src/schema/types/imageAsset.js
@@ -32,6 +32,11 @@ export default {
       title: 'Description',
     },
     {
+      name: 'altText',
+      type: 'string',
+      title: 'Alternative text',
+    },
+    {
       name: 'sha1hash',
       type: 'string',
       title: 'SHA1 hash',


### PR DESCRIPTION
The [media plugin](https://github.com/robinpyon/sanity-plugin-media) defines a new "altText" field on the image and file assets, which we agree should be an option, but wasn't currently included in the schema. With this change, GraphQL schemas and such will have access to the field.