### PR TITLE
chore: upgrade image-url library

### DIFF
--- a/examples/test-studio/package.json
+++ b/examples/test-studio/package.json
@@ -31,7 +31,7 @@
     "@sanity/desk-tool": "2.17.2",
     "@sanity/google-maps-input": "2.17.2",
     "@sanity/icons": "^1.1.4",
-    "@sanity/image-url": "^0.140.19",
+    "@sanity/image-url": "^1.0.1",
     "@sanity/production-preview": "2.15.0",
     "@sanity/studio-hints": "2.17.2",
     "@sanity/types": "2.17.1",

--- a/packages/@sanity/base/package.json
+++ b/packages/@sanity/base/package.json
@@ -49,7 +49,7 @@
     "@sanity/color": "^2.1.4",
     "@sanity/generate-help-url": "2.15.0",
     "@sanity/icons": "^1.1.4",
-    "@sanity/image-url": "^0.140.19",
+    "@sanity/image-url": "^1.0.1",
     "@sanity/initial-value-templates": "2.17.2",
     "@sanity/mutator": "2.15.0",
     "@sanity/schema": "2.17.2",

--- a/packages/@sanity/dashboard/package.json
+++ b/packages/@sanity/dashboard/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "@sanity/icons": "^1.1.4",
-    "@sanity/image-url": "^0.140.19",
+    "@sanity/image-url": "^1.0.1",
     "@sanity/types": "2.17.1",
     "@sanity/ui": "^0.36.3",
     "lodash": "^4.17.15",

--- a/packages/@sanity/field/package.json
+++ b/packages/@sanity/field/package.json
@@ -42,7 +42,7 @@
     "@sanity/color": "^2.1.4",
     "@sanity/diff": "2.15.0",
     "@sanity/icons": "^1.1.4",
-    "@sanity/image-url": "^0.140.19",
+    "@sanity/image-url": "^1.0.1",
     "@sanity/react-hooks": "2.17.1",
     "@sanity/types": "2.17.1",
     "@sanity/ui": "^0.36.3",


### PR DESCRIPTION
### Description

Upgrades the image library to the latest version, which solves a (small) annoyance where passing a dpr property of `1` would result in `dpr=1` to be added to the URL (which is unnecessary, given that is the default). Also - a more logical semver range - yay!

### What to review

That things still work
