### PR TITLE
feat(schema): warn when providing superfluous image metadata props

### DIFF
--- a/packages/@sanity/schema/src/sanity/validation/types/image.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/image.ts
@@ -13,7 +13,7 @@ export default (typeDef, visitorContext) => {
 
   let options = typeDef.options
   const metadata = options?.metadata
-  const superflousMeta = Array.isArray(metadata)
+  const superfluousMeta = Array.isArray(metadata)
     ? metadata.filter((meta) => autoMeta.includes(meta))
     : []
 
@@ -24,10 +24,10 @@ export default (typeDef, visitorContext) => {
         HELP_IDS.ASSET_METADATA_FIELD_INVALID
       )
     )
-  } else if (superflousMeta.length > 0) {
+  } else if (superfluousMeta.length > 0) {
     problems.push(
       warning(
-        `Image \`metadata\` field contains superflous properties (they are always included): ${superflousMeta.join(
+        `Image \`metadata\` field contains superfluous properties (they are always included): ${superfluousMeta.join(
           ', '
         )}`
       )

--- a/packages/@sanity/schema/src/sanity/validation/types/image.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/image.ts
@@ -1,29 +1,43 @@
-import {error, HELP_IDS} from '../createValidationResult'
+import {error, warning, HELP_IDS} from '../createValidationResult'
 import {validateFields, validateField} from './object'
+
+const autoMeta = ['dimensions', 'hasAlpha', 'isOpaque']
 
 export default (typeDef, visitorContext) => {
   const problems = []
-  let fields = typeDef.fields
+  const fields = typeDef.fields
 
   if (fields) {
     problems.push(...validateFields(fields, {allowEmpty: true}))
   }
 
-  if (
-    typeDef.options &&
-    typeof typeDef.options.metadata !== 'undefined' &&
-    !Array.isArray(typeDef.options.metadata)
-  ) {
+  let options = typeDef.options
+  const metadata = options?.metadata
+  const superflousMeta = Array.isArray(metadata)
+    ? metadata.filter((meta) => autoMeta.includes(meta))
+    : []
+
+  if (typeof metadata !== 'undefined' && !Array.isArray(metadata)) {
     problems.push(
       error(
         `Invalid type for image \`metadata\` field - must be an array of strings`,
         HELP_IDS.ASSET_METADATA_FIELD_INVALID
       )
     )
+  } else if (superflousMeta.length > 0) {
+    problems.push(
+      warning(
+        `Image \`metadata\` field contains superflous properties (they are always included): ${superflousMeta.join(
+          ', '
+        )}`
+      )
+    )
+    options = {...options, metadata: metadata.filter((meta) => !autoMeta.includes(meta))}
   }
 
   return {
     ...typeDef,
+    options,
     fields: (Array.isArray(fields) ? fields : []).map((field, index) => {
       const {name, ...fieldTypeDef} = field
       const {_problems, ...fieldType} = visitorContext.visit(fieldTypeDef, index)


### PR DESCRIPTION
### Description

The properties `isOpaque`, `hasAlpha` and `dimensions` are automatically extracted and populated for any image asset. Specifying these will make the backend reject the request, as they are not user configurable.

Because they are listed as part of the image metadata, it is likely that users _will_ provide these, and have the upload requests fail.

This PR warns when specifying these properties, and removes them from the array of metadata before returning the compiled schema type.

### What to review

That the warning makes sense from a user perspective, and that the code looks correct.

### Notes for release

- Added a check for superfluous image metadata properties being specified
