### PR TITLE
fix(default-layout): prevent crash on invalid schema

### DIFF
--- a/packages/@sanity/default-layout/src/constants.ts
+++ b/packages/@sanity/default-layout/src/constants.ts
@@ -1,4 +1,0 @@
-import {getNewDocumentModalActions} from './util/getNewDocumentModalActions'
-
-export const NEW_DOCUMENT_ACTIONS = getNewDocumentModalActions()
-export const NEW_DOCUMENT_TYPES = NEW_DOCUMENT_ACTIONS.map((action) => action.schemaType)

--- a/packages/@sanity/default-layout/src/defaultLayout/DefaultLayout.tsx
+++ b/packages/@sanity/default-layout/src/defaultLayout/DefaultLayout.tsx
@@ -11,10 +11,13 @@ import Sidecar from '../addons/Sidecar'
 import {RenderTool} from '../main/RenderTool'
 import {CreateDocumentDialog} from '../createDocumentDialog'
 import {SchemaErrorReporter} from '../schemaErrors/SchemaErrorReporter'
+import {
+  getNewDocumentModalActions,
+  getNewDocumentModalSchemaTypes,
+} from '../util/getNewDocumentModalActions'
 import {SideMenu} from '../sideMenu'
 import {Navbar} from '../navbar'
 import {useDefaultLayoutRouter} from '../useDefaultLayoutRouter'
-import {NEW_DOCUMENT_ACTIONS, NEW_DOCUMENT_TYPES} from '../constants'
 import {RootFlex, MainAreaFlex, ToolBox, SidecarBox, PortalDiv} from './styles'
 import {LoadingScreen} from './LoadingScreen'
 
@@ -91,7 +94,7 @@ export const DefaultLayout = memo(function DefaultLayout() {
             createMenuIsOpen={createMenuIsOpen}
             onCreateButtonClick={handleCreateButtonClick}
             onToggleMenu={handleToggleMenu}
-            documentTypes={NEW_DOCUMENT_TYPES}
+            documentTypes={getNewDocumentModalSchemaTypes()}
             onUserLogout={handleLogout}
             onSearchOpen={handleSearchOpen}
             searchPortalElement={portalElement}
@@ -135,7 +138,10 @@ export const DefaultLayout = memo(function DefaultLayout() {
 
         {createMenuIsOpen && (
           <LegacyLayerProvider zOffset="navbar">
-            <CreateDocumentDialog onClose={handleActionModalClose} actions={NEW_DOCUMENT_ACTIONS} />
+            <CreateDocumentDialog
+              onClose={handleActionModalClose}
+              actions={getNewDocumentModalActions()}
+            />
           </LegacyLayerProvider>
         )}
 

--- a/packages/@sanity/default-layout/src/util/getNewDocumentModalActions.tsx
+++ b/packages/@sanity/default-layout/src/util/getNewDocumentModalActions.tsx
@@ -7,7 +7,14 @@ import newDocumentStructure from 'part:@sanity/base/new-document-structure?'
 import {getTemplateById} from '@sanity/base/initial-value-templates'
 import S from '@sanity/base/structure-builder'
 
+let cachedModalActions
+let cachedSchemaTypes
+
 export function getNewDocumentModalActions() {
+  if (cachedModalActions) {
+    return cachedModalActions
+  }
+
   let structure = newDocumentStructure
 
   if (structure && !Array.isArray(structure)) {
@@ -31,7 +38,13 @@ export function getNewDocumentModalActions() {
     structure = S.defaultInitialValueTemplateItems()
   }
 
-  return createModalActions(structure)
+  cachedModalActions = createModalActions(structure)
+  cachedSchemaTypes = cachedModalActions.map((action) => action.schemaType)
+  return cachedModalActions
+}
+
+export function getNewDocumentModalSchemaTypes() {
+  return cachedSchemaTypes || (getNewDocumentModalActions() && cachedSchemaTypes)
 }
 
 function createModalActions(structure) {
@@ -63,6 +76,10 @@ function createModalAction(templateItem) {
 
   // Build up an item suited for the "action modal" dialog
   const type = schema.get(tpl.schemaType)
+  if (!type) {
+    throw new Error(`Schema type "${tpl.schemaType}" not declared`)
+  }
+
   const title = item.title || tpl.title
   const description = item.description || tpl.description
   return {


### PR DESCRIPTION
### Description

This fixes a regression where if the schema had validation errors ("problems" internally), the studio would crash when attempting to use the schema for building actions in the "new documents" dialog, because it was being executed at import-time.

This PR moves it to a lazy getter-based approach which still caches the result after the initial call, but since it's called from the render lifecycle, it won't actually get called because the schema problem checker will prevent the studio from rendering.

I'm sure this could be done better, but it fixes a somewhat serious regression.

### What to review

- That the studio builds and works as before
- That the studio does not crash on invalid schemas

### Notes for release

- Fixed an issue where invalid schemas might crash the studio instead of displaying a list of errors
