### PR TITLE
fix search limit issues

### DIFF
--- a/packages/@sanity/base/src/search/weighted/createWeightedSearch.ts
+++ b/packages/@sanity/base/src/search/weighted/createWeightedSearch.ts
@@ -71,7 +71,7 @@ export function createWeightedSearch(
         {
           ...toGroqParams(terms),
           __types: searchSpec.map((spec) => spec.typeName),
-          __limit: searchOpts.limit ?? 100,
+          __limit: searchOpts.limit ?? 1000,
           ...(params || {}),
         },
         {tag}


### PR DESCRIPTION
### Description

This fixes a couple of oversights/unintentional changes from the references in place release:
1) the default limit on studio searches were reduced from 1000 to 100. Since the search results comes unranked from the API this could cause better matches to disappear from the result list in cases where you had a lot of documents.
2) when fetching for existence of draft/published counterparts from hits returned from the reference search we used a `debug` request tag. Also, upping the amount of displayed search results in the reference input from 50 to 100 (after ranking)

### What to review
That studio search works as expected, both global document search and reference search.

### Notes for release
- Fixed an issue that could in some cases cause matching documents to be excluded from the search results
