### PR TITLE
Update createWithSchemaTypes.ts

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithSchemaTypes.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithSchemaTypes.ts
@@ -14,7 +14,8 @@ export function createWithSchemaTypes(portableTextFeatures: PortableTextFeatures
       return (
         !editor.isVoid(value) &&
         'markDefs' in value &&
-        'style' in value &&
+        // style is not required in TextBlock 
+        /*'style' in value && */  
         'children' in value &&
         '_type' in value &&
         portableTextFeatures.types.block.name === value._type


### PR DESCRIPTION

### Description
editor.isTextBlock() fails when blocks including ListItemBlock which does not require 'style'
But in this plugin, it's forcing to have style causing errors on multiple location 
ex) When deleting text in ListItemBlock, removeTextPatch throws error due to this bug. 

### What to review

Create document with portable text field. 
Add ListItemBlock with external links in it. 
And try to delete text with back space. Then you'll see error child not found w/o this patch. 

### Notes for release

"style" property is not required in TextBlock.
