### PR TITLE
feat(cli): allow selecting organization during project creation

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -69,6 +69,7 @@
     "opn": "^5.2.0",
     "ora": "^5.4.1",
     "osenv": "^0.1.4",
+    "p-filter": "^2.1.0",
     "p-timeout": "^2.0.1",
     "promise-props-recursive": "^1.0.0",
     "resolve-from": "^4.0.0",

--- a/packages/@sanity/cli/src/commands/init/initCommand.js
+++ b/packages/@sanity/cli/src/commands/init/initCommand.js
@@ -5,6 +5,7 @@ const helpText = `
 Options
   -y, --yes Use unattended mode, accepting defaults and using only flags for choices
   --project <projectId> Project ID to use for the studio
+  --organization <organizationId> Organization ID to use for the project
   --dataset <dataset> Dataset name for the studio
   --dataset-default Set up a project with a public dataset named "production"
   --output-path <path> Path to write studio project to


### PR DESCRIPTION
### Description

When creating new projects using the `sanity init` command, this PR will allow you to attach it directly to an organization - either using the `--organization` flag or by prompting the user. It does require an organization to already exist and that the user has "attach project" grants to it. If no organizations are found with these permissions, it skips the prompt.

Closes [sc-13493]
Supersedes #2271

### What to review

That the behavior, messaging and code looks right

### Notes for release

- Allow selecting an organization to attach new projects to during `sanity init`
