### PR TITLE
fix(base): render list items in object previews (#2631)

### DIFF
--- a/examples/test-studio/schemas/author.js
+++ b/examples/test-studio/schemas/author.js
@@ -1,5 +1,11 @@
 import icon from 'part:@sanity/base/user-icon'
 
+const AUTHOR_ROLES = [
+  {value: 'developer', title: 'Developer'},
+  {value: 'designer', title: 'Designer'},
+  {value: 'ops', title: 'Operations'},
+]
+
 export default {
   name: 'author',
   type: 'document',
@@ -12,13 +18,15 @@ export default {
     select: {
       title: 'name',
       awards: 'awards',
+      role: 'role',
       relatedAuthors: 'relatedAuthors',
       lastUpdated: '_updatedAt',
       media: 'image',
     },
-    prepare({title, media, awards}) {
+    prepare({title, media, awards, role}) {
+      const roleName = role ? AUTHOR_ROLES.find((option) => option.value === role) : undefined
       return {
-        title: title,
+        title: roleName ? `${title} (${roleName})` : title,
         media: media,
         subtitle: awards && awards.join(', '),
       }
@@ -42,11 +50,7 @@ export default {
       title: 'Role',
       type: 'string',
       options: {
-        list: [
-          {value: 'developer', title: 'Developer'},
-          {value: 'designer', title: 'Designer'},
-          {value: 'ops', title: 'Operations'},
-        ],
+        list: AUTHOR_ROLES,
       },
     },
     {

--- a/packages/@sanity/base/src/preview/prepareForPreview.ts
+++ b/packages/@sanity/base/src/preview/prepareForPreview.ts
@@ -250,7 +250,7 @@ export default function prepareForPreview(
       const selectedOption = listOptions.find(
         (opt) => opt.value === (rawValue as any)[selection[key]]
       )
-      acc[key] = get(selectedOption, key)
+      selectedOption ? acc[key] = selectedOption.title : delete acc[key];
       return acc
     }
     acc[key] = get(rawValue, selection[key])


### PR DESCRIPTION
Resolves issue #2631.

### Description

Modifies the return from `targetKeys.reduce()` in base/src/preview/prepareForPreview.ts. This solves the empty return encountered when using options.list and a prepare function (issue #2631 and https://sanity-io-land.slack.com/archives/C9Z7RC3V1/p1626976557089000).

### What to review

This code was compiled and tested against the [test studio](https://github.com/sanity-io/sanity/commit/d23ec5d0b3bb311b4b92653e206f15e3097ee3c1).

### Notes for release

Resolves issue #2631.
