### PR TITLE
fix(desk-tool): fix create intents not appearing in pane headers

### DIFF
--- a/packages/@sanity/desk-tool/src/components/paneHeaderActions/PaneHeaderCreateButton.tsx
+++ b/packages/@sanity/desk-tool/src/components/paneHeaderActions/PaneHeaderCreateButton.tsx
@@ -17,7 +17,7 @@ const POPOVER_PROPS: PopoverProps = {
 type Intent = React.ComponentProps<typeof IntentButton>['intent']
 
 const getIntent = (item: InitialValueTemplateItem): Intent | null => {
-  const typeName = getTemplateById(item.id)?.schemaType
+  const typeName = getTemplateById(item.templateId)?.schemaType
   if (!typeName) return null
 
   const baseParams = {


### PR DESCRIPTION
### Description

Partially addresses #2977.

This fixes a bug that caused items created from create intents to not appear in the menu potentially causing an empty menu like so:

<img width="155" alt="CleanShot 2021-12-13 at 11 59 50@2x" src="https://user-images.githubusercontent.com/10551026/145855538-a06951e8-68e6-4c78-a1ec-ef33961371ee.png">


### What to review

Try creating custom create intents in menu items [(see here)](https://github.com/sanity-io/sanity/blob/561daac611da830d1cc0c61b2f74424983060b2a/dev/test-studio/parts/deskStructure.js#L209-L214). They should show up in the menu.

### Notes for release

Fixes an issue where create intents would not appear in pane headers.
