### PR TITLE
fix(cli): use authless requests when logging in

### DIFF
--- a/packages/@sanity/cli/src/actions/login/login.js
+++ b/packages/@sanity/cli/src/actions/login/login.js
@@ -166,7 +166,7 @@ async function getProvider({output, client, sso, experimental, prompt}) {
 }
 
 async function getSSOProvider({client, prompt, slug}) {
-  const providers = await client.withConfig({apiVersion: 'X'}).request({
+  const providers = await client.withConfig({apiVersion: '2021-10-01'}).request({
     uri: `/auth/organizations/by-slug/${slug}/providers`,
   })
 

--- a/packages/@sanity/cli/src/actions/login/login.js
+++ b/packages/@sanity/cli/src/actions/login/login.js
@@ -11,7 +11,12 @@ import canLaunchBrowser from '../../util/canLaunchBrowser'
 export default async function login(args, context) {
   const {prompt, output, apiClient} = context
   const {sso, experimental} = args.extOptions
-  const client = apiClient({requireUser: false, requireProject: false})
+
+  // _Potentially_ already authed client
+  const authedClient = apiClient({requireUser: false, requireProject: false})
+
+  // Explicitly tell _this_ client not to use a token
+  const client = authedClient.clone().config({token: undefined})
 
   // Get the desired authentication provider
   const provider = await getProvider({client, sso, experimental, output, prompt})


### PR DESCRIPTION
### Description

When attempting to log in, if the CLI already has an auth token it will be used for requests to endpoints such as `/providers`. These requests might be rejected if the session is timed out or invalid, which is unfortunate - it might be the reason why the user is attempting to log in, after all.

This PR:
- Uses an unauthenticated client for requesting these routes, to prevent them from being rejected
- Attempts to log out any existing session upon successful login
- (Unrelated) Sets a stable API version for the SAML providers endpoint instead of using `vX`

### Notes for release

- Fixes a bug where the CLI would not be able to log a user in an existing invalid/expired session was present
