### PR TITLE
feat(base): improve change indicators

### DIFF
--- a/packages/@sanity/base/src/change-indicators/ChangeBar.styled.tsx
+++ b/packages/@sanity/base/src/change-indicators/ChangeBar.styled.tsx
@@ -1,7 +1,5 @@
-import React from 'react'
 import styled, {css} from 'styled-components'
 import {Theme} from '@sanity/ui'
-import {EditIcon} from '@sanity/icons'
 
 interface ThemeContext {
   theme: Theme
@@ -13,17 +11,6 @@ interface RootProps {
   changed: boolean
   isReviewChangeOpen: boolean
   disabled: boolean
-}
-
-const Shape = (props: Omit<React.SVGProps<SVGElement>, 'ref'>) => {
-  return (
-    <svg {...props} viewBox="0 0 20 27" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path
-        d="M9 0.448608C9 2.49663 7.38382 4.13678 5.57253 5.09261C2.55605 6.68443 0.5 9.8521 0.5 13.5C0.5 17.1479 2.55605 20.3155 5.57253 21.9074C7.38382 22.8632 9 24.5033 9 26.5514V27H11V26.5514C11 24.5033 12.6162 22.8632 14.4275 21.9074C17.4439 20.3155 19.5 17.1479 19.5 13.5C19.5 9.8521 17.4439 6.68443 14.4275 5.09261C12.6162 4.13678 11 2.49663 11 0.448608V0H9V0.448608Z"
-        fill="currentColor"
-      />
-    </svg>
-  )
 }
 
 const animationSpeed = 150
@@ -76,75 +63,70 @@ export const BadgeWrapper = styled.div(({theme}: ThemeContext) => {
   `
 })
 
-export const EditIconWrapper = styled(EditIcon)`
-  display: block;
-  position: relative;
-  margin: 0;
-  font-size: calc(19 / 16 * 1rem);
-  color: var(--card-bg-color);
-  opacity: 0;
-  transition: opacity ${animationSpeed}ms;
-
-  & path {
-    stroke-width: 1.5px;
-  }
-`
-
-export const ShapeWrapper = styled.div(({theme}: ThemeContext) => {
+export const HitAreaButton = styled.button(({theme}: ThemeContext) => {
   /* these colours aren't freely available on the current theme */
   const notSelectedColor = theme.sanity.color.spot.yellow
-  const maxScreenMedium = theme.sanity.media[0] - 1
 
   return css`
+    appearance: none;
+    border: 0;
+    outline: 0;
     display: block;
+    padding: 0;
+    background: transparent;
+    opacity: 0;
     position: absolute;
-    width: 15px;
     height: 100%;
-    border-radius: 12px;
-    background: ${notSelectedColor};
-    color: ${notSelectedColor};
+    cursor: pointer;
+    pointer-events: all;
+    left: -0.25rem;
+    width: 1rem;
+    transition: opacity ${animationSpeed}ms;
 
-    @media (max-width: ${maxScreenMedium}px) {
-      /* hide on mobile */
-      display: none;
+    &:focus {
+      border: 0;
+      outline: 0;
+    }
+
+    &:after {
+      content: '';
+      width: 16px;
+      height: calc(100% + 16px);
+      display: block;
+      position: absolute;
+      top: -8px;
+      left: -4px;
+      border-radius: 16px;
+      background: ${notSelectedColor};
+    }
+
+    &:focus {
+      border: 0;
+      outline: 0;
+    }
+
+    &:hover {
+      opacity: 0.2;
     }
   `
 })
 
-export const HitAreaButton = styled.button`
-  appearance: none;
-  border: 0;
-  outline: 0;
-  display: block;
-  padding: 0;
-  background: 0;
-  position: absolute;
-  height: 100%;
-  cursor: pointer;
-  pointer-events: all;
-  left: -0.25rem;
-  width: 1rem;
-
-  &:focus {
-    border: 0;
-    outline: 0;
-  }
-`
-
-// For when the shape and icon need to appear on the page
+/* for when the shape and icon need to appear on the page */
 const BadgeOpen = css`
   ${BadgeWrapper} {
     opacity: 0.2;
     transition: opacity ${animationSpeed}ms;
   }
-
-  ${EditIconWrapper} {
-    opacity: 1;
-  }
 `
 
 export const ChangeBarWrapper = styled.div(
-  ({focus, hover, changed, disabled, isReviewChangeOpen}: RootProps) => {
+  ({
+    // focus,
+    hover,
+    changed,
+    disabled,
+    isReviewChangeOpen,
+  }: RootProps) => {
     if (disabled)
       return css`
         ${TooltipTriggerWrapper} {
@@ -161,23 +143,6 @@ export const ChangeBarWrapper = styled.div(
           z-index: 10;
         }
       }
-
-      /* on focus */
-
-      /* ${focus &&
-      css`
-        ${ShapeWrapper} {
-          color: var(--card-focus-ring-color);
-        }
-
-        ${BarWrapper},
-        ${TooltipTriggerWrapper} {
-          &:focus-within {
-            ${BadgeOpen}
-          }
-          background-color: var(--card-focus-ring-color);
-        }
-      `} */
 
       /* on hover */
 

--- a/packages/@sanity/base/src/change-indicators/ChangeBar.styled.tsx
+++ b/packages/@sanity/base/src/change-indicators/ChangeBar.styled.tsx
@@ -42,12 +42,11 @@ export const BarWrapper = styled.div(({theme}: ThemeContext) => {
   return css`
     position: absolute;
     top: 0;
-    left: -1px;
+    left: 2px;
     width: 2px;
     bottom: 0;
     background-color: ${notSelectedColor};
-    border-bottom-right-radius: 2px;
-    border-top-right-radius: 2px;
+    border-radius: 2px;
 
     @media (min-width: ${screenMedium}px) {
       display: unset;
@@ -60,13 +59,13 @@ export const BadgeWrapper = styled.div(({theme}: ThemeContext) => {
 
   return css`
     position: absolute;
-    top: 50%;
-    left: -9px;
+    top: -8px;
+    left: -4px;
     width: 19px;
-    height: 19px;
+    height: calc(100% + 16px);
     border-radius: 9.5px;
-    transform: translate3d(-0.5px, -10px, 0) scale(0, 1);
-    transition: transform ${animationSpeed}ms, opacity ${animationSpeed}ms;
+    opacity: 0;
+    transition: opacity ${animationSpeed}ms;
     z-index: 12;
     pointer-events: none;
 
@@ -91,7 +90,7 @@ export const EditIconWrapper = styled(EditIcon)`
   }
 `
 
-export const ShapeWrapper = styled(Shape)(({theme}: ThemeContext) => {
+export const ShapeWrapper = styled.div(({theme}: ThemeContext) => {
   /* these colours aren't freely available on the current theme */
   const notSelectedColor = theme.sanity.color.spot.yellow
   const maxScreenMedium = theme.sanity.media[0] - 1
@@ -99,9 +98,10 @@ export const ShapeWrapper = styled(Shape)(({theme}: ThemeContext) => {
   return css`
     display: block;
     position: absolute;
-    width: 20px;
-    height: 27px;
-    transform: translate3d(-0.5px, -4px, 0);
+    width: 15px;
+    height: 100%;
+    border-radius: 12px;
+    background: ${notSelectedColor};
     color: ${notSelectedColor};
 
     @media (max-width: ${maxScreenMedium}px) {
@@ -134,7 +134,8 @@ export const HitAreaButton = styled.button`
 // For when the shape and icon need to appear on the page
 const BadgeOpen = css`
   ${BadgeWrapper} {
-    transform: translate3d(-0.5px, -10px, 0) scale(1);
+    opacity: 0.2;
+    transition: opacity ${animationSpeed}ms;
   }
 
   ${EditIconWrapper} {
@@ -162,7 +163,8 @@ export const ChangeBarWrapper = styled.div(
       }
 
       /* on focus */
-      ${focus &&
+
+      /* ${focus &&
       css`
         ${ShapeWrapper} {
           color: var(--card-focus-ring-color);
@@ -175,7 +177,7 @@ export const ChangeBarWrapper = styled.div(
           }
           background-color: var(--card-focus-ring-color);
         }
-      `}
+      `} */
 
       /* on hover */
 
@@ -184,8 +186,7 @@ export const ChangeBarWrapper = styled.div(
         ${BadgeOpen}
       `}
 
-
-    /* when field changed */
+      /* when field changed */
 
     ${!changed &&
       css`

--- a/packages/@sanity/base/src/change-indicators/ChangeBar.tsx
+++ b/packages/@sanity/base/src/change-indicators/ChangeBar.tsx
@@ -1,4 +1,3 @@
-import {Box, Text, Tooltip} from '@sanity/ui'
 import React, {useCallback, useMemo, useState} from 'react'
 import {ConnectorContext} from './ConnectorContext'
 
@@ -31,36 +30,25 @@ export function ChangeBar(props: {
   const tooltip = useMemo(
     () =>
       disabled ? null : (
-        <Tooltip
-          content={
-            <Box padding={2}>
-              <Text size={1}>Review changes</Text>
-            </Box>
-          }
-          disabled={!isChanged || isReviewChangesOpen}
-          placement="top"
-          portal
-        >
-          <TooltipTriggerWrapper data-testid="change-bar__tooltip-wrapper">
-            <BarWrapper />
+        <TooltipTriggerWrapper data-testid="change-bar__tooltip-wrapper">
+          <BarWrapper />
 
-            {withBadge && (
-              <BadgeWrapper>
-                <ShapeWrapper />
-                <EditIconWrapper />
-              </BadgeWrapper>
-            )}
+          {withBadge && (
+            <BadgeWrapper>
+              <ShapeWrapper />
+              <EditIconWrapper />
+            </BadgeWrapper>
+          )}
 
-            <HitAreaButton
-              aria-label="Review changes"
-              onClick={isReviewChangesOpen ? undefined : onOpenReviewChanges}
-              onMouseEnter={handleMouseEnter}
-              onMouseLeave={handleMouseLeave}
-              tabIndex={isReviewChangesOpen || !isChanged ? -1 : 0}
-              type="button"
-            />
-          </TooltipTriggerWrapper>
-        </Tooltip>
+          <HitAreaButton
+            aria-label="Review changes"
+            onClick={isReviewChangesOpen ? undefined : onOpenReviewChanges}
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
+            tabIndex={isReviewChangesOpen || !isChanged ? -1 : 0}
+            type="button"
+          />
+        </TooltipTriggerWrapper>
       ),
     [
       handleMouseEnter,

--- a/packages/@sanity/base/src/change-indicators/ChangeBar.tsx
+++ b/packages/@sanity/base/src/change-indicators/ChangeBar.tsx
@@ -1,15 +1,11 @@
 import React, {useCallback, useMemo, useState} from 'react'
 import {ConnectorContext} from './ConnectorContext'
-
 import {
   ChangeBarWrapper,
   FieldWrapper,
+  HitAreaButton,
   TooltipTriggerWrapper,
   BarWrapper,
-  BadgeWrapper,
-  ShapeWrapper,
-  EditIconWrapper,
-  HitAreaButton,
 } from './ChangeBar.styled'
 
 export function ChangeBar(props: {
@@ -17,9 +13,8 @@ export function ChangeBar(props: {
   hasFocus: boolean
   isChanged: boolean
   disabled?: boolean
-  withBadge?: boolean
 }) {
-  const {children, hasFocus, isChanged, disabled, withBadge = true} = props
+  const {children, hasFocus, isChanged, disabled} = props
 
   const [hover, setHover] = useState(false)
   const {onOpenReviewChanges, isReviewChangesOpen} = React.useContext(ConnectorContext)
@@ -32,13 +27,6 @@ export function ChangeBar(props: {
       disabled ? null : (
         <TooltipTriggerWrapper data-testid="change-bar__tooltip-wrapper">
           <BarWrapper />
-
-          {withBadge && (
-            <BadgeWrapper>
-              <ShapeWrapper />
-              <EditIconWrapper />
-            </BadgeWrapper>
-          )}
 
           <HitAreaButton
             aria-label="Review changes"
@@ -57,7 +45,6 @@ export function ChangeBar(props: {
       onOpenReviewChanges,
       isChanged,
       disabled,
-      withBadge,
     ]
   )
 

--- a/packages/@sanity/base/src/change-indicators/ChangeIndicator.tsx
+++ b/packages/@sanity/base/src/change-indicators/ChangeIndicator.tsx
@@ -5,7 +5,7 @@ import * as PathUtils from '@sanity/util/paths'
 import {Path} from '@sanity/types'
 import {useReporter} from './tracker'
 import {ChangeIndicatorContext} from './ChangeIndicatorContext'
-import {ChangeBar} from './ChangeBar'
+import {ElementWithChangeBar} from './ElementWithChangeBar'
 
 const EMPTY_PATH: Path = []
 
@@ -59,9 +59,9 @@ const ChangeBarWrapper = memo(function ChangeBarWrapper(
 
   return (
     <div ref={ref} className={className} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
-      <ChangeBar hasFocus={hasFocus} isChanged={isChanged} disabled={disabled}>
+      <ElementWithChangeBar hasFocus={hasFocus} isChanged={isChanged} disabled={disabled}>
         {children}
-      </ChangeBar>
+      </ElementWithChangeBar>
     </div>
   )
 })

--- a/packages/@sanity/base/src/change-indicators/ChangeIndicator.tsx
+++ b/packages/@sanity/base/src/change-indicators/ChangeIndicator.tsx
@@ -34,10 +34,9 @@ const ChangeBarWrapper = memo(function ChangeBarWrapper(
     hasFocus: boolean
     fullPath: Path
     disabled?: boolean
-    withBadge?: boolean
   }
 ) {
-  const {children, className, fullPath, hasFocus, isChanged, disabled, withBadge} = props
+  const {children, className, fullPath, hasFocus, isChanged, disabled} = props
   const layer = useLayer()
   const [hasHover, setHover] = React.useState(false)
   const onMouseEnter = React.useCallback(() => setHover(true), [])
@@ -60,12 +59,7 @@ const ChangeBarWrapper = memo(function ChangeBarWrapper(
 
   return (
     <div ref={ref} className={className} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
-      <ChangeBar
-        hasFocus={hasFocus}
-        isChanged={isChanged}
-        disabled={disabled}
-        withBadge={withBadge}
-      >
+      <ChangeBar hasFocus={hasFocus} isChanged={isChanged} disabled={disabled}>
         {children}
       </ChangeBar>
     </div>
@@ -138,7 +132,6 @@ interface CoreProps {
   hasFocus: boolean
   compareValue: unknown
   children?: React.ReactNode
-  withBadge?: boolean
 }
 
 export function CoreChangeIndicator(props: CoreProps) {
@@ -151,7 +144,6 @@ export function CoreChangeIndicator(props: CoreProps) {
     hasFocus,
     compareDeep,
     children,
-    withBadge,
   } = props
   // todo: lazy compare debounced (possibly with intersection observer)
   const isChanged =
@@ -165,7 +157,6 @@ export function CoreChangeIndicator(props: CoreProps) {
       fullPath={fullPath}
       hasFocus={hasFocus}
       disabled={disabled}
-      withBadge={withBadge}
     >
       {children}
     </ChangeBarWrapper>
@@ -209,13 +200,12 @@ interface ChangeIndicatorWithProvidedFullPathProps {
   hasFocus: boolean
   compareDeep?: boolean
   children?: React.ReactNode
-  withBadge?: boolean
 }
 
 export function ChangeIndicatorWithProvidedFullPath(
   props: ChangeIndicatorWithProvidedFullPathProps
 ) {
-  const {className, disabled, path, value, hasFocus, compareDeep, children, withBadge} = props
+  const {className, disabled, path, value, hasFocus, compareDeep, children} = props
   const parentContext = React.useContext(ChangeIndicatorContext)
 
   const fullPath = React.useMemo(() => PathUtils.pathFor(parentContext.fullPath.concat(path)), [
@@ -232,7 +222,6 @@ export function ChangeIndicatorWithProvidedFullPath(
       hasFocus={hasFocus}
       fullPath={fullPath}
       compareDeep={compareDeep}
-      withBadge={withBadge}
     >
       {children}
     </CoreChangeIndicator>

--- a/packages/@sanity/base/src/change-indicators/ElementWithChangeBar.styled.tsx
+++ b/packages/@sanity/base/src/change-indicators/ElementWithChangeBar.styled.tsx
@@ -13,15 +13,15 @@ interface RootProps {
   disabled: boolean
 }
 
-const animationSpeed = 150
+const animationSpeed = 250
 
-export const TooltipTriggerWrapper = styled.div`
+export const ChangeBar = styled.div`
   position: relative;
   opacity: 1;
   transition: opacity 100ms;
 `
 
-export const BarWrapper = styled.div(({theme}: ThemeContext) => {
+export const ChangeBarMarker = styled.div(({theme}: ThemeContext) => {
   /* these colours aren't freely available on the current theme */
   const notSelectedColor = theme.sanity.color.spot.yellow
   const screenMedium = theme.sanity.media[0]
@@ -41,29 +41,7 @@ export const BarWrapper = styled.div(({theme}: ThemeContext) => {
   `
 })
 
-export const BadgeWrapper = styled.div(({theme}: ThemeContext) => {
-  const maxScreenMedium = theme.sanity.media[0] - 1
-
-  return css`
-    position: absolute;
-    top: -8px;
-    left: -4px;
-    width: 19px;
-    height: calc(100% + 16px);
-    border-radius: 9.5px;
-    opacity: 0;
-    transition: opacity ${animationSpeed}ms;
-    z-index: 12;
-    pointer-events: none;
-
-    @media (max-width: ${maxScreenMedium}px) {
-      /* hide on mobile */
-      display: none;
-    }
-  `
-})
-
-export const HitAreaButton = styled.button(({theme}: ThemeContext) => {
+export const ChangeBarButton = styled.button(({theme}: ThemeContext) => {
   /* these colours aren't freely available on the current theme */
   const notSelectedColor = theme.sanity.color.spot.yellow
 
@@ -111,68 +89,42 @@ export const HitAreaButton = styled.button(({theme}: ThemeContext) => {
   `
 })
 
-/* for when the shape and icon need to appear on the page */
-const BadgeOpen = css`
-  ${BadgeWrapper} {
-    opacity: 0.2;
-    transition: opacity ${animationSpeed}ms;
-  }
-`
-
-export const ChangeBarWrapper = styled.div(
-  ({
-    // focus,
-    hover,
-    changed,
-    disabled,
-    isReviewChangeOpen,
-  }: RootProps) => {
-    if (disabled)
-      return css`
-        ${TooltipTriggerWrapper} {
-          display: none;
-        }
-      `
-
+export const ChangeBarWrapper = styled.div(({changed, disabled, isReviewChangeOpen}: RootProps) => {
+  if (disabled)
     return css`
-      display: flex;
-      position: relative;
-
-      @media (hover: hover) {
-        &:hover {
-          z-index: 10;
-        }
+      ${ChangeBar} {
+        display: none;
       }
-
-      /* on hover */
-
-      ${hover &&
-      css`
-        ${BadgeOpen}
-      `}
-
-      /* when field changed */
-
-    ${!changed &&
-      css`
-        ${TooltipTriggerWrapper} {
-          opacity: 0;
-          pointer-events: none;
-        }
-      `}
-
-      /* when review change is open */
-
-      ${isReviewChangeOpen &&
-      css`
-        ${BadgeWrapper} {
-          opacity: 0;
-          pointer-events: none;
-        }
-      `}
     `
-  }
-)
+
+  return css`
+    display: flex;
+    position: relative;
+
+    @media (hover: hover) {
+      &:hover {
+        z-index: 10;
+      }
+    }
+
+    /* hide when field is not changed */
+    ${!changed &&
+    css`
+      ${ChangeBar} {
+        opacity: 0;
+        pointer-events: none;
+      }
+    `}
+
+    /* hide hover effect when review changes is open */
+    ${isReviewChangeOpen &&
+    css`
+      ${ChangeBarButton} {
+        opacity: 0;
+      }
+    `}
+  `
+})
 
 export const FieldWrapper = styled.div`
   flex-grow: 1;

--- a/packages/@sanity/base/src/change-indicators/ElementWithChangeBar.styled.tsx
+++ b/packages/@sanity/base/src/change-indicators/ElementWithChangeBar.styled.tsx
@@ -69,11 +69,11 @@ export const ChangeBarButton = styled.button(({theme}: ThemeContext) => {
     &:after {
       content: '';
       width: 16px;
-      height: calc(100% + 16px);
+      height: calc(100% + 14px);
       display: block;
       position: absolute;
-      top: -8px;
-      left: -4px;
+      top: -7px;
+      left: -5px;
       border-radius: 16px;
       background: ${notSelectedColor};
     }

--- a/packages/@sanity/base/src/change-indicators/ElementWithChangeBar.styled.tsx
+++ b/packages/@sanity/base/src/change-indicators/ElementWithChangeBar.styled.tsx
@@ -15,80 +15,6 @@ interface RootProps {
 
 const animationSpeed = 250
 
-export const ChangeBar = styled.div`
-  position: relative;
-  opacity: 1;
-  transition: opacity 100ms;
-`
-
-export const ChangeBarMarker = styled.div(({theme}: ThemeContext) => {
-  /* these colours aren't freely available on the current theme */
-  const notSelectedColor = theme.sanity.color.spot.yellow
-  const screenMedium = theme.sanity.media[0]
-
-  return css`
-    position: absolute;
-    top: 0;
-    left: 2px;
-    width: 2px;
-    bottom: 0;
-    background-color: ${notSelectedColor};
-    border-radius: 1px;
-
-    @media (min-width: ${screenMedium}px) {
-      display: unset;
-    }
-  `
-})
-
-export const ChangeBarButton = styled.button(({theme}: ThemeContext) => {
-  /* these colours aren't freely available on the current theme */
-  const notSelectedColor = theme.sanity.color.spot.yellow
-
-  return css`
-    appearance: none;
-    border: 0;
-    outline: 0;
-    display: block;
-    padding: 0;
-    background: transparent;
-    opacity: 0;
-    position: absolute;
-    height: 100%;
-    cursor: pointer;
-    pointer-events: all;
-    left: -0.25rem;
-    width: 1rem;
-    transition: opacity ${animationSpeed}ms;
-
-    &:focus {
-      border: 0;
-      outline: 0;
-    }
-
-    &:after {
-      content: '';
-      width: 16px;
-      height: calc(100% + 14px);
-      display: block;
-      position: absolute;
-      top: -7px;
-      left: -5px;
-      border-radius: 16px;
-      background: ${notSelectedColor};
-    }
-
-    &:focus {
-      border: 0;
-      outline: 0;
-    }
-
-    &:hover {
-      opacity: 0.2;
-    }
-  `
-})
-
 export const ChangeBarWrapper = styled.div(({changed, disabled, isReviewChangeOpen}: RootProps) => {
   if (disabled)
     return css`
@@ -98,6 +24,8 @@ export const ChangeBarWrapper = styled.div(({changed, disabled, isReviewChangeOp
     `
 
   return css`
+    --change-bar-offset: 2px;
+
     display: flex;
     position: relative;
 
@@ -130,3 +58,77 @@ export const FieldWrapper = styled.div`
   flex-grow: 1;
   min-width: 0;
 `
+
+export const ChangeBar = styled.div`
+  position: relative;
+  opacity: 1;
+  transition: opacity 100ms;
+`
+
+export const ChangeBarMarker = styled.div(({theme}: ThemeContext) => {
+  /* these colours aren't freely available on the current theme */
+  const notSelectedColor = theme.sanity.color.spot.yellow
+  const screenMedium = theme.sanity.media[0]
+
+  return css`
+    position: absolute;
+    top: 0;
+    left: var(--change-bar-offset);
+    width: 2px;
+    bottom: 0;
+    background-color: ${notSelectedColor};
+    border-radius: 1px;
+
+    @media (min-width: ${screenMedium}px) {
+      display: unset;
+    }
+  `
+})
+
+export const ChangeBarButton = styled.button(({theme}: ThemeContext) => {
+  /* these colours aren't freely available on the current theme */
+  const notSelectedColor = theme.sanity.color.spot.yellow
+
+  return css`
+    appearance: none;
+    border: 0;
+    outline: 0;
+    display: block;
+    padding: 0;
+    background: transparent;
+    opacity: 0;
+    position: absolute;
+    height: 100%;
+    cursor: pointer;
+    pointer-events: all;
+    left: calc(-0.25rem + var(--change-bar-offset));
+    width: 1rem;
+    transition: opacity ${animationSpeed}ms;
+
+    &:focus {
+      border: 0;
+      outline: 0;
+    }
+
+    &:after {
+      content: '';
+      width: 16px;
+      height: calc(100% + 14px);
+      display: block;
+      position: absolute;
+      top: -7px;
+      left: -3px;
+      border-radius: 8px;
+      background: ${notSelectedColor};
+    }
+
+    &:focus {
+      border: 0;
+      outline: 0;
+    }
+
+    &:hover {
+      opacity: 0.2;
+    }
+  `
+})

--- a/packages/@sanity/base/src/change-indicators/ElementWithChangeBar.styled.tsx
+++ b/packages/@sanity/base/src/change-indicators/ElementWithChangeBar.styled.tsx
@@ -33,7 +33,7 @@ export const ChangeBarMarker = styled.div(({theme}: ThemeContext) => {
     width: 2px;
     bottom: 0;
     background-color: ${notSelectedColor};
-    border-radius: 2px;
+    border-radius: 1px;
 
     @media (min-width: ${screenMedium}px) {
       display: unset;

--- a/packages/@sanity/base/src/change-indicators/ElementWithChangeBar.tsx
+++ b/packages/@sanity/base/src/change-indicators/ElementWithChangeBar.tsx
@@ -25,11 +25,12 @@ export function ElementWithChangeBar(props: {
   const changeBar = useMemo(
     () =>
       disabled ? null : (
-        <ChangeBar data-testid="change-bar__tooltip-wrapper">
-          <ChangeBarMarker />
+        <ChangeBar data-testid="change-bar">
+          <ChangeBarMarker data-testid="change-bar__marker" />
 
           <ChangeBarButton
             aria-label="Review changes"
+            data-testid="change-bar__button"
             onClick={isReviewChangesOpen ? undefined : onOpenReviewChanges}
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
@@ -43,7 +44,7 @@ export function ElementWithChangeBar(props: {
 
   return (
     <ChangeBarWrapper
-      data-testid="change-bar"
+      data-testid="change-bar-wrapper"
       focus={hasFocus}
       hover={hover}
       changed={isChanged}

--- a/packages/@sanity/base/src/change-indicators/ElementWithChangeBar.tsx
+++ b/packages/@sanity/base/src/change-indicators/ElementWithChangeBar.tsx
@@ -33,19 +33,12 @@ export function ElementWithChangeBar(props: {
             onClick={isReviewChangesOpen ? undefined : onOpenReviewChanges}
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
-            tabIndex={isReviewChangesOpen || !isChanged ? -1 : 0}
+            tabIndex={-1}
             type="button"
           />
         </ChangeBar>
       ),
-    [
-      handleMouseEnter,
-      handleMouseLeave,
-      isReviewChangesOpen,
-      onOpenReviewChanges,
-      isChanged,
-      disabled,
-    ]
+    [handleMouseEnter, handleMouseLeave, isReviewChangesOpen, onOpenReviewChanges, disabled]
   )
 
   return (

--- a/packages/@sanity/base/src/change-indicators/ElementWithChangeBar.tsx
+++ b/packages/@sanity/base/src/change-indicators/ElementWithChangeBar.tsx
@@ -3,12 +3,12 @@ import {ConnectorContext} from './ConnectorContext'
 import {
   ChangeBarWrapper,
   FieldWrapper,
-  HitAreaButton,
-  TooltipTriggerWrapper,
-  BarWrapper,
-} from './ChangeBar.styled'
+  ChangeBar,
+  ChangeBarMarker,
+  ChangeBarButton,
+} from './ElementWithChangeBar.styled'
 
-export function ChangeBar(props: {
+export function ElementWithChangeBar(props: {
   children: React.ReactNode
   hasFocus: boolean
   isChanged: boolean
@@ -22,13 +22,13 @@ export function ChangeBar(props: {
   const handleMouseEnter = useCallback(() => setHover(true), [])
   const handleMouseLeave = useCallback(() => setHover(false), [])
 
-  const tooltip = useMemo(
+  const changeBar = useMemo(
     () =>
       disabled ? null : (
-        <TooltipTriggerWrapper data-testid="change-bar__tooltip-wrapper">
-          <BarWrapper />
+        <ChangeBar data-testid="change-bar__tooltip-wrapper">
+          <ChangeBarMarker />
 
-          <HitAreaButton
+          <ChangeBarButton
             aria-label="Review changes"
             onClick={isReviewChangesOpen ? undefined : onOpenReviewChanges}
             onMouseEnter={handleMouseEnter}
@@ -36,7 +36,7 @@ export function ChangeBar(props: {
             tabIndex={isReviewChangesOpen || !isChanged ? -1 : 0}
             type="button"
           />
-        </TooltipTriggerWrapper>
+        </ChangeBar>
       ),
     [
       handleMouseEnter,
@@ -58,7 +58,7 @@ export function ChangeBar(props: {
       disabled={disabled}
     >
       <FieldWrapper data-testid="change-bar__field-wrapper">{children}</FieldWrapper>
-      {tooltip}
+      {changeBar}
     </ChangeBarWrapper>
   )
 }

--- a/packages/@sanity/base/src/change-indicators/__workshop__/example.tsx
+++ b/packages/@sanity/base/src/change-indicators/__workshop__/example.tsx
@@ -1,7 +1,7 @@
 import {Container, Flex, TextArea} from '@sanity/ui'
 import {useBoolean} from '@sanity/ui-workshop'
 import React, {useCallback, useState} from 'react'
-import {ChangeBar} from '../ChangeBar'
+import {ElementWithChangeBar} from '../ElementWithChangeBar'
 
 export default function ExampleStory() {
   const isChanged = useBoolean('Changed', true, 'Props')
@@ -13,9 +13,9 @@ export default function ExampleStory() {
   return (
     <Flex align="center" height="fill" justify="center" padding={4} sizing="border">
       <Container width={0}>
-        <ChangeBar isChanged={isChanged} hasFocus={focused}>
+        <ElementWithChangeBar isChanged={isChanged} hasFocus={focused}>
           <TextArea onBlur={handleBlur} onFocus={handleFocus} rows={5} />
-        </ChangeBar>
+        </ElementWithChangeBar>
       </Container>
     </Flex>
   )

--- a/packages/@sanity/base/src/change-indicators/overlay/Connector.styled.tsx
+++ b/packages/@sanity/base/src/change-indicators/overlay/Connector.styled.tsx
@@ -3,9 +3,6 @@ import styled, {css} from 'styled-components'
 import {ClampedRect} from './ClampedRect'
 
 interface PathProps {
-  focused: boolean
-  revertedHovered: boolean
-  hovered: boolean
   theme: Theme
 }
 

--- a/packages/@sanity/base/src/change-indicators/overlay/Connector.styled.tsx
+++ b/packages/@sanity/base/src/change-indicators/overlay/Connector.styled.tsx
@@ -16,72 +16,45 @@ export const DebugRect = styled.rect`
   stroke-linecap: round;
 `
 
-export const ConnectorPath = styled.path(
-  ({focused, revertedHovered, hovered, theme}: PathProps) => {
-    /* these colours aren't freely available on the current theme */
-    const hoveredColor = theme.sanity.color.spot.yellow
+export const ConnectorPath = styled.path(({theme}: PathProps) => {
+  /* these colours aren't freely available on the current theme */
+  const strokeColor = theme.sanity.color.spot.yellow
 
-    return css`
-      fill: none;
-      pointer-events: none;
-      stroke-linecap: round;
-      stroke-linejoin: round;
+  return css`
+    fill: none;
+    pointer-events: none;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke: ${strokeColor};
+  `
+})
 
-      ${focused &&
-      css`
-        stroke: var(--card-focus-ring-color);
-      `}
+export const InteractivePath = styled.path(({theme}: PathProps) => {
+  /* these colours aren't freely available on the current theme */
+  const strokeColor = theme.sanity.color.spot.yellow
 
-      ${revertedHovered &&
-      css`
-        stroke: var(--card-accent-fg-color);
-      `}
+  return css`
+    fill: none;
+    pointer-events: stroke;
+    stroke: ${strokeColor};
+    cursor: pointer;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    opacity: 0;
 
-    ${hovered &&
-      css`
-        stroke: ${hoveredColor};
-      `}
-    `
-  }
-)
+    &:hover {
+      opacity: 0.2;
+    }
+  `
+})
 
-export const InteractivePath = styled.path`
-  fill: none;
-  pointer-events: stroke;
-  stroke: var(--card-focus-ring-color);
-  cursor: pointer;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  opacity: 0;
+export const RightBarWrapper = styled(ClampedRect)(({theme}: PathProps) => {
+  /* these colours aren't freely available on the current theme */
+  const strokeColor = theme.sanity.color.spot.yellow
 
-  &:hover {
-    opacity: 0.1;
-  }
-`
-
-export const RightBarWrapper = styled(ClampedRect)(
-  ({focused, revertedHovered, hovered, theme}: PathProps) => {
-    /* these colours aren't freely available on the current theme */
-    const hoveredColor = theme.sanity.color.spot.yellow
-
-    return css`
-      stroke: none;
-      pointer-events: none;
-
-      ${focused &&
-      css`
-        fill: var(--card-focus-ring-color);
-      `}
-
-      ${revertedHovered &&
-      css`
-        fill: var(--card-accent-fg-color);
-      `}
-
-    ${hovered &&
-      css`
-        fill: ${hoveredColor};
-      `}
-    `
-  }
-)
+  return css`
+    stroke: none;
+    pointer-events: none;
+    fill: ${strokeColor};
+  `
+})

--- a/packages/@sanity/base/src/change-indicators/overlay/Connector.tsx
+++ b/packages/@sanity/base/src/change-indicators/overlay/Connector.tsx
@@ -17,12 +17,9 @@ import {DebugRect, ConnectorPath, InteractivePath, RightBarWrapper} from './Conn
 interface Props {
   from: {rect: Rect; bounds: Rect}
   to: {rect: Rect; bounds: Rect}
-  hovered: boolean
-  revertHovered: boolean
-  focused: boolean
 }
 
-export function Connector({from, to, hovered, focused, revertHovered}: Props) {
+export function Connector({from, to}: Props) {
   const line = mapConnectorToLine({from, to})
 
   // If both ends of the connector are out of bounds, then do not render
@@ -36,17 +33,8 @@ export function Connector({from, to, hovered, focused, revertHovered}: Props) {
     <>
       <InteractivePath d={linePathDescription} strokeWidth={INTERACTIVE_STROKE_WIDTH} />
 
-      <ConnectorPath
-        focused={focused}
-        revertedHovered={revertHovered}
-        hovered={hovered && !focused && !revertHovered}
-        d={linePathDescription}
-        strokeWidth={STROKE_WIDTH}
-      />
+      <ConnectorPath d={linePathDescription} strokeWidth={STROKE_WIDTH} />
       <RightBarWrapper
-        focused={focused}
-        revertedHovered={revertHovered}
-        hovered={hovered && !focused && !revertHovered}
         top={to.rect.top}
         left={to.rect.left}
         height={to.rect.height}
@@ -56,9 +44,6 @@ export function Connector({from, to, hovered, focused, revertHovered}: Props) {
 
       {line.from.isAbove && (
         <ConnectorPath
-          focused={focused}
-          revertedHovered={revertHovered}
-          hovered={hovered && !focused && !revertHovered}
           d={arrowPath(
             line.from.left + ARROW_MARGIN_X,
             line.from.bounds.top - ARROW_THRESHOLD + ARROW_MARGIN_Y,
@@ -70,9 +55,6 @@ export function Connector({from, to, hovered, focused, revertHovered}: Props) {
 
       {line.from.isBelow && (
         <ConnectorPath
-          focused={focused}
-          revertedHovered={revertHovered}
-          hovered={hovered && !focused && !revertHovered}
           d={arrowPath(
             line.from.left + ARROW_MARGIN_X,
             line.from.bounds.top + line.from.bounds.height + ARROW_THRESHOLD - ARROW_MARGIN_Y,
@@ -84,9 +66,6 @@ export function Connector({from, to, hovered, focused, revertHovered}: Props) {
 
       {line.to.isAbove && (
         <ConnectorPath
-          focused={focused}
-          revertedHovered={revertHovered}
-          hovered={hovered && !focused && !revertHovered}
           d={arrowPath(
             line.to.bounds.left + ARROW_MARGIN_X,
             line.to.bounds.top - ARROW_THRESHOLD + ARROW_MARGIN_Y,
@@ -98,9 +77,6 @@ export function Connector({from, to, hovered, focused, revertHovered}: Props) {
 
       {line.to.isBelow && (
         <ConnectorPath
-          focused={focused}
-          revertedHovered={revertHovered}
-          hovered={hovered && !focused && !revertHovered}
           d={arrowPath(
             line.to.bounds.left + ARROW_MARGIN_X,
             line.to.bounds.top + line.to.bounds.height + ARROW_THRESHOLD - ARROW_MARGIN_Y,

--- a/packages/@sanity/base/src/change-indicators/overlay/ConnectorsOverlay.tsx
+++ b/packages/@sanity/base/src/change-indicators/overlay/ConnectorsOverlay.tsx
@@ -176,7 +176,15 @@ function ConnectorGroup(props: ConnectorGroupProps) {
     <>
       <g onClick={onConnectorClick} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
         <Connector
-          from={{rect: field.rect, bounds: field.bounds}}
+          from={{
+            rect: {
+              left: field.rect.left + 2,
+              top: field.rect.top,
+              height: field.rect.height,
+              width: field.rect.width,
+            },
+            bounds: field.bounds,
+          }}
           to={{rect: change.rect, bounds: change.bounds}}
           focused={hasFocus}
           hovered={hasHover || isHoverConnector}

--- a/packages/@sanity/base/src/change-indicators/overlay/ConnectorsOverlay.tsx
+++ b/packages/@sanity/base/src/change-indicators/overlay/ConnectorsOverlay.tsx
@@ -97,7 +97,7 @@ export function ConnectorsOverlay(props: ConnectorsOverlayProps) {
   const allReportedValues = useReportedValues()
   const byId = useMemo(() => new Map(allReportedValues), [allReportedValues])
 
-  const [{connectors, isHoverConnector}, setState] = useState<State>(() =>
+  const [{connectors}, setState] = useState<State>(() =>
     getState(allReportedValues, hovered, byId, rootElement)
   )
 
@@ -115,7 +115,7 @@ export function ConnectorsOverlay(props: ConnectorsOverlayProps) {
   return (
     <ScrollMonitor onScroll={handleScrollOrResize}>
       <SvgWrapper style={{zIndex: visibleConnectors[0] && visibleConnectors[0].field.zIndex}}>
-        {visibleConnectors.map(({field, change, hasFocus, hasHover, hasRevertHover}) => {
+        {visibleConnectors.map(({field, change}) => {
           if (!change) {
             return null
           }
@@ -124,13 +124,9 @@ export function ConnectorsOverlay(props: ConnectorsOverlayProps) {
             <ConnectorGroup
               field={field}
               change={change}
-              hasFocus={hasFocus}
-              hasHover={hasHover}
-              hasRevertHover={hasRevertHover}
               key={field.id}
               onSetFocus={onSetFocus}
               setHovered={setHovered}
-              isHoverConnector={isHoverConnector}
             />
           )
         })}
@@ -142,25 +138,12 @@ export function ConnectorsOverlay(props: ConnectorsOverlayProps) {
 interface ConnectorGroupProps {
   field: TrackedChange & {id: string; rect: Rect; bounds: Rect}
   change: TrackedChange & {id: string; rect: Rect; bounds: Rect}
-  hasFocus: boolean
-  hasHover: boolean
-  hasRevertHover: boolean
   setHovered: (id: string | null) => void
   onSetFocus: (nextFocusPath: Path) => void
-  isHoverConnector: boolean
 }
 
 function ConnectorGroup(props: ConnectorGroupProps) {
-  const {
-    change,
-    field,
-    hasFocus,
-    hasHover,
-    hasRevertHover,
-    onSetFocus,
-    setHovered,
-    isHoverConnector,
-  } = props
+  const {change, field, onSetFocus, setHovered} = props
 
   const onConnectorClick = useCallback(() => {
     scrollIntoView(field)
@@ -186,9 +169,6 @@ function ConnectorGroup(props: ConnectorGroupProps) {
             bounds: field.bounds,
           }}
           to={{rect: change.rect, bounds: change.bounds}}
-          focused={hasFocus}
-          hovered={hasHover || isHoverConnector}
-          revertHovered={hasRevertHover}
         />
       </g>
 

--- a/packages/@sanity/base/src/components/formField/__workshop__/example.tsx
+++ b/packages/@sanity/base/src/components/formField/__workshop__/example.tsx
@@ -2,7 +2,7 @@ import type {ValidationMarker} from '@sanity/types'
 import {Card, Code, Container, Flex, LayerProvider, TextInput} from '@sanity/ui'
 import {useBoolean, useNumber, useString} from '@sanity/ui-workshop'
 import React, {useCallback, useMemo, useState} from 'react'
-import {ChangeBar} from '../../../change-indicators/ChangeBar'
+import {ElementWithChangeBar} from '../../../change-indicators/ElementWithChangeBar'
 import type {FormFieldPresence} from '../../../presence'
 import {useCurrentUser} from '../../../_exports/hooks'
 import {FormField} from '../FormField'
@@ -71,9 +71,9 @@ export default function ExampleStory() {
             title={title}
             description={description}
           >
-            <ChangeBar isChanged={isChanged} hasFocus={focused}>
+            <ElementWithChangeBar isChanged={isChanged} hasFocus={focused}>
               <TextInput id={inputId} onBlur={handleBlur} onFocus={handleFocus} />
-            </ChangeBar>
+            </ElementWithChangeBar>
           </FormField>
         </LayerProvider>
 

--- a/packages/@sanity/form-builder/src/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/object/BlockObject.tsx
@@ -106,10 +106,9 @@ const ChangeIndicatorWrapper = styled.div(({theme}: {theme: Theme}) => {
   return css`
     position: absolute;
     width: ${space[2]}px;
-    right: -${space[2]}px;
+    right: 0;
     top: -${space[1]}px;
     bottom: -${space[1]}px;
-    overflow-x: hidden;
     padding-left: ${space[1]}px;
 
     [data-dragged] & {

--- a/packages/@sanity/form-builder/src/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/object/BlockObject.tsx
@@ -312,7 +312,6 @@ export function BlockObject(props: BlockObjectProps) {
             value={block}
             hasFocus={focused}
             path={blockPath}
-            withBadge={false}
           />
         </ChangeIndicatorWrapper>
       )}

--- a/packages/@sanity/form-builder/src/inputs/PortableText/text/TextBlock.styles.ts
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/text/TextBlock.styles.ts
@@ -155,10 +155,9 @@ export const ChangeIndicatorWrapper = styled.div(({theme}: {theme: Theme}) => {
   return css`
     position: absolute;
     width: ${space[2]}px;
-    right: -${space[2]}px;
+    right: 0;
     top: -${space[1]}px;
     bottom: -${space[1]}px;
-    overflow-x: hidden;
     padding-left: ${space[1]}px;
     user-select: none;
   `

--- a/packages/@sanity/form-builder/src/inputs/PortableText/text/TextBlock.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/text/TextBlock.tsx
@@ -182,7 +182,6 @@ export function TextBlock(props: TextBlockProps): React.ReactElement {
                 value={block}
                 hasFocus={focused}
                 path={blockPath}
-                withBadge={false}
               />
             </ChangeIndicatorWrapper>
           )}

--- a/packages/@sanity/form-builder/src/inputs/arrays/common/list.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/common/list.tsx
@@ -31,9 +31,9 @@ export function List(props: ListProps) {
 
   if (isGrid) {
     return isSortable ? (
-      <SortableGrid columns={[2, 3, 4]} gap={1} onSortEnd={onSortEnd} {...rest} />
+      <SortableGrid columns={[2, 3, 4]} gap={2} onSortEnd={onSortEnd} {...rest} />
     ) : (
-      <Grid columns={[2, 3, 4]} gap={1} {...rest} />
+      <Grid columns={[2, 3, 4]} gap={2} {...rest} />
     )
   }
 


### PR DESCRIPTION
### Description

A small redesign of change indicators (yellow lines suggesting that input has changed since last published)

- indicators are now moved outside of the inputs, 2px to the right
- the hover effect is much simpler now, icon and tooltip are removed
- indicators (and therefore connectors) are always yellow, don't turn blue when a field is focused
- indicators are not recognised when navigating a form with a keyboard (when you tab from a field, the focus jumps directly to the next input, ignoring the indicator. it makes it inaccessible for keyboard users but this is acceptable as we have other ways of opening review changes that keyboard users can exploit. whereas this behaviour is annoying and breaks patterns regarding what is usually expected from web forms)
- spacing between array items in grid layout is increased to accommodate new indicators

### What to review

only review changes related elements should be affected.
it's a plainly visual change, the behaviour of change indicators, connectors and review changes should not change.

### Notes for release

* updates change indicators and connectors in Review Changes
