### PR TITLE
fix(base): fix permissions bugs by fallbacking back to published variant

### DIFF
--- a/packages/@sanity/base/src/datastores/grants/createGrantsStore.ts
+++ b/packages/@sanity/base/src/datastores/grants/createGrantsStore.ts
@@ -75,7 +75,7 @@ export function createGrantsStore(): GrantsStore {
   )
 
   return {
-    checkDocumentPermission(permission: DocumentValuePermission, document: SanityDocument) {
+    checkDocumentPermission(permission: DocumentValuePermission, document: SanityDocument | null) {
       return currentUserDatasetGrants.pipe(
         switchMap((grants) => grantsPermissionOn(grants, permission, document)),
         distinctUntilChanged(shallowEquals)

--- a/packages/@sanity/base/src/datastores/grants/documentPairPermissions.test.ts
+++ b/packages/@sanity/base/src/datastores/grants/documentPairPermissions.test.ts
@@ -342,7 +342,7 @@ describe('getPairPermission', () => {
       granted: false,
       reason:
         'Unable to duplicate:\n' +
-        '\tnot allowed to create new draft document from existing draft: No matching grants found',
+        '\tnot allowed to create new draft document from existing draft document: No matching grants found',
     })
   })
 
@@ -353,6 +353,51 @@ describe('getPairPermission', () => {
       documentPair: {
         draft: {_id: 'drafts.book-id', _type: 'book', locked: true},
         published: {_id: 'book-id', _type: 'book', locked: false},
+      },
+    })
+
+    await expect(
+      getAdminPairPermissions({
+        id: 'book-id',
+        permission: 'duplicate',
+        type: 'book',
+      })
+    ).resolves.toEqual({granted: true, reason: ''})
+  })
+
+  it("disallows `duplicate` if a new document can't be created with the contents of the published document", async () => {
+    const getRequiresApprovalPairPermissions = setupTest({
+      grants: exampleGrants.requiresApproval,
+      liveEdit: false,
+      // this is the case right after a publish where there is no draft version
+      documentPair: {
+        draft: null,
+        published: {_id: 'book-id', _type: 'book', locked: true},
+      },
+    })
+
+    await expect(
+      getRequiresApprovalPairPermissions({
+        id: 'book-id',
+        permission: 'duplicate',
+        type: 'book',
+      })
+    ).resolves.toEqual({
+      granted: false,
+      reason:
+        'Unable to duplicate:\n' +
+        '\tnot allowed to create new draft document from existing published document: No matching grants found',
+    })
+  })
+
+  it('allows `duplicate` if a new document can be created with the contents of the published document', async () => {
+    const getAdminPairPermissions = setupTest({
+      grants: exampleGrants.administrator,
+      liveEdit: false,
+      // this is the case right after a publish where there is no draft version
+      documentPair: {
+        draft: null,
+        published: {_id: 'book-id', _type: 'book', locked: true},
       },
     })
 

--- a/packages/@sanity/base/src/datastores/grants/types.ts
+++ b/packages/@sanity/base/src/datastores/grants/types.ts
@@ -14,9 +14,19 @@ export interface PermissionCheckResult {
 }
 
 export interface GrantsStore {
+  /**
+   * Returns an observable of `PermissionCheckResult`
+   *
+   * This API is returns an observable (vs a promise) so the consumer can reac
+   * to incoming changes to the user permissions (e.g. for changing _debug_
+   * roles).
+   *
+   * This API also accepts a `null` document in which it should return
+   * `granted: true`
+   */
   checkDocumentPermission(
     checkPermissionName: DocumentValuePermission,
-    document: Partial<SanityDocument>
+    document: Partial<SanityDocument> | null
   ): Observable<PermissionCheckResult>
 }
 


### PR DESCRIPTION
### Description

Fixes incorrect permissions in certain permissions cases + adds failing tests to cover this case in the future. Details in the comments of the code.

### What to review

Review the changes and the new tests.

### Notes for release

Fixes a bug that caused some false warnings with `duplicate` and `update` permissions.