### PR TITLE
fix(cli): throw a better error message in case of a failed dataset copy job

### DIFF
--- a/packages/@sanity/core/src/commands/dataset/copyDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/copyDatasetCommand.js
@@ -90,8 +90,9 @@ const followProgress = (jobId, client, output) => {
 
       spinner.text = `Copy in progress: ${currentProgress}%`
     },
-    error: (err) => {
-      spinner.fail(`There was an error copying the dataset: ${err.message}`)
+    error: (event) => {
+      spinner.fail()
+      throw new Error(`There was an error copying dataset: ${event.data}`)
     },
     complete: () => {
       spinner.succeed('Copy finished.')


### PR DESCRIPTION
### Description

The error method receives an event object, which doesn't have an error property nor a message property.
The message is changed to print the event data in case of a failed job.