### PR TITLE
fix(portable-text-editor): fix spellcheck defaults issue

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/PortableText/Compositor.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Compositor.tsx
@@ -33,7 +33,6 @@ import {RenderBlockActions, RenderCustomMarkers} from './types'
 import {Editor} from './Editor'
 import {ExpandedLayer, Root} from './Compositor.styles'
 import {useObjectEditData} from './hooks/useObjectEditData'
-import {useSpellcheck} from './hooks/useSpellCheck'
 import {useScrollSelectionIntoView} from './hooks/useScrollSelectionIntoView'
 import {useObjectEditFormBuilderFocus} from './hooks/useObjectEditFormBuilderFocus'
 import {useObjectEditFormBuilderChange} from './hooks/useObjectEditFormBuilderChange'
@@ -83,7 +82,6 @@ export function Compositor(props: InputProps) {
   } = props
 
   const editor = usePortableTextEditor()
-  const spellcheck = useSpellcheck()
 
   const [isActive, setIsActive] = useState(false)
   const [wrapperElement, setWrapperElement] = useState<HTMLDivElement | null>(null)
@@ -198,7 +196,6 @@ export function Compositor(props: InputProps) {
             markers={blockMarkers}
             onChange={onChange}
             readOnly={readOnly}
-            spellCheck={spellcheck}
             renderBlockActions={hasContent && renderBlockActions}
             renderCustomMarkers={hasContent && renderCustomMarkers}
           >
@@ -237,7 +234,6 @@ export function Compositor(props: InputProps) {
       readOnly,
       renderBlockActions,
       renderCustomMarkers,
-      spellcheck,
     ]
   )
 

--- a/packages/@sanity/form-builder/src/inputs/PortableText/Editor.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Editor.tsx
@@ -23,6 +23,7 @@ import {
   Scroller,
   ToolbarCard,
 } from './Editor.styles'
+import {useSpellcheck} from './hooks/useSpellCheck'
 
 interface EditorProps {
   initialSelection?: EditorSelection
@@ -96,6 +97,7 @@ export function Editor(props: EditorProps) {
   }, [])
 
   const renderPlaceholder = useCallback(() => <>Empty</>, [])
+  const spellcheck = useSpellcheck()
 
   const editable = useMemo(
     () => (
@@ -111,7 +113,7 @@ export function Editor(props: EditorProps) {
         renderPlaceholder={renderPlaceholder}
         scrollSelectionIntoView={scrollSelectionIntoView}
         selection={initialSelection}
-        spellCheck={false} // This is taken care of via renderBlock prop
+        spellCheck={spellcheck}
       />
     ),
     [
@@ -124,6 +126,7 @@ export function Editor(props: EditorProps) {
       renderChild,
       renderPlaceholder,
       scrollSelectionIntoView,
+      spellcheck,
     ]
   )
 


### PR DESCRIPTION
In order to mitigate the Chrome v.96 spellcheck perf issue, spellcheck control was moved from the outer container of the PTE to just be active on the actual text blocks.

Since this is not longer a issue, go back to outer container spellcheck control.

This will also fix a bug that was introduced not respecting the browser default settings when spellcheck is undefined
on the schema type setting it to not enabled in that case.

### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fixed an issue where spellchecking in the Portable Text Editor would be disabled when not defined.

<!--
A description of the change(s) that should be used in the release notes.
-->
