### PR TITLE
fix(form-builder): fix overflow when there are many types

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/InsertMenu.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/InsertMenu.tsx
@@ -9,7 +9,12 @@ interface Props {
   onInsert: (pos: 'before' | 'after', type: SchemaType) => void
 }
 
-const MENU_POPOVER_PROPS = {portal: true, tone: 'default', placement: 'left'} as const
+const MENU_POPOVER_PROPS = {
+  portal: true,
+  tone: 'default',
+  placement: 'left',
+  constrainSize: true,
+} as const
 
 export const InsertMenu = memo(function InsertMenu(props: Props) {
   const {types, onInsert} = props

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/InsertMenu.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/InsertMenu.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-no-bind */
 import {SchemaType} from '@sanity/types'
 import React, {ComponentProps, memo} from 'react'
-import {MenuGroup, MenuItem} from '@sanity/ui'
+import {MenuGroup, MenuItem, PopoverProps} from '@sanity/ui'
 import {InsertAboveIcon, InsertBelowIcon} from '@sanity/icons'
 
 interface Props {
@@ -9,7 +9,7 @@ interface Props {
   onInsert: (pos: 'before' | 'after', type: SchemaType) => void
 }
 
-const MENU_POPOVER_PROPS = {
+const MENU_POPOVER_PROPS: PopoverProps = {
   portal: true,
   tone: 'default',
   placement: 'left',


### PR DESCRIPTION
### Description

Added `constrainSize` to the MenuGroup popover to limit the overflow of type options that the array input can have

![image](https://user-images.githubusercontent.com/6951139/151803480-e5d8f59b-ed8a-4855-8416-fc6cfaf76724.png)

### What to review

- Add schema that adds a lot of different types
  - example in `array.js` schema:
 ```
{
      name: 'arrayOfALLTypesPopover',
      title: 'Array of ALL the types',
      type: 'array',
      of: range(0, 60).map((value) => {
        return {
          type: 'image',
          name: value,
        }
      }),
    },
```
- Go to any of the array tests 
- Make sure that regardless of how many types are available, that the menu is readable and scrollable

### Notes for release

Fix bug where when there were multiple types available in the array input "add before / add after" the options didn't scroll
