### PR TITLE
fix(portable-text-editor): disallow pointer events on placeholder

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -40,6 +40,7 @@ const PLACEHOLDER_STYLE: React.CSSProperties = {
   opacity: 0.5,
   position: 'absolute',
   userSelect: 'none',
+  pointerEvents: 'none',
 }
 
 const NOOP = () => {
@@ -221,11 +222,11 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
     [
       keyGenerator,
       portableTextFeatures,
+      readOnly,
       renderAnnotation,
       renderChild,
       renderDecorator,
       renderPlaceholder,
-      readOnly,
     ]
   )
 

--- a/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditor.test.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditor.test.tsx
@@ -63,7 +63,7 @@ describe('initialization', () => {
                   >
                     <div
                       contenteditable="false"
-                      style="opacity: 0.5; position: absolute; user-select: none;"
+                      style="opacity: 0.5; position: absolute; user-select: none; pointer-events: none;"
                     >
                       Jot something down here
                     </div>


### PR DESCRIPTION
The placeholder in the PTE should not take any pointer events. On Webkit this manifested as an issue setting focus in the editor  with some pointer events.

### Description

Even though it has `user-select: none;` it was still possible in Webkit to select this text for some weird reason, making it troublesome to set focus in the editor and start typing afterwards.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

That you always get focus and can type when using the mouse to set focus in an empty editor.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Fixed an issue where the empty editor placeholder text sometimes would cause focus problems in Webkit.

<!--
A description of the change(s) that should be used in the release notes.
-->
