### PR TITLE
Add more tests and fix bug in insert blocks into empty editor

### DIFF
--- a/packages/@sanity/portable-text-editor/src/utils/__tests__/operationToPatches.test.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/__tests__/operationToPatches.test.ts
@@ -112,7 +112,6 @@ describe('operationToPatches', () => {
             children: [{_key: '1', _type: 'span', text: '', marks: []}],
           },
         },
-
         createDefaultValue()
       )
     ).toMatchInlineSnapshot(`
@@ -128,6 +127,50 @@ describe('operationToPatches', () => {
             Object {
               "_key": "1f2e64b47787",
             },
+          ],
+          "position": "before",
+          "type": "insert",
+        },
+      ]
+    `)
+  })
+
+  it('produce correct insert block patch with an empty editor', () => {
+    editor.children = []
+    editor.onChange()
+    expect(
+      operationToPatches.insertNodePatch(
+        editor,
+        {
+          type: 'insert_node',
+          path: [0],
+          node: {
+            _type: 'someObject',
+            _key: 'c130395c640c',
+            value: {},
+            __inline: false,
+            children: [{_key: '1', _type: 'span', text: '', marks: []}],
+          },
+        },
+
+        []
+      )
+    ).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "path": Array [],
+          "type": "setIfMissing",
+          "value": Array [],
+        },
+        Object {
+          "items": Array [
+            Object {
+              "_key": "c130395c640c",
+              "_type": "someObject",
+            },
+          ],
+          "path": Array [
+            0,
           ],
           "position": "before",
           "type": "insert",

--- a/packages/@sanity/portable-text-editor/src/utils/operationToPatches.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/operationToPatches.ts
@@ -117,7 +117,7 @@ export function createOperationToPatches(
     if (operation.path.length === 1) {
       const position = operation.path[0] === 0 ? 'before' : 'after'
       const beforeBlock = beforeValue[operation.path[0] - 1]
-      const targetKey = operation.path[0] === 0 ? block._key : beforeBlock?._key
+      const targetKey = operation.path[0] === 0 ? block?._key : beforeBlock?._key
       if (targetKey) {
         return [
           insert([fromSlateValue([operation.node], textBlockName)[0]], position, [
@@ -125,15 +125,10 @@ export function createOperationToPatches(
           ]),
         ]
       }
-      if (beforeValue.length === 0) {
-        return [
-          setIfMissing(beforeValue, []),
-          insert([fromSlateValue([operation.node], textBlockName)[0]], 'before', [
-            operation.path[0],
-          ]),
-        ]
-      }
-      throw new Error('Target key not found!')
+      return [
+        setIfMissing(beforeValue, []),
+        insert([fromSlateValue([operation.node], textBlockName)[0]], 'before', [operation.path[0]]),
+      ]
     } else if (operation.path.length === 2 && editor.children[operation.path[0]]) {
       if (!editor.isTextBlock(block)) {
         throw new Error('Invalid block')
@@ -159,13 +154,12 @@ export function createOperationToPatches(
             : {_key: block.children[operation.path[1] - 1]._key},
         ]),
       ]
-    } else {
-      throw new Error(
-        `Unexpected path encountered: ${JSON.stringify(operation.path)} - ${JSON.stringify(
-          beforeValue
-        )}`
-      )
     }
+    throw new Error(
+      `Unexpected path encountered: ${JSON.stringify(operation.path)} - ${JSON.stringify(
+        beforeValue
+      )}`
+    )
   }
 
   function splitNodePatch(

--- a/packages/@sanity/portable-text-editor/src/utils/operationToPatches.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/operationToPatches.ts
@@ -45,7 +45,7 @@ export function createOperationToPatches(
     }
     const path: Path = [{_key: block._key}, 'children', {_key: textChild._key}, 'text']
     const prevBlock = beforeValue[operation.path[0]]
-    const prevChild = Editor.isBlock(editor, prevBlock) && prevBlock.children[operation.path[1]]
+    const prevChild = editor.isTextBlock(prevBlock) && prevBlock.children[operation.path[1]]
     const prevText = Text.isText(prevChild) ? prevChild.text : ''
     const patch = diffMatchPatch(prevText, textChild.text, path)
     return patch.value.length ? [patch] : []
@@ -274,8 +274,8 @@ export function createOperationToPatches(
       const block = beforeValue[operation.path[0]]
       const mergedSpan = block.children[operation.path[1]]
       const targetBlock = editor.children[operation.path[0]]
-      if (!Editor.isBlock(editor, targetBlock)) {
-        throw new Error('Block expected')
+      if (!editor.isTextBlock(targetBlock)) {
+        throw new Error('Invalid block')
       }
       const targetSpan = targetBlock.children[operation.path[1] - 1]
       if (Text.isText(targetSpan)) {


### PR DESCRIPTION
### Description

This will add more tests for the `operationToPatches` functions.

Also, refactor two block determinators to be more spesific (test that it's actually text blocks we are dealing with).

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Doesn't need to be mentioned as this doesn't really change anything.

<!--
A description of the change(s) that should be used in the release notes.
-->
