### PR TITLE
fix(client): emit error if query is too large for listener

### DIFF
--- a/packages/@sanity/client/test/listen.test.js
+++ b/packages/@sanity/client/test/listen.test.js
@@ -185,3 +185,21 @@ test('[listener] emits channel errors with deep error description', (t) => {
     })
     .catch(t.end)
 })
+
+test('[listener] emits error if request URL is too large', (t) => {
+  testSse(({request, channel}) => {
+    channel.close()
+    process.nextTick(() => channel.close())
+  })
+    .then(({server, client}) => {
+      const pad = '_'.repeat(16000)
+      client.listen(`*{"foo":"${pad}"`).subscribe({
+        error: (err) => {
+          t.equal(err.message, 'Query too large for listener', 'should have passed error message')
+          server.close()
+          t.end()
+        },
+      })
+    })
+    .catch(t.end)
+})


### PR DESCRIPTION
### Description

This PR introduces a client-side check to see if the EventSource URLs we construct surpasses the 16KB limit that Google's load balancers put in place, and throws an error instead of attempting to open the eventsource.

This is done because the error returned by Google does not have the appropriate CORS-headers, so it's hard to debug what the issue is.

### What to review

- That the change makes sense and the code looks correct
- That the way I am throwing an error here makes sense, or if there are better ways of doing this (deferred or similar?)

### Notes for release

- Add a client-side check for max query length on listeners
