### PR TITLE
chore(cli): add output to inform that `--skip-history` flag exists

### DIFF
--- a/packages/@sanity/core/src/commands/dataset/copyDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/copyDatasetCommand.js
@@ -161,6 +161,13 @@ export default {
       output.print(
         `Copying dataset ${chalk.green(sourceDatasetName)} to ${chalk.green(targetDatasetName)}...`
       )
+
+      if (!shouldSkipHistory) {
+        output.print(
+          `Note: You can run this command with flag '--skip-history'. The flag will reduce copy time in larger datasets.`
+        )
+      }
+
       output.print(`Job ${chalk.green(response.jobId)} started`)
 
       if (flags.detach) {


### PR DESCRIPTION


### Description

This has been added after investigations into long processing times. Copying with history is slow.

This information is an alternative to changing the default settings and breaking backwards compatibility.

### What to review

New output. Run copy process with and without flag to see output.

```sanity dataset copy production backup-1```
<img width="772" alt="image" src="https://user-images.githubusercontent.com/1180172/172355431-33f696b4-6bb5-41e2-890c-d9fbb8374776.png">

```sanity dataset copy production backup-2 --skip-history```
<img width="509" alt="image" src="https://user-images.githubusercontent.com/1180172/172355591-a1cc96a7-4906-4c03-abb4-bc21d048089d.png">


### Notes for release

N/A
