### PR TITLE
feat(cli): use non-legacy yarn v1.22.17 under the hood

### DIFF
--- a/packages/@sanity/cli/src/actions/yarn/yarnWithProgress.js
+++ b/packages/@sanity/cli/src/actions/yarn/yarnWithProgress.js
@@ -44,6 +44,8 @@ export default function yarnWithProgress(args, options = {}) {
     '--json',
     '--non-interactive',
     '--ignore-engines',
+    '--network-timeout',
+    '60000',
     '--registry',
     'https://registry.npmjs.org',
   ])

--- a/packages/@sanity/cli/src/scripts/package-yarn.js
+++ b/packages/@sanity/cli/src/scripts/package-yarn.js
@@ -3,9 +3,9 @@ import path from 'path'
 import fse from 'fs-extra'
 import simpleGet from 'simple-get'
 
-const version = '1.22.10'
+const version = '1.22.17'
 const baseUrl = 'https://github.com/yarnpkg/yarn/releases/download'
-const bundleUrl = `${baseUrl}/v${version}/yarn-legacy-${version}.js`
+const bundleUrl = `${baseUrl}/v${version}/yarn-${version}.js`
 const licenseUrl = 'https://raw.githubusercontent.com/yarnpkg/yarn/master/LICENSE'
 const destination = path.join(__dirname, '..', '..', 'vendor', 'yarn')
 const writeFlags = {encoding: 'utf8', mode: 0o755}


### PR DESCRIPTION
### Description

- Upgrades yarn to the latest 1.x version, and uses the non-legacy version (eg the one that only works on node 8 and up) for less transpiled code
- Bumps the network timeout when running yarn commands to 1 minute instead of the default (30 seconds). This _might_ help the issues we're seeing on CI where windows builds fail to install dependencies during the init step
