### PR TITLE
fix(base): add alignment styling to a columnar fieldset

### DIFF
--- a/packages/@sanity/base/src/components/formField/FormFieldSet.tsx
+++ b/packages/@sanity/base/src/components/formField/FormFieldSet.tsx
@@ -127,7 +127,7 @@ export const FormFieldSet = forwardRef(
         return null
       }
       return (
-        <Grid columns={columns} gapX={4} gapY={5}>
+        <Grid columns={columns} gapX={4} gapY={5} style={{alignItems: 'flex-end'}}>
           {changeIndicator ? (
             <ChangeIndicator {...(changeIndicator === true ? {} : changeIndicator)}>
               {getChildren(children)}

--- a/packages/@sanity/base/src/components/formField/FormFieldSet.tsx
+++ b/packages/@sanity/base/src/components/formField/FormFieldSet.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 
 import {Marker} from '@sanity/types'
-import {Box, Flex, Grid, rem, Stack, Text, Theme, useForwardedRef} from '@sanity/ui'
+import {Box, Flex, rem, Stack, Text, Theme, useForwardedRef} from '@sanity/ui'
 import React, {forwardRef, useState, useCallback, useEffect, useMemo} from 'react'
 import styled, {css} from 'styled-components'
 import {ChangeIndicator, ChangeIndicatorContextProvidedProps} from '../../change-indicators'
@@ -9,7 +9,7 @@ import {FieldPresence, FormFieldPresence} from '../../presence'
 import {FormFieldValidationStatus} from './FormFieldValidationStatus'
 import {FormFieldSetLegend} from './FormFieldSetLegend'
 import {markersToValidationList} from './helpers'
-import {focusRingStyle} from './styles'
+import {focusRingStyle, StyledGrid} from './styles'
 
 export interface FormFieldSetProps {
   /**
@@ -127,7 +127,7 @@ export const FormFieldSet = forwardRef(
         return null
       }
       return (
-        <Grid columns={columns} gapX={4} gapY={5} style={{alignItems: 'flex-end'}}>
+        <StyledGrid columns={columns} gapX={4} gapY={5}>
           {changeIndicator ? (
             <ChangeIndicator {...(changeIndicator === true ? {} : changeIndicator)}>
               {getChildren(children)}
@@ -135,7 +135,7 @@ export const FormFieldSet = forwardRef(
           ) : (
             getChildren(children)
           )}
-        </Grid>
+        </StyledGrid>
       )
     }, [changeIndicator, children, collapsed, columns])
 

--- a/packages/@sanity/base/src/components/formField/styles.ts
+++ b/packages/@sanity/base/src/components/formField/styles.ts
@@ -1,3 +1,6 @@
+import styled from 'styled-components'
+import {Grid} from '@sanity/ui'
+
 function focusRingBorderStyle(border: {color: string; width: number}): string {
   return `inset 0 0 0 ${border.width}px ${border.color}`
 }
@@ -21,3 +24,7 @@ export function focusRingStyle(opts: {
     .filter(Boolean)
     .join(',')
 }
+
+export const StyledGrid = styled(Grid)`
+  align-items: flex-end;
+`


### PR DESCRIPTION
### Description

Add styling to the alignment of a columnar fieldset. 
Issue: https://github.com/sanity-io/sanity/issues/3032 

**Before and after** 
![Screenshot 2022-05-09 at 10 38 43](https://user-images.githubusercontent.com/44635000/167409040-476dc236-2960-4c8e-8aba-8f70dc42d628.png)
![Screenshot 2022-05-09 at 10 38 26](https://user-images.githubusercontent.com/44635000/167409117-a0de1b38-5adf-46f7-b372-bbe1527d7e1e.png)

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

The styling of items in the `Grid` with several columns are now aligned as `flex-end`. 

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

Add a fieldset with more than one column and see the alignment. 

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
Fix styling of alignment to a columnar fieldset