### PR TITLE
fix(base): strip symbols from user initials

### DIFF
--- a/packages/@sanity/base/src/components/UserAvatar.tsx
+++ b/packages/@sanity/base/src/components/UserAvatar.tsx
@@ -25,11 +25,14 @@ interface UnloadedUserProps extends BaseProps {
 
 type UserProps = LoadedUserProps | UnloadedUserProps
 
+const symbols = /[^\p{Alpha}\p{White_Space}]/gu
+const whitespace = /\p{White_Space}+/u
+
 function nameToInitials(fullName: string) {
-  const namesArray = fullName.split(' ')
+  const namesArray = fullName.replace(symbols, '').split(whitespace)
 
   if (namesArray.length === 1) {
-    return `${namesArray[0].charAt(0)}`
+    return `${namesArray[0].charAt(0)}`.toUpperCase()
   }
 
   return `${namesArray[0].charAt(0)}${namesArray[namesArray.length - 1].charAt(0)}`


### PR DESCRIPTION
When trying to find a user's initials and the name contains symbols (eg `Espen "Hooverdam"`), we can end up with initials like  `E"`. This PR removes symbols from the name before trying to find the first character of the last word, which would change the previous examples initials into `EH`. 

Couldn't find any regex class or similar that would catch _all_ cases, for instance we can't use `\w` as we want to Make `Albert Åberg` into `AÅ`, not `AB`. Better than nothing?