### PR TITLE
Fix permission issue panel

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/documentPanel/DocumentPanel.tsx
@@ -64,7 +64,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
   const requiredPermission = value._createdAt ? 'update' : 'create'
   const liveEdit = useMemo(() => Boolean(getSchemaType(documentType)?.liveEdit), [documentType])
   const docPermissionsInput = useMemo(() => {
-    return {...value, _id: liveEdit ? 'dummy-id' : 'drafts.dummy-id'}
+    return {...value, _id: liveEdit ? value._id : `drafts.${value._id}`}
   }, [liveEdit, value])
   const [permissions, isPermissionsLoading] = useDocumentValuePermissions({
     document: docPermissionsInput,

--- a/packages/@sanity/desk-tool/src/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/documentPanel/DocumentPanel.tsx
@@ -4,6 +4,7 @@ import {ScrollContainer} from '@sanity/base/components'
 import {unstable_useDocumentValuePermissions as useDocumentValuePermissions} from '@sanity/base/hooks'
 import styled, {css} from 'styled-components'
 import {SchemaType} from '@sanity/types'
+import {getPublishedId, getDraftId} from '@sanity/base/_internal'
 import {PaneContent} from '../../../components/pane'
 import {usePaneLayout} from '../../../components/pane/usePaneLayout'
 import {useDeskTool} from '../../../contexts/deskTool'
@@ -63,9 +64,13 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
 
   const requiredPermission = value._createdAt ? 'update' : 'create'
   const liveEdit = useMemo(() => Boolean(getSchemaType(documentType)?.liveEdit), [documentType])
+  const docId = value._id ? value._id : 'dummy-id'
   const docPermissionsInput = useMemo(() => {
-    return {...value, _id: liveEdit ? value._id : `drafts.${value._id}`}
-  }, [liveEdit, value])
+    return {
+      ...value,
+      _id: liveEdit ? getPublishedId(docId) : getDraftId(docId),
+    }
+  }, [liveEdit, value, docId])
   const [permissions, isPermissionsLoading] = useDocumentValuePermissions({
     document: docPermissionsInput,
     permission: requiredPermission,


### PR DESCRIPTION
### Description

Fix an [issue](https://sanity-io.slack.com/archives/CL088LK3K/p1642514167011200) where a user with a role and rule wasn't being allowed to edit a document when they should.

## Edit: Decided to drop the update to the `community-studio`
I've also added an updated version of the `community-studio` to the examples. My plan would have been to add this in a separate PR but it does make testing this fix much easier. So if we want (and likely should), I can drop the commit before pushing the fix so that it's just itself. Especially since there seems to be a lot of things failing because of it.

I don't know if there's a reason / situation where we needed the dummy in this situation. 🤔 

### What to review

1. install dependencies + run `npm run community-studio`
2. use `#_debug_roles=editor` in the url (this is to be able to go to a grant rule where you can edit your own profile)

So here is what needs to happen:
- Going to your user: you should be able to update
![image](https://user-images.githubusercontent.com/6951139/150182984-1048e1f8-5cc2-461f-b1f7-6d3d269dc203.png)
- Going to any other user: you should **not** be able to update
![Screenshot 2022-01-19 at 18 23 05](https://user-images.githubusercontent.com/6951139/150183115-77a70c1e-b976-465d-b9d0-f69c5cd46dfe.jpg)



### Notes for release
- Fix permission issue on update documents in the panel
