### PR TITLE
chore: require node 12

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
       "@babel/env",
       {
         "targets": {
-          "node": "10",
+          "node": "12",
           "chrome": "59",
           "safari": "10",
           "firefox": "56",

--- a/packages/@sanity/diff/package.json
+++ b/packages/@sanity/diff/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/dts",
   "author": "Sanity.io <hello@sanity.io>",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "license": "MIT",
   "scripts": {

--- a/packages/@sanity/export/package.json
+++ b/packages/@sanity/export/package.json
@@ -4,7 +4,7 @@
   "description": "Export Sanity documents and assets",
   "main": "lib/export.js",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",

--- a/packages/@sanity/field/package.json
+++ b/packages/@sanity/field/package.json
@@ -17,7 +17,7 @@
   },
   "author": "Sanity.io <hello@sanity.io>",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "license": "MIT",
   "scripts": {

--- a/packages/@sanity/import-cli/package.json
+++ b/packages/@sanity/import-cli/package.json
@@ -7,7 +7,7 @@
     "sanity-import": "./lib/sanity-import.js"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",

--- a/packages/@sanity/import/package.json
+++ b/packages/@sanity/import/package.json
@@ -4,7 +4,7 @@
   "description": "Import documents to a Sanity dataset",
   "main": "lib/import.js",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",

--- a/packages/@sanity/initial-value-templates/package.json
+++ b/packages/@sanity/initial-value-templates/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/dts",
   "author": "Sanity.io <hello@sanity.io>",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "license": "MIT",
   "scripts": {

--- a/packages/@sanity/plugin-loader/package.json
+++ b/packages/@sanity/plugin-loader/package.json
@@ -8,7 +8,7 @@
     "coverage": "nyc --reporter=html ava"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/portable-text-editor/package.json
+++ b/packages/@sanity/portable-text-editor/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/dts/index.d.ts",
   "author": "Sanity.io <hello@sanity.io>",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "license": "MIT",
   "scripts": {
@@ -24,6 +24,7 @@
     "headless",
     "realtime",
     "content",
+    "portable-text-editor",
     "structure",
     "api",
     "collaborative",
@@ -88,7 +89,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sanity/sanity.git"
+    "url": "git+https://github.com/sanity-io/sanity.git",
+    "directory": "packages/@sanity/portable-text-editor"
   },
   "bugs": {
     "url": "https://github.com/sanity-io/sanity/issues"

--- a/packages/@sanity/react-hooks/package.json
+++ b/packages/@sanity/react-hooks/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/dts",
   "author": "Sanity.io <hello@sanity.io>",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "license": "MIT",
   "scripts": {

--- a/packages/@sanity/resolver/package.json
+++ b/packages/@sanity/resolver/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/server/package.json
+++ b/packages/@sanity/server/package.json
@@ -14,7 +14,7 @@
     "sanity-server": "./bin/sanity-server.js"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/structure/package.json
+++ b/packages/@sanity/structure/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/dts",
   "author": "Sanity.io <hello@sanity.io>",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "license": "MIT",
   "scripts": {

--- a/packages/@sanity/transaction-collator/package.json
+++ b/packages/@sanity/transaction-collator/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/dts/index.d.ts",
   "author": "Sanity.io <hello@sanity.io>",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "license": "MIT",
   "scripts": {

--- a/packages/@sanity/util/package.json
+++ b/packages/@sanity/util/package.json
@@ -19,7 +19,7 @@
     "test": "jest"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/@sanity/webpack-integration/package.json
+++ b/packages/@sanity/webpack-integration/package.json
@@ -22,7 +22,7 @@
     "webpack"
   ],
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",

--- a/packages/@sanity/webpack-loader/package.json
+++ b/packages/@sanity/webpack-loader/package.json
@@ -9,7 +9,7 @@
     "prebuild": "npm run clean"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/create-sanity/package.json
+++ b/packages/create-sanity/package.json
@@ -4,7 +4,7 @@
   "description": "Initialize a new Sanity project",
   "bin": "index.js",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "keywords": [
     "sanity",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -18,7 +18,7 @@
     "content"
   ],
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "homepage": "https://www.sanity.io/",
   "license": "MIT",

--- a/scripts/normalizePackageFields.js
+++ b/scripts/normalizePackageFields.js
@@ -2,7 +2,7 @@ const uniq = require('lodash/uniq')
 const transformPkgs = require('./utils/transformPkgs')
 
 const COMMON_KEYWORDS = ['sanity', 'cms', 'headless', 'realtime', 'content']
-const supportedNodeVersionRange = '>=10.0.0'
+const supportedNodeVersionRange = '>=12.0.0'
 
 transformPkgs((pkgManifest) => {
   const name = pkgManifest.name.split('/').slice(-1)[0]


### PR DESCRIPTION
### Description

- Node.js 10 is out of LTS since April - we should be safe to require node 12 for our modules. 
- Ran the normalization script which yielded some smaller changes/fixes to the portable text package.json

### Notes for release

- Changed minimum node.js version to v12 or higher
  