### PR TITLE
fix(desk-tool): fix flashing reference changed banner; update copy

### DIFF
--- a/packages/@sanity/desk-tool/package.json
+++ b/packages/@sanity/desk-tool/package.json
@@ -60,6 +60,7 @@
     "@sanity/base": "2.22.3",
     "@sanity/ui-workshop": "^0.3.5",
     "@testing-library/react": "^11.2.5",
+    "@testing-library/jest-dom": "^5.11.10",
     "@types/is-hotkey": "^0.1.3",
     "@types/shallow-equals": "^1.0.0",
     "@types/webpack-env": "^1.16.2",

--- a/packages/@sanity/desk-tool/src/panes/document/documentPanel/ReferenceChangedBanner.test.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/documentPanel/ReferenceChangedBanner.test.tsx
@@ -1,0 +1,132 @@
+// eslint-disable-next-line import/no-unassigned-import
+import '@testing-library/jest-dom'
+import React from 'react'
+import {render, waitFor} from '@testing-library/react'
+import {RouterProvider} from '@sanity/base/router'
+import {toString as pathToString} from '@sanity/util/paths'
+import {AvailabilityReason, unstable_observePathsDocumentPair} from '@sanity/base/_internal'
+import {studioTheme, ThemeProvider} from '@sanity/ui'
+import {of} from 'rxjs'
+import {PaneRouterProvider} from '../../../contexts/paneRouter'
+import deskTool from '../../../_parts/base-tool'
+import {ReferenceChangedBanner} from './ReferenceChangedBanner'
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  ;(unstable_observePathsDocumentPair as jest.Mock).mockImplementation(() =>
+    of({
+      id: 'parent-id',
+      type: 'string | null',
+      draft: {
+        availability: {
+          available: true,
+          reason: AvailabilityReason.READABLE,
+        },
+        snapshot: {
+          _id: 'parent-id',
+          _type: 'example-type',
+          exampleReferenceField: {
+            _ref: 'example-id',
+          },
+        },
+      },
+      published: {
+        availability: {
+          available: false,
+          reason: AvailabilityReason.NOT_FOUND,
+        },
+      },
+    })
+  )
+})
+
+jest.mock('@sanity/base/_internal', () => {
+  const actualModule = jest.requireActual('@sanity/base/_internal')
+  const Rx = require('rxjs')
+
+  const mockObservePathsDocumentPair = jest.fn()
+
+  return new Proxy(actualModule, {
+    get: (target, property) => {
+      switch (property) {
+        case 'unstable_observePathsDocumentPair': {
+          return mockObservePathsDocumentPair
+        }
+        default: {
+          return target[property]
+        }
+      }
+    },
+  })
+})
+
+describe('ReferenceChangedBanner', () => {
+  it('appears when there is an ID mismatch', async () => {
+    const params = {
+      parentRefPath: pathToString(['exampleReferenceField']),
+    }
+
+    const {findByTestId} = render(
+      <ThemeProvider scheme="light" theme={studioTheme}>
+        <RouterProvider
+          onNavigate={jest.fn()}
+          router={deskTool.router}
+          state={{
+            panes: [
+              [{id: 'parent-id'}],
+              // this ID is different from the mock
+              [{id: 'different-id', params}],
+            ],
+          }}
+        >
+          <PaneRouterProvider
+            flatIndex={2}
+            index={2}
+            siblingIndex={0}
+            params={params}
+            payload={undefined}
+          >
+            <ReferenceChangedBanner />
+          </PaneRouterProvider>
+        </RouterProvider>
+      </ThemeProvider>
+    )
+
+    await findByTestId('reference-changed-banner', undefined, {timeout: 5 * 1000})
+  })
+
+  it('disappears when the IDs match', async () => {
+    const params = {
+      parentRefPath: pathToString(['exampleReferenceField']),
+    }
+
+    const {queryByTestId} = render(
+      <ThemeProvider scheme="light" theme={studioTheme}>
+        <RouterProvider
+          onNavigate={jest.fn()}
+          router={deskTool.router}
+          state={{
+            panes: [
+              [{id: 'parent-id'}],
+              // this ID is the same as the mock
+              [{id: 'example-id', params}],
+            ],
+          }}
+        >
+          <PaneRouterProvider
+            flatIndex={2}
+            index={2}
+            siblingIndex={0}
+            params={params}
+            payload={undefined}
+          >
+            <ReferenceChangedBanner />
+          </PaneRouterProvider>
+        </RouterProvider>
+      </ThemeProvider>
+    )
+
+    await waitFor(() => expect(unstable_observePathsDocumentPair).toHaveBeenCalledTimes(1))
+    expect(queryByTestId('reference-changed-banner')).not.toBeInTheDocument()
+  })
+})

--- a/packages/@sanity/desk-tool/src/panes/document/documentPanel/ReferenceChangedBanner.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/documentPanel/ReferenceChangedBanner.tsx
@@ -4,14 +4,13 @@ import {WarningOutlineIcon, SyncIcon, CloseIcon} from '@sanity/icons'
 import styled from 'styled-components'
 import {fromString as pathFromString, get as pathGet} from '@sanity/util/paths'
 import {KeyedSegment, Reference} from '@sanity/types'
-import {map, startWith} from 'rxjs/operators'
+import {debounceTime, map} from 'rxjs/operators'
 import {
   getPublishedId,
-  // eslint-disable-next-line camelcase
   unstable_observePathsDocumentPair,
   DocumentAvailability,
 } from '@sanity/base/_internal'
-import {Observable, of} from 'rxjs'
+import {concat, Observable, of} from 'rxjs'
 import {useMemoObservable} from 'react-rx'
 
 import {usePaneRouter} from '../../../contexts/paneRouter'
@@ -44,14 +43,27 @@ export const ReferenceChangedBanner = memo(() => {
   const parentGroup = routerPanesState[groupIndex - 1] as RouterPaneGroup | undefined
   const parentSibling = parentGroup?.[0]
   const parentId = parentSibling?.id
-  const parentHasRev = !!parentSibling?.params?.rev
+  const hasHistoryOpen = Boolean(parentSibling?.params?.rev)
   const parentRefPath = useMemo(() => {
     return (params?.parentRefPath && pathFromString(params.parentRefPath)) || null
   }, [params?.parentRefPath])
 
-  const parentRef: ParentReferenceInfo = useMemoObservable(
+  /**
+   * Loads information regarding the reference field of the parent pane. This
+   * is only applicable to child references (aka references-in-place).
+   *
+   * It utilizes the pane ID of the parent pane (which is a document ID) along
+   * with the `parentRefPath` router param on the current pane to find the
+   * current value of the reference field on the parent document.
+   *
+   * This is used to compare with the current pane's document ID. If the IDs
+   * don't match then this banner should reveal itself
+   */
+  const referenceInfo = useMemoObservable(
     (): Observable<ParentReferenceInfo> => {
       const parentRefPathSegment = parentRefPath?.[0] as string | undefined
+
+      // short-circuit: this document pane is not a child reference pane
       if (!parentId || !parentRefPathSegment || !parentRefPath) {
         return of({loading: false})
       }
@@ -63,23 +75,34 @@ export const ReferenceChangedBanner = memo(() => {
       const keyedSegmentIndex = path.findIndex(
         (p): p is KeyedSegment => typeof p == 'object' && '_key' in p
       )
-      return unstable_observePathsDocumentPair(
-        publishedId,
-        (keyedSegmentIndex === -1 ? path : path.slice(0, keyedSegmentIndex)) as string[][]
-      ).pipe(
-        map(
-          ({draft, published}): ParentReferenceInfo => {
-            return {
+
+      return concat(
+        // emit a loading state instantly
+        of({loading: true}),
+        // then emit the values from watching the published ID's path
+        unstable_observePathsDocumentPair(
+          publishedId,
+          (keyedSegmentIndex === -1 ? path : path.slice(0, keyedSegmentIndex)) as string[][]
+        ).pipe(
+          // this debounce time is needed to prevent flashing banners due to
+          // the router state updating faster than the content-lake state. we
+          // debounce to wait for more emissions because the value pulled
+          // initially could be stale.
+          debounceTime(750),
+          map(
+            ({draft, published}): ParentReferenceInfo => ({
               loading: false,
               result: {
-                availability: {draft: draft.availability, published: published.availability},
+                availability: {
+                  draft: draft.availability,
+                  published: published.availability,
+                },
                 refValue: pathGet<Reference>(draft.snapshot || published.snapshot, parentRefPath)
                   ?._ref,
               },
-            }
-          }
-        ),
-        startWith({loading: true})
+            })
+          )
+        )
       )
     },
     [parentId, parentRefPath],
@@ -87,39 +110,43 @@ export const ReferenceChangedBanner = memo(() => {
   )
 
   const handleReloadReference = useCallback(() => {
-    if (parentRef.loading) return
+    if (referenceInfo.loading) return
 
-    if (parentRef.result?.refValue) {
-      replaceCurrent({id: parentRef.result.refValue, params: params as Record<string, string>})
+    if (referenceInfo.result?.refValue) {
+      replaceCurrent({
+        id: referenceInfo.result.refValue,
+        params: params as Record<string, string>,
+      })
     }
-  }, [parentRef.loading, parentRef.result, replaceCurrent, params])
+  }, [referenceInfo.loading, referenceInfo.result, replaceCurrent, params])
 
-  // this will be true if viewing history, in that case, hide this banner
-  if (parentHasRev) return null
-
-  if (
-    parentRef.loading ||
+  const shouldHide =
+    // if `parentId` or `parentRefPath` is not present then this banner is n/a
     !parentId ||
     !parentRefPath ||
-    parentRef.result?.refValue === routerReferenceId ||
-    // if the parent document is not available (i.e. due to permission denied or not found)
-    // we don't want to display a warning here, but instead rely on the parent
-    // view to display the appropriate message
-    (!parentRef.result?.availability.draft.available &&
-      !parentRef.result?.availability.published.available)
-  ) {
-    return null
-  }
+    // if viewing this pane via history, then hide
+    hasHistoryOpen ||
+    // if loading, hide
+    referenceInfo.loading ||
+    // if the parent document is not available (e.g. due to permission denied or
+    // not found) we don't want to display a warning here, but instead rely on the
+    // parent view to display the appropriate message
+    (!referenceInfo.result?.availability.draft.available &&
+      !referenceInfo.result?.availability.published.available) ||
+    // if the references are the same, then hide the reference changed banner
+    referenceInfo.result?.refValue === routerReferenceId
+
+  if (shouldHide) return null
 
   return (
-    <Root shadow={1} tone="caution">
+    <Root shadow={1} tone="caution" data-testid="reference-changed-banner">
       <Container paddingX={4} paddingY={2} sizing="border" width={1}>
         <Flex align="center">
           <Text size={1}>
             <WarningOutlineIcon />
           </Text>
 
-          {parentRef.result?.refValue ? (
+          {referenceInfo.result?.refValue ? (
             <>
               <Box flex={1} marginLeft={3}>
                 <TextOneLine title="This reference has changed since you opened it." size={1}>


### PR DESCRIPTION
### Description

This PR re-works the reference changed banner a bit to fix some bugs + updates the copy. I noticed that if you quickly switch templates, you'll get the reference changed banner flash.

### What to review

Try replacing an existing reference with a new document created in-place. In the current branch, you should see the reference banner flash but in this version, it's fixed.
