### PR TITLE
fix(state-router): prevent ID flashing when resolving intents

### DIFF
--- a/packages/@sanity/state-router/src/components/RouterProvider.tsx
+++ b/packages/@sanity/state-router/src/components/RouterProvider.tsx
@@ -77,15 +77,16 @@ export default class RouterProvider extends React.Component<RouterProviderProps>
     }
   }
 
-  componentDidUpdate() {
-    const {state} = this.props
+  componentDidUpdate(prevProps) {
+    const {state: currentState} = this.props
+    const {state: prevState} = prevProps
 
-    if (!isEqual(this._state, state)) {
-      this._state = state
+    if (!isEqual(currentState, prevState)) {
+      this._state = currentState
 
       setTimeout(() => {
         batchedUpdates(() => {
-          this.__internalRouter.channel.publish(state)
+          this.__internalRouter.channel.publish(currentState)
         })
       }, 0)
     }


### PR DESCRIPTION
### Description

Fixes a small bug that causes URLs to flash while resolving intent IDs.

### What to review

Try creating a new document via intent links and ensure there is no URL flashing.

### Notes for release

Fixes a bug that caused the URL to flash different IDs while resolving create intents.