### PR TITLE
test: update document creation and navigation

### DIFF
--- a/cypress/integration/form-builder/conditionalFieldset.test.js
+++ b/cypress/integration/form-builder/conditionalFieldset.test.js
@@ -1,21 +1,10 @@
 import testSanityClient from '../../helpers/sanityClientSetUp'
 
-let testDocumentId = ''
-
-function setUpSuite() {
-  cy.login()
-
-  testSanityClient.create(doc).then((res) => {
-    testDocumentId = res._id
-    cy.visit(`/test/desk/input-ci;conditionalFieldset;${res._id}%2Csince%3D%40lastPublished`)
-  })
-}
-
-function tearDownSuite() {
-  testSanityClient.delete(testDocumentId)
-}
+const testDocumentId = 'conditional-fieldset-test'
+const testLocation = `/test/desk/input-ci;conditionalFieldset;${testDocumentId}%2Csince%3D%40lastPublished`
 
 const doc = {
+  _id: testDocumentId,
   _type: 'conditionalFieldset',
   title: 'Conditional fieldset [Cypress]',
   hidden: true,
@@ -49,12 +38,13 @@ const doc = {
 }
 
 describe('@sanity/field: Multi fieldset and review changes', () => {
-  before(() => {
-    setUpSuite()
+  before(async () => {
+    await testSanityClient.createOrReplace(doc)
   })
 
   beforeEach(() => {
     cy.viewport(2000, 3500)
+    cy.visit(testLocation)
   })
 
   // Hidden boolean false
@@ -62,43 +52,43 @@ describe('@sanity/field: Multi fieldset and review changes', () => {
     cy.get('[data-testid="fieldset-multiHiddenBooleanFalse"]').should('be.visible')
   })
 
-  //Hidden boolean true
+  // Hidden boolean true
   it('when hidden property is true, the fieldset is not rendered', () => {
     cy.get('[data-testid="fieldset-multiHiddenBooleanTrue"]').should('not.exist')
   })
 
-  //Hidden callback (document) false
+  // Hidden callback (document) false
   it('when the hidden callback (document) returns false, the fieldset is rendered', () => {
     cy.get('[data-testid="fieldset-multiHiddenCallbackFalse"]').should('be.visible')
   })
 
-  //Hidden callback (document) true
+  // Hidden callback (document) true
   it('when the hidden callback (document) returns true, the fieldset is not rendered', () => {
     cy.get('[data-testid="fieldset-multiHiddenCallbackTrue"]').should('not.exist')
   })
 
-  //Read only boolean false
+  // Read only boolean false
   it('when the readOnly property is false, the fieldset is enabled', () => {
     cy.get('[data-testid="fieldset-multiReadOnlyBooleanFalse"]')
       .find('input')
       .should('not.have.attr', 'readonly')
   })
 
-  //Read only boolean true
+  // Read only boolean true
   it('when the readOnly property is true, the fieldset is disabled', () => {
     cy.get('[data-testid="fieldset-multiReadOnlyBooleanTrue"]')
       .find('input')
       .should('have.attr', 'readonly')
   })
 
-  //Read only callback (document) false
+  // Read only callback (document) false
   it('when the readOnly callback (document) returns false, the fieldset is enabled', () => {
     cy.get('[data-testid="fieldset-multiReadOnlyCallbackFalse"]')
       .find('input')
       .should('not.have.attr', 'readonly')
   })
 
-  //Read only callback (document) true
+  // Read only callback (document) true
   it('when the readOnly callback (document) returns true, the fieldset is disabled', () => {
     cy.get('[data-testid="fieldset-multiReadOnlyCallbackTrue"]')
       .find('input')
@@ -134,17 +124,17 @@ describe('@sanity/field: Multi fieldset and review changes', () => {
     cy.get('[data-testid="group-change-multiHiddenBooleanTrue"]').should('not.exist')
   })
 
-  //Hidden callback (document) false
+  // Hidden callback (document) false
   it('when the hidden callback (document) returns false, the review change for fieldset is rendered', () => {
     cy.get('[data-testid="group-change-multiHiddenCallbackFalse"]').should('be.visible')
   })
 
-  //Hidden callback (document) true
+  // Hidden callback (document) true
   it('when the hidden callback (document) returns true, the review change for fieldset is not rendered', () => {
     cy.get('[data-testid="group-change-multiHiddenCallbackTrue"]').should('not.exist')
   })
 
-  //Read only boolean false
+  // Read only boolean false
   it('when the readOnly property is false, the review change for fieldset is enabled', () => {
     cy.get('[data-testid="group-change-revert-button-multiReadOnlyBooleanFalse"]').should(
       'not.be.disabled'
@@ -158,7 +148,7 @@ describe('@sanity/field: Multi fieldset and review changes', () => {
     )
   })
 
-  //Read only boolean true
+  // Read only boolean true
   it('when the readOnly property is true, the review change for fieldset is disabled', () => {
     cy.get('[data-testid="group-change-revert-button-multiReadOnlyBooleanTrue"]').should(
       'be.disabled'
@@ -172,7 +162,7 @@ describe('@sanity/field: Multi fieldset and review changes', () => {
     )
   })
 
-  //Read only callback (document) false
+  // Read only callback (document) false
   it('when the readOnly callback (document) returns false, the review change for fieldset is enabled', () => {
     cy.get('[data-testid="group-change-revert-button-multiReadOnlyCallbackFalse"]').should(
       'not.be.disabled'
@@ -186,7 +176,7 @@ describe('@sanity/field: Multi fieldset and review changes', () => {
     )
   })
 
-  //Read only callback (document) true
+  // Read only callback (document) true
   it('when the readOnly callback (document) returns true, the review change for fieldset is disabled', () => {
     cy.get('[data-testid="group-change-revert-button-multiReadOnlyCallbackTrue"]').should(
       'be.disabled'
@@ -202,7 +192,7 @@ describe('@sanity/field: Multi fieldset and review changes', () => {
 
   // eslint-disable-next-line no-warning-comments
   /* @TODO
-  
+
   - when readOnly callback (parent) returns false, the review change for fieldset is not disabled
   - when readOnly callback (parent) returns true, the review change for fieldset is disabled
   - when readOnly callback (currentUser) returns false, the review change for fieldset is not disabled
@@ -216,63 +206,60 @@ describe('@sanity/field: Multi fieldset and review changes', () => {
   - when hidden callback (value) returns false, the review change for fieldset is rendered
   - when hidden callback (value) returns true, the review change for fieldset is not rendered'
   */
-
-  after(() => {
-    tearDownSuite()
-  })
 })
 
 describe('@sanity/field: Single fieldset and review changes', () => {
-  before(() => {
-    setUpSuite()
+  before(async () => {
+    await testSanityClient.createOrReplace(doc)
   })
 
   beforeEach(() => {
     cy.viewport(2000, 3500)
+    cy.visit(testLocation)
   })
 
-  //Hidden boolean false
+  // Hidden boolean false
   it('when hidden property is false, the fieldset is rendered', () => {
     cy.get('[data-testid="fieldset-singleHiddenBooleanFalse"]').should('be.visible')
   })
 
-  //Hidden boolean true
+  // Hidden boolean true
   it('when hidden property is true, the fieldset is not rendered', () => {
     cy.get('[data-testid="fieldset-singleHiddenBooleanTrue"]').should('not.exist')
   })
 
-  //Hidden callback (document) false
+  // Hidden callback (document) false
   it('when hidden callback (document) returns false, the fieldset is rendered', () => {
     cy.get('[data-testid="fieldset-singleHiddenCallbackFalse"]').should('be.visible')
   })
 
-  //Hidden callback (document) true
+  // Hidden callback (document) true
   it('when hidden callback (document) returns true, the fieldset is not rendered', () => {
     cy.get('[data-testid="fieldset-singleHiddenCallbackTrue"]').should('not.exist')
   })
 
-  //Read only boolean false
+  // Read only boolean false
   it('when readOnly property is false, the fieldset is enabled', () => {
     cy.get('[data-testid="fieldset-singleReadOnlyBooleanFalse"]')
       .find('input')
       .should('not.have.attr', 'readonly')
   })
 
-  //Read only boolean true
+  // Read only boolean true
   it('when readOnly property is true, the fieldset is disabled', () => {
     cy.get('[data-testid="fieldset-singleReadOnlyBooleanTrue"]')
       .find('input')
       .should('have.attr', 'readonly')
   })
 
-  //Read only callback (document) false
+  // Read only callback (document) false
   it('when readOnly callback (document) returns false, the fieldset is not disabled', () => {
     cy.get('[data-testid="fieldset-singleReadOnlyCallbackFalse"]')
       .find('input')
       .should('not.have.attr', 'readonly')
   })
 
-  //Read only callback (document) true
+  // Read only callback (document) true
   it('when readOnly callback (document) returns true, the fieldset is disabled', () => {
     cy.get('[data-testid="fieldset-singleReadOnlyCallbackTrue"]')
       .find('input')
@@ -298,56 +285,56 @@ describe('@sanity/field: Single fieldset and review changes', () => {
 
   /* --- Review Changes --- */
 
-  //Hidden boolean false
+  // Hidden boolean false
   it('when hidden property is false, the review change for fieldset is rendered', () => {
     cy.get('[data-testid="single-change-revert-button-singleHiddenBooleanFalse1"').should(
       'be.visible'
     )
   })
 
-  //Hidden boolean true
+  // Hidden boolean true
   it('when hidden property is true, the review change for fieldset is not rendered', () => {
     cy.get('[data-testid="single-change-revert-button-singleHiddenBooleanTrue1"').should(
       'not.exist'
     )
   })
 
-  //Hidden callback (document) false
+  // Hidden callback (document) false
   it('when hidden callback (document) returns false, the review change for fieldset is rendered', () => {
     cy.get('[data-testid="single-change-revert-button-singleHiddenCallbackFalse1"').should(
       'be.visible'
     )
   })
 
-  //Hidden callback (document) true
+  // Hidden callback (document) true
   it('when hidden callback (document) returns true, the review change for fieldset is not rendered', () => {
     cy.get('[data-testid="single-change-revert-button-singleHiddenCallbackTrue1"').should(
       'not.exist'
     )
   })
 
-  //Read only boolean false
+  // Read only boolean false
   it('when readOnly property is false, the review change for fieldset is enabled', () => {
     cy.get('[data-testid="single-change-revert-button-singleReadOnlyBooleanFalse1"').should(
       'not.be.disabled'
     )
   })
 
-  //Read only boolean true
+  // Read only boolean true
   it('when readOnly property is true, the review change for fieldset is disabled', () => {
     cy.get('[data-testid="single-change-revert-button-singleReadOnlyBooleanTrue1"').should(
       'be.disabled'
     )
   })
 
-  //Read only callback (document) false
+  // Read only callback (document) false
   it('when readOnly callback (document) (document) returns false, the review change for fieldset is not disabled', () => {
     cy.get('[data-testid="single-change-revert-button-singleReadOnlyCallbackFalse1"').should(
       'not.be.disabled'
     )
   })
 
-  //Read only callback (document) true
+  // Read only callback (document) true
   it('when readOnly callback (document) returns true, the review change for fieldset is disabled', () => {
     cy.get('[data-testid="single-change-revert-button-singleReadOnlyCallbackTrue1"').should(
       'be.disabled'
@@ -356,7 +343,7 @@ describe('@sanity/field: Single fieldset and review changes', () => {
 
   // eslint-disable-next-line no-warning-comments
   /* @TODO
-  
+
   - when readOnly callback (parent) returns false, the review change for fieldset is not disabled
   - when readOnly callback (parent) returns true, the review change for fieldset is disabled
   - when readOnly callback (currentUser) returns false, the review change for fieldset is not disabled
@@ -370,8 +357,4 @@ describe('@sanity/field: Single fieldset and review changes', () => {
   - when hidden callback (value) returns false, the review change for fieldset is rendered
   - when hidden callback (value) returns true, the review change for fieldset is not rendered'
   */
-
-  after(() => {
-    tearDownSuite()
-  })
 })


### PR DESCRIPTION
### Description

This PR fixes the failing e2e tests for conditional fields by hard-coding a specific test document ID and moving some async logic around. I also removed the clean up phase so concurrent runs shouldn't fail

### What to review

Do the e2e test pass now? Do the changes break any existing assumptions?

