### PR TITLE
fix(base): fix regression causing drafts to be included as results in reference search

### DIFF
--- a/packages/@sanity/base/src/search/weighted/types.ts
+++ b/packages/@sanity/base/src/search/weighted/types.ts
@@ -39,5 +39,8 @@ export interface WeightedHit {
 export interface WeightedSearchOptions {
   filter?: string
   params?: Record<string, unknown>
+}
+
+export interface SearchOptions {
   includeDrafts?: boolean
 }


### PR DESCRIPTION

### Description

Fixes #2440

### What to review

Check that drafts no longer appears when searching for references.

### Notes for release

- Fixes a bug that accidentally permitted referencing drafts
