### PR TITLE
fix(base): Add new prop called withtooltip & fix visual navigation in timeline

### DIFF
--- a/packages/@sanity/base/src/components/UserAvatar.tsx
+++ b/packages/@sanity/base/src/components/UserAvatar.tsx
@@ -1,4 +1,4 @@
-import {Avatar, AvatarPosition, AvatarSize, AvatarStatus} from '@sanity/ui'
+import {Avatar, AvatarPosition, AvatarSize, AvatarStatus, Box, Text, Tooltip} from '@sanity/ui'
 import React, {useState} from 'react'
 import type {User} from '@sanity/types'
 import {useUserColor} from '../user-color'
@@ -12,6 +12,7 @@ interface BaseProps {
   size?: LegacyAvatarSize | AvatarSize
   status?: AvatarStatus
   tone?: 'navbar'
+  withTooltip?: boolean
 }
 
 export type Props = BaseProps & UserProps
@@ -47,10 +48,34 @@ function nameToInitials(fullName: string) {
 
 export function UserAvatar(props: Props) {
   if (isLoaded(props)) {
+    if (props.withTooltip) {
+      return <TooltipUserAvatar {...props} />
+    }
     return <StaticUserAvatar {...props} />
   }
 
   return <UserAvatarLoader {...props} />
+}
+
+function TooltipUserAvatar(props: LoadedUserProps) {
+  const {
+    user: {displayName},
+  } = props
+  return (
+    <Tooltip
+      content={
+        <Box padding={2}>
+          <Text size={1}>{displayName}</Text>
+        </Box>
+      }
+      placement="top"
+      portal
+    >
+      <div>
+        <StaticUserAvatar {...props} />
+      </div>
+    </Tooltip>
+  )
 }
 
 function StaticUserAvatar({user, animateArrowFrom, position, size, status, tone}: LoadedUserProps) {

--- a/packages/@sanity/base/src/components/UserAvatar.tsx
+++ b/packages/@sanity/base/src/components/UserAvatar.tsx
@@ -12,10 +12,12 @@ interface BaseProps {
   size?: LegacyAvatarSize | AvatarSize
   status?: AvatarStatus
   tone?: 'navbar'
-  withTooltip?: boolean
 }
 
-export type Props = BaseProps & UserProps
+export type Props = BaseProps &
+  UserProps & {
+    withTooltip?: boolean
+  }
 
 interface LoadedUserProps extends BaseProps {
   user: User

--- a/packages/@sanity/desk-tool/src/panes/document/timeline/timelineItem.styled.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/timeline/timelineItem.styled.tsx
@@ -78,7 +78,7 @@ export const Root = styled(MenuItem)(({state = 'enabled', isHovered, theme}: Tim
       }
     `}
 
-    // line styling👇
+    // line styling 👇
       &:first-child ${IconWrapper}::before {
       height: 50%;
       top: unset;

--- a/packages/@sanity/desk-tool/src/panes/document/timeline/timelineItem.styled.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/timeline/timelineItem.styled.tsx
@@ -78,6 +78,7 @@ export const Root = styled(MenuItem)(({state = 'enabled', isHovered, theme}: Tim
       }
     `}
 
+    // line styling👇
       &:first-child ${IconWrapper}::before {
       height: 50%;
       top: unset;
@@ -94,6 +95,11 @@ export const Root = styled(MenuItem)(({state = 'enabled', isHovered, theme}: Tim
         background: transparent;
       }
     `}
+
+    // Remove timeline lines when using the keyboard to navigate timeline items
+    &:focus ${IconWrapper}::before {
+      background: transparent;
+    }
   `
 })
 

--- a/packages/@sanity/desk-tool/src/panes/document/timeline/userAvatarStack.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/timeline/userAvatarStack.tsx
@@ -14,7 +14,7 @@ export function UserAvatarStack({maxLength, userIds}: UserAvatarStackProps) {
   return (
     <AvatarStack maxLength={maxLength}>
       {userIds.map((userId) => (
-        <UserAvatar key={userId} userId={userId} />
+        <UserAvatar key={userId} userId={userId} withTooltip />
       ))}
     </AvatarStack>
   )


### PR DESCRIPTION
### Description

Added a tooltip with the `displayName` to the timeline section
![image](https://user-images.githubusercontent.com/6951139/135308893-824a39c1-2120-45e0-a7f1-371d50cfdf19.png)

Also fixed a smaller visual bug when you used the keyboard keys up and down in the timeline
Before

https://user-images.githubusercontent.com/6951139/135309179-78cd832f-96c9-4388-acba-d38da3dfdcd5.mov

After

https://user-images.githubusercontent.com/6951139/135309195-9c3c4339-312f-41f1-a1ef-2f52c251f4bc.mov


### What to review

The situations mentioned above ☝️ 

### Notes for release

Add tooltip to the avatars in the timeline so it's easier to check who made changes in the document.
Fix visual bug in the timeline when using keyboard.
