### PR TITLE
fix(client): bump max dataset length to 64 characters

### DIFF
--- a/packages/@sanity/client/src/validators.js
+++ b/packages/@sanity/client/src/validators.js
@@ -2,9 +2,9 @@ const VALID_ASSET_TYPES = ['image', 'file']
 const VALID_INSERT_LOCATIONS = ['before', 'after', 'replace']
 
 exports.dataset = (name) => {
-  if (!/^(~[a-z0-9]{1}[-\w]{0,25}|[a-z0-9]{1}[-\w]{0,19})$/.test(name)) {
+  if (!/^(~[a-z0-9]{1}[-\w]{0,63}|[a-z0-9]{1}[-\w]{0,63})$/.test(name)) {
     throw new Error(
-      'Datasets can only contain lowercase characters, numbers, underscores and dashes, and start with tilde, and be maximum 20 characters'
+      'Datasets can only contain lowercase characters, numbers, underscores and dashes, and start with tilde, and be maximum 64 characters'
     )
   }
 }


### PR DESCRIPTION
### Description

We recently increased the maximum dataset name length to 64 characters, but seem to have forgotten to update the client to align with this. This PR fixes that. 

### What to review

That the changes looks correct.

### Notes for release

- Increased maximum dataset name length to 64 characters in client
