### PR TITLE
Show the date and time when change is hovered

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/document/timeline/timelineItem.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/timeline/timelineItem.tsx
@@ -33,6 +33,7 @@ export function TimelineItem(props: {
   const iconComponent = getTimelineEventIconComponent(type)
   const authorUserIds = Array.from(chunk.authors)
   const timeAgo = useTimeAgo(timestamp, {minimal: true})
+  const formattedTimestamp = new Date(timestamp).toISOString()
 
   const isSelected = state === 'selected'
   const isWithinSelection = state === 'withinSelection'
@@ -66,6 +67,7 @@ export function TimelineItem(props: {
       data-selection-bottom={isSelectionBottom}
       data-selection-top={isSelectionTop}
       onClick={handleClick}
+      title={formattedTimestamp}
     >
       <div
         // eslint-disable-next-line react/jsx-no-bind

--- a/packages/@sanity/desk-tool/src/panes/document/timeline/timelineItem.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/timeline/timelineItem.tsx
@@ -33,7 +33,6 @@ export function TimelineItem(props: {
   const iconComponent = getTimelineEventIconComponent(type)
   const authorUserIds = Array.from(chunk.authors)
   const timeAgo = useTimeAgo(timestamp, {minimal: true})
-  const formattedTimestamp = new Date(timestamp).toISOString()
 
   const isSelected = state === 'selected'
   const isWithinSelection = state === 'withinSelection'
@@ -67,7 +66,7 @@ export function TimelineItem(props: {
       data-selection-bottom={isSelectionBottom}
       data-selection-top={isSelectionTop}
       onClick={handleClick}
-      title={formattedTimestamp}
+      title={timestamp}
     >
       <div
         // eslint-disable-next-line react/jsx-no-bind


### PR DESCRIPTION
### Description

This pull request adds a hover effect that shows the date and time (or ISO timestamp) for a given change. 

This helps out users that are looking at changes made weeks or months ago, that need to know the precise moment a change occurred (or at least the actual date), instead of "2w", "1y" etc.

### What to review

Make sure the code compiles, and that you want to use the ISO format. This was the quickest way to provide as much detail as possible without cluttering up the code with date formatting.

### Notes for release

Add support for showing the exact date and time a timeline item happened, by hovering a given timeline item.
