### PR TITLE
fix(portable-text-editor): fix pasted plain text normalization issue

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithInsertData.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithInsertData.ts
@@ -188,10 +188,13 @@ export function createWithInsertData(
             )
             .join('')
           const textToHtml = `<html><body>${blocks}</body></html>`
-          portableText = htmlToBlocks(textToHtml, portableTextFeatures.types.portableText)
+          portableText = htmlToBlocks(
+            textToHtml,
+            portableTextFeatures.types.portableText
+          ).map((block: PortableTextBlock) => normalizeBlock(block, {blockTypeName}))
           fragment = toSlateValue(portableText, {
             portableTextFeatures,
-          }).map((block: PortableTextBlock) => normalizeBlock(block, {blockTypeName}))
+          })
           insertedType = 'text'
         }
 


### PR DESCRIPTION
### Description

There was a rare bug when pasting plain texti into the PTE where it sometimes would error with "Children for text block with _key '659301731a2e' is empty".

The reason is we are normalizing the wrong value. We must normalize the portableText value here, as this is the one being validated and cause the error further down in the code.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

That plain text pasting works as expected. We haven't found a way of reproducing this bug though (which content actually triggers it), only got reports. But it's very obvious what is causing it. 

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Fix issue with pasting plain text into the Portable Text editor where it in some rare circumstances would error with "Children for text block is empty"

<!--
A description of the change(s) that should be used in the release notes.
-->
