### PR TITLE
fix(desk-tool): Restore S.documentList().defaultOrdering() functionality

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/documentList/useDocumentList.ts
+++ b/packages/@sanity/desk-tool/src/panes/documentList/useDocumentList.ts
@@ -44,7 +44,7 @@ export function useDocumentList(opts: UseDocumentListOpts): DocumentListState {
     const extendedProjection = sortOrder?.extendedProjection
     const projectionFields = ['_id', '_type']
     const finalProjection = projectionFields.join(',')
-    const sortBy = sortOrder?.by || defaultOrdering || []
+    const sortBy = defaultOrdering || sortOrder?.by || []
     const limit = fullList ? FULL_LIST_LIMIT : PARTIAL_PAGE_LIMIT
     const sort = sortBy.length > 0 ? sortBy : DEFAULT_ORDERING.by
     const order = toOrderClause(sort)


### PR DESCRIPTION
### Description

Restores the ability to implement a default document order in the desk structure via `S.documentList().documentOrdering()`.
 
Fixes #2947.

### What to review

The desk structure should respect `.defaultOrdering()` when specified or fall back on the default if one is omitted.

### Notes for release

- Restores the ability to specify a default ordering in the desk structure.