### PR TITLE
feat(client): respect useCdn when queries are sent with POST

### DIFF
--- a/packages/@sanity/client/src/data/dataMethods.js
+++ b/packages/@sanity/client/src/data/dataMethods.js
@@ -120,6 +120,7 @@ module.exports = {
 
   _dataRequest(endpoint, body, options = {}) {
     const isMutation = endpoint === 'mutate'
+    const isQuery = endpoint === 'query'
 
     // Check if the query string is within a configured threshold,
     // in which case we can use GET. Otherwise, use POST.
@@ -140,6 +141,7 @@ module.exports = {
       timeout,
       token,
       tag,
+      canUseCdn: isQuery,
     }
 
     return this._requestObservable(reqOptions).pipe(


### PR DESCRIPTION
### Description

`useCdn: true` only applied to GET/HEAD requests sent to the /data-endpoint. However, in the case of a huge query then we send the query as a POST request and this is still supported and cached by the API CDN. This PR makes sure that these requests also gets sent to the API CDN.

This implements it by introducing an internal `canUseCdn`-option to the `_requestObservable` method. (A potential improvement in the future would be to also use this explicitly in the code base instead of having a magical `if (uri.startsWith("/data"))` deep inside a core method, but I decided against to keep the diff small).

### What to review

- Check that adding this functionality into the `_requestObservable` method doesn't cause any problems elsewhere.

### Notes for release

- Calling `fetch` with huge queries will now respect `useCdn: true`.
