### PR TITLE
fix(base): ensure esm interoperability in root package reexports

### DIFF
--- a/packages/@sanity/base/_internal.js
+++ b/packages/@sanity/base/_internal.js
@@ -1,2 +1,2 @@
 // Legacy package export for non-esm environments
-module.exports = require('./lib/_exports/_internal')
+require('./_interopReexport')(module.exports, require('./lib/_exports/_internal'))

--- a/packages/@sanity/base/_interopReexport.js
+++ b/packages/@sanity/base/_interopReexport.js
@@ -1,0 +1,30 @@
+/**
+ * esm/commonjs interop reexport helper
+ * this should be used instead of doing `module.exports = require('./some/file')
+ * since that doesn't work properly with esm imports from the consuming end
+ * @param moduleExports export object from the exporting module
+ * @param importedModule the imported module to be reexported
+ */
+module.exports = function _interopReexport(moduleExports, importedModule) {
+  Object.defineProperty(moduleExports, '__esModule', {
+    value: true,
+  })
+
+  Object.defineProperty(moduleExports, 'default', {
+    enumerable: true,
+    get: function get() {
+      return importedModule.default
+    },
+  })
+
+  Object.keys(importedModule).forEach(function (key) {
+    if (key === 'default' || key === '__esModule') return
+    if (key in moduleExports && moduleExports[key] === importedModule[key]) return
+    Object.defineProperty(moduleExports, key, {
+      enumerable: true,
+      get: function get() {
+        return importedModule[key]
+      },
+    })
+  })
+}

--- a/packages/@sanity/base/change-indicators.js
+++ b/packages/@sanity/base/change-indicators.js
@@ -1,2 +1,2 @@
 // Legacy package export for non-esm environments
-module.exports = require('./lib/_exports/change-indicators')
+require('./_interopReexport')(module.exports, require('./lib/_exports/change-indicators'))

--- a/packages/@sanity/base/components.js
+++ b/packages/@sanity/base/components.js
@@ -1,2 +1,2 @@
 // Legacy package export for non-esm environments
-module.exports = require('./lib/_exports/components')
+require('./_interopReexport')(module.exports, require('./lib/_exports/components'))

--- a/packages/@sanity/base/hooks.js
+++ b/packages/@sanity/base/hooks.js
@@ -1,2 +1,2 @@
 // Legacy package export for non-esm environments
-module.exports = require('./lib/_exports/hooks')
+require('./_interopReexport')(module.exports, require('./lib/_exports/hooks'))

--- a/packages/@sanity/base/initial-value-template-builder.js
+++ b/packages/@sanity/base/initial-value-template-builder.js
@@ -1,2 +1,5 @@
 // Legacy package export for non-esm environments
-module.exports = require('./lib/_exports/initial-value-template-builder')
+require('./_interopReexport')(
+  module.exports,
+  require('./lib/_exports/initial-value-template-builder')
+)

--- a/packages/@sanity/base/initial-value-templates.js
+++ b/packages/@sanity/base/initial-value-templates.js
@@ -1,2 +1,2 @@
 // Legacy package export for non-esm environments
-module.exports = require('./lib/_exports/initial-value-templates')
+require('./_interopReexport')(module.exports, require('./lib/_exports/initial-value-templates'))

--- a/packages/@sanity/base/presence.js
+++ b/packages/@sanity/base/presence.js
@@ -1,2 +1,2 @@
 // Legacy package export for non-esm environments
-module.exports = require('./lib/_exports/presence')
+require('./_interopReexport')(module.exports, require('./lib/_exports/presence'))

--- a/packages/@sanity/base/preview.js
+++ b/packages/@sanity/base/preview.js
@@ -1,2 +1,2 @@
 // Legacy package export for non-esm environments
-module.exports = require('./lib/_exports/preview')
+require('./_interopReexport')(module.exports, require('./lib/_exports/preview'))

--- a/packages/@sanity/base/structure-builder.js
+++ b/packages/@sanity/base/structure-builder.js
@@ -1,2 +1,2 @@
 // Legacy package export for non-esm environments
-module.exports = require('./lib/_exports/structure-builder')
+require('./_interopReexport')(module.exports, require('./lib/_exports/structure-builder'))

--- a/packages/@sanity/base/user-color.js
+++ b/packages/@sanity/base/user-color.js
@@ -1,2 +1,2 @@
 // Legacy package export for non-esm environments
-module.exports = require('./lib/_exports/user-color')
+require('./_interopReexport')(module.exports, require('./lib/_exports/user-color'))


### PR DESCRIPTION
### Description
Fixes #2680

The (legacy) package export entries in `@sanity/base` have up until now been doing:
```js
module.exports = require('./<path-to-module>')
```
... this caused an issue with an internal _default_ import that got reexported this way (#2680).  For better interoperability with ESM consumers, this PR makes sure the package export entries now writes the exports to `module.exports` the same way as babel are doing when transpiling ESM => CommonJS:

```js
export * from './<path-to-module>'
export {default} from './<path-to-module>'
```

Note: I'm not exactly sure _why_ this change fixes the linked issue, but suspect is has something to do with circular imports, and that the getter approach solves it.

### Notes for release

Fixes a regression in 2.15.0 causing an error with boolean fields