### PR TITLE
fix(desk-tool): fix line when withinSelection

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/document/timeline/timelineItem.styled.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/timeline/timelineItem.styled.tsx
@@ -63,6 +63,12 @@ export const Root = styled(MenuItem)(({state = 'enabled', isHovered, theme}: Tim
       &:not([data-selection-top='true']) {
         border-radius: 0;
       }
+
+      ${IconWrapper} {
+        &::before {
+          background: var(--card-hairline-soft-color);
+        }
+      }
     `}
 
       ${state === 'disabled' &&


### PR DESCRIPTION
### Description

Fix issue where the line between timeline items looked wrong when within two separate selections


| before | after |  
|--------|-------|
| ![image](https://user-images.githubusercontent.com/6951139/135093228-57bb5170-2e58-4367-b6f4-403e4bd2870d.png) | ![image](https://user-images.githubusercontent.com/6951139/135093504-594c456a-a05b-4366-acca-61a00db842e3.png)

### What to review

Make sure that the colours of the lines work with the different cases.
You can test it out on the test-studio on the document-actions

### Notes for release

Fix visual issue with the connecting line between timeline items.