### PR TITLE
refactor(import): improve error message on duplicate IDs

### DIFF
--- a/packages/@sanity/import/src/util/ensureUniqueIds.js
+++ b/packages/@sanity/import/src/util/ensureUniqueIds.js
@@ -23,5 +23,7 @@ module.exports = function ensureUniqueIds(documents) {
     return
   }
 
-  throw new Error(`Found ${numDupes} duplicate IDs:\n- ${duplicates.join('\n- ')}`)
+  throw new Error(
+    `Found ${numDupes} duplicate IDs in the source file:\n- ${duplicates.join('\n- ')}`
+  )
 }

--- a/packages/@sanity/import/test/import.test.js
+++ b/packages/@sanity/import/test/import.test.js
@@ -83,7 +83,7 @@ test('rejects on duplicate IDs', async () => {
   expect.assertions(1)
   await expect(importer(getFixtureStream('duplicate-ids'), importOptions)).rejects.toHaveProperty(
     'message',
-    'Found 2 duplicate IDs:\n- pk\n- espen'
+    'Found 2 duplicate IDs in the source file:\n- pk\n- espen'
   )
 })
 


### PR DESCRIPTION
### Description

There was confusion about duplicate IDs and the `--replace` script in the community. I added a bit more context in the error message copy when there are documents with duplicate IDs in the source file in the CLI import script. 

### What to review

It's just a small change to the copy, so shouldn't be too much to test.

### Notes for release

Improved error message for the import script when there are documents with duplicate IDs in the source file.
