### PR TITLE
fix(form-builder): prevent race condition crashing the studio in arrays

### DIFF
--- a/dev/test-studio/schema/standard/arrays.js
+++ b/dev/test-studio/schema/standard/arrays.js
@@ -364,6 +364,12 @@ export default {
       type: 'topLevelPrimitiveArrayType',
     },
     {
+      name: 'requiredFieldOfTopLevelPrimitiveArrayType',
+      title: 'Required field of top level primitive array type',
+      type: 'topLevelPrimitiveArrayType',
+      validation: (R) => R.required(),
+    },
+    {
       name: 'imageArrayInGrid',
       title: 'Image array',
       description: 'An array of images. options: {layout: "grid"}',

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
@@ -196,7 +196,7 @@ export class ArrayOfPrimitivesInput extends React.PureComponent<Props> {
       const prevFocusedValue = prevProps.value[snapshot.prevFocusedIndex]
 
       const nearestIndex = nearestIndexOf(
-        this.props.value,
+        this.props.value || [],
         snapshot.prevFocusedIndex,
         prevFocusedValue
       )


### PR DESCRIPTION
### Description

This PR fixes a race condition where required array input with primitives some times crashes while a document is being published/deleted.

Theory is that the code is assuming `value` is always an array, but in this particular case it is temporarily undefined while the prop is being updated.

### What to review

- That it makes sense to fallback to a empty array in this particular case

### Notes for release

- Fix a race condition where required arrays with primitive values some times crashes while a document is being published/deleted.
