### PR TITLE
fix(desk-tool): add project IDs to delete dialog

### DIFF
--- a/packages/@sanity/desk-tool/src/components/confirmDeleteDialog/ConfirmDeleteDialog.tsx
+++ b/packages/@sanity/desk-tool/src/components/confirmDeleteDialog/ConfirmDeleteDialog.tsx
@@ -59,7 +59,8 @@ export function ConfirmDeleteDialog({
     internalReferences,
     crossDatasetReferences,
     isLoading,
-    totalCount: total,
+    totalCount,
+    projectIds,
   } = useReferringDocuments(id)
   const capitalizedAction = `${action.substring(0, 1).toUpperCase()}${action.substring(1)}`
 
@@ -78,7 +79,7 @@ export function ConfirmDeleteDialog({
           {showConfirmButton && (
             <Button
               data-testid="confirm-delete-button"
-              text={total > 0 ? `${capitalizedAction} anyway` : `${capitalizedAction} now`}
+              text={totalCount > 0 ? `${capitalizedAction} anyway` : `${capitalizedAction} now`}
               tone="critical"
               onClick={onConfirm}
             />
@@ -94,8 +95,9 @@ export function ConfirmDeleteDialog({
             internalReferences={internalReferences}
             documentTitle={documentTitle}
             isLoading={isLoading}
-            totalCount={total}
+            totalCount={totalCount}
             action={action}
+            projectIds={projectIds}
           />
         ) : (
           <LoadingContainer data-testid="loading-container">

--- a/packages/@sanity/desk-tool/src/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
+++ b/packages/@sanity/desk-tool/src/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
@@ -43,6 +43,7 @@ export function ConfirmDeleteDialogBody({
   documentTitle,
   totalCount,
   action,
+  projectIds,
 }: DeletionConfirmationDialogBodyProps) {
   const toast = useToast()
 
@@ -53,6 +54,13 @@ export function ConfirmDeleteDialogBody({
       </Text>
     )
   }
+
+  const documentCount =
+    crossDatasetReferences.totalCount === 1
+      ? '1 document'
+      : `${crossDatasetReferences.totalCount.toLocaleString()} documents`
+  const projectCount = projectIds.length === 1 ? 'another project' : `${projectIds.length} projects`
+  const projectIdList = `Project ID${projectIds.length === 1 ? '' : 's'}: ${projectIds.join(', ')}`
 
   return (
     <>
@@ -132,18 +140,18 @@ export function ConfirmDeleteDialogBody({
                       <DocumentsIcon />
                     </Text>
                   </Box>
-                  <Box marginRight={4}>
-                    <Text>
-                      {crossDatasetReferences.totalCount === 1 ? (
-                        <>1 document in another project</>
-                      ) : (
-                        <>
-                          {crossDatasetReferences.totalCount.toLocaleString()} documents in other
-                          projects
-                        </>
-                      )}
-                    </Text>
-                  </Box>
+                  <Flex marginRight={4} direction="column">
+                    <Box marginBottom={2}>
+                      <Text>
+                        {documentCount} in {projectCount}
+                      </Text>
+                    </Box>
+                    <Box>
+                      <Text title={projectIdList} textOverflow="ellipsis" size={1} muted>
+                        {projectIdList}
+                      </Text>
+                    </Box>
+                  </Flex>
                   <ChevronWrapper>
                     <Text muted>
                       <ChevronDownIcon />
@@ -174,8 +182,15 @@ export function ConfirmDeleteDialogBody({
                     </tr>
                   </thead>
                   <tbody>
-                    {crossDatasetReferences.references.map(
-                      ({projectId, datasetName, documentId}, index) => (
+                    {crossDatasetReferences.references
+                      .filter((reference): reference is Required<typeof reference> => {
+                        return (
+                          'projectId' in reference &&
+                          'datasetName' in reference &&
+                          'documentId' in reference
+                        )
+                      })
+                      .map(({projectId, datasetName, documentId}, index) => (
                         // eslint-disable-next-line react/no-array-index-key
                         <tr key={`${documentId}-${index}`}>
                           <td>
@@ -210,8 +225,7 @@ export function ConfirmDeleteDialogBody({
                             </Flex>
                           </td>
                         </tr>
-                      )
-                    )}
+                      ))}
                   </tbody>
                 </Table>
                 <Box padding={2}>

--- a/packages/@sanity/desk-tool/src/components/confirmDeleteDialog/__tests__/index.test.tsx
+++ b/packages/@sanity/desk-tool/src/components/confirmDeleteDialog/__tests__/index.test.tsx
@@ -138,7 +138,7 @@ describe('ConfirmDeleteDialog', () => {
       })
     })
 
-    // when the loading is finished then the
+    // when the loading is finished then the confirm-delete-button is rendered
     await findByTestId('confirm-delete-button')
 
     const internalReferences = queryByTestId('internal-references')
@@ -147,6 +147,7 @@ describe('ConfirmDeleteDialog', () => {
 
     const crossDatasetReferences = queryByTestId('cross-dataset-references')
     expect(crossDatasetReferences).toContainElement(queryByText('1 document in another project'))
+    expect(crossDatasetReferences).toContainElement(queryByText('Project ID: test-project'))
   })
 
   it('shows a fallback dialog if an error occurs', async () => {

--- a/packages/@sanity/desk-tool/src/components/confirmDeleteDialog/useReferringDocuments.ts
+++ b/packages/@sanity/desk-tool/src/components/confirmDeleteDialog/useReferringDocuments.ts
@@ -1,3 +1,4 @@
+import {useMemo} from 'react'
 import documentStore from 'part:@sanity/base/datastore/document'
 import client from 'part:@sanity/base/client'
 import {ClientError} from '@sanity/client'
@@ -16,7 +17,9 @@ import {
   catchError,
 } from 'rxjs/operators'
 
-// this is used in place of `instanceof` so the matching can be more robust
+// this is used in place of `instanceof` so the matching can be more robust and
+// won't have any issues with dual packages etc
+// https://nodejs.org/api/packages.html#dual-package-hazard
 function isClientError(e: unknown): e is ClientError {
   if (typeof e !== 'object') return false
   if (!e) return false
@@ -47,13 +50,34 @@ const visiblePoll$ = fromEvent(document, 'visibilitychange').pipe(
 export type ReferringDocuments = {
   isLoading: boolean
   totalCount: number
+  projectIds: string[]
   internalReferences?: {
     totalCount: number
     references: Array<{_id: string; _type: string}>
   }
   crossDatasetReferences?: {
     totalCount: number
-    references: Array<{documentId: string; projectId: string; datasetName: string}>
+    references: Array<{
+      /**
+       * The project ID of the document that is currently referencing the subject
+       * document. Unlike `documentId` and `datasetName`, this should always be
+       * defined.
+       */
+      projectId: string
+      /**
+       * The ID of the document that is currently referencing the subject
+       * document. This will be omitted if there is no access to the current
+       * project and dataset pair (e.g. if no `sanity-project-token` were
+       * configured)
+       */
+      documentId?: string
+      /**
+       * The dataset name that is currently referencing the subject document.
+       * This will be omitted if there is no access to the current project and
+       * dataset pair (e.g. if no `sanity-project-token` were configured)
+       */
+      datasetName?: string
+    }>
   }
 }
 
@@ -118,8 +142,19 @@ export function useReferringDocuments(documentId: string): ReferringDocuments {
     publishedId
   )
 
+  const projectIds = useMemo(() => {
+    return Array.from(
+      new Set(
+        crossDatasetReferences?.references
+          .map((crossDatasetReference) => crossDatasetReference.projectId)
+          .filter(Boolean)
+      )
+    ).sort()
+  }, [crossDatasetReferences?.references])
+
   return {
     totalCount: (internalReferences?.totalCount || 0) + (crossDatasetReferences?.totalCount || 0),
+    projectIds,
     internalReferences,
     crossDatasetReferences,
     isLoading: isInternalReferencesLoading || isCrossDatasetReferencesLoading,


### PR DESCRIPTION
### Description

![CleanShot 2022-02-25 at 12 50 46@2x](https://user-images.githubusercontent.com/10551026/155763309-4bfdcdfa-645b-48a2-b8cd-17b49cc8c873.png)

Following up from a discussion in Slack, this checks for falsy document IDs and dataset names and adds a top-level display of project IDs.

### What to review

Review the code and see if all the copy and changes makes sense.
