### PR TITLE
feat(cli): allow specifying --api to filter which APIs to deploy

### DIFF
--- a/packages/@sanity/cli/src/types.ts
+++ b/packages/@sanity/cli/src/types.ts
@@ -207,6 +207,12 @@ export interface SanityJson {
 
 export interface GraphQLAPIConfig {
   /**
+   * ID of GraphQL API. Only (currently) required when using the `--api` flag
+   * for `sanity graphql deploy`, in order to only deploy a specific API.
+   */
+  id?: string
+
+  /**
    * Name of workspace containing the schema to deploy
    *
    * Optional, defaults to `default` (eg the one used if no `name` is defined)

--- a/packages/sanity/src/cli/commands/graphql/deployGraphQLAPICommand.ts
+++ b/packages/sanity/src/cli/commands/graphql/deployGraphQLAPICommand.ts
@@ -3,23 +3,19 @@ import {lazyRequire} from '../../util/lazyRequire'
 
 const helpText = `
 Options
-  --dataset <dataset> Deploy API for the given dataset
-  --tag <tag> Deploy API to given tag (defaults to 'default')
-  --generation <generation> API generation to deploy (defaults to 'gen3')
-  --non-null-document-fields Set document interface fields (_id, _type etc) as non-null
-  --playground Deploy a GraphQL playground for easily testing queries (public)
-  --no-playground Skip playground prompt (do not deploy a playground)
+  --dry-run Validate defined APIs, exiting with an error on breaking changes
   --force Deploy API without confirming breaking changes
+  --api <api-id> Only deploy API with this ID. Can be specified multiple times.
 
 Examples
+  # Deploy all defined GraphQL APIs
   sanity graphql deploy
-  sanity graphql deploy --playground
-  sanity graphql deploy --generation gen1
-  sanity graphql deploy --dataset staging --no-playground
-  sanity graphql deploy --dataset staging --tag next --no-playground
-  sanity graphql deploy --no-playground --force
-  sanity graphql deploy --playground --non-null-document-fields
+
+  # Validate defined GraphQL APIs and check for breaking changes
   sanity graphql deploy --dry-run
+
+  # Deploy only the GraphQL APIs with the IDs "staging" and "ios"
+  sanity graphql deploy --api staging --api ios
 `
 
 const deployGraphQLAPICommand: CliCommandDefinition = {


### PR DESCRIPTION
### Description

When defining multiple GraphQL APIs, you might want to only deploy certain defined APIs instead of all of them (see https://github.com/sanity-io/sanity/discussions/3344)

This PR allows you to specify an `id` for each API, and then reference it using the `--api <api-id>` flag when running `sanity graphql deploy`.

It also updates the help text for this command, which didn't match the command in v3.

### What to review

- That the changes makes sense
- That it works. Example `sanity.cli.ts`:

```ts
import {createCliConfig} from 'sanity/cli'

export default createCliConfig({
  api: {
    projectId: 'ppsg7ml5',
    dataset: 'blog',
  },

  graphql: [
    {id: 'ancient', tag: 'ancient', generation: 'gen1'},
    {id: 'default', tag: 'default', generation: 'gen3'},
  ],
})
```

### Notes for release

- Allow specifying a specific GraphQL API to deploy using the new `--api` flag
