### PR TITLE
Fix bug with splitting lines including inline objects

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithEditableAPI.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithEditableAPI.ts
@@ -106,7 +106,7 @@ export function createWithEditableAPI(
               })
             )[0] || [undefined]
             if (node && !Editor.isBlock(editor, node)) {
-              const pseudoBlock = {
+              const pseudoBlock: PortableTextBlock = {
                 _key: 'pseudo',
                 _type: portableTextFeatures.types.block.name,
                 children: [node],

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithInsertData.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithInsertData.ts
@@ -1,4 +1,4 @@
-import {Node, Element, Transforms, Editor, Descendant, Range} from 'slate'
+import {Node, Element, Transforms, Editor, Descendant, Range, Text} from 'slate'
 import {htmlToBlocks, normalizeBlock} from '@sanity/block-tools'
 import {ReactEditor} from '@sanity/slate-react'
 import {PortableTextFeatures, PortableTextBlock, PortableTextChild} from '../../types/portableText'
@@ -271,7 +271,7 @@ function regenerateKeys(
         const newKey = keyGenerator()
         if (Array.isArray(newNode.children)) {
           newNode.children = newNode.children.map((child) =>
-            child._type === spanTypeName
+            child._type === spanTypeName && Text.isText(child)
               ? {
                   ...child,
                   marks:

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPatches.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPatches.ts
@@ -35,8 +35,7 @@ import {
 import {PortableTextBlock, PortableTextFeatures} from '../../types/portableText'
 import {EditorChange, PatchObservable, PortableTextSlateEditor} from '../../types/editor'
 import {debugWithName} from '../../utils/debug'
-import {createPatchToOperations} from '../../utils/patchToOperations'
-import {PATCHING, withoutPatching, isPatching} from '../../utils/withoutPatching'
+import {PATCHING, isPatching} from '../../utils/withoutPatching'
 import {KEY_TO_VALUE_ELEMENT} from '../../utils/weakMaps'
 
 const debug = debugWithName('plugin:withPatches')
@@ -106,7 +105,6 @@ export function createWithPatches(
 ): (editor: PortableTextSlateEditor) => PortableTextSlateEditor {
   let previousChildren: Descendant[]
   let previousSelection: Range | null
-  let isThrottling = false
   return function withPatches(editor: PortableTextSlateEditor) {
     PATCHING.set(editor, true)
     previousChildren = editor.children
@@ -114,7 +112,6 @@ export function createWithPatches(
     // This will cancel the throttle when the user is not producing anything for a short time
     const cancelThrottle = debounce(() => {
       change$.next({type: 'throttle', throttle: false})
-      isThrottling = false
     }, THROTTLE_EDITOR_MS)
 
     // Inspect incoming patches and adjust editor selection accordingly.
@@ -201,7 +198,6 @@ export function createWithPatches(
       if (patches.length > 0) {
         // Signal throttling
         change$.next({type: 'throttle', throttle: true})
-        isThrottling = true
         // Emit all patches immediately
         patches.forEach((patch) => {
           change$.next({

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPortableTextMarkModel.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPortableTextMarkModel.ts
@@ -5,20 +5,17 @@
  *
  */
 
-import {Subject} from 'rxjs'
 import {isEqual, flatten, uniq} from 'lodash'
 import {Editor, Range, Transforms, Text, Path, NodeEntry, Element} from 'slate'
 
 import {debugWithName} from '../../utils/debug'
-import {EditorChange, PortableTextSlateEditor} from '../../types/editor'
-import {toPortableTextRange} from '../../utils/ranges'
+import {PortableTextSlateEditor} from '../../types/editor'
 import {PortableTextFeatures} from '../../types/portableText'
 
 const debug = debugWithName('plugin:withPortableTextMarkModel')
 
 export function createWithPortableTextMarkModel(
-  portableTextFeatures: PortableTextFeatures,
-  change$: Subject<EditorChange>
+  portableTextFeatures: PortableTextFeatures
 ): (editor: PortableTextSlateEditor) => PortableTextSlateEditor {
   return function withPortableTextMarkModel(editor: PortableTextSlateEditor) {
     const {apply, normalizeNode} = editor
@@ -347,7 +344,9 @@ export function createWithPortableTextMarkModel(
         if (editor.isTextBlock(block)) {
           const newMarkDefs = block.markDefs.filter((def) => {
             return block.children.find((child) => {
-              return Array.isArray(child.marks) && child.marks.includes(def._key)
+              return (
+                Text.isText(child) && Array.isArray(child.marks) && child.marks.includes(def._key)
+              )
             })
           })
           if (!isEqual(newMarkDefs, block.markDefs)) {

--- a/packages/@sanity/portable-text-editor/src/editor/withPortableText.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/withPortableText.ts
@@ -55,7 +55,7 @@ export const withPortableText = <T extends Editor>(
   const withUndoRedo = readOnly
     ? disablePlugin('withUndoRedo')
     : createWithUndoRedo(incomingPatches$)
-  const withPortableTextMarkModel = createWithPortableTextMarkModel(portableTextFeatures, change$)
+  const withPortableTextMarkModel = createWithPortableTextMarkModel(portableTextFeatures)
   const withPortableTextBlockStyle = createWithPortableTextBlockStyle(portableTextFeatures, change$)
   const withUtils = createWithUtils(portableTextFeatures)
   const withPortableTextSelections = createWithPortableTextSelections(change$)

--- a/packages/@sanity/portable-text-editor/src/types/slate.ts
+++ b/packages/@sanity/portable-text-editor/src/types/slate.ts
@@ -12,10 +12,14 @@ interface VoidElement {
   }
 }
 
+interface SlateTextBlock extends TextBlock {
+  children: Descendant[]
+}
+
 declare module 'slate' {
   interface CustomTypes {
     Editor: BaseEditor & ReactEditor & PortableTextSlateEditor
-    Element: TextBlock | VoidElement
+    Element: SlateTextBlock | VoidElement
     Text: TextSpan
   }
 }

--- a/packages/@sanity/portable-text-editor/src/utils/__tests__/operationToPatches.test.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/__tests__/operationToPatches.test.ts
@@ -1,0 +1,90 @@
+import {createEditor, Descendant} from 'slate'
+import {Subject} from 'rxjs'
+import {getPortableTextFeatures} from '../getPortableTextFeatures'
+import {type} from '../../editor/__tests__/PortableTextEditorTester'
+import {createOperationToPatches} from '../operationToPatches'
+import {withPortableText} from '../../editor/withPortableText'
+import {keyGenerator} from '../..'
+
+const portableTextFeatures = getPortableTextFeatures(type)
+
+const operationToPatches = createOperationToPatches(portableTextFeatures)
+const editor = withPortableText(createEditor(), {
+  portableTextFeatures,
+  keyGenerator,
+  change$: new Subject(),
+  readOnly: false,
+})
+
+const defaultValue = [
+  {
+    _type: 'myTestBlockType',
+    _key: '1f2e64b47787',
+    style: 'normal',
+    markDefs: [],
+    children: [
+      {_type: 'span', _key: 'c130395c640c', text: '', marks: []},
+      {_key: '773866318fa8', _type: 'someObject', value: {title: 'The Object'}, __inline: true},
+      {_type: 'span', _key: 'fd9b4a4e6c0b', text: '', marks: []},
+    ],
+  },
+] as Descendant[]
+
+describe('operationToPatches', () => {
+  beforeEach(() => {
+    editor.children = defaultValue
+    editor.onChange()
+  })
+  it('translates void items correctly when splitting spans', () => {
+    expect(
+      operationToPatches.splitNodePatch(
+        editor,
+        {
+          type: 'split_node',
+          path: [0, 0],
+          position: 0,
+          properties: {_type: 'span', _key: 'c130395c640c', marks: []},
+        },
+
+        defaultValue
+      )
+    ).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "items": Array [
+            Object {
+              "_key": "773866318fa8",
+              "_type": "someObject",
+              "title": "The Object",
+            },
+          ],
+          "path": Array [
+            Object {
+              "_key": "1f2e64b47787",
+            },
+            "children",
+            Object {
+              "_key": "c130395c640c",
+            },
+          ],
+          "position": "after",
+          "type": "insert",
+        },
+        Object {
+          "path": Array [
+            Object {
+              "_key": "1f2e64b47787",
+            },
+            "children",
+            Object {
+              "_key": "c130395c640c",
+            },
+            "text",
+          ],
+          "type": "set",
+          "value": "",
+        },
+      ]
+    `)
+  })
+})

--- a/packages/@sanity/portable-text-editor/src/utils/__tests__/values.test.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/__tests__/values.test.ts
@@ -1,4 +1,3 @@
-import {Node, Descendant} from 'slate'
 import {fromSlateValue, toSlateValue} from '../values'
 
 describe('toSlateValue', () => {
@@ -143,13 +142,14 @@ describe('fromSlateValue', () => {
             {
               _type: 'span',
               _key: '252f4swet',
+              marks: [],
               text: 'Hey ',
             },
             {
               _type: 'image',
               _key: 'e324t4s',
               __inline: true,
-              children: [{_key: '1', _type: 'span', text: ''}],
+              children: [{_key: '1', _type: 'span', text: '', marks: []}],
               value: {
                 asset: {_ref: '32423r32rewr3rwerwer'},
               },
@@ -161,7 +161,7 @@ describe('fromSlateValue', () => {
         {
           _type: 'image',
           _key: 'wer32434',
-          children: [{_key: '1', _type: 'span', text: ''}],
+          children: [{_key: '1', _type: 'span', text: '', marks: []}],
           value: {
             asset: {_ref: 'werwer452423423'},
           },
@@ -177,6 +177,7 @@ describe('fromSlateValue', () => {
           {
             _type: 'span',
             _key: '252f4swet',
+            marks: [],
             text: 'Hey ',
           },
           {
@@ -211,6 +212,7 @@ describe('fromSlateValue', () => {
           {
             _type: 'span',
             _key: '252f4swet',
+            marks: [],
             text: 'Hey ',
           },
           {

--- a/packages/@sanity/portable-text-editor/src/utils/operationToPatches.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/operationToPatches.ts
@@ -14,7 +14,7 @@ import {
   Descendant,
 } from 'slate'
 import {set, insert, unset, diffMatchPatch, setIfMissing} from '../patch/PatchEvent'
-import {PortableTextFeatures, PortableTextBlock, PortableTextChild} from '../types/portableText'
+import {PortableTextFeatures, PortableTextBlock, TextSpan} from '../types/portableText'
 import type {Patch, InsertPosition} from '../types/patch'
 import {PatchFunctions} from '../editor/plugins/createWithPatches'
 import {fromSlateValue} from './values'
@@ -22,73 +22,56 @@ import {debugWithName} from './debug'
 
 const debug = debugWithName('operationToPatches')
 
-// TODO: optimize how nodes are found and make sure everything here uses those finders.
-
-function findBlock(path: Path, value: PortableTextBlock[] | undefined) {
-  const _key = typeof path[0] === 'object' && '_key' in path[0] && path[0]._key
-  if (_key) {
-    return value?.find((blk) => blk._key === _key)
-  }
-  if (Number.isInteger(path[0])) {
-    const index = path[0] as number
-    return value && value[index]
-  }
-  throw new Error('Invalid first path segment')
-}
-
 export function createOperationToPatches(
   portableTextFeatures: PortableTextFeatures
 ): PatchFunctions {
+  const textBlockName = portableTextFeatures.types.block.name
   function insertTextPatch(
     editor: Editor,
     operation: InsertTextOperation,
-    beforeValue: PortableTextBlock[]
+    beforeValue: Descendant[]
   ) {
-    const block = editor && editor.children[operation.path[0]]
+    const block =
+      editor.isTextBlock(editor.children[operation.path[0]]) && editor.children[operation.path[0]]
     if (!block) {
       throw new Error('Could not find block')
     }
-    if (typeof block._key !== 'string') {
-      throw new Error('Expected block to have a _key')
-    }
-    const child = editor.isTextBlock(block) && block.children[operation.path[1]]
-    if (!child) {
+    const textChild =
+      editor.isTextBlock(block) &&
+      Text.isText(block.children[operation.path[1]]) &&
+      (block.children[operation.path[1]] as TextSpan)
+    if (!textChild) {
       throw new Error('Could not find child')
     }
-    const path: Path = [{_key: block._key}, 'children', {_key: child._key}, 'text']
-    const prevBlock = findBlock(operation.path, beforeValue)
-    const prevText =
-      prevBlock &&
-      prevBlock.children &&
-      prevBlock.children[operation.path[1]] &&
-      prevBlock.children[operation.path[1]].text
-    const patch = diffMatchPatch(prevText || '', child.text, path)
+    const path: Path = [{_key: block._key}, 'children', {_key: textChild._key}, 'text']
+    const prevBlock = beforeValue[operation.path[0]]
+    const prevChild = Editor.isBlock(editor, prevBlock) && prevBlock.children[operation.path[1]]
+    const prevText = Text.isText(prevChild) ? prevChild.text : ''
+    const patch = diffMatchPatch(prevText, textChild.text, path)
     return patch.value.length ? [patch] : []
   }
 
   function removeTextPatch(
     editor: Editor,
     operation: RemoveTextOperation,
-    beforeValue: PortableTextBlock[]
+    beforeValue: Descendant[]
   ) {
     const block = editor && editor.children[operation.path[0]]
     if (!block) {
       throw new Error('Could not find block')
     }
-    if (typeof block._key !== 'string') {
-      throw new Error('Expected block to have a _key')
-    }
-    const child = editor.isTextBlock(block) && block.children[operation.path[1]]
-    if (!child) {
+    const textChild =
+      editor.isTextBlock(block) &&
+      Text.isText(block.children[operation.path[1]]) &&
+      (block.children[operation.path[1]] as TextSpan)
+    if (!textChild) {
       throw new Error('Could not find child')
     }
-    const path: Path = [{_key: block._key}, 'children', {_key: child._key}, 'text']
-    const prevText =
-      beforeValue[operation.path[0]] &&
-      beforeValue[operation.path[0]].children &&
-      beforeValue[operation.path[0]].children[operation.path[1]] &&
-      beforeValue[operation.path[0]].children[operation.path[1]].text
-    const patch = diffMatchPatch(prevText || '', child.text, path)
+    const path: Path = [{_key: block._key}, 'children', {_key: textChild._key}, 'text']
+    const beforeBlock = beforeValue[operation.path[0]]
+    const prevTextChild = editor.isTextBlock(beforeBlock) && beforeBlock.children[operation.path[1]]
+    const prevText = Text.isText(prevTextChild) && prevTextChild.text
+    const patch = diffMatchPatch(prevText || '', textChild.text, path)
     return patch.value ? [patch] : []
   }
 
@@ -102,11 +85,7 @@ export function createOperationToPatches(
         {...editor.children[operation.path[0]], ...operation.newProperties},
         isUndefined
       )
-      return [
-        set(fromSlateValue([setNode], portableTextFeatures.types.block.name)[0], [
-          {_key: block._key},
-        ]),
-      ]
+      return [set(fromSlateValue([setNode], textBlockName)[0], [{_key: block._key}])]
     } else if (operation.path.length === 2) {
       const block = editor.children[operation.path[0]]
       if (editor.isTextBlock(block)) {
@@ -134,31 +113,27 @@ export function createOperationToPatches(
     operation: InsertNodeOperation,
     beforeValue: Descendant[]
   ): Patch[] {
-    const block = beforeValue[operation.path[0]] as PortableTextBlock
+    const block = beforeValue[operation.path[0]]
+    if (!Editor.isBlock(editor, block)) {
+      throw new Error('Not a valid block')
+    }
     if (operation.path.length === 1) {
       const position = operation.path[0] === 0 ? 'before' : 'after'
-      const targetKey =
-        operation.path[0] === 0
-          ? block && block._key
-          : beforeValue[operation.path[0] - 1] &&
-            (beforeValue[operation.path[0] - 1] as PortableTextBlock)._key
+      const beforeBlock = beforeValue[operation.path[0] - 1]
+      const targetKey = operation.path[0] === 0 ? block._key : beforeBlock?._key
       if (targetKey) {
         return [
-          insert(
-            [fromSlateValue([operation.node], portableTextFeatures.types.block.name)[0]],
-            position,
-            [{_key: targetKey}]
-          ),
+          insert([fromSlateValue([operation.node], textBlockName)[0]], position, [
+            {_key: targetKey},
+          ]),
         ]
       }
       if (beforeValue.length === 0) {
         return [
           setIfMissing(beforeValue, []),
-          insert(
-            [fromSlateValue([operation.node], portableTextFeatures.types.block.name)[0]],
-            'before',
-            [operation.path[0]]
-          ),
+          insert([fromSlateValue([operation.node], textBlockName)[0]], 'before', [
+            operation.path[0],
+          ]),
         ]
       }
       throw new Error('Target key not found!')
@@ -169,16 +144,11 @@ export function createOperationToPatches(
         [
           {
             _key: 'bogus',
-            _type: portableTextFeatures.types.block.name,
-            children: [
-              {
-                ...operation.node,
-                _type: operation.node._type || portableTextFeatures.types.span.name,
-              },
-            ],
+            _type: textBlockName,
+            children: [operation.node as Descendant],
           },
         ],
-        portableTextFeatures.types.block.name
+        textBlockName
       )[0].children[0]
       return [
         insert([child], position, [
@@ -201,21 +171,28 @@ export function createOperationToPatches(
   function splitNodePatch(
     editor: Editor,
     operation: SplitNodeOperation,
-    beforeValue: PortableTextBlock[]
+    beforeValue: Descendant[]
   ) {
     const patches: Patch[] = []
     const splitBlock = editor.children[operation.path[0]]
-    if (!Editor.isBlock(editor, splitBlock) || typeof splitBlock._key !== 'string') {
-      throw new Error(`Block with path ${JSON.stringify(operation.path[0])} could not be found`)
+    if (!editor.isTextBlock(splitBlock)) {
+      throw new Error(
+        `Block with path ${JSON.stringify(
+          operation.path[0]
+        )} is not a text block and can't be split`
+      )
     }
     if (operation.path.length === 1) {
       const oldBlock = beforeValue[operation.path[0]]
-      if (oldBlock && oldBlock._key) {
-        const targetValue = editor.children[operation.path[0] + 1]
+      if (editor.isTextBlock(oldBlock)) {
+        const targetValue = fromSlateValue(
+          [editor.children[operation.path[0] + 1]],
+          textBlockName
+        )[0]
         if (targetValue) {
           patches.push(insert([targetValue], 'after', [{_key: splitBlock._key}]))
-          const spansToUnset = beforeValue[operation.path[0]].children.slice(operation.position)
-          spansToUnset.forEach((span: any) => {
+          const spansToUnset = oldBlock.children.slice(operation.position)
+          spansToUnset.forEach((span) => {
             const path = [{_key: oldBlock._key}, 'children', {_key: span._key}]
             patches.push(unset(path))
           })
@@ -225,8 +202,17 @@ export function createOperationToPatches(
     }
     if (operation.path.length === 2) {
       const splitSpan = splitBlock.children[operation.path[1]]
-      if (splitSpan && Text.isText(splitSpan)) {
-        const targetSpans = splitBlock.children.slice(operation.path[1] + 1, operation.path[1] + 2)
+      if (Text.isText(splitSpan)) {
+        const targetSpans = fromSlateValue(
+          [
+            {
+              ...splitBlock,
+              children: splitBlock.children.slice(operation.path[1] + 1, operation.path[1] + 2),
+            },
+          ],
+          textBlockName
+        )[0].children
+
         patches.push(
           insert(targetSpans, 'after', [
             {_key: splitBlock._key},
@@ -278,14 +264,11 @@ export function createOperationToPatches(
       const block = beforeValue[operation.path[0]]
       const targetKey = block && block._key
       if (targetKey) {
-        const newBlock = fromSlateValue(
-          [editor.children[operation.path[0] - 1]],
-          portableTextFeatures.types.block.name
-        )[0]
+        const newBlock = fromSlateValue([editor.children[operation.path[0] - 1]], textBlockName)[0]
         patches.push(set(newBlock, [{_key: newBlock._key}]))
         patches.push(unset([{_key: targetKey}]))
       } else {
-        throw new Error('Targetkey not found!')
+        throw new Error('Target key not found!')
       }
     } else if (operation.path.length === 2) {
       const block = beforeValue[operation.path[0]]
@@ -309,7 +292,7 @@ export function createOperationToPatches(
   }
 
   function moveNodePatch(
-    editor: Editor,
+    _: Editor,
     operation: MoveNodeOperation,
     beforeValue: PortableTextBlock[]
   ) {
@@ -320,16 +303,13 @@ export function createOperationToPatches(
       const position: InsertPosition = operation.path[0] > operation.newPath[0] ? 'before' : 'after'
       patches.push(unset([{_key: block._key}]))
       patches.push(
-        insert([fromSlateValue([block], portableTextFeatures.types.block.name)[0]], position, [
-          {_key: targetBlock._key},
-        ])
+        insert([fromSlateValue([block], textBlockName)[0]], position, [{_key: targetBlock._key}])
       )
     } else if (operation.path.length === 2) {
-      const child = block.children[operation.path[1]] as PortableTextChild
-      const targetChild = targetBlock.children[operation.newPath[1]] as PortableTextChild
+      const child = block.children[operation.path[1]]
+      const targetChild = targetBlock.children[operation.newPath[1]]
       const position = operation.newPath[1] === targetBlock.children.length ? 'after' : 'before'
-      const childToInsert = fromSlateValue([block], portableTextFeatures.types.block.name)[0]
-        .children[operation.path[1]]
+      const childToInsert = fromSlateValue([block], textBlockName)[0].children[operation.path[1]]
       patches.push(unset([{_key: block._key}, 'children', {_key: child._key}]))
       patches.push(
         insert([childToInsert], position, [


### PR DESCRIPTION
### Description

Fixed a bug where splitting lines in the Portable Text Editor including a inline object would corrupt the inline object data.

This turned out to be a bug in the `operationToPatches` where we would not convert between the formats properly when a void node was involved.

Added a test for this as well.

Also fixed some type issues and removed obsolete code as part of this fix.

Fixes issue #2522

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

That the issue described in #2522 is solved and the example operation succeeds.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Fixed a bug where splitting lines in the Portable Text Editor including a inline object would corrupt the inline object data.

<!--
A description of the change(s) that should be used in the release notes.
-->
