### PR TITLE
fix(cli): show correct error msg for sanity deploy errors

### DIFF
--- a/packages/@sanity/core/src/actions/deploy/deployAction.js
+++ b/packages/@sanity/core/src/actions/deploy/deployAction.js
@@ -173,5 +173,10 @@ function validateHostname(value, client) {
   return client
     .request({uri, method: 'PATCH', body: {studioHost}})
     .then(() => true)
-    .catch(() => 'Hostname already taken')
+    .catch((error) => {
+      if (error?.response?.body?.message) {
+        return error.response.body.message
+      }
+      throw error
+    })
 }


### PR DESCRIPTION
### Description

When a user with the role as "Editor" tried to run `sanity deploy`, an error message of "Hostname already taken" would be provided, even if the hostname was available. Link to issue: https://github.com/sanity-io/sanity/issues/2665. 

This commit improves the error messages provided to the user.
Instead of a hardcoded "Hostname already taken" for any `sanity deploy` error, a correct error message belonging to the error will be shown.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Run `sanity deploy` with the role as "Editor, or when providing a Studio hostname that is already taken. Make sure that correct and appropriate error message is given. 

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Fixed an issue where `sanity deploy` would give "Hostname already taken" for all errors

<!--
A description of the change(s) that should be used in the release notes.
-->
