### PR TITLE
fix(core): remove require.context in execScript

### DIFF
--- a/packages/@sanity/core/src/actions/exec/execScript.js
+++ b/packages/@sanity/core/src/actions/exec/execScript.js
@@ -32,12 +32,9 @@ module.exports = async function execScript(args, context) {
 
   const babel = require.resolve('./babel')
   const loader = require.resolve('./pluginLoader')
-  const requireContextPath = require.resolve('./requireContext')
   const browserEnvPath = require.resolve('./registerBrowserEnv')
   const configClientPath = require.resolve('./configClient')
-  const baseArgs = mockBrowserEnv
-    ? ['-r', browserEnvPath]
-    : ['-r', babel, '-r', loader, '-r', requireContextPath]
+  const baseArgs = mockBrowserEnv ? ['-r', browserEnvPath] : ['-r', babel, '-r', loader]
 
   const nodeArgs = baseArgs
     .concat(withUserToken ? ['-r', configClientPath] : [])

--- a/packages/@sanity/core/src/actions/exec/requireContext.js
+++ b/packages/@sanity/core/src/actions/exec/requireContext.js
@@ -1,3 +1,0 @@
-const requireContext = require('../../util/requireContext')
-
-requireContext.register()


### PR DESCRIPTION
### Description

I forgot to delete a thing! This should fix the `sanity exec` issue related to `require.context`.

Closes #2923 