### PR TITLE
feature(grants): add support for validating built-in $identity param

### DIFF
--- a/packages/@sanity/base/src/datastores/grants/highlevel.ts
+++ b/packages/@sanity/base/src/datastores/grants/highlevel.ts
@@ -18,13 +18,13 @@ function getSchemaType(typeName: string): SchemaType {
   return type
 }
 
-export function canCreateType(typeName: string) {
+export function canCreateType(id: string, typeName: string) {
   const type = getSchemaType(typeName)
   return from(resolveInitialValueForType(type)).pipe(
     mergeMap((initialValue: any) => {
       return grantsStore.checkDocumentPermission('create', {
         ...initialValue,
-        _id: type.liveEdit ? 'dummy-id' : 'drafts.dummy-id',
+        _id: type.liveEdit ? id : `drafts.${id}`,
         _type: typeName,
       })
     })
@@ -32,7 +32,7 @@ export function canCreateType(typeName: string) {
 }
 
 export function canCreateAnyOf(types: string[]) {
-  return combineLatest(types.map((typeName) => canCreateType(typeName))).pipe(
+  return combineLatest(types.map((typeName) => canCreateType('dummy-id', typeName))).pipe(
     map((results) => {
       const granted = results.some((res) => res.granted)
       return {

--- a/packages/@sanity/base/src/datastores/grants/hooks.ts
+++ b/packages/@sanity/base/src/datastores/grants/hooks.ts
@@ -52,7 +52,7 @@ export function unstable_useCheckDocumentPermission(
             return canUpdate(id, type)
           }
           if (permission === 'create') {
-            return canCreateType(type)
+            return canCreateType(id, type)
           }
           if (permission === 'publish') {
             return canPublish(id, type)

--- a/packages/@sanity/base/src/datastores/grants/types.ts
+++ b/packages/@sanity/base/src/datastores/grants/types.ts
@@ -19,3 +19,7 @@ export interface GrantsStore {
     document: Partial<SanityDocument>
   ): Observable<PermissionCheckResult>
 }
+
+export interface EvaluationParams {
+  identity?: string
+}


### PR DESCRIPTION
### Description

To support more advanced ACL where users have access to edit their own
documents we need to inject the user id when evaluating the grant
filters

### What to review

* Is this the idiomatic way of getting the current user?

### Notes for release

add support for validating built-in $identity param