### PR TITLE
fix(portable-text-editor): fix normalization bug in adding marks + test

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/plugins/__tests__/withPortableTextMarkModelNormalization.test.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/__tests__/withPortableTextMarkModelNormalization.test.tsx
@@ -396,4 +396,98 @@ describe('plugin:withPortableTextMarksModel: normalization', () => {
       ]
     `)
   })
+  it('toggles marks on children with annotation marks correctly', () => {
+    const editorRef: React.RefObject<PortableTextEditor> = React.createRef()
+    const initialValue = [
+      {
+        _key: 'a',
+        _type: 'myTestBlockType',
+        children: [
+          {
+            _key: 'a1',
+            _type: 'span',
+            marks: ['abc'],
+            text: 'A link',
+          },
+          {
+            _key: 'a2',
+            _type: 'span',
+            marks: [],
+            text: ', not a link',
+          },
+        ],
+        markDefs: [
+          {
+            _type: 'link',
+            _key: 'abc',
+            href: 'http://www.link.com',
+          },
+        ],
+        style: 'normal',
+      },
+    ]
+    const onChange = jest.fn()
+    act(() => {
+      render(
+        <PortableTextEditorTester
+          onChange={onChange}
+          ref={editorRef}
+          type={type}
+          value={initialValue}
+        />
+      )
+    })
+    if (!editorRef.current) {
+      throw new Error('No editor')
+    }
+    act(() => {
+      if (editorRef.current) {
+        PortableTextEditor.focus(editorRef.current)
+        PortableTextEditor.select(editorRef.current, {
+          focus: {path: [{_key: 'a'}, 'children', {_key: 'a1'}], offset: 0},
+          anchor: {path: [{_key: 'a'}, 'children', {_key: 'b1'}], offset: 12},
+        })
+      }
+    })
+    act(() => {
+      if (editorRef.current) {
+        PortableTextEditor.toggleMark(editorRef.current, 'bold')
+      }
+    })
+    expect(PortableTextEditor.getValue(editorRef.current)).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "_key": "a",
+          "_type": "myTestBlockType",
+          "children": Array [
+            Object {
+              "_key": "a1",
+              "_type": "span",
+              "marks": Array [
+                "abc",
+                "bold",
+              ],
+              "text": "A link",
+            },
+            Object {
+              "_key": "a2",
+              "_type": "span",
+              "marks": Array [
+                "bold",
+              ],
+              "text": ", not a link",
+            },
+          ],
+          "markDefs": Array [
+            Object {
+              "_key": "abc",
+              "_type": "link",
+              "href": "http://www.link.com",
+            },
+          ],
+          "style": "normal",
+        },
+      ]
+    `)
+  })
 })

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPortableTextMarkModel.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPortableTextMarkModel.ts
@@ -195,21 +195,22 @@ export function createWithPortableTextMarkModel(
             editor.removeMark(mark)
             return
           }
-          splitTextNodes.forEach(([node]) => {
-            const marks = [
-              ...(Array.isArray(node.marks) ? node.marks : []).filter(
-                (eMark: string) => eMark !== mark
-              ),
-              mark,
-            ]
-            if (location && editor.selection) {
+          Editor.withoutNormalizing(editor, () => {
+            splitTextNodes.forEach(([node, path]) => {
+              const marks = [
+                ...(Array.isArray(node.marks) ? node.marks : []).filter(
+                  (eMark: string) => eMark !== mark
+                ),
+                mark,
+              ]
               Transforms.setNodes(
                 editor,
                 {marks},
-                {at: editor.selection, match: Text.isText, split: true, hanging: true}
+                {at: path, match: Text.isText, split: true, hanging: true}
               )
-            }
+            })
           })
+          Editor.normalize(editor)
         } else {
           const existingMarks: string[] =
             {


### PR DESCRIPTION
### Description

Fixed a bug where adding marks to a portable text block child would  be normalized wrong, and loosing existing marks in some situations. 

Basically the same fix as this commit: a8918d5fed325a639ea4f26cd84486ebc6cb29ec only for `addMark` as well.

Added test for this.

### Notes for release

Fixed a bug where adding marks to a portable text block would cause loosing existing marks in some situations. 
