### PR TITLE
fix(form-builder): allow for upload of items when dropping over text

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/files/common/PlaceholderText.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/common/PlaceholderText.tsx
@@ -1,5 +1,4 @@
-import React from 'react'
-
+import React, {useMemo} from 'react'
 import {BinaryDocumentIcon, AccessDeniedIcon, ImageIcon, ReadOnlyIcon} from '@sanity/icons'
 import {Flex, Text} from '@sanity/ui'
 import styled from 'styled-components'
@@ -14,7 +13,7 @@ interface Props {
   directUploads: boolean
 }
 
-const FlexWrapper = styled(Flex)`
+const RootFlex = styled(Flex)`
   pointer-events: none;
 `
 
@@ -22,7 +21,7 @@ export function PlaceholderText(props: Props) {
   const {hoveringFiles, type, readOnly, acceptedFiles, rejectedFilesCount, directUploads} = props
   const isFileType = type === 'file'
 
-  function MessageIcon() {
+  const messageIcon = useMemo(() => {
     if (readOnly) {
       return <ReadOnlyIcon />
     }
@@ -32,13 +31,13 @@ export function PlaceholderText(props: Props) {
     }
 
     return isFileType ? <BinaryDocumentIcon /> : <ImageIcon />
-  }
+  }, [directUploads, hoveringFiles, isFileType, readOnly, rejectedFilesCount])
 
-  function MessageText() {
+  const messageText = useMemo(() => {
     let message = `Drag or paste ${type} here`
 
     if (!directUploads) {
-      message = `Can't upload files here`
+      return `Can't upload files here`
     }
 
     if (readOnly) {
@@ -54,23 +53,16 @@ export function PlaceholderText(props: Props) {
       }
     }
 
-    return (
-      <Text size={1} muted>
-        {message}
-      </Text>
-    )
-  }
+    return message
+  }, [acceptedFiles.length, directUploads, hoveringFiles, readOnly, rejectedFilesCount, type])
 
   return (
-    <>
-      <Flex justify="center">
-        <Text muted>
-          <MessageIcon />
-        </Text>
-      </Flex>
-      <FlexWrapper justify="center">
-        <MessageText />
-      </FlexWrapper>
-    </>
+    <RootFlex align="center" gap={2} justify="center">
+      <Text muted>{messageIcon}</Text>
+
+      <Text size={1} muted>
+        {messageText}
+      </Text>
+    </RootFlex>
   )
 }

--- a/packages/@sanity/form-builder/src/inputs/files/common/PlaceholderText.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/common/PlaceholderText.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import {BinaryDocumentIcon, AccessDeniedIcon, ImageIcon, ReadOnlyIcon} from '@sanity/icons'
 import {Flex, Text} from '@sanity/ui'
+import styled from 'styled-components'
 import {FileLike} from '../../../sanity/uploads/types'
 
 interface Props {
@@ -12,6 +13,10 @@ interface Props {
   rejectedFilesCount: number
   directUploads: boolean
 }
+
+const FlexWrapper = styled(Flex)`
+  pointer-events: none;
+`
 
 export function PlaceholderText(props: Props) {
   const {hoveringFiles, type, readOnly, acceptedFiles, rejectedFilesCount, directUploads} = props
@@ -63,9 +68,9 @@ export function PlaceholderText(props: Props) {
           <MessageIcon />
         </Text>
       </Flex>
-      <Flex justify="center">
+      <FlexWrapper justify="center">
         <MessageText />
-      </Flex>
+      </FlexWrapper>
     </>
   )
 }


### PR DESCRIPTION
### Description

allow for upload of items when dropping over text

### What to review

Drag image over the "drop to upload image" text in an empty image input and see that it uploads the image instead of opening a new tab.

**old behavior:**

https://user-images.githubusercontent.com/6951139/161958840-0bb6dce5-533b-4698-80d3-92c34cb9f833.mov



### Notes for release

Allow for upload of items when dropping over placeholder text
