### PR TITLE
fix: field presence tooltip issues

### DIFF
--- a/packages/@sanity/base/src/presence/FieldPresence.tsx
+++ b/packages/@sanity/base/src/presence/FieldPresence.tsx
@@ -104,7 +104,7 @@ export const FieldPresenceInner = memo(function FieldPresenceInner({
     <FlexWrapper justify="flex-end" style={{width: maxWidth}}>
       <div />
 
-      <PresenceTooltip items={uniquePresence} placement="top">
+      <PresenceTooltip items={uniquePresence}>
         <InnerBox direction="row-reverse" style={{width: currWidth}}>
           {avatars.map(
             (av, i) =>

--- a/packages/@sanity/base/src/presence/PresenceTooltip.tsx
+++ b/packages/@sanity/base/src/presence/PresenceTooltip.tsx
@@ -1,37 +1,44 @@
-import React from 'react'
-import {Tooltip, Placement, Box, Flex} from '@sanity/ui'
+import React, {useMemo} from 'react'
+import {Tooltip, Box, Flex} from '@sanity/ui'
 import {UserAvatar} from '../components/UserAvatar'
 import type {FormFieldPresence} from './types'
-
 import {TextWrapper} from './PresenceTooltip.styled'
 
 interface PresenceTooltipProps {
   children?: React.ReactElement
   items: FormFieldPresence[]
-  placement?: Placement
 }
 
+/**
+ * The "documentScrollElement" is being passed to the PortalProvider in DocumentPanel.
+ * The default portal element provided by the PortalProvider causes some layout issues with the Tooltip.
+ * Therefore, another portal element (i.e. the "documentScrollElement") is being used to solve this.
+ */
+
 export function PresenceTooltip(props: PresenceTooltipProps) {
-  const {children, items, placement} = props
+  const {children, items} = props
 
-  const content = (
-    <Box padding={1}>
-      {items.map((item) => (
-        <Box key={item.user.id} padding={1}>
-          <Flex align="center">
-            <div>
-              <UserAvatar user={item.user} status="online" />
-            </div>
+  const content = useMemo(
+    () => (
+      <Box padding={1}>
+        {items.map((item) => (
+          <Box key={item.user.id} padding={1}>
+            <Flex align="center">
+              <div>
+                <UserAvatar user={item.user} status="online" />
+              </div>
 
-            <TextWrapper>{item.user.displayName}</TextWrapper>
-          </Flex>
-        </Box>
-      ))}
-    </Box>
+              <TextWrapper>{item.user.displayName}</TextWrapper>
+            </Flex>
+          </Box>
+        ))}
+      </Box>
+    ),
+    [items]
   )
 
   return (
-    <Tooltip content={content} placement={placement}>
+    <Tooltip content={content} placement="top" portal="documentScrollElement">
       {children}
     </Tooltip>
   )

--- a/packages/@sanity/desk-tool/src/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/documentPanel/DocumentPanel.tsx
@@ -140,7 +140,10 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
       <DocumentPanelHeader rootElement={rootElement} ref={setHeaderElement} />
 
       <PaneContent>
-        <PortalProvider element={portalElement}>
+        <PortalProvider
+          element={portalElement}
+          __unstable_elements={{documentScrollElement: documentScrollElement}}
+        >
           <BoundaryElementProvider element={documentScrollElement}>
             {activeView.type === 'form' && !isPermissionsLoading && ready && (
               <>


### PR DESCRIPTION
### Description

This PR fixes z-index issues in `PresenceTooltip`. In order to solve these issues without adding specific z-index values – the `PresenceTooltip` is now using the `portal` attribute. However,  the positioning of the `Tooltip` was not behaving correctly when using the default portal element provided by the `PortalProvider` in `DocumentPanel`. To solve this, I added another portal element with the `__unstable_elements` to be used by the `PresenceTooltip`.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->


<img width="1337" alt="Screenshot 2022-05-03 at 15 06 39" src="https://user-images.githubusercontent.com/15094168/166458325-01690434-d92e-444f-be49-a5d70aade780.png">

### What to review
- Does the use of `__unstable_elements` make sense, or could this be solved in another way?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fix field presence tooltip z-index issues

<!--
A description of the change(s) that should be used in the release notes.
-->
