### PR TITLE
fix(validation): make cloneWithMessage optional

### DIFF
--- a/packages/@sanity/types/src/validation/types.ts
+++ b/packages/@sanity/types/src/validation/types.ts
@@ -283,7 +283,7 @@ export interface ValidationError {
    * value.
    */
   paths?: Path[]
-  cloneWithMessage(message: string): ValidationError
+  cloneWithMessage?(message: string): ValidationError
 }
 
 export type CustomValidatorResult = true | string | ValidationError


### PR DESCRIPTION
### Description

Makes `cloneWithMessage` optional so the `ValidationError` type is more usable

### What to review

This change is very minor so I would say it's good to go if the typechecking CI passes

### Notes for release

Improves usability of `ValidationError` by making `cloneWithMessage` optional
