### PR TITLE
fix(form-builder): add prop for passing the item component to array of objects input

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/ArrayInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/ArrayInput.tsx
@@ -66,6 +66,7 @@ export interface Props {
   ReferenceItemComponent: ReferenceItemComponentType
   filterField: () => any
   ArrayFunctionsImpl: typeof ArrayFunctions
+  ArrayItemImpl: typeof ArrayItem
   resolveUploader?: (type: SchemaType, file: FileLike) => Uploader | null
   resolveInitialValue?: (type: ObjectSchemaType, value: any) => Promise<any>
   presence: FormFieldPresence[]
@@ -291,6 +292,7 @@ export class ArrayInput extends React.Component<Props> {
       filterField,
       ReferenceItemComponent,
       ArrayFunctionsImpl,
+      ArrayItemImpl = ArrayItem,
     } = this.props
 
     const {isResolvingInitialValue} = this.state
@@ -414,7 +416,7 @@ export class ArrayInput extends React.Component<Props> {
                           value={item}
                           parent={value}
                         >
-                          <ArrayItem
+                          <ArrayItemImpl
                             compareValue={compareValue}
                             filterField={filterField}
                             focusPath={focusPath}


### PR DESCRIPTION
### Description

Adds a small  change to the array of objects input that allows for passing the array item component. Potentially something we could provide as part of an official API in the future, but I'd consider it internal for now.


### Notes for release

N/A (internal only)