### PR TITLE
fix(form-builder): Removes display: -webkit-box;

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/PortableText/Toolbar/OverflowMenu.css
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Toolbar/OverflowMenu.css
@@ -2,7 +2,6 @@
 
 .root {
   display: flex;
-  display: -webkit-box;
 }
 
 .actionBar {


### PR DESCRIPTION
### Description

Using the deprecated -webkit-box on display causes a different behaviour
in the blink-engine ([1], [2]). With a less strict Browserslist configuration the
-webkit vendor-prefixes are removed, but not the display: -webkit-box
then again causing unexpected behaviour where the Actionmenu gets
completely hidden


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

The changes was introduced here, https://github.com/sanity-io/sanity/commit/f8fb3ef54ac61ffa2d57b2865c7b77a628c36218, to facilitate support on linux, but should no longer be needed

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

Fixes issue where the editor ActionMenu gets hidden when the Studio is built with a custom Browserslist configuration

[1]: https://chromium.googlesource.com/chromium/src/third_party/+/main/blink/renderer/core/style/computed_style.h#1149
[2]: https://chromium.googlesource.com/chromium/src/third_party/+/main/blink/renderer/core/layout/flexible_box_algorithm.cc#947