### PR TITLE
fix(cli): don't remove dash from output path

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.js
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.js
@@ -134,7 +134,7 @@ export default async function initSanity(args, context) {
   const {projectId, displayName, isFirstProject} = await getOrCreateProject()
   const sluggedName = deburr(displayName.toLowerCase())
     .replace(/\s+/g, '-')
-    .replace(/[^a-z0-9]/g, '')
+    .replace(/[^a-z0-9-]/g, '')
 
   debug(`Project with name ${displayName} selected`)
 


### PR DESCRIPTION

### Description
If the project name is for instance brown-bee, the output path would exclude the dash.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Test that running init with a project that includes a dash in the name also includes the dash in the output name. 

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fixed a bug that would not include dash in the output path when initializing a new project. 

<!--
A description of the change(s) that should be used in the release notes.
-->
