### PR TITLE
update readme for consistency with @sanity/document-internationalization

### DIFF
--- a/packages/@sanity/language-filter/README.md
+++ b/packages/@sanity/language-filter/README.md
@@ -1,12 +1,36 @@
-### @sanity/language-filter
+# Field-level translation filter Plugin for Sanity.io
 
 A Sanity plugin that supports filtering localized fields by language
 
-## Usage
+![Language Filter UI](https://user-images.githubusercontent.com/9684022/150549913-68f1b7c7-3305-48b4-b72b-41b95e82450c.gif)
 
-### Install plugin
+## What this plugin solves
 
-> sanity install @sanity/language-filter
+There are two popular methods of internationalization in Sanity Studio:
+
+- **Field-level translation**
+  - A single document with many languages of content
+  - Achieved by mapping over languages on each field, to create an object
+  - Best for documents that have a mix of language-specific and common fields
+  - Not recommended for Portable Text
+- **Document-level translation**
+  - A unique document version for every language
+  - Joined together by references and/or a predictable `_id`
+  - Best for documents that have unique, language-specific fields and no common content across languages
+  - Best for translating content using Portable Text
+
+This plugin adds features to the Studio to improve handling **field-level translations**.
+
+- A "Filter Languages" button to show/hide fields in an object of language-specific fields
+- Configuration to set "default" languages which are always visible
+
+For **document-level translations** you should use the [@sanity/document-internationalization plugin](https://www.npmjs.com/package/@sanity/document-internationalization).
+
+## Installation
+
+```
+sanity install @sanity/language-filter
+```
 
 Installing with `sanity install` updates your `sanity.json` to include this plugin. If installing with npm or yarn, ensure your `plugins` array includes `@sanity/language-filter`.
 
@@ -33,7 +57,7 @@ export default {
     {id: 'en', title: 'English'},
     {id: 'es', title: 'Spanish'},
     {id: 'arb', title: 'Arabic'},
-    {id: 'pt', title: 'Portuguese'}
+    {id: 'pt', title: 'Portuguese'},
     //...
   ],
   // Select Norwegian (Bokmål) by default
@@ -41,7 +65,7 @@ export default {
   // Only show language filter for document type `page` (schemaType.name)
   documentTypes: ['page'],
   filterField: (enclosingType, field, selectedLanguageIds) =>
-    !enclosingType.name.startsWith('locale') || selectedLanguageIds.includes(field.name)
+    !enclosingType.name.startsWith('locale') || selectedLanguageIds.includes(field.name),
 }
 ```
 


### PR DESCRIPTION
### Description

Update the @sanity/language-filter readme to be more like the new [@sanity/document-internationalization readme](https://www.npmjs.com/package/@sanity/document-internationalization)

- Adding a gif
- Adding a “what this plugin solves” section at the start

### What to review

The new readme, comparing it to [@sanity/document-internationalization readme](https://www.npmjs.com/package/@sanity/document-internationalization)

### Notes for release

- Updated `@sanity/language-filter` readme with more explanation about internationalization patterns in Sanity
