### PR TITLE
chore(portable-text-editor): upgrade @sanity/slate-react

### DIFF
--- a/packages/@sanity/portable-text-editor/package.json
+++ b/packages/@sanity/portable-text-editor/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@sanity/block-tools": "2.16.0",
     "@sanity/schema": "2.16.0",
-    "@sanity/slate-react": "0.58.6",
+    "@sanity/slate-react": "0.58.7",
     "@sanity/types": "2.16.0",
     "@sanity/util": "2.16.0",
     "debug": "^3.2.7",


### PR DESCRIPTION
Fixes focus bugs in upstream dependency when you have multiple portable text editors in the same DOM with the same value.
