### PR TITLE
fix(form-builder): add fix for reference input when it's disabled

### DIFF
--- a/packages/@sanity/base/src/components/IntentButton.tsx
+++ b/packages/@sanity/base/src/components/IntentButton.tsx
@@ -11,5 +11,5 @@ export function IntentButton(
     params: Record<string, string>
   }
 ) {
-  return props.disabled ? <Button {...props} as={'a'} /> : <Button {...props} as={IntentLink} />
+  return props.disabled ? <Button {...props} as="a" /> : <Button {...props} as={IntentLink} />
 }

--- a/packages/@sanity/base/src/components/IntentButton.tsx
+++ b/packages/@sanity/base/src/components/IntentButton.tsx
@@ -11,5 +11,5 @@ export function IntentButton(
     params: Record<string, string>
   }
 ) {
-  return props.disabled ? <Button {...props} as="a" /> : <Button {...props} as={IntentLink} />
+  return props.disabled ? <Button {...props} as="a" role="link" aria-disabled="true" /> : <Button {...props} as={IntentLink} />
 }

--- a/packages/@sanity/base/src/components/IntentButton.tsx
+++ b/packages/@sanity/base/src/components/IntentButton.tsx
@@ -11,5 +11,5 @@ export function IntentButton(
     params: Record<string, string>
   }
 ) {
-  return <Button {...props} as={IntentLink} />
+  return props.disabled ? <Button {...props} as={'a'} /> : <Button {...props} as={IntentLink} />
 }

--- a/packages/@sanity/base/src/components/IntentButton.tsx
+++ b/packages/@sanity/base/src/components/IntentButton.tsx
@@ -11,5 +11,9 @@ export function IntentButton(
     params: Record<string, string>
   }
 ) {
-  return props.disabled ? <Button {...props} as="a" role="link" aria-disabled="true" /> : <Button {...props} as={IntentLink} />
+  return props.disabled ? (
+    <Button {...props} as="a" role="link" aria-disabled="true" />
+  ) : (
+    <Button {...props} as={IntentLink} />
+  )
 }

--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
@@ -210,6 +210,7 @@ export const ReferenceInput = forwardRef(function ReferenceInput(
   )
 
   const placeholder = preview.isLoading ? 'Loading…' : 'Type to search…'
+  const noSnapshotText = value?._ref ? 'Loading…' : ''
   return (
     <FormField
       __unstable_markers={markers}
@@ -313,7 +314,7 @@ export const ReferenceInput = forwardRef(function ReferenceInput(
                   <IntentButton
                     disabled={!preview.snapshot}
                     icon={LinkIcon}
-                    title={preview.snapshot ? `Open ${preview.snapshot?.title}` : 'Loading…'}
+                    title={preview.snapshot ? `Open ${preview.snapshot?.title}` : noSnapshotText}
                     intent="edit"
                     mode="bleed"
                     padding={2}


### PR DESCRIPTION
### Description

This fixes a problem with IntentLinks that is passed the disabled prop or in other ways isn't "ready", as with the link in the reference input.

![image](https://user-images.githubusercontent.com/6951139/135454339-3f55218e-f838-4aae-9ee3-e6253ba80887.png)

Before this fix you could click the intent link, and it just sent you to a non-existing url `/intent/edit//`, which in turn gave you an error screen.

### What to review

- Make sure that you cannot click on the link (no navigation) when the reference input is empty
- Make sure that the title anchor (even when empty) shows the right text (should be empty when the anchor is empty)

### Notes for release

Fixed JS error when clicking intent links in empty reference inputs

