### PR TITLE
fix(form-builder): guard unset operation with value check

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/files/FileInput/FileInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/FileInput/FileInput.tsx
@@ -152,7 +152,9 @@ export default class FileInput extends React.PureComponent<Props, FileInputState
 
   clearUploadStatus() {
     // todo: this is kind of hackish
-    this.props.onChange(PatchEvent.from([unset(['_upload'])]))
+    if (this.props.value?._upload) {
+      this.props.onChange(PatchEvent.from([unset(['_upload'])]))
+    }
   }
 
   cancelUpload() {

--- a/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImageInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImageInput.tsx
@@ -159,7 +159,9 @@ export default class ImageInput extends React.PureComponent<Props, ImageInputSta
 
   clearUploadStatus() {
     // todo: this is kind of hackish
-    this.props.onChange(PatchEvent.from([unset(['_upload'])]))
+    if (this.props.value?._upload) {
+      this.props.onChange(PatchEvent.from([unset(['_upload'])]))
+    }
   }
 
   cancelUpload() {


### PR DESCRIPTION
### Description

Because we are now unsetting empty object fields (I assume), there are cases where we try to call unset on `someFileField._upload`, but `someFileField` is undefined.

When this happens, the form builder will throw an error because applying deep operations on undefined is not allowed.

Theoretically we might want to mirror the APIs behavior here and treat it as a noop, but given I am not confident about the ramifications, this change will at the very least fix two common instances where this happens.

Fixes #2811

### What to review

- Does the change make sense?
- Should we consider making [this code path](https://github.com/sanity-io/sanity/blob/28ada0d342ce6cd37c345aab6ec4547a9ab1c8fb/packages/@sanity/form-builder/src/patch/primitive.ts#L33) a noop instead of throwing?

### Notes for release

- Fixed an error where the image and file inputs might throw an error about unsetting deep values on a primitive value
