### PR TITLE
fix(validation): fix broken date validation message

### DIFF
--- a/dev/test-studio/schema/standard/datetime.js
+++ b/dev/test-studio/schema/standard/datetime.js
@@ -68,6 +68,17 @@ export default {
       placeholder: 'Enter a date here',
     },
     {
+      name: 'startDate',
+      type: 'datetime',
+      title: 'Start date',
+    },
+    {
+      name: 'endTime',
+      type: 'datetime',
+      title: 'End date',
+      validation: (Rule) => Rule.min(Rule.valueOfField('startDate')),
+    },
+    {
       name: 'inArray',
       type: 'array',
       of: [

--- a/packages/@sanity/validation/src/validators/dateValidator.ts
+++ b/packages/@sanity/validation/src/validators/dateValidator.ts
@@ -21,17 +21,20 @@ const getFormattedDate = (type = '', value: number | Date, options?: DateTimeOpt
   if (options && options.dateFormat) {
     format = options.dateFormat
   }
+
   if (type === 'date') {
     // If the type is date only
-    return formatDate(value, format)
+    return formatDate(new Date(value), format)
   }
+
   // If the type is datetime
   if (options && options.timeFormat) {
     format += ` ${options.timeFormat}`
   } else {
     format += ' HH:mm'
   }
-  return formatDate(value, format)
+
+  return formatDate(new Date(value), format)
 }
 
 function parseDate(date: unknown): Date | null
@@ -80,6 +83,7 @@ const dateValidators: Validators = {
       : {}
 
     const date = getFormattedDate(context.type.name, minDate, dateTimeOptions)
+
     return message || `Must be at or after ${date}`
   },
 

--- a/packages/@sanity/validation/src/validators/dateValidator.ts
+++ b/packages/@sanity/validation/src/validators/dateValidator.ts
@@ -16,7 +16,7 @@ interface DateTimeOptions {
   timeFormat?: string
 }
 
-const getFormattedDate = (type = '', value: number | Date, options?: DateTimeOptions) => {
+const getFormattedDate = (type = '', value: string | number | Date, options?: DateTimeOptions) => {
   let format = 'yyyy-MM-dd'
   if (options && options.dateFormat) {
     format = options.dateFormat


### PR DESCRIPTION
### Description

This PR fixes an issue with the date formatting in `dateValidator`, which caused the validation message shown in the tooltip to be incorrect. The format function from `date-fns` got an invalid time value. 

**Before and after**

<img width="1239" alt="Screenshot 2022-05-09 at 14 02 59" src="https://user-images.githubusercontent.com/15094168/167406036-87bcb7b5-c196-421a-8467-5106236c7394.png">

**Schema**
```js
    {
      name: 'startDate',
      type: 'datetime',
      title: 'Start date',
      validation: (Rule) => Rule.required(),
    },
    {
      name: 'endTime',
      type: 'datetime',
      title: 'End date',
      validation: (Rule) => Rule.min(Rule.valueOfField('startDate')).error('My error msg'),
    }
```

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

- Review the code
- Try out the schema above 

### Notes for release

Fix broken date validation message 

<!--
A description of the change(s) that should be used in the release notes.
-->
