### PR TITLE
feat(datasets): increase max dataset name length

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/promptForDatasetName.js
+++ b/packages/@sanity/cli/src/actions/init-project/promptForDatasetName.js
@@ -1,9 +1,11 @@
 import chalk from 'chalk'
 
+const MAX_DATASET_NAME_LENGTH = 64
+
 const datasetNameError =
   'Dataset names can only contain lowercase characters,' +
   'numbers, underscores and dashes' +
-  'and can be at most 20 characters.'
+  `and can be at most ${MAX_DATASET_NAME_LENGTH} characters.`
 
 export default function promptForDatasetName(prompt, options = {}, existingDatasets = []) {
   return prompt.single({
@@ -14,8 +16,8 @@ export default function promptForDatasetName(prompt, options = {}, existingDatas
         return `Dataset name already exists`
       }
 
-      if (!name || name.length < 2 || name.length > 20) {
-        return 'Dataset name must be between 2 and 20 characters'
+      if (!name || name.length < 2 || name.length > MAX_DATASET_NAME_LENGTH) {
+        return `Dataset name must be between 2 and ${MAX_DATASET_NAME_LENGTH} characters`
       }
 
       if (name.toLowerCase() !== name) {

--- a/packages/@sanity/core/src/actions/dataset/alias/validateDatasetAliasName.js
+++ b/packages/@sanity/core/src/actions/dataset/alias/validateDatasetAliasName.js
@@ -1,3 +1,5 @@
+const MAX_DATASET_NAME_LENGTH = 64
+
 module.exports = (datasetName) => {
   if (!datasetName) {
     return 'Alias name is missing'
@@ -13,8 +15,8 @@ module.exports = (datasetName) => {
     return 'Alias name must be at least two characters long'
   }
 
-  if (name.length > 20) {
-    return 'Alias name must be at most 20 characters'
+  if (name.length > MAX_DATASET_NAME_LENGTH) {
+    return `Alias name must be at most ${MAX_DATASET_NAME_LENGTH} characters`
   }
 
   if (!/^[a-z0-9~]/.test(name)) {

--- a/packages/@sanity/core/src/actions/dataset/validateDatasetName.js
+++ b/packages/@sanity/core/src/actions/dataset/validateDatasetName.js
@@ -1,3 +1,5 @@
+const MAX_DATASET_NAME_LENGTH = 64
+
 module.exports = (datasetName) => {
   if (!datasetName) {
     return 'Dataset name is missing'
@@ -13,8 +15,8 @@ module.exports = (datasetName) => {
     return 'Dataset name must be at least two characters long'
   }
 
-  if (name.length > 20) {
-    return 'Dataset name must be at most 20 characters'
+  if (name.length > MAX_DATASET_NAME_LENGTH) {
+    return `Dataset name must be at most ${MAX_DATASET_NAME_LENGTH} characters`
   }
 
   if (!/^[a-z0-9]/.test(name)) {


### PR DESCRIPTION
### Description

Increase the dataset name character limit to 64

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Dataset name limit increased to 64 characters
