### PR TITLE
feat(core): add `dry-run` flag

### DIFF
--- a/packages/@sanity/core/src/actions/graphql/deployApiAction.js
+++ b/packages/@sanity/core/src/actions/graphql/deployApiAction.js
@@ -127,22 +127,22 @@ module.exports = async function deployApiActions(args, context) {
     // not valid and a dry run? then it can exit with a error
     if (dryRun) {
       process.exit(1)
-    } else {
-      if (!isInteractive) {
-        throw new Error(
-          'Dangerous changes found - falling back. Re-run the command with the `--force` flag to force deployment.'
-        )
-      }
+    }
 
-      const shouldDeploy = await prompt.single({
-        type: 'confirm',
-        message: 'Do you want to deploy a new API despite the dangerous changes?',
-        default: false,
-      })
+    if (!isInteractive) {
+      throw new Error(
+        'Dangerous changes found - falling back. Re-run the command with the `--force` flag to force deployment.'
+      )
+    }
 
-      if (!shouldDeploy) {
-        return
-      }
+    const shouldDeploy = await prompt.single({
+      type: 'confirm',
+      message: 'Do you want to deploy a new API despite the dangerous changes?',
+      default: false,
+    })
+
+    if (!shouldDeploy) {
+      return
     }
   } else if (dryRun) {
     output.print('GraphQL API is valid and has no breaking changes')

--- a/packages/@sanity/core/src/actions/graphql/deployApiAction.js
+++ b/packages/@sanity/core/src/actions/graphql/deployApiAction.js
@@ -177,6 +177,7 @@ function parseCliFlags(args) {
     .option('generation', {type: 'string'})
     .option('non-null-document-fields', {type: 'boolean', default: false})
     .option('playground', {type: 'boolean'})
+    .option('dry-run', {type: 'boolean', default: false})
     .option('force', {type: 'boolean'}).argv
 }
 

--- a/packages/@sanity/core/src/commands/graphql/deployGraphQLAPICommand.js
+++ b/packages/@sanity/core/src/commands/graphql/deployGraphQLAPICommand.js
@@ -18,6 +18,7 @@ Examples
   sanity graphql deploy --dataset staging --tag next --no-playground
   sanity graphql deploy --no-playground --force
   sanity graphql deploy --playground --non-null-document-fields
+  sanity graphql deploy --dry-run
 `
 
 export default {


### PR DESCRIPTION
### Description

Add `dry-run` flag as an option when running `sanity graphql deploy` 

### What to review

To test:
- Running `sanity graphql deploy --dry-run` will not deploy anything
  - It won't ask for the playground and, if there are conflicts, will not confirm that you want to deploy
- Running `sanity graphql deploy` will work exactly as before
- Do breaking changes to the schema. When running with the dry-run flag you should have a list of the changes and you won't be prompted about deploying with breaking changes

### Notes for release

Add `dry-run` flag as an option when running `sanity graphql deploy`
