### PR TITLE
fix(form-builder): Fix overflowing PT toolbar menu inside of dialog

### DIFF
--- a/packages/@sanity/form-builder/src/FormBuilderInput.tsx
+++ b/packages/@sanity/form-builder/src/FormBuilderInput.tsx
@@ -11,6 +11,7 @@ import {emptyArray} from './utils/empty'
 const EMPTY_MARKERS: Marker[] = emptyArray()
 const EMPTY_PATH: Path = emptyArray()
 const EMPTY_PRESENCE: FormFieldPresence[] = emptyArray()
+const WRAPPER_INNER_STYLES = {minWidth: 0}
 
 interface Props {
   value: unknown
@@ -316,7 +317,10 @@ function FormBuilderInputInner(props: FormBuilderInputInnerProps & Props) {
   )
 
   return (
-    <div data-testid={path.length === 0 ? 'input-$root' : `input-${PathUtils.toString(path)}`}>
+    <div
+      data-testid={path.length === 0 ? 'input-$root' : `input-${PathUtils.toString(path)}`}
+      style={WRAPPER_INNER_STYLES}
+    >
       <FormFieldPresenceContext.Provider value={childPresenceInfo}>
         <ChangeIndicatorProvider
           path={path}


### PR DESCRIPTION
### Description

If you have a rich text editor inside of an object alongside an image, and the editor has a ton of items in the toolbar, this causes an overflow issue where the modal content is clipped.

We have a smart `OverflowMenu` component that normally is supposed to prevent overflows in the toolbar.

The overflow in this case happens because of the content, in this case the toolbar, defines the width of the parent wrapper.
Each column inside the CSS grid wrapper by default has a width of `auto` instead of `0`.

More details here: https://css-tricks.com/preventing-a-grid-blowout/

### More details

Screenshot of the problem:
![image](https://user-images.githubusercontent.com/10508/122411260-e801d900-cf84-11eb-9e64-6e27c12e9a5c.png)

### Notes for release

- Fixed a problem where a rich text editor with too many toolbar items inside of a object inside of a modal caused the content to overflow and be clipped