### PR TITLE
fix(desk-tool): use `editState` as source for publish status

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/documentPane/statusBar/sparkline/documentSparkline.styled.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/statusBar/sparkline/documentSparkline.styled.tsx
@@ -5,7 +5,6 @@ export const MetadataBox = styled(ElementQuery)`
   /* To be overridden by JS below */
   --session-layout-width: auto;
 
-  transition: transform 200ms;
   display: flex;
   align-items: center;
   flex: 1;
@@ -13,6 +12,10 @@ export const MetadataBox = styled(ElementQuery)`
 
   /* Hide review changes button when not changed */
   transform: translate3d(calc(0px - var(--session-layout-width) - 12px), 0, 0);
+
+  &[data-transition] {
+    transition: transform 200ms;
+  }
 
   /* Transition a fixed distance on smaller screens */
   &[data-eq-max~='0'] {
@@ -26,8 +29,11 @@ export const MetadataBox = styled(ElementQuery)`
 
 export const ReviewChangesBadgeBox = styled.div`
   display: none;
-  transition: opacity 100ms;
   opacity: 1;
+
+  [data-transition] > & {
+    transition: opacity 100ms;
+  }
 
   div:not([data-changed]) > & {
     opacity: 0;
@@ -41,8 +47,11 @@ export const ReviewChangesBadgeBox = styled.div`
 
 export const ReviewChangesButtonBox = styled.div`
   min-width: min-content;
-  transition: opacity 100ms;
   opacity: 1;
+
+  [data-transition] > & {
+    transition: opacity 100ms;
+  }
 
   div:not([data-changed]) > & {
     pointer-events: none;

--- a/packages/@sanity/desk-tool/src/panes/documentPane/statusBar/sparkline/documentSparkline.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentPane/statusBar/sparkline/documentSparkline.tsx
@@ -59,6 +59,10 @@ export function DocumentSparkline(props: DocumentSparklineProps) {
   const [transition, setTransition] = useState(false)
   useEffect(() => {
     if (!transition && loaded) {
+      // NOTE: the reason for double RAF here is a common "bug" in browsers.
+      // See: https://stackoverflow.com/questions/44145740/how-does-double-requestanimationframe-work
+      // There is no need to cancel this animation,
+      // since calling it again will cause the same result (transition=true).
       requestAnimationFrame(() => requestAnimationFrame(() => setTransition(true)))
     }
   }, [loaded, transition])


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

- With this change, the document sparkline uses the `editState` to find out if a document is published or not (instead of looking at the history events and finding the last `publish` or `unpublish` event).

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

- Test both live document and regular published/draft documents, and make sure the publish state is accurate in the document status bar.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

n/a
