### PR TITLE
fix(desk-tool): force re-renders on user components on navigation

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/userComponent/UserComponentPane.tsx
+++ b/packages/@sanity/desk-tool/src/panes/userComponent/UserComponentPane.tsx
@@ -40,6 +40,11 @@ export function UserComponentPane(props: UserComponentPaneProps) {
 
       {isValidElementType(component) &&
         createElement(component, {
+          // this forces a re-render when the router panes change. note: in
+          // theory, this shouldn't be necessary and the downstream user
+          // component could internally handle these updates, but this was done
+          // to preserve older desk tool behavior
+          key: `${restProps.itemId}-${restProps.childItemId}`,
           ...restProps,
           ...restPane,
           ref: userComponent,


### PR DESCRIPTION
### Description

The performance improvements of the desk-tool preserves the instance of the existing child component. For certain edge cases, this behavior is not desired and is unexpected.

This change forces user-defined components to render on pane navigation changes.

### Notes for release

Fixes an edge case for user-defined components. All user-defined components are re-rendered on navigation regardless if the structure child is a function or not.
