### PR TITLE
fix(base): prevent cancellation of list fetching while receiving mutation events

### DIFF
--- a/packages/@sanity/base/package.json
+++ b/packages/@sanity/base/package.json
@@ -75,6 +75,7 @@
     "react-sortable-hoc": "^1.11.0",
     "react-split-pane": "^0.1.84",
     "rxjs": "^6.5.3",
+    "rxjs-exhaustmap-with-trailing": "^1.0.0",
     "semver-compare": "^1.0.0",
     "shallow-equals": "^1.0.0",
     "styled-components": "^5.2.1"

--- a/packages/@sanity/base/src/datastores/document/listenQuery.ts
+++ b/packages/@sanity/base/src/datastores/document/listenQuery.ts
@@ -1,5 +1,6 @@
 import {defer, partition, merge, of, throwError, asyncScheduler, Observable} from 'rxjs'
-import {mergeMap, throttleTime, share, switchMapTo, take} from 'rxjs/operators'
+import {mergeMap, throttleTime, share, take} from 'rxjs/operators'
+import {exhaustMapToWithTrailing} from 'rxjs-exhaustmap-with-trailing'
 import {versionedClient} from '../../client/versionedClient'
 import {ReconnectEvent, WelcomeEvent, MutationEvent} from './types'
 
@@ -52,5 +53,5 @@ export const listenQuery = (query: string, params: Params = {}) => {
   return merge(
     welcome$.pipe(take(1)),
     mutationAndReconnect$.pipe(throttleTime(1000, asyncScheduler, {leading: true, trailing: true}))
-  ).pipe(switchMapTo(fetchOnce$))
+  ).pipe(exhaustMapToWithTrailing(fetchOnce$))
 }


### PR DESCRIPTION
Currently, if a list fetch takes > 1 second and receive mutation events in the meantime, the request would be cancelled and a new one re-initated. In cases where you'd have many ongoing mutations happening while loading a list this could make the list load forever (or until the mutations stops from arriving).

This patch fixes the issue by instead using an rxjs operator that will ignore received mutation events during ongoing fetces, and issue a new one at the trailing end for any mutation event received during the preceding fetch.

**Type of change (check at least one)**

- [x]  Bug fix (non-breaking change which fixes an issue)

**Note for release**
- Fixes an issue that could in some cases cause loading of document lists in the studio to take a long time.