### PR TITLE
fix(workshop): support inspection using react devtools in workshop frame

### DIFF
--- a/dev/workshop/src/frame/index.html
+++ b/dev/workshop/src/frame/index.html
@@ -29,6 +29,11 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      if (window.parent !== window) {
+        window.__REACT_DEVTOOLS_GLOBAL_HOOK__ = window.parent.__REACT_DEVTOOLS_GLOBAL_HOOK__
+      }
+    </script>
     <script type="module" src="/frame/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
### Description

This adds support for inspecting workshop frames in React Devtools

### What to review

Verify that you can now inspect the component tree in a workshop frame

### Notes for release

N/A (internal)