### PR TITLE
refactor(form-builder): clean up

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable max-nested-callbacks */
+
 import React, {ForwardedRef, forwardRef, useCallback, useMemo, useState} from 'react'
 import {isValidationErrorMarker, Marker, Path, Reference, ReferenceSchemaType} from '@sanity/types'
 import {LinkIcon} from '@sanity/icons'
@@ -39,7 +40,6 @@ type SearchFunction = (query: string) => Observable<SearchHit[]>
 
 export type Props = {
   value?: Reference
-  compareValue?: Reference
   type: ReferenceSchemaType
   markers: Marker[]
   focusPath: Path
@@ -81,7 +81,6 @@ export const ReferenceInput = forwardRef(function ReferenceInput(
     onSearch,
     onChange,
     presence,
-    compareValue,
     focusPath = EMPTY_ARRAY,
     onFocus,
     onBlur,
@@ -286,7 +285,6 @@ export const ReferenceInput = forwardRef(function ReferenceInput(
           path={[]}
           hasFocus={focusPath[0] === '_ref'}
           value={value?._ref}
-          compareValue={compareValue?._ref}
         >
           <div style={{lineHeight: 0}}>
             <Autocomplete

--- a/packages/@sanity/form-builder/src/inputs/files/FileInput/FileInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/FileInput/FileInput.tsx
@@ -551,7 +551,6 @@ export default class FileInput extends React.PureComponent<Props, FileInputState
                 path={[]}
                 hasFocus={this.hasFileTargetFocus()}
                 value={value?.asset?._ref}
-                compareValue={compareValue?.asset?._ref}
               >
                 <FileTarget
                   tabIndex={readOnly ? undefined : 0}


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

- Adds missing TS types to various things.
- Removes unused `compareValue` from `FileInput` and `ReferenceInput` (earlier, these passed `compareValue` on to `ChangeIndicatorWithProvidedFullPath` which doesn’t use it).
