### PR TITLE
fix(cli): include gitignore in bootstrapped studios

### DIFF
--- a/packages/@sanity/cli/.npmignore
+++ b/packages/@sanity/cli/.npmignore
@@ -7,3 +7,4 @@
 /.eslintrc
 /yarn.lock
 tsconfig.tsbuildinfo
+!templates/**/.gitignore

--- a/packages/@sanity/cli/templates/blog/.gitignore
+++ b/packages/@sanity/cli/templates/blog/.gitignore
@@ -1,10 +1,12 @@
 # Logs
-logs
+/logs
 *.log
 
 # Coverage directory used by tools like istanbul
-coverage
+/coverage
 
 # Dependency directories
 node_modules
-dist
+
+# Compiled sanity studio
+/dist

--- a/packages/@sanity/cli/templates/clean/.gitignore
+++ b/packages/@sanity/cli/templates/clean/.gitignore
@@ -1,10 +1,12 @@
 # Logs
-logs
+/logs
 *.log
 
 # Coverage directory used by tools like istanbul
-coverage
+/coverage
 
 # Dependency directories
 node_modules
-dist
+
+# Compiled sanity studio
+/dist

--- a/packages/@sanity/cli/templates/ecommerce/.gitignore
+++ b/packages/@sanity/cli/templates/ecommerce/.gitignore
@@ -1,10 +1,12 @@
 # Logs
-logs
+/logs
 *.log
 
 # Coverage directory used by tools like istanbul
-coverage
+/coverage
 
 # Dependency directories
 node_modules
-dist
+
+# Compiled sanity studio
+/dist

--- a/packages/@sanity/cli/templates/moviedb/.gitignore
+++ b/packages/@sanity/cli/templates/moviedb/.gitignore
@@ -1,10 +1,12 @@
 # Logs
-logs
+/logs
 *.log
 
 # Coverage directory used by tools like istanbul
-coverage
+/coverage
 
 # Dependency directories
 node_modules
-dist
+
+# Compiled sanity studio
+/dist


### PR DESCRIPTION
### Description

This PR fixes a (fairly old) regression where bootstrapped studios would not include a gitignore, often leading to the inclusion of `node_modules` and such in version control. The issue was simply that `.gitignore` would be ignored when packing by npm. We now explicitly lists gitignore files within the `templates` directory to _not_ be ignored, which fixes this.

Also tweaked the gitignores included a bit with some comments and less wide patterns.

### What to review

That the change makes sense, and that the `init` command includes the gitignore file.

### Notes for release

- New studios now include a `.gitignore` file by default

