### PR TITLE
fix(form-builder): update tests for DST

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/DateInputs/__tests__/CommonDateTimeInput.test.tsx
+++ b/packages/@sanity/form-builder/src/inputs/DateInputs/__tests__/CommonDateTimeInput.test.tsx
@@ -66,7 +66,13 @@ function renderInput() {
 // Note: for the tests to be deterministic we need this to ensure tests are run in a predefined timezone
 // see globalSetup in jest config for details about how this is set up
 test('timezone for the test environment should be set to America/Los_Angeles', () => {
-  expect(new Date().getTimezoneOffset()).toBe(420)
+  const timezoneOffset = new Date().getTimezoneOffset()
+  expect(
+    // this is true during DST
+    timezoneOffset === 420 ||
+      // this is true with no DST
+      timezoneOffset === 480
+  ).toBe(true)
 })
 
 test('does not emit onChange after invalid value has been typed', () => {

--- a/packages/@sanity/form-builder/src/inputs/DateInputs/__tests__/CommonDateTimeInput.test.tsx
+++ b/packages/@sanity/form-builder/src/inputs/DateInputs/__tests__/CommonDateTimeInput.test.tsx
@@ -66,13 +66,7 @@ function renderInput() {
 // Note: for the tests to be deterministic we need this to ensure tests are run in a predefined timezone
 // see globalSetup in jest config for details about how this is set up
 test('timezone for the test environment should be set to America/Los_Angeles', () => {
-  const timezoneOffset = new Date().getTimezoneOffset()
-  expect(
-    // this is true during DST
-    timezoneOffset === 420 ||
-      // this is true with no DST
-      timezoneOffset === 480
-  ).toBe(true)
+  expect(Intl.DateTimeFormat().resolvedOptions().timeZone).toBe('America/Los_Angeles')
 })
 
 test('does not emit onChange after invalid value has been typed', () => {

--- a/packages/@sanity/form-builder/src/inputs/DateInputs/__tests__/DateInput.test.tsx
+++ b/packages/@sanity/form-builder/src/inputs/DateInputs/__tests__/DateInput.test.tsx
@@ -34,7 +34,13 @@ function renderInput(props: Partial<Props> = {}) {
 // Note: for the tests to be deterministic we need this to ensure tests are run in a predefined timezone
 // see globalSetup in jest config for details about how this is set up
 test('timezone for the test environment should be set to America/Los_Angeles', () => {
-  expect(new Date().getTimezoneOffset()).toBe(420)
+  const timezoneOffset = new Date().getTimezoneOffset()
+  expect(
+    // this is true during DST
+    timezoneOffset === 420 ||
+      // this is true with no DST
+      timezoneOffset === 480
+  ).toBe(true)
 })
 
 test('does not emit onChange after invalid value has been typed', () => {

--- a/packages/@sanity/form-builder/src/inputs/DateInputs/__tests__/DateInput.test.tsx
+++ b/packages/@sanity/form-builder/src/inputs/DateInputs/__tests__/DateInput.test.tsx
@@ -34,13 +34,7 @@ function renderInput(props: Partial<Props> = {}) {
 // Note: for the tests to be deterministic we need this to ensure tests are run in a predefined timezone
 // see globalSetup in jest config for details about how this is set up
 test('timezone for the test environment should be set to America/Los_Angeles', () => {
-  const timezoneOffset = new Date().getTimezoneOffset()
-  expect(
-    // this is true during DST
-    timezoneOffset === 420 ||
-      // this is true with no DST
-      timezoneOffset === 480
-  ).toBe(true)
+  expect(Intl.DateTimeFormat().resolvedOptions().timeZone).toBe('America/Los_Angeles')
 })
 
 test('does not emit onChange after invalid value has been typed', () => {

--- a/packages/@sanity/form-builder/src/inputs/DateInputs/__tests__/DateTimeInput.test.tsx
+++ b/packages/@sanity/form-builder/src/inputs/DateInputs/__tests__/DateTimeInput.test.tsx
@@ -35,7 +35,13 @@ function renderInput(props: Partial<Props> = {}) {
 // Note: for the tests to be deterministic we need this to ensure tests are run in a predefined timezone
 // see globalSetup in jest config for details about how this is set up
 test('timezone for the test environment should be set to America/Los_Angeles', () => {
-  expect(new Date().getTimezoneOffset()).toBe(420)
+  const timezoneOffset = new Date().getTimezoneOffset()
+  expect(
+    // this is true during DST
+    timezoneOffset === 420 ||
+      // this is true with no DST
+      timezoneOffset === 480
+  ).toBe(true)
 })
 
 test('does not emit onChange after invalid value has been typed', () => {

--- a/packages/@sanity/form-builder/src/inputs/DateInputs/__tests__/DateTimeInput.test.tsx
+++ b/packages/@sanity/form-builder/src/inputs/DateInputs/__tests__/DateTimeInput.test.tsx
@@ -35,13 +35,7 @@ function renderInput(props: Partial<Props> = {}) {
 // Note: for the tests to be deterministic we need this to ensure tests are run in a predefined timezone
 // see globalSetup in jest config for details about how this is set up
 test('timezone for the test environment should be set to America/Los_Angeles', () => {
-  const timezoneOffset = new Date().getTimezoneOffset()
-  expect(
-    // this is true during DST
-    timezoneOffset === 420 ||
-      // this is true with no DST
-      timezoneOffset === 480
-  ).toBe(true)
+  expect(Intl.DateTimeFormat().resolvedOptions().timeZone).toBe('America/Los_Angeles')
 })
 
 test('does not emit onChange after invalid value has been typed', () => {


### PR DESCRIPTION
### Description

Did you know that `getTimezoneOffset()` returns different things during DST? I did not. TIL lol

### What to review

Do the tests pass now?

### Notes for release

N/A
