### PR TITLE
feat(core): add --api-version flag for documents query command

### DIFF
--- a/packages/@sanity/core/package.json
+++ b/packages/@sanity/core/package.json
@@ -74,6 +74,7 @@
     "@types/inquirer": "^6.0.2",
     "@types/resolve-from": "^4.0.0",
     "@types/semver": "^6.2.3",
+    "chalk": "^2.4.2",
     "inquirer": "^6.0.0"
   },
   "repository": {

--- a/packages/@sanity/core/src/commands/documents/queryDocumentsCommand.ts
+++ b/packages/@sanity/core/src/commands/documents/queryDocumentsCommand.ts
@@ -17,7 +17,7 @@ Examples
   sanity documents query '*[_type == "movie"]|order(releaseDate asc)[0]{title}' --dataset staging
 
   # Use API version v2021-06-07 and do a query
-  sanity documents query '*[_id == "header"] { "headerText": pt::text(body) }'
+  sanity documents query --api-version v2021-06-07 '*[_id == "header"] { "headerText": pt::text(body) }'
 `
 
 interface CliQueryCommandFlags {

--- a/packages/@sanity/core/src/commands/documents/queryDocumentsCommand.ts
+++ b/packages/@sanity/core/src/commands/documents/queryDocumentsCommand.ts
@@ -1,4 +1,5 @@
-const colorizeJson = require('../../util/colorizeJson')
+import colorizeJson from '../../util/colorizeJson'
+import type {CliCommandArguments, CliCommandContext} from '../../types'
 
 const helpText = `
 Run a query against the projects configured dataset
@@ -6,6 +7,7 @@ Run a query against the projects configured dataset
 Options
   --pretty colorized JSON output
   --dataset NAME to override dataset
+  --api-version API version to use (defaults to \`v1\`)
 
 Examples
   # Fetch 5 documents of type "movie"
@@ -13,7 +15,16 @@ Examples
 
   # Fetch title of the oldest movie in the dataset named "staging"
   sanity documents query '*[_type == "movie"]|order(releaseDate asc)[0]{title}' --dataset staging
+
+  # Use API version v2021-06-07 and do a query
+  sanity documents query '*[_id == "header"] { "headerText": pt::text(body) }'
 `
+
+interface CliQueryCommandFlags {
+  pretty?: boolean
+  dataset?: string
+  apiVersion?: string
+}
 
 export default {
   name: 'query',
@@ -21,16 +32,28 @@ export default {
   signature: '[QUERY]',
   helpText,
   description: 'Query for documents',
-  action: async (args, context) => {
+  action: async (
+    args: CliCommandArguments<CliQueryCommandFlags>,
+    context: CliCommandContext
+  ): Promise<void> => {
     const {apiClient, output, chalk} = context
-    const {pretty, dataset} = args.extOptions
+    const {pretty, dataset, apiVersion} = args.extOptions
     const [query] = args.argsWithoutOptions
 
     if (!query) {
       throw new Error('Query must be specified')
     }
 
-    const client = dataset ? apiClient().clone().config({dataset}) : apiClient()
+    if (!apiVersion) {
+      output.warn(chalk.yellow('--api-version not specified, using `v1`'))
+    }
+
+    const baseClient = apiClient().clone()
+    const {dataset: originalDataset} = baseClient.config()
+    const client = baseClient.config({
+      dataset: dataset || originalDataset,
+      apiVersion: apiVersion || 'v1',
+    })
 
     try {
       const docs = await client.fetch(query)

--- a/packages/@sanity/core/src/types.ts
+++ b/packages/@sanity/core/src/types.ts
@@ -7,6 +7,15 @@
 import type {ChildProcessWithoutNullStreams} from 'child_process'
 import type {SanityClient} from '@sanity/client'
 import type {prompt, Separator, DistinctQuestion} from 'inquirer'
+import type chalk from 'chalk'
+
+export interface CliCommandArguments<F = Record<string, unknown>> {
+  groupOrCommand: string
+  argv: string[]
+  extOptions: F
+  argsWithoutOptions: string[]
+  extraArguments: string[]
+}
 
 export interface CliCommandContext {
   output: CliOutputter
@@ -16,9 +25,7 @@ export interface CliCommandContext {
   cliRoot: string
   workDir: string
   corePath: string
-
-  // @todo add chalk typings (it's a direct assignment of chalk@^2.4.2)
-  // chalk: Chalk
+  chalk: typeof chalk
 }
 
 export interface CliOutputter {
@@ -36,7 +43,7 @@ export type CliPrompter = typeof prompt & {
   single: <T = string>(question: Omit<DistinctQuestion, 'name'> & {choices: string[]}) => Promise<T>
 }
 
-export type CliApiClient = (options: {
+export type CliApiClient = (options?: {
   requireUser?: boolean
   requireProject?: boolean
 }) => SanityClient


### PR DESCRIPTION
### Description

Adds a `--api-version` flag to the `sanity documents query` command that... allows you to specify the API version to use!

For now we'll default to `v1` as before so as not to break any potential workflows depending on this command, but in the future (in an upcoming breaking version change) we might force the user to specify an API version either as a flag or as a stored CLI configuration somewhere.

If you don't specify the API version, we'll warn (to stderr):

```
➜ blog-studio ✗ sanity documents query '*[0]{_id}'
--api-version not specified, using `v1`
{
  "_id": "08353495-d4c9-43fc-8ea1-71e502a626fb"
}

➜ blog-studio ✗ sanity documents query '*[0]{"text": pt::text(body)}' --apiVersion=2021-03-25
{
  "text": "Nana"
}
```

Also expanded on the CLI typings slightly, adding the things needed for this CLI command. Gradual transition for the win?

### What to review

- That the command works as expected
- That you agree on the change

To test, you'll have to install dependencies and run `npm run build`, then execute the command inside one of the example studios.

### Notes for release

- Added `--api-version` flag to the `sanity documents query` command
