### PR TITLE
Change plugin callstack

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -157,7 +157,7 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
   )
 
   // Update the Slate instance's plugins which are dependent on props for Editable
-  useMemo(() => withHotKeys(withInsertData(withEditableAPI(withReact(slateEditor)))), [
+  useMemo(() => withReact(withEditableAPI(withInsertData(withHotKeys(slateEditor)))), [
     slateEditor,
     withEditableAPI,
     withHotKeys,

--- a/packages/@sanity/portable-text-editor/src/editor/withPortableText.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/withPortableText.ts
@@ -61,16 +61,12 @@ export const withPortableText = <T extends Editor>(
   const withPortableTextSelections = createWithPortableTextSelections(change$)
 
   // Ordering is important here, selection dealing last, data manipulation in the middle and core model stuff first.
-  return withPortableTextSelections(
-    withPatches(
-      withUndoRedo(
-        withMaxBlocks(
-          withUtils(
-            withPortableTextLists(
-              withPortableTextBlockStyle(
-                withPortableTextMarkModel(withObjectKeys(withSchemaTypes(e)))
-              )
-            )
+  return withSchemaTypes(
+    withObjectKeys(
+      withPortableTextMarkModel(
+        withPortableTextBlockStyle(
+          withPortableTextLists(
+            withUtils(withMaxBlocks(withUndoRedo(withPatches(withPortableTextSelections(e)))))
           )
         )
       )

--- a/packages/@sanity/portable-text-editor/test/web-server/components/Editor.tsx
+++ b/packages/@sanity/portable-text-editor/test/web-server/components/Editor.tsx
@@ -41,6 +41,8 @@ function getRandomColor() {
   return color
 }
 
+const renderPlaceholder = () => 'Type here!'
+
 export const Editor = ({
   value,
   onMutation,
@@ -157,7 +159,7 @@ export const Editor = ({
     >
       <Box padding={4} style={{outline: '1px solid #999'}}>
         <PortableTextEditable
-          placeholderText="Type here!"
+          renderPlaceholder={renderPlaceholder}
           hotkeys={HOTKEYS}
           renderBlock={renderBlock}
           renderDecorator={renderDecorator}


### PR DESCRIPTION
### Description

I noticed that the call order of the PTE plugin stack is in the reverse order of what I intended. The idea is to have the most core ones being called first and the selection emitter plugin last (as plugins may manipulate the selection).

Also updated a test with the correct prop for the placeholder (was refactored a while ago).

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Doesn't need to be mentioned.

<!--
A description of the change(s) that should be used in the release notes.
-->
