### PR TITLE
Fix missing render defaults for list block elements

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Element.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Element.tsx
@@ -132,9 +132,9 @@ export const Element: FunctionComponent<ElementProps> = ({
       if (Number.isInteger(element.level)) {
         renderAttribs.level = element.level
       } else {
-        element.level = 1
+        renderAttribs.level = 1
       }
-      className += ` pt-list-item pt-list-item-${element.listItem} pt-list-item-level-${element.level}`
+      className += ` pt-list-item pt-list-item-${renderAttribs.listItem} pt-list-item-level-${renderAttribs.level}`
     }
     const textBlock = (
       <TextBlock block={element} portableTextFeatures={portableTextFeatures}>


### PR DESCRIPTION
### Description

If a block is a `listItem` but doens't have a `level` set, then default the render attributes to level 1. The element itself should not be changed.

Though listItem blocks should not miss the level property, it can still happen as we have no control over the underlaying raw data.

One could discuss if this should cause a validation error with the editor and a way to resolve it (like with missing keys etc), but it makes sense to have default render attributes like this anyway.

The origin of this particular bug report seems to be an error within the Word-HTML-serializer in `@sanity/block-tools`, which fails to set level in some circumstances when pasting Word list items from Windows Word. It should be followed up in a separate patch.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### Notes for release

Fixed a bug where list items in Portable Text without a level property set would cause an error.

<!--
A description of the change(s) that should be used in the release notes.
-->
