### PR TITLE
fix(desk-tool): prevent crash if roles property does not exist on current user

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/permissionCheckBanner.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/permissionCheckBanner.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 export function PermissionCheckBanner(props: Props) {
   const {permission, requiredPermission, currentUser} = props
-  const plural = currentUser?.roles.length !== 1
+  const plural = currentUser?.roles?.length !== 1
   return permission.granted ? null : (
     <Card tone="transparent" padding={2} paddingX={3} shadow={1}>
       <Flex padding={2} align="center">


### PR DESCRIPTION
This can happen in the case of third-party login (eg SSO). Working on addressing it at a deeper level, but this should at least prevent it from crashing.