### PR TITLE
fix(base): respect client already configured with token

### DIFF
--- a/packages/@sanity/base/src/client/wrappedClient.ts
+++ b/packages/@sanity/base/src/client/wrappedClient.ts
@@ -70,16 +70,17 @@ export const wrappedClient = {
     }
     const newClient = configuredClient.clone().config(newConfig)
     instances.push(newClient)
-
-    // Subscribe to auth token stream and configure the client depending on token value
-    authToken$.subscribe((token) => {
-      const currentHasToken = Boolean(newClient.config().token)
-      const nextHasToken = Boolean(token)
-      if (currentHasToken !== nextHasToken) {
-        newClient.config({...newConfig, token})
-      }
-    })
-
+    // Subscribe to auth token stream and configure the client depending on token value unless the client was originally configured with a token.
+    const preconfiguredToken = Boolean(configuredClient.config().token)
+    if (!preconfiguredToken) {
+      authToken$.subscribe((token) => {
+        const currentHasToken = Boolean(newClient.config().token)
+        const nextHasToken = Boolean(token)
+        if (currentHasToken !== nextHasToken) {
+          newClient.config({...newConfig, token})
+        }
+      })
+    }
     return newClient
   },
 }


### PR DESCRIPTION
The part 'part:@sanity/base/configure-client' may implement configuring a static token for clients. This should be respected and not overridden by the wrappedClient's token subscription.

### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

That implementations of `part:@sanity/base/configure-client` where a token is set will not be reset.


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

* Fixes an issue where token configured via `part:@sanity/base/configure-client` would be reset.

<!--
A description of the change(s) that should be used in the release notes.
-->
