### PR TITLE
fix(form-builder): don't unset empty objects if on root level

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ObjectInput/ObjectInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ObjectInput/ObjectInput.tsx
@@ -96,15 +96,15 @@ export const ObjectInput = memo(
             event.append(unset(['_type'])).patches
           )
 
-        // if the result has no keys left in it.
-        // note: for arrays we retain empty objects so `_key` is not considered
-        if (isRecord(result) && Object.keys(result).length === 0) {
-          // then unset the whole object
-          onChange?.(PatchEvent.from(unset()))
-          return
-        }
-
         if (!isRoot) {
+          // if the result has no keys left in it.
+          // note: for arrays we retain empty objects so `_key` is not considered
+          if (isRecord(result) && Object.keys(result).length === 0) {
+            // then unset the whole object
+            onChange?.(PatchEvent.from(unset()))
+            return
+          }
+
           event = event.prepend(setIfMissing(type.name === 'object' ? {} : {_type: type.name}))
           if (value) {
             const valueTypeName = value && value._type


### PR DESCRIPTION
### Description

This fixes an issue introduced in v2.18.0 that would in some rare cases trigger an unset patch on the document itself, which again would trigger studio error. The fix is to not do the empty check if we're on root level (e.g. the object input is used for the document itself).

### What to review
The proposed code change to see if it makes sense.

### Notes for release

Fixes a bug that could in some rare cases trigger an error saying "Cannot read properties of null (reading 'expr')"

