### PR TITLE
fix(cli): add missing undeclared dependency

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -40,6 +40,7 @@
   "homepage": "https://www.sanity.io/",
   "devDependencies": {
     "@sanity/client": "2.11.0",
+    "@sanity/generate-help-url": "^2.2.6",
     "@sanity/resolver": "2.11.0",
     "@sanity/util": "2.11.0",
     "boxen": "^4.1.0",


### PR DESCRIPTION
### Description

`@sanity/cli` was implicitly depending on `@sanity/generate-help-url` in `clientWrapper`, but did not declare it as a dependency. This only works because other modules depend on it and the CLI bundles dependencies to a single file on publish. This PR adds the missing dependency.
