### PR TITLE
fix(form-builder): the PTE dialogs should not close when clicking outside

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/PortableText/Input.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Input.tsx
@@ -14,7 +14,14 @@ import {
   Type,
 } from '@sanity/portable-text-editor'
 import {Path, isKeySegment, Marker, isKeyedObject} from '@sanity/types'
-import {Portal, PortalProvider, Text, usePortal} from '@sanity/ui'
+import {
+  BoundaryElementProvider,
+  Portal,
+  PortalProvider,
+  Text,
+  useBoundaryElement,
+  usePortal,
+} from '@sanity/ui'
 import {isEqual} from 'lodash'
 import {ChangeIndicatorWithProvidedFullPath} from '@sanity/base/components'
 import ActivateOnFocus from '../../components/ActivateOnFocus/ActivateOnFocus'
@@ -75,6 +82,7 @@ export function Input(props: InputProps) {
   const selection = usePortableTextEditorSelection()
   const ptFeatures = useMemo(() => PortableTextEditor.getPortableTextFeatures(editor), [editor])
   const portal = usePortal()
+  const {element: boundaryElement} = useBoundaryElement()
 
   // States
   const [isActive, setIsActive] = useState(false)
@@ -393,18 +401,20 @@ export function Input(props: InputProps) {
   )
 
   const editObjectNode = (
-    <EditObject
-      focusPath={focusPath}
-      objectEditData={objectEditData}
-      markers={markers} // TODO: filter relevant
-      onBlur={handleEditObjectFormBuilderBlur}
-      onChange={handleFormBuilderEditObjectChange}
-      onClose={handleEditObjectClose}
-      onFocus={handleEditObjectFormBuilderFocus}
-      readOnly={readOnly}
-      presence={presence}
-      value={value}
-    />
+    <BoundaryElementProvider element={isFullscreen ? scrollElement : boundaryElement}>
+      <EditObject
+        focusPath={focusPath}
+        objectEditData={objectEditData}
+        markers={markers} // TODO: filter relevant
+        onBlur={handleEditObjectFormBuilderBlur}
+        onChange={handleFormBuilderEditObjectChange}
+        onClose={handleEditObjectClose}
+        onFocus={handleEditObjectFormBuilderFocus}
+        readOnly={readOnly}
+        presence={presence}
+        value={value}
+      />
+    </BoundaryElementProvider>
   )
 
   const children = (

--- a/packages/@sanity/form-builder/src/inputs/PortableText/object/renderers/DefaultObjectEditing.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/object/renderers/DefaultObjectEditing.tsx
@@ -73,7 +73,6 @@ export function DefaultObjectEditing(props: DefaultObjectEditingProps) {
     <Dialog
       id={dialogId || ''}
       onClose={onClose}
-      onClickOutside={onClose}
       header={type.title}
       portal="default"
       ref={setRootElement}

--- a/packages/@sanity/form-builder/src/inputs/PortableText/object/renderers/PopoverObjectEditing.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/object/renderers/PopoverObjectEditing.tsx
@@ -148,6 +148,7 @@ function Content(
     width = 'small',
   } = props
   const {isTopLayer} = useLayer()
+  const {element: boundaryElement} = useBoundaryElement()
 
   const handleChange = useCallback((patchEvent: PatchEvent): void => onChange(patchEvent, path), [
     onChange,
@@ -165,7 +166,7 @@ function Content(
     [handleClose]
   )
 
-  useClickOutside(handleClose, [rootElement])
+  useClickOutside(handleClose, [rootElement], boundaryElement)
 
   useEffect(() => {
     window.addEventListener('keydown', handleKeyDown)


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

- Disables click-outside-to-close for dialogs in the PTE.
- Wraps `editObjectNode` with the correct boundary element in the PTE.
- Passes a `boundaryElement` (the third argument) to `useClickOutside` to prevent popovers from closing when clicking outside of the boundary element (the current pane content).
