### PR TITLE
fix(portable-text-editor): fix bug in value conversion

### DIFF
--- a/packages/@sanity/portable-text-editor/src/utils/values.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/values.ts
@@ -74,9 +74,10 @@ export function fromSlateValue(
           const {_type} = child
           if (_type !== 'span' && typeof child.value === 'object') {
             hasInlines = true
-            const {value: _v, _key: _k, _type: _t, ...rest} = child
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const {value: v, _key: k, _type: t, __inline: _i, children: _c, ...rest} = child
             return keepObjectEquality(
-              {_key: _k as string, _type: _t as string, ...rest, ..._v},
+              {_key: k as string, _type: t as string, ...rest, ...v},
               keyMap
             )
           }


### PR DESCRIPTION
This bug was introduced when the editor was moved into the monorepo in order to fix TS warnings/errors with the monorepo setup. It went a little wrong.

### Notes for release

Fix bug introduced in v2.16.0 where inline Sanity references in Portable Text would not be saved properly.