### PR TITLE
feat(structure): allow specifying API version for document lists

### DIFF
--- a/packages/@sanity/base/src/client/versionedClient.ts
+++ b/packages/@sanity/base/src/client/versionedClient.ts
@@ -7,6 +7,7 @@
  * Preconfigured, versioned client used for all the
  * internal tooling within @sanity/base.
  */
+import type {SanityClient} from '@sanity/client'
 import sanityClient from 'part:@sanity/base/client'
 
 /**
@@ -23,3 +24,25 @@ export const versionedClient = sanityClient.withConfig({
    */
   apiVersion: '1',
 })
+
+/**
+ * Only for use inside of @sanity/base
+ * Don't import this from external modules.
+ *
+ * Gets a client configured with the passed API version,
+ * re-using clients where possible
+ *
+ * @internal
+ */
+export const getVersionedClient = (() => {
+  const clientMap = new Map<string, SanityClient>()
+  return function getVersionedSanityClient(version: string | undefined): SanityClient {
+    const apiVersion = version || '1'
+
+    if (!clientMap.has(apiVersion)) {
+      clientMap.set(apiVersion, sanityClient.withConfig({apiVersion}))
+    }
+
+    return clientMap.get(apiVersion)
+  }
+})()

--- a/packages/@sanity/base/src/datastores/document/listenQuery.ts
+++ b/packages/@sanity/base/src/datastores/document/listenQuery.ts
@@ -1,18 +1,19 @@
 import {defer, partition, merge, of, throwError, asyncScheduler, Observable} from 'rxjs'
 import {mergeMap, throttleTime, share, take} from 'rxjs/operators'
 import {exhaustMapToWithTrailing} from 'rxjs-exhaustmap-with-trailing'
-import {versionedClient} from '../../client/versionedClient'
+import {getVersionedClient} from '../../client/versionedClient'
 import {ReconnectEvent, WelcomeEvent, MutationEvent} from './types'
 
 type Params = Record<string, string>
 
 export interface ListenQueryOptions {
   tag?: string
+  apiVersion?: string
 }
 
 const fetch = (query: string, params: Params, options: ListenQueryOptions) =>
   defer(() =>
-    versionedClient.observable.fetch(query, params, {
+    getVersionedClient(options.apiVersion).observable.fetch(query, params, {
       tag: options.tag,
       filterResponse: true,
     })
@@ -20,7 +21,7 @@ const fetch = (query: string, params: Params, options: ListenQueryOptions) =>
 
 const listen = (query: string, params: Params, options: ListenQueryOptions) =>
   defer(() =>
-    versionedClient.listen(query, params, {
+    getVersionedClient(options.apiVersion).listen(query, params, {
       events: ['welcome', 'mutation', 'reconnect'],
       includeResult: false,
       visibility: 'query',

--- a/packages/@sanity/desk-tool/src/panes/documentsListPane/DocumentsListPane.js
+++ b/packages/@sanity/desk-tool/src/panes/documentsListPane/DocumentsListPane.js
@@ -236,8 +236,12 @@ export default class DocumentsListPane extends React.PureComponent {
 
     const params = this.props.options.params || {}
     const query = this.buildListQuery({fullList})
+    const apiVersion = this.props.options.apiVersion || '1'
 
-    this.queryResults$ = getQueryResults(of({query, params}), {tag: 'desk.document-list'})
+    this.queryResults$ = getQueryResults(of({query, params}), {
+      tag: 'desk.document-list',
+      apiVersion,
+    })
       .pipe(filterEvents(fullList ? ({result}) => result : () => true))
       .subscribe((queryResult) =>
         this.setState({queryResult, isLoadingMore: false, hasFullSubscription: fullList})

--- a/packages/@sanity/desk-tool/test/mocks/client.js
+++ b/packages/@sanity/desk-tool/test/mocks/client.js
@@ -1,5 +1,8 @@
-module.exports = {
+const client = {
   withConfig: () => ({
     fetch: () => Promise.resolve(['book', 'book']),
+    withConfig: () => client,
   }),
 }
+
+module.exports = client

--- a/packages/@sanity/structure/src/DocumentList.ts
+++ b/packages/@sanity/structure/src/DocumentList.ts
@@ -161,6 +161,10 @@ export class DocumentListBuilder extends GenericListBuilder<
       child: this.spec.child || resolveDocumentChildForItem,
       options: {
         ...this.spec.options,
+        apiVersion:
+          this.spec.options.apiVersion ||
+          // If this is a simple type filter, use modern API version - otherwise default to v1
+          (this.spec.options?.filter === '_type == $type' ? '2021-06-07' : '1'),
         filter: validateFilter(this.spec, options),
       },
     }

--- a/packages/@sanity/structure/src/DocumentList.ts
+++ b/packages/@sanity/structure/src/DocumentList.ts
@@ -1,7 +1,7 @@
 import {getParameterlessTemplatesBySchemaType} from '@sanity/initial-value-templates'
 import {SchemaType, getDefaultSchema} from './parts/Schema'
 import {isActionEnabled} from './parts/documentActionUtils'
-import {client} from './parts/Client'
+import {structureClient} from './parts/Client'
 import {SortItem} from './Sort'
 import {SerializeError, HELP_URL} from './SerializeError'
 import {SerializeOptions, Child} from './StructureNodes'
@@ -19,7 +19,7 @@ const resolveTypeForDocument = (id: string): Promise<string | undefined> => {
   const query = '*[_id in [$documentId, $draftId]]._type'
   const documentId = id.replace(/^drafts\./, '')
   const draftId = `drafts.${documentId}`
-  return client
+  return structureClient
     .fetch(query, {documentId, draftId}, {tag: 'structure.resolve-type'})
     .then((types) => types[0])
 }

--- a/packages/@sanity/structure/src/DocumentList.ts
+++ b/packages/@sanity/structure/src/DocumentList.ts
@@ -70,6 +70,7 @@ export interface DocumentList extends GenericList {
 interface DocumentListOptions {
   filter: string
   params?: {[key: string]: any}
+  apiVersion?: string
   defaultOrdering?: SortItem[]
 }
 
@@ -83,6 +84,14 @@ export class DocumentListBuilder extends GenericListBuilder<
     super()
     this.spec = spec ? spec : {}
     this.initialValueTemplatesSpecified = Boolean(spec && spec.initialValueTemplates)
+  }
+
+  apiVersion(apiVersion: string): DocumentListBuilder {
+    return this.clone({options: {...(this.spec.options || {filter: ''}), apiVersion}})
+  }
+
+  getApiVersion(): string | undefined {
+    return this.spec.options?.apiVersion
   }
 
   filter(filter: string): DocumentListBuilder {

--- a/packages/@sanity/structure/src/DocumentList.ts
+++ b/packages/@sanity/structure/src/DocumentList.ts
@@ -42,8 +42,8 @@ const resolveDocumentChildForItem: ChildResolver = (
   options: ChildResolverOptions
 ): ItemChild | Promise<ItemChild> | undefined => {
   const parentItem = options.parent as DocumentList
-  const schemaType = parentItem.schemaTypeName || resolveTypeForDocument(itemId)
-  return Promise.resolve(schemaType).then((schemaType) =>
+  const type = parentItem.schemaTypeName || resolveTypeForDocument(itemId)
+  return Promise.resolve(type).then((schemaType) =>
     schemaType
       ? getDefaultDocumentNode({schemaType, documentId: itemId})
       : new DocumentBuilder().id('editor').documentId(itemId).schemaType('')
@@ -87,8 +87,8 @@ export class DocumentListBuilder extends GenericListBuilder<
     return this.clone({options: {...(this.spec.options || {}), filter}})
   }
 
-  getFilter() {
-    return this.spec.options && this.spec.options.filter
+  getFilter(): string | undefined {
+    return this.spec.options?.filter
   }
 
   schemaType(type: SchemaType | string): DocumentListBuilder {
@@ -96,18 +96,18 @@ export class DocumentListBuilder extends GenericListBuilder<
     return this.clone({schemaTypeName})
   }
 
-  getSchemaType() {
+  getSchemaType(): string | undefined {
     return this.spec.schemaTypeName
   }
 
-  params(params: {}): DocumentListBuilder {
+  params(params: Record<string, unknown>): DocumentListBuilder {
     return this.clone({
       options: {...(this.spec.options || {filter: ''}), params},
     })
   }
 
-  getParams() {
-    return this.spec.options && this.spec.options.params
+  getParams(): Record<string, unknown> | undefined {
+    return this.spec.options?.params
   }
 
   defaultOrdering(ordering: SortItem[]): DocumentListBuilder {
@@ -120,8 +120,8 @@ export class DocumentListBuilder extends GenericListBuilder<
     })
   }
 
-  getDefaultOrdering() {
-    return this.spec.options && this.spec.options.defaultOrdering
+  getDefaultOrdering(): SortItem[] | undefined {
+    return this.spec.options?.defaultOrdering
   }
 
   serialize(options: SerializeOptions = {path: []}): DocumentList {
@@ -170,7 +170,7 @@ export class DocumentListBuilder extends GenericListBuilder<
     return builder
   }
 
-  getSpec() {
+  getSpec(): PartialDocumentList {
     return this.spec
   }
 }
@@ -187,7 +187,7 @@ function inferInitialValueTemplates(
     return undefined
   }
 
-  let templateItems: InitialValueTemplateItem[] = []
+  const templateItems: InitialValueTemplateItem[] = []
   return typeNames.reduce((items, typeName) => {
     const schemaType = schema.get(typeName)
     if (!isActionEnabled(schemaType, 'create')) {

--- a/packages/@sanity/structure/src/DocumentList.ts
+++ b/packages/@sanity/structure/src/DocumentList.ts
@@ -19,7 +19,9 @@ const resolveTypeForDocument = (id: string): Promise<string | undefined> => {
   const query = '*[_id in [$documentId, $draftId]]._type'
   const documentId = id.replace(/^drafts\./, '')
   const draftId = `drafts.${documentId}`
-  return client.fetch(query, {documentId, draftId}).then((types) => types[0])
+  return client
+    .fetch(query, {documentId, draftId}, {tag: 'structure.resolve-type'})
+    .then((types) => types[0])
 }
 
 const validateFilter = (spec: PartialDocumentList, options: SerializeOptions) => {

--- a/packages/@sanity/structure/src/parts/Client.ts
+++ b/packages/@sanity/structure/src/parts/Client.ts
@@ -3,10 +3,21 @@ import getDefaultModule from './getDefaultModule'
 
 type StudioClient = SanityClient & {withConfig: (config: Partial<ClientConfig>) => SanityClient}
 
-// We are lazy-loading the part to work around typescript trying to resolve it
-const client = ((): SanityClient => {
+/**
+ * Default client for queries, using API version 1 for backwards compatibility
+ *
+ * @internal
+ */
+export const client = ((): SanityClient => {
+  // We are lazy-loading the part to work around typescript trying to resolve it
   const sanityClient: StudioClient = getDefaultModule(require('part:@sanity/base/client'))
   return sanityClient.withConfig({apiVersion: '1'})
 })()
 
-export {client}
+/**
+ * For structure-internal requests that we have control of the filter on,
+ * we'll use this client with a more modern API version
+ *
+ * @internal
+ */
+export const structureClient = client.withConfig({apiVersion: '2021-06-07'})

--- a/packages/@sanity/structure/test/DocumentList.test.ts
+++ b/packages/@sanity/structure/test/DocumentList.test.ts
@@ -60,6 +60,20 @@ test('builds document lists through setters (alt order #2)', () => {
   ).toMatchSnapshot()
 })
 
+test('builds document lists with custom api version', () => {
+  expect(
+    S.documentList()
+      .id('pets')
+      .title('Pets')
+      .filter('_type == $type && count(humanAssociates[name == $human]) > 0')
+      .params({type: 'pet', human: 'Espen'})
+      .apiVersion('v2021-09-17')
+      .defaultLayout('detail')
+      .defaultOrdering([{field: 'title', direction: 'asc'}])
+      .serialize()
+  ).toMatchSnapshot()
+})
+
 test('default child resolver resolves to editor', (done) => {
   const list = S.documentList()
     .id('books')
@@ -96,6 +110,7 @@ test('builder is immutable', () => {
   expect(original.id('foo')).not.toBe(original)
   expect(original.title('foo')).not.toBe(original)
   expect(original.filter('foo == "bar"')).not.toBe(original)
+  expect(original.apiVersion('v1')).not.toBe(original)
   expect(original.params({foo: 'bar'})).not.toBe(original)
   expect(original.menuItems([])).not.toBe(original)
   expect(original.showIcons(false)).not.toBe(original)
@@ -115,6 +130,7 @@ test('getters work', () => {
   expect(original.id('foo').getId()).toEqual('foo')
   expect(original.title('bar').getTitle()).toEqual('bar')
   expect(original.filter('foo == "bar"').getFilter()).toEqual('foo == "bar"')
+  expect(original.apiVersion('v2021-03-25').getApiVersion()).toEqual('v2021-03-25')
   expect(original.params({foo: 'bar'}).getParams()).toEqual({foo: 'bar'})
   expect(original.menuItems([]).getMenuItems()).toEqual([])
   expect(original.menuItemGroups([]).getMenuItemGroups()).toEqual([])

--- a/packages/@sanity/structure/test/DocumentTypeList.test.ts
+++ b/packages/@sanity/structure/test/DocumentTypeList.test.ts
@@ -1,6 +1,6 @@
 import {StructureBuilder as S} from '../src'
-import serializeStructure from './util/serializeStructure'
 import {getDefaultSchema, SchemaType} from '../src/parts/Schema'
+import serializeStructure from './util/serializeStructure'
 
 test('builds document type lists with only required properties', () => {
   expect(
@@ -44,6 +44,19 @@ test('throws if no filter is set', () => {
   expect(() =>
     S.documentTypeList('author').id('foo').filter('').serialize()
   ).toThrowErrorMatchingSnapshot()
+})
+
+test('defaults to modern api version ', () => {
+  expect(S.documentTypeList('author').serialize()).toHaveProperty(
+    'options.apiVersion',
+    '2021-06-07'
+  )
+})
+
+test('defaults to api version v1 if custom filter is specified', () => {
+  expect(
+    S.documentTypeList('author').filter('_type == $type && custom == "prop"').serialize()
+  ).toHaveProperty('options.apiVersion', '1')
 })
 
 test('builds document type lists through setters', () => {

--- a/packages/@sanity/structure/test/__snapshots__/DocumentList.test.ts.snap
+++ b/packages/@sanity/structure/test/__snapshots__/DocumentList.test.ts.snap
@@ -11,6 +11,7 @@ Object {
   "menuItemGroups": Array [],
   "menuItems": Array [],
   "options": Object {
+    "apiVersion": "2021-06-07",
     "defaultOrdering": Array [
       Object {
         "direction": "desc",
@@ -39,6 +40,7 @@ Object {
   "menuItemGroups": Array [],
   "menuItems": Array [],
   "options": Object {
+    "apiVersion": "2021-06-07",
     "defaultOrdering": Array [
       Object {
         "direction": "desc",
@@ -67,6 +69,7 @@ Object {
   "menuItemGroups": Array [],
   "menuItems": Array [],
   "options": Object {
+    "apiVersion": "2021-06-07",
     "defaultOrdering": Array [
       Object {
         "direction": "asc",
@@ -84,6 +87,36 @@ Object {
 }
 `;
 
+exports[`builds document lists with custom api version 1`] = `
+Object {
+  "canHandleIntent": [Function],
+  "child": [Function],
+  "defaultLayout": "detail",
+  "displayOptions": undefined,
+  "id": "pets",
+  "initialValueTemplates": Array [],
+  "menuItemGroups": Array [],
+  "menuItems": Array [],
+  "options": Object {
+    "apiVersion": "v2021-09-17",
+    "defaultOrdering": Array [
+      Object {
+        "direction": "asc",
+        "field": "title",
+      },
+    ],
+    "filter": "_type == $type && count(humanAssociates[name == $human]) > 0",
+    "params": Object {
+      "human": "Espen",
+      "type": "pet",
+    },
+  },
+  "schemaTypeName": undefined,
+  "title": "Pets",
+  "type": "documentList",
+}
+`;
+
 exports[`builds document lists with only required properties 1`] = `
 Object {
   "canHandleIntent": [Function],
@@ -95,6 +128,7 @@ Object {
   "menuItemGroups": Array [],
   "menuItems": Array [],
   "options": Object {
+    "apiVersion": "1",
     "filter": "_type == \\"book\\"",
   },
   "schemaTypeName": undefined,

--- a/packages/@sanity/structure/test/__snapshots__/DocumentListItem.test.ts.snap
+++ b/packages/@sanity/structure/test/__snapshots__/DocumentListItem.test.ts.snap
@@ -58,6 +58,7 @@ Object {
     "menuItemGroups": Array [],
     "menuItems": Array [],
     "options": Object {
+      "apiVersion": "1",
       "filter": "author == \\"grrm\\"",
     },
     "schemaTypeName": undefined,

--- a/packages/@sanity/structure/test/__snapshots__/DocumentTypeList.test.ts.snap
+++ b/packages/@sanity/structure/test/__snapshots__/DocumentTypeList.test.ts.snap
@@ -75,6 +75,7 @@ Object {
     },
   ],
   "options": Object {
+    "apiVersion": "2021-06-07",
     "defaultOrdering": Array [
       Object {
         "direction": "desc",
@@ -167,6 +168,7 @@ Object {
     },
   ],
   "options": Object {
+    "apiVersion": "2021-06-07",
     "defaultOrdering": Array [
       Object {
         "direction": "desc",
@@ -259,6 +261,7 @@ Object {
     },
   ],
   "options": Object {
+    "apiVersion": "2021-06-07",
     "defaultOrdering": Array [
       Object {
         "direction": "asc",
@@ -351,6 +354,7 @@ Object {
     },
   ],
   "options": Object {
+    "apiVersion": "2021-06-07",
     "defaultOrdering": Array [
       Object {
         "direction": "desc",
@@ -443,6 +447,7 @@ Object {
     },
   ],
   "options": Object {
+    "apiVersion": "2021-06-07",
     "defaultOrdering": Array [
       Object {
         "direction": "desc",
@@ -535,6 +540,7 @@ Object {
     },
   ],
   "options": Object {
+    "apiVersion": "2021-06-07",
     "defaultOrdering": Array [
       Object {
         "direction": "desc",
@@ -627,6 +633,7 @@ Object {
     },
   ],
   "options": Object {
+    "apiVersion": "2021-06-07",
     "defaultOrdering": Array [
       Object {
         "direction": "desc",

--- a/packages/@sanity/structure/test/__snapshots__/ListItem.test.ts.snap
+++ b/packages/@sanity/structure/test/__snapshots__/ListItem.test.ts.snap
@@ -22,6 +22,7 @@ Object {
     "menuItemGroups": Array [],
     "menuItems": Array [],
     "options": Object {
+      "apiVersion": "1",
       "filter": "author == \\"grrm\\"",
     },
     "schemaTypeName": undefined,


### PR DESCRIPTION
### Description

This PR introduces two new methods on `DocumentList` and friends:
- `apiVersion(someApiVersion)` - sets the API version to use for the given filter
- `getApiVersion()` - retrieves the set API version

This allows the user to use new GROQ functions, as well as getting faster queries in some cases.

To allow for this, we also expand the `listenQuery` utility to allow specifying API version, and try to re-use studio clients where possible.

The default API version is still `v1` for most lists, since we can't guarantee that the previous filter will work with newer API versions. Simply document type lists however will default to `v2021-06-07`, since we can guarantee that those work.

### What to review 

- Does the API version get passed on correctly?
- Does the API align with current APIs?

### Notes for release

**Highlight**: Added ability to specify API version for document list structures by using the new `apiVersion()` method.