### PR TITLE
fix issue causing image input to emit hotspot/crop out of bounds values for hotspot/crop

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/files/ImageToolInput/ImageToolInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/ImageToolInput/ImageToolInput.tsx
@@ -102,31 +102,34 @@ export const ImageToolInput = forwardRef(function ImageToolInput(
     }
   })
 
-  const handleChangeEnd = useCallback(() => {
-    if (readOnly) {
-      return
-    }
-    // For backwards compatibility, where hotspot/crop might not have a named type yet
-    const cropField = type.fields.find(
-      (field) => field.name === 'crop' && field.type.name !== 'object'
-    )
+  const handleChangeEnd = useCallback(
+    (finalValue) => {
+      if (readOnly) {
+        return
+      }
+      // For backwards compatibility, where hotspot/crop might not have a named type yet
+      const cropField = type.fields.find(
+        (field) => field.name === 'crop' && field.type.name !== 'object'
+      )
 
-    const hotspotField = type.fields.find(
-      (field) => field.type.name !== 'object' && field.name === 'hotspot'
-    )
+      const hotspotField = type.fields.find(
+        (field) => field.type.name !== 'object' && field.name === 'hotspot'
+      )
 
-    // Note: when either hotspot or crop change we fill in the default if the other is missing
-    // (we can't have one without the other)
-    const crop = cropField
-      ? {_type: cropField.type.name, ...(localValue.crop || DEFAULT_CROP)}
-      : localValue.crop
+      // Note: when either hotspot or crop change we fill in the default if the other is missing
+      // (we can't have one without the other)
+      const crop = cropField
+        ? {_type: cropField.type.name, ...(finalValue.crop || DEFAULT_CROP)}
+        : finalValue.crop
 
-    const hotspot = hotspotField
-      ? {_type: hotspotField.type.name, ...(localValue.hotspot || DEFAULT_HOTSPOT)}
-      : localValue.hotspot
+      const hotspot = hotspotField
+        ? {_type: hotspotField.type.name, ...(finalValue.hotspot || DEFAULT_HOTSPOT)}
+        : finalValue.hotspot
 
-    onChange(PatchEvent.from([set(crop, ['crop']), set(hotspot, ['hotspot'])]))
-  }, [localValue, onChange, readOnly, type.fields])
+      onChange(PatchEvent.from([set(crop, ['crop']), set(hotspot, ['hotspot'])]))
+    },
+    [onChange, readOnly, type.fields]
+  )
 
   return (
     <FormField

--- a/packages/@sanity/imagetool/src/ImageTool.js
+++ b/packages/@sanity/imagetool/src/ImageTool.js
@@ -676,7 +676,7 @@ export default class ImageTool extends React.PureComponent {
     }
     onChange(finalValue)
     if (onChangeEnd) {
-      onChangeEnd()
+      onChangeEnd(finalValue)
     }
   }
 

--- a/packages/@sanity/imagetool/src/ImageTool.js
+++ b/packages/@sanity/imagetool/src/ImageTool.js
@@ -19,6 +19,17 @@ const MARGIN_PX = 8
 const CROP_HANDLE_SIZE = 12
 const HOTSPOT_HANDLE_SIZE = 10
 
+function normalizeRect(rect) {
+  const flippedY = rect.top > rect.bottom
+  const flippedX = rect.left > rect.right
+  return {
+    top: flippedY ? rect.bottom : rect.top,
+    bottom: flippedY ? rect.top : rect.bottom,
+    left: flippedX ? rect.right : rect.left,
+    right: flippedX ? rect.left : rect.right,
+  }
+}
+
 function checkCropBoundaries(value, delta) {
   // Make the experience a little better. Still offsets when dragging back from outside
   if (
@@ -658,7 +669,9 @@ export default class ImageTool extends React.PureComponent {
   handleDragEnd = (pos) => {
     const {onChange, onChangeEnd} = this.props
     this.setState({moving: false, resizing: false, cropping: false, cropMoving: false})
-    const {hotspot, crop} = this.getClampedValue()
+    const {hotspot, crop: rawCrop} = this.getClampedValue()
+
+    const crop = normalizeRect(rawCrop)
 
     const finalValue = {
       crop: {


### PR DESCRIPTION
### Description
This fixes an issue introduced in 38644082ff7053449b849ea533f43b9d13449826 that caused image fields to emit out of bounds values for hotspot/crop fields.

### What to review
- Open an image with hotspot tool enabled
- Drag the hotspot ellipse or crop rect out of bounds
- Verify that it get's "corrected" and doesn't stay out of bounds after drag ends

### Notes for release
- Fixes bug that caused out of bounds values for hotspot/crop to be saved to the data store
