### PR TITLE
fix(portable-text-editor): fix instance props support for readOnly and maxBlocks

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/PortableTextEditor.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/PortableTextEditor.tsx
@@ -203,12 +203,12 @@ export class PortableTextEditor extends React.Component<PortableTextEditorProps,
     this.readOnly = props.readOnly || false
     this.state = state
     this.slateInstance = withPortableText(createEditor(), {
-      portableTextFeatures: this.portableTextFeatures,
-      keyGenerator: this.keyGenerator,
       change$: this.change$,
-      maxBlocks: this.maxBlocks,
       incomingPatches$: this.incomingPatches$,
-      readOnly: !!this.props.readOnly,
+      keyGenerator: this.keyGenerator,
+      maxBlocks: this.maxBlocks,
+      portableTextFeatures: this.portableTextFeatures,
+      readOnly: this.readOnly,
     })
   }
 
@@ -218,7 +218,17 @@ export class PortableTextEditor extends React.Component<PortableTextEditorProps,
   }
 
   componentDidUpdate(prevProps: PortableTextEditorProps) {
-    this.readOnly = this.props.readOnly || false
+    if (this.props.readOnly !== prevProps.readOnly) {
+      this.readOnly = this.props.readOnly || false
+      this.slateInstance.readOnly = this.readOnly
+    }
+    if (this.props.maxBlocks !== prevProps.maxBlocks) {
+      this.maxBlocks =
+        typeof this.props.maxBlocks === 'undefined'
+          ? undefined
+          : parseInt(this.props.maxBlocks.toString(), 10) || undefined
+      this.slateInstance.maxBlocks = this.maxBlocks
+    }
     // Validate again if value length has changed
     if (this.props.value && (prevProps.value || []).length !== this.props.value.length) {
       debug('Validating')

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithMaxBlocks.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithMaxBlocks.ts
@@ -4,10 +4,11 @@ import {PortableTextSlateEditor} from '../../types/editor'
  * This plugin makes sure that the PTE maxBlocks prop is respected
  *
  */
-export function createWithMaxBlocks(rows: number) {
+export function createWithMaxBlocks() {
   return function withMaxBlocks(editor: PortableTextSlateEditor): PortableTextSlateEditor {
     const {apply} = editor
     editor.apply = (operation) => {
+      const rows = editor.maxBlocks || -1
       if (rows > 0 && editor.children.length >= rows) {
         if (
           (operation.type === 'insert_node' || operation.type === 'split_node') &&

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPatches.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPatches.ts
@@ -127,6 +127,9 @@ export function createWithPatches(
     const {apply} = editor
 
     editor.apply = (operation: Operation): void | Editor => {
+      if (editor.readOnly) {
+        editor.apply(operation)
+      }
       let patches: Patch[] = []
 
       // The previous value is needed to figure out the _key of deleted nodes. The editor.children would no

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithUndoRedo.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithUndoRedo.ts
@@ -56,6 +56,10 @@ export function createWithUndoRedo(incomingPatches$?: PatchObservable) {
     const {apply} = editor
     // Apply function for merging and saving local history inspired from 'slate-history' by Ian Storm Taylor
     editor.apply = (op: Operation) => {
+      if (editor.readOnly) {
+        apply(op)
+        return
+      }
       const {operations, history} = editor
       const {undos} = history
       const step = undos[undos.length - 1]
@@ -106,6 +110,9 @@ export function createWithUndoRedo(incomingPatches$?: PatchObservable) {
     }
 
     editor.undo = () => {
+      if (editor.readOnly) {
+        return
+      }
       const {undos} = editor.history
       if (undos.length > 0) {
         const step = undos[undos.length - 1]
@@ -144,6 +151,9 @@ export function createWithUndoRedo(incomingPatches$?: PatchObservable) {
     }
 
     editor.redo = () => {
+      if (editor.readOnly) {
+        return
+      }
       const {redos} = editor.history
       if (redos.length > 0) {
         const step = redos[redos.length - 1]

--- a/packages/@sanity/portable-text-editor/src/types/editor.ts
+++ b/packages/@sanity/portable-text-editor/src/types/editor.ts
@@ -80,6 +80,8 @@ export interface PortableTextSlateEditor extends ReactEditor {
   isListBlock: (value: unknown) => value is ListItem
   isSelecting: boolean
   isThrottling: boolean
+  readOnly: boolean
+  maxBlocks: number | undefined
 
   /**
    * Increments selected list items levels, or decrements them if @reverse is true.


### PR DESCRIPTION
### Description

There was a undetected bug where the `readOnly` and `maxBlocks` properties of the editor were only set at contruction time on the slate editor instance. This will add support for the editor's plugin chain to have always use current values from the outside props.

This was the cause of the heisen-bug where the patch plugin suddenly stopped producing patches. It got stuck with an old `readOnly` value. With the roles support of the studio, the change of these props have become more common and the problem has surfaced to some users. Some of those clients have been running this branch for a while reporting that they no longer see this issue.

This will also fix https://github.com/sanity-io/sanity/issues/3184 which is related.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fix a rare occurring bug in the Portable Text Editor where it would stop producing patches due to non-updated instance props.

<!--
A description of the change(s) that should be used in the release notes.
-->
