### PR TITLE
fix(desk-tool): fix width issue on publish and review changes button tooltip

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/document/statusBar/sparkline/PublishStatus.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/statusBar/sparkline/PublishStatus.tsx
@@ -30,6 +30,7 @@ export function PublishStatus(props: PublishStatusProps) {
   return (
     <Root align="center" data-ui="SessionLayout" sizing="border">
       <Tooltip
+        portal
         content={
           <Stack padding={3} space={3}>
             <Text size={1} muted>

--- a/packages/@sanity/desk-tool/src/panes/document/statusBar/sparkline/ReviewChangesButton.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/statusBar/sparkline/ReviewChangesButton.tsx
@@ -29,6 +29,7 @@ export const ReviewChangesButton = forwardRef(function ReviewChangesButton(
 
   return (
     <Tooltip
+      portal
       content={
         <Stack padding={3} space={3}>
           <Text size={1} weight="semibold">


### PR DESCRIPTION
Fix visual bug where the tooltip width was tied to the width of the publish and review changes buttons

| before | after |
|--------|-------|
|    ![image](https://user-images.githubusercontent.com/6951139/144823084-fd88fd6a-8d2f-4138-9b13-9c9dcf7a417b.png)  |    ![image](https://user-images.githubusercontent.com/6951139/144823381-de689792-7628-4745-b2c8-14077eaee70d.png) |





### What to review

- Make the panel window small
- Hover over the publish & the review changes buttons at the bottom

### Notes for release

Fix visual bug where the tooltip width was tied to the width of the publish and review changes buttons