### PR TITLE
chore(import-cli): upgrade meow dependency

### DIFF
--- a/packages/@sanity/import-cli/package.json
+++ b/packages/@sanity/import-cli/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@sanity/client": "2.18.0",
     "@sanity/import": "2.18.0",
-    "meow": "^3.7.0",
+    "meow": "^9.0.0",
     "ora": "^2.1.0",
     "pretty-ms": "^7.0.1",
     "simple-get": "^4.0.0"

--- a/packages/@sanity/import-cli/src/sanity-import.js
+++ b/packages/@sanity/import-cli/src/sanity-import.js
@@ -43,18 +43,53 @@ const cli = meow(
     --token = SANITY_IMPORT_TOKEN
 `,
   {
-    boolean: [
-      'replace',
-      'missing',
-      'allow-failing-assets',
-      'allow-assets-in-different-dataset',
-      'replace-assets',
-    ],
-    alias: {
-      p: 'project',
-      d: 'dataset',
-      t: 'token',
-      c: 'asset-concurrency',
+    flags: {
+      // Required, but validated below for better error output
+      project: {
+        type: 'string',
+        alias: 'p',
+      },
+
+      dataset: {
+        type: 'string',
+        alias: 'd',
+      },
+
+      token: {
+        type: 'string',
+        alias: 't',
+      },
+
+      // Optional
+      replace: {
+        type: 'boolean',
+        default: false,
+      },
+
+      missing: {
+        type: 'boolean',
+        default: false,
+      },
+
+      allowFailingAssets: {
+        type: 'boolean',
+        default: false,
+      },
+
+      allowAssetsInDifferentDataset: {
+        type: 'boolean',
+        default: false,
+      },
+
+      replaceAssets: {
+        type: 'boolean',
+        default: false,
+      },
+
+      assetConcurrency: {
+        type: 'number',
+        alias: 'c',
+      },
     },
   }
 )


### PR DESCRIPTION
### Description

Upgrades the meow dependency to the latest version that still supports node.js 10. This fixes a security issue that Snyk reported: https://github.com/sanity-io/sanity/pull/2735

Closes #2735

### What to review

- Run the CLI tool and make sure it parses the flags correctly (it should, from my testing)

```
packages/@sanity/import-cli$ node src/sanity-import.js -p abc123 -d dataset --token=foo --replace --allow-failing-assets some-source.ndjson
```

### Notes for release

None (invisible for end-user)
