### PR TITLE
fix(eventsource): check for window before using it

### DIFF
--- a/packages/@sanity/eventsource/browser.js
+++ b/packages/@sanity/eventsource/browser.js
@@ -1,4 +1,9 @@
 /* eslint-disable no-var */
 var evs = require('@rexxars/eventsource-polyfill')
 
-module.exports = window.EventSource || evs.EventSource
+module.exports =
+  typeof window === 'undefined' || !window.EventSource
+    ? // Use polyfill in non-browser/legacy environments
+      evs.EventSource
+    : // Use native EventSource when we can
+      window.EventSource


### PR DESCRIPTION
### Description

In our eventsource polyfill module, we are "branching" the environments based on the `package.json` [`browser` field](https://github.com/sanity-io/sanity/blob/next/packages/%40sanity/eventsource/package.json#L5-L6).

This has worked fine up until now, but we're starting to see some browser-like environments use the browser path even though they don't have a global `window` object. The result is that this crashes when we attempt to check `window.EventSource`.

With this PR, we explicitly check whether or not `window` is `undefined` before attempting to use it. A bit of an edge case, but technically more correct way of doing things anyway.

### What to review

That the code still makes sense

### Notes for release

- Fix a bug where importing the `@sanity/eventsource` module (or `@sanity/client`) in non-browser environments could potentially crash because of a `window` reference
