### PR TITLE
fix(server): prevent json imports from passing through babel

### DIFF
--- a/packages/@sanity/server/src/configs/webpack.config.js
+++ b/packages/@sanity/server/src/configs/webpack.config.js
@@ -89,7 +89,7 @@ export default (config = {}) => {
     module: {
       rules: [
         {
-          test: /(\.jsx?|\.tsx?)/,
+          test: /(\.jsx?|\.tsx?)(\?|$)/,
           exclude: /(node_modules|bower_components)/,
           use: {
             loader: resolve('babel-loader'),


### PR DESCRIPTION
### Description

An unconstrained regex in our webpack config is leading to any files containing `.js`, `.jsx`, `.ts` and `.tsx` to be passed through the babel loader. This is a problem when loading `.json` files, as they match the regex.

This PR makes sure we only run files _ending_ with these extensions through babel.

Fixes #2494

### What to review

- `import data from './data.json'` will fail currently but will work with this fix.
- Check that the regex makes sense (the `?` matcher is because of module loaders having the ability to append query string options)

### Notes for release

- Fixes issue where importing JSON files would crash the studio build process
