### PR TITLE
fix(cli): correct checks for cli auth token

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.js
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.js
@@ -332,7 +332,7 @@ export default async function initSanity(args, context) {
     let projects
     let organizations
     try {
-      const client = apiClient({requireProject: false})
+      const client = apiClient({requireUser: true, requireProject: false})
       const [allProjects, allOrgs] = await Promise.all([
         client.projects.list(),
         client.request({uri: '/organizations'}),

--- a/packages/@sanity/cli/src/actions/login/login.js
+++ b/packages/@sanity/cli/src/actions/login/login.js
@@ -12,7 +12,8 @@ import {getCliToken} from '../../util/clientWrapper'
 export default async function login(args, context) {
   const {prompt, output, apiClient} = context
   const {sso, experimental, provider: specifiedProvider} = args.extOptions
-  const hasExistingToken = Boolean(getCliToken())
+  const previousToken = getCliToken()
+  const hasExistingToken = Boolean(previousToken)
 
   // Explicitly tell this client not to use a token
   const client = apiClient({requireUser: false, requireProject: false})
@@ -69,6 +70,8 @@ export default async function login(args, context) {
   // If we had a session previously, attempt to clear it
   if (hasExistingToken) {
     await apiClient({requireUser: true, requireProject: false})
+      .clone()
+      .config({token: previousToken})
       .request({uri: '/auth/logout', method: 'POST'})
       .catch((err) => {
         const statusCode = err && err.response && err.response.statusCode

--- a/packages/@sanity/cli/src/actions/login/login.js
+++ b/packages/@sanity/cli/src/actions/login/login.js
@@ -7,17 +7,17 @@ import EventSource from 'eventsource'
 import {parseJson} from '@sanity/util/lib/safeJson'
 import getUserConfig from '../../util/getUserConfig'
 import canLaunchBrowser from '../../util/canLaunchBrowser'
+import {getCliToken} from '../../util/clientWrapper'
 
 export default async function login(args, context) {
   const {prompt, output, apiClient} = context
   const {sso, experimental, provider: specifiedProvider} = args.extOptions
+  const hasExistingToken = Boolean(getCliToken())
 
-  // _Potentially_ already authed client
-  const authedClient = apiClient({requireUser: false, requireProject: false})
-  const hasExistingToken = Boolean(authedClient.config().token)
-
-  // Explicitly tell _this_ client not to use a token
-  const client = authedClient.clone().config({token: undefined})
+  // Explicitly tell this client not to use a token
+  const client = apiClient({requireUser: false, requireProject: false})
+    .clone()
+    .config({token: undefined})
 
   // Get the desired authentication provider
   const provider = await getProvider({client, sso, experimental, output, prompt, specifiedProvider})
@@ -68,12 +68,14 @@ export default async function login(args, context) {
 
   // If we had a session previously, attempt to clear it
   if (hasExistingToken) {
-    await authedClient.request({uri: '/auth/logout', method: 'POST'}).catch((err) => {
-      const statusCode = err && err.response && err.response.statusCode
-      if (statusCode !== 401) {
-        output.warn('[warn] Failed to log out existing session')
-      }
-    })
+    await apiClient({requireUser: true, requireProject: false})
+      .request({uri: '/auth/logout', method: 'POST'})
+      .catch((err) => {
+        const statusCode = err && err.response && err.response.statusCode
+        if (statusCode !== 401) {
+          output.warn('[warn] Failed to log out existing session')
+        }
+      })
   }
 
   output.print(chalk.green('Login successful'))

--- a/packages/@sanity/cli/src/commands/debug/printDebugInfo.js
+++ b/packages/@sanity/cli/src/commands/debug/printDebugInfo.js
@@ -96,7 +96,7 @@ function printKeyValue(obj, context) {
 
 async function gatherInfo(context) {
   const baseInfo = await promiseProps({
-    globalConfig: gatherGlobalConfigInfo(context),
+    globalConfig: gatherGlobalConfigInfo(),
     projectConfig: gatherProjectConfigInfo(context),
   })
 

--- a/packages/@sanity/cli/src/commands/debug/printDebugInfo.js
+++ b/packages/@sanity/cli/src/commands/debug/printDebugInfo.js
@@ -6,6 +6,7 @@ import fse from 'fs-extra'
 import xdgBasedir from 'xdg-basedir'
 import promiseProps from 'promise-props-recursive'
 import {pick, omit} from 'lodash'
+import {getCliToken} from '../../util/clientWrapper'
 import getUserConfig from '../../util/getUserConfig'
 import {printResult as printVersionsResult} from '../versions/printVersionResult'
 import findSanityModuleVersions from '../../actions/versions/findSanityModuleVersions'
@@ -120,7 +121,7 @@ function getGlobalConfigLocation() {
   return path.join(configDir, 'sanity', 'config.json')
 }
 
-function gatherGlobalConfigInfo(context) {
+function gatherGlobalConfigInfo() {
   return getUserConfig().all
 }
 
@@ -143,7 +144,7 @@ async function gatherProjectConfigInfo(context) {
 }
 
 async function gatherProjectInfo(context, baseInfo) {
-  const client = context.apiClient({requireUser: false, requireProject: false})
+  const client = context.apiClient({requireProject: false})
   const projectId = client.config().projectId
   if (!projectId) {
     return null
@@ -166,12 +167,12 @@ async function gatherProjectInfo(context, baseInfo) {
 }
 
 async function gatherUserInfo(context, info = {}) {
-  const client = context.apiClient({requireUser: false, requireProject: info.projectBased})
-  const hasToken = Boolean(client.config().token)
+  const hasToken = Boolean(getCliToken())
   if (!hasToken) {
     return new Error('Not logged in')
   }
 
+  const client = context.apiClient({requireUser: true, requireProject: info.projectBased})
   const userInfo = await client.users.getById('me')
   if (!userInfo) {
     return new Error('Token expired or invalid')

--- a/packages/@sanity/cli/src/commands/logout/logoutCommand.js
+++ b/packages/@sanity/cli/src/commands/logout/logoutCommand.js
@@ -14,7 +14,7 @@ export default {
       return
     }
 
-    const client = apiClient({requireUser: false, requireProject: false})
+    const client = apiClient({requireUser: true, requireProject: false})
     try {
       await client.request({uri: '/auth/logout', method: 'POST'})
     } catch (err) {

--- a/packages/@sanity/cli/src/util/clientWrapper.js
+++ b/packages/@sanity/cli/src/util/clientWrapper.js
@@ -30,6 +30,13 @@ const authErrors = () => ({
   },
 })
 
+export function getCliToken() {
+  // eslint-disable-next-line no-process-env
+  const envAuthToken = process.env.SANITY_AUTH_TOKEN
+  const userConfig = getUserConfig()
+  return envAuthToken || userConfig.get('authToken')
+}
+
 export default function clientWrapper(manifest, configPath) {
   const requester = client.requester.clone()
   requester.use(authErrors())
@@ -38,13 +45,11 @@ export default function clientWrapper(manifest, configPath) {
     // Read these environment variables "late" to allow `.env` files
 
     /* eslint-disable no-process-env */
-    const envAuthToken = process.env.SANITY_AUTH_TOKEN
     const sanityEnv = process.env.SANITY_INTERNAL_ENV || 'production'
     /* eslint-enable no-process-env */
 
     const {requireUser, requireProject, api} = {...defaults, ...opts}
-    const userConfig = getUserConfig()
-    const token = envAuthToken || userConfig.get('authToken')
+    const token = getCliToken()
     const apiHost = apiHosts[sanityEnv]
     const apiConfig = {
       ...((manifest && manifest.api) || {}),

--- a/packages/@sanity/cli/src/util/getProjectDefaults.js
+++ b/packages/@sanity/cli/src/util/getProjectDefaults.js
@@ -4,6 +4,7 @@ import gitConfigLocal from 'gitconfiglocal'
 import gitUserInfo from 'git-user-info'
 import promiseProps from 'promise-props-recursive'
 import {promisify} from 'es6-promisify'
+import {getCliToken} from './clientWrapper'
 
 export default (workDir, {isPlugin, context}) => {
   const cwd = process.cwd()
@@ -46,12 +47,12 @@ function getUserInfo(context) {
 }
 
 function getSanityUserInfo(context) {
-  const client = context.apiClient({requireUser: false, requireProject: false})
-  const hasToken = Boolean(client.config().token)
+  const hasToken = Boolean(getCliToken())
   if (!hasToken) {
     return null
   }
 
+  const client = context.apiClient({requireUser: true, requireProject: false})
   return client.users
     .getById('me')
     .then((user) => `${user.name} <${user.email}>`)


### PR DESCRIPTION
### Description

PR #3250 introduced some unintended behavior changes, as parts of the CLI depended on
being able to say `requireUser: false` when using the `clientWrapper` utility, and then
checking for a `token` in its config to do conditional logic.

With the token not being part of the config after #3250, this broke. This commit changes
the checks to use a `getCliToken()` utility instead, which does not depend on the client
configuration per se, but rather the stored CLI config, as well as any environment
variable.

### What to review

That the CLI still works, and that the change appears to be correct. In particular, the `sanity login`, `sanity logout`, `sanity debug` and `sanity init` commands should be tested.

### Notes for release

- Fixed an issue where `sanity debug` would give "unauthorized" errors when used
- Fixed an issue where `sanity login` would not clear existing session on a new login
- Fixed an issue where `sanity init` might crash when attempting to fetch current user name
