### PR TITLE
fix(base): use same-origin referrer policy

### DIFF
--- a/packages/@sanity/base/src/components/Document.tsx
+++ b/packages/@sanity/base/src/components/Document.tsx
@@ -78,6 +78,7 @@ export default function Document(props: DocumentProps) {
         <title>{title}</title>
         <meta name="viewport" content={viewport} />
         <meta name="robots" content="noindex" />
+        <meta name="referrer" content="same-origin" />
         <style>{`html {background-color: #f1f3f6;}`}</style>
         {stylesheets}
         {subresources}

--- a/packages/@sanity/base/src/preview/components/SanityDefaultPreview.tsx
+++ b/packages/@sanity/base/src/preview/components/SanityDefaultPreview.tsx
@@ -83,6 +83,7 @@ export default class SanityDefaultPreview extends React.PureComponent<SanityDefa
     return (
       <img
         alt={isString(value.title) ? value.title : undefined}
+        referrerPolicy="strict-origin-when-cross-origin"
         src={
           imageBuilder
             .image(media)

--- a/packages/@sanity/default-layout/src/update/PortableTextContent/PortableTextContent.tsx
+++ b/packages/@sanity/default-layout/src/update/PortableTextContent/PortableTextContent.tsx
@@ -26,7 +26,7 @@ function Image({value}: {value: MaterializedImage}) {
     <SpaceBox marginY={4}>
       <Stack space={3} as="figure">
         <ImageCard radius={1} shadow={1} overflow="hidden" $aspectRatio={aspectRatio} $lqip={lqip}>
-          <img src={url} alt={alt || caption} />
+          <img src={url} alt={alt || caption} referrerPolicy="strict-origin-when-cross-origin" />
         </ImageCard>
         {caption && (
           <Text align="center" as="figcaption" muted size={1}>

--- a/packages/@sanity/default-login/src/util/getProviderLogo.js
+++ b/packages/@sanity/default-login/src/util/getProviderLogo.js
@@ -51,7 +51,11 @@ export function getProviderLogo(provider) {
     default:
       return function CustomLogo() {
         return provider.logo ? (
-          <img src={provider.logo} alt={`Logo for ${provider.name}`} />
+          <img
+            src={provider.logo}
+            alt={`Logo for ${provider.name}`}
+            referrerPolicy="strict-origin-when-cross-origin"
+          />
         ) : (
           <QuestionmarkLogo />
         )

--- a/packages/@sanity/form-builder/src/inputs/CrossDatasetReferenceInput/CrossDatasetReferencePreview.tsx
+++ b/packages/@sanity/form-builder/src/inputs/CrossDatasetReferenceInput/CrossDatasetReferencePreview.tsx
@@ -78,6 +78,7 @@ export function CrossDatasetReferencePreview(props: {
               .withOptions(dimensions)
               .url()}
             alt="Image preview of referenced document"
+            referrerPolicy="strict-origin-when-cross-origin"
           />
         )
       }

--- a/packages/@sanity/form-builder/src/inputs/common/fileTarget/utils/imageUrlToBlob.ts
+++ b/packages/@sanity/form-builder/src/inputs/common/fileTarget/utils/imageUrlToBlob.ts
@@ -9,6 +9,7 @@ export function imageUrlToBlob(
   return new Promise((resolve, reject) => {
     const loader = new Image()
     loader.crossOrigin = 'anonymous'
+    loader.referrerPolicy = 'strict-origin-when-cross-origin'
     loader.onload = () => {
       const canvas = document.createElement('canvas')
       canvas.width = loader.width

--- a/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImagePreview.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/ImageInput/ImagePreview.tsx
@@ -18,8 +18,8 @@ interface Props {
   alt: string
 }
 
-/* 
-  Used for setting the initial image height - specifically for images 
+/*
+  Used for setting the initial image height - specifically for images
   that are small and so can take less space in the document
 */
 const getImageSize = (src) => {
@@ -51,7 +51,7 @@ export function ImagePreview(props: ComponentProps<typeof Card> & Props) {
   // is the image wider than root? if so calculate the resized height
   const renderedImageHeight = imageWidth > rootWidth ? rootWidth / imageRatio : imageHeight
 
-  /* 
+  /*
     if the rendered image is smaller than the max height then it doesn't require a height set
     otherwise, set the max height (to prevent a large image in the document)
   */
@@ -71,7 +71,13 @@ export function ImagePreview(props: ComponentProps<typeof Card> & Props) {
     <RatioBox {...rest} ref={setRootElement} style={{height: rootHeight}} tone="transparent">
       <Card data-container tone="inherit">
         {!isLoaded && <OverlayComponent cardTone="transparent" drag content={<SpinnerWrapper />} />}
-        <img src={src} data-testid="hotspot-image-input" alt={props.alt} onLoad={onLoadChange} />
+        <img
+          src={src}
+          data-testid="hotspot-image-input"
+          alt={props.alt}
+          onLoad={onLoadChange}
+          referrerPolicy="strict-origin-when-cross-origin"
+        />
       </Card>
 
       {drag && (

--- a/packages/@sanity/form-builder/src/sanity/DefaultAssetSource/ConfirmMessage.tsx
+++ b/packages/@sanity/form-builder/src/sanity/DefaultAssetSource/ConfirmMessage.tsx
@@ -48,7 +48,12 @@ export const ConfirmMessage = ({asset, assetType, hasResults = false}: ConfirmMe
           {isImage && (
             <Card __unstable_checkered border radius={1} style={STYLE_CONFIRM_CARD}>
               <Flex align="center" justify="center" style={STYLE_IMAGE_WRAPPER}>
-                <img src={`${asset.url}?w=200`} style={STYLE_ASSET_IMAGE} alt="Preview of image" />
+                <img
+                  src={`${asset.url}?w=200`}
+                  style={STYLE_ASSET_IMAGE}
+                  alt="Preview of image"
+                  referrerPolicy="strict-origin-when-cross-origin"
+                />
               </Flex>
             </Card>
           )}
@@ -78,7 +83,12 @@ export const ConfirmMessage = ({asset, assetType, hasResults = false}: ConfirmMe
         {isImage && (
           <Card __unstable_checkered border radius={1} style={STYLE_CONFIRM_CARD}>
             <Flex align="center" justify="center" style={STYLE_IMAGE_WRAPPER}>
-              <img src={`${asset.url}?w=200`} style={STYLE_ASSET_IMAGE} alt="Preview of image" />
+              <img
+                src={`${asset.url}?w=200`}
+                style={STYLE_ASSET_IMAGE}
+                alt="Preview of image"
+                referrerPolicy="strict-origin-when-cross-origin"
+              />
             </Flex>
           </Card>
         )}

--- a/packages/@sanity/imagetool/src/ImageLoader.js
+++ b/packages/@sanity/imagetool/src/ImageLoader.js
@@ -39,6 +39,7 @@ export default class ImageLoader extends React.Component {
       })
     }
 
+    image.referrerPolicy = 'strict-origin-when-cross-origin'
     image.src = src
   }
 


### PR DESCRIPTION
### Description

This PR adds the `same-origin` referrer policy on the studio level, while opting for `strict-origin-when-cross-origin` on requests to the image CDN (`cdn.sanity.io`).

Rationale:

- When sending requests for user avatars to third-parties such as Google (`googleusercontent.com`) and GitHub (`avatars.githubusercontent.com`), we don't want to include a referrer, as this is leaking information. It can apparently also cause Google to return 403s if they get enough requests from the same origin.
- My initial thought was to add a referrer policy for these requests explicitly, but the avatars are rendered using the SVG `<image>` tag, which for some reason does not support setting a referrer policy.
- For requests to our image CDN, we want to include the origin (but not the full path) in order to answer questions about bandwidth usage grouped by origin.

### What to review

- That things still render as expected

### Notes for release

- Requests to third-party domains from the studio will no longer send a `referrer` header by default
