### PR TITLE
fix(portable-text-editor): fix paste of listItems

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Element.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Element.tsx
@@ -132,7 +132,7 @@ export const Element: FunctionComponent<ElementProps> = ({
       if (Number.isInteger(element.level)) {
         renderAttribs.level = element.level
       } else {
-        element.level = 1
+        renderAttribs.level = 1
       }
       className += ` pt-list-item pt-list-item-${element.listItem} pt-list-item-level-${element.level}`
     }


### PR DESCRIPTION
### Description

In certain environments, pasting an unordered list item followed by a paragraph into a portable text field would crash the desk.

The else block was throwing an error as `element.level` is read-only.

### What to review

Confirm that pasting into the portable text field works as expected.

### Notes for release

Fixes a regression when pasting from certain text editors into a portable text field.
