### PR TITLE
Fix typo: “WAW Audio” » “WAV Audio”

### DIFF
--- a/packages/@sanity/form-builder/src/sanity/DefaultAssetSource/utils/mimeType.ts
+++ b/packages/@sanity/form-builder/src/sanity/DefaultAssetSource/utils/mimeType.ts
@@ -45,7 +45,7 @@ const MIME_TYPES: Record<string, MimeTypeInfo> = {
     title: 'OGG Audio',
   },
   'audio/wav': {
-    title: 'WAW Audio',
+    title: 'WAV Audio',
   },
   'audio/webm': {
     title: 'WebM Audio',


### PR DESCRIPTION
### Description

Fixes https://github.com/sanity-io/sanity/pull/2542#discussion_r684286240

### What to review

Confirm that this was actually a typo and not intentional.

### Notes for release

Probably not worth adding to release notes.