### PR TITLE
feat(studio): add not authenticated screen

### DIFF
--- a/packages/sanity/src/studio/AuthBoundary.tsx
+++ b/packages/sanity/src/studio/AuthBoundary.tsx
@@ -28,7 +28,7 @@ export function AuthBoundary({
   }, [activeWorkspace.auth])
 
   useEffect(() => {
-    activeWorkspace.auth.state.subscribe({
+    const subscription = activeWorkspace.auth.state.subscribe({
       next: ({authenticated, currentUser}) => {
         if (currentUser?.roles?.length === 0) {
           setLoggedIn('unauthorized')
@@ -40,6 +40,10 @@ export function AuthBoundary({
       },
       error: handleError,
     })
+
+    return () => {
+      subscription.unsubscribe()
+    }
   }, [activeWorkspace])
 
   if (loggedIn === 'loading') return <LoadingComponent />

--- a/packages/sanity/src/studio/StudioProvider.tsx
+++ b/packages/sanity/src/studio/StudioProvider.tsx
@@ -15,7 +15,13 @@ import {ActiveWorkspaceMatcher} from './activeWorkspaceMatcher'
 import {StudioThemeProvider} from './StudioThemeProvider'
 import {StudioErrorBoundary} from './StudioErrorBoundary'
 import {WorkspaceLoader} from './workspaceLoader'
-import {ConfigErrorsScreen, LoadingScreen, NotAuthenticatedScreen, NotFoundScreen} from './screens'
+import {
+  ConfigErrorsScreen,
+  LoadingScreen,
+  AuthenticateScreen,
+  NotFoundScreen,
+  NotAuthenticatedScreen,
+} from './screens'
 import {WorkspacesProvider} from './workspaces'
 import {AuthBoundary} from './AuthBoundary'
 
@@ -60,6 +66,7 @@ export function StudioProvider({
               <UserColorManagerProvider>
                 <ConditionalAuthBoundary
                   LoadingComponent={LoadingScreen}
+                  AuthenticateComponent={AuthenticateScreen}
                   NotAuthenticatedComponent={NotAuthenticatedScreen}
                 >
                   <WorkspaceLoader

--- a/packages/sanity/src/studio/screens/AuthenticateScreen.tsx
+++ b/packages/sanity/src/studio/screens/AuthenticateScreen.tsx
@@ -1,0 +1,15 @@
+import {Flex, Card, Container} from '@sanity/ui'
+import React from 'react'
+import {WorkspaceAuth} from '../components/navbar/workspace'
+
+export function AuthenticateScreen() {
+  return (
+    <Card height="fill">
+      <Flex align="center" justify="center" height="fill">
+        <Container width={0}>
+          <WorkspaceAuth />
+        </Container>
+      </Flex>
+    </Card>
+  )
+}

--- a/packages/sanity/src/studio/screens/NotAuthenticatedScreen.tsx
+++ b/packages/sanity/src/studio/screens/NotAuthenticatedScreen.tsx
@@ -20,12 +20,16 @@ export function NotAuthenticatedScreen() {
   }, [activeWorkspace.auth])
 
   useEffect(() => {
-    activeWorkspace.auth.state.subscribe({
+    const subscription = activeWorkspace.auth.state.subscribe({
       next: ({currentUser: user}) => {
         setCurrentUser(user)
       },
       error: handleError,
     })
+
+    return () => {
+      subscription.unsubscribe()
+    }
   }, [activeWorkspace])
 
   return (

--- a/packages/sanity/src/studio/screens/NotAuthenticatedScreen.tsx
+++ b/packages/sanity/src/studio/screens/NotAuthenticatedScreen.tsx
@@ -1,15 +1,61 @@
-import {Flex, Card, Container} from '@sanity/ui'
-import React from 'react'
-import {WorkspaceAuth} from '../components/navbar/workspace'
+import {CurrentUser} from '@sanity/types'
+import {Button, Card, Dialog, Stack, Text} from '@sanity/ui'
+import React, {useCallback, useEffect, useState} from 'react'
+import {useActiveWorkspace} from '../activeWorkspaceMatcher'
 
 export function NotAuthenticatedScreen() {
+  const [currentUser, setCurrentUser] = useState<CurrentUser | null>(null)
+  const [error, handleError] = useState<unknown>(null)
+
+  if (error) throw error
+
+  const {activeWorkspace} = useActiveWorkspace()
+
+  const handleLogout = useCallback(() => {
+    activeWorkspace.auth.logout?.()
+  }, [activeWorkspace])
+
+  useEffect(() => {
+    activeWorkspace.auth.handleCallbackUrl?.().catch(handleError)
+  }, [activeWorkspace.auth])
+
+  useEffect(() => {
+    activeWorkspace.auth.state.subscribe({
+      next: ({currentUser: user}) => {
+        setCurrentUser(user)
+      },
+      error: handleError,
+    })
+  }, [activeWorkspace])
+
   return (
     <Card height="fill">
-      <Flex align="center" justify="center" height="fill">
-        <Container width={0}>
-          <WorkspaceAuth />
-        </Container>
-      </Flex>
+      <Dialog
+        id="not-authorized-dialog"
+        header="Not authorized"
+        width={1}
+        footer={
+          <Stack paddingX={3} paddingY={2}>
+            <Button text="Sign out" onClick={handleLogout} />
+          </Stack>
+        }
+      >
+        <Stack paddingX={4} paddingY={5} space={4}>
+          <Text>
+            You are not authorized to access this studio. Maybe you could ask someone to invite you
+            to collaborate on this project?
+          </Text>
+
+          <Text>
+            If you think this is an error, verify that you are signed in with the correct account.
+            You are currently signed in as{' '}
+            <strong>
+              {currentUser?.name} ({currentUser?.email})
+            </strong>
+            .
+          </Text>
+        </Stack>
+      </Dialog>
     </Card>
   )
 }

--- a/packages/sanity/src/studio/screens/index.ts
+++ b/packages/sanity/src/studio/screens/index.ts
@@ -1,5 +1,6 @@
 export * from './LoadingScreen'
 export * from './schemaErrors'
 export * from './NotFoundScreen'
-export * from './NotAuthenticatedScreen'
+export * from './AuthenticateScreen'
 export * from './ConfigErrorsScreen'
+export * from './NotAuthenticatedScreen'


### PR DESCRIPTION
This PR adds a screen that is displayed when a user is signed in to a studio without any roles (i.e. is unauthorized). 

The previous `NotAuthenticatedScreen`, which handled authorization, has been renamed to `AuthenticateScreen` – and the new screen added in this PR is now called `NotAuthenticatedScreen` instead. 

<img width="811" alt="Screenshot 2022-06-28 at 13 52 57" src="https://user-images.githubusercontent.com/15094168/176171976-8a967e14-ef09-4ca5-853e-a9c2f7b69570.png">

