### PR TITLE
fix(base): ignore presence sessions with no user profile

### DIFF
--- a/packages/@sanity/base/src/datastores/presence/mock-events.ts
+++ b/packages/@sanity/base/src/datastores/presence/mock-events.ts
@@ -1,5 +1,5 @@
-import {defer, from, timer} from 'rxjs'
-import {map, mapTo, mergeMapTo, shareReplay} from 'rxjs/operators'
+import {defer, timer} from 'rxjs'
+import {map, mergeMapTo, shareReplay} from 'rxjs/operators'
 import {sample} from 'lodash'
 import {StateEvent} from './message-transports/transport'
 
@@ -24,6 +24,10 @@ const USERIDS = [
   'pdLr4quHv',
   'pkJXiDgg6',
   'pkl4UAKcA',
+
+  // Included to ensure we handle the case when a user profile cannot
+  // be fetched due to insufficient privileges or similar
+  'pNoExists',
 ]
 
 const PATHS = [


### PR DESCRIPTION
### Description

When a user profile does not exist or cannot be fetched due to insufficient permissions, we should handle the case gracefully by removing the presence session altogether. Currently, the studio crashes.

### Review notes

- I removed a few unused rxjs imports while I was in these files. Gardening and all that.
- Included a non-existent user ID in the mock debug presence data to make it easier to test

### Notes for release

- Fixes a bug where the studio could crash if a user had insufficient permissions to fetch user profiles while collaborating with others
