### PR TITLE
fix(desk-tool): use `getDefaultDocumentNode` in fallback editor

### DIFF
--- a/packages/@sanity/desk-tool/src/defaultStructure.tsx
+++ b/packages/@sanity/desk-tool/src/defaultStructure.tsx
@@ -17,3 +17,5 @@ export function defaultStructure() {
 
   return pane
 }
+
+export const defaultDocument = Structure.defaultDocument

--- a/packages/@sanity/desk-tool/src/utils/resolvePanes.ts
+++ b/packages/@sanity/desk-tool/src/utils/resolvePanes.ts
@@ -24,7 +24,7 @@ import {
   StructureErrorType,
 } from '../types'
 import {LOADING_PANE} from '../constants'
-import {defaultStructure} from '../defaultStructure'
+import {defaultStructure, defaultDocument} from '../defaultStructure'
 import {isRecord, isSubscribable} from './typePredicates'
 import validateStructure from './validateStructure'
 import serializeStructure from './serializeStructure'
@@ -47,18 +47,21 @@ const fallbackEditorChild: FallbackEditorChild = (nodeId, _, {params, payload}) 
     )
   }
 
-  const documentPane: DocumentPaneNode = {
-    id: 'editor',
-    type: 'document',
-    title: 'Editor',
-    options: {
-      id,
+  let defaultDocumentBuilder = defaultDocument({
+    schemaType: type,
+    documentId: id,
+  })
+
+  defaultDocumentBuilder = defaultDocumentBuilder.id('editor').title('Editor')
+
+  if (template) {
+    defaultDocumentBuilder = defaultDocumentBuilder.initialValueTemplate(
       template,
-      type,
-      templateParameters: payload as Record<string, unknown>,
-    },
+      payload as {[key: string]: any}
+    )
   }
-  return documentPane
+
+  return defaultDocumentBuilder.serialize() as DocumentPaneNode
 }
 
 const KNOWN_STRUCTURE_EXPORTS = ['getDefaultDocumentNode']


### PR DESCRIPTION
### Description

This PR makes the fallback editor utilize `getDefaultDocumentNode` so that configured views in there will still show up when the intent can't be resolved.

### What to review

Implement getDefaultDocumentNode and then use an intent link that resolves to the fallback editor. Views configured there should be visible in the fallback editor now.

### Notes for release

- Fixes an issue where document views would not appear in certain cases when implementing `getDefaultDocumentNode`
