### PR TITLE
fix(base): reintroduce missing font part loading

### DIFF
--- a/packages/@sanity/base/src/components/SanityRoot.tsx
+++ b/packages/@sanity/base/src/components/SanityRoot.tsx
@@ -32,6 +32,14 @@ import MissingProjectConfig from './MissingProjectConfig'
 import VersionChecker from './VersionChecker'
 import {useZIndex, ZIndexProvider} from './zOffsets'
 
+/**
+ * When importing fonts in the variables font, you end up with many duplicates.
+ * To work around this, we instead have a separate part for only the font imports.
+ * This is what is imported here, to kick things off.
+ **/
+// eslint-disable-next-line import/no-unassigned-import
+import 'part:@sanity/base/theme/variables/fonts-style'
+
 Refractor.registerLanguage(bash)
 Refractor.registerLanguage(javascript)
 Refractor.registerLanguage(json)


### PR DESCRIPTION
### Description

When fonts are imported in a CSS file which is itself imported multiple places (such as the variables part), the built CSS includes a large number of duplicate font imports. To work around this, we introduced a separate font part for this specific purpose, but it seems to have been left by the wayside at some point.

This commit reintroduces the import, but users will need to use the correct part name in order to see this fixed.

### What to review

- That the studio still builds
- That there aren't any drawbacks with this approach

### Notes for release

- Provided workaround for custom fonts being loaded many times in built studios, by (re)introducing separate font loading CSS part