### PR TITLE
fix(default-layout): Add a missing word to the current version text

### DIFF
--- a/packages/@sanity/default-layout/src/update/changelog/ChangelogDialog.tsx
+++ b/packages/@sanity/default-layout/src/update/changelog/ChangelogDialog.tsx
@@ -32,7 +32,7 @@ export function ChangelogDialog(props: ChangelogDialogProps) {
               <Stack space={3}>
                 {hasChangelog && <Text weight="semibold">Changelog</Text>}
                 <Text muted size={1}>
-                  Your Sanity Studio version <code>{currentVersion}</code>. The latest version is{' '}
+                  Your Sanity Studio is version <code>{currentVersion}</code>. The latest version is{' '}
                   <code>{latestVersion}</code>.
                 </Text>
               </Stack>


### PR DESCRIPTION
### Description

Changes "Your Sanity Studio version 2.29.29" to "Your Sanity Studio version is 2.29.29"

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
Added a missing word in the current version paragraph
