### PR TITLE
fix(structure): clone with `schemaTypeName`

### DIFF
--- a/packages/@sanity/structure/src/DocumentList.ts
+++ b/packages/@sanity/structure/src/DocumentList.ts
@@ -178,7 +178,7 @@ export class DocumentListBuilder extends GenericListBuilder<
       builder.spec.initialValueTemplates = inferInitialValueTemplates(builder.spec)
     }
 
-    if (!this.spec.schemaTypeName) {
+    if (!builder.spec.schemaTypeName) {
       builder.spec.schemaTypeName = inferTypeName(builder.spec)
     }
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

After the launch of the UI migration of `@sanity/desk-tool` to Sanity UI, there‘s an issue with nested document lists. The `schemaTypeName` parameter is no longer provided to these lists.

```ts
S.documentList().schemaType('foo')
```

The  `DocumentListPane` receives `<structureNode>.schemaTypeName = undefined`.

The solution seems to be to fix how the `DocumentList` is cloned within `@sanity/structure`.
