### PR TITLE
fix(desk-tool): prevent stale `actionHandlers`

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/userComponent/UserComponentPane.tsx
+++ b/packages/@sanity/desk-tool/src/panes/userComponent/UserComponentPane.tsx
@@ -1,4 +1,4 @@
-import React, {createElement, isValidElement, useRef} from 'react'
+import React, {createElement, isValidElement, useState} from 'react'
 import {isValidElementType} from 'react-is'
 import {Pane} from '../../components/pane'
 import {usePaneRouter} from '../../contexts/paneRouter'
@@ -25,19 +25,20 @@ export function UserComponentPane(props: UserComponentPaneProps) {
     __preserveInstance = false,
     ...restPane
   } = pane
-  const userComponent = useRef<{
+  const [ref, setRef] = useState<{
     actionHandlers?: Record<string, DeskToolPaneActionHandler>
   } | null>(null)
 
   return (
     <Pane id={paneKey} minWidth={320} selected={restProps.isSelected}>
       <UserComponentPaneHeader
-        actionHandlers={userComponent.current?.actionHandlers}
+        actionHandlers={ref?.actionHandlers}
         index={index}
         menuItems={menuItems}
         menuItemGroups={menuItemGroups}
         title={title}
       />
+
       <UserComponentPaneContent>
         {isValidElementType(component) &&
           createElement(component, {
@@ -51,7 +52,9 @@ export function UserComponentPane(props: UserComponentPaneProps) {
             }),
             ...restProps,
             ...restPane,
-            ref: userComponent,
+            // NOTE: here we're utilizing the function form of refs so setting
+            // the ref causes a re-render for `UserComponentPaneHeader`
+            ref: setRef,
             // NOTE: this is for backwards compatibility (<= 2.20.0)
             urlParams: params,
           })}


### PR DESCRIPTION
### Description

Refactors `UserComponentPane` to `useState` instead of `useRef` so that `UserComponentPaneHeader` can re-render when the component does.

Closes #3025

### What to review

Try out a custom component pane and see if it still works. Then try changing the component instance with a different set of action handlers. It should re-render.

### Notes for release

Fixes a bug that caused some action handlers to never bind.