### PR TITLE
feat(base): add breadcrumbs to validation markers

### DIFF
--- a/packages/@sanity/base/src/__legacy/@sanity/components/validation/ValidationListItem.css
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/validation/ValidationListItem.css
@@ -69,6 +69,26 @@
   font-size: var(--font-size-small);
   line-height: var(--line-height-small);
   font-weight: 600;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+
+  @nest & > *:not(:last-child) {
+    position: relative;
+    margin-right: var(--medium-padding);
+  }
+
+  @nest & > *:not(:last-child)::before {
+    content: '/';
+    font-size: var(--font-size-xsmall);
+    font-style: italic;
+    font-weight: 400;
+    color: var(--text-muted);
+    position: absolute;
+    top: 50%;
+    left: calc(100% + var(--medium-padding) / 2);
+    transform: translate(-50%, -50%);
+  }
 }
 
 .message {

--- a/packages/@sanity/base/src/__legacy/@sanity/components/validation/ValidationListItem.tsx
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/validation/ValidationListItem.tsx
@@ -14,13 +14,14 @@ interface ValidationListItemProps {
   kind?: 'simple'
   marker: Marker
   onClick?: (path?: Path) => void
-  path: string
+  path: string | string[]
   // showLink?: boolean
   truncate?: boolean
 }
 
 function ValidationListItem(props: ValidationListItemProps) {
-  const {hasFocus, kind, marker, onClick, path, truncate} = props
+  const {hasFocus, kind, marker, onClick, truncate} = props
+  const path = Array.isArray(props.path) ? props.path : [props.path || '']
   const hasOnClick = Boolean(props.onClick)
   const rootRef = useRef<HTMLDivElement | null>(null)
   const hasFocusRef = useRef(hasFocus || false)
@@ -55,7 +56,14 @@ function ValidationListItem(props: ValidationListItemProps) {
       </span>
 
       <div className={styles.content}>
-        {path && <div className={styles.path}>{path}</div>}
+        {path.length && (
+          <div title={path.join(' / ')} className={styles.path}>
+            {path.map((pathSegment, i) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <span key={`${pathSegment}-${i}`}>{pathSegment}</span>
+            ))}
+          </div>
+        )}
         {marker.item.message && <div className={styles.message}>{marker.item.message}</div>}
       </div>
     </>


### PR DESCRIPTION
### Description

This add breadcrumbs to the validation list.

<img width="969" alt="screenshot of breadcrumbs" src="https://user-images.githubusercontent.com/10551026/131229076-c7e0208e-9843-4ece-8e50-e610ffe6387e.png">

Updated CSS to match the review changes breadcrumbs

<img width="322" alt="updated screenshot" src="https://user-images.githubusercontent.com/10551026/131618541-f8ae9d00-11e1-4146-83e7-9c078d24e2e1.png">

### What to review

I would just review the idea and see if you like it. I fully expect this PR to be superseded by #2610

This is related to #2718. I thought it would be a good idea to include breadcrumbs if we start showing validation errors for nested items more often.

Edit: I'm not sure where #2718 stands. Should this wait for that? @mariuslundgard 

### Notes for release

Validation markers now show breadcrumbs
