### PR TITLE
adding calendarTodayLabel

### DIFF
--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -185,6 +185,7 @@ export namespace Schema {
   }
 
   export interface DateOptions {
+    calendarTodayLabel?: string
     dateFormat?: string
   }
 
@@ -194,6 +195,7 @@ export namespace Schema {
   }
 
   export interface DatetimeOptions {
+    calendarTodayLabel?: string
     dateFormat?: string
     timeFormat?: string
     timeStep?: number


### PR DESCRIPTION
`calendarTodayLabel` appears inconsistently in the date and datetime documentation. Not sure it truly does anything #3354 but adding it to types regardless.

https://www.sanity.io/docs/date-type
https://www.sanity.io/docs/datetime-type