### PR TITLE
fix(import): use json format for checking image assets

### DIFF
--- a/packages/@sanity/field/package.json
+++ b/packages/@sanity/field/package.json
@@ -36,7 +36,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sanity/asset-utils": "^1.1.2",
+    "@sanity/asset-utils": "^1.2.0",
     "@sanity/base": "2.20.0",
     "@sanity/client": "2.19.0",
     "@sanity/color": "^2.1.5",

--- a/packages/@sanity/import-cli/.babelrc
+++ b/packages/@sanity/import-cli/.babelrc
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "8"
+          "node": "12"
         }
       }
     ]

--- a/packages/@sanity/import/.babelrc
+++ b/packages/@sanity/import/.babelrc
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "8"
+          "node": "12"
         }
       }
     ]

--- a/packages/@sanity/import/package.json
+++ b/packages/@sanity/import/package.json
@@ -25,6 +25,7 @@
     "ndjson"
   ],
   "dependencies": {
+    "@sanity/asset-utils": "^1.2.0",
     "@sanity/generate-help-url": "2.18.0",
     "@sanity/mutator": "2.18.0",
     "@sanity/uuid": "^3.0.1",

--- a/packages/@sanity/import/src/uploadAssets.js
+++ b/packages/@sanity/import/src/uploadAssets.js
@@ -2,6 +2,7 @@ const basename = require('path').basename
 const parseUrl = require('url').parse
 const debug = require('debug')('sanity:import')
 const pMap = require('p-map')
+const {isSanityImageUrl} = require('@sanity/asset-utils')
 const progressStepper = require('./util/progressStepper')
 const getHashedBufferForUri = require('./util/getHashedBufferForUri')
 const retryOnFailure = require('./util/retryOnFailure')
@@ -171,7 +172,9 @@ async function getAssetDocumentIdForHash(client, type, sha1hash, attemptNum, tag
       return null
     }
 
-    const exists = await urlExists(assetDoc.url)
+    // By adding `fm=json` to image requests, we do a slightly cheaper operation
+    const assetUrl = isSanityImageUrl(assetDoc.url) ? `${assetDoc.url}?fm=json` : assetDoc.url
+    const exists = await urlExists(assetUrl)
     if (!exists) {
       debug(`Asset document ${assetDoc._id} exists, but file does not. Overwriting.`)
       return null


### PR DESCRIPTION
### Description

When checking whether or not an asset exists, we were doing a HEAD-request against the image asset URL, which triggers a transformation in order to output the correct content-length and such. Because we only care about the _presence_ of the asset, this PR introduces a change that (if an asset URL is a sanity image url) append `?fm=json` to the URL, resulting in a cheaper check.

Also took the liberty of updating the babel config to compile for node 12, as that is our current minimally supported version.

### Notes for release

- Speed up asset imports from `sanity dataset import` in certain cases
