### PR TITLE
fix(portable-text-editor): fix order of outer plugin stack

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -157,7 +157,7 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
   )
 
   // Update the Slate instance's plugins which are dependent on props for Editable
-  useMemo(() => withReact(withEditableAPI(withInsertData(withHotKeys(slateEditor)))), [
+  useMemo(() => withEditableAPI(withInsertData(withHotKeys(withReact(slateEditor)))), [
     slateEditor,
     withEditableAPI,
     withHotKeys,


### PR DESCRIPTION
`withReact` must be the inner plugin here, as insertData and insertFragmentData are defined here and should be overwritten by the insertData plugin.

### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Fix regression from ` v2.29.3` where formatting was lost when pasting HTML into the Portable Text editor.

<!--
A description of the change(s) that should be used in the release notes.
-->
