### PR TITLE
fix(base): show change indicator pencil on hover only

### DIFF
--- a/packages/@sanity/base/src/change-indicators/ChangeBar.styled.tsx
+++ b/packages/@sanity/base/src/change-indicators/ChangeBar.styled.tsx
@@ -163,14 +163,15 @@ export const ChangeBarWrapper = styled.div(
 
       ${focus &&
       css`
-        ${BadgeOpen}
-
         ${ShapeWrapper} {
           color: var(--card-focus-ring-color);
         }
 
         ${BarWrapper},
         ${TooltipTriggerWrapper} {
+          &:focus-within {
+            ${BadgeOpen}
+          }
           background-color: var(--card-focus-ring-color);
         }
       `}


### PR DESCRIPTION
### Description

This change will hide the change indicator/pencil icon when a changed field is focused, but still show it on hover and when the pencil itself receives focus (e.g. is tabbed to)

### What to review
- Make sure that change indicators on changed fields works like before, except from not showing the pencil icon when the field has focus.

### Notes for release

- Hides the pencil icon on changed fields when they have focus, instead showing them on hover only.