### PR TITLE
feat(base): add preview override for references permissions

### DIFF
--- a/packages/@sanity/base/src/preview/components/ObserveForPreview.tsx
+++ b/packages/@sanity/base/src/preview/components/ObserveForPreview.tsx
@@ -62,7 +62,6 @@ const connect = (props$: Observable<OuterProps>): Observable<ReceivedProps> => {
         observeForPreview(
           props.value,
           props.type,
-          props.fields,
           props.ordering ? {ordering: props.ordering} : {}
         ).pipe(
           map((result) => ({

--- a/packages/@sanity/base/src/preview/constants.ts
+++ b/packages/@sanity/base/src/preview/constants.ts
@@ -1,5 +1,0 @@
-export const INCLUDE_FIELDS_QUERY = ['_id', '_rev', '_type']
-export const INCLUDE_FIELDS = [...INCLUDE_FIELDS_QUERY, '_key']
-
-export const INVALID_PREVIEW_CONFIG = Symbol('invalid preview config')
-export const INSUFFICIENT_PERMISSIONS = Symbol('insufficient permissions')

--- a/packages/@sanity/base/src/preview/constants.ts
+++ b/packages/@sanity/base/src/preview/constants.ts
@@ -2,3 +2,4 @@ export const INCLUDE_FIELDS_QUERY = ['_id', '_rev', '_type']
 export const INCLUDE_FIELDS = [...INCLUDE_FIELDS_QUERY, '_key']
 
 export const INVALID_PREVIEW_CONFIG = Symbol('invalid preview config')
+export const INSUFFICIENT_PERMISSIONS = Symbol('insufficient permissions')

--- a/packages/@sanity/base/src/preview/constants.tsx
+++ b/packages/@sanity/base/src/preview/constants.tsx
@@ -7,18 +7,16 @@ import {PreparedValue} from './prepareForPreview'
 export const INCLUDE_FIELDS_QUERY = ['_id', '_rev', '_type']
 export const INCLUDE_FIELDS = [...INCLUDE_FIELDS_QUERY, '_key']
 
-// The `<small>` element is used for more compatibility
-// with the different downstream preview components
-const SmallText = styled.small`
-  color: ${({theme}) => theme.sanity.color.muted.default.enabled.fg};
+// NOTE: have to use color inherit to make it work correctly with the
+// `isSelected` state in the list pane
+const IconSizer = styled(Text)`
+  color: inherit;
 `
 
 function IconWrapper({children}: {children: React.ReactNode}) {
   return (
     <Flex>
-      <Text muted size={3}>
-        {children}
-      </Text>
+      <IconSizer size={3}>{children}</IconSizer>
     </Flex>
   )
 }
@@ -26,8 +24,10 @@ function IconWrapper({children}: {children: React.ReactNode}) {
 export class InsufficientPermissionsError extends Error {}
 
 export const INVALID_PREVIEW_FALLBACK: PreparedValue = {
-  title: <SmallText>Invalid preview config</SmallText>,
-  subtitle: <SmallText>Check the error log in the console</SmallText>,
+  // The `<small>` element is used for more compatibility
+  // with the different downstream preview components.
+  title: <small>Invalid preview config</small>,
+  subtitle: <small>Check the error log in the console</small>,
   media: (
     <IconWrapper>
       <WarningOutlineIcon />
@@ -37,7 +37,9 @@ export const INVALID_PREVIEW_FALLBACK: PreparedValue = {
 }
 
 export const INSUFFICIENT_PERMISSIONS_FALLBACK: PreparedValue = {
-  title: <SmallText>Insufficient permissions to access this reference</SmallText>,
+  // The `<small>` element is used for more compatibility
+  // with the different downstream preview components.
+  title: <small>Insufficient permissions to access this reference</small>,
   media: (
     <IconWrapper>
       <AccessDeniedIcon />

--- a/packages/@sanity/base/src/preview/constants.tsx
+++ b/packages/@sanity/base/src/preview/constants.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import styled from 'styled-components'
+import {Flex, Text} from '@sanity/ui'
+import {WarningOutlineIcon, AccessDeniedIcon} from '@sanity/icons'
+import {PreparedValue} from './prepareForPreview'
+
+export const INCLUDE_FIELDS_QUERY = ['_id', '_rev', '_type']
+export const INCLUDE_FIELDS = [...INCLUDE_FIELDS_QUERY, '_key']
+
+// The `<small>` element is used for more compatibility
+// with the different downstream preview components
+const SmallText = styled.small`
+  color: ${({theme}) => theme.sanity.color.muted.default.enabled.fg};
+`
+
+function IconWrapper({children}: {children: React.ReactNode}) {
+  return (
+    <Flex>
+      <Text muted size={3}>
+        {children}
+      </Text>
+    </Flex>
+  )
+}
+
+export class InsufficientPermissionsError extends Error {}
+
+export const INVALID_PREVIEW_FALLBACK: PreparedValue = {
+  title: <SmallText>Invalid preview config</SmallText>,
+  subtitle: <SmallText>Check the error log in the console</SmallText>,
+  media: (
+    <IconWrapper>
+      <WarningOutlineIcon />
+    </IconWrapper>
+  ),
+  meta: {type: 'invalid_preview'},
+}
+
+export const INSUFFICIENT_PERMISSIONS_FALLBACK: PreparedValue = {
+  title: <SmallText>Insufficient permissions to access this reference</SmallText>,
+  media: (
+    <IconWrapper>
+      <AccessDeniedIcon />
+    </IconWrapper>
+  ),
+  meta: {type: 'insufficient_permissions'},
+}

--- a/packages/@sanity/base/src/preview/constants.tsx
+++ b/packages/@sanity/base/src/preview/constants.tsx
@@ -33,7 +33,7 @@ export const INVALID_PREVIEW_FALLBACK: PreparedValue = {
       <WarningOutlineIcon />
     </IconWrapper>
   ),
-  meta: {type: 'invalid_preview'},
+  _meta: {type: 'invalid_preview'},
 }
 
 export const INSUFFICIENT_PERMISSIONS_FALLBACK: PreparedValue = {
@@ -45,5 +45,5 @@ export const INSUFFICIENT_PERMISSIONS_FALLBACK: PreparedValue = {
       <AccessDeniedIcon />
     </IconWrapper>
   ),
-  meta: {type: 'insufficient_permissions'},
+  _meta: {type: 'insufficient_permissions'},
 }

--- a/packages/@sanity/base/src/preview/constants.tsx
+++ b/packages/@sanity/base/src/preview/constants.tsx
@@ -33,7 +33,7 @@ export const INVALID_PREVIEW_FALLBACK: PreparedValue = {
       <WarningOutlineIcon />
     </IconWrapper>
   ),
-  _meta: {type: 'invalid_preview'},
+  _internalMeta: {type: 'invalid_preview'},
 }
 
 export const INSUFFICIENT_PERMISSIONS_FALLBACK: PreparedValue = {
@@ -45,5 +45,5 @@ export const INSUFFICIENT_PERMISSIONS_FALLBACK: PreparedValue = {
       <AccessDeniedIcon />
     </IconWrapper>
   ),
-  _meta: {type: 'insufficient_permissions'},
+  _internalMeta: {type: 'insufficient_permissions'},
 }

--- a/packages/@sanity/base/src/preview/createPreviewObserver.ts
+++ b/packages/@sanity/base/src/preview/createPreviewObserver.ts
@@ -2,7 +2,7 @@ import {of as observableOf, Observable} from 'rxjs'
 import {map, switchMap, catchError} from 'rxjs/operators'
 import {isReferenceSchemaType, ReferenceSchemaType, SchemaType} from '@sanity/types'
 import prepareForPreview, {invokePrepare, PreparedValue} from './prepareForPreview'
-import {Reference, PrepareViewOptions} from './types'
+import {Reference, PrepareViewOptions, Path} from './types'
 import {INSUFFICIENT_PERMISSIONS_FALLBACK, InsufficientPermissionsError} from './constants'
 
 const INSUFFICIENT_PERMISSIONS = Symbol('INSUFFICIENT_PERMISSIONS')
@@ -14,7 +14,7 @@ export interface PreparedSnapshot {
 
 // Takes a value and its type and prepares a snapshot for it that can be passed to a preview component
 export function createPreviewObserver(
-  observePaths: (value: any, paths: Array<string[]>) => any,
+  observePaths: (value: any, paths: Path[]) => any,
   resolveRefType: (
     value: Reference,
     ownerType: ReferenceSchemaType

--- a/packages/@sanity/base/src/preview/createPreviewObserver.ts
+++ b/packages/@sanity/base/src/preview/createPreviewObserver.ts
@@ -64,13 +64,7 @@ export function createPreviewObserver(
       return observePaths(value, paths).pipe(
         map((snapshot) => ({
           type: type,
-          snapshot:
-            snapshot &&
-            prepareForPreview({
-              rawValue: snapshot,
-              type,
-              viewOptions,
-            }),
+          snapshot: snapshot && prepareForPreview(snapshot, type, viewOptions),
         }))
       )
     }

--- a/packages/@sanity/base/src/preview/prepareForPreview.ts
+++ b/packages/@sanity/base/src/preview/prepareForPreview.ts
@@ -22,7 +22,7 @@ export type PreparedValue = {
    * currently used to add a flag for the invalid preview error fallback and
    * insufficient permissions fallback
    */
-  meta?: {type?: string}
+  _meta?: {type?: string}
 }
 
 export type PrepareInvocationResult = {

--- a/packages/@sanity/base/src/preview/prepareForPreview.ts
+++ b/packages/@sanity/base/src/preview/prepareForPreview.ts
@@ -22,7 +22,7 @@ export type PreparedValue = {
    * currently used to add a flag for the invalid preview error fallback and
    * insufficient permissions fallback
    */
-  _meta?: {type?: string}
+  _internalMeta?: {type?: string}
 }
 
 export type PrepareInvocationResult = {

--- a/packages/@sanity/base/src/preview/prepareForPreview.ts
+++ b/packages/@sanity/base/src/preview/prepareForPreview.ts
@@ -1,6 +1,6 @@
-// @flow
+import type {SchemaType} from '@sanity/types'
 import {debounce, flatten, get, isPlainObject, pick, uniqBy} from 'lodash'
-import {INVALID_PREVIEW_CONFIG} from './constants'
+import {INVALID_PREVIEW_FALLBACK} from './constants'
 import {isPortableTextArray, extractTextFromBlocks} from './utils/portableText'
 import {PrepareViewOptions, Type} from './types'
 import {keysOf} from './utils/keysOf'
@@ -10,10 +10,19 @@ const EMPTY = []
 
 type SelectedValue = Record<string, unknown>
 
+// TODO: unify types with `@sanity/form-builder`
+// see `PreviewSnapshot` in `usePreviewSnapshot`
 export type PreparedValue = {
-  title: string
-  subtitle: string
-  description: string
+  title?: React.ReactNode
+  subtitle?: React.ReactNode
+  description?: React.ReactNode
+  media?: React.ReactNode
+  /**
+   * optional object used to attach meta data to the prepared result.
+   * currently used to add a flag for the invalid preview error fallback and
+   * insufficient permissions fallback
+   */
+  meta?: {type?: string}
 }
 
 export type PrepareInvocationResult = {
@@ -212,15 +221,25 @@ export function invokePrepare(
   }
 }
 
-function withErrors(result, type, selectedValue) {
+function withErrors(result, type, selectedValue): PreparedValue {
   result.errors.forEach((error) => errorCollector.add(type, selectedValue, error))
   reportErrors()
 
-  return INVALID_PREVIEW_CONFIG
+  return INVALID_PREVIEW_FALLBACK
 }
 
-export default function prepareForPreview(rawValue, type, viewOptions): symbol | PreparedValue {
-  const selection = type.preview.select
+interface PrepareForPreviewOptions {
+  rawValue: unknown
+  type: SchemaType
+  viewOptions?: PrepareViewOptions
+}
+
+export default function prepareForPreview({
+  rawValue,
+  type,
+  viewOptions = {},
+}: PrepareForPreviewOptions): PreparedValue {
+  const selection = type.preview?.select || {}
   const targetKeys = Object.keys(selection)
 
   const selectedValue = targetKeys.reduce((acc, key) => {
@@ -246,5 +265,5 @@ export default function prepareForPreview(rawValue, type, viewOptions): symbol |
   const returnValueResult = validateReturnedPreview(invokePrepare(type, selectedValue, viewOptions))
   return returnValueResult.errors.length > 0
     ? withErrors(returnValueResult, type, selectedValue)
-    : ({...pick(rawValue, PRESERVE_KEYS), ...prepareResult.returnValue} as PreparedValue)
+    : {...pick(rawValue, PRESERVE_KEYS), ...prepareResult.returnValue}
 }

--- a/packages/@sanity/base/src/preview/prepareForPreview.ts
+++ b/packages/@sanity/base/src/preview/prepareForPreview.ts
@@ -228,28 +228,28 @@ function withErrors(result, type, selectedValue): PreparedValue {
   return INVALID_PREVIEW_FALLBACK
 }
 
-interface PrepareForPreviewOptions {
-  rawValue: unknown
-  type: SchemaType
-  viewOptions?: PrepareViewOptions
-}
-
-export default function prepareForPreview({
-  rawValue,
-  type,
-  viewOptions = {},
-}: PrepareForPreviewOptions): PreparedValue {
+export default function prepareForPreview(
+  rawValue: unknown,
+  type: SchemaType,
+  viewOptions: PrepareViewOptions = {}
+): PreparedValue {
   const selection = type.preview?.select || {}
   const targetKeys = Object.keys(selection)
 
   const selectedValue = targetKeys.reduce((acc, key) => {
     // Find the field the value belongs to
-    const valueField = type?.fields?.find((f) => f.name === selection[key])
+    const typeWithFields = 'fields' in type ? type : null
+    const valueField = typeWithFields?.fields?.find((f) => f.name === selection[key])
+
     // Check if predefined options exist
-    const listOptions = valueField?.type?.options?.list
+    const options = valueField?.type?.options
+    const listOptions = options && typeof options === 'object' ? (options as any).list : null
+
     if (listOptions) {
       // Find the selected option that matches the raw value
-      const selectedOption = listOptions.find((opt) => opt.value === rawValue[selection[key]])
+      const selectedOption = listOptions.find(
+        (opt) => opt.value === (rawValue as any)[selection[key]]
+      )
       acc[key] = get(selectedOption, key)
       return acc
     }

--- a/packages/@sanity/base/src/preview/utils/resolveRefType.ts
+++ b/packages/@sanity/base/src/preview/utils/resolveRefType.ts
@@ -2,7 +2,7 @@ import {from as observableFrom, Observable} from 'rxjs'
 import {map} from 'rxjs/operators'
 import {Reference, ReferenceSchemaType, SchemaType} from '@sanity/types'
 import {versionedClient} from '../../client/versionedClient'
-import {INSUFFICIENT_PERMISSIONS} from '../constants'
+import {InsufficientPermissionsError} from '../constants'
 
 // todo: use a LRU cache instead (e.g. hashlru or quick-lru)
 const CACHE: Record<string, Promise<string | null>> = Object.create(null)
@@ -21,10 +21,15 @@ function resolveRefTypeName(reference: Reference): Observable<string | null> {
 export default function resolveRefType(
   value: Reference,
   type: ReferenceSchemaType
-): Observable<SchemaType | typeof INSUFFICIENT_PERMISSIONS | undefined> {
+): Observable<SchemaType | undefined> {
   return resolveRefTypeName(value).pipe(
     map((refTypeName) => {
-      if (!refTypeName && !type.weak) return INSUFFICIENT_PERMISSIONS
+      if (!refTypeName && !type.weak) {
+        throw new InsufficientPermissionsError(
+          `Could not resolve _type ${refTypeName} and the reference was marked as weak.`
+        )
+      }
+
       return type.to.find((toType) => toType.name === refTypeName)
     })
   )

--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
@@ -111,17 +111,11 @@ export const ReferenceInput = forwardRef(function ReferenceInput(
 
   const weakIs = value?._weak ? 'weak' : 'strong'
   const weakShouldBe = type.weak === true ? 'weak' : 'strong'
+  const hasInsufficientPermissions = preview.snapshot?.meta?.type === 'insufficient_permissions'
   const isMissing =
-    !!value?._ref &&
-    !preview.isLoading &&
-    preview.snapshot &&
-    // TODO: this check would be cleaner if the INSUFFICIENT_PERMISSIONS symbol could be imported directly
-    typeof preview.snapshot !== 'object'
+    !hasInsufficientPermissions && !!value?._ref && !preview.isLoading && preview.snapshot
 
   const hasRef = value && value._ref
-
-  const hasInsufficientPermissions =
-    hasRef && isMissing && weakIs === 'strong' && weakShouldBe === 'strong'
 
   const handleFixStrengthMismatch = useCallback(() => {
     onChange(PatchEvent.from(type.weak === true ? set(true, ['_weak']) : unset(['_weak'])))

--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
@@ -111,7 +111,7 @@ export const ReferenceInput = forwardRef(function ReferenceInput(
 
   const weakIs = value?._weak ? 'weak' : 'strong'
   const weakShouldBe = type.weak === true ? 'weak' : 'strong'
-  const hasInsufficientPermissions = preview.snapshot?.meta?.type === 'insufficient_permissions'
+  const hasInsufficientPermissions = preview.snapshot?._meta?.type === 'insufficient_permissions'
   const isMissing =
     !hasInsufficientPermissions && !!value?._ref && !preview.isLoading && preview.snapshot
 

--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
@@ -109,11 +109,19 @@ export const ReferenceInput = forwardRef(function ReferenceInput(
 
   const preview = usePreviewSnapshot(value, getPreviewSnapshot)
 
-  const weakIs = value && value._weak ? 'weak' : 'strong'
+  const weakIs = value?._weak ? 'weak' : 'strong'
   const weakShouldBe = type.weak === true ? 'weak' : 'strong'
-  const isMissing = value?._ref && !preview.isLoading && preview.snapshot === null
+  const isMissing =
+    !!value?._ref &&
+    !preview.isLoading &&
+    preview.snapshot &&
+    // TODO: this check would be cleaner if the INSUFFICIENT_PERMISSIONS symbol could be imported directly
+    typeof preview.snapshot !== 'object'
 
   const hasRef = value && value._ref
+
+  const hasInsufficientPermissions =
+    hasRef && isMissing && weakIs === 'strong' && weakShouldBe === 'strong'
 
   const handleFixStrengthMismatch = useCallback(() => {
     onChange(PatchEvent.from(type.weak === true ? set(true, ['_weak']) : unset(['_weak'])))
@@ -170,12 +178,15 @@ export const ReferenceInput = forwardRef(function ReferenceInput(
       if (autocompleteValue === '') {
         return ''
       }
+      if (hasInsufficientPermissions) {
+        return '<insufficient permissions>'
+      }
       if (isMissing) {
-        return `<nonexistent document>`
+        return '<nonexistent document>'
       }
       return preview.isLoading ? 'Loading…' : preview.snapshot?.title || 'Untitled'
     },
-    [isMissing, preview]
+    [isMissing, hasInsufficientPermissions, preview]
   )
 
   const inputId = useId()
@@ -217,6 +228,15 @@ export const ReferenceInput = forwardRef(function ReferenceInput(
       description={type.description}
     >
       <Stack space={3}>
+        {hasInsufficientPermissions && (
+          <Alert title="Insufficient permissions to access this reference" status="warning">
+            <Text as="p" muted size={1}>
+              You don't have access to the referenced document. Please contact an admin for access
+              or remove this reference.
+            </Text>
+          </Alert>
+        )}
+
         {hasRef && !isMissing && weakIs !== weakShouldBe && (
           <Alert
             title="Reference strength mismatch"
@@ -258,7 +278,7 @@ export const ReferenceInput = forwardRef(function ReferenceInput(
           </Alert>
         )}
 
-        {value && isMissing && (
+        {value && isMissing && !hasInsufficientPermissions && (
           <Alert title="Nonexistent document reference" status="warning">
             <Text as="p" muted size={1}>
               This field is currently referencing a document that doesn't exist (ID:{' '}

--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
@@ -111,7 +111,8 @@ export const ReferenceInput = forwardRef(function ReferenceInput(
 
   const weakIs = value?._weak ? 'weak' : 'strong'
   const weakShouldBe = type.weak === true ? 'weak' : 'strong'
-  const hasInsufficientPermissions = preview.snapshot?._meta?.type === 'insufficient_permissions'
+  const hasInsufficientPermissions =
+    preview.snapshot?._internalMeta?.type === 'insufficient_permissions'
   const isMissing =
     !hasInsufficientPermissions && !!value?._ref && !preview.isLoading && preview.snapshot
 

--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/usePreviewSnapshot.ts
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/usePreviewSnapshot.ts
@@ -25,7 +25,7 @@ type PreviewSnapshot = {
   _type: string
   title: string
   description: string
-  meta?: {type?: string}
+  _meta?: {type?: string}
 }
 
 export function usePreviewSnapshot(

--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/usePreviewSnapshot.ts
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/usePreviewSnapshot.ts
@@ -18,11 +18,14 @@ const NULL_SNAPSHOT: SnapshotState = {
   snapshot: null,
 }
 
+// TODO: unify types with `@sanity/base`
+// see `PreparedValue` in `prepareForPreview`
 type PreviewSnapshot = {
   _id: string
   _type: string
   title: string
   description: string
+  meta?: {type?: string}
 }
 
 export function usePreviewSnapshot(

--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/usePreviewSnapshot.ts
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/usePreviewSnapshot.ts
@@ -25,7 +25,7 @@ type PreviewSnapshot = {
   _type: string
   title: string
   description: string
-  _meta?: {type?: string}
+  _internalMeta?: {type?: string}
 }
 
 export function usePreviewSnapshot(


### PR DESCRIPTION
### Description

This implements a notice for insufficient permissions for references. This approach augments the `resolveRefType` implementation that goes downstream to the `ObserveForPreview` component. This is a particularly nice spot since it's already attempting to query the ref and it has access to the type resolving the ref. If a ref could not be resolved while the related type says the reference is not `weak` then we can assume the user has insufficient permissions and return a Symbol.

Similar to the `INVALID_PREVIEW_FALLBACK`, we can catch this symbol in `ObserveForPreview` and return a similar fallback for insufficient permissions.

Questions/Notes on the approach:

~1. As a result of handling this at such a low level, the snapshot value can sometimes be a Symbol. I'm not sure if this will affect anything downstream. I believe the invalid preview config also does this that's more of an edge case. Is this okay?
2. Does it make sense to expose this symbol? It would be nice to import it and check if the snapshot matches (especially in the ReferenceInput component)?
3. If reference is marked as weak, there is no way to distinguish between non-existence and not allowed.
4. How does it look? cc @mikolajdobrucki~

Update: I remove the possibility of a symbol being sent downstream in both the invalid preview case and the insufficient permissions case. This one should be good to go now.

<img width="576" alt="CleanShot 2021-06-28 at 17 34 01@2x" src="https://user-images.githubusercontent.com/10551026/123709082-722a2700-d83a-11eb-9a72-aa2d3d77622f.png">
<img width="544" alt="CleanShot 2021-06-28 at 17 33 53@2x" src="https://user-images.githubusercontent.com/10551026/123709083-72c2bd80-d83a-11eb-8eae-0fde9c1d1456.png">

### What to review

Take a look at the approach and think of how this could affect things downstream. I also left a few comments in the code in this draft state I could use some help with.

Update: I also added a `meta` property to the prepared result. This is used in the ReferenceInput component to check if the snapshot is an insufficient permissions notice.

### Notes for release

Adds a notice for insufficient permissions for references