### PR TITLE
refactor: alias __experimental_search to searchConfig for CDRs

### DIFF
--- a/dev/test-studio/schema/debug/circularCrossDatasetReference.js
+++ b/dev/test-studio/schema/debug/circularCrossDatasetReference.js
@@ -23,8 +23,7 @@ export const circularCrossDatasetReferenceTest = {
         {
           type: 'circularCrossDatasetReferenceTest',
           icon: CircleIcon,
-          // eslint-disable-next-line camelcase
-          __experimental_search: [{path: 'title', weight: 10}],
+          searchConfig: [{path: 'title', weight: 10}],
           preview: {
             select: {
               title: 'title',
@@ -48,8 +47,7 @@ export const circularCrossDatasetReferenceTest = {
         {
           type: 'circularCrossDatasetReferenceTest',
           icon: CircleIcon,
-          // eslint-disable-next-line camelcase
-          __experimental_search: [{path: 'title', weight: 10}],
+          searchConfig: [{path: 'title', weight: 10}],
           preview: {
             select: {
               title: 'title',
@@ -71,8 +69,7 @@ export const circularCrossDatasetReferenceTest = {
         {
           type: 'article',
           icon: BookIcon,
-          // eslint-disable-next-line camelcase
-          __experimental_search: [{path: 'title', weight: 10}],
+          searchConfig: [{path: 'title', weight: 10}],
           preview: {
             select: {
               title: 'title',

--- a/dev/test-studio/schema/standard/crossDatasetReference.js
+++ b/dev/test-studio/schema/standard/crossDatasetReference.js
@@ -10,8 +10,7 @@ export const crossDatasetSubtype = {
     {
       type: 'book',
       icon: BookIcon,
-      // eslint-disable-next-line camelcase
-      __experimental_search: [{path: ['title'], weight: 10}],
+      searchConfig: [{path: ['title'], weight: 10}],
       preview: {
         select: {
           title: 'title',
@@ -54,8 +53,7 @@ export default {
         {
           type: 'book',
           icon: BookIcon,
-          // eslint-disable-next-line camelcase
-          __experimental_search: [{path: 'title', weight: 10}],
+          searchConfig: [{path: 'title', weight: 10}],
           preview: {
             select: {
               title: 'title',
@@ -87,8 +85,7 @@ export default {
         {
           type: 'book',
           icon: BookIcon,
-          // eslint-disable-next-line camelcase
-          __experimental_search: [{path: 'title', weight: 10}],
+          searchConfig: [{path: 'title', weight: 10}],
           preview: {
             select: {
               title: 'title',
@@ -134,8 +131,7 @@ export default {
         {
           type: 'article',
           icon: BookIcon,
-          // eslint-disable-next-line camelcase
-          __experimental_search: [{path: 'title', weight: 10}],
+          searchConfig: [{path: 'title', weight: 10}],
           preview: {
             select: {
               title: 'title',
@@ -167,8 +163,7 @@ export default {
             {
               type: 'article',
               icon: BookIcon,
-              // eslint-disable-next-line camelcase
-              __experimental_search: [{path: 'title', weight: 10}],
+              searchConfig: [{path: 'title', weight: 10}],
               preview: {
                 select: {
                   title: 'title',
@@ -201,8 +196,7 @@ export default {
             {
               type: 'article',
               icon: BookIcon,
-              // eslint-disable-next-line camelcase
-              __experimental_search: [{path: 'title', weight: 10}],
+              searchConfig: [{path: 'title', weight: 10}],
               preview: {
                 select: {
                   title: 'title',

--- a/packages/@sanity/form-builder/src/inputs/CrossDatasetReferenceInput/__tests__/CrossDatasetReferenceInput.test.tsx
+++ b/packages/@sanity/form-builder/src/inputs/CrossDatasetReferenceInput/__tests__/CrossDatasetReferenceInput.test.tsx
@@ -74,7 +74,7 @@ describe('render states', () => {
           type: 'crossDatasetReference',
           dataset: 'products',
           projectId: 'abcxyz',
-          to: [{type: 'product', __experimental_search: [{path: 'title'}]}],
+          to: [{type: 'product', searchConfig: [{path: 'title'}]}],
         },
       ],
     })
@@ -107,7 +107,7 @@ describe('render states', () => {
           type: 'crossDatasetReference',
           dataset: 'products',
           projectId: 'abcxyz',
-          to: [{type: 'product', __experimental_search: [{path: 'title'}]}],
+          to: [{type: 'product', searchConfig: [{path: 'title'}]}],
         },
       ],
     })
@@ -141,7 +141,7 @@ describe('render states', () => {
           dataset: 'products',
           projectId: 'abcxyz',
           weak: true,
-          to: [{type: 'product', __experimental_search: [{path: 'title'}]}],
+          to: [{type: 'product', searchConfig: [{path: 'title'}]}],
         },
       ],
     })
@@ -187,7 +187,7 @@ describe('user interaction happy paths', () => {
           type: 'crossDatasetReference',
           dataset: 'products',
           projectId: 'abcxyz',
-          to: [{type: 'product', __experimental_search: [{path: 'title'}]}],
+          to: [{type: 'product', searchConfig: [{path: 'title'}]}],
         },
       ],
     })
@@ -266,7 +266,7 @@ describe('user interaction happy paths', () => {
           type: 'crossDatasetReference',
           dataset: 'products',
           projectId: 'abcxyz',
-          to: [{type: 'product', __experimental_search: [{path: 'title'}]}],
+          to: [{type: 'product', searchConfig: [{path: 'title'}]}],
         },
       ],
     })
@@ -366,7 +366,7 @@ describe('user interaction happy paths', () => {
           type: 'crossDatasetReference',
           dataset: 'products',
           projectId: 'abcxyz',
-          to: [{type: 'product', __experimental_search: [{path: 'title'}]}],
+          to: [{type: 'product', searchConfig: [{path: 'title'}]}],
         },
       ],
     })

--- a/packages/@sanity/form-builder/src/sanity/inputs/crossDatasetReference/datastores/search.ts
+++ b/packages/@sanity/form-builder/src/sanity/inputs/crossDatasetReference/datastores/search.ts
@@ -23,7 +23,11 @@ export function search(
     type.to.map((crossDatasetType) => ({
       name: crossDatasetType.type,
       // eslint-disable-next-line camelcase
-      __experimental_search: crossDatasetType.__experimental_search,
+      __experimental_search:
+        // NOTE: `__experimental_search` is aliased to `searchConfig` because
+        // cross-dataset refs require this config and we don't want to have the
+        // this experimental API be required
+        crossDatasetType.searchConfig || crossDatasetType.__experimental_search,
     })),
     client,
     options

--- a/packages/@sanity/schema/src/legacy/types/crossDatasetReference.ts
+++ b/packages/@sanity/schema/src/legacy/types/crossDatasetReference.ts
@@ -18,7 +18,7 @@ export const WEAK_FIELD = {
 
 const REFERENCE_FIELDS = [REF_FIELD, WEAK_FIELD]
 
-const OVERRIDABLE_FIELDS = [...DEFAULT_OVERRIDEABLE_FIELDS]
+const OVERRIDABLE_FIELDS = [...DEFAULT_OVERRIDEABLE_FIELDS, 'searchConfig']
 
 const CROSS_DATASET_REFERENCE_CORE = {
   name: 'crossDatasetReference',
@@ -79,7 +79,7 @@ export const CrossDatasetReferenceType = {
         return {
           ...toType,
           // eslint-disable-next-line camelcase
-          __experimental_search: normalizeSearchConfigs(toType.__experimental_search),
+          searchConfig: normalizeSearchConfigs(toType.searchConfig || toType.__experimental_search),
         }
       })
     })

--- a/packages/@sanity/schema/src/sanity/validation/types/crossDatasetReference.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/crossDatasetReference.ts
@@ -76,10 +76,12 @@ export default (typeDef, visitorContext) => {
         )
       )
     }
-    validateExperimentalSearch(crossDatasetTypeDef.__experimental_search).forEach((err) => {
+    validateExperimentalSearch(
+      crossDatasetTypeDef.searchConfig || crossDatasetTypeDef.__experimental_search
+    ).forEach((err) => {
       problems.push(
         error(
-          `Invalid "__experimental_search" config for referenced type "${
+          `Invalid search config for referenced type "${
             crossDatasetTypeDef.type || '<unknown type>'
           }": ${err}`,
           HELP_IDS.CROSS_DATASET_REFERENCE_INVALID

--- a/packages/@sanity/types/src/crossDatasetReference/types.ts
+++ b/packages/@sanity/types/src/crossDatasetReference/types.ts
@@ -34,8 +34,12 @@ export interface CrossDatasetType {
   title?: string
   icon: ComponentType
   preview: PreviewConfig
+  searchConfig: ObjectSchemaType['__experimental_search']
+  /**
+   * @deprecated use `searchConfig` instead
+   */
   // eslint-disable-next-line camelcase
-  __experimental_search: ObjectSchemaType['__experimental_search']
+  __experimental_search?: ObjectSchemaType['__experimental_search']
 }
 
 export interface CrossDatasetReferenceSchemaType extends Omit<ObjectSchemaType, 'fields'> {


### PR DESCRIPTION
### Description

The following PR aliases the `__experimental_search` schema property to `searchConfig` for **`crossDatasetReference`s only**. Cross-dataset references are special here because this configuration is required even though it shares the same API as `__experimental_search`

Note: we went with the key `searchConfig` instead of the simpler `search` so we could potentially use that key in the future for another API.

### What to review

- Does the alias work as expected? Are the example cross-dataset refs in the studio working correctly?

### Notes for release

N/A