### PR TITLE
feat: portable text review changes design update

### DIFF
--- a/packages/@sanity/base/src/change-indicators/ElementWithChangeBar.styled.tsx
+++ b/packages/@sanity/base/src/change-indicators/ElementWithChangeBar.styled.tsx
@@ -11,6 +11,7 @@ interface RootProps {
   changed: boolean
   isReviewChangeOpen: boolean
   disabled: boolean
+  $withHoverEffect?: boolean
 }
 
 const animationSpeed = 250
@@ -59,10 +60,11 @@ export const FieldWrapper = styled.div`
   min-width: 0;
 `
 
-export const ChangeBar = styled.div`
+export const ChangeBar = styled.div<{$zIndex: number}>`
   position: relative;
   opacity: 1;
   transition: opacity 100ms;
+  z-index: ${({$zIndex}) => $zIndex};
 `
 
 export const ChangeBarMarker = styled.div(({theme}: ThemeContext) => {
@@ -85,50 +87,57 @@ export const ChangeBarMarker = styled.div(({theme}: ThemeContext) => {
   `
 })
 
-export const ChangeBarButton = styled.button(({theme}: ThemeContext) => {
-  /* these colours aren't freely available on the current theme */
-  const notSelectedColor = theme.sanity.color.spot.yellow
+export const ChangeBarButton = styled.button(
+  ({theme, $withHoverEffect}: {theme: Theme; $withHoverEffect?: boolean}) => {
+    /* these colours aren't freely available on the current theme */
+    const notSelectedColor = theme.sanity.color.spot.yellow
 
-  return css`
-    appearance: none;
-    border: 0;
-    outline: 0;
-    display: block;
-    padding: 0;
-    background: transparent;
-    opacity: 0;
-    position: absolute;
-    height: 100%;
-    cursor: pointer;
-    pointer-events: all;
-    left: calc(-0.25rem + var(--change-bar-offset));
-    width: 1rem;
-    transition: opacity ${animationSpeed}ms;
-
-    &:focus {
+    return css`
+      appearance: none;
       border: 0;
       outline: 0;
-    }
-
-    &:after {
-      content: '';
-      width: 16px;
-      height: calc(100% + 14px);
       display: block;
+      padding: 0;
+      background: transparent;
+      opacity: 0;
       position: absolute;
-      top: -7px;
-      left: -3px;
-      border-radius: 8px;
-      background: ${notSelectedColor};
-    }
+      height: 100%;
+      cursor: pointer;
+      pointer-events: all;
+      left: calc(-0.25rem + var(--change-bar-offset));
+      width: 1rem;
+      transition: opacity ${animationSpeed}ms;
 
-    &:focus {
-      border: 0;
-      outline: 0;
-    }
+      &:focus {
+        border: 0;
+        outline: 0;
+      }
 
-    &:hover {
-      opacity: 0.2;
-    }
-  `
-})
+      &:after {
+        content: '';
+        width: 16px;
+        height: calc(100% + 14px);
+        display: block;
+        position: absolute;
+        top: -7px;
+        left: -3px;
+        border-radius: 8px;
+        background: ${notSelectedColor};
+      }
+
+      &:focus {
+        border: 0;
+        outline: 0;
+      }
+
+      ${$withHoverEffect &&
+      css`
+        @media (hover: hover) {
+          &:hover {
+            opacity: 0.2;
+          }
+        }
+      `}
+    `
+  }
+)

--- a/packages/@sanity/base/src/change-indicators/ElementWithChangeBar.tsx
+++ b/packages/@sanity/base/src/change-indicators/ElementWithChangeBar.tsx
@@ -1,3 +1,4 @@
+import {useLayer} from '@sanity/ui'
 import React, {useCallback, useMemo, useState} from 'react'
 import {ConnectorContext} from './ConnectorContext'
 import {
@@ -10,22 +11,24 @@ import {
 
 export function ElementWithChangeBar(props: {
   children: React.ReactNode
+  disabled?: boolean
   hasFocus: boolean
   isChanged: boolean
-  disabled?: boolean
+  withHoverEffect?: boolean
 }) {
-  const {children, hasFocus, isChanged, disabled} = props
+  const {children, disabled, hasFocus, isChanged, withHoverEffect = true} = props
 
   const [hover, setHover] = useState(false)
   const {onOpenReviewChanges, isReviewChangesOpen} = React.useContext(ConnectorContext)
+  const {zIndex} = useLayer()
 
   const handleMouseEnter = useCallback(() => setHover(true), [])
   const handleMouseLeave = useCallback(() => setHover(false), [])
 
   const changeBar = useMemo(
     () =>
-      disabled ? null : (
-        <ChangeBar data-testid="change-bar">
+      disabled || !isChanged ? null : (
+        <ChangeBar data-testid="change-bar" $zIndex={zIndex}>
           <ChangeBarMarker data-testid="change-bar__marker" />
 
           <ChangeBarButton
@@ -36,20 +39,30 @@ export function ElementWithChangeBar(props: {
             onMouseLeave={handleMouseLeave}
             tabIndex={-1}
             type="button"
+            $withHoverEffect={withHoverEffect}
           />
         </ChangeBar>
       ),
-    [handleMouseEnter, handleMouseLeave, isReviewChangesOpen, onOpenReviewChanges, disabled]
+    [
+      disabled,
+      isChanged,
+      zIndex,
+      isReviewChangesOpen,
+      onOpenReviewChanges,
+      handleMouseEnter,
+      handleMouseLeave,
+      withHoverEffect,
+    ]
   )
 
   return (
     <ChangeBarWrapper
+      changed={isChanged}
       data-testid="change-bar-wrapper"
+      disabled={disabled}
       focus={hasFocus}
       hover={hover}
-      changed={isChanged}
       isReviewChangeOpen={isReviewChangesOpen}
-      disabled={disabled}
     >
       <FieldWrapper data-testid="change-bar__field-wrapper">{children}</FieldWrapper>
       {changeBar}

--- a/packages/@sanity/form-builder/src/inputs/PortableText/Editor.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Editor.tsx
@@ -139,14 +139,10 @@ export function Editor(props: EditorProps) {
         />
       </ToolbarCard>
 
-      <EditableCard flex={1} tone="transparent">
+      <EditableCard flex={1}>
         <Scroller ref={setScrollElement}>
           <EditableContainer padding={isFullscreen ? 2 : 0} sizing="border" width={1}>
-            <EditableWrapper
-              shadow={isFullscreen ? 1 : 0}
-              $isFullscreen={isFullscreen}
-              $readOnly={readOnly}
-            >
+            <EditableWrapper $isFullscreen={isFullscreen} $readOnly={readOnly}>
               <BoundaryElementProvider element={isFullscreen ? scrollElement : boundaryElement}>
                 {editable}
               </BoundaryElementProvider>

--- a/packages/@sanity/form-builder/src/inputs/PortableText/_common/ReviewChangesHighlightBlock.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/_common/ReviewChangesHighlightBlock.tsx
@@ -1,0 +1,17 @@
+import {rgba} from '@sanity/ui'
+import styled, {css} from 'styled-components'
+
+export const ReviewChangesHighlightBlock = styled.div(({theme}) => {
+  const {radius, space, color} = theme.sanity
+  const bg = rgba(color.spot.yellow, 0.2)
+
+  return css`
+    position: absolute;
+    border-radius: ${radius[3]}px;
+    top: -${space[2]}px;
+    bottom: -${space[1] + space[1]}px;
+    left: ${space[4] + space[1]}px;
+    right: 0;
+    background-color: ${bg};
+  `
+})

--- a/packages/@sanity/form-builder/src/inputs/PortableText/_common/StyledChangeIndicatorWithProvidedFullPath.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/_common/StyledChangeIndicatorWithProvidedFullPath.tsx
@@ -1,0 +1,15 @@
+import {ChangeIndicatorWithProvidedFullPath} from '@sanity/base/change-indicators'
+import styled, {css} from 'styled-components'
+
+export const StyledChangeIndicatorWithProvidedFullPath = styled(
+  ChangeIndicatorWithProvidedFullPath
+)(() => {
+  return css`
+    width: 1px;
+    height: 100%;
+
+    & > div {
+      height: 100%;
+    }
+  `
+})

--- a/packages/@sanity/form-builder/src/inputs/PortableText/_common/index.ts
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/_common/index.ts
@@ -1,0 +1,2 @@
+export * from './ReviewChangesHighlightBlock'
+export * from './StyledChangeIndicatorWithProvidedFullPath'

--- a/packages/@sanity/form-builder/src/inputs/PortableText/object/BlockObject.styles.ts
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/object/BlockObject.styles.ts
@@ -1,0 +1,136 @@
+import {hues} from '@sanity/color'
+import {Card, Theme, Flex, Box} from '@sanity/ui'
+import styled, {css} from 'styled-components'
+
+export const Root = styled(Card)((props: {theme: Theme}) => {
+  const {color, radius, space} = props.theme.sanity
+
+  const overlay = css`
+    pointer-events: none;
+    content: '';
+    position: absolute;
+    top: -${space[1]}px;
+    bottom: -${space[1]}px;
+    left: -${space[1]}px;
+    right: -${space[1]}px;
+    border-radius: ${radius[2]}px;
+    mix-blend-mode: ${color.dark ? 'screen' : 'multiply'};
+  `
+
+  return css`
+    box-shadow: 0 0 0 1px var(--card-border-color);
+    border-radius: ${radius[1]}px;
+    pointer-events: all;
+    position: relative;
+
+    &[data-focused] {
+      box-shadow: 0 0 0 1px ${color.selectable.primary.selected.border};
+    }
+
+    &:not([data-focused]):not([data-selected]) {
+      @media (hover: hover) {
+        &:hover {
+          --card-border-color: ${color.input.default.hovered.border};
+        }
+      }
+    }
+
+    &[data-markers] {
+      &:after {
+        ${overlay}
+        background-color: ${color.dark ? hues.purple[950].hex : hues.purple[50].hex};
+      }
+    }
+
+    &[data-warning] {
+      &:after {
+        ${overlay}
+        background-color: ${color.muted.caution.hovered.bg};
+      }
+
+      @media (hover: hover) {
+        &:hover {
+          --card-border-color: ${color.muted.caution.hovered.border};
+        }
+      }
+    }
+
+    &[data-invalid] {
+      &:after {
+        ${overlay}
+        background-color: ${color.input.invalid.enabled.bg};
+      }
+
+      @media (hover: hover) {
+        &:hover {
+          --card-border-color: ${color.input.invalid.hovered.border};
+        }
+      }
+    }
+  `
+})
+
+export const PreviewContainer = styled(Flex)`
+  user-select: none;
+  pointer-events: none;
+`
+
+export const ChangeIndicatorWrapper = styled.div<{$hasChanges: boolean}>(
+  ({theme, $hasChanges}: {theme: Theme; $hasChanges: boolean}) => {
+    const {space} = theme.sanity
+
+    return css`
+      position: absolute;
+      width: ${space[2]}px;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      padding-left: ${space[1]}px;
+      user-select: none;
+
+      ${!$hasChanges &&
+      css`
+        display: none;
+      `}
+
+      [data-dragged] & {
+        visibility: hidden;
+      }
+    `
+  }
+)
+
+export const InnerFlex = styled(Flex)`
+  position: relative;
+
+  [data-dragged] > & {
+    opacity: 0.5;
+  }
+`
+
+export const BlockActionsOuter = styled(Box)`
+  width: 25px;
+  position: relative;
+
+  [data-dragged] & {
+    visibility: hidden;
+  }
+`
+
+export const BlockActionsInner = styled(Flex)`
+  position: absolute;
+  right: 0;
+  [data-dragged] & {
+    visibility: hidden;
+  }
+`
+
+export const TooltipBox = styled(Box)`
+  max-width: 250px;
+`
+export const BlockPreview = styled(Box)((props: {theme: Theme}) => {
+  const color = props.theme.sanity.color.input
+  return css`
+    background-color: ${color.default.enabled.bg};
+  `
+})

--- a/packages/@sanity/form-builder/src/inputs/PortableText/text/TextBlock.styles.ts
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/text/TextBlock.styles.ts
@@ -1,4 +1,3 @@
-import {ChangeIndicatorWithProvidedFullPath} from '@sanity/base/change-indicators'
 import {hues} from '@sanity/color'
 import {Box, Flex, Theme} from '@sanity/ui'
 import styled, {css} from 'styled-components'
@@ -146,27 +145,23 @@ export const TextFlex = styled(Flex)<{$level?: number}>`
   padding-left: ${({$level}) => ($level ? $level * 32 : 0)}px;
 `
 
-export const ChangeIndicatorWrapper = styled.div(({theme}: {theme: Theme}) => {
-  const {space} = theme.sanity
+export const ChangeIndicatorWrapper = styled.div<{$hasChanges: boolean}>(
+  ({theme, $hasChanges}: {theme: Theme; $hasChanges: boolean}) => {
+    const {space} = theme.sanity
 
-  return css`
-    position: absolute;
-    width: ${space[2]}px;
-    right: 0;
-    top: -${space[1]}px;
-    bottom: -${space[1]}px;
-    padding-left: ${space[1]}px;
-    user-select: none;
-  `
-})
+    return css`
+      position: absolute;
+      width: ${space[2]}px;
+      right: 0;
+      top: -${space[1]}px;
+      bottom: -${space[1]}px;
+      padding-left: ${space[1]}px;
+      user-select: none;
 
-export const StyledChangeIndicatorWithProvidedFullPath = styled(
-  ChangeIndicatorWithProvidedFullPath
-)`
-  width: 1px;
-  height: 100%;
-
-  & > div {
-    height: 100%;
+      ${!$hasChanges &&
+      css`
+        display: none;
+      `}
+    `
   }
-`
+)

--- a/packages/@sanity/form-builder/src/inputs/PortableText/text/TextBlock.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/text/TextBlock.tsx
@@ -1,11 +1,12 @@
 import {PortableTextBlock, RenderAttributes} from '@sanity/portable-text-editor'
 import {isKeySegment, isValidationMarker, Marker} from '@sanity/types'
 import {Box, ResponsivePaddingProps, Tooltip} from '@sanity/ui'
-import React, {useMemo} from 'react'
+import React, {useCallback, useMemo, useState} from 'react'
 import {Markers} from '../../../legacyParts'
 import PatchEvent from '../../../PatchEvent'
 import {BlockActions} from '../BlockActions'
 import {RenderBlockActions, RenderCustomMarkers} from '../types'
+import {ReviewChangesHighlightBlock, StyledChangeIndicatorWithProvidedFullPath} from '../_common'
 import {TEXT_STYLE_PADDING} from './constants'
 import {
   BlockActionsInner,
@@ -13,7 +14,6 @@ import {
   BlockExtrasContainer,
   ChangeIndicatorWrapper,
   ListPrefixWrapper,
-  StyledChangeIndicatorWithProvidedFullPath,
   TextBlockFlexWrapper,
   TextFlex,
   TextRoot,
@@ -50,9 +50,17 @@ export function TextBlock(props: TextBlockProps): React.ReactElement {
     spellCheck,
   } = props
 
+  const [reviewChangesHovered, setReviewChangesHovered] = useState<boolean>(false)
+  const [hasChanges, setHasChanges] = useState<boolean>(false)
+
   const {focused} = attributes
 
   const blockKey = block._key
+
+  const handleMouseOver = useCallback(() => setReviewChangesHovered(true), [])
+  const handleMouseOut = useCallback(() => setReviewChangesHovered(false), [])
+
+  const handleOnHasChanges = useCallback((changed: boolean) => setHasChanges(changed), [])
 
   // These are marker that is only for the block level (things further up, like annotations and inline objects are dealt with in their respective components)
   const blockMarkers = useMemo(
@@ -174,16 +182,24 @@ export function TextBlock(props: TextBlockProps): React.ReactElement {
           )}
 
           {isFullscreen && (
-            <ChangeIndicatorWrapper>
+            <ChangeIndicatorWrapper
+              onMouseOver={handleMouseOver}
+              onMouseOut={handleMouseOut}
+              $hasChanges={Boolean(hasChanges)}
+            >
               <StyledChangeIndicatorWithProvidedFullPath
                 compareDeep
                 value={block}
                 hasFocus={focused}
                 path={blockPath}
+                withHoverEffect={false}
+                onHasChanges={handleOnHasChanges}
               />
             </ChangeIndicatorWrapper>
           )}
         </BlockExtrasContainer>
+
+        {reviewChangesHovered && <ReviewChangesHighlightBlock />}
       </TextBlockFlexWrapper>
     </Box>
   )


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR adds a design update in the PTE where a block in the editor gets a background color when hovering on the changes indicator. See screenshot below.

<img width="1063" alt="Screenshot 2022-01-26 at 15 00 03" src="https://user-images.githubusercontent.com/15094168/151369784-0bec3328-ef03-4f46-a406-d95d6817774c.png">

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

- The block should only be highlighted on hover when there are changes
- Does the `onHasChanges` callback make sense? We need to know if the block has changes in order to be able to determine if the hover effect should be disabled or enabled inside `TextBlock` and` BlockObject`. Could this be approached differently?

### Notes for release
Add background color to blocks in Portable Text Editor when hovering the changes indicator

<!--
A description of the change(s) that should be used in the release notes.
-->
