### PR TITLE
feat: allow --coupon for sanity init

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.js
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.js
@@ -357,6 +357,7 @@ export default async function initSanity(args, context) {
       return createProject(apiClient, {
         displayName: projectName,
         subscription: {planId: selectedPlan},
+        metadata: {coupon: intendedCoupon},
       }).then((response) => ({
         ...response,
         isFirstProject: isUsersFirstProject,
@@ -388,6 +389,7 @@ export default async function initSanity(args, context) {
           default: 'My Sanity Project',
         }),
         subscription: {planId: selectedPlan},
+        metadata: {coupon: intendedCoupon},
       }).then((response) => ({
         ...response,
         isFirstProject: isUsersFirstProject,
@@ -619,6 +621,7 @@ export default async function initSanity(args, context) {
       const createdProject = await createProject(apiClient, {
         displayName: createProjectName.trim(),
         subscription: {planId: selectedPlan},
+        metadata: {coupon: intendedCoupon},
       })
       debug('Project with ID %s created', createdProject.projectId)
 

--- a/packages/@sanity/cli/src/commands/init/initCommand.js
+++ b/packages/@sanity/cli/src/commands/init/initCommand.js
@@ -12,6 +12,7 @@ Options
   --visibility <mode> Visibility mode for dataset (public/private)
   --create-project <name> Create a new project with the given name
   --project-plan <name> Optionally select a plan for a new project
+  --coupon <name> Optionally select a coupon for a new project (cannot be used with --project-plan)
   --reconfigure Reconfigure Sanity studio in current folder with new project/dataset
 
 Examples


### PR DESCRIPTION
### sanity init --coupon some-coupon

We'd like to expose coupon selection on the cli, similar to `--project-plan` to allow users to more easily create plans with different subscription plans.

### What to review

`sanity init` is affected, please review project creation and using `--project-plan` and the new `--coupon`

### Notes for release

Select a coupon code using `--coupon` for new projects with `sanity init`
