### PR TITLE
fix(form-builder): ensure asset sources is array before usage

### DIFF
--- a/dev/test-studio/parts/assetSources/noop.tsx
+++ b/dev/test-studio/parts/assetSources/noop.tsx
@@ -1,18 +1,20 @@
 import React from 'react'
 
+interface Props {
+  onClose: () => void
+}
+
 export default {
   name: 'noop-asset-source',
   title: 'Noop asset source',
-  component: NoopAssetSource,
-}
-
-function NoopAssetSource(props) {
-  return (
-    <div>
-      This is a noop asset source that doesn't do anything meaningful{' '}
-      <button type="button" onClick={props.onClose}>
-        Ok
-      </button>
-    </div>
-  )
+  component: React.forwardRef<HTMLDivElement, Props>(function NoopAssetSource(props, ref) {
+    return (
+      <div ref={ref}>
+        This is a noop asset source that doesn't do anything meaningful{' '}
+        <button type="button" onClick={props.onClose}>
+          Ok
+        </button>
+      </div>
+    )
+  }),
 }

--- a/packages/@sanity/form-builder/src/sanity/DefaultAssetSource/DefaultSource.tsx
+++ b/packages/@sanity/form-builder/src/sanity/DefaultAssetSource/DefaultSource.tsx
@@ -46,7 +46,7 @@ const CardLoadMore = styled(Card)`
   z-index: 200;
 `
 
-export const DefaultSource = React.memo(function DefaultSource(props: Props) {
+const DefaultAssetSource = function DefaultAssetSource(props: Props, ref) {
   const _elementId = useRef(`default-asset-source-${uniqueId()}`)
   const currentPageNumber = useRef(0)
   const fetch$ = useRef<Subscription>()
@@ -200,6 +200,7 @@ export const DefaultSource = React.memo(function DefaultSource(props: Props) {
 
   return (
     <Dialog
+      ref={ref}
       id={_elementId.current}
       header={dialogHeaderTitle}
       width={2}
@@ -224,4 +225,6 @@ export const DefaultSource = React.memo(function DefaultSource(props: Props) {
       )}
     </Dialog>
   )
-})
+}
+
+export const DefaultSource = React.memo(React.forwardRef(DefaultAssetSource))

--- a/packages/@sanity/form-builder/src/sanity/inputs/SanityFileInput.tsx
+++ b/packages/@sanity/form-builder/src/sanity/inputs/SanityFileInput.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import type {AssetSource} from '@sanity/types'
 import FileInput from '../../inputs/files/FileInput'
 import resolveUploader from '../uploads/resolveUploader'
 import {
@@ -10,8 +11,8 @@ import withValuePath from '../../utils/withValuePath'
 import {observeFileAsset} from './client-adapters/assets'
 import {wrapWithDocument} from './wrapWithDocument'
 
-const globalAssetSources = userDefinedFileAssetSources
-  ? userDefinedFileAssetSources
+const globalAssetSources: AssetSource[] = userDefinedFileAssetSources
+  ? ensureArrayOfSources(userDefinedFileAssetSources)
   : defaultFileAssetSources
 
 const SUPPORT_DIRECT_UPLOADS = formBuilderConfig?.files?.directUploads !== false
@@ -41,3 +42,14 @@ export default React.forwardRef(function SanityFileInput(props: Props, forwarded
     />
   )
 })
+
+function ensureArrayOfSources(sources: unknown): AssetSource[] {
+  if (Array.isArray(sources)) {
+    return sources
+  }
+
+  console.warn(
+    'Configured file asset sources is not an array - if `part:@sanity/form-builder/input/file/asset-sources` is defined, make sure it returns an array!'
+  )
+  return defaultFileAssetSources
+}

--- a/packages/@sanity/form-builder/src/sanity/inputs/SanityImageInput.tsx
+++ b/packages/@sanity/form-builder/src/sanity/inputs/SanityImageInput.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {AssetSource} from '@sanity/types'
+import type {AssetSource} from '@sanity/types'
 import imageUrlBuilder from '@sanity/image-url'
 import ImageInput from '../../inputs/files/ImageInput'
 import resolveUploader from '../uploads/resolveUploader'
@@ -13,8 +13,8 @@ import withValuePath from '../../utils/withValuePath'
 import {observeImageAsset} from './client-adapters/assets'
 import {wrapWithDocument} from './wrapWithDocument'
 
-const globalAssetSources = userDefinedImageAssetSources
-  ? userDefinedImageAssetSources
+const globalAssetSources: AssetSource[] = userDefinedImageAssetSources
+  ? ensureArrayOfSources(userDefinedImageAssetSources)
   : defaultImageAssetSources
 
 const SUPPORT_DIRECT_UPLOADS = formBuilderConfig?.images?.directUploads !== false
@@ -29,7 +29,7 @@ export default React.forwardRef(function SanityImageInput(props: Props, forwarde
   // note: type.options.sources may be an empty array and in that case we're
   // disabling selecting images from asset source  (it's a feature, not a bug)
   const assetSources = React.useMemo(
-    (): AssetSource[] => (sourcesFromSchema || globalAssetSources).map(wrapWithDocument),
+    () => (sourcesFromSchema || globalAssetSources).map(wrapWithDocument),
     [sourcesFromSchema]
   )
 
@@ -47,3 +47,14 @@ export default React.forwardRef(function SanityImageInput(props: Props, forwarde
     />
   )
 })
+
+function ensureArrayOfSources(sources: unknown): AssetSource[] {
+  if (Array.isArray(sources)) {
+    return sources
+  }
+
+  console.warn(
+    'Configured image asset sources is not an array - if `part:@sanity/form-builder/input/image/asset-sources` is defined, make sure it returns an array!'
+  )
+  return defaultImageAssetSources
+}


### PR DESCRIPTION
### Description

The part names and export shapes are easy to get wrong, eg the distinction between `part:@sanity/form-builder/input/file/asset-source` and `part:@sanity/form-builder/input/file/asset-sources` is very subtle. If you happen to implement `part:@sanity/form-builder/input/file/asset-sources` and it exports a single asset source, the studio crashes in spectacular ways.

This PR checks that the part exports an array, and if not warns and uses the default asset sources instead. 

I also took the liberty of fixing a ref warning/error that was being thrown when opening the default asset source while I was at it, sorry for the slightly unrelated commit.

### Notes for release

- Added validation and warnings on incorrectly implemented asset sources part
