### PR TITLE
fix(base): fix [object Object] for title value

### DIFF
--- a/packages/@sanity/base/src/__legacy/@sanity/components/previews/MediaPreview.tsx
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/previews/MediaPreview.tsx
@@ -46,7 +46,7 @@ export default class MediaPreview extends React.PureComponent<MediaPreviewProps>
     }
 
     return (
-      <div className={styles.root} title={title}>
+      <div className={styles.root} title={typeof title === 'string' ? title : undefined}>
         <div className={styles.padder} style={{paddingTop: `${100 / aspect}%`}} />
 
         <div className={styles.mediaContainer}>


### PR DESCRIPTION
### Description

I noticed that sending a `title` node that's a react node (vs a string)` will make the browser tooltip say `[object object]` instead of the correct title.

This PR fixes that by adding a ref callback + `el.innerText`

### What to review

Ensure I didn't change the API of one and it works as intended. If the one looks good to you, feel free to merge it. 😄 
