### PR TITLE
feat(copy dataset): Allow API to determine if target dataset exists

### DIFF
--- a/packages/@sanity/core/src/commands/dataset/copyDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/copyDatasetCommand.js
@@ -172,7 +172,7 @@ export default {
       if (error.statusCode) {
         output.print(`${chalk.red(`Dataset copying failed: \n${error.response.body.message}`)}\n`)
       } else {
-        output.print(`${chalk.red(`Dataset copying failed: SECIBD >>>\n${error.message}`)}\n`)
+        output.print(`${chalk.red(`Dataset copying failed: \n${error.message}`)}\n`)
       }
     }
   },

--- a/packages/@sanity/core/src/commands/dataset/copyDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/copyDatasetCommand.js
@@ -142,9 +142,6 @@ export default {
 
     const targetDatasetName = await (targetDataset ||
       promptForDatasetName(prompt, {message: 'Target dataset name:'}))
-    if (existingDatasets.includes(targetDatasetName)) {
-      throw new Error(`Target dataset "${targetDatasetName}" already exists`)
-    }
 
     const err = validateDatasetName(targetDatasetName)
     if (err) {
@@ -173,9 +170,9 @@ export default {
       followProgress(response.jobId, client, output)
     } catch (error) {
       if (error.statusCode) {
-        output.print(`${chalk.red(`Dataset copying failed:\n${error.response.body.message}`)}\n`)
+        output.print(`${chalk.red(`Dataset copying failed: \n${error.response.body.message}`)}\n`)
       } else {
-        output.print(`${chalk.red(`Dataset copying failed:\n${error.message}`)}\n`)
+        output.print(`${chalk.red(`Dataset copying failed: SECIBD >>>\n${error.message}`)}\n`)
       }
     }
   },

--- a/packages/@sanity/core/src/commands/dataset/copyDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/copyDatasetCommand.js
@@ -170,9 +170,9 @@ export default {
       followProgress(response.jobId, client, output)
     } catch (error) {
       if (error.statusCode) {
-        output.print(`${chalk.red(`Dataset copying failed: \n${error.response.body.message}`)}\n`)
+        output.print(`${chalk.red(`Dataset copying failed:\n${error.response.body.message}`)}\n`)
       } else {
-        output.print(`${chalk.red(`Dataset copying failed: \n${error.message}`)}\n`)
+        output.print(`${chalk.red(`Dataset copying failed:\n${error.message}`)}\n`)
       }
     }
   },


### PR DESCRIPTION
### Description
Allow API to determine if the target dataset exists or if a copy job is currently in progress.
New functionality in API to determine the difference between existing dataset and running job.
Stops confusion when a copy job is in progress but the UI says "dataset name already exists".

### What to review

Simply removing a check against local storage.

### Notes for release
New functionality in API to determine the difference between existing dataset and running job.
CLI will now let the API determine the state of the target dataset.
