### PR TITLE
fix(form-builder): make sure hidden/filtered fields are actually hidden

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ObjectInput/ObjectInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ObjectInput/ObjectInput.tsx
@@ -99,6 +99,10 @@ export const ObjectInput = memo(
 
     const renderField = React.useCallback(
       (field: ObjectField, fieldLevel: number, index: number) => {
+        if (!filterField(type, field) || field.type.hidden) {
+          return null
+        }
+
         const fieldValue = value && value[field.name]
         return (
           <ObjectInputField
@@ -130,6 +134,7 @@ export const ObjectInput = memo(
         onFocus,
         presence,
         readOnly,
+        type,
         value,
       ]
     )

--- a/packages/@sanity/form-builder/src/inputs/ObjectInput/__tests__/ObjectInput.test.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ObjectInput/__tests__/ObjectInput.test.tsx
@@ -43,6 +43,26 @@ const schema = Schema.compile({
         },
       ],
     },
+    {
+      title: 'Hidden test',
+      name: 'hiddenTest',
+      type: 'object',
+      fields: [
+        {
+          name: 'thisIsVisible',
+          type: 'string',
+        },
+        {
+          name: 'thisIsHidden',
+          type: 'string',
+          hidden: true,
+        },
+        {
+          name: 'thisMayBeVisible',
+          type: 'string',
+        },
+      ],
+    },
   ],
 })
 // eslint-disable-next-line no-empty-function,@typescript-eslint/no-empty-function
@@ -139,6 +159,34 @@ describe('collapsible behavior', () => {
     expect(onFocus).toHaveBeenLastCalledWith(['collapsibleAndCollapsedByDefault'])
 
     expect(queryByTestId('input-field1')).toBeNull()
+  })
+
+  it('does not show hidden fields', () => {
+    const onFocus = jest.fn()
+
+    const {queryByTestId} = render(
+      <ObjectInputTester onFocus={onFocus} type={schema.get('hiddenTest')} />
+    )
+
+    expect(queryByTestId('input-thisIsVisible')).toBeVisible()
+    expect(queryByTestId('input-thisIsHidden')).toBeNull()
+    expect(queryByTestId('input-thisMayBeVisible')).toBeVisible()
+  })
+
+  it('supports filtering fields based on a predicate', () => {
+    const onFocus = jest.fn()
+
+    const {queryByTestId} = render(
+      <ObjectInputTester
+        onFocus={onFocus}
+        type={schema.get('hiddenTest')}
+        filterField={(type, field) => field.name !== 'thisMayBeVisible'}
+      />
+    )
+
+    expect(queryByTestId('input-thisIsVisible')).toBeVisible()
+    expect(queryByTestId('input-thisIsHidden')).toBeNull()
+    expect(queryByTestId('input-thisMayBeVisible')).toBeNull()
   })
 
   it("expands a field that's been manually collapsed when receiving a focus path that targets it", () => {

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -135,7 +135,7 @@ export interface SlugSchemaType extends BaseSchemaType {
 export interface ObjectField<T extends SchemaType = SchemaType> {
   name: string
   fieldset?: string
-  type: T
+  type: T & {hidden?: boolean}
 }
 
 export interface ObjectSchemaType extends BaseSchemaType {


### PR DESCRIPTION
### Description

The refactor of Object Input in v2.12.0 accidentally removed support for hidden object fields/field filtering. This adds it back, along with a unit test to catch future regressions.

### What to review
Verify that it looks ok implementation wise, and that hidden fields actually gets hidden

### Notes for release
- Fixes a bug introduced in v2.12.0 that made hidden fields appear visible
