### PR TITLE
fix(cli): version SAML login under non-experimental version

### DIFF
--- a/packages/@sanity/cli/src/actions/login/login.js
+++ b/packages/@sanity/cli/src/actions/login/login.js
@@ -67,7 +67,7 @@ function getAuthChannel(baseUrl, provider, iv) {
   const uuid = crypto.randomBytes(16).toString('hex')
   let listenUrl
   if (provider.type === 'saml') {
-    listenUrl = `${baseUrl}/vX/auth/saml/listen/${provider.id}/${uuid}?iv=${iv}`
+    listenUrl = `${baseUrl}/v2021-10-01/auth/saml/listen/${provider.id}/${uuid}?iv=${iv}`
   } else {
     listenUrl = `${baseUrl}/v1/auth/listen/${provider.name}/${uuid}?iv=${iv}`
   }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

SSO login should be versioned under `v2021-10-01`

```
sg-sanity :: github.com/sanity-io/sanity ‹fix/vx-sso-version› » ./packages/@sanity/cli/bin/sanity login --sso sanity                                                                                                                                                                                                                                                130 ↵
This is an experimental API version, which will change without warning and may have serious bugs.

Opening browser at https://api.sanity.io/v2021-10-01/auth/saml/login/a9fd8216?type=listen&uuid=xxx&source=cli

Login successful
sg-sanity :: github.com/sanity-io/sanity ‹fix/vx-sso-version› » ./packages/@sanity/cli/bin/sanity login --sso sanity
```

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->
* Build CLI
* Test to login with SSO

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
N/A