### PR TITLE
chore: upgrade terser

### DIFF
--- a/packages/@sanity/client/package.json
+++ b/packages/@sanity/client/package.json
@@ -48,7 +48,7 @@
     "rxjs": "^6.5.3",
     "sse-channel": "^2.0.6",
     "tape": "^4.8.0",
-    "terser": "4.6.7",
+    "terser": "^5.7.2",
     "uglifyify": "^5.0.1",
     "xtend": "4.0.2"
   },

--- a/packages/@sanity/core/.depcheckignore.json
+++ b/packages/@sanity/core/.depcheckignore.json
@@ -1,1 +1,0 @@
-{"ignore": ["terser"]}

--- a/packages/@sanity/core/package.json
+++ b/packages/@sanity/core/package.json
@@ -59,14 +59,13 @@
     "pirates": "^4.0.0",
     "pluralize": "^7.0.0",
     "pretty-ms": "^7.0.1",
-    "resolve-bin": "^0.4.0",
     "resolve-from": "^4.0.0",
     "rimraf": "^2.7.1",
     "rxjs": "^6.5.3",
     "semver": "^6.1.2",
     "simple-get": "^4.0.0",
     "tar-fs": "^1.16.0",
-    "terser": "4.6.7",
+    "terser": "^5.7.2",
     "yargs": "^16.2.0"
   },
   "repository": {


### PR DESCRIPTION
### Description

There were some issue around the minification step in `sanity build` around `resolve-bin` so I removed it and opted for the Terser JS API.

### What to review

See if `sanity build` still works with no regression. Also affects the `@sanity/client` build since that was also using an older version of terser.

### Notes for release

N/A
