### PR TITLE
feat(search): apply pt::text() when searching portable text fields

### DIFF
--- a/packages/@sanity/base/src/search/index.ts
+++ b/packages/@sanity/base/src/search/index.ts
@@ -6,6 +6,11 @@ import {versionedClient} from '../client/versionedClient'
 import {getSearchableTypes} from './common/utils'
 import {createWeightedSearch} from './weighted/createWeightedSearch'
 
-export default createWeightedSearch(getSearchableTypes(schema), versionedClient, {
+// Use >= 2021-03-25 for pt::text() support
+const searchClient = versionedClient.withConfig({
+  apiVersion: '2021-03-25',
+})
+
+export default createWeightedSearch(getSearchableTypes(schema), searchClient, {
   tag: 'search.global',
 })

--- a/packages/@sanity/base/src/search/weighted/types.ts
+++ b/packages/@sanity/base/src/search/weighted/types.ts
@@ -1,9 +1,18 @@
 /**
  * @internal
  */
+export interface SearchPath {
+  weight: number
+  path: string
+  mapWith?: string
+}
+
+/**
+ * @internal
+ */
 export interface SearchSpec {
   typeName: string
-  paths: {weight: number; path: string}[]
+  paths: SearchPath[]
 }
 
 /**

--- a/packages/@sanity/schema/src/legacy/types/object.ts
+++ b/packages/@sanity/schema/src/legacy/types/object.ts
@@ -32,6 +32,7 @@ const normalizeSearchConfig = (configs) => {
     return {
       weight: 'weight' in conf ? conf.weight : 1,
       path: toPath(conf.path),
+      mapWith: typeof conf.mapWith === 'string' ? conf.mapWith : undefined,
     }
   })
 }

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -147,7 +147,7 @@ export interface ObjectSchemaType extends BaseSchemaType {
 
   // Experimentals
   /* eslint-disable camelcase */
-  __experimental_search?: {path: string; weight: number}[]
+  __experimental_search?: {path: string; weight: number; mapWith?: string}[]
   /* eslint-enable camelcase */
 }
 


### PR DESCRIPTION
**Note**: This was already reviewed and approved in #2433 but had to be rolled back due to some backend issues. Now that those are solved, I'm re-opening it.

### Description

This PR allows users to search for a term mentioned in portable documents portable text field in the global search. 

### Technical changes

- Use the `v2021-03-25` API version for the studio search
- Allow a `mapWith` property on the experimental search (primarily for internal use) - wraps the field in the GROQ-function given. Not sure about the naming on this.
- Detect portable text fields and include them in the automatically resolved search configuration

### What to review

- Try searching the [test studio](https://test-studio-git-feat-pt-text-search.sanity.build/test/desk) for strings that appear in portable text fields
- Technical implementation (and naming)

### Notes for release

- Add support for searching portable text fields