### PR TITLE
feat(desk-tool): experimental `__preserveInstance` prop

### DIFF
--- a/dev/test-studio/parts/deskStructure.js
+++ b/dev/test-studio/parts/deskStructure.js
@@ -201,55 +201,59 @@ export default () =>
                 .id('component1')
                 .title('Component pane (1)')
                 .child(
-                  S.component(DebugPane)
-                    .id('component1')
-                    .title('Component pane #1')
-                    .options({no: 1})
-                    .menuItems([
-                      S.menuItem()
-                        .title('From Menu Item Create Intent')
-                        .intent({
-                          type: 'create',
-                          params: {type: 'author', id: `special.${uuid()}`},
-                        }),
-                      S.menuItem()
-                        .title('Also Menu Item Create Intent')
-                        .intent({
-                          type: 'create',
-                          params: {type: 'author', id: uuid()},
-                        }),
-                      S.menuItem()
-                        .title('Test 1')
-                        // eslint-disable-next-line no-alert
-                        .action(() => alert('you clicked!'))
-                        .showAsAction(true),
-                      S.menuItem()
-                        .title('Test Edit Intent (as action)')
-                        .intent({
-                          type: 'edit',
-                          params: {id: 'grrm', type: 'author'},
-                        })
-                        .icon(RocketIcon)
-                        .showAsAction(),
-                      S.menuItem().title('Should warn in console').action('shouldWarn'),
-                      S.menuItem()
-                        .title('Test Edit Intent (in menu)')
-                        .intent({
-                          type: 'edit',
-                          params: {id: 'foo-bar', type: 'author'},
-                        }),
-                    ])
-                    .child(
-                      S.component(DebugPane)
-                        .id('component1-1')
-                        .title('Component pane #1.1')
-                        .options({no: 1})
-                        .menuItems([
-                          S.menuItem().title('Test 1').action('test-1').showAsAction(true),
-                          S.menuItem().title('Test 2').action('test-2'), //.showAsAction(true),
-                        ])
-                        .child(S.document().documentId('component1-1-child').schemaType('author'))
-                    )
+                  Object.assign(
+                    S.component(DebugPane)
+                      .id('component1')
+                      .title('Component pane #1')
+                      .options({no: 1})
+                      .menuItems([
+                        S.menuItem()
+                          .title('From Menu Item Create Intent')
+                          .intent({
+                            type: 'create',
+                            params: {type: 'author', id: `special.${uuid()}`},
+                          }),
+                        S.menuItem()
+                          .title('Also Menu Item Create Intent')
+                          .intent({
+                            type: 'create',
+                            params: {type: 'author', id: uuid()},
+                          }),
+                        S.menuItem()
+                          .title('Test 1')
+                          // eslint-disable-next-line no-alert
+                          .action(() => alert('you clicked!'))
+                          .showAsAction(true),
+                        S.menuItem()
+                          .title('Test Edit Intent (as action)')
+                          .intent({
+                            type: 'edit',
+                            params: {id: 'grrm', type: 'author'},
+                          })
+                          .icon(RocketIcon)
+                          .showAsAction(),
+                        S.menuItem().title('Should warn in console').action('shouldWarn'),
+                        S.menuItem()
+                          .title('Test Edit Intent (in menu)')
+                          .intent({
+                            type: 'edit',
+                            params: {id: 'foo-bar', type: 'author'},
+                          }),
+                      ])
+                      .child(
+                        S.component(DebugPane)
+                          .id('component1-1')
+                          .title('Component pane #1.1')
+                          .options({no: 1})
+                          .menuItems([
+                            S.menuItem().title('Test 1').action('test-1').showAsAction(true),
+                            S.menuItem().title('Test 2').action('test-2'), //.showAsAction(true),
+                          ])
+                          .child(S.document().documentId('component1-1-child').schemaType('author'))
+                      )
+                      .serialize(),
+                    {__preserveInstance: true}
+                  )
                 ),
               S.listItem()
                 .id('component2')

--- a/dev/test-studio/parts/panes/debug/DebugPane.tsx
+++ b/dev/test-studio/parts/panes/debug/DebugPane.tsx
@@ -1,5 +1,11 @@
 import {usePaneRouter} from '@sanity/desk-tool'
-import {ChevronDownIcon, ChevronRightIcon, ControlsIcon, LinkIcon} from '@sanity/icons'
+import {
+  ChevronDownIcon,
+  ChevronRightIcon,
+  ControlsIcon,
+  LinkIcon,
+  IceCreamIcon,
+} from '@sanity/icons'
 import {Box, Card, Code, Flex, Stack, Text} from '@sanity/ui'
 import React, {useMemo} from 'react'
 
@@ -42,6 +48,13 @@ export function DebugPane(props: any) {
     params: {param1: 'test'},
     payload: {key: 'foo'},
   })
+
+  // this is used to see whether or not the component re-renders.
+  //
+  // notice that the ID is only created on mount and should not change between
+  // subsequent re-renders, therefore this ID will only change when the parent
+  // component re-renders.
+  const randomId = useMemo(() => Math.floor(Math.random() * 10000000).toString(16), [])
 
   return (
     <Box height="fill">
@@ -92,6 +105,24 @@ export function DebugPane(props: any) {
                 <Text>
                   <ChevronDownIcon />
                 </Text>
+              </Box>
+            </Flex>
+          </Card>
+
+          <Card padding={3} radius={2}>
+            <Flex align="center">
+              <Box>
+                <Text>
+                  <IceCreamIcon />
+                </Text>
+              </Box>
+              <Box flex={1} marginLeft={3}>
+                <Flex direction="column" gap={1}>
+                  <Text textOverflow="ellipsis">Random ID: {randomId}</Text>
+                  <Text textOverflow="ellipsis" size={1} muted>
+                    Assigned on component mount
+                  </Text>
+                </Flex>
               </Box>
             </Flex>
           </Card>

--- a/packages/@sanity/desk-tool/src/panes/userComponent/UserComponentPane.tsx
+++ b/packages/@sanity/desk-tool/src/panes/userComponent/UserComponentPane.tsx
@@ -22,6 +22,7 @@ export function UserComponentPane(props: UserComponentPaneProps) {
     title = '',
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     type: _unused,
+    __preserveInstance = false,
     ...restPane
   } = pane
   const userComponent = useRef<{
@@ -43,8 +44,11 @@ export function UserComponentPane(props: UserComponentPaneProps) {
             // this forces a re-render when the router panes change. note: in
             // theory, this shouldn't be necessary and the downstream user
             // component could internally handle these updates, but this was done
-            // to preserve older desk tool behavior
-            key: `${restProps.itemId}-${restProps.childItemId}`,
+            // to preserve older desk tool behavior. if the experimental flag
+            // `__preserveInstance` is true, then no key will be applied.
+            ...(!__preserveInstance && {
+              key: `${restProps.itemId}-${restProps.childItemId}`,
+            }),
             ...restProps,
             ...restPane,
             ref: userComponent,

--- a/packages/@sanity/desk-tool/src/types/types.ts
+++ b/packages/@sanity/desk-tool/src/types/types.ts
@@ -131,6 +131,12 @@ export interface CustomComponentPaneNode<
   Props extends CustomComponentPaneNodeProps = CustomComponentPaneNodeProps
 > extends BaseResolvedPaneNode<'component'> {
   component: React.ComponentType<Props> | React.ReactNode
+  /**
+   * An experimental flag that can be used to opt out of the forced refresh when
+   * the `itemId` or `childItemId` changes. See `UserComponentPane`:
+   * https://github.com/sanity-io/sanity/commit/8340a003043edf6de3afd9ff628ce93be79978e2
+   */
+  __preserveInstance?: boolean
 }
 
 export interface CustomComponentPaneNodeProps {


### PR DESCRIPTION
### Description

This PR allows serialized panes to pass the option `__preserveInstance` in order to tell the desk tool to preserve the instance (and not add the key).

### What to review

Try the option with a custom pane component. Add a child. The custom component instance should not re-render.

### Notes for release

N/A (keep it more hidden)
