### PR TITLE
fix(form-builder): hide array actions if read-only

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/item/RowItem.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/item/RowItem.tsx
@@ -140,23 +140,21 @@ export const RowItem = React.forwardRef(function RegularItem(
               />
             </Box>
           )}
-          <MenuButton
-            button={<Button padding={2} mode="bleed" icon={EllipsisVerticalIcon} />}
-            id={`${id}-menuButton`}
-            menu={
-              <Menu>
-                {!readOnly && (
-                  <>
-                    <MenuItem text="Remove" tone="critical" icon={TrashIcon} onClick={onRemove} />
-                    <MenuItem text="Duplicate" icon={DuplicateIcon} onClick={handleDuplicate} />
-                    <InsertMenu types={insertableTypes} onInsert={handleInsert} />
-                  </>
-                )}
-              </Menu>
-            }
-            placement="right"
-            popover={MENU_POPOVER_PROPS}
-          />
+          {!readOnly && (
+            <MenuButton
+              button={<Button padding={2} mode="bleed" icon={EllipsisVerticalIcon} />}
+              id={`${id}-menuButton`}
+              menu={
+                <Menu>
+                  <MenuItem text="Remove" tone="critical" icon={TrashIcon} onClick={onRemove} />
+                  <MenuItem text="Duplicate" icon={DuplicateIcon} onClick={handleDuplicate} />
+                  <InsertMenu types={insertableTypes} onInsert={handleInsert} />
+                </Menu>
+              }
+              placement="right"
+              popover={MENU_POPOVER_PROPS}
+            />
+          )}
           {!value._key && (
             <Box marginLeft={1}>
               <Tooltip


### PR DESCRIPTION
### Description

This hides the array actions for row items if array is read-only.

![Clipboard 2022-03-02 at 2 32 35 PM](https://user-images.githubusercontent.com/10508/152353308-a25c8e98-ecaf-429b-a6f3-360667f93cd3.png)

### What to review

- That we are happy with UI

### Notes for release

- Fixed a bug where read-only arrays showed a empty actions menu
