### PR TITLE
fix(base): add scrolling to dropdown when adding new reference

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/CreateButton.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/CreateButton.tsx
@@ -73,7 +73,7 @@ export function CreateButton(props: Props) {
         </Menu>
       }
       placement="right"
-      popover={{portal: true, tone: 'default'}}
+      popover={{portal: true, tone: 'default', constrainSize: true}}
     />
   ) : (
     <Button


### PR DESCRIPTION
### Description
The type selector list when adding a new reference did not have a size constraint. A size constraint was therefore added to aid for scrolling.

Link to issue: https://github.com/sanity-io/sanity/issues/2997 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Add a new reference and check that the list is scrollable when screensize is smaller than the list. 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Add scrolling to the list of types when adding a new reference. 
<!--
A description of the change(s) that should be used in the release notes.
-->
