### PR TITLE
feat(vision): make default api version configurable

### DIFF
--- a/dev/test-studio/config/@sanity/vision.json
+++ b/dev/test-studio/config/@sanity/vision.json
@@ -1,0 +1,3 @@
+{
+  "defaultApiVersion": "2021-10-21"
+}

--- a/packages/@sanity/vision/README.md
+++ b/packages/@sanity/vision/README.md
@@ -10,3 +10,21 @@ Vision is a plugin for Sanity Studio for testing GROQ queries. It features:
 
 ## Installation
 `sanity install @sanity/vision`
+
+### Configuring
+
+It is possible to override the default configuration by setting up a config file.
+
+Create a file named `vision.json` and place it at `config/@sanity/vision.json` relative to your root studio folder.
+
+Currently we only support overriding the default API version.
+
+Here's an example `vision.json` file:
+
+```js
+{
+  "defaultApiVersion": "v2021-10-21"
+}
+```
+
+- `defaultApiVersion` Valid options is `v1`, `vX`, `v2021-03-25` or `v2021-10-21`

--- a/packages/@sanity/vision/config.dist.json
+++ b/packages/@sanity/vision/config.dist.json
@@ -1,0 +1,3 @@
+{
+  "defaultApiVersion": "2021-10-21"
+}

--- a/packages/@sanity/vision/src/apiVersions.js
+++ b/packages/@sanity/vision/src/apiVersions.js
@@ -1,1 +1,1 @@
-export const apiVersions = ['v1', 'vX', 'v2021-03-25']
+export const apiVersions = ['v1', 'vX', 'v2021-03-25', 'v2021-10-21']

--- a/packages/@sanity/vision/src/components/VisionGui.js
+++ b/packages/@sanity/vision/src/components/VisionGui.js
@@ -8,8 +8,10 @@ import isHotkey from 'is-hotkey'
 import {Flex, Card, Stack, Box, Hotkeys, Select, Text, TextInput, Tooltip, Grid} from '@sanity/ui'
 import studioClient from 'part:@sanity/base/client'
 import {FormFieldValidationStatus} from '@sanity/base/components'
+import config from 'config:@sanity/vision'
 import {storeState, getState} from '../util/localState'
 import parseApiQueryString from '../util/parseApiQueryString'
+import prefixApiVersion from '../util/prefixApiVersion'
 import tryParseParams from '../util/tryParseParams'
 import encodeQueryString from '../util/encodeQueryString'
 import {apiVersions} from '../apiVersions'
@@ -80,6 +82,8 @@ function calculatePaneSizeOptions(rootHeight) {
   }
 }
 
+const DEFAULT_API_VERSION = '2021-03-25'
+
 class VisionGui extends React.PureComponent {
   constructor(props) {
     super(props)
@@ -89,7 +93,7 @@ class VisionGui extends React.PureComponent {
 
     const firstDataset = this.props.datasets[0] && this.props.datasets[0].name
     const defaultDataset = studioClient.config().dataset || firstDataset
-    const defaultApiVersion = `v${studioClient.config().apiVersion || '1'}`
+    const defaultApiVersion = prefixApiVersion(`${config.defaultApiVersion || DEFAULT_API_VERSION}`)
 
     let dataset = getState('dataset', defaultDataset)
     let apiVersion = getState('apiVersion', defaultApiVersion)

--- a/packages/@sanity/vision/src/util/prefixApiVersion.js
+++ b/packages/@sanity/vision/src/util/prefixApiVersion.js
@@ -1,0 +1,7 @@
+export default function prefixApiVersion(version) {
+  if (version[0] !== 'v' && version !== 'other') {
+    return `v${version}`
+  }
+
+  return version
+}


### PR DESCRIPTION
### Description

This increases the default API version in Vision to `v2021-10-21`, and makes it configurable via config file `config/@sanity/vision.json`.

### What to review

- ~That the config convention is the one we prefer (`config:` vs `part:` import)~
- That the readme update on how to configure Vision reads okay

### Notes for release

- Set default API version in Vision to `v2021-10-21`
- Made default API version in Vision configurable