### PR TITLE
feat(default-login): add support for sso login providers

### DIFF
--- a/packages/@sanity/default-login/src/util/getProviders.js
+++ b/packages/@sanity/default-login/src/util/getProviders.js
@@ -9,7 +9,7 @@ export default function getProviders() {
       withCredentials: true,
     })
     .then((res) => {
-      const {providers, thirdPartyLogin} = res
+      const {providers, thirdPartyLogin, sso} = res
       const customProviders = (config.providers && config.providers.entries) || []
       if (customProviders.length === 0) {
         return providers
@@ -20,7 +20,9 @@ export default function getProviders() {
         // login options through the config. These shouldn't be treated as custom login providers
         // which require the third-party login feature, but as the official provider
         const isOfficial = providers.some((official) => official.url === provider.url)
-        return {...provider, custom: !isOfficial, supported: isOfficial || thirdPartyLogin}
+        const isSupported =
+          isOfficial || thirdPartyLogin || (sso && Object.values(sso).some(Boolean))
+        return {...provider, custom: !isOfficial, supported: isSupported}
       })
 
       if (config.providers.mode === 'replace') {


### PR DESCRIPTION
### Description

With the introduction of SSO we need a way to determine if we should allow sso prompts on studio login. The `/auth/providers` endpoint has been updated to include an `sso` object which contains the keys of enabled `sso` types. This PR checks if any of those flags are set and if so, allow custom entities in `default-login.json`.

### Notes for release

This will be a silent release until after the beta period.
