### PR TITLE
Change upgrade text depending on number of modules

### DIFF
--- a/packages/@sanity/cli/src/commands/upgrade/upgradeDependencies.js
+++ b/packages/@sanity/cli/src/commands/upgrade/upgradeDependencies.js
@@ -153,7 +153,9 @@ function getMajorUpgradeText(mods, chalk) {
   const modNames = mods.map((mod) => `${mod.name} (v${semver.major(mod.latest)})`).join('\n - ')
 
   return [
-    `The following modules has new major versions\n`,
+    mods.length === 1
+      ? `The following module has a new major version\n`
+      : `The following modules have new major versions\n`,
     `released and will have to be manually upgraded:\n\n`,
     ` - ${modNames}\n\n`,
     chalk.yellow('⚠'),


### PR DESCRIPTION
### Description

After running sanity upgrade

> The following modules has new major versions

Text updated to check the number of module updates and write either
* “The following modules have new major versions”
* “The following module has a new major version”

### What to review

First line of upgrade text

### Notes for release

Fixed grammar in major version upgrade text