### PR TITLE
Export types correctly in built @sanity/base package

### DIFF
--- a/packages/@sanity/base/components.d.ts
+++ b/packages/@sanity/base/components.d.ts
@@ -1,3 +1,3 @@
-import * as components from './src/components'
+import * as components from './lib/components'
 
 export = components

--- a/packages/@sanity/base/hooks.d.ts
+++ b/packages/@sanity/base/hooks.d.ts
@@ -1,3 +1,3 @@
-import * as hooks from './src/hooks'
+import * as hooks from './lib/hooks'
 
 export = hooks

--- a/packages/@sanity/base/presence.d.ts
+++ b/packages/@sanity/base/presence.d.ts
@@ -1,3 +1,3 @@
-import * as presence from './src/presence'
+import * as presence from './lib/presence'
 
 export = presence

--- a/packages/@sanity/base/user-color.d.ts
+++ b/packages/@sanity/base/user-color.d.ts
@@ -1,3 +1,3 @@
-import * as userColor from './src/user-color'
+import * as userColor from './lib/user-color'
 
 export = userColor

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,7 @@
       "@sanity/base/lib/util/resizeObserver": ["./@sanity/base/src/util/resizeObserver"],
       "@sanity/base/presence": ["./@sanity/base/src/presence"],
       "@sanity/base/structure-builder": ["./@sanity/base/structure-builder"],
+      "@sanity/base/user-color": ["./@sanity/base/user-color"],
       "@sanity/base": ["./@sanity/base/src"],
       "@sanity/block-tools": ["./@sanity/block-tools/src"],
       "@sanity/components/lib/fieldsets/FieldStatus": ["./@sanity/base/src/__legacy/@sanity/components/fieldsets/FieldStatus"],


### PR DESCRIPTION
### Description

These files are compiled by anything during packaging which means that they end up referring to `src`-directories which is not included in the NPM package.

This changes the imports to refer to `lib` which should work in the
built NPM package.

Fixes #2519.

### What to review

- Check that we didn't break "Go to definition" in an IDE.

### Notes for release

-  `@sanity/base` now exports TypeScript definitions for the `presence`, `user-color`, `components` and `hooks` files.
