### PR TITLE
Fix glitch in placeholder rendering

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -188,7 +188,7 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
 
   const renderLeaf = useCallback(
     (lProps) => {
-      if (renderPlaceholder && lProps.leaf.placeholder) {
+      if (renderPlaceholder && lProps.leaf.placeholder && lProps.text.text === '') {
         return (
           <>
             <div style={PLACEHOLDER_STYLE} contentEditable={false}>


### PR DESCRIPTION
Check that the leaf text is really empty before displaying the placeholder as the decoration array is lagging behind typing.

### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
