### PR TITLE
fix(language-filter): fixes popover placement issue when language list is long

### DIFF
--- a/packages/@sanity/language-filter/src/SelectLanguage.tsx
+++ b/packages/@sanity/language-filter/src/SelectLanguage.tsx
@@ -94,23 +94,21 @@ const SelectLanguage = ({
   }
 
   const content = (
-    <div onKeyUp={handleKeyUp}>
-      <Box padding={2}>
-        <Flex>
-          <Button
-            type="button"
-            mode="ghost"
-            tone="default"
-            onClick={allIsSelected ? handleSelectNone : handleSelectAll}
-            paddingX={3}
-            paddingY={2}
-            autoFocus
-            style={STYLES_TOGGLE}
-          >
-            Select {allIsSelected ? 'none' : 'all'}
-          </Button>
-        </Flex>
-      </Box>
+    <Box overflow="auto" sizing="border" onKeyUp={handleKeyUp}>
+      <Flex padding={2}>
+        <Button
+          type="button"
+          mode="ghost"
+          tone="default"
+          onClick={allIsSelected ? handleSelectNone : handleSelectAll}
+          paddingX={3}
+          paddingY={2}
+          autoFocus
+          style={STYLES_TOGGLE}
+        >
+          Select {allIsSelected ? 'none' : 'all'}
+        </Button>
+      </Flex>
       <Box padding={3} paddingX={2}>
         <Stack as="ul" space={3}>
           {languages.map((lang) => {
@@ -138,7 +136,7 @@ const SelectLanguage = ({
           })}
         </Stack>
       </Box>
-    </div>
+    </Box>
   )
 
   return (
@@ -165,9 +163,10 @@ const SelectLanguage = ({
       <Popover
         content={content}
         open={isOpen}
-        placement="top"
+        placement="bottom"
         ref={setPopoverRef}
         referenceElement={triggerRef}
+        constrainSize
         autoFocus
         portal
       />


### PR DESCRIPTION
### Description

This fixes an overflowing popover and its placement when list of languages to filter is long.

| before | after |  
|--------|-------|
|![image](https://user-images.githubusercontent.com/10508/134487634-738bfea6-a8a2-4082-84ea-a31201ea96c3.png)|![image](https://user-images.githubusercontent.com/10508/134487765-008e93c9-4f42-4fdd-8182-5aca912ae607.png)|


### What to review

Run the example studio `npm run example-studio` and review a document of type `Blogpost`. You will find the filter menu in the right top corner.

That the popover is placed correctly when the list of languages is long, and that it is scrollable.

### Notes for release

- Fixes overflowing popover placement when list of languages to filter is long