### PR TITLE
fix: add star matcher to cypress intercept

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -5,7 +5,7 @@ Cypress.Commands.add('login', (sanitySessionToken) => {
     throw new Error('Missing sanity token')
   }
 
-  cy.intercept({url: 'v1/users/me', method: 'GET'}).as('getUser')
+  cy.intercept({url: '*/**/users/me*', method: 'GET'}).as('getUser')
 
   return cy.visit('/').then(() => {
     cy.wait('@getUser').then((interception) => {


### PR DESCRIPTION
### Description

Just trying to fix the e2e tests. This adds a `*` matcher to the cypress intercept. This is probably what we want but I wonder whether or not to use the `vX` should stay in the code.

### What to review

If it passes, we should be good.
