### PR TITLE
support adding a new item before/after existing array items

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/ArrayItemReferenceInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/ArrayItemReferenceInput.tsx
@@ -9,12 +9,13 @@ import React, {
   useRef,
   useState,
 } from 'react'
-import {isValidationErrorMarker, isValidationMarker, Reference} from '@sanity/types'
+import {isValidationErrorMarker, isValidationMarker, Reference, SchemaType} from '@sanity/types'
 import {
   EllipsisVerticalIcon,
   LaunchIcon as OpenInNewTabIcon,
   SyncIcon as ReplaceIcon,
   TrashIcon,
+  CopyIcon as DuplicateIcon,
 } from '@sanity/icons'
 import {concat, Observable, of} from 'rxjs'
 import {catchError, distinctUntilChanged, filter, map, scan, switchMap, tap} from 'rxjs/operators'
@@ -50,6 +51,9 @@ import {isNonNullable} from '../../utils/isNonNullable'
 import {AlertStrip} from '../../AlertStrip'
 import {RowWrapper} from '../arrays/ArrayOfObjectsInput/item/components/RowWrapper'
 import {DragHandle} from '../arrays/common/DragHandle'
+import {InsertEvent} from '../arrays/ArrayOfObjectsInput/types'
+import randomKey from '../arrays/common/randomKey'
+import {InsertMenu} from '../arrays/ArrayOfObjectsInput/InsertMenu'
 import {BaseInputProps, CreateOption, SearchState} from './types'
 import {OptionPreview} from './OptionPreview'
 import {useReferenceInfo} from './useReferenceInfo'
@@ -68,6 +72,8 @@ const INITIAL_SEARCH_STATE: SearchState = {
 export interface Props extends BaseInputProps {
   value: OptionalRef
   isSortable: boolean
+  insertableTypes?: SchemaType[]
+  onInsert?: (event: InsertEvent) => void
 }
 
 const NO_FILTER = () => true
@@ -97,6 +103,7 @@ export const ArrayItemReferenceInput = forwardRef(function ReferenceInput(
     liveEdit,
     onSearch,
     onChange,
+    insertableTypes,
     focusPath = EMPTY_ARRAY,
     onFocus,
     presence,
@@ -104,6 +111,7 @@ export const ArrayItemReferenceInput = forwardRef(function ReferenceInput(
     isSortable,
     level,
     onBlur,
+    onInsert,
     selectedState,
     editReferenceLinkComponent: EditReferenceLink,
     onEditReference,
@@ -129,6 +137,24 @@ export const ArrayItemReferenceInput = forwardRef(function ReferenceInput(
 
     onEditReference({id, type: option.type, template: option.template})
     onFocus?.([])
+  }
+
+  const handleDuplicate = () => {
+    onInsert({
+      item: {...value, _key: randomKey()},
+      position: 'after',
+      path: [{_key: value._key}],
+      edit: false,
+    })
+  }
+
+  const handleInsert = (pos: 'before' | 'after') => {
+    const key = randomKey()
+    onInsert({
+      item: {_type: type.name, _key: key},
+      position: pos,
+      path: [{_key: value._key}],
+    })
   }
 
   const handleChange = useCallback(
@@ -549,6 +575,8 @@ export const ArrayItemReferenceInput = forwardRef(function ReferenceInput(
                           onFocus?.(['_ref'])
                         }}
                       />
+                      <MenuItem text="Duplicate" icon={DuplicateIcon} onClick={handleDuplicate} />
+                      <InsertMenu onInsert={handleInsert} types={insertableTypes} />
                     </>
                   )}
                   {!readOnly && hasRef && <MenuDivider />}

--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/ArrayItemReferenceInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/ArrayItemReferenceInput.tsx
@@ -139,23 +139,25 @@ export const ArrayItemReferenceInput = forwardRef(function ReferenceInput(
     onFocus?.([])
   }
 
-  const handleDuplicate = () => {
-    onInsert({
+  const handleDuplicate = useCallback(() => {
+    onInsert?.({
       item: {...value, _key: randomKey()},
       position: 'after',
       path: [{_key: value._key}],
       edit: false,
     })
-  }
+  }, [onInsert, value])
 
-  const handleInsert = (pos: 'before' | 'after') => {
-    const key = randomKey()
-    onInsert({
-      item: {_type: type.name, _key: key},
-      position: pos,
-      path: [{_key: value._key}],
-    })
-  }
+  const handleInsert = useCallback(
+    (pos: 'before' | 'after') => {
+      onInsert?.({
+        item: {_type: type.name, _key: randomKey()},
+        position: pos,
+        path: [{_key: value._key}],
+      })
+    },
+    [onInsert, type.name, value._key]
+  )
 
   const handleChange = useCallback(
     (id: string) => {

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/ArrayInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/ArrayInput.tsx
@@ -177,10 +177,12 @@ export class ArrayInput extends React.Component<Props> {
       this.uploadSubscriptions[item._key].unsubscribe()
     }
 
+    // move focus to the nearest sibling
     const idx = value.indexOf(item)
-    const nextItem = value[idx + 1] || value[idx - 1]
+    const nearestSibling = value[idx + 1] || value[idx - 1]
 
-    onFocus([nextItem ? {_key: nextItem._key} : FOCUS_TERMINATOR])
+    // if there's no siblings we want to focus the input itself
+    onFocus(nearestSibling ? [{_key: nearestSibling._key}] : [])
   }
 
   handleItemChange = (event: PatchEvent, item: ArrayMember) => {

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/ArrayInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/ArrayInput.tsx
@@ -26,7 +26,7 @@ import ArrayFunctions from '../common/ArrayFunctions'
 import {applyAll} from '../../../patch/applyPatch'
 import {ConditionalReadOnlyField} from '../../common'
 import {ArrayItem} from './item'
-import type {ArrayMember, ReferenceItemComponentType} from './types'
+import type {ArrayMember, InsertEvent, ReferenceItemComponentType} from './types'
 import {uploadTarget} from './uploadTarget/uploadTarget'
 
 declare const __DEV__: boolean
@@ -41,7 +41,7 @@ function getUploadTargetFieldset() {
   return UploadTargetFieldsetMemo
 }
 
-function createProtoValue(type: SchemaType): ArrayMember {
+export function createProtoValue(type: SchemaType): ArrayMember {
   if (!isObjectSchemaType(type)) {
     throw new Error(
       `Invalid item type: "${type.type}". Default array input can only contain objects (for now)`
@@ -89,29 +89,33 @@ export class ArrayInput extends React.Component<Props> {
     isResolvingInitialValue: false,
   }
 
-  insert = (itemValue: ArrayMember, position: 'before' | 'after', atIndex: number) => {
+  insert = (item: ArrayMember, position: 'before' | 'after', path: Path) => {
     const {onChange} = this.props
-
-    onChange(PatchEvent.from(setIfMissing([]), insert([itemValue], position, [atIndex])))
+    onChange(PatchEvent.from(setIfMissing([]), insert([item], position, path)))
   }
 
   handlePrepend = (value: ArrayMember) => {
-    this.insert(value, 'before', 0)
-    this.handleFocusItem(value)
+    this.insert(value, 'before', [0])
+    this.openItem(value._key)
+  }
+  handleAppend = (value: ArrayMember) => {
+    this.insert(value, 'after', [-1])
+    this.openItem(value._key)
   }
 
-  handleAppend = (value: ArrayMember) => {
-    const {resolveInitialValue} = this.props
+  handleInsert = (event: InsertEvent) => {
+    const {resolveInitialValue, onFocus} = this.props
     this.setState({isResolvingInitialValue: true})
-    const memberType = this.getMemberTypeOfItem(value)
+    const memberType = this.getMemberTypeOfItem(event.item)
     const resolvedInitialValue = resolveInitialValue
-      ? resolveInitialValue(memberType as ObjectSchemaType, value)
+      ? resolveInitialValue(memberType as ObjectSchemaType, event.item)
       : Promise.resolve({})
+
     resolvedInitialValue
+      .then((initial) => ({...event.item, ...initial}))
       .then(
-        (initial) => {
-          this.insert({...value, ...initial}, 'after', -1)
-          this.handleFocusItem(value)
+        (value) => {
+          this.insert(value, event.position, event.path)
         },
         (error) => {
           this.toast?.push({
@@ -119,12 +123,16 @@ export class ArrayInput extends React.Component<Props> {
             description: `Unable to resolve initial value for type: ${memberType.name}: ${error.message}.`,
             status: 'error',
           })
-          this.insert(value, 'after', -1)
-          this.handleFocusItem(value)
+          this.insert(event.item, event.position, event.path)
         }
       )
       .finally(() => {
         this.setState({isResolvingInitialValue: false})
+        if (event.edit === false) {
+          onFocus([{_key: event.item._key}])
+        } else {
+          this.openItem(event.item._key)
+        }
       })
   }
 
@@ -142,9 +150,8 @@ export class ArrayInput extends React.Component<Props> {
     }
   }
 
-  handleFocusItem = (item: ArrayMember) => {
-    this.props.onFocus([{_key: item._key}, FOCUS_TERMINATOR])
-    // this.props.onFocus([{_key: item._key}, item._type === 'reference' ? '_ref' : FOCUS_TERMINATOR])
+  openItem = (key: string) => {
+    this.props.onFocus([{_key: key}, FOCUS_TERMINATOR])
   }
 
   removeItem(item: ArrayMember) {
@@ -259,7 +266,7 @@ export class ArrayInput extends React.Component<Props> {
     const item = createProtoValue(type)
     const key = item._key
 
-    this.insert(item, 'after', -1)
+    this.insert(item, 'after', [-1])
 
     const events$ = uploader
       .upload(file, type)
@@ -273,6 +280,10 @@ export class ArrayInput extends React.Component<Props> {
       ...this.uploadSubscriptions,
       [key]: events$.subscribe(onChange),
     }
+  }
+
+  handleFocusItem = (item: ArrayMember) => {
+    this.openItem(item._key)
   }
 
   render() {
@@ -428,6 +439,7 @@ export class ArrayInput extends React.Component<Props> {
                             onChange={this.handleItemChange}
                             onFocus={onFocus}
                             onRemove={this.handleRemoveItem}
+                            onInsert={this.handleInsert}
                             presence={presence}
                             readOnly={readOnly || hasMissingKeys}
                             type={type}

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/InsertMenu.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/InsertMenu.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-no-bind */
 import {SchemaType} from '@sanity/types'
-import React, {ComponentProps} from 'react'
+import React, {ComponentProps, memo} from 'react'
 import {MenuGroup, MenuItem} from '@sanity/ui'
 import {InsertAboveIcon, InsertBelowIcon} from '@sanity/icons'
 
@@ -11,7 +11,7 @@ interface Props {
 
 const MENU_POPOVER_PROPS = {portal: true, tone: 'default', placement: 'left'} as const
 
-export function InsertMenu(props: Props) {
+export const InsertMenu = memo(function InsertMenu(props: Props) {
   const {types, onInsert} = props
   return (
     <>
@@ -31,7 +31,7 @@ export function InsertMenu(props: Props) {
       />
     </>
   )
-}
+})
 
 function InsertMenuGroup(
   props: Props & {

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/InsertMenu.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/InsertMenu.tsx
@@ -1,0 +1,60 @@
+/* eslint-disable react/jsx-no-bind */
+import {SchemaType} from '@sanity/types'
+import React, {ComponentProps} from 'react'
+import {MenuGroup, MenuItem} from '@sanity/ui'
+import {InsertAboveIcon, InsertBelowIcon} from '@sanity/icons'
+
+interface Props {
+  types: SchemaType[]
+  onInsert: (pos: 'before' | 'after', type: SchemaType) => void
+}
+
+const MENU_POPOVER_PROPS = {portal: true, tone: 'default', placement: 'left'} as const
+
+export function InsertMenu(props: Props) {
+  const {types, onInsert} = props
+  return (
+    <>
+      <InsertMenuGroup
+        pos="before"
+        types={types}
+        onInsert={onInsert}
+        text="Add item before"
+        icon={InsertAboveIcon}
+      />
+      <InsertMenuGroup
+        pos="after"
+        types={types}
+        onInsert={onInsert}
+        text="Add item after"
+        icon={InsertBelowIcon}
+      />
+    </>
+  )
+}
+
+function InsertMenuGroup(
+  props: Props & {
+    pos: 'before' | 'after'
+    text: ComponentProps<typeof MenuItem>['text']
+    icon: ComponentProps<typeof MenuItem>['icon']
+  }
+) {
+  const {types, onInsert, pos, text, icon} = props
+
+  if (types.length === 1) {
+    return <MenuItem key={pos} text={text} icon={icon} onClick={() => onInsert(pos, types[0])} />
+  }
+  return (
+    <MenuGroup text={text} key={pos} popover={MENU_POPOVER_PROPS}>
+      {types.map((insertableType) => (
+        <MenuItem
+          key={insertableType.name}
+          icon={insertableType.icon}
+          text={insertableType.title}
+          onClick={() => onInsert(pos, insertableType)}
+        />
+      ))}
+    </MenuGroup>
+  )
+}

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/item/ArrayItem.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/item/ArrayItem.tsx
@@ -13,7 +13,7 @@ import React, {memo, useCallback, useMemo, useRef} from 'react'
 import {FOCUS_TERMINATOR, pathFor, startsWith} from '@sanity/util/paths'
 import {Box} from '@sanity/ui'
 import PatchEvent from '../../../../PatchEvent'
-import {ArrayMember, ReferenceItemComponentType} from '../types'
+import {ArrayMember, InsertEvent, ReferenceItemComponentType} from '../types'
 import {EMPTY_ARRAY} from '../../../../utils/empty'
 import {hasFocusAtPath, hasFocusWithinPath} from '../../../../utils/focusUtils'
 import {useScrollIntoViewOnFocusWithin} from '../../../../hooks/useScrollIntoViewOnFocusWithin'
@@ -33,6 +33,7 @@ interface ArrayInputListItemProps {
   itemKey: string | undefined
   layout?: 'media' | 'default'
   onRemove: (value: ArrayMember) => void
+  onInsert: (event: InsertEvent) => void
   onChange: (event: PatchEvent, value: ArrayMember) => void
   onFocus: (path: Path) => void
   onBlur: () => void
@@ -56,6 +57,7 @@ export const ArrayItem = memo(function ArrayItem(props: ArrayInputListItemProps)
     onFocus,
     onChange,
     onRemove,
+    onInsert,
     onBlur,
     filterField,
     compareValue,
@@ -92,12 +94,14 @@ export const ArrayItem = memo(function ArrayItem(props: ArrayInputListItemProps)
     },
     [emitFocus]
   )
+
   const handleEditOpen = useCallback(() => emitFocus([FOCUS_TERMINATOR]), [emitFocus])
   const handleEditClose = useCallback(() => {
     if (isEmpty(value)) {
       onRemove(value)
+    } else {
+      emitFocus([])
     }
-    emitFocus([])
   }, [value, onRemove, emitFocus])
 
   const handleChange = useCallback(
@@ -167,6 +171,8 @@ export const ArrayItem = memo(function ArrayItem(props: ArrayInputListItemProps)
         focusPath={focusPath}
         onFocus={onFocus}
         onBlur={onBlur}
+        onInsert={onInsert}
+        insertableTypes={type.of}
         type={itemType}
         value={value}
         isSortable={isSortable}
@@ -206,6 +212,7 @@ export const ArrayItem = memo(function ArrayItem(props: ArrayInputListItemProps)
     itemType,
     onBlur,
     onFocus,
+    onInsert,
     readOnly,
     type?.options?.editModal,
     value,
@@ -218,9 +225,11 @@ export const ArrayItem = memo(function ArrayItem(props: ArrayInputListItemProps)
       value={value}
       readOnly={readOnly}
       type={itemType}
+      insertableTypes={type.of}
       presence={isEditing ? EMPTY_ARRAY : itemPresence}
       validation={scopedValidation}
       isSortable={isSortable}
+      onInsert={onInsert}
       onFocus={handleItemElementFocus}
       onClick={itemType ? handleEditOpen : undefined}
       onRemove={handleRemove}

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/item/CellItem.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/item/CellItem.tsx
@@ -5,7 +5,7 @@ import {
   WarningOutlineIcon,
 } from '@sanity/icons'
 import {FieldPresence} from '@sanity/base/presence'
-import React, {useMemo} from 'react'
+import React, {useCallback, useMemo} from 'react'
 import {Badge, Box, Button, Card, Flex, Menu, MenuButton, MenuItem, Text, Tooltip} from '@sanity/ui'
 import {FormFieldValidationStatus} from '@sanity/base/components'
 import styled from 'styled-components'
@@ -125,24 +125,25 @@ export const CellItem = React.forwardRef(function ItemCell(
     return undefined
   }, [hasError, hasWarning, hasKey])
 
-  const handleDuplicate = () => {
-    const key = randomKey()
-    onInsert({
-      item: {...value, _key: key},
+  const handleDuplicate = useCallback(() => {
+    onInsert?.({
+      item: {...value, _key: randomKey()},
       position: 'after',
       path: [{_key: value._key}],
       edit: false,
     })
-  }
+  }, [onInsert, value])
 
-  const handleInsert = (pos: 'before' | 'after', insertType: SchemaType) => {
-    const key = randomKey()
-    onInsert({
-      item: {...createProtoValue(insertType), _key: key},
-      position: pos,
-      path: [{_key: value._key}],
-    })
-  }
+  const handleInsert = useCallback(
+    (pos: 'before' | 'after', insertType: SchemaType) => {
+      onInsert?.({
+        item: createProtoValue(insertType),
+        position: pos,
+        path: [{_key: value._key}],
+      })
+    },
+    [onInsert, value._key]
+  )
 
   const id = useId()
 

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/item/CellItem.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/item/CellItem.tsx
@@ -1,13 +1,21 @@
-import {WarningOutlineIcon} from '@sanity/icons'
+import {
+  CopyIcon as DuplicateIcon,
+  EllipsisVerticalIcon,
+  TrashIcon,
+  WarningOutlineIcon,
+} from '@sanity/icons'
 import {FieldPresence} from '@sanity/base/presence'
 import React, {useMemo} from 'react'
-import {Badge, Box, Card, Flex, Text, Tooltip} from '@sanity/ui'
+import {Badge, Box, Button, Card, Flex, Menu, MenuButton, MenuItem, Text, Tooltip} from '@sanity/ui'
 import {FormFieldValidationStatus} from '@sanity/base/components'
 import styled from 'styled-components'
-import {isValidationWarningMarker, isValidationErrorMarker} from '@sanity/types'
+import {isValidationErrorMarker, isValidationWarningMarker, SchemaType} from '@sanity/types'
+import {useId} from '@reach/auto-id'
 import Preview from '../../../../Preview'
-import {ConfirmDeleteButton} from '../ConfirmDeleteButton'
 import {DragHandle} from '../../common/DragHandle'
+import randomKey from '../../common/randomKey'
+import {createProtoValue} from '../ArrayInput'
+import {InsertMenu} from '../InsertMenu'
 import {ItemWithMissingType} from './ItemWithMissingType'
 import {ItemLayoutProps} from './ItemLayoutProps'
 
@@ -88,6 +96,8 @@ export const CellItem = React.forwardRef(function ItemCell(
     onClick,
     onKeyPress,
     onFocus,
+    onInsert,
+    insertableTypes,
     type,
     readOnly,
     presence,
@@ -114,6 +124,27 @@ export const CellItem = React.forwardRef(function ItemCell(
 
     return undefined
   }, [hasError, hasWarning, hasKey])
+
+  const handleDuplicate = () => {
+    const key = randomKey()
+    onInsert({
+      item: {...value, _key: key},
+      position: 'after',
+      path: [{_key: value._key}],
+      edit: false,
+    })
+  }
+
+  const handleInsert = (pos: 'before' | 'after', insertType: SchemaType) => {
+    const key = randomKey()
+    onInsert({
+      item: {...createProtoValue(insertType), _key: key},
+      position: pos,
+      path: [{_key: value._key}],
+    })
+  }
+
+  const id = useId()
 
   return (
     <Root {...rest} radius={2} ref={ref} border tone={tone}>
@@ -182,16 +213,23 @@ export const CellItem = React.forwardRef(function ItemCell(
             </Tooltip>
           )}
         </Flex>
-
-        {/* Delete button */}
-        <Box>
-          <ConfirmDeleteButton
-            disabled={readOnly || !onRemove}
-            onConfirm={onRemove}
-            placement="bottom"
-            title="Remove item"
-          />
-        </Box>
+        {/* Menu */}
+        {!readOnly && (
+          <Box>
+            <MenuButton
+              button={<Button padding={2} mode="bleed" icon={EllipsisVerticalIcon} />}
+              id={`${id}-menuButton`}
+              portal
+              menu={
+                <Menu>
+                  <MenuItem text="Remove" tone="critical" icon={TrashIcon} onClick={onRemove} />
+                  <MenuItem text="Duplicate" icon={DuplicateIcon} onClick={handleDuplicate} />
+                  <InsertMenu types={insertableTypes} onInsert={handleInsert} />
+                </Menu>
+              }
+            />
+          </Box>
+        )}
       </FooterFlex>
     </Root>
   )

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/item/ItemForm.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/item/ItemForm.tsx
@@ -2,7 +2,7 @@ import {isReferenceSchemaType, Marker, Path, SchemaType} from '@sanity/types'
 import React, {ForwardedRef, forwardRef, useMemo} from 'react'
 import {FormFieldPresence} from '@sanity/base/presence'
 import {FormBuilderInput} from '../../../../FormBuilderInput'
-import {ArrayMember, ReferenceItemComponentType} from '../types'
+import {ArrayMember, InsertEvent, ReferenceItemComponentType} from '../types'
 import PatchEvent from '../../../../PatchEvent'
 import {Props as InputProps} from '../../../types'
 
@@ -10,9 +10,11 @@ type Props = {
   type: SchemaType
   value: ArrayMember
   compareValue?: ArrayMember[]
+  onInsert?: (event: InsertEvent) => void
   markers: Marker[]
   onChange: (event: PatchEvent) => void
   onFocus: (path: Path) => void
+  insertableTypes?: SchemaType[]
   ReferenceItemComponent: ReferenceItemComponentType
   onBlur: () => void
   filterField: () => any
@@ -32,10 +34,12 @@ export const ItemForm = forwardRef(function ItemForm(props: Props, ref: Forwarde
     onBlur,
     onChange,
     ReferenceItemComponent,
+    insertableTypes,
     readOnly,
     isSortable,
     filterField,
     presence,
+    onInsert,
     compareValue,
   } = props
 
@@ -48,10 +52,19 @@ export const ItemForm = forwardRef(function ItemForm(props: Props, ref: Forwarde
             givenProps: InputProps,
             inputRef: ForwardedRef<{focus: () => void}>
           ) {
-            return <ReferenceItemComponent {...givenProps} isSortable={isSortable} ref={inputRef} />
+            return (
+              <ReferenceItemComponent
+                {...givenProps}
+                insertableTypes={insertableTypes}
+                onInsert={onInsert}
+                isSortable={isSortable}
+                onChange={onChange}
+                ref={inputRef}
+              />
+            )
           })
         : undefined,
-    [ReferenceItemComponent, isReference, isSortable]
+    [ReferenceItemComponent, insertableTypes, isReference, isSortable, onInsert, onChange]
   )
 
   return (

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/item/ItemLayoutProps.ts
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/item/ItemLayoutProps.ts
@@ -1,6 +1,7 @@
 import {Marker, SchemaType} from '@sanity/types'
 import React from 'react'
 import {FormFieldPresence} from '@sanity/base/presence'
+import {InsertEvent} from '../types'
 
 export interface ItemLayoutProps {
   isSortable: boolean
@@ -8,9 +9,11 @@ export interface ItemLayoutProps {
   index: number
   value: {_key?: string; _ref?: string}
   type?: SchemaType // note: type might be undefined here if the value doesn't have a matching schema type definition
+  insertableTypes?: SchemaType[]
   onClick?: () => void
   onFocus?: (event: React.FocusEvent) => void
   onRemove: () => void
+  onInsert?: (event: InsertEvent) => void
   onKeyPress: (event: React.KeyboardEvent<any>) => void
   presence: FormFieldPresence[]
   validation: Marker[]

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/item/RowItem.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/item/RowItem.tsx
@@ -14,17 +14,23 @@ import {
   Text,
   Tooltip,
 } from '@sanity/ui'
-import {EllipsisVerticalIcon, TrashIcon} from '@sanity/icons'
+import {CopyIcon as DuplicateIcon, EllipsisVerticalIcon, TrashIcon} from '@sanity/icons'
 import {FormFieldValidationStatus} from '@sanity/base/components'
 import {useId} from '@reach/auto-id'
+import {SchemaType} from '@sanity/types'
 import Preview from '../../../../Preview'
 
 import {DragHandle} from '../../common/DragHandle'
+import randomKey from '../../common/randomKey'
+import {createProtoValue} from '../ArrayInput'
+import {InsertMenu} from '../InsertMenu'
 import {ItemWithMissingType} from './ItemWithMissingType'
 import {ItemLayoutProps} from './ItemLayoutProps'
 import {RowWrapper} from './components/RowWrapper'
 
 const dragHandle = <DragHandle paddingX={1} paddingY={3} />
+
+const MENU_POPOVER_PROPS = {portal: true, tone: 'default'} as const
 
 export const RowItem = React.forwardRef(function RegularItem(
   props: ItemLayoutProps,
@@ -40,6 +46,8 @@ export const RowItem = React.forwardRef(function RegularItem(
     type,
     readOnly,
     presence,
+    onInsert,
+    insertableTypes,
     onRemove,
     validation,
     ...rest
@@ -47,6 +55,25 @@ export const RowItem = React.forwardRef(function RegularItem(
 
   const hasErrors = validation.some((v) => v.level === 'error')
   const hasWarnings = validation.some((v) => v.level === 'warning')
+
+  const handleDuplicate = () => {
+    const key = randomKey()
+    onInsert({
+      item: {...value, _key: key},
+      position: 'after',
+      path: [{_key: value._key}],
+      edit: false,
+    })
+  }
+
+  const handleInsert = (pos: 'before' | 'after', insertType: SchemaType) => {
+    const key = randomKey()
+    onInsert({
+      item: {...createProtoValue(insertType), _key: key},
+      position: pos,
+      path: [{_key: value._key}],
+    })
+  }
 
   const id = useId()
   return (
@@ -120,12 +147,14 @@ export const RowItem = React.forwardRef(function RegularItem(
                 {!readOnly && (
                   <>
                     <MenuItem text="Remove" tone="critical" icon={TrashIcon} onClick={onRemove} />
+                    <MenuItem text="Duplicate" icon={DuplicateIcon} onClick={handleDuplicate} />
+                    <InsertMenu types={insertableTypes} onInsert={handleInsert} />
                   </>
                 )}
               </Menu>
             }
             placement="right"
-            popover={{portal: true, tone: 'default'}}
+            popover={MENU_POPOVER_PROPS}
           />
           {!value._key && (
             <Box marginLeft={1}>

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/item/RowItem.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/item/RowItem.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-nested-ternary */
 import {FieldPresence} from '@sanity/base/presence'
-import React from 'react'
+import React, {useCallback} from 'react'
 import {
   Badge,
   Box,
@@ -56,24 +56,25 @@ export const RowItem = React.forwardRef(function RegularItem(
   const hasErrors = validation.some((v) => v.level === 'error')
   const hasWarnings = validation.some((v) => v.level === 'warning')
 
-  const handleDuplicate = () => {
-    const key = randomKey()
-    onInsert({
-      item: {...value, _key: key},
+  const handleDuplicate = useCallback(() => {
+    onInsert?.({
+      item: {...value, _key: randomKey()},
       position: 'after',
       path: [{_key: value._key}],
       edit: false,
     })
-  }
+  }, [onInsert, value])
 
-  const handleInsert = (pos: 'before' | 'after', insertType: SchemaType) => {
-    const key = randomKey()
-    onInsert({
-      item: {...createProtoValue(insertType), _key: key},
-      position: pos,
-      path: [{_key: value._key}],
-    })
-  }
+  const handleInsert = useCallback(
+    (pos: 'before' | 'after', insertType: SchemaType) => {
+      onInsert?.({
+        item: {...createProtoValue(insertType), _key: randomKey()},
+        position: pos,
+        path: [{_key: value._key}],
+      })
+    },
+    [onInsert, value._key]
+  )
 
   const id = useId()
   return (

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/types.ts
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/types.ts
@@ -1,4 +1,5 @@
 import type {ComponentType} from 'react'
+import {Path} from '@sanity/types'
 
 export type ModalType = 'modal' | 'fullscreen' | string
 
@@ -8,4 +9,10 @@ export type ArrayMember = {
   [key: string]: any
 }
 
+export interface InsertEvent {
+  position: 'before' | 'after'
+  item: ArrayMember
+  path: Path
+  edit?: boolean
+}
 export type ReferenceItemComponentType = ComponentType<any>

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
@@ -57,7 +57,6 @@ export interface Props {
   markers: Marker[]
   presence: FormFieldPresence[]
 }
-type Focusable = {focus: () => void}
 
 export class ArrayOfPrimitivesInput extends React.PureComponent<Props> {
   _element: HTMLElement | null = null

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
@@ -12,8 +12,7 @@ import ArrayFunctions from '../common/ArrayFunctions'
 import {ConditionalReadOnlyField} from '../../common'
 import getEmptyValue from './getEmptyValue'
 import {ItemRow} from './ItemRow'
-
-type Primitive = string | number | boolean
+import {PrimitiveValue} from './types'
 
 const NO_MARKERS: Marker[] = []
 
@@ -25,16 +24,25 @@ function move<T>(arr: T[], from: number, to: number): T[] {
   return copy
 }
 
-function insertAt<T>(arr: T[], index: number, item: T): T[] {
+/**
+ * @param index index to insert item after. An index of -1 will prepend the item
+ * @param arr the array to insert the item into
+ * @param item the item to insert
+ *
+ * example:
+ *  insertAfter(-1, ["one", "two"], "hello")
+ *  => ["hello", "one", "two"]
+ */
+function insertAfter<T>(index: number, arr: T[], item: T): T[] {
   const copy = arr.slice()
   copy.splice(index + 1, 0, item)
   return copy
 }
 
 export interface Props {
-  type: ArraySchemaType<Primitive>
-  value: Primitive[]
-  compareValue?: Primitive[]
+  type: ArraySchemaType<PrimitiveValue>
+  value: PrimitiveValue[]
+  compareValue?: PrimitiveValue[]
   level: number
   onChange: (event: PatchEvent) => void
   onFocus: (path: Path) => void
@@ -51,7 +59,7 @@ export class ArrayOfPrimitivesInput extends React.PureComponent<Props> {
   _element: Focusable | null = null
   _lastAddedIndex = -1
 
-  set(nextValue: Primitive[]) {
+  set(nextValue: PrimitiveValue[]) {
     this._lastAddedIndex = -1
     const patch = nextValue.length === 0 ? unset() : set(nextValue)
     this.props.onChange(PatchEvent.from(patch))
@@ -63,30 +71,37 @@ export class ArrayOfPrimitivesInput extends React.PureComponent<Props> {
     this.props.onFocus([Math.max(0, index - 1)])
   }
 
-  handleAppend = (itemValue: Primitive) => {
+  handleAppend = (itemValue: PrimitiveValue) => {
     const {value = [], onFocus} = this.props
     this.set(value.concat(itemValue))
     onFocus([value.length])
   }
 
-  handlePrepend = (itemValue: Primitive) => {
+  handlePrepend = (itemValue: PrimitiveValue) => {
     const {value = [], onFocus} = this.props
     this.set([itemValue].concat(value))
     onFocus([value.length])
   }
 
-  insertAt(index: number, type: SchemaType) {
+  insertAfter(index: number, type: SchemaType) {
     const {value = [], onFocus} = this.props
     const emptyValue = getEmptyValue(type)
     if (emptyValue === undefined) {
       throw new Error(`Cannot create empty primitive value from ${type.name}`)
     }
-    this.set(insertAt(value, index, emptyValue))
+    this.set(insertAfter(index, value, emptyValue))
     onFocus([index + 1])
   }
 
   handleRemoveItem = (index: number) => {
     this.removeAt(index)
+  }
+
+  handleInsert = (pos: 'before' | 'after', index: number, item: PrimitiveValue) => {
+    const {value = [], onFocus} = this.props
+    const insertIndex = index + (pos === 'before' ? -1 : 0)
+    this.set(insertAfter(insertIndex, value, item))
+    onFocus([insertIndex + 1])
   }
 
   handleItemChange = (event: PatchEvent) => {
@@ -97,7 +112,7 @@ export class ArrayOfPrimitivesInput extends React.PureComponent<Props> {
   handleItemEnterKey = (index: number) => {
     const firstType = this.props.type?.of[0]
     if (firstType) {
-      this.insertAt(index, firstType)
+      this.insertAfter(index, firstType)
       this._lastAddedIndex = index + 1
     }
   }
@@ -110,9 +125,10 @@ export class ArrayOfPrimitivesInput extends React.PureComponent<Props> {
   }
 
   handleSortEnd = (event: {oldIndex: number; newIndex: number}) => {
-    const {value} = this.props
+    const {value, onFocus} = this.props
     const {oldIndex, newIndex} = event
     this.set(move(value, oldIndex, newIndex))
+    onFocus([newIndex])
   }
 
   getMemberType(typeName: string) {
@@ -132,11 +148,17 @@ export class ArrayOfPrimitivesInput extends React.PureComponent<Props> {
     }
   }
 
-  handleFocusRoot = () => {
-    this.props.onFocus([])
+  handleFocusRoot = (event) => {
+    // We want to handle focus when the array input *itself* element receives
+    // focus, not when a child element receives focus, but React has decided
+    // to let focus bubble, so this workaround is needed
+    // Background: https://github.com/facebook/react/issues/6410#issuecomment-671915381
+    if (event.currentTarget === event.target && event.currentTarget === this._element) {
+      this.props.onFocus([])
+    }
   }
 
-  handleFocusItem = (item: Primitive, index: number) => {
+  handleFocusItem = (item: PrimitiveValue, index: number) => {
     this.props.onFocus([index])
   }
 
@@ -184,10 +206,15 @@ export class ArrayOfPrimitivesInput extends React.PureComponent<Props> {
                     const childPresence = presence.filter((pItem) =>
                       startsWith([index], pItem.path)
                     )
+                    const memberType = this.getMemberType(resolveTypeName(item))
 
+                    // Best effort attempt to make a stable key for each item in the array
+                    // Since items may be reordered and change at any time, there's no way to reliably address each item uniquely
+                    // This is a "best effort"-attempt at making sure we don't re-use internal state for item inputs
+                    // when items gets added or removed to the array
+                    const key = memberType.name + String(index) + String(value.length)
                     return (
-                      // eslint-disable-next-line react/no-array-index-key
-                      <Item key={index} index={index} isSortable={isSortable}>
+                      <Item key={key} index={index} isSortable={isSortable}>
                         <ConditionalReadOnlyField
                           readOnly={readOnly || this.getMemberType(resolveTypeName(item))?.readOnly}
                           value={item}
@@ -201,13 +228,15 @@ export class ArrayOfPrimitivesInput extends React.PureComponent<Props> {
                             readOnly={readOnly}
                             markers={filteredMarkers.length === 0 ? NO_MARKERS : filteredMarkers}
                             isSortable={isSortable}
-                            type={this.getMemberType(resolveTypeName(item))}
+                            type={memberType}
                             focusPath={focusPath}
                             onFocus={onFocus}
                             onBlur={onBlur}
+                            insertableTypes={type.of}
                             onEnterKey={this.handleItemEnterKey}
                             onEscapeKey={this.handleItemEscapeKey}
                             onChange={this.handleItemChange}
+                            onInsert={this.handleInsert}
                             onRemove={this.handleRemoveItem}
                             presence={childPresence}
                           />
@@ -219,7 +248,7 @@ export class ArrayOfPrimitivesInput extends React.PureComponent<Props> {
               </Card>
             )}
           </Stack>
-          <ArrayFunctionsImpl<Primitive>
+          <ArrayFunctionsImpl<PrimitiveValue>
             type={type}
             value={value}
             readOnly={readOnly}

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfPrimitivesInput/ItemRow.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfPrimitivesInput/ItemRow.tsx
@@ -80,13 +80,13 @@ export const ItemRow = React.forwardRef(function ItemRow(
 
   const handleInsert = useCallback(
     (pos: 'before' | 'after', insertType: SchemaType) => {
-      onInsert(pos, index, getEmptyValue(insertType))
+      onInsert?.(pos, index, getEmptyValue(insertType))
     },
     [index, onInsert]
   )
 
   const handleDuplicate = useCallback(() => {
-    onInsert('after', index, value)
+    onInsert?.('after', index, value)
   }, [index, onInsert, value])
 
   const handleKeyPress = useCallback(
@@ -199,18 +199,14 @@ export const ItemRow = React.forwardRef(function ItemRow(
                 popover={{portal: true, tone: 'default'}}
                 menu={
                   <Menu>
-                    {!readOnly && (
-                      <>
-                        <MenuItem
-                          text="Remove"
-                          tone="critical"
-                          icon={TrashIcon}
-                          onClick={handleRemove}
-                        />
-                        <MenuItem text="Duplicate" icon={DuplicateIcon} onClick={handleDuplicate} />
-                        <InsertMenu types={insertableTypes} onInsert={handleInsert} />
-                      </>
-                    )}
+                    <MenuItem
+                      text="Remove"
+                      tone="critical"
+                      icon={TrashIcon}
+                      onClick={handleRemove}
+                    />
+                    <MenuItem text="Duplicate" icon={DuplicateIcon} onClick={handleDuplicate} />
+                    <InsertMenu types={insertableTypes} onInsert={handleInsert} />
                   </Menu>
                 }
               />

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfPrimitivesInput/types.ts
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfPrimitivesInput/types.ts
@@ -1,0 +1,1 @@
+export type PrimitiveValue = string | number | boolean

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfPrimitivesInput/utils/nearestIndex.test.ts
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfPrimitivesInput/utils/nearestIndex.test.ts
@@ -1,0 +1,20 @@
+import {nearestIndexOf} from './nearestIndex'
+
+test('nearestIndexOf', () => {
+  expect(nearestIndexOf(['a', 'b', 'b', 'c', 'a'], 0, 'a')).toBe(0)
+  expect(nearestIndexOf(['a', 'b', 'b', 'c', 'a'], 1, 'a')).toBe(0)
+
+  // it prefers the nearest match from the first half if there's a tie
+  expect(nearestIndexOf(['a', 'b', 'b', 'c', 'a'], 2, 'a')).toBe(0)
+
+  expect(nearestIndexOf(['a', 'b', 'b', 'c', 'a'], 3, 'a')).toBe(4)
+  expect(nearestIndexOf(['a', 'b', 'b', 'c', 'a'], 4, 'a')).toBe(4)
+})
+
+test('nearestIndexOf with no matches', () => {
+  expect(nearestIndexOf(['a', 'b', 'b', 'c', 'a'], 0, 'x')).toBe(-1)
+  expect(nearestIndexOf(['a', 'b', 'b', 'c', 'a'], 1, 'x')).toBe(-1)
+  expect(nearestIndexOf(['a', 'b', 'b', 'c', 'a'], 2, 'x')).toBe(-1)
+  expect(nearestIndexOf(['a', 'b', 'b', 'c', 'a'], 3, 'x')).toBe(-1)
+  expect(nearestIndexOf(['a', 'b', 'b', 'c', 'a'], 4, 'x')).toBe(-1)
+})

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfPrimitivesInput/utils/nearestIndex.ts
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfPrimitivesInput/utils/nearestIndex.ts
@@ -1,0 +1,42 @@
+/**
+ * Find the index of the nearest element with the same value. Starts at given index and looks incrementally in either direction for the searchElement
+ * It's *NOT* inclusive: If the element matches the element at the startIdx, startIdx will be returned
+ * It prefers matches in the first half. If there's a tie it will pick the first element that comes before
+ * @param array
+ * @param startIdx
+ * @param searchElement
+ */
+export function nearestIndexOf<T>(array: T[], startIdx: number, searchElement: T) {
+  return nearestIndex(array, startIdx, (element) => element === searchElement)
+}
+
+/**
+ * Find the index of the nearest element matching the predicate. Starts at given index and looks incrementally in either direction
+ * It's *NOT* inclusive: If the predicate matches the element at the startIdx, startIdx will be returned
+ * It prefers matches in the first half. If there's a tie it will pick the first element that comes before
+ * @param array
+ * @param startIdx
+ * @param predicate
+ */
+export function nearestIndex<T>(
+  array: T[],
+  startIdx: number,
+  predicate: (element: T, index: number) => boolean
+) {
+  let lowerIdx = startIdx - 1
+  let upperIdx = startIdx
+  const len = array.length
+  while (lowerIdx > -1 || upperIdx < len) {
+    const upper = array[upperIdx]
+    if (upperIdx < len && predicate(upper, upperIdx)) {
+      return upperIdx
+    }
+    const lower = array[lowerIdx]
+    if (lowerIdx > -1 && predicate(lower, lowerIdx)) {
+      return lowerIdx
+    }
+    lowerIdx--
+    upperIdx++
+  }
+  return -1
+}

--- a/packages/@sanity/form-builder/src/sanity/inputs/reference/SanityArrayItemReferenceInput.tsx
+++ b/packages/@sanity/form-builder/src/sanity/inputs/reference/SanityArrayItemReferenceInput.tsx
@@ -8,6 +8,7 @@ import {
   ReferenceOptions,
   ReferenceSchemaType,
   SanityDocument,
+  SchemaType,
 } from '@sanity/types'
 import * as PathUtils from '@sanity/util/paths'
 import {get} from '@sanity/util/paths'
@@ -22,6 +23,7 @@ import * as adapter from '../client-adapters/reference'
 import {ArrayItemReferenceInput} from '../../../inputs/ReferenceInput/ArrayItemReferenceInput'
 import {EditReferenceEvent} from '../../../inputs/ReferenceInput/types'
 import {schema} from '../../../legacyParts'
+import {InsertEvent} from '../../../inputs/arrays/ArrayOfObjectsInput/types'
 
 // eslint-disable-next-line require-await
 async function resolveUserDefinedFilter(
@@ -53,6 +55,8 @@ export type Props = {
   focusPath: Path
   readOnly?: boolean
   isSortable: boolean
+  onInsert?: (event: InsertEvent) => void
+  insertableTypes?: SchemaType[]
   onFocus: (path: Path) => void
   onChange: (event: PatchEvent) => void
   level: number


### PR DESCRIPTION
### Description
This adds "add before"/"add after" menu items to the array input

The commit 8393ece6e7e141b2e51af348b14dbdcb5fad01d1 is a "best effort fix" to an existing issue that is made worse by this feature: when editing a string value in an array of primitive values and someone else simultaneously adds or remove a value above, your cursor/selection will stay at the same _array index_, which makes it appear as if your cursor is jumping to the input above (if added) or below (if deleted).

### What to review

Make sure it works as expected for
- Arrays with primitive values (strings, numbers, booleans)
- Arrays of object values
- Arrays of references

### Notes for release
- Supports adding new items before/after existing array items

Note: the depcheck CI failure is a false positive. Looking into it now.