### PR TITLE
fix(portable-text-editor): fix re-render regression from v2.16.0

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -239,8 +239,8 @@ export const PortableTextEditable = (props: Props) => {
   }
 
   useEffect(() => {
-    KEY_TO_SLATE_ELEMENT.set(editor, undefined)
-    KEY_TO_VALUE_ELEMENT.set(editor, undefined)
+    KEY_TO_SLATE_ELEMENT.set(editor, {})
+    KEY_TO_VALUE_ELEMENT.set(editor, {})
     return () => {
       KEY_TO_SLATE_ELEMENT.delete(editor)
       KEY_TO_VALUE_ELEMENT.delete(editor)

--- a/packages/@sanity/portable-text-editor/src/utils/weakMaps.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/weakMaps.ts
@@ -15,5 +15,5 @@ export const IS_DRAGGING_ELEMENT_RANGE: WeakMap<Editor, Range> = new WeakMap()
 // Target position for dragging over a block
 export const IS_DRAGGING_BLOCK_TARGET_POSITION: WeakMap<Editor, 'top' | 'bottom'> = new WeakMap()
 
-export const KEY_TO_SLATE_ELEMENT: WeakMap<Editor, Element | undefined> = new WeakMap()
+export const KEY_TO_SLATE_ELEMENT: WeakMap<Editor, any | undefined> = new WeakMap()
 export const KEY_TO_VALUE_ELEMENT: WeakMap<Editor, any | undefined> = new WeakMap()


### PR DESCRIPTION
### Description

When moving the PTE into the monorepo some refactoring was done to please typescript. It went wrong here obviously making block re-render themselves even though they weren't changed. This is a regression since v2.16.0.

I have fixed the regression.

It should also be added a test for this in the test branch we are working on.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### Notes for release
Fix regression in portable text editor since 2.16.0 where blocks are re-rendered when they should not be.

<!--
A description of the change(s) that should be used in the release notes.
-->
