### PR TITLE
feat(cli): format dataset copy output with console-table-printer

### DIFF
--- a/packages/@sanity/core/package.json
+++ b/packages/@sanity/core/package.json
@@ -43,6 +43,7 @@
     "chokidar": "^3.0.0",
     "configstore": "^5.0.1",
     "date-fns": "^2.16.1",
+    "console-table-printer": "^2.11.0",
     "debug": "^3.2.7",
     "deep-sort-object": "^1.0.1",
     "es6-promisify": "^6.0.0",


### PR DESCRIPTION
### Description

Change the formatting of the `dataset jobs list` output.
Introduces a new npm dependency [console-table-printer](https://www.npmjs.com/package/console-table-printer)

With this library we are able to get rid of the index column and the quotes around the values in the table, which are present in the solution with `console.table()`

<img width="1008" alt="Screenshot 2022-06-08 at 16 07 49" src="https://user-images.githubusercontent.com/24877689/172637717-4aca2209-7c9e-475d-a901-f7a46d4f9b5e.png">
