### PR TITLE
feat: Implemented fallback component for language-filter

### DIFF
--- a/packages/@sanity/language-filter/src/SelectLanguageProvider.tsx
+++ b/packages/@sanity/language-filter/src/SelectLanguageProvider.tsx
@@ -1,10 +1,11 @@
 // @todo: remove the following line when part imports has been removed from this file
 ///<reference types="@sanity/types/parts" />
 
-import React, {useRef, useEffect, useState} from 'react'
+import React, {useRef, useEffect, useState, useMemo} from 'react'
 import config from 'part:@sanity/language-filter/config'
 import {SchemaType} from '@sanity/types'
 import {Subscription} from 'rxjs'
+import languageFilterImplementations from 'all:part:@sanity/desk-tool/language-select-component'
 import {selectedLanguages$, setLangs} from './datastore'
 import SelectLanguage from './SelectLanguage'
 
@@ -16,6 +17,20 @@ const SelectLanguageProvider = ({schemaType}: Props) => {
   const subscriptionRef$ = useRef<Subscription | null>(null)
   const [selected, setSelected] = useState<string[]>([])
   const [currentDocumentType, setCurrentDocumentType] = useState<string | undefined>()
+  const shouldShow = useMemo(() => {
+    const {documentTypes} = config
+    return !!(documentTypes && schemaType?.name && documentTypes.includes(schemaType.name))
+  }, [schemaType])
+  const FallbackImplementation = useMemo(() => {
+    if (languageFilterImplementations && Array.isArray(languageFilterImplementations)) {
+      return (
+        languageFilterImplementations?.filter(
+          (component) => SelectLanguageProvider !== component
+        )?.[0] ?? null
+      )
+    }
+    return null
+  }, [])
 
   useEffect(() => {
     setCurrentDocumentType(schemaType?.name)
@@ -32,16 +47,24 @@ const SelectLanguageProvider = ({schemaType}: Props) => {
     }
   }, [])
 
-  return (
-    <SelectLanguage
-      languages={config.supportedLanguages}
-      defaultLanguages={config.defaultLanguages}
-      documentTypes={config.documentTypes}
-      currentDocumentType={currentDocumentType}
-      selected={selected}
-      onChange={setLangs}
-    />
-  )
+  if (shouldShow) {
+    return (
+      <SelectLanguage
+        languages={config.supportedLanguages}
+        defaultLanguages={config.defaultLanguages}
+        documentTypes={config.documentTypes}
+        currentDocumentType={currentDocumentType}
+        selected={selected}
+        onChange={setLangs}
+      />
+    )
+  }
+
+  if (FallbackImplementation) {
+    return <FallbackImplementation schemaType={schemaType} />
+  }
+
+  return null
 }
 
 export default SelectLanguageProvider

--- a/packages/@sanity/types/parts/part.@sanity/language-filter/language-filter.d.ts
+++ b/packages/@sanity/types/parts/part.@sanity/language-filter/language-filter.d.ts
@@ -1,3 +1,10 @@
+declare module 'all:part:@sanity/desk-tool/language-select-component' {
+  const implementations: React.FC<{
+    schemaType?: import('@sanity/types').SchemaType
+  }>[] | undefined
+  export default implementations
+}
+
 declare module 'part:@sanity/language-filter/config' {
   interface Config {
     supportedLanguages: {


### PR DESCRIPTION
### Description
This change was already made in the i18n plugin so it can fallback to other language select implementations if i18n is not enabled for the selected schema type. This PR introduces the same behavior for the field level localization. 

### What to review
When the plugin `@sanity/language-filter` is below `@sanity/document-internationalization` both implementations should still work. The language filter should show for object level translation schemas and the language switch dropdown should show for document level translations.

### Notes for release
This change introduces support to fallback to different language select implementations when the current is not relevant
