### PR TITLE
fix(form-builder): fix the number input to accept decimal values when default

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/NumberInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/NumberInput.tsx
@@ -42,6 +42,7 @@ const NumberInput = React.forwardRef(function NumberInput(
     >
       <TextInput
         type="number"
+        step="any"
         inputMode={onlyPositiveNumber ? 'numeric' : 'text'}
         id={id}
         customValidity={errors && errors.length > 0 ? errors[0].item.message : ''}

--- a/packages/@sanity/form-builder/src/inputs/__tests__/NumberInput.test.tsx
+++ b/packages/@sanity/form-builder/src/inputs/__tests__/NumberInput.test.tsx
@@ -1,0 +1,48 @@
+// eslint-disable-next-line import/no-unassigned-import
+import '@testing-library/jest-dom/extend-expect'
+import Schema from '@sanity/schema'
+import {inputTester} from '../../utils/tests/FormBuilderTester'
+
+const schema = Schema.compile({
+  name: 'test',
+  types: [
+    {
+      name: 'book',
+      type: 'document',
+      fields: [{name: 'num', title: 'Number', type: 'number'}],
+    },
+  ],
+})
+const documentType = schema.get('book')
+const dummyDocument = {
+  _createdAt: '2021-11-04T15:41:48Z',
+  _id: 'drafts.10053a07-8647-4ebd-9d1d-33a512d30d3a',
+  _rev: '5hb8s6-k75-ip4-4bq-5ztbf3fbx',
+  _type: 'numberFieldTest',
+  _updatedAt: '2021-11-05T12:34:29Z',
+  num: 0,
+  title: 'Hello world',
+}
+
+function renderInput(testId: string) {
+  return inputTester(dummyDocument, documentType, schema, testId)
+}
+
+describe('number-input', () => {
+  it('renders the number input field', () => {
+    const {inputContainer} = renderInput('input-num')
+    const input = inputContainer.querySelector('input')
+
+    expect(input).toBeDefined()
+    expect(input).toHaveAttribute('type', 'number')
+  })
+
+  it('accepts decimals by default', () => {
+    const {inputContainer} = renderInput('input-num')
+    const input = inputContainer.querySelector('input')
+
+    input.value = '1.2'
+    expect(input.value).toBe('1.2')
+    expect(input.checkValidity()).toBe(true)
+  })
+})


### PR DESCRIPTION
### Description

Fix issue where the number input wasn't allowing for decimal numbers (when the input is active)

### What to review

Check that you can add any decimal number on a basic number schema

### Notes for release

Fix issue where the number input wasn't allowing for decimal numbers (when the input is active)