### PR TITLE
refactor(cli): migrate schema icon to `@sanity/icons`

### DIFF
--- a/packages/@sanity/cli/.depcheckignore.json
+++ b/packages/@sanity/cli/.depcheckignore.json
@@ -1,4 +1,4 @@
 {
   "//": "these are used by template projects and doesn't need to be project dependencies",
-  "ignore": ["react-icons", "react", "prop-types", "react-barcode", "@sanity/base", "@sanity/ui", "@sanity/form-builder", "styled-components"]
+  "ignore": ["react-icons", "react", "prop-types", "react-barcode", "@sanity/base", "@sanity/ui", "@sanity/icons", "@sanity/form-builder", "styled-components"]
 }

--- a/packages/@sanity/cli/templates/moviedb/schemas/person.js
+++ b/packages/@sanity/cli/templates/moviedb/schemas/person.js
@@ -1,4 +1,4 @@
-import UserIcon from 'part:@sanity/base/user-icon'
+import {UserIcon} from '@sanity/icons'
 
 export default {
   name: 'person',


### PR DESCRIPTION
### Description

This migrates the schema icon in `packages/@sanity/cli/templates/moviedb/schemas/person.js` to `@sanity/icons`.

### Notes for release

None. Transparent to the user.