### PR TITLE
chore(portable-text-editor): upgrade to latest slate and slate-react

### DIFF
--- a/packages/@sanity/portable-text-editor/package.json
+++ b/packages/@sanity/portable-text-editor/package.json
@@ -38,13 +38,13 @@
   "dependencies": {
     "@sanity/block-tools": "2.29.3",
     "@sanity/schema": "2.29.3",
-    "@sanity/slate-react": "2.24.3",
+    "@sanity/slate-react": "2.30.1",
     "@sanity/types": "2.29.5",
     "@sanity/util": "2.29.5",
     "debug": "^3.2.7",
     "is-hotkey": "^0.1.6",
     "lodash": "^4.17.15",
-    "slate": "0.72.3"
+    "slate": "0.81.1"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",


### PR DESCRIPTION
Previous used version of slate-react had problems with Cromium > 100, reporting no beforeInput support.

### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Upgrade dependencies for the Portable Text Editor, fixing issues where Chrome would be reported as missing `beforeInput`- support after Chrome went above version 100. This broke spellchecking in Chrome and degraded performance.

<!--
A description of the change(s) that should be used in the release notes.
-->
