### PR TITLE
fix(code-input): remove webpack-resolver-import

### DIFF
--- a/packages/@sanity/code-input/src/editorSupport.ts
+++ b/packages/@sanity/code-input/src/editorSupport.ts
@@ -1,7 +1,6 @@
 /* eslint-disable import/no-unassigned-import */
 // NOTE: MAKE SURE THESE ALIGN WITH SUPPORTED_LANGUAGES in ./config
 import './groq'
-import 'ace-builds/webpack-resolver'
 
 import 'ace-builds/src-noconflict/mode-batchfile'
 import 'ace-builds/src-noconflict/mode-csharp'


### PR DESCRIPTION
### Description

During development of #3056 I hit a bug that was apparently fixed by importing the webpack resolver, but this import turned out to break the `graphql deploy` command (#3069). I tried removing it now, and everything seems to still work 🤷🏼 

### What to review
- Check that the code input still works as expected

### Notes for release
- Fixed an issue causing graphql deploy to error with the message "TypeError: Cannot read property 'setModuleUrl' of undefined"

Closes #3069 