### PR TITLE
fix(vision): fix min and max pane sizes so controls or results is never cut off

### DIFF
--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -20,6 +20,7 @@
     "admin"
   ],
   "dependencies": {
+    "@juggle/resize-observer": "^3.3.1",
     "@sanity/icons": "^1.2.1",
     "@sanity/ui": "^0.37.2",
     "classnames": "^2.2.5",

--- a/packages/@sanity/vision/src/components/ParamsEditor.styled.js
+++ b/packages/@sanity/vision/src/components/ParamsEditor.styled.js
@@ -34,6 +34,7 @@ export const ReactCodeMirror = styled(BaseReactCodeMirror)`
     bottom: 0;
     left: 0;
     width: 100%;
+    pointer-events: none;
   }
 
   .CodeMirror-sizer {

--- a/packages/@sanity/vision/src/components/ResultView.styled.js
+++ b/packages/@sanity/vision/src/components/ResultView.styled.js
@@ -2,6 +2,14 @@ import styled from 'styled-components'
 import {rem} from '@sanity/ui'
 
 export const ReactJsonViewContainer = styled.div`
+  padding-bottom: ${({theme}) =>
+    rem(
+      theme.sanity.space[3] * 2 +
+        theme.sanity.fonts.text.sizes[2].lineHeight -
+        theme.sanity.fonts.text.sizes[2].ascenderHeight -
+        theme.sanity.fonts.text.sizes[2].descenderHeight
+    )};
+
   .react-json-view {
     font-family: ${({theme}) => theme.sanity.fonts.code.family} !important;
     font-size: ${({theme}) => rem(theme.sanity.fonts.code.sizes[1].fontSize)} !important;

--- a/packages/@sanity/vision/src/components/VisionGui.js
+++ b/packages/@sanity/vision/src/components/VisionGui.js
@@ -509,9 +509,15 @@ class VisionGui extends React.PureComponent {
           </Grid>
         </Header>
         <SplitpaneContainer flex={1}>
-          <SplitPane split="vertical" minSize={150} defaultSize={400}>
+          <SplitPane split="vertical" minSize={280} defaultSize={400} maxSize={-400}>
             <Box height="stretch" flex={1}>
-              <SplitPane split="horizontal" defaultSize={'50%'}>
+              <SplitPane
+                split="horizontal"
+                defaultSize={'50%'}
+                minSize={160}
+                maxSize={-300}
+                primary="second"
+              >
                 <InputContainer display="flex" ref={this._queryEditorContainer}>
                   <Card flex={1}>
                     <InputBackgroundContainerLeft>

--- a/packages/@sanity/vision/src/components/VisionGui.js
+++ b/packages/@sanity/vision/src/components/VisionGui.js
@@ -5,19 +5,7 @@ import queryString from 'query-string'
 import SplitPane from 'react-split-pane'
 import {PlayIcon, StopIcon, CopyIcon} from '@sanity/icons'
 import isHotkey from 'is-hotkey'
-import {
-  Flex,
-  Card,
-  Stack,
-  Box,
-  Hotkeys,
-  Label,
-  Select,
-  Text,
-  TextInput,
-  Tooltip,
-  Grid,
-} from '@sanity/ui'
+import {Flex, Card, Stack, Box, Hotkeys, Select, Text, TextInput, Tooltip, Grid} from '@sanity/ui'
 import studioClient from 'part:@sanity/base/client'
 import {FormFieldValidationStatus} from '@sanity/base/components'
 import {storeState, getState} from '../util/localState'
@@ -39,6 +27,7 @@ import {
   InputBackgroundContainer,
   InputBackgroundContainerLeft,
   InputContainer,
+  StyledLabel,
   ResultOuterContainer,
   ResultInnerContainer,
   ResultContainer,
@@ -437,7 +426,7 @@ class VisionGui extends React.PureComponent {
             <Box padding={1} column={2}>
               <Stack>
                 <Card paddingY={2}>
-                  <Label>Dataset</Label>
+                  <StyledLabel>Dataset</StyledLabel>
                 </Card>
                 <Select value={dataset} onChange={this.handleChangeDataset}>
                   {datasets.map((ds) => (
@@ -451,7 +440,7 @@ class VisionGui extends React.PureComponent {
             <Box padding={1} column={2}>
               <Stack>
                 <Card paddingY={2}>
-                  <Label>API version</Label>
+                  <StyledLabel>API version</StyledLabel>
                 </Card>
                 <Select
                   value={customApiVersion ? 'other' : apiVersion}
@@ -472,7 +461,7 @@ class VisionGui extends React.PureComponent {
               <Box padding={1} column={2}>
                 <Stack>
                   <Card paddingY={2}>
-                    <Label>Custom API version</Label>
+                    <StyledLabel>Custom API version</StyledLabel>
                   </Card>
 
                   <TextInput
@@ -489,10 +478,10 @@ class VisionGui extends React.PureComponent {
               <Box padding={1} flex={1} column={customApiVersion ? 6 : 8}>
                 <Stack>
                   <Card paddingY={2}>
-                    <Label>
+                    <StyledLabel>
                       Query URL&nbsp;
                       <QueryCopyLink onClick={handleCopyUrl}>[copy]</QueryCopyLink>
-                    </Label>
+                    </StyledLabel>
                   </Card>
                   <TextInput
                     readOnly
@@ -522,7 +511,7 @@ class VisionGui extends React.PureComponent {
                   <Card flex={1}>
                     <InputBackgroundContainerLeft>
                       <Flex marginLeft={3}>
-                        <Label muted>Query</Label>
+                        <StyledLabel muted>Query</StyledLabel>
                       </Flex>
                     </InputBackgroundContainerLeft>
                     <QueryEditor
@@ -537,7 +526,7 @@ class VisionGui extends React.PureComponent {
                   <Card flex={1} tone={validParams ? 'default' : 'critical'}>
                     <InputBackgroundContainerLeft>
                       <Flex marginLeft={3}>
-                        <Label muted>Params</Label>
+                        <StyledLabel muted>Params</StyledLabel>
                         {paramValidationMarkers.length > 0 && (
                           <Box marginLeft={2}>
                             <FormFieldValidationStatus
@@ -619,7 +608,7 @@ class VisionGui extends React.PureComponent {
                   <Result padding={3} paddingTop={5} overflow="auto" $isInvalid={error}>
                     <InputBackgroundContainer>
                       <Box marginLeft={3}>
-                        <Label muted>Result</Label>
+                        <StyledLabel muted>Result</StyledLabel>
                       </Box>
                     </InputBackgroundContainer>
                     {queryInProgress && (

--- a/packages/@sanity/vision/src/components/VisionGui.js
+++ b/packages/@sanity/vision/src/components/VisionGui.js
@@ -463,7 +463,7 @@ class VisionGui extends React.PureComponent {
       >
         <GlobalCodeMirrorStyle />
         <Header paddingX={3} paddingY={2}>
-          <Grid columns={12}>
+          <Grid columns={[6, 6, 12]}>
             {/* Dataset selector */}
             <Box padding={1} column={2}>
               <Stack>

--- a/packages/@sanity/vision/src/components/VisionGui.styled.js
+++ b/packages/@sanity/vision/src/components/VisionGui.styled.js
@@ -91,6 +91,8 @@ export const Header = styled(Card)`
   border-bottom: 1px solid var(--card-border-color);
 `
 
+export const StyledLabel = styled(Label)``
+
 export const SplitpaneContainer = styled(Box)`
   position: relative;
 `
@@ -109,7 +111,7 @@ export const InputBackgroundContainer = styled(Box)`
   z-index: 10;
   right: 0;
 
-  ${Label} {
+  ${StyledLabel} {
     user-select: none;
   }
 `

--- a/packages/@sanity/vision/src/components/VisionGui.styled.js
+++ b/packages/@sanity/vision/src/components/VisionGui.styled.js
@@ -9,6 +9,10 @@ export const Root = styled(Card)`
   height: 100%;
   flex-direction: column;
 
+  .sidebarPanes .Pane {
+    overflow: auto;
+  }
+
   .Resizer {
     background: var(--card-border-color);
     opacity: 1;

--- a/packages/@sanity/vision/src/util/resizeObserver.js
+++ b/packages/@sanity/vision/src/util/resizeObserver.js
@@ -1,0 +1,5 @@
+import {ResizeObserver as ResizeObserverPolyfill} from '@juggle/resize-observer'
+
+export const RO = window.ResizeObserver || ResizeObserverPolyfill
+
+export {RO as ResizeObserver}


### PR DESCRIPTION
### Description

This improves the pane resizing by setting better min/max boundaries for all panes (current version of library doesn't support percentages).

It also fixes a padding issue that prevented users from getting to the bottom of results.

### Video that shows the new behaviour

https://user-images.githubusercontent.com/10508/150348812-7b88d6b5-0745-46aa-9b17-a879bedf1c0a.mp4

**Results**
![image](https://user-images.githubusercontent.com/10508/140726883-f008a4f3-d8b5-4e2f-9073-bc2203f145cd.png)


### What to review

- That panes resizes well
- That min and max size for panes looks good
- That results bottom is not cut off
- That disabling resize when container is lower than 550px behaves fine

### Notes for release

- Improves the panes in Vision so controls or result never is cut off when there isn't enough room
