### PR TITLE
feat(desk-tool): make inspect dialog pane specific

### DIFF
--- a/packages/@sanity/desk-tool/package.json
+++ b/packages/@sanity/desk-tool/package.json
@@ -52,7 +52,6 @@
     "nanoid": "^3.1.30",
     "react-is": "^17.0.2",
     "react-json-inspector": "^7.1.1",
-    "react-props-stream": "^1.0.0",
     "react-rx": "^1.0.0-beta.6",
     "rxjs": "^6.5.3",
     "shallow-equals": "^1.0.0"

--- a/packages/@sanity/desk-tool/src/panes/document/DocumentPane.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/DocumentPane.tsx
@@ -2,7 +2,7 @@ import {
   unstable_useTemplatePermissions as useUnstableTemplatePermissions,
   useDocumentType,
 } from '@sanity/base/hooks'
-import {LegacyLayerProvider, useZIndex} from '@sanity/base/components'
+import {useZIndex} from '@sanity/base/components'
 import {ChangeConnectorRoot} from '@sanity/base/change-indicators'
 import {getTemplateById} from '@sanity/base/initial-value-templates'
 import {
@@ -32,7 +32,6 @@ import {LoadingPane} from '../loading'
 import {ChangesPanel} from './changesPanel'
 import {DocumentPanel} from './documentPanel'
 import {DocumentOperationResults} from './DocumentOperationResults'
-import {InspectDialog} from './inspectDialog'
 import {DocumentActionShortcuts} from './keyboardShortcuts'
 import {DocumentStatusBar} from './statusBar'
 import {useDocumentPane} from './useDocumentPane'
@@ -179,7 +178,6 @@ function mergeDocumentType(
 function InnerDocumentPane() {
   const {
     changesOpen,
-    displayed,
     documentSchema,
     documentType,
     handleFocus,
@@ -199,8 +197,14 @@ function InnerDocumentPane() {
   const footerH = footerRect?.height
 
   const documentPanel = useMemo(
-    () => <DocumentPanel footerHeight={footerH || null} rootElement={rootElement} />,
-    [footerH, rootElement]
+    () => (
+      <DocumentPanel
+        footerHeight={footerH || null}
+        rootElement={rootElement}
+        isInspectOpen={inspectOpen}
+      />
+    ),
+    [footerH, rootElement, inspectOpen]
   )
 
   const footer = useMemo(
@@ -210,15 +214,6 @@ function InnerDocumentPane() {
       </PaneFooter>
     ),
     []
-  )
-
-  const inspectDialog = useMemo(
-    () => (
-      <LegacyLayerProvider zOffset="fullscreen">
-        {inspectOpen && <InspectDialog value={displayed || value} />}
-      </LegacyLayerProvider>
-    ),
-    [displayed, value, inspectOpen]
   )
 
   const changesPanel = useMemo(() => {
@@ -292,7 +287,6 @@ function InnerDocumentPane() {
         </DialogProvider>
         {footer}
         <DocumentOperationResults />
-        {inspectDialog}
       </>
     )
   }, [
@@ -304,7 +298,6 @@ function InnerDocumentPane() {
     footer,
     handleFocus,
     handleHistoryOpen,
-    inspectDialog,
     layoutCollapsed,
     paneKey,
     value,

--- a/packages/@sanity/desk-tool/src/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/documentPanel/DocumentPanel.tsx
@@ -8,6 +8,7 @@ import {PaneContent} from '../../../components/pane'
 import {usePaneLayout} from '../../../components/pane/usePaneLayout'
 import {useDeskTool} from '../../../contexts/deskTool'
 import {useDocumentPane} from '../useDocumentPane'
+import {InspectDialog} from '../inspectDialog'
 import {DocumentPanelHeader} from './header'
 import {FormView} from './documentViews'
 import {PermissionCheckBanner} from './PermissionCheckBanner'
@@ -24,6 +25,7 @@ function getSchemaType(typeName: string): SchemaType | null {
 interface DocumentPanelProps {
   footerHeight: number | null
   rootElement: HTMLDivElement | null
+  isInspectOpen: boolean
 }
 
 const Scroller = styled(ScrollContainer)<{$disabled: boolean}>(({$disabled}) => {
@@ -41,7 +43,7 @@ const Scroller = styled(ScrollContainer)<{$disabled: boolean}>(({$disabled}) => 
 })
 
 export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
-  const {footerHeight, rootElement} = props
+  const {footerHeight, rootElement, isInspectOpen} = props
   const {
     activeViewId,
     displayed,
@@ -124,6 +126,10 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     documentScrollElement.scrollTo(0, 0)
   }, [documentId, documentScrollElement])
 
+  const inspectDialog = useMemo(() => {
+    return isInspectOpen ? <InspectDialog value={displayed || value} /> : null
+  }, [isInspectOpen, displayed, value])
+
   return (
     <Flex direction="column" flex={2} overflow={layoutCollapsed ? undefined : 'hidden'}>
       <DocumentPanelHeader rootElement={rootElement} ref={setHeaderElement} />
@@ -154,6 +160,8 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
               />
               {activeViewNode}
             </Scroller>
+
+            {inspectDialog}
 
             <div data-testid="document-panel-portal" ref={portalRef} />
           </BoundaryElementProvider>


### PR DESCRIPTION
### Description

Move the inspect dialog to be pane specific and allow for a user to use the actions in the footer
![image](https://user-images.githubusercontent.com/6951139/150363513-b73c10fa-c552-4777-925c-87e9ca1ecc7e.png)


### What to review

- Open references in place and try to open the inspect dialog in both
- Change the tabs between the two
- Try to publish changes / revert changes / duplicate actions in the footer

### Notes for release

- Make inspect dialog pane specific and allow footer actions to be used when it is open