### PR TITLE
fix(form-builder): remove 1px gap above pte in fullscreen mode

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/PortableText/PortableTextInput.css
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/PortableTextInput.css
@@ -10,7 +10,7 @@
   */
   &.fullscreenPortal {
     position: absolute;
-    top: 1px;
+    top: 0;
     left: 0;
     right: 0;
     bottom: 0;


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Thin 1px gap above fullscreen PTE shows the form underneath.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

Go to a blocks test document and open a pt editor in fullscreen mode, and make sure the form below isn't visible.

Not sure why it had `top: 1px;`, maybe for a specific reason.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

- Fixed the form being visible above the PTE toolbar in fullscreen mode
