### PR TITLE
fix(desk-tool): fix issue with singletons with no type not loading

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/document/DocumentPane.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/DocumentPane.tsx
@@ -68,7 +68,7 @@ export const DocumentPane = memo(function DocumentPane(props: DocumentPaneProvid
   const [templatePermissions, isTemplatePermissionsLoading] = useUnstableTemplatePermissions(
     getNewDocumentOptions()
   )
-  const isLoaded = isDocumentLoaded && isTemplatePermissionsLoading
+  const isLoaded = isDocumentLoaded && !isTemplatePermissionsLoading
 
   const providerProps = useMemo(() => {
     return isLoaded && documentType && options.type !== documentType


### PR DESCRIPTION
### Description

Fixes the root cause of #3011.

This issue was occurring because the `isLoaded` boolean was never being set to true causing 

### What to review

Try the current broken singleton case in the test-studio with this branch. It should load now.

i.e. `/test/desk/custom;foo-bar`

### Notes for release

Fixes an issue that caused singleton documents to never load if no schemaType was provided.
