### PR TITLE
fix(conditional-fields): resolve readOnly in changes panel

### DIFF
--- a/examples/test-studio/schema/debug/conditionalFields.js
+++ b/examples/test-studio/schema/debug/conditionalFields.js
@@ -2,7 +2,7 @@ export default {
   name: 'conditionalFieldsTest',
   type: 'document',
   title: 'Conditional fields',
-
+  readOnly: () => false,
   fields: [
     {
       name: 'title',
@@ -13,6 +13,7 @@ export default {
       name: 'isPublished',
       type: 'boolean',
       description: 'Is published?',
+      // readOnly: () => true,
     },
     {
       name: 'readOnlyIfTitleIsReadOnly',
@@ -30,6 +31,7 @@ export default {
       readOnly: ({document}) => {
         return Boolean(document.title && document.title.includes('read only'))
       },
+      hidden: () => false,
       fields: [
         {
           name: 'field1',
@@ -53,7 +55,7 @@ export default {
           name: 'hiddenIfPublished',
           type: 'string',
           description: 'This will be hidden if the document is published',
-          hidden: ({document}) => document.isPublished,
+          hidden: ({document}) => Boolean(document.isPublished),
         },
         {
           name: 'readOnlyIfPublished',
@@ -74,7 +76,7 @@ export default {
           name: 'field3',
           type: 'string',
           description: 'This will be hidden if its value becomes "hideme"',
-          hidden: ({value}) => value === 'hideme',
+          hidden: ({value}) => value === 'hid',
         },
       ],
     },

--- a/packages/@sanity/base/src/_exports/hooks.ts
+++ b/packages/@sanity/base/src/_exports/hooks.ts
@@ -11,4 +11,5 @@ export {useUserColor} from '../user-color/hooks'
 export {useTimeAgo} from '../time/useTimeAgo'
 export {useDocumentValues} from '../datastores/document/useDocumentValues'
 export {useModuleStatus} from '../module-status'
-export {useResolveConditionalProperty} from '../conditional-property'
+// eslint-disable-next-line camelcase
+export {unstable_useConditionalProperty} from '../conditional-property'

--- a/packages/@sanity/base/src/conditional-property/__tests__/useResolveConditionalProperty.test.tsx
+++ b/packages/@sanity/base/src/conditional-property/__tests__/useResolveConditionalProperty.test.tsx
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-unassigned-import
 import '@testing-library/jest-dom/extend-expect'
 import {renderHook} from '@testing-library/react-hooks'
-import {useResolveConditionalProperty} from '..'
+import {unstable_useConditionalProperty as useConditionalProperty} from '..'
 
 /* 
   @TODO
@@ -33,7 +33,7 @@ const callbackFn = jest.fn(() => true)
 describe('Conditional property resolver', () => {
   it('calls callback function', () => {
     renderHook(() =>
-      useResolveConditionalProperty({
+      useConditionalProperty({
         checkProperty: callbackFn,
         ...DEFAULT_PROPS,
       })
@@ -63,7 +63,7 @@ describe('Conditional property resolver', () => {
 
   it('resolves callback to true', () => {
     const {result} = renderHook(() =>
-      useResolveConditionalProperty({
+      useConditionalProperty({
         // eslint-disable-next-line max-nested-callbacks
         checkProperty: jest.fn(() => true),
         ...DEFAULT_PROPS,
@@ -74,7 +74,7 @@ describe('Conditional property resolver', () => {
 
   it('returns false with callback that returns false', () => {
     const {result} = renderHook(() =>
-      useResolveConditionalProperty({
+      useConditionalProperty({
         // eslint-disable-next-line max-nested-callbacks
         checkProperty: jest.fn(() => false),
         ...DEFAULT_PROPS,
@@ -85,7 +85,7 @@ describe('Conditional property resolver', () => {
 
   it('returns false if document title does not match', () => {
     const {result} = renderHook(() =>
-      useResolveConditionalProperty({
+      useConditionalProperty({
         // eslint-disable-next-line max-nested-callbacks
         checkProperty: jest.fn(({document}) => document?.title !== 'Hello world'),
         ...DEFAULT_PROPS,
@@ -96,7 +96,7 @@ describe('Conditional property resolver', () => {
 
   it('returns true if document is published', () => {
     const {result} = renderHook(() =>
-      useResolveConditionalProperty({
+      useConditionalProperty({
         // eslint-disable-next-line max-nested-callbacks
         checkProperty: jest.fn(({document}) => Boolean(document?.isPublished)),
         ...DEFAULT_PROPS,
@@ -107,7 +107,7 @@ describe('Conditional property resolver', () => {
 
   it('returns undefined because callback returns undefined', () => {
     const {result} = renderHook(() =>
-      useResolveConditionalProperty({
+      useConditionalProperty({
         // eslint-disable-next-line max-nested-callbacks
         checkProperty: jest.fn(() => undefined),
         ...DEFAULT_PROPS,
@@ -118,7 +118,7 @@ describe('Conditional property resolver', () => {
 
   it('returns true because value matches', () => {
     const {result} = renderHook(() =>
-      useResolveConditionalProperty({
+      useConditionalProperty({
         // eslint-disable-next-line max-nested-callbacks
         checkProperty: jest.fn(({value}) => value === 'test value'),
         ...DEFAULT_PROPS,
@@ -130,7 +130,7 @@ describe('Conditional property resolver', () => {
 
   it('returns false because value does not match', () => {
     const {result} = renderHook(() =>
-      useResolveConditionalProperty({
+      useConditionalProperty({
         // eslint-disable-next-line max-nested-callbacks
         checkProperty: jest.fn(({value}) => value === 'test'),
         ...DEFAULT_PROPS,

--- a/packages/@sanity/base/src/conditional-property/index.ts
+++ b/packages/@sanity/base/src/conditional-property/index.ts
@@ -1,1 +1,1 @@
-export * from './useResolveConditionalProperty'
+export * from './useConditionalProperty'

--- a/packages/@sanity/base/src/conditional-property/useConditionalProperty.tsx
+++ b/packages/@sanity/base/src/conditional-property/useConditionalProperty.tsx
@@ -1,6 +1,14 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 import {SanityDocument, ConditionalProperty} from '@sanity/types'
 import {useCurrentUser} from '../_exports/hooks'
 import {omitDeprecatedRole, useCheckCondition} from './utils'
+
+/**
+ * Resolve a callback function to a boolean using the passed arguments
+ *
+ * @beta This API will change. DO NOT USE IN PRODUCTION.
+ * @internal Not a stable API yet
+ */
 
 export interface ConditionalPropertyProps {
   parent?: Record<string, unknown> | undefined
@@ -10,7 +18,8 @@ export interface ConditionalPropertyProps {
   checkPropertyKey: string
 }
 
-export const useResolveConditionalProperty = (props: ConditionalPropertyProps) => {
+// eslint-disable-next-line camelcase
+export const unstable_useConditionalProperty = (props: ConditionalPropertyProps) => {
   const {document, parent, value, checkProperty, checkPropertyKey} = props
 
   const {value: currentUser} = useCurrentUser()

--- a/packages/@sanity/desk-tool/src/panes/document/changesPanel/ChangesPanel.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/changesPanel/ChangesPanel.tsx
@@ -27,7 +27,13 @@ const Scroller = styled(ScrollContainer)`
 `
 
 export function ChangesPanel(): React.ReactElement | null {
-  const {documentId, documentSchema, handleHistoryClose, historyController} = useDocumentPane()
+  const {
+    documentId,
+    documentSchema,
+    handleHistoryClose,
+    historyController,
+    value,
+  } = useDocumentPane()
   const {collapsed} = usePane()
   const scrollRef = useRef<HTMLDivElement | null>(null)
   const historyState = historyController.selectionState
@@ -43,8 +49,9 @@ export function ChangesPanel(): React.ReactElement | null {
       FieldWrapper: ChangeFieldWrapper,
       rootDiff: diff,
       isComparingCurrent,
+      value,
     }),
-    [documentId, documentSchema, diff, isComparingCurrent]
+    [documentId, documentSchema, diff, isComparingCurrent, value]
   )
 
   const changeAnnotations = React.useMemo(

--- a/packages/@sanity/desk-tool/src/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/documentPanel/documentViews/FormView.tsx
@@ -1,7 +1,10 @@
 // @todo: remove the following line when part imports has been removed from this file
 ///<reference types="@sanity/types/parts" />
 
-import {useDocumentPresence, useResolveConditionalProperty} from '@sanity/base/hooks'
+import {
+  useDocumentPresence,
+  unstable_useConditionalProperty as useConditionalProperty,
+} from '@sanity/base/hooks'
 import {PresenceOverlay} from '@sanity/base/presence'
 import {Box, Container, Flex, Spinner, Text} from '@sanity/ui'
 import afterEditorComponents from 'all:part:@sanity/desk-tool/after-editor-component'
@@ -61,7 +64,7 @@ export function FormView(props: FormViewProps) {
     patchChannelRef.current = FormBuilder.createPatchChannel()
   }
 
-  const resolvedReadOnly = useResolveConditionalProperty({
+  const resolvedReadOnly = useConditionalProperty({
     document: value as SanityDocument,
     value: undefined,
     checkProperty: documentSchema.readOnly,

--- a/packages/@sanity/field/src/diff/components/ChangeList.tsx
+++ b/packages/@sanity/field/src/diff/components/ChangeList.tsx
@@ -2,7 +2,11 @@ import {useDocumentOperation} from '@sanity/react-hooks'
 import {Button, Box, Card, Grid, Stack, Text, useClickOutside} from '@sanity/ui'
 import {RevertIcon} from '@sanity/icons'
 import React, {useState} from 'react'
-import {unstable_useCheckDocumentPermission as useCheckDocumentPermission} from '@sanity/base/hooks'
+import {
+  unstable_useCheckDocumentPermission as useCheckDocumentPermission,
+  useResolveConditionalProperty,
+} from '@sanity/base/hooks'
+import {SanityDocument} from '@sanity/client'
 import {ObjectDiff, ObjectSchemaType, ChangeNode, OperationsAPI} from '../../types'
 import {DiffContext} from '../contexts/DiffContext'
 import {buildObjectChangeList} from '../changes/buildChangeList'
@@ -20,12 +24,19 @@ interface Props {
 }
 
 export function ChangeList({diff, fields, schemaType}: Props): React.ReactElement | null {
-  const {documentId, isComparingCurrent} = React.useContext(DocumentChangeContext)
+  const {documentId, isComparingCurrent, value} = React.useContext(DocumentChangeContext)
   const docOperations = useDocumentOperation(documentId, schemaType.name) as OperationsAPI
   const {path} = React.useContext(DiffContext)
   const isRoot = path.length === 0
   const [confirmRevertAllOpen, setConfirmRevertAllOpen] = React.useState(false)
   const [confirmRevertAllHover, setConfirmRevertAllHover] = React.useState(false)
+
+  const isReadOnly = useResolveConditionalProperty({
+    document: value as SanityDocument,
+    value: undefined,
+    checkProperty: schemaType.readOnly,
+    checkPropertyKey: 'readOnly',
+  })
 
   if (schemaType.jsonType !== 'object') {
     throw new Error(`Only object schema types are allowed in ChangeList`)
@@ -84,7 +95,7 @@ export function ChangeList({diff, fields, schemaType}: Props): React.ReactElemen
               change={change}
               key={change.key}
               data-revert-all-changes-hover={confirmRevertAllHover ? '' : undefined}
-              readOnly={schemaType.readOnly}
+              readOnly={isReadOnly}
             />
           ))}
         </Stack>
@@ -119,7 +130,7 @@ export function ChangeList({diff, fields, schemaType}: Props): React.ReactElemen
                 onClick={handleRevertAllChangesClick}
                 onMouseEnter={handleRevertAllChangesMouseEnter}
                 onMouseLeave={handleRevertAllChangesMouseLeave}
-                disabled={schemaType?.readOnly}
+                disabled={isReadOnly}
               />
             </Stack>
           </PopoverWrapper>

--- a/packages/@sanity/field/src/diff/components/ChangeList.tsx
+++ b/packages/@sanity/field/src/diff/components/ChangeList.tsx
@@ -4,7 +4,7 @@ import {RevertIcon} from '@sanity/icons'
 import React, {useState} from 'react'
 import {
   unstable_useCheckDocumentPermission as useCheckDocumentPermission,
-  useResolveConditionalProperty,
+  unstable_useConditionalProperty as useConditionalProperty,
 } from '@sanity/base/hooks'
 import {SanityDocument} from '@sanity/client'
 import {ObjectDiff, ObjectSchemaType, ChangeNode, OperationsAPI} from '../../types'
@@ -31,7 +31,7 @@ export function ChangeList({diff, fields, schemaType}: Props): React.ReactElemen
   const [confirmRevertAllOpen, setConfirmRevertAllOpen] = React.useState(false)
   const [confirmRevertAllHover, setConfirmRevertAllHover] = React.useState(false)
 
-  const isReadOnly = useResolveConditionalProperty({
+  const isReadOnly = useConditionalProperty({
     document: value as SanityDocument,
     value: undefined,
     checkProperty: schemaType.readOnly,

--- a/packages/@sanity/field/src/diff/components/ChangeResolver.tsx
+++ b/packages/@sanity/field/src/diff/components/ChangeResolver.tsx
@@ -1,4 +1,4 @@
-import {useResolveConditionalProperty} from '@sanity/base/hooks'
+import {unstable_useConditionalProperty as useConditionalProperty} from '@sanity/base/hooks'
 import {ConditionalProperty, SanityDocument} from '@sanity/types/src'
 import * as React from 'react'
 import {ChangeNode} from '../../types'
@@ -95,7 +95,7 @@ const ConditionalHiddenChange = ({
   document,
   ...props
 }: Props & {hidden?: ConditionalProperty; children: React.ReactElement}) => {
-  const isHidden = useResolveConditionalProperty({
+  const isHidden = useConditionalProperty({
     ...props,
     document: document as SanityDocument,
     checkProperty: hidden,
@@ -109,7 +109,7 @@ const ConditionalReadOnlyChange = ({
   document,
   ...props
 }: Props & {readOnly?: ConditionalProperty; children: React.ReactElement}) => {
-  const isReadOnly = useResolveConditionalProperty({
+  const isReadOnly = useConditionalProperty({
     ...props,
     document: document as SanityDocument,
     checkProperty: readOnly,

--- a/packages/@sanity/field/src/diff/components/ChangeResolver.tsx
+++ b/packages/@sanity/field/src/diff/components/ChangeResolver.tsx
@@ -1,19 +1,120 @@
+import {useResolveConditionalProperty} from '@sanity/base/hooks'
+import {ConditionalProperty, SanityDocument} from '@sanity/types/src'
 import * as React from 'react'
 import {ChangeNode} from '../../types'
+import {DocumentChangeContext} from './DocumentChangeContext'
 import {FieldChange} from './FieldChange'
 import {GroupChange} from './GroupChange'
 
 export function ChangeResolver({
   change,
+  hidden,
+  readOnly,
   ...restProps
-}: {change: ChangeNode; readOnly?: boolean} & React.HTMLAttributes<HTMLDivElement>) {
+}: {
+  change: ChangeNode
+  readOnly?: ConditionalProperty
+  hidden?: ConditionalProperty | boolean
+} & React.HTMLAttributes<HTMLDivElement>) {
+  const {value} = React.useContext(DocumentChangeContext)
+
   if (change.type === 'field') {
-    return <FieldChange change={change} {...restProps} />
+    // Resolve the readOnly property if it's a function
+    const resolvedReadOnlyField =
+      typeof readOnly === 'function' || typeof change.schemaType.readOnly === 'function' ? (
+        <ConditionalReadOnlyChange
+          readOnly={readOnly || change.schemaType.readOnly}
+          document={value}
+          value={change.diff.toValue}
+          {...restProps}
+        >
+          <FieldChange change={change} {...restProps} hidden={hidden} />
+        </ConditionalReadOnlyChange>
+      ) : (
+        <FieldChange change={change} {...restProps} hidden={hidden} readOnly={readOnly} />
+      )
+
+    // Resolve the hidden property if it's a function
+    if (typeof hidden === 'function' || typeof change.schemaType.hidden === 'function') {
+      return (
+        <ConditionalHiddenChange
+          hidden={hidden || change.schemaType.hidden}
+          document={value}
+          value={change.diff.toValue}
+          {...restProps}
+        >
+          {resolvedReadOnlyField}
+        </ConditionalHiddenChange>
+      )
+    }
+    return resolvedReadOnlyField
   }
 
   if (change.type === 'group') {
-    return <GroupChange change={change} {...restProps} />
+    // Resolve the group's readOnly property if it's a function
+    const resolvedReadOnlyGroup =
+      typeof readOnly === 'function' || typeof change?.schemaType?.readOnly === 'function' ? (
+        <ConditionalReadOnlyChange
+          readOnly={readOnly || change.schemaType?.readOnly}
+          document={value}
+          value={undefined}
+          {...restProps}
+        >
+          <GroupChange change={change} {...restProps} />
+        </ConditionalReadOnlyChange>
+      ) : (
+        <GroupChange change={change} {...restProps} hidden={hidden} readOnly={readOnly} />
+      )
+
+    if (typeof hidden === 'function' || typeof change?.schemaType?.hidden === 'function') {
+      return (
+        <ConditionalHiddenChange
+          hidden={hidden || change?.schemaType?.hidden}
+          document={value}
+          value={undefined}
+          {...restProps}
+        >
+          {resolvedReadOnlyGroup}
+        </ConditionalHiddenChange>
+      )
+    }
+    return resolvedReadOnlyGroup
   }
 
   return <div>Unknown change type: {(change as any).type}</div>
+}
+
+type Props = {
+  parent?: Record<string, unknown> | undefined
+  value: unknown
+  document: Partial<SanityDocument>
+}
+
+const ConditionalHiddenChange = ({
+  hidden,
+  document,
+  ...props
+}: Props & {hidden?: ConditionalProperty; children: React.ReactElement}) => {
+  const isHidden = useResolveConditionalProperty({
+    ...props,
+    document: document as SanityDocument,
+    checkProperty: hidden,
+    checkPropertyKey: 'hidden',
+  })
+  return isHidden ? null : <>{props.children}</>
+}
+
+const ConditionalReadOnlyChange = ({
+  readOnly,
+  document,
+  ...props
+}: Props & {readOnly?: ConditionalProperty; children: React.ReactElement}) => {
+  const isReadOnly = useResolveConditionalProperty({
+    ...props,
+    document: document as SanityDocument,
+    checkProperty: readOnly,
+    checkPropertyKey: 'readOnly',
+  })
+
+  return React.cloneElement(props.children, {readOnly: isReadOnly})
 }

--- a/packages/@sanity/field/src/diff/components/ConditionalPropertyResolver.tsx
+++ b/packages/@sanity/field/src/diff/components/ConditionalPropertyResolver.tsx
@@ -1,0 +1,19 @@
+import {useResolveConditionalProperty} from '@sanity/base/hooks'
+import {ConditionalProperty, SanityDocument} from '@sanity/types'
+import React from 'react'
+
+type Props = {
+  parent?: Record<string, unknown> | undefined
+  value: unknown
+  document: SanityDocument
+  checkProperty: ConditionalProperty
+  checkPropertyKey: string
+  callback: (isTruthy: boolean) => void
+}
+
+export function ConditionalPropertyResolver({callback, ...props}: Props) {
+  const isTruthy = useResolveConditionalProperty({
+    ...props,
+  })
+  return <>{callback(isTruthy)}</>
+}

--- a/packages/@sanity/field/src/diff/components/ConditionalPropertyResolver.tsx
+++ b/packages/@sanity/field/src/diff/components/ConditionalPropertyResolver.tsx
@@ -1,4 +1,4 @@
-import {useResolveConditionalProperty} from '@sanity/base/hooks'
+import {unstable_useConditionalProperty as useConditionalProperty} from '@sanity/base/hooks'
 import {ConditionalProperty, SanityDocument} from '@sanity/types'
 import React from 'react'
 
@@ -12,7 +12,7 @@ type Props = {
 }
 
 export function ConditionalPropertyResolver({callback, ...props}: Props) {
-  const isTruthy = useResolveConditionalProperty({
+  const isTruthy = useConditionalProperty({
     ...props,
   })
   return <>{callback(isTruthy)}</>

--- a/packages/@sanity/field/src/diff/components/DocumentChangeContext.tsx
+++ b/packages/@sanity/field/src/diff/components/DocumentChangeContext.tsx
@@ -1,6 +1,6 @@
 import {createContext} from 'react'
+import {Path, SanityDocument} from '@sanity/types'
 import {ObjectDiff, SchemaType} from '../../types'
-import {Path} from '@sanity/types'
 
 export type DocumentChangeContextInstance = {
   documentId: string
@@ -8,6 +8,7 @@ export type DocumentChangeContextInstance = {
   rootDiff: ObjectDiff | null
   isComparingCurrent: boolean
   FieldWrapper: React.ComponentType<{path: Path; children: React.ReactNode; hasHover: boolean}>
+  value: Partial<SanityDocument>
 }
 
 export const DocumentChangeContext = createContext<DocumentChangeContextInstance>({} as any)

--- a/packages/@sanity/field/src/diff/components/FieldChange.tsx
+++ b/packages/@sanity/field/src/diff/components/FieldChange.tsx
@@ -1,5 +1,6 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import {useDocumentOperation} from '@sanity/react-hooks'
-import React, {useCallback, useContext, useState} from 'react'
+import React, {useCallback, useContext, useMemo, useState} from 'react'
 import {unstable_useCheckDocumentPermission as useCheckDocumentPermission} from '@sanity/base/hooks'
 import {Stack, Box, Button, Text, Grid, useClickOutside} from '@sanity/ui'
 import {undoChange} from '../changes/undoChange'
@@ -17,9 +18,12 @@ import {FieldChangeContainer, DiffBorder, PopoverWrapper} from './FieldChange.st
 
 export function FieldChange({
   change,
+  hidden,
   readOnly,
   ...restProps
-}: {change: FieldChangeNode; readOnly?: boolean} & React.HTMLAttributes<HTMLDivElement>) {
+}: {change: FieldChangeNode; readOnly?: boolean; hidden?: boolean} & React.HTMLAttributes<
+  HTMLDivElement
+>) {
   const DiffComponent = change.diffComponent || FallbackDiff
   const {
     documentId,
@@ -27,6 +31,7 @@ export function FieldChange({
     rootDiff,
     isComparingCurrent,
     FieldWrapper = React.Fragment,
+    value,
   } = useContext(DocumentChangeContext)
   const docOperations = useDocumentOperation(documentId, schemaType.name) as OperationsAPI
   const [confirmRevertOpen, setConfirmRevertOpen] = React.useState(false)
@@ -57,61 +62,65 @@ export function FieldChange({
 
   useClickOutside(() => setConfirmRevertOpen(false), [revertButtonElement])
 
-  return change.schemaType.hidden === true ? null : (
-    <Stack space={1} as={FieldChangeContainer} {...restProps}>
-      {change.showHeader && <ChangeBreadcrumb change={change} titlePath={change.titlePath} />}
-      <FieldWrapper path={change.path} hasHover={revertHovered}>
-        <DiffInspectWrapper
-          change={change}
-          as={DiffBorder}
-          data-revert-field-hover={revertHovered ? '' : undefined}
-          data-error={change.error ? '' : undefined}
-          data-revert-all-hover
-        >
-          {change.error ? (
-            <ValueError error={change.error} />
-          ) : (
-            <DiffErrorBoundary>
-              <DiffContext.Provider value={{path: change.path}}>
-                <DiffComponent diff={change.diff} schemaType={change.schemaType as any} />
-              </DiffContext.Provider>
-            </DiffErrorBoundary>
-          )}
-          {isComparingCurrent && updatePermission.granted && (
-            <PopoverWrapper
-              content={
-                <Box padding={3} sizing="border">
-                  Are you sure you want to revert the changes?
-                  <Grid columns={2} gap={2} marginTop={2}>
-                    <Button mode="ghost" onClick={closeRevertChangesConfirmDialog}>
-                      <Text align="center">Cancel</Text>
-                    </Button>
-                    <Button tone="critical" onClick={handleRevertChanges}>
-                      <Text align="center">Revert change</Text>
-                    </Button>
-                  </Grid>
-                </Box>
-              }
-              open={confirmRevertOpen}
-              portal
-              placement="left"
-              ref={setRevertButtonElement}
+  const content = useMemo(
+    () =>
+      hidden ? null : (
+        <Stack space={1} as={FieldChangeContainer} {...restProps}>
+          {change.showHeader && <ChangeBreadcrumb change={change} titlePath={change.titlePath} />}
+          <FieldWrapper path={change.path} hasHover={revertHovered}>
+            <DiffInspectWrapper
+              change={change}
+              as={DiffBorder}
+              data-revert-field-hover={revertHovered ? '' : undefined}
+              data-error={change.error ? '' : undefined}
+              data-revert-all-hover
             >
-              <Box flex={1}>
-                <RevertChangesButton
-                  onClick={handleRevertChangesConfirm}
-                  onMouseEnter={handleRevertButtonMouseEnter}
-                  onMouseLeave={handleRevertButtonMouseLeave}
-                  selected={confirmRevertOpen}
-                  disabled={
-                    readOnly || change?.parentSchema?.readOnly || change.schemaType.readOnly
+              {change.error ? (
+                <ValueError error={change.error} />
+              ) : (
+                <DiffErrorBoundary>
+                  <DiffContext.Provider value={{path: change.path}}>
+                    <DiffComponent diff={change.diff} schemaType={change.schemaType as any} />
+                  </DiffContext.Provider>
+                </DiffErrorBoundary>
+              )}
+              {isComparingCurrent && updatePermission.granted && (
+                <PopoverWrapper
+                  content={
+                    <Box padding={3} sizing="border">
+                      Are you sure you want to revert the changes?
+                      <Grid columns={2} gap={2} marginTop={2}>
+                        <Button mode="ghost" onClick={closeRevertChangesConfirmDialog}>
+                          <Text align="center">Cancel</Text>
+                        </Button>
+                        <Button tone="critical" onClick={handleRevertChanges}>
+                          <Text align="center">Revert change</Text>
+                        </Button>
+                      </Grid>
+                    </Box>
                   }
-                />
-              </Box>
-            </PopoverWrapper>
-          )}
-        </DiffInspectWrapper>
-      </FieldWrapper>
-    </Stack>
+                  open={confirmRevertOpen}
+                  portal
+                  placement="left"
+                  ref={setRevertButtonElement}
+                >
+                  <Box flex={1}>
+                    <RevertChangesButton
+                      onClick={handleRevertChangesConfirm}
+                      onMouseEnter={handleRevertButtonMouseEnter}
+                      onMouseLeave={handleRevertButtonMouseLeave}
+                      selected={confirmRevertOpen}
+                      disabled={readOnly}
+                    />
+                  </Box>
+                </PopoverWrapper>
+              )}
+            </DiffInspectWrapper>
+          </FieldWrapper>
+        </Stack>
+      ),
+    [hidden, readOnly]
   )
+
+  return content
 }

--- a/packages/@sanity/field/src/diff/components/GroupChange.tsx
+++ b/packages/@sanity/field/src/diff/components/GroupChange.tsx
@@ -1,5 +1,6 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import {useDocumentOperation} from '@sanity/react-hooks'
-import React, {useCallback, useContext, useState} from 'react'
+import React, {useCallback, useContext, useMemo, useState} from 'react'
 import {unstable_useCheckDocumentPermission as useCheckDocumentPermission} from '@sanity/base/hooks'
 import {Box, Stack, Button, Grid, Text, useClickOutside} from '@sanity/ui'
 import {undoChange} from '../changes/undoChange'
@@ -13,14 +14,14 @@ import {ChangeBreadcrumb} from './ChangeBreadcrumb'
 import {ChangeResolver} from './ChangeResolver'
 import {DocumentChangeContext} from './DocumentChangeContext'
 import {RevertChangesButton} from './RevertChangesButton'
-
 import {ChangeListWrapper, GroupChangeContainer, PopoverWrapper} from './GroupChange.styled'
 
 export function GroupChange({
   change: group,
   readOnly,
+  hidden,
   ...restProps
-}: {change: GroupChangeNode; readOnly?: boolean} & React.HTMLAttributes<
+}: {change: GroupChangeNode; readOnly?: boolean; hidden?: boolean} & React.HTMLAttributes<
   HTMLDivElement
 >): React.ReactElement | null {
   const {titlePath, changes, path: groupPath} = group
@@ -64,60 +65,60 @@ export function GroupChange({
     },
     [hoverRef]
   )
-  const content = (
-    <Stack
-      space={1}
-      as={GroupChangeContainer}
-      data-revert-group-hover={isHoveringRevert ? '' : undefined}
-      data-portable-text={isPortableText ? '' : undefined}
-      data-revert-all-groups-hover={
-        restProps['data-revert-all-changes-hover'] === '' ? '' : undefined
-      }
-    >
-      <Stack as={ChangeListWrapper} space={5}>
-        {changes.map((change) => (
-          <ChangeResolver
-            key={change.key}
-            change={change}
-            readOnly={readOnly || group?.schemaType?.readOnly}
-          />
-        ))}
-      </Stack>
-      {isComparingCurrent && updatePermission.granted && (
-        <PopoverWrapper
-          content={
+
+  const content = useMemo(
+    () => (
+      <Stack
+        space={1}
+        as={GroupChangeContainer}
+        data-revert-group-hover={isHoveringRevert ? '' : undefined}
+        data-portable-text={isPortableText ? '' : undefined}
+        data-revert-all-groups-hover={
+          restProps['data-revert-all-changes-hover'] === '' ? '' : undefined
+        }
+      >
+        <Stack as={ChangeListWrapper} space={5}>
+          {changes.map((change) => (
+            <ChangeResolver key={change.key} change={change} readOnly={readOnly} hidden={hidden} />
+          ))}
+        </Stack>
+        {isComparingCurrent && updatePermission.granted && (
+          <PopoverWrapper
+            content={
+              <Box>
+                Are you sure you want to revert the changes?
+                <Grid columns={2} gap={2} marginTop={2}>
+                  <Button mode="ghost" onClick={closeRevertChangesConfirmDialog}>
+                    <Text align="center">Cancel</Text>
+                  </Button>
+                  <Button tone="critical" onClick={handleRevertChanges}>
+                    <Text align="center">Revert change</Text>
+                  </Button>
+                </Grid>
+              </Box>
+            }
+            portal
+            padding={4}
+            placement={'left'}
+            open={confirmRevertOpen}
+            ref={setRevertButtonElement}
+          >
             <Box>
-              Are you sure you want to revert the changes?
-              <Grid columns={2} gap={2} marginTop={2}>
-                <Button mode="ghost" onClick={closeRevertChangesConfirmDialog}>
-                  <Text align="center">Cancel</Text>
-                </Button>
-                <Button tone="critical" onClick={handleRevertChanges}>
-                  <Text align="center">Revert change</Text>
-                </Button>
-              </Grid>
+              <RevertChangesButton
+                onClick={handleRevertChangesConfirm}
+                ref={setRevertButtonRef}
+                selected={confirmRevertOpen}
+                disabled={readOnly}
+              />
             </Box>
-          }
-          portal
-          padding={4}
-          placement={'left'}
-          open={confirmRevertOpen}
-          ref={setRevertButtonElement}
-        >
-          <Box>
-            <RevertChangesButton
-              onClick={handleRevertChangesConfirm}
-              ref={setRevertButtonRef}
-              selected={confirmRevertOpen}
-              disabled={group?.schemaType?.readOnly || readOnly}
-            />
-          </Box>
-        </PopoverWrapper>
-      )}
-    </Stack>
+          </PopoverWrapper>
+        )}
+      </Stack>
+    ),
+    [readOnly, hidden]
   )
 
-  return (group?.schemaType as any)?.hidden ? null : (
+  return hidden ? null : (
     <Stack space={1} {...restProps}>
       <ChangeBreadcrumb titlePath={titlePath} />
       {isNestedInDiff || !FieldWrapper ? (

--- a/packages/@sanity/form-builder/src/FormBuilderInput.tsx
+++ b/packages/@sanity/form-builder/src/FormBuilderInput.tsx
@@ -213,7 +213,9 @@ export class FormBuilderInput extends React.Component<FormBuilderInputProps> {
   }
 
   render() {
-    const {type, readOnly, parent, value} = this.props
+    const {type, parent, value} = this.props
+    // Separate readOnly in order to resolve it to a boolean type
+    const {readOnly, ...restProps} = this.props
     const InputComponent = this.resolveInputComponent(type)
 
     if (!InputComponent) {
@@ -232,7 +234,7 @@ export class FormBuilderInput extends React.Component<FormBuilderInputProps> {
           readOnly={readOnly ?? type.readOnly}
         >
           <FormBuilderInputInner
-            {...this.props}
+            {...restProps}
             childFocusPath={this.getChildFocusPath()}
             context={this.context}
             component={InputComponent}
@@ -247,7 +249,8 @@ export class FormBuilderInput extends React.Component<FormBuilderInputProps> {
 
     return (
       <FormBuilderInputInner
-        {...this.props}
+        {...restProps}
+        readOnly={readOnly}
         childFocusPath={this.getChildFocusPath()}
         context={this.context}
         component={InputComponent}
@@ -265,6 +268,7 @@ interface FormBuilderInputInnerProps extends FormBuilderInputProps {
   component: React.ComponentType<InputProps>
   context: Context
   setInput: (component: FormBuilderInput | HTMLDivElement | null) => void
+  readOnly?: boolean
 }
 
 function FormBuilderInputInner(props: FormBuilderInputInnerProps) {
@@ -319,7 +323,7 @@ function FormBuilderInputInner(props: FormBuilderInputInnerProps) {
       isRoot,
       value,
       compareValue: childCompareValue,
-      readOnly: readOnly ?? type.readOnly,
+      readOnly,
       markers: childMarkers.length === 0 ? EMPTY_MARKERS : childMarkers,
       type,
       presence: childPresenceInfo,

--- a/packages/@sanity/form-builder/src/inputs/common/ConditionalHiddenField.tsx
+++ b/packages/@sanity/form-builder/src/inputs/common/ConditionalHiddenField.tsx
@@ -1,5 +1,5 @@
 import React, {forwardRef} from 'react'
-import {useResolveConditionalProperty} from '@sanity/base/hooks'
+import {unstable_useConditionalProperty as useConditionalProperty} from '@sanity/base/hooks'
 import {ConditionalProperty} from '@sanity/types'
 import {SanityDocument} from '@sanity/client'
 import withDocument from '../../utils/withDocument'
@@ -25,7 +25,7 @@ const ConditionalHiddenWithDocument = withDocument(
     ref /* ignore ref as there's no place to put it */
   ) {
     const {hidden, value, parent, document, children} = props
-    const isHidden = useResolveConditionalProperty({
+    const isHidden = useConditionalProperty({
       checkProperty: hidden,
       checkPropertyKey: 'hidden',
       value,

--- a/packages/@sanity/form-builder/src/inputs/common/ConditionalReadOnlyField.tsx
+++ b/packages/@sanity/form-builder/src/inputs/common/ConditionalReadOnlyField.tsx
@@ -1,7 +1,7 @@
 import React, {forwardRef} from 'react'
 import {ConditionalProperty} from '@sanity/types'
 import {SanityDocument} from '@sanity/client'
-import {useResolveConditionalProperty} from '@sanity/base/hooks'
+import {unstable_useConditionalProperty as useConditionalProperty} from '@sanity/base/hooks'
 import withDocument from '../../utils/withDocument'
 
 type Props = {
@@ -25,7 +25,7 @@ const ConditionalReadOnlyWithDocument = withDocument(
     ref /* ignore ref as there's no place to put it */
   ) {
     const {readOnly, value, parent, document, children} = props
-    const isReadOnly = useResolveConditionalProperty({
+    const isReadOnly = useConditionalProperty({
       checkProperty: readOnly,
       checkPropertyKey: 'readOnly',
       value,

--- a/packages/@sanity/form-builder/src/inputs/common/ConditionalReadOnlyField.tsx
+++ b/packages/@sanity/form-builder/src/inputs/common/ConditionalReadOnlyField.tsx
@@ -15,7 +15,7 @@ export const ConditionalReadOnlyField = ({readOnly, ...rest}: Props) => {
   return typeof readOnly === 'function' ? (
     <ConditionalReadOnlyWithDocument {...rest} readOnly={readOnly} />
   ) : (
-    <>{rest.children}</>
+    <>{mappedChildren({children: rest.children, childProps: {readOnly: readOnly}})}</>
   )
 }
 

--- a/packages/@sanity/form-builder/src/inputs/types.ts
+++ b/packages/@sanity/form-builder/src/inputs/types.ts
@@ -1,7 +1,6 @@
 import {
   ArraySchemaType,
   BooleanSchemaType,
-  ConditionalProperty,
   Marker,
   NumberSchemaType,
   ObjectSchemaType,
@@ -30,7 +29,7 @@ export type Props<
   level: number
   value: T | null | undefined
   onChange: (patchEvent: PatchEvent) => void
-  readOnly?: ConditionalProperty
+  readOnly?: boolean
   // Note: we should allow implementors of custom inputs to forward the passed onFocus to native element's onFocus handler,
   // but use Path consistently on internal inputs
   onFocus: (path?: Path | React.FocusEvent<any>) => void

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -42,7 +42,7 @@ export interface ConditionalPropertyCallbackContext {
 }
 
 export type ConditionalPropertyCallback = (context: ConditionalPropertyCallbackContext) => boolean
-export type ConditionalProperty = boolean | ConditionalPropertyCallback
+export type ConditionalProperty = boolean | ConditionalPropertyCallback | undefined
 
 export type InitialValueParams = Record<string, unknown>
 export type InitialValueResolver<T> = (params?: InitialValueParams) => Promise<T> | T
@@ -85,6 +85,7 @@ export interface BaseSchemaType {
   type?: SchemaType
   liveEdit?: boolean
   readOnly?: ConditionalProperty
+  hidden?: ConditionalProperty
   icon?: React.ComponentType
   initialValue?: InitialValueProperty
   options?: Record<string, any>


### PR DESCRIPTION
- Fixes a problem where the form view would not know that a whole document is read-only and it also accepts a callback, so now the resolved readOnly value is passed down through the document
- Updates the context the changes panel uses to include the document value so that FieldChange and GroupChange can resolve their readOnly callbacks if any.
- Updates the change components to resolve the hidden property if it's a function