### PR TITLE
Adds a plain custom string input component to the CLI plugin init

### DIFF
--- a/packages/@sanity/cli/src/actions/init-plugin/pluginTemplates.js
+++ b/packages/@sanity/cli/src/actions/init-plugin/pluginTemplates.js
@@ -15,14 +15,14 @@ module.exports = [
     url: 'https://github.com/sanity-io/plugin-template-tool-with-routing/archive/master.zip',
   },
   {
-    value: 'chessInput',
-    name: 'Chess board input component w/ block preview',
-    url: 'https://github.com/sanity-io/plugin-template-chess-input/archive/master.zip',
-  },
-  {
     value: 'customInput',
     name: 'A custom string input starting point',
     url: 'https://github.com/sanity-io/sanity-plugin-custom-string/archive/refs/heads/main.zip',
+  },
+  {
+    value: 'chessInput',
+    name: 'Chess board input component w/ block preview',
+    url: 'https://github.com/sanity-io/plugin-template-chess-input/archive/master.zip',
   },
   {
     value: 'dashboardWidget',

--- a/packages/@sanity/cli/src/actions/init-plugin/pluginTemplates.js
+++ b/packages/@sanity/cli/src/actions/init-plugin/pluginTemplates.js
@@ -20,6 +20,11 @@ module.exports = [
     url: 'https://github.com/sanity-io/plugin-template-chess-input/archive/master.zip',
   },
   {
+    value: 'customInput',
+    name: 'A custom string input starting point',
+    url: 'https://github.com/sanity-io/sanity-plugin-custom-string/archive/refs/heads/main.zip',
+  },
+  {
     value: 'dashboardWidget',
     name: 'A Dashboard widget with cats',
     url: 'https://github.com/sanity-io/plugin-template-dashboard-widget-cats/archive/master.zip',


### PR DESCRIPTION


### Description
This adds a new "starter" plugin to the `sanity init plugin` command.

This is in the hopes that a clear, clean custom input component plugin can help folks get started a bit quicker at creating their own.

### What to review
It'll be good to test the CLI for it, as well as take a look at the plugin it will install which you can find here: https://github.com/sanity-io/sanity-plugin-custom-string

### Notes for release

`sanity init plugin` now has an option to create a starting point for a custom string input to help create your next custom input plugin.