### PR TITLE
fix(base): uniq and chunk availability requests

### DIFF
--- a/packages/@sanity/base/src/preview/utils/debounceCollect.ts
+++ b/packages/@sanity/base/src/preview/utils/debounceCollect.ts
@@ -1,15 +1,13 @@
 import {Observable} from 'rxjs'
 
-// Takes a observable returning function and returns a debounced function that, when called
+// Takes an observable returning function and returns a debounced function that, when called
 // collects its passed arguments until wait time has passed without receiving new calls.
 // When wait period is over, calls the original function with the collected arguments
 export function debounceCollect<Fn extends (...args: any[]) => Observable<any[]>>(
   fn: Fn,
   wait: number
 ): Fn extends (collectedArgs: [...infer TArgs][]) => Observable<(infer TReturnValue)[]>
-  ? (...args: TArgs) => Observable<TReturnValue[]>
-  : Fn extends (collectedArgs: (infer TArgs)[]) => Observable<(infer TReturnValue)[]>
-  ? (arg: TArgs) => Observable<TReturnValue>
+  ? (...args: TArgs) => Observable<TReturnValue>
   : never
 export function debounceCollect(fn, wait: number) {
   let timer


### PR DESCRIPTION
When requesting document availability we're collecting all requests within the same event loop tick and batches them into a single request to the endpoint that checks for availability reason. In cases where a document had a lot of references this could produce a request that was above the max request size. This commit splits the list of ids to check into chunks of 300 documents and fetches their availability in parallel, at most 10 requests at a time. These numbers are merely guesses about what would be reasonable limits.

Also includes a fixed typing issue with `debounceCollect` that didn't reflect real world behavior.

### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
- Fixes an issue that could cause a max request size exceeded error for documents with many references.