### PR TITLE
fix(core): explicitly exit on successful graphql deploy

### DIFF
--- a/packages/@sanity/core/src/actions/graphql/deployApiAction.js
+++ b/packages/@sanity/core/src/actions/graphql/deployApiAction.js
@@ -132,6 +132,11 @@ module.exports = async function deployApiActions(args, context) {
     spinner.succeed()
     output.print('GraphQL API deployed to:')
     output.print(client.getUrl(response.location.replace(/^\/(v1|v\d{4}-\d{2}-\d{2})\//, '/')))
+
+    // Because of side effects when loading the schema, we can end up in situations where
+    // the API has been successfully deployed, but some timer or other handle is keeping
+    // the process from naturally exiting.
+    process.exit(0)
   } catch (err) {
     spinner.fail()
     throw err


### PR DESCRIPTION
### Description

Every once in a while, we hear cases from users where after the GraphQL API deployment succeeds, the command does not. Most likely this is caused by some side-effect of loading the schema - often this can lead to pulling in React components, requesting animation frames, setting up timers/intervals and similar.

While it would be ideal that things would naturally close their handles and exit normally, this PR is a compromise which exits explicitly when deployment is successful. In a future version we might instead do the schema collection part as a forked child process, where we can exit only the schema collection process when complete, but I'll leave that for: the future.

### Notes for release

- Fixed a case where the `sanity graphql deploy` command would not exit after a successful deploy
