### PR TITLE
test: add form validation test

### DIFF
--- a/cypress/integration/form-builder/validation.test.js
+++ b/cypress/integration/form-builder/validation.test.js
@@ -1,0 +1,102 @@
+import {nanoid} from 'nanoid'
+import client from '../../helpers/sanityClientSetUp'
+
+const docId = `drafts.${nanoid()}`
+
+const doc = {
+  _id: docId,
+  _type: 'validationCI',
+  errorString: '',
+  warningString: '',
+  infoString: '',
+}
+
+/** Each fields validation rule is configured with min(5) */
+const VALID_VALUE = 'String longer than 5'
+const INVALID_VALUE = 'abc'
+
+async function patchDocument(payload) {
+  return client.patch(docId).set(payload).commit({visibility: 'async'})
+}
+
+describe('@sanity/form-builder: Validation', () => {
+  before(async () => {
+    cy.viewport(1000, 1500)
+    await client.create(doc, {visibility: 'async'})
+  })
+
+  beforeEach(() => {
+    cy.visit(`/test/desk/input-ci;validationCI;${docId}%2Ctemplate%3DvalidationCI`)
+  })
+
+  /** Error */
+  it('when there are validation errors, the publish button is disabled', () => {
+    cy.wrap(patchDocument({errorString: INVALID_VALUE})).then(() => {
+      cy.get('[data-testid="action-Publish"]').should('have.attr', 'disabled')
+    })
+  })
+
+  it('when there are validation errors, the error icon is visible', () => {
+    cy.get('[data-testid="input-errorString"]')
+      .find('[data-testid="input-validation-icon-error"]')
+      .should('be.visible')
+  })
+
+  it('when there are no validation errors, the publish button is enabled', () => {
+    cy.wrap(patchDocument({errorString: VALID_VALUE})).then(() => {
+      cy.get('[data-testid="action-Publish"]').should('not.have.attr', 'disabled')
+    })
+  })
+
+  it('when there are no validation errors, the error icon is hidden', () => {
+    cy.get('[data-testid="input-errorString"]')
+      .find('[data-testid="input-validation-icon-error"]')
+      .should('not.exist')
+  })
+
+  /** Warning */
+  it('when there are validation warnings, the publish button is enabled', () => {
+    cy.wrap(patchDocument({warningString: INVALID_VALUE})).then(() => {
+      cy.get('[data-testid="action-Publish"]').should('not.have.attr', 'disabled')
+    })
+  })
+
+  it('when there are validation warnings, the warning icon is visible', () => {
+    cy.get('[data-testid="input-warningString"]')
+      .find('[data-testid="input-validation-icon-warning"]')
+      .should('be.visible')
+  })
+
+  it('when there are no validation warnings, the warning icon is hidden', () => {
+    cy.wrap(patchDocument({warningString: VALID_VALUE})).then(() => {
+      cy.get('[data-testid="input-warningString"]')
+        .find('[data-testid="input-validation-icon-warning"]')
+        .should('not.exist')
+    })
+  })
+
+  /** Info */
+  it('when there are validation infos, the publish button is enabled', () => {
+    cy.wrap(patchDocument({infoString: INVALID_VALUE})).then(() => {
+      cy.get('[data-testid="action-Publish"]').should('not.have.attr', 'disabled')
+    })
+  })
+
+  it('when there are validation infos, the info icon is visible', () => {
+    cy.get('[data-testid="input-infoString"]')
+      .find('[data-testid="input-validation-icon-info"]')
+      .should('be.visible')
+  })
+
+  it('when there are no validation infos, the info icon is hidden', () => {
+    cy.wrap(patchDocument({infoString: VALID_VALUE})).then(() => {
+      cy.get('[data-testid="input-infoString"]')
+        .find('[data-testid="input-validation-icon-info"]')
+        .should('not.exist')
+    })
+  })
+
+  after(async () => {
+    await client.delete(docId, {visibility: 'async'})
+  })
+})

--- a/dev/test-studio/parts/deskStructure.js
+++ b/dev/test-studio/parts/deskStructure.js
@@ -85,7 +85,7 @@ const DEBUG_INPUT_TYPES = [
   'withDocumentTest',
 ]
 
-const CI_INPUT_TYPES = ['conditionalFieldset']
+const CI_INPUT_TYPES = ['conditionalFieldset', 'validationCI']
 
 const EXTERNAL_PLUGIN_INPUT_TYPES = ['markdownTest', 'muxVideoPost']
 

--- a/dev/test-studio/schema/ci/validationCI.js
+++ b/dev/test-studio/schema/ci/validationCI.js
@@ -1,0 +1,25 @@
+export default {
+  name: 'validationCI',
+  type: 'document',
+  title: 'Validation CI',
+  fields: [
+    {
+      name: 'errorString',
+      type: 'string',
+      title: 'Error string',
+      validation: (rule) => rule.min(5).error('Error message'),
+    },
+    {
+      name: 'warningString',
+      type: 'string',
+      title: 'Warning string',
+      validation: (rule) => rule.min(5).warning('Warning message'),
+    },
+    {
+      name: 'infoString',
+      type: 'string',
+      title: 'Info string',
+      validation: (rule) => rule.min(5).info('Info message'),
+    },
+  ],
+}

--- a/dev/test-studio/schema/index.js
+++ b/dev/test-studio/schema/index.js
@@ -85,6 +85,7 @@ import species from './species'
 
 // CI documents
 import conditionalFieldset from './ci/conditionalFieldset'
+import validationTest from './ci/validationCI'
 
 export default createSchema({
   name: 'test-examples',
@@ -169,6 +170,7 @@ export default createSchema({
     urls,
     validation,
     validationArraySuperType,
+    validationTest,
     withDocumentTestSchemaType,
   ]),
 })

--- a/packages/@sanity/base/src/components/formField/FormFieldValidationStatus.tsx
+++ b/packages/@sanity/base/src/components/formField/FormFieldValidationStatus.tsx
@@ -35,9 +35,9 @@ const VALIDATION_COLORS: Record<'error' | 'warning' | 'info', string> = {
 }
 
 const VALIDATION_ICONS: Record<'error' | 'warning' | 'info', React.ReactElement> = {
-  error: <ErrorOutlineIcon />,
-  warning: <WarningOutlineIcon />,
-  info: <InfoOutlineIcon />,
+  error: <ErrorOutlineIcon data-testid="input-validation-icon-error" />,
+  warning: <WarningOutlineIcon data-testid="input-validation-icon-warning" />,
+  info: <InfoOutlineIcon data-testid="input-validation-icon-info" />,
 }
 
 export function FormFieldValidationStatus(props: FormFieldValidationStatusProps) {


### PR DESCRIPTION
### Description

This test focuses on the visibility of the validation icons displayed in each field, and whether the publish button is enabled or disabled depending on the validation of a document.

<img width="659" alt="Screenshot 2021-12-09 at 15 10 28" src="https://user-images.githubusercontent.com/15094168/145411823-64ce7c01-f914-4dea-a2db-702290ebe738.png">

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

- The test in general and how it is authored
- Should more scenarios be tested?

### Notes for release

Add form validation test

<!--
A description of the change(s) that should be used in the release notes.
-->
