### PR TITLE
fix(default-layout): respect space redirect on initial load

### DIFF
--- a/packages/@sanity/default-layout/src/Root.tsx
+++ b/packages/@sanity/default-layout/src/Root.tsx
@@ -39,7 +39,7 @@ function DefaultLayoutRoot() {
         const next = {
           urlState: event.state || prev.urlState,
           isNotFound: event.isNotFound || prev.isNotFound,
-          intent: event.intent || prev.intent,
+          intent: event.type === 'snapshot' ? event.intent || prev.intent : prev.intent,
         }
 
         // If you update a State Hook to the same value as the current state,

--- a/packages/@sanity/default-layout/src/datasetSelect/DatasetSelect.tsx
+++ b/packages/@sanity/default-layout/src/datasetSelect/DatasetSelect.tsx
@@ -1,7 +1,7 @@
 import React, {useCallback, useEffect, useState} from 'react'
 import {filter, map} from 'rxjs/operators'
 import {Select} from '@sanity/ui'
-import {isSnapshotEvent, state as urlState} from '../datastores/urlState'
+import {isStateUpdateEvent, state as urlState} from '../datastores/urlState'
 import {CONFIGURED_SPACES} from '../util/spaces'
 import {useDefaultLayoutRouter} from '../useDefaultLayoutRouter'
 
@@ -11,7 +11,7 @@ export function DatasetSelect(props: Omit<React.HTMLProps<HTMLSelectElement>, 'r
 
   useEffect(() => {
     const currentSpace$ = urlState.pipe(
-      filter(isSnapshotEvent),
+      filter(isStateUpdateEvent),
       map((event) => event.state && event.state.space),
       map((spaceName) => CONFIGURED_SPACES.find((sp) => sp.name === spaceName))
     )


### PR DESCRIPTION
### Description

When the router redirects, a `change` event is emitted instead of a `snapshot` event, which caused the reconfiguration of the client not to be triggered. This PR makes sure that both snapshot and change events are treated equally when setting the client configuration.

### Notes for release

- Fixes a bug where if a space was configured as the default but not the first in the spaces array, the initial studio load would redirect to the correct URL but not configure the client to use the correct dataset
