### PR TITLE
Fix dragging issue in PTE with array input

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/common/fileTarget/fileTarget.tsx
+++ b/packages/@sanity/form-builder/src/inputs/common/fileTarget/fileTarget.tsx
@@ -121,13 +121,14 @@ export function fileTarget<ComponentProps>(Component: React.ComponentType<Compon
     const handleDragEnter = useCallback(
       (event: React.DragEvent) => {
         event.stopPropagation()
-        /* this is a (hackish) work around to have the drag and drop work when the file is hovered back and forth over it
+
+        if (onFilesOver) {
+          /* this is a (hackish) work around to have the drag and drop work when the file is hovered back and forth over it
           as part of the refactor and adding more components to the "hover" state, it didn't recognise that it just kept adding the same
           element over and over, so when it tried to remove them on the handleDragLeave, it only removed the last instance. 
         */
-        enteredElements.current = [...new Set(enteredElements.current), event.currentTarget]
+          enteredElements.current = [...new Set(enteredElements.current), event.currentTarget]
 
-        if (onFilesOver && enteredElements.current.length === 1) {
           const fileTypes = Array.from(event.dataTransfer.items).map((item) => ({
             type: item.type,
             kind: item.kind,


### PR DESCRIPTION
### Description

- I've added a test studio which allows you to directly test the use case (`dev/sanity-drag-handler-bug-14502`) which will be removed before merging into `next`

The issue was when moving items around in a PTE (adding an item to an array input), it was triggering the hovering of the array items beneath and preventing users from making any additional changes afterwards. Check video:

https://user-images.githubusercontent.com/6951139/158134688-f874f712-7974-498e-a6d5-f600793f4d84.mov

### What to review
Follow the same path as shown in the video and make sure that the behavior is no longer happening. 
Also try to drag an image on the image input (inside of the PTE) and make sure that it still doesn't trigger the same bug mentioned before.

### Notes for release

Fix drag issue with the array input with PTE items (not super sure about this note 🥲 )
