### PR TITLE
feat(desk-tool): add document action dialog size and padding options

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/documentPane/statusBar/actionStateDialog.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/statusBar/actionStateDialog.tsx
@@ -19,6 +19,8 @@ interface ModalDialogProps {
   content: React.ReactNode
   onClose: () => void
   showCloseButton: true
+  size?: 'small' | 'medium' | 'large' | 'auto'
+  padding?: 'none' | 'small' | 'medium' | 'large'
 }
 
 // Todo: move these to action spec/core types
@@ -139,8 +141,8 @@ export function ActionStateDialog(props: Props) {
         onClose={dialog.onClose}
         onClickOutside={dialog.onClose}
         showCloseButton={dialog.showCloseButton}
-        size="medium"
-        padding="large"
+        size={dialog.size ?? 'medium'}
+        padding={dialog.padding ?? 'large'}
       >
         {dialog.content}
       </Dialog>


### PR DESCRIPTION
### Description

[Document Actions with a Modal type](https://www.sanity.io/docs/document-actions-api#037f877ad3f1) currently don't pass `size` or `padding` options to the `<Dialog />` component.

These changes would allow you to pass those options in – with the fallback the original defaults.

A client requested this to be able to have full-window sizes modals in a Document Action.

### What to review

Create a document action with these settings:

```
    dialog: dialogOpen && {
      type: 'modal',
      size: 'auto',
      padding: 'large',
      content: <div>Hello</div>,
      onClose: () => onComplete(),
    },
```

### Notes for release

Added `size` and `padding` options to `modal` type Document Actions.