### PR TITLE
fix(desk-tool): hide version dropdown on mobile

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/document/documentPanel/header/DocumentPanelHeader.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/documentPanel/header/DocumentPanelHeader.tsx
@@ -46,8 +46,8 @@ export const DocumentPanelHeader = forwardRef(function DocumentPanelHeader(
   const contextMenuItems = useMemo(() => menuItems.filter(isMenuButton), [menuItems])
   const [isValidationOpen, setValidationOpen] = React.useState<boolean>(false)
   const showTabs = views.length > 1
-  const showVersionMenu = features.reviewChanges || views.length === 1
   const closable = siblingIndex > 0
+  const showVersionMenu = features.reviewChanges
 
   const languageMenu = useMemo(
     () => LanguageFilter && <LanguageFilter key="language-menu" schemaType={documentSchema} />,


### PR DESCRIPTION
### Description

This hides version dropdown on small screens so forms are easier to use for mobile users in documents that do not have views. Without the version dropdown, header is significantly smaller, therefore less of the screen space is occupied as you scroll down.

### What to review

Is there some repercussion of this I am not thinking about?

### Notes for release

Doesn't have to be mentioned in release