### PR TITLE
fix(validation): fix issue causing field validations on object types to be unintentionally re-used across contexts

### DIFF
--- a/examples/test-studio/schemas/fieldValidationInferRepro.js
+++ b/examples/test-studio/schemas/fieldValidationInferRepro.js
@@ -1,0 +1,31 @@
+export const fieldValidationInferReproSharedObject = {
+  type: 'object',
+  name: 'someObjectType',
+  fields: [
+    {name: 'first', type: 'string'},
+    {name: 'second', type: 'string'},
+  ],
+}
+export const fieldValidationInferReproDoc = {
+  name: 'fieldValidationInferReproDoc',
+  type: 'document',
+  title: 'FieldValidationRepro',
+  fields: [
+    {
+      name: 'withValidation',
+      type: 'someObjectType',
+      title: 'Field of someObjectType with validation',
+      description: 'First field should be required',
+      validation: (Rule) =>
+        Rule.fields({
+          first: (fieldRule) => fieldRule.required(),
+        }),
+    },
+    {
+      name: 'withoutValidation',
+      type: 'someObjectType',
+      title: 'Field of someObjectType without validation',
+      description: 'First field should not be required',
+    },
+  ],
+}

--- a/examples/test-studio/schemas/schema.js
+++ b/examples/test-studio/schemas/schema.js
@@ -62,6 +62,10 @@ import gallery from './gallery'
 import presence, {objectWithNestedArray} from './presence'
 import {customBlock, hoistedPt, hoistedPtDocument} from './hoistedPt'
 import {initialValuesTest, superlatives} from './initialValuesTest'
+import {
+  fieldValidationInferReproSharedObject,
+  fieldValidationInferReproDoc,
+} from './fieldValidationInferRepro'
 
 export default createSchema({
   name: 'test-examples',
@@ -117,6 +121,8 @@ export default createSchema({
     myObject,
     codeInputType,
     notitle,
+    fieldValidationInferReproSharedObject,
+    fieldValidationInferReproDoc,
     typeWithNoToplevelStrings,
     reservedFieldNames,
     previewImageUrlTest,

--- a/packages/@sanity/validation/src/inferFromSchemaType.js
+++ b/packages/@sanity/validation/src/inferFromSchemaType.js
@@ -79,16 +79,7 @@ function inferForFields(typeDef, schema, visited) {
     return
   }
 
-  const fieldRules = typeDef.validation
-    .map((rule) => rule._fieldRules)
-    .filter(Boolean)
-    .reduce((acc, current) => ({fields: {...acc.fields, ...current}, hasRules: true}), {
-      fields: {},
-      hasRules: false,
-    })
-
   typeDef.fields.forEach((field) => {
-    field.type.validation = fieldRules.fields[field.name] || field.type.validation
     inferFromSchemaType(field.type, schema, visited)
   })
 }


### PR DESCRIPTION
### Description

This fixes the issue documented in https://github.com/sanity-io/sanity/issues/2257 by not assigning field rules to the individual fields. Instead of constructing the field validation at the time it gets inferred from the schema, this PR will call the rule creator at _validation_ time, which may be suboptimal in some cases. I don't know this code well enough to find a better way, but this solution may be good enough for now. Thoughts?

### What to review
- All things related to validation, especially field validations on object types.

### Notes for release

- Fixes an issue that caused field validations on object types to be written on individual field types, causing unintentional re-use of validation rules.