### PR TITLE
Add missing document language to Sanity Studio

### DIFF
--- a/packages/@sanity/base/src/components/Document.tsx
+++ b/packages/@sanity/base/src/components/Document.tsx
@@ -12,6 +12,7 @@ export interface DocumentAsset {
 export interface DocumentProps {
   basePath?: string
   charset?: string
+  lang?: string
   title?: string
   viewport?: string
   loading?: React.ReactNode
@@ -29,6 +30,7 @@ export default function Document(props: DocumentProps) {
     charset = 'utf-8',
     title = 'Sanity',
     viewport = 'width=device-width, initial-scale=1, viewport-fit=cover',
+    lang = 'en',
     loading = 'Connecting to Sanity.io',
     staticPath: staticPathProp = '/static',
     favicons: faviconsProp = DEFAULT_FAVICONS,
@@ -72,7 +74,7 @@ export default function Document(props: DocumentProps) {
   )
 
   return (
-    <html>
+    <html lang={lang}>
       <head>
         <meta charSet={charset} />
         <title>{title}</title>

--- a/packages/@sanity/core/src/actions/start/startAction.js
+++ b/packages/@sanity/core/src/actions/start/startAction.js
@@ -31,6 +31,7 @@ export default async (args, context) => {
     httpPort,
     context,
     project: sanityConfig.get('project'),
+    lang: sanityConfig.get('lang'),
   }
 
   await checkStudioDependencyVersions(workDir)

--- a/packages/@sanity/server/src/baseServer.js
+++ b/packages/@sanity/server/src/baseServer.js
@@ -40,7 +40,10 @@ export function getBaseServer() {
   return express()
 }
 
-export function getDocumentElement({project, basePath, hashes, isSanityMonorepo}, props = {}) {
+export function getDocumentElement(
+  {project, basePath, hashes, isSanityMonorepo, lang},
+  props = {}
+) {
   const assetHashes = hashes || {}
 
   // Project filesystem base path
@@ -56,6 +59,7 @@ export function getDocumentElement({project, basePath, hashes, isSanityMonorepo}
           scripts: ['js/vendor.bundle.js', 'js/app.bundle.js'].map((item) =>
             assetify(item, assetHashes)
           ),
+          lang,
         },
         props
       )


### PR DESCRIPTION
### Description

The Sanity Studio currently does not define a language via the `lang` attribute on the `<html>` element. This is a violation of [Success Criterion 3.1.1](https://www.w3.org/WAI/WCAG21/Understanding/language-of-page.html) of the Web Content Accessibility Guidelines, which requires the language to be programmatically determinable. 

The Sanity interface is hard-coded in English. Everything that is not user-defined from the login form, to generic error messages, to the default actions and badges is authored in English directly within the codebase. I discussed it with @hidde and we agreed that setting English as a default value — at the risk of being partly incorrect for people configuring their schema to use non-English content — is worth it.

This pull-request therefore sets English (`en`) as a default language. Additionally, this pull-request provides a way to override the default language via the Sanity configuration. 

People can opt out from this fix (which they shouldn’t really, but maybe in some cases it might be better?) by setting `"lang": null` in their `sanity.json`. This will cause the default value to be skipped and go back to the `lang` attribute being absent from the root node.

---

There are two ways to properly solve that issue for people building a studio that is not in English:
- Consider English to be the main language (since it’s what Sanity uses). Hard-code `lang="en"` on the document element. Set `lang={config.lang}` (pseudo-code) around every piece of user-defined content (any piece of string users define in their schema such as the value of the `title` key, fieldsets, custom validation messages, warnings…).
- Consider the configuration language to be the main one. Set `lang={config.lang}` on the `<html>` element. Hard-code `lang="en"` around every English piece of content displayed by Sanity.

I am not sure one is better than the other. I guess it depends what content is the most present on a given page: Sanity-defined or user-defined. I would argue probably the latter? In any case, this requires a subsequent PR which will be notably bigger.

### What to review

It took me a little while to understand how the data flows through different packages, but I think I eventually got it. I did some manual tests and it seems alright from what I can tell. If there is a good way to write tests for that, let me know and I can update the pull-request.

I would also be happy writing documentation on this, although I would need you to put me on the right track. 😊 

### Notes for release

It is technically a breaking change for screen-reader users since we go from no programmatically defined language to English. Although that should be for the better in most cases.  