### PR TITLE
feat(cli): print copy dataset job id

### DIFF
--- a/packages/@sanity/core/src/commands/dataset/copyDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/copyDatasetCommand.js
@@ -164,13 +164,9 @@ export default {
       output.print(
         `Copying dataset ${chalk.green(sourceDatasetName)} to ${chalk.green(targetDatasetName)}...`
       )
+      output.print(`Job ${chalk.green(response.jobId)} started`)
 
       if (flags.detach) {
-        output.print('Copy initiated.')
-        output.print(
-          `\nRun:\n\n    sanity dataset copy --attach ${response.jobId}\n\nto watch attach`
-        )
-
         return
       }
 


### PR DESCRIPTION
### Description

Clean up the copy dataset out to always print the underlying job id.
https://app.shortcut.com/sanity-io/story/18215/copy-dataset-always-print-job-id-to-console

### What to review

Copy output makes sense

Normal copy:
```
% sanity dataset copy foo bar
Copying dataset foo to bar...
Job jahrirhbil created
✔ Copy finished.
%
```

Detached copy:
```
% sanity dataset copy foo bar --detach
Copying dataset foo to bar...
Job jahrirhbil created
%
```

### Notes for release

CLI copy dataset command now always prints a job id to make it easier to resume watching running jobs.
