### PR TITLE
Fix(form-builder): fix hovering issue in array input with PTE block

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/common/fileTarget/fileTarget.tsx
+++ b/packages/@sanity/form-builder/src/inputs/common/fileTarget/fileTarget.tsx
@@ -122,7 +122,7 @@ export function fileTarget<ComponentProps>(Component: React.ComponentType<Compon
       (event: React.DragEvent) => {
         event.stopPropagation()
 
-        if (onFilesOver) {
+        if (onFilesOver && forwardedRef.current === event.currentTarget) {
           /* this is a (hackish) work around to have the drag and drop work when the file is hovered back and forth over it
           as part of the refactor and adding more components to the "hover" state, it didn't recognise that it just kept adding the same
           element over and over, so when it tried to remove them on the handleDragLeave, it only removed the last instance. 
@@ -136,7 +136,7 @@ export function fileTarget<ComponentProps>(Component: React.ComponentType<Compon
           onFilesOver(fileTypes)
         }
       },
-      [onFilesOver]
+      [onFilesOver, forwardedRef]
     )
 
     const handleDragLeave = useCallback(


### PR DESCRIPTION
### Description

There was a bug where when you had an array input that had a pte block with parts that could be dragged up and down where the FileTarget warning appeared when it didn't make sense.

before

https://user-images.githubusercontent.com/6951139/167607108-0d1d9a90-e37a-4738-b08c-fd859cb1102f.mov


after

https://user-images.githubusercontent.com/6951139/168052659-561c0007-361c-410a-9774-fb7dbcda0a69.mov






### What to review

**Array:**
1. Go to the array test and pick Rita Test
2. Scroll all the way down to `Array of Objects in PTE`
3. Try to drag items up and down and trigger the same affect as before.
 3.1. I noticed that it was easier to trigger the error when you created a new "sensory organ" and then tried to drag it up or down

Because the fix happens in a component that is affecting the image and file input, it is also necessary to check that everything there is still working as expected.

**Image:**
1. Go to image test and pick any document
2. In empty inputs: Drag images in and out. Try uploading gifs in inputs that only accept png / jpeg and confirm the hover message works and is right.
3. In inputs that have images: Drag images in and out. Try uploading types that aren't accepted in there and confirm the hover message works and is right.

*File:**
1. Go to file test and pick any document
2. In empty inputs: Drag files in and out. 
3. In inputs that have images: Drag images in and out

### Notes for release

Fix hovering issue in array input with PTE block