### PR TITLE
fix(base): fix active state issue with `PaneItem` in `DocumentsListPane`

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/documentsListPane/DocumentsListPane.js
+++ b/packages/@sanity/desk-tool/src/panes/documentsListPane/DocumentsListPane.js
@@ -199,7 +199,7 @@ export default class DocumentsListPane extends React.PureComponent {
       icon={this.props.displayOptions.showIcons === false ? false : undefined}
       schemaType={schema.get(item._type)}
       isSelected={this.itemIsSelected(item)}
-      isActive
+      isActive={this.props.isActive}
     />
   )
 
@@ -395,6 +395,7 @@ export default class DocumentsListPane extends React.PureComponent {
       menuItems,
       menuItemGroups,
       initialValueTemplates,
+      isActive,
     } = this.props
 
     return (
@@ -408,6 +409,7 @@ export default class DocumentsListPane extends React.PureComponent {
         initialValueTemplates={initialValueTemplates}
         isSelected={isSelected}
         isCollapsed={isCollapsed}
+        isActive={isActive}
         onCollapse={onCollapse}
         onAction={this.handleAction}
         onExpand={onExpand}


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR fixes a bug where several `PaneItem`:s sometimes got an active state in `DocumentsListPane`

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

Make sure that only one `PaneItem`:s gets an active state in `DocumentsListPane`

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

fix(base): fix active state issue with `PaneItem` in `DocumentsListPane`