### PR TITLE
test(desk-tool): proxy module instead of spread

### DIFF
--- a/packages/@sanity/desk-tool/src/DeskTool.test.tsx
+++ b/packages/@sanity/desk-tool/src/DeskTool.test.tsx
@@ -46,16 +46,26 @@ jest.mock('part:@sanity/base/schema', () => {
 })
 
 jest.mock('@sanity/base/hooks', () => {
-  const baseHooks = jest.requireActual('@sanity/base/hooks')
+  const actualModule = jest.requireActual('@sanity/base/hooks')
 
-  return {
-    ...baseHooks,
-    /* eslint-disable camelcase */
-    unstable_useDocumentPairPermissions: () => [{granted: true, reason: ''}, false],
-    unstable_useDocumentValuePermissions: () => [{granted: true, reason: ''}, false],
-    unstable_useTemplatePermissions: () => [{}, false],
-    /* eslint-enable camelcase */
-  }
+  return new Proxy(actualModule, {
+    get: (target, property) => {
+      switch (property) {
+        case 'unstable_useDocumentPairPermissions': {
+          return jest.fn(() => [{granted: true, reason: ''}, false])
+        }
+        case 'unstable_useDocumentValuePermissions': {
+          return jest.fn(() => [{granted: true, reason: ''}, false])
+        }
+        case 'unstable_useTemplatePermissions': {
+          return jest.fn(() => [{}, false])
+        }
+        default: {
+          return target[property]
+        }
+      }
+    },
+  })
 })
 
 jest.mock('part:@sanity/base/grants', () => {


### PR DESCRIPTION
### Description

This PR improves the reliability of the desk-tool tests by using a proxy instead of an object spread.

@sjelfull showed me [a run](https://github.com/sanity-io/sanity/runs/4369598916?check_suite_focus=true) where this test broke to a very strange error `TypeError: Cannot read property 'unstable_useConditionalProperty' of undefined`. This PR fixes that issue by preserving the module and intercepting property calls instead of creating a new object.

### Notes for release

N/A
