### PR TITLE
fix(form-builder): fix missing focus ring on focused day

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/DateInputs/base/calendar/CalendarDay.tsx
+++ b/packages/@sanity/form-builder/src/inputs/DateInputs/base/calendar/CalendarDay.tsx
@@ -23,6 +23,7 @@ export function CalendarDay(props: CalendarDayProps) {
         aria-label={date.toDateString()}
         aria-pressed={selected}
         as="button"
+        __unstable_focusRing
         data-weekday
         data-focused={focused ? 'true' : ''}
         role="button"
@@ -30,10 +31,11 @@ export function CalendarDay(props: CalendarDayProps) {
         onClick={handleClick}
         padding={3}
         radius={2}
-        tone={isToday ? 'primary' : 'default'}
+        selected={selected}
+        tone={isToday || selected ? 'primary' : 'default'}
       >
         <Text
-          muted={!isCurrentMonth}
+          muted={!selected && !isCurrentMonth}
           style={{textAlign: 'center'}}
           weight={isCurrentMonth ? 'medium' : 'regular'}
         >


### PR DESCRIPTION
### Description

This adds a visible indicator on the focused day when using arrow keys to navigate through the calendar days in the date picker

### What to review

Open the date picker in a datetime/date input field, change date by using the arrow keys and verify that there's a focus ring around the focused date.


### Notes for release
- Adds a visible indicator on the focused day when using arrow keys to navigate through the calendar days in the date input
