### PR TITLE
feat(search): apply pt::text() when searching portable text fields

### DIFF
--- a/packages/@sanity/base/src/search/index.ts
+++ b/packages/@sanity/base/src/search/index.ts
@@ -3,4 +3,9 @@ import {versionedClient} from '../client/versionedClient'
 import {getSearchableTypes} from './common/utils'
 import {createWeightedSearch} from './weighted/createWeightedSearch'
 
-export default createWeightedSearch(getSearchableTypes(schema), versionedClient)
+// Use >= 2021-03-25 for pt::text() support
+const searchClient = versionedClient.withConfig({
+  apiVersion: '2021-03-25',
+})
+
+export default createWeightedSearch(getSearchableTypes(schema), searchClient)

--- a/packages/@sanity/base/src/search/weighted/createWeightedSearch.ts
+++ b/packages/@sanity/base/src/search/weighted/createWeightedSearch.ts
@@ -8,7 +8,7 @@ import {joinPath} from '../../util/searchUtils'
 import {removeDupes} from '../../util/draftUtils'
 import {tokenize} from '../common/tokenize'
 import {applyWeights} from './applyWeights'
-import {WeightedHit, WeightedSearchOptions} from './types'
+import {WeightedHit, WeightedSearchOptions, SearchPath} from './types'
 
 const combinePaths = flow([flatten, union, compact])
 
@@ -19,6 +19,9 @@ const toGroqParams = (terms: string[]): Record<string, string> => {
     return acc
   }, params)
 }
+
+const pathWithMapper = ({mapWith, path}: SearchPath): string =>
+  mapWith ? `${mapWith}(${path})` : path
 
 export function createWeightedSearch(
   types: ObjectSchemaType[],
@@ -31,17 +34,19 @@ export function createWeightedSearch(
     paths: type.__experimental_search.map((config) => ({
       weight: config.weight,
       path: joinPath(config.path),
+      mapWith: config.mapWith,
     })),
   }))
 
   const combinedSearchPaths = combinePaths(
-    searchSpec.map((configForType) => configForType.paths.map((opt) => opt.path))
+    searchSpec.map((configForType) => configForType.paths.map((opt) => pathWithMapper(opt)))
   )
 
-  const selections = searchSpec.map(
-    (spec) =>
-      `_type == "${spec.typeName}" => {${spec.paths.map((cfg, i) => `"w${i}": ${cfg.path}`)}}`
-  )
+  const selections = searchSpec.map((spec) => {
+    const constraint = `_type == "${spec.typeName}" => `
+    const selection = `{ ${spec.paths.map((cfg, i) => `"w${i}": ${pathWithMapper(cfg)}`)} }`
+    return `${constraint}${selection}`
+  })
 
   // this is the actual search function that takes the search string and returns the hits
   return function search(queryString: string) {

--- a/packages/@sanity/base/src/search/weighted/types.ts
+++ b/packages/@sanity/base/src/search/weighted/types.ts
@@ -1,9 +1,18 @@
 /**
  * @internal
  */
+export interface SearchPath {
+  weight: number
+  path: string
+  mapWith?: string
+}
+
+/**
+ * @internal
+ */
 export interface SearchSpec {
   typeName: string
-  paths: {weight: number; path: string}[]
+  paths: SearchPath[]
 }
 
 /**

--- a/packages/@sanity/schema/src/legacy/types/object.ts
+++ b/packages/@sanity/schema/src/legacy/types/object.ts
@@ -31,6 +31,7 @@ const normalizeSearchConfig = (configs) => {
     return {
       weight: 'weight' in conf ? conf.weight : 1,
       path: toPath(conf.path),
+      mapWith: typeof conf.mapWith === 'string' ? conf.mapWith : undefined,
     }
   })
 }

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -140,7 +140,7 @@ export interface ObjectSchemaType extends BaseSchemaType {
 
   // Experimentals
   /* eslint-disable camelcase */
-  __experimental_search?: {path: string; weight: number}[]
+  __experimental_search?: {path: string; weight: number; mapWith?: string}[]
   /* eslint-enable camelcase */
 }
 


### PR DESCRIPTION
### Description

This PR allows users to search for a term mentioned in portable documents portable text field in the global search. 

### Technical changes

- Use the `v2021-03-25` API version for the studio search
- Allow a `mapWith` property on the experimental search (primarily for internal use) - wraps the field in the GROQ-function given. Not sure about the naming on this.
- Detect portable text fields and include them in the automatically resolved search configuration

### What to review

- Try searching the [test studio](https://test-studio-git-feat-pt-text-search.sanity.build/test/desk) for strings that appear in portable text fields
- Technical implementation (and naming)

### Notes for release

- Add support for searching portable text fields