### PR TITLE
fix(field): prevent crash when unable to resolve reference type

### DIFF
--- a/packages/@sanity/field/src/schema/helpers.ts
+++ b/packages/@sanity/field/src/schema/helpers.ts
@@ -1,21 +1,5 @@
-import schema from 'part:@sanity/base/schema'
 import {isTypedObject} from '@sanity/types'
-import {Diff, ArraySchemaType, SchemaType, ReferenceSchemaType} from '../diff'
-
-export function getReferencedType(referenceType: ReferenceSchemaType): SchemaType | undefined {
-  if (!referenceType.to) {
-    return referenceType.type
-      ? getReferencedType(referenceType.type as ReferenceSchemaType)
-      : undefined
-  }
-
-  if (Array.isArray(referenceType.to) && referenceType.to.length !== 1) {
-    return undefined
-  }
-
-  const targetType = schema.get(referenceType.to[0].name) as SchemaType
-  return targetType
-}
+import {Diff, ArraySchemaType, SchemaType} from '../diff'
 
 export function resolveTypeName(value: unknown): string {
   return isTypedObject(value) ? value._type : resolveJSType(value)

--- a/packages/@sanity/field/src/types/reference/preview/ReferencePreview.tsx
+++ b/packages/@sanity/field/src/types/reference/preview/ReferencePreview.tsx
@@ -1,9 +1,8 @@
 import {Reference} from '@sanity/types'
 import React from 'react'
 import Preview from 'part:@sanity/base/preview'
-import {getReferencedType} from '../../../schema/helpers'
 import {PreviewComponent} from '../../../preview/types'
 
 export const ReferencePreview: PreviewComponent<Reference> = ({value, schemaType}) => (
-  <Preview type={getReferencedType(schemaType)} value={value} layout="default" />
+  <Preview type={schemaType} value={value} layout="default" />
 )


### PR DESCRIPTION
### Description

The preview component seems to handle reference types just fine without us having to look up the individual type ahead of time. In fact, it might technically be incorrect to pass the target schema type along with a reference value. I'm not sure why I implemented it this way in the first place, but it seems to have started crashing when showing a diff of a schema type that can be of multiple different types.

### What to review

Diffs for references - both those of a single type and of those targeting multiple types.

### Notes for release

- Fixed bug where review changes might crash when showing change in a reference that could target more than one schema type