### PR TITLE
test(base): add preview observer tests

### DIFF
--- a/packages/@sanity/base/fixtures/clients.ts
+++ b/packages/@sanity/base/fixtures/clients.ts
@@ -1,0 +1,11 @@
+import createClient from '@sanity/client'
+
+export const clientV1 = createClient({
+  // eslint-disable-next-line no-process-env
+  token: process.env.CYPRESS_SANITY_SESSION_TOKEN,
+  apiVersion: '1',
+  projectId: 'ppsg7ml5',
+  dataset: 'test',
+  useCdn: false,
+  ignoreBrowserTokenWarning: true,
+})

--- a/packages/@sanity/base/jest.config.js
+++ b/packages/@sanity/base/jest.config.js
@@ -1,10 +1,11 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 module.exports = {
   testRegex: 'test\\/.*\\.test\\.(js|ts)$',
   testURL: 'http://localhost/',
+  setupFiles: ['./setup-jest.js'],
   moduleNameMapper: {
-    '^part:@sanity/base/schema?': '<rootDir>/test/mocks/schema.js',
-    '^part:@sanity/base/client': '<rootDir>/test/mocks/client.js',
-    '^part:@sanity/base/initial-value-templates?': '<rootDir>/test/mocks/templates.js',
+    '^part:@sanity/base/schema?': '<rootDir>/test/mocks/schema',
+    '^part:@sanity/base/client': '<rootDir>/test/mocks/client',
+    '^part:@sanity/base/initial-value-templates?': '<rootDir>/test/mocks/templates',
+    '^part:@sanity/base/util/search-utils$': '<rootDir>/src/util/searchUtils',
   },
 }

--- a/packages/@sanity/base/setup-jest.js
+++ b/packages/@sanity/base/setup-jest.js
@@ -1,0 +1,4 @@
+const path = require('path')
+const dotenv = require('dotenv')
+
+dotenv.config({path: path.resolve(__dirname, '../../../.env')})

--- a/packages/@sanity/base/src/preview/components/ObserveForPreview.tsx
+++ b/packages/@sanity/base/src/preview/components/ObserveForPreview.tsx
@@ -62,7 +62,6 @@ const connect = (props$: Observable<OuterProps>): Observable<ReceivedProps> => {
         observeForPreview(
           props.value,
           props.type,
-          props.fields,
           props.ordering ? {ordering: props.ordering} : {}
         ).pipe(
           map((result) => ({

--- a/packages/@sanity/base/src/preview/constants.ts
+++ b/packages/@sanity/base/src/preview/constants.ts
@@ -1,5 +1,0 @@
-export const INCLUDE_FIELDS_QUERY = ['_id', '_rev', '_type']
-export const INCLUDE_FIELDS = [...INCLUDE_FIELDS_QUERY, '_key']
-
-export const INVALID_PREVIEW_CONFIG = Symbol('invalid preview config')
-export const INSUFFICIENT_PERMISSIONS = Symbol('insufficient permissions')

--- a/packages/@sanity/base/src/preview/constants.ts
+++ b/packages/@sanity/base/src/preview/constants.ts
@@ -2,3 +2,4 @@ export const INCLUDE_FIELDS_QUERY = ['_id', '_rev', '_type']
 export const INCLUDE_FIELDS = [...INCLUDE_FIELDS_QUERY, '_key']
 
 export const INVALID_PREVIEW_CONFIG = Symbol('invalid preview config')
+export const INSUFFICIENT_PERMISSIONS = Symbol('insufficient permissions')

--- a/packages/@sanity/base/src/preview/constants.tsx
+++ b/packages/@sanity/base/src/preview/constants.tsx
@@ -7,18 +7,16 @@ import {PreparedValue} from './prepareForPreview'
 export const INCLUDE_FIELDS_QUERY = ['_id', '_rev', '_type']
 export const INCLUDE_FIELDS = [...INCLUDE_FIELDS_QUERY, '_key']
 
-// The `<small>` element is used for more compatibility
-// with the different downstream preview components
-const SmallText = styled.small`
-  color: ${({theme}) => theme.sanity.color.muted.default.enabled.fg};
+// NOTE: have to use color inherit to make it work correctly with the
+// `isSelected` state in the list pane
+const IconSizer = styled(Text)`
+  color: inherit;
 `
 
 function IconWrapper({children}: {children: React.ReactNode}) {
   return (
     <Flex>
-      <Text muted size={3}>
-        {children}
-      </Text>
+      <IconSizer size={3}>{children}</IconSizer>
     </Flex>
   )
 }
@@ -26,8 +24,10 @@ function IconWrapper({children}: {children: React.ReactNode}) {
 export class InsufficientPermissionsError extends Error {}
 
 export const INVALID_PREVIEW_FALLBACK: PreparedValue = {
-  title: <SmallText>Invalid preview config</SmallText>,
-  subtitle: <SmallText>Check the error log in the console</SmallText>,
+  // The `<small>` element is used for more compatibility
+  // with the different downstream preview components.
+  title: <small>Invalid preview config</small>,
+  subtitle: <small>Check the error log in the console</small>,
   media: (
     <IconWrapper>
       <WarningOutlineIcon />
@@ -37,7 +37,9 @@ export const INVALID_PREVIEW_FALLBACK: PreparedValue = {
 }
 
 export const INSUFFICIENT_PERMISSIONS_FALLBACK: PreparedValue = {
-  title: <SmallText>Insufficient permissions to access this reference</SmallText>,
+  // The `<small>` element is used for more compatibility
+  // with the different downstream preview components.
+  title: <small>Insufficient permissions to access this reference</small>,
   media: (
     <IconWrapper>
       <AccessDeniedIcon />

--- a/packages/@sanity/base/src/preview/constants.tsx
+++ b/packages/@sanity/base/src/preview/constants.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import styled from 'styled-components'
+import {Flex, Text} from '@sanity/ui'
+import {WarningOutlineIcon, AccessDeniedIcon} from '@sanity/icons'
+import {PreparedValue} from './prepareForPreview'
+
+export const INCLUDE_FIELDS_QUERY = ['_id', '_rev', '_type']
+export const INCLUDE_FIELDS = [...INCLUDE_FIELDS_QUERY, '_key']
+
+// The `<small>` element is used for more compatibility
+// with the different downstream preview components
+const SmallText = styled.small`
+  color: ${({theme}) => theme.sanity.color.muted.default.enabled.fg};
+`
+
+function IconWrapper({children}: {children: React.ReactNode}) {
+  return (
+    <Flex>
+      <Text muted size={3}>
+        {children}
+      </Text>
+    </Flex>
+  )
+}
+
+export class InsufficientPermissionsError extends Error {}
+
+export const INVALID_PREVIEW_FALLBACK: PreparedValue = {
+  title: <SmallText>Invalid preview config</SmallText>,
+  subtitle: <SmallText>Check the error log in the console</SmallText>,
+  media: (
+    <IconWrapper>
+      <WarningOutlineIcon />
+    </IconWrapper>
+  ),
+  meta: {type: 'invalid_preview'},
+}
+
+export const INSUFFICIENT_PERMISSIONS_FALLBACK: PreparedValue = {
+  title: <SmallText>Insufficient permissions to access this reference</SmallText>,
+  media: (
+    <IconWrapper>
+      <AccessDeniedIcon />
+    </IconWrapper>
+  ),
+  meta: {type: 'insufficient_permissions'},
+}

--- a/packages/@sanity/base/src/preview/constants.tsx
+++ b/packages/@sanity/base/src/preview/constants.tsx
@@ -33,7 +33,7 @@ export const INVALID_PREVIEW_FALLBACK: PreparedValue = {
       <WarningOutlineIcon />
     </IconWrapper>
   ),
-  meta: {type: 'invalid_preview'},
+  _meta: {type: 'invalid_preview'},
 }
 
 export const INSUFFICIENT_PERMISSIONS_FALLBACK: PreparedValue = {
@@ -45,5 +45,5 @@ export const INSUFFICIENT_PERMISSIONS_FALLBACK: PreparedValue = {
       <AccessDeniedIcon />
     </IconWrapper>
   ),
-  meta: {type: 'insufficient_permissions'},
+  _meta: {type: 'insufficient_permissions'},
 }

--- a/packages/@sanity/base/src/preview/constants.tsx
+++ b/packages/@sanity/base/src/preview/constants.tsx
@@ -33,7 +33,7 @@ export const INVALID_PREVIEW_FALLBACK: PreparedValue = {
       <WarningOutlineIcon />
     </IconWrapper>
   ),
-  _meta: {type: 'invalid_preview'},
+  _internalMeta: {type: 'invalid_preview'},
 }
 
 export const INSUFFICIENT_PERMISSIONS_FALLBACK: PreparedValue = {
@@ -45,5 +45,5 @@ export const INSUFFICIENT_PERMISSIONS_FALLBACK: PreparedValue = {
       <AccessDeniedIcon />
     </IconWrapper>
   ),
-  _meta: {type: 'insufficient_permissions'},
+  _internalMeta: {type: 'insufficient_permissions'},
 }

--- a/packages/@sanity/base/src/preview/createPathObserver.ts
+++ b/packages/@sanity/base/src/preview/createPathObserver.ts
@@ -87,6 +87,10 @@ function observePaths(value: Value, paths: Path[], observeFields: ObserveFieldsF
     {...value}
   )
 
+  // NOTE: there may be a bug here.
+  // if an object is passed into `observePaths` and that object contains every
+  // path, those selections will never be sent to `observeFields` and will not
+  // receive update
   return observableOf(next).pipe(props({wait: true}))
 }
 

--- a/packages/@sanity/base/src/preview/createPreviewObserver.ts
+++ b/packages/@sanity/base/src/preview/createPreviewObserver.ts
@@ -2,7 +2,7 @@ import {of as observableOf, Observable} from 'rxjs'
 import {map, switchMap, catchError} from 'rxjs/operators'
 import {isReferenceSchemaType, ReferenceSchemaType, SchemaType} from '@sanity/types'
 import prepareForPreview, {invokePrepare, PreparedValue} from './prepareForPreview'
-import {Reference, PrepareViewOptions} from './types'
+import {Reference, PrepareViewOptions, Path} from './types'
 import {INSUFFICIENT_PERMISSIONS_FALLBACK, InsufficientPermissionsError} from './constants'
 
 const INSUFFICIENT_PERMISSIONS = Symbol('INSUFFICIENT_PERMISSIONS')
@@ -14,7 +14,7 @@ export interface PreparedSnapshot {
 
 // Takes a value and its type and prepares a snapshot for it that can be passed to a preview component
 export function createPreviewObserver(
-  observePaths: (value: any, paths: Array<string[]>) => any,
+  observePaths: (value: any, paths: Path[]) => any,
   resolveRefType: (
     value: Reference,
     ownerType: ReferenceSchemaType

--- a/packages/@sanity/base/src/preview/createPreviewObserver.ts
+++ b/packages/@sanity/base/src/preview/createPreviewObserver.ts
@@ -64,13 +64,7 @@ export function createPreviewObserver(
       return observePaths(value, paths).pipe(
         map((snapshot) => ({
           type: type,
-          snapshot:
-            snapshot &&
-            prepareForPreview({
-              rawValue: snapshot,
-              type,
-              viewOptions,
-            }),
+          snapshot: snapshot && prepareForPreview(snapshot, type, viewOptions),
         }))
       )
     }

--- a/packages/@sanity/base/src/preview/prepareForPreview.ts
+++ b/packages/@sanity/base/src/preview/prepareForPreview.ts
@@ -22,7 +22,7 @@ export type PreparedValue = {
    * currently used to add a flag for the invalid preview error fallback and
    * insufficient permissions fallback
    */
-  meta?: {type?: string}
+  _meta?: {type?: string}
 }
 
 export type PrepareInvocationResult = {

--- a/packages/@sanity/base/src/preview/prepareForPreview.ts
+++ b/packages/@sanity/base/src/preview/prepareForPreview.ts
@@ -22,7 +22,7 @@ export type PreparedValue = {
    * currently used to add a flag for the invalid preview error fallback and
    * insufficient permissions fallback
    */
-  _meta?: {type?: string}
+  _internalMeta?: {type?: string}
 }
 
 export type PrepareInvocationResult = {

--- a/packages/@sanity/base/src/preview/prepareForPreview.ts
+++ b/packages/@sanity/base/src/preview/prepareForPreview.ts
@@ -1,6 +1,6 @@
-// @flow
+import type {SchemaType} from '@sanity/types'
 import {debounce, flatten, get, isPlainObject, pick, uniqBy} from 'lodash'
-import {INVALID_PREVIEW_CONFIG} from './constants'
+import {INVALID_PREVIEW_FALLBACK} from './constants'
 import {isPortableTextArray, extractTextFromBlocks} from './utils/portableText'
 import {PrepareViewOptions, Type} from './types'
 import {keysOf} from './utils/keysOf'
@@ -10,10 +10,19 @@ const EMPTY = []
 
 type SelectedValue = Record<string, unknown>
 
+// TODO: unify types with `@sanity/form-builder`
+// see `PreviewSnapshot` in `usePreviewSnapshot`
 export type PreparedValue = {
-  title: string
-  subtitle: string
-  description: string
+  title?: React.ReactNode
+  subtitle?: React.ReactNode
+  description?: React.ReactNode
+  media?: React.ReactNode
+  /**
+   * optional object used to attach meta data to the prepared result.
+   * currently used to add a flag for the invalid preview error fallback and
+   * insufficient permissions fallback
+   */
+  meta?: {type?: string}
 }
 
 export type PrepareInvocationResult = {
@@ -212,15 +221,25 @@ export function invokePrepare(
   }
 }
 
-function withErrors(result, type, selectedValue) {
+function withErrors(result, type, selectedValue): PreparedValue {
   result.errors.forEach((error) => errorCollector.add(type, selectedValue, error))
   reportErrors()
 
-  return INVALID_PREVIEW_CONFIG
+  return INVALID_PREVIEW_FALLBACK
 }
 
-export default function prepareForPreview(rawValue, type, viewOptions): symbol | PreparedValue {
-  const selection = type.preview.select
+interface PrepareForPreviewOptions {
+  rawValue: unknown
+  type: SchemaType
+  viewOptions?: PrepareViewOptions
+}
+
+export default function prepareForPreview({
+  rawValue,
+  type,
+  viewOptions = {},
+}: PrepareForPreviewOptions): PreparedValue {
+  const selection = type.preview?.select || {}
   const targetKeys = Object.keys(selection)
 
   const selectedValue = targetKeys.reduce((acc, key) => {
@@ -246,5 +265,5 @@ export default function prepareForPreview(rawValue, type, viewOptions): symbol |
   const returnValueResult = validateReturnedPreview(invokePrepare(type, selectedValue, viewOptions))
   return returnValueResult.errors.length > 0
     ? withErrors(returnValueResult, type, selectedValue)
-    : ({...pick(rawValue, PRESERVE_KEYS), ...prepareResult.returnValue} as PreparedValue)
+    : {...pick(rawValue, PRESERVE_KEYS), ...prepareResult.returnValue}
 }

--- a/packages/@sanity/base/src/preview/prepareForPreview.ts
+++ b/packages/@sanity/base/src/preview/prepareForPreview.ts
@@ -228,28 +228,28 @@ function withErrors(result, type, selectedValue): PreparedValue {
   return INVALID_PREVIEW_FALLBACK
 }
 
-interface PrepareForPreviewOptions {
-  rawValue: unknown
-  type: SchemaType
-  viewOptions?: PrepareViewOptions
-}
-
-export default function prepareForPreview({
-  rawValue,
-  type,
-  viewOptions = {},
-}: PrepareForPreviewOptions): PreparedValue {
+export default function prepareForPreview(
+  rawValue: unknown,
+  type: SchemaType,
+  viewOptions: PrepareViewOptions = {}
+): PreparedValue {
   const selection = type.preview?.select || {}
   const targetKeys = Object.keys(selection)
 
   const selectedValue = targetKeys.reduce((acc, key) => {
     // Find the field the value belongs to
-    const valueField = type?.fields?.find((f) => f.name === selection[key])
+    const typeWithFields = 'fields' in type ? type : null
+    const valueField = typeWithFields?.fields?.find((f) => f.name === selection[key])
+
     // Check if predefined options exist
-    const listOptions = valueField?.type?.options?.list
+    const options = valueField?.type?.options
+    const listOptions = options && typeof options === 'object' ? (options as any).list : null
+
     if (listOptions) {
       // Find the selected option that matches the raw value
-      const selectedOption = listOptions.find((opt) => opt.value === rawValue[selection[key]])
+      const selectedOption = listOptions.find(
+        (opt) => opt.value === (rawValue as any)[selection[key]]
+      )
       acc[key] = get(selectedOption, key)
       return acc
     }

--- a/packages/@sanity/base/src/preview/utils/resolveRefType.ts
+++ b/packages/@sanity/base/src/preview/utils/resolveRefType.ts
@@ -2,7 +2,7 @@ import {from as observableFrom, Observable} from 'rxjs'
 import {map} from 'rxjs/operators'
 import {Reference, ReferenceSchemaType, SchemaType} from '@sanity/types'
 import {versionedClient} from '../../client/versionedClient'
-import {INSUFFICIENT_PERMISSIONS} from '../constants'
+import {InsufficientPermissionsError} from '../constants'
 
 // todo: use a LRU cache instead (e.g. hashlru or quick-lru)
 const CACHE: Record<string, Promise<string | null>> = Object.create(null)
@@ -21,10 +21,15 @@ function resolveRefTypeName(reference: Reference): Observable<string | null> {
 export default function resolveRefType(
   value: Reference,
   type: ReferenceSchemaType
-): Observable<SchemaType | typeof INSUFFICIENT_PERMISSIONS | undefined> {
+): Observable<SchemaType | undefined> {
   return resolveRefTypeName(value).pipe(
     map((refTypeName) => {
-      if (!refTypeName && !type.weak) return INSUFFICIENT_PERMISSIONS
+      if (!refTypeName && !type.weak) {
+        throw new InsufficientPermissionsError(
+          `Could not resolve _type ${refTypeName} and the reference was marked as weak.`
+        )
+      }
+
       return type.to.find((toType) => toType.name === refTypeName)
     })
   )

--- a/packages/@sanity/base/test/observeFields.test.ts
+++ b/packages/@sanity/base/test/observeFields.test.ts
@@ -1,0 +1,102 @@
+import {v4 as uuid} from 'uuid'
+import {first, take, toArray} from 'rxjs/operators'
+import {clientV1 as client} from '../fixtures/clients'
+import observeFields, {__INTERNAL_CLOSE as close} from '../src/preview/observeFields'
+
+const createId = () => `test.doc.delete.me.${uuid()}`
+const wait = (milliseconds: number) => new Promise((resolve) => setTimeout(resolve, milliseconds))
+
+jest.setTimeout(30 * 1000)
+jest.mock('part:@sanity/base/client', () => require('../fixtures/clients').clientV1)
+
+describe('observeFields', () => {
+  afterAll(async () => {
+    close()
+    await client.mutate([{delete: {query: '*[_id match "test.doc.delete.me"]'}}])
+  })
+
+  it('takes in an ID and an array of fields and returns an observable', async () => {
+    const id = createId()
+
+    const testDoc = {
+      _id: id,
+      _type: 'tempTestDocObserveFields',
+      name: 'testing',
+      otherValue: 'foo',
+    }
+
+    await client.createOrReplace(testDoc)
+
+    const result = await observeFields(
+      id,
+      // only watch the name field
+      ['name']
+    )
+      .pipe(first())
+      .toPromise()
+
+    expect(result).toHaveProperty('name')
+    expect(result.name).toBe(testDoc.name)
+    expect(result).not.toHaveProperty('otherValue')
+
+    expect(Object.keys(result).sort()).toMatchInlineSnapshot(`
+      Array [
+        "_id",
+        "_rev",
+        "_type",
+        "name",
+      ]
+    `)
+  })
+
+  it('pushes new values down as they update', async () => {
+    const id = createId()
+
+    const testDoc = {
+      _id: id,
+      _type: 'tempTestDocObserveFields',
+      name: 'testing',
+      otherValue: 'foo',
+    }
+
+    await client.createOrReplace(testDoc)
+
+    const resultPromise = observeFields(
+      id,
+      // only watch the name field
+      ['name']
+    )
+      .pipe(take(3), toArray())
+      .toPromise()
+
+    await client.patch(id, {set: {name: 'testing CHANGED'}}).commit()
+    await wait(500)
+
+    await client.patch(id, {set: {otherValue: 'foo CHANGED'}}).commit()
+    await wait(500)
+
+    await client.patch(id, {set: {name: 'testing CHANGED AGAIN'}}).commit()
+    await wait(500)
+
+    const result = await resultPromise
+
+    expect(result.length).toBe(3)
+    const [a, b, c] = result
+
+    expect(Object.keys({...a, ...b, ...c}).sort()).toMatchInlineSnapshot(`
+      Array [
+        "_id",
+        "_rev",
+        "_type",
+        "name",
+      ]
+    `)
+
+    // first emission is the initial value
+    expect(a.name).toBe('testing')
+    // second value is the testing CHANGED (note: otherValue is not watched)
+    expect(b.name).toBe('testing CHANGED')
+    // third value is the last emission
+    expect(c.name).toBe('testing CHANGED AGAIN')
+  })
+})

--- a/packages/@sanity/base/test/observeForPreview.test.ts
+++ b/packages/@sanity/base/test/observeForPreview.test.ts
@@ -1,0 +1,521 @@
+import {SchemaType, ReferenceSchemaType} from '@sanity/types'
+import {first, take, toArray, share, delay} from 'rxjs/operators'
+import {v4 as uuid} from 'uuid'
+import {clientV1 as client} from '../fixtures/clients'
+import observeFields, {__INTERNAL_CLOSE as close} from '../src/preview/observeFields'
+import {createPreviewObserver} from '../src/preview/createPreviewObserver'
+import {createPathObserver} from '../src/preview/createPathObserver'
+import resolveRefType from '../src/preview/utils/resolveRefType'
+import {INSUFFICIENT_PERMISSIONS_FALLBACK, INVALID_PREVIEW_FALLBACK} from '../src/preview/constants'
+
+const observePaths = createPathObserver(observeFields)
+const observeForPreview = createPreviewObserver(observePaths, resolveRefType)
+
+const createId = () => `test.doc.delete.me.${uuid()}`
+const wait = (milliseconds: number) => new Promise((resolve) => setTimeout(resolve, milliseconds))
+
+jest.setTimeout(30 * 1000)
+jest.mock('part:@sanity/base/client', () => require('../fixtures/clients').clientV1)
+
+describe('createPreviewObserver', () => {
+  afterAll(async () => {
+    close()
+    await client.mutate([{delete: {query: '*[_id match "test.doc.delete.me"]'}}])
+  })
+
+  it('returns an observable factory that takes in a value and returns a prepared preview snapshot stream', async () => {
+    const mockValue = {name: 'Name'}
+    const mockType: SchemaType = {
+      jsonType: 'object',
+      name: 'object',
+      // @ts-expect-error types are not accurate to usage
+      preview: {select: {title: 'name'}},
+      fields: [
+        {
+          name: 'name',
+          type: {name: 'name', jsonType: 'string'},
+        },
+      ],
+    }
+
+    const result = await observeForPreview(mockValue, mockType).pipe(first()).toPromise()
+
+    expect(result).toEqual({
+      snapshot: {title: 'Name'},
+      type: mockType,
+    })
+  })
+
+  it('works with no preview config', async () => {
+    const mockValue = {title: 'Title'}
+    const mockType: SchemaType = {
+      jsonType: 'object',
+      name: 'object',
+      fields: [
+        {
+          name: 'title',
+          type: {name: 'title', jsonType: 'string'},
+        },
+      ],
+    }
+
+    const result = await observeForPreview(mockValue, mockType).pipe(first()).toPromise()
+
+    expect(result).toEqual({
+      snapshot: {title: 'Title'},
+      type: mockType,
+    })
+  })
+
+  it('returns a null snapshot with a non-object value', async () => {
+    const mockType: SchemaType = {
+      jsonType: 'object',
+      name: 'object',
+      fields: [
+        {
+          name: 'title',
+          type: {name: 'title', jsonType: 'string'},
+        },
+      ],
+    }
+
+    const result = await observeForPreview('title', mockType).pipe(first()).toPromise()
+
+    expect(result).toEqual({
+      snapshot: null,
+      type: mockType,
+    })
+  })
+
+  it('utilizes the schema preview selection and prepare', async () => {
+    const mockValue = {name: 'Name'}
+    const mockType: SchemaType = {
+      jsonType: 'object',
+      name: 'object',
+      preview: {
+        select: {title: 'name'},
+        prepare: ({title}) => ({title: `cool ${title}`}),
+      },
+      fields: [
+        {
+          name: 'name',
+          type: {name: 'name', jsonType: 'string'},
+        },
+      ],
+    }
+
+    const result = await observeForPreview(mockValue, mockType).pipe(first()).toPromise()
+
+    expect(result).toEqual({
+      snapshot: {title: 'cool Name'},
+      type: mockType,
+    })
+  })
+
+  it('watches for changes for the selected preview values', async () => {
+    const id = createId()
+
+    await client.createOrReplace({
+      _id: id,
+      _type: 'tempTestDocObserveForPreview',
+      name: 'Name',
+      otherValue: 'foo',
+    })
+
+    const mockType: SchemaType = {
+      jsonType: 'object',
+      name: 'tempTestDocObserveForPreview',
+      // @ts-expect-error types are not accurate to usage
+      preview: {select: {title: 'name'}},
+      fields: [
+        {
+          name: 'name',
+          type: {name: 'name', jsonType: 'string'},
+        },
+        {
+          name: 'otherValue',
+          type: {name: 'otherValue', jsonType: 'string'},
+        },
+      ],
+    }
+
+    const shared = observeForPreview(id, mockType).pipe(delay(1000), share())
+    const resultPromise = shared.pipe(take(2), toArray()).toPromise()
+    await shared.pipe(first()).toPromise() // wait for next one
+
+    await client.patch(id, {set: {name: 'Name CHANGED'}}).commit()
+    await shared.pipe(first()).toPromise() // wait for next one
+
+    const result = await resultPromise
+
+    expect(result).toHaveLength(2)
+    const [a, b] = result
+
+    expect(a).toEqual({
+      snapshot: {
+        _id: id,
+        _type: 'tempTestDocObserveForPreview',
+        title: 'Name',
+      },
+      type: mockType,
+    })
+
+    expect(b).toEqual({
+      snapshot: {
+        _id: id,
+        _type: 'tempTestDocObserveForPreview',
+        title: 'Name CHANGED',
+      },
+      type: mockType,
+    })
+  })
+
+  it('resolves and updates references', async () => {
+    const refId = createId()
+
+    const refDoc = {
+      _id: refId,
+      _type: 'tempTestDocObservePathsRef',
+      name: 'testing ref',
+      otherValue: 'foo',
+    }
+
+    await client.createOrReplace(refDoc)
+    await wait(1000)
+
+    const mockType: ReferenceSchemaType = {
+      jsonType: 'object',
+      name: 'tempTestDocObserveForPreview',
+      to: [
+        {
+          // @ts-expect-error types are not accurate to usage
+          preview: {select: {title: 'name'}},
+          jsonType: 'object',
+          name: 'tempTestDocObservePathsRef',
+          fields: [
+            {
+              name: 'name',
+              type: {name: 'name', jsonType: 'string'},
+            },
+          ],
+        },
+      ],
+      fields: [
+        {
+          name: '_ref',
+          type: {name: '_ref', jsonType: 'string'},
+        },
+        {
+          name: '_type',
+          type: {name: '_type', jsonType: 'string'},
+        },
+      ],
+    }
+
+    const shared = observeForPreview({_ref: refId}, mockType).pipe(delay(1000), share())
+    const resultPromise = shared.pipe(take(2), toArray()).toPromise()
+    await shared.pipe(first()).toPromise() // wait for next one
+
+    await client.patch(refId, {set: {name: 'testing ref CHANGED'}}).commit()
+    await shared.pipe(first()).toPromise() // wait for next one
+
+    const result = await resultPromise
+    expect(result).toHaveLength(2)
+
+    const [a, b] = result
+
+    expect(a).toEqual({
+      type: mockType.to[0],
+      snapshot: {
+        _id: refId,
+        _type: 'tempTestDocObservePathsRef',
+        title: 'testing ref',
+      },
+    })
+
+    expect(b).toEqual({
+      type: mockType.to[0],
+      snapshot: {
+        _id: refId,
+        _type: 'tempTestDocObservePathsRef',
+        title: 'testing ref CHANGED',
+      },
+    })
+  })
+
+  it('resolves to a null snapshot if `_ref` is not found', async () => {
+    const mockType: ReferenceSchemaType = {
+      jsonType: 'object',
+      name: 'tempTestDocObserveForPreview',
+      to: [
+        {
+          // @ts-expect-error types are not accurate to usage
+          preview: {select: {title: 'name'}},
+          jsonType: 'object',
+          name: 'tempTestDocObservePathsRef',
+          fields: [
+            {
+              name: 'name',
+              type: {name: 'name', jsonType: 'string'},
+            },
+          ],
+        },
+      ],
+      fields: [
+        {
+          name: '_ref',
+          type: {name: '_ref', jsonType: 'string'},
+        },
+        {
+          name: '_type',
+          type: {name: '_type', jsonType: 'string'},
+        },
+      ],
+    }
+
+    const result = await observeForPreview({}, mockType).toPromise()
+
+    // notice how there is no type
+    expect(result).toEqual({snapshot: null})
+  })
+
+  it('resolves to a null snapshot + parent type if no matching ref type is found', async () => {
+    const refId = createId()
+
+    const refDoc = {
+      _id: refId,
+      _type: 'tempTestDocObservePathsRef',
+      name: 'testing ref',
+      otherValue: 'foo',
+    }
+
+    const mockType: ReferenceSchemaType = {
+      jsonType: 'object',
+      name: 'tempTestDocObserveForPreview',
+      to: [
+        // NOTE: no matching types will cause the returned snapshot to be null
+      ],
+      fields: [
+        {
+          name: '_ref',
+          type: {name: '_ref', jsonType: 'string'},
+        },
+        {
+          name: '_type',
+          type: {name: '_type', jsonType: 'string'},
+        },
+      ],
+    }
+
+    await client.createOrReplace(refDoc)
+    await wait(1000)
+
+    const result = await observeForPreview({_ref: refId}, mockType).toPromise()
+
+    // notice how there is no type
+    expect(result).toEqual({snapshot: null, type: mockType})
+  })
+
+  it('resolves and updates previews with references paths and a prepare function', async () => {
+    const refId = createId()
+    const id = createId()
+
+    const refDoc = {
+      _id: refId,
+      _type: 'tempTestDocObservePathsRef',
+      name: 'testing ref',
+      otherValue: 'foo',
+    }
+
+    const testDoc = {
+      _id: id,
+      _type: 'tempTestDocObservePaths',
+      name: 'testing',
+      otherValueTwo: 'bar',
+      reference: {
+        _type: 'reference',
+        _ref: refId,
+      },
+    }
+
+    await client.createOrReplace(refDoc)
+    await wait(1000)
+
+    await client.createOrReplace(testDoc)
+    await wait(1000)
+
+    const mockType: SchemaType = {
+      jsonType: 'object',
+      name: 'tempTestDocObserveForPreview',
+      preview: {
+        // @ts-expect-error types are not accurate to usage
+        select: {foo: 'reference.name'},
+        // @ts-expect-error types are not accurate to usage
+        prepare: ({foo}) => ({title: foo, subtitle: 'hard-coded'}),
+      },
+      fields: [
+        {
+          name: 'name',
+          type: {name: 'name', jsonType: 'string'},
+        },
+        {
+          name: 'otherValue',
+          type: {name: 'otherValue', jsonType: 'string'},
+        },
+        {
+          name: 'reference',
+          type: {
+            name: 'reference',
+            jsonType: 'object',
+            fields: [
+              {
+                name: '_ref',
+                type: {name: '_ref', jsonType: 'string'},
+              },
+              {
+                name: '_type',
+                type: {name: '_type', jsonType: 'string'},
+              },
+            ],
+          },
+        },
+      ],
+    }
+
+    const shared = observeForPreview(id, mockType).pipe(delay(1000), share())
+    const resultPromise = shared.pipe(take(3), toArray()).toPromise()
+    await shared.pipe(first()).toPromise() // wait for next one
+
+    await client.patch(id, {set: {name: 'testing CHANGED'}}).commit()
+    await shared.pipe(first()).toPromise() // wait for next one
+
+    await client.patch(refId, {set: {name: 'testing ref CHANGED'}}).commit()
+    await shared.pipe(first()).toPromise() // wait for next one
+
+    const result = await resultPromise
+    expect(result).toHaveLength(3)
+
+    const [a, b, c] = result
+
+    expect(a).toEqual({
+      type: mockType,
+      snapshot: {
+        _id: id,
+        _type: 'tempTestDocObservePaths',
+        title: 'testing ref',
+        subtitle: 'hard-coded',
+      },
+    })
+
+    expect(b).toEqual({
+      type: mockType,
+      snapshot: {
+        _id: id,
+        _type: 'tempTestDocObservePaths',
+        title: 'testing ref',
+        subtitle: 'hard-coded',
+      },
+    })
+
+    expect(c).toEqual({
+      type: mockType,
+      snapshot: {
+        _id: id,
+        _type: 'tempTestDocObservePaths',
+        title: 'testing ref CHANGED',
+        subtitle: 'hard-coded',
+      },
+    })
+  })
+
+  it('resolves to an insufficient permissions fallback if ref is non-existence but marked as strong', async () => {
+    const nonexistentId = createId()
+    const id = createId()
+
+    const mockType: ReferenceSchemaType = {
+      jsonType: 'object',
+      weak: false,
+      name: 'tempTestDocObserveForPreview',
+      // @ts-expect-error types are not accurate to usage
+      preview: {select: {title: 'name'}},
+      to: [
+        {
+          jsonType: 'object',
+          name: 'reference',
+          fields: [{name: 'name', type: {name: 'name', jsonType: 'string'}}],
+        },
+      ],
+      fields: [
+        {
+          name: '_ref',
+          type: {name: '_ref', jsonType: 'string'},
+        },
+        {
+          name: '_type',
+          type: {name: '_type', jsonType: 'string'},
+        },
+      ],
+    }
+
+    const testDoc = {
+      _id: id,
+      _type: 'tempTestDocObservePaths',
+      name: 'testing',
+      otherValueTwo: 'bar',
+      reference: {
+        _type: 'reference',
+        _weak: true,
+        _ref: nonexistentId,
+      },
+    }
+
+    await client.createOrReplace(testDoc)
+    await wait(1000)
+
+    const result = await observeForPreview({_ref: nonexistentId}, mockType)
+      .pipe(first())
+      .toPromise()
+
+    expect(result).toEqual({
+      type: mockType,
+      snapshot: INSUFFICIENT_PERMISSIONS_FALLBACK,
+    })
+  })
+
+  it('resolves to an invalid preview fallback if the prepare function throws', async () => {
+    const id = createId()
+
+    const mockType: SchemaType = {
+      jsonType: 'object',
+      name: 'tempTestDocObserveForPreview',
+      preview: {
+        select: {title: 'name'},
+        prepare: () => {
+          throw new Error()
+        },
+      },
+      fields: [
+        {
+          name: 'name',
+          type: {name: 'name', jsonType: 'string'},
+        },
+      ],
+    }
+
+    const testDoc = {
+      _id: id,
+      _type: 'tempTestDocObservePaths',
+      name: 'testing',
+    }
+
+    await client.createOrReplace(testDoc)
+    await wait(1000)
+
+    const result = await observeForPreview(id, mockType).pipe(first()).toPromise()
+
+    expect(result).toEqual({
+      type: mockType,
+      snapshot: INVALID_PREVIEW_FALLBACK,
+    })
+  })
+})

--- a/packages/@sanity/base/test/observePaths.test.ts
+++ b/packages/@sanity/base/test/observePaths.test.ts
@@ -1,0 +1,205 @@
+import {v4 as uuid} from 'uuid'
+import {first, take, toArray, share, delay} from 'rxjs/operators'
+import {clientV1 as client} from '../fixtures/clients'
+import observeFields, {__INTERNAL_CLOSE as close} from '../src/preview/observeFields'
+import {createPathObserver} from '../src/preview/createPathObserver'
+
+const observePaths = createPathObserver(observeFields)
+const wait = (milliseconds: number) => new Promise((resolve) => setTimeout(resolve, milliseconds))
+
+const createId = () => `test.doc.delete.me.${uuid()}`
+
+jest.setTimeout(30 * 1000)
+jest.mock('part:@sanity/base/client', () => require('../fixtures/clients').clientV1)
+
+describe('observePaths', () => {
+  afterAll(async () => {
+    close()
+    await client.mutate([{delete: {query: '*[_id match "test.doc.delete.me"]'}}])
+  })
+
+  it('takes in a document ID and paths and returns a stream of resolved values', async () => {
+    const id = createId()
+    const testDoc = {
+      _id: id,
+      _type: 'tempTestDocObservePaths',
+      name: 'testing',
+      second: 'foo',
+      otherValue: 'bar',
+    }
+
+    await client.createOrReplace(testDoc)
+
+    const result = await observePaths(id, [['name'], ['second']])
+      .pipe(first())
+      .toPromise()
+
+    expect(Object.keys(result).sort()).toMatchInlineSnapshot(`
+      Array [
+        "_id",
+        "_rev",
+        "_type",
+        "name",
+        "second",
+      ]
+    `)
+
+    expect(result.name).toBe('testing')
+    expect(result.second).toBe('foo')
+    expect(result).not.toHaveProperty('otherValue')
+  })
+
+  it('recursively resolves references', async () => {
+    const refId = createId()
+    const id = createId()
+
+    const refDoc = {
+      _id: refId,
+      _type: 'tempTestDocObservePaths',
+      name: 'testing',
+      otherValue: 'foo',
+    }
+
+    const testDoc = {
+      _id: id,
+      _type: 'tempTestDocObservePaths',
+      name: 'testing',
+      reference: {
+        _type: 'reference',
+        _ref: refId,
+      },
+    }
+
+    await client.createOrReplace(refDoc)
+    await wait(500)
+
+    await client.createOrReplace(testDoc)
+    await wait(500)
+
+    const result = await observePaths(id, [['reference', 'name']])
+      .pipe(first())
+      .toPromise()
+
+    expect(result).toHaveProperty('reference')
+    expect(result.reference).toHaveProperty('name')
+
+    expect(Object.keys(result).sort()).toMatchInlineSnapshot(`
+      Array [
+        "_id",
+        "_rev",
+        "_type",
+        "reference",
+      ]
+    `)
+    expect(Object.keys(result.reference).sort()).toMatchInlineSnapshot(`
+      Array [
+        "_id",
+        "_rev",
+        "_type",
+        "name",
+      ]
+    `)
+  })
+
+  it('accepts paths with dots in them', async () => {
+    const refId = createId()
+    const id = createId()
+
+    const refDoc = {
+      _id: refId,
+      _type: 'tempTestDocObservePaths',
+      name: 'testing',
+      otherValue: 'foo',
+    }
+
+    const testDoc = {
+      _id: id,
+      _type: 'tempTestDocObservePaths',
+      name: 'testing',
+      reference: {
+        _type: 'reference',
+        _ref: refId,
+      },
+    }
+
+    await client.createOrReplace(refDoc)
+    await wait(500)
+
+    await client.createOrReplace(testDoc)
+    await wait(500)
+
+    const result = await observePaths(id, ['reference.name']).pipe(first()).toPromise()
+
+    expect(result).toHaveProperty('reference')
+    expect(result.reference).toHaveProperty('name')
+
+    expect(Object.keys(result).sort()).toMatchInlineSnapshot(`
+      Array [
+        "_id",
+        "_rev",
+        "_type",
+        "reference",
+      ]
+    `)
+    expect(Object.keys(result.reference).sort()).toMatchInlineSnapshot(`
+      Array [
+        "_id",
+        "_rev",
+        "_type",
+        "name",
+      ]
+    `)
+  })
+
+  it('pushes doc values when either the doc or the referenced doc updates', async () => {
+    const refId = createId()
+    const id = createId()
+
+    const refDoc = {
+      _id: refId,
+      _type: 'tempTestDocObservePaths',
+      name: 'testing',
+      otherValue: 'foo',
+    }
+
+    const testDoc = {
+      _id: id,
+      _type: 'tempTestDocObservePaths',
+      name: 'testing',
+      otherValueTwo: 'bar',
+      reference: {
+        _type: 'reference',
+        _ref: refId,
+      },
+    }
+
+    await client.createOrReplace(refDoc)
+    await wait(1000)
+
+    await client.createOrReplace(testDoc)
+    await wait(1000)
+
+    const shared = observePaths(id, [['name'], ['reference', 'name']]).pipe(delay(1000), share())
+    const resultPromise = shared.pipe(take(3), toArray()).toPromise()
+    await shared.pipe(first()).toPromise() // wait for next one
+
+    await client.patch(id, {set: {name: 'testing CHANGED'}}).commit()
+    await shared.pipe(first()).toPromise() // wait for next one
+
+    await client.patch(refId, {set: {name: 'testing CHANGED'}}).commit()
+    await shared.pipe(first()).toPromise() // wait for next one
+
+    const result = await resultPromise
+    expect(result).toHaveLength(3)
+    const [a, b, c] = result
+
+    expect(a.name).toBe('testing')
+    expect((a.reference as Record<string, unknown>).name).toBe('testing')
+
+    expect(b.name).toBe('testing CHANGED')
+    expect((b.reference as Record<string, unknown>).name).toBe('testing')
+
+    expect(c.name).toBe('testing CHANGED')
+    expect((c.reference as Record<string, unknown>).name).toBe('testing CHANGED')
+  })
+})

--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
@@ -111,17 +111,11 @@ export const ReferenceInput = forwardRef(function ReferenceInput(
 
   const weakIs = value?._weak ? 'weak' : 'strong'
   const weakShouldBe = type.weak === true ? 'weak' : 'strong'
+  const hasInsufficientPermissions = preview.snapshot?.meta?.type === 'insufficient_permissions'
   const isMissing =
-    !!value?._ref &&
-    !preview.isLoading &&
-    preview.snapshot &&
-    // TODO: this check would be cleaner if the INSUFFICIENT_PERMISSIONS symbol could be imported directly
-    typeof preview.snapshot !== 'object'
+    !hasInsufficientPermissions && !!value?._ref && !preview.isLoading && preview.snapshot
 
   const hasRef = value && value._ref
-
-  const hasInsufficientPermissions =
-    hasRef && isMissing && weakIs === 'strong' && weakShouldBe === 'strong'
 
   const handleFixStrengthMismatch = useCallback(() => {
     onChange(PatchEvent.from(type.weak === true ? set(true, ['_weak']) : unset(['_weak'])))

--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
@@ -111,7 +111,7 @@ export const ReferenceInput = forwardRef(function ReferenceInput(
 
   const weakIs = value?._weak ? 'weak' : 'strong'
   const weakShouldBe = type.weak === true ? 'weak' : 'strong'
-  const hasInsufficientPermissions = preview.snapshot?.meta?.type === 'insufficient_permissions'
+  const hasInsufficientPermissions = preview.snapshot?._meta?.type === 'insufficient_permissions'
   const isMissing =
     !hasInsufficientPermissions && !!value?._ref && !preview.isLoading && preview.snapshot
 

--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
@@ -109,11 +109,19 @@ export const ReferenceInput = forwardRef(function ReferenceInput(
 
   const preview = usePreviewSnapshot(value, getPreviewSnapshot)
 
-  const weakIs = value && value._weak ? 'weak' : 'strong'
+  const weakIs = value?._weak ? 'weak' : 'strong'
   const weakShouldBe = type.weak === true ? 'weak' : 'strong'
-  const isMissing = value?._ref && !preview.isLoading && preview.snapshot === null
+  const isMissing =
+    !!value?._ref &&
+    !preview.isLoading &&
+    preview.snapshot &&
+    // TODO: this check would be cleaner if the INSUFFICIENT_PERMISSIONS symbol could be imported directly
+    typeof preview.snapshot !== 'object'
 
   const hasRef = value && value._ref
+
+  const hasInsufficientPermissions =
+    hasRef && isMissing && weakIs === 'strong' && weakShouldBe === 'strong'
 
   const handleFixStrengthMismatch = useCallback(() => {
     onChange(PatchEvent.from(type.weak === true ? set(true, ['_weak']) : unset(['_weak'])))
@@ -170,12 +178,15 @@ export const ReferenceInput = forwardRef(function ReferenceInput(
       if (autocompleteValue === '') {
         return ''
       }
+      if (hasInsufficientPermissions) {
+        return '<insufficient permissions>'
+      }
       if (isMissing) {
-        return `<nonexistent document>`
+        return '<nonexistent document>'
       }
       return preview.isLoading ? 'Loading…' : preview.snapshot?.title || 'Untitled'
     },
-    [isMissing, preview]
+    [isMissing, hasInsufficientPermissions, preview]
   )
 
   const inputId = useId()
@@ -217,6 +228,15 @@ export const ReferenceInput = forwardRef(function ReferenceInput(
       description={type.description}
     >
       <Stack space={3}>
+        {hasInsufficientPermissions && (
+          <Alert title="Insufficient permissions to access this reference" status="warning">
+            <Text as="p" muted size={1}>
+              You don't have access to the referenced document. Please contact an admin for access
+              or remove this reference.
+            </Text>
+          </Alert>
+        )}
+
         {hasRef && !isMissing && weakIs !== weakShouldBe && (
           <Alert
             title="Reference strength mismatch"
@@ -258,7 +278,7 @@ export const ReferenceInput = forwardRef(function ReferenceInput(
           </Alert>
         )}
 
-        {value && isMissing && (
+        {value && isMissing && !hasInsufficientPermissions && (
           <Alert title="Nonexistent document reference" status="warning">
             <Text as="p" muted size={1}>
               This field is currently referencing a document that doesn't exist (ID:{' '}

--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
@@ -111,7 +111,8 @@ export const ReferenceInput = forwardRef(function ReferenceInput(
 
   const weakIs = value?._weak ? 'weak' : 'strong'
   const weakShouldBe = type.weak === true ? 'weak' : 'strong'
-  const hasInsufficientPermissions = preview.snapshot?._meta?.type === 'insufficient_permissions'
+  const hasInsufficientPermissions =
+    preview.snapshot?._internalMeta?.type === 'insufficient_permissions'
   const isMissing =
     !hasInsufficientPermissions && !!value?._ref && !preview.isLoading && preview.snapshot
 

--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/usePreviewSnapshot.ts
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/usePreviewSnapshot.ts
@@ -25,7 +25,7 @@ type PreviewSnapshot = {
   _type: string
   title: string
   description: string
-  meta?: {type?: string}
+  _meta?: {type?: string}
 }
 
 export function usePreviewSnapshot(

--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/usePreviewSnapshot.ts
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/usePreviewSnapshot.ts
@@ -18,11 +18,14 @@ const NULL_SNAPSHOT: SnapshotState = {
   snapshot: null,
 }
 
+// TODO: unify types with `@sanity/base`
+// see `PreparedValue` in `prepareForPreview`
 type PreviewSnapshot = {
   _id: string
   _type: string
   title: string
   description: string
+  meta?: {type?: string}
 }
 
 export function usePreviewSnapshot(

--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/usePreviewSnapshot.ts
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/usePreviewSnapshot.ts
@@ -25,7 +25,7 @@ type PreviewSnapshot = {
   _type: string
   title: string
   description: string
-  _meta?: {type?: string}
+  _internalMeta?: {type?: string}
 }
 
 export function usePreviewSnapshot(


### PR DESCRIPTION
### Description

This PR adds some test coverage for the preview observer. This was done on top of #2585 to ensure all the necessary cases were still working.

Note: these tests are integration tests because they actually call the API.

<img width="840" alt="CleanShot 2021-07-02 at 20 23 40@2x" src="https://user-images.githubusercontent.com/10551026/124337975-6bb9e900-db73-11eb-8bdd-717180df1ee6.png">

### What to review

Ensure this is the right approach and everything looks good 😁

I also updated some of `observeFields` in order to create some small hooks for closing and cleaning up after tests.

Update: Looks like the Cypress token used here does not have permission to create docs. We probably need to add another for this suite.
