### PR TITLE
feat(cli): respect specified ranges when upgrading

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -56,7 +56,7 @@
     "fs-extra": "^7.0.0",
     "gauge": "^2.7.4",
     "get-it": "^5.2.1",
-    "get-latest-version": "^1.0.0",
+    "get-latest-version": "^3.0.1",
     "git-user-info": "^1.0.1",
     "gitconfiglocal": "^2.0.1",
     "inquirer": "^6.0.0",

--- a/packages/@sanity/cli/src/commands/debug/printDebugInfo.js
+++ b/packages/@sanity/cli/src/commands/debug/printDebugInfo.js
@@ -107,7 +107,7 @@ async function gatherInfo(context) {
     Object.assign(
       {
         project: gatherProjectInfo(context, baseInfo),
-        versions: findSanityModuleVersions(context),
+        versions: findSanityModuleVersions(context, {target: 'latest'}),
       },
       baseInfo
     )

--- a/packages/@sanity/cli/src/commands/upgrade/upgradeDependencies.js
+++ b/packages/@sanity/cli/src/commands/upgrade/upgradeDependencies.js
@@ -1,5 +1,8 @@
+import util from 'util'
 import path from 'path'
-import fse from 'fs-extra'
+import {promises as fs} from 'fs'
+import boxen from 'boxen'
+import rimrafCb from 'rimraf'
 import semver from 'semver'
 import {padStart, noop} from 'lodash'
 import readLocalManifest from '@sanity/util/lib/readLocalManifest'
@@ -7,22 +10,15 @@ import findSanityModuleVersions from '../../actions/versions/findSanityModuleVer
 import {getFormatters} from '../versions/printVersionResult'
 import debug from '../../debug'
 
-async function deleteIfNotSymlink(modPath) {
-  const stats = await fse.lstat(modPath).catch(noop)
-  if (!stats || stats.isSymbolicLink()) {
-    return null
-  }
+const rimraf = util.promisify(rimrafCb)
 
-  return fse.remove(modPath)
-}
-
-export default async (args, context) => {
+export default async function upgradeDependencies(args, context) {
   const {output, workDir, yarn, chalk} = context
   const {extOptions, argsWithoutOptions} = args
   const modules = argsWithoutOptions.slice()
   const {range, tag} = extOptions
   const saveExact = extOptions['save-exact']
-  const targetRange = tag || range || 'latest'
+  const targetRange = tag || range
 
   if (range && tag) {
     throw new Error('Both --tag and --range specified, can only use one')
@@ -33,7 +29,9 @@ export default async (args, context) => {
   }
 
   // Find which modules needs update according to the target range
-  const allNeedsUpdate = await getModulesInNeedOfUpdate(context, targetRange)
+  const versions = await findSanityModuleVersions(context, {target: targetRange, includeCli: false})
+  const allNeedsUpdate = versions.filter((mod) => mod.needsUpdate)
+
   debug('In need of update: %s', allNeedsUpdate.map((mod) => mod.name).join(', '))
 
   const needsUpdate =
@@ -41,16 +39,44 @@ export default async (args, context) => {
       ? allNeedsUpdate
       : allNeedsUpdate.filter((outOfDate) => modules.indexOf(outOfDate.name) !== -1)
 
+  const semverBreakingUpgrades = versions.filter(hasSemverBreakingUpgrade)
+  const baseMajorUpgrade = semverBreakingUpgrades.find((mod) => mod.name === '@sanity/base')
+  const majorUpgrades = semverBreakingUpgrades.filter((mod) => mod.name !== '@sanity/base')
+  schedulePrintMajorUpgrades({baseMajorUpgrade, majorUpgrades}, context)
+
   // If all modules are up-to-date, say so and exit
   if (needsUpdate.length === 0) {
     const specified = modules.length === 0 ? 'All' : 'All *specified*'
-    context.output.print(`${chalk.green('✔')} ${specified} Sanity modules are at latest versions`)
+    context.output.print(
+      `${chalk.green('✔')} ${specified} Sanity modules are at latest compatible versions`
+    )
     return
+  }
+
+  // Ignore modules that are pinned, but give some indication that this has happened
+  const pinned = needsUpdate.filter((mod) => mod.isPinned)
+  const nonPinned = needsUpdate.filter((mod) => !mod.isPinned)
+  const pinnedNames = pinned.map((mod) => mod.name).join(`\n - `)
+  if (nonPinned.length === 0) {
+    context.output.warn(
+      `${chalk.yellow(
+        '⚠'
+      )} All modules are pinned to specific versions, not upgrading:\n - ${pinnedNames}`
+    )
+    return
+  }
+
+  if (pinned.length > 0) {
+    context.output.warn(
+      `${chalk.yellow(
+        '⚠'
+      )} The follow modules are pinned to specific versions, not upgrading:\n - ${pinnedNames}`
+    )
   }
 
   // Forcefully remove non-symlinked module paths to force upgrade
   await Promise.all(
-    needsUpdate.map((mod) =>
+    nonPinned.map((mod) =>
       deleteIfNotSymlink(
         path.join(context.workDir, 'node_modules', mod.name.replace(/\//g, path.sep))
       )
@@ -60,17 +86,19 @@ export default async (args, context) => {
   // Replace versions in `package.json`
   const versionPrefix = saveExact ? '' : '^'
   const oldManifest = await readLocalManifest(workDir)
-  const newManifest = needsUpdate.reduce((target, mod) => {
+  const newManifest = nonPinned.reduce((target, mod) => {
     if (oldManifest.dependencies && oldManifest.dependencies[mod.name]) {
       target.dependencies[mod.name] =
-        mod.latest === 'unknown' ? oldManifest.dependencies[mod.name] : versionPrefix + mod.latest
+        mod.latestInRange === 'unknown'
+          ? oldManifest.dependencies[mod.name]
+          : versionPrefix + mod.latestInRange
     }
 
     if (oldManifest.devDependencies && oldManifest.devDependencies[mod.name]) {
       target.devDependencies[mod.name] =
-        mod.latest === 'unknown'
+        mod.latestInRange === 'unknown'
           ? oldManifest.devDependencies[mod.name]
-          : versionPrefix + mod.latest
+          : versionPrefix + mod.latestInRange
     }
 
     return target
@@ -78,15 +106,7 @@ export default async (args, context) => {
 
   // Write new `package.json`
   const manifestPath = path.join(context.workDir, 'package.json')
-  await fse.writeJson(manifestPath, newManifest, {spaces: 2})
-
-  // Delete `yarn.lock` to ensure we're getting new modules
-  // (workaround, shouldnt be needed in the future)
-  const yarnLockPath = path.join(context.workDir, 'yarn.lock')
-  const hasLockFile = fse.existsSync(yarnLockPath) // eslint-disable-line no-sync
-  if (hasLockFile) {
-    await fse.unlink(yarnLockPath)
-  }
+  await writeJson(manifestPath, newManifest, {spaces: 2})
 
   // Run `yarn install`
   const flags = extOptions.offline ? ['--offline'] : []
@@ -98,15 +118,78 @@ export default async (args, context) => {
   context.output.print('')
   context.output.print(`${chalk.green('✔')} Modules upgraded:`)
 
-  const {versionLength, formatName} = getFormatters(needsUpdate)
-  needsUpdate.forEach((mod) => {
-    const current = chalk.yellow(padStart(mod.version, versionLength))
-    const latest = chalk.green(mod.latest)
+  const {versionLength, formatName} = getFormatters(nonPinned)
+  nonPinned.forEach((mod) => {
+    const current = chalk.yellow(padStart(mod.installed, versionLength))
+    const latest = chalk.green(mod.latestInRange)
     context.output.print(`${formatName(mod.name)} ${current} → ${latest}`)
   })
 }
 
-async function getModulesInNeedOfUpdate(context, target) {
-  const versions = await findSanityModuleVersions(context, target, {includeCli: false})
-  return versions.filter((mod) => mod.needsUpdate)
+function writeJson(filePath, data) {
+  return fs.writeFile(filePath, `${JSON.stringify(data, null, 2)}\n`)
+}
+
+async function deleteIfNotSymlink(modPath) {
+  const stats = await fs.lstat(modPath).catch(noop)
+  if (!stats || stats.isSymbolicLink()) {
+    return null
+  }
+
+  return rimraf(modPath)
+}
+
+function hasSemverBreakingUpgrade(mod) {
+  return !semver.satisfies(mod.latest, `^${mod.installed}`) && semver.gt(mod.latest, mod.installed)
+}
+
+function getMajorUpgradeText(mods, chalk) {
+  const modNames = mods.map((mod) => `${mod.name} (v${semver.major(mod.latest)})`).join('\n - ')
+
+  return [
+    `The following modules has new major versions\n`,
+    `released and will have to be manually upgraded:\n\n`,
+    ` - ${modNames}\n\n`,
+    chalk.yellow('⚠'),
+    ` Note that major versions can contain backwards\n`,
+    `  incompatible changes and should be handled with care.`,
+  ].join('')
+}
+
+function getMajorStudioUpgradeText(mod, chalk) {
+  const prev = semver.major(mod.installed)
+  const next = semver.major(mod.latest)
+  return [
+    'There is now a new major version of Sanity Studio!',
+    '',
+    'Read more about the new version and how to upgrade:',
+    chalk.blueBright(`https://www.sanity.io/changelog/studio?from=v${prev}&to=v${next}`),
+  ].join('\n')
+}
+
+function schedulePrintMajorUpgrades({baseMajorUpgrade, majorUpgrades}, {chalk, output}) {
+  if (majorUpgrades.length === 0 && !baseMajorUpgrade) {
+    return
+  }
+
+  process.on('beforeExit', () => {
+    output.print('') // Separate previous output with a newline
+
+    if (baseMajorUpgrade) {
+      output.warn(
+        boxen(getMajorStudioUpgradeText(baseMajorUpgrade, chalk), {
+          borderColor: 'green',
+          padding: 1,
+        })
+      )
+      return
+    }
+
+    output.warn(
+      boxen(getMajorUpgradeText(majorUpgrades, chalk), {
+        borderColor: 'yellow',
+        padding: 1,
+      })
+    )
+  })
 }

--- a/packages/@sanity/cli/src/commands/versions/printVersionResult.js
+++ b/packages/@sanity/cli/src/commands/versions/printVersionResult.js
@@ -3,15 +3,15 @@ import {padStart, padEnd} from 'lodash'
 import findSanityModuleVersions from '../../actions/versions/findSanityModuleVersions'
 
 export default async (args, context) => {
-  printResult(await findSanityModuleVersions(context), context.output.print)
+  printResult(await findSanityModuleVersions(context, {target: 'latest'}), context.output.print)
 }
 
 export function printResult(versions, print) {
   const {versionLength, formatName} = getFormatters(versions)
   versions.forEach((mod) => {
-    const version = padStart(mod.version, versionLength)
+    const version = padStart(mod.installed, versionLength)
     const latest =
-      mod.version === mod.latest
+      mod.installed === mod.latest
         ? chalk.green('(up to date)')
         : `(latest: ${chalk.yellow(mod.latest)})`
     print(`${formatName(mod.name)} ${version} ${latest}`)
@@ -20,7 +20,7 @@ export function printResult(versions, print) {
 
 export function getFormatters(versions) {
   const nameLength = versions.reduce(longestProp('name'), 0)
-  const versionLength = versions.reduce(longestProp('version'), 0)
+  const versionLength = versions.reduce(longestProp('installed'), 0)
   const formatName = (name) =>
     padEnd(name, nameLength + 1).replace(
       /^@sanity\/(.*)/,

--- a/scripts/validateMonorepoDependencies.js
+++ b/scripts/validateMonorepoDependencies.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
-const readPackages = require('./utils/readPackages')
 const path = require('path')
 const chalk = require('chalk')
+const readPackages = require('./utils/readPackages')
 
 function getMismatches(pkg, monorepoPackages) {
   const pkgDeps = {...pkg.content.dependencies, ...pkg.content.devDependencies}
@@ -12,9 +12,10 @@ function getMismatches(pkg, monorepoPackages) {
       if (!monorepoPackage || expectedVersion === monorepoPackage.content.version) {
         return null
       }
+      const devDependencies = pkg.content.devDependencies || {}
       return {
         name: depName,
-        dev: Boolean(pkg.content.devDependencies[depName]),
+        dev: Boolean(devDependencies[depName]),
         expected: expectedVersion,
         actual: monorepoPackage.content.version,
       }


### PR DESCRIPTION
### Description

When running `sanity upgrade`, we would previously resolve the `latest` tag for
each installed `@sanity` module and blindly upgrade them to this version.

This is confusing, as it breaks with how npm/yarn handles upgrades. With this
PR, we instead find the maximum version compatible with the specified range for
a dependency. This also means that modules with pinned version numbers will
stay on their given version.

In addition to these improvements, this PR fixes an old pet peeve of mine where
the command would also upgrade dependencies like `@sanity/block-tools`, which
might be used in import tooling or similar. It _should_ only upgrade studio
dependencies, but we don't have an explicit list of these modules, so we use
an exclude list instead for now.

Most important change of this PR is to respect the semver ranges specified:
If you're on `@sanity/base` @ `v2.23.0` and a new `v3.0.0` is released, we
can't blindly upgrade to it, as this might have backwards incompatible changes.
With these changes, we'll warn about semver-incompatible upgrades that are
available, with a special handling for `@sanity/base`, which will signify a
new major version of the studio.

### Notes for release

- `sanity upgrade` now behaves slightly differently:
  - It now respects the version ranges/pinned versions declared in `package.json`
  - Tries not to upgrade non-studio modules such as `@sanity/block-content-to-html`
  - Shows a more prominent message if there are major updates available, with a link to the changelog
