### PR TITLE
fix(core): provide ace globals when mocking browser env

### DIFF
--- a/packages/@sanity/core/src/util/mockBrowserEnvironment.js
+++ b/packages/@sanity/core/src/util/mockBrowserEnvironment.js
@@ -1,5 +1,6 @@
 const pirates = require('pirates')
 const jsdomGlobal = require('jsdom-global')
+const resolveFrom = require('resolve-from')
 const pluginLoader = require('@sanity/plugin-loader')
 const registerBabelLoader = require('./registerBabelLoader')
 
@@ -9,26 +10,41 @@ const jsdomDefaultHtml = `<!doctype html>
   <body></body>
 </html>`
 
-const getFakeGlobals = () => ({
+const getFakeGlobals = (basePath) => ({
   __DEV__: false,
   requestAnimationFrame: (cb) => setTimeout(cb, 0),
   cancelAnimationFrame: (timer) => clearTimeout(timer),
   InputEvent: global.window && global.window.InputEvent,
+  ace: tryGetAceGlobal(basePath),
 })
 
-function provideFakeGlobals() {
-  const fakeGlobals = getFakeGlobals()
-  const stubbedKeys = []
+function provideFakeGlobals(basePath) {
+  const fakeGlobals = getFakeGlobals(basePath)
+  const stubbedGlobalKeys = []
+  const stubbedWindowKeys = []
   Object.keys(fakeGlobals).forEach((key) => {
+    if (typeof fakeGlobals[key] === 'undefined') {
+      return
+    }
+
     if (!global[key]) {
       global[key] = fakeGlobals[key]
-      stubbedKeys.push(key)
+      stubbedGlobalKeys.push(key)
+    }
+
+    if (!global.window[key]) {
+      global.window[key] = fakeGlobals[key]
+      stubbedWindowKeys.push(key)
     }
   })
 
   return () => {
-    stubbedKeys.forEach((key) => {
+    stubbedGlobalKeys.forEach((key) => {
       delete global[key]
+    })
+
+    stubbedWindowKeys.forEach((key) => {
+      delete global.window[key]
     })
   }
 }
@@ -36,7 +52,7 @@ function provideFakeGlobals() {
 function mockBrowserEnvironment(basePath) {
   const domCleanup = jsdomGlobal(jsdomDefaultHtml, {url: 'http://localhost:3333/'})
   const windowCleanup = () => global.window.close()
-  const globalCleanup = provideFakeGlobals()
+  const globalCleanup = provideFakeGlobals(basePath)
   const cleanupFileLoader = pirates.addHook(
     (code, filename) => `module.exports = ${JSON.stringify(filename)}`,
     {
@@ -53,6 +69,22 @@ function mockBrowserEnvironment(basePath) {
     globalCleanup()
     windowCleanup()
     domCleanup()
+  }
+}
+
+function tryGetAceGlobal(basePath) {
+  // Work around an issue where using the @sanity/code-input plugin would crash
+  // due to `ace` not being defined on the global due to odd bundling stategy.
+  const acePath = resolveFrom.silent(basePath, 'ace-builds')
+  if (!acePath) {
+    return undefined
+  }
+
+  try {
+    // eslint-disable-next-line import/no-dynamic-require
+    return require(acePath)
+  } catch (err) {
+    return undefined
   }
 }
 


### PR DESCRIPTION
### Description

It seems the code input is still breaking GraphQL deployments (at least I can reproduce this when adding the input to a studio and having a code field). It is likely that the way we are mocking a browser environment might lead ace to be somewhat confused, and attempting to use a global `ace` instance, which does not exist.

This PR attempts to find the `ace-builds` dependency as a studio dependency, and if it does, import it and set it to an `ace` global when mocking the environment. It's pretty hacky, but it's the best I could come up with short term.

### What to review

- Add `@sanity/code-input` to a studios `package.json` dependencies
- Add `@sanity/code-input` to `plugins` in `sanity.json`
- Add a field of type `code` to any document/object schema type
- Run `sanity graphql deploy`
- Ensure that it does not crash

### Notes for release

- Fixes a bug where using the `@sanity/code-input` might lead to `sanity graphql deploy` crashing due to an undefined `ace` variable
