### PR TITLE
Add `params` property to `MutationSelection` interface

### DIFF
--- a/packages/@sanity/types/src/mutations/types.ts
+++ b/packages/@sanity/types/src/mutations/types.ts
@@ -15,7 +15,7 @@ export interface PatchOperations {
   ifRevisionID?: string
 }
 
-export type MutationSelection = {query: string} | {id: string}
+export type MutationSelection = {query: string, params?: Record<string, unknown> } | {id: string}
 export type PatchMutationOperation = PatchOperations & MutationSelection
 
 export interface CreateMutation {


### PR DESCRIPTION
### Description

According to [documentation](https://www.sanity.io/docs/js-client#delete-documents), a `params` property is supported when deleting documents by query: 

```
client.delete({ query: "GROQ query", params: { key: value } })
```

I assume the same holds for patching/updating documents by query?

This PR adds the property to the `MutationSelection` type, so that TypeScript will also acknowledge it.

### What to review

* Check that deleting documents by query with params work as intended: `client.delete({
      query: "*[ _type == $testType ]",
      params: { testType: "test" }
})
`
* Check that patching documents by query with params work as intended: `client.patch({
      query: "*[ _type == $testType ]",
      params: { testType: "test" }
}).set('test', 'test').commit()
`

### Notes for release

* chore(types): add params property to MutationSelection interface
