### PR TITLE
fix(form-builder): render array item menu in a portal

### DIFF
--- a/examples/test-studio/schemas/poppers.js
+++ b/examples/test-studio/schemas/poppers.js
@@ -49,6 +49,66 @@ const arraysInArrays = {
                 },
               ],
             },
+            {
+              type: 'object',
+              name: 'object2',
+              title: 'Object 2',
+              fields: [
+                {
+                  type: 'string',
+                  name: 'title',
+                  title: 'Title',
+                },
+              ],
+            },
+            {
+              type: 'object',
+              name: 'object3',
+              title: 'Object 3',
+              fields: [
+                {
+                  type: 'string',
+                  name: 'title',
+                  title: 'Title',
+                },
+              ],
+            },
+            {
+              type: 'object',
+              name: 'object4',
+              title: 'Object 4',
+              fields: [
+                {
+                  type: 'string',
+                  name: 'title',
+                  title: 'Title',
+                },
+              ],
+            },
+            {
+              type: 'object',
+              name: 'object5',
+              title: 'Object 5',
+              fields: [
+                {
+                  type: 'string',
+                  name: 'title',
+                  title: 'Title',
+                },
+              ],
+            },
+            {
+              type: 'object',
+              name: 'object6',
+              title: 'Object 6',
+              fields: [
+                {
+                  type: 'string',
+                  name: 'title',
+                  title: 'Title',
+                },
+              ],
+            },
           ],
         },
       ],

--- a/packages/@sanity/form-builder/src/inputs/arrays/common/ArrayFunctions.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/common/ArrayFunctions.tsx
@@ -1,6 +1,6 @@
 import {ArraySchemaType, isReferenceSchemaType} from '@sanity/types'
 import {AddIcon} from '@sanity/icons'
-import React, {ReactNode} from 'react'
+import React, {ReactNode, useMemo} from 'react'
 import {Button, Grid, Menu, MenuButton, MenuItem} from '@sanity/ui'
 import {useId} from '@reach/auto-id'
 import PatchEvent from '../../../PatchEvent'
@@ -38,6 +38,8 @@ export default function ArrayFunctions<MemberType>(
     insertItem(type.of[0])
   }, [type, insertItem])
 
+  const popoverProps = useMemo(() => ({constrainSize: true, portal: true}), [])
+
   if (readOnly) {
     return null
   }
@@ -71,6 +73,7 @@ export default function ArrayFunctions<MemberType>(
               })}
             </Menu>
           }
+          popover={popoverProps}
         />
       )}
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

- Added test cases in Test Studio for showing an array menu with more than 1 object type
- Use the `constrainSize` and `portal` properties on Sanity UI’s `Popover` to make sure the popover renders in a portal element, and that the popover has a `maxHeight`.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

- Open https://test-studio-8pv11zpc4.sanity.build/test/desk/poppers;7ab62dbe-d336-4b05-9245-b61c608449f9
- Add an item under "Arrays in arrays"
- Click the "Add item…" in the nested "Arrays in arrays"
- Make sure the popover menu works as expected – even on small screens.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

- Fixes overflow issues with the array item menu.