### PR TITLE
fix(desk-tool): hide custom pane content if the pane is collapsed

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/userComponent/UserComponentPane.tsx
+++ b/packages/@sanity/desk-tool/src/panes/userComponent/UserComponentPane.tsx
@@ -5,6 +5,7 @@ import {usePaneRouter} from '../../contexts/paneRouter'
 import {BaseDeskToolPaneProps} from '../types'
 import {DeskToolPaneActionHandler} from '../../types'
 import {UserComponentPaneHeader} from './UserComponentPaneHeader'
+import {UserComponentPaneContent} from './UserComponentPaneContent'
 
 type UserComponentPaneProps = BaseDeskToolPaneProps<'component'>
 
@@ -36,22 +37,23 @@ export function UserComponentPane(props: UserComponentPaneProps) {
         menuItemGroups={menuItemGroups}
         title={title}
       />
+      <UserComponentPaneContent>
+        {isValidElementType(component) &&
+          createElement(component, {
+            // this forces a re-render when the router panes change. note: in
+            // theory, this shouldn't be necessary and the downstream user
+            // component could internally handle these updates, but this was done
+            // to preserve older desk tool behavior
+            key: `${restProps.itemId}-${restProps.childItemId}`,
+            ...restProps,
+            ...restPane,
+            ref: userComponent,
+            // NOTE: this is for backwards compatibility (<= 2.20.0)
+            urlParams: params,
+          })}
 
-      {isValidElementType(component) &&
-        createElement(component, {
-          // this forces a re-render when the router panes change. note: in
-          // theory, this shouldn't be necessary and the downstream user
-          // component could internally handle these updates, but this was done
-          // to preserve older desk tool behavior
-          key: `${restProps.itemId}-${restProps.childItemId}`,
-          ...restProps,
-          ...restPane,
-          ref: userComponent,
-          // NOTE: this is for backwards compatibility (<= 2.20.0)
-          urlParams: params,
-        })}
-
-      {isValidElement(component) && component}
+        {isValidElement(component) && component}
+      </UserComponentPaneContent>
     </Pane>
   )
 }

--- a/packages/@sanity/desk-tool/src/panes/userComponent/UserComponentPaneContent.tsx
+++ b/packages/@sanity/desk-tool/src/panes/userComponent/UserComponentPaneContent.tsx
@@ -1,0 +1,23 @@
+import {Box} from '@sanity/ui'
+import React from 'react'
+import styled from 'styled-components'
+import {usePane} from '../../components'
+
+interface UserComponentPaneContentProps {
+  children: React.ReactNode
+}
+
+const Root = styled(Box)`
+  position: relative;
+`
+
+export function UserComponentPaneContent(props: UserComponentPaneContentProps) {
+  const {children} = props
+  const {collapsed} = usePane()
+
+  return (
+    <Root hidden={collapsed} height="fill" overflow="auto">
+      {children}
+    </Root>
+  )
+}


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Hide custom pane content when the pane is collapsed.

<img width="257" alt="Screenshot 2021-10-18 at 13 04 31" src="https://user-images.githubusercontent.com/15094168/137719204-3e632497-1514-4e1c-8fbe-3a14bc79260f.png">

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

fix(desk-tool): hide custom pane content if the pane is collapsed
