### PR TITLE
refactor(desk-tool): add test-id to missing document type schema

### DIFF
--- a/packages/@sanity/desk-tool/src/components/MissingDocumentTypesMessage.tsx
+++ b/packages/@sanity/desk-tool/src/components/MissingDocumentTypesMessage.tsx
@@ -3,7 +3,13 @@ import {Card, Container, Heading, Stack, Text} from '@sanity/ui'
 
 export function MissingDocumentTypesMessage() {
   return (
-    <Card height="fill" paddingX={[5, 5, 7]} paddingY={[5, 5, 6]} sizing="border">
+    <Card
+      data-testid="missing-document-types-message"
+      height="fill"
+      paddingX={[5, 5, 7]}
+      paddingY={[5, 5, 6]}
+      sizing="border"
+    >
       <Container>
         <Stack space={5}>
           <Heading as="h1">Empty schema</Heading>


### PR DESCRIPTION
### Description

Add test-id to MissingDocumentTypesMessage. The objective of this addition is to make sure that it can be accessible from the template side.

### What to review

Nothing, this is the same change as [this](https://github.com/sanity-io/sanity/pull/3209/commits/cb8cac5d7fe4b3af2ea07604ed273baa4f68feb9) commit from the main feature branch

### Notes for release

Add test-id to MissingDocumentTypesMessage
