### PR TITLE
chore(schema): warn if inputComponent is set on type but doesn't look like a React component

### DIFF
--- a/examples/test-studio/schemas/customInputs.js
+++ b/examples/test-studio/schemas/customInputs.js
@@ -9,6 +9,8 @@ export default {
   title: 'Custom input tests',
   type: 'document',
   icon,
+  // this should make a validation warning to appear in the console
+  inputComponent: 'NOT A REACT COMPONENT',
   fields: [
     {
       name: 'author',
@@ -38,6 +40,14 @@ export default {
       description: 'Custom input that has a bundled, custom font',
       type: 'string',
       inputComponent: CustomFontStringInput,
+    },
+    {
+      name: 'Undefined',
+      title: 'Undefined input componnet',
+      description: 'This should be a schema warning',
+      type: 'string',
+      // this should make a validation warning to appear in the console
+      inputComponent: undefined,
     },
     {
       name: 'taskEstimate',

--- a/packages/@sanity/schema/src/sanity/validation/types/object.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/object.ts
@@ -1,6 +1,8 @@
 import {isPlainObject} from 'lodash'
 import {error, HELP_IDS, warning} from '../createValidationResult'
 import inspect from '../../inspect'
+import {isReactComponentIsh} from '../utils/isReactComponentIsh'
+import {validateInputComponent} from '../utils/validateInputComponent'
 
 const VALID_FIELD_RE = /^[A-Za-z]+[0-9A-Za-z_]*$/
 const CONVENTIONAL_FIELD_RE = /^[A-Za-z_]+[0-9A-Za-z_]*$/
@@ -66,10 +68,14 @@ export function validateField(field, _visitorContext) {
     ]
   }
 
-  const {name} = field
-  return 'name' in field
-    ? validateFieldName(name)
-    : [error('Missing field name', HELP_IDS.OBJECT_FIELD_NAME_INVALID)]
+  const problems = []
+  problems.push(
+    ...('name' in field
+      ? validateFieldName(field.name)
+      : [error('Missing field name', HELP_IDS.OBJECT_FIELD_NAME_INVALID)])
+  )
+  problems.push(...validateInputComponent(field))
+  return problems
 }
 
 function getDuplicateFields(array: Array<Field>): Array<Array<Field>> {

--- a/packages/@sanity/schema/src/sanity/validation/types/rootType.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/rootType.ts
@@ -1,4 +1,6 @@
 import {error, HELP_IDS, warning} from '../createValidationResult'
+import {inspect} from 'util'
+import {validateInputComponent} from '../utils/validateInputComponent'
 
 export default (typeDef, visitorContext) => {
   const hasName = Boolean(typeDef.name)
@@ -38,6 +40,8 @@ export default (typeDef, visitorContext) => {
       )
     )
   }
+
+  problems.push(...validateInputComponent(typeDef))
 
   if (!('title' in typeDef)) {
     problems.push(

--- a/packages/@sanity/schema/src/sanity/validation/utils/isReactComponentIsh.ts
+++ b/packages/@sanity/schema/src/sanity/validation/utils/isReactComponentIsh.ts
@@ -1,0 +1,9 @@
+const REACT_SYM_RE = /^Symbol\(react\..+\)$/
+
+export function isReactComponentIsh(value: any) {
+  const type = typeof value
+  return (
+    type === 'function' ||
+    (typeof value?.$$typeof === 'symbol' && REACT_SYM_RE.test(String(value?.$$typeof)))
+  )
+}

--- a/packages/@sanity/schema/src/sanity/validation/utils/validateInputComponent.ts
+++ b/packages/@sanity/schema/src/sanity/validation/utils/validateInputComponent.ts
@@ -1,0 +1,17 @@
+import {warning} from '../createValidationResult'
+import inspect from '../../inspect'
+import {isReactComponentIsh} from './isReactComponentIsh'
+
+export function validateInputComponent(typeDef: any) {
+  if ('inputComponent' in typeDef && !isReactComponentIsh(typeDef.inputComponent)) {
+    return [
+      warning(
+        `The \`inputComponent\` property is set but does not appear to be a valid React component (expected a function, but saw ${inspect(
+          typeDef.inputComponent
+        )}). If you have imported a custom input component, please verify that you have imported the correct named/default export.`
+      ),
+    ]
+  }
+
+  return []
+}


### PR DESCRIPTION
### Description

When setting `inputComponent` on a type or field it's easy to import the wrong symbol or forget to export the input component. This PR adds a schema warning if we see the existence of a `inputComponent`-property on the type or field  definition, but it doesn't seem to be a React component. This warning will be displayed in the console along with other schema warnings. Example:

![image](https://user-images.githubusercontent.com/876086/117144373-231fc280-adb2-11eb-9953-10799fa0a16a.png)


Note: didn't find a reliable way of checking whether a value is a React Component that did not import React itself, so wrote a basic function to detect it. It's limited to checking whether the value is a function or has a symbol property added by React for some of their built in higher order components like forwardRef, memo, etc, and is only meant to catch the most obvious cases. Worst case we might get some false positives here, but it should be pretty straightforward to add new cases as we discover them.

### What to review

Add `inputComponent: undefined` to a type in your schema, and verify that the schema warning appears in the developer console.

### Notes for release

- Warns if the `inputComponent` for a type or field doesn't look like a React component