### PR TITLE
fix(base): fix collapse text option in `CollapseMenu`

### DIFF
--- a/packages/@sanity/base/src/components/__workshop__/CollapseMenuStory.tsx
+++ b/packages/@sanity/base/src/components/__workshop__/CollapseMenuStory.tsx
@@ -9,7 +9,7 @@ const GAP_OPTIONS = {'0': 0, '1': 1, '2': 2, '3': 3, '4': 4}
 export default function CollapseMenuStory() {
   const collapsed = useBoolean('Collapsed', false)
   const gap = useSelect('Gap', GAP_OPTIONS, 1)
-  const collapseText = useBoolean('Collapse text', false)
+  const collapseText = useBoolean('Collapse text', true)
 
   return (
     <Flex align="center" height="fill" justify="center" padding={2}>

--- a/packages/@sanity/base/src/components/collapseMenu/CollapseMenu.tsx
+++ b/packages/@sanity/base/src/components/collapseMenu/CollapseMenu.tsx
@@ -71,7 +71,7 @@ export const CollapseMenu = forwardRef(function CollapseMenu(
   const {
     children: childrenProp,
     collapsed,
-    collapseText,
+    collapseText = true,
     disableRestoreFocusOnClose,
     gap,
     menuButtonProps,
@@ -144,7 +144,7 @@ export const CollapseMenu = forwardRef(function CollapseMenu(
       children.map((child) => {
         const {collapsedProps, expandedProps} = child.props
         const modeProps = hasOverflow ? collapsedProps : expandedProps
-        const text = hasOverflow && !collapseText ? undefined : child.props.text
+        const text = hasOverflow && collapseText ? undefined : child.props.text
 
         return cloneElement(child, {
           ...modeProps,


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

The refactored `CollapseMenu` had a minor issue with the `collapseText` option. The `collapseText` option controls whether the text is to be hidden or displayed when the menu is "collapsed". In the PTE toolbar we do not want to collapse the text for the `InsertMenu` – which did not work after the refactor work. This PR adds a fix to this!

<img width="1555" alt="Screenshot 2022-02-18 at 16 18 18" src="https://user-images.githubusercontent.com/15094168/154710395-2cb8ee23-90d8-4c39-a8aa-2bd9d47c017b.png">


### What to review

The `InsertMenu` in PTE toolbar should always show the text on buttons.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Fix `collapseText` option in `CollapseMenu`

<!--
A description of the change(s) that should be used in the release notes.
-->
