### PR TITLE
fix(default-layout): protect against undefined state tool

### DIFF
--- a/packages/@sanity/default-layout/src/DefaultLayout.tsx
+++ b/packages/@sanity/default-layout/src/DefaultLayout.tsx
@@ -138,6 +138,7 @@ class DefaultLayout extends React.PureComponent<Props, State> {
     const {tools, router} = this.props
     const {createMenuIsOpen, menuIsOpen, searchIsOpen} = this.state
     const isOverlayVisible = menuIsOpen || searchIsOpen
+    const tool = router.state?.tool || ''
 
     return (
       <div
@@ -178,7 +179,7 @@ class DefaultLayout extends React.PureComponent<Props, State> {
 
         <div className={styles.sideMenuContainer}>
           <SideMenu
-            activeToolName={router.state.tool}
+            activeToolName={tool}
             isOpen={menuIsOpen}
             onClose={this.handleToggleMenu}
             /* eslint-disable-next-line react/jsx-handler-names */
@@ -192,8 +193,8 @@ class DefaultLayout extends React.PureComponent<Props, State> {
 
         <div className={styles.mainArea}>
           <div className={styles.toolContainer}>
-            <RouteScope scope={router.state.tool}>
-              <RenderTool tool={router.state.tool} />
+            <RouteScope scope={tool}>
+              <RenderTool tool={tool} />
             </RouteScope>
           </div>
 

--- a/packages/@sanity/default-layout/src/navbar/Navbar.tsx
+++ b/packages/@sanity/default-layout/src/navbar/Navbar.tsx
@@ -62,6 +62,7 @@ export default function Navbar(props: Props) {
   const rootState = HAS_SPACES && router.state.space ? {space: router.state.space} : {}
   const className = classNames(styles.root, showToolMenu && styles.withToolMenu)
   const searchClassName = classNames(styles.search, searchIsOpen && styles.searchIsOpen)
+  const tool = router.state?.tool || ''
 
   return (
     <div className={className} data-search-open={searchIsOpen}>
@@ -127,7 +128,7 @@ export default function Navbar(props: Props) {
             direction="horizontal"
             isVisible={showToolMenu}
             tools={tools}
-            activeToolName={router.state.tool}
+            activeToolName={tool}
             onSwitchTool={onSwitchTool}
             router={router}
             showLabel={showLabel}


### PR DESCRIPTION
### Description
Fix a bug where the desk tool crashes when opened from a link in the studio.

![image](https://user-images.githubusercontent.com/452455/117787655-f272d980-b246-11eb-95e0-3b89e9b1876c.png)

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
This was difficult to reproduce on dev versions of the studio. A production build is required.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fixed issue where opening internal links in a new tab causes the studio to crash
<!--
A description of the change(s) that should be used in the release notes.
-->
