### PR TITLE
fix(cli): handle missing dependencies on upgrade/versions

### DIFF
--- a/packages/@sanity/cli/src/actions/versions/findSanityModuleVersions.js
+++ b/packages/@sanity/cli/src/actions/versions/findSanityModuleVersions.js
@@ -1,5 +1,6 @@
 import path from 'path'
 import promiseProps from 'promise-props-recursive'
+import semver from 'semver'
 import semverCompare from 'semver-compare'
 import getLatestVersion from 'get-latest-version'
 import dynamicRequire from '../../util/dynamicRequire'
@@ -46,9 +47,10 @@ export default async function findSanityModuleVersions(context, opts = {}) {
   spin.stop()
 
   return packages.map((mod) => {
+    const current = mod.installed || semver.minVersion(mod.declared).toString()
     mod.needsUpdate =
       target === 'latest'
-        ? semverCompare(mod.installed, mod.latest) === -1
+        ? semverCompare(current, mod.latest) === -1
         : mod.installed !== mod.latestInRange
     return mod
   })
@@ -87,10 +89,12 @@ function buildPackageArray(packages, workDir, options = {}) {
     const latest = tryFindLatestVersion(pkg.name, target || `^${cliMajor}`)
     modules.push({
       name: pkg.name,
+      declared: `^${pkg.version}`,
       installed: pkg.version,
       latest: latest.then((versions) => versions.latest),
       latestInRange: latest.then((versions) => versions.latestInRange),
       isPinned: false,
+      isGlobal: true,
     })
   }
 
@@ -100,7 +104,8 @@ function buildPackageArray(packages, workDir, options = {}) {
       const latest = tryFindLatestVersion(pkgName, target || packages[pkgName] || 'latest')
       return {
         name: pkgName,
-        installed: getLocalVersion(pkgName, workDir) || '<missing>',
+        declared: packages[pkgName],
+        installed: getLocalVersion(pkgName, workDir) || undefined,
         latest: latest.then((versions) => versions.latest),
         latestInRange: latest.then((versions) => versions.latestInRange),
         isPinned: isPinnedVersion(packages[pkgName]),

--- a/packages/@sanity/cli/src/commands/upgrade/upgradeDependencies.js
+++ b/packages/@sanity/cli/src/commands/upgrade/upgradeDependencies.js
@@ -77,7 +77,7 @@ export default async function upgradeDependencies(args, context) {
   }
 
   // Yarn fails to upgrade `react-ace` in some versions, see function for details
-  maybeDeleteReactAce(nonPinned, workDir)
+  await maybeDeleteReactAce(nonPinned, workDir)
 
   // Forcefully remove non-symlinked module paths to force upgrade
   await Promise.all(

--- a/packages/@sanity/cli/src/commands/upgrade/upgradeDependencies.js
+++ b/packages/@sanity/cli/src/commands/upgrade/upgradeDependencies.js
@@ -4,8 +4,10 @@ import {promises as fs} from 'fs'
 import boxen from 'boxen'
 import rimrafCb from 'rimraf'
 import semver from 'semver'
+import resolveFrom from 'resolve-from'
 import {padStart, noop} from 'lodash'
 import readLocalManifest from '@sanity/util/lib/readLocalManifest'
+
 import findSanityModuleVersions from '../../actions/versions/findSanityModuleVersions'
 import {getFormatters} from '../versions/printVersionResult'
 import debug from '../../debug'
@@ -73,6 +75,9 @@ export default async function upgradeDependencies(args, context) {
       )} The follow modules are pinned to specific versions, not upgrading:\n - ${pinnedNames}`
     )
   }
+
+  // Yarn fails to upgrade `react-ace` in some versions, see function for details
+  maybeDeleteReactAce(nonPinned, workDir)
 
   // Forcefully remove non-symlinked module paths to force upgrade
   await Promise.all(
@@ -192,4 +197,34 @@ function schedulePrintMajorUpgrades({baseMajorUpgrade, majorUpgrades}, {chalk, o
       })
     )
   })
+}
+
+// Workaround for https://github.com/securingsincity/react-ace/issues/1048
+// Yarn fails to upgrade `react-ace` because `react-ace.min.js` is a _file_ in one version
+// but a _folder_ in the next. If we're upgrading the `@sanity/code-input`, remove the
+// `react-ace` dependency before installing
+async function maybeDeleteReactAce(toUpgrade, workDir) {
+  const codeInputUpdate = toUpgrade.find((mod) => mod.name === '@sanity/code-input')
+  if (!codeInputUpdate) {
+    return
+  }
+
+  // Assume it's an old version if we can't figure it out
+  const installed = codeInputUpdate.installed === '<missing>' ? '1.0.0' : codeInputUpdate.installed
+  const upgradeTo = codeInputUpdate.latestInRange
+
+  // react-ace was upgraded in 2.24.1, so if we're going from <= 2.24.0 to => 2.24.1,
+  // we should remove it.
+  const shouldDelete = semver.lte(installed, '2.24.0') && semver.gte(upgradeTo, '2.24.1')
+  if (!shouldDelete) {
+    return
+  }
+
+  // Try to find the path to it from `@sanity/code-input`, otherwise try the studio root `node_modules`
+  const depRootPath = path.join(workDir, 'node_modules')
+  const closestReactAcePath =
+    resolveFrom.silent(path.join(depRootPath, '@sanity', 'code-input'), 'react-ace') ||
+    path.join(depRootPath, 'react-ace')
+
+  await deleteIfNotSymlink(closestReactAcePath)
 }

--- a/packages/@sanity/cli/src/commands/versions/printVersionResult.js
+++ b/packages/@sanity/cli/src/commands/versions/printVersionResult.js
@@ -9,18 +9,23 @@ export default async (args, context) => {
 export function printResult(versions, print) {
   const {versionLength, formatName} = getFormatters(versions)
   versions.forEach((mod) => {
-    const version = padStart(mod.installed, versionLength)
+    const version = padStart(mod.installed || '<missing>', versionLength)
     const latest =
       mod.installed === mod.latest
         ? chalk.green('(up to date)')
         : `(latest: ${chalk.yellow(mod.latest)})`
+
     print(`${formatName(mod.name)} ${version} ${latest}`)
   })
 }
 
 export function getFormatters(versions) {
-  const nameLength = versions.reduce(longestProp('name'), 0)
-  const versionLength = versions.reduce(longestProp('installed'), 0)
+  const nameLength = versions.reduce((max, mod) => Math.max(max, mod.name.length), 0)
+  const versionLength = versions.reduce(
+    (max, mod) => Math.max(max, (mod.installed || '<missing>').length),
+    0
+  )
+
   const formatName = (name) =>
     padEnd(name, nameLength + 1).replace(
       /^@sanity\/(.*)/,
@@ -28,8 +33,4 @@ export function getFormatters(versions) {
     )
 
   return {nameLength, versionLength, formatName}
-}
-
-function longestProp(prop) {
-  return (max, obj) => Math.max(max, obj[prop].length)
 }


### PR DESCRIPTION
### Description

This PR fixes two issues with the `sanity upgrade` command: 

1. #3009 introduced a bug where if you are missing (eg not installed) any of the declared `@sanity` modules, the CLI would crash when running `sanity upgrade`, `sanity versions` or `sanity debug` (since these all tried to fetch the installed and latest versions of a module, and a change was made in #3009 where it returned `<missing>`, which would fail for semver utility functions). Fixed this by returning `undefined` instead, and manually using `<missing>` where we wanted to print the version number. 
2. Fixes a super obscure bug where yarn would crash when upgrading `@sanity/code-input` to the latest version, as the `react-ace` dependency has a `react-ace.min.js` file in `<= 8.x` that has in `>=9.x` turned into a _folder_ (*sigh*). More details: https://github.com/securingsincity/react-ace/issues/1048 . The workaround is pretty ugly - we check to see if the code input is scheduled for an upgrade, and if it is upgraded to a version that will include an update to `react-ace`. If so, it'll manually delete the `react-ace` dependency in `node_modules` before upgrading. 

Fixes #3083

### What to review

- That the code makes sense
- That `sanity upgrade`, `sanity versions` and `sanity debug` works as expected both with and without installed dependencies
- That `sanity upgrade` works when going from `@sanity/code-input@2.23.x` to `@sanity/code-input@2.24.x`

### Notes for release

- Fixed an issue where `sanity upgrade` would fail if `@sanity/code-input` was installed
- Fixed an issue where `sanity upgrade`, `sanity versions` and `sanity debug` would fail if running without any dependencies installed
