### PR TITLE
fix(desk-tool): wrap with publishReplay(1)

### DIFF
--- a/packages/@sanity/desk-tool/src/utils/createPaneResolver.ts
+++ b/packages/@sanity/desk-tool/src/utils/createPaneResolver.ts
@@ -1,5 +1,5 @@
 import {Observable, of as observableOf, from as observableFrom, Subscribable} from 'rxjs'
-import {switchMap} from 'rxjs/operators'
+import {publishReplay, refCount, switchMap} from 'rxjs/operators'
 import {PaneNode, RouterPaneSiblingContext, UnresolvedPaneNode} from '../types'
 import {isRecord} from './isRecord'
 import {PaneResolutionError} from './PaneResolutionError'
@@ -53,37 +53,49 @@ const rethrowWithPaneResolutionErrors: PaneResolverMiddleware = (next) => (
   }
 }
 
+const wrapWithPublishReplay: PaneResolverMiddleware = (next) => (...args) => {
+  return next(...args).pipe(
+    // need to add publishReplay + refCount to ensure new subscribers always
+    // get an emission. without this, memoized observables may get stuck
+    // waiting for their first emissions resulting in a loading pane
+    publishReplay(1),
+    refCount()
+  )
+}
+
 export function createPaneResolver(middleware: PaneResolverMiddleware): PaneResolver {
   // note: this API includes a middleware/wrapper function because the function
   // is recursive. we want to call the wrapped version of the function always
   // (even inside of nested calls) so the identifier invoked for the recursion
   // should be the wrapped version
   const resolvePane = rethrowWithPaneResolutionErrors(
-    middleware((unresolvedPane, context, flatIndex) => {
-      if (!unresolvedPane) {
-        throw new PaneResolutionError({
-          message: 'Pane returned no child',
-          context,
-          helpId: 'structure-item-returned-no-child',
-        })
-      }
+    wrapWithPublishReplay(
+      middleware((unresolvedPane, context, flatIndex) => {
+        if (!unresolvedPane) {
+          throw new PaneResolutionError({
+            message: 'Pane returned no child',
+            context,
+            helpId: 'structure-item-returned-no-child',
+          })
+        }
 
-      if (isSubscribable(unresolvedPane)) {
-        return observableFrom(unresolvedPane).pipe(
-          switchMap((result) => resolvePane(result, context, flatIndex))
-        )
-      }
+        if (isSubscribable(unresolvedPane)) {
+          return observableFrom(unresolvedPane).pipe(
+            switchMap((result) => resolvePane(result, context, flatIndex))
+          )
+        }
 
-      if (isSerializable(unresolvedPane)) {
-        return resolvePane(unresolvedPane.serialize(context), context, flatIndex)
-      }
+        if (isSerializable(unresolvedPane)) {
+          return resolvePane(unresolvedPane.serialize(context), context, flatIndex)
+        }
 
-      if (typeof unresolvedPane === 'function') {
-        return resolvePane(unresolvedPane(context.id, context), context, flatIndex)
-      }
+        if (typeof unresolvedPane === 'function') {
+          return resolvePane(unresolvedPane(context.id, context), context, flatIndex)
+        }
 
-      return observableOf(unresolvedPane)
-    })
+        return observableOf(unresolvedPane)
+      })
+    )
   )
 
   return resolvePane


### PR DESCRIPTION
### Description

Fix a pane resolution bug where new subscribers of an observable would not get an emission causing a stuck loading pane.

### What to review

I'll have a loom internally with more info.

### Notes for release

Fixes an issue where desk structures with observables would be stuck loading.
