### PR TITLE
chore: upgrade to typescript 4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "stylelint": "^13.4.1",
     "stylelint-config-prettier": "^8.0.1",
     "stylelint-prettier": "^1.1.2",
-    "typescript": "^4.1.3",
+    "typescript": "^4.4.2",
     "yarn": "^1.3.2"
   },
   "husky": {

--- a/packages/@sanity/portable-text-editor/package.json
+++ b/packages/@sanity/portable-text-editor/package.json
@@ -70,7 +70,7 @@
     "rxjs": "^6.5.3",
     "ts-jest": "^26.5.4",
     "typedoc": "^0.17.3",
-    "typescript": "^4.1.3",
+    "typescript": "^4.4.2",
     "vite": "^2.4.4"
   },
   "peerDependencies": {

--- a/packages/@sanity/portable-text-editor/src/editor/DraggableChild.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/DraggableChild.tsx
@@ -7,6 +7,13 @@ import {IS_DRAGGING, IS_DRAGGING_ELEMENT_RANGE, IS_DRAGGING_CHILD_ELEMENT} from 
 const debug = debugWithName('components:DraggableChild')
 const debugRenders = false
 
+declare global {
+  interface Document {
+    // TypeScript removed this function from the default types (2021-08-26)
+    caretPositionFromPoint?(x: number, y: number): {offsetNode: Node; offset: number}
+  }
+}
+
 type ElementProps = {
   children: ReactElement
   element: SlateElement
@@ -53,7 +60,7 @@ export const DraggableChild: FunctionComponent<ElementProps> = ({
     // COMPAT: In Firefox, `caretRangeFromPoint` doesn't exist. (2020-05-14)
     if (document.caretRangeFromPoint) {
       domRange = document.caretRangeFromPoint(x, y)
-    } else {
+    } else if (document.caretPositionFromPoint) {
       const position = document.caretPositionFromPoint(x, y)
 
       if (position) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "preserveConstEnums": true,
     "moduleResolution": "node",
     "esModuleInterop": true,
-
+    "useUnknownInCatchVariables": false,
     "strict": true,
     "skipLibCheck": true
   },


### PR DESCRIPTION
### Description

TypeScript 4.4 introduced some breaking changes that caused the build to break. This was due to the new option `useUnknownInCatchVariables`.

[See here.](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables)

### What to review

Take a look at the new config options.
