### PR TITLE
Ensure `margins` doesn't make its way to the DOM

### DIFF
--- a/packages/@sanity/base/src/presence/overlay/WithIntersection.tsx
+++ b/packages/@sanity/base/src/presence/overlay/WithIntersection.tsx
@@ -11,7 +11,7 @@ export interface WithIntersectionProps {
 export const WithIntersection = (
   props: WithIntersectionProps & React.HTMLProps<HTMLDivElement>
 ) => {
-  const {onIntersection, io, id, ...rest} = props
+  const {onIntersection, io, id, margins, ...rest} = props
   const element = React.useRef<HTMLDivElement | null>(null)
   React.useEffect(() => {
     const el = element.current


### PR DESCRIPTION
### Description

The `WithIntersection` component spreads its props on the rendered `<div>` element which results in the `margins` prop making its way onto the DOM. This is not a valid prop and shouldn’t be rendered in the HTML.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
