### PR TITLE
Add .pnpm conditional to expectedPath

### DIFF
--- a/packages/sanity/bin/sanity
+++ b/packages/sanity/bin/sanity
@@ -5,7 +5,7 @@ var fs = require('fs')
 var path = require('path')
 var readPkgUp = require('read-pkg-up')
 
-var expectedPath = path.join(__dirname, '..', 'node_modules', '.bin', 'sanity')
+var expectedPath = __dirname.indexOf('.pnpm') ?  path.join(__dirname, '../../../', 'node_modules', '.bin', 'sanity') :  path.join(__dirname, '..', 'node_modules', '.bin', 'sanity')
 if (fs.existsSync(expectedPath)) {
   require(expectedPath)
 } else {


### PR DESCRIPTION
### Description

Fixing [#3336](https://github.com/sanity-io/sanity/issues/3336)!

[PNPM creates a shim .bin file of its own](https://dev.to/elpddev/debug-jest-spec-in-vscode-error-missing-after-argument-list-1p3b) to work around symlink issues. This results in a deeply nested set of directories like so: `node_modules/.pnpm/sanity@3.0.0-dev-preview.9_xxoq2orp2zssb7i4726r2xjrpu/node_modules/sanity/node_modules/.bin/sanity`;

The file in node_modules/.bin/sanity seems to not work from inside this deeply nested folder, we want to run the one that's a few directories up. 

### What to review

- Not sure if you prefer a different syntax on path.join (no trailing slash, separate `'..', '..'` etc).
- Wondering if there's a better way than hard-coding in the .pnpm check?
- Standard package testing works for me!

### Notes for release
Fix issue [#3336](https://github.com/sanity-io/sanity/issues/3336): Dev preview failing on `pnpm start`.
