### PR TITLE
feat(cli): list dataset copy jobs

### DIFF
--- a/packages/@sanity/cli/src/outputters/cliOutputter.js
+++ b/packages/@sanity/cli/src/outputters/cliOutputter.js
@@ -9,6 +9,10 @@ export default {
     console.log(...args)
   },
 
+  table(...args) {
+    console.table(...args)
+  },
+
   warn(...args) {
     console.warn(...args)
   },

--- a/packages/@sanity/core/package.json
+++ b/packages/@sanity/core/package.json
@@ -42,6 +42,7 @@
     "chalk": "^2.4.2",
     "chokidar": "^3.0.0",
     "configstore": "^5.0.1",
+    "date-fns": "^2.16.1",
     "debug": "^3.2.7",
     "deep-sort-object": "^1.0.1",
     "es6-promisify": "^6.0.0",

--- a/packages/@sanity/core/src/actions/dataset/listDatasetCopyJobs.js
+++ b/packages/@sanity/core/src/actions/dataset/listDatasetCopyJobs.js
@@ -25,7 +25,7 @@ module.exports = async function listDatasetCopyJobs(args, context) {
     if (error.statusCode) {
       output.error(`${chalk.red(`Dataset copy list failed:\n${error.response.body.message}`)}\n`)
     } else {
-      output.print(`${chalk.red(`Dataset copy list failed:\n${error.message}`)}\n`)
+      output.error(`${chalk.red(`Dataset copy list failed:\n${error.message}`)}\n`)
     }
   }
 

--- a/packages/@sanity/core/src/actions/dataset/listDatasetCopyJobs.js
+++ b/packages/@sanity/core/src/actions/dataset/listDatasetCopyJobs.js
@@ -1,0 +1,72 @@
+import {parseISO, formatDistanceToNow, formatDistance} from 'date-fns'
+
+module.exports = async function listDatasetCopyJobs(args, context) {
+  const {apiClient, output, chalk} = context
+  const flags = args.extOptions
+  const client = apiClient()
+  const projectId = client.config().projectId
+  const query = {}
+  let response
+
+  if (flags.offset && flags.offset >= 0) {
+    query.offset = flags.offset
+  }
+  if (flags.limit && flags.limit > 0) {
+    query.limit = flags.limit
+  }
+
+  try {
+    response = await client.request({
+      method: 'GET',
+      uri: `/projects/${projectId}/datasets/copy`,
+      query,
+    })
+  } catch (error) {
+    if (error.statusCode) {
+      output.error(`${chalk.red(`Dataset copy list failed:\n${error.response.body.message}`)}\n`)
+    } else {
+      output.print(`${chalk.red(`Dataset copy list failed:\n${error.message}`)}\n`)
+    }
+  }
+
+  if (response && response.length > 0) {
+    output.print('Dataset copy jobs for this project:')
+    const print = []
+
+    response.forEach((job) => {
+      const {id, state, createdAt, updatedAt, sourceDataset, targetDataset, withHistory} = job
+
+      let timeStarted = ''
+      if (createdAt !== '') {
+        timeStarted = formatDistanceToNow(parseISO(createdAt))
+      }
+
+      let timeTaken = ''
+      if (updatedAt !== '') {
+        timeTaken = formatDistance(parseISO(updatedAt), parseISO(createdAt))
+      }
+
+      print.push({
+        'Job ID': id,
+        State: state,
+        History: withHistory,
+        'Time started': timeStarted === '' ? '' : `${timeStarted} ago`,
+        'Time taken': timeTaken,
+        'Source dataset': sourceDataset,
+        'Target dataset': targetDataset,
+      })
+    })
+
+    output.table(print, [
+      'Job ID',
+      'Source dataset',
+      'Target dataset',
+      'State',
+      'History',
+      'Time started',
+      'Time taken',
+    ])
+  } else {
+    output.print("This project doesn't have any dataset copy jobs")
+  }
+}

--- a/packages/@sanity/core/src/commands/dataset/listCopyDatasetJobs.js
+++ b/packages/@sanity/core/src/commands/dataset/listCopyDatasetJobs.js
@@ -1,0 +1,30 @@
+import lazyRequire from '@sanity/util/lib/lazyRequire'
+
+const helpText = `
+    Options
+        --offset Start position in the list of jobs. Default 0.
+        --limit Maximum number of jobs returned. Default 10. Maximum 1000.
+
+    Examples
+        sanity dataset copy list
+        sanity dataset copy list --offset=2
+        sanity dataset copy list --offset=2 --limit=10
+
+    Returns table of jobs with:
+    - jobId
+    - current state - pending, completed, failed, terminating, terminated
+    - History - whether or not dataset copy included document history
+    - time started - when the job was started
+    - time taken - the amount of time the job took to finish
+    - source - source dataset name
+    - target - target dataset name
+`
+
+export default {
+  name: 'jobs',
+  signature: 'list',
+  group: 'dataset',
+  description: 'Lists all dataset copy jobs corresponding to a certain criteria',
+  action: lazyRequire(require.resolve('../../actions/dataset/listDatasetCopyJobs')),
+  helpText,
+}

--- a/packages/@sanity/core/src/commands/index.js
+++ b/packages/@sanity/core/src/commands/index.js
@@ -5,6 +5,7 @@ import datasetGroup from './dataset/datasetGroup'
 import deployCommand from './deploy/deployCommand'
 import undeployCommand from './deploy/undeployCommand'
 import listDatasetsCommand from './dataset/listDatasetsCommand'
+import listCopyDatasetJobs from './dataset/listCopyDatasetJobs'
 import createDatasetCommand from './dataset/createDatasetCommand'
 import datasetVisibilityCommand from './dataset/datasetVisibilityCommand'
 import deleteDatasetCommand from './dataset/deleteDatasetCommand'
@@ -47,6 +48,7 @@ export default [
   deployCommand,
   undeployCommand,
   listDatasetsCommand,
+  listCopyDatasetJobs,
   createDatasetCommand,
   datasetVisibilityCommand,
   exportDatasetCommand,

--- a/packages/@sanity/core/src/types.ts
+++ b/packages/@sanity/core/src/types.ts
@@ -30,6 +30,7 @@ export interface CliCommandContext {
 
 export interface CliOutputter {
   print: (...args: any[]) => void
+  table: (...args: any[]) => void
   warn: (...args: any[]) => void
   error: (...args: any[]) => void
   clear: () => void


### PR DESCRIPTION
### Description

Introduce a new cli command `sanity dataset jobs list` which prints out information about the dataset copy jobs related to the project.
This new command will help users find out the status of copy jobs without needing the job id.
[Story 18247](https://app.shortcut.com/sanity-io/story/18247/list-job-history-sanity-cli) 

### What to review

This PR introduces a new outputter function `printTable` and a new dataset action `listDatasetCopyJob`.
You can test it locally by running `sanity dataset jobs list` in `/dev/test-studio` for example. 

<img width="1353" alt="Screenshot 2022-05-18 at 16 50 17" src="https://user-images.githubusercontent.com/24877689/169082029-175632fc-c7cf-4e9a-85fc-e5ff1cf40ba1.png">

### Notes for release

New CLI command `sanity dataset jobs list`.
