### PR TITLE
docs(sanity): improve placeholder package readme text

### DIFF
--- a/packages/sanity/README.md
+++ b/packages/sanity/README.md
@@ -1,13 +1,7 @@
-#### [Sanity](https://www.sanity.io) is a real-time content infrastructure with a scalable, hosted backend featuring a Graph Oriented Query Language (GROQ), asset pipelines and fast edge caches.
+# 👋 This is a placeholder package. In order to get started with Sanity, please head over to our [getting started guide](https://sanity.io/docs/introduction/getting-started)
 
-## THIS IS NOT THE PACKAGE YOU ARE LOOKING FOR ##
+-----
 
-To get started with Sanity, please head over to our [getting started guide](https://sanity.io/docs/introduction/getting-started)
+###### Looking for [adamyanalunas/sanity](https://github.com/adamyanalunas/sanity)?
 
-
-
-#### Looking for [adamyanalunas/sanity](https://github.com/adamyanalunas/sanity)?
-
-Huge thanks to Adam Yanalunas for being so kind to transfer the `sanity` package to [Sanity.io](https://sanity.io)
-
-If you're looking for the latest version of his `sanity`, you want to make sure to pin the version of `sanity` to `v0.2.2`
+Huge thanks to Adam Yanalunas for being so kind to transfer the `sanity` package to [Sanity.io](https://sanity.io). If you're looking for the latest version of his `sanity`, you want to make sure to pin the version of `sanity` to `v0.2.2`


### PR DESCRIPTION
Small change that makes the `sanity` package README sound less scary.