### PR TITLE
fix(desk-tool): prevent sortBy from overtaking the defaultOrdering

### DIFF
--- a/dev/test-studio/parts/deskStructure.js
+++ b/dev/test-studio/parts/deskStructure.js
@@ -527,6 +527,10 @@ export default () =>
 
       S.divider(),
 
+      S.documentTypeListItem('author')
+        .id('test-sorting')
+        .child(S.documentTypeList('author').defaultOrdering([{field: 'role', direction: 'desc'}])),
+
       ...S.documentTypeListItems().filter(
         (listItem) =>
           !CI_INPUT_TYPES.includes(listItem.getId()) &&

--- a/packages/@sanity/desk-tool/src/panes/documentList/DocumentListPane.tsx
+++ b/packages/@sanity/desk-tool/src/panes/documentList/DocumentListPane.tsx
@@ -5,7 +5,7 @@ import {useShallowUnique} from '../../utils/useShallowUnique'
 import {useUnique} from '../../utils/useUnique'
 import {useDeskToolSetting} from '../../settings'
 import {BaseDeskToolPaneProps} from '../types'
-import {DEFAULT_ORDERING, EMPTY_RECORD} from './constants'
+import {EMPTY_RECORD} from './constants'
 import {
   applyOrderingFunctions,
   getTypeNameFromSingleTypeFilter,
@@ -40,10 +40,16 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
   const typeName = useMemo(() => getTypeNameFromSingleTypeFilter(filter, params), [filter, params])
   const showIcons = displayOptions?.showIcons !== false
   const [layout, setLayout] = useDeskToolSetting<Layout>(typeName, 'layout', defaultLayout)
+  const defaultOrderingBy = useMemo(
+    () => ({
+      by: defaultOrdering,
+    }),
+    [defaultOrdering]
+  )
   const [sortOrderRaw, setSortOrder] = useDeskToolSetting<SortOrder>(
     typeName,
     'sortOrder',
-    DEFAULT_ORDERING
+    defaultOrderingBy
   )
 
   const sortWithOrderingFn =
@@ -55,7 +61,6 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
   const filterIsSimpleTypeContraint = isSimpleTypeFilter(filter)
 
   const {error, fullList, handleListChange, isLoading, items, onRetry} = useDocumentList({
-    defaultOrdering,
     filter,
     params,
     sortOrder,

--- a/packages/@sanity/desk-tool/src/panes/documentList/constants.ts
+++ b/packages/@sanity/desk-tool/src/panes/documentList/constants.ts
@@ -1,6 +1,3 @@
-import {SortOrder} from './types'
-
 export const PARTIAL_PAGE_LIMIT = 100
 export const FULL_LIST_LIMIT = 2000
-export const DEFAULT_ORDERING: SortOrder = {by: [{field: '_createdAt', direction: 'desc'}]}
 export const EMPTY_RECORD: Record<string, unknown> = {}

--- a/packages/@sanity/desk-tool/src/panes/documentList/useDocumentList.ts
+++ b/packages/@sanity/desk-tool/src/panes/documentList/useDocumentList.ts
@@ -3,12 +3,11 @@ import {getQueryResults} from 'part:@sanity/base/query-container'
 import {useEffect, useState, useCallback, useMemo, useRef} from 'react'
 import {of} from 'rxjs'
 import {filter as filterEvents} from 'rxjs/operators'
-import {DocumentListPaneItem, QueryResult, SortOrder, SortOrderBy} from './types'
+import {DocumentListPaneItem, QueryResult, SortOrder} from './types'
 import {removePublishedWithDrafts, toOrderClause} from './helpers'
-import {DEFAULT_ORDERING, FULL_LIST_LIMIT, PARTIAL_PAGE_LIMIT} from './constants'
+import {FULL_LIST_LIMIT, PARTIAL_PAGE_LIMIT} from './constants'
 
 interface UseDocumentListOpts {
-  defaultOrdering: SortOrderBy[]
   filter: string
   params: Record<string, unknown>
   sortOrder?: SortOrder
@@ -24,11 +23,13 @@ interface DocumentListState {
   onRetry?: (event: unknown) => void
 }
 
+const DEFAULT_ORDERING: SortOrder = {by: [{field: '_updatedAt', direction: 'desc'}]}
+
 /**
  * @internal
  */
 export function useDocumentList(opts: UseDocumentListOpts): DocumentListState {
-  const {defaultOrdering, filter, params, sortOrder, apiVersion} = opts
+  const {filter, params, sortOrder, apiVersion} = opts
   const [fullList, setFullList] = useState(false)
   const fullListRef = useRef(fullList)
   const [result, setResult] = useState<QueryResult | null>(null)
@@ -44,7 +45,7 @@ export function useDocumentList(opts: UseDocumentListOpts): DocumentListState {
     const extendedProjection = sortOrder?.extendedProjection
     const projectionFields = ['_id', '_type']
     const finalProjection = projectionFields.join(',')
-    const sortBy = defaultOrdering || sortOrder?.by || []
+    const sortBy = sortOrder?.by || []
     const limit = fullList ? FULL_LIST_LIMIT : PARTIAL_PAGE_LIMIT
     const sort = sortBy.length > 0 ? sortBy : DEFAULT_ORDERING.by
     const order = toOrderClause(sort)
@@ -59,7 +60,7 @@ export function useDocumentList(opts: UseDocumentListOpts): DocumentListState {
     }
 
     return `*[${filter}]|order(${order})[0...${limit}]{${finalProjection}}`
-  }, [defaultOrdering, filter, fullList, sortOrder])
+  }, [filter, fullList, sortOrder])
 
   const handleListChange = useCallback(
     ({toIndex}: VirtualListChangeOpts) => {


### PR DESCRIPTION
### Description

Fix two bugs:
- Using `defaultOrdering` in the desk structure will now work.
- With this fix we revert a bug that was introduced in a past PR where the document list appeared to be loading forever when changing the sorting.

I will drop the last commit shown since it's only for pr testing purposes.

### What to review

1. Go to the test studio
2. At the bottom of the desk structure, you will find two authors: The first one has the `defaultOrdering` based on `role` while the second is a normal one based on name. *They should have the documents in different order*
3. Double check that the order of the documents is different
4. Double check that when changing sorting options that it will keep trying to load the documents forever

### Notes for release

- Using `defaultOrdering` in the desk structure will now work.
- Revert a bug that was introduced in a past PR where the document list appeared to be loading forever when changing the sorting.
