### PR TITLE
fix(form-builder) fix image resizing on initial load

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImageInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImageInput.tsx
@@ -5,7 +5,7 @@ import {Box, Button, Card, Dialog, Menu, MenuButton, MenuItem, Stack, ToastParam
 import {get, groupBy, uniqueId} from 'lodash'
 import {Observable, Subscription} from 'rxjs'
 import {ChangeIndicatorForFieldPath} from '@sanity/base/change-indicators'
-import {ImageIcon, SearchIcon} from '@sanity/icons'
+import {ChevronDownIcon, ImageIcon, SearchIcon} from '@sanity/icons'
 import {
   ImageAsset,
   AssetFromSource,
@@ -523,7 +523,7 @@ export default class ImageInput extends React.PureComponent<Props, ImageInputSta
       assetSources && assetSources?.length === 0 ? null : (
         <MenuItem
           icon={SearchIcon}
-          text="Browse"
+          text="Select"
           onClick={() => {
             this.setState({isMenuOpen: false})
             this.handleSelectImageFromAssetSource(assetSources[0])
@@ -593,9 +593,10 @@ export default class ImageInput extends React.PureComponent<Props, ImageInputSta
           button={
             <Button
               mode="ghost"
-              text="Browse"
+              text="Select"
               data-testid="file-input-multi-browse-button"
               icon={SearchIcon}
+              iconRight={ChevronDownIcon}
             />
           }
           menu={
@@ -624,7 +625,7 @@ export default class ImageInput extends React.PureComponent<Props, ImageInputSta
     return (
       <Button
         fontSize={2}
-        text="Browse"
+        text="Select"
         icon={SearchIcon}
         mode="ghost"
         onClick={() => {

--- a/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImageInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImageInput.tsx
@@ -50,7 +50,6 @@ export type Props = {
   type: ImageSchemaType
   level: number
   onChange: (event: PatchEvent) => void
-  resolveUploader: UploaderResolver
   observeAsset: (documentId: string) => Observable<ImageAsset>
   onBlur: () => void
   onFocus: (path: Path) => void

--- a/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImagePreview.styled.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImagePreview.styled.tsx
@@ -1,12 +1,15 @@
 import {studioTheme, rgba, Card, Flex, CardTone, Spinner} from '@sanity/ui'
 import styled, {css} from 'styled-components'
 
+export const MAX_HEIGHT = 30
+
 export const RatioBox = styled(Card)`
   position: relative;
   width: 100%;
   resize: vertical;
   overflow: hidden;
   min-height: 3.75rem;
+  max-height: ${MAX_HEIGHT}vh;
 
   & > div[data-container] {
     //position: absolute;

--- a/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImagePreview.styled.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImagePreview.styled.tsx
@@ -12,7 +12,6 @@ export const RatioBox = styled(Card)`
   max-height: ${MAX_HEIGHT}vh;
 
   & > div[data-container] {
-    //position: absolute;
     top: 0;
     left: 0;
     width: 100%;

--- a/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImagePreview.styled.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImagePreview.styled.tsx
@@ -1,7 +1,7 @@
 import {studioTheme, rgba, Card, Flex, CardTone, Spinner} from '@sanity/ui'
 import styled, {css} from 'styled-components'
 
-export const MAX_HEIGHT = 30
+export const MAX_DEFAULT_HEIGHT = 30
 
 export const RatioBox = styled(Card)`
   position: relative;
@@ -9,7 +9,7 @@ export const RatioBox = styled(Card)`
   resize: vertical;
   overflow: hidden;
   min-height: 3.75rem;
-  max-height: ${MAX_HEIGHT}vh;
+  max-height: 40rem;
 
   & > div[data-container] {
     top: 0;

--- a/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImagePreview.styled.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImagePreview.styled.tsx
@@ -9,7 +9,7 @@ export const RatioBox = styled(Card)`
   min-height: 3.75rem;
 
   & > div[data-container] {
-    position: absolute;
+    //position: absolute;
     top: 0;
     left: 0;
     width: 100%;

--- a/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImagePreview.styled.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImagePreview.styled.tsx
@@ -6,10 +6,9 @@ export const MAX_DEFAULT_HEIGHT = 30
 export const RatioBox = styled(Card)`
   position: relative;
   width: 100%;
-  resize: vertical;
   overflow: hidden;
   min-height: 3.75rem;
-  max-height: 40rem;
+  max-height: 20rem;
 
   & > div[data-container] {
     top: 0;

--- a/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImagePreview.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImagePreview.tsx
@@ -29,8 +29,7 @@ export function ImagePreview(props: ComponentProps<typeof Card> & Props) {
 
   const onLoadChange = useCallback(({target: img}) => {
     const imgHeight = img.offsetWidth
-    const maxHeightToPx = (MAX_HEIGHT * document.documentElement.clientHeight) / 100
-    // convert from vh to px
+    const maxHeightToPx = (MAX_HEIGHT * document.documentElement.clientHeight) / 100 // convert from vh to px
 
     if (imgHeight > maxHeightToPx) {
       setUseInitialHeight(true)

--- a/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImagePreview.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImagePreview.tsx
@@ -2,7 +2,13 @@ import React, {ComponentProps, useCallback, useEffect, useState} from 'react'
 
 import {AccessDeniedIcon, ImageIcon, ReadOnlyIcon} from '@sanity/icons'
 import {Card, Box, Heading, Text} from '@sanity/ui'
-import {MAX_HEIGHT, RatioBox, Overlay, FlexOverlay, SpinnerWrapper} from './ImagePreview.styled'
+import {
+  MAX_DEFAULT_HEIGHT,
+  RatioBox,
+  Overlay,
+  FlexOverlay,
+  SpinnerWrapper,
+} from './ImagePreview.styled'
 
 interface Props {
   readOnly?: boolean | null
@@ -19,7 +25,7 @@ export function ImagePreview(props: ComponentProps<typeof Card> & Props) {
   const acceptTone = isRejected || readOnly ? 'critical' : 'primary'
   const tone = drag ? acceptTone : 'default'
 
-  const [useInitialHeight, setUseInitialHeight] = useState(false)
+  const [initialHeight, setInitialHeight] = useState(null)
 
   useEffect(() => {
     /* set for when the src is being switched when the image input already had a image src
@@ -28,18 +34,18 @@ export function ImagePreview(props: ComponentProps<typeof Card> & Props) {
   }, [src])
 
   const onLoadChange = useCallback(({target: img}) => {
-    const imgHeight = img.offsetWidth
-    const maxHeightToPx = (MAX_HEIGHT * document.documentElement.clientHeight) / 100 // convert from vh to px
+    const imgHeight = img.height
+    const maxHeightToPx = (MAX_DEFAULT_HEIGHT * document.documentElement.clientHeight) / 100 // convert from vh to px, max height of the input
 
     if (imgHeight > maxHeightToPx) {
-      setUseInitialHeight(true)
+      setInitialHeight(`${MAX_DEFAULT_HEIGHT}vh`)
     }
 
     setLoaded(true)
   }, [])
 
   return (
-    <RatioBox {...rest} style={{height: useInitialHeight ? '30vh' : ''}} tone="transparent">
+    <RatioBox {...rest} style={{height: initialHeight}} tone="transparent">
       <Card data-container tone="inherit">
         {!isLoaded && <OverlayComponent cardTone="transparent" drag content={<SpinnerWrapper />} />}
         <img src={src} data-testid="hotspot-image-input" alt={props.alt} onLoad={onLoadChange} />

--- a/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImagePreview.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImagePreview.tsx
@@ -18,6 +18,10 @@ interface Props {
   alt: string
 }
 
+/* 
+  Used for setting the initial image height - specifically for images 
+  that are small and so can take less space in the document
+*/
 const getImageSize = (src) => {
   const imageUrlParams = new URLSearchParams(src.split('?')[1])
   const rect = imageUrlParams.get('rect')
@@ -44,9 +48,13 @@ export function ImagePreview(props: ComponentProps<typeof Card> & Props) {
 
   const imageRatio = imageWidth / imageHeight
 
-  // is image wider than root? if so calculate the resized height
+  // is the image wider than root? if so calculate the resized height
   const renderedImageHeight = imageWidth > rootWidth ? rootWidth / imageRatio : imageHeight
 
+  /* 
+    if the rendered image is smaller than the max height then it doesn't require a height set
+    otherwise, set the max height (to prevent a large image in the document)
+  */
   const rootHeight = renderedImageHeight < maxHeightToPx ? null : `${MAX_DEFAULT_HEIGHT}vh`
 
   useEffect(() => {

--- a/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImagePreview.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImagePreview.tsx
@@ -30,7 +30,7 @@ export function ImagePreview(props: ComponentProps<typeof Card> & Props) {
   }, [])
 
   return (
-    <RatioBox {...rest} style={{height: '30vh'}} tone="transparent">
+    <RatioBox {...rest} tone="transparent">
       <Card data-container tone="inherit">
         {!isLoaded && <OverlayComponent cardTone="transparent" drag content={<SpinnerWrapper />} />}
         <img src={src} data-testid="hotspot-image-input" alt={props.alt} onLoad={onLoadChange} />

--- a/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImagePreview.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImagePreview.tsx
@@ -2,7 +2,7 @@ import React, {ComponentProps, useCallback, useEffect, useState} from 'react'
 
 import {AccessDeniedIcon, ImageIcon, ReadOnlyIcon} from '@sanity/icons'
 import {Card, Box, Heading, Text} from '@sanity/ui'
-import {RatioBox, Overlay, FlexOverlay, SpinnerWrapper} from './ImagePreview.styled'
+import {MAX_HEIGHT, RatioBox, Overlay, FlexOverlay, SpinnerWrapper} from './ImagePreview.styled'
 
 interface Props {
   readOnly?: boolean | null
@@ -19,18 +19,28 @@ export function ImagePreview(props: ComponentProps<typeof Card> & Props) {
   const acceptTone = isRejected || readOnly ? 'critical' : 'primary'
   const tone = drag ? acceptTone : 'default'
 
+  const [useInitialHeight, setUseInitialHeight] = useState(false)
+
   useEffect(() => {
     /* set for when the src is being switched when the image input already had a image src
     - meaning it already had an asset */
     setLoaded(false)
   }, [src])
 
-  const onLoadChange = useCallback(() => {
+  const onLoadChange = useCallback(({target: img}) => {
+    const imgHeight = img.offsetWidth
+    const maxHeightToPx = (MAX_HEIGHT * document.documentElement.clientHeight) / 100
+    // convert from vh to px
+
+    if (imgHeight > maxHeightToPx) {
+      setUseInitialHeight(true)
+    }
+
     setLoaded(true)
   }, [])
 
   return (
-    <RatioBox {...rest} tone="transparent">
+    <RatioBox {...rest} style={{height: useInitialHeight ? '30vh' : ''}} tone="transparent">
       <Card data-container tone="inherit">
         {!isLoaded && <OverlayComponent cardTone="transparent" drag content={<SpinnerWrapper />} />}
         <img src={src} data-testid="hotspot-image-input" alt={props.alt} onLoad={onLoadChange} />

--- a/packages/@sanity/form-builder/src/inputs/files/common/ActionsMenu.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/common/ActionsMenu.tsx
@@ -45,7 +45,7 @@ export function ActionsMenu(props: Props) {
       {browse}
 
       <MenuDivider />
-      <MenuItem as="a" icon={DownloadIcon} text="Download original file" href={downloadUrl} />
+      <MenuItem as="a" icon={DownloadIcon} text="Download" href={downloadUrl} />
       <MenuItem icon={ClipboardIcon} text="Copy URL" onClick={handleCopyURL} />
 
       <MenuDivider />

--- a/packages/@sanity/form-builder/src/sanity/inputs/SanityImageInput.tsx
+++ b/packages/@sanity/form-builder/src/sanity/inputs/SanityImageInput.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import type {AssetSource} from '@sanity/types'
 import imageUrlBuilder from '@sanity/image-url'
 import ImageInput from '../../inputs/files/ImageInput'
-import resolveUploader from '../uploads/resolveUploader'
 import {
   defaultImageAssetSources,
   formBuilderConfig,
@@ -38,7 +37,6 @@ export default React.forwardRef(function SanityImageInput(props: Props, forwarde
   return (
     <ImageInputWithValuePath
       {...props}
-      resolveUploader={resolveUploader}
       observeAsset={observeImageAsset}
       assetSources={assetSources}
       directUploads={SUPPORT_DIRECT_UPLOADS}


### PR DESCRIPTION
### Description

When loading a document that has an image input and that image is a smaller one, then the input should be of the height of the image. 
If the image is large, then it should be set to a max height that we have set.

After some discussion with Design, it was also decided to remove the resizing of the input for keeping consistency with how we do other inputs


### What to review

These following states are meant to be like that when you first open a document (especially for smaller images)

| default | small image | big image (max) |
|---------|-------------|-----------|
|   <img width="600" alt="image" src="https://user-images.githubusercontent.com/6951139/158384901-483a5b1b-ef3f-4a85-8257-74019c7b42fb.png">      |       <img width="600" alt="image" src="https://user-images.githubusercontent.com/6951139/158385200-d5b0e1bb-fae0-4f74-b3bd-7e72568df1de.png">  |   <img width="600" alt="image" src="https://user-images.githubusercontent.com/6951139/158385401-0507795e-179a-4ea7-9fcb-21843581a96f.png"> |

It should also work when you crop the image (so if it's a large image, but you've cropped it, then when you open the document, the image input will be the size of the cropped version)

### Notes for release

Update image input height based on image size
