### PR TITLE
fix(base): fixes a bug where isMissing was triggered when the reference exists

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
@@ -114,7 +114,7 @@ export const ReferenceInput = forwardRef(function ReferenceInput(
   const hasInsufficientPermissions =
     preview.snapshot?._internalMeta?.type === 'insufficient_permissions'
   const isMissing =
-    !hasInsufficientPermissions && !!value?._ref && !preview.isLoading && preview.snapshot
+    !hasInsufficientPermissions && !!value?._ref && !preview.isLoading && preview.snapshot === null
 
   const hasRef = value && value._ref
 


### PR DESCRIPTION
### Description

The reference was marked as missing when the document existed because of a missing conditional clause.

For cross reference: https://github.com/sanity-io/sanity/pull/2585/files#diff-0419dde3aa4b7ffa09d19c960d248addc8fe46dd8955042a28018f8df203d444L114

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
