### PR TITLE
fix(desk-tool): force document pane re-render on expand

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/documentList/DocumentListPaneContent.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentList/DocumentListPaneContent.tsx
@@ -55,7 +55,7 @@ export function DocumentListPaneContent(props: DocumentListPaneContentProps) {
   } = props
 
   const {collapsed: layoutCollapsed} = usePaneLayout()
-  const {collapsed} = usePane()
+  const {collapsed, index} = usePane()
   const [shouldRender, setShouldRender] = useState(false)
 
   useEffect(() => {
@@ -161,6 +161,8 @@ export function DocumentListPaneContent(props: DocumentListPaneContentProps) {
             items={items}
             renderItem={renderItem}
             onChange={onListChange}
+            // prevents bug when panes won't render if first rendered while collapsed
+            key={`${index}-${collapsed}`}
           />
         )}
 
@@ -191,6 +193,8 @@ export function DocumentListPaneContent(props: DocumentListPaneContentProps) {
     onRetry,
     renderItem,
     shouldRender,
+    collapsed,
+    index,
   ])
 
   return <PaneContent overflow={layoutCollapsed ? undefined : 'auto'}>{content}</PaneContent>


### PR DESCRIPTION
### Description

Fixes a bug where the document lists were not rendering on expansion if first rendered while collapsed.


### Notes for release

Fixes a bug where the document lists were not rendering on expansion if first rendered while collapsed.

