### PR TITLE
chore: use @typescript-eslint/no-shadow

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,6 +42,8 @@ module.exports = {
         '@typescript-eslint/no-dupe-class-members': ['error'],
         'no-unused-vars': 'off',
         '@typescript-eslint/no-unused-vars': ['warn'],
+        'no-shadow': 'off',
+        '@typescript-eslint/no-shadow': ['error'],
       },
     },
     {

--- a/packages/@sanity/base/src/datastores/grants/hooks.ts
+++ b/packages/@sanity/base/src/datastores/grants/hooks.ts
@@ -46,7 +46,7 @@ export function unstable_useCheckDocumentPermission(
       pipe(
         distinctUntilChanged(shallowEquals),
         debounceTime(10),
-        // eslint-disable-next-line no-shadow
+        // eslint-disable-next-line @typescript-eslint/no-shadow
         switchMap(([id, type, permission]) => {
           if (permission === 'update') {
             return canUpdate(id, type)

--- a/packages/@sanity/default-layout/src/navbar/presence/PresenceMenuItem.tsx
+++ b/packages/@sanity/default-layout/src/navbar/presence/PresenceMenuItem.tsx
@@ -25,7 +25,7 @@ export function PresenceMenuItem({presence}: PresenceListRowProps) {
 
   const LinkComponent = useMemo(
     () =>
-      // eslint-disable-next-line no-shadow
+      // eslint-disable-next-line @typescript-eslint/no-shadow
       forwardRef(function LinkComponent(linkProps, ref: React.ForwardedRef<HTMLAnchorElement>) {
         return (
           <IntentLink

--- a/packages/@sanity/default-layout/src/navbar/search/SearchItem.tsx
+++ b/packages/@sanity/default-layout/src/navbar/search/SearchItem.tsx
@@ -20,7 +20,7 @@ export function SearchItem({data, onClick, ...restProps}: SearchItemProps) {
 
   const LinkComponent = useMemo(
     () =>
-      // eslint-disable-next-line no-shadow
+      // eslint-disable-next-line @typescript-eslint/no-shadow
       forwardRef(function LinkComponent(linkProps, ref: React.ForwardedRef<HTMLAnchorElement>) {
         return (
           <IntentLink

--- a/packages/@sanity/desk-tool/src/components/IntentButton.tsx
+++ b/packages/@sanity/desk-tool/src/components/IntentButton.tsx
@@ -11,7 +11,7 @@ export const IntentButton = forwardRef(function IntentButton(
 
   const Link = useMemo(
     () =>
-      // eslint-disable-next-line no-shadow
+      // eslint-disable-next-line @typescript-eslint/no-shadow
       forwardRef(function Link(
         linkProps: {children: React.ReactNode},
         linkRef: React.ForwardedRef<HTMLAnchorElement>

--- a/packages/@sanity/desk-tool/src/components/IntentMenuItem.tsx
+++ b/packages/@sanity/desk-tool/src/components/IntentMenuItem.tsx
@@ -13,7 +13,7 @@ export const IntentMenuItem = forwardRef(function IntentMenuItem(
 
   const Link = useMemo(
     () =>
-      // eslint-disable-next-line no-shadow
+      // eslint-disable-next-line @typescript-eslint/no-shadow
       forwardRef(function Link(
         linkProps: {children: React.ReactNode},
         linkRef: React.ForwardedRef<HTMLAnchorElement>

--- a/packages/@sanity/desk-tool/src/components/paneItem/PaneItem.tsx
+++ b/packages/@sanity/desk-tool/src/components/paneItem/PaneItem.tsx
@@ -60,7 +60,7 @@ export function PaneItem(props: PaneItemProps) {
 
   const LinkComponent = useMemo(
     () =>
-      // eslint-disable-next-line no-shadow
+      // eslint-disable-next-line @typescript-eslint/no-shadow
       forwardRef(function LinkComponent(linkProps: any, ref: any) {
         return <ChildLink {...linkProps} childId={id} ref={ref} />
       }),

--- a/packages/@sanity/form-builder/src/hooks/useDidUpdate.ts
+++ b/packages/@sanity/form-builder/src/hooks/useDidUpdate.ts
@@ -1,6 +1,3 @@
-/* eslint-disable no-shadow */
-// eslint is giving false positives no-shadow for typed arguments here
-
 import {useEffect} from 'react'
 import {usePrevious} from './usePrevious'
 

--- a/packages/@sanity/form-builder/src/inputs/ObjectInput/UnknownFields.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ObjectInput/UnknownFields.tsx
@@ -89,7 +89,6 @@ function UnknownField({
   value,
 }: {
   fieldName: string
-  // eslint-disable-next-line no-shadow
   onUnsetClick: (fieldName: string) => void
   readOnly?: boolean
   value: unknown

--- a/packages/@sanity/structure/src/SerializeError.ts
+++ b/packages/@sanity/structure/src/SerializeError.ts
@@ -21,7 +21,6 @@ export class SerializeError extends Error {
   }
 }
 
-// eslint-disable-next-line no-shadow
 export enum HELP_URL {
   ID_REQUIRED = 'structure-node-id-required',
   TITLE_REQUIRED = 'structure-title-required',

--- a/packages/@sanity/util/src/legacyDateFormat.ts
+++ b/packages/@sanity/util/src/legacyDateFormat.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-shadow */
+/* eslint-disable @typescript-eslint/no-shadow */
 import moment from 'moment'
 
 export type ParseResult = {isValid: boolean; date?: Date; error?: string} & (

--- a/packages/@sanity/validation/test/infer.test.ts
+++ b/packages/@sanity/validation/test/infer.test.ts
@@ -58,7 +58,7 @@ describe('schema validation inference', () => {
       name: 'fieldValidationInferReproDoc',
       type: 'document',
       title: 'FieldValidationRepro',
-      // eslint-disable-next-line no-shadow
+      // eslint-disable-next-line @typescript-eslint/no-shadow
       validation: (Rule: Rule) =>
         Rule.fields({
           stringField: (fieldRule) => fieldRule.required(),


### PR DESCRIPTION
### Description

Updates the global eslint config to use `@typescript-eslint/no-shadow` instead of the normal `no-shadow`. This removes from false positives with types. I ran into this in another branch and want to bring the change out here first.

### What to review

Check the configs :D