### PR TITLE
Fix issue with readOnly state in the PTE

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/PortableTextInput.tsx
@@ -119,6 +119,7 @@ const PortableTextInputWithRef = React.forwardRef(function PortableTextInput(
 
   // Memoized patch stream
   const patche$: Subject<EditorPatch> = useMemo(() => new Subject(), [])
+  const patchObservable = useMemo(() => patche$.asObservable(), [patche$])
 
   // Handle incoming patches from withPatchSubscriber HOC
   function handleDocumentPatches({
@@ -196,7 +197,7 @@ const PortableTextInputWithRef = React.forwardRef(function PortableTextInput(
     () => (
       <PortableTextEditor
         ref={ref}
-        incomingPatches$={patche$.asObservable()}
+        incomingPatches$={patchObservable}
         key={`portable-text-editor-${editorId}`}
         onChange={handleEditorChange}
         maxBlocks={undefined} // TODO: from schema?

--- a/packages/@sanity/form-builder/src/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/PortableTextInput.tsx
@@ -220,7 +220,6 @@ const PortableTextInputWithRef = React.forwardRef(function PortableTextInput(
           hasFocus={hasFocus}
           hotkeys={hotkeys}
           isFullscreen={isFullscreen}
-          key={`portable-text-input-${editorId}`}
           markers={markers}
           onBlur={onBlur}
           onChange={onChange}
@@ -283,7 +282,12 @@ export default (withPatchSubscriber(
           presence={presence}
           changeIndicator={false}
         >
-          <PortableTextInputWithRef {...this.props} ref={this.editorRef} />
+          <PortableTextInputWithRef
+            {...this.props}
+            // NOTE: this should be a temporary fix
+            key={this.props.readOnly ? '$readOnly' : '$editable'}
+            ref={this.editorRef}
+          />
         </FormField>
       )
     }


### PR DESCRIPTION
### Description

After #2814 it became an issue in the editor with the readOnly state of things. We need to make sure the editor is re-rendered whenever readOnly changes.

This will be dealt with more gracefully in another branch in a PR at a later time.

Also I have discovered a prop that is not memoized and triggers unnecessary re-renders. This is now fixed in it's own commit.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

That you can edit Portable Text after reloading the page with an PT editor on that page.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Not needed as the problem is solely in `next`.
<!--
A description of the change(s) that should be used in the release notes.
-->
