### PR TITLE
fix(form-builder): rewrite missing ids query

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/types.ts
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/types.ts
@@ -58,8 +58,8 @@ export type SearchFunction = (query: string) => Observable<SearchHit[]>
 export interface SearchHit {
   id: string
   type: string
-  draft: undefined | {_id: string; _type: string}
-  published: undefined | {_id: string; _type: string}
+  draft?: {_id: string; _type: string}
+  published?: {_id: string; _type: string}
 }
 
 export interface BaseInputProps {


### PR DESCRIPTION
### Description
This rewrites the query we use to fetch "counterpart" ids, which makes the query run a lot faster.

### What to review
Make sure that we get correct draft/published status icons when searching for keywords that only yields hits in either the draft or the published document, but not both.

Note: during development I observed the original query to be faster, but that does not seem to be the case anymore (or maybe my conclusion was wrong). Local testing revealed that for some queries it went all the way from ~850ms to ~30ms.

### Notes for release

- Made searching for references significantly faster.
