### PR TITLE
Allow `null` Tools for conditional rendering

### DIFF
--- a/dev/test-studio/parts/tools/test-conditional-tool.tsx
+++ b/dev/test-studio/parts/tools/test-conditional-tool.tsx
@@ -1,17 +1,24 @@
 import React from 'react'
-import {Container, Box, Text} from '@sanity/ui'
+import {Container, Stack, Text} from '@sanity/ui'
+import {CheckmarkIcon} from '@sanity/icons'
 
-const isTestDataset = window?.location?.pathname?.startsWith(`/test/`)
+const pathName = (typeof window !== 'undefined' && window.location.pathname) || '/'
+const isTestDataset = pathName.startsWith('/test') || pathName === '/'
 
 function ConditionalTool() {
   return (
     <Container>
-      <Box padding={5}>
+      <Stack padding={5} space={4}>
         <Text>
           This Tool should only be visible in the Navbar, registered to the Router and rendering
           this Component if the current URL pathname starts with <code>/test/</code>.
         </Text>
-      </Box>
+        <Text>
+          <strong>Note:</strong> This is a "hack", not a "core feature" - in the future we will
+          provide better primitives for conditionally determining tools based on user roles and
+          similar.
+        </Text>
+      </Stack>
     </Container>
   )
 }
@@ -21,5 +28,6 @@ export default isTestDataset
       title: 'Conditional Tool',
       name: 'test-conditional-tool',
       component: ConditionalTool,
+      icon: CheckmarkIcon,
     }
   : null

--- a/dev/test-studio/parts/tools/test-conditional-tool.tsx
+++ b/dev/test-studio/parts/tools/test-conditional-tool.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import {Container, Box, Text} from '@sanity/ui'
+
+const isTestDataset = window?.location?.pathname?.startsWith(`/test/`)
+
+function ConditionalTool() {
+  return (
+    <Container>
+      <Box padding={5}>
+        <Text>
+          This Tool should only be visible in the Navbar, registered to the Router and rendering
+          this Component if the current URL pathname starts with <code>/test/</code>.
+        </Text>
+      </Box>
+    </Container>
+  )
+}
+
+export default isTestDataset
+  ? {
+      title: 'Conditional Tool',
+      name: 'test-conditional-tool',
+      component: ConditionalTool,
+    }
+  : null

--- a/dev/test-studio/sanity.json
+++ b/dev/test-studio/sanity.json
@@ -110,6 +110,10 @@
     {
       "implements": "part:@sanity/base/tool",
       "path": "parts/tools/ui-test-bed-tool/tool"
+    },
+    {
+      "implements": "part:@sanity/base/tool",
+      "path": "parts/tools/test-conditional-tool"
     }
   ],
   "env": {

--- a/packages/@sanity/default-layout/src/main/RenderTool.tsx
+++ b/packages/@sanity/default-layout/src/main/RenderTool.tsx
@@ -19,7 +19,7 @@ interface Props {
 export const RenderTool = memo(function RenderTool(props: Props) {
   const {tool: activeToolName} = props
   const activeToolNameRef = useRef(activeToolName)
-  const activeTool = tools.find((tool) => tool.name === activeToolName)
+  const activeTool = tools.find((tool) => tool?.name === activeToolName)
   const [state, setState] = useState({error: null, showErrorDetails: __DEV__})
 
   useEffect(() => {

--- a/packages/@sanity/default-layout/src/main/RenderTool.tsx
+++ b/packages/@sanity/default-layout/src/main/RenderTool.tsx
@@ -3,7 +3,7 @@
 
 import React, {createElement, memo, useCallback, useEffect, useRef, useState} from 'react'
 import {Box, Card, Container, ErrorBoundary, Heading, Stack, Text} from '@sanity/ui'
-import tools from 'all:part:@sanity/base/tool'
+import {getRegisteredTools} from '../util/getRegisteredTools'
 import {RenderToolErrorScreen} from './ErrorScreen'
 
 declare const __DEV__: boolean
@@ -17,9 +17,10 @@ interface Props {
 }
 
 export const RenderTool = memo(function RenderTool(props: Props) {
+  const tools = getRegisteredTools()
   const {tool: activeToolName} = props
   const activeToolNameRef = useRef(activeToolName)
-  const activeTool = tools.find((tool) => tool?.name === activeToolName)
+  const activeTool = tools.find((tool) => tool.name === activeToolName)
   const [state, setState] = useState({error: null, showErrorDetails: __DEV__})
 
   useEffect(() => {

--- a/packages/@sanity/default-layout/src/router.tsx
+++ b/packages/@sanity/default-layout/src/router.tsx
@@ -9,7 +9,7 @@ import {CONFIGURED_SPACES, HAS_SPACES} from './util/spaces'
 const basePath = ((config.project && config.project.basePath) || '').replace(/\/+$/, '')
 
 const toolRoute = route('/:tool', (toolParams: any) => {
-  const foundTool = tools.find((current) => current.name === toolParams.tool)
+  const foundTool = tools.find((current) => current && current.name === toolParams.tool)
   return foundTool ? (route as any).scope(foundTool.name, '/', foundTool.router) : route('/')
 })
 

--- a/packages/@sanity/default-layout/src/router.tsx
+++ b/packages/@sanity/default-layout/src/router.tsx
@@ -1,15 +1,16 @@
 // @todo: remove the following line when part imports has been removed from this file
 ///<reference types="@sanity/types/parts" />
 
-import tools from 'all:part:@sanity/base/tool'
 import config from 'config:sanity'
 import {route} from '@sanity/base/router'
 import {CONFIGURED_SPACES, HAS_SPACES} from './util/spaces'
+import {getRegisteredTools} from './util/getRegisteredTools'
 
+const tools = getRegisteredTools()
 const basePath = ((config.project && config.project.basePath) || '').replace(/\/+$/, '')
 
 const toolRoute = route('/:tool', (toolParams: any) => {
-  const foundTool = tools.find((current) => current && current.name === toolParams.tool)
+  const foundTool = tools.find((current) => current.name === toolParams.tool)
   return foundTool ? (route as any).scope(foundTool.name, '/', foundTool.router) : route('/')
 })
 

--- a/packages/@sanity/default-layout/src/types.ts
+++ b/packages/@sanity/default-layout/src/types.ts
@@ -9,7 +9,7 @@ export interface Tool {
     params: Record<string, any>,
     state: Record<string, any>
   ) => void
-  component?: React.ComponentType
+  component?: React.ComponentType<{tool: string}>
   icon?: React.ComponentType
   getIntentState?: (
     intent: Record<string, any>,

--- a/packages/@sanity/default-layout/src/util/getOrderedTools.tsx
+++ b/packages/@sanity/default-layout/src/util/getOrderedTools.tsx
@@ -9,12 +9,13 @@ export default function getOrderedTools(): Tool[] {
   const config = pluginConfig.toolSwitcher || {}
   const order = config.order || []
   const hidden = config.hidden || []
+  const toolsFiltered = tools.filter(Boolean)
 
   if (!order.length && !hidden.length) {
-    return tools
+    return toolsFiltered
   }
 
-  const keyed = tools.reduce((target, tool) => {
+  const keyed = toolsFiltered.reduce((target, tool) => {
     const title = tool.title || '<unknown>'
 
     if (!tool.name) {
@@ -38,7 +39,7 @@ export default function getOrderedTools(): Tool[] {
 
   const isVisible = (tool: Tool) => hidden.indexOf(tool.name) === -1
 
-  return tools.filter(isVisible).sort((tool1, tool2) => {
+  return toolsFiltered.filter(isVisible).sort((tool1, tool2) => {
     const toolA = keyed[tool1.name]
     const toolB = keyed[tool2.name]
 

--- a/packages/@sanity/default-layout/src/util/getOrderedTools.tsx
+++ b/packages/@sanity/default-layout/src/util/getOrderedTools.tsx
@@ -2,20 +2,20 @@
 ///<reference types="@sanity/types/parts" />
 
 import pluginConfig from 'config:@sanity/default-layout'
-import tools from 'all:part:@sanity/base/tool'
 import {Tool} from '../types'
+import {getRegisteredTools} from './getRegisteredTools'
 
 export default function getOrderedTools(): Tool[] {
   const config = pluginConfig.toolSwitcher || {}
   const order = config.order || []
   const hidden = config.hidden || []
-  const toolsFiltered = tools.filter(Boolean)
+  const tools = getRegisteredTools()
 
   if (!order.length && !hidden.length) {
-    return toolsFiltered
+    return tools
   }
 
-  const keyed = toolsFiltered.reduce((target, tool) => {
+  const keyed = tools.reduce((target, tool) => {
     const title = tool.title || '<unknown>'
 
     if (!tool.name) {
@@ -39,7 +39,7 @@ export default function getOrderedTools(): Tool[] {
 
   const isVisible = (tool: Tool) => hidden.indexOf(tool.name) === -1
 
-  return toolsFiltered.filter(isVisible).sort((tool1, tool2) => {
+  return tools.filter(isVisible).sort((tool1, tool2) => {
     const toolA = keyed[tool1.name]
     const toolB = keyed[tool2.name]
 

--- a/packages/@sanity/default-layout/src/util/getRegisteredTools.tsx
+++ b/packages/@sanity/default-layout/src/util/getRegisteredTools.tsx
@@ -1,0 +1,8 @@
+import allTools from 'all:part:@sanity/base/tool'
+import {Tool} from '../types'
+
+export function getRegisteredTools(): Tool[] {
+  const tools = allTools.filter(Boolean)
+
+  return tools
+}


### PR DESCRIPTION
This ended up being _more_ than a one liner so I understand if it gets rejected / requires more discussion for a better approach!

### Description

Allows for Tools to be 
1. Conditionally rendered and 
2. Conditionally registered to the Router. 
3. 
4. This way a Tool may only appear in the Navbar and loaded if it satisfies a particular condition like current Dataset or a User's Role. 

For example:

```js
export default isTestDataset
  ? {
      title: 'Conditional Tool',
      name: 'test-conditional-tool',
      component: ConditionalTool,
    }
  : null
```

Changes have been made to no longer assume all registered Tools are objects and will filter out any _falsy_ Tools.

### What to review

In the test studio, `private` dataset:

* http://localhost:3333/playground/conditional-tool
* Should not render component
* "Conditional Tool" should not be in navbar

In the test studio, `test` dataset:

* http://localhost:3333/test/test-conditional-tool
* Should load component
* "Conditional Tool" should be in navbar

### Notes for release

Desk Tools can be conditionally rendered