### PR TITLE
feat(base): add flag to ignore schema types in search

### DIFF
--- a/packages/@sanity/base/src/search/common/utils.ts
+++ b/packages/@sanity/base/src/search/common/utils.ts
@@ -5,6 +5,8 @@ const isDocumentType = (type: SchemaType): type is ObjectSchemaType =>
 
 const isSanityType = (type: SchemaType): boolean => type.name.startsWith('sanity.')
 
+const isSearchable = (type: SchemaType): boolean => type.__experimental_search_ignore !== true
+
 export const getSearchableTypes = (
   schema: Schema
   // eslint-disable-next-line camelcase
@@ -14,3 +16,4 @@ export const getSearchableTypes = (
     .map((typeName) => schema.get(typeName))
     .filter(isDocumentType)
     .filter((type) => !isSanityType(type))
+    .filter(isSearchable)

--- a/packages/@sanity/base/src/search/common/utils.ts
+++ b/packages/@sanity/base/src/search/common/utils.ts
@@ -5,7 +5,7 @@ const isDocumentType = (type: SchemaType): type is ObjectSchemaType =>
 
 const isSanityType = (type: SchemaType): boolean => type.name.startsWith('sanity.')
 
-const isSearchable = (type: SchemaType): boolean => type.__experimental_search_ignore !== true
+const isSearchable = (type: ObjectSchemaType): boolean => type.__experimental_search_ignore !== true
 
 export const getSearchableTypes = (
   schema: Schema

--- a/packages/@sanity/base/test/getSearchableTypes.test.js
+++ b/packages/@sanity/base/test/getSearchableTypes.test.js
@@ -1,0 +1,55 @@
+import Schema from '@sanity/schema'
+import {getSearchableTypes} from '../src/search/common/utils'
+
+const person = {
+  type: 'document',
+  name: 'person',
+  title: 'Person',
+  fields: [
+    {
+      type: 'string',
+      name: 'name',
+    },
+  ],
+}
+
+const article = {
+  type: 'document',
+  name: 'article',
+  title: 'Article',
+  fields: [{type: 'string', name: 'headline'}],
+}
+
+const systemDoc = {
+  type: 'document',
+  name: 'sanity.something',
+  title: 'Internal schema',
+  fields: [{type: 'boolean', name: 'name'}],
+}
+
+describe('getSearchableTypes', () => {
+  it('contains the user defined documents', () => {
+    const schema = new Schema({
+      name: 'test',
+      types: [person, article, systemDoc],
+    })
+    const searchTypes = getSearchableTypes(schema)
+    expect(searchTypes.map((s) => s.name)).toEqual(['person', 'article'])
+  })
+
+  it('filters out __experimental_search_ignore === true', () => {
+    const hiddenPerson = {
+      ...person,
+      // eslint-disable-next-line camelcase
+      __experimental_search_ignore: true,
+    }
+
+    const schema = new Schema({
+      name: 'test',
+      types: [hiddenPerson, article],
+    })
+
+    const searchTypes = getSearchableTypes(schema)
+    expect(searchTypes.map((s) => s.name)).toEqual(['article'])
+  })
+})

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -247,6 +247,8 @@ export interface ObjectSchemaType extends BaseSchemaType {
   // string array in the schema normalization/compilation step
   // eslint-disable-next-line camelcase
   __experimental_search: {path: string[]; weight: number; mapWith?: string}[]
+  // eslint-disable-next-line camelcase
+  __experimental_search_ignore: boolean
 }
 
 export interface ObjectSchemaTypeWithOptions extends ObjectSchemaType {


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->
This PR adds a boolean property `__experimental_search_ignore` to the ObjectSchemaType for indicating that a type should be ignored in Studio search.

This is added to give more control over studio search results. A common scenario would be system documents, or otherwise non-editor documents showing up in search and confusing editors. A solution for the use case without this PR requires the removal of the schema from the schema definitions, but this also excludes the document type(s) from Desk editing.

The change is introduced along the existing `__experimental_search` property as a stop-gap feature until the Studio has stable APIs for customising the search experience. The reason for a new property is that the existing `__experimental_search` is an array of paths and weights, and there was no natural way to add this new functionality to that API.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->
The added unit test should illustrate the change well. Should however be tested in a running Studio.

One possible blocker for this PR is that I believe this code path is also used for searching for documents from reference fields, so if you wish to filter these documents only from global search and not from reference fields, more changes and updates to the calling sites will have to be done.

This PR, if merged, need not appear in the release notes, as it is an experimental feature only to be used in certain blocking cases.