### PR TITLE
fix(cli): improve `sanity upgrade` tag/range handling

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -56,7 +56,7 @@
     "fs-extra": "^7.0.0",
     "gauge": "^2.7.4",
     "get-it": "^5.2.1",
-    "get-latest-version": "^3.0.1",
+    "get-latest-version": "^4.0.0",
     "git-user-info": "^1.0.1",
     "gitconfiglocal": "^2.0.1",
     "inquirer": "^6.0.0",

--- a/packages/@sanity/cli/src/actions/versions/findSanityModuleVersions.js
+++ b/packages/@sanity/cli/src/actions/versions/findSanityModuleVersions.js
@@ -51,7 +51,7 @@ export default async function findSanityModuleVersions(context, opts = {}) {
     mod.needsUpdate =
       target === 'latest'
         ? semverCompare(current, mod.latest) === -1
-        : mod.installed !== mod.latestInRange
+        : Boolean(mod.latestInRange && mod.installed !== mod.latestInRange)
     return mod
   })
 }
@@ -117,7 +117,7 @@ function buildPackageArray(packages, workDir, options = {}) {
 function tryFindLatestVersion(pkgName, range) {
   return getLatestVersion(pkgName, {range, includeLatest: true})
     .then(({latest, inRange}) => ({latest, latestInRange: inRange}))
-    .catch(() => ({latest: 'unknown', latestInRange: 'unknown'}))
+    .catch(() => ({latest: undefined, latestInRange: undefined}))
 }
 
 function isPinnedVersion(version) {

--- a/packages/@sanity/cli/src/actions/versions/findSanityModuleVersions.js
+++ b/packages/@sanity/cli/src/actions/versions/findSanityModuleVersions.js
@@ -47,13 +47,21 @@ export default async function findSanityModuleVersions(context, opts = {}) {
   spin.stop()
 
   return packages.map((mod) => {
-    const current = mod.installed || semver.minVersion(mod.declared).toString()
+    const current = mod.installed || tryGetMinVersion(mod.declared)
     mod.needsUpdate =
       target === 'latest'
-        ? semverCompare(current, mod.latest) === -1
+        ? Boolean(current && semverCompare(current, mod.latest) === -1)
         : Boolean(mod.latestInRange && mod.installed !== mod.latestInRange)
     return mod
   })
+}
+
+function tryGetMinVersion(version) {
+  try {
+    return semver.minVersion(version).toString()
+  } catch (err) {
+    return undefined
+  }
 }
 
 function getLocalManifest(workDir) {

--- a/packages/@sanity/cli/src/actions/versions/findSanityModuleVersions.js
+++ b/packages/@sanity/cli/src/actions/versions/findSanityModuleVersions.js
@@ -98,7 +98,7 @@ function buildPackageArray(packages, workDir, options = {}) {
     modules.push({
       name: pkg.name,
       declared: `^${pkg.version}`,
-      installed: pkg.version,
+      installed: trimHash(pkg.version),
       latest: latest.then((versions) => versions.latest),
       latestInRange: latest.then((versions) => versions.latestInRange),
       isPinned: false,
@@ -110,10 +110,11 @@ function buildPackageArray(packages, workDir, options = {}) {
     ...modules,
     ...Object.keys(packages).map((pkgName) => {
       const latest = tryFindLatestVersion(pkgName, target || packages[pkgName] || 'latest')
+      const localVersion = getLocalVersion(pkgName, workDir)
       return {
         name: pkgName,
         declared: packages[pkgName],
-        installed: getLocalVersion(pkgName, workDir) || undefined,
+        installed: localVersion ? trimHash(localVersion) : undefined,
         latest: latest.then((versions) => versions.latest),
         latestInRange: latest.then((versions) => versions.latestInRange),
         isPinned: isPinnedVersion(packages[pkgName]),
@@ -130,4 +131,12 @@ function tryFindLatestVersion(pkgName, range) {
 
 function isPinnedVersion(version) {
   return /^\d+\.\d+\.\d+/.test(version)
+}
+
+/**
+ * `2.27.3-cookieless-auth.34+8ba9c1504` =>
+ * `2.27.3-cookieless-auth.34`
+ */
+function trimHash(version) {
+  return version.replace(/\+[a-z0-9]{8,}$/, '')
 }

--- a/packages/@sanity/cli/src/commands/upgrade/upgradeCommand.js
+++ b/packages/@sanity/cli/src/commands/upgrade/upgradeCommand.js
@@ -1,19 +1,34 @@
 import upgradeDependencies from './upgradeDependencies'
 
-const help = `
-Upgrades installed Sanity modules to the latest available version within the
-semantic versioning range specified in "package.json".
+const helpText = `
+Upgrades installed Sanity studio modules to the latest available version within
+the semantic versioning range specified in "package.json".
 
 If a specific module name is provided, only that module will be upgraded.
 
-If the --save-exact option is given, the new version will be saved without the
-^-prefix in package.json.
+Options
+  --range [range] Version range to upgrade to, eg '^2.2.7' or '2.1.x'
+  --tag [tag]     Tagged release to upgrade to, eg 'canary' or 'some-feature'
+  --save-exact    Pin the resolved version numbers in package.json (no ^ prefix)
+
+Examples
+  # Upgrade modules to the latest semver compatible versions
+  sanity upgrade
+
+  # Update to the latest within the 2.2 range
+  sanity upgrade --range 2.2.x
+
+  # Update to the latest semver compatible versions and pin the versions
+  sanity upgrade --save-exact
+
+  # Update to the latest 'canary' npm tag
+  sanity upgrade --tag canary
 `
 
 export default {
   name: 'upgrade',
-  signature: '[MODULE_NAME] [--tag DIST_TAG] [--range SEMVER_RANGE] [--save-exact]',
+  signature: '[--tag DIST_TAG] [--range SEMVER_RANGE] [--save-exact]',
   description: 'Upgrades all (or some) Sanity modules to their latest versions',
   action: upgradeDependencies,
-  helpText: help,
+  helpText,
 }

--- a/packages/@sanity/cli/src/commands/upgrade/upgradeDependencies.js
+++ b/packages/@sanity/cli/src/commands/upgrade/upgradeDependencies.js
@@ -76,18 +76,6 @@ export default async function upgradeDependencies(args, context) {
     )
   }
 
-  // Yarn fails to upgrade `react-ace` in some versions, see function for details
-  await maybeDeleteReactAce(nonPinned, workDir)
-
-  // Forcefully remove non-symlinked module paths to force upgrade
-  await Promise.all(
-    nonPinned.map((mod) =>
-      deleteIfNotSymlink(
-        path.join(context.workDir, 'node_modules', mod.name.replace(/\//g, path.sep))
-      )
-    )
-  )
-
   // Replace versions in `package.json`
   const versionPrefix = saveExact || targetRange ? '' : '^'
   const oldManifest = await readLocalManifest(workDir)
@@ -119,6 +107,18 @@ export default async function upgradeDependencies(args, context) {
   // Write new `package.json`
   const manifestPath = path.join(context.workDir, 'package.json')
   await writeJson(manifestPath, newManifest, {spaces: 2})
+
+  // Yarn fails to upgrade `react-ace` in some versions, see function for details
+  await maybeDeleteReactAce(nonPinned, workDir)
+
+  // Forcefully remove non-symlinked module paths to force upgrade
+  await Promise.all(
+    nonPinned.map((mod) =>
+      deleteIfNotSymlink(
+        path.join(context.workDir, 'node_modules', mod.name.replace(/\//g, path.sep))
+      )
+    )
+  )
 
   // Run `yarn install`
   const flags = extOptions.offline ? ['--offline'] : []

--- a/packages/@sanity/cli/src/commands/upgrade/upgradeDependencies.js
+++ b/packages/@sanity/cli/src/commands/upgrade/upgradeDependencies.js
@@ -94,14 +94,14 @@ export default async function upgradeDependencies(args, context) {
   const newManifest = nonPinned.reduce((target, mod) => {
     if (oldManifest.dependencies && oldManifest.dependencies[mod.name]) {
       target.dependencies[mod.name] =
-        mod.latestInRange === 'unknown'
+        typeof mod.latestInRange === 'undefined'
           ? oldManifest.dependencies[mod.name]
           : versionPrefix + mod.latestInRange
     }
 
     if (oldManifest.devDependencies && oldManifest.devDependencies[mod.name]) {
       target.devDependencies[mod.name] =
-        mod.latestInRange === 'unknown'
+        typeof mod.latestInRange === 'undefined'
           ? oldManifest.devDependencies[mod.name]
           : versionPrefix + mod.latestInRange
     }

--- a/packages/@sanity/cli/src/commands/upgrade/upgradeDependencies.js
+++ b/packages/@sanity/cli/src/commands/upgrade/upgradeDependencies.js
@@ -16,8 +16,7 @@ const rimraf = util.promisify(rimrafCb)
 
 export default async function upgradeDependencies(args, context) {
   const {output, workDir, yarn, chalk} = context
-  const {extOptions, argsWithoutOptions} = args
-  const modules = argsWithoutOptions.slice()
+  const {extOptions} = args
   const {range, tag} = extOptions
   const saveExact = extOptions['save-exact']
   const targetRange = tag || range
@@ -32,14 +31,9 @@ export default async function upgradeDependencies(args, context) {
 
   // Find which modules needs update according to the target range
   const versions = await findSanityModuleVersions(context, {target: targetRange, includeCli: false})
-  const allNeedsUpdate = versions.filter((mod) => mod.needsUpdate)
+  const needsUpdate = versions.filter((mod) => mod.needsUpdate)
 
-  debug('In need of update: %s', allNeedsUpdate.map((mod) => mod.name).join(', '))
-
-  const needsUpdate =
-    modules.length === 0
-      ? allNeedsUpdate
-      : allNeedsUpdate.filter((outOfDate) => modules.indexOf(outOfDate.name) !== -1)
+  debug('In need of update: %s', needsUpdate.map((mod) => mod.name).join(', '))
 
   const semverBreakingUpgrades = versions.filter(hasSemverBreakingUpgrade)
   const baseMajorUpgrade = semverBreakingUpgrades.find((mod) => mod.name === '@sanity/base')
@@ -48,10 +42,7 @@ export default async function upgradeDependencies(args, context) {
 
   // If all modules are up-to-date, say so and exit
   if (needsUpdate.length === 0) {
-    const specified = modules.length === 0 ? 'All' : 'All *specified*'
-    context.output.print(
-      `${chalk.green('✔')} ${specified} Sanity modules are at latest compatible versions`
-    )
+    context.output.print(`${chalk.green('✔')} All Sanity modules are at latest compatible versions`)
     return
   }
 


### PR DESCRIPTION
### Description

This PR attempts to address a number of annoyances/bugs with the `sanity upgrade` command:

1. The command currently fails when using `--tag` altogether.
    - Fixed by upgrading `get-latest-version` and returning `undefined` instead of `'unknown'` when a package is not found with the given range. If we can't find it, we stick with the version as-is.
2. When using `--tag`, we incorrectly add a `^` prefix to the tag in `package.json`, unless `--save-exact` is specified.
    - Fixed by using the tag or range given as-is. When using `--save-exact`, we store the actual, resolved version numbers - otherwise we just store the tag/range.
3. The command currently fails if any of the declared packages are not installed when running `sanity upgrade`
    - Fixed by additional checks, try/catching and adding `--check-files` flag when running yarn
4. When upgrading to a tagged release, it would always see the versions as "new", because of a mismatch between the version on npm and the version in `package.json` locally (a `+hash` postfix locally, vs none remotely)
    - Fixed by stripping the hash when comparing
5. Currently you can specify specific modules to upgrade. This will in the vast majority of cases break things, as you will end up with conflicting/multiple versions of the same modules as dependencies.
    - "Fixed" by removing this option. I cannot picture anyone having used this successfully.

In addition to this, I took the liberty of improving the documentation for the command with examples.

Fixes [sc14620]

### How to review

You will probably want to go through the changes commit by commit - is is more digestable that way. 

To run the command, you will want to check out the branch and run `npm run build`, then from another studio run:
`~/path/to/sanity-checkout/packages/@sanity/cli/bin/sanity upgrade <whatever options you want to test>`

### Notes for release

Fixes a number of issues with the `sanity upgrade` command when using `--tag` or `--range`

