### PR TITLE
perf(form-builder): improve array input performance

### DIFF
--- a/packages/@sanity/base/src/change-indicators/ChangeIndicator.tsx
+++ b/packages/@sanity/base/src/change-indicators/ChangeIndicator.tsx
@@ -102,7 +102,10 @@ export function ChangeIndicatorProvider(props: {
   const path = props.path
   const focusPath = useMemo(() => props.focusPath || EMPTY_PATH, [props.focusPath])
   const parentFullPath = parentContext.fullPath
-  const fullPath = React.useMemo(() => parentFullPath.concat(path), [parentFullPath, path])
+  const fullPath = React.useMemo(() => PathUtils.pathFor(parentFullPath.concat(path)), [
+    parentFullPath,
+    path,
+  ])
 
   const contextValue = React.useMemo(() => {
     return {
@@ -177,7 +180,7 @@ export const ChangeIndicatorForFieldPath = ({
 }) => {
   const parentContext = React.useContext(ChangeIndicatorContext)
 
-  const fullPath = React.useMemo(() => parentContext.fullPath.concat(path), [
+  const fullPath = React.useMemo(() => PathUtils.pathFor(parentContext.fullPath.concat(path)), [
     parentContext.fullPath,
     path,
   ])
@@ -206,7 +209,7 @@ export const ChangeIndicatorWithProvidedFullPath = ({
 }: any) => {
   const parentContext = React.useContext(ChangeIndicatorContext)
 
-  const fullPath = React.useMemo(() => parentContext.fullPath.concat(path), [
+  const fullPath = React.useMemo(() => PathUtils.pathFor(parentContext.fullPath.concat(path)), [
     parentContext.fullPath,
     path,
   ])


### PR DESCRIPTION
### Description

Some low hanging performance optimizations after seeing regressions from #2350.

Comparison of typing A-Z in a text field inside an object in an array of 100 items:
*base branch*: Average of 4 samples: **5799ms**
*this branch*: Average of 4 samples: **1588ms**

### What to review

Edit an array of objects and verify that presence/markers works as before, but faster.

### Notes for release
- Improved performance of editing array items
