### PR TITLE
fix(cypress): use uuid instead of nanoid for document ids

### DIFF
--- a/cypress/integration/form-builder/validation.test.js
+++ b/cypress/integration/form-builder/validation.test.js
@@ -1,7 +1,7 @@
-import {nanoid} from 'nanoid'
+import {uuid} from '@sanity/uuid'
 import client from '../../helpers/sanityClientSetUp'
 
-const docId = `drafts.${nanoid()}`
+const docId = `drafts.${uuid()}`
 
 const doc = {
   _id: docId,
@@ -15,7 +15,7 @@ const doc = {
 const VALID_VALUE = 'String longer than 5'
 const INVALID_VALUE = 'abc'
 
-async function patchDocument(payload) {
+function patchDocument(payload) {
   return client.patch(docId).set(payload).commit({visibility: 'async'})
 }
 


### PR DESCRIPTION
### Description

nanoid can generate IDs that contain characters we dont allow in document IDs, such as a leading dash. This PR replaces it with `@sanity/uuid` for "safe" IDs.

### What to review

- That the code still runs as expected

### Notes for release

None.
