### PR TITLE
fix(form-builder): fix initial value not resolved when adding array i…

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/ArrayInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/ArrayInput.tsx
@@ -95,12 +95,10 @@ export class ArrayInput extends React.Component<Props> {
   }
 
   handlePrepend = (value: ArrayMember) => {
-    this.insert(value, 'before', [0])
-    this.openItem(value._key)
+    this.handleInsert({item: value, position: 'before', path: [0]})
   }
   handleAppend = (value: ArrayMember) => {
-    this.insert(value, 'after', [-1])
-    this.openItem(value._key)
+    this.handleInsert({item: value, position: 'after', path: [-1]})
   }
 
   handleInsert = (event: InsertEvent) => {


### PR DESCRIPTION

### Description
Looks like the previous version accidentally broke initial value resolution when adding array items from the "Add item"-button below the list (or when using a custom ArrayFunctions implementation). This PR restores the previous behavior.

### What to review
- Verify that initial value resolution works when adding new items to an array.

### Notes for release

- Fix an issue with initial values when adding items to an array