### PR TITLE
chore(server): use forked webpack-dev-middleware

### DIFF
--- a/packages/@sanity/server/package.json
+++ b/packages/@sanity/server/package.json
@@ -48,6 +48,7 @@
     "@sanity/eventsource": "2.14.0",
     "@sanity/resolver": "2.19.0",
     "@sanity/util": "2.19.0",
+    "@sanity/webpack-dev-middleware": "^2.0.6",
     "@sanity/webpack-integration": "2.19.0",
     "babel-loader": "^8.0.6",
     "eventsource-polyfill": "^0.9.6",
@@ -67,18 +68,15 @@
     "style-loader": "^0.20.1",
     "symbol-observable": "^1.2.0",
     "webpack": "^3.8.1",
-    "webpack-dev-middleware": "^2.0.5",
     "webpack-hot-middleware": "2.25.0"
   },
   "devDependencies": {
     "find-config": "^1.0.0",
-    "prop-types": "^15.6.0",
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "rimraf": "^2.7.1"
   },
   "peerDependencies": {
-    "prop-types": "^15.6 || ^16",
     "react": "^16.9 || ^17",
     "react-dom": "^16.9 || ^17"
   }

--- a/packages/@sanity/server/src/devServer.js
+++ b/packages/@sanity/server/src/devServer.js
@@ -1,7 +1,7 @@
 import path from 'path'
 import webpack from 'webpack'
 import registerBabel from '@babel/register'
-import webpackDevMiddleware from 'webpack-dev-middleware'
+import webpackDevMiddleware from '@sanity/webpack-dev-middleware'
 import webpackHotMiddleware from 'webpack-hot-middleware'
 import {getBaseServer, applyStaticRoutes} from './baseServer'
 import getWebpackDevConfig from './configs/webpack.config.dev'


### PR DESCRIPTION
### Description

This works arounds a deprecation warning on node 16 caused by an incorrect "main" field in the original module:

```
❯ sanity start
(node:66158) [DEP0128] DeprecationWarning: Invalid 'main' field in '/Users/espenh/webdev/studio/node_modules/webpack-dev-middleware/package.json' of 'middleware.js'. Please either fix that or report it to the module author
(Use `node --trace-deprecation ...` to show where the warning was created)
```

### What to review

That the studio still works in development mode

### Notes for release

- Fixed a deprecation warning being printed when running `sanity start` on node.js 16 or higher
