### PR TITLE
Make sure editor content has normalized style prop

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -133,7 +133,7 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
     () =>
       toSlateValue(
         getValueOrInitialValue(value, [placeHolderBlock]),
-        blockType.name,
+        portableTextEditor,
         KEY_TO_SLATE_ELEMENT.get(slateEditor)
       ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -246,13 +246,13 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
       const defaultValue = [placeHolderBlock]
       const slateValueFromProps = toSlateValue(
         getValueOrInitialValue(value, defaultValue),
-        blockType.name,
+        portableTextEditor,
         KEY_TO_SLATE_ELEMENT.get(slateEditor)
       )
       const val: PortableTextBlock[] = value || defaultValue
       val.forEach((blk, index) => {
         if (slateEditor.isTextBlock(blk)) {
-          if (!isEqual(toSlateValue([blk], blockType.name)[0], slateEditor.children[index])) {
+          if (!isEqual(toSlateValue([blk], portableTextEditor)[0], slateEditor.children[index])) {
             equal = false
           }
         } else {
@@ -281,7 +281,16 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
       }
       change$.next({type: 'value', value})
     }
-  }, [change$, isSelecting, isThrottling, placeHolderBlock, blockType.name, slateEditor, value])
+  }, [
+    change$,
+    isSelecting,
+    isThrottling,
+    placeHolderBlock,
+    blockType.name,
+    slateEditor,
+    value,
+    portableTextEditor,
+  ])
 
   // Restore selection from props
   useEffect(() => {

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithEditableAPI.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithEditableAPI.ts
@@ -153,7 +153,7 @@ export function createWithEditableAPI(
               ],
             },
           ],
-          portableTextFeatures.types.block.name
+          portableTextEditor
         )[0] as unknown) as SlateElement
         const child = block.children[0]
         Editor.insertNode(editor, child as Node)
@@ -172,7 +172,7 @@ export function createWithEditableAPI(
               ...(value ? value : {}),
             },
           ],
-          portableTextFeatures.types.block.name
+          portableTextEditor
         )[0] as unknown) as Node
         Editor.insertNode(editor, block)
         editor.onChange()

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithHotKeys.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithHotKeys.ts
@@ -52,7 +52,7 @@ export function createWithHotkeys(
           ],
         },
       ],
-      portableTextFeatures.types.block.name
+      portableTextEditor
     )[0]
   return function withHotKeys(editor: PortableTextSlateEditor & ReactEditor) {
     editor.pteWithHotKeys = (event: React.KeyboardEvent<HTMLDivElement>): void => {

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithInsertData.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithInsertData.ts
@@ -130,7 +130,7 @@ export function createWithInsertData(
         if (Array.isArray(parsed) && parsed.length > 0) {
           const slateValue = regenerateKeys(
             editor,
-            toSlateValue(parsed, blockTypeName),
+            toSlateValue(parsed, {portableTextFeatures}),
             keyGenerator,
             spanTypeName
           )
@@ -177,7 +177,7 @@ export function createWithInsertData(
             html,
             portableTextFeatures.types.portableText
           ).map((block: PortableTextBlock) => normalizeBlock(block, {blockTypeName}))
-          fragment = toSlateValue(portableText, blockTypeName)
+          fragment = toSlateValue(portableText, {portableTextFeatures})
           insertedType = 'HTML'
         } else {
           // plain text
@@ -189,9 +189,9 @@ export function createWithInsertData(
             .join('')
           const textToHtml = `<html><body>${blocks}</body></html>`
           portableText = htmlToBlocks(textToHtml, portableTextFeatures.types.portableText)
-          fragment = toSlateValue(portableText, blockTypeName).map((block: PortableTextBlock) =>
-            normalizeBlock(block, {blockTypeName})
-          )
+          fragment = toSlateValue(portableText, {
+            portableTextFeatures,
+          }).map((block: PortableTextBlock) => normalizeBlock(block, {blockTypeName}))
           insertedType = 'text'
         }
 

--- a/packages/@sanity/portable-text-editor/src/utils/__tests__/valueNormalization.test.tsx
+++ b/packages/@sanity/portable-text-editor/src/utils/__tests__/valueNormalization.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment ./test/setup/jsdom.jest.env.ts
+ */
+// eslint-disable-next-line import/no-unassigned-import
+import '@testing-library/jest-dom/extend-expect'
+import {act} from 'react-dom/test-utils'
+import {render} from '@testing-library/react'
+
+import React from 'react'
+import {PortableTextEditor} from '../../editor/PortableTextEditor'
+import {PortableTextEditorTester, type} from '../../editor/__tests__/PortableTextEditorTester'
+
+describe('values: normalization', () => {
+  it("accepts incoming value with blocks without a style or markDefs prop, but doesn't leave them without them when editing them", () => {
+    const editorRef: React.RefObject<PortableTextEditor> = React.createRef()
+    const initialValue = [
+      {
+        _key: '5fc57af23597',
+        _type: 'myTestBlockType',
+        children: [
+          {
+            _key: 'be1c67c6971a',
+            _type: 'span',
+            marks: [],
+            text: 'Hello',
+          },
+        ],
+        markDefs: [],
+      },
+    ]
+    const onChange = jest.fn()
+    act(() => {
+      render(
+        <PortableTextEditorTester
+          onChange={onChange}
+          ref={editorRef}
+          type={type}
+          value={initialValue}
+        />
+      )
+    })
+    if (!editorRef.current) {
+      throw new Error('No editor')
+    }
+    act(() => {
+      if (editorRef.current) {
+        PortableTextEditor.focus(editorRef.current)
+        PortableTextEditor.select(editorRef.current, {
+          focus: {path: [{_key: '5fc57af23597'}, 'children', {_key: 'be1c67c6971a'}], offset: 0},
+          anchor: {path: [{_key: '5fc57af23597'}, 'children', {_key: 'be1c67c6971a'}], offset: 5},
+        })
+      }
+    })
+    act(() => {
+      if (editorRef.current) {
+        PortableTextEditor.toggleMark(editorRef.current, 'strong')
+      }
+    })
+    expect(PortableTextEditor.getValue(editorRef.current)).toEqual([
+      {
+        _key: '5fc57af23597',
+        _type: 'myTestBlockType',
+        children: [
+          {
+            _key: 'be1c67c6971a',
+            _type: 'span',
+            marks: ['strong'],
+            text: 'Hello',
+          },
+        ],
+        markDefs: [],
+        style: 'normal',
+      },
+    ])
+  })
+})

--- a/packages/@sanity/portable-text-editor/src/utils/__tests__/values.test.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/__tests__/values.test.ts
@@ -1,13 +1,17 @@
 import {fromSlateValue, toSlateValue} from '../values'
+import {type} from '../../editor/__tests__/PortableTextEditorTester'
+import {getPortableTextFeatures} from '../getPortableTextFeatures'
+
+const portableTextFeatures = getPortableTextFeatures(type)
 
 describe('toSlateValue', () => {
   it('checks undefined', () => {
-    const result = toSlateValue(undefined, 'image')
+    const result = toSlateValue(undefined, {portableTextFeatures})
     expect(result).toHaveLength(0)
   })
 
   it('runs given empty array', () => {
-    const result = toSlateValue([], 'image')
+    const result = toSlateValue([], {portableTextFeatures})
     expect(result).toHaveLength(0)
   })
 
@@ -19,7 +23,7 @@ describe('toSlateValue', () => {
           _key: '123',
         },
       ],
-      'block'
+      {portableTextFeatures}
     )
 
     expect(result).toMatchObject([
@@ -40,39 +44,43 @@ describe('toSlateValue', () => {
     const result = toSlateValue(
       [
         {
-          _type: 'block',
+          _type: portableTextFeatures.types.block.name,
           _key: '123',
           children: [
             {
               _type: 'span',
               _key: '1231',
-              value: '123',
+              text: '123',
             },
           ],
         },
       ],
-      'block'
+      {portableTextFeatures}
     )
-    expect(result).toEqual([
-      {
-        _key: '123',
-        _type: 'block',
-        children: [
-          {
-            _key: '1231',
-            _type: 'span',
-            value: '123',
-          },
-        ],
-      },
-    ])
+    expect(result).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "_key": "123",
+          "_type": "myTestBlockType",
+          "children": Array [
+            Object {
+              "_key": "1231",
+              "_type": "span",
+              "text": "123",
+            },
+          ],
+          "markDefs": Array [],
+          "style": "normal",
+        },
+      ]
+    `)
   })
 
   it('given type is block and has custom object in children', () => {
     const result = toSlateValue(
       [
         {
-          _type: 'block',
+          _type: portableTextFeatures.types.block.name,
           _key: '123',
           children: [
             {
@@ -90,39 +98,43 @@ describe('toSlateValue', () => {
           ],
         },
       ],
-      'block'
+      {portableTextFeatures}
     )
-    expect(result).toEqual([
-      {
-        _key: '123',
-        _type: 'block',
-        children: [
-          {
-            _key: '1231',
-            _type: 'span',
-            text: '123',
-          },
-          {
-            _key: '1232',
-            _type: 'image',
-            __inline: true,
-            children: [
-              {
-                _key: '123-void-child',
-                _type: 'span',
-                marks: [],
-                text: '',
-              },
-            ],
-            value: {
-              asset: {
-                _ref: 'ref-123',
+    expect(result).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "_key": "123",
+          "_type": "myTestBlockType",
+          "children": Array [
+            Object {
+              "_key": "1231",
+              "_type": "span",
+              "text": "123",
+            },
+            Object {
+              "__inline": true,
+              "_key": "1232",
+              "_type": "image",
+              "children": Array [
+                Object {
+                  "_key": "123-void-child",
+                  "_type": "span",
+                  "marks": Array [],
+                  "text": "",
+                },
+              ],
+              "value": Object {
+                "asset": Object {
+                  "_ref": "ref-123",
+                },
               },
             },
-          },
-        ],
-      },
-    ])
+          ],
+          "markDefs": Array [],
+          "style": "normal",
+        },
+      ]
+    `)
   })
 })
 
@@ -225,8 +237,8 @@ describe('fromSlateValue', () => {
         style: 'normal',
       },
     ]
-    const toSlate1 = toSlateValue(value, 'block', keyMap)
-    const toSlate2 = toSlateValue(value, 'block', keyMap)
+    const toSlate1 = toSlateValue(value, {portableTextFeatures}, keyMap)
+    const toSlate2 = toSlateValue(value, {portableTextFeatures}, keyMap)
     expect(toSlate1[0]).toBe(toSlate2[0])
     expect(toSlate1[1]).toBe(toSlate2[1])
     const fromSlate1 = fromSlateValue(toSlate1, 'block', keyMap)

--- a/packages/@sanity/portable-text-editor/src/utils/patchToOperations.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/patchToOperations.ts
@@ -8,13 +8,15 @@ import {KEY_TO_SLATE_ELEMENT} from './weakMaps'
 
 const debug = debugWithName('operationToPatches')
 
-export function createPatchToOperations(portableTextFeatures: PortableTextFeatures) {
+export function createPatchToOperations(
+  portableTextFeatures: PortableTextFeatures
+): (editor: Editor, patch: Patch) => boolean {
   function insertPatch(editor: Editor, patch: InsertPatch) {
     if (patch.path.length === 1) {
       const {items, position} = patch
       const blocksToInsert = (toSlateValue(
         items as PortableTextBlock[],
-        portableTextFeatures.types.block.name,
+        {portableTextFeatures},
         KEY_TO_SLATE_ELEMENT.get(editor)
       ) as unknown) as Node[]
       const posKey = findLastKey(patch.path)


### PR DESCRIPTION
### Description

When a PT value is loaded into the editor, the blocks should be normalized with a style
property. This prop is not required in the TS type or PT spec, but we should put the default
style on the in-memory value so that it's initialized and set when editing that block
with the editor (the editor should not leave it unset after the fact).

I have changed the internal util function (for converting values) to have better options in order to safely be able to set the default style (which is previously was unaware of).

Also added tests and changed an existing test to better test this.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### Notes for release
* Fixed a bug where Portable Text block values without a style property defined would throw an error when editing that block with the PT editor.

<!--
A description of the change(s) that should be used in the release notes.
-->
