### PR TITLE
refactor(base): preview improvements

### DIFF
--- a/packages/@sanity/base/src/components/previews/defaultPreview.tsx
+++ b/packages/@sanity/base/src/components/previews/defaultPreview.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {Box, Flex, Stack, Text, Skeleton, TextSkeleton} from '@sanity/ui'
+import {Box, Flex, Stack, Text, Skeleton, TextSkeleton, rem} from '@sanity/ui'
 import styled from 'styled-components'
 import {getDevicePixelRatio} from 'use-device-pixel-ratio'
 import {PreviewProps} from './types'
@@ -13,29 +13,41 @@ const MediaWrapper = styled(Flex)`
   width: 35px;
   height: 35px;
   min-width: 35px;
-  border-radius: ${({theme}) => theme.sanity.radius[2]}px;
+  border-radius: ${({theme}) => rem(theme.sanity.radius[2])};
 
   & img {
+    display: block;
     position: absolute;
     left: 0;
     top: 0;
-    width: 100%;
-    height: 100%;
+    right: 0;
+    bottom: 0;
     object-fit: contain;
     border-radius: inherit;
+    width: 100%;
+    height: 100%;
   }
 
   & svg {
     display: block;
     font-size: calc(21 / 16 * 1em);
-
-    &[data-sanity-icon] {
-      font-size: calc(33 / 16 * 1em);
-      margin: calc(6 / 36 * -1em);
-    }
   }
 
-  & img + span {
+  & [data-sanity-icon] {
+    display: block;
+    font-size: calc(33 / 16 * 1em);
+  }
+
+  /*
+    NOTE on why we can’t use the ":after" pseudo-element:
+
+    The thing is we only want the shadow when then <MediaWrapper> contains
+    something else than <svg> – icons should not have the shadow.
+
+    This is why we use the "*:not(svg) + span" selector to target only that
+    situation to render the shadow.
+  */
+  & *:not(svg) + span {
     display: block;
     position: absolute;
     left: 0;
@@ -48,6 +60,8 @@ const MediaWrapper = styled(Flex)`
   }
 `
 
+MediaWrapper.displayName = 'MediaWrapper'
+
 export const DefaultPreview = (props: PreviewProps<'default'>) => {
   const {title, subtitle, media, status, isPlaceholder, children} = props
 
@@ -55,8 +69,11 @@ export const DefaultPreview = (props: PreviewProps<'default'>) => {
     <Root align="center">
       {isPlaceholder && (
         <>
-          <Skeleton style={{width: 35, height: 35}} radius={2} marginRight={2} animated />
-          <Stack space={2} flex={1}>
+          {media !== false && (
+            <Skeleton style={{width: 35, height: 35}} radius={2} marginRight={2} animated />
+          )}
+
+          <Stack flex={1} paddingLeft={media === false ? 1 : 0} space={2}>
             <TextSkeleton style={{maxWidth: 320}} radius={1} animated />
             <TextSkeleton style={{maxWidth: 200}} radius={1} size={1} animated />
           </Stack>
@@ -66,13 +83,7 @@ export const DefaultPreview = (props: PreviewProps<'default'>) => {
       {!isPlaceholder && (
         <>
           {media !== false && media !== undefined && (
-            <MediaWrapper
-              align="center"
-              justify="center"
-              marginRight={2}
-              sizing="border"
-              overflow="hidden"
-            >
+            <MediaWrapper align="center" justify="center" marginRight={2} overflow="hidden">
               {typeof media === 'function' &&
                 media({
                   dimensions: {
@@ -93,7 +104,7 @@ export const DefaultPreview = (props: PreviewProps<'default'>) => {
             </MediaWrapper>
           )}
 
-          <Stack space={2} flex={1}>
+          <Stack flex={1} paddingLeft={media === false ? 1 : 0} space={2}>
             <Text textOverflow="ellipsis" style={{color: 'inherit'}}>
               {title && typeof title === 'function' ? title({layout: 'default'}) : title}
               {!title && <>Untitled</>}
@@ -109,7 +120,7 @@ export const DefaultPreview = (props: PreviewProps<'default'>) => {
           </Stack>
 
           {status && (
-            <Box padding={3}>
+            <Box paddingLeft={3} paddingRight={1}>
               {typeof status === 'function' ? status({layout: 'default'}) : status}
             </Box>
           )}

--- a/packages/@sanity/base/src/components/previews/detailPreview.styled.tsx
+++ b/packages/@sanity/base/src/components/previews/detailPreview.styled.tsx
@@ -1,4 +1,4 @@
-import {Box, Flex, Stack} from '@sanity/ui'
+import {Box, Flex, rem, Stack} from '@sanity/ui'
 import styled from 'styled-components'
 
 export const Root = styled(Flex)`
@@ -18,28 +18,55 @@ export const Header = styled(Stack)`
 `
 
 export const MediaWrapper = styled(Flex)`
-  flex-basis: 5em;
-  flex-grow: 1;
-  min-width: 5em;
   width: 5em;
-  max-width: 5em;
-  overflow: hidden;
+  height: 5em;
   position: relative;
+  border-radius: ${({theme}) => rem(theme.sanity.radius[2])};
 
-  img {
+  & img {
     display: block;
-    width: 5em;
-    height: 5em;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
     object-fit: contain;
+    border-radius: inherit;
+    width: 100%;
+    height: 100%;
   }
 
-  svg {
-    font-size: 3rem;
-    color: inherit;
+  & svg {
+    display: block;
+    font-size: calc(37 / 16 * 1em);
+  }
+
+  & [data-sanity-icon] {
+    display: block;
+    font-size: calc(51 / 16 * 1em);
+  }
+
+  /*
+    NOTE on why we can’t use the ":after" pseudo-element:
+
+    The thing is we only want the shadow when then <MediaWrapper> contains
+    something else than <svg> – icons should not have the shadow.
+
+    This is why we use the "*:not(svg) + span" selector to target only that
+    situation to render the shadow.
+  */
+  & *:not(svg) + span {
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    box-shadow: inset 0 0 0 1px var(--card-fg-color);
+    opacity: 0.2;
+    border-radius: inherit;
   }
 `
-
-export const MediaString = styled(Box)``
 
 export const StatusWrapper = styled(Box)`
   white-space: nowrap;

--- a/packages/@sanity/base/src/components/previews/detailPreview.tsx
+++ b/packages/@sanity/base/src/components/previews/detailPreview.tsx
@@ -2,15 +2,7 @@ import React from 'react'
 import {Box, Stack, Text, Skeleton, TextSkeleton, useTheme} from '@sanity/ui'
 import {getDevicePixelRatio} from 'use-device-pixel-ratio'
 import {MediaDimensions, PreviewProps} from './types'
-import {
-  Root,
-  Top,
-  Content,
-  Header,
-  StatusWrapper,
-  MediaWrapper,
-  MediaString,
-} from './detailPreview.styled'
+import {Root, Top, Content, Header, StatusWrapper, MediaWrapper} from './detailPreview.styled'
 
 const DEFAULT_MEDIA_DIMENSIONS: MediaDimensions = {
   width: 80,
@@ -56,11 +48,13 @@ export const DetailPreview: React.FunctionComponent<PreviewProps<'detail'>> = (p
               dimensions: mediaDimensions,
               layout: 'detail',
             })}
-          {typeof media === 'string' && <MediaString>{media}</MediaString>}
+          {typeof media === 'string' && <div>{media}</div>}
           {React.isValidElement(media) && media}
+          <span />
         </MediaWrapper>
       )}
-      <Content justify="center" direction="column">
+
+      <Content flex={1} justify="center" direction="column" paddingLeft={media === false ? 1 : 0}>
         <Top align="center" justify="space-between">
           <Header space={2} flex={1}>
             <Text textOverflow="ellipsis" style={{color: 'inherit'}}>
@@ -74,12 +68,14 @@ export const DetailPreview: React.FunctionComponent<PreviewProps<'detail'>> = (p
               </Text>
             )}
           </Header>
+
           {status && (
-            <StatusWrapper paddingLeft={1}>
+            <StatusWrapper paddingLeft={3} paddingRight={1}>
               {typeof status === 'function' ? status({layout: 'detail'}) : status}
             </StatusWrapper>
           )}
         </Top>
+
         {description && (
           <Box marginTop={3} overflow="hidden" style={{maxHeight}}>
             <Text muted size={1}>

--- a/packages/@sanity/base/src/preview/components/ObserveForPreview.tsx
+++ b/packages/@sanity/base/src/preview/components/ObserveForPreview.tsx
@@ -84,6 +84,7 @@ type ReceivedProps = {
   error?: Error
   children: (props: unknown) => React.ReactElement
 }
+
 export default withPropsStream<OuterProps, ReceivedProps>(connect, function ObserveForPreview(
   props: ReceivedProps
 ) {

--- a/packages/@sanity/base/src/preview/components/PreviewFields.tsx
+++ b/packages/@sanity/base/src/preview/components/PreviewFields.tsx
@@ -1,24 +1,30 @@
+import {SanityDocument} from '@sanity/types'
 import React from 'react'
-import PreviewSubscriber from './PreviewSubscriber'
 import {Type} from '../types'
+import PreviewSubscriber from './PreviewSubscriber'
 
-function arrify<T>(val: T | T[]) {
+function toArray<T>(val: T | T[]) {
   if (Array.isArray(val)) {
     return val
   }
+
   return typeof val === undefined ? [] : [val]
 }
 
-type Props = {
-  document: Document
+interface PreviewFieldsProps {
+  document: SanityDocument
   fields: string | string[]
+  layout?: 'inline' | 'block' | 'default' | 'card' | 'media'
   type: Type
-  children: (snapshot: Document) => React.ReactChildren
+  children: (snapshot: SanityDocument) => React.ReactElement
 }
-export default function PreviewFields(props: Props) {
+
+export default function PreviewFields(props: PreviewFieldsProps) {
+  const {children, document, fields, layout, type} = props
+
   return (
-    <PreviewSubscriber value={props.document} type={props.type} fields={arrify(props.fields)}>
-      {({snapshot}) => <span>{snapshot ? props.children(snapshot) : null}</span>}
+    <PreviewSubscriber layout={layout} value={document} type={type} fields={toArray(fields)}>
+      {({snapshot}) => (snapshot ? children(snapshot) : null)}
     </PreviewSubscriber>
   )
 }

--- a/packages/@sanity/base/src/preview/components/PreviewSubscriber.tsx
+++ b/packages/@sanity/base/src/preview/components/PreviewSubscriber.tsx
@@ -11,7 +11,7 @@ interface Props {
   value: any
   ordering?: SortOrdering
   children: (props: any) => React.ReactElement
-  layout?: string
+  layout?: 'inline' | 'block' | 'default' | 'card' | 'media' | 'detail'
 }
 
 export default class PreviewSubscriber extends React.Component<Props> {
@@ -48,6 +48,7 @@ export default class PreviewSubscriber extends React.Component<Props> {
     if (this.props.layout && ['inline', 'block'].includes(this.props.layout)) {
       return this.renderChild(true)
     }
+
     return <WithVisibility hideDelay={HIDE_DELAY}>{this.renderChild}</WithVisibility>
   }
 }

--- a/packages/@sanity/base/src/preview/components/SanityDefaultPreview.tsx
+++ b/packages/@sanity/base/src/preview/components/SanityDefaultPreview.tsx
@@ -3,8 +3,8 @@
 
 import React from 'react'
 import imageUrlBuilder from '@sanity/image-url'
+import {DocumentIcon} from '@sanity/icons'
 import {assetUrlBuilder} from '../../assets'
-import FileIcon from '../../components/icons/File'
 import {versionedClient} from '../../client/versionedClient'
 import {
   DefaultPreview,
@@ -87,7 +87,7 @@ export default class SanityDefaultPreview extends React.PureComponent<Props> {
 
   renderIcon = () => {
     const {icon} = this.props
-    const Icon = icon || FileIcon
+    const Icon = icon || DocumentIcon
     return Icon && <Icon className="sanity-studio__preview-fallback-icon" />
   }
 

--- a/packages/@sanity/base/src/preview/components/SanityPreview.tsx
+++ b/packages/@sanity/base/src/preview/components/SanityPreview.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
+import {SortOrdering, Type} from '../types'
 import PreviewSubscriber from './PreviewSubscriber'
 import RenderPreviewSnapshot from './RenderPreviewSnapshot'
-import {SortOrdering, Type} from '../types'
 
 interface Props {
   type: Type
@@ -9,7 +9,7 @@ interface Props {
   value: any
   ordering?: SortOrdering
   children: (props: any) => React.ComponentType
-  layout: string
+  layout?: 'inline' | 'block' | 'default' | 'card' | 'media' | 'detail'
 }
 
 export default function SanityPreview(props: Props) {

--- a/packages/@sanity/base/src/preview/constants.tsx
+++ b/packages/@sanity/base/src/preview/constants.tsx
@@ -1,49 +1,21 @@
-import React from 'react'
-import styled from 'styled-components'
-import {Flex, Text} from '@sanity/ui'
 import {WarningOutlineIcon, AccessDeniedIcon} from '@sanity/icons'
+import React from 'react'
 import {PreparedValue} from './prepareForPreview'
 
 export const INCLUDE_FIELDS_QUERY = ['_id', '_rev', '_type']
 export const INCLUDE_FIELDS = [...INCLUDE_FIELDS_QUERY, '_key']
 
-// NOTE: have to use color inherit to make it work correctly with the
-// `isSelected` state in the list pane
-const IconSizer = styled(Text)`
-  color: inherit;
-`
-
-function IconWrapper({children}: {children: React.ReactNode}) {
-  return (
-    <Flex>
-      <IconSizer size={3}>{children}</IconSizer>
-    </Flex>
-  )
-}
-
 export class InsufficientPermissionsError extends Error {}
 
 export const INVALID_PREVIEW_FALLBACK: PreparedValue = {
-  // The `<small>` element is used for more compatibility
-  // with the different downstream preview components.
-  title: <small>Invalid preview config</small>,
-  subtitle: <small>Check the error log in the console</small>,
-  media: (
-    <IconWrapper>
-      <WarningOutlineIcon />
-    </IconWrapper>
-  ),
+  title: <>Invalid preview config</>,
+  subtitle: <>Check the error log in the console</>,
+  media: <WarningOutlineIcon />,
   _internalMeta: {type: 'invalid_preview'},
 }
 
 export const INSUFFICIENT_PERMISSIONS_FALLBACK: PreparedValue = {
-  // The `<small>` element is used for more compatibility
-  // with the different downstream preview components.
-  title: <small>Insufficient permissions to access this reference</small>,
-  media: (
-    <IconWrapper>
-      <AccessDeniedIcon />
-    </IconWrapper>
-  ),
+  title: <>Insufficient permissions to access this reference</>,
+  media: <AccessDeniedIcon />,
   _internalMeta: {type: 'insufficient_permissions'},
 }

--- a/packages/@sanity/cli/src/commands/init/initCommand.js
+++ b/packages/@sanity/cli/src/commands/init/initCommand.js
@@ -41,7 +41,7 @@ Examples
 
 export default {
   name: 'init',
-  signature: 'init [plugin]',
+  signature: '[plugin]',
   description: 'Initialize a new Sanity project or plugin',
   helpText,
   action: (args, context) => {


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Notable changes:
- `DefaultPreview`
  - Hides the skeleton for `media`, if the preview is configured to not have icon/image.
  - Adjusts padding depending on existence of `media`
- `DetailPreview`
  - Adds rounded corner to media images, similar to `DefaultPreview`.
  - Adds inner shadow to media images, similar to `DefaultPreview`
  - Adjusts the sizing of the icons
  - Remove CSS that is provided by `@sanity/ui`
- `SanityDefaultPreview`
  - Migrate to using icons from `@sanity/icons`
