### PR TITLE
fix(form-builder): unset image/file field when last subfield is cleared

### DIFF
--- a/dev/test-studio/schema/standard/images.js
+++ b/dev/test-studio/schema/standard/images.js
@@ -45,6 +45,7 @@ export default {
           options: {
             isHighlighted: true,
           },
+          validation: (Rule) => Rule.required(),
         },
         {
           name: 'detailedCaption',


### PR DESCRIPTION
### Description

When an image has a field on it (e.g., an alt text string field), a certain sequence of events causes the image not to be unset. This poses a problem when that field is required, as it will prevent the document from being published even when the user deletes the field's contents.

The fix is a bit verbose, but leans on the same logic that the asset removal logic uses - eg if an asset is removed and it is the last non-crop/hotspot field with a value, unset the entire object. In this case we check if the patch being emitted from the field is an unset patch (eg the `alt` field wants to unset itself) and if so, whether or not there are any other non-empty values left in the object.

Fixes [sc-12411]

### Steps to reproduce

Schema example:

```
export default {
  name: 'imageTest',
  title: 'Image Test',
  type: 'document',
  fields: [
    {
      name: 'someImage',
      title: 'Some Image',
      type: 'image',
      fields: [
        {
          name: 'alt',
          type: 'string',
          title: 'Alt',
          options: {
            isHighlighted: true,
          },
          validation: Rule => Rule.required(),
        }
      ]
    },
  ]
}
```

1. Upload or select an image.
2. Add alt text.
3. Remove the image.
4. Delete the alt text.

You should observe a validation error, and in the JSON, the image field will persist.

### What to review

- That the patch makes sense
- That there isn't a better way of doing this
- Whether or not there could be some abstraction/reusable way to write this (given the same logic goes for both files and images)

### Notes for release

- Fixes an issue where image or file fields with nested, required fields would trigger validation even when image/file field was missing an asset

