### PR TITLE
fix(base): use title, not value in prepare preview when field has predefined string options

### DIFF
--- a/examples/test-studio/schemas/arrays.js
+++ b/examples/test-studio/schemas/arrays.js
@@ -43,6 +43,48 @@ export default {
       type: 'string',
     },
     {
+      name: 'predefinedStringArray',
+      title: 'Array of strings',
+      description: 'First field in object is string with list options',
+      type: 'array',
+      of: [{type: 'string'}],
+      options: {
+        list: [
+          {title: 'Cats', value: 'cats4ever'},
+          {title: 'Dogs', value: 'dogs4ever'},
+        ],
+      },
+    },
+    {
+      name: 'objectArrayWithPrefinedStringField',
+      title: 'Array of objects',
+      description: 'First field in object is string with list options',
+      type: 'array',
+      of: [
+        {
+          type: 'object',
+          fields: [
+            {
+              name: 'stringOptions',
+              title: 'String options',
+              type: 'string',
+              options: {
+                list: [
+                  {title: 'Cats', value: 'cats4ever'},
+                  {title: 'Sweden', value: 'swe'},
+                ],
+              },
+            },
+            {
+              title: 'test',
+              name: 'testImage',
+              type: 'image',
+            },
+          ],
+        },
+      ],
+    },
+    {
       name: 'arrayOfMultipleTypes',
       title: 'Array of multiple types',
       type: 'array',

--- a/packages/@sanity/base/src/preview/prepareForPreview.ts
+++ b/packages/@sanity/base/src/preview/prepareForPreview.ts
@@ -224,6 +224,16 @@ export default function prepareForPreview(rawValue, type, viewOptions): symbol |
   const targetKeys = Object.keys(selection)
 
   const selectedValue = targetKeys.reduce((acc, key) => {
+    // Find the field the value belongs to
+    const valueField = type?.fields?.find((f) => f.name === selection[key])
+    // Check if predefined options exist
+    const listOptions = valueField?.type?.options?.list
+    if (listOptions) {
+      // Find the selected option that matches the raw value
+      const selectedOption = listOptions.find((opt) => opt.value === rawValue[selection[key]])
+      acc[key] = get(selectedOption, key)
+      return acc
+    }
     acc[key] = get(rawValue, selection[key])
     return acc
   }, {})


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

When a string field with predefined options is the first field in an object in an array, the preview renders using the value of the field, instead of the title defined in the list option (fixes #769).

I've added some logic to make sure the `title` and not the `value` is used when preparing the preview in these special cases, however I'm not sure if this is done in the right place and that it's too far up and should be done someplace else. However, with this approach the previews in document lists also use the `title` instead of the `value` if the first field in the document is a string field with predefined list options, which is nicer.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

I've added some test cases in the `arrays.js` schema in the test studio, please test it there and if possible with other combinations you can think of. Please let me know if it's suboptimal that the logic lives in `prepareForPreview.ts`.

To see this fix work in the document lists previews, add a string field with predefined list options as the first field in a document, and you'll see that it uses the `title` as the title instead of the value for that field.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

- Fixed an issue where the preview of a string field with predefined list options used the value of the field when selecting it for previewing instead of the title specified in the list options.