### PR TITLE
fix(validation): resolve array items without _type

### DIFF
--- a/packages/@sanity/validation/package.json
+++ b/packages/@sanity/validation/package.json
@@ -32,12 +32,20 @@
     "directory": "packages/@sanity/validation"
   },
   "devDependencies": {
-    "@sanity/schema": "2.16.0",
+    "@sanity/client": "^2.16.0",
+    "@sanity/schema": "^2.16.0",
     "jest": "^26.6.3"
   },
+  "peerDependencies": {
+    "@sanity/client": "^2.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@sanity/client": {
+      "optional": true
+    }
+  },
   "dependencies": {
-    "@sanity/client": "2.16.0",
-    "@sanity/types": "2.17.0",
+    "@sanity/types": "^2.17.0",
     "date-fns": "^2.16.1",
     "lodash": "^4.17.15"
   }

--- a/packages/@sanity/validation/src/util/typeString.test.ts
+++ b/packages/@sanity/validation/src/util/typeString.test.ts
@@ -1,0 +1,27 @@
+import typeString from './typeString'
+
+describe('typeString', () => {
+  it('returns the a type string of built in types', () => {
+    expect(typeString({})).toBe('Object')
+    expect(
+      typeString(function () {
+        // intentionally blank
+      })
+    ).toBe('Function')
+    expect(typeString(['hey'])).toBe('Array')
+    expect(typeString('some string')).toBe('String')
+    expect(typeString(false)).toBe('Boolean')
+    expect(typeString(5)).toBe('Number')
+    expect(typeString(new Date())).toBe('Date')
+  })
+
+  it('returns a type string string using the constructor', () => {
+    class ExampleClass {}
+    expect(typeString(new ExampleClass())).toBe('ExampleClass')
+  })
+
+  it('returns a type string for null or undefined', () => {
+    expect(typeString(null)).toBe('null')
+    expect(typeString(undefined)).toBe('undefined')
+  })
+})

--- a/packages/@sanity/validation/src/util/typeString.ts
+++ b/packages/@sanity/validation/src/util/typeString.ts
@@ -11,19 +11,13 @@ function isBuiltIn(_constructor: unknown) {
   return false
 }
 
-function getConstructorOf(obj: unknown) {
-  if (obj === null || obj === undefined) return obj
-
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  return (obj as object).constructor
-}
-
 export default function typeString(obj: unknown): string {
   // [object Blah] -> Blah
   const stringType = _toString.call(obj).slice(8, -1)
   if (obj === null || obj === undefined) return stringType.toLowerCase()
 
-  const constructorType = getConstructorOf(obj)
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  const constructorType = (obj as object).constructor
   if (constructorType && !isBuiltIn(constructorType)) return constructorType.name
   return stringType
 }

--- a/packages/@sanity/validation/src/validateDocument.test.ts
+++ b/packages/@sanity/validation/src/validateDocument.test.ts
@@ -1,0 +1,156 @@
+/// <reference types="@sanity/types/parts" />
+
+import {Rule, SanityDocument, Schema} from '@sanity/types'
+import createSchema from 'part:@sanity/base/schema-creator'
+import validateDocument, {resolveTypeForArrayItem} from './validateDocument'
+
+describe('validateDocument', () => {
+  it('takes in a document + a compiled schema and returns a list of validation markers', async () => {
+    const schema = createSchema({
+      types: [
+        {
+          name: 'simpleDoc',
+          type: 'document',
+          title: 'Simple Document',
+          fields: [
+            {
+              name: 'title',
+              type: 'string',
+              validation: (rule: Rule) => rule.required(),
+            },
+          ],
+        },
+      ],
+    })
+
+    const document: SanityDocument = {
+      _id: 'testId',
+      _createdAt: '2021-08-27T14:48:51.650Z',
+      _rev: 'exampleRev',
+      _type: 'simpleDoc',
+      _updatedAt: '2021-08-27T14:48:51.650Z',
+      title: null,
+    }
+
+    const result = await validateDocument(document, schema)
+    expect(result).toMatchObject([
+      {
+        type: 'validation',
+        level: 'error',
+        item: {
+          message: 'Expected type "String", got "null"',
+          paths: [],
+        },
+        path: ['title'],
+      },
+      {
+        type: 'validation',
+        level: 'error',
+        item: {
+          message: 'Required',
+          paths: [],
+        },
+        path: ['title'],
+      },
+    ])
+  })
+
+  it('should be able to resolve an array item type if there is just one type', async () => {
+    const schema = createSchema({
+      types: [
+        {
+          name: 'testDoc',
+          type: 'document',
+          title: 'Test Document',
+          fields: [
+            {
+              name: 'values',
+              type: 'array',
+              // note that there is only one type available
+              of: [{type: 'arrayItem'}],
+              validation: (rule: Rule) => rule.required(),
+            },
+          ],
+        },
+        {
+          name: 'arrayItem',
+          type: 'object',
+          fields: [{name: 'title', type: 'string'}],
+        },
+      ],
+    })
+
+    const document: SanityDocument = {
+      _id: 'testId',
+      _createdAt: '2021-08-27T14:48:51.650Z',
+      _rev: 'exampleRev',
+      _type: 'testDoc',
+      _updatedAt: '2021-08-27T14:48:51.650Z',
+      values: [
+        {
+          // note how this doesn't have a _type
+          title: 5,
+          _key: 'exampleKey',
+        },
+      ],
+    }
+
+    await expect(validateDocument(document, schema)).resolves.toEqual([
+      {
+        type: 'validation',
+        level: 'error',
+        item: {
+          message: 'Expected type "String", got "Number"',
+          paths: [],
+        },
+        path: ['values', {_key: 'exampleKey'}, 'title'],
+      },
+    ])
+  })
+})
+
+describe('resolveTypeForArrayItem', () => {
+  const schema: Schema = createSchema({
+    types: [
+      {
+        name: 'foo',
+        type: 'object',
+        fields: [{name: 'title', type: 'number'}],
+      },
+      {
+        name: 'bar',
+        type: 'object',
+        fields: [{name: 'title', type: 'string'}],
+      },
+    ],
+  })
+
+  const fooType = schema.get('foo')
+  const barType = schema.get('bar')
+
+  it('finds a matching schema type for an array item value given a list of candidate types', () => {
+    const resolved = resolveTypeForArrayItem(
+      {
+        _type: 'bar',
+        _key: 'exampleKey',
+        title: 5,
+      },
+      [fooType, barType]
+    )
+
+    expect(resolved).toBe(barType)
+  })
+
+  it('assumes the type if there is only one possible candidate', () => {
+    const resolved = resolveTypeForArrayItem(
+      {
+        // notice no _type
+        _key: 'exampleKey',
+        title: 5,
+      },
+      [fooType]
+    )
+
+    expect(resolved).toBe(fooType)
+  })
+})


### PR DESCRIPTION
### Description

This PR fixes some regressions from the validation refactor as well as ups the test coverage. 

### What to review

Review the changes to the code and the new tests.

### Notes for release

Fixes regression in `@sanity/validation` "Unable to resolve type for item" (#2715)