### PR TITLE
fix(portable-text-editor): fix bug with removing annotations

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithEditableAPI.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithEditableAPI.ts
@@ -427,31 +427,6 @@ export function createWithEditableAPI(
                   }
                 })
               }
-              // Merge similar adjecent spans
-              if (changed) {
-                // eslint-disable-next-line max-depth
-                for (const [node] of Array.from(
-                  Editor.nodes(editor, {
-                    at: Editor.range(editor, [selection.anchor.path[0]], [selection.focus.path[0]]),
-                    match: Text.isText,
-                  })
-                ).reverse()) {
-                  const [parent] = Editor.node(editor, SlatePath.parent(path))
-                  // eslint-disable-next-line max-depth
-                  if (Editor.isBlock(editor, parent)) {
-                    const nextPath = [path[0], path[1] + 1]
-                    const nextTextNode = parent.children[nextPath[1]]
-                    // eslint-disable-next-line max-depth
-                    if (
-                      nextTextNode &&
-                      typeof nextTextNode.text === 'string' &&
-                      isEqual(nextTextNode.marks, node.marks)
-                    ) {
-                      Transforms.mergeNodes(editor, {at: nextPath, voids: true})
-                    }
-                  }
-                }
-              }
             }
             if (changed) {
               editor.onChange()


### PR DESCRIPTION
This will fix a bug where removing an annotation in the beginning of a block with other following  annotations will try to merge spans where it should not.
 
There is no need to merge adjacent spans in this remove annotation function as it has already been taken care of
in withPortableTextMarkModel plugin (mergeSpans fn) as a general normalization function.

### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

Fixed a bug where removing an annotation in the beginning of a Portable Text block would accidentally mutate trailing annotations inside that same block.