### PR TITLE
fix(cypress): improve e2e test speed

### DIFF
--- a/cypress/helpers/createUniqueDocument.js
+++ b/cypress/helpers/createUniqueDocument.js
@@ -1,17 +1,14 @@
 import {uuid} from '@sanity/uuid'
 import testSanityClient from './sanityClientSetUp'
 
-export async function createUniqueDocument({_type, ...restProps}) {
+export async function createUniqueDocument({_type, _id, ...restProps}) {
   const doc = {
     _type,
+    _id: _id || uuid(),
     ...restProps,
   }
 
-  if (!doc?._id) {
-    doc._id = uuid()
-  }
-
-  await testSanityClient.createOrReplace(doc)
+  await testSanityClient.create(doc)
 
   return doc
 }

--- a/cypress/integration/form-builder/conditionalFieldset.test.js
+++ b/cypress/integration/form-builder/conditionalFieldset.test.js
@@ -12,6 +12,12 @@ function deleteOldDocuments() {
   })
 }
 
+const TEST_CONFIG = {
+  defaultCommandTimeout: 15000,
+  viewportWidth: 2000,
+  viewportHeight: 3500,
+}
+
 const doc = {
   _type: 'conditionalFieldset',
   title: 'Conditional fieldset [Cypress]',
@@ -51,19 +57,32 @@ const waitForReviewChanges = () => {
   cy.get('[data-testid="review-changes-pane"]', {timeout: 10000}).should('be.visible')
 }
 
-describe('@sanity/field: Multi fieldset and review changes', () => {
+const ensureCorrectUri = (checkLocation) => {
+  cy.location('pathname').should('eq', checkLocation)
+}
+
+const getTestLocationUri = async () => {
+  const testDoc = await createUniqueDocument(doc)
+  return getTestLocation(testDoc?._id)
+}
+
+describe('@sanity/field: Multi fieldset and review changes', TEST_CONFIG, () => {
   let testLocation
+  let alreadyOnLocation = false
 
   before(async () => {
     deleteOldDocuments()
-    const testDoc = await createUniqueDocument(doc)
-    testLocation = getTestLocation(testDoc?._id)
+    testLocation = await getTestLocationUri()
   })
 
   beforeEach(() => {
-    cy.viewport(2000, 3500)
-    cy.visit(testLocation)
-    waitForReviewChanges()
+    if (!alreadyOnLocation) {
+      cy.visit(testLocation)
+      waitForReviewChanges()
+      alreadyOnLocation = true
+    }
+
+    ensureCorrectUri(testLocation)
   })
 
   // Hidden boolean false
@@ -227,18 +246,22 @@ describe('@sanity/field: Multi fieldset and review changes', () => {
   */
 })
 
-describe('@sanity/field: Single fieldset and review changes', () => {
+describe('@sanity/field: Single fieldset and review changes', TEST_CONFIG, () => {
   let testLocation
+  let alreadyOnLocation = false
 
   before(async () => {
-    const testDoc = await createUniqueDocument(doc)
-    testLocation = getTestLocation(testDoc?._id)
+    testLocation = await getTestLocationUri()
   })
 
   beforeEach(() => {
-    cy.viewport(2000, 3500)
-    cy.visit(testLocation)
-    waitForReviewChanges()
+    if (!alreadyOnLocation) {
+      cy.visit(testLocation)
+      waitForReviewChanges()
+      alreadyOnLocation = true
+    }
+
+    ensureCorrectUri(testLocation)
   })
 
   // Hidden boolean false

--- a/cypress/integration/form-builder/conditionalFieldset.test.js
+++ b/cypress/integration/form-builder/conditionalFieldset.test.js
@@ -6,9 +6,9 @@ const getTestLocation = (documentId) =>
   `/test/desk/input-ci;conditionalFieldset;${documentId}%2Csince%3D%40lastPublished`
 
 function deleteOldDocuments() {
-  const threeHoursAgo = sub(new Date(), {hours: -2}).toISOString()
+  const timestampOneDayAgo = sub(new Date(), {days: -1}).toISOString()
   testSanityClient.delete({
-    query: `*[_type == "conditionalFieldset" && title match "[Cypress]" && dateTime(_updatedAt) < dateTime('${threeHoursAgo}')]`,
+    query: `*[_type == "conditionalFieldset" && dateTime(_updatedAt) < dateTime('${timestampOneDayAgo}') && title match "[Cypress]" &&]`,
   })
 }
 


### PR DESCRIPTION
### Description

This is a second pass of #3021 after it turned out tests were still flaky.

The most important improvement over #3021 is that I discovered two things:
- Most of the test time was spent waiting for the studio to reload before each test.
- All tests in a test group could be tested against the same version of the DOM, so there was no reason to reload the studio

The test speed went from a consistently 2+ minutes to running at around 16 seconds, or from 4 to 2 minutes for all tests.

### What to review

- That all tests runs as expected

### Notes for release

N/a
