### PR TITLE
Determine correct base path for `sanity exec`

### DIFF
--- a/packages/@sanity/core/src/actions/exec/pluginLoader.js
+++ b/packages/@sanity/core/src/actions/exec/pluginLoader.js
@@ -1,3 +1,4 @@
 const registerLoader = require('@sanity/plugin-loader')
 
-registerLoader({basePath: process.cwd(), stubCss: true})
+// eslint-disable-next-line no-process-env
+registerLoader({basePath: process.env.SANITY_BASE_PATH || process.cwd(), stubCss: true})


### PR DESCRIPTION
### Description

`sanity exec` assumed that it would be executed in the project directory, but it is possible run it in a subdirectory. This changes the pluginLoader to use the determined Sanity base path instead.

Fixes #2525

### What to review

I haven't been able to actually test it since I'm not quite sure how to do it…

### Notes for release

* Make it possible to run `sanity exec` inside sub-directories.
