### PR TITLE
Add proper type exports to desk-tool

### DIFF
--- a/.webpack-aliases.json5
+++ b/.webpack-aliases.json5
@@ -5,14 +5,14 @@
   "@sanity/base/__legacy/@sanity/components": "./packages/@sanity/base/src/__legacy/@sanity/components",
   '@sanity/base': './packages/@sanity/base/src/_exports',
 
+  '@sanity/desk-tool': './packages/@sanity/desk-tool/src/_exports',
+
   '@sanity/schema/lib': './packages/@sanity/schema/src',
   '@sanity/schema': './packages/@sanity/schema/src/legacy',
 
-  '@sanity/desk-tool/structure-builder': './packages/@sanity/desk-tool/structure-builder',
   '@sanity/block-tools': './packages/@sanity/block-tools/src',
   '@sanity/components': './packages/@sanity/components/src',
   '@sanity/diff': './packages/@sanity/diff/src',
-  '@sanity/desk-tool': './packages/@sanity/desk-tool/src',
   '@sanity/field': './packages/@sanity/field/src',
   '@sanity/form-builder/PatchEvent': './packages/@sanity/form-builder/src/PatchEvent',
   '@sanity/form-builder': './packages/@sanity/form-builder/src',

--- a/packages/@sanity/desk-tool/_interopReexport.js
+++ b/packages/@sanity/desk-tool/_interopReexport.js
@@ -1,0 +1,30 @@
+/**
+ * esm/commonjs interop reexport helper
+ * this should be used instead of doing `module.exports = require('./some/file')
+ * since that doesn't work properly with esm imports from the consuming end
+ * @param moduleExports export object from the exporting module
+ * @param importedModule the imported module to be reexported
+ */
+module.exports = function _interopReexport(moduleExports, importedModule) {
+  Object.defineProperty(moduleExports, '__esModule', {
+    value: true,
+  })
+
+  Object.defineProperty(moduleExports, 'default', {
+    enumerable: true,
+    get: function get() {
+      return importedModule.default
+    },
+  })
+
+  Object.keys(importedModule).forEach(function (key) {
+    if (key === 'default' || key === '__esModule') return
+    if (key in moduleExports && moduleExports[key] === importedModule[key]) return
+    Object.defineProperty(moduleExports, key, {
+      enumerable: true,
+      get: function get() {
+        return importedModule[key]
+      },
+    })
+  })
+}

--- a/packages/@sanity/desk-tool/package.json
+++ b/packages/@sanity/desk-tool/package.json
@@ -2,8 +2,15 @@
   "name": "@sanity/desk-tool",
   "version": "2.15.1",
   "description": "Tool for managing all sorts of content in a structured manner",
-  "main": "./lib/index.js",
-  "types": "./dist/dts",
+  "main": "./lib/_exports/index.js",
+  "types": "index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/dts/_exports/*"
+      ]
+    }
+  },
   "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",
   "scripts": {

--- a/packages/@sanity/desk-tool/src/_exports/index.ts
+++ b/packages/@sanity/desk-tool/src/_exports/index.ts
@@ -1,0 +1,2 @@
+export * from '../constants'
+export * from '../contexts/PaneRouterContext'

--- a/packages/@sanity/desk-tool/src/_exports/structure-builder.ts
+++ b/packages/@sanity/desk-tool/src/_exports/structure-builder.ts
@@ -1,0 +1,1 @@
+export {default} from '../structure-builder'

--- a/packages/@sanity/desk-tool/src/defaultStructure.js
+++ b/packages/@sanity/desk-tool/src/defaultStructure.js
@@ -2,7 +2,7 @@
 /* eslint-disable react/jsx-filename-extension */
 
 import React from 'react'
-import Structure from '../structure-builder'
+import Structure from './structure-builder'
 import {MissingDocumentTypesMessage} from './components/MissingDocumentTypesMessage'
 
 export default () => {

--- a/packages/@sanity/desk-tool/src/index.js
+++ b/packages/@sanity/desk-tool/src/index.js
@@ -1,2 +1,0 @@
-export * from './constants'
-export * from './contexts/PaneRouterContext'

--- a/packages/@sanity/desk-tool/src/structure-builder.ts
+++ b/packages/@sanity/desk-tool/src/structure-builder.ts
@@ -1,0 +1,1 @@
+export {StructureBuilder as default} from '@sanity/structure'

--- a/packages/@sanity/desk-tool/structure-builder.js
+++ b/packages/@sanity/desk-tool/structure-builder.js
@@ -1,2 +1,2 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-module.exports = require('@sanity/structure').StructureBuilder
+require('./_interopReexport')(module.exports, require('./lib/_exports/structure-builder'))

--- a/packages/@sanity/desk-tool/test/resolvePanes.test.js
+++ b/packages/@sanity/desk-tool/test/resolvePanes.test.js
@@ -1,7 +1,7 @@
 import {of as observableOf} from 'rxjs'
 import {takeWhile, concatMap, reduce} from 'rxjs/operators'
-import {LOADING_PANE} from '../src'
 import {resolvePanes} from '../src/utils/resolvePanes'
+import {LOADING_PANE} from '../src/constants'
 import singleStatsStructure from './fixtures/structures/singleStatsStructure'
 import singletonStructure from './fixtures/structures/singletonStructure'
 import recursiveStructure from './fixtures/structures/recursiveStructure'


### PR DESCRIPTION
### Description

This exports proper TS types from both `@sanity/desk-tool` and `@sanity/desk-tool/structure-builder`

### Notes for release

n/a