### PR TITLE
Remove normalize css from Studio CSS bundle

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/files/common/FileInputButton/FileInputButton.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/common/FileInputButton/FileInputButton.tsx
@@ -30,12 +30,6 @@ const SelectButton = styled(Button)(({theme}: {theme: Theme}) => {
   const border = {width: 1, color: 'var(--card-border-color)'}
 
   return css`
-    //---
-    // Needed because normalize.css in the studio overrides this in Safari.
-    // Safe to remove the following line when when we no longer use normalize.css
-    appearance: none !important;
-    //----
-
     &:not([data-disabled='true']) {
       &:focus-within {
         box-shadow: ${focusRingStyle({

--- a/packages/@sanity/server/package.json
+++ b/packages/@sanity/server/package.json
@@ -57,7 +57,6 @@
     "find-config": "^1.0.0",
     "json-loader": "^0.5.4",
     "lodash": "^4.17.15",
-    "normalize.css": "^5.0.0",
     "postcss-loader": "^2.0.6",
     "querystring": "^0.2.0",
     "react-hot-loader": "^4.12.11",

--- a/packages/@sanity/server/src/configs/webpack.config.js
+++ b/packages/@sanity/server/src/configs/webpack.config.js
@@ -66,10 +66,9 @@ export default (config = {}) => {
 
   return {
     entry: {
-      app: [
-        resolve('normalize.css'),
-        path.join(__dirname, '..', 'browser', isProd ? 'entry.js' : 'entry-dev.js'),
-      ].filter(Boolean),
+      app: [path.join(__dirname, '..', 'browser', isProd ? 'entry.js' : 'entry-dev.js')].filter(
+        Boolean
+      ),
       vendor: ['react', 'react-dom'],
     },
     output: {

--- a/packages/@sanity/storybook/package.json
+++ b/packages/@sanity/storybook/package.json
@@ -36,7 +36,6 @@
     "@storybook/addons": "^3.2.6",
     "@storybook/react": "3.2.8",
     "classnames": "^2.2.5",
-    "normalize.css": "^5.0.0",
     "react-addons-create-fragment": "^15.4.2",
     "shelljs": "^0.7.6",
     "styled-components": "^5.2.1",

--- a/packages/@sanity/storybook/src/config/config.js
+++ b/packages/@sanity/storybook/src/config/config.js
@@ -3,8 +3,6 @@
 
 const {configure, sanity} = require('part:@sanity/storybook')
 
-require('normalize.css')
-
 configure(() => {
   // Trigger loading of stories (side-effect of registering them)
   require('all:part:@sanity/base/component')


### PR DESCRIPTION
Our inclusion of normalize.css in the studio css bundle is occasionally causing hard-to-debug issues with rendering (see 5eb2905 for an example). I think removing it is a good idea, and also something that is in more in line with the direction we're currently going in (less assumptions about the global environment, etc.).

If we absolutely need to normalize browser styles, we should probably consider something more up-to-date like [sindresorhus/modern-normalize](https://github.com/sindresorhus/modern-normalize) instead.

Thoughts?