### PR TITLE
build(ci): skip cypress binary install on non-cypress workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Install npm dependencies
         env:
          PUPPETEER_SKIP_DOWNLOAD: 'true'
+         CYPRESS_INSTALL_BINARY: '0'
         run: npm install
 
       # Required for import lint rules to work - packages pointing to ex

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,8 @@ jobs:
 
       - name: Install npm dependencies
         env:
-         PUPPETEER_SKIP_DOWNLOAD: 'true'
+          CYPRESS_INSTALL_BINARY: '0'
+          PUPPETEER_SKIP_DOWNLOAD: 'true'
         run: npm install
 
       - name: Build modules

--- a/.github/workflows/verify_format.yml
+++ b/.github/workflows/verify_format.yml
@@ -26,7 +26,8 @@ jobs:
 
       - name: Install npm dependencies
         env:
-         PUPPETEER_SKIP_DOWNLOAD: 'true'
+          CYPRESS_INSTALL_BINARY: '0'
+          PUPPETEER_SKIP_DOWNLOAD: 'true'
         # --ignore-scripts disables postinstall because it's not needed
         # in this CI step and takes a long time
         run: npm install --ignore-scripts


### PR DESCRIPTION
### Description

Like with puppeteer, let's skip downloading the cypress binary on non-e2e github workflows