### PR TITLE
fix(portable-text-editor): fix bug with insertNodePatch

### DIFF
--- a/packages/@sanity/portable-text-editor/src/utils/__tests__/operationToPatches.test.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/__tests__/operationToPatches.test.ts
@@ -87,4 +87,84 @@ describe('operationToPatches', () => {
       ]
     `)
   })
+  it('produce correct insert block patch', () => {
+    expect(
+      operationToPatches.insertNodePatch(
+        editor,
+        {
+          type: 'insert_node',
+          path: [0],
+          node: {
+            _type: 'someObject',
+            _key: 'c130395c640c',
+            value: {},
+            __inline: false,
+            children: [{_key: '1', _type: 'span', text: '', marks: []}],
+          },
+        },
+
+        defaultValue
+      )
+    ).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "items": Array [
+            Object {
+              "_key": "c130395c640c",
+              "_type": "someObject",
+            },
+          ],
+          "path": Array [
+            Object {
+              "_key": "1f2e64b47787",
+            },
+          ],
+          "position": "before",
+          "type": "insert",
+        },
+      ]
+    `)
+  })
+  it('produce correct insert child patch', () => {
+    expect(
+      operationToPatches.insertNodePatch(
+        editor,
+        {
+          type: 'insert_node',
+          path: [0, 3],
+          node: {
+            _type: 'someObject',
+            _key: 'c130395c640c',
+            value: {},
+            __inline: true,
+            children: [{_key: '1', _type: 'span', text: '', marks: []}],
+          },
+        },
+
+        defaultValue
+      )
+    ).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "items": Array [
+            Object {
+              "_key": "c130395c640c",
+              "_type": "someObject",
+            },
+          ],
+          "path": Array [
+            Object {
+              "_key": "1f2e64b47787",
+            },
+            "children",
+            Object {
+              "_key": "fd9b4a4e6c0b",
+            },
+          ],
+          "position": "after",
+          "type": "insert",
+        },
+      ]
+    `)
+  })
 })

--- a/packages/@sanity/portable-text-editor/src/utils/operationToPatches.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/operationToPatches.ts
@@ -114,9 +114,6 @@ export function createOperationToPatches(
     beforeValue: Descendant[]
   ): Patch[] {
     const block = beforeValue[operation.path[0]]
-    if (!Editor.isBlock(editor, block)) {
-      throw new Error('Not a valid block')
-    }
     if (operation.path.length === 1) {
       const position = operation.path[0] === 0 ? 'before' : 'after'
       const beforeBlock = beforeValue[operation.path[0] - 1]
@@ -138,6 +135,9 @@ export function createOperationToPatches(
       }
       throw new Error('Target key not found!')
     } else if (operation.path.length === 2 && editor.children[operation.path[0]]) {
+      if (!editor.isTextBlock(block)) {
+        throw new Error('Invalid block')
+      }
       const position =
         block.children.length === 0 || !block.children[operation.path[1] - 1] ? 'before' : 'after'
       const child = fromSlateValue(


### PR DESCRIPTION
### Description

Fixes a bug introduced in d4705d406f52bea868ede20b3a48416f5de3770d where an error would be thrown when producing a insertNode patch.

Also added tests for this.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
