### PR TITLE
fix(form-builder): skip initial value resolution when inserting non-empty array items

### DIFF
--- a/dev/test-studio/schema/standard/arrays.js
+++ b/dev/test-studio/schema/standard/arrays.js
@@ -115,6 +115,24 @@ export default {
       ],
     },
     {
+      name: 'arrayWithInitialValue',
+      title: 'Array of types that has initial values defined',
+      type: 'array',
+      of: [
+        {
+          type: 'object',
+          title: 'Dog breed',
+          fields: [
+            {
+              name: 'name',
+              type: 'string',
+            },
+          ],
+          initialValue: {name: 'Miniature Schnauzer'},
+        },
+      ],
+    },
+    {
       name: 'arrayOfMultipleTypesPopover',
       title: 'Array of multiple types (editModal=popover)',
       options: {

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/ArrayInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/ArrayInput.tsx
@@ -28,6 +28,7 @@ import {ConditionalReadOnlyField} from '../../common'
 import {ArrayItem} from './item'
 import type {ArrayMember, InsertEvent, ReferenceItemComponentType} from './types'
 import {uploadTarget} from './uploadTarget/uploadTarget'
+import {isEmpty} from './item/helpers'
 
 declare const __DEV__: boolean
 
@@ -105,9 +106,11 @@ export class ArrayInput extends React.Component<Props> {
     const {resolveInitialValue, onFocus} = this.props
     this.setState({isResolvingInitialValue: true})
     const memberType = this.getMemberTypeOfItem(event.item)
-    const resolvedInitialValue = resolveInitialValue
-      ? resolveInitialValue(memberType as ObjectSchemaType, event.item)
-      : Promise.resolve({})
+
+    const resolvedInitialValue =
+      isEmpty(event.item) && resolveInitialValue
+        ? resolveInitialValue(memberType as ObjectSchemaType, event.item)
+        : Promise.resolve({})
 
     resolvedInitialValue
       .then((initial) => ({...event.item, ...initial}))


### PR DESCRIPTION

### Description
When duplicating an array item, an item's initialValues currently take precedence over the duplicated data. This wasn't  intentional and this patch fixes it.

### What to review
There's an example of an array of items with initial values here: https://test-studio-git-bug-sc-13780array-of-objects-initial-val-9183e9.sanity.build/test/desk/input-standard;arraysTest;8135c43b-9f28-46bb-8d87-3207901dced4%2Cpath%3DarrayWithInitialValue
 - Make sure initial value is *not* inserted when duplicating an item
 - Make sure initial value is still used when adding new items

### Notes for release

- Fixes a bug that caused "duplicate array item" to insert the initial value instead of a duplicate of the chosen item
