### PR TITLE
refactor(validation): convert to ES modules

### DIFF
--- a/packages/@sanity/validation/src/Rule.js
+++ b/packages/@sanity/validation/src/Rule.js
@@ -1,6 +1,6 @@
-const cloneDeep = require('clone-deep')
-const escapeRegex = require('./util/escapeRegex')
-const validate = require('./validate')
+import cloneDeep from 'clone-deep'
+import escapeRegex from './util/escapeRegex'
+import validate from './validate'
 
 const knownTypes = ['Object', 'String', 'Number', 'Boolean', 'Array', 'Date']
 const isExclusive = ['type', 'uri', 'email']
@@ -279,4 +279,4 @@ function getBaseType(type) {
   return type && type.type ? getBaseType(type.type) : type
 }
 
-module.exports = Rule
+export default Rule

--- a/packages/@sanity/validation/src/ValidationError.js
+++ b/packages/@sanity/validation/src/ValidationError.js
@@ -22,4 +22,4 @@ class ValidationError extends ExtendableError {
   }
 }
 
-module.exports = ValidationError
+export default ValidationError

--- a/packages/@sanity/validation/src/getClient.js
+++ b/packages/@sanity/validation/src/getClient.js
@@ -1,6 +1,6 @@
 let client
 
-module.exports = function getClient() {
+export default function getClient() {
   if (!client) {
     // Lazy-loading to not cause issues when loading schema in node environment
     const sanityClient = require('part:@sanity/base/client')

--- a/packages/@sanity/validation/src/index.js
+++ b/packages/@sanity/validation/src/index.js
@@ -1,6 +1,13 @@
-module.exports = {
-  Rule: require('./Rule'),
-  validateDocument: require('./validateDocument'),
-  inferFromSchema: require('./inferFromSchema'),
-  inferFromSchemaType: require('./inferFromSchemaType'),
+import Rule from './Rule'
+import validateDocument from './validateDocument'
+import inferFromSchema from './inferFromSchema'
+import inferFromSchemaType from './inferFromSchemaType'
+
+export default {
+  Rule,
+  validateDocument,
+  inferFromSchema,
+  inferFromSchemaType,
 }
+
+export {Rule, validateDocument, inferFromSchema, inferFromSchemaType}

--- a/packages/@sanity/validation/src/inferFromSchema.js
+++ b/packages/@sanity/validation/src/inferFromSchema.js
@@ -1,4 +1,4 @@
-const inferFromSchemaType = require('./inferFromSchemaType')
+import inferFromSchemaType from './inferFromSchemaType'
 
 // Note: Mutates schema. Refactor when @sanity/schema supports middlewares
 function inferFromSchema(schema) {
@@ -9,4 +9,4 @@ function inferFromSchema(schema) {
   return schema
 }
 
-module.exports = inferFromSchema
+export default inferFromSchema

--- a/packages/@sanity/validation/src/inferFromSchemaType.js
+++ b/packages/@sanity/validation/src/inferFromSchemaType.js
@@ -1,6 +1,6 @@
-const Rule = require('./Rule')
-const {slugValidator} = require('./validators/slugValidator')
-const {blockValidator} = require('./validators/blockValidator')
+import Rule from './Rule'
+import {slugValidator} from './validators/slugValidator'
+import {blockValidator} from './validators/blockValidator'
 
 // eslint-disable-next-line complexity
 function inferFromSchemaType(typeDef, schema, visited = new Set()) {
@@ -127,4 +127,4 @@ function inferValidation(field, baseRule) {
   return Array.isArray(validation) ? validation : [validation]
 }
 
-module.exports = inferFromSchemaType
+export default inferFromSchemaType

--- a/packages/@sanity/validation/src/util/deepEquals.js
+++ b/packages/@sanity/validation/src/util/deepEquals.js
@@ -4,7 +4,7 @@
  **/
 
 /* eslint max-depth: 4 */
-module.exports = function equal(a, b) {
+export default function equal(a, b) {
   if (a === b) {
     return true
   }

--- a/packages/@sanity/validation/src/util/deepEquals.js
+++ b/packages/@sanity/validation/src/util/deepEquals.js
@@ -3,7 +3,7 @@
  * MIT-licensed, copyright (c) 2017 Evgeny Poberezkin
  **/
 
-/* eslint max-depth: 4 */
+/* eslint max-depth: ["error", 4] */
 export default function equal(a, b) {
   if (a === b) {
     return true

--- a/packages/@sanity/validation/src/util/escapeRegex.js
+++ b/packages/@sanity/validation/src/util/escapeRegex.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-useless-escape */
-module.exports = (string) => {
+export default (string) => {
   // Escape ^$.*+-?=!:|\/()[]{},
   return string.replace(/[\^\$\.\*\+\-\?\=\!\:\|\\\/\(\)\[\]\{\}\,]/g, '\\$&')
 }

--- a/packages/@sanity/validation/src/util/handleValidationResult.js
+++ b/packages/@sanity/validation/src/util/handleValidationResult.js
@@ -1,8 +1,8 @@
 /* eslint-disable complexity */
-const ValidationError = require('../ValidationError')
-const pathToString = require('./pathToString')
+import ValidationError from '../ValidationError'
+import pathToString from './pathToString'
 
-module.exports = (result, message, options) => {
+export default (result, message, options) => {
   if (Array.isArray(result)) {
     if (result.length === 0) {
       return true

--- a/packages/@sanity/validation/src/util/pathToString.js
+++ b/packages/@sanity/validation/src/util/pathToString.js
@@ -1,4 +1,4 @@
-module.exports = function pathToString(path) {
+export default function pathToString(path) {
   return path.reduce((target, segment, i) => {
     const segmentType = typeof segment
     if (segmentType === 'number') {

--- a/packages/@sanity/validation/src/util/prefixPaths.js
+++ b/packages/@sanity/validation/src/util/prefixPaths.js
@@ -1,4 +1,4 @@
-module.exports = (result, prefix) => {
+export default (result, prefix) => {
   return Object.keys(result).reduce((acc, key) => {
     acc[key] = result[key].map((err) => err.prefixPaths(prefix))
     return acc

--- a/packages/@sanity/validation/src/validate.js
+++ b/packages/@sanity/validation/src/validate.js
@@ -1,19 +1,26 @@
-const {get, flatten} = require('lodash')
-const ValidationError = require('./ValidationError')
-const genericValidator = require('./validators/genericValidator')
+import {get, flatten} from 'lodash'
+import ValidationError from './ValidationError'
+import genericValidator from './validators/genericValidator'
+
+import booleanValidator from './validators/booleanValidator'
+import numberValidator from './validators/numberValidator'
+import stringValidator from './validators/stringValidator'
+import arrayValidator from './validators/arrayValidator'
+import objectValidator from './validators/objectValidator'
+import dateValidator from './validators/dateValidator'
 
 const typeValidators = {
-  Boolean: require('./validators/booleanValidator'),
-  Number: require('./validators/numberValidator'),
-  String: require('./validators/stringValidator'),
-  Array: require('./validators/arrayValidator'),
-  Object: require('./validators/objectValidator'),
-  Date: require('./validators/dateValidator'),
+  Boolean: booleanValidator,
+  Number: numberValidator,
+  String: stringValidator,
+  Array: arrayValidator,
+  Object: objectValidator,
+  Date: dateValidator,
 }
 
 const EMPTY_ARRAY = []
 
-module.exports = (rule, value, options = {}) => {
+export default (rule, value, options = {}) => {
   let rules = rule._rules
 
   const valueIsUndefined = value === null || typeof value === 'undefined'

--- a/packages/@sanity/validation/src/validateDocument.js
+++ b/packages/@sanity/validation/src/validateDocument.js
@@ -1,10 +1,10 @@
-const Type = require('type-of-is')
-const {flatten} = require('lodash')
-const ValidationError = require('./ValidationError')
-const Rule = require('./Rule')
+import Type from 'type-of-is'
+import {flatten} from 'lodash'
+import ValidationError from './ValidationError'
+import Rule from './Rule'
 
 /* eslint-disable no-console */
-module.exports = async (doc, schema) => {
+export default async (doc, schema) => {
   const documentType = schema.get(doc._type)
   if (!documentType) {
     console.warn('Schema type for object type "%s" not found, skipping validation', doc._type)
@@ -19,7 +19,7 @@ module.exports = async (doc, schema) => {
   }
 }
 
-function validateItem(item, type, path, options) {
+export function validateItem(item, type, path, options) {
   if (Array.isArray(item)) {
     return validateArray(item, type, path, options)
   }
@@ -30,8 +30,6 @@ function validateItem(item, type, path, options) {
 
   return validatePrimitive(item, type, path, options)
 }
-
-module.exports.validateItem = validateItem
 
 function validateObject(obj, type, path, options) {
   if (!type) {

--- a/packages/@sanity/validation/src/validators/arrayValidator.js
+++ b/packages/@sanity/validation/src/validators/arrayValidator.js
@@ -1,6 +1,6 @@
-const deepEquals = require('../util/deepEquals')
-const ValidationError = require('../ValidationError')
-const genericValidator = require('./genericValidator')
+import deepEquals from '../util/deepEquals'
+import ValidationError from '../ValidationError'
+import genericValidator from './genericValidator'
 
 const min = (minLength, value, message) => {
   if (!value || value.length >= minLength) {
@@ -94,7 +94,7 @@ const unique = (flag, value, message) => {
     : true
 }
 
-module.exports = Object.assign({}, genericValidator, {
+export default Object.assign({}, genericValidator, {
   presence,
   unique,
   length,

--- a/packages/@sanity/validation/src/validators/blockValidator.js
+++ b/packages/@sanity/validation/src/validators/blockValidator.js
@@ -1,6 +1,5 @@
-const validateDocument = require('../validateDocument')
-const {validateItem} = validateDocument
-const {flatten} = require('lodash')
+import {flatten} from 'lodash'
+import {validateItem} from '../validateDocument'
 
 // eslint-disable-next-line import/prefer-default-export
 export const blockValidator = async (value, options) => {

--- a/packages/@sanity/validation/src/validators/booleanValidator.js
+++ b/packages/@sanity/validation/src/validators/booleanValidator.js
@@ -1,5 +1,5 @@
-const ValidationError = require('../ValidationError')
-const genericValidator = require('./genericValidator')
+import ValidationError from '../ValidationError'
+import genericValidator from './genericValidator'
 
 const presence = (flag, value, message) => {
   if (flag === 'required' && typeof value !== 'boolean') {
@@ -9,6 +9,6 @@ const presence = (flag, value, message) => {
   return true
 }
 
-module.exports = Object.assign({}, genericValidator, {
+export default Object.assign({}, genericValidator, {
   presence,
 })

--- a/packages/@sanity/validation/src/validators/dateValidator.js
+++ b/packages/@sanity/validation/src/validators/dateValidator.js
@@ -1,7 +1,6 @@
 import formatDate from 'date-fns/format'
-
-const ValidationError = require('../ValidationError')
-const genericValidator = require('./genericValidator')
+import ValidationError from '../ValidationError'
+import genericValidator from './genericValidator'
 
 const isoDate = /^(?:[-+]\d{2})?(?:\d{4}(?!\d{2}\b))(?:(-?)(?:(?:0[1-9]|1[0-2])(?:\1(?:[12]\d|0[1-9]|3[01]))?|W(?:[0-4]\d|5[0-2])(?:-?[1-7])?|(?:00[1-9]|0[1-9]\d|[12]\d{2}|3(?:[0-5]\d|6[1-6])))(?![T]$|[T][\d]+Z$)(?:[T\s](?:(?:(?:[01]\d|2[0-3])(?:(:?)[0-5]\d)?|24\:?00)(?:[.,]\d+(?!:))?)(?:\2[0-5]\d(?:[.,]\d+)?)?(?:[Z]|(?:[+-])(?:[01]\d|2[0-3])(?::?[0-5]\d)?)?)?)?$/
 
@@ -73,7 +72,7 @@ function parseDate(date, throwOnError) {
   return isInvalid ? null : parsed
 }
 
-module.exports = Object.assign({}, genericValidator, {
+export default Object.assign({}, genericValidator, {
   type,
   min,
   max,

--- a/packages/@sanity/validation/src/validators/dateValidator.js
+++ b/packages/@sanity/validation/src/validators/dateValidator.js
@@ -2,6 +2,7 @@ import formatDate from 'date-fns/format'
 import ValidationError from '../ValidationError'
 import genericValidator from './genericValidator'
 
+// eslint-disable-next-line no-useless-escape
 const isoDate = /^(?:[-+]\d{2})?(?:\d{4}(?!\d{2}\b))(?:(-?)(?:(?:0[1-9]|1[0-2])(?:\1(?:[12]\d|0[1-9]|3[01]))?|W(?:[0-4]\d|5[0-2])(?:-?[1-7])?|(?:00[1-9]|0[1-9]\d|[12]\d{2}|3(?:[0-5]\d|6[1-6])))(?![T]$|[T][\d]+Z$)(?:[T\s](?:(?:(?:[01]\d|2[0-3])(?:(:?)[0-5]\d)?|24\:?00)(?:[.,]\d+(?!:))?)(?:\2[0-5]\d(?:[.,]\d+)?)?(?:[Z]|(?:[+-])(?:[01]\d|2[0-3])(?::?[0-5]\d)?)?)?)?$/
 
 const getFormattedDate = (type = '', value, options) => {

--- a/packages/@sanity/validation/src/validators/genericValidator.js
+++ b/packages/@sanity/validation/src/validators/genericValidator.js
@@ -1,9 +1,10 @@
-const Type = require('type-of-is')
-const {flatten} = require('lodash')
-const deepEquals = require('../util/deepEquals')
-const pathToString = require('../util/pathToString')
-const handleValidationResult = require('../util/handleValidationResult')
-const ValidationError = require('../ValidationError')
+import Type from 'type-of-is'
+import {flatten} from 'lodash'
+import deepEquals from '../util/deepEquals'
+import pathToString from '../util/pathToString'
+import handleValidationResult from '../util/handleValidationResult'
+import ValidationError from '../ValidationError'
+import validate from '../validate'
 
 const SLOW_VALIDATOR_TIMEOUT = 5000
 
@@ -25,8 +26,6 @@ const presence = (expected, value, message) => {
 }
 
 const multiple = (children, value) => {
-  const validate = require('../validate')
-
   const items = children.map((child) => validate(child, value, {isChild: true}))
   return Promise.all(items).then(flatten)
 }
@@ -105,7 +104,7 @@ function formatValidationErrors(message, results, options = {}) {
       )
 }
 
-module.exports = {
+export default {
   all,
   type,
   either,

--- a/packages/@sanity/validation/src/validators/numberValidator.js
+++ b/packages/@sanity/validation/src/validators/numberValidator.js
@@ -1,5 +1,5 @@
-const ValidationError = require('../ValidationError')
-const genericValidator = require('./genericValidator')
+import ValidationError from '../ValidationError'
+import genericValidator from './genericValidator'
 
 const precisionRx = /(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/
 
@@ -59,7 +59,7 @@ const lessThan = (maxNum, value, message) => {
   return new ValidationError(message || `Must be less than ${maxNum}`)
 }
 
-module.exports = Object.assign({}, genericValidator, {
+export default Object.assign({}, genericValidator, {
   min,
   max,
   lessThan,

--- a/packages/@sanity/validation/src/validators/objectValidator.js
+++ b/packages/@sanity/validation/src/validators/objectValidator.js
@@ -1,7 +1,7 @@
-const ValidationError = require('../ValidationError')
-const pathToString = require('../util/pathToString')
-const handleValidationResult = require('../util/handleValidationResult')
-const genericValidator = require('./genericValidator')
+import ValidationError from '../ValidationError'
+import pathToString from '../util/pathToString'
+import handleValidationResult from '../util/handleValidationResult'
+import genericValidator from './genericValidator'
 
 const metaKeys = ['_key', '_type', '_weak']
 
@@ -52,7 +52,7 @@ const assetRequired = (flag, value, message) => {
   return true
 }
 
-module.exports = Object.assign({}, genericValidator, {
+export default Object.assign({}, genericValidator, {
   presence,
   reference,
   block,

--- a/packages/@sanity/validation/src/validators/slugValidator.js
+++ b/packages/@sanity/validation/src/validators/slugValidator.js
@@ -1,5 +1,5 @@
-const {get, memoize} = require('lodash')
-const getClient = require('../getClient')
+import {get, memoize} from 'lodash'
+import getClient from '../getClient'
 
 const memoizedWarnOnArraySlug = memoize(warnOnArraySlug)
 

--- a/packages/@sanity/validation/src/validators/stringValidator.js
+++ b/packages/@sanity/validation/src/validators/stringValidator.js
@@ -1,5 +1,5 @@
-const ValidationError = require('../ValidationError')
-const genericValidator = require('./genericValidator')
+import ValidationError from '../ValidationError'
+import genericValidator from './genericValidator'
 
 const DUMMY_ORIGIN = 'http://sanity'
 const emailRegex = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
@@ -113,7 +113,7 @@ const email = (options, value, message) => {
   return new ValidationError(message || 'Must be a valid email address')
 }
 
-module.exports = Object.assign({}, genericValidator, {
+export default Object.assign({}, genericValidator, {
   stringCasing,
   presence,
   regex,

--- a/packages/@sanity/validation/test/array.test.js
+++ b/packages/@sanity/validation/test/array.test.js
@@ -1,4 +1,4 @@
-const {Rule} = require('../src')
+import {Rule} from '../src'
 
 describe('array', () => {
   test('required constraint', async () => {

--- a/packages/@sanity/validation/test/children.test.js
+++ b/packages/@sanity/validation/test/children.test.js
@@ -1,4 +1,4 @@
-const {Rule} = require('../src')
+import {Rule} from '../src'
 
 describe('child rules', () => {
   // --- ALL ---

--- a/packages/@sanity/validation/test/generics.test.js
+++ b/packages/@sanity/validation/test/generics.test.js
@@ -1,4 +1,4 @@
-const {Rule} = require('../src')
+import {Rule} from '../src'
 
 describe('generics', () => {
   test('should be able to construct an empty rule', () => {

--- a/packages/@sanity/validation/test/infer.test.js
+++ b/packages/@sanity/validation/test/infer.test.js
@@ -1,5 +1,5 @@
-const Schema = require('@sanity/schema').default
-const inferFromSchema = require('../src/inferFromSchema')
+import Schema from '@sanity/schema'
+import inferFromSchema from '../src/inferFromSchema'
 
 describe('schema validation inference', () => {
   describe('object with `options.list` and `value` field', () => {

--- a/packages/@sanity/validation/test/numbers.test.js
+++ b/packages/@sanity/validation/test/numbers.test.js
@@ -1,4 +1,4 @@
-const {Rule} = require('../src')
+import {Rule} from '../src'
 
 describe('number', () => {
   test('required constraint', async () => {

--- a/packages/@sanity/validation/test/strings.test.js
+++ b/packages/@sanity/validation/test/strings.test.js
@@ -1,4 +1,4 @@
-const {Rule} = require('../src')
+import {Rule} from '../src'
 
 describe('string', () => {
   test('required constraint', async () => {


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

- Replaced `const ... = require(...)` with from `import ... from ...` throughout `@sanity/validation`. This change will make it possible to tree-shake `@sanity/validation`, and makes it easier to migrate to TypeScript later on.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

- That nothing breaks as a consequence of this refactor.
