### PR TITLE
chore(workshop): remove unused dep

### DIFF
--- a/dev/workshop/package.json
+++ b/dev/workshop/package.json
@@ -16,7 +16,6 @@
     "type-check": "tsc -b"
   },
   "dependencies": {
-    "@sanity/icons": "^1.2.1",
     "@sanity/ui": "^0.36.15",
     "@sanity/ui-workshop": "^0.3.5",
     "qs": "^6.10.1",


### PR DESCRIPTION
### Description

The CI started failing due to a new update to depcheck so this should fix it.

### What to review

Does the CI pass? Does the workshop still run?

