### PR TITLE
Add defaultLocale to @sanity/google-maps-input config

### DIFF
--- a/packages/@sanity/google-maps-input/config.dist.json
+++ b/packages/@sanity/google-maps-input/config.dist.json
@@ -1,6 +1,7 @@
 {
   "apiKey": null,
   "defaultZoom": 11,
+  "defaultLocale": "en-US",
   "defaultLocation": {
     "lat": 40.7058254,
     "lng": -74.1180863

--- a/packages/@sanity/google-maps-input/config.dist.json
+++ b/packages/@sanity/google-maps-input/config.dist.json
@@ -1,7 +1,7 @@
 {
   "apiKey": null,
   "defaultZoom": 11,
-  "defaultLocale": "en-US",
+  "defaultLocale": null,
   "defaultLocation": {
     "lat": 40.7058254,
     "lng": -74.1180863

--- a/packages/@sanity/google-maps-input/src/loader/loadGoogleMapsApi.ts
+++ b/packages/@sanity/google-maps-input/src/loader/loadGoogleMapsApi.ts
@@ -28,7 +28,7 @@ export type GoogleLoadState = LoadingState | LoadedState | LoadErrorState | Auth
 let subject: BehaviorSubject<GoogleLoadState>
 
 export function loadGoogleMapsApi(): Observable<GoogleLoadState> {
-  const selectedLocale = locale || 'en-US'
+  const selectedLocale = config.defaultLocale || locale || 'en-US'
 
   if (subject) {
     return subject


### PR DESCRIPTION
### Description
What changes are introduced?
ADD new config variable than can be used to set locale
Why are these changes introduced?
ADD possibilty to set your own locale in the Google Maps input plugin
What issue(s) does this solve? (with link, if possible)
None that i found.


### What to review
What steps should the reviewer take in order to review?
Just see if the variable names are ok
What parts/flows of the application/packages/tooling is affected?
@sanity/google-maps-input


### Notes for release

You can now add a default locale for Google Maps, it will make the search prioritize places/addresses in that locale.