### PR TITLE
fix: use correct width/height for preview images, scale by dpr

### DIFF
--- a/packages/@sanity/base/package.json
+++ b/packages/@sanity/base/package.json
@@ -95,7 +95,8 @@
     "rxjs-exhaustmap-with-trailing": "^1.0.0",
     "semver-compare": "^1.0.0",
     "shallow-equals": "^1.0.0",
-    "styled-components": "^5.2.1"
+    "styled-components": "^5.2.1",
+    "use-device-pixel-ratio": "^1.1.0"
   },
   "devDependencies": {
     "@types/chance": "^1.1.0",

--- a/packages/@sanity/base/src/__legacy/@sanity/components/previews/types.ts
+++ b/packages/@sanity/base/src/__legacy/@sanity/components/previews/types.ts
@@ -2,5 +2,6 @@ export interface MediaDimensions {
   width?: number
   height?: number
   fit?: 'clip' | 'crop' | 'fill' | 'fillmax' | 'max' | 'scale' | 'min'
+  dpr?: number
   aspect?: number
 }

--- a/packages/@sanity/base/src/components/previews/defaultPreview.tsx
+++ b/packages/@sanity/base/src/components/previews/defaultPreview.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {Box, Flex, Stack, Text, Skeleton, TextSkeleton} from '@sanity/ui'
 import styled from 'styled-components'
+import {getDevicePixelRatio} from 'use-device-pixel-ratio'
 import {PreviewProps} from './types'
 
 const Root = styled(Flex)`
@@ -71,7 +72,13 @@ export const DefaultPreview = (props: PreviewProps<'default'>) => {
             >
               {typeof media === 'function' &&
                 media({
-                  dimensions: {width: 80, height: 80, aspect: 1, fit: 'crop'},
+                  dimensions: {
+                    width: 35,
+                    height: 35,
+                    aspect: 1,
+                    fit: 'crop',
+                    dpr: getDevicePixelRatio(),
+                  },
                   layout: 'default',
                 })}
 

--- a/packages/@sanity/base/src/components/previews/types.ts
+++ b/packages/@sanity/base/src/components/previews/types.ts
@@ -30,6 +30,7 @@ export type MediaDimensions = {
   height?: number
   fit?: ImageUrlFitMode
   aspect?: number
+  dpr?: number
 }
 
 export interface PreviewProps<LayoutKey = PreviewLayoutKey> {

--- a/packages/@sanity/base/src/preview/components/SanityDefaultPreview.tsx
+++ b/packages/@sanity/base/src/preview/components/SanityDefaultPreview.tsx
@@ -58,6 +58,7 @@ export default class SanityDefaultPreview extends React.PureComponent<Props> {
             .width(dimensions.width || 100)
             .height(dimensions.height || 100)
             .fit(dimensions.fit)
+            .dpr(dimensions.dpr || 1)
             .url() || ''
         }
       />


### PR DESCRIPTION
### Description

Recently we changed the default previews to be a bit smaller (35px vs 40px). The thumbnail _image_ that we are fetching is however still 80px, which creates a slightly unclear thumbnail when scaled down, since it's not a factor of 2 larger.

This changes the dimensions to 35 pixels which is the actually correct size, and passes a `dpr` property to the image URL library based on what the device reports as it's DPR (through the `window.devicePixelRatio` property, rounded down and capped at 3). 

This makes the thumbnails clearer on regular screens (because the size is correct - 35px vs 40px) and clearer on high-DPI monitors such as Mac retina displays and mobile phone displays.

Current (1 DPR display):

![image](https://user-images.githubusercontent.com/48200/131139719-3b3c1ede-7657-4068-8643-09264a496b63.png)

With this change  (1 DPR display):

![image](https://user-images.githubusercontent.com/48200/131140059-d3281de0-5bd4-4ff4-a26f-1c9b36acf67f.png)

### What to review

- Does the change in default media size have any side-effects that I have not accounted for?
- Does the (slightly) added complexity make sense?

### Notes for release

- Make preview images clearer, especially on high-DPI devices
