### PR TITLE
docs(core): fix typo in help text and error message

### DIFF
--- a/packages/@sanity/core/src/commands/documents/queryDocumentsCommand.ts
+++ b/packages/@sanity/core/src/commands/documents/queryDocumentsCommand.ts
@@ -7,7 +7,7 @@ Run a query against the projects configured dataset
 Options
   --pretty colorized JSON output
   --dataset NAME to override dataset
-  --api-version API version to use (defaults to \`v1\`)
+  --apiVersion API version to use (defaults to \`v1\`)
 
 Examples
   # Fetch 5 documents of type "movie"
@@ -45,7 +45,7 @@ export default {
     }
 
     if (!apiVersion) {
-      output.warn(chalk.yellow('--api-version not specified, using `v1`'))
+      output.warn(chalk.yellow('--apiVersion not specified, using `v1`'))
     }
 
     const baseClient = apiClient().clone()

--- a/packages/@sanity/core/src/commands/documents/queryDocumentsCommand.ts
+++ b/packages/@sanity/core/src/commands/documents/queryDocumentsCommand.ts
@@ -1,3 +1,5 @@
+import yargs from 'yargs/yargs'
+import {hideBin} from 'yargs/helpers'
 import colorizeJson from '../../util/colorizeJson'
 import type {CliCommandArguments, CliCommandContext} from '../../types'
 
@@ -7,7 +9,7 @@ Run a query against the projects configured dataset
 Options
   --pretty colorized JSON output
   --dataset NAME to override dataset
-  --apiVersion API version to use (defaults to \`v1\`)
+  --api-version API version to use (defaults to \`v1\`)
 
 Examples
   # Fetch 5 documents of type "movie"
@@ -36,8 +38,9 @@ export default {
     args: CliCommandArguments<CliQueryCommandFlags>,
     context: CliCommandContext
   ): Promise<void> => {
+    // Reparsing arguments for improved control of flags
+    const {pretty, dataset, 'api-version': apiVersion} = parseCliFlags(args)
     const {apiClient, output, chalk} = context
-    const {pretty, dataset, apiVersion} = args.extOptions
     const [query] = args.argsWithoutOptions
 
     if (!query) {
@@ -45,7 +48,7 @@ export default {
     }
 
     if (!apiVersion) {
-      output.warn(chalk.yellow('--apiVersion not specified, using `v1`'))
+      output.warn(chalk.yellow('--api-version not specified, using `v1`'))
     }
 
     const baseClient = apiClient().clone()
@@ -66,4 +69,11 @@ export default {
       throw new Error(`Failed to run query:\n${err.message}`)
     }
   },
+}
+
+function parseCliFlags(args: CliCommandArguments<CliQueryCommandFlags>) {
+  return yargs(hideBin(args.argv || process.argv).slice(2))
+    .option('pretty', {type: 'boolean', default: false})
+    .option('dataset', {type: 'string'})
+    .option('api-version', {type: 'string'}).argv
 }

--- a/packages/@sanity/core/src/commands/documents/queryDocumentsCommand.ts
+++ b/packages/@sanity/core/src/commands/documents/queryDocumentsCommand.ts
@@ -11,6 +11,10 @@ Options
   --dataset NAME to override dataset
   --api-version API version to use (defaults to \`v1\`)
 
+Environment variables
+  \`SANITY_CLI_QUERY_API_VERSION\` - will use the defined API version,
+  unless \`--api-version\` is specified.
+
 Examples
   # Fetch 5 documents of type "movie"
   sanity documents query '*[_type == "movie"][0..4]'
@@ -72,8 +76,10 @@ export default {
 }
 
 function parseCliFlags(args: CliCommandArguments<CliQueryCommandFlags>) {
+  // eslint-disable-next-line no-process-env
+  const defaultApiVersion = process.env.SANITY_CLI_QUERY_API_VERSION
   return yargs(hideBin(args.argv || process.argv).slice(2))
     .option('pretty', {type: 'boolean', default: false})
     .option('dataset', {type: 'string'})
-    .option('api-version', {type: 'string'}).argv
+    .option('api-version', {type: 'string', default: defaultApiVersion}).argv
 }

--- a/packages/@sanity/core/src/util/colorizeJson.js
+++ b/packages/@sanity/core/src/util/colorizeJson.js
@@ -10,8 +10,7 @@ const formatters = {
 }
 
 function colorize(input, chalk) {
-  const data = typeof input === 'string' ? JSON.parse(input) : input
-  const json = JSON.stringify(data, null, 2)
+  const json = JSON.stringify(input, null, 2)
 
   return tokenize(json)
     .map((token, i, arr) => {
@@ -27,7 +26,7 @@ function colorize(input, chalk) {
 
       return token
     })
-    .map((token, i) => {
+    .map((token) => {
       const formatter = chalk[formatters[token.type]] || identity
       return formatter(token.raw)
     })


### PR DESCRIPTION
### Description

`--api-version` didn't work because the code looks for `--apiVersion`. I also wonder if we shouldn't support setting it as an environment variable or something? Having the warning appear just because you didn't care to specify it, is pretty annoying.

### What to review

Check if
```sh
sanity documents query --apiVersion 2021-11-03 '*[]' 
```
works.

### Notes for release

Fixes help text and warning for `sanity documents query` when the API version isn't set