### PR TITLE
build: update `@sanity/color` dependency

### DIFF
--- a/examples/design-studio/package.json
+++ b/examples/design-studio/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@sanity/base": "2.9.1",
     "@sanity/cli": "2.9.1",
+    "@sanity/color": "^2.0.15",
     "@sanity/core": "2.9.1",
     "@sanity/default-layout": "2.9.1",
     "@sanity/default-login": "2.8.0",

--- a/packages/@sanity/base/package.json
+++ b/packages/@sanity/base/package.json
@@ -34,7 +34,7 @@
     "@reach/auto-id": "^0.13.2",
     "@sanity/bifur-client": "^0.0.8",
     "@sanity/client": "2.8.0",
-    "@sanity/color": "^1.0.0",
+    "@sanity/color": "^2.0.15",
     "@sanity/generate-help-url": "2.2.6",
     "@sanity/icons": "1.0.5",
     "@sanity/image-url": "^0.140.19",

--- a/packages/@sanity/base/src/__legacy/@sanity/components/avatar/stories/stack.tsx
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/avatar/stories/stack.tsx
@@ -1,4 +1,4 @@
-import {color} from '@sanity/color'
+import {hues} from '@sanity/color'
 import {Avatar, AvatarStack} from 'part:@sanity/components/avatar'
 import {number, select} from 'part:@sanity/storybook/addons/knobs'
 import Sanity from 'part:@sanity/storybook/addons/sanity'
@@ -6,12 +6,12 @@ import {CenteredContainer} from 'part:@sanity/storybook/components'
 import React from 'react'
 
 const colors = [
-  {dark: color.blue[400].hex, light: color.blue[500].hex},
-  {dark: color.purple[400].hex, light: color.purple[500].hex},
-  {dark: color.magenta[400].hex, light: color.magenta[500].hex},
-  {dark: color.orange[400].hex, light: color.orange[500].hex},
-  {dark: color.yellow[400].hex, light: color.yellow[500].hex},
-  {dark: color.cyan[400].hex, light: color.cyan[500].hex},
+  {dark: hues.blue[400].hex, light: hues.blue[500].hex},
+  {dark: hues.purple[400].hex, light: hues.purple[500].hex},
+  {dark: hues.magenta[400].hex, light: hues.magenta[500].hex},
+  {dark: hues.orange[400].hex, light: hues.orange[500].hex},
+  {dark: hues.yellow[400].hex, light: hues.yellow[500].hex},
+  {dark: hues.cyan[400].hex, light: hues.cyan[500].hex},
 ]
 
 function getRandomColor() {

--- a/packages/@sanity/base/src/components/formField/FormFieldValidationStatus.tsx
+++ b/packages/@sanity/base/src/components/formField/FormFieldValidationStatus.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 
-import {color} from '@sanity/color'
+import {hues} from '@sanity/color'
 import {ErrorOutlineIcon, WarningOutlineIcon} from '@sanity/icons'
 import {
   isValidationErrorMarker,
@@ -39,7 +39,7 @@ export function FormFieldValidationStatus(props: FormFieldValidationStatusProps)
   const errors = validation.filter((v) => v.type === 'error')
   const hasErrors = errors.length > 0
   const statusIcon = hasErrors ? ErrorOutlineIcon : WarningOutlineIcon
-  const statusColor = hasErrors ? color.red[500].hex : color.yellow[500].hex
+  const statusColor = hasErrors ? hues.red[500].hex : hues.yellow[500].hex
 
   return (
     <Tooltip
@@ -72,7 +72,7 @@ export function FormFieldValidationStatus(props: FormFieldValidationStatusProps)
 function FormFieldValidationStatusItem(props: {item: FormFieldValidation}) {
   const {item} = props
   const statusIcon = item.type === 'error' ? ErrorOutlineIcon : WarningOutlineIcon
-  const statusColor = item.type === 'error' ? color.red[500].hex : color.yellow[500].hex
+  const statusColor = item.type === 'error' ? hues.red[500].hex : hues.yellow[500].hex
 
   return (
     <Flex>

--- a/packages/@sanity/base/src/theme/color.ts
+++ b/packages/@sanity/base/src/theme/color.ts
@@ -1,4 +1,4 @@
-import {color as hues} from '@sanity/color'
+import {hues} from '@sanity/color'
 import {createColorTheme, rgba} from '@sanity/ui'
 import {_multiply, _screen, _isDark} from './helpers'
 import {legacyPalette} from './legacyPalette'

--- a/packages/@sanity/form-builder/package.json
+++ b/packages/@sanity/form-builder/package.json
@@ -22,7 +22,7 @@
     "@sanity/base": "2.9.1",
     "@sanity/block-tools": "2.9.1",
     "@sanity/client": "2.8.0",
-    "@sanity/color": "^2.0.14",
+    "@sanity/color": "^2.0.15",
     "@sanity/generate-help-url": "2.2.6",
     "@sanity/icons": "^1.0.1",
     "@sanity/imagetool": "2.9.0",

--- a/packages/@sanity/types/package.json
+++ b/packages/@sanity/types/package.json
@@ -21,6 +21,7 @@
   ],
   "dependencies": {
     "@sanity/client": "2.8.0",
+    "@sanity/color": "^2.0.15",
     "@types/react": "^17.0.0",
     "rxjs": "^6.5.3"
   },


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

- This change updates `@sanity/color` from 1.0.0 to 2.0.15 in `@sanity/base` (required updating code in the user color manager + form validation component).
- This change adds `@sanity/color` as dependency where it was missing.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

- The studio builds and runs using the new version of `@sanity/color`.
- Look especially at presence avatars (if the studio doesn’t crash when rendering user avatars, it works)
