### PR TITLE
refactor(sanity): make inline objects and annotations open in popover by default

### DIFF
--- a/packages/sanity/src/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/form/inputs/PortableText/Compositor.tsx
@@ -19,7 +19,7 @@ import {
   usePortal,
 } from '@sanity/ui'
 import {ChangeIndicator} from '../../../components/changeIndicators'
-import {ArrayOfObjectsInputProps, FIXME, RenderCustomMarkers} from '../../types'
+import {ArrayOfObjectsInputProps, RenderCustomMarkers} from '../../types'
 import {ActivateOnFocus} from '../../components/ActivateOnFocus/ActivateOnFocus'
 import {EMPTY_ARRAY} from '../../utils/empty'
 import {FormInput} from '../../FormInput'
@@ -33,7 +33,7 @@ import {useHotkeys} from './hooks/useHotKeys'
 import {ObjectEditModal} from './object/renderers/ObjectEditModal'
 import {useScrollToFocusFromOutside} from './hooks/useScrollToFocusFromOutside'
 import {usePortableTextMemberItems} from './hooks/usePortableTextMembers'
-import {isBlockType} from './PortableTextInput'
+import {_isBlockType} from './_helpers'
 
 interface InputProps extends ArrayOfObjectsInputProps<PortableTextBlock> {
   hasFocus: boolean
@@ -246,10 +246,7 @@ export function Compositor(props: InputProps) {
   const [portalElement, setPortalElement] = useState<HTMLDivElement | null>(null)
 
   const openMemberItems = useMemo(
-    () =>
-      portableTextMemberItems.filter(
-        (m) => m.member.open && !isBlockType(m.member.item.schemaType)
-      ),
+    () => portableTextMemberItems.filter((m) => m.member.open && !_isBlockType(m.node.schemaType)),
     [portableTextMemberItems]
   )
 
@@ -306,15 +303,13 @@ export function Compositor(props: InputProps) {
             {openMemberItems.map((dMemberItem) => {
               return (
                 <ObjectEditModal
+                  kind={dMemberItem.kind}
                   key={dMemberItem.member.key}
                   memberItem={dMemberItem}
                   onClose={onCloseItem}
                   scrollElement={boundaryElm}
                 >
-                  <FormInput
-                    absolutePath={dMemberItem.member.item.path as FIXME}
-                    {...(props as FIXME)}
-                  />
+                  <FormInput absolutePath={dMemberItem.node.path} {...(props as any)} />
                 </ObjectEditModal>
               )
             })}

--- a/packages/sanity/src/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/form/inputs/PortableText/PortableTextInput.tsx
@@ -51,9 +51,8 @@ export type PTObjectMember = ArrayOfObjectsItemMember<
     ObjectSchemaType
   >
 >
-
 export interface PortableTextMemberItem {
-  kind: 'annotation' | 'object' | 'inlineObject'
+  kind: 'annotation' | 'textBlock' | 'objectBlock' | 'inlineObject'
   key: string
   member: PTObjectMember
   node: ObjectFormNode
@@ -150,23 +149,18 @@ export function PortableTextInput(props: PortableTextInputProps) {
   // Populate the portableTextMembers Map
   const portableTextMemberItems: PortableTextMemberItem[] = useMemo(() => {
     const result: {
-      kind: 'annotation' | 'object' | 'inlineObject'
+      kind: PortableTextMemberItem['kind']
       member: PTObjectMember
       node: ObjectFormNode
     }[] = []
 
     for (const member of members) {
-      // ignore errors
-      // if (member.kind === 'error') {
-      // }
-
       if (member.kind === 'item') {
         if (!_isBlockType(member.item.schemaType)) {
-          result.push({kind: 'object', member, node: member.item})
-        }
-
-        if (member.item.validation.length > 0) {
-          result.push({kind: 'object', member, node: member.item})
+          result.push({kind: 'objectBlock', member, node: member.item})
+        } else if (member.item.validation.length > 0) {
+          // Only text blocks that have validation
+          result.push({kind: 'textBlock', member, node: member.item})
         }
 
         if (_isBlockType(member.item.schemaType)) {

--- a/packages/sanity/src/form/inputs/PortableText/_helpers.ts
+++ b/packages/sanity/src/form/inputs/PortableText/_helpers.ts
@@ -1,0 +1,22 @@
+import {SchemaType} from '@sanity/types'
+import {ArrayOfObjectsFormNode, FieldMember, ObjectMember} from '../../store'
+
+export function _isBlockType(type: SchemaType): boolean {
+  if (type.type) {
+    return _isBlockType(type.type)
+  }
+
+  return type.name === 'block'
+}
+
+export function _isObjectFieldMember(
+  member: ObjectMember
+): member is FieldMember<ArrayOfObjectsFormNode> {
+  return member.kind === 'field' && member.field.schemaType.jsonType === 'object'
+}
+
+export function _isArrayOfObjectsFieldMember(
+  member: ObjectMember
+): member is FieldMember<ArrayOfObjectsFormNode> {
+  return member.kind === 'field' && member.field.schemaType.jsonType === 'array'
+}

--- a/packages/sanity/src/form/inputs/PortableText/hooks/useMemberValidation.tsx
+++ b/packages/sanity/src/form/inputs/PortableText/hooks/useMemberValidation.tsx
@@ -1,18 +1,23 @@
 import {useMemo} from 'react'
-import {ArrayOfObjectsItemMember, ObjectFormNode} from '../../../store'
+import {BaseFormNode} from '../../../store'
 import {EMPTY_ARRAY} from '../../../utils/empty'
 import {useChildValidation} from '../../../studio/contexts/Validation'
-import {isBlockType} from '../PortableTextInput'
+import {_isBlockType} from '../_helpers'
 
 const NONEXISTENT_PATH = ['@@_NONEXISTENT_PATH_@@']
 
-export function useMemberValidation(member: ArrayOfObjectsItemMember<ObjectFormNode> | undefined) {
-  const memberValidation = member?.item.validation || EMPTY_ARRAY
-  const childValidation = useChildValidation(member?.item.path || NONEXISTENT_PATH)
-  const validation =
-    member && isBlockType(member.item.schemaType)
-      ? memberValidation
-      : memberValidation.concat(childValidation)
+export function useMemberValidation(member: BaseFormNode | undefined) {
+  const memberValidation = member?.validation || EMPTY_ARRAY
+  const childValidation = useChildValidation(member?.path || NONEXISTENT_PATH)
+
+  const validation = useMemo(
+    () =>
+      member?.schemaType && _isBlockType(member?.schemaType)
+        ? memberValidation
+        : memberValidation.concat(childValidation),
+    [childValidation, member, memberValidation]
+  )
+
   const [hasError, hasWarning, hasInfo] = useMemo(
     () => [
       validation.filter((v) => v.level === 'error').length > 0,
@@ -21,6 +26,7 @@ export function useMemberValidation(member: ArrayOfObjectsItemMember<ObjectFormN
     ],
     [validation]
   )
+
   return useMemo(() => {
     return {
       validation,

--- a/packages/sanity/src/form/inputs/PortableText/hooks/useScrollToFocusFromOutside.tsx
+++ b/packages/sanity/src/form/inputs/PortableText/hooks/useScrollToFocusFromOutside.tsx
@@ -7,7 +7,7 @@ import {Path} from '@sanity/types'
 import {isEqual} from '@sanity/util/paths'
 import {useEffect} from 'react'
 import scrollIntoView from 'scroll-into-view-if-needed'
-import {isBlockType} from '../PortableTextInput'
+import {_isBlockType} from '../_helpers'
 import {usePortableTextMemberItems} from './usePortableTextMembers'
 
 interface Props {
@@ -51,7 +51,7 @@ export function useScrollToFocusFromOutside(props: Props): void {
         PortableTextEditor.focus(editor)
       }
       // Auto-close regular blocks
-      if (isBlockType(memberItem.member.item.schemaType)) {
+      if (_isBlockType(memberItem.member.item.schemaType)) {
         onCloseItem()
       }
     }

--- a/packages/sanity/src/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/form/inputs/PortableText/object/BlockObject.tsx
@@ -17,6 +17,7 @@ import {useFormBuilder} from '../../../useFormBuilder'
 import {useMemberValidation} from '../hooks/useMemberValidation'
 import {usePortableTextMarkers} from '../hooks/usePortableTextMarkers'
 import {usePortableTextMemberItem} from '../hooks/usePortableTextMembers'
+import {pathToString} from '../../../../field/paths'
 import {BlockObjectPreview} from './BlockObjectPreview'
 import {
   Root,
@@ -60,14 +61,14 @@ export function BlockObject(props: BlockObjectProps) {
   const [reviewChangesHovered, setReviewChangesHovered] = useState<boolean>(false)
   const markers = usePortableTextMarkers(path)
   const editor = usePortableTextEditor()
-  const memberItem = usePortableTextMemberItem(JSON.stringify(path))
+  const memberItem = usePortableTextMemberItem(pathToString(path))
 
   const handleMouseOver = useCallback(() => setReviewChangesHovered(true), [])
   const handleMouseOut = useCallback(() => setReviewChangesHovered(false), [])
 
   const handleEdit = useCallback(() => {
     if (memberItem) {
-      onOpenItem(memberItem.member.item.path)
+      onOpenItem(memberItem.node.path)
     }
   }, [onOpenItem, memberItem])
 
@@ -128,11 +129,11 @@ export function BlockObject(props: BlockObjectProps) {
     return {paddingX: 3}
   }, [isFullscreen, renderBlockActions])
 
-  const {validation, hasError, hasWarning, hasInfo} = useMemberValidation(memberItem?.member)
+  const {validation, hasError, hasWarning, hasInfo} = useMemberValidation(memberItem?.node)
 
   const hasMarkers = Boolean(markers.length > 0)
 
-  const isImagePreview = memberItem?.member.item.schemaType.name === 'image'
+  const isImagePreview = memberItem?.node.schemaType.name === 'image'
 
   const tooltipEnabled = hasError || hasWarning || hasInfo || (hasMarkers && renderCustomMarkers)
 

--- a/packages/sanity/src/form/inputs/PortableText/object/InlineObject.tsx
+++ b/packages/sanity/src/form/inputs/PortableText/object/InlineObject.tsx
@@ -17,6 +17,7 @@ import {PortableTextEditorElement} from '../Compositor'
 import {usePortableTextMarkers} from '../hooks/usePortableTextMarkers'
 import {useMemberValidation} from '../hooks/useMemberValidation'
 import {usePortableTextMemberItem} from '../hooks/usePortableTextMembers'
+import {pathToString} from '../../../../field/paths'
 import {InlineObjectToolbarPopover} from './InlineObjectToolbarPopover'
 
 interface InlineObjectProps {
@@ -126,8 +127,8 @@ export const InlineObject = React.forwardRef(function InlineObject(
   const editor = usePortableTextEditor()
   const editorSelection = usePortableTextEditorSelection()
   const markers = usePortableTextMarkers(path)
-  const memberItem = usePortableTextMemberItem(JSON.stringify(path))
-  const {validation, hasError, hasWarning} = useMemberValidation(memberItem?.member)
+  const memberItem = usePortableTextMemberItem(pathToString(path))
+  const {validation, hasError, hasWarning} = useMemberValidation(memberItem?.node)
   const hasValidationMarkers = validation.length > 0
   const [showPopover, setShowPopover] = useState(false)
 
@@ -206,7 +207,7 @@ export const InlineObject = React.forwardRef(function InlineObject(
     setShowPopover(false)
     PortableTextEditor.blur(editor)
     if (memberItem) {
-      onOpenItem(memberItem.member.item.path)
+      onOpenItem(memberItem.node.path)
     }
   }, [editor, memberItem, onOpenItem])
 

--- a/packages/sanity/src/form/inputs/PortableText/object/helpers.ts
+++ b/packages/sanity/src/form/inputs/PortableText/object/helpers.ts
@@ -7,8 +7,8 @@ export interface ModalOption {
   width?: ModalWidth
 }
 
-export function _getModalOption(opts: {type?: ObjectSchemaType}): ModalOption {
-  const {type} = opts
+export function _getModalOption(opts: {schemaType?: ObjectSchemaType}): ModalOption {
+  const {schemaType} = opts
 
-  return (get(type, 'options.modal') || {}) as ModalOption
+  return (get(schemaType, 'options.modal') || {}) as ModalOption
 }

--- a/packages/sanity/src/form/inputs/PortableText/text/Annotation.tsx
+++ b/packages/sanity/src/form/inputs/PortableText/text/Annotation.tsx
@@ -16,6 +16,7 @@ import {useFormBuilder} from '../../../useFormBuilder'
 import {useMemberValidation} from '../hooks/useMemberValidation'
 import {usePortableTextMarkers} from '../hooks/usePortableTextMarkers'
 import {usePortableTextMemberItem} from '../hooks/usePortableTextMembers'
+import {pathToString} from '../../../../field/paths'
 import {AnnotationToolbarPopover} from './AnnotationToolbarPopover'
 
 interface AnnotationProps {
@@ -83,8 +84,8 @@ export const Annotation = function Annotation(props: AnnotationProps) {
     [path, value._key]
   )
   const [textElement, setTextElement] = useState<HTMLSpanElement | null>(null)
-  const memberItem = usePortableTextMemberItem(JSON.stringify(markDefPath))
-  const {validation, hasError, hasWarning} = useMemberValidation(memberItem?.member)
+  const memberItem = usePortableTextMemberItem(pathToString(markDefPath))
+  const {validation, hasError, hasWarning} = useMemberValidation(memberItem?.node)
   const markers = usePortableTextMarkers(path)
   const [showPopover, setShowPopover] = useState(false)
 
@@ -137,7 +138,7 @@ export const Annotation = function Annotation(props: AnnotationProps) {
       event.preventDefault()
       event.stopPropagation()
       if (memberItem) {
-        onOpenItem(memberItem.member.item.path)
+        onOpenItem(memberItem.node.path)
       }
     },
     [editor, memberItem, onOpenItem]

--- a/packages/sanity/src/form/inputs/PortableText/text/TextBlock.tsx
+++ b/packages/sanity/src/form/inputs/PortableText/text/TextBlock.tsx
@@ -10,6 +10,7 @@ import {RenderBlockActionsCallback} from '../types'
 import {useMemberValidation} from '../hooks/useMemberValidation'
 import {usePortableTextMarkers} from '../hooks/usePortableTextMarkers'
 import {usePortableTextMemberItem} from '../hooks/usePortableTextMembers'
+import {pathToString} from '../../../../field/paths'
 import {TEXT_STYLE_PADDING} from './constants'
 import {
   BlockActionsInner,
@@ -51,12 +52,12 @@ export function TextBlock(props: TextBlockProps) {
   const {Markers} = useFormBuilder().__internal.components
   const [reviewChangesHovered, setReviewChangesHovered] = useState<boolean>(false)
   const markers = usePortableTextMarkers(path)
-  const memberItem = usePortableTextMemberItem(JSON.stringify(path))
+  const memberItem = usePortableTextMemberItem(pathToString(path))
 
   const handleChangeIndicatorMouseEnter = useCallback(() => setReviewChangesHovered(true), [])
   const handleChangeIndicatorMouseLeave = useCallback(() => setReviewChangesHovered(false), [])
 
-  const {validation, hasError, hasWarning, hasInfo} = useMemberValidation(memberItem?.member)
+  const {validation, hasError, hasWarning, hasInfo} = useMemberValidation(memberItem?.node)
 
   const hasMarkers = Boolean(renderCustomMarkers) && markers.length > 0
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR makes it so the Portable Text input treats inline objects, annotations, and custom block objects differently:
- Inline objects open in a popover by default.
- Annotations open in a popover by default.
- Custom block objects open in a dialog by default,



### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

Make sure opening and closing of inline objects, annotations and custom block objects works as expected.
