### PR TITLE
refactor(base): migrate missingProjectConfig to `@sanity/ui`

### DIFF
--- a/packages/@sanity/base/src/components/MissingProjectConfig.tsx
+++ b/packages/@sanity/base/src/components/MissingProjectConfig.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import config from 'config:sanity'
-import FullscreenMessageDialog from 'part:@sanity/components/dialogs/fullscreen-message'
+import {Dialog, Stack, Code, Text, Card} from '@sanity/ui'
 
 export default function MissingProjectConfig() {
   const {root, project, plugins} = config
@@ -9,19 +9,21 @@ export default function MissingProjectConfig() {
   const desiredConfig = {root, project, api, plugins}
   const missing = [!projectId && '"projectId"', !dataset && '"dataset"'].filter(Boolean)
   return (
-    <FullscreenMessageDialog title="Project details missing">
-      <p>
-        The <code>sanity.json</code> file in your studio folder seems to be missing the{' '}
-        {missing.join(' and ')} configuration {missing.length > 1 ? 'options ' : 'option '}
-        under the <code>api</code> key.
-      </p>
-      <p>
-        A valid <code>sanity.json</code> file looks something like the following:
-      </p>
-      <pre>
-        <code>{highlightMissing(JSON.stringify(desiredConfig, null, 2))}</code>
-      </pre>
-    </FullscreenMessageDialog>
+    <Dialog id="missing-project-config" header="Project details missing" padding={2} width={1}>
+      <Stack space={4} padding={4}>
+        <Text as="p">
+          The <code>sanity.json</code> file in your studio folder seems to be missing the{' '}
+          {missing.join(' and ')} configuration {missing.length > 1 ? 'options ' : 'option '}
+          under the <code>api</code> key.
+        </Text>
+        <Text as="p">
+          A valid <code>sanity.json</code> file looks something like the following:
+        </Text>
+        <Card tone="transparent" padding={4} radius={2}>
+          <Code>{highlightMissing(JSON.stringify(desiredConfig, null, 2))}</Code>
+        </Card>
+      </Stack>
+    </Dialog>
   )
 }
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Migrate `missingProjectConfig` to `@sanity/ui`.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->
**Before**

<img width="608" alt="Screenshot 2021-10-04 at 14 38 31" src="https://user-images.githubusercontent.com/25737281/135852960-eba6e213-db95-4881-8d54-eae590607804.png">

**After**


<img width="646" alt="Screenshot 2021-10-04 at 14 42 33" src="https://user-images.githubusercontent.com/25737281/135853353-cb8559cf-7cd0-4047-9a64-a6afbff20def.png">


### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

n/a
