### PR TITLE
fix(desk-tool): handle blur events

### DIFF
--- a/packages/@sanity/base/sanity.json
+++ b/packages/@sanity/base/sanity.json
@@ -1012,18 +1012,6 @@
       "path": "components/icons/Compose"
     },
     {
-      "implements": "part:@sanity/base/publish-icon",
-      "path": "components/icons/Publish"
-    },
-    {
-      "implements": "part:@sanity/base/unpublish-icon",
-      "path": "components/icons/Unpublish"
-    },
-    {
-      "implements": "part:@sanity/base/truncate-icon",
-      "path": "components/icons/Truncate"
-    },
-    {
       "implements": "part:@sanity/base/reset-icon",
       "path": "components/icons/Reset"
     },
@@ -1649,10 +1637,6 @@
     {
       "implements": "part:@sanity/components/selects/style",
       "path": "__legacy/@sanity/components/selects/StyleSelect"
-    },
-    {
-      "implements": "part:@sanity/components/selects/style-style",
-      "path": "__legacy/@sanity/components/selects/StyleSelect.css"
     },
     {
       "implements": "part:@sanity/components/dialogs/default",

--- a/packages/@sanity/client/sanityClient.d.ts
+++ b/packages/@sanity/client/sanityClient.d.ts
@@ -42,6 +42,7 @@ interface RawRequestOptions {
   query?: {[key: string]: string | string[]}
   headers?: {[key: string]: string}
   timeout?: number
+  proxy?: string
   body?: any
 }
 
@@ -499,6 +500,7 @@ export interface ClientConfig {
   token?: string
   apiHost?: string
   apiVersion?: string
+  proxy?: string
   requestTagPrefix?: string
   ignoreBrowserTokenWarning?: boolean
   withCredentials?: boolean

--- a/packages/@sanity/client/src/http/requestOptions.js
+++ b/packages/@sanity/client/src/http/requestOptions.js
@@ -24,6 +24,7 @@ module.exports = (config, overrides = {}) => {
   return assign({}, overrides, {
     headers: assign({}, headers, overrides.headers || {}),
     timeout: typeof timeout === 'undefined' ? 5 * 60 * 1000 : timeout,
+    proxy: overrides.proxy || config.proxy,
     json: true,
     withCredentials,
   })

--- a/packages/@sanity/core/src/actions/exec/pluginLoader.js
+++ b/packages/@sanity/core/src/actions/exec/pluginLoader.js
@@ -1,3 +1,4 @@
 const registerLoader = require('@sanity/plugin-loader')
 
-registerLoader({basePath: process.cwd(), stubCss: true})
+// eslint-disable-next-line no-process-env
+registerLoader({basePath: process.env.SANITY_BASE_PATH || process.cwd(), stubCss: true})

--- a/packages/@sanity/default-layout/tsconfig.json
+++ b/packages/@sanity/default-layout/tsconfig.json
@@ -11,5 +11,6 @@
     "rootDir": "src",
     "outDir": "./dist/dts",
     "jsx": "react"
-  }
+  },
+  "references": [{"path": "../base"}, {"path": "../util"}]
 }

--- a/packages/@sanity/desk-tool/src/panes/documentPane/documentPane.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/documentPane.tsx
@@ -90,6 +90,10 @@ export function DocumentPane(props: DocumentPaneProps) {
   )
   const isInspectOpen = paneRouter.params.inspect === 'on'
 
+  const handleBlur = useCallback(() => {
+    setFocusPath([])
+  }, [])
+
   const handleFocus = useCallback(
     (nextFocusPath: Path) => {
       setFocusPath(PathUtils.pathFor(nextFocusPath))
@@ -199,6 +203,7 @@ export function DocumentPane(props: DocumentPaneProps) {
                 draft={draft}
                 idPrefix={paneKey}
                 formInputFocusPath={formInputFocusPath}
+                onFormInputBlur={handleBlur}
                 onFormInputFocus={handleFocus}
                 initialValue={initialValue}
                 isClosable={isClosable}

--- a/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/documentPanel.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/documentPanel.tsx
@@ -36,6 +36,7 @@ interface DocumentPanelProps {
   menuItemGroups: MenuItemGroup[]
   onChange: (patches: any[]) => void
   formInputFocusPath: Path
+  onFormInputBlur: () => void
   onFormInputFocus: (focusPath: Path) => void
   onCloseView: () => void
   onCollapse?: () => void
@@ -181,6 +182,7 @@ export function DocumentPanel(props: DocumentPanelProps) {
                   id={props.documentId}
                   initialValue={props.initialValue}
                   focusPath={props.formInputFocusPath}
+                  onBlur={props.onFormInputBlur}
                   onFocus={props.onFormInputFocus}
                   markers={props.markers}
                   onChange={props.onChange}

--- a/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/views/editForm.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/views/editForm.tsx
@@ -65,7 +65,7 @@ export const EditForm = memo((props: Props) => {
         subscriptionRef.current = null
       }
     }
-  }, [])
+  }, [patchChannel, props.id, props.type.name])
 
   return (
     <form onSubmit={preventDefault}>

--- a/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/views/formView.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/documentPanel/views/formView.tsx
@@ -32,6 +32,7 @@ interface Props {
   markers: Array<{path: any[]}>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   focusPath: Path
+  onBlur: () => void
   onFocus: (path: Path) => void
   margins: [number, number, number, number]
 }
@@ -68,10 +69,6 @@ export class FormView extends React.PureComponent<Props> {
     }
   }
 
-  handleBlur = () => {
-    // do nothing
-  }
-
   handleEditAsActualType = () => {
     // TODO
   }
@@ -92,6 +89,7 @@ export class FormView extends React.PureComponent<Props> {
     const {
       id,
       focusPath,
+      onBlur,
       onFocus,
       value,
       initialValue,
@@ -127,7 +125,7 @@ export class FormView extends React.PureComponent<Props> {
             filterField={filterField}
             focusPath={focusPath}
             markers={markers}
-            onBlur={this.handleBlur}
+            onBlur={onBlur}
             onChange={readOnly ? noop : this.props.onChange}
             onFocus={onFocus}
             readOnly={readOnly}

--- a/packages/@sanity/form-builder/src/FormBuilderInput.tsx
+++ b/packages/@sanity/form-builder/src/FormBuilderInput.tsx
@@ -93,8 +93,14 @@ export class FormBuilderInput extends React.Component<Props> {
   }
 
   componentDidUpdate(prevProps: Props) {
+    // Do not trigger focus when the focus path is empty
+    if (this.props.focusPath.length === 0) {
+      return
+    }
+
     const hadFocus = PathUtils.hasFocus(prevProps.focusPath, prevProps.path)
     const hasFocus = PathUtils.hasFocus(this.props.focusPath, this.props.path)
+
     if (!hadFocus && hasFocus) {
       this.focus()
     }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

- This change add a blur handler that resets `focusPath` when a user leaves a form field.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

- That presence works as it used to.
- That focusing works as it used to.
- That focusing works when clicking diffs.
- That focusing works when clicking validation menu items.
- [currently fails] That focusing/blurring within arrray dialogs work as expected.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

n/a
