### PR TITLE
feat(util): add SANITY_STUDIO_PROJECT_NAME env variable

### DIFF
--- a/packages/@sanity/util/src/reduceConfig.ts
+++ b/packages/@sanity/util/src/reduceConfig.ts
@@ -6,14 +6,9 @@ import dotenv from 'dotenv'
 
 const readEnvFile = memoize(tryReadEnvFile)
 const sanityEnv = process.env.SANITY_INTERNAL_ENV || 'production'
-const basePath = process.env.SANITY_STUDIO_PROJECT_BASEPATH || process.env.STUDIO_BASEPATH
 const apiHosts = {
   staging: 'https://api.sanity.work',
   development: 'http://api.sanity.wtf',
-}
-
-const processEnvConfig = {
-  project: basePath ? {basePath} : {},
 }
 
 function clean(obj) {
@@ -60,9 +55,15 @@ export default (rawConfig, env = 'development', options: {studioRootPath?: strin
 
   const projectId = envVars.SANITY_STUDIO_API_PROJECT_ID
   const dataset = envVars.SANITY_STUDIO_API_DATASET
+  const basePath = process.env.SANITY_STUDIO_PROJECT_BASEPATH || process.env.STUDIO_BASEPATH
+  const name = process.env.SANITY_STUDIO_PROJECT_NAME
 
   const apiHost = apiHosts[sanityEnv]
   const api = clean({apiHost, projectId, dataset})
+  const project = clean({basePath, name})
+
+  const processEnvConfig = {project}
+
   const sanityConf = {api}
   const envConfig = (rawConfig.env || {})[env] || {}
   const config = mergeWith({}, rawConfig, envConfig, sanityConf, processEnvConfig, merge)

--- a/packages/@sanity/util/test/envConfig.test.ts
+++ b/packages/@sanity/util/test/envConfig.test.ts
@@ -1,0 +1,47 @@
+/* eslint-disable no-process-env */
+
+let backup = {}
+beforeAll(() => {
+  const {
+    SANITY_STUDIO_API_PROJECT_ID,
+    SANITY_STUDIO_API_DATASET,
+    SANITY_STUDIO_PROJECT_BASEPATH,
+  } = process.env
+
+  backup = {
+    SANITY_STUDIO_API_PROJECT_ID,
+    SANITY_STUDIO_API_DATASET,
+    SANITY_STUDIO_PROJECT_BASEPATH,
+  }
+})
+
+afterAll(() => {
+  Object.keys(backup).forEach((key) => {
+    if (backup[key]) {
+      process.env[key] = backup[key]
+    } else {
+      delete process.env[key]
+    }
+  })
+})
+
+test('respects env config', () => {
+  process.env.SANITY_STUDIO_API_PROJECT_ID = 'abc'
+  process.env.SANITY_STUDIO_API_DATASET = 'overridden'
+  process.env.SANITY_STUDIO_PROJECT_BASEPATH = 'myRoot'
+  const {reduceConfig} = require('../src/_exports/index')
+
+  const reduced = reduceConfig({
+    project: {
+      name: 'Project',
+    },
+    api: {
+      projectId: 'kbrhtt13',
+      dataset: 'production',
+    },
+  })
+
+  expect(reduced.api.projectId).toEqual('abc')
+  expect(reduced.api.dataset).toEqual('overridden')
+  expect(reduced.project.basePath).toEqual('myRoot')
+})


### PR DESCRIPTION
### Description

This PR adds `SANITY_STUDIO_PROJECT_NAME` env variable for setting the configured Studio project name via environment variables. It also adds previously missing tests for env variable config overrides.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Tests and the changed logic of util reduceConfig. I moved some env handling from the global scope of this file into the exported function. This change should affect all usages involving running, building or otherwise using the Studio config.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Added `SANITY_STUDIO_PROJECT_NAME` environment config variable

<!--
A description of the change(s) that should be used in the release notes.
-->
