### PR TITLE
chore(base): enable TypeScript's checkJs

### DIFF
--- a/packages/@sanity/base/src/@types/css.d.ts
+++ b/packages/@sanity/base/src/@types/css.d.ts
@@ -1,4 +1,5 @@
 declare module '*.css' {
   const styles: Record<string, string>
+  export = styles
   export default styles
 }

--- a/packages/@sanity/base/src/components/DevServerStatus.ts
+++ b/packages/@sanity/base/src/components/DevServerStatus.ts
@@ -1,7 +1,9 @@
 import {useToast} from '@sanity/ui'
 import {useCallback, useEffect, useState} from 'react'
 
-const eventBus = window.__webpack_hot_middleware_eventbus__
+declare const __DEV__: boolean
+
+const eventBus = (window as any).__webpack_hot_middleware_eventbus__
 const events = eventBus ? eventBus.eventTypes : {}
 
 const CONNECTION_TOAST_ID = 'dev-server-status'
@@ -58,30 +60,29 @@ function DevServerStatus() {
       id: CONNECTION_TOAST_ID,
       status: 'warning',
       title: 'Disconnected from dev server',
-      timeout: Infinity,
     })
   }, [connectionState, push])
 
   const handleEvent = useCallback(
     (evt) => {
       if (evt.type === events.EVENT_BUILT) {
-        handleBuilt(evt)
+        handleBuilt()
       }
 
       if (evt.type === events.EVENT_BUILDING) {
-        handleBuilding(evt)
+        handleBuilding()
       }
 
       if (evt.type === events.EVENT_CONNECTING) {
-        handleConnecting(evt)
+        handleConnecting()
       }
 
       if (evt.type === events.EVENT_CONNECTED) {
-        handleConnected(evt)
+        handleConnected()
       }
 
       if (evt.type === events.EVENT_DISCONNECTED) {
-        handleDisconnected(evt)
+        handleDisconnected()
       }
     },
     [handleBuilding, handleBuilt, handleConnected, handleConnecting, handleDisconnected]

--- a/packages/@sanity/base/src/components/ErrorHandler.ts
+++ b/packages/@sanity/base/src/components/ErrorHandler.ts
@@ -1,5 +1,6 @@
 import {useToast} from '@sanity/ui'
 import {useCallback, useEffect, useRef} from 'react'
+declare const __DEV__: boolean
 
 const SANITY_ERROR_HANDLER = Symbol.for('SANITY_ERROR_HANDLER')
 
@@ -49,19 +50,18 @@ function ErrorHandler({onUIError}) {
         status: 'error',
         title: __DEV__ ? `Error: ${err.message}` : 'An error occured',
         description: "Check your browser's JavaScript console for details.",
-        timeout: 8000,
       })
     },
     [onUIError, push]
   )
 
-  handleGlobalError.identity = SANITY_ERROR_HANDLER
+  ;(handleGlobalError as any).identity = SANITY_ERROR_HANDLER
 
   useEffect(() => {
     let originalErrorHandler
 
     // Only store the original error handler if it wasn't a copy of _this_ error handler
-    if (window.onerror && window.onerror.identity !== SANITY_ERROR_HANDLER) {
+    if (window.onerror && (window.onerror as any).identity !== SANITY_ERROR_HANDLER) {
       originalErrorHandler = window.onerror
     }
 

--- a/packages/@sanity/base/src/datastores/history/createHistoryStore.ts
+++ b/packages/@sanity/base/src/datastores/history/createHistoryStore.ts
@@ -1,4 +1,5 @@
 import {from, merge} from 'rxjs'
+// eslint-disable-next-line import/no-unresolved
 import {transactionsToEvents} from '@sanity/transaction-collator'
 import {map, mergeMap, reduce, scan} from 'rxjs/operators'
 import {omit, isUndefined} from 'lodash'
@@ -26,7 +27,9 @@ const ndjsonToArray = (ndjson) => {
     .map((line) => JSON.parse(line))
 }
 
-const getHistory = (documentIds, options = {}) => {
+type HistoryTransaction = any
+
+const getHistory = (documentIds, options: {time?: number; revision?: string} = {}) => {
   const ids = Array.isArray(documentIds) ? documentIds : [documentIds]
   const {time, revision} = options
 
@@ -79,7 +82,7 @@ function historyEventsFor(documentId) {
 
   const pastTransactions$ = from(getTransactions(pairs)).pipe(
     mergeMap((transactions) => from(transactions)),
-    map((trans) => ({
+    map((trans: HistoryTransaction) => ({
       author: trans.author,
       documentIDs: pairs,
       id: trans.id,
@@ -173,7 +176,7 @@ function restore(id, targetId, rev) {
         _id: targetId,
       })
     ),
-    mergeMap((restoredDraft) =>
+    mergeMap((restoredDraft: any) =>
       versionedClient.observable.transaction().createOrReplace(restoredDraft).commit()
     )
   )

--- a/packages/@sanity/base/src/datastores/project/createProjectStore.js
+++ b/packages/@sanity/base/src/datastores/project/createProjectStore.js
@@ -3,19 +3,19 @@ import createActions from '../utils/createActions'
 import projectFetcher from 'part:@sanity/base/project-fetcher'
 import config from 'config:sanity'
 
-function AccessDeniedError(message) {
+export function AccessDeniedError(message) {
   this.name = 'AccessDeniedError'
   this.message = message || ''
 }
 AccessDeniedError.prototype = Object.create(Error.prototype)
 
-function NotFoundError(message) {
+export function NotFoundError(message) {
   this.name = 'NotFoundError'
   this.message = message || ''
 }
 NotFoundError.prototype = Object.create(Error.prototype)
 
-function UnknownApiError(error) {
+export function UnknownApiError(error) {
   this.name = 'UnknownApiError'
   this.message = error.message
   this.code = error.code

--- a/packages/@sanity/base/src/schema/createSchema.ts
+++ b/packages/@sanity/base/src/schema/createSchema.ts
@@ -2,6 +2,7 @@ import Schema from '@sanity/schema'
 import legacyRichDate from 'part:@sanity/form-builder/input/legacy-date/schema?'
 import validateSchema from '@sanity/schema/lib/sanity/validateSchema'
 import groupProblems from '@sanity/schema/lib/sanity/groupProblems'
+// eslint-disable-next-line import/no-unresolved
 import {inferFromSchema as inferValidation} from '@sanity/validation'
 import slug from './types/slug'
 import geopoint from './types/geopoint'
@@ -47,8 +48,8 @@ module.exports = (schemaDef) => {
     types,
   })
 
-  compiled._source = schemaDef
-  compiled._validation = validation
+  ;(compiled as any)._source = schemaDef
+  ;(compiled as any)._validation = validation
 
   return inferValidation(compiled)
 }

--- a/packages/@sanity/base/src/search/weighted/applyWeights.ts
+++ b/packages/@sanity/base/src/search/weighted/applyWeights.ts
@@ -1,7 +1,7 @@
 import {words, uniq, compact, union, intersection, keyBy, toLower} from 'lodash'
 
 // takes a set of terms and a value and returns a [score, story] pair where score is a value between 0, 1 and story is the explanation
-export const calculateScore = (searchTerms, value) => {
+export const calculateScore = (searchTerms, value): [number, string] => {
   const uniqueValueTerms = uniq(compact(words(toLower(value))))
   const uniqueSearchTerms = uniq(searchTerms.map(toLower))
   const matches = intersection(uniqueSearchTerms, uniqueValueTerms)

--- a/packages/@sanity/base/tsconfig.json
+++ b/packages/@sanity/base/tsconfig.json
@@ -10,6 +10,8 @@
     "strictNullChecks": false,
     "strictPropertyInitialization": false,
     // --
+    "checkJs": true,
+    "allowJs": true,
     "jsx": "react",
     "plugins": [
       {

--- a/packages/@sanity/types/parts/config:sanity/index.d.ts
+++ b/packages/@sanity/types/parts/config:sanity/index.d.ts
@@ -1,5 +1,6 @@
 declare module 'config:sanity' {
   interface SanityConfig {
+    root: boolean
     project: {
       name?: string
       basePath?: string
@@ -8,6 +9,7 @@ declare module 'config:sanity' {
       projectId: string
       dataset: string
     }
+    plugins: string[]
   }
 
   const config: SanityConfig


### PR DESCRIPTION
Note: this builds on changes in #2405

This enables the `checkJs` TypeScript compiler option in @sanity/base, giving us improved type checking on `.js`-files as well, and ease the migration path towards better ts coverage.

I had to do some minor code changes and cleanup to pass the type checker, but they shouldn't change any actual code behavior.

**Type of change (check at least one)**

- [x]  Maintenance

**Does this change require a documentation update? (Check one)**

- [x]  No

**Note for release**
N/A