### PR TITLE
feat(cli): allow plan selection through CLI flag

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.js
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.js
@@ -31,6 +31,7 @@ export default async function initSanity(args, context) {
   const unattended = cliFlags.y || cliFlags.yes
   const print = unattended ? noop : output.print
   const specifiedOutputPath = cliFlags['output-path']
+  const intendedPlan = cliFlags['project-plan']
   let reconfigure = cliFlags.reconfigure
   let defaultConfig = cliFlags['dataset-default']
   let showDefaultConfigPrompt = !defaultConfig
@@ -335,7 +336,10 @@ export default async function initSanity(args, context) {
     if (isUsersFirstProject) {
       debug('No projects found for user, prompting for name')
       const projectName = await prompt.single({message: 'Project name'})
-      return createProject(apiClient, {displayName: projectName}).then((response) => ({
+      return createProject(apiClient, {
+        displayName: projectName,
+        subscription: {planId: intendedPlan},
+      }).then((response) => ({
         ...response,
         isFirstProject: isUsersFirstProject,
       }))
@@ -365,6 +369,7 @@ export default async function initSanity(args, context) {
           message: 'Your project name:',
           default: 'My Sanity Project',
         }),
+        subscription: {planId: intendedPlan},
       }).then((response) => ({
         ...response,
         isFirstProject: isUsersFirstProject,
@@ -595,6 +600,7 @@ export default async function initSanity(args, context) {
       debug('--create-project specified, creating a new project')
       const createdProject = await createProject(apiClient, {
         displayName: createProjectName.trim(),
+        subscription: {planId: intendedPlan},
       })
       debug('Project with ID %s created', createdProject.projectId)
 

--- a/packages/@sanity/cli/src/commands/init/initCommand.js
+++ b/packages/@sanity/cli/src/commands/init/initCommand.js
@@ -11,6 +11,7 @@ Options
   --template <template> Project template to use [default: "clean"]
   --visibility <mode> Visibility mode for dataset (public/private)
   --create-project <name> Create a new project with the given name
+  --project-plan <name> Optionally select a plan for a new project
   --reconfigure Reconfigure Sanity studio in current folder with new project/dataset
 
 Examples


### PR DESCRIPTION
### Description

Updates the CLI to take in a parameter (`--project-plan`) to allow a user to choose a plan from the cli. If a plan is invalid (for whatever reason) it just blows up!

```
? Select project to use Create new project
? Your project name: will-definitely-fail

ClientError: Plan "not-a-plan" does not exist
    at onResponse (~/projects/sanity/sanity/packages/@sanity/client/lib/http/request.js:27:13)
    at applyMiddleware (~/projects/sanity/sanity/node_modules/get-it/lib-node/util/middlewareReducer.js:14:23)
    at onResponse (~/projects/sanity/sanity/node_modules/get-it/lib-node/index.js:81:22)
    at ~/projects/sanity/sanity/node_modules/get-it/lib-node/index.js:48:55
    at callback (~/projects/sanity/sanity/node_modules/get-it/lib-node/request/node-request.js:57:46)
    at ~/projects/sanity/sanity/node_modules/get-it/lib-node/request/node-request.js:141:14
    at DestroyableTransform.<anonymous> (~/projects/sanity/sanity/node_modules/simple-concat/index.js:8:13)
    at Object.onceWrapper (node:events:509:28)
    at DestroyableTransform.emit (node:events:402:35)
    at endReadableNT (~/projects/sanity/sanity/node_modules/readable-stream/lib/_stream_readable.js:1010:12)
```

### What to review

Test plan creation with valid ids such as the (current) default `free-2021-05-01`.

### Notes for release

Allow plan selection with `sanity init --project-plan xxxxx`
