### PR TITLE
fix(validation): run nested validation in nested fields if required

### DIFF
--- a/examples/test-studio/schemas/validation.js
+++ b/examples/test-studio/schemas/validation.js
@@ -533,5 +533,32 @@ export default {
       },
       inputComponent: CustomObjectSelectInput,
     },
+    {
+      name: 'requiredObjectWithFields',
+      description:
+        'Because this object is required, the sub-field validation will run even if the object is undefined.',
+      type: 'object',
+      validation: (Rule) => Rule.required().error('Please fill out this object'),
+      fields: [
+        {
+          name: 'title',
+          type: 'string',
+          validation: (Rule) => Rule.required().error('Title is required'),
+        },
+      ],
+    },
+    {
+      name: 'optionalObjectWithFields',
+      description:
+        'Because this object is not required, the sub-field validation will NOT run if the object is undefined. You must touch it first.',
+      type: 'object',
+      fields: [
+        {
+          name: 'title',
+          type: 'string',
+          validation: (Rule) => Rule.required().error('Title is required.'),
+        },
+      ],
+    },
   ],
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,9 +7,9 @@ const changed = require('gulp-changed')
 const filter = require('gulp-filter')
 const chalk = require('chalk')
 const babel = require('gulp-babel')
-const {runTsc} = require('./scripts/runTsc')
 const log = require('fancy-log')
 const through = require('through2')
+const {runTsc} = require('./scripts/runTsc')
 
 const {getPackagePaths} = require('./scripts/utils/getPackagePaths')
 
@@ -60,7 +60,7 @@ const compileTaskName = (taskType, packagePath, extra = '') => {
 
 function buildJavaScript(packageDir, destDir) {
   return withDisplayName(compileTaskName('babel', packageDir, 'cjs'), () =>
-    src(`${SRC_DIR}/**/*.{js,ts,tsx}`, {cwd: packageDir})
+    src(['!**/*.{test,spec}.{js,ts,tsx}', `${SRC_DIR}/**/*.{js,ts,tsx}`], {cwd: packageDir})
       .pipe(
         changed(destDir, {
           cwd: packageDir,

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -71,7 +71,7 @@ export type InitialValueProperty<T = unknown> = T | InitialValueResolver<T> | un
  * }
  * ```
  */
-type ValidationValue = false | Rule[] | ((rule: Rule) => Rule | Rule[])
+export type SchemaValidationValue = false | Rule | Rule[] | ((rule: Rule) => Rule | Rule[])
 
 export interface BaseSchemaType {
   name: string
@@ -123,7 +123,7 @@ export interface StringSchemaType extends BaseSchemaType {
     timeFormat?: string
   }
   initialValue?: ((arg?: any) => Promise<string> | string) | string | undefined
-  validation?: ValidationValue
+  validation?: SchemaValidationValue
 }
 
 export interface TextSchemaType extends StringSchemaType {
@@ -134,7 +134,7 @@ export interface NumberSchemaType extends BaseSchemaType {
   jsonType: 'number'
   options?: EnumListProps<number>
   initialValue?: InitialValueProperty<number>
-  validation?: ValidationValue
+  validation?: SchemaValidationValue
 }
 
 export interface BooleanSchemaType extends BaseSchemaType {
@@ -143,7 +143,7 @@ export interface BooleanSchemaType extends BaseSchemaType {
     layout: 'checkbox' | 'switch'
   }
   initialValue?: InitialValueProperty<boolean>
-  validation?: ValidationValue
+  validation?: SchemaValidationValue
 }
 
 export interface ArraySchemaType<V = unknown> extends BaseSchemaType {
@@ -160,7 +160,7 @@ export interface ArraySchemaType<V = unknown> extends BaseSchemaType {
      */
     editModal?: 'dialog' | 'fullscreen' | 'popover' | 'fold'
   }
-  validation?: ValidationValue
+  validation?: SchemaValidationValue
 }
 
 export interface BlockSchemaType extends ObjectSchemaType {
@@ -187,7 +187,7 @@ export interface ObjectSchemaType extends BaseSchemaType {
   fields: ObjectField[]
   fieldsets?: Fieldset[]
   initialValue?: InitialValueProperty<Record<string, unknown>>
-  validation?: ValidationValue
+  validation?: SchemaValidationValue
 
   // Experimentals
   /* eslint-disable camelcase */

--- a/packages/@sanity/types/src/validation/types.ts
+++ b/packages/@sanity/types/src/validation/types.ts
@@ -1,10 +1,10 @@
 import {Path} from '../paths'
-import {SchemaType} from '../schema'
+import {SchemaType, SchemaValidationValue} from '../schema'
 import {SanityDocument} from '../documents'
 import {ValidationMarker} from '../markers'
 
 export type RuleTypeConstraint = 'Array' | 'Boolean' | 'Date' | 'Number' | 'Object' | 'String'
-export type FieldRules = {[fieldKey: string]: (fieldRule: Rule) => Rule}
+export type FieldRules = {[fieldKey: string]: SchemaValidationValue}
 
 // Note: `RuleClass` and `Rule` are split to fit the current `@sanity/types`
 // setup. Classes are a bit weird in the `@sanity/types` package because classes

--- a/packages/@sanity/validation/src/Rule.ts
+++ b/packages/@sanity/validation/src/Rule.ts
@@ -392,10 +392,6 @@ const Rule: RuleClass = class Rule implements IRule {
 
         let specConstraint = 'constraint' in curr ? curr.constraint : null
         if (isFieldRef(specConstraint)) {
-          if (!context.parent) {
-            throw new Error('Field reference provided, but no parent received')
-          }
-
           specConstraint = get(context.parent, specConstraint.path)
         }
 

--- a/packages/@sanity/validation/src/validators/blockValidator.ts
+++ b/packages/@sanity/validation/src/validators/blockValidator.ts
@@ -32,9 +32,14 @@ export const blockValidator: BlockValidator = async (value, context) => {
   const annotationValidations: Promise<ValidationMarker[]>[] = []
   value.markDefs.forEach((markDef: any) => {
     const annotationType = activeAnnotationTypes.find((aType) => aType.name === markDef._type)
-    const validations = validateItem(markDef, annotationType, ['markDefs', {_key: markDef._key}], {
-      parent: value,
-      document: context.document,
+    const validations = validateItem({
+      value: markDef,
+      type: annotationType,
+      path: ['markDefs', {_key: markDef._key}],
+      context: {
+        parent: value,
+        document: context.document,
+      },
     })
     annotationValidations.push(validations)
   })


### PR DESCRIPTION
### Description

> currently if the value is undefined or null, it won't run any nested validation at all. even if required.
> I think we should run nested validation if the field is required — even if that value is undefined.

See here: https://github.com/sanity-io/sanity/issues/1713#issuecomment-907546288

Closes #1713
Closes #2630

<img width="890" alt="CleanShot 2021-08-27 at 21 45 05@2x" src="https://user-images.githubusercontent.com/10551026/131202421-a73e93c9-dce2-4121-b5fe-897bff1db927.png">

See the changes to the example validation schema for more info.

### What to review

- Ensure this change doesn't break any of the current expectations in validation
- Try it out in the studio and see if it behaves the way you'd expect it to or if it's a regression.

### Notes for release

- Validation markers will appear on nested fields if the containing field is marked as `Rule.required()`.<br />Fixes #1713
- Objects and arrays are now unset if they are empty.<br />Fixes #2630