### PR TITLE
feat(client): allow api version to be overridden for requests

### DIFF
--- a/packages/@sanity/client/src/sanityClient.js
+++ b/packages/@sanity/client/src/sanityClient.js
@@ -11,7 +11,7 @@ const UsersClient = require('./users/usersClient')
 const AuthClient = require('./auth/authClient')
 const httpRequest = require('./http/request')
 const getRequestOptions = require('./http/requestOptions')
-const {defaultConfig, initConfig} = require('./config')
+const {defaultConfig, initConfig, validateApiVersion, formatBaseUrl} = require('./config')
 const validate = require('./validators')
 
 const toPromise = (observable) => observable.toPromise()
@@ -64,6 +64,17 @@ assign(SanityClient.prototype, {
     return `${base}/${uri.replace(/^\//, '')}`
   },
 
+  getUrlWithVersion(uri, apiVersion, canUseCdn = false) {
+    if (apiVersion) {
+      validateApiVersion(apiVersion)
+      const base = canUseCdn
+        ? formatBaseUrl(this.clientConfig, {apiVersion, cdn: true})
+        : formatBaseUrl(this.clientConfig, {apiVersion})
+      return `${base}/${uri.replace(/^\//, '')}`
+    }
+    return this.getUrl(uri, canUseCdn)
+  },
+
   isPromiseAPI() {
     return this.clientConfig.isPromiseAPI
   },
@@ -87,7 +98,7 @@ assign(SanityClient.prototype, {
     const reqOptions = getRequestOptions(
       this.clientConfig,
       assign({}, options, {
-        url: this.getUrl(uri, canUseCdn),
+        url: this.getUrlWithVersion(uri, options.apiVersion, canUseCdn),
       })
     )
 

--- a/packages/@sanity/client/test/client.test.js
+++ b/packages/@sanity/client/test/client.test.js
@@ -6,11 +6,11 @@
 // eslint-disable-next-line import/no-unassigned-import
 require('hard-rejection/register')
 
+const path = require('path')
+const fs = require('fs')
 const test = require('tape')
 const nock = require('nock')
 const assign = require('xtend')
-const path = require('path')
-const fs = require('fs')
 const validators = require('../src/validators')
 const observableOf = require('rxjs').of
 const {filter} = require('rxjs/operators')
@@ -160,6 +160,24 @@ test('can use request() for API-relative requests (custom api version)', (t) => 
     .then((res) => t.equal(res.pong, true))
     .catch(t.ifError)
     .then(t.end)
+})
+
+test('can use request() to specify API version on requests', (t) => {
+  nock(projectHost()).get('/vX/ping').reply(200, {pong: true})
+
+  getClient()
+    .request({uri: '/ping', apiVersion: 'X'})
+    .then((res) => t.equal(res.pong, true))
+    .catch(t.ifError)
+    .then(t.end)
+})
+
+test('thows on invalid API version with request()', (t) => {
+  t.throws(
+    () => getClient().request({uri: '/ping', apiVersion: 'invalid version'}),
+    /Invalid api version string/i
+  )
+  t.end()
 })
 
 test('can use getUrl() to get API-relative paths', (t) => {


### PR DESCRIPTION
### Description

When calling `client.request()` allow the api version to be overridden. This is to support only using the experimental api for certain requests.

### What to review

* The logic for generating the base url from the config. This was broken out to allow the same logic to be used when overriding the api version.

### Notes for release

This patch allows the api version to be set on a per request basis.
