### PR TITLE
Restore PTE spellchecking defaults for Chromium

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/PortableText/hooks/useSpellCheck.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/hooks/useSpellCheck.tsx
@@ -1,13 +1,25 @@
 import {usePortableTextEditor} from '@sanity/portable-text-editor'
 import {useMemo} from 'react'
 
+declare global {
+  interface Window {
+    chrome?: any
+  }
+}
+
 export function useSpellcheck(): boolean {
   const editor = usePortableTextEditor()
   return useMemo(() => {
+    let spellCheckOption = editor.portableTextFeatures.types.block.options?.spellCheck
+    // Slate will set spellcheck for false when undefined with Chrome browsers
+    const isChrome = typeof window === 'undefined' ? false : !!window.chrome
+    if (spellCheckOption === undefined && isChrome) {
+      spellCheckOption = true
+    }
     // Chrome 96. has serious perf. issues with spellchecking
     // https://bugs.chromium.org/p/chromium/issues/detail?id=1271918
     // This issue is verified fixed in Chrome 97.
-    const spellCheckOption = editor.portableTextFeatures.types.block.options?.spellCheck
+    // Disable spellcheck for those browsers.
     const isChrome96 =
       typeof navigator === 'undefined' ? false : /Chrome\/96/.test(navigator.userAgent)
     return spellCheckOption === undefined && isChrome96 === true ? false : spellCheckOption

--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -182,9 +182,10 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
         readOnly={readOnly}
         renderBlock={renderBlock}
         renderChild={renderChild}
+        spellCheck={spellCheck}
       />
     ),
-    [portableTextFeatures, readOnly, renderBlock, renderChild]
+    [portableTextFeatures, readOnly, renderBlock, renderChild, spellCheck]
   )
 
   const renderLeaf = useCallback(

--- a/packages/@sanity/portable-text-editor/src/editor/Element.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Element.tsx
@@ -24,6 +24,7 @@ type ElementProps = {
   readOnly: boolean
   renderBlock?: RenderBlockFunction
   renderChild?: RenderChildFunction
+  spellCheck?: boolean
 }
 
 const inlineBlockStyle = {display: 'inline-block'}
@@ -41,6 +42,7 @@ export const Element: FunctionComponent<ElementProps> = ({
   readOnly,
   renderBlock,
   renderChild,
+  spellCheck,
 }) => {
   const editor = useSlateStatic()
   const selected = useSelected()
@@ -151,7 +153,7 @@ export const Element: FunctionComponent<ElementProps> = ({
         )
       : textBlock
     return (
-      <div {...attributes} key={element._key} className={className}>
+      <div {...attributes} key={element._key} className={className} spellCheck={spellCheck}>
         <DraggableBlock element={element} readOnly={readOnly} blockRef={blockRef}>
           <div ref={blockRef}>{propsOrDefaultRendered}</div>
         </DraggableBlock>


### PR DESCRIPTION
### Description

This will have Chromium based browsers default to spell checking when spellCheck prop is `undefined`.

For other browsers this works as expected (user settings when undefined).


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Fix issue with Chromium based browsers where spell check in the PortableText editor didn't follow user settings when unspecified in schema.

<!--
A description of the change(s) that should be used in the release notes.
-->
