### PR TITLE
refactor(form-builder): simplify block components

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/PortableText/Editor.styles.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Editor.styles.tsx
@@ -1,7 +1,7 @@
 import {ScrollContainer} from '@sanity/base/components'
 import {Card, Container, rem} from '@sanity/ui'
 import styled, {css} from 'styled-components'
-import {createListName, LEVELS} from './text'
+import {createListName, TEXT_LEVELS} from './text'
 
 export const Root = styled(Card)<{$fullscreen: boolean}>`
   height: ${({$fullscreen}) => ($fullscreen ? '100%' : '15em')};
@@ -68,7 +68,7 @@ export const EditableWrapper = styled(Card)<{$isFullscreen: boolean}>`
   position: relative;
   flex-direction: column;
   height: 100%;
-  counter-reset: ${LEVELS.map((l) => createListName(l)).join(' ')};
+  counter-reset: ${TEXT_LEVELS.map((l) => createListName(l)).join(' ')};
 
   & > div {
     height: 100%;
@@ -80,7 +80,7 @@ export const EditableWrapper = styled(Card)<{$isFullscreen: boolean}>`
     flex: 1;
     min-height: 100%;
 
-    ${LEVELS.map((l) => {
+    ${TEXT_LEVELS.map((l) => {
       return css`
         & > .pt-list-item-number[class~='pt-list-item-level-${l}'] {
           counter-increment: ${createListName(l)};
@@ -91,7 +91,7 @@ export const EditableWrapper = styled(Card)<{$isFullscreen: boolean}>`
     & > .pt-list-item-bullet + .pt-list-item-number,
     & > .pt-list-item-number + .pt-list-item-bullet {
       margin-top: ${({theme}) => theme.sanity.space[3]}px;
-      counter-reset: ${LEVELS.map((l) => createListName(l)).join(' ')};
+      counter-reset: ${TEXT_LEVELS.map((l) => createListName(l)).join(' ')};
     }
 
     & > :not(.pt-list-item) + .pt-list-item {
@@ -100,10 +100,10 @@ export const EditableWrapper = styled(Card)<{$isFullscreen: boolean}>`
 
     /* Reset the list count if the element is not a numbered list item */
     & > :not(.pt-list-item-number) {
-      counter-reset: ${LEVELS.map((l) => createListName(l)).join(' ')};
+      counter-reset: ${TEXT_LEVELS.map((l) => createListName(l)).join(' ')};
     }
 
-    ${LEVELS.slice(1).map((l) => {
+    ${TEXT_LEVELS.slice(1).map((l) => {
       return css`
         & > .pt-list-item-level-${l} + .pt-list-item-level-${l - 1} {
           counter-reset: ${createListName(l)};
@@ -125,10 +125,12 @@ export const EditableWrapper = styled(Card)<{$isFullscreen: boolean}>`
       }
     }
 
-    .pt-drop-indicator {
+    & .pt-drop-indicator {
+      pointer-events: none;
       border: 1px solid var(--card-focus-ring-color) !important;
       height: 0px !important;
       border-radius: 1px;
+      margin-top: -3px;
       left: calc(
         ${({$isFullscreen, theme}) =>
             $isFullscreen ? rem(theme.sanity.space[5]) : rem(theme.sanity.space[3])} - 1px

--- a/packages/@sanity/form-builder/src/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/object/BlockObject.tsx
@@ -209,17 +209,18 @@ export function BlockObject(props: BlockObjectProps) {
 
   const innerPaddingProps: ResponsivePaddingProps = useMemo(() => {
     if (isFullscreen && !renderBlockActions) {
-      return {paddingX: 5}
+      return {paddingX: 5, paddingBottom: 1}
     }
 
     if (isFullscreen && renderBlockActions) {
-      return {paddingLeft: 5, paddingRight: 2}
+      return {paddingLeft: 5, paddingRight: 2, paddingBottom: 1}
     }
 
     if (renderBlockActions) {
       return {
         paddingLeft: 3,
         paddingRight: 2,
+        paddingBottom: 1,
       }
     }
 

--- a/packages/@sanity/form-builder/src/inputs/PortableText/text/Annotation.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/text/Annotation.tsx
@@ -114,9 +114,10 @@ export function Annotation(props: AnnotationProps) {
   }, [markDefPath, onFocus])
 
   const handleRemoveClick = useCallback(
-    (e): void => {
-      e.preventDefault()
-      e.stopPropagation()
+    (event: React.MouseEvent<HTMLButtonElement>): void => {
+      event.preventDefault()
+      event.stopPropagation()
+
       PortableTextEditor.removeAnnotation(editor, type)
       PortableTextEditor.focus(editor)
     },

--- a/packages/@sanity/form-builder/src/inputs/PortableText/text/AnnotationToolbarPopover.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/text/AnnotationToolbarPopover.tsx
@@ -17,6 +17,7 @@ const ToolbarPopover = styled(Popover)`
     display: none !important;
   }
 `
+
 const POPOVER_FALLBACK_PLACEMENTS: PopoverProps['fallbackPlacements'] = ['top', 'bottom']
 
 interface AnnotationToolbarPopoverProps {
@@ -27,7 +28,7 @@ interface AnnotationToolbarPopoverProps {
   annotationElement: HTMLElement
   textElement: HTMLElement
   onEdit: () => void
-  onDelete: (e) => void
+  onDelete: (event: React.MouseEvent<HTMLButtonElement>) => void
   title: string
 }
 

--- a/packages/@sanity/form-builder/src/inputs/PortableText/text/Decorator.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/text/Decorator.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
+import {TEXT_DECORATOR_TAGS} from './constants'
 
 interface DecoratorProps {
   mark: string
@@ -8,41 +9,19 @@ interface DecoratorProps {
 
 const Root = styled.span`
   /* Make sure the annotation styling is visible */
-  [data-annotation] &[data-decorator='code'] {
+  &[data-mark='code'] {
     mix-blend-mode: multiply;
     color: inherit;
   }
 `
 
-/**
- * @todo: Consider adding `data-mark` to all return paths
- */
 export function Decorator(props: DecoratorProps) {
   const {mark, children} = props
+  const tag = TEXT_DECORATOR_TAGS[mark]
 
-  if (mark === 'em') {
-    return <Root as="em">{children}</Root>
-  }
-
-  if (mark === 'strike-through') {
-    return <Root as="s">{children}</Root>
-  }
-
-  if (mark === 'underline') {
-    return <Root as="u">{children}</Root>
-  }
-
-  if (mark === 'strong') {
-    return <Root as="strong">{children}</Root>
-  }
-
-  if (mark === 'code') {
-    return (
-      <Root as="code" data-mark={mark}>
-        {children}
-      </Root>
-    )
-  }
-
-  return <Root>{children}</Root>
+  return (
+    <Root as={tag} data-mark={mark}>
+      {children}
+    </Root>
+  )
 }

--- a/packages/@sanity/form-builder/src/inputs/PortableText/text/TextBlock.styles.ts
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/text/TextBlock.styles.ts
@@ -119,11 +119,26 @@ export const BlockActionsOuter = styled(Box)`
   }
 `
 
-export const BlockActionsInner = styled(Flex)`
-  position: absolute;
-  right: 0;
-  top: -7px;
-`
+export const BlockActionsInner = styled(Flex)(({theme}: {theme: Theme}) => {
+  const {fonts, space} = theme.sanity
+  const textSize1 = fonts.text.sizes[1]
+  const textSize2 = fonts.text.sizes[2]
+  const capHeight1 = textSize1.lineHeight - textSize1.ascenderHeight - textSize1.descenderHeight
+  const capHeight2 = textSize2.lineHeight - textSize2.ascenderHeight - textSize2.descenderHeight
+  const buttonHeight = capHeight1 + space[2] + space[2]
+
+  // This calculates the following:
+  // > var buttonHeight = 25px
+  // > var capHeight2 = 11px
+  // > 0 - (buttonHeight - capHeight2) / 2 = -7px
+  const negativeTop = 0 - (buttonHeight - capHeight2) / 2
+
+  return css`
+    position: absolute;
+    right: 0;
+    top: ${negativeTop}px;
+  `
+})
 
 export const TooltipBox = styled(Box)`
   max-width: 250px;

--- a/packages/@sanity/form-builder/src/inputs/PortableText/text/TextBlock.styles.ts
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/text/TextBlock.styles.ts
@@ -1,0 +1,161 @@
+import {ChangeIndicatorWithProvidedFullPath} from '@sanity/base/change-indicators'
+import {hues} from '@sanity/color'
+import {Box, Flex, Theme} from '@sanity/ui'
+import styled, {css} from 'styled-components'
+import {TEXT_BULLET_MARKERS, TEXT_NUMBER_FORMATS} from './constants'
+import {createListName} from './helpers'
+
+interface TextBlockStyleProps {
+  $level?: number
+}
+
+function textBlockStyle(props: TextBlockStyleProps & {theme: Theme}) {
+  const {$level, theme} = props
+  const {color, fonts, radius, space} = theme.sanity
+  const numberMarker = TEXT_NUMBER_FORMATS[($level - 1) % TEXT_NUMBER_FORMATS.length]
+  const bulletMarker = TEXT_BULLET_MARKERS[($level - 1) % TEXT_BULLET_MARKERS.length]
+
+  return css`
+    --marker-bg-color: transparent;
+
+    mix-blend-mode: ${color.dark ? 'screen' : 'multiply'};
+    position: relative;
+
+    & > [data-ui='TextBlock_inner'] {
+      position: relative;
+      flex: 1;
+    }
+
+    & > div:before {
+      content: '';
+      position: absolute;
+      top: -${space[1]}px;
+      bottom: -${space[1]}px;
+      left: -${space[1]}px;
+      right: -${space[1]}px;
+      border-radius: ${radius[2]}px;
+      background-color: var(--marker-bg-color);
+    }
+
+    &[data-custom-markers] {
+      --marker-bg-color: ${color.dark ? hues.purple[950].hex : hues.purple[50].hex};
+    }
+
+    &[data-warning] {
+      --card-border-color: ${color.muted.caution.enabled.border};
+      --marker-bg-color: ${color.muted.caution.hovered.bg};
+    }
+
+    &[data-error] {
+      --card-border-color: ${color.muted.critical.enabled.border};
+      --marker-bg-color: ${color.muted.critical.hovered.bg};
+    }
+
+    & [data-list-prefix] {
+      position: absolute;
+      margin-left: -4.5rem;
+      width: 3.75rem;
+      text-align: right;
+      box-sizing: border-box;
+    }
+
+    &[data-list-item='number'] [data-list-prefix] {
+      font-variant-numeric: tabular-nums;
+
+      & > span:before {
+        content: counter(${createListName($level)}) '.';
+        content: counter(${createListName($level)}, ${numberMarker}) '.';
+      }
+    }
+
+    &[data-list-item='bullet'] [data-list-prefix] {
+      & > span {
+        position: relative;
+        top: -0.1875em;
+
+        &:before {
+          content: '${bulletMarker}';
+          font-size: 0.46666em;
+        }
+      }
+    }
+
+    & [data-text] {
+      overflow-wrap: anywhere;
+      text-transform: none;
+      white-space: pre-wrap;
+      font-family: ${fonts.text.family};
+      flex: 1;
+
+      *::selection {
+        background-color: ${color.selectable.primary.pressed.bg};
+      }
+    }
+  `
+}
+
+export const TextRoot = styled.div<TextBlockStyleProps>(textBlockStyle)
+
+export const TextBlockFlexWrapper = styled(Flex)`
+  position: relative;
+`
+
+export const ListPrefixWrapper = styled.div`
+  user-select: none;
+  white-space: nowrap;
+`
+
+export const BlockActionsOuter = styled(Box)`
+  line-height: 0;
+  width: 25px;
+  position: relative;
+  user-select: none;
+
+  /* Without this, select all (CMD-A) will not work properly */
+  /* when the editor is in non-fullscreen mode. */
+  &:before {
+    content: ' ';
+    font-size: 0;
+  }
+`
+
+export const BlockActionsInner = styled(Flex)`
+  position: absolute;
+  right: 0;
+  top: -7px;
+`
+
+export const TooltipBox = styled(Box)`
+  max-width: 250px;
+`
+
+export const TextFlex = styled(Flex)<{$level?: number}>`
+  position: relative;
+  padding-left: ${({$level}) => ($level ? $level * 32 : 0)}px;
+`
+
+export const ChangeIndicatorWrapper = styled.div(({theme}: {theme: Theme}) => {
+  const {space} = theme.sanity
+
+  return css`
+    position: absolute;
+    width: ${space[2]}px;
+    right: -${space[2]}px;
+    top: -${space[1]}px;
+    bottom: -${space[1]}px;
+    overflow-x: hidden;
+    padding-left: ${space[1]}px;
+    user-select: none;
+  `
+})
+
+export const StyledChangeIndicatorWithProvidedFullPath = styled(
+  ChangeIndicatorWithProvidedFullPath
+)`
+  width: 1px;
+  height: 100%;
+
+  & > div {
+    height: 100%;
+  }
+`

--- a/packages/@sanity/form-builder/src/inputs/PortableText/text/TextBlock.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/text/TextBlock.tsx
@@ -1,17 +1,26 @@
-import React, {useMemo} from 'react'
-import {Box, Flex, ResponsivePaddingProps, Theme, Tooltip} from '@sanity/ui'
-import styled, {css} from 'styled-components'
-import {hues} from '@sanity/color'
-import {isKeySegment, Marker} from '@sanity/types'
 import {PortableTextBlock, RenderAttributes} from '@sanity/portable-text-editor'
-import {ChangeIndicatorWithProvidedFullPath} from '@sanity/base/change-indicators'
+import {isKeySegment, isValidationMarker, Marker} from '@sanity/types'
+import {Box, ResponsivePaddingProps, Tooltip} from '@sanity/ui'
+import React, {useMemo} from 'react'
 import {Markers} from '../../../legacyParts'
-import {RenderBlockActions, RenderCustomMarkers} from '../types'
 import PatchEvent from '../../../PatchEvent'
 import {BlockActions} from '../BlockActions'
+import {RenderBlockActions, RenderCustomMarkers} from '../types'
+import {TEXT_STYLE_PADDING} from './constants'
+import {
+  BlockActionsInner,
+  BlockActionsOuter,
+  ChangeIndicatorWrapper,
+  ListPrefixWrapper,
+  StyledChangeIndicatorWithProvidedFullPath,
+  TextBlockFlexWrapper,
+  TextFlex,
+  TextRoot,
+  TooltipBox,
+} from './TextBlock.styles'
 import {TEXT_STYLES} from './textStyles'
 
-export interface TextBlockProps {
+interface TextBlockProps {
   attributes: RenderAttributes
   block: PortableTextBlock
   blockRef?: React.RefObject<HTMLDivElement>
@@ -23,192 +32,6 @@ export interface TextBlockProps {
   renderBlockActions?: RenderBlockActions
   renderCustomMarkers?: RenderCustomMarkers
 }
-
-interface TextBlockStyleProps {
-  $level?: number
-  $listItem?: 'bullet' | 'number'
-  $size: number
-}
-
-const HEADER_SIZES: {[key: string]: number | undefined} = {
-  h1: 5,
-  h2: 4,
-  h3: 3,
-  h4: 2,
-  h5: 1,
-  h6: 0,
-}
-
-const TEXT_STYLES_KEYS = Object.keys(TEXT_STYLES)
-const HEADER_SIZES_KEYS = Object.keys(HEADER_SIZES)
-
-const BULLET_MARKERS = ['●', '○', '■']
-const NUMBER_FORMATS = ['number', 'lower-alpha', 'lower-roman']
-
-export const LEVELS = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-
-export function createListName(level: number) {
-  return `list-level-${level}`
-}
-
-function textBlockStyle(props: TextBlockStyleProps & {theme: Theme}) {
-  const {$level, $listItem, theme} = props
-  const {fonts, color} = theme.sanity
-
-  const overlay = css`
-    content: '';
-    position: absolute;
-    top: -4px;
-    bottom: -4px;
-    left: -4px;
-    right: -4px;
-    border-radius: ${theme.sanity.radius[2]}px;
-  `
-
-  return css`
-    mix-blend-mode: ${color.dark ? 'screen' : 'multiply'};
-    position: relative;
-
-    & > [data-ui='TextBlock_inner'] {
-      position: relative;
-      flex: 1;
-    }
-
-    &[data-markers] > div:before {
-      ${overlay}
-      background-color: ${color.dark ? hues.purple[950].hex : hues.purple[50].hex};
-    }
-
-    &[data-warning] {
-      --card-border-color: ${color.muted.caution.enabled.border};
-      & > div:before {
-        ${overlay}
-        background-color: ${color.muted.caution.hovered.bg};
-      }
-    }
-
-    &[data-invalid] {
-      --card-border-color: ${color.muted.critical.enabled.border};
-      & > div:before {
-        ${overlay}
-        background-color: ${color.muted.critical.hovered.bg};
-      }
-    }
-
-    & [data-ui='TextBlock__text'] {
-      overflow-wrap: anywhere;
-      text-transform: none;
-      white-space: pre-wrap;
-      font-family: ${fonts.text.family};
-      flex: 1;
-      *::selection {
-        background-color: ${color.selectable.primary.pressed.bg};
-      }
-    }
-
-    & [data-list-prefix] {
-      position: absolute;
-      margin-left: -4.5rem;
-      width: 3.75rem;
-      text-align: right;
-      box-sizing: border-box;
-
-      ${$listItem === 'number' &&
-      css`
-        font-variant-numeric: tabular-nums;
-        & > span:before {
-          content: ${`counter(${createListName($level)})`} '.';
-          content: ${`counter(${createListName($level)}, ${
-              NUMBER_FORMATS[($level - 1) % NUMBER_FORMATS.length]
-            })`}
-            '.';
-        }
-      `}
-
-      ${$listItem === 'bullet' &&
-      css`
-        & > span {
-          position: relative;
-          top: -0.1875em;
-
-          &:before {
-            content: '${BULLET_MARKERS[($level - 1) % BULLET_MARKERS.length]}';
-            font-size: 0.46666em;
-          }
-        }
-      `}
-    }
-  `
-}
-
-const TextRoot = styled(Flex)<TextBlockStyleProps>(textBlockStyle)
-
-const InnerFlex = styled(Flex)`
-  position: relative;
-`
-
-const ListPrefixWrap = styled.div`
-  user-select: none;
-  white-space: nowrap;
-`
-
-const BlockActionsOuter = styled(Box)`
-  line-height: 0;
-  width: 25px;
-  position: relative;
-  user-select: none;
-
-  /* Without this, select all (CMD-A) will not work properly */
-  /* when the editor is in non-fullscreen mode. */
-  &:before {
-    content: ' ';
-    font-size: 0;
-  }
-`
-
-const BlockActionsInner = styled(Flex)`
-  position: absolute;
-  right: 0;
-  top: -7px;
-`
-
-const TooltipBox = styled(Box)`
-  max-width: 250px;
-`
-
-const TextFlex = styled(Flex)<{$level?: number}>`
-  position: relative;
-
-  ${({$level}) =>
-    $level &&
-    css`
-      padding-left: ${$level * 32}px;
-    `}
-`
-
-const ChangeIndicatorWrapper = styled.div(({theme}: {theme: Theme}) => {
-  const {space} = theme.sanity
-
-  return css`
-    position: absolute;
-    width: ${space[2]}px;
-    right: -${space[2]}px;
-    top: -${space[1]}px;
-    bottom: -${space[1]}px;
-    overflow-x: hidden;
-    padding-left: ${space[1]}px;
-    user-select: none;
-  `
-})
-
-const StyledChangeIndicatorWithProvidedFullPath = styled(ChangeIndicatorWithProvidedFullPath)`
-  width: 1px;
-  height: 100%;
-
-  & > div {
-    height: 100%;
-  }
-`
 
 export function TextBlock(props: TextBlockProps): React.ReactElement {
   const {
@@ -223,7 +46,10 @@ export function TextBlock(props: TextBlockProps): React.ReactElement {
     renderBlockActions,
     renderCustomMarkers,
   } = props
+
   const {focused} = attributes
+
+  const blockKey = block._key
 
   // These are marker that is only for the block level (things further up, like annotations and inline objects are dealt with in their respective components)
   const blockMarkers = useMemo(
@@ -232,103 +58,44 @@ export function TextBlock(props: TextBlockProps): React.ReactElement {
         (marker) =>
           marker.path.length === 1 &&
           isKeySegment(marker.path[0]) &&
-          marker.path[0]._key === block._key
+          marker.path[0]._key === blockKey
       ),
-    [block._key, markers]
+    [blockKey, markers]
   )
 
   const errorMarkers = useMemo(
-    () => blockMarkers.filter((marker) => marker.type === 'validation' && marker.level === 'error'),
-    [blockMarkers]
-  )
-  const warningMarkers = useMemo(
-    () =>
-      blockMarkers.filter((marker) => marker.type === 'validation' && marker.level === 'warning'),
+    () => blockMarkers.filter((marker) => isValidationMarker(marker) && marker.level === 'error'),
     [blockMarkers]
   )
 
-  const hasMarkers = blockMarkers.length > 0
+  const warningMarkers = useMemo(
+    () => blockMarkers.filter((marker) => isValidationMarker(marker) && marker.level === 'warning'),
+    [blockMarkers]
+  )
+
+  const hasCustomMarkers =
+    Boolean(renderCustomMarkers) && blockMarkers.filter((m) => !isValidationMarker(m)).length > 0
   const hasErrors = errorMarkers.length > 0
   const hasWarnings = warningMarkers.length > 0
 
-  const {$size, $style} = useMemo((): {$size: number; $style: 'text' | 'heading'} => {
-    if (HEADER_SIZES_KEYS.includes(block.style)) {
-      return {$style: 'heading', $size: HEADER_SIZES[block.style]}
-    }
+  const tooltipEnabled = hasErrors || hasWarnings || hasCustomMarkers
 
-    return {$size: 2, $style: 'text'}
-  }, [block])
+  const blockPath = useMemo(() => [{_key: blockKey}], [blockKey])
 
   const text = useMemo(() => {
-    const hasTextStyle = TEXT_STYLES_KEYS.includes(block.style)
-    const TextComponent = TEXT_STYLES[hasTextStyle ? block?.style : 'normal']
+    const TextStyle = TEXT_STYLES[block.style || 'normal']
 
-    if (hasTextStyle) {
-      return (
-        <TextFlex align="flex-start" $level={block?.level}>
-          {block.listItem && (
-            <ListPrefixWrap contentEditable={false}>
-              <TextComponent data-list-prefix />
-            </ListPrefixWrap>
-          )}
-          <div data-ui="TextBlock__text">
-            <TextComponent>{children}</TextComponent>
-          </div>
-        </TextFlex>
-      )
-    }
-
-    if (block.listItem) {
-      return (
-        <TextFlex align="flex-start" $level={block?.level}>
-          {block.listItem && (
-            <ListPrefixWrap contentEditable={false}>
-              <TextComponent data-list-prefix />
-            </ListPrefixWrap>
-          )}
-          <div data-ui="TextBlock__text">{children}</div>
-        </TextFlex>
-      )
-    }
-
-    return <div data-ui="TextBlock__text">{children}</div>
+    return (
+      <TextFlex align="flex-start" $level={block?.level}>
+        {block.listItem && (
+          <ListPrefixWrapper contentEditable={false}>
+            <TextStyle data-list-prefix="" />
+          </ListPrefixWrapper>
+        )}
+        <TextStyle data-text="">{children}</TextStyle>
+      </TextFlex>
+    )
   }, [block.style, block.listItem, block.level, children])
-
-  const outerPaddingProps: ResponsivePaddingProps = useMemo(() => {
-    if (block.listItem) {
-      return {paddingY: 2}
-    }
-
-    switch (block.style) {
-      case 'h1': {
-        return {paddingTop: 5, paddingBottom: 4}
-      }
-      case 'h2': {
-        return {paddingTop: 4, paddingBottom: 4}
-      }
-      case 'h3': {
-        return {paddingTop: 4, paddingBottom: 3}
-      }
-      case 'h4': {
-        return {paddingTop: 4, paddingBottom: 3}
-      }
-      case 'h5': {
-        return {paddingTop: 4, paddingBottom: 3}
-      }
-      case 'h6': {
-        return {paddingTop: 4, paddingBottom: 2}
-      }
-      case 'normal': {
-        return {paddingTop: 2, paddingBottom: 3}
-      }
-      case 'blockquote': {
-        return {paddingTop: 2, paddingBottom: 3}
-      }
-      default: {
-        return {paddingY: 2}
-      }
-    }
-  }, [block])
 
   const innerPaddingProps: ResponsivePaddingProps = useMemo(() => {
     if (isFullscreen && !renderBlockActions) {
@@ -349,11 +116,17 @@ export function TextBlock(props: TextBlockProps): React.ReactElement {
     return {paddingX: 3}
   }, [isFullscreen, renderBlockActions])
 
-  const tooltipEnabled = hasErrors || hasWarnings || Boolean(hasMarkers && renderCustomMarkers)
+  const outerPaddingProps: ResponsivePaddingProps = useMemo(() => {
+    if (block.listItem) {
+      return {paddingY: 2}
+    }
+
+    return TEXT_STYLE_PADDING[block.style] || {paddingY: 2}
+  }, [block])
 
   return (
-    <Box {...outerPaddingProps}>
-      <InnerFlex>
+    <Box data-testid="text-block" {...outerPaddingProps}>
+      <TextBlockFlexWrapper data-testid="text-block__wrapper">
         <Box flex={1} {...innerPaddingProps}>
           <Tooltip
             placement="top"
@@ -370,22 +143,18 @@ export function TextBlock(props: TextBlockProps): React.ReactElement {
           >
             <TextRoot
               $level={block.level}
-              $listItem={block.listItem}
-              $size={$size}
-              data-invalid={hasErrors || undefined}
-              data-warning={hasWarnings || undefined}
-              data-level={block.level}
+              data-error={hasErrors ? '' : undefined}
+              data-warning={hasWarnings ? '' : undefined}
               data-list-item={block.listItem}
-              data-markers={hasMarkers || undefined}
-              data-style={$style}
-              data-testid="text-block"
+              data-custom-markers={hasCustomMarkers ? '' : undefined}
+              data-testid="text-block__text"
               ref={blockRef}
-              flex={1}
             >
-              <Box data-testid="text-block__inner">{text}</Box>
+              {text}
             </TextRoot>
           </Tooltip>
         </Box>
+
         <div
           contentEditable={false}
           // NOTE: it’s important that this element does not have the `user-select: none` CSS
@@ -412,13 +181,13 @@ export function TextBlock(props: TextBlockProps): React.ReactElement {
                 compareDeep
                 value={block}
                 hasFocus={focused}
-                path={[{_key: block._key}]}
+                path={blockPath}
                 withBadge={false}
               />
             </ChangeIndicatorWrapper>
           )}
         </div>
-      </InnerFlex>
+      </TextBlockFlexWrapper>
     </Box>
   )
 }

--- a/packages/@sanity/form-builder/src/inputs/PortableText/text/constants.ts
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/text/constants.ts
@@ -1,0 +1,48 @@
+export const TEXT_LEVELS = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+export const TEXT_BULLET_MARKERS = ['●', '○', '■']
+
+export const TEXT_NUMBER_FORMATS = ['number', 'lower-alpha', 'lower-roman']
+
+export const TEXT_DECORATOR_TAGS = {
+  em: 'em',
+  'strike-through': 's',
+  underline: 'u',
+  strong: 'strong',
+  code: 'code',
+}
+
+export const TEXT_STYLE_PADDING = {
+  h1: {
+    paddingTop: 5,
+    paddingBottom: 4,
+  },
+  h2: {
+    paddingTop: 4,
+    paddingBottom: 4,
+  },
+  h3: {
+    paddingTop: 4,
+    paddingBottom: 3,
+  },
+  h4: {
+    paddingTop: 4,
+    paddingBottom: 3,
+  },
+  h5: {
+    paddingTop: 4,
+    paddingBottom: 3,
+  },
+  h6: {
+    paddingTop: 4,
+    paddingBottom: 2,
+  },
+  normal: {
+    paddingTop: 2,
+    paddingBottom: 3,
+  },
+  blockquote: {
+    paddingTop: 2,
+    paddingBottom: 3,
+  },
+}

--- a/packages/@sanity/form-builder/src/inputs/PortableText/text/helpers.ts
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/text/helpers.ts
@@ -1,0 +1,3 @@
+export function createListName(level: number): string {
+  return `list-level-${level}`
+}

--- a/packages/@sanity/form-builder/src/inputs/PortableText/text/index.ts
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/text/index.ts
@@ -1,5 +1,7 @@
 export * from './Annotation'
 export * from './AnnotationToolbarPopover'
+export * from './constants'
 export * from './Decorator'
+export * from './helpers'
 export * from './TextBlock'
 export * from './textStyles'


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This refactors `TextBlock` and `Decorator`:

- Removes unused `data-*` attributes.
- Uses `data-*` attributes instead of conditional CSS.
- Moves styles to a separate file – `TextBlock.styles.ts`.
- Moves constants to a separate file – `constants.ts`.
- Moves helpers to a separate file – `helpers.ts`.
- Replaces `switch` statements with constant config objects.
- Uses CSS variables to colorize marker backgrounds.

And `BlockObject`:

- Add missing bottom padding.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

- That markers work as they have been.
- That blocks render and function as they have been.