### PR TITLE
fix(form-builder): fix ui issues in PTE toolbar

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/PortableText/toolbar/Toolbar.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/toolbar/Toolbar.tsx
@@ -32,23 +32,20 @@ const RootFlex = styled(Flex)`
 `
 
 const StyleSelectBox = styled(Box)`
-  min-width: 8em;
+  width: 8em;
 `
 
 const StyleSelectFlex = styled(Flex)`
   border-right: 1px solid var(--card-border-color);
 `
 
-const ActionMenuBox = styled(Box)<{$withMaxWidth: boolean}>`
-  ${({$withMaxWidth}) =>
-    $withMaxWidth &&
+const ActionMenuBox = styled(Box)<{$withInsertMenu: boolean}>`
+  ${({$withInsertMenu}) =>
+    $withInsertMenu &&
     css`
       max-width: max-content;
+      border-right: 1px solid var(--card-border-color);
     `}
-`
-
-const InsertMenuBox = styled(Box)`
-  border-left: 1px solid var(--card-border-color);
 `
 
 const FullscreenButtonBox = styled(Box)`
@@ -102,32 +99,33 @@ const InnerToolbar = memo(function InnerToolbar({
         </StyleSelectBox>
       </StyleSelectFlex>
 
-      {showActionMenu && (
-        <ActionMenuBox
-          flex={collapsed ? undefined : 1}
-          padding={isFullscreen ? 2 : 1}
-          $withMaxWidth={showInsertMenu}
-        >
-          <ActionMenu
-            disabled={disabled}
-            collapsed={collapsed}
-            groups={actionGroups}
-            isFullscreen={isFullscreen}
-          />
-        </ActionMenuBox>
-      )}
+      <Flex flex={1}>
+        {showActionMenu && (
+          <ActionMenuBox
+            flex={collapsed ? undefined : 1}
+            padding={isFullscreen ? 2 : 1}
+            $withInsertMenu={showInsertMenu}
+          >
+            <ActionMenu
+              disabled={disabled}
+              collapsed={collapsed}
+              groups={actionGroups}
+              isFullscreen={isFullscreen}
+            />
+          </ActionMenuBox>
+        )}
 
-      {showInsertMenu && (
-        <InsertMenuBox flex={collapsed ? undefined : 1} padding={isFullscreen ? 2 : 1}>
-          <InsertMenu
-            disabled={disabled}
-            collapsed={collapsed}
-            items={insertMenuItems}
-            isFullscreen={isFullscreen}
-          />
-        </InsertMenuBox>
-      )}
-
+        {showInsertMenu && (
+          <Box flex={collapsed ? undefined : 1} padding={isFullscreen ? 2 : 1}>
+            <InsertMenu
+              disabled={disabled}
+              collapsed={collapsed}
+              items={insertMenuItems}
+              isFullscreen={isFullscreen}
+            />
+          </Box>
+        )}
+      </Flex>
       <FullscreenButtonBox padding={isFullscreen ? 2 : 1}>
         <Tooltip
           content={


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR fixes an issue where the toolbar sometimes gets double borders, and the expand button was incorrectly positioned when there were no action / insert items.

<img width="1580" alt="Screenshot 2021-12-23 at 13 00 57" src="https://user-images.githubusercontent.com/15094168/147237834-5f7c1a7f-f496-4681-a6d5-79462bafe399.png">



### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
