### PR TITLE
fix(form-builder): enforce that DateInput value is constrained to timeStep

### DIFF
--- a/examples/example-studio/schemas/blogpost.js
+++ b/examples/example-studio/schemas/blogpost.js
@@ -25,7 +25,8 @@ export default {
       author: 'authorRef.name',
     },
     prepare(value) {
-      const timeSince = formatDistanceToNow(value.createdAt, {addSuffix: true})
+      const createdAt = new Date(value.createdAt)
+      const timeSince = createdAt && formatDistanceToNow(createdAt, {addSuffix: true})
       return Object.assign({}, value, {
         title: value.title ? pickFirst(value.title, LANGUAGE_PRIORITY) : '',
         subtitle: value.author ? `By ${value.author}, ${timeSince}` : timeSince,


### PR DESCRIPTION
### Description

If a datetime is configured with `timeStep=60` the user is not able to select minutes because there's only one option `00` and onSelect doesn't trigger on a "non-change". This PR adds an effect that ensures that the value for date time minutes are compatible with the configured `timeStep`-value

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Enforce that DateInput value is constrained to timeStep
