### PR TITLE
fix(desk-tool): correct document list ordering on first load

### DIFF
--- a/packages/@sanity/desk-tool/package.json
+++ b/packages/@sanity/desk-tool/package.json
@@ -58,6 +58,7 @@
   },
   "devDependencies": {
     "@sanity/base": "2.27.2",
+    "@sanity/schema": "2.27.0",
     "@sanity/ui-workshop": "^0.3.12",
     "@testing-library/jest-dom": "^5.11.10",
     "@testing-library/react": "^11.2.5",

--- a/packages/@sanity/desk-tool/src/panes/documentList/DocumentListPane.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentList/DocumentListPane.tsx
@@ -1,11 +1,16 @@
 import React, {memo, useMemo} from 'react'
+import schema from 'part:@sanity/base/schema'
 import {Pane} from '../../components/pane'
 import {useShallowUnique} from '../../utils/useShallowUnique'
 import {useUnique} from '../../utils/useUnique'
 import {useDeskToolSetting} from '../../settings'
 import {BaseDeskToolPaneProps} from '../types'
 import {DEFAULT_ORDERING, EMPTY_RECORD} from './constants'
-import {getTypeNameFromSingleTypeFilter, isSimpleTypeFilter} from './helpers'
+import {
+  applyOrderingFunctions,
+  getTypeNameFromSingleTypeFilter,
+  isSimpleTypeFilter,
+} from './helpers'
 import {DocumentListPaneContent} from './DocumentListPaneContent'
 import {DocumentListPaneHeader} from './DocumentListPaneHeader'
 import {Layout, SortOrder} from './types'
@@ -40,7 +45,13 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
     'sortOrder',
     DEFAULT_ORDERING
   )
-  const sortOrder = useUnique(sortOrderRaw)
+
+  const sortWithOrderingFn =
+    typeName && sortOrderRaw
+      ? applyOrderingFunctions(sortOrderRaw, schema.get(typeName))
+      : sortOrderRaw
+
+  const sortOrder = useUnique(sortWithOrderingFn)
   const filterIsSimpleTypeContraint = isSimpleTypeFilter(filter)
 
   const {error, fullList, handleListChange, isLoading, items, onRetry} = useDocumentList({

--- a/packages/@sanity/desk-tool/src/panes/documentList/__tests__/helpers.test.ts
+++ b/packages/@sanity/desk-tool/src/panes/documentList/__tests__/helpers.test.ts
@@ -1,0 +1,173 @@
+import Schema from '@sanity/schema'
+import {ObjectSchemaType} from '@sanity/types'
+import {applyOrderingFunctions, fieldExtendsType} from '../helpers'
+
+const mockSchema = Schema.compile({
+  name: 'default',
+  types: [
+    {
+      name: 'category',
+      title: 'Category',
+      type: 'document',
+      fields: [{name: 'title', type: 'string'}],
+    },
+    {
+      name: 'span',
+      type: 'object',
+      fields: [{name: 'text', type: 'string'}],
+    },
+    {
+      name: 'block',
+      type: 'object',
+      fields: [{name: 'children', type: 'array', of: [{type: 'span'}]}],
+    },
+    {
+      name: 'image',
+      type: 'object',
+      fields: [{name: 'url', type: 'string'}],
+    },
+    {
+      name: 'aliasedDateTime',
+      type: 'datetime',
+    },
+    {
+      name: 'article',
+      title: 'Article',
+      type: 'document',
+      fields: [
+        {name: 'title', type: 'object', fields: [{name: 'en', type: 'string'}]},
+        {name: 'description', type: 'text'},
+        {
+          name: 'views',
+          type: 'number',
+        },
+        {
+          name: 'intro',
+          type: 'array',
+          of: [{type: 'block'}],
+        },
+        {
+          name: 'body',
+          type: 'array',
+          of: [{type: 'block'}, {type: 'image'}],
+        },
+        {
+          name: 'publishDate',
+          type: 'datetime',
+        },
+        {
+          name: 'relevantUntil',
+          type: 'aliasedDateTime',
+        },
+      ],
+    },
+  ],
+})
+
+jest.mock('part:@sanity/base/schema', () => {
+  return mockSchema
+})
+
+describe('applyOrderingFunctions()', () => {
+  test('does not apply to orderings with mapper', () => {
+    const ordering = {by: [{field: 'title', direction: 'desc' as const, mapWith: 'upper'}]}
+    const withFn = applyOrderingFunctions(ordering, mockSchema.get('category'))
+    expect(withFn).toStrictEqual(ordering)
+  })
+
+  test('does not apply to non-string orderings', () => {
+    const ordering = {by: [{field: 'views', direction: 'desc' as const}]}
+    const withFn = applyOrderingFunctions(ordering, mockSchema.get('article'))
+    expect(withFn).toStrictEqual(ordering)
+  })
+
+  test('applies `dateTime()` to shallow datetime field orderings', () => {
+    const ordering = {by: [{field: 'publishDate', direction: 'desc' as const}]}
+    const withFn = applyOrderingFunctions(ordering, mockSchema.get('article'))
+    expect(withFn).toEqual({by: [{...ordering.by[0], mapWith: 'dateTime'}]})
+  })
+
+  test('applies `lower()` to shallow string field orderings', () => {
+    const ordering = {by: [{field: 'title', direction: 'desc' as const}]}
+    const withFn = applyOrderingFunctions(ordering, mockSchema.get('category'))
+    expect(withFn).toEqual({by: [{...ordering.by[0], mapWith: 'lower'}]})
+  })
+
+  test('applies `lower()` to deep string field orderings', () => {
+    const ordering = {by: [{field: 'title.en', direction: 'desc' as const}]}
+    const withFn = applyOrderingFunctions(ordering, mockSchema.get('article'))
+    expect(withFn).toEqual({by: [{...ordering.by[0], mapWith: 'lower'}]})
+  })
+
+  test('applies `lower()` to deep array-indexed string field orderings within single-type arrays', () => {
+    const ordering = {by: [{field: 'intro[0].children[0].text', direction: 'desc' as const}]}
+    const withFn = applyOrderingFunctions(ordering, mockSchema.get('article'))
+    expect(withFn).toEqual({by: [{...ordering.by[0], mapWith: 'lower'}]})
+  })
+
+  test('applies `lower()` to deep key-indexed string field orderings within single-type arrays', () => {
+    const ordering = {
+      by: [{field: 'intro[_key=="static"].children[0].text', direction: 'desc' as const}],
+    }
+    const withFn = applyOrderingFunctions(ordering, mockSchema.get('article'))
+    expect(withFn).toEqual({by: [{...ordering.by[0], mapWith: 'lower'}]})
+  })
+
+  test('does not apply to multi-type arrays with array-index accessor', () => {
+    const ordering = {by: [{field: 'body[0].children[0].text', direction: 'desc' as const}]}
+    const withFn = applyOrderingFunctions(ordering, mockSchema.get('article'))
+    expect(withFn).toStrictEqual(ordering)
+  })
+
+  test('does not apply to multi-type arrays with key accessor', () => {
+    const ordering = {
+      by: [{field: 'body[_key=="someValue"].children[0].text', direction: 'desc' as const}],
+    }
+    const withFn = applyOrderingFunctions(ordering, mockSchema.get('article'))
+    expect(withFn).toStrictEqual(ordering)
+  })
+})
+
+describe('fieldExtendsType()', () => {
+  /* eslint-disable @typescript-eslint/no-non-null-assertion */
+  test('correctly identifies string fields', () => {
+    const field = (mockSchema.get('category') as ObjectSchemaType).fields.find(
+      (current) => current.name === 'title'
+    )!
+
+    expect(fieldExtendsType(field, 'string')).toBe(true)
+  })
+
+  test('correctly identifies text fields as string', () => {
+    const field = (mockSchema.get('article') as ObjectSchemaType).fields.find(
+      (current) => current.name === 'description'
+    )!
+
+    expect(fieldExtendsType(field, 'string')).toBe(true)
+  })
+
+  test('correctly identifies datetime fields', () => {
+    const field = (mockSchema.get('article') as ObjectSchemaType).fields.find(
+      (current) => current.name === 'publishDate'
+    )!
+
+    expect(fieldExtendsType(field, 'datetime')).toBe(true)
+  })
+
+  test('correctly identifies aliased datetime fields as datetime', () => {
+    const field = (mockSchema.get('article') as ObjectSchemaType).fields.find(
+      (current) => current.name === 'relevantUntil'
+    )!
+
+    expect(fieldExtendsType(field, 'datetime')).toBe(true)
+  })
+
+  test('correctly identifies aliased datetime fields as not a number', () => {
+    const field = (mockSchema.get('article') as ObjectSchemaType).fields.find(
+      (current) => current.name === 'relevantUntil'
+    )!
+
+    expect(fieldExtendsType(field, 'number')).toBe(false)
+  })
+  /* eslint-enable @typescript-eslint/no-non-null-assertion */
+})

--- a/packages/@sanity/desk-tool/src/panes/documentList/helpers.ts
+++ b/packages/@sanity/desk-tool/src/panes/documentList/helpers.ts
@@ -1,9 +1,19 @@
 // @todo: remove the following line when part imports has been removed from this file
 ///<reference types="@sanity/types/parts" />
 
-import {SanityDocument} from '@sanity/types'
+import * as PathUtils from '@sanity/util/paths'
+import {
+  isIndexSegment,
+  isKeySegment,
+  isReferenceSchemaType,
+  ObjectField,
+  ObjectFieldType,
+  ObjectSchemaType,
+  SanityDocument,
+  SchemaType,
+} from '@sanity/types'
 import {collate, getPublishedId} from 'part:@sanity/base/util/draft-utils'
-import {DocumentListPaneItem, SortOrderBy} from './types'
+import {DocumentListPaneItem, SortOrder, SortOrderBy} from './types'
 
 export function getDocumentKey(value: DocumentListPaneItem, index: number): string {
   return value._id ? getPublishedId(value._id) : `item-${index}`
@@ -19,10 +29,6 @@ export function removePublishedWithDrafts(documents: SanityDocument[]): Document
     }
   })
 }
-
-// export function getDocumentKey(document: DocumentListPaneItem): string {
-//   return getPublishedId(document._id)
-// }
 
 const RE_TYPE_NAME_IN_FILTER = /\b_type\s*==\s*(['"].*?['"]|\$.*?(?:\s|$))|\B(['"].*?['"]|\$.*?(?:\s|$))\s*==\s*_type\b/
 export function getTypeNameFromSingleTypeFilter(
@@ -54,10 +60,110 @@ export function isSimpleTypeFilter(filter: string): boolean {
 export function toOrderClause(orderBy: SortOrderBy[]): string {
   return orderBy
     .map((ordering) =>
-      [ordering.field, (ordering.direction || '').toLowerCase()]
+      [wrapFieldWithFn(ordering), (ordering.direction || '').toLowerCase()]
         .map((str) => str.trim())
         .filter(Boolean)
         .join(' ')
     )
     .join(',')
+}
+
+function wrapFieldWithFn(ordering: SortOrderBy): string {
+  return ordering.mapWith ? `${ordering.mapWith}(${ordering.field})` : ordering.field
+}
+
+export function applyOrderingFunctions(order: SortOrder, schemaType: ObjectSchemaType): SortOrder {
+  const orderBy = order.by.map((by) => {
+    // Skip those that already have a mapper
+    if (by.mapWith) {
+      return by
+    }
+
+    const fieldType = tryResolveSchemaTypeForPath(schemaType, by.field)
+    if (!fieldType) {
+      return by
+    }
+
+    // Note: order matters here, since the jsonType of a date field is `string`,
+    // but we want to apply `datetime()`, not `lower()`
+    if (fieldExtendsType(fieldType, 'datetime')) {
+      return {...by, mapWith: 'dateTime'}
+    }
+
+    if (fieldType.jsonType === 'string') {
+      return {...by, mapWith: 'lower'}
+    }
+
+    return by
+  })
+
+  return orderBy.every((item, index) => item === order.by[index]) ? order : {...order, by: orderBy}
+}
+
+function tryResolveSchemaTypeForPath(baseType: SchemaType, path: string): SchemaType | undefined {
+  const pathSegments = PathUtils.fromString(path)
+
+  let current: SchemaType | undefined = baseType
+  for (const segment of pathSegments) {
+    if (!current) {
+      return undefined
+    }
+
+    if (typeof segment === 'string') {
+      current = getFieldTypeByName(current, segment)
+      continue
+    }
+
+    const isArrayAccessor = isKeySegment(segment) || isIndexSegment(segment)
+    if (!isArrayAccessor || current.jsonType !== 'array') {
+      return undefined
+    }
+
+    const [memberType, otherType] = current.of || []
+    if (otherType || !memberType) {
+      // Can't figure out the type without knowing the value
+      return undefined
+    }
+
+    if (!isReferenceSchemaType(memberType)) {
+      current = memberType
+      continue
+    }
+
+    const [refType, otherRefType] = memberType.to || []
+    if (otherRefType || !refType) {
+      // Can't figure out the type without knowing the value
+      return undefined
+    }
+
+    current = refType
+  }
+
+  return current
+}
+
+function getFieldTypeByName(type: SchemaType, fieldName: string): SchemaType | undefined {
+  if (!('fields' in type)) {
+    return undefined
+  }
+
+  const fieldType = type.fields.find((field) => field.name === fieldName)
+  return fieldType ? fieldType.type : undefined
+}
+
+export function fieldExtendsType(field: ObjectField | ObjectFieldType, ofType: string): boolean {
+  let current: SchemaType | undefined = field.type
+  while (current) {
+    if (current.name === ofType) {
+      return true
+    }
+
+    if (!current.type && current.jsonType === ofType) {
+      return true
+    }
+
+    current = current.type
+  }
+
+  return false
 }

--- a/packages/@sanity/desk-tool/src/panes/documentList/types.ts
+++ b/packages/@sanity/desk-tool/src/panes/documentList/types.ts
@@ -7,7 +7,7 @@ export interface DocumentListPaneItem extends SanityDocument {
 
 export type Layout = 'default' | 'detail' | 'card' | 'media'
 
-export type SortOrderBy = {field: string; direction: 'asc' | 'desc'}
+export type SortOrderBy = {field: string; direction: 'asc' | 'desc'; mapWith?: string}
 
 export type SortOrder = {
   by: SortOrderBy[]

--- a/packages/@sanity/desk-tool/src/panes/documentList/useDocumentList.ts
+++ b/packages/@sanity/desk-tool/src/panes/documentList/useDocumentList.ts
@@ -51,18 +51,9 @@ export function useDocumentList(opts: UseDocumentListOpts): DocumentListState {
 
     if (extendedProjection) {
       const firstProjection = projectionFields.concat(extendedProjection).join(',')
-
-      // At first glance, you might think that 'order' should come before 'slice'?
-      // However, this is actually a counter-bug
-      // to https://github.com/sanity-io/gradient/issues/922 which causes:
-      // 1. case-insensitive ordering (we want this)
-      // 2. null-values to sort to the top, even when order is desc (we don't want this)
-      // Because Studios in the wild rely on the buggy nature of this
-      // do not change this until we have API versioning
       return [
-        `*[${filter}] [0...${limit}]`,
-        `{${firstProjection}}`,
-        `order(${order})`,
+        `*[${filter}] {${firstProjection}}`,
+        `order(${order}) [0...${limit}]`,
         `{${finalProjection}}`,
       ].join('|')
     }
@@ -104,7 +95,7 @@ export function useDocumentList(opts: UseDocumentListOpts): DocumentListState {
     const sub = queryResults$.subscribe(setResult)
 
     return () => sub.unsubscribe()
-  }, [fullList, query, params])
+  }, [fullList, query, params, apiVersion])
 
   // If `filter` or `params` changed, set up a new query from scratch.
   // If `sortOrder` changed, set up a new query from scratch as well.
@@ -112,7 +103,7 @@ export function useDocumentList(opts: UseDocumentListOpts): DocumentListState {
     setResult(null)
     setFullList(false)
     fullListRef.current = false
-  }, [filter, params, sortOrder])
+  }, [filter, params, sortOrder, apiVersion])
 
   return {error, fullList, handleListChange, isLoading, items, onRetry}
 }


### PR DESCRIPTION
### Description

TL;DR: This fixes an issue where the initial load of the document list does not respect the ordering if more than 100 items are present in the list, as well as improving the ordering of datetime fields.

Long version:

We previously had a bit of an odd ordering implementation because of some internal inconsistencies and the lacking ability to order items in a case-insensitive manner. Since then, we've resolved these issues, which now means we can utilize the correct ordering.

To do so, we have to know whether or not a field that is being sorted is a string, since applying `lower()` to other types will yield `null` and break ordering of those. Since I already put this logic in place, a similar approach was implemented for datetime fields - we apply the `dateTime()` method for those (this isn't _usually_ needed as ISO-dates in UTC sort just fine, but in cases where people might have imported data or similar, timezones might come into play and break the ordering). 

The implementation has some caveats:
- We need to be able to extract the document type from the GROQ filter, if any, and can only apply the logic if we do.
    - If you have a filter without a type constraint, we cannot apply these fixes
    - If you have a multi-type filter, we are not able to do so either. This case is theoretically solvable if we implement a better GROQ filter parsing and can extract multi-type filters. We then would need to assure that the field being sorted on is of the same type in all the matched types
    - If you have a type filter written in some exotic/non-obvious way, we're not able to extract the type and thus won't apply the fix

### Notes for release

- Fixes a bug where document lists would not always show items in the correct order until scrolling down and back up again
