### PR TITLE
feat: network connection handling

### DIFF
--- a/packages/sanity/src/desk/panes/document/statusBar/sparkline/DocumentSparkline.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/sparkline/DocumentSparkline.tsx
@@ -1,5 +1,5 @@
 import {Box, Flex, useElementRect} from '@sanity/ui'
-import React, {useEffect, useMemo, useState, memo, useLayoutEffect} from 'react'
+import React, {useEffect, useMemo, useState, memo, useLayoutEffect, useCallback} from 'react'
 import {useSyncState} from '../../../../../hooks'
 import {useDocumentPane} from '../../useDocumentPane'
 import {DocumentBadges} from './DocumentBadges'
@@ -37,7 +37,7 @@ export const DocumentSparkline = memo(function DocumentSparkline() {
 
   // eslint-disable-next-line consistent-return
   useEffect(() => {
-    if (status === 'syncing') {
+    if (status === 'syncing' && !syncState.isSyncing) {
       // status changed to 'syncing', schedule an update to set it to 'saved'
       const timerId = setTimeout(() => setStatus('saved'), SYNCING_TIMEOUT)
       return () => clearTimeout(timerId)
@@ -47,7 +47,7 @@ export const DocumentSparkline = memo(function DocumentSparkline() {
       const timerId = setTimeout(() => setStatus(null), SAVED_TIMEOUT)
       return () => clearTimeout(timerId)
     }
-  }, [status, lastUpdated])
+  }, [status, lastUpdated, syncState.isSyncing])
 
   useLayoutEffect(() => {
     // clear sync status when documentId changes

--- a/packages/sanity/src/studio/components/navbar/NavBanner.tsx
+++ b/packages/sanity/src/studio/components/navbar/NavBanner.tsx
@@ -1,0 +1,40 @@
+import {Icon, IconSymbol} from '@sanity/icons'
+import {Card, CardTone, Flex, Stack, Text} from '@sanity/ui'
+import React from 'react'
+
+interface NavBannerProps {
+  title?: string
+  description?: string
+  iconSymbol?: IconSymbol
+  tone?: CardTone
+}
+
+export function NavBanner(props: NavBannerProps) {
+  const {description, iconSymbol, title, tone} = props
+
+  return (
+    <Card paddingX={4} paddingY={3} tone={tone}>
+      <Flex align="center" gap={1}>
+        {iconSymbol && (
+          <Text muted size={1}>
+            <Icon symbol={iconSymbol} />
+          </Text>
+        )}
+
+        <Stack space={2} marginLeft={3}>
+          {title && (
+            <Text muted size={1} weight="semibold">
+              {title}
+            </Text>
+          )}
+
+          {description && (
+            <Text muted size={1}>
+              {description}
+            </Text>
+          )}
+        </Stack>
+      </Flex>
+    </Card>
+  )
+}

--- a/packages/sanity/src/studio/components/navbar/Navbar.tsx
+++ b/packages/sanity/src/studio/components/navbar/Navbar.tsx
@@ -5,6 +5,7 @@ import {
   Card,
   Flex,
   Layer,
+  Stack,
   Text,
   Tooltip,
   useGlobalKeyDown,
@@ -27,6 +28,7 @@ import {useColorScheme} from '../../colorScheme'
 import {RouterState, useRouterState, useStateLink} from '../../../router'
 import {useWorkspaces} from '../../workspaces'
 import {isDev} from '../../../environment'
+import {useNetworkStatus} from '../../hooks'
 import {UserMenu} from './userMenu'
 import {NewDocumentButton} from './NewDocumentButton'
 import {PresenceMenu} from './presence'
@@ -36,6 +38,7 @@ import {ToolMenu as DefaultToolMenu} from './tools/ToolMenu'
 import {ChangelogButton} from './changelog'
 import {WorkspaceMenuButton} from './workspace'
 import {ConfigIssuesButton} from './configIssues/ConfigIssuesButton'
+import {NavBanner} from './NavBanner'
 
 const RootLayer = styled(Layer)`
   min-height: auto;
@@ -83,6 +86,8 @@ export function Navbar(props: NavbarProps) {
   const rootLink = useStateLink({state: {}})
   const mediaIndex = useMediaIndex()
   const activeToolName = typeof routerState.tool === 'string' ? routerState.tool : undefined
+
+  const networkStatus = useNetworkStatus()
 
   const [searchOpen, setSearchOpen] = useState<boolean>(false)
   const [drawerOpen, setDrawerOpen] = useState<boolean>(false)
@@ -183,145 +188,160 @@ export function Navbar(props: NavbarProps) {
   )
 
   return (
-    <RootLayer zOffset={100} data-search-open={searchOpen}>
-      <Card
-        scheme="dark"
-        shadow={scheme === 'dark' ? 1 : undefined}
-        style={{lineHeight: 0}}
-        padding={2}
-        sizing="border"
-        data-ui="Navbar"
-      >
-        <Flex align="center" justify="space-between">
-          <LeftFlex align="center" flex={shouldRender.brandingCenter ? undefined : 1}>
-            {!shouldRender.tools && (
-              <Box marginRight={1}>
-                <Button
-                  mode="bleed"
-                  icon={MenuIcon}
-                  onClick={handleOpenDrawer}
-                  ref={setDrawerButtonEl}
-                />
-              </Box>
-            )}
-
-            {!shouldRender.brandingCenter && <Box marginRight={1}>{brandingComponent}</Box>}
-
-            {shouldRender.workspaces && (
-              <Box marginRight={2}>
-                <Tooltip
-                  content={
-                    <Box padding={2}>
-                      <Text size={1}>Select workspace</Text>
-                    </Box>
-                  }
-                  placement="bottom"
-                  portal
-                  scheme={scheme}
-                >
-                  <Box>
-                    <WorkspaceMenuButton />
-                  </Box>
-                </Tooltip>
-              </Box>
-            )}
-
-            <Box marginRight={shouldRender.brandingCenter ? undefined : 2}>
-              <NewDocumentButton />
-            </Box>
-
-            {(searchOpen || !shouldRender.searchFullscreen) && (
-              <SearchCard
-                data-fullscreen={shouldRender.searchFullscreen}
-                data-ui="SearchRoot"
-                flex={1}
-                padding={shouldRender.searchFullscreen ? 2 : undefined}
-                scheme={shouldRender.searchFullscreen ? 'light' : undefined}
-                shadow={shouldRender.searchFullscreen ? 1 : undefined}
-              >
-                <Flex>
-                  <Box flex={1} marginRight={shouldRender.tools ? undefined : [1, 1, 2]}>
-                    <SearchField
-                      fullScreen={shouldRender.searchFullscreen}
-                      onSearchItemClick={handleCloseSearch}
-                      portalElement={fullscreenSearchPortalEl}
-                      setSearchInputElement={setSearchInputElement}
-                      relatedElements={searchRelatedElements}
-                    />
-                  </Box>
-
-                  {shouldRender.searchFullscreen && (
-                    <Button
-                      aria-label="Close search"
-                      icon={CloseIcon}
-                      mode="bleed"
-                      onClick={handleCloseSearch}
-                      ref={setSearchCloseButtonEl}
-                    />
-                  )}
-                </Flex>
-              </SearchCard>
-            )}
-
-            {shouldRender.tools && (
-              <Card borderRight flex={1} marginX={2} overflow="visible" paddingRight={1}>
-                <ToolMenu
-                  activeToolName={activeToolName}
-                  context="topbar"
-                  isDrawerOpen={false}
-                  tools={tools}
-                  closeDrawer={handleCloseDrawer}
-                />
-              </Card>
-            )}
-          </LeftFlex>
-
-          {shouldRender.brandingCenter && <Box marginX={1}>{brandingComponent}</Box>}
-
-          <Flex align="center">
-            {shouldRender.changelog && (
-              <Box marginRight={1}>
-                <ChangelogButton />
-              </Box>
-            )}
-
-            {shouldRender.configIssues && (
-              <Box marginRight={2}>
-                <ConfigIssuesButton />
-              </Box>
-            )}
-
-            <Box marginRight={1}>
-              <PresenceMenu collapse={shouldRender.collapsedPresenceMenu} />
-            </Box>
-
-            {shouldRender.tools && (
-              <Box>
-                <UserMenu />
-              </Box>
-            )}
-
-            {shouldRender.searchFullscreen && (
-              <Button
-                aria-label="Open search"
-                icon={SearchIcon}
-                mode="bleed"
-                onClick={handleOpenSearch}
-                ref={setSearchOpenButtonEl}
-              />
-            )}
-          </Flex>
-        </Flex>
-      </Card>
-
-      {!shouldRender.tools && (
-        <NavDrawer
-          activeToolName={activeToolName}
-          isOpen={drawerOpen}
-          onClose={handleCloseDrawer}
-          tools={tools}
+    <Stack>
+      {networkStatus === 'offline' && (
+        <NavBanner
+          title="Network connection lost"
+          description="Your changes will not be saved. Please connect to a network to continue editing."
+          iconSymbol="warning-outline"
+          tone="caution"
         />
       )}
-    </RootLayer>
+
+      <RootLayer zOffset={100} data-search-open={searchOpen}>
+        <Card
+          scheme="dark"
+          shadow={scheme === 'dark' ? 1 : undefined}
+          style={{lineHeight: 0}}
+          padding={2}
+          sizing="border"
+          data-ui="Navbar"
+        >
+          <Flex align="center" justify="space-between">
+            <LeftFlex align="center" flex={shouldRender.brandingCenter ? undefined : 1}>
+              {!shouldRender.tools && (
+                <Box marginRight={1}>
+                  <Button
+                    mode="bleed"
+                    icon={MenuIcon}
+                    onClick={handleOpenDrawer}
+                    ref={setDrawerButtonEl}
+                  />
+                </Box>
+              )}
+
+              {!shouldRender.brandingCenter && <Box marginRight={1}>{brandingComponent}</Box>}
+
+              {shouldRender.workspaces && (
+                <Box marginRight={2}>
+                  <Tooltip
+                    content={
+                      <Box padding={2}>
+                        <Text size={1}>Select workspace</Text>
+                      </Box>
+                    }
+                    placement="bottom"
+                    portal
+                    scheme={scheme}
+                  >
+                    <Box>
+                      <WorkspaceMenuButton />
+                    </Box>
+                  </Tooltip>
+                </Box>
+              )}
+
+              <Box marginRight={shouldRender.brandingCenter ? undefined : 2}>
+                <NewDocumentButton />
+              </Box>
+
+              {(searchOpen || !shouldRender.searchFullscreen) && (
+                <SearchCard
+                  data-fullscreen={shouldRender.searchFullscreen}
+                  data-ui="SearchRoot"
+                  flex={1}
+                  padding={shouldRender.searchFullscreen ? 2 : undefined}
+                  scheme={shouldRender.searchFullscreen ? 'light' : undefined}
+                  shadow={shouldRender.searchFullscreen ? 1 : undefined}
+                >
+                  <Flex>
+                    <Box flex={1} marginRight={shouldRender.tools ? undefined : [1, 1, 2]}>
+                      <SearchField
+                        fullScreen={shouldRender.searchFullscreen}
+                        onSearchItemClick={handleCloseSearch}
+                        portalElement={fullscreenSearchPortalEl}
+                        setSearchInputElement={setSearchInputElement}
+                        relatedElements={searchRelatedElements}
+                      />
+                    </Box>
+
+                    {shouldRender.searchFullscreen && (
+                      <Button
+                        aria-label="Close search"
+                        icon={CloseIcon}
+                        mode="bleed"
+                        onClick={handleCloseSearch}
+                        ref={setSearchCloseButtonEl}
+                      />
+                    )}
+                  </Flex>
+                </SearchCard>
+              )}
+
+              {shouldRender.tools && (
+                <Card borderRight flex={1} marginX={2} overflow="visible" paddingRight={1}>
+                  <ToolMenu
+                    activeToolName={activeToolName}
+                    context="topbar"
+                    isDrawerOpen={false}
+                    tools={tools}
+                    closeDrawer={handleCloseDrawer}
+                  />
+                </Card>
+              )}
+            </LeftFlex>
+
+            {shouldRender.brandingCenter && <Box marginX={1}>{brandingComponent}</Box>}
+
+            <Flex align="center">
+              {shouldRender.changelog && (
+                <Box marginRight={1}>
+                  <ChangelogButton />
+                </Box>
+              )}
+
+              <Box marginRight={1}>
+                <PresenceMenu collapse={shouldRender.collapsedPresenceMenu} />
+              </Box>
+
+              {shouldRender.configIssues && (
+                <Box marginRight={2}>
+                  <ConfigIssuesButton />
+                </Box>
+              )}
+
+              <Box marginRight={1}>
+                <PresenceMenu collapse={shouldRender.collapsedPresenceMenu} />
+              </Box>
+
+              {shouldRender.tools && (
+                <Box>
+                  <UserMenu />
+                </Box>
+              )}
+
+              {shouldRender.searchFullscreen && (
+                <Button
+                  aria-label="Open search"
+                  icon={SearchIcon}
+                  mode="bleed"
+                  onClick={handleOpenSearch}
+                  ref={setSearchOpenButtonEl}
+                />
+              )}
+            </Flex>
+          </Flex>
+        </Card>
+
+        {!shouldRender.tools && (
+          <NavDrawer
+            activeToolName={activeToolName}
+            isOpen={drawerOpen}
+            onClose={handleCloseDrawer}
+            tools={tools}
+          />
+        )}
+      </RootLayer>
+    </Stack>
   )
 }

--- a/packages/sanity/src/studio/components/navbar/__workshop__/NavBannerStory.tsx
+++ b/packages/sanity/src/studio/components/navbar/__workshop__/NavBannerStory.tsx
@@ -1,0 +1,30 @@
+import {useBoolean, useSelect, useString, useText} from '@sanity/ui-workshop'
+import React from 'react'
+import {NavBanner} from '../NavBanner'
+
+const TONE_OPTIONS = {
+  Default: 'default',
+  Primary: 'primary',
+  Positive: 'positive',
+  Caution: 'caution',
+  Critical: 'critical',
+} as const
+
+export default function NavBannerStory() {
+  const title = useString('Title', 'Network connection lost')
+  const description = useText(
+    'Description',
+    'Your changes will not be saved. Please connect to a network to continue editing.'
+  )
+  const icon = useBoolean('Icon', true)
+  const tone = useSelect('Tone', TONE_OPTIONS, 'caution')
+
+  return (
+    <NavBanner
+      title={title}
+      description={description}
+      iconSymbol={icon ? 'warning-outline' : undefined}
+      tone={tone}
+    />
+  )
+}

--- a/packages/sanity/src/studio/components/navbar/__workshop__/index.ts
+++ b/packages/sanity/src/studio/components/navbar/__workshop__/index.ts
@@ -12,4 +12,9 @@ export default defineScope('sanity/studio/navbar', 'Navbar', [
     title: 'ChangelogDialog',
     component: lazy(() => import('./ChangelogDialogStory')),
   },
+  {
+    name: 'nav-banner',
+    title: 'NavBanner',
+    component: lazy(() => import('./NavBannerStory')),
+  },
 ])

--- a/packages/sanity/src/studio/hooks/index.ts
+++ b/packages/sanity/src/studio/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useNetworkStatus'

--- a/packages/sanity/src/studio/hooks/useNetworkStatus.ts
+++ b/packages/sanity/src/studio/hooks/useNetworkStatus.ts
@@ -1,0 +1,35 @@
+import {useState, useCallback, useEffect} from 'react'
+
+type NetworkStatus = 'online' | 'offline'
+
+export function useNetworkStatus(): NetworkStatus {
+  const [status, setStatus] = useState<NetworkStatus>('online')
+
+  const handleOnline = useCallback(() => {
+    setStatus('online')
+  }, [])
+
+  const handleOffline = useCallback(() => {
+    setStatus('offline')
+  }, [])
+
+  useEffect(() => {
+    if (typeof window.navigator.onLine !== 'undefined') {
+      const online = window.navigator.onLine
+
+      setStatus(online ? 'online' : 'offline')
+    }
+  }, [])
+
+  useEffect(() => {
+    window.addEventListener('online', handleOnline)
+    window.addEventListener('offline', handleOffline)
+
+    return () => {
+      window.removeEventListener('online', handleOnline)
+      window.removeEventListener('offline', handleOffline)
+    }
+  }, [handleOnline, handleOffline])
+
+  return status
+}


### PR DESCRIPTION
This PR adds a banner that is displayed when the network connection is lost, and improvements to the sync indicator.

**Banner**
The banner is displayed when the new `useNetworkStatus` hook returns `"offline"`.

- Does the `useNetworkStatus` look OK – or are there any cases that it does not take into account?
- Does the design of the banner look OK?
- Not sure about the copy – any suggestions?

<img width="1276" alt="Screenshot 2022-06-29 at 12 55 58" src="https://user-images.githubusercontent.com/15094168/176420381-493b119d-84fc-43ea-8523-fedc7fca6cf8.png">

**Sync indicator**
If you edited a document when the network connection was lost, the sync indicator animation still showed the "saved" step. This is incorrect, as the document is not saved. This PR fixes this issue so that the "saved" step is only displayed if the document has actually been saved. 

To test this, navigate to a document, turn off the network connection, and edit the document. The "saved" step should never be displayed.


