### PR TITLE
refactor(desk-tool): remove closable prop

### DIFF
--- a/packages/@sanity/desk-tool/src/DeskTool.tsx
+++ b/packages/@sanity/desk-tool/src/DeskTool.tsx
@@ -189,7 +189,6 @@ export function DeskTool(props: DeskToolProps) {
       const {
         active,
         childItemId,
-        closable,
         groupIndex,
         itemId,
         key: paneKey,
@@ -217,7 +216,6 @@ export function DeskTool(props: DeskToolProps) {
       return (
         <DeskToolPane
           active={active}
-          closable={closable}
           groupIndex={groupIndex}
           index={paneIndex}
           key={`${pane.type}-${paneIndex}`}

--- a/packages/@sanity/desk-tool/src/getPanes.ts
+++ b/packages/@sanity/desk-tool/src/getPanes.ts
@@ -5,7 +5,6 @@ import {RouterPaneGroup} from './types'
 interface PaneData {
   active: boolean
   childItemId: string | null
-  closable: boolean
   groupIndex: number
   index: number
   itemId: string
@@ -52,7 +51,6 @@ export function getPanes(resolvedPanes: any[], routerPanes: RouterPaneGroup[]): 
         ret.push({
           active: groupIndex === groupsLen - 2,
           childItemId: (nextGroup && nextGroup[0].id) || null,
-          closable: siblingIndex > 0,
           index: paneIndex,
           itemId,
           groupIndex,

--- a/packages/@sanity/desk-tool/src/panes/DeskToolPane.tsx
+++ b/packages/@sanity/desk-tool/src/panes/DeskToolPane.tsx
@@ -11,7 +11,6 @@ import {UserComponentPane} from './userComponent'
 interface DeskToolPaneProps {
   active: boolean
   childItemId: string | null
-  closable: boolean
   groupIndex: number
   index: number
   itemId: string
@@ -42,7 +41,6 @@ export const DeskToolPane = memo(function DeskToolPane(props: DeskToolPaneProps)
   const {
     active,
     childItemId,
-    closable,
     groupIndex,
     index,
     itemId,
@@ -70,7 +68,6 @@ export const DeskToolPane = memo(function DeskToolPane(props: DeskToolPaneProps)
         itemId={itemId}
         isActive={active}
         isSelected={selected}
-        isClosable={closable}
         paneKey={paneKey}
         pane={pane}
       />

--- a/packages/@sanity/desk-tool/src/panes/document/DocumentPaneContext.ts
+++ b/packages/@sanity/desk-tool/src/panes/document/DocumentPaneContext.ts
@@ -16,7 +16,6 @@ export interface DocumentPaneContextValue {
   actions: DocumentActionDescription[] | null
   badges: DocumentBadgeDescription[] | null
   changesOpen: boolean
-  closable: boolean
   compareValue: Partial<SanityDocument> | null
   connectionState: 'connecting' | 'reconnecting' | 'connected'
   displayed: Partial<SanityDocument> | null

--- a/packages/@sanity/desk-tool/src/panes/document/DocumentPaneProvider.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/DocumentPaneProvider.tsx
@@ -41,7 +41,7 @@ declare const __DEV__: boolean
 export const DocumentPaneProvider = function DocumentPaneProvider(
   props: {children: React.ReactElement} & DocumentPaneProviderProps
 ) {
-  const {children, index, isClosable: closable, pane, paneKey} = props
+  const {children, index, pane, paneKey} = props
   const paneRouter = usePaneRouter()
   const {features} = useDeskTool()
   const {push: pushToast} = useToast()
@@ -220,7 +220,6 @@ export const DocumentPaneProvider = function DocumentPaneProvider(
       activeViewId,
       badges,
       changesOpen,
-      closable,
       compareValue,
       connectionState,
       displayed,
@@ -264,7 +263,6 @@ export const DocumentPaneProvider = function DocumentPaneProvider(
       activeViewId,
       badges,
       changesOpen,
-      closable,
       compareValue,
       connectionState,
       displayed,

--- a/packages/@sanity/desk-tool/src/panes/document/documentPanel/header/DocumentPanelHeader.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/documentPanel/header/DocumentPanelHeader.tsx
@@ -29,7 +29,6 @@ export const DocumentPanelHeader = forwardRef(function DocumentPanelHeader(
 ) {
   const {rootElement} = props
   const {
-    closable,
     documentSchema,
     handleMenuAction,
     handlePaneClose,
@@ -43,11 +42,12 @@ export const DocumentPanelHeader = forwardRef(function DocumentPanelHeader(
   } = useDocumentPane()
   const {revTime: rev} = historyController
   const {features} = useDeskTool()
-  const {index} = usePaneRouter()
+  const {index, siblingIndex} = usePaneRouter()
   const contextMenuItems = useMemo(() => menuItems.filter(isMenuButton), [menuItems])
   const [isValidationOpen, setValidationOpen] = React.useState<boolean>(false)
   const showTabs = views.length > 1
   const showVersionMenu = features.reviewChanges || views.length === 1
+  const closable = siblingIndex > 0
 
   const languageMenu = useMemo(
     () => LanguageFilter && <LanguageFilter key="language-menu" schemaType={documentSchema} />,

--- a/packages/@sanity/desk-tool/src/panes/types.ts
+++ b/packages/@sanity/desk-tool/src/panes/types.ts
@@ -4,7 +4,6 @@ export interface BaseDeskToolPaneProps<Pane> {
   itemId: string
   childItemId: string
   isSelected: boolean
-  isClosable: boolean
   isActive: boolean
   pane: Pane
 }


### PR DESCRIPTION
### Description

This change removes the `closable` props from the desk-tool since it can be taken from the router pane context. This is for a related change for another project.

One thing to note is that is technically changes the received props for the custom "user" component but this isClosable field is not all that useful because it's for split panes which is more or less a document-pane-only concept.

### What to review

Can this isClosable prop be removed safely?
