### PR TITLE
fix(core): emit reconnect on non-channel error in dataset copy job listener

### DIFF
--- a/packages/@sanity/core/src/commands/dataset/copyDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/copyDatasetCommand.js
@@ -47,13 +47,13 @@ const progress = (url) => {
     function onMessage(event) {
       const data = JSON.parse(event.data)
       if (data.state === 'failed') {
-        debug(`Job failed. Data: ${event}`)
+        debug('Job failed. Data: %o', event)
         observer.error(event)
       } else if (data.state === 'completed') {
-        debug(`Job succeeded. Data: ${event}`)
+        debug('Job succeeded. Data: %o', event)
         onComplete()
       } else {
-        debug(`Job progressed. Data: ${event}`)
+        debug(`Job progressed. Data: %o`, event)
         observer.next(data)
       }
     }

--- a/packages/@sanity/core/src/commands/dataset/copyDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/copyDatasetCommand.js
@@ -75,23 +75,26 @@ const progress = (url) => {
 }
 
 const followProgress = (jobId, client, output) => {
-  const spinner = output.spinner({}).start()
+  let currentProgress = 0
 
+  const spinner = output.spinner({}).start()
   const listenUrl = client.getUrl(`jobs/${jobId}/listen`)
 
   debug(`Listening to ${listenUrl}`)
 
   progress(listenUrl).subscribe({
     next: (event) => {
-      const eventProgress = event.progress ? event.progress : 0
+      if (typeof event.progress === 'number') {
+        currentProgress = event.progress
+      }
 
-      spinner.text = `Copy in progress: ${eventProgress}%`
+      spinner.text = `Copy in progress: ${currentProgress}%`
     },
     error: (err) => {
       spinner.fail(`There was an error copying the dataset: ${err.message}`)
     },
     complete: () => {
-      spinner.succeed(`Copy finished.`)
+      spinner.succeed('Copy finished.')
     },
   })
 }
@@ -163,7 +166,7 @@ export default {
       )
 
       if (flags.detach) {
-        output.print(`Copy initiated.`)
+        output.print('Copy initiated.')
         output.print(
           `\nRun:\n\n    sanity dataset copy --attach ${response.jobId}\n\nto watch attach`
         )


### PR DESCRIPTION
### Description

1. Dataset copy job listener hits network related timeouts for long running jobs. Today, CLI prints `There was an error copying the dataset` even when copying is in progress. This PR adds a reconnection logic non-channel error.
2. It seems event type for channel error is `channel_error` and not `channelError`, which caused CLI to skip the actual error from console.