### PR TITLE
feat: conditional document lists via roles

### DIFF
--- a/packages/@sanity/base/src/datastores/grants/createGrantsStore.ts
+++ b/packages/@sanity/base/src/datastores/grants/createGrantsStore.ts
@@ -52,6 +52,7 @@ export function createGrantsStore(): GrantsStore {
   )
 
   return {
+    grants: currentUserDatasetGrants,
     checkDocumentPermission(permission: DocumentPermissionName, document: SanityDocument) {
       return currentUserDatasetGrants.pipe(
         switchMap((grants) => grantsPermissionOn(grants, permission, document))

--- a/packages/@sanity/base/src/datastores/grants/types.ts
+++ b/packages/@sanity/base/src/datastores/grants/types.ts
@@ -14,6 +14,7 @@ export interface PermissionCheckResult {
 }
 
 export interface GrantsStore {
+  grants: Observable<Grant[]>
   checkDocumentPermission(
     checkPermissionName: DocumentPermissionName,
     document: Partial<SanityDocument>

--- a/packages/@sanity/desk-tool/src/panes/listPane/ListPane.js
+++ b/packages/@sanity/desk-tool/src/panes/listPane/ListPane.js
@@ -1,128 +1,157 @@
-import React from 'react'
+import React, {useMemo, useState, useEffect} from 'react'
 import PropTypes from 'prop-types'
 import DefaultPane from 'part:@sanity/components/panes/default'
 import listStyles from 'part:@sanity/components/lists/default-style'
-import {PaneRouterContext} from '../../contexts/PaneRouterContext'
+import {from as observableFrom, merge} from 'rxjs'
+import {map, scan, debounceTime} from 'rxjs/operators'
 import {PaneItem} from '../../components/paneItem'
 import {ListView} from '../../components/listView'
 
 const EMPTY_ARRAY = []
 const EMPTY_RECORD = {}
 
-export default class ListPane extends React.PureComponent {
-  static contextType = PaneRouterContext
+function ListPane({
+  className = '',
+  items = EMPTY_ARRAY,
+  menuItems = EMPTY_ARRAY,
+  menuItemGroups = EMPTY_ARRAY,
+  displayOptions = EMPTY_RECORD,
+  title,
+  styles,
+  defaultLayout,
+  index,
+  isSelected,
+  isCollapsed,
+  onCollapse,
+  onExpand,
+  childItemId,
+}) {
+  // create a variable to short-circuit loading states.
+  const nothingHidden = useMemo(() => items.every((item) => !item.hidden), [items])
+  const [hiddenIds, setHiddenIds] = useState({})
 
-  static propTypes = {
-    index: PropTypes.number.isRequired,
-    title: PropTypes.string.isRequired,
-    childItemId: PropTypes.string.isRequired,
-    className: PropTypes.string,
-    styles: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-    defaultLayout: PropTypes.string,
-    items: PropTypes.arrayOf(
-      PropTypes.shape({
-        id: PropTypes.string.isRequired,
-        type: PropTypes.string.isRequired,
-        schemaType: PropTypes.shape({name: PropTypes.string}),
-      })
-    ),
-    menuItems: PropTypes.arrayOf(
-      PropTypes.shape({
-        title: PropTypes.string.isRequired,
-      })
-    ),
-    menuItemGroups: PropTypes.arrayOf(
-      PropTypes.shape({
-        id: PropTypes.string.isRequired,
-      })
-    ),
-    displayOptions: PropTypes.shape({
-      showIcons: PropTypes.bool,
-    }),
-    isSelected: PropTypes.bool.isRequired,
-    isCollapsed: PropTypes.bool.isRequired,
-    onExpand: PropTypes.func,
-    onCollapse: PropTypes.func,
-  }
+  const loading = useMemo(() => {
+    // if nothing is hidden then immediately show without a loading spinner
+    if (nothingHidden) return false
 
-  static defaultProps = {
-    className: '',
-    items: EMPTY_ARRAY,
-    menuItems: EMPTY_ARRAY,
-    menuItemGroups: EMPTY_ARRAY,
-    displayOptions: EMPTY_RECORD,
-    styles: undefined,
-    onExpand: undefined,
-    onCollapse: undefined,
-    defaultLayout: undefined,
-  }
+    return Object.keys(hiddenIds).length < items.length
+  }, [hiddenIds, nothingHidden, items.length])
 
-  itemIsSelected(item) {
-    return this.props.childItemId === item.id
-  }
+  useEffect(() => {
+    const normalizedHiddenObservables = items.map((item) => {
+      const result = typeof item.hidden === 'function' ? item.hidden() : item.hidden
 
-  shouldShowIconForItem = (item) => {
-    const paneShowIcons = this.props.displayOptions.showIcons
-    const itemShowIcon = item.displayOptions && item.displayOptions.showIcon
+      const normalizedObservable =
+        result && typeof result === 'object' && ('then' in result || 'subscribe' in result)
+          ? observableFrom(result)
+          : observableFrom([typeof result === 'boolean' ? result : false])
 
-    // Specific true/false on item should have presedence over list setting
-    if (typeof itemShowIcon !== 'undefined') {
-      return itemShowIcon === false ? false : item.icon
-    }
+      return normalizedObservable.pipe(map((isHidden) => [item.id, isHidden]))
+    })
 
-    // If no item setting is defined, defer to the pane settings
-    return paneShowIcons === false ? false : item.icon
-  }
+    const subscription = merge(...normalizedHiddenObservables)
+      .pipe(
+        scan(
+          (acc, [itemId, isHidden]) =>
+            // Note: this needs to be a new memory reference on each emit or
+            // react will skip the re-render
+            ({...acc, [itemId]: isHidden}),
+          {}
+        ),
+        // debounce just a little so we don't set state for every synchronous value
+        debounceTime(50)
+      )
+      .subscribe((next) => setHiddenIds(next))
 
-  render() {
-    const {
-      title,
-      styles,
-      className,
-      defaultLayout,
-      items,
-      index,
-      menuItems,
-      menuItemGroups,
-      isSelected,
-      isCollapsed,
-      onCollapse,
-      onExpand,
-    } = this.props
+    return () => subscription.unsubscribe()
+  }, [items])
 
-    return (
-      <DefaultPane
-        data-testid="desk-tool-list-pane"
-        index={index}
-        title={title}
-        styles={styles}
-        className={className}
-        isSelected={isSelected}
-        isCollapsed={isCollapsed}
-        onCollapse={onCollapse}
-        onExpand={onExpand}
-        menuItems={menuItems}
-        menuItemGroups={menuItemGroups}
-      >
+  return (
+    <DefaultPane
+      data-testid="desk-tool-list-pane"
+      index={index}
+      title={title}
+      styles={styles}
+      className={className}
+      isSelected={isSelected}
+      isCollapsed={isCollapsed}
+      onCollapse={onCollapse}
+      onExpand={onExpand}
+      menuItems={menuItems}
+      menuItemGroups={menuItemGroups}
+    >
+      {loading ? (
+        // TODO: better loading component.
+        <>LOADING…</>
+      ) : (
         <ListView layout={defaultLayout}>
-          {items.map((item) =>
-            item.type === 'divider' ? (
-              <hr key={item.id} className={listStyles.divider} />
-            ) : (
-              <PaneItem
-                key={item.id}
-                id={item.id}
-                index={index}
-                value={item}
-                icon={this.shouldShowIconForItem(item)}
-                layout={defaultLayout}
-                isSelected={this.itemIsSelected(item)}
-                schemaType={item.schemaType}
-              />
-            )
-          )}
+          {items
+            .filter((item) => !hiddenIds[item.id])
+            .map((item) => {
+              const shouldShowIconForItem = (() => {
+                // Specific true/false on item should have precedence over list setting
+                const itemShowIcon = item.displayOptions?.showIcon
+                if (typeof itemShowIcon !== 'undefined') {
+                  return itemShowIcon === false ? false : item.icon
+                }
+
+                // If no item setting is defined, defer to the pane settings
+                const paneShowIcons = displayOptions.showIcons
+                return paneShowIcons === false ? false : item.icon
+              })()
+
+              return item.type === 'divider' ? (
+                <hr key={item.id} className={listStyles.divider} />
+              ) : (
+                <PaneItem
+                  key={item.id}
+                  id={item.id}
+                  index={index}
+                  value={item}
+                  icon={shouldShowIconForItem}
+                  layout={defaultLayout}
+                  isSelected={childItemId === item.id}
+                  schemaType={item.schemaType}
+                />
+              )
+            })}
         </ListView>
-      </DefaultPane>
-    )
-  }
+      )}
+    </DefaultPane>
+  )
 }
+
+ListPane.propTypes = {
+  index: PropTypes.number.isRequired,
+  title: PropTypes.string.isRequired,
+  childItemId: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  styles: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  defaultLayout: PropTypes.string,
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      type: PropTypes.string.isRequired,
+      schemaType: PropTypes.shape({name: PropTypes.string}),
+    })
+  ),
+  menuItems: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string.isRequired,
+    })
+  ),
+  menuItemGroups: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+    })
+  ),
+  displayOptions: PropTypes.shape({
+    showIcons: PropTypes.bool,
+  }),
+  isSelected: PropTypes.bool.isRequired,
+  isCollapsed: PropTypes.bool.isRequired,
+  onExpand: PropTypes.func,
+  onCollapse: PropTypes.func,
+}
+
+export default ListPane

--- a/packages/@sanity/structure/src/ListItem.ts
+++ b/packages/@sanity/structure/src/ListItem.ts
@@ -1,4 +1,5 @@
 import {camelCase} from 'lodash'
+import {Observable} from 'rxjs'
 import {SerializeOptions, Serializable, Collection, CollectionBuilder} from './StructureNodes'
 import {getDefaultSchema, SchemaType} from './parts/Schema'
 import {ChildResolver} from './ChildResolver'
@@ -13,6 +14,14 @@ import {validateId} from './util/validateId'
 type UnserializedListItemChild = Collection | CollectionBuilder | ChildResolver
 
 type ListItemChild = Collection | ChildResolver | undefined
+
+type ListItemHidden =
+  | boolean
+  | Promise<boolean>
+  | Observable<boolean>
+  | (() => boolean)
+  | (() => Promise<boolean>)
+  | (() => Observable<boolean>)
 
 interface ListItemSerializeOptions extends SerializeOptions {
   titleIsOptional?: boolean
@@ -39,6 +48,7 @@ export interface ListItem {
   child?: ListItemChild
   displayOptions?: ListItemDisplayOptions
   schemaType?: SchemaType
+  hidden?: ListItemHidden
 }
 
 export interface UnserializedListItem {
@@ -48,6 +58,7 @@ export interface UnserializedListItem {
   child?: UnserializedListItemChild
   displayOptions?: ListItemDisplayOptions
   schemaType?: SchemaType | string
+  hidden?: ListItemHidden
 }
 
 type PartialListItem = Partial<UnserializedListItem>
@@ -99,6 +110,14 @@ export class ListItemBuilder implements Serializable {
 
   getChild() {
     return this.spec.child
+  }
+
+  hidden(hidden: ListItemHidden): ListItemBuilder {
+    return this.clone({hidden})
+  }
+
+  getHidden() {
+    return this.spec.hidden
   }
 
   schemaType(schemaType: SchemaType | string): ListItemBuilder {

--- a/packages/@sanity/structure/src/documentTypeListItems.ts
+++ b/packages/@sanity/structure/src/documentTypeListItems.ts
@@ -1,4 +1,6 @@
 import memoizeOne from 'memoize-one'
+import {map} from 'rxjs/operators'
+import grantsStore from 'part:@sanity/base/grants'
 import {Schema, getDefaultSchema, SchemaType} from './parts/Schema'
 import {dataAspects, DataAspectsResolver} from './parts/DataAspects'
 import {getListIcon, getDetailsIcon} from './parts/Icon'
@@ -51,6 +53,20 @@ export function getDocumentTypeListItem(typeName: string, sanitySchema?: Schema)
       }
 
       return list
+    })
+    .hidden(() => {
+      return grantsStore.grants.pipe(
+        // TODO: add correct types
+        map((grants: any[]) =>
+          grants.some(
+            (grant) =>
+              // TODO: implement this
+              // this should utilize the new GROQ.js compare function to return
+              // whether or not the user has the ability to read this schema type
+              true
+          )
+        )
+      )
     })
 }
 


### PR DESCRIPTION
### Description

This PR aims to implement conditional document lists based on roles.

**This is a work-in-progress.**

The current spec is:

> - When a list contains only the documents or lists you don't have access to, such a list remains hidden and it should not be visible in any other list or pane.
> - When a list contains a mix of documents or lists you have access to and not have access to you should still be able to see this list but without elements you don't have access to
> - We do not notify users that, due to permissions, a list or a document is hidden, neither from lists nor from the reference picker

What we have available to implement this is:

- [Dataset Access Control List](https://www.sanity.io/docs/roles-reference?skipCdn=true#15773f25851b) result
- A GROQ filter from the document list structure [`.filter` method](https://www.sanity.io/docs/structure-builder-reference#filter-c0dc69f8c387)
- (wip) [A new `compare` util in groq.js](https://github.com/sanity-io/groq-js/pull/40). This function accepts two groq filters and returns whether or not they overlap.

Here's the plan:

1. Add a new `hidden` method to the `ListItemBuilder` that accepts an observable of `boolean`
2. If that observable emits `true` then in the `ListPane` component, hide that item
3. Expose the grants stream from the grants store so we transform its result
4. Add some default implementations to structure builder methods such as [`documentTypeListItem `](https://www.sanity.io/docs/structure-builder-reference#f6208b48be60) that emit `true` if the filter provided from the document list does not overlap with the filter provided from the access control list

If dev does not want this list to be hidden based on roles, they can override the default `hidden` implementation.

### What to review

As of right now, comment on the idea and API proposals. The code is still a work-in-progress.
