### PR TITLE
fix(base): fallback to published version if no draft exists

### DIFF
--- a/packages/@sanity/base/src/datastores/grants/highlevel.ts
+++ b/packages/@sanity/base/src/datastores/grants/highlevel.ts
@@ -54,14 +54,18 @@ export function canUpdate(id: string, typeName: string) {
   const idPair = getIdPairFromPublished(id)
   return snapshotPair(idPair).pipe(
     mergeMap((pair) => combineLatest([pair.draft.snapshots$, pair.published.snapshots$])),
-    map(([draft, published]) => [
-      draft || stub(idPair.draftId, typeName),
-      published || stub(idPair.publishedId, typeName),
-    ]),
     switchMap(([draft, published]) => {
       return type.liveEdit
-        ? grantsStore.checkDocumentPermission('update', published)
-        : grantsStore.checkDocumentPermission('update', draft)
+        ? grantsStore.checkDocumentPermission(
+            'update',
+            published || stub(idPair.publishedId, typeName)
+          )
+        : grantsStore.checkDocumentPermission(
+            'update',
+            // note: we check against the published document (if it exist) here since that's the
+            // document that will be created as new draft when user edits it
+            draft || published || stub(idPair.draftId, typeName)
+          )
     })
   )
 }


### PR DESCRIPTION
### Description

Currently we check for update permission by stubbing the drafts document (a stub only includes _id and _type). In cases where a document is published and you have a grants check that requires certain conditions to be met on the document itself, we then end up running the grants check on the stubbed version, which may miss the fact that the published version meet the conditions specified in the grants rule. This PR changes it so we run the check against the published version (if exists) instead of the stub.

### Notes for release
- Fixes an issue that could prevent drafts from being edited even in cases where a grant rule would permit it