### PR TITLE
fix(server): alias styled-components in webpack config

### DIFF
--- a/packages/@sanity/server/src/configs/webpack.config.js
+++ b/packages/@sanity/server/src/configs/webpack.config.js
@@ -78,6 +78,7 @@ export default (config = {}) => {
       alias: {
         react: getModulePath('react'),
         'react-dom': getModulePath('react-dom'),
+        'styled-components': getModulePath('styled-components'),
         moment$: 'moment/moment.js',
         'react-native': 'react-native-web',
         ...rxPaths(),


### PR DESCRIPTION
### Description

This PR aliases `styled-components` to the version installed in the studio (or a hoisted copy, potentially) within the webpack config. This is done to prevent the error where multiple versions of `styled-components` are used in the same app unintentionally. Ideally we wouldn't need this, but it seems npm/yarn hoisting isn't always perfect, so this at least provides some way to alleviate that pain. 

### What to review

- Does it make sense?
