### PR TITLE
feat(core): support new roles api in user invite command

### DIFF
--- a/packages/@sanity/cli/src/util/noSuchCommandText.js
+++ b/packages/@sanity/cli/src/util/noSuchCommandText.js
@@ -12,9 +12,12 @@ const coreCommands = [
   'deploy',
   'documents',
   'exec',
+  'graphql',
   'hook',
   'start',
+  'undeploy',
   'uninstall',
+  'users',
 ]
 
 const helpText = `
@@ -28,7 +31,7 @@ export default (cmdName, parentGroupName, groups) => {
 
   const isCoreCommand = coreCommands.includes(cmdName)
   if (isCoreCommand) {
-    return `"${cmdName}" is not available outside of a Sanity project context.${helpText}`
+    return `Command "${cmdName}" is not available outside of a Sanity project context.${helpText}`
   }
 
   return suggestCommand(cmdName, groups ? groups.default : [])


### PR DESCRIPTION
### Description

Updates the `sanity users invite` command to use the new roles and invitations API in order to support new and custom roles.

Also found a few commands/command groups that weren't picked up when running `sanity <command>` outside of a sanity studio directory, so they gave a more generic error message than they should have.
