### PR TITLE
fix(cli): include explanation in exec helptext of how to pass arbitrary arguments

### DIFF
--- a/packages/@sanity/core/src/commands/exec/execCommand.js
+++ b/packages/@sanity/core/src/commands/exec/execCommand.js
@@ -10,8 +10,17 @@ Examples
   sanity exec some/script.js
 
   # Run the script at migrations/fullname.js and configure \`part:@sanity/base/client\`
-  # to include the current users token
+  # to include the current user's token
   sanity exec migrations/fullname.js --with-user-token
+  
+  # Run the script at scripts/browserScript.js in a mock browser environment
+  sanity exec scripts/browserScript.js --mock-browser-env
+
+  # Pass arbitrary arguments to scripts by separating them with a \`--\`.
+  # Arguments are available in \`process.argv\` as they would in regular node scripts
+  # eg the following command would yield a \`process.argv\` of:
+  # ['/path/to/node', '/path/to/myscript.js', '--dry-run', 'positional-argument']
+  sanity exec --mock-browser-env myscript.js -- --dry-run positional-argument
 `
 
 export default {


### PR DESCRIPTION
### Description
Arbitrary arguments can be added to scripts in the `sanity exec` command. This was not informed about in `sanity exec --help`. An explanation of how to add arbitrary arguments is now included in the helptext, together with an example. 
Link to issue: https://github.com/sanity-io/sanity/issues/2765

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Test by running `sanity exec --help`. 
Make sure that the helptext is correct and understandable. 

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Added explanation in `sanity exec --help` on how to add arbitrary arguments to the script. 

<!--
A description of the change(s) that should be used in the release notes.
-->
