### PR TITLE
refactor(form-builder): stabilize objectEditData object

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/PortableText/__workshop__/editObjects/EditObjectsStory.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/__workshop__/editObjects/EditObjectsStory.tsx
@@ -96,7 +96,6 @@ export function EditObjectsStory() {
       editorPath,
       formBuilderPath: focusPath,
       kind: kind as any,
-      returnToSelection: null,
     }),
     [editorPath, focusPath, kind]
   )

--- a/packages/@sanity/form-builder/src/inputs/PortableText/hooks/useObjectEditFormBuilderFocus.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/hooks/useObjectEditFormBuilderFocus.tsx
@@ -33,15 +33,8 @@ export function useObjectEditFormBuilderFocus(onFocus: (path: Path) => void) {
   const onEditObjectFormBuilderBlur = onBlur
 
   const onEditObjectClose = useCallback(() => {
-    if (selection) {
-      PortableTextEditor.focus(editor)
-      // Not sure why, but Safari resets the selection for some reason if the path isn't emitted as a new object here.
-      onFocus([...selection.focus.path])
-    } else {
-      onFocus([])
-      PortableTextEditor.focus(editor)
-    }
-  }, [editor, onFocus, selection])
+    PortableTextEditor.focus(editor)
+  }, [editor])
 
   return useMemo(
     () => ({onEditObjectFormBuilderFocus, onEditObjectFormBuilderBlur, onEditObjectClose}),

--- a/packages/@sanity/form-builder/src/inputs/PortableText/object/EditObject.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/object/EditObject.tsx
@@ -59,6 +59,7 @@ export const EditObject = (props: EditObjectProps) => {
     () => findObjectAndType(objectEditData, value, ptFeatures),
     [objectEditData, ptFeatures, value]
   )
+
   const [object, setObject] = useState(objectFromValue)
   const [timeoutInstance, setTimeoutInstance] = useState(undefined)
   const formBuilderPath = objectEditData && objectEditData.formBuilderPath

--- a/packages/@sanity/form-builder/src/inputs/PortableText/types.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/types.tsx
@@ -1,11 +1,10 @@
-import {EditorSelection, PortableTextBlock} from '@sanity/portable-text-editor'
+import {PortableTextBlock} from '@sanity/portable-text-editor'
 import {Path, Marker} from '@sanity/types'
 
 export type ObjectEditData = {
   editorPath: Path // The object representation in the editor (i.e. an text for an annotation)
   formBuilderPath: Path // The actual data storage path in the PT model (like .markDefs for annotations)
   kind: 'annotation' | 'blockObject' | 'inlineObject'
-  returnToSelection: EditorSelection | null
   editorHTMLElementRef?: React.MutableRefObject<HTMLElement> // Optional reference to editor HTML Element
 }
 


### PR DESCRIPTION
### Description

They way this was implemented the objectEditData object was changing on every focusPath change causing unnecessary re-renderes.

I have optimized it so that it keeps a stable object when something is edited, and null otherwise.

Also `returnToSelection` in this object is no longer needed as the selection now is kept in the editor in the background.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
That object editing works as expected.
* Blocks objects
* Inline objects
* Annotations

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Doesn't need to be mentioned.

<!--
A description of the change(s) that should be used in the release notes.
-->
