### PR TITLE
misc validation fixes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,6 +40,8 @@ module.exports = {
         // the normal `no-dupe-class-members` doesn't work with TS overrides
         'no-dupe-class-members': 'off',
         '@typescript-eslint/no-dupe-class-members': ['error'],
+        'no-unused-vars': 'off',
+        '@typescript-eslint/no-unused-vars': ['warn'],
       },
     },
   ],

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -60,7 +60,7 @@ const compileTaskName = (taskType, packagePath, extra = '') => {
 
 function buildJavaScript(packageDir, destDir) {
   return withDisplayName(compileTaskName('babel', packageDir, 'cjs'), () =>
-    src(['!**/*.{test,spec}.{js,ts,tsx}', `${SRC_DIR}/**/*.{js,ts,tsx}`], {cwd: packageDir})
+    src([`${SRC_DIR}/**/*.{js,ts,tsx}`, '!**/*.{test,spec}.{js,ts,tsx}'], {cwd: packageDir})
       .pipe(
         changed(destDir, {
           cwd: packageDir,

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -1,5 +1,5 @@
-const moduleAliases = require('./.module-aliases')
 const path = require('path')
+const moduleAliases = require('./.module-aliases')
 
 /**
  * Takes a list of path aliases and converts them into jest module mappings with some
@@ -38,8 +38,8 @@ module.exports = {
       },
     ],
   },
-  testRegex:
-    '(src/(.*__tests__/.*|(\\.|/)(test|spec))\\.[jt]sx?$)|(test/((.*\\.|/)(test|spec))\\.[jt]sx?$)',
+  testMatch: ['**/*.{test,spec}.{js,ts,tsx}'],
+  testPathIgnorePatterns: ['/(node_modules|lib|dist|bin|coverage)/'],
   moduleNameMapper: jestify({
     ...moduleAliases,
     'part:@sanity/components/fieldsets/default':

--- a/packages/@sanity/form-builder/src/utils/getValidationRule.ts
+++ b/packages/@sanity/form-builder/src/utils/getValidationRule.ts
@@ -12,7 +12,7 @@ const normalizeRules = (
     )
   }
   if (!validation) return []
-  if (Array.isArray(validation)) return validation
+  if (Array.isArray(validation)) return validation as Rule[]
   return [validation]
 }
 

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -71,7 +71,12 @@ export type InitialValueProperty<T = unknown> = T | InitialValueResolver<T> | un
  * }
  * ```
  */
-export type SchemaValidationValue = false | Rule | Rule[] | ((rule: Rule) => Rule | Rule[])
+export type SchemaValidationValue =
+  | false
+  | undefined
+  | Rule
+  | SchemaValidationValue[]
+  | ((rule: Rule) => SchemaValidationValue)
 
 export interface BaseSchemaType {
   name: string
@@ -82,7 +87,9 @@ export interface BaseSchemaType {
   liveEdit?: boolean
   icon?: React.ComponentType
   initialValue?: InitialValueProperty
-  options?: unknown
+  options?: Record<string, any>
+
+  validation?: SchemaValidationValue
 
   preview?: {
     select?: PreviewValue
@@ -123,7 +130,6 @@ export interface StringSchemaType extends BaseSchemaType {
     timeFormat?: string
   }
   initialValue?: ((arg?: any) => Promise<string> | string) | string | undefined
-  validation?: SchemaValidationValue
 }
 
 export interface TextSchemaType extends StringSchemaType {
@@ -134,7 +140,6 @@ export interface NumberSchemaType extends BaseSchemaType {
   jsonType: 'number'
   options?: EnumListProps<number>
   initialValue?: InitialValueProperty<number>
-  validation?: SchemaValidationValue
 }
 
 export interface BooleanSchemaType extends BaseSchemaType {
@@ -143,7 +148,6 @@ export interface BooleanSchemaType extends BaseSchemaType {
     layout: 'checkbox' | 'switch'
   }
   initialValue?: InitialValueProperty<boolean>
-  validation?: SchemaValidationValue
 }
 
 export interface ArraySchemaType<V = unknown> extends BaseSchemaType {
@@ -160,7 +164,6 @@ export interface ArraySchemaType<V = unknown> extends BaseSchemaType {
      */
     editModal?: 'dialog' | 'fullscreen' | 'popover' | 'fold'
   }
-  validation?: SchemaValidationValue
 }
 
 export interface BlockSchemaType extends ObjectSchemaType {
@@ -187,7 +190,6 @@ export interface ObjectSchemaType extends BaseSchemaType {
   fields: ObjectField[]
   fieldsets?: Fieldset[]
   initialValue?: InitialValueProperty<Record<string, unknown>>
-  validation?: SchemaValidationValue
 
   // Experimentals
   /* eslint-disable camelcase */

--- a/packages/@sanity/types/src/validation/types.ts
+++ b/packages/@sanity/types/src/validation/types.ts
@@ -33,32 +33,41 @@ export interface RuleClass {
 }
 
 export interface Rule {
+  // Note: these prop is not actually deprecated but there is better TS Doc
+  // support for `@deprecated` than `@internal`
   /**
    * @internal
+   * @deprecated internal use only
    */
   _type: RuleTypeConstraint | undefined
   /**
    * @internal
+   * @deprecated internal use only
    */
   _level: 'error' | 'warning' | undefined
   /**
    * @internal
+   * @deprecated internal use only
    */
   _required: 'required' | 'optional' | undefined
   /**
    * @internal
+   * @deprecated internal use only
    */
   _typeDef: SchemaType | undefined
   /**
    * @internal
+   * @deprecated internal use only
    */
   _message: string | undefined
   /**
    * @internal
+   * @deprecated internal use only
    */
   _rules: RuleSpec[]
   /**
    * @internal
+   * @deprecated internal use only
    */
   _fieldRules: FieldRules | undefined
 

--- a/packages/@sanity/validation/src/inferFromSchema.ts
+++ b/packages/@sanity/validation/src/inferFromSchema.ts
@@ -5,7 +5,7 @@ import inferFromSchemaType from './inferFromSchemaType'
 function inferFromSchema(schema: Schema): Schema {
   const typeNames = schema.getTypeNames()
   typeNames.forEach((typeName) => {
-    inferFromSchemaType(schema.get(typeName), schema)
+    inferFromSchemaType(schema.get(typeName))
   })
   return schema
 }

--- a/packages/@sanity/validation/src/inferFromSchemaType.ts
+++ b/packages/@sanity/validation/src/inferFromSchemaType.ts
@@ -1,64 +1,25 @@
-import {Schema, SchemaType, Rule as IRule} from '@sanity/types'
-import RuleClass from './Rule'
-import {slugValidator} from './validators/slugValidator'
-import {blockValidator} from './validators/blockValidator'
+import {Schema, SchemaType} from '@sanity/types'
+import normalizeValidationRules from './util/normalizeValidationRules'
 
-function inferFromSchemaType(
-  typeDef: SchemaType,
-  schema: Schema,
-  visited = new Set<SchemaType>()
-): SchemaType {
+function traverse(typeDef: SchemaType, visited: Set<SchemaType>) {
   if (visited.has(typeDef)) {
-    return typeDef
+    return
   }
 
   visited.add(typeDef)
 
-  if (typeDef.validation === false) {
-    typeDef.validation = []
-    return typeDef
+  typeDef.validation = normalizeValidationRules(typeDef)
+
+  if ('fields' in typeDef) {
+    for (const field of typeDef.fields) {
+      traverse(field.type, visited)
+    }
   }
 
-  const isInitialized =
-    Array.isArray(typeDef.validation) &&
-    typeDef.validation.every((item) => typeof item?.validate === 'function')
-
-  if (isInitialized) {
-    inferForFields(typeDef, schema, visited)
-    inferForMemberTypes(typeDef, schema, visited)
-    return typeDef
-  }
-
-  const type = typeDef.type
-  const typed = RuleClass[typeDef.jsonType]
-  let base = typed ? typed(typeDef) : new RuleClass(typeDef)
-
-  if (type && type.name === 'datetime') {
-    base = base.type('Date')
-  }
-
-  if (type && type.name === 'date') {
-    base = base.type('Date')
-  }
-
-  if (type && type.name === 'url') {
-    base = base.uri()
-  }
-
-  if (type && type.name === 'slug') {
-    base = base.custom(slugValidator)
-  }
-
-  if (type && type.name === 'reference') {
-    base = base.reference()
-  }
-
-  if (type && type.name === 'email') {
-    base = base.email()
-  }
-
-  if (type && type.name === 'block') {
-    base = base.block(blockValidator)
+  if ('of' in typeDef) {
+    for (const candidate of typeDef.of) {
+      traverse(candidate, visited)
+    }
   }
 
   // eslint-disable-next-line no-warning-comments
@@ -66,83 +27,24 @@ function inferFromSchemaType(
   if (typeDef.annotations) {
     // eslint-disable-next-line no-warning-comments
     // @ts-expect-error TODO (eventually): `annotations` does not exist on the SchemaType yet
-    typeDef.annotations.forEach((annotation) => inferFromSchemaType(annotation))
+    for (const annotation of typeDef.annotations) {
+      traverse(annotation, visited)
+    }
   }
+}
 
-  // eslint-disable-next-line no-warning-comments
-  // @ts-expect-error TODO (eventually): fix options list grabbing
-  if (typeDef.options && typeDef.options.list && Array.isArray(typeDef.options.list)) {
-    base = base.valid(
-      // eslint-disable-next-line no-warning-comments
-      // @ts-expect-error TODO (eventually): fix options list grabbing
-      typeDef.options.list.map((option) => extractValueFromListOption(option, typeDef))
-    )
-  }
-
-  typeDef.validation = inferValidation(typeDef, base)
-  inferForFields(typeDef, schema, visited)
-  inferForMemberTypes(typeDef, schema, visited)
-
+// NOTE: this overload is for TS API compatibility with a previous implementation
+function inferFromSchemaType(
+  typeDef: SchemaType,
+  // these are intentionally unused
+  _schema: Schema,
+  _visited?: Set<SchemaType>
+): SchemaType
+// note: this seemingly redundant overload is required
+function inferFromSchemaType(typeDef: SchemaType): SchemaType
+function inferFromSchemaType(typeDef: SchemaType): SchemaType {
+  traverse(typeDef, new Set())
   return typeDef
-}
-
-function inferForFields(typeDef: SchemaType, schema: Schema, visited: Set<SchemaType>): void {
-  if (typeDef.jsonType !== 'object' || !typeDef.fields) {
-    return
-  }
-
-  typeDef.fields.forEach((field) => {
-    inferFromSchemaType(field.type, schema, visited)
-  })
-}
-
-function inferForMemberTypes(typeDef: SchemaType, schema: Schema, visited: Set<SchemaType>): void {
-  if (typeDef.jsonType === 'array' && typeDef.of) {
-    typeDef.of.forEach((candidate) => inferFromSchemaType(candidate, schema, visited))
-  }
-}
-
-function extractValueFromListOption(option: unknown, typeDef: SchemaType): unknown {
-  // If you define a `list` option with object items, where the item has a `value` field,
-  // we don't want to treat that as the value but rather the surrounding object
-  // This differs from the case where you have a title/value pair setup for a string/number, for instance
-  if (typeDef.jsonType === 'object' && hasValueField(typeDef)) {
-    return option
-  }
-
-  return (option as Record<string, unknown>).value === undefined
-    ? option
-    : (option as Record<string, unknown>).value
-}
-
-function hasValueField(typeDef: SchemaType): boolean {
-  if (!('fields' in typeDef) && typeDef.type) {
-    return hasValueField(typeDef.type)
-  }
-
-  if (!typeDef || !('fields' in typeDef)) {
-    return false
-  }
-
-  if (!Array.isArray(typeDef.fields)) {
-    return false
-  }
-
-  if (typeDef.fields.some((field) => field.name === 'value')) {
-    return true
-  }
-
-  return false
-}
-
-function inferValidation(field: SchemaType, baseRule: IRule): IRule[] {
-  if (!field.validation) {
-    return [baseRule]
-  }
-
-  const validation =
-    typeof field.validation === 'function' ? field.validation(baseRule) : field.validation
-  return Array.isArray(validation) ? validation : [validation]
 }
 
 export default inferFromSchemaType

--- a/packages/@sanity/validation/src/inferFromSchemaType.ts
+++ b/packages/@sanity/validation/src/inferFromSchemaType.ts
@@ -21,7 +21,7 @@ function inferFromSchemaType(
 
   const isInitialized =
     Array.isArray(typeDef.validation) &&
-    typeDef.validation.every((item) => typeof item.validate === 'function')
+    typeDef.validation.every((item) => typeof item?.validate === 'function')
 
   if (isInitialized) {
     inferForFields(typeDef, schema, visited)

--- a/packages/@sanity/validation/src/util/normalizeValidationRules.test.ts
+++ b/packages/@sanity/validation/src/util/normalizeValidationRules.test.ts
@@ -1,0 +1,170 @@
+import {NumberSchemaType, SchemaType, StringSchemaType} from '@sanity/types'
+import RuleClass from '../Rule'
+import normalizeValidationRules from './normalizeValidationRules'
+
+describe('normalizeValidationRules', () => {
+  // see `infer.test.ts` for more related tests.
+  // note the Schema.compile runs this function indirectly via `inferFromSchema`
+  it('utilizes schema types to infer base rules', () => {
+    const coolNumberType: NumberSchemaType = {
+      jsonType: 'number',
+      name: 'coolNumber',
+    }
+
+    const rules = normalizeValidationRules(coolNumberType)
+    expect(rules).toHaveLength(1)
+    const [rule] = rules
+
+    expect(rule).toBeInstanceOf(RuleClass)
+    expect(rule._rules).toMatchObject([
+      {
+        constraint: 'Number',
+        flag: 'type',
+      },
+    ])
+  })
+
+  it('follows the type chain to determine the base rule', () => {
+    const sickDatetime = {
+      type: {
+        type: {
+          jsonType: 'string',
+        },
+        name: 'datetime',
+      },
+      name: 'sickDatetime',
+    }
+
+    const rules = normalizeValidationRules(sickDatetime as SchemaType)
+    expect(rules).toHaveLength(1)
+    const [rule] = rules
+
+    // type chain is applied from inner to outer so the resulting type should be
+    // date instead of string
+    expect(rule._rules).toMatchObject([
+      {
+        constraint: 'Date',
+        flag: 'type',
+      },
+    ])
+  })
+
+  it('converts a validation function to a rule instance', () => {
+    const coolStringType: StringSchemaType = {
+      jsonType: 'string',
+      name: 'coolString',
+      validation: (rule) => rule.uppercase(),
+    }
+
+    const rules = normalizeValidationRules(coolStringType)
+    expect(rules).toHaveLength(1)
+    const [rule] = rules
+
+    expect(rule).toBeInstanceOf(RuleClass)
+    expect(rule._rules).toMatchObject([
+      {
+        constraint: 'String',
+        flag: 'type',
+      },
+      {
+        constraint: 'uppercase',
+        flag: 'stringCasing',
+      },
+    ])
+  })
+
+  it('converts falsy values to an empty array', () => {
+    expect(normalizeValidationRules(undefined)).toEqual([])
+  })
+
+  it('converts schema list options with titles to `rule.valid` constraints', () => {
+    const stringTypeWithOptions: StringSchemaType = {
+      jsonType: 'string',
+      name: 'stringTypeWithOptions',
+      options: {
+        list: [
+          {title: 'Blue', value: 'blue'},
+          {title: 'Red', value: 'red'},
+        ],
+      },
+    }
+
+    const rules = normalizeValidationRules(stringTypeWithOptions)
+    expect(rules).toHaveLength(1)
+    const [rule] = rules
+
+    expect(rule).toBeInstanceOf(RuleClass)
+    expect(rule._rules).toMatchObject([
+      {
+        constraint: 'String',
+        flag: 'type',
+      },
+      {
+        constraint: ['blue', 'red'],
+        flag: 'valid',
+      },
+    ])
+  })
+
+  it('converts schema list options with strings only to `rule.valid` constraints', () => {
+    const stringTypeWithOptions: StringSchemaType = {
+      jsonType: 'string',
+      name: 'stringTypeWithOptions',
+      options: {
+        list: ['blue', 'red'],
+      },
+    }
+
+    const rules = normalizeValidationRules(stringTypeWithOptions)
+    expect(rules).toHaveLength(1)
+    const [rule] = rules
+
+    expect(rule).toBeInstanceOf(RuleClass)
+    expect(rule._rules).toMatchObject([
+      {
+        constraint: 'String',
+        flag: 'type',
+      },
+      {
+        constraint: ['blue', 'red'],
+        flag: 'valid',
+      },
+    ])
+  })
+
+  it('converts arrays of validation', () => {
+    const coolNumberType: NumberSchemaType = {
+      jsonType: 'number',
+      name: 'coolNumber',
+      validation: [(rule) => rule.greaterThan(3), RuleClass.number().lessThan(5)],
+    }
+
+    const rules = normalizeValidationRules(coolNumberType)
+    expect(rules).toHaveLength(2)
+    const [first, second] = rules
+
+    expect(first).toBeInstanceOf(RuleClass)
+    expect(first._rules).toMatchObject([
+      {
+        constraint: 'Number',
+        flag: 'type',
+      },
+      {
+        constraint: 3,
+        flag: 'greaterThan',
+      },
+    ])
+
+    expect(second).toBeInstanceOf(RuleClass)
+    expect(second._rules).toMatchObject([
+      {
+        constraint: 'Number',
+        flag: 'type',
+      },
+      {
+        constraint: 5,
+        flag: 'lessThan',
+      },
+    ])
+  })
+})

--- a/packages/@sanity/validation/src/util/normalizeValidationRules.ts
+++ b/packages/@sanity/validation/src/util/normalizeValidationRules.ts
@@ -1,0 +1,120 @@
+import {SchemaType, Rule, RuleTypeConstraint} from '@sanity/types'
+import RuleClass from '../Rule'
+import {blockValidator} from '../validators/blockValidator'
+import {slugValidator} from '../validators/slugValidator'
+
+const ruleConstraintTypes: {[P in Lowercase<RuleTypeConstraint>]: true} = {
+  array: true,
+  boolean: true,
+  date: true,
+  number: true,
+  object: true,
+  string: true,
+}
+
+const isRuleConstraint = (typeString: string): typeString is Lowercase<RuleTypeConstraint> =>
+  typeString in ruleConstraintTypes
+
+function getTypeChain(type: SchemaType | undefined, visited: Set<SchemaType>): SchemaType[] {
+  if (!type) return []
+  if (visited.has(type)) return []
+
+  visited.add(type)
+
+  const next = type.type ? getTypeChain(type.type, visited) : []
+  return [...next, type]
+}
+
+function baseRuleReducer(inputRule: Rule, type: SchemaType) {
+  let baseRule = inputRule
+
+  if (isRuleConstraint(type.jsonType)) {
+    baseRule = baseRule.type(type.jsonType)
+  }
+
+  const typeOptionsList =
+    // if type.options is truthy
+    type?.options &&
+    // and type.options is an object (non-null from the previous)
+    typeof type.options === 'object' &&
+    // and if `list` is in options
+    'list' in type.options &&
+    // then finally access the list
+    type.options.list
+
+  if (Array.isArray(typeOptionsList)) {
+    baseRule = baseRule.valid(
+      typeOptionsList.map((option) => extractValueFromListOption(option, type))
+    )
+  }
+
+  if (type.name === 'datetime') return baseRule.type('Date')
+  if (type.name === 'date') return baseRule.type('Date')
+  if (type.name === 'url') return baseRule.uri()
+  if (type.name === 'slug') return baseRule.custom(slugValidator)
+  if (type.name === 'reference') return baseRule.reference()
+  if (type.name === 'email') return baseRule.email()
+  if (type.name === 'block') return baseRule.block(blockValidator)
+  return baseRule
+}
+
+function hasValueField(typeDef: SchemaType | undefined): boolean {
+  if (!typeDef) return false
+  if (!('fields' in typeDef) && typeDef.type) return hasValueField(typeDef.type)
+  if (!('fields' in typeDef)) return false
+  if (!Array.isArray(typeDef.fields)) return false
+  return typeDef.fields.some((field) => field.name === 'value')
+}
+
+function extractValueFromListOption(option: unknown, typeDef: SchemaType): unknown {
+  // If you define a `list` option with object items, where the item has a `value` field,
+  // we don't want to treat that as the value but rather the surrounding object
+  // This differs from the case where you have a title/value pair setup for a string/number, for instance
+  if (typeDef.jsonType === 'object' && hasValueField(typeDef)) return option
+
+  return (option as Record<string, unknown>).value === undefined
+    ? option
+    : (option as Record<string, unknown>).value
+}
+
+/**
+ * Takes in `SchemaValidationValue` and returns an array of `Rule` instances.
+ */
+export default function normalizeValidationRules(typeDef: SchemaType | undefined): Rule[] {
+  if (!typeDef) {
+    return []
+  }
+
+  const validation = typeDef.validation
+
+  if (Array.isArray(validation)) {
+    return validation.flatMap((i) =>
+      normalizeValidationRules({
+        ...typeDef,
+        validation: i,
+      })
+    )
+  }
+
+  if (validation instanceof RuleClass) {
+    return [validation]
+  }
+
+  const baseRule =
+    // using an object + Object.values to de-dupe the type chain by type name
+    Object.values(
+      getTypeChain(typeDef, new Set()).reduce<Record<string, SchemaType>>((acc, type) => {
+        acc[type.name] = type
+        return acc
+      }, {})
+    ).reduce(baseRuleReducer, new RuleClass(typeDef))
+
+  if (!validation) {
+    return [baseRule]
+  }
+
+  return normalizeValidationRules({
+    ...typeDef,
+    validation: validation(baseRule),
+  })
+}

--- a/packages/@sanity/validation/src/validateDocument.test.ts
+++ b/packages/@sanity/validation/src/validateDocument.test.ts
@@ -1,8 +1,63 @@
 /// <reference types="@sanity/types/parts" />
 
-import {Rule, SanityDocument, Schema} from '@sanity/types'
+import {Rule, SchemaType, SanityDocument, Schema, ArraySchemaType} from '@sanity/types'
 import createSchema from 'part:@sanity/base/schema-creator'
-import validateDocument, {resolveTypeForArrayItem} from './validateDocument'
+import validateDocument, {resolveTypeForArrayItem, validateItem} from './validateDocument'
+import convertToValidationMarker from './util/convertToValidationMarker'
+
+jest.mock('./util/convertToValidationMarker', () => {
+  return jest.fn(jest.requireActual('./util/convertToValidationMarker').default)
+})
+
+beforeEach(() => {
+  ;(convertToValidationMarker as jest.Mock).mockClear()
+})
+
+describe('resolveTypeForArrayItem', () => {
+  const schema: Schema = createSchema({
+    types: [
+      {
+        name: 'foo',
+        type: 'object',
+        fields: [{name: 'title', type: 'number'}],
+      },
+      {
+        name: 'bar',
+        type: 'object',
+        fields: [{name: 'title', type: 'string'}],
+      },
+    ],
+  })
+
+  const fooType = schema.get('foo')
+  const barType = schema.get('bar')
+
+  it('finds a matching schema type for an array item value given a list of candidate types', () => {
+    const resolved = resolveTypeForArrayItem(
+      {
+        _type: 'bar',
+        _key: 'exampleKey',
+        title: 5,
+      },
+      [fooType, barType]
+    )
+
+    expect(resolved).toBe(barType)
+  })
+
+  it('assumes the type if there is only one possible candidate', () => {
+    const resolved = resolveTypeForArrayItem(
+      {
+        // notice no _type
+        _key: 'exampleKey',
+        title: 5,
+      },
+      [fooType]
+    )
+
+    expect(resolved).toBe(fooType)
+  })
+})
 
 describe('validateDocument', () => {
   it('takes in a document + a compiled schema and returns a list of validation markers', async () => {
@@ -54,61 +109,10 @@ describe('validateDocument', () => {
       },
     ])
   })
+})
 
-  it('should be able to resolve an array item type if there is just one type', async () => {
-    const schema = createSchema({
-      types: [
-        {
-          name: 'testDoc',
-          type: 'document',
-          title: 'Test Document',
-          fields: [
-            {
-              name: 'values',
-              type: 'array',
-              // note that there is only one type available
-              of: [{type: 'arrayItem'}],
-              validation: (rule: Rule) => rule.required(),
-            },
-          ],
-        },
-        {
-          name: 'arrayItem',
-          type: 'object',
-          fields: [{name: 'title', type: 'string'}],
-        },
-      ],
-    })
-
-    const document: SanityDocument = {
-      _id: 'testId',
-      _createdAt: '2021-08-27T14:48:51.650Z',
-      _rev: 'exampleRev',
-      _type: 'testDoc',
-      _updatedAt: '2021-08-27T14:48:51.650Z',
-      values: [
-        {
-          // note how this doesn't have a _type
-          title: 5,
-          _key: 'exampleKey',
-        },
-      ],
-    }
-
-    await expect(validateDocument(document, schema)).resolves.toEqual([
-      {
-        type: 'validation',
-        level: 'error',
-        item: {
-          message: 'Expected type "String", got "Number"',
-          paths: [],
-        },
-        path: ['values', {_key: 'exampleKey'}, 'title'],
-      },
-    ])
-  })
-
-  it("runs nested validation on an undefined value if it's required", async () => {
+describe('validateItem', () => {
+  it("runs nested validation on an undefined value for object types if it's required", async () => {
     const validation = (rule: Rule) => [
       rule.required().error('This is required!'),
       rule.max(160).warning('Too long!'),
@@ -117,9 +121,9 @@ describe('validateDocument', () => {
     const schema = createSchema({
       types: [
         {
-          name: 'testDoc',
-          type: 'document',
-          title: 'Test Document',
+          name: 'testObj',
+          type: 'object',
+          title: 'Test Object',
           fields: [
             {name: 'registeredString', type: 'registeredString'},
             {name: 'inlineString', type: 'string', validation},
@@ -154,15 +158,15 @@ describe('validateDocument', () => {
       ],
     })
 
-    const document: SanityDocument = {
-      _id: 'testId',
-      _createdAt: '2021-08-27T14:48:51.650Z',
-      _rev: 'exampleRev',
-      _type: 'testDoc',
-      _updatedAt: '2021-08-27T14:48:51.650Z',
-    }
-
-    await expect(validateDocument(document, schema)).resolves.toMatchObject([
+    await expect(
+      validateItem({
+        value: {},
+        document: undefined,
+        path: [],
+        parent: undefined,
+        type: schema.get('testObj'),
+      })
+    ).resolves.toMatchObject([
       {
         type: 'validation',
         level: 'error',
@@ -201,50 +205,329 @@ describe('validateDocument', () => {
       },
     ])
   })
-})
 
-describe('resolveTypeForArrayItem', () => {
-  const schema: Schema = createSchema({
-    types: [
+  it('runs nested validation for object-level rules set via Rule.fields()', async () => {
+    const schema = createSchema({
+      types: [
+        {
+          name: 'testObj',
+          type: 'object',
+          title: 'Test Object',
+          fields: [
+            {name: 'foo', type: 'string'},
+            {name: 'bar', type: 'string'},
+          ],
+          validation: (rule: Rule) => [
+            rule.required(),
+            rule.fields({
+              foo: (r) => r.required(),
+              bar: (r) => r.required(),
+            }),
+          ],
+        },
+      ],
+    })
+
+    await expect(
+      validateItem({
+        document: undefined,
+        parent: undefined,
+        path: undefined,
+        type: schema.get('testObj'),
+        value: {foo: 5},
+      })
+    ).resolves.toMatchObject([
       {
-        name: 'foo',
-        type: 'object',
-        fields: [{name: 'title', type: 'number'}],
+        item: {message: 'Expected type "String", got "Number"'},
+        level: 'error',
+        path: ['foo'],
+        type: 'validation',
       },
       {
-        name: 'bar',
-        type: 'object',
-        fields: [{name: 'title', type: 'string'}],
+        item: {message: 'Required'},
+        level: 'error',
+        path: ['bar'],
+        type: 'validation',
       },
-    ],
+    ])
   })
 
-  const fooType = schema.get('foo')
-  const barType = schema.get('bar')
+  it('resolves an array item type if there is just one type', async () => {
+    const schema = createSchema({
+      types: [
+        {
+          name: 'values',
+          type: 'array',
+          // note that there is only one type available
+          of: [{type: 'arrayItem'}],
+          validation: (rule: Rule) => rule.required(),
+        },
+        {
+          name: 'arrayItem',
+          type: 'object',
+          fields: [{name: 'title', type: 'string'}],
+        },
+      ],
+    })
 
-  it('finds a matching schema type for an array item value given a list of candidate types', () => {
-    const resolved = resolveTypeForArrayItem(
+    const values = [
       {
-        _type: 'bar',
-        _key: 'exampleKey',
+        // note how this doesn't have a _type
         title: 5,
+        _key: 'exampleKey',
       },
-      [fooType, barType]
-    )
+    ]
 
-    expect(resolved).toBe(barType)
+    await expect(
+      validateItem({
+        document: undefined,
+        parent: undefined,
+        path: [],
+        type: schema.get('values'),
+        value: values,
+      })
+    ).resolves.toEqual([
+      {
+        type: 'validation',
+        level: 'error',
+        item: {
+          message: 'Expected type "String", got "Number"',
+          paths: [],
+        },
+        path: [{_key: 'exampleKey'}, 'title'],
+      },
+    ])
   })
 
-  it('assumes the type if there is only one possible candidate', () => {
-    const resolved = resolveTypeForArrayItem(
-      {
-        // notice no _type
-        _key: 'exampleKey',
-        title: 5,
-      },
-      [fooType]
-    )
+  it('properly passes the nested value, type, and path to rule.validate', async () => {
+    const schema: Schema = createSchema({
+      types: [
+        {
+          name: 'root',
+          type: 'object',
+          fields: [
+            {
+              name: 'level1Object',
+              type: 'object',
+              validation: (rule: Rule) => rule.custom(() => 'from level 1 object'),
+              fields: [
+                {
+                  name: 'level2String',
+                  type: 'string',
+                  validation: (rule: Rule) => rule.custom(() => 'from level 2 via object'),
+                },
+              ],
+            },
+            {
+              name: 'level1Array',
+              type: 'array',
+              validation: (rule: Rule) => rule.custom(() => 'from level 1 array'),
+              of: [
+                {
+                  type: 'object',
+                  fields: [
+                    {
+                      name: 'level2Number',
+                      type: 'number',
+                      validation: (rule: Rule) => rule.custom(() => 'from level 2 via array'),
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          validation: (rule: Rule) => rule.custom(() => 'from root'),
+        },
+      ],
+    })
 
-    expect(resolved).toBe(fooType)
+    const value = {
+      level1Object: {level3String: 'a string'},
+      level1Array: [{level2Number: 5}],
+    }
+
+    const document: SanityDocument = {
+      value,
+      _type: 'something',
+      _createdAt: '2021-09-05T19:28:30.882Z',
+      _id: 'something.id',
+      _rev: 'exampleRev',
+      _updatedAt: '2021-09-05T19:28:30.882Z',
+    }
+
+    const getField = ({in: type, name}: {in: SchemaType; name: string}) => {
+      const result = 'fields' in type && type.fields.find((f) => f.name === name)?.type
+      if (!result) throw new Error(`Could not find field \`${name}\` in \`${type.name}\``)
+      return result
+    }
+
+    const rootType = schema.get('root')
+    const level1ObjectType = getField({in: rootType, name: 'level1Object'})
+    const level2StringType = getField({in: level1ObjectType, name: 'level2String'})
+    const level1ArrayType = getField({in: rootType, name: 'level1Array'})
+    const level2NumberType = getField({
+      in: (level1ArrayType as ArraySchemaType).of[0],
+      name: 'level2Number',
+    })
+
+    await expect(
+      validateItem({
+        value,
+        type: rootType,
+        document,
+        parent: document,
+        path: undefined,
+      })
+    ).resolves.toMatchObject([
+      {
+        item: {message: 'from root'},
+        path: [],
+      },
+      {
+        item: {message: 'from level 1 object'},
+        path: ['level1Object'],
+      },
+      {
+        item: {message: 'from level 2 via object'},
+        path: ['level1Object', 'level2String'],
+      },
+      {
+        item: {message: 'from level 1 array'},
+        path: ['level1Array'],
+      },
+      {
+        item: {message: 'from level 2 via array'},
+        path: ['level1Array', 0, 'level2Number'],
+      },
+    ])
+
+    const calls = (convertToValidationMarker as jest.Mock).mock.calls
+
+    expect(calls.find((call) => call[0] === 'from root')).toMatchObject([
+      'from root',
+      'error',
+      {
+        parent: document,
+        document: document,
+        path: [],
+        type: rootType,
+      },
+    ])
+    expect(calls.find((call) => call[0] === 'from level 1 object')).toMatchObject([
+      'from level 1 object',
+      'error',
+      {
+        parent: value,
+        document: document,
+        path: ['level1Object'],
+        type: level1ObjectType,
+      },
+    ])
+    expect(calls.find((call) => call[0] === 'from level 2 via object')).toMatchObject([
+      'from level 2 via object',
+      'error',
+      {
+        parent: value.level1Object,
+        document: document,
+        path: ['level1Object', 'level2String'],
+        type: level2StringType,
+      },
+    ])
+    expect(calls.find((call) => call[0] === 'from level 1 array')).toMatchObject([
+      'from level 1 array',
+      'error',
+      {
+        parent: value,
+        document: document,
+        path: ['level1Array'],
+        type: level1ArrayType,
+      },
+    ])
+    expect(calls.find((call) => call[0] === 'from level 2 via array')).toMatchObject([
+      'from level 2 via array',
+      'error',
+      {
+        parent: value.level1Array[0],
+        document: document,
+        path: ['level1Array', 0, 'level2Number'],
+        type: level2NumberType,
+      },
+    ])
+  })
+
+  it('runs all nested validation checks concurrently', async () => {
+    type Resolver = (value: true) => void
+    const resolvers = new Set<Resolver>()
+    const customValidationFn = () => new Promise<true>((resolve) => resolvers.add(resolve))
+
+    const schema: Schema = createSchema({
+      types: [
+        {
+          name: 'root',
+          type: 'object',
+          fields: [
+            {
+              name: 'level1Object',
+              type: 'object',
+              validation: (rule: Rule) => [
+                rule.custom(customValidationFn),
+                rule.fields({
+                  level2String: (r) => r.custom(customValidationFn),
+                }),
+              ],
+              fields: [
+                {
+                  name: 'level2String',
+                  type: 'string',
+                  validation: (rule: Rule) => rule.custom(customValidationFn),
+                },
+              ],
+            },
+            {
+              name: 'level1Array',
+              type: 'array',
+              validation: (rule: Rule) => rule.custom(customValidationFn),
+              of: [
+                {
+                  type: 'object',
+                  fields: [
+                    {
+                      name: 'level2Number',
+                      type: 'number',
+                      validation: (rule: Rule) => rule.custom(customValidationFn),
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          validation: (rule: Rule) => rule.custom(customValidationFn),
+        },
+      ],
+    })
+
+    const value = {
+      level1Object: {level3String: 'a string'},
+      level1Array: [{level2Number: 5}],
+    }
+
+    const resultPromise = validateItem({
+      value,
+      document: undefined,
+      parent: undefined,
+      path: undefined,
+      type: schema.get('root'),
+    })
+
+    // after `validateItem(...)` has been initiated, all of the custom
+    // validation calls should have fired so the resolver size should equal the
+    // amount of total fields
+    expect(resolvers.size).toBe(6)
+
+    for (const resolver of resolvers) {
+      resolver(true)
+    }
+
+    await resultPromise
   })
 })

--- a/packages/@sanity/validation/src/validateDocument.ts
+++ b/packages/@sanity/validation/src/validateDocument.ts
@@ -87,7 +87,7 @@ const normalizeRules = (
     return normalizeRules(validation(new RuleClass(type)))
   }
   if (!validation) return []
-  if (Array.isArray(validation)) return validation
+  if (Array.isArray(validation)) return normalizeRules(validation)
   return [validation]
 }
 

--- a/packages/@sanity/validation/src/validators/blockValidator.ts
+++ b/packages/@sanity/validation/src/validators/blockValidator.ts
@@ -33,13 +33,11 @@ export const blockValidator: BlockValidator = async (value, context) => {
   value.markDefs.forEach((markDef: any) => {
     const annotationType = activeAnnotationTypes.find((aType) => aType.name === markDef._type)
     const validations = validateItem({
+      document: context.document,
       value: markDef,
       type: annotationType,
-      path: ['markDefs', {_key: markDef._key}],
-      context: {
-        parent: value,
-        document: context.document,
-      },
+      path: (context.path || []).concat(['markDefs', {_key: markDef._key}]),
+      parent: value,
     })
     annotationValidations.push(validations)
   })


### PR DESCRIPTION
### Description

The following PR fixes a few bugs and ups test coverage for the validation lib:

- fixes a bug where item paths were not being properly propagated in `validateItem`
- fixes an existing/older bug where reference validation was not running. this fix involves recursively pulling the type chain from the schema. see the function `getTypeChain`
- refactors parts of `inferFromSchema` into a new function `normalizeValidationRules` that runs all schema validation functions without the assumption of `inferFromSchema` mutation. this fixes another existing/older bug where `Rule.fields({})` would not give the correct rule context of the nested field type. this also greatly simplified the `inferTypeFromSchema` function
- the previous change required de-duping `Rule.fields` validation results. see the function `dedupeValidationMarkers`
- some misc configuration updates

### What to review

- review all of the above + the new tests 😀

### Notes for release

N/A
