### PR TITLE
fix(default-layout): missing template id in new document dialog

### DIFF
--- a/packages/@sanity/default-layout/src/createDocumentDialog/CreateDocumentItem.tsx
+++ b/packages/@sanity/default-layout/src/createDocumentDialog/CreateDocumentItem.tsx
@@ -94,7 +94,7 @@ export function CreateDocumentItem({
     return (
       <StyledIntentButton
         intent="create"
-        params={[{type: template.schemaType}, parameters]}
+        params={[{type: template.schemaType, template: template.id}, parameters]}
         title={subtitle ? `Create new ${title} (${subtitle})` : `Create new ${title}`}
         onClick={onClick}
         mode="ghost"


### PR DESCRIPTION
### Description

The  "new document" dialog seems to have lost its "template" parameter, which means only the schema type is respected. This PR adds the missing ID. It does however need tests to prevent regressions.

### Notes for release

- Fixed issue where the "new documents" dialog would not use the selected template
