### PR TITLE
fix(form-builder): improve empty read-only array state

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/arrays/common/ArrayFunctions.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/common/ArrayFunctions.tsx
@@ -1,7 +1,7 @@
 import {ArraySchemaType, isReferenceSchemaType} from '@sanity/types'
 import {AddIcon} from '@sanity/icons'
 import React, {ReactNode, useMemo} from 'react'
-import {Button, Grid, Menu, MenuButton, MenuItem} from '@sanity/ui'
+import {Box, Button, Grid, Menu, MenuButton, MenuItem, Tooltip, Text} from '@sanity/ui'
 import {useId} from '@reach/auto-id'
 import {useConditionalReadOnly} from '@sanity/base/_internal'
 import PatchEvent from '../../../PatchEvent'
@@ -43,7 +43,27 @@ export default function ArrayFunctions<MemberType>(
   const popoverProps = useMemo(() => ({constrainSize: true, portal: true}), [])
 
   if (conditionalReadOnly) {
-    return null
+    return (
+      <Tooltip
+        portal
+        content={
+          <Box padding={2} sizing="border">
+            <Text size={1} muted>
+              This field is read-only
+            </Text>
+          </Box>
+        }
+      >
+        <Grid>
+          <Button
+            icon={AddIcon}
+            mode="ghost"
+            disabled
+            text={type.of.length === 1 ? 'Add item' : 'Add item...'}
+          />
+        </Grid>
+      </Tooltip>
+    )
   }
 
   return (


### PR DESCRIPTION
### Description

This improves the state of read-only, empty arrays by showing a disabled Add button w/ an explanatory tooltip that tells the user that this field is read-only.

Before you would just see the title/description of a field with no array UI.

|Before|After|
|-|-|
|![](https://user-images.githubusercontent.com/10508/152373321-447b260b-ce98-4d8d-ac6e-24ceae38f005.png)|![image](https://user-images.githubusercontent.com/10508/152373586-a2027002-a397-4f4c-b4cd-c9cd76efe7d3.png)|

### What to review

- UI

### Notes for release

- Improved empty read-only array state