### PR TITLE
Configure PT spellchecking via the schema

### DIFF
--- a/dev/test-studio/schema/standard/portableText/simpleBlock.js
+++ b/dev/test-studio/schema/standard/portableText/simpleBlock.js
@@ -65,6 +65,9 @@ export default {
               const text = extractTextFromBlocks([block])
               return text.length === 1 ? 'Please write a longer paragraph.' : true
             }),
+          options: {
+            spellCheck: true,
+          },
         },
         {type: 'image', name: 'image'},
         myStringType,

--- a/packages/@sanity/form-builder/src/inputs/PortableText/Editor.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Editor.tsx
@@ -203,7 +203,6 @@ export function Editor(props: EditorProps) {
                   renderDecorator={renderDecorator}
                   scrollSelectionIntoView={handleScrollSelectionIntoView}
                   selection={initialSelection}
-                  spellCheck
                 />
               </BoundaryElementProvider>
             </EditableWrapper>

--- a/packages/@sanity/form-builder/src/inputs/PortableText/Input.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Input.tsx
@@ -86,6 +86,16 @@ export function Input(props: InputProps) {
   const [scrollElement, setScrollElement] = useState<HTMLElement | null>(null)
   const handledFocusPath = useRef(null)
 
+  const textBlockSpellCheck = useMemo(() => {
+    // Chrome 96. has serious perf. issues with spellchecking
+    // https://bugs.chromium.org/p/chromium/issues/detail?id=1271918
+    // TODO: check up on the status of this.
+    const spellCheckOption = editor.portableTextFeatures.types.block.options?.spellCheck
+    const isChrome96 =
+      typeof navigator === 'undefined' ? false : /Chrome\/96/.test(navigator.userAgent)
+    return spellCheckOption === undefined && isChrome96 === true ? false : spellCheckOption
+  }, [editor])
+
   // Respond to focusPath changes
   useEffect(() => {
     // Wait until the editor is properly initialized
@@ -249,6 +259,7 @@ export function Input(props: InputProps) {
             markers={blockMarkers}
             onChange={onChange}
             readOnly={readOnly}
+            spellCheck={textBlockSpellCheck}
             renderBlockActions={isEmptyValue ? undefined : renderBlockActions}
             renderCustomMarkers={isEmptyValue ? undefined : renderCustomMarkers}
           >

--- a/packages/@sanity/form-builder/src/inputs/PortableText/text/TextBlock.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/text/TextBlock.tsx
@@ -31,6 +31,7 @@ interface TextBlockProps {
   readOnly: boolean
   renderBlockActions?: RenderBlockActions
   renderCustomMarkers?: RenderCustomMarkers
+  spellCheck?: boolean
 }
 
 export function TextBlock(props: TextBlockProps): React.ReactElement {
@@ -45,6 +46,7 @@ export function TextBlock(props: TextBlockProps): React.ReactElement {
     readOnly,
     renderBlockActions,
     renderCustomMarkers,
+    spellCheck,
   } = props
 
   const {focused} = attributes
@@ -148,6 +150,7 @@ export function TextBlock(props: TextBlockProps): React.ReactElement {
               data-list-item={block.listItem}
               data-custom-markers={hasCustomMarkers ? '' : undefined}
               data-testid="text-block__text"
+              spellCheck={spellCheck}
               ref={blockRef}
             >
               {text}

--- a/packages/@sanity/schema/src/sanity/validation/types/block.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/block.ts
@@ -5,7 +5,17 @@ import {isJSONTypeOf} from '../utils/isJSONTypeOf'
 
 const getTypeOf = (thing) => (Array.isArray(thing) ? 'array' : typeof thing)
 const quote = (str) => `"${str}"`
-const allowedKeys = ['type', 'styles', 'marks', 'lists', 'of', 'title', 'name', 'validation']
+const allowedKeys = [
+  'lists',
+  'marks',
+  'name',
+  'of',
+  'options',
+  'styles',
+  'title',
+  'type',
+  'validation',
+]
 const allowedMarkKeys = ['decorators', 'annotations']
 const allowedStyleKeys = ['title', 'value', 'blockEditor']
 const allowedDecoratorKeys = ['title', 'value', 'blockEditor', 'icon']


### PR DESCRIPTION
### Description

Latest Chromium has some serious performance issues when it comes to spellchecking via the browsers default spellchecking.

This is really noticable on larger documents, and it seems that almost everyone doing text editing online is being hit by this regardless of editor.

https://bugs.chromium.org/p/chromium/issues/detail?id=1271918

To work around this let's finally make spellchecking configurable via the schema for the `block` type:

```
        {
          type: 'block',
          options: {
            spellCheck: true,
          },
        },
```

Spellchecking is off by default with this change which should probably be the default anyway.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->


### What to review
That this option does the default and is configurable.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Disabled default-on spellchecking for the Portable Text Input, and introduced schema option to configure this via `options.spellCheck`

<!--
A description of the change(s) that should be used in the release notes.
-->
