### PR TITLE
fix(form-builder): fix issue with editing inline object references in PTE

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/PortableText/hooks/useObjectEditFormBuilderFocus.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/hooks/useObjectEditFormBuilderFocus.tsx
@@ -5,6 +5,8 @@ import {
 } from '@sanity/portable-text-editor'
 import {Path} from '@sanity/types'
 import {useCallback, useMemo} from 'react'
+import {FOCUS_TERMINATOR} from '@sanity/util/paths'
+import {isEqual} from 'lodash'
 
 const onBlur = () => {
   // We don't need to act on these.
@@ -16,10 +18,14 @@ export function useObjectEditFormBuilderFocus(onFocus: (path: Path) => void) {
 
   const onEditObjectFormBuilderFocus = useCallback(
     (nextPath: Path): void => {
+      let newPath
       if (selection) {
+        if (isEqual(nextPath, selection.focus.path)) {
+          newPath = [...nextPath, FOCUS_TERMINATOR]
+        }
         PortableTextEditor.blur(editor)
       }
-      onFocus(nextPath)
+      onFocus(newPath || nextPath)
     },
     [editor, onFocus, selection]
   )


### PR DESCRIPTION
There was an issue where if the input of a inline object in the Portable Text Editor set an empty focusPath,
it would close the object editing interface as the editor would interpret that as focus on the editor node itself.

In these cases, make sure we end the focusPath with the focus terminator symbol.

### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
That editing inline objects of type Reference is possible.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

Create a inline object of type reference and set it to an actual reference. Close the editing interface and try to open it again. 

### Notes for release
Fixes a bug in the Portable Text Editor where opening inline objects of type reference would not open the editing interface if set already.

<!--
A description of the change(s) that should be used in the release notes.
-->
