### PR TITLE
feat: info level validation

### DIFF
--- a/dev/test-studio/schema/debug/validation.js
+++ b/dev/test-studio/schema/debug/validation.js
@@ -71,6 +71,12 @@ export default {
       },
     },
     {
+      type: 'string',
+      name: 'infoValidation',
+      title: 'Info validation',
+      validation: (rule) => rule.min(8).info('This is an information validation message'),
+    },
+    {
       name: 'myUrlField',
       type: 'url',
       title: 'Plain url',

--- a/packages/@sanity/base/src/components/formField/FormFieldValidationStatus.tsx
+++ b/packages/@sanity/base/src/components/formField/FormFieldValidationStatus.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 
 import {hues} from '@sanity/color'
-import {ErrorOutlineIcon, WarningOutlineIcon} from '@sanity/icons'
+import {ErrorOutlineIcon, InfoOutlineIcon, WarningOutlineIcon} from '@sanity/icons'
 import {
   isValidationErrorMarker,
   isValidationMarker,
@@ -10,7 +10,7 @@ import {
   ValidationMarker,
 } from '@sanity/types'
 import {Box, Flex, Placement, Stack, Text, Tooltip} from '@sanity/ui'
-import React, {createElement} from 'react'
+import React from 'react'
 import {markersToValidationList} from './helpers'
 import {FormFieldValidation} from './types'
 
@@ -28,6 +28,18 @@ export interface FormFieldValidationStatusProps {
   portal?: boolean
 }
 
+const VALIDATION_COLORS: Record<'error' | 'warning' | 'info', string> = {
+  error: hues.red[500].hex,
+  warning: hues.yellow[500].hex,
+  info: hues.blue[500].hex,
+}
+
+const VALIDATION_ICONS: Record<'error' | 'warning' | 'info', React.ReactElement> = {
+  error: <ErrorOutlineIcon />,
+  warning: <WarningOutlineIcon />,
+  info: <InfoOutlineIcon />,
+}
+
 export function FormFieldValidationStatus(props: FormFieldValidationStatusProps) {
   const {
     __unstable_markers: markers = [],
@@ -39,9 +51,26 @@ export function FormFieldValidationStatus(props: FormFieldValidationStatusProps)
   const validationMarkers = markers.filter(isValidationMarker)
   const validation = markersToValidationList(validationMarkers)
   const errors = validation.filter((v) => v.type === 'error')
+  const warnings = validation.filter((v) => v.type === 'warning')
+  const info = validation.filter((v) => v.type === 'info')
+
   const hasErrors = errors.length > 0
-  const statusIcon = hasErrors ? ErrorOutlineIcon : WarningOutlineIcon
-  const statusColor = hasErrors ? hues.red[500].hex : hues.yellow[500].hex
+  const hasWarnings = warnings.length > 0
+  const hasInfo = info.length > 0
+
+  const statusIcon = () => {
+    if (hasErrors) return VALIDATION_ICONS.error
+    if (hasWarnings) return VALIDATION_ICONS.warning
+    if (hasInfo) return VALIDATION_ICONS.info
+    return null
+  }
+
+  const statusColor = () => {
+    if (hasErrors) return VALIDATION_COLORS.error
+    if (hasWarnings) return VALIDATION_COLORS.warning
+    if (hasInfo) return VALIDATION_COLORS.info
+    return null
+  }
 
   return (
     <Tooltip
@@ -64,8 +93,8 @@ export function FormFieldValidationStatus(props: FormFieldValidationStatusProps)
       fallbackPlacements={['bottom', 'right', 'left']}
     >
       <div>
-        <Text muted size={fontSize} weight="semibold" style={{color: statusColor}}>
-          {createElement(statusIcon)}
+        <Text muted size={fontSize} weight="semibold" style={{color: statusColor()}}>
+          {statusIcon()}
         </Text>
       </div>
     </Tooltip>
@@ -74,14 +103,26 @@ export function FormFieldValidationStatus(props: FormFieldValidationStatusProps)
 
 function FormFieldValidationStatusItem(props: {item: FormFieldValidation}) {
   const {item} = props
-  const statusIcon = item.type === 'error' ? ErrorOutlineIcon : WarningOutlineIcon
-  const statusColor = item.type === 'error' ? hues.red[500].hex : hues.yellow[500].hex
+
+  const statusIcon = () => {
+    if (item.type === 'error') return VALIDATION_ICONS.error
+    if (item.type === 'warning') return VALIDATION_ICONS.warning
+    if (item.type === 'info') return VALIDATION_ICONS.info
+    return null
+  }
+
+  const statusColor = () => {
+    if (item.type === 'error') return VALIDATION_COLORS.error
+    if (item.type === 'warning') return VALIDATION_COLORS.warning
+    if (item.type === 'info') return VALIDATION_COLORS.info
+    return null
+  }
 
   return (
     <Flex>
       <Box marginRight={2}>
-        <Text size={1} style={{color: statusColor}}>
-          {createElement(statusIcon)}
+        <Text size={1} style={{color: statusColor()}}>
+          {statusIcon()}
         </Text>
       </Box>
       <Box flex={1}>

--- a/packages/@sanity/base/src/components/formField/helpers.ts
+++ b/packages/@sanity/base/src/components/formField/helpers.ts
@@ -6,7 +6,7 @@ export function markersToValidationList(markers: ValidationMarker[]): FormFieldV
 
   return validationMarkers.map((marker) => {
     return {
-      type: marker.level === 'error' ? 'error' : 'warning',
+      type: marker.level,
       label: marker.item.message,
     }
   })

--- a/packages/@sanity/base/src/components/formField/types.ts
+++ b/packages/@sanity/base/src/components/formField/types.ts
@@ -8,4 +8,12 @@ interface FormFieldValidationError {
   label: string
 }
 
-export type FormFieldValidation = FormFieldValidationWarning | FormFieldValidationError
+interface FormFieldValidationInfo {
+  type: 'info'
+  label: string
+}
+
+export type FormFieldValidation =
+  | FormFieldValidationWarning
+  | FormFieldValidationError
+  | FormFieldValidationInfo

--- a/packages/@sanity/base/src/components/validation/listItem.tsx
+++ b/packages/@sanity/base/src/components/validation/listItem.tsx
@@ -1,7 +1,7 @@
 import {Marker, Path} from '@sanity/types'
-import React, {useCallback} from 'react'
-import {WarningOutlineIcon, ErrorOutlineIcon} from '@sanity/icons'
-import {Box, Text, MenuItem, Stack, Flex} from '@sanity/ui'
+import React, {useCallback, useMemo} from 'react'
+import {WarningOutlineIcon, ErrorOutlineIcon, InfoOutlineIcon} from '@sanity/icons'
+import {Box, Text, MenuItem, Stack, Flex, ButtonTone} from '@sanity/ui'
 import styled from 'styled-components'
 
 interface ValidationListItemProps {
@@ -15,10 +15,14 @@ const StyledText = styled(Text)`
   white-space: initial;
 `
 
+const MENU_ITEM_TONES: Record<'error' | 'warning' | 'info', ButtonTone> = {
+  error: 'critical',
+  warning: 'caution',
+  info: 'primary',
+}
+
 export function ListItem(props: ValidationListItemProps) {
   const {marker, onClick, path, truncate} = props
-
-  const tone = marker.level === 'warning' ? 'caution' : 'critical'
 
   const handleClick = useCallback(() => {
     if (onClick) {
@@ -26,12 +30,15 @@ export function ListItem(props: ValidationListItemProps) {
     }
   }, [marker.path, onClick])
 
+  const menuItemTone = MENU_ITEM_TONES[marker?.level] || undefined
+
   const children = (
     <Flex>
       <Box>
         <Text size={1}>
           {marker.level === 'error' && <ErrorOutlineIcon />}
           {marker.level === 'warning' && <WarningOutlineIcon />}
+          {marker.level === 'info' && <InfoOutlineIcon />}
         </Text>
       </Box>
 
@@ -50,7 +57,7 @@ export function ListItem(props: ValidationListItemProps) {
     </Flex>
   )
   return (
-    <MenuItem padding={1} onClick={handleClick} radius={2} tone={tone}>
+    <MenuItem padding={1} onClick={handleClick} radius={2} tone={menuItemTone}>
       <Box padding={2}>{children}</Box>
     </MenuItem>
   )

--- a/packages/@sanity/base/src/components/validation/validationList.tsx
+++ b/packages/@sanity/base/src/components/validation/validationList.tsx
@@ -5,6 +5,7 @@ import {
   Marker,
   isValidationErrorMarker,
   isValidationWarningMarker,
+  isValidationInfoMarker,
 } from '@sanity/types'
 import {Container} from '@sanity/ui'
 import {ListItem} from './listItem'
@@ -23,6 +24,7 @@ export function ValidationList(props: ValidationListProps) {
 
   const errors = markers.filter(isValidationErrorMarker)
   const warnings = markers.filter(isValidationWarningMarker)
+  const info = markers.filter(isValidationInfoMarker)
 
   const handleClick = useCallback(
     (path: Path = []) => {
@@ -41,32 +43,44 @@ export function ValidationList(props: ValidationListProps) {
 
   const hasErrors = errors.length > 0
   const hasWarnings = warnings.length > 0
+  const hasInfo = info.length > 0
 
-  if (!hasErrors && !hasWarnings) {
+  if (!hasErrors && !hasWarnings && !hasInfo) {
     return null
   }
 
   return (
     <Container width={0} data-kind={kind}>
       {hasErrors &&
-        errors.map((error, i) => (
+        errors.map((_error, i) => (
           <ListItem
             // eslint-disable-next-line react/no-array-index-key
             key={i}
             truncate={truncate}
-            path={resolvePathTitle(error.path)}
-            marker={error}
+            path={resolvePathTitle(_error.path)}
+            marker={_error}
             onClick={handleClick}
           />
         ))}
       {hasWarnings &&
-        warnings.map((warning, i) => (
+        warnings.map((_warning, i) => (
           <ListItem
             // eslint-disable-next-line react/no-array-index-key
             key={i}
             truncate={truncate}
-            path={resolvePathTitle(warning.path)}
-            marker={warning}
+            path={resolvePathTitle(_warning.path)}
+            marker={_warning}
+            onClick={handleClick}
+          />
+        ))}
+      {hasInfo &&
+        info.map((_info, i) => (
+          <ListItem
+            // eslint-disable-next-line react/no-array-index-key
+            key={i}
+            truncate={truncate}
+            path={resolvePathTitle(_info.path)}
+            marker={_info}
             onClick={handleClick}
           />
         ))}

--- a/packages/@sanity/desk-tool/src/panes/document/documentPanel/header/ValidationMenu.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/documentPanel/header/ValidationMenu.tsx
@@ -1,6 +1,11 @@
 import {useId} from '@reach/auto-id'
 import {ValidationList} from '@sanity/base/components'
 import {ErrorOutlineIcon} from '@sanity/icons'
+import {
+  isValidationInfoMarker,
+  isValidationWarningMarker,
+  isValidationErrorMarker,
+} from '@sanity/types'
 import {Button, Menu, MenuButton} from '@sanity/ui'
 import React, {useCallback, useMemo} from 'react'
 import {useDocumentPane} from '../../useDocumentPane'
@@ -20,21 +25,28 @@ export function ValidationMenu(props: ValidationMenuProps) {
     [markers]
   )
 
-  const validationErrorMarkers = useMemo(
-    () => validationMarkers.filter((marker) => marker.level === 'error'),
+  const validationErrorMarkers = useMemo(() => validationMarkers.filter(isValidationErrorMarker), [
+    validationMarkers,
+  ])
+
+  const validationWarningMarkers = useMemo(
+    () => validationMarkers.filter(isValidationWarningMarker),
     [validationMarkers]
   )
 
-  const validationWarningwarnings = useMemo(
-    () => validationMarkers.filter((marker) => marker.level === 'warning'),
-    [validationMarkers]
-  )
+  const validationInfoMarkers = useMemo(() => validationMarkers.filter(isValidationInfoMarker), [
+    validationMarkers,
+  ])
 
   const id = useId()
 
   const handleClose = useCallback(() => setOpen(false), [setOpen])
 
-  if (validationErrorMarkers.length === 0 && validationWarningwarnings.length === 0) {
+  if (
+    validationErrorMarkers.length === 0 &&
+    validationWarningMarkers.length === 0 &&
+    validationInfoMarkers.length === 0
+  ) {
     return null
   }
 

--- a/packages/@sanity/form-builder/src/inputs/PortableText/_legacyDefaultParts/Markers.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/_legacyDefaultParts/Markers.tsx
@@ -21,6 +21,10 @@ const getIcon = (level) => {
 
 const IconText = styled(Text)(({theme}: {theme: Theme}) => {
   return css`
+    &[data-info] {
+      color: ${theme.sanity.color.muted.primary.enabled.fg};
+    }
+
     &[data-warning] {
       color: ${theme.sanity.color.muted.caution.enabled.fg};
     }
@@ -60,6 +64,7 @@ export default function Markers(props: Props) {
                 size={1}
                 data-error={level === 'error' ? '' : undefined}
                 data-warning={level === 'warning' ? '' : undefined}
+                data-info={level === 'info' ? '' : undefined}
               >
                 {getIcon(level)}
               </IconText>

--- a/packages/@sanity/form-builder/src/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/object/BlockObject.tsx
@@ -246,15 +246,21 @@ export function BlockObject(props: BlockObjectProps) {
     [blockMarkers]
   )
 
-  const hasMarkers = blockMarkers.length > 0
+  const infoMarkers = useMemo(
+    () => blockMarkers.filter((marker) => marker.type === 'validation' && marker.level === 'info'),
+    [blockMarkers]
+  )
+
+  const hasMarkers = Boolean(blockMarkers.length > 0 && renderCustomMarkers)
   const hasErrors = errorMarkers.length > 0
   const hasWarnings = warningMarkers.length > 0
+  const hasInfo = infoMarkers.length > 0
 
   const isImagePreview = type?.type?.name === 'image'
 
   const blockPath = useMemo(() => [{_key: block._key}], [block._key])
 
-  const tooltipEnabled = hasErrors || hasWarnings || Boolean(hasMarkers && renderCustomMarkers)
+  const tooltipEnabled = hasErrors || hasWarnings || hasInfo || hasMarkers
 
   return (
     <InnerFlex marginY={3}>
@@ -272,11 +278,11 @@ export function BlockObject(props: BlockObjectProps) {
           }
         >
           <Root
-            data-focused={focused || undefined}
-            data-invalid={hasErrors || undefined}
-            data-selected={selected || undefined}
-            data-markers={hasMarkers || undefined}
-            data-warning={hasWarnings || undefined}
+            data-focused={focused ? '' : undefined}
+            data-invalid={hasErrors ? '' : undefined}
+            data-selected={selected ? '' : undefined}
+            data-markers={hasMarkers ? '' : undefined}
+            data-warning={hasWarnings ? '' : undefined}
             data-testid="pte-block-object"
             data-image-preview={isImagePreview ? '' : undefined}
             flex={1}

--- a/packages/@sanity/types/src/markers/asserters.ts
+++ b/packages/@sanity/types/src/markers/asserters.ts
@@ -15,3 +15,9 @@ export function isValidationWarningMarker(
 ): marker is ValidationMarker & {level: 'warning'} {
   return isValidationMarker(marker) && marker.level === 'warning'
 }
+
+export function isValidationInfoMarker(
+  marker: Marker
+): marker is ValidationMarker & {level: 'info'} {
+  return isValidationMarker(marker) && marker.level === 'info'
+}

--- a/packages/@sanity/types/src/markers/types.ts
+++ b/packages/@sanity/types/src/markers/types.ts
@@ -16,6 +16,6 @@ interface BaseMarker {
 
 export interface ValidationMarker extends BaseMarker {
   type: 'validation'
-  level: 'error' | 'warning'
+  level: 'error' | 'warning' | 'info'
   item: ValidationError
 }

--- a/packages/@sanity/types/src/validation/types.ts
+++ b/packages/@sanity/types/src/validation/types.ts
@@ -97,6 +97,7 @@ export interface Rule {
   valueOfField: (path: string | string[]) => {type: symbol; path: string | string[]}
   error(message?: string): Rule
   warning(message?: string): Rule
+  info(message?: string): Rule
   reset(): this
   isRequired(): boolean
   clone(): Rule

--- a/packages/@sanity/types/src/validation/types.ts
+++ b/packages/@sanity/types/src/validation/types.ts
@@ -45,7 +45,7 @@ export interface Rule {
    * @internal
    * @deprecated internal use only
    */
-  _level: 'error' | 'warning' | undefined
+  _level: 'error' | 'warning' | 'info' | undefined
   /**
    * @internal
    * @deprecated internal use only

--- a/packages/@sanity/validation/src/Rule.ts
+++ b/packages/@sanity/validation/src/Rule.ts
@@ -83,7 +83,7 @@ const Rule: RuleClass = class Rule implements IRule {
   })
 
   _type: RuleTypeConstraint | undefined = undefined
-  _level: 'error' | 'warning' | undefined = undefined
+  _level: 'error' | 'warning' | 'info' | undefined = undefined
   _required: 'required' | 'optional' | undefined = undefined
   _typeDef: SchemaType | undefined = undefined
   _message: string | undefined = undefined
@@ -114,6 +114,13 @@ const Rule: RuleClass = class Rule implements IRule {
   warning(message?: string): Rule {
     const rule = this.clone()
     rule._level = 'warning'
+    rule._message = message || undefined
+    return rule
+  }
+
+  info(message?: string): Rule {
+    const rule = this.clone()
+    rule._level = 'info'
     rule._message = message || undefined
     return rule
   }

--- a/packages/@sanity/validation/src/util/convertToValidationMarker.ts
+++ b/packages/@sanity/validation/src/util/convertToValidationMarker.ts
@@ -18,7 +18,7 @@ export default function convertToValidationMarker(
     | ValidationError[]
     | ValidationErrorLike
     | ValidationErrorLike[],
-  level: 'error' | 'warning' | undefined,
+  level: 'error' | 'warning' | 'info' | undefined,
   context: ValidationContext
 ): ValidationMarker[] {
   if (validatorResult === true) return []

--- a/packages/@sanity/validation/test/__snapshots__/generics.test.ts.snap
+++ b/packages/@sanity/validation/test/__snapshots__/generics.test.ts.snap
@@ -16,6 +16,22 @@ Array [
 ]
 `;
 
+exports[`generics can customize info messages 1`] = `
+Array [
+  Object {
+    "item": ValidationError {
+      "children": undefined,
+      "message": "Dude it should probably be a string",
+      "operation": undefined,
+      "paths": Array [],
+    },
+    "level": "info",
+    "path": Array [],
+    "type": "validation",
+  },
+]
+`;
+
 exports[`generics can customize warning messages 1`] = `
 Array [
   Object {

--- a/packages/@sanity/validation/test/generics.test.ts
+++ b/packages/@sanity/validation/test/generics.test.ts
@@ -44,6 +44,12 @@ describe('generics', () => {
     expect(result).toMatchSnapshot()
   })
 
+  test('can customize info messages', async () => {
+    const result = await Rule.string().info('Dude it should probably be a string').validate(123)
+
+    expect(result).toMatchSnapshot()
+  })
+
   test('can merge rules', async () => {
     const rule = new Rule().required()
     const stringRule = Rule.string().min(5)


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR introduces a new `info` validation rule. The rule works like the `warning` rule, that is, it does not block the ability to publish a document.
##

####  Example 1

##### Schema
```
{
    type: 'string',
    name: 'myString',
    title: 'My string',
    validation: (rule) => rule.min(5).info('Info validation message'),
}
```
##### Studio

<img width="627" alt="Screenshot 2021-11-29 at 15 40 35" src="https://user-images.githubusercontent.com/15094168/143887768-592a9712-ed7f-4b55-86c4-8896672555e1.png">

##

#### Example 2

##### Schema
```
{
    type: 'string',
    name: 'myString',
    title: 'My string',
    validation: (rule) => [
        rule.min(5).error('Error validation message'),
        rule.min(5).warning('Warning validation message'),
        rule.min(5).info('Info validation message'),
    ]
}
```

##### Studio
<img width="627" alt="Screenshot 2021-11-29 at 15 53 54" src="https://user-images.githubusercontent.com/15094168/143890024-640b787f-5aff-4ffb-b491-d6fa8660dc67.png">

### What to review
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

- The rule should not block the ability to publish a document
- General code review

### Notes for release

Add info validation rule 

<!--
A description of the change(s) that should be used in the release notes.
-->
