### PR TITLE
fix(base): return ready state from useEditState()

### DIFF
--- a/packages/@sanity/base/src/datastores/document/document-pair/editState.ts
+++ b/packages/@sanity/base/src/datastores/document/document-pair/editState.ts
@@ -1,6 +1,6 @@
 import {SanityDocument} from '@sanity/types'
 import {Observable} from 'rxjs'
-import {map, publishReplay, refCount} from 'rxjs/operators'
+import {map, publishReplay, refCount, startWith} from 'rxjs/operators'
 import {IdPair} from '../types'
 import {memoize} from '../utils/createMemoizer'
 import {isLiveEditEnabled} from './utils/isLiveEditEnabled'
@@ -12,18 +12,29 @@ export interface EditStateFor {
   draft: SanityDocument | null
   published: SanityDocument | null
   liveEdit: boolean
+  ready: boolean
 }
 
 export const editState = memoize(
   (idPair: IdPair, typeName: string): Observable<EditStateFor> => {
+    const liveEdit = isLiveEditEnabled(typeName)
     return operationArgs(idPair, typeName).pipe(
       map(({snapshots}) => ({
         id: idPair.publishedId,
         type: typeName,
         draft: snapshots.draft,
         published: snapshots.published,
-        liveEdit: isLiveEditEnabled(typeName),
+        liveEdit,
+        ready: true,
       })),
+      startWith({
+        id: idPair.publishedId,
+        type: typeName,
+        draft: null,
+        published: null,
+        liveEdit,
+        ready: false,
+      }),
       publishReplay(1),
       refCount()
     )

--- a/packages/@sanity/desk-tool/src/panes/document/DocumentPaneProvider.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/DocumentPaneProvider.tsx
@@ -108,7 +108,7 @@ export const DocumentPaneProvider = function DocumentPaneProvider(
   const compareValue: Partial<SanityDocument> | null = changesOpen
     ? historyController.sinceAttributes()
     : editState?.published || null
-  const ready = connectionState === 'connected' && !patch.disabled
+  const ready = connectionState === 'connected' && editState.ready
   const displayed: Partial<SanityDocument> | null = useMemo(
     () => {
       return historyController.onOlderRevision() ? historyController.displayed() : value

--- a/packages/@sanity/react-hooks/src/useEditState.ts
+++ b/packages/@sanity/react-hooks/src/useEditState.ts
@@ -4,20 +4,10 @@
 import type {EditStateFor} from '@sanity/base/_internal'
 import documentStore from 'part:@sanity/base/datastore/document'
 import {useMemoObservable} from 'react-rx'
-import {startWith} from 'rxjs/operators'
 
 export function useEditState(publishedDocId: string, docTypeName: string): EditStateFor {
-  return useMemoObservable(
-    () =>
-      documentStore.pair.editState(publishedDocId, docTypeName).pipe(
-        startWith({
-          id: publishedDocId,
-          type: docTypeName,
-          draft: null,
-          published: null,
-          liveEdit: false,
-        })
-      ),
-    [publishedDocId, docTypeName]
-  ) as EditStateFor
+  return useMemoObservable(() => documentStore.pair.editState(publishedDocId, docTypeName), [
+    publishedDocId,
+    docTypeName,
+  ]) as EditStateFor
 }


### PR DESCRIPTION
### Description

the [fix](https://github.com/sanity-io/sanity/pull/2855/files#diff-71d84315d36afd91007989c6e025ab7aded8fe1e2b336cd6baa2be74ace1f27aR108) for the `undefined` document passed to the withDocument HOC in #2855 was built on the assumption that the patch operation was disabled until the document was fully loaded. This turned out to be wrong, so this PR instead fixes the issue by adding a ready state on the edit state of the document.

### Notes for release

- Fixes an earlier regression that caused the withDocument HOC to pass on the edited document before it was fully loaded.
