### PR TITLE
Use check for direct uploads support in resolveUploader + improve feedback on dragging over drop targets

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/ArrayInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/ArrayInput.tsx
@@ -16,7 +16,7 @@ import {map} from 'rxjs/operators'
 import {Subscription} from 'rxjs'
 import {randomKey, resolveTypeName} from '@sanity/util/content'
 import {insert, PatchEvent, set, setIfMissing, unset} from '../../../PatchEvent'
-import {ResolvedUploader, Uploader, UploadEvent} from '../../../sanity/uploads/types'
+import {FileLike, Uploader, UploadEvent} from '../../../sanity/uploads/types'
 import {Alert} from '../../../components/Alert'
 import {Details} from '../../../components/Details'
 import {Item, List} from '../common/list'
@@ -60,10 +60,9 @@ export interface Props {
   onBlur: () => void
   focusPath: Path
   readOnly: boolean
-  directUploads?: boolean
   filterField: () => any
   ArrayFunctionsImpl: typeof ArrayFunctions
-  resolveUploader?: (type: SchemaType, file: File) => Uploader | null
+  resolveUploader?: (type: SchemaType, file: FileLike) => Uploader | null
   resolveInitialValue?: (type: ObjectSchemaType, value: any) => Promise<any>
   presence: FormFieldPresence[]
 }
@@ -213,21 +212,6 @@ export class ArrayInput extends React.Component<Props> {
     this._focusArea = el
   }
 
-  getUploadOptions = (file: File): ResolvedUploader[] => {
-    const {type, resolveUploader} = this.props
-
-    if (!resolveUploader) {
-      return []
-    }
-
-    return type.of
-      .map((memberType) => ({
-        type: memberType,
-        uploader: resolveUploader(memberType, file),
-      }))
-      .filter((member) => member.uploader) as ResolvedUploader[]
-  }
-
   handleFixMissingKeys = () => {
     const {onChange, value} = this.props
     const patches = value.map((val, i) => setIfMissing(randomKey(), [i, '_key']))
@@ -282,7 +266,6 @@ export class ArrayInput extends React.Component<Props> {
       onFocus,
       compareValue,
       filterField,
-      directUploads,
       ArrayFunctionsImpl,
     } = this.props
 
@@ -348,7 +331,7 @@ export class ArrayInput extends React.Component<Props> {
         level={level - 1}
         __unstable_presence={fieldPresence.length > 0 ? fieldPresence : EMPTY_ARRAY}
         __unstable_markers={markers}
-        disabled={!directUploads || readOnly}
+        disabled={readOnly}
         ref={this.setFocusArea}
         getUploadOptions={this.getUploadOptions}
         onUpload={this.handleUpload}

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/ArrayInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/ArrayInput.tsx
@@ -263,6 +263,7 @@ export class ArrayInput extends React.Component<Props> {
       presence,
       focusPath,
       onBlur,
+      resolveUploader,
       onFocus,
       compareValue,
       filterField,
@@ -333,7 +334,8 @@ export class ArrayInput extends React.Component<Props> {
         __unstable_markers={markers}
         disabled={readOnly}
         ref={this.setFocusArea}
-        getUploadOptions={this.getUploadOptions}
+        resolveUploader={resolveUploader}
+        types={type.of}
         onUpload={this.handleUpload}
       >
         <ImperativeToast ref={this.setToast} />

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/uploadTarget/styles.ts
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/uploadTarget/styles.ts
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 export const Overlay: React.ComponentType = styled.div`
   position: absolute;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   top: -2px;

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/uploadTarget/styles.ts
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/uploadTarget/styles.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
+import {Layer} from '@sanity/ui'
 
-export const Overlay: React.ComponentType = styled.div`
+export const Overlay = styled(Layer)`
   position: absolute;
   display: flex;
   flex-direction: column;
@@ -11,6 +12,5 @@ export const Overlay: React.ComponentType = styled.div`
   right: -2px;
   bottom: -2px;
   background-color: var(--card-bg-color);
-  z-index: 3;
   opacity: 0.8;
 `

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/uploadTarget/uploadTarget.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/uploadTarget/uploadTarget.tsx
@@ -90,6 +90,11 @@ export function uploadTarget<Props>(Component: React.ComponentType<Props>) {
     const [hoveringFiles, setHoveringFiles] = React.useState<FileInfo[]>([])
     const handleFilesOut = React.useCallback(() => setHoveringFiles([]), [])
 
+    const acceptedFiles = hoveringFiles.filter(
+      (hoverFile) => getUploadOptions(hoverFile).length > 0
+    )
+    const rejectedFilesCount = hoveringFiles.length - acceptedFiles.length
+
     return (
       <Root>
         <FileTarget
@@ -101,7 +106,28 @@ export function uploadTarget<Props>(Component: React.ComponentType<Props>) {
         >
           {hoveringFiles.length > 0 && (
             <Overlay>
-              <Text>Drop to upload</Text>
+              {acceptedFiles.length > 0 ? (
+                <>
+                  <Box>
+                    <Text>
+                      Drop to upload {acceptedFiles.length} file
+                      {acceptedFiles.length > 1 ? 's' : ''}
+                    </Text>
+                  </Box>
+                  <Box marginTop={2}>
+                    {rejectedFilesCount > 0 && (
+                      <Text muted size={1}>
+                        ({rejectedFilesCount} file
+                        {rejectedFilesCount > 1 ? 's' : ''} can't be uploaded here)
+                      </Text>
+                    )}
+                  </Box>
+                </>
+              ) : (
+                <Text>
+                  Can't upload {hoveringFiles.length > 1 ? 'any of these files' : 'this file'} here
+                </Text>
+              )}
             </Overlay>
           )}
           {children}

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/uploadTarget/uploadTarget.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/uploadTarget/uploadTarget.tsx
@@ -3,12 +3,12 @@ import React from 'react'
 import {SchemaType} from '@sanity/types'
 import {sortBy} from 'lodash'
 import styled from 'styled-components'
-import {ResolvedUploader, Uploader} from '../../../../sanity/uploads/types'
+import {FileLike, ResolvedUploader, Uploader} from '../../../../sanity/uploads/types'
 import {FileInfo, fileTarget} from '../../../common/fileTarget'
 import {Overlay} from './styles'
 
 type UploadTargetProps = {
-  getUploadOptions: (file: File) => ResolvedUploader[]
+  getUploadOptions: (file: FileLike) => ResolvedUploader[]
   onUpload?: (event: {type: SchemaType; file: File; uploader: Uploader}) => void
   children?: React.ReactNode
 }

--- a/packages/@sanity/form-builder/src/inputs/files/FileInput/FileInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/FileInput/FileInput.tsx
@@ -20,7 +20,7 @@ import {Box, Button, Container, Dialog, Flex, Grid, Stack, Text, ToastParams} fr
 import {PresenceOverlay} from '@sanity/base/presence'
 import {FormFieldPresence} from '@sanity/base/lib/presence'
 import WithMaterializedReference from '../../../utils/WithMaterializedReference'
-import {ResolvedUploader, Uploader, UploaderResolver} from '../../../sanity/uploads/types'
+import {Uploader, UploaderResolver} from '../../../sanity/uploads/types'
 import PatchEvent, {setIfMissing, unset} from '../../../PatchEvent'
 import {FormBuilderInput} from '../../../FormBuilderInput'
 import UploadPlaceholder from '../common/UploadPlaceholder'
@@ -28,6 +28,7 @@ import {FileInputButton} from '../common/FileInputButton/FileInputButton'
 import {FileTarget, FileInfo, Overlay} from '../common/styles'
 import {UploadState} from '../types'
 import {UploadProgress} from '../common/UploadProgress'
+import {DropMessage} from '../common/DropMessage'
 import {AssetBackground} from './styles'
 
 type Field = {
@@ -342,12 +343,6 @@ export default class FileInput extends React.PureComponent<Props, FileInputState
     this._focusRef = ref
   }
 
-  getUploadOptions = (file: globalThis.File): ResolvedUploader[] => {
-    const {type, resolveUploader} = this.props
-    const uploader = resolveUploader && resolveUploader(type, file)
-    return uploader ? [{type: type, uploader}] : []
-  }
-
   handleUpload = ({file, uploader}: {file: DOMFile; uploader: Uploader}) => {
     this.uploadWith(uploader, file)
   }
@@ -357,7 +352,16 @@ export default class FileInput extends React.PureComponent<Props, FileInputState
   }
 
   render() {
-    const {type, value, compareValue, level, markers, readOnly, presence} = this.props
+    const {
+      type,
+      value,
+      compareValue,
+      level,
+      markers,
+      resolveUploader,
+      readOnly,
+      presence,
+    } = this.props
     const {isAdvancedEditOpen, hoveringFiles} = this.state
     const [highlightedFields, otherFields] = partition(
       type.fields.filter((field) => !HIDDEN_FIELDS.includes(field.name)),
@@ -408,7 +412,13 @@ export default class FileInput extends React.PureComponent<Props, FileInputState
                       {!value?._upload && value?.asset && this.renderAsset()}
                       {!value?._upload && !value?.asset && this.renderUploadPlaceholder()}
                       {!value?._upload && !readOnly && hoveringFiles.length > 0 && (
-                        <Overlay>Drop top upload</Overlay>
+                        <Overlay>
+                          <DropMessage
+                            hoveringFiles={hoveringFiles}
+                            resolveUploader={resolveUploader}
+                            types={[type]}
+                          />
+                        </Overlay>
                       )}
                     </Container>
                   </AssetBackground>

--- a/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImageInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImageInput.tsx
@@ -36,6 +36,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import {FormFieldPresence, PresenceOverlay} from '@sanity/base/presence'
 import * as PathUtils from '@sanity/util/paths'
+import deepCompare from 'react-fast-compare'
 import {FormBuilderInput} from '../../../FormBuilderInput'
 import {
   ResolvedUploader,
@@ -53,8 +54,8 @@ import {UploadState} from '../types'
 import {UploadProgress} from '../common/UploadProgress'
 import {RatioBox} from '../common/RatioBox'
 import {EMPTY_ARRAY} from '../../../utils/empty'
+import {DropMessage} from '../common/DropMessage'
 import {base64ToFile, urlToFile} from './utils/image'
-import deepCompare from 'react-fast-compare'
 
 export interface Image extends Partial<BaseImage> {
   _upload?: UploadState
@@ -681,6 +682,7 @@ export default class ImageInput extends React.PureComponent<Props, ImageInputSta
 
     return fields.some((field) => !deepCompare(value?.[field.name], compareValue?.[field.name]))
   }
+
   render() {
     const {
       type,
@@ -692,6 +694,7 @@ export default class ImageInput extends React.PureComponent<Props, ImageInputSta
       presence,
       focusPath = EMPTY_ARRAY,
       directUploads,
+      resolveUploader,
     } = this.props
     const {hoveringFiles, selectedAssetSource} = this.state
 
@@ -751,7 +754,13 @@ export default class ImageInput extends React.PureComponent<Props, ImageInputSta
                     {!value?._upload && value?.asset && this.renderAsset()}
                     {!value?._upload && !value?.asset && this.renderUploadPlaceholder()}
                     {!value?._upload && !readOnly && hoveringFiles.length > 0 && (
-                      <Overlay>Drop to upload</Overlay>
+                      <Overlay>
+                        <DropMessage
+                          hoveringFiles={hoveringFiles}
+                          resolveUploader={resolveUploader}
+                          types={[type]}
+                        />
+                      </Overlay>
                     )}
                   </Flex>
                 </RatioBox>

--- a/packages/@sanity/form-builder/src/inputs/files/common/DropMessage.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/common/DropMessage.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import {SchemaType} from '@sanity/types'
+import {Box, Text, Inline} from '@sanity/ui'
+import {AccessDeniedIcon, UploadIcon} from '@sanity/icons'
+import {FileLike, UploaderResolver} from '../../../sanity/uploads/types'
+
+interface Props {
+  hoveringFiles: FileLike[]
+  types: SchemaType[]
+  resolveUploader: UploaderResolver
+}
+
+export function DropMessage(props: Props) {
+  const {hoveringFiles, types, resolveUploader} = props
+  const acceptedFiles = hoveringFiles.filter((file) =>
+    types.some((type) => resolveUploader(type, file))
+  )
+  const rejectedFilesCount = hoveringFiles.length - acceptedFiles.length
+  const multiple = types.length > 1
+  return (
+    <>
+      {acceptedFiles.length > 0 ? (
+        <>
+          <Inline space={2}>
+            <Text>
+              <UploadIcon />
+            </Text>
+            <Text>
+              Drop to upload{' '}
+              {multiple && (
+                <>
+                  {acceptedFiles.length} file{acceptedFiles.length > 1 ? 's' : ''}
+                </>
+              )}
+            </Text>
+          </Inline>
+          {rejectedFilesCount > 0 && (
+            <Box marginTop={4}>
+              <Inline space={2}>
+                <Text muted size={1}>
+                  <AccessDeniedIcon />
+                </Text>
+                <Text muted size={1}>
+                  {rejectedFilesCount} file
+                  {rejectedFilesCount > 1 ? 's' : ''} can't be uploaded here
+                </Text>
+              </Inline>
+            </Box>
+          )}
+        </>
+      ) : (
+        <Inline space={2}>
+          <Text>
+            <AccessDeniedIcon />
+          </Text>
+          <Text>
+            Can't upload {hoveringFiles.length > 1 ? 'any of these files' : 'this file'} here
+          </Text>
+        </Inline>
+      )}
+    </>
+  )
+}

--- a/packages/@sanity/form-builder/src/inputs/files/common/styles.ts
+++ b/packages/@sanity/form-builder/src/inputs/files/common/styles.ts
@@ -12,12 +12,13 @@ export const FileTarget = withFocusRing(fileTarget(Card))
 export const Overlay: StyledComponent<'div', DefaultTheme> = styled.div`
   position: absolute;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  top: 2px;
+  left: 2px;
+  right: 2px;
+  bottom: 2px;
   background-color: var(--card-bg-color);
   z-index: 3;
   pointer-events: none;

--- a/packages/@sanity/form-builder/src/sanity/inputs/SanityArrayInput.tsx
+++ b/packages/@sanity/form-builder/src/sanity/inputs/SanityArrayInput.tsx
@@ -22,7 +22,6 @@ export const SanityArrayInput = forwardRef(function SanityArrayInput(
       resolveUploader={resolveUploader}
       resolveInitialValue={resolveInitialValueForType}
       ArrayFunctionsImpl={ArrayFunctions}
-      directUploads={SUPPORT_DIRECT_UPLOADS}
     />
   )
 })

--- a/packages/@sanity/form-builder/src/sanity/inputs/SanityArrayInput.tsx
+++ b/packages/@sanity/form-builder/src/sanity/inputs/SanityArrayInput.tsx
@@ -2,14 +2,27 @@ import React, {ForwardedRef, forwardRef} from 'react'
 import formBuilderConfig from 'config:@sanity/form-builder'
 import ArrayFunctions from 'part:@sanity/form-builder/input/array/functions'
 import {resolveInitialValueForType} from '@sanity/initial-value-templates'
+import {SchemaType} from '@sanity/types'
 import resolveUploader from '../uploads/resolveUploader'
 import ArrayInput, {Props} from '../../inputs/arrays/ArrayOfObjectsInput'
 import {
   ArrayOfPrimitivesInput,
   Props as PrimitiveArrayInputProps,
 } from '../../inputs/arrays/ArrayOfPrimitivesInput'
+import * as is from '../../utils/is'
+import {FileLike} from '../uploads/types'
 
-const SUPPORT_DIRECT_UPLOADS = formBuilderConfig?.images?.directUploads
+const arrayResolveUploader = (type: SchemaType, file: FileLike) => {
+  const SUPPORT_DIRECT_IMAGE_UPLOADS = formBuilderConfig?.images?.directUploads
+  const SUPPORT_DIRECT_FILE_UPLOADS = formBuilderConfig?.files?.directUploads
+  if (is.type('image', type) && !SUPPORT_DIRECT_IMAGE_UPLOADS) {
+    return null
+  }
+  if (is.type('file', type) && !SUPPORT_DIRECT_FILE_UPLOADS) {
+    return null
+  }
+  return resolveUploader(type, file)
+}
 
 export const SanityArrayInput = forwardRef(function SanityArrayInput(
   props: Props,
@@ -19,7 +32,7 @@ export const SanityArrayInput = forwardRef(function SanityArrayInput(
     <ArrayInput
       {...props}
       ref={ref}
-      resolveUploader={resolveUploader}
+      resolveUploader={arrayResolveUploader}
       resolveInitialValue={resolveInitialValueForType}
       ArrayFunctionsImpl={ArrayFunctions}
     />

--- a/packages/@sanity/form-builder/src/sanity/uploads/resolveUploader.ts
+++ b/packages/@sanity/form-builder/src/sanity/uploads/resolveUploader.ts
@@ -2,9 +2,9 @@ import {SchemaType} from '@sanity/types'
 import accept from 'attr-accept'
 import * as is from '../../utils/is'
 import uploaders from './uploaders'
-import {Uploader} from './types'
+import {FileLike, Uploader} from './types'
 
-export default function resolveUploader(type: SchemaType, file: File): Uploader | null {
+export default function resolveUploader(type: SchemaType, file: FileLike): Uploader | null {
   return uploaders.find((uploader) => {
     return (
       is.type(uploader.type, type) &&

--- a/packages/@sanity/form-builder/src/sanity/uploads/types.ts
+++ b/packages/@sanity/form-builder/src/sanity/uploads/types.ts
@@ -39,4 +39,4 @@ export interface FileLike {
   name?: string
 }
 
-export type UploaderResolver = (type: SchemaType, file: File) => Uploader | null
+export type UploaderResolver = (type: SchemaType, file: FileLike) => Uploader | null

--- a/packages/@sanity/form-builder/src/sanity/uploads/types.ts
+++ b/packages/@sanity/form-builder/src/sanity/uploads/types.ts
@@ -32,4 +32,11 @@ export type Uploader = {
   priority: number
 }
 
+export interface FileLike {
+  // mime type
+  type: string
+  // file name (e.g. somefile.jpg)
+  name?: string
+}
+
 export type UploaderResolver = (type: SchemaType, file: File) => Uploader | null


### PR DESCRIPTION
### Description
This refactors the resolveUploader interface so it takes a "file-like" argument (an object that has a mime type and a  name) instead of an actual `File` instance. This allows us to check the data transfer items we get from the drag event when files are dragged over the drop target, and allows us to show instant feedback about what files (if any) will be uploaded when dropped. See screenshots below.

This PR also includes a commit that factors in the `directUploads` studio configuration into the `resolveUploader` function instead of having a separate code path to handle this.

![image](https://user-images.githubusercontent.com/876086/121487240-2ec66080-c9d2-11eb-8096-3dd9cb7b4037.png)
![image](https://user-images.githubusercontent.com/876086/121487259-34bc4180-c9d2-11eb-8ea6-80686c196b95.png)
(note: the wrong pluralization in the above screenshot has been fixed)

### What to review
- Drag some files of various types from disk over to the drop area in a file/image input and see that it works as expected

### Notes for release

- Give better feedback about accepted files when dragging over file and image inputs
