### PR TITLE
fix: intent resolver follow up

### DIFF
--- a/packages/@sanity/desk-tool/src/getIntentState.ts
+++ b/packages/@sanity/desk-tool/src/getIntentState.ts
@@ -40,8 +40,12 @@ export function getIntentState(
         index: i,
       }) ||
       // OR
-      // the pane is a documentList with a matching schemaTypeName
-      (pane.type === 'documentList' && pane.schemaTypeName === params.type)
+      // if the resolved pane is a document list
+      (pane.type === 'documentList' &&
+        // and the schema type matches
+        pane.schemaTypeName === params.type &&
+        // and the filter is the default filter
+        pane.options.filter === '_type == $type')
     ) {
       const paneParams = isTemplate ? {template: params.template} : EMPTY_PARAMS
 

--- a/packages/@sanity/desk-tool/src/getIntentState.ts
+++ b/packages/@sanity/desk-tool/src/getIntentState.ts
@@ -33,18 +33,16 @@ export function getIntentState(
 
     if (typeof pane !== 'object') continue
 
+    // NOTE: if you update this logic, please also update the similar handler in
+    // `resolveIntent.ts`
     if (
-      // if the pane can handle the intent
       pane.canHandleIntent?.(intentName, params, {
         pane,
         index: i,
       }) ||
-      // OR
-      // if the resolved pane is a document list
+      // see `resolveIntent.ts` for more info
       (pane.type === 'documentList' &&
-        // and the schema type matches
         pane.schemaTypeName === params.type &&
-        // and the filter is the default filter
         pane.options.filter === '_type == $type')
     ) {
       const paneParams = isTemplate ? {template: params.template} : EMPTY_PARAMS

--- a/packages/@sanity/desk-tool/src/utils/resolveIntent.test.ts
+++ b/packages/@sanity/desk-tool/src/utils/resolveIntent.test.ts
@@ -128,7 +128,7 @@ describe('resolveIntent', () => {
     ])
   })
 
-  it('returns the shallowest match (breadth first search)', async () => {
+  it('returns the shallowest match', async () => {
     const rootPaneNode = S.list()
       .title('Content')
       .items([

--- a/packages/@sanity/desk-tool/src/utils/resolveIntent.ts
+++ b/packages/@sanity/desk-tool/src/utils/resolveIntent.ts
@@ -117,8 +117,12 @@ export async function resolveIntent(options: ResolveIntentOptions): Promise<Rout
         [{id: targetId, params: otherParams, payload}],
       ]
     } else if (
-      // if the resolved pane is a document list and the schema type matches
-      (resolvedPane.type === 'documentList' && resolvedPane.schemaTypeName === schemaTypeName) ||
+      // if the resolved pane is a document list
+      (resolvedPane.type === 'documentList' &&
+        // and the schema type matches
+        resolvedPane.schemaTypeName === schemaTypeName &&
+        // and the filter is the default filter
+        resolvedPane.options.filter === '_type == $type') ||
       // OR
       // if the pane can handle the intent
       resolvedPane.canHandleIntent?.(intent, params, {


### PR DESCRIPTION
### Description

This is a small follow up to the new (unreleased as of now) intent resolver. This PR:

- limits default resolution to the default filter (e.g. `_type == $type`). This is to prevent false positive matches where the user may not want an intent match.
- refactors the breadth depth search into a concurrent search using `Promise.all` for structure that use promises

### What to review

See the changes to `resolveIntent.ts` and that all intents resolve as expected.

### Notes for release

N/A