### PR TITLE
test(desk-tool): add tests for default document actions

### DIFF
--- a/cypress/helpers/constants.js
+++ b/cypress/helpers/constants.js
@@ -1,0 +1,7 @@
+export const DEFAULT_CONFIG = {
+  defaultCommandTimeout: 15000,
+  viewportWidth: 2000,
+  viewportHeight: 3500,
+}
+
+export const DATASET_NAME = 'test'

--- a/cypress/helpers/index.js
+++ b/cypress/helpers/index.js
@@ -1,0 +1,5 @@
+export * from './constants'
+export * from './createUniqueDocument'
+export {default as sanityClientConfig} from './sanityClientSetUp'
+
+export const getTestId = (name) => `[data-testid="${name}"]`

--- a/cypress/integration/desk-tool/documentActions.test.js
+++ b/cypress/integration/desk-tool/documentActions.test.js
@@ -1,0 +1,116 @@
+import {
+  createUniqueDocument,
+  DEFAULT_CONFIG,
+  getTestId,
+  DATASET_NAME,
+  sanityClientConfig,
+} from '../../helpers'
+
+const TITLE = 'Document actions [Cypress]'
+const ACTIONS = ['publish', 'unpublish', 'delete', 'duplicate', 'duplicate', 'discard-changes']
+
+const documentActionPath = (action) =>
+  `mutate/${DATASET_NAME}?tag=sanity.studio.document.${action}*`
+
+const documentUri = (docId) => `/${DATASET_NAME}/desk/input-ci;documentActionsCi;${docId}`
+
+const addDocumentTitle = () =>
+  cy.get(getTestId('input-title')).find('input').type(TITLE).should('have.value', TITLE)
+
+async function getDocumentUri() {
+  const testDoc = await createUniqueDocument({_type: 'documentActionsCi'})
+  return [testDoc?._id, documentUri(testDoc?._id)]
+}
+
+async function deleteDocument(payload) {
+  return sanityClientConfig.delete(payload)
+}
+
+describe('@sanity/desk-tool: base document actions', DEFAULT_CONFIG, () => {
+  let documentId
+  let documentPath
+
+  beforeEach(() => {
+    // Delete all the documents already created
+    cy.wrap(deleteDocument({query: `*[_type == "documentActionsCi"]`}))
+
+    cy.wrap(getDocumentUri()).then(([id, path]) => {
+      documentId = id
+      documentPath = path
+      cy.visit(path)
+    })
+
+    // Create aliases for each document action
+    ACTIONS.forEach((action) =>
+      cy.intercept({method: 'POST', url: `*/**/${documentActionPath(action)}`}).as(action)
+    )
+  })
+
+  it('@sanity/desk-tool: publish document', () => {
+    addDocumentTitle()
+
+    cy.get(getTestId('action-Publish')).should('not.have.attr', 'disabled')
+    cy.get(getTestId('action-Publish')).click()
+    cy.wait('@publish')
+
+    cy.get(getTestId('action-Publish')).should('have.attr', 'disabled')
+  })
+
+  it(`'@sanity/desk-tool: unpublish document`, () => {
+    addDocumentTitle()
+
+    // Publish the document before unpublishing it
+    cy.get(getTestId('action-Publish')).click()
+    cy.wait('@publish')
+
+    cy.get(getTestId('action-menu-button')).click()
+    cy.get(getTestId('action-Unpublish')).click()
+    cy.get(getTestId('confirm-unpublish')).click()
+    cy.wait('@unpublish')
+
+    cy.get(getTestId('action-Publish')).should('not.have.attr', 'disabled')
+  })
+
+  it(`'@sanity/desk-tool: duplicate document`, () => {
+    addDocumentTitle()
+
+    cy.get(getTestId('action-menu-button')).click()
+    cy.get(getTestId('action-Duplicate')).click()
+    cy.wait('@duplicate')
+
+    // Check if we are actually viewing the new document
+    // and not the one created for this test
+    cy.url().should('not.contain', documentId)
+  })
+
+  it(`'@sanity/desk-tool: delete document`, () => {
+    addDocumentTitle()
+
+    cy.get(getTestId('action-menu-button')).click()
+    cy.get(getTestId('action-Delete')).click()
+    cy.get(getTestId('confirm-delete')).click()
+    cy.wait('@delete')
+
+    cy.get(getTestId('pane-content')).within((pane) => {
+      cy.get(`a[href*="${documentPath}"]`).should('not.exist')
+    })
+  })
+
+  it(`'@sanity/desk-tool: discard changes`, () => {
+    addDocumentTitle()
+
+    // Publish the document in order to discard changes
+    cy.get(getTestId('action-Publish')).click()
+    cy.wait('@publish')
+
+    // Make a change to the document
+    cy.get(getTestId('input-title')).find('input').type('123')
+
+    cy.get(getTestId('action-menu-button')).click()
+    cy.get(getTestId('action-Discardchanges')).click()
+    cy.get(getTestId('confirm-discard-changes')).click()
+    cy.wait('@discard-changes')
+
+    cy.get(getTestId('input-title')).find('input').should('have.value', TITLE)
+  })
+})

--- a/dev/test-studio/parts/deskStructure.js
+++ b/dev/test-studio/parts/deskStructure.js
@@ -93,7 +93,7 @@ const DEBUG_INPUT_TYPES = [
   'withDocumentTest',
 ]
 
-const CI_INPUT_TYPES = ['conditionalFieldset', 'validationCI']
+const CI_INPUT_TYPES = ['conditionalFieldset', 'validationCI', 'documentActionsCi']
 const FIELD_GROUP_TYPES = [
   'fieldGroups',
   'fieldGroupsDefault',

--- a/dev/test-studio/schema/ci/documentActions.js
+++ b/dev/test-studio/schema/ci/documentActions.js
@@ -1,0 +1,12 @@
+export default {
+  name: 'documentActionsCi',
+  title: 'Document actions',
+  type: 'document',
+  fields: [
+    {
+      name: 'title',
+      type: 'string',
+      title: 'Title',
+    },
+  ],
+}

--- a/dev/test-studio/schema/index.js
+++ b/dev/test-studio/schema/index.js
@@ -90,6 +90,7 @@ import species from './species'
 // CI documents
 import conditionalFieldset from './ci/conditionalFieldset'
 import validationTest from './ci/validationCI'
+import documentActionsCi from './ci/documentActions'
 
 export default createSchema({
   name: 'test-examples',
@@ -180,5 +181,6 @@ export default createSchema({
     fieldGroupsDefault,
     fieldGroupsMany,
     fieldGroupsWithValidation,
+    documentActionsCi,
   ]),
 })

--- a/packages/@sanity/desk-tool/src/actions/DiscardChangesAction.tsx
+++ b/packages/@sanity/desk-tool/src/actions/DiscardChangesAction.tsx
@@ -46,6 +46,7 @@ export const DiscardChangesAction: DocumentActionComponent = ({
         onCancel: onComplete,
         onConfirm: handleConfirm,
         message: <>Are you sure you want to discard all changes since last published?</>,
+        actionName: 'discard-changes',
       },
     [handleConfirm, isConfirmDialogOpen, onComplete]
   )

--- a/packages/@sanity/desk-tool/src/components/ConfirmDelete.tsx
+++ b/packages/@sanity/desk-tool/src/components/ConfirmDelete.tsx
@@ -43,6 +43,7 @@ export const ConfirmDelete = enhanceWithReferringDocuments(function ConfirmDelet
           onClick={onConfirm}
           text={hasReferringDocuments ? 'Delete anyway' : 'Delete now'}
           tone="critical"
+          data-testid="confirm-delete"
         />
       )}
     </Grid>

--- a/packages/@sanity/desk-tool/src/components/ConfirmUnpublish.tsx
+++ b/packages/@sanity/desk-tool/src/components/ConfirmUnpublish.tsx
@@ -42,6 +42,7 @@ export const ConfirmUnpublish = enhanceWithReferringDocuments(function ConfirmUn
           onClick={onConfirm}
           text={hasReferringDocuments ? 'Try to unpublish anyway' : 'Unpublish now'}
           tone="critical"
+          data-testid="confirm-unpublish"
         />
       )}
     </Grid>

--- a/packages/@sanity/desk-tool/src/panes/document/statusBar/dialogs/ConfirmDialog.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/statusBar/dialogs/ConfirmDialog.tsx
@@ -42,6 +42,7 @@ function ConfirmDialogContent(props: {dialog: DocumentActionConfirmDialogProps})
     message,
     onCancel,
     onConfirm,
+    actionName,
   } = dialog
   const {isTopLayer} = useLayer()
   const [element, setElement] = useState<HTMLElement | null>(null)
@@ -78,6 +79,7 @@ function ConfirmDialogContent(props: {dialog: DocumentActionConfirmDialogProps})
             onClick={onConfirm}
             text={confirmButtonText || 'Confirm'}
             tone={color ? LEGACY_DIALOG_TO_UI_COLOR[color] : 'primary'}
+            data-testid={actionName ? `confirm-${actionName}` : ''}
           />
         </Grid>
       </Box>


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Adding e2e tests for:
- Default document actions: publish, unpublish, duplicate, delete, discard changes

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

If tests are as they should, are there ways to improve them?

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
