### PR TITLE
fix(form-builder): reexport PatchEvent default export

### DIFF
--- a/packages/@sanity/form-builder/src/sanity/legacyPartImplementations/patch-event.ts
+++ b/packages/@sanity/form-builder/src/sanity/legacyPartImplementations/patch-event.ts
@@ -1,1 +1,2 @@
 export * from '../../PatchEvent'
+export {default} from '../../PatchEvent'


### PR DESCRIPTION
### Description
So apparently `export * from …` does not reexport the `default` export (TIL), which is likely to cause the issue described in #2576.

### Notes for release
- Fixes an issue that caused some plugins to error with the message "Cannot read property 'from' of undefined".
