### PR TITLE
feat(desk-tool): update `MissingDocumentTypesMessage` design

### DIFF
--- a/packages/@sanity/desk-tool/src/components/MissingDocumentTypesMessage.tsx
+++ b/packages/@sanity/desk-tool/src/components/MissingDocumentTypesMessage.tsx
@@ -1,23 +1,28 @@
-import {Heading, Stack, Text} from '@sanity/ui'
 import React from 'react'
+import {Card, Container, Heading, Stack, Text} from '@sanity/ui'
 
 export function MissingDocumentTypesMessage() {
   return (
-    <Stack space={4}>
-      <Heading as="h2">Empty schema</Heading>
-      <Text as="p">
-        Your schema does not contain any document types. If it did, those types would be listed
-        here.{' '}
-        <a
-          title="Schema documentation"
-          target="_blank"
-          rel="noopener noreferrer"
-          href="https://www.sanity.io/docs/content-studio/the-schema"
-        >
-          Read more about how to add schema types
-        </a>
-        .
-      </Text>
-    </Stack>
+    <Card height="fill" paddingX={[5, 5, 7]} paddingY={[5, 5, 6]} sizing="border">
+      <Container>
+        <Stack space={5}>
+          <Heading as="h1">Empty schema</Heading>
+
+          <Text as="p">
+            Your schema does not contain any document types. If it did, those types would be listed
+            here.{' '}
+            <a
+              title="Schema documentation"
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://www.sanity.io/docs/content-studio/the-schema"
+            >
+              Read more about how to add schema types
+            </a>
+            .
+          </Text>
+        </Stack>
+      </Container>
+    </Card>
   )
 }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->
This PR updates the design of the `MissingDocumentTypesMessage` component that is displayed if the schema is empty.

Before/after:

<img width="1169" alt="Screenshot 2022-01-28 at 10 40 40" src="https://user-images.githubusercontent.com/15094168/151523823-08577840-a9d2-4ba6-b7bd-e5ef866e228f.png">

**How to make this screen render:**

Remove the schema part in `sanity.json`:

```
{
  "name": "part:@sanity/base/schema",
  "path": "schema"
}
```

Return empty array in `createSchema`:

```
export default createSchema({
  name: 'test-examples',
  types: schemaTypes.concat([]),
})
```

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

- Review the design

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

Update design of empty schema message
