### PR TITLE
fix(block-tools) global/class var issue

### DIFF
--- a/packages/@sanity/block-tools/package.json
+++ b/packages/@sanity/block-tools/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@sanity/schema": "2.10.0",
+    "@types/jsdom": "^12.2.4",
     "assert": "^1.4.1",
     "jest": "^26.6.3",
     "jsdom": "^12.0.0",

--- a/packages/@sanity/block-tools/src/HtmlDeserializer/index.ts
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/index.ts
@@ -1,6 +1,5 @@
 import {flatten} from 'lodash'
 import resolveJsType from '../util/resolveJsType'
-import blockContentTypeFeatures from '../util/blockContentTypeFeatures'
 import {
   createRuleOptions,
   defaultParseHtml,
@@ -16,7 +15,6 @@ import createRules from './rules'
  * A internal variable to keep track of annotation mark definitions
  *
  */
-let _markDefs = []
 
 /**
  * HTML Deserializer
@@ -26,6 +24,7 @@ export default class HtmlDeserializer {
   blockContentType: any
   rules: any[]
   parseHtml: (html: string) => any
+  _markDefs = []
   /**
    * Create a new serializer respecting a Sanity block content type's schema
    *
@@ -60,7 +59,7 @@ export default class HtmlDeserializer {
    * @return {Array}
    */
   deserialize = (html) => {
-    _markDefs = []
+    this._markDefs = []
     const {parseHtml} = this
     const fragment = parseHtml(html)
     const children = Array.from(fragment.childNodes)
@@ -68,13 +67,13 @@ export default class HtmlDeserializer {
     const blocks = trimWhitespace(
       flattenNestedBlocks(ensureRootIsBlocks(this.deserializeElements(children)))
     )
-    if (_markDefs.length > 0) {
+    if (this._markDefs.length > 0) {
       blocks
         .filter((block) => block._type === 'block')
         .forEach((block) => {
           block.markDefs = block.markDefs || []
           block.markDefs = block.markDefs.concat(
-            _markDefs.filter((def) => {
+            this._markDefs.filter((def) => {
               return flatten(block.children.map((child) => child.marks || [])).includes(def._key)
             })
           )
@@ -242,7 +241,7 @@ export default class HtmlDeserializer {
    */
   deserializeAnnotation = (annotation) => {
     const {markDef} = annotation
-    _markDefs.push(markDef)
+    this._markDefs.push(markDef)
     const applyAnnotation = (node) => {
       if (node._type === '__annotation') {
         return this.deserializeAnnotation(node)

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/fromTheWild5/index.ts
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/fromTheWild5/index.ts
@@ -1,0 +1,45 @@
+import {JSDOM} from 'jsdom'
+import defaultSchema from '../../../fixtures/defaultSchema'
+
+const blockContentType = defaultSchema.get('blogPost').fields.find((field) => field.name === 'body')
+  .type
+
+export default (html, blockTools, commonOptions) => {
+  const findElement = (nodes, target) => nodes.find((i) => i.nodeName.toLowerCase() === target)
+
+  function getCtaBlock(ctaNodes) {
+    const title = findElement(ctaNodes, 'h2')
+    const intro = findElement(ctaNodes, 'div')?.childNodes[0]
+    const anchor = findElement(ctaNodes, 'a')
+
+    return {
+      _type: 'promo',
+      title: title.textContent,
+      intro: blockTools.htmlToBlocks(intro.innerHTML, blockContentType, {
+        parseHtml: (_html) => new JSDOM(_html).window.document,
+      }),
+      link: {
+        _type: 'link',
+        url: anchor.href,
+      },
+    }
+  }
+
+  const rules = [
+    {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      deserialize(el, next, block) {
+        if (el.tagName.toLowerCase() === 'cta') {
+          const items = Array.from(el.childNodes)
+          return block(getCtaBlock(items))
+        }
+        return undefined
+      },
+    },
+  ]
+  const options = {
+    ...commonOptions,
+    rules,
+  }
+  return blockTools.htmlToBlocks(html, blockContentType, options)
+}

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/fromTheWild5/index.ts
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/fromTheWild5/index.ts
@@ -1,13 +1,15 @@
 import {JSDOM} from 'jsdom'
 import defaultSchema from '../../../fixtures/defaultSchema'
 
-const blockContentType = defaultSchema.get('blogPost').fields.find((field) => field.name === 'body')
-  .type
+const blockContentType = defaultSchema
+  .get('blogPost')
+  .fields.find((field: any) => field.name === 'body').type
 
-export default (html, blockTools, commonOptions) => {
-  const findElement = (nodes, target) => nodes.find((i) => i.nodeName.toLowerCase() === target)
+export default (html: string, blockTools: any, commonOptions: any) => {
+  const findElement = (nodes: any, target: any) =>
+    nodes.find((i: ChildNode) => i.nodeName.toLowerCase() === target)
 
-  function getCtaBlock(ctaNodes) {
+  function getCtaBlock(ctaNodes: ChildNode[]) {
     const title = findElement(ctaNodes, 'h2')
     const intro = findElement(ctaNodes, 'div')?.childNodes[0]
     const anchor = findElement(ctaNodes, 'a')
@@ -16,7 +18,7 @@ export default (html, blockTools, commonOptions) => {
       _type: 'promo',
       title: title.textContent,
       intro: blockTools.htmlToBlocks(intro.innerHTML, blockContentType, {
-        parseHtml: (_html) => new JSDOM(_html).window.document,
+        parseHtml: (_html: string) => new JSDOM(_html).window.document,
       }),
       link: {
         _type: 'link',
@@ -28,7 +30,7 @@ export default (html, blockTools, commonOptions) => {
   const rules = [
     {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      deserialize(el, next, block) {
+      deserialize(el: Element, next: any, block: any) {
         if (el.tagName.toLowerCase() === 'cta') {
           const items = Array.from(el.childNodes)
           return block(getCtaBlock(items))

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/fromTheWild5/input.html
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/fromTheWild5/input.html
@@ -1,0 +1,9 @@
+<p>TRANSFORM is currently supporting over
+	<a href="https://www.transform.global/modules/help/Market.aspx?id=6&amp;appid=2">45 projects across 11 countries</a>,
+	which have reached more than a million people so far.</p>
+	<CTA>
+	<h2>Unlocking the power of markets</h2>
+	<img src="/Users/davidhoulker/Code/unilever/unilever-static/packages/migration/export/src/helpers/../../exports/sanity/assets/CTA.jpg" alt="Drinking water" />
+			<div><p>
+	TRANSFORM brings together the public and private sectors to address the world's most pressing development challenges</p></div>
+	<a href="https://www.transform.global/Intro.aspx">Visit the TRANSFORM website to discover more</a></CTA>

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/fromTheWild5/output.json
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/fromTheWild5/output.json
@@ -1,0 +1,56 @@
+[
+  {
+    "_key": "randomKey2",
+    "_type": "block",
+    "children": [
+      {
+        "_key": "randomKey20",
+        "_type": "span",
+        "marks": [],
+        "text": "TRANSFORM is currently supporting over "
+      },
+      {
+        "_key": "randomKey21",
+        "_type": "span",
+        "marks": ["randomKey0"],
+        "text": "45 projects across 11 countries"
+      },
+      {
+        "_key": "randomKey22",
+        "_type": "span",
+        "marks": [],
+        "text": ", which have reached more than a million people so far."
+      }
+    ],
+    "markDefs": [
+      {
+        "_key": "randomKey0",
+        "_type": "link",
+        "href": "https://www.transform.global/modules/help/Market.aspx?id=6&appid=2"
+      }
+    ],
+    "style": "normal"
+  },
+  {
+    "_key": "randomKey3",
+    "_type": "promo",
+    "intro": [
+      {
+        "_key": "randomKey1",
+        "_type": "block",
+        "children": [
+          {
+            "_key": "randomKey10",
+            "_type": "span",
+            "marks": [],
+            "text": "TRANSFORM brings together the public and private sectors to address the world's most pressing development challenges"
+          }
+        ],
+        "markDefs": [],
+        "style": "normal"
+      }
+    ],
+    "link": {"_type": "link", "url": "https://www.transform.global/Intro.aspx"},
+    "title": "Unlocking the power of markets"
+  }
+]

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/index.test.ts
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/index.test.ts
@@ -14,9 +14,10 @@ describe('HtmlDeserializer', () => {
       const dir = path.resolve(__dirname, test)
       const input = fs.readFileSync(path.resolve(dir, 'input.html')).toString()
       const expected = JSON.parse(fs.readFileSync(path.resolve(dir, 'output.json'), 'utf-8'))
+      // eslint-disable-next-line import/no-dynamic-require
       const fn = require(path.resolve(dir)).default
       const commonOptions = {
-        parseHtml: (html) => new JSDOM(html).window.document,
+        parseHtml: (html: string) => new JSDOM(html).window.document,
       }
       const output = fn(input, blockTools, commonOptions)
       // console.log(JSON.stringify(output, null, 2))

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/index.test.ts
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/index.test.ts
@@ -20,7 +20,7 @@ describe('HtmlDeserializer', () => {
       }
       const output = fn(input, blockTools, commonOptions)
       // console.log(JSON.stringify(output, null, 2))
-      assert.deepEqual(output, expected)
+      assert.deepStrictEqual(output, expected)
     })
   })
 })


### PR DESCRIPTION
### Description

This will fix an issue when combining several HTML serializers on the same time.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Using this global temp var here to store the serialized markDefs while we deserialize, will not support running multiple HTML-deserializers at the same time, which the test will show (fails before the fix commit).

I have a vague memory that it was a reason I used this a var like that and not put it on the class itself, but I can't seem to remember it now. :facepalm: 

However all the tests pass. And I can't really see why it needs to be a global var. There are no other matches on that used by other files.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Fix issue with combining multiple block-tools HTML deserializers.

<!--
A description of the change(s) that should be used in the release notes.
-->
