### PR TITLE
fix(default-layout): restore focus on buttons when closing dialogs in navbar

### DIFF
--- a/packages/@sanity/default-layout/src/defaultLayout/DefaultLayout.tsx
+++ b/packages/@sanity/default-layout/src/defaultLayout/DefaultLayout.tsx
@@ -32,8 +32,9 @@ export const DefaultLayout = memo(function DefaultLayout() {
   const [searchIsOpen, setSearchIsOpen] = useState<boolean>(false)
   const [loadingScreenElement, setLoadingScreenElement] = useState<HTMLDivElement | null>(null)
   const [portalElement, setPortalElement] = useState<HTMLDivElement | null>(null)
-  const {value: currentUser} = useCurrentUser()
+  const [createButtonElement, setCreateButtonElement] = useState<HTMLButtonElement | null>(null)
 
+  const {value: currentUser} = useCurrentUser()
   const [templatePermissions, isTemplatePermissionsLoading] = useTemplatePermissions(
     newDocumentOptions
   )
@@ -65,7 +66,12 @@ export const DefaultLayout = memo(function DefaultLayout() {
 
   const handleActionModalClose = useCallback(() => {
     setCreateMenuIsOpen(false)
-  }, [])
+
+    // Restore focus on the button when closing the dialog
+    if (createButtonElement) {
+      createButtonElement.focus()
+    }
+  }, [createButtonElement])
 
   const handleToggleMenu = useCallback(() => {
     setMenuIsOpen((prev) => !prev)
@@ -105,6 +111,7 @@ export const DefaultLayout = memo(function DefaultLayout() {
             onUserLogout={handleLogout}
             onSearchOpen={handleSearchOpen}
             searchPortalElement={portalElement}
+            setCreateButtonElement={setCreateButtonElement}
           />
         </LegacyLayerProvider>
 

--- a/packages/@sanity/default-layout/src/navbar/Navbar.tsx
+++ b/packages/@sanity/default-layout/src/navbar/Navbar.tsx
@@ -22,14 +22,15 @@ import {ChangelogContainer} from './changelog'
 import {PresenceMenu, LoginStatus, SearchField} from '.'
 
 interface NavbarProps {
-  templatePermissions: TemplatePermissionsResult[] | undefined
-  isTemplatePermissionsLoading: boolean
   createMenuIsOpen: boolean
+  isTemplatePermissionsLoading: boolean
   onCreateButtonClick: () => void
+  onSearchOpen: (open: boolean) => void
   onToggleMenu: () => void
   onUserLogout: () => void
-  onSearchOpen: (open: boolean) => void
   searchPortalElement: HTMLDivElement | null
+  setCreateButtonElement?: (el: HTMLButtonElement | null) => void
+  templatePermissions: TemplatePermissionsResult[] | undefined
 }
 
 const Root = styled(Card)<{$onSearchOpen: boolean}>`
@@ -107,13 +108,14 @@ const newDocumentOptions = getNewDocumentOptions()
 export const Navbar = memo(function Navbar(props: NavbarProps) {
   const {
     createMenuIsOpen,
+    isTemplatePermissionsLoading,
     onCreateButtonClick,
+    onSearchOpen,
     onToggleMenu,
     onUserLogout,
-    onSearchOpen,
     searchPortalElement,
+    setCreateButtonElement,
     templatePermissions,
-    isTemplatePermissionsLoading,
   } = props
 
   const [searchOpen, setSearchOpen] = useState<boolean>(false)
@@ -266,6 +268,7 @@ export const Navbar = memo(function Navbar(props: NavbarProps) {
                   icon={ComposeIcon}
                   mode="bleed"
                   onClick={onCreateButtonClick}
+                  ref={setCreateButtonElement}
                   selected={createMenuIsOpen}
                 />
               </SpacingBox>

--- a/packages/@sanity/default-layout/src/navbar/changelog/ChangelogContainer.tsx
+++ b/packages/@sanity/default-layout/src/navbar/changelog/ChangelogContainer.tsx
@@ -1,38 +1,36 @@
 import React, {useCallback, useMemo, useState} from 'react'
 import {useModuleStatus} from '@sanity/base/hooks'
 import {PackageIcon} from '@sanity/icons'
-import {DialogProps, useGlobalKeyDown} from '@sanity/ui'
-import {ChangelogDialog, UpgradeAccordion} from '../../update'
+import {DialogProps} from '@sanity/ui'
 import {StatusButton} from '../components'
+import {ChangelogDialog, UpgradeAccordion} from '../../update'
 
 declare const __DEV__: boolean
 
 export function ChangelogContainer() {
   const [open, setOpen] = useState<boolean>(false)
+  const [buttonElement, setButtonElement] = useState<HTMLButtonElement | null>(null)
   const {value, error, isLoading} = useModuleStatus()
   const {changelog, currentVersion, latestVersion, isUpToDate} = value || {}
 
-  const handleToggleOpen = useCallback(() => setOpen((v) => !v), [])
+  const handleOpen = useCallback(() => setOpen(true), [])
 
-  useGlobalKeyDown(
-    useCallback(
-      (e) => {
-        if (e.key === 'Escape' && open) {
-          setOpen(false)
-        }
-      },
-      [open]
-    )
-  )
+  const handleClose = useCallback(() => {
+    setOpen(false)
+
+    if (buttonElement) {
+      buttonElement.focus()
+    }
+  }, [buttonElement])
 
   const dialogProps: Omit<DialogProps, 'id'> = useMemo(
     () => ({
       footer: <UpgradeAccordion defaultOpen={__DEV__} />,
-      onClickOutside: handleToggleOpen,
-      onClose: handleToggleOpen,
+      onClickOutside: handleClose,
+      onClose: handleClose,
       scheme: 'light',
     }),
-    [handleToggleOpen]
+    [handleClose]
   )
 
   if (error || isLoading || isUpToDate) {
@@ -44,15 +42,16 @@ export function ChangelogContainer() {
       <StatusButton
         icon={PackageIcon}
         mode="bleed"
-        onClick={handleToggleOpen}
+        onClick={handleOpen}
+        ref={setButtonElement}
         selected={open}
         statusTone="primary"
       />
       {open && (
         <ChangelogDialog
-          dialogProps={dialogProps}
           changelog={changelog}
           currentVersion={currentVersion}
+          dialogProps={dialogProps}
           latestVersion={latestVersion}
         />
       )}


### PR DESCRIPTION
### Description

This PR fixes so that focus is restored on the buttons that opens the create document and changelog dialogs when closing the dialogs. Currently, focus is lost when these dialogs are closed.

<img width="983" alt="Screenshot 2022-05-04 at 10 47 36" src="https://user-images.githubusercontent.com/15094168/166649602-441574e0-a2dc-4c1f-a504-681f4bb6f153.png">


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Open and close the dialogs using the keyboard, and the focus should be set back on the buttons. To make the changelog dialog button visible – set the `fakeOutdatedModule` boolean to true in `moduleStatus.ts`.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Fix focus issue on dialog buttons in navbar

<!--
A description of the change(s) that should be used in the release notes.
-->
