### PR TITLE
fix(form-builder): prevent studio crash when component passed to `withDocument()` is missing a focus() method

### DIFF
--- a/packages/@sanity/form-builder/src/utils/withDocument.tsx
+++ b/packages/@sanity/form-builder/src/utils/withDocument.tsx
@@ -1,8 +1,23 @@
 import PropTypes from 'prop-types'
 import React from 'react'
+
+function getDisplayName(component) {
+  return component.displayName || component.name || '<Anonymous>'
+}
+
+function warnMissingFocusMethod(ComposedComponent) {
+  console.warn(
+    `withDocument(${getDisplayName(
+      ComposedComponent
+    )}): The passed component did not expose a ".focus()" method. Either implement an imperative focus method on the component instance, or forward it's received ref to an element that exposes a .focus() method. The component passed to withDocument was: %O`,
+    ComposedComponent
+  )
+}
+
 export default function withDocument(ComposedComponent: any) {
   return class WithDocument extends React.PureComponent {
     _input: any
+    _didShowFocusWarning = false
     static displayName = `withDocument(${ComposedComponent.displayName || ComposedComponent.name})`
     static contextTypes = {
       formBuilder: PropTypes.any,
@@ -26,7 +41,12 @@ export default function withDocument(ComposedComponent: any) {
       this.unsubscribe()
     }
     focus() {
-      this._input.focus()
+      if (typeof this._input?.focus === 'function') {
+        this._input.focus()
+      } else if (!this._didShowFocusWarning) {
+        warnMissingFocusMethod(ComposedComponent)
+        this._didShowFocusWarning = true
+      }
     }
     setInput = (input) => {
       this._input = input


### PR DESCRIPTION

### Description

If the component passed to `withDocument()` doesn't expose a `.focus()` instance method or forwards it's ref to a component that implements a .focus() method, the studio will crash with an error saying "Cannot read property 'focus' of undefined". This PR adds a safeguard against it and also issues a console warning that should make it easier to pinpoint the issue.

### What to review
Review and see if the code/message makes sense

### Notes for release
- Adds safeguard against missing `.focus()` method on components used with the `withDocument()` higher order component.
