### PR TITLE
fix(code-input): ace mode variable is interpreted wrongly

### DIFF
--- a/dev/test-studio/schema/plugins/code.js
+++ b/dev/test-studio/schema/plugins/code.js
@@ -2,6 +2,7 @@ import {CodeBlockIcon} from '@sanity/icons'
 
 // eslint-disable-next-line import/no-unassigned-import
 import 'ace-builds/src-noconflict/mode-rust'
+import 'ace-builds/src-noconflict/mode-c_cpp'
 
 export default {
   name: 'codeTest',
@@ -32,6 +33,7 @@ export default {
         languageAlternatives: [
           {title: 'Rust', value: 'rust', mode: 'rust'},
           {title: 'JavaScript', value: 'javascript'},
+          {title: 'C++', value: 'cpp', mode: 'c_cpp'},
         ],
       },
     },

--- a/packages/@sanity/code-input/src/CodeInput.tsx
+++ b/packages/@sanity/code-input/src/CodeInput.tsx
@@ -299,7 +299,7 @@ const CodeInput = React.forwardRef(
       // is the language officially supported (e.g. we import the mode by default)
       const supported = language && isSupportedLanguage(language)
 
-      const mode = configured?.mode || supported ? language : 'text'
+      let mode = configured?.mode || (supported ? language : 'text')
 
       return (
         <EditorContainer radius={1} shadow={1} readOnly={readOnly}>

--- a/packages/@sanity/code-input/src/CodeInput.tsx
+++ b/packages/@sanity/code-input/src/CodeInput.tsx
@@ -299,7 +299,7 @@ const CodeInput = React.forwardRef(
       // is the language officially supported (e.g. we import the mode by default)
       const supported = language && isSupportedLanguage(language)
 
-      let mode = configured?.mode || (supported ? language : 'text')
+      const mode = configured?.mode || (supported ? language : 'text')
 
       return (
         <EditorContainer radius={1} shadow={1} readOnly={readOnly}>


### PR DESCRIPTION
### Description

Address the following issue of the changes from #3056.  Due to JavaScript [Operator precedence](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR#operator_precedence), the mode variable is interpreted wrongly, 

When the ace mode name is different from the language name, the following issue occurred. The mode is `c_cpp` while the language value is `cpp`.
![image](https://user-images.githubusercontent.com/52971804/149877813-739de7f3-903b-42a2-a4f8-c9aa95eab86b.png)

Before:
![image](https://user-images.githubusercontent.com/52971804/149878483-256fa494-89af-43d7-8e61-d9d79312980d.png)

After:
![image](https://user-images.githubusercontent.com/52971804/149878403-e7fd1b8c-8d89-4c13-ac37-2dccb16fed99.png)

Note: This issue is not visible if the ace mode and language value is the same.

### What to review

- Check that the code input work with an alternative language that has a different ace mode name to the language value name.
- Check that the code input work with default supported languages
- See file `dev/test-studio/schema/plugins/code.js`

### Notes for release

- Fixed an issue causing the code-input plugin to wrongly assign the ace mode with the error message "Uncaught SyntaxError: Unexpected token '<'"
