### PR TITLE
chore: add verify monorepo dependency script + run on postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "prettier": "node_modules/.bin/prettier '**/*.{ts,js,tsx,jsx}'",
     "lint-next": "npm run eslint -- `git diff --name-only next --diff-filter ACMRTUXB`",
     "verify-format": "lerna run clean && npm run prettier -- -c",
-    "postinstall": "npm run bootstrap",
+    "postinstall": "node ./scripts/validateMonorepoDependencies.js && npm run bootstrap",
     "vercel-build": "npm run build:js && cd examples/test-studio && npm run build -- -y",
     "type-check": "tsc -b --force",
     "cypress:open": "cypress open --config-file cypress/cypress.json",

--- a/scripts/validateMonorepoDependencies.js
+++ b/scripts/validateMonorepoDependencies.js
@@ -1,0 +1,66 @@
+/* eslint-disable no-console */
+const readPackages = require('./utils/readPackages')
+const path = require('path')
+const chalk = require('chalk')
+
+function getMismatches(pkg, monorepoPackages) {
+  const pkgDeps = {...pkg.content.dependencies, ...pkg.content.devDependencies}
+  const mismatches = Object.keys(pkgDeps)
+    .map((depName) => {
+      const expectedVersion = pkgDeps[depName]
+      const monorepoPackage = getMonorepoPackage(depName)
+      if (!monorepoPackage || expectedVersion === monorepoPackage.content.version) {
+        return null
+      }
+      return {
+        name: depName,
+        dev: Boolean(pkg.content.devDependencies[depName]),
+        expected: expectedVersion,
+        actual: monorepoPackage.content.version,
+      }
+    })
+    .filter(Boolean)
+
+  return {
+    package: pkg,
+    mismatches,
+  }
+
+  function getMonorepoPackage(candidate) {
+    return monorepoPackages.find((package) => package.content.name === candidate)
+  }
+}
+
+const monorepoPackages = readPackages()
+const packageValidations = monorepoPackages.map((pkg) => getMismatches(pkg, monorepoPackages))
+
+const invalidPackages = packageValidations.filter((validation) => validation.mismatches.length > 0)
+
+if (invalidPackages.length > 0) {
+  console.log(chalk.red(`⚠️  Monorepo version mismatches detected!\n`))
+  console.log(
+    invalidPackages
+      .map(({package, mismatches}) => {
+        const relativePkgJsonPath = `./${path.relative(process.cwd(), package.path)}`
+        return [
+          `${chalk.bold.whiteBright(package.content.name)}: ${mismatches
+            .map(
+              (mismatch) => `
+  ${mismatch.name}@v${chalk.bold.red(mismatch.expected)} should be @v${chalk.bold.green(
+                mismatch.actual
+              )}
+  👉  ${chalk.greenBright(
+    `fix by updating ${chalk.greenBright.bold(
+      relativePkgJsonPath
+    )} and change the ${chalk.greenBright.bold(mismatch.name)} ${chalk.greenBright.bold(
+      mismatch.dev ? 'devDependency' : 'dependency'
+    )} to version ${chalk.greenBright.bold(mismatch.actual)}`
+  )}`
+            )
+            .join('\n')}`,
+        ]
+      })
+      .join('\n\n')
+  )
+  process.exit(1)
+}


### PR DESCRIPTION
### Description

This adds a script that verifies that monorepo packages depends on other monorepo packages at *their current versions*. E.g. if `@sanity/desk-tool`'s package.json depends on a version of `@sanity/base` which is not the version `@sanity/base` is currently on, you will now get an error on `npm install`, telling you to fix the version discrepancy.

This helps in recovering from a problem that happens quite frequent when working in a feature branch where you add a monorepo package as a dependency to another monorepo package. If a new version of the newly added dependency has been released and you're doing a rebase against main, the version of the added dependency falls behind, usually undetected. This again is causing strange and disruptive behavior like whole packages getting deleted from disk, etc.

A nice future improvement would be to offer a way to fix this issue automatically (e.g. by adding `--fix`)

Example of the output you'll get when you have version mismatches:
![image](https://user-images.githubusercontent.com/876086/136779890-4fe11793-85e2-4e09-9aef-006824455e29.png)

### What to review

Code + make sure the message is clear and understandable.

There's an example of what this looks like on CI here: https://github.com/sanity-io/sanity/runs/3858262949

### Notes for release

None. Internal only.