### PR TITLE
fix(base): fix issue that disallowed editing the draft of a document that has been published

### DIFF
--- a/packages/@sanity/base/src/datastores/grants/highlevel.ts
+++ b/packages/@sanity/base/src/datastores/grants/highlevel.ts
@@ -65,9 +65,9 @@ export function canUpdate(id: string, typeName: string) {
           )
         : grantsStore.checkDocumentPermission(
             'update',
-            // note: we check against the published document (if it exist) here since that's the
+            // note: we check against the published document (if it exist) with draft id since that's the
             // document that will be created as new draft when user edits it
-            draft || published || stub(idPair.draftId, typeName)
+            draft || {...published, _id: idPair.draftId} || stub(idPair.draftId, typeName)
           )
     })
   )


### PR DESCRIPTION
### Description

When checking whether the current user has update access to the draft of a published document we currently check the access rules against the published document (if it exists) _as is_. This gives false negatives for access rules that requires the id to be in the drafts path e.g. `_id in path("drafts.**")`. This patch fixes the issue by checking against the published document _with the draft id_ instead.

### What to review
Publish any document in the test studio, then add `#_debug_roles=contributor` to the url and verify that you can still edit the document ([see the access rules for the `contributor` debug role](https://github.com/sanity-io/sanity/blob/5280c51937e7987e50a96767f7f5e2e59aab22eb/packages/@sanity/base/src/datastores/grants/debug/exampleGrants.ts#L24-L33))

### Notes for release
- fixes an issue that in some cases would disallow editing a document that has been published for certain roles
