### PR TITLE
fix(vision): fix codemirror autocomplete styling

### DIFF
--- a/packages/@sanity/vision/src/components/QueryEditor.js
+++ b/packages/@sanity/vision/src/components/QueryEditor.js
@@ -80,6 +80,7 @@ class QueryEditor extends React.PureComponent {
 
   render() {
     const options = {
+      theme: 'default CodeMirror-vision',
       lineNumbers: true,
       tabSize: 2,
       mode: {name: 'javascript', json: true},

--- a/packages/@sanity/vision/src/components/VisionGui.js
+++ b/packages/@sanity/vision/src/components/VisionGui.js
@@ -48,6 +48,7 @@ import {
   TimingsFooter,
   TimingsCard,
   TimingsTextContainer,
+  GlobalCodeMirrorStyle,
 } from './VisionGui.styled'
 
 /* eslint-disable import/no-unassigned-import, import/no-unresolved */
@@ -429,6 +430,7 @@ class VisionGui extends React.PureComponent {
         sizing="border"
         overflow="hidden"
       >
+        <GlobalCodeMirrorStyle />
         <Header paddingX={3} paddingY={2}>
           <Grid columns={12}>
             {/* Dataset selector */}

--- a/packages/@sanity/vision/src/components/VisionGui.styled.js
+++ b/packages/@sanity/vision/src/components/VisionGui.styled.js
@@ -1,4 +1,4 @@
-import styled, {css} from 'styled-components'
+import styled, {css, createGlobalStyle} from 'styled-components'
 import {Button, Card, Box, Flex, Label, rem} from '@sanity/ui'
 
 export const Root = styled(Card)`
@@ -64,6 +64,24 @@ export const Root = styled(Card)`
   .CodeMirror-line,
   pre.CodeMirror-line {
     padding-left: ${({theme}) => rem(theme.sanity.space[3])};
+  }
+`
+
+export const GlobalCodeMirrorStyle = createGlobalStyle`
+  // This is for the autocomplete menu when you do ctrl-space in in the Query editor
+  .CodeMirror-hints.CodeMirror-vision {
+    z-index: 20;
+    font-family: ${({theme}) => theme.sanity.fonts.code.family};
+    font-size: ${({theme}) => rem(theme.sanity.fonts.code.sizes[1].fontSize)};
+    padding: ${({theme}) => rem(theme.sanity.space[2])};
+  }
+
+  .CodeMirror-hint {
+    padding: ${({theme}) => `${rem(theme.sanity.space[1])} ${rem(theme.sanity.space[1])}`};
+  }
+
+  .CodeMirror-hint-active {
+    background-color: var(--card-bg-color);
   }
 `
 


### PR DESCRIPTION
### Description

This fixes the autocomplete menu styling and z-index issues when pressing ctrl-space inside the Query editor.

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/10508/137899939-9c160563-5c9c-4e14-8b7b-149366dbc148.png)|![image](https://user-images.githubusercontent.com/10508/137899831-114ee6d3-c3a6-45c7-9144-ef0e020c0765.png)|

### What to review

- That this fixes the z-index issue where the autocomplete dialog is behind the Result content
- That the styling fixes looks good

### Notes for release

- Fixes Query autocomplete menu in Vision