### PR TITLE
feat(client): support `proxy` in config + options

### DIFF
--- a/packages/@sanity/client/sanityClient.d.ts
+++ b/packages/@sanity/client/sanityClient.d.ts
@@ -42,6 +42,7 @@ interface RawRequestOptions {
   query?: {[key: string]: string | string[]}
   headers?: {[key: string]: string}
   timeout?: number
+  proxy?: string
   body?: any
 }
 
@@ -499,6 +500,7 @@ export interface ClientConfig {
   token?: string
   apiHost?: string
   apiVersion?: string
+  proxy?: string
   requestTagPrefix?: string
   ignoreBrowserTokenWarning?: boolean
   withCredentials?: boolean

--- a/packages/@sanity/client/src/http/requestOptions.js
+++ b/packages/@sanity/client/src/http/requestOptions.js
@@ -24,6 +24,7 @@ module.exports = (config, overrides = {}) => {
   return assign({}, overrides, {
     headers: assign({}, headers, overrides.headers || {}),
     timeout: typeof timeout === 'undefined' ? 5 * 60 * 1000 : timeout,
+    proxy: overrides.proxy || config.proxy,
     json: true,
     withCredentials,
   })


### PR DESCRIPTION
### Description

This adds support for configuring a single client and/or request to use a proxy.

Fixes #2652.

### What to review

I was not able to write a test for this since it doesn't seem like Nock supports retrieving the proxy of a request:

```js
test('can be configured with proxy', (t) => {
  // TODO: How to check that example.com is being used?
  nock(projectHost()).get('/v1/ping').reply(200, {pong: true})

  getClient({proxy: 'http://example.com'})
    .request({uri: '/ping'})
    .then((res) => t.equal(res.pong, true))
    .catch(t.ifError)
    .then(t.end)
})
```

Would like feedback on suggestions to verify that this works as expected.

### Notes for release

* Support `proxy`-option in `@sanity/client`.