### PR TITLE
fix: use portal for validation menu

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/header/validationMenu.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/header/validationMenu.tsx
@@ -48,6 +48,7 @@ export function ValidationMenu(props: ValidationMenuProps) {
       }}
       menu={popoverContent}
       open={isOpen}
+      portal
       placement="bottom"
       setOpen={setOpen}
     />


### PR DESCRIPTION
### Description
This PR makes the validation menu open in a portal, fixes an issue where it got hidden behind the fullscreen Portable Text Editor.
​
### What to review
​Open or create a document that has a portable text editor and also validation errors. Open portable text editor in fullscreen. See that the validation menu is displayed on top and doesn't get layered behind the portable text editor.

### Notes for release
- ​Fixes issue where the validation menu got hidden behind the fullscreen Portable Text Editor​