### PR TITLE
fix(default-layout): prevent changelog crash by filtering out entries without data to display

### DIFF
--- a/packages/@sanity/default-layout/src/update/changelog/ChangelogDialog.tsx
+++ b/packages/@sanity/default-layout/src/update/changelog/ChangelogDialog.tsx
@@ -20,7 +20,8 @@ const StickyBox = styled(Box)`
 export function ChangelogDialog(props: ChangelogDialogProps) {
   const {changelog, currentVersion, dialogProps, latestVersion} = props
 
-  const hasChangelog = changelog.filter((c) => c?.changeItems).length > 0
+  const changelogWithChangeItems = (changelog || []).filter((c) => c?.changeItems?.length > 0)
+  const hasChangelog = changelogWithChangeItems.length > 0
 
   return (
     <Dialog header="Upgrade the Sanity Studio" width={1} {...dialogProps} id="changelog-dialog">
@@ -41,9 +42,9 @@ export function ChangelogDialog(props: ChangelogDialogProps) {
 
         {hasChangelog && (
           <Stack space={5} paddingY={4}>
-            {changelog?.map((log, index) => {
+            {changelogWithChangeItems?.map((log, index) => {
               const {changeItems, version} = log
-              const showDivider = index < changelog.length - 1
+              const showDivider = index < changelogWithChangeItems.length - 1
               const isLatest = version === latestVersion
 
               return (

--- a/packages/@sanity/default-layout/src/update/changelog/ChangelogList.tsx
+++ b/packages/@sanity/default-layout/src/update/changelog/ChangelogList.tsx
@@ -40,7 +40,13 @@ export function ChangelogList(props: ChangelogListProps) {
 
       <Flex justify="flex-end">
         <Text size={1}>
-          <a href="#">See full changelog on GitHub</a>
+          <a
+            href="https://github.com/sanity-io/sanity/releases"
+            rel="noreferrer noopener"
+            target="_blank"
+          >
+            See full changelog on GitHub
+          </a>
         </Text>
       </Flex>
     </Stack>


### PR DESCRIPTION
### Description

- The changelog crashes when a changelog entry is passed to the `ChangelogList` without any `changeItems` data. This PR fixes this issue by filtering out all the changelog entries that does not contain any `changeItems` before the changelog is passed to the `ChangelogList`.
- Add missing `href` to the "See full changelog on Github" link

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

n/a

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

Prevent changelog crash by filtering out entries without data to display
