### PR TITLE
Update requestOptions.js

### DIFF
--- a/packages/@sanity/client/src/http/requestOptions.js
+++ b/packages/@sanity/client/src/http/requestOptions.js
@@ -6,6 +6,7 @@ module.exports = (config, overrides = {}) => {
   const headers = {}
 
   const token = overrides.token || config.token
+  const proxy = config.proxy || "";
   if (token) {
     headers.Authorization = `Bearer ${token}`
   }
@@ -26,5 +27,6 @@ module.exports = (config, overrides = {}) => {
     timeout: typeof timeout === 'undefined' ? 5 * 60 * 1000 : timeout,
     json: true,
     withCredentials,
+    proxy
   })
 }


### PR DESCRIPTION
This is to use corporate proxy with sanity client config object

const client = sanityClient({
	projectId: 'projectid',
	token: 'token',
	useCdn: false,
	dataset:'production',
	proxy:"some-proxyhost:port"
});

Above proxy can be set in sanity client config object for all requests

### Description
What changes are introduced?
Created a new proxy object

Why are these changes introduced?
To use corporate proxy when using sanity client object

What issue(s) does this solve? (with link, if possible)
I can use sanity client without setting env variable for proxy. Env variable is applicable for all requests. With this change I can use proxy just for sanity client, all other request need not go through proxy

### What to review


What steps should the reviewer take in order to review?
Review  - packages/@sanity/client/src/http/requestOptions.js

What parts/flows of the application/packages/tooling is affected?
All http requests with sanity client

Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
