### PR TITLE
fix(base): fix invalid query when preview selection targets both a reference field and a field on the referenced document

### DIFF
--- a/examples/test-studio/schemas/previewSelectBugRepro.js
+++ b/examples/test-studio/schemas/previewSelectBugRepro.js
@@ -1,0 +1,30 @@
+export const previewSelectBugRepro = {
+  name: 'previewSelectBugRepro',
+  type: 'document',
+  title: 'Preview selection bug repro',
+  description:
+    'Reproduction case for a bug in preview selection that caused invalid query when targeting both a reference field and fields on the referenced document',
+  fields: [
+    {
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+    },
+    {name: 'book', type: 'reference', to: [{type: 'book'}]},
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      hasBook: 'book',
+      bookRef: 'book._ref',
+      bookId: 'book._id',
+      bookTitle: 'book.title',
+    },
+    prepare(selection) {
+      return {
+        title: selection.title,
+        subtitle: `Book: ${selection.hasBook ? selection.bookTitle : '(no book)'}`,
+      }
+    },
+  },
+}

--- a/examples/test-studio/schemas/schema.js
+++ b/examples/test-studio/schemas/schema.js
@@ -66,6 +66,7 @@ import {
   fieldValidationInferReproSharedObject,
   fieldValidationInferReproDoc,
 } from './fieldValidationInferRepro'
+import {previewSelectBugRepro} from './previewSelectBugRepro'
 
 export default createSchema({
   name: 'test-examples',
@@ -127,6 +128,7 @@ export default createSchema({
     reservedFieldNames,
     previewImageUrlTest,
     previewMediaTest,
+    previewSelectBugRepro,
     invalidPreviews,
     readOnly,
     empty,

--- a/packages/@sanity/base/src/preview/createPathObserver.ts
+++ b/packages/@sanity/base/src/preview/createPathObserver.ts
@@ -53,7 +53,7 @@ function observePaths(value: Value, paths: Path[], observeFields: ObserveFieldsF
           return observePaths(
             {
               ...createEmpty(nextHeads),
-              ...(isRef ? {} : value),
+              ...(isRef ? {_ref: value._ref} : value),
               ...snapshot,
             },
             paths,
@@ -76,8 +76,8 @@ function observePaths(value: Value, paths: Path[], observeFields: ObserveFieldsF
 
   const next = Object.keys(leads).reduce(
     (res: Record<string, unknown>, head) => {
-      const tails = leads[head]
-      if (tails.every((tail) => tail.length === 0)) {
+      const tails = leads[head].filter((tail) => tail.length > 0)
+      if (tails.length === 0) {
         res[head] = value[head]
       } else {
         res[head] = observePaths(value[head], tails, observeFields)


### PR DESCRIPTION
### Description

This PR fixes an issue that makes the following preview selection result in an invalid groq query, which again will make the studio error with a 400.

https://github.com/sanity-io/sanity/blob/a02a45cbca906d422ffa805cd3330c923a3274ce/examples/test-studio/schemas/previewSelectBugRepro.js#L16-L22

### What to review

Open the studio at https://test-studio-git-fix-preview-select-causing-400.sanity.build/test/desk/previewSelectBugRepro;9fe0d4ac-58aa-4dd7-b181-85ade1b7b34f and verify that there's no errors and that previews works as expected.

### Notes for release

- Fixes an issue that in some rare cases could make the preview selection result in an invalid query
