### PR TITLE
fix(core): fix file asset urls not working with ndjson target

### DIFF
--- a/packages/@sanity/import-cli/src/sanity-import.js
+++ b/packages/@sanity/import-cli/src/sanity-import.js
@@ -2,6 +2,7 @@
 
 /* eslint-disable id-length, no-console, no-process-env */
 const fs = require('fs')
+const path = require('path')
 const ora = require('ora')
 const get = require('simple-get')
 const meow = require('meow')
@@ -154,6 +155,7 @@ getStream()
       allowAssetsInDifferentDataset,
       assetConcurrency,
       replaceAssets,
+      assetsBase: getAssetsBase(),
     })
   )
   .then(({numDocs, warnings}) => {
@@ -195,6 +197,20 @@ function getStream() {
   }
 
   return Promise.resolve(source === '-' ? process.stdin : fs.createReadStream(source))
+}
+
+function getAssetsBase() {
+  if (/^https:\/\//i.test(source) || source === '-') {
+    return undefined
+  }
+
+  try {
+    const fileStats = fs.statSync(source)
+    const sourceIsFolder = fileStats.isDirectory()
+    return sourceIsFolder ? source : path.dirname(source)
+  } catch {
+    return undefined
+  }
 }
 
 function getUriStream(uri) {


### PR DESCRIPTION
### Description

If you try to run `sanity dataset import <someNdJsonFile>` or `sanity-import <someNdJsonFile>`, any relative file URLs within that file will cause the upload to fail. 

If you point to a folder _containing_ an ndjson file, it will work - as will pointing to a tarball.

This PR fixes the issue by passing the directory root path to use for relative assets when importing from a stream (which will happen with ndjson files).

### Notes for release

- Fixes `sanity dataset import` not working when targeting an ndjson file with relative file URLs
