### PR TITLE
fix(schema): improve default title resolution for references

### DIFF
--- a/packages/@sanity/schema/src/legacy/types/reference.ts
+++ b/packages/@sanity/schema/src/legacy/types/reference.ts
@@ -36,18 +36,13 @@ function humanize(arr, conjunction) {
 }
 
 function buildTitle(type) {
-  if (type.title) {
-    return type.title
-  }
   if (!type.to || type.to.length === 0) {
     return 'Reference'
   }
   return `Reference to ${humanize(
-    arrify(type.to).map((toType) =>
-      (toType.title || toType.name || toType.type || '').toLowerCase()
-    ),
+    arrify(type.to).map((toType) => toType.title),
     'or'
-  )}`
+  ).toLowerCase()}`
 }
 
 export const ReferenceType = {
@@ -62,7 +57,6 @@ export const ReferenceType = {
     }
     const parsed = Object.assign(pick(REFERENCE_CORE, OVERRIDABLE_FIELDS), subTypeDef, {
       type: REFERENCE_CORE,
-      title: subTypeDef.title || buildTitle(subTypeDef),
     })
 
     lazyGetter(parsed, 'fields', () => {
@@ -78,6 +72,8 @@ export const ReferenceType = {
     lazyGetter(parsed, 'to', () => {
       return arrify(subTypeDef.to).map((toType) => createMemberType(toType))
     })
+
+    lazyGetter(parsed, 'title', () => subTypeDef.title || buildTitle(parsed))
 
     return subtype(parsed)
 


### PR DESCRIPTION
### Description
When no title is given for a referenced document type, we currently default to the type name as-is, which makes the UI less user friendly (as pointed out in #3046).

This PR fixes it so that we display the referenced type in this order:
- The title defined for the referenced type at the reference field/array item, if any
- The title specified for the referenced document type, if any
- A [startCase](https://lodash.com/docs/3.10.1#startCase)'d version of the referenced document's type name (note: this follows from how we already resolve the default title for object types)

### What to review
Verify that the UI displays titles of reference fields and array items in a user friendly way

### Notes for release

- Made the default title of referenced document types more user friendly


Fixes #3046