### PR TITLE
fix(client): deprecate defer and add deferred visibility

### DIFF
--- a/packages/@sanity/client/sanityClient.d.ts
+++ b/packages/@sanity/client/sanityClient.d.ts
@@ -553,7 +553,7 @@ export interface RequestOptions {
 }
 
 type BaseMutationOptions = RequestOptions & {
-  visibility?: 'sync' | 'async' | 'defer'
+  visibility?: 'sync' | 'async' | 'deferred'
   returnDocuments?: boolean
   returnFirst?: boolean
 }


### PR DESCRIPTION
### Description

Transaction visibility doesn't support the defer keyword, so deprecate the old in case someone is using it, and add deferred.
See https://www.sanity.io/docs/transactions#80cd6d6bd47b

Note that sending `visibility=defer` will cause:

```
{"error":{"description":"Could not decode query string parameter \"visibility\" value \"defer\": Invalid visibility value","type":"httpBadRequest"}}
```

### What to review

* Implementation 
* 
### Notes for release

Fixes `deferred` mutations 