### PR TITLE
feature(desk-tool): No history message

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/documentPane/timeline/timeline.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/timeline/timeline.tsx
@@ -1,5 +1,6 @@
 import React, {forwardRef, useCallback, useEffect, useRef, useState} from 'react'
 import {Chunk} from '@sanity/field/diff'
+import {Stack, Text} from '@sanity/ui'
 import Spinner from 'part:@sanity/components/loading/spinner'
 import {Timeline as TimelineModel} from '../documentHistory/history/timeline'
 import {TimelineItem} from './timelineItem'
@@ -78,6 +79,15 @@ export const Timeline = forwardRef<HTMLDivElement, TimelineProps>(
 
     return (
       <div className={styles.root} ref={setRef} onScroll={checkIfLoadIsNeeded}>
+        {timeline.chunkCount === 0 && (
+          <Stack padding={4} space={3} style={{maxWidth: 200}}>
+            <Text weight="bold">No document history</Text>
+            <Text muted size={1}>
+              When changing the content of the document, the document versions will appear in this
+              menu.
+            </Text>
+          </Stack>
+        )}
         <ol className={styles.list} ref={listRef}>
           {timeline.mapChunks((chunk) => {
             const isSelectionTop = topSelection === chunk


### PR DESCRIPTION
### Description

Show a message when there's no history available for a document

![image](https://user-images.githubusercontent.com/1627633/117268309-6f710e00-ae57-11eb-882f-00252044605d.png)


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

* Is the use of the `timeline.chunkCount` correct? 🤔 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
