### PR TITLE
build: run build before publish-tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "publish": "npm run build && lerna publish --exact",
     "publish-canary": "RELEASE_TAG=canary npm run publish-tag",
     "publish-current-branch": "RELEASE_TAG=`git rev-parse --abbrev-ref HEAD | sed 's/\\//\\_/g'` npm run publish-tag",
-    "publish-tag": "RELEASE_TAG=\"${RELEASE_TAG:-canary}\"; lerna publish --canary --force-publish --no-git-tag-version --dist-tag=$RELEASE_TAG --preid=$RELEASE_TAG --exact",
+    "publish-tag": "RELEASE_TAG=\"${RELEASE_TAG:-canary}\"; npm run build && lerna publish --canary --force-publish --no-git-tag-version --dist-tag=$RELEASE_TAG --preid=$RELEASE_TAG --exact",
     "package": "npm run package-yarn && npm run package-cli",
     "package-cli": "(cd packages/@sanity/cli && npm run pack)",
     "package-yarn": "(cd packages/@sanity/cli && npm run package-yarn)",


### PR DESCRIPTION
### Description

I had to run the build prior to running publish tag and that might be a missed step in the future so this may help.

notice that `npm run publish` runs the build prior too

### What to review

Check the logic; try the command

