### PR TITLE
chore(deps): upgrade dependencies

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -66,7 +66,7 @@
     "minimist": "^1.2.0",
     "neat-stack": "^1.0.1",
     "opn": "^5.2.0",
-    "ora": "^2.1.0",
+    "ora": "^5.4.1",
     "osenv": "^0.1.4",
     "p-timeout": "^2.0.1",
     "promise-props-recursive": "^1.0.0",

--- a/packages/@sanity/import-cli/package.json
+++ b/packages/@sanity/import-cli/package.json
@@ -28,7 +28,7 @@
     "@sanity/client": "2.21.7",
     "@sanity/import": "2.21.7",
     "meow": "^9.0.0",
-    "ora": "^2.1.0",
+    "ora": "^5.4.1",
     "pretty-ms": "^7.0.1",
     "simple-get": "^4.0.0"
   },

--- a/packages/@sanity/server/package.json
+++ b/packages/@sanity/server/package.json
@@ -64,7 +64,7 @@
     "resolve": "^1.3.3",
     "resolve-from": "^4.0.0",
     "rxjs": "^6.5.3",
-    "strip-ansi": "^5.2.0",
+    "strip-ansi": "^6.0.1",
     "style-loader": "^0.20.1",
     "symbol-observable": "^1.2.0",
     "webpack": "^3.8.1",


### PR DESCRIPTION
### Description

- Upgrades ora and strip-ansi to latest non-esm versions to fix security vulnerabilities

Supersedes #2766 and #2767

### What to review

That the code runs and works as expected.

`ora` is used in the CLI for all spinners, and `strip-ansi` is used for hot module reloading in development mode of the server.

### Notes for release

None, transparent to the end-user.
