### PR TITLE
refactor(state-router): move hooks to separate files and simplify

### DIFF
--- a/packages/@sanity/state-router/src/RouterContext.ts
+++ b/packages/@sanity/state-router/src/RouterContext.ts
@@ -1,11 +1,11 @@
-import React, {useContext, useState, useEffect} from 'react'
+import React from 'react'
 import {InternalRouter} from './components/types'
 
 const missingContext = () => {
   throw new Error('No router context provider found')
 }
 
-const missingRouter: InternalRouter = {
+export const RouterContext = React.createContext<InternalRouter>({
   channel: {subscribe: missingContext, publish: missingContext},
   getState: missingContext,
   navigate: missingContext,
@@ -13,21 +13,4 @@ const missingRouter: InternalRouter = {
   navigateUrl: missingContext,
   resolveIntentLink: missingContext,
   resolvePathFromState: missingContext,
-}
-
-export const RouterContext = React.createContext<InternalRouter>(missingRouter)
-export const useRouter = () => useContext(RouterContext)
-export const useRouterState = (deps?: string[]) => {
-  const router = useContext(RouterContext)
-  const [routerState, setState] = useState(router.getState())
-
-  let dependencies
-  if (deps) {
-    dependencies = deps.map((key) => routerState[key])
-  }
-
-  // subscribe() returns an unsubscribe function, so this'll handle unmounting
-  useEffect(() => router.channel.subscribe(() => setState(router.getState())), dependencies)
-
-  return routerState
-}
+})

--- a/packages/@sanity/state-router/src/index.ts
+++ b/packages/@sanity/state-router/src/index.ts
@@ -3,7 +3,10 @@ import resolvePathFromState from './resolvePathFromState'
 
 export type {Router} from './types'
 export {default as route} from './route'
-export {RouterContext, useRouter, useRouterState} from './RouterContext'
+export {RouterContext} from './RouterContext'
+
+export * from './useRouter'
+export * from './useRouterState'
 
 export {resolveStateFromPath}
 export {resolvePathFromState}

--- a/packages/@sanity/state-router/src/useRouter.ts
+++ b/packages/@sanity/state-router/src/useRouter.ts
@@ -1,0 +1,7 @@
+import {useContext} from 'react'
+import {InternalRouter} from './components/types'
+import {RouterContext} from './RouterContext'
+
+export function useRouter(): InternalRouter {
+  return useContext(RouterContext)
+}

--- a/packages/@sanity/state-router/src/useRouterState.ts
+++ b/packages/@sanity/state-router/src/useRouterState.ts
@@ -1,0 +1,17 @@
+import {useContext, useEffect, useState} from 'react'
+import {RouterState} from './components/types'
+import {RouterContext} from './RouterContext'
+
+export const useRouterState = (): RouterState => {
+  const router = useContext(RouterContext)
+  const [routerState, setState] = useState<RouterState>(router.getState())
+
+  useEffect(() => {
+    // subscribe() returns an unsubscribe function, so this'll handle unmounting
+    return router.channel.subscribe(() => {
+      setState(router.getState())
+    })
+  }, [router])
+
+  return routerState
+}

--- a/packages/@sanity/state-router/src/useRouterState.ts
+++ b/packages/@sanity/state-router/src/useRouterState.ts
@@ -3,15 +3,15 @@ import {RouterState} from './components/types'
 import {RouterContext} from './RouterContext'
 
 export const useRouterState = (): RouterState => {
-  const router = useContext(RouterContext)
-  const [routerState, setState] = useState<RouterState>(router.getState())
+  const {channel, getState} = useContext(RouterContext)
+  const [routerState, setState] = useState<RouterState>(getState())
 
   useEffect(() => {
     // subscribe() returns an unsubscribe function, so this'll handle unmounting
-    return router.channel.subscribe(() => {
-      setState(router.getState())
+    return channel.subscribe(() => {
+      setState(getState())
     })
-  }, [router])
+  }, [channel, getState])
 
   return routerState
 }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

- Moves `useRouter` and `useRouterState` to separate files.
- Removes opaque `deps` logic from `useRouterState` (it was not in use).
