### PR TITLE
fix(base): prevent crash if type `*` is provided to structure

### DIFF
--- a/packages/@sanity/base/src/datastores/grants/documentPairPermissions.ts
+++ b/packages/@sanity/base/src/datastores/grants/documentPairPermissions.ts
@@ -149,6 +149,15 @@ function getDocumentPairPermissions({
   type,
   permission,
 }: DocumentPermissionsOptions): Observable<PermissionCheckResult> {
+  // this case was added to fix a crash that would occur if the `schemaType` was
+  // omitted from `S.documentList()`
+  //
+  // see `resolveTypeForDocument` which returns `'*'` if no type is provided
+  // https://github.com/sanity-io/sanity/blob/4d49b83a987d5097064d567f75d21b268a410cbf/packages/%40sanity/base/src/datastores/document/resolveTypeForDocument.ts#L7
+  if (type === '*') {
+    return of({granted: false, reason: 'Type specified was `*`'})
+  }
+
   const liveEdit = Boolean(getSchemaType(type).liveEdit)
 
   return snapshotPair({draftId: getDraftId(id), publishedId: getPublishedId(id)}, type).pipe(


### PR DESCRIPTION
### Description

This PR prevents a crash from the newer `unstable_useDocumentPermissions` API.

This comes from an internal bug report where the reporter was trying to create an `S.documentList()` with a `.filter('...')` and no `.schemaType('...')` in attempt to have the document list return more than one type.

Prior to this API, this was not supported and resulted in this: 

<img width="1179" alt="CleanShot 2021-12-16 at 16 02 30@2x" src="https://user-images.githubusercontent.com/10551026/146572760-2519ba20-3ca3-4b5a-b46d-ba5a7f18bbe8.png">

However, with the new API, you'll get a "the Desk Tool crashed" error which is much less clear.

### What to review

You can reproduce the error by creating a structure with `S.documentList().filter("_type in ['post', 'author']")`. When you try to load an item from that list in `next`, it will throw. With this patch, you should get an error similar to the screenshot above.

### Notes for release

- Fixes an issue that caused a crash instead of a warning screen when omitting `schemaType` from `S.documentList()`