### PR TITLE
feat(cli): upgrade to yarn v1.22.10

### DIFF
--- a/packages/@sanity/cli/src/scripts/package-yarn.js
+++ b/packages/@sanity/cli/src/scripts/package-yarn.js
@@ -3,7 +3,7 @@ import path from 'path'
 import fse from 'fs-extra'
 import simpleGet from 'simple-get'
 
-const version = '1.6.0'
+const version = '1.22.10'
 const baseUrl = 'https://github.com/yarnpkg/yarn/releases/download'
 const bundleUrl = `${baseUrl}/v${version}/yarn-legacy-${version}.js`
 const licenseUrl = 'https://raw.githubusercontent.com/yarnpkg/yarn/master/LICENSE'


### PR DESCRIPTION
### Description

Upgrades the bundled version of yarn from `1.6.0` to `1.22.10`. This fixes some of the weird errors users see where running `sanity install <plugin>` sometimes mangles `node_modules` in weird ways.

This is a stopgap measure, until we fork out to yarn/npm instead, obviously.

### What to review

Run `npm run package-yarn` in the monorepo, then run `node /path/to/monorepo/packages/@sanity/cli/bin/sanity-cli.js install` and `node /path/to/monorepo/packages/@sanity/cli/bin/sanity-cli.js install media` or similar.


### Notes for release

- Upgraded bundled version of yarn