### PR TITLE
Fix activate on focus when used in combination with change indicator

### DIFF
--- a/packages/@sanity/form-builder/src/components/ActivateOnFocus/ActivateOnFocus.styles.tsx
+++ b/packages/@sanity/form-builder/src/components/ActivateOnFocus/ActivateOnFocus.styles.tsx
@@ -6,7 +6,7 @@ export const OverlayContainer = styled.div`
 `
 
 export const ContentContainer = styled.div`
-  z-index: 7;
+  z-index: 13;
   opacity: 0;
   transition: opacity 300ms linear;
 `
@@ -18,7 +18,7 @@ export const CardContainer = styled(Card)`
   left: 0;
   width: 100%;
   height: 100%;
-  z-index: 6;
+  z-index: 12;
   transition: opacity 150ms ease-in-out;
   opacity: 0;
   box-sizing: border-box;


### PR DESCRIPTION
### Description

Increased the `z-index` for the contents within the `ActivateOnFocus` overlay to appear above the change indicator and so show the content regardless of which direction the content is hovered.

### What to review

1. Go to the blocks tests
2. Find one with the change indicator active (the first one should do it)
