### PR TITLE
adding name to SortOrdering type

### DIFF
--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -384,6 +384,7 @@ export interface SortOrderingItem {
 
 export type SortOrdering = {
   title: string
+  name: string
   by: SortOrderingItem[]
 }
 export interface ConditionalPropertyCallbackContext {


### PR DESCRIPTION
`name` should be in the sort ordering: https://www.sanity.io/docs/sort-orders