### PR TITLE
fix(form-builder): fix Safari issue with PTE popovers

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/PortableText/object/renderers/PopoverObjectEditing.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/object/renderers/PopoverObjectEditing.tsx
@@ -33,7 +33,8 @@ interface PopoverObjectEditingProps {
 
 const Root = styled(Popover)`
   &[data-popper-reference-hidden='true'] {
-    display: none;
+    visibility: hidden;
+    pointer-events: none;
   }
 
   & > div {


### PR DESCRIPTION
Safari would blink and cause layout issues when editing through popover modals in the PTE.

This is probably because we set `display: none` on the refElement and Safari can't compute the dimensions correctly. 

Instead of display, we now use `visibility: hidden` so that element keeps its dimensions.

