### PR TITLE
feat(desk-tool): add timeline event for live edits

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/documentPane/documentHistory/history/chunker.ts
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/documentHistory/history/chunker.ts
@@ -76,6 +76,8 @@ export function chunkFromTransaction(transaction: Transaction): Chunk {
     // We don't really know anything more at this point since the actual
     // behavior depends on the earlier state.
     type = 'delete'
+  } else if (modifiedPublished) {
+    type = 'editLive'
   }
 
   return {

--- a/packages/@sanity/desk-tool/src/panes/documentPane/timeline/helpers.ts
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/timeline/helpers.ts
@@ -12,6 +12,7 @@ const LABELS: {[key: string]: string} = {
   discardDraft: 'discarded draft',
   initial: 'created',
   editDraft: 'edited',
+  editLive: 'live edited',
   publish: 'published',
   unpublish: 'unpublished',
 }
@@ -22,6 +23,7 @@ const ICON_COMPONENTS: {[key: string]: React.ComponentType<Record<string, unknow
   discardDraft: CloseIcon,
   initial: PlusIcon,
   editDraft: EditIcon,
+  editLive: EditIcon,
   publish: PublishIcon,
   unpublish: UnpublishIcon,
 }

--- a/packages/@sanity/desk-tool/src/panes/documentPane/timeline/timelineItem.css
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/timeline/timelineItem.css
@@ -146,6 +146,11 @@
     color: var(--timeline-event-enabled-icon-edited-fg);
   }
 
+  @nest .root[data-type='editLive'] & {
+    background-color: var(--timeline-event-enabled-icon-published-bg);
+    color: var(--timeline-event-enabled-icon-published-fg);
+  }
+
   @nest .root[data-type='publish'] & {
     background-color: var(--timeline-event-enabled-icon-published-bg);
     color: var(--timeline-event-enabled-icon-published-fg);

--- a/packages/@sanity/field/src/types.ts
+++ b/packages/@sanity/field/src/types.ts
@@ -41,6 +41,7 @@ export type ChunkType =
   | 'publish'
   | 'unpublish'
   | 'discardDraft'
+  | 'editLive'
 
 export type Chunk = {
   index: number


### PR DESCRIPTION
### Description

This will differentiate between when when a document is edited through
the api and edited as a draft. Fixes a bug where the studio shows that
there are changes when there are none

### What to review

Are we comparing chunk types anywhere else in the codebase that I have missed?

### Notes for release

fixes #2599
