### PR TITLE
fix(desk-tool/base): update permission calls

### DIFF
--- a/cypress/integration/desk-tool/actionPermission.test.js
+++ b/cypress/integration/desk-tool/actionPermission.test.js
@@ -86,3 +86,41 @@ describe('@sanity/desk-tool: duplicate permission', () => {
     cy.get('[data-testid=action-Duplicate]').should('have.attr', 'disabled')
   })
 })
+
+describe('@sanity/desk-tool: delete permission', () => {
+  it('as an administrator user, the duplicate button will be active', () => {
+    cy.visit(
+      '/test/desk/input-standard;booleansTest;1053af2f-84af-49a1-b42b-e2156470bb77%2Ctemplate%3DbooleansTest#_debug_roles=administrator'
+    )
+
+    cy.get('[data-testid=action-menu-button').click()
+    cy.get('[data-testid=action-Delete]').should('not.have.attr', 'disabled')
+  })
+
+  it('as an restricted user, the duplicate button will be disabled', () => {
+    cy.visit(
+      '/test/desk/input-standard;booleansTest;1053af2f-84af-49a1-b42b-e2156470bb77%2Ctemplate%3DbooleansTest#_debug_roles=restricted'
+    )
+
+    cy.get('[data-testid=action-menu-button').click()
+    cy.get('[data-testid=action-Delete]').should('have.attr', 'disabled')
+  })
+
+  it('as a requiresApproval user on an approved published document, the duplicate button will be active', () => {
+    cy.visit(
+      '/test/desk/author;914bcbf4-9ead-4be1-b797-8d2995c50380%2Ctemplate%3Dauthor-unlocked#_debug_roles=requiresApproval'
+    )
+
+    cy.get('[data-testid=action-menu-button').click()
+    cy.get('[data-testid=action-Delete]').should('not.have.attr', 'disabled')
+  })
+
+  it('as a requiresApproval user on a non-approved document, the duplicate button will be disabled', () => {
+    cy.visit(
+      '/test/desk/input-standard;booleansTest;1053af2f-84af-49a1-b42b-e2156470bb77%2Ctemplate%3DbooleansTest#_debug_roles=requiresApproval'
+    )
+
+    cy.get('[data-testid=action-menu-button').click()
+    cy.get('[data-testid=action-Delete]').should('have.attr', 'disabled')
+  })
+})

--- a/cypress/integration/desk-tool/actionPermission.test.js
+++ b/cypress/integration/desk-tool/actionPermission.test.js
@@ -33,7 +33,7 @@ describe('@sanity/desk-tool: publish permission', () => {
 
     // as the publish button works right now, unless changes are made to the document once opened, the button will always be disaled
     // this is expected behaviour for now.
-    cy.get('input', {wait: 4000}).eq(1).type(' ')
+    cy.get('input').eq(1).type(' ')
 
     cy.get('[data-testid=action-Publish]').should('not.have.attr', 'disabled')
   })
@@ -122,5 +122,46 @@ describe('@sanity/desk-tool: delete permission', () => {
 
     cy.get('[data-testid=action-menu-button').click()
     cy.get('[data-testid=action-Delete]').should('have.attr', 'disabled')
+  })
+})
+
+describe('@sanity/desk-tool: unpublish permission', () => {
+  it('as an administrator user, the unpublish button will be active', () => {
+    cy.visit(
+      '/test/desk/input-standard;booleansTest;1053af2f-84af-49a1-b42b-e2156470bb77%2Ctemplate%3DbooleansTest#_debug_roles=administrator'
+    )
+
+    cy.get('[data-testid=action-menu-button').click()
+    cy.get('[data-testid=action-Unpublish]').should('not.have.attr', 'disabled')
+  })
+
+  it('as an restricted user, the unpublish button will be disabled', () => {
+    cy.visit(
+      '/test/desk/input-standard;booleansTest;1053af2f-84af-49a1-b42b-e2156470bb77%2Ctemplate%3DbooleansTest#_debug_roles=restricted'
+    )
+
+    cy.get('[data-testid=action-menu-button').click()
+    cy.get('[data-testid=action-Unpublish]').should('have.attr', 'disabled')
+  })
+
+  it('as a requiresApproval user on an approved published document, the unpublish button will be active', () => {
+    cy.visit(
+      '/test/desk/author;914bcbf4-9ead-4be1-b797-8d2995c50380%2Ctemplate%3Dauthor-unlocked#_debug_roles=requiresApproval'
+    )
+
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(4500)
+
+    cy.get('[data-testid=action-menu-button').click()
+    cy.get('[data-testid=action-Unpublish]').should('not.have.attr', 'disabled')
+  })
+
+  it('as a requiresApproval user on a non-approved document, the unpublish button will be disabled', () => {
+    cy.visit(
+      '/test/desk/input-standard;booleansTest;1053af2f-84af-49a1-b42b-e2156470bb77%2Ctemplate%3DbooleansTest#_debug_roles=requiresApproval'
+    )
+
+    cy.get('[data-testid=action-menu-button').click()
+    cy.get('[data-testid=action-Unpublish]').should('have.attr', 'disabled')
   })
 })

--- a/cypress/integration/desk-tool/actionPermission.test.js
+++ b/cypress/integration/desk-tool/actionPermission.test.js
@@ -1,4 +1,4 @@
-describe('@sanity/desk-tool: publishing permission', () => {
+describe('@sanity/desk-tool: publish permission', () => {
   it('as an administrator user, the publish button will be active', () => {
     cy.visit(
       '/test/desk/input-standard;booleansTest;1053af2f-84af-49a1-b42b-e2156470bb77%2Ctemplate%3DbooleansTest#_debug_roles=administrator'
@@ -46,5 +46,43 @@ describe('@sanity/desk-tool: publishing permission', () => {
     // this whole document will be disabled and is outside of the scope of this test
 
     cy.get('[data-testid=action-Publish]').should('have.attr', 'disabled')
+  })
+})
+
+describe('@sanity/desk-tool: duplicate permission', () => {
+  it('as an administrator user, the duplicate button will be active', () => {
+    cy.visit(
+      '/test/desk/input-standard;booleansTest;1053af2f-84af-49a1-b42b-e2156470bb77%2Ctemplate%3DbooleansTest#_debug_roles=administrator'
+    )
+
+    cy.get('[data-testid=action-menu-button').click()
+    cy.get('[data-testid=action-Duplicate]').should('not.have.attr', 'disabled')
+  })
+
+  it('as an restricted user, the duplicate button will be disabled', () => {
+    cy.visit(
+      '/test/desk/input-standard;booleansTest;1053af2f-84af-49a1-b42b-e2156470bb77%2Ctemplate%3DbooleansTest#_debug_roles=restricted'
+    )
+
+    cy.get('[data-testid=action-menu-button').click()
+    cy.get('[data-testid=action-Duplicate]').should('have.attr', 'disabled')
+  })
+
+  it('as a requiresApproval user on an approved published document, the duplicate button will be active', () => {
+    cy.visit(
+      '/test/desk/author;914bcbf4-9ead-4be1-b797-8d2995c50380%2Ctemplate%3Dauthor-unlocked#_debug_roles=requiresApproval'
+    )
+
+    cy.get('[data-testid=action-menu-button').click()
+    cy.get('[data-testid=action-Duplicate]').should('not.have.attr', 'disabled')
+  })
+
+  it('as a requiresApproval user on a non-approved document, the duplicate button will be disabled', () => {
+    cy.visit(
+      '/test/desk/input-standard;booleansTest;1053af2f-84af-49a1-b42b-e2156470bb77%2Ctemplate%3DbooleansTest#_debug_roles=requiresApproval'
+    )
+
+    cy.get('[data-testid=action-menu-button').click()
+    cy.get('[data-testid=action-Duplicate]').should('have.attr', 'disabled')
   })
 })

--- a/cypress/integration/desk-tool/actionPermission.test.js
+++ b/cypress/integration/desk-tool/actionPermission.test.js
@@ -171,3 +171,44 @@ describe('@sanity/desk-tool: unpublish permission', () => {
     cy.get('[data-testid=action-Unpublish]').should('have.attr', 'disabled')
   })
 })
+
+describe('@sanity/desk-tool: discardDraft permission', () => {
+  it('as an administrator user, the discard changes button will be active', () => {
+    cy.visit(
+      '/test/desk/input-standard;booleansTest;1053af2f-84af-49a1-b42b-e2156470bb77%2Ctemplate%3DbooleansTest#_debug_roles=administrator'
+    )
+
+    cy.get('[data-testid=action-menu-button').click()
+    cy.get('[data-testid=action-Discardchanges]').should('not.have.attr', 'disabled')
+  })
+
+  it('as an restricted user, the discard changes button will be disabled', () => {
+    cy.visit(
+      '/test/desk/input-standard;booleansTest;1053af2f-84af-49a1-b42b-e2156470bb77%2Ctemplate%3DbooleansTest#_debug_roles=restricted'
+    )
+
+    cy.get('[data-testid=action-menu-button').click()
+    cy.get('[data-testid=action-Discardchanges]').should('have.attr', 'disabled')
+  })
+
+  it('as a requiresApproval user on an approved published document, the discard changes button will be active', () => {
+    cy.visit(
+      '/test/desk/author;914bcbf4-9ead-4be1-b797-8d2995c50380%2Ctemplate%3Dauthor-unlocked#_debug_roles=requiresApproval'
+    )
+
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(4500)
+
+    cy.get('[data-testid=action-menu-button').click()
+    cy.get('[data-testid=action-Discardchanges]').should('not.have.attr', 'disabled')
+  })
+
+  it('as a requiresApproval user on a non-approved document, the discard changes button will be disabled', () => {
+    cy.visit(
+      '/test/desk/input-standard;booleansTest;1053af2f-84af-49a1-b42b-e2156470bb77%2Ctemplate%3DbooleansTest#_debug_roles=requiresApproval'
+    )
+
+    cy.get('[data-testid=action-menu-button').click()
+    cy.get('[data-testid=action-Discardchanges]').should('have.attr', 'disabled')
+  })
+})

--- a/cypress/integration/desk-tool/actionPermission.test.js
+++ b/cypress/integration/desk-tool/actionPermission.test.js
@@ -73,6 +73,9 @@ describe('@sanity/desk-tool: duplicate permission', () => {
       '/test/desk/author;914bcbf4-9ead-4be1-b797-8d2995c50380%2Ctemplate%3Dauthor-unlocked#_debug_roles=requiresApproval'
     )
 
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(4500)
+
     cy.get('[data-testid=action-menu-button').click()
     cy.get('[data-testid=action-Duplicate]').should('not.have.attr', 'disabled')
   })
@@ -110,6 +113,9 @@ describe('@sanity/desk-tool: delete permission', () => {
     cy.visit(
       '/test/desk/author;914bcbf4-9ead-4be1-b797-8d2995c50380%2Ctemplate%3Dauthor-unlocked#_debug_roles=requiresApproval'
     )
+
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(4500)
 
     cy.get('[data-testid=action-menu-button').click()
     cy.get('[data-testid=action-Delete]').should('not.have.attr', 'disabled')

--- a/cypress/integration/desk-tool/actionPermission.test.js
+++ b/cypress/integration/desk-tool/actionPermission.test.js
@@ -1,0 +1,50 @@
+describe('@sanity/desk-tool: publishing permission', () => {
+  it('as an administrator user, the publish button will be active', () => {
+    cy.visit(
+      '/test/desk/input-standard;booleansTest;1053af2f-84af-49a1-b42b-e2156470bb77%2Ctemplate%3DbooleansTest#_debug_roles=administrator'
+    )
+
+    // as the publish button works right now, unless changes are made to the document once opened, the button will always be disaled
+    // this is expected behaviour for now.
+
+    cy.get('#21').click({force: true})
+    cy.get('#21').click({force: true})
+
+    cy.get('[data-testid=action-Publish]').should('not.have.attr', 'disabled')
+  })
+
+  it('as an restricted user, the publish button will be disabled', () => {
+    cy.visit(
+      '/test/desk/input-standard;booleansTest;1053af2f-84af-49a1-b42b-e2156470bb77%2Ctemplate%3DbooleansTest#_debug_roles=restricted'
+    )
+
+    // this whole document will be disabled and is outside of the scope of this test
+
+    cy.get('[data-testid=action-Publish]').should('have.attr', 'disabled')
+  })
+
+  it('as a requiresApproval user on an approved published document, the publish button will be active', () => {
+    cy.visit(
+      '/test/desk/author;914bcbf4-9ead-4be1-b797-8d2995c50380%2Ctemplate%3Dauthor-unlocked#_debug_roles=requiresApproval'
+    )
+
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(4500)
+
+    // as the publish button works right now, unless changes are made to the document once opened, the button will always be disaled
+    // this is expected behaviour for now.
+    cy.get('input', {wait: 4000}).eq(1).type(' ')
+
+    cy.get('[data-testid=action-Publish]').should('not.have.attr', 'disabled')
+  })
+
+  it('as a requiresApproval user on a non-approved document, the publish button will be disabled', () => {
+    cy.visit(
+      '/test/desk/input-standard;booleansTest;1053af2f-84af-49a1-b42b-e2156470bb77%2Ctemplate%3DbooleansTest#_debug_roles=requiresApproval'
+    )
+
+    // this whole document will be disabled and is outside of the scope of this test
+
+    cy.get('[data-testid=action-Publish]').should('have.attr', 'disabled')
+  })
+})

--- a/cypress/integration/desk-tool/bannerPermission.test.js
+++ b/cypress/integration/desk-tool/bannerPermission.test.js
@@ -1,4 +1,4 @@
-describe('@sanity/desk-tool: banner permissions on update (existing documents)', () => {
+describe('@sanity/desk-tool: banner permissions on update', () => {
   it('as an administrator user, the permission banner will not be visible (has permissions)', () => {
     cy.visit(
       '/test/desk/input-standard;booleansTest;1053af2f-84af-49a1-b42b-e2156470bb77%2Ctemplate%3DbooleansTest#_debug_roles=administrator'

--- a/cypress/integration/desk-tool/bannerPermission.test.js
+++ b/cypress/integration/desk-tool/bannerPermission.test.js
@@ -1,0 +1,61 @@
+describe('@sanity/desk-tool: banner permissions on update (existing documents)', () => {
+  it('as an administrator user, the permission banner will not be visible (has permissions)', () => {
+    cy.visit(
+      '/test/desk/input-standard;booleansTest;1053af2f-84af-49a1-b42b-e2156470bb77%2Ctemplate%3DbooleansTest#_debug_roles=administrator'
+    )
+
+    cy.get('[data-testid=permission-check-banner]').should('not.exist')
+  })
+
+  it('as a restricted user, the permission banner will be visible (does not have permission)', () => {
+    cy.visit(
+      '/test/desk/input-standard;booleansTest;1053af2f-84af-49a1-b42b-e2156470bb77%2Ctemplate%3DbooleansTest#_debug_roles=restricted'
+    )
+
+    cy.get('[data-testid=permission-check-banner]').should('exist')
+  })
+
+  it('as a requiresApproval user, the permission banner will be not visible (does have permission) when updating approved published documents', () => {
+    cy.visit(
+      '/test/desk/author;914bcbf4-9ead-4be1-b797-8d2995c50380%2Ctemplate%3Dauthor-unlocked#_debug_roles=requiresApproval'
+    )
+
+    cy.get('[data-testid=permission-check-banner]').should('not.exist')
+  })
+
+  it('as a requiresApproval user, the permission banner will be visible (does not have permission) on non-approved published documents', () => {
+    cy.visit(
+      '/test/desk/input-standard;booleansTest;1053af2f-84af-49a1-b42b-e2156470bb77%2Ctemplate%3DbooleansTest#_debug_roles=requiresApproval'
+    )
+
+    cy.get('[data-testid=permission-check-banner]').should('exist')
+  })
+
+  it('as a requiresApproval user, the permission banner will be not visible (does have permission) when updating draft documents', () => {
+    cy.visit(
+      '/test/desk/author;3c14d049-198b-4c1b-a0fe-7865528166ce%2Ctemplate%3Dauthor-unlocked#_debug_roles=requiresApproval'
+    )
+
+    cy.get('[data-testid=permission-check-banner]').should('not.exist')
+  })
+})
+
+describe('@sanity/desk-tool: banner permissions on create (document list header)', () => {
+  it('as an administrator user, the permission banner will not be visible (has permissions)', () => {
+    cy.visit('/test/desk/input-standard;booleansTest#_debug_roles=administrator')
+
+    cy.get('[data-testid=action-intent-button]').click()
+
+    cy.get('[data-testid=permission-check-banner]').should('not.exist')
+  })
+
+  it('as a requiresApproval user, the permission banner will be not visible (does have permission) on specific document types', () => {
+    cy.visit('/test/desk/author#_debug_roles=requiresApproval')
+
+    cy.get('[data-testid=multi-action-intent-button]').click()
+
+    cy.get('[data-testid=action-intent-button-2').click()
+
+    cy.get('[data-testid=permission-check-banner]').should('not.exist')
+  })
+})

--- a/dev/test-studio/parts/initialValueTemplates.js
+++ b/dev/test-studio/parts/initialValueTemplates.js
@@ -21,4 +21,12 @@ export default [
       author: {_type: 'reference', _ref: params.authorId},
     }),
   }),
+
+  T.template({
+    id: 'author-unlocked',
+    title: 'Author unlocked',
+    description: `An unlocked author`,
+    schemaType: 'author',
+    value: (params) => ({locked: false}),
+  }),
 ]

--- a/packages/@sanity/base/src/_exports/hooks.ts
+++ b/packages/@sanity/base/src/_exports/hooks.ts
@@ -6,6 +6,8 @@ export {
   unstable_useCheckDocumentPermission,
   // eslint-disable-next-line camelcase
   unstable_useCanCreateAnyOf,
+  // eslint-disable-next-line camelcase
+  useCheckDocumentPermission_temp,
 } from '../datastores/grants/hooks'
 export {useUserColor} from '../user-color/hooks'
 export {useTimeAgo} from '../time/useTimeAgo'

--- a/packages/@sanity/base/src/_exports/hooks.ts
+++ b/packages/@sanity/base/src/_exports/hooks.ts
@@ -6,8 +6,7 @@ export {
   unstable_useCheckDocumentPermission,
   // eslint-disable-next-line camelcase
   unstable_useCanCreateAnyOf,
-  // eslint-disable-next-line camelcase
-  useCheckDocumentPermission_temp,
+  useCheckDocumentPermissions,
 } from '../datastores/grants/hooks'
 export {useUserColor} from '../user-color/hooks'
 export {useTimeAgo} from '../time/useTimeAgo'

--- a/packages/@sanity/base/src/datastores/grants/debug/exampleGrants.ts
+++ b/packages/@sanity/base/src/datastores/grants/debug/exampleGrants.ts
@@ -39,6 +39,13 @@ export const viewer: Grant[] = [
   },
 ]
 
+export const requiresApproval: Grant[] = [
+  {
+    filter: '!locked',
+    permissions: ['read', 'create', 'update'],
+  },
+]
+
 export const restricted: Grant[] = [
   {
     filter: '_id in path("drafts.**") && _type in ["stringsTest", "book", "author"]',

--- a/packages/@sanity/base/src/datastores/grants/debug/exampleRoles.ts
+++ b/packages/@sanity/base/src/datastores/grants/debug/exampleRoles.ts
@@ -10,6 +10,7 @@ export const exampleRoles: Record<string, Role> = {
 
   // custom
   restricted: {name: 'restricted', title: 'Restricted'},
+  requiresApproval: {name: 'requiresApproval', title: 'Requires approval'},
 
   // legacy
   read: {name: 'read', title: 'Read'},

--- a/packages/@sanity/base/src/datastores/grants/debug/roleGrants.ts
+++ b/packages/@sanity/base/src/datastores/grants/debug/roleGrants.ts
@@ -14,6 +14,7 @@ const DEBUG_ROLE_GRANTS_MAP: Record<ExampleRoleName, Grant[]> = {
 
   // custom
   restricted: grants.restricted,
+  requiresApproval: grants.requiresApproval,
 
   // legacy
   read: grants.viewer,

--- a/packages/@sanity/base/src/datastores/grants/documentPair.ts
+++ b/packages/@sanity/base/src/datastores/grants/documentPair.ts
@@ -4,14 +4,13 @@
 ///<reference types="@sanity/types/parts" />
 
 import {SanityDocument, SchemaType} from '@sanity/types'
-import {mergeMap, switchMap, tap} from 'rxjs/operators'
+import {mergeMap, switchMap} from 'rxjs/operators'
 import {combineLatest} from 'rxjs'
 import schema from 'part:@sanity/base/schema'
-import {getDraftId} from 'part:@sanity/base/util/draft-utils'
 
 import {snapshotPair} from '../document/document-pair/snapshotPair'
 import {IdPair} from '../document/types'
-import {getPublishedId} from '../../util/draftUtils'
+import {getPublishedId, getDraftId} from '../../util/draftUtils'
 import {checkDeletePermission, checkPublishPermission, checkUnpublishPermission} from './pairChecks'
 import grantsStore from '.'
 
@@ -60,13 +59,9 @@ export function canDelete(document: Partial<SanityDocument>) {
 }
 
 export function canPublish(document: Partial<SanityDocument>) {
-  const idPair = getIdPairFromPublished(document._id)
-  return snapshotPair(idPair).pipe(
-    mergeMap((pair) => combineLatest([pair.draft.snapshots$, pair.published.snapshots$])),
-    switchMap(([draft, published]) => {
-      return checkPublishPermission({draft, published})
-    })
-  )
+  const published = {...document, _id: getPublishedId(document._id)}
+  const draft = {...document, _id: getDraftId(document._id)}
+  return checkPublishPermission({published, draft})
 }
 
 export function canUnpublish(document: Partial<SanityDocument>) {

--- a/packages/@sanity/base/src/datastores/grants/documentPair.ts
+++ b/packages/@sanity/base/src/datastores/grants/documentPair.ts
@@ -1,0 +1,92 @@
+/* these methods deal with the draft / published pair of documents */
+
+// @todo: remove the following line when part imports has been removed from this file
+///<reference types="@sanity/types/parts" />
+
+import {SanityDocument, SchemaType} from '@sanity/types'
+import {mergeMap, switchMap, tap} from 'rxjs/operators'
+import {combineLatest} from 'rxjs'
+import schema from 'part:@sanity/base/schema'
+import {getDraftId} from 'part:@sanity/base/util/draft-utils'
+
+import {snapshotPair} from '../document/document-pair/snapshotPair'
+import {IdPair} from '../document/types'
+import {getPublishedId} from '../../util/draftUtils'
+import {checkDeletePermission, checkPublishPermission, checkUnpublishPermission} from './pairChecks'
+import grantsStore from '.'
+
+function getSchemaType(typeName: string): SchemaType {
+  const type = schema.get(typeName)
+  if (!type) {
+    throw new Error(`No such schema type: ${typeName}`)
+  }
+  return type
+}
+
+export function canCreateType(document: Partial<SanityDocument>) {
+  const type = getSchemaType(document._type)
+  const id = document._id
+  return grantsStore.checkDocumentPermission('create', {
+    ...document,
+    _id: type.liveEdit ? id : `drafts.${id}`,
+    type,
+  })
+}
+
+export function canUpdate(document: Partial<SanityDocument>) {
+  const type = getSchemaType(document._type)
+  const idPair = getIdPairFromPublished(document._id)
+  return type.liveEdit
+    ? grantsStore.checkDocumentPermission('update', document)
+    : grantsStore.checkDocumentPermission(
+        'update',
+        // note: we check against the published document (if it exist) with draft id since that's the
+        // document that will be created as new draft when user edits it
+        {...document, _id: idPair.draftId}
+      )
+}
+
+export function canDelete(document: Partial<SanityDocument>) {
+  const type = getSchemaType(document._type)
+  const idPair = getIdPairFromPublished(document._id)
+  return snapshotPair(idPair).pipe(
+    mergeMap((pair) => combineLatest([pair.draft.snapshots$, pair.published.snapshots$])),
+    switchMap(([draft, published]) => {
+      return type.liveEdit
+        ? grantsStore.checkDocumentPermission('update', published)
+        : checkDeletePermission({draft, published})
+    })
+  )
+}
+
+export function canPublish(document: Partial<SanityDocument>) {
+  const idPair = getIdPairFromPublished(document._id)
+  return snapshotPair(idPair).pipe(
+    mergeMap((pair) => combineLatest([pair.draft.snapshots$, pair.published.snapshots$])),
+    switchMap(([draft, published]) => {
+      return checkPublishPermission({draft, published})
+    })
+  )
+}
+
+export function canUnpublish(document: Partial<SanityDocument>) {
+  const idPair = getIdPairFromPublished(document._id)
+  return snapshotPair(idPair).pipe(
+    mergeMap((pair) => combineLatest([pair.draft.snapshots$, pair.published.snapshots$])),
+    switchMap(([draft, published]) => {
+      return checkUnpublishPermission({draft, published})
+    })
+  )
+}
+
+export function canDiscardDraft(document: Partial<SanityDocument>) {
+  const idPair = getIdPairFromPublished(document._id)
+  return snapshotPair(idPair).pipe(
+    mergeMap((pair) => pair.draft.snapshots$),
+    switchMap((draft) => grantsStore.checkDocumentPermission('update', draft))
+  )
+}
+
+function getIdPairFromPublished(documentId: string): IdPair {
+  return {publishedId: getPublishedId(documentId), draftId: getDraftId(documentId)}
+}

--- a/packages/@sanity/base/src/datastores/grants/documentPair.ts
+++ b/packages/@sanity/base/src/datastores/grants/documentPair.ts
@@ -4,14 +4,10 @@
 ///<reference types="@sanity/types/parts" />
 
 import {SanityDocument, SchemaType} from '@sanity/types'
-import {mergeMap, switchMap} from 'rxjs/operators'
-import {combineLatest} from 'rxjs'
 import schema from 'part:@sanity/base/schema'
 
-import {snapshotPair} from '../document/document-pair/snapshotPair'
-import {IdPair} from '../document/types'
 import {getPublishedId, getDraftId} from '../../util/draftUtils'
-import {checkDeletePermission, checkPublishPermission, checkUnpublishPermission} from './pairChecks'
+import {checkPublishPermission} from './pairChecks'
 import grantsStore from '.'
 
 function getSchemaType(typeName: string): SchemaType {
@@ -34,54 +30,19 @@ export function canCreateType(document: Partial<SanityDocument>) {
 
 export function canUpdate(document: Partial<SanityDocument>) {
   const type = getSchemaType(document._type)
-  const idPair = getIdPairFromPublished(document._id)
+  const draft = {...document, _id: getDraftId(document._id)}
   return type.liveEdit
     ? grantsStore.checkDocumentPermission('update', document)
     : grantsStore.checkDocumentPermission(
         'update',
         // note: we check against the published document (if it exist) with draft id since that's the
         // document that will be created as new draft when user edits it
-        {...document, _id: idPair.draftId}
+        {...document, _id: draft._id}
       )
-}
-
-export function canDelete(document: Partial<SanityDocument>) {
-  const type = getSchemaType(document._type)
-  const idPair = getIdPairFromPublished(document._id)
-  return snapshotPair(idPair).pipe(
-    mergeMap((pair) => combineLatest([pair.draft.snapshots$, pair.published.snapshots$])),
-    switchMap(([draft, published]) => {
-      return type.liveEdit
-        ? grantsStore.checkDocumentPermission('update', published)
-        : checkDeletePermission({draft, published})
-    })
-  )
 }
 
 export function canPublish(document: Partial<SanityDocument>) {
   const published = {...document, _id: getPublishedId(document._id)}
   const draft = {...document, _id: getDraftId(document._id)}
   return checkPublishPermission({published, draft})
-}
-
-export function canUnpublish(document: Partial<SanityDocument>) {
-  const idPair = getIdPairFromPublished(document._id)
-  return snapshotPair(idPair).pipe(
-    mergeMap((pair) => combineLatest([pair.draft.snapshots$, pair.published.snapshots$])),
-    switchMap(([draft, published]) => {
-      return checkUnpublishPermission({draft, published})
-    })
-  )
-}
-
-export function canDiscardDraft(document: Partial<SanityDocument>) {
-  const idPair = getIdPairFromPublished(document._id)
-  return snapshotPair(idPair).pipe(
-    mergeMap((pair) => pair.draft.snapshots$),
-    switchMap((draft) => grantsStore.checkDocumentPermission('update', draft))
-  )
-}
-
-function getIdPairFromPublished(documentId: string): IdPair {
-  return {publishedId: getPublishedId(documentId), draftId: getDraftId(documentId)}
 }

--- a/packages/@sanity/base/src/datastores/grants/hooks.ts
+++ b/packages/@sanity/base/src/datastores/grants/hooks.ts
@@ -5,12 +5,15 @@ import shallowEquals from 'shallow-equals'
 import {pipe} from 'rxjs'
 import {useObservable, useAsObservable, useMemoObservable} from 'react-rx'
 import {
+  // eslint-disable-next-line camelcase
   canCreateType as old_canCreateType,
   canCreateAnyOf,
   canDelete,
   canDiscardDraft,
+  // eslint-disable-next-line camelcase
   canPublish as old_canPublish,
   canUnpublish,
+  // eslint-disable-next-line camelcase
   canUpdate as old_canUpdate,
 } from './highlevel'
 

--- a/packages/@sanity/base/src/datastores/grants/hooks.ts
+++ b/packages/@sanity/base/src/datastores/grants/hooks.ts
@@ -5,23 +5,16 @@ import shallowEquals from 'shallow-equals'
 import {pipe} from 'rxjs'
 import {useObservable, useAsObservable, useMemoObservable} from 'react-rx'
 import {
-  canCreateType,
+  canCreateType as old_canCreateType,
   canCreateAnyOf,
   canDelete,
   canDiscardDraft,
-  canPublish,
+  canPublish as old_canPublish,
   canUnpublish,
-  canUpdate,
+  canUpdate as old_canUpdate,
 } from './highlevel'
 
-import {
-  canCreateType as canCreateType2,
-  canDelete as canDelete2,
-  canDiscardDraft as canDiscardDraft2,
-  canPublish as canPublish2,
-  canUnpublish as canUnpublish2,
-  canUpdate as canUpdate2,
-} from './documentPair'
+import {canCreateType, canPublish, canUpdate} from './documentPair'
 
 const INITIAL = {granted: true, reason: '<pending>'}
 
@@ -41,29 +34,22 @@ export function unstable_useCanCreateAnyOf(typeNames: string[]) {
     INITIAL
   )
 }
-// eslint-disable-next-line camelcase
-export function useCheckDocumentPermission_temp(
+
+// this is the new hook to check for permissions. It only needs the document and does not resolve the initial value templates
+export function useCheckDocumentPermissions(
   document: Partial<SanityDocument>,
   permission: 'update' | 'create' | 'delete' | 'publish' | 'unpublish' | 'discardDraft'
 ) {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   return useMemoObservable(() => {
     if (permission === 'update') {
-      return canUpdate2(document)
+      return canUpdate(document)
     }
     if (permission === 'create') {
-      return canCreateType2(document)
+      return canCreateType(document)
     }
     if (permission === 'publish') {
-      return canPublish2(document)
-    }
-    if (permission === 'delete') {
-      return canDelete2(document)
-    }
-    if (permission === 'unpublish') {
-      return canUnpublish2(document)
-    }
-    if (permission === 'discardDraft') {
-      return canDiscardDraft2(document)
+      return canPublish(document)
     }
     throw new Error(`Unknown permission: "${permission}"`)
   }, [document, permission])
@@ -86,13 +72,13 @@ export function unstable_useCheckDocumentPermission(
         // eslint-disable-next-line @typescript-eslint/no-shadow
         switchMap(([id, type, permission]) => {
           if (permission === 'update') {
-            return canUpdate(id, type)
+            return old_canUpdate(id, type)
           }
           if (permission === 'create') {
-            return canCreateType(id, type)
+            return old_canCreateType(id, type)
           }
           if (permission === 'publish') {
-            return canPublish(id, type)
+            return old_canPublish(id, type)
           }
           if (permission === 'delete') {
             return canDelete(id, type)

--- a/packages/@sanity/base/src/datastores/grants/hooks.ts
+++ b/packages/@sanity/base/src/datastores/grants/hooks.ts
@@ -1,8 +1,9 @@
 import {debounceTime, distinctUntilChanged, switchMap} from 'rxjs/operators'
 
+import {SanityDocument} from '@sanity/types'
 import shallowEquals from 'shallow-equals'
 import {pipe} from 'rxjs'
-import {useObservable, useAsObservable} from 'react-rx'
+import {useObservable, useAsObservable, useMemoObservable} from 'react-rx'
 import {
   canCreateType,
   canCreateAnyOf,
@@ -12,6 +13,15 @@ import {
   canUnpublish,
   canUpdate,
 } from './highlevel'
+
+import {
+  canCreateType as canCreateType2,
+  canDelete as canDelete2,
+  canDiscardDraft as canDiscardDraft2,
+  canPublish as canPublish2,
+  canUnpublish as canUnpublish2,
+  canUpdate as canUpdate2,
+} from './documentPair'
 
 const INITIAL = {granted: true, reason: '<pending>'}
 
@@ -30,6 +40,33 @@ export function unstable_useCanCreateAnyOf(typeNames: string[]) {
     ),
     INITIAL
   )
+}
+// eslint-disable-next-line camelcase
+export function useCheckDocumentPermission_temp(
+  document: Partial<SanityDocument>,
+  permission: 'update' | 'create' | 'delete' | 'publish' | 'unpublish' | 'discardDraft'
+) {
+  return useMemoObservable(() => {
+    if (permission === 'update') {
+      return canUpdate2(document)
+    }
+    if (permission === 'create') {
+      return canCreateType2(document)
+    }
+    if (permission === 'publish') {
+      return canPublish2(document)
+    }
+    if (permission === 'delete') {
+      return canDelete2(document)
+    }
+    if (permission === 'unpublish') {
+      return canUnpublish2(document)
+    }
+    if (permission === 'discardDraft') {
+      return canDiscardDraft2(document)
+    }
+    throw new Error(`Unknown permission: "${permission}"`)
+  }, [document, permission])
 }
 
 // eslint-disable-next-line camelcase

--- a/packages/@sanity/desk-tool/src/actions/DuplicateAction.tsx
+++ b/packages/@sanity/desk-tool/src/actions/DuplicateAction.tsx
@@ -4,12 +4,7 @@ import {uuid} from '@sanity/uuid'
 import {useDocumentOperation} from '@sanity/react-hooks'
 import {useRouter} from '@sanity/base/router'
 import React, {useCallback, useMemo, useState} from 'react'
-import {
-  unstable_useCheckDocumentPermission as useCheckDocumentPermission,
-  useCurrentUser,
-  // eslint-disable-next-line camelcase
-  useCheckDocumentPermission_temp,
-} from '@sanity/base/hooks'
+import {useCurrentUser, useCheckDocumentPermissions} from '@sanity/base/hooks'
 import {InsufficientPermissionsMessage} from '@sanity/base/components'
 
 const DISABLED_REASON_TITLE = {
@@ -27,7 +22,7 @@ export const DuplicateAction: DocumentActionComponent = ({
   const router = useRouter()
   const [isDuplicating, setDuplicating] = useState(false)
   const emptyDoc = useMemo(() => ({_id: 'dummy-id', _type: type}), [type])
-  const createPermission = useCheckDocumentPermission_temp(draft || published || emptyDoc, 'create')
+  const createPermission = useCheckDocumentPermissions(draft || published || emptyDoc, 'create')
 
   const {value: currentUser} = useCurrentUser()
 

--- a/packages/@sanity/desk-tool/src/actions/PublishAction.tsx
+++ b/packages/@sanity/desk-tool/src/actions/PublishAction.tsx
@@ -1,9 +1,10 @@
 import {DocumentActionComponent} from '@sanity/base'
 import {useSyncState, useDocumentOperation, useValidationStatus} from '@sanity/react-hooks'
 import {CheckmarkIcon, PublishIcon} from '@sanity/icons'
-import React, {useCallback, useEffect, useState} from 'react'
+import React, {useCallback, useEffect, useMemo, useState} from 'react'
 import {
-  unstable_useCheckDocumentPermission as useCheckDocumentPermission,
+  // eslint-disable-next-line camelcase
+  useCheckDocumentPermission_temp,
   useCurrentUser,
 } from '@sanity/base/hooks'
 import {InsufficientPermissionsMessage} from '@sanity/base/components'
@@ -44,7 +45,12 @@ export const PublishAction: DocumentActionComponent = (props) => {
   // we use this to "schedule" publish after pending tasks (e.g. validation and sync) has completed
   const [publishScheduled, setPublishScheduled] = useState<boolean>(false)
   const isNeitherSyncingNorValidating = !syncState.isSyncing && !validationStatus.isValidating
-  const publishPermission = useCheckDocumentPermission(id, type, 'publish')
+  const emptyDoc = useMemo(() => ({_id: id, _type: type}), [id, type])
+  const publishPermission = useCheckDocumentPermission_temp(
+    draft || published || emptyDoc,
+    'publish'
+  )
+
   const {value: currentUser} = useCurrentUser()
 
   // eslint-disable-next-line no-nested-ternary
@@ -105,7 +111,7 @@ export const PublishAction: DocumentActionComponent = (props) => {
     }
   }
 
-  if (!publishPermission.granted) {
+  if (!publishPermission?.granted) {
     return {
       color: 'success',
       label: 'Publish',

--- a/packages/@sanity/desk-tool/src/actions/PublishAction.tsx
+++ b/packages/@sanity/desk-tool/src/actions/PublishAction.tsx
@@ -2,11 +2,7 @@ import {DocumentActionComponent} from '@sanity/base'
 import {useSyncState, useDocumentOperation, useValidationStatus} from '@sanity/react-hooks'
 import {CheckmarkIcon, PublishIcon} from '@sanity/icons'
 import React, {useCallback, useEffect, useMemo, useState} from 'react'
-import {
-  // eslint-disable-next-line camelcase
-  useCheckDocumentPermission_temp,
-  useCurrentUser,
-} from '@sanity/base/hooks'
+import {useCurrentUser, useCheckDocumentPermissions} from '@sanity/base/hooks'
 import {InsufficientPermissionsMessage} from '@sanity/base/components'
 import {TimeAgo} from '../components/TimeAgo'
 import {useDocumentPane} from '../panes/document/useDocumentPane'
@@ -46,10 +42,7 @@ export const PublishAction: DocumentActionComponent = (props) => {
   const [publishScheduled, setPublishScheduled] = useState<boolean>(false)
   const isNeitherSyncingNorValidating = !syncState.isSyncing && !validationStatus.isValidating
   const emptyDoc = useMemo(() => ({_id: id, _type: type}), [id, type])
-  const publishPermission = useCheckDocumentPermission_temp(
-    draft || published || emptyDoc,
-    'publish'
-  )
+  const publishPermission = useCheckDocumentPermissions(draft || published || emptyDoc, 'publish')
 
   const {value: currentUser} = useCurrentUser()
 

--- a/packages/@sanity/desk-tool/src/panes/document/DocumentPaneProvider.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/DocumentPaneProvider.tsx
@@ -3,11 +3,7 @@
 
 import React, {useCallback, useEffect, useMemo, useState} from 'react'
 import {Path, SanityDocument} from '@sanity/types'
-import {
-  unstable_useCheckDocumentPermission as useCheckDocumentPermission,
-  // eslint-disable-next-line camelcase
-  useCheckDocumentPermission_temp,
-} from '@sanity/base/hooks'
+import {useCheckDocumentPermissions} from '@sanity/base/hooks'
 import {
   useConnectionState,
   useDocumentOperation,
@@ -108,9 +104,8 @@ export const DocumentPaneProvider = function DocumentPaneProvider(
     previewUrl,
   ])
   const requiredPermission = value?._createdAt ? 'update' : 'create'
-  const permission_old = useCheckDocumentPermission(documentId, documentType, requiredPermission)
 
-  const permission = useCheckDocumentPermission_temp(value, requiredPermission)
+  const permission = useCheckDocumentPermissions(value, requiredPermission)
 
   const inspectOpen = params.inspect === 'on'
   const compareValue: Partial<SanityDocument> | null = changesOpen

--- a/packages/@sanity/desk-tool/src/panes/document/DocumentPaneProvider.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/DocumentPaneProvider.tsx
@@ -3,7 +3,11 @@
 
 import React, {useCallback, useEffect, useMemo, useState} from 'react'
 import {Path, SanityDocument} from '@sanity/types'
-import {unstable_useCheckDocumentPermission as useCheckDocumentPermission} from '@sanity/base/hooks'
+import {
+  unstable_useCheckDocumentPermission as useCheckDocumentPermission,
+  // eslint-disable-next-line camelcase
+  useCheckDocumentPermission_temp,
+} from '@sanity/base/hooks'
 import {
   useConnectionState,
   useDocumentOperation,
@@ -105,6 +109,10 @@ export const DocumentPaneProvider = function DocumentPaneProvider(
   ])
   const requiredPermission = value?._createdAt ? 'update' : 'create'
   const permission = useCheckDocumentPermission(documentId, documentType, requiredPermission)
+
+  const permission2 = useCheckDocumentPermission_temp(value, requiredPermission)
+  console.log(permission2)
+
   const inspectOpen = params.inspect === 'on'
   const compareValue: Partial<SanityDocument> | null = changesOpen
     ? historyController.sinceAttributes()

--- a/packages/@sanity/desk-tool/src/panes/document/DocumentPaneProvider.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/DocumentPaneProvider.tsx
@@ -108,10 +108,9 @@ export const DocumentPaneProvider = function DocumentPaneProvider(
     previewUrl,
   ])
   const requiredPermission = value?._createdAt ? 'update' : 'create'
-  const permission = useCheckDocumentPermission(documentId, documentType, requiredPermission)
+  const permission_old = useCheckDocumentPermission(documentId, documentType, requiredPermission)
 
-  const permission2 = useCheckDocumentPermission_temp(value, requiredPermission)
-  console.log(permission2)
+  const permission = useCheckDocumentPermission_temp(value, requiredPermission)
 
   const inspectOpen = params.inspect === 'on'
   const compareValue: Partial<SanityDocument> | null = changesOpen

--- a/packages/@sanity/desk-tool/src/panes/document/documentPanel/PermissionCheckBanner.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/documentPanel/PermissionCheckBanner.tsx
@@ -24,7 +24,7 @@ export function PermissionCheckBanner() {
   if (permission.granted) return null
 
   return (
-    <Root shadow={1} tone="transparent">
+    <Root data-testid="permission-check-banner" shadow={1} tone="transparent">
       <Container paddingX={4} paddingY={3} sizing="border" width={1}>
         <Flex align="flex-start">
           <Text size={1}>

--- a/packages/@sanity/desk-tool/src/panes/document/documentPanel/PermissionCheckBanner.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/documentPanel/PermissionCheckBanner.tsx
@@ -20,6 +20,7 @@ export function PermissionCheckBanner() {
     ', '
   )
 
+  if (!permission) return null
   if (permission.granted) return null
 
   return (

--- a/packages/@sanity/desk-tool/src/panes/document/statusBar/ActionMenuButton.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/statusBar/ActionMenuButton.tsx
@@ -111,7 +111,7 @@ function ActionMenuListItem(props: ActionMenuListItemProps) {
 
   return (
     <MenuItem
-      data-testid={`action-${actionState.label}`}
+      data-testid={`action-${actionState.label.replace(' ', '')}`}
       disabled={disabled || Boolean(actionState.disabled)}
       onClick={handleClick}
       padding={0}

--- a/packages/@sanity/desk-tool/src/panes/document/statusBar/ActionMenuButton.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/statusBar/ActionMenuButton.tsx
@@ -52,6 +52,7 @@ export function ActionMenuButton(props: ActionMenuButtonProps) {
         id={`${idPrefix}-action-menu`}
         button={
           <Button
+            data-testid="action-menu-button"
             aria-label="Open document actions"
             disabled={disabled}
             icon={ChevronDownIcon}
@@ -110,6 +111,7 @@ function ActionMenuListItem(props: ActionMenuListItemProps) {
 
   return (
     <MenuItem
+      data-testid={`action-${actionState.label}`}
       disabled={disabled || Boolean(actionState.disabled)}
       onClick={handleClick}
       padding={0}

--- a/packages/@sanity/desk-tool/src/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -48,6 +48,7 @@ function DocumentStatusBarActionsInner(props: DocumentStatusBarActionsInnerProps
           <Tooltip disabled={!tooltipContent} content={tooltipContent} portal placement="top">
             <Stack flex={1}>
               <Button
+                data-testid={`action-${firstActionState.label}`}
                 disabled={disabled || Boolean(firstActionState.disabled)}
                 icon={firstActionState.icon}
                 // eslint-disable-next-line react/jsx-handler-names

--- a/packages/@sanity/desk-tool/src/panes/documentList/CreateMenuButton.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentList/CreateMenuButton.tsx
@@ -15,7 +15,14 @@ export function CreateMenuButton(props: {items: PaneMenuItem[]}) {
 
   return (
     <MenuButton
-      button={<Button icon={ComposeIcon} mode="bleed" padding={3} />}
+      button={
+        <Button
+          data-testid="multi-action-intent-button"
+          icon={ComposeIcon}
+          mode="bleed"
+          padding={3}
+        />
+      }
       id="create-menu"
       menu={
         <Menu>
@@ -24,6 +31,7 @@ export function CreateMenuButton(props: {items: PaneMenuItem[]}) {
           </Box>
           {items.map((createItem, createItemIndex) => (
             <IntentMenuItem
+              data-testid={`action-intent-button-${createItemIndex}`}
               icon={createItem.icon}
               intent={createItem.intent!}
               key={createItemIndex}

--- a/packages/@sanity/desk-tool/src/panes/documentList/DocumentListPaneHeader.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentList/DocumentListPaneHeader.tsx
@@ -146,6 +146,7 @@ export function DocumentListPaneHeader(props: {
             placement="bottom"
           >
             <IntentButton
+              data-testid="action-intent-button"
               aria-label={String(action.title)}
               icon={action.icon || UnknownIcon}
               intent={action.intent}


### PR DESCRIPTION
### Description

As part of a list of bugs regarding roles, it became clear that we would need to refactor our permission calls to not only having to rely on the roles of the user but also on the initialValues from the documents and schema. This was detected when a user with permissions only based on document properties (`requiresApproval`) were not returning the right permissions. 

To reduce the scope of this task, only a few methods were refactored (where the initialValues are not resolved in the `documentPair` (new) / `highlevel` (old) methods). The plan is to eventually move all of the methods to the new `documentPair` file. But for now, to keep this scope small and the potential impact reduced, only the needed methods were replaced: 

- `create` call in the `desk-tool`
- `update` call in the `desk-tool`
- `publish` call in the `PublishAction`
- `duplicate` call in the `DuplicateAction`

All other calls are using the old calls.
The `create` call outside of the `desk-tool` (in the NavBar) will be updated in a different pr.

### What to review

Check the use cases in the tests.

#### Update
- [x] as an administrator user, the permission banner will not be visible (has permissions)
- [x] as a restricted user, the permission banner will be visible (does not have permission)
- [x] as a requiresApproval user, the permission banner will be not visible (does have permission) when updating approved published documents
- [x] as a requiresApproval user, the permission banner will be visible (does not have permission) on non-approved published documents
- [x] as a requiresApproval user, the permission banner will be not visible (does have permission) when updating draft documents

#### Create
- [x] as an administrator user, the permission banner will not be visible (has permissions)
- [x] as a requiresApproval user, the permission banner will be not visible (does have permission) on specific document types

#### Publish
- [x] as an administrator user, the publish button will be active
- [x] as an restricted user, the publish button will be disabled
- [x] as a requiresApproval user on an approved published document, the publish button will be active
- [x] as a requiresApproval user on a non-approved document, the publish button will be disabled

#### Duplicate
- [x] as an administrator user, the duplicate button will be active
- [x] as an restricted user, the duplicate button will be disabled
- [x] as a requiresApproval user on an approved published document, the duplicate button will be active
- [x] as a requiresApproval user on a non-approved document, the duplicate button will be disabled

Also added tests for the permissions that haven't been changed (as a safety net for next time)
- `Delete`
- `Unpublish`
- `DiscardDraft`


### Notes for release

Fix roles permissions on document based on document permissions
