### PR TITLE
fix(desk-tool): use the selected document revision as value for inspect document

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/documentPane/documentPane.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/documentPane.tsx
@@ -76,7 +76,7 @@ export function DocumentPane(props: DocumentPaneProps) {
   } = props
   const rootRef = useRef<HTMLDivElement | null>(null)
   const features = useDeskToolFeatures()
-  const {historyController, setTimelineMode, timelineMode, open} = useDocumentHistory()
+  const {historyController, setTimelineMode, timelineMode, open, displayed} = useDocumentHistory()
   const historyState = historyController.selectionState
   const [showValidationTooltip, setShowValidationTooltip] = useState<boolean>(false)
   const paneRouter = usePaneRouter()
@@ -163,6 +163,8 @@ export function DocumentPane(props: DocumentPaneProps) {
   const isTimelineOpen = timelineMode !== 'closed'
 
   const zOffsets = useZIndex()
+
+  const inspectValue = displayed || initialValue
 
   return (
     <LegacyLayerProvider zOffset="pane">
@@ -266,7 +268,11 @@ export function DocumentPane(props: DocumentPaneProps) {
 
         <LegacyLayerProvider zOffset="fullscreen">
           {isInspectOpen && (
-            <InspectDialog idPrefix={paneKey} onClose={handleInspectClose} value={value as any} />
+            <InspectDialog
+              idPrefix={paneKey}
+              onClose={handleInspectClose}
+              value={inspectValue as any}
+            />
           )}
         </LegacyLayerProvider>
       </DocumentActionShortcuts>


### PR DESCRIPTION
### Description

If you change the document to another revision, the "Inspect document" dialog would still be displaying the latest version. This is very confusing.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This is fixed by using the `displayed` value from the history provider as prop for `InspectDialog` and not the `value` which will always be the latest (current version).

### What to review

Is there is anything we didn't think of doing this change? We do have support to fallback to `initialValue` if there currently isn't anything in the`displayed` value. For instance if you select the "create" (first) revision. 

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
Fix issue where the inspected document version is always the latest version and not the current selected version.
