### PR TITLE
fix(client): make projectId optional; combine config types

### DIFF
--- a/packages/@sanity/client/sanityClient.d.ts
+++ b/packages/@sanity/client/sanityClient.d.ts
@@ -492,7 +492,9 @@ export class Transaction {
   reset(): this
 }
 
-export interface BaseClientConfig {
+export interface ClientConfig {
+  projectId?: string
+  dataset?: string
   useCdn?: boolean
   token?: string
   apiHost?: string
@@ -522,19 +524,18 @@ export interface BaseClientConfig {
   requester?: GetItRequester
 }
 
-export type ProjectlessClientConfig = BaseClientConfig & {
-  useProjectHostname: false
-  projectId?: string
-  dataset?: string
-}
+/**
+ * @deprecated Don't use
+ */
+export type ProjectlessClientConfig = ClientConfig & {useProjectHostname: false}
 
-export type ProjectClientConfig = BaseClientConfig & {
+/**
+ * @deprecated Don't use
+ */
+export type ProjectClientConfig = ClientConfig & {
   useProjectHostname?: true
   projectId: string
-  dataset?: string
 }
-
-export type ClientConfig = ProjectClientConfig | ProjectlessClientConfig
 
 export interface RequestOptions {
   timeout?: number


### PR DESCRIPTION
### Description

#### What changes are introduced?

Updates the types for the config object in the client to work with environment vars (e.g. `process.env.EXAMPLE_SANITY_PROJECT_ID`). This is common in tools like next.js.

#### Why are these changes introduced?

See here: https://github.com/sanity-io/sanity/issues/2508#issuecomment-848283281

#### What issue(s) does this solve? (with link, if possible)

Closes #2508

### What to review

Take a look at the types and check to see if there are any breaking changes.

### Notes for release

Allow `projectId` to be optional in all cases to prevent typescript DX issues. See #2508.
