### PR TITLE
feat(form-builder): add option to hide empty value in fields of type string with predefined list option

### DIFF
--- a/examples/test-studio/schemas/strings.js
+++ b/examples/test-studio/schemas/strings.js
@@ -52,6 +52,30 @@ export default {
       },
     },
     {
+      name: 'selectWithoutEmptyValue',
+      type: 'string',
+      title: 'Select string, without empty value',
+      description:
+        'Select a single string value from a set of predefined options. It should NOT be possible to unset a selected value.',
+      options: {
+        hideEmptyValue: true,
+        list: [
+          {
+            title: 'One (1)',
+            value: 'one',
+          },
+          {
+            title: 'Two (2)',
+            value: 'two',
+          },
+          {
+            title: 'Three (3)',
+            value: 'three',
+          },
+        ],
+      },
+    },
+    {
       name: 'radioSelectHorizontal',
       title: 'Select (layout: radio, direction: horizontal)',
       type: 'string',

--- a/packages/@sanity/form-builder/src/inputs/SelectInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/SelectInput.tsx
@@ -92,7 +92,8 @@ const SelectInput = React.forwardRef(function SelectInput(
         />
       )
     }
-
+    const listItems =
+      value !== undefined && type?.options?.hideEmptyValue ? items : [EMPTY_ITEM, ...items]
     return (
       <Select
         onChange={handleSelectChange}
@@ -103,7 +104,7 @@ const SelectInput = React.forwardRef(function SelectInput(
         customValidity={errors?.[0]?.item.message}
         value={optionValueFromItem(currentItem)}
       >
-        {[EMPTY_ITEM, ...items].map((item, i) => (
+        {listItems.map((item, i) => (
           <option key={`${i - 1}`} value={i - 1}>
             {item.title}
           </option>
@@ -123,6 +124,7 @@ const SelectInput = React.forwardRef(function SelectInput(
     optionValueFromItem,
     readOnly,
     type.options.direction,
+    type.options.hideEmptyValue,
   ])
 
   return (

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -75,6 +75,7 @@ interface EnumListProps<V = unknown> {
   list?: TitledListValue<V>[] | V[]
   layout?: 'radio' | 'dropdown'
   direction?: 'horizontal' | 'vertical'
+  hideEmptyValue?: boolean
 }
 
 export interface StringSchemaType extends BaseSchemaType {


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

We've received feedback that some wants to be able to not be able to select an empty value when using the predefined list option for the string input (which renders a select dropdown). This PR adds an option to hide the undefined/empty value, while keeping the default behaviour of it being rendered. 

I've added an example field in the `stringsTest` document type called `Select string, without empty value`.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

- Open the test studio and test the string input with predefined lists (the `Select string` and `Select string, without empty value` fields in the string test documents (`/test/desk/stringsTest`).

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

- add option to hide empty value in fields of type string with predefined list option