### PR TITLE
refactor(structure): replace icons with icons from `@sanity/icons`

### DIFF
--- a/packages/@sanity/initial-value-templates/package.json
+++ b/packages/@sanity/initial-value-templates/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@sanity/util": "2.20.0",
     "@types/lodash": "^4.14.149",
+    "@sanity/icons": "^1.2.1",
     "lodash": "^4.17.15",
     "oneline": "^1.0.3"
   },

--- a/packages/@sanity/initial-value-templates/src/parts/Icon.ts
+++ b/packages/@sanity/initial-value-templates/src/parts/Icon.ts
@@ -1,9 +1,6 @@
-import getDefaultModule from './getDefaultModule'
+import {ComposeIcon, SortIcon, StackCompactIcon, SplitHorizontalIcon} from '@sanity/icons'
 
-// We are lazy-loading the part to work around typescript trying to resolve it
-export const getPlusIcon = (): Function =>
-  getDefaultModule(require('part:@sanity/base/compose-icon'))
-export const getSortIcon = (): Function => getDefaultModule(require('part:@sanity/base/sort-icon'))
-export const getListIcon = (): Function => getDefaultModule(require('part:@sanity/base/bars-icon'))
-export const getDetailsIcon = (): Function =>
-  getDefaultModule(require('part:@sanity/base/th-list-icon'))
+export const getPlusIcon = (): React.ComponentType => ComposeIcon
+export const getSortIcon = (): React.ComponentType => SortIcon
+export const getListIcon = (): React.ComponentType => StackCompactIcon
+export const getDetailsIcon = (): React.ComponentType => SplitHorizontalIcon

--- a/packages/@sanity/initial-value-templates/src/parts/Icon.ts
+++ b/packages/@sanity/initial-value-templates/src/parts/Icon.ts
@@ -1,6 +1,12 @@
 import {ComposeIcon, SortIcon, StackCompactIcon, SplitHorizontalIcon} from '@sanity/icons'
 
-export const getPlusIcon = (): React.ComponentType => ComposeIcon
-export const getSortIcon = (): React.ComponentType => SortIcon
-export const getListIcon = (): React.ComponentType => StackCompactIcon
-export const getDetailsIcon = (): React.ComponentType => SplitHorizontalIcon
+// @todo This legacy typing causes linting errors once we touch anything
+// in the structure package. We should update it in the future when we do
+// a pass on types
+// eslint-disable-next-line @typescript-eslint/ban-types
+type FixMe = Function
+
+export const getPlusIcon = (): FixMe => ComposeIcon
+export const getSortIcon = (): FixMe => SortIcon
+export const getListIcon = (): FixMe => StackCompactIcon
+export const getDetailsIcon = (): FixMe => SplitHorizontalIcon

--- a/packages/@sanity/structure/package.json
+++ b/packages/@sanity/structure/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@sanity/client": "2.19.0",
     "@sanity/initial-value-templates": "2.20.0",
+    "@sanity/icons": "^1.2.1",
     "@types/lodash": "^4.14.149",
     "@types/memoize-one": "^3.1.1",
     "lodash": "^4.17.15",

--- a/packages/@sanity/structure/src/ChildResolver.ts
+++ b/packages/@sanity/structure/src/ChildResolver.ts
@@ -1,4 +1,5 @@
 import {CollectionBuilder, Collection, SerializePath, SerializeOptions} from './StructureNodes'
+import {FixMe} from './types'
 
 export interface ChildResolverOptions {
   index: number
@@ -8,10 +9,10 @@ export interface ChildResolverOptions {
   serializeOptions?: SerializeOptions
 }
 
-export type ItemChild = CollectionBuilder | Collection | Function | undefined
+export type ItemChild = CollectionBuilder | Collection | FixMe | undefined
 
 interface ChildObservable {
-  subscribe: (child: ItemChild | Promise<ItemChild>) => {}
+  subscribe: (child: ItemChild | Promise<ItemChild>) => Record<string, unknown>
 }
 
 export interface ChildResolver {

--- a/packages/@sanity/structure/src/Component.ts
+++ b/packages/@sanity/structure/src/Component.ts
@@ -4,27 +4,28 @@ import {SerializeError, HELP_URL} from './SerializeError'
 import {MenuItem, MenuItemBuilder, maybeSerializeMenuItem} from './MenuItem'
 import {MenuItemGroup, MenuItemGroupBuilder, maybeSerializeMenuItemGroup} from './MenuItemGroup'
 import {validateId} from './util/validateId'
+import {FixMe} from './types'
 
 export interface Component extends StructureNode {
-  component: Function
+  component: FixMe
   child?: Child
   menuItems: MenuItem[]
   menuItemGroups: MenuItemGroup[]
-  options: {[key: string]: any}
+  options: {[key: string]: unknown}
 }
 
 export interface ComponentInput extends StructureNode {
-  component: Function
+  component: FixMe
   child?: Child
-  options?: {[key: string]: any}
+  options?: {[key: string]: unknown}
   menuItems?: (MenuItem | MenuItemBuilder)[]
   menuItemGroups?: (MenuItemGroup | MenuItemGroupBuilder)[]
 }
 
 export interface BuildableComponent extends Partial<StructureNode> {
-  component?: Function
+  component?: FixMe
   child?: Child
-  options?: {[key: string]: any}
+  options?: {[key: string]: unknown}
   menuItems?: (MenuItem | MenuItemBuilder)[]
   menuItemGroups?: (MenuItemGroup | MenuItemGroupBuilder)[]
 }
@@ -60,7 +61,7 @@ export class ComponentBuilder implements Serializable {
     return this.spec.child
   }
 
-  component(component: Function) {
+  component(component: FixMe) {
     return this.clone({component})
   }
 
@@ -68,7 +69,7 @@ export class ComponentBuilder implements Serializable {
     return this.spec.component
   }
 
-  options(options: {[key: string]: any}) {
+  options(options: {[key: string]: unknown}) {
     return this.clone({options})
   }
 

--- a/packages/@sanity/structure/src/ListItem.ts
+++ b/packages/@sanity/structure/src/ListItem.ts
@@ -9,6 +9,7 @@ import {ListBuilder} from './List'
 import {DocumentBuilder} from './Document'
 import {ComponentBuilder} from './Component'
 import {validateId} from './util/validateId'
+import {FixMe} from './types'
 
 type UnserializedListItemChild = Collection | CollectionBuilder | ChildResolver
 
@@ -25,7 +26,7 @@ interface ListItemDisplayOptions {
 export interface ListItemInput {
   id: string
   title?: string
-  icon?: Function
+  icon?: FixMe
   child?: ListItemChild
   displayOptions?: ListItemDisplayOptions
   schemaType?: SchemaType | string
@@ -35,7 +36,7 @@ export interface ListItem {
   id: string
   type: string
   title?: string
-  icon?: Function
+  icon?: FixMe
   child?: ListItemChild
   displayOptions?: ListItemDisplayOptions
   schemaType?: SchemaType
@@ -44,7 +45,7 @@ export interface ListItem {
 export interface UnserializedListItem {
   id: string
   title: string
-  icon?: Function
+  icon?: FixMe
   child?: UnserializedListItemChild
   displayOptions?: ListItemDisplayOptions
   schemaType?: SchemaType | string
@@ -75,7 +76,7 @@ export class ListItemBuilder implements Serializable {
     return this.spec.title
   }
 
-  icon(icon: Function): ListItemBuilder {
+  icon(icon: FixMe): ListItemBuilder {
     return this.clone({icon})
   }
 
@@ -152,8 +153,8 @@ export class ListItemBuilder implements Serializable {
     // context, so we may lazily resolve it at some point in the future without losing context
     if (typeof listChild === 'function') {
       const originalChild = listChild
-      listChild = (itemId, options) => {
-        return originalChild(itemId, {...options, serializeOptions})
+      listChild = (itemId, childOptions) => {
+        return originalChild(itemId, {...childOptions, serializeOptions})
       }
     }
 

--- a/packages/@sanity/structure/src/MenuItem.ts
+++ b/packages/@sanity/structure/src/MenuItem.ts
@@ -6,6 +6,7 @@ import {Partial} from './Partial'
 import {SortItem, Ordering, DEFAULT_ORDERING_OPTIONS} from './Sort'
 import {SerializeOptions, Serializable, SerializePath} from './StructureNodes'
 import {SerializeError, HELP_URL} from './SerializeError'
+import {FixMe} from './types'
 
 const SortIcon = getSortIcon()
 
@@ -21,13 +22,16 @@ type ShowAsAction = {
   whenCollapsed: boolean
 }
 
+type ActionType = string | ((params: Record<string, string> | undefined, scope?: any) => void)
+type ParamsType = Record<string, string | unknown | undefined>
+
 export interface MenuItem {
   title: string
-  action?: string | Function
+  action?: ActionType
   intent?: Intent
   group?: string
-  icon?: Function
-  params?: object
+  icon?: FixMe
+  params?: ParamsType
   showAsAction?: boolean | ShowAsAction
 }
 
@@ -40,7 +44,7 @@ export class MenuItemBuilder implements Serializable {
     this.spec = spec ? spec : {}
   }
 
-  action(action: string | Function): MenuItemBuilder {
+  action(action: ActionType): MenuItemBuilder {
     return this.clone({action})
   }
 
@@ -72,7 +76,7 @@ export class MenuItemBuilder implements Serializable {
     return this.spec.group
   }
 
-  icon(icon: Function): MenuItemBuilder {
+  icon(icon: FixMe): MenuItemBuilder {
     return this.clone({icon})
   }
 
@@ -80,7 +84,7 @@ export class MenuItemBuilder implements Serializable {
     return this.spec.icon
   }
 
-  params(params: object): MenuItemBuilder {
+  params(params: ParamsType): MenuItemBuilder {
     return this.clone({params})
   }
 

--- a/packages/@sanity/structure/src/parts/Icon.ts
+++ b/packages/@sanity/structure/src/parts/Icon.ts
@@ -1,6 +1,7 @@
 import {ComposeIcon, SortIcon, StackCompactIcon, SplitHorizontalIcon} from '@sanity/icons'
+import {FixMe} from '../types'
 
-export const getPlusIcon = (): React.ComponentType => ComposeIcon
-export const getSortIcon = (): React.ComponentType => SortIcon
-export const getListIcon = (): React.ComponentType => StackCompactIcon
-export const getDetailsIcon = (): React.ComponentType => SplitHorizontalIcon
+export const getPlusIcon = (): FixMe => ComposeIcon
+export const getSortIcon = (): FixMe => SortIcon
+export const getListIcon = (): FixMe => StackCompactIcon
+export const getDetailsIcon = (): FixMe => SplitHorizontalIcon

--- a/packages/@sanity/structure/src/parts/Icon.ts
+++ b/packages/@sanity/structure/src/parts/Icon.ts
@@ -1,10 +1,6 @@
-import getDefaultModule from './getDefaultModule'
+import {ComposeIcon, SortIcon, StackCompactIcon, SplitHorizontalIcon} from '@sanity/icons'
 
-// We are lazy-loading the part to work around typescript trying to resolve it
-export const getPlusIcon = (): Function =>
-  getDefaultModule(require('part:@sanity/base/compose-icon'))
-export const getSortIcon = (): Function => getDefaultModule(require('part:@sanity/base/sort-icon'))
-export const getListIcon = (): Function =>
-  getDefaultModule(require('part:@sanity/base/stack-compact-icon'))
-export const getDetailsIcon = (): Function =>
-  getDefaultModule(require('part:@sanity/base/stack-icon'))
+export const getPlusIcon = (): React.ComponentType => ComposeIcon
+export const getSortIcon = (): React.ComponentType => SortIcon
+export const getListIcon = (): React.ComponentType => StackCompactIcon
+export const getDetailsIcon = (): React.ComponentType => SplitHorizontalIcon

--- a/packages/@sanity/structure/src/parts/Schema.ts
+++ b/packages/@sanity/structure/src/parts/Schema.ts
@@ -1,5 +1,6 @@
-import getDefaultModule from './getDefaultModule'
 import {Ordering} from '../Sort'
+import {FixMe} from '../types'
+import getDefaultModule from './getDefaultModule'
 
 interface Schema {
   name: string
@@ -17,18 +18,18 @@ interface PreviewFields {
 }
 
 interface PreviewPreparer {
-  (selection: {}): PreviewFields
+  (selection: Record<string, unknown>): PreviewFields
 }
 
 export interface SchemaType {
   name: string
   title?: string
-  icon?: Function
+  icon?: FixMe
   type?: SchemaType
   to?: SchemaField[]
   fields?: SchemaField[]
   orderings?: Ordering[]
-  initialValue?: Function | {[key: string]: any}
+  initialValue?: FixMe | {[key: string]: unknown}
   preview?: {
     select?: PreviewFields
     prepare?: PreviewPreparer

--- a/packages/@sanity/structure/src/types.ts
+++ b/packages/@sanity/structure/src/types.ts
@@ -1,0 +1,5 @@
+// @todo This legacy typing causes linting errors once we touch anything
+// in the structure package. We should update it in the future when we do
+// a pass on types
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type FixMe = Function

--- a/packages/@sanity/structure/src/views/ComponentView.ts
+++ b/packages/@sanity/structure/src/views/ComponentView.ts
@@ -1,9 +1,10 @@
-import {View, GenericViewBuilder} from './View'
 import {SerializeOptions} from '../StructureNodes'
 import {SerializeError, HELP_URL} from '../SerializeError'
+import {FixMe} from '../types'
+import {View, GenericViewBuilder} from './View'
 
 export interface ComponentView extends View {
-  component: Function
+  component: FixMe
   options: {[key: string]: any}
 }
 
@@ -17,7 +18,7 @@ export class ComponentViewBuilder extends GenericViewBuilder<
 > {
   protected spec: Partial<ComponentView>
 
-  constructor(componentOrSpec?: Function | Partial<ComponentView>) {
+  constructor(componentOrSpec?: FixMe | Partial<ComponentView>) {
     const spec = isComponentSpec(componentOrSpec) ? {...componentOrSpec} : {options: {}}
 
     super()
@@ -32,7 +33,7 @@ export class ComponentViewBuilder extends GenericViewBuilder<
     }
   }
 
-  component(component: Function) {
+  component(component: FixMe) {
     return this.clone({component})
   }
 

--- a/packages/@sanity/structure/src/views/View.ts
+++ b/packages/@sanity/structure/src/views/View.ts
@@ -3,6 +3,7 @@ import {Serializable, SerializeOptions, SerializePath} from '../StructureNodes'
 import {SerializeError} from '..'
 import {HELP_URL} from '../SerializeError'
 import {validateId} from '../util/validateId'
+import {FixMe} from '../types'
 import {ComponentViewBuilder} from './ComponentView'
 import {FormViewBuilder} from './FormView'
 
@@ -10,7 +11,7 @@ export interface View {
   type: string
   id: string
   title: string
-  icon?: Function
+  icon?: FixMe
 }
 
 export abstract class GenericViewBuilder<L extends Partial<View>, ConcreteImpl>
@@ -33,7 +34,7 @@ export abstract class GenericViewBuilder<L extends Partial<View>, ConcreteImpl>
     return this.spec.title
   }
 
-  icon(icon: Function) {
+  icon(icon: FixMe) {
     return this.clone({icon})
   }
 

--- a/packages/@sanity/structure/src/views/index.ts
+++ b/packages/@sanity/structure/src/views/index.ts
@@ -1,6 +1,7 @@
+import {FixMe} from '../types'
 import {FormViewBuilder, FormView} from './FormView'
 import {ComponentView, ComponentViewBuilder} from './ComponentView'
 
 export const form = (spec?: Partial<FormView>) => new FormViewBuilder(spec)
-export const component = (componentOrSpec?: Function | Partial<ComponentView>) =>
+export const component = (componentOrSpec?: FixMe | Partial<ComponentView>) =>
   new ComponentViewBuilder(componentOrSpec)

--- a/packages/@sanity/structure/test/__snapshots__/DocumentTypeList.test.ts.snap
+++ b/packages/@sanity/structure/test/__snapshots__/DocumentTypeList.test.ts.snap
@@ -28,7 +28,10 @@ Object {
     Object {
       "action": "setSortOrder",
       "group": "sorting",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "by": Array [
           Object {
@@ -43,7 +46,10 @@ Object {
     Object {
       "action": "setSortOrder",
       "group": "sorting",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "by": Array [
           Object {
@@ -58,7 +64,10 @@ Object {
     Object {
       "action": "setLayout",
       "group": "layout",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "layout": "default",
       },
@@ -67,7 +76,10 @@ Object {
     Object {
       "action": "setLayout",
       "group": "layout",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "layout": "detail",
       },
@@ -121,7 +133,10 @@ Object {
     Object {
       "action": "setSortOrder",
       "group": "sorting",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "by": Array [
           Object {
@@ -136,7 +151,10 @@ Object {
     Object {
       "action": "setSortOrder",
       "group": "sorting",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "by": Array [
           Object {
@@ -151,7 +169,10 @@ Object {
     Object {
       "action": "setLayout",
       "group": "layout",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "layout": "default",
       },
@@ -160,7 +181,10 @@ Object {
     Object {
       "action": "setLayout",
       "group": "layout",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "layout": "detail",
       },
@@ -214,7 +238,10 @@ Object {
     Object {
       "action": "setSortOrder",
       "group": "sorting",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "by": Array [
           Object {
@@ -229,7 +256,10 @@ Object {
     Object {
       "action": "setSortOrder",
       "group": "sorting",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "by": Array [
           Object {
@@ -244,7 +274,10 @@ Object {
     Object {
       "action": "setLayout",
       "group": "layout",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "layout": "default",
       },
@@ -253,7 +286,10 @@ Object {
     Object {
       "action": "setLayout",
       "group": "layout",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "layout": "detail",
       },
@@ -307,7 +343,10 @@ Object {
     Object {
       "action": "setSortOrder",
       "group": "sorting",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "by": Array [
           Object {
@@ -322,7 +361,10 @@ Object {
     Object {
       "action": "setSortOrder",
       "group": "sorting",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "by": Array [
           Object {
@@ -337,7 +379,10 @@ Object {
     Object {
       "action": "setLayout",
       "group": "layout",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "layout": "default",
       },
@@ -346,7 +391,10 @@ Object {
     Object {
       "action": "setLayout",
       "group": "layout",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "layout": "detail",
       },
@@ -400,7 +448,10 @@ Object {
     Object {
       "action": "setSortOrder",
       "group": "sorting",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "by": Array [
           Object {
@@ -415,7 +466,10 @@ Object {
     Object {
       "action": "setSortOrder",
       "group": "sorting",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "by": Array [
           Object {
@@ -430,7 +484,10 @@ Object {
     Object {
       "action": "setLayout",
       "group": "layout",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "layout": "default",
       },
@@ -439,7 +496,10 @@ Object {
     Object {
       "action": "setLayout",
       "group": "layout",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "layout": "detail",
       },
@@ -493,7 +553,10 @@ Object {
     Object {
       "action": "setSortOrder",
       "group": "sorting",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "by": Array [
           Object {
@@ -508,7 +571,10 @@ Object {
     Object {
       "action": "setSortOrder",
       "group": "sorting",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "by": Array [
           Object {
@@ -523,7 +589,10 @@ Object {
     Object {
       "action": "setLayout",
       "group": "layout",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "layout": "default",
       },
@@ -532,7 +601,10 @@ Object {
     Object {
       "action": "setLayout",
       "group": "layout",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "layout": "detail",
       },
@@ -586,7 +658,10 @@ Object {
     Object {
       "action": "setSortOrder",
       "group": "sorting",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "by": Array [
           Object {
@@ -601,7 +676,10 @@ Object {
     Object {
       "action": "setSortOrder",
       "group": "sorting",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "by": Array [
           Object {
@@ -616,7 +694,10 @@ Object {
     Object {
       "action": "setLayout",
       "group": "layout",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "layout": "default",
       },
@@ -625,7 +706,10 @@ Object {
     Object {
       "action": "setLayout",
       "group": "layout",
-      "icon": [Function],
+      "icon": Object {
+        "$$typeof": Symbol(react.forward_ref),
+        "render": [Function],
+      },
       "params": Object {
         "layout": "detail",
       },


### PR DESCRIPTION
### Description

This migrates the icons used in @sanity/structure to use `@sanity/icons`.

This also caused a series of linting/type issues in structure because the types currently use legacy types like `Function` that isn't allowed in newer lint rules. The test snapshots does not match either since the icons is wrapped in `React.forwardRef`.

I have worked around/fixed this by:
- mapped a custom type `FixMe` to `Function` with a comment explaining why we lint ignore it and replaced all instances with the new `FixMe` type
- updated types where I think it made sense, like replacing `{}` with `Record<string, unknown>`, replacing `any` with `unknown` etc.
- updating the test snapshots.

[sc-11466] [sc-11467]

### What to review

- That all the type fixes looks fine.
- That the test snapshot change is okay

### Notes for release

n/a
