### PR TITLE
feat(cli): Update @babel/register config to support monorepos

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -58,11 +58,11 @@ const compileTaskName = (taskType, packagePath, extra = '') => {
 
 function buildJavaScript(packageDir, destDir) {
   return withDisplayName(compileTaskName('babel', packageDir, 'cjs'), () =>
-    src([`${SRC_DIR}/**/*.{js,ts,tsx}`, '!**/*.{test,spec}.{js,ts,tsx}'], {cwd: packageDir})
+    src([`${SRC_DIR}/**/*.{js,jsx,ts,tsx}`, '!**/*.{test,spec}.{js,jsx,ts,tsx}'], {cwd: packageDir})
       .pipe(
         changed(destDir, {
           cwd: packageDir,
-          transformPath: (orgPath) => orgPath.replace(/\.tsx?$/, '.js'),
+          transformPath: (orgPath) => orgPath.replace(/\.(t|j)sx?$/, '.js'),
         })
       )
       .pipe(babel())
@@ -73,7 +73,7 @@ function buildJavaScript(packageDir, destDir) {
 function copyAssets(packageDir, destDir) {
   return withDisplayName(compileTaskName('assets', packageDir), () =>
     src(`${SRC_DIR}/**/*`, {cwd: packageDir})
-      .pipe(filter(['**/*.*', '!**/*.js', '!**/*.ts', '!**/*.tsx']))
+      .pipe(filter(['**/*.*', '!**/*.js', '!**/*.jsx', '!**/*.ts', '!**/*.tsx']))
       .pipe(changed(destDir, {cwd: packageDir}))
       .pipe(dest(destDir, {cwd: packageDir}))
   )

--- a/packages/@sanity/core/src/actions/exec/babel.js
+++ b/packages/@sanity/core/src/actions/exec/babel.js
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import registerBabel from '@babel/register'
+import escapeRegExp from "lodash/escapeRegExp";
 
 function getConfig() {
   try {
@@ -23,6 +24,9 @@ function getConfig() {
       ],
       plugins: [require.resolve('@babel/plugin-proposal-class-properties')],
       extensions: ['.js', '.jsx', '.es6', '.es', '.mjs', '.ts', '.tsx'],
+      ignore: [
+        escapeRegExp(path.sep + "node_modules" + path.sep),
+      ]
     }
   }
 }


### PR DESCRIPTION
### Description

#### The problem

`sanity exec` can be used with TypeScript files since they are transpiled on-the-fly using the `@babel/register` configuration defined in [actions/exec/babel.js](https://github.com/sanity-io/sanity/blob/a3f7158016d63728a9b435e6ab444ff2b90fd424/packages/%40sanity/core/src/actions/exec/babel.js). 

Since the configuration does not specify `ignore` or `only`, `@babel/register` uses the defaults defined in [babel-register/src/node.js#L140-L157](https://github.com/babel/babel/blob/master/packages/babel-register/src/node.js#L140-L157). The problem is that these confine transpilation to the current working directory. In a monorepo (We're using Lerna, but I don't think the problem is specific to Lerna) this means files included from another package are not transpiled.

<details>
  <summary>Creating a .babelrc file does not work</summary>

Since [actions/exec/babel.js](https://github.com/sanity-io/sanity/blob/a3f7158016d63728a9b435e6ab444ff2b90fd424/packages/%40sanity/core/src/actions/exec/babel.js) reads `.babelrc` if present, my first attempt was to just create my own `.babelrc` file based on the defaults from Sanity, and adding `ignore`:

```
{
  "presets": [
    "@babel/preset-typescript",
    "@babel/preset-react",
    [
      "@babel/env",
      {
        "targets": {
          "node": "current"
        },
        "modules": "commonjs"
      }
    ]
  ],
  "plugins": ["babel-plugin-styled-components", "@babel/plugin-proposal-class-properties"],
  "extensions": [".js", ".jsx", ".es6", ".es", ".mjs", ".ts", ".tsx"],
  "ignore": ["/node_modules/"]
}
```

The problem is that since it's named `.babelrc`, it will not only be read by Sanity's `babel.js`, but also by `@babel/register` itself, as mentioned in [the documentation](https://babeljs.io/docs/en/babel-register/):

> Note that config files will also be loaded and the programmatic config will be merged over top of the file config options. @babel/register does not support ignore and only in config files.

, and so it fails with

```
Error: Unknown option: .extensions. Check out https://babeljs.io/docs/en/babel-core/#options for more information about options.
```

because "extensions" is not a general Babel option, just an option for `@babel/register`. And if we remove `extensions`, TypeScript transpilation will stop working altogether since `.ts` is not part of the default extensions.

</details>

#### The suggested fix

To make `sanity exec` work better with monorepos, I suggest configuring `@babel/register` so that it includes files outside the current working directory, but still excludes files in `node_modules`.

### What to review

Test that `sanity exec` runs in the same way as before on a few test scripts, and not noticeably slower. In a non-monorepo, the runtime should not change at all since the new `ignore` pattern should check the same files as the old default).

It should work on both Windows and *nix since `path.sep` has been used in the pattern.

### Notes for release

* The default babel config for `sanity exec` has been updated to better support monorepos
