### PR TITLE
feat: improve delete dialog with references

### DIFF
--- a/packages/@sanity/desk-tool/src/components/DraftStatus.tsx
+++ b/packages/@sanity/desk-tool/src/components/DraftStatus.tsx
@@ -7,6 +7,7 @@ import {TimeAgo} from './TimeAgo'
 
 export const DraftStatus = ({document}: {document?: SanityDocument | null}) => (
   <Tooltip
+    portal
     content={
       <Box padding={2}>
         <Text size={1}>

--- a/packages/@sanity/desk-tool/src/components/PublishedStatus.tsx
+++ b/packages/@sanity/desk-tool/src/components/PublishedStatus.tsx
@@ -7,6 +7,7 @@ import {TimeAgo} from './TimeAgo'
 
 export const PublishedStatus = ({document}: {document?: SanityDocument | null}) => (
   <Tooltip
+    portal
     content={
       <Box padding={2}>
         <Text size={1}>

--- a/packages/@sanity/desk-tool/src/components/ReferencePreviewLink.tsx
+++ b/packages/@sanity/desk-tool/src/components/ReferencePreviewLink.tsx
@@ -1,0 +1,53 @@
+import {PreviewCard} from '@sanity/base/components'
+import {getPublishedId} from 'part:@sanity/base/util/draft-utils'
+import {useDocumentPresence} from '@sanity/base/hooks'
+import React, {useCallback} from 'react'
+import {SanityDocument, SchemaType} from '@sanity/types'
+import {usePaneRouter} from '../contexts/paneRouter'
+import {PaneItemPreview} from './paneItem/PaneItemPreview'
+
+const EMPTY_ARRAY: [] = []
+
+interface ReferencePreviewLinkProps {
+  onClick?: () => void
+  type: SchemaType & {icon?: any}
+  value: SanityDocument
+}
+
+export function ReferencePreviewLink(props: ReferencePreviewLinkProps) {
+  const {onClick, type, value} = props
+  const publishedId = getPublishedId(value?._id)
+  const documentPresence = useDocumentPresence(publishedId)
+  const {ReferenceChildLink} = usePaneRouter()
+
+  const Link = useCallback(
+    (linkProps: {children: React.ReactNode}) => (
+      <ReferenceChildLink
+        documentId={value?._id}
+        documentType={type?.name}
+        parentRefPath={EMPTY_ARRAY}
+        {...linkProps}
+      />
+    ),
+    [ReferenceChildLink, type?.name, value?._id]
+  )
+
+  return (
+    <PreviewCard
+      __unstable_focusRing
+      as={Link}
+      data-as="a"
+      onClick={onClick}
+      padding={2}
+      radius={2}
+    >
+      <PaneItemPreview
+        icon={type?.icon}
+        layout="default"
+        presence={documentPresence?.length > 0 ? documentPresence : EMPTY_ARRAY}
+        schemaType={type}
+        value={value}
+      />
+    </PreviewCard>
+  )
+}

--- a/packages/@sanity/desk-tool/src/components/confirmDeleteDialog/ConfirmDeleteDialog.tsx
+++ b/packages/@sanity/desk-tool/src/components/confirmDeleteDialog/ConfirmDeleteDialog.tsx
@@ -87,6 +87,7 @@ export function ConfirmDeleteDialog({
         </Grid>
       }
       onClose={onCancel}
+      onClickOutside={onCancel}
     >
       <DialogBody>
         {crossDatasetReferences && internalReferences && !isLoading ? (
@@ -98,6 +99,7 @@ export function ConfirmDeleteDialog({
             totalCount={totalCount}
             action={action}
             projectIds={projectIds}
+            onReferenceLinkClick={onCancel}
           />
         ) : (
           <LoadingContainer data-testid="loading-container">

--- a/packages/@sanity/desk-tool/src/components/confirmDeleteDialog/ConfirmDeleteDialogBody.styles.tsx
+++ b/packages/@sanity/desk-tool/src/components/confirmDeleteDialog/ConfirmDeleteDialogBody.styles.tsx
@@ -1,18 +1,10 @@
 import React from 'react'
 import styled from 'styled-components'
-import {rem, Text, Card, Box, Inline, Tooltip} from '@sanity/ui'
+import {rem, Text, Card, Box, Tooltip, Container, Inline} from '@sanity/ui'
 import {InfoOutlineIcon} from '@sanity/icons'
 
 export const ChevronWrapper = styled(Box)`
   margin-left: auto;
-`
-
-export const InternalReferences = styled.ul`
-  height: 300px;
-  overflow: auto;
-  padding: 0;
-  margin: 0;
-  flex: initial;
 `
 
 export const CrossDatasetReferencesDetails = styled.details`
@@ -80,23 +72,26 @@ export const OtherReferenceCount = (props: {totalCount: number; references: unkn
   return (
     <Inline space={2}>
       <Text size={1} muted>
-        {difference} other reference{difference === 1 ? '' : 's'} not shown.
+        {difference} other reference{difference === 1 ? '' : 's'} not shown{' '}
       </Text>
+
       <Tooltip
         portal
+        placement="top"
         content={
-          <Box padding={2}>
-            <Text>
-              We can't show metadata about these references because no token with access to the
-              datasets they are in was found. Read more about how to configure tokens in the{' '}
-              <a href="https://www.sanity.io/docs/cross-dataset-references">
-                Cross dataset references documentation
-              </a>
-            </Text>
-          </Box>
+          <Container width={0}>
+            <Box padding={2}>
+              <Text size={1}>
+                We can't show metadata about these references because no token with access to the
+                datasets they are in was found.
+              </Text>
+            </Box>
+          </Container>
         }
       >
-        <InfoOutlineIcon />
+        <Text size={1} muted>
+          <InfoOutlineIcon />
+        </Text>
       </Tooltip>
     </Inline>
   )

--- a/packages/@sanity/desk-tool/src/components/confirmDeleteDialog/__tests__/index.test.tsx
+++ b/packages/@sanity/desk-tool/src/components/confirmDeleteDialog/__tests__/index.test.tsx
@@ -22,6 +22,7 @@ jest.mock('part:@sanity/base/schema', () => {
     ],
   })
 })
+
 jest.mock('part:@sanity/base/datastore/document', () => {
   const actualModule = jest.requireActual('part:@sanity/base/datastore/document').default
   const {Subject} = require('rxjs')
@@ -86,6 +87,34 @@ jest.mock('@sanity/base/preview', () => {
       switch (property) {
         case 'SanityPreview': {
           return MockSanityPreview
+        }
+        default: {
+          return target[property]
+        }
+      }
+    },
+  })
+})
+
+jest.mock('../../../contexts/paneRouter', () => {
+  const actualModule = jest.requireActual('../../../contexts/paneRouter')
+
+  const MockSanityPreview = jest.fn(({value}) => (
+    <div data-testid="mock-preview">{JSON.stringify({value})}</div>
+  ))
+
+  function useMockPaneRouter() {
+    return {
+      ReferenceChildLink: MockSanityPreview,
+    }
+  }
+
+  // partially mock the module
+  return new Proxy(actualModule, {
+    get: (target, property) => {
+      switch (property) {
+        case 'usePaneRouter': {
+          return useMockPaneRouter
         }
         default: {
           return target[property]


### PR DESCRIPTION
### Description

This PR makes it possible to navigate to a document from the dialog that lists all referring documents to the document you are trying to delete. When you click on a document in the list, the dialog closes and the document opens in a new pane. Aside from that, this PR also adds:

- Presence + published/edited status icons to the document previews
- Some design improvements to `ConfirmDeleteDialogBody`

<img width="1435" alt="Screenshot 2022-05-05 at 14 36 40" src="https://user-images.githubusercontent.com/15094168/166924277-664bedb8-61a2-4f3a-aaa7-65b7b03489a5.png">

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

**How to test**
1. Navigate to a document that other documents refer to
2. Try to delete that document
3. Navigate to a document in the list of documents by clicking on it

**Implementation questions**
- I am passing an empty array to `ReferenceChildLink`:s `parentRefPath` prop. Can this cause any problems?

### Notes for release

Make it possible to navigate to a referring document from the 'delete dialog'

<!--
A description of the change(s) that should be used in the release notes.
-->
