### PR TITLE
fix(code-input): preview loading non-existant mode

### DIFF
--- a/dev/test-studio/schema/plugins/code.js
+++ b/dev/test-studio/schema/plugins/code.js
@@ -54,6 +54,7 @@ export default {
             languageAlternatives: [
               {title: 'Rust', value: 'rust', mode: 'rust'},
               {title: 'JavaScript', value: 'javascript'},
+              {title: 'C++', value: 'cpp', mode: 'c_cpp'},
             ],
           },
         },

--- a/packages/@sanity/code-input/src/CodeInput.tsx
+++ b/packages/@sanity/code-input/src/CodeInput.tsx
@@ -255,10 +255,17 @@ const CodeInput = React.forwardRef(
     const handleLanguageChange = useCallback(
       (event: React.ChangeEvent<HTMLSelectElement>) => {
         const val = event.currentTarget.value
+        const configured = languages.find((entry) => entry.value === val)
         const path = PATH_LANGUAGE
 
         onChange(
           PatchEvent.from([setIfMissing({_type: type.name}), val ? set(val, path) : unset(path)])
+        )
+        onChange(
+          PatchEvent.from([
+            setIfMissing({_type: type.name}),
+            configured?.mode ? set(configured?.mode, ['mode']) : unset(['mode']),
+          ])
         )
       },
       [onChange, type.name]

--- a/packages/@sanity/code-input/src/PreviewCode.tsx
+++ b/packages/@sanity/code-input/src/PreviewCode.tsx
@@ -54,7 +54,7 @@ export default function PreviewCode(props: PreviewCodeProps) {
   const {value, type} = props
   const fixedLanguage = type?.options?.language
 
-  const mode = value?.language || fixedLanguage || 'text'
+  const mode = value?.mode || value?.language || fixedLanguage || 'text'
 
   return (
     <PreviewContainer>

--- a/packages/@sanity/code-input/src/schema.tsx
+++ b/packages/@sanity/code-input/src/schema.tsx
@@ -48,12 +48,14 @@ export default {
       code: 'code',
       filename: 'filename',
       highlightedLines: 'highlightedLines',
+      mode: 'mode',
     },
     prepare: (value: {
       language?: string
       code?: string
       filename?: string
       highlightedLines?: number[]
+      mode?: string
     }) => {
       return {
         title: value.filename || (value.language || 'unknown').toUpperCase(),

--- a/packages/@sanity/code-input/src/types.ts
+++ b/packages/@sanity/code-input/src/types.ts
@@ -23,4 +23,5 @@ export interface CodeInputValue {
   filename?: string
   language?: string
   highlightedLines?: number[]
+  mode?: string
 }


### PR DESCRIPTION
### Description

Address the following issue of the changes from #3056, a fix for the same issue in #3077 but not fixed in the code-input preview component. 

Similarly, when the ace mode name is different from the language name, the following issue occurred. The mode is c_cpp while the language value is cpp.
![issue](https://user-images.githubusercontent.com/52971804/149877813-739de7f3-903b-42a2-a4f8-c9aa95eab86b.png)

This can be tested under Plugin inputs > Code test > _Some Document_ > Code in arrays in the Test studio. If there is a cleaner way to solve this issue, please do let me know.

Before         |  After
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/52971804/158519561-381ffc6c-e204-4ed0-84c2-773bfe895d00.png)  |  ![image](https://user-images.githubusercontent.com/52971804/158518439-18ccca6d-c7f5-4f0c-895e-8be19aaf5922.png)


### What to review

- Check that the code input **preview** work with an alternative language that has a different ace mode name to the language value name.
- Check that the code input **preview** work with other default supported languages

### Notes for release

- Fixed an issue with the code-input plugin's preview assigning wrong ace mode for additional languages
