### PR TITLE
fix(state-router): fix disabled intent links

### DIFF
--- a/packages/@sanity/state-router/src/components/IntentLink.tsx
+++ b/packages/@sanity/state-router/src/components/IntentLink.tsx
@@ -12,11 +12,16 @@ const IntentLink = forwardRef(function IntentLink(
   props: IntentLinkProps & React.HTMLProps<HTMLAnchorElement>,
   ref: ForwardedRef<HTMLAnchorElement>
 ) {
-  const {intent, params, ...rest} = props
+  const {intent, params, disabled, ...rest} = props
 
   const routerContext = useContext(RouterContext)
 
   if (!routerContext) throw new Error('IntentLink: missing context value')
+
+  // We return early because the intent link will be triggered regardless of it being a span if we don't
+  if (disabled) {
+    return <Link {...rest} disabled ref={ref} />
+  }
 
   return <Link {...rest} href={routerContext.resolveIntentLink(intent, params)} ref={ref} />
 })

--- a/packages/@sanity/state-router/src/components/Link.tsx
+++ b/packages/@sanity/state-router/src/components/Link.tsx
@@ -11,13 +11,14 @@ function isModifiedEvent(event: MouseEvent) {
 
 interface LinkProps {
   replace?: boolean
+  disabled?: boolean
 }
 const Link = forwardRef(function Link(
   props: LinkProps & React.HTMLProps<HTMLAnchorElement>,
   ref: ForwardedRef<HTMLAnchorElement>
 ) {
   const routerContext = useContext(RouterContext)
-  const {onClick, href, target, replace = false, ...rest} = props
+  const {onClick, href, target, replace = false, disabled = false, ...rest} = props
 
   const handleClick = useCallback(
     (event: React.MouseEvent<HTMLAnchorElement>): void => {
@@ -32,6 +33,8 @@ const Link = forwardRef(function Link(
       }
 
       if (!href) return
+
+      if (!disabled) return
 
       if (onClick) {
         onClick(event)
@@ -53,7 +56,9 @@ const Link = forwardRef(function Link(
     [href, onClick, replace, routerContext, target]
   )
 
-  return <a {...rest} onClick={handleClick} href={href} target={target} ref={ref} />
+  const LinkElement = disabled ? 'span' : 'a'
+
+  return <LinkElement {...rest} onClick={handleClick} href={href} target={target} ref={ref} />
 })
 
 export default Link


### PR DESCRIPTION
### Description

This fixes a problem with IntentLinks that is passed the `disabled` prop or in other ways isn't "ready", as with the link in the reference input.

![image](https://user-images.githubusercontent.com/10508/135242440-4c36d804-268b-451a-8e5b-c851cce9e070.png)

Before this fix you could click the intent link, and it just sent you to a non-existing url `/intent/edit//`, which in turn gave you an error screen.

### What to review

- Compare behaviour of the intent link on the reference input before and after the fix is applied
- Does a `span` for a "disabled" link make sense?

### Notes for release

- Fixed JS error when clicking intent links in empty reference inputs 

[sc-11533]
