### PR TITLE
refactor(dashboard): update `DefaultPreview` in `ProjectUsers` widget

### DIFF
--- a/packages/@sanity/dashboard/src/widgets/projectUsers/ProjectUsers.js
+++ b/packages/@sanity/dashboard/src/widgets/projectUsers/ProjectUsers.js
@@ -3,9 +3,10 @@ import {map, switchMap} from 'rxjs/operators'
 import {Stack, Spinner, Card, Box, Text, Button} from '@sanity/ui'
 import {RobotIcon} from '@sanity/icons'
 import styled from 'styled-components'
+import {DefaultPreview} from '@sanity/base/components'
 import {versionedClient} from '../../versionedClient'
 import {DashboardWidget} from '../../DashboardTool'
-import {DefaultPreview, userStore} from '../../legacyParts'
+import {userStore} from '../../legacyParts'
 
 const AvatarWrapper = styled(Card)`
   box-sizing: border-box;


### PR DESCRIPTION
### Description

This uses the new `DefaultPreview` component in the `ProjectUsers` widget.

![image](https://user-images.githubusercontent.com/10508/133593582-c1157896-e501-478d-882a-9cfea4bef7e7.png)

### What to review

That the widget looks and behaves the same in the test studio dashboard.

### Notes for release

- Us new `DefaultPreview` component in the `ProjectUsers` widget.
