### PR TITLE
fix(form-builder): fix clearing invalid date values

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/DateInputs/CommonDateTimeInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/DateInputs/CommonDateTimeInput.tsx
@@ -55,15 +55,22 @@ export const CommonDateTimeInput = React.forwardRef(function CommonDateTimeInput
     (event) => {
       const nextInputValue = event.currentTarget.value
       const result = nextInputValue === '' ? null : parseInputValue(nextInputValue)
+
       if (result === null) {
         onChange(null)
+
+        // If the field value is undefined and we are clearing the invalid value
+        // the above useEffect won't trigger, so we do some extra clean up here
+        if (typeof value === 'undefined' && localValue) {
+          setLocalValue(null)
+        }
       } else if (result.isValid) {
         onChange(serialize(result.date))
       } else {
         setLocalValue(nextInputValue)
       }
     },
-    [serialize, onChange, parseInputValue]
+    [localValue, serialize, onChange, parseInputValue]
   )
 
   const handleDatePickerChange = React.useCallback(

--- a/packages/@sanity/form-builder/src/inputs/DateInputs/base/LazyTextInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/DateInputs/base/LazyTextInput.tsx
@@ -66,6 +66,7 @@ export const LazyTextInput = React.forwardRef(function LazyTextInput(
   return (
     <TextInput
       {...rest}
+      data-testid="date-input"
       ref={forwardedRef}
       value={inputValue === undefined ? value : inputValue}
       onChange={handleChange}


### PR DESCRIPTION
### Description

This fixes an issue where you weren't able to clear an invalid date in a date field if the field `value` was empty/`undefined`.

Normally this would be handled by the `useEffect` triggering on `value` changing, but in this case `value` is always `undefined` since the invalid date is saved in local state.

### What to review

- That you are able to enter a invalid date like `this is invalid`, then able to clear it again

### Notes for release

- Fixes an issue that prevents clearing a invalid date value when the field is empty
