### PR TITLE
fix(cli): unset NODE_ENV for built CLI bundle (don't assume production)

### DIFF
--- a/packages/@sanity/cli/scripts/pack.js
+++ b/packages/@sanity/cli/scripts/pack.js
@@ -75,6 +75,11 @@ const compiler = webpack({
 
       // Workaround for rc module console.logging if module.parent does not exist
       'module.parent': JSON.stringify({}),
+
+      // Do _NOT_ set NODE_ENV to production (default with `mode: production`),
+      // as it will make `.env` file loading inconsistent - always loading production
+      // unless `SANITY_ACTIVE_ENV` is set
+      'process.env.NODE_ENV': undefined,
     }),
   ],
   target: 'node',


### PR DESCRIPTION
### Description

When building the Sanity CLI to a single file using webpack, we were using `mode: 'production'`, which by default defines `process.env.NODE_ENV` as `production`. This created some interesting issues - several CLI commands that use environment variables from `.env` files might resolve to the wrong environment because they used `process.env.SANITY_ACTIVE_ENV || process.env.NODE_ENV || 'development'` or similar.

This PR unsets the `NODE_ENV` environment variable from the webpack bundle, which should respect the `NODE_ENV` set by the system host.

It's tempting to remove the fallback to `NODE_ENV`, but that would be a breaking change.

### What to review

To review, build the Sanity CLI using `npm run package-cli` from the monorepo root, and use it when running commands, eg: `node /path/to/monorepo/packages/@sanity/cli/bin/sanity-cli.js <some cli command>` instead of `sanity <some cli command>`.

Primary impact is studios with`.env.<environment>` file(s) - if you switch project IDs or datasets based on environments, many commands will be impacted. 

### Notes for release

- Fixed bug where Sanity CLI command would use incorrect `.env` file in certain situations
