### PR TITLE
feat(base): support presence for cookieless auth users

### DIFF
--- a/packages/@sanity/base/package.json
+++ b/packages/@sanity/base/package.json
@@ -45,7 +45,7 @@
     "@popperjs/core": "^2.5.4",
     "@reach/auto-id": "^0.13.2",
     "@sanity/asset-utils": "^1.2.0",
-    "@sanity/bifur-client": "^0.0.8",
+    "@sanity/bifur-client": "^0.3.0",
     "@sanity/client": "^3.2.0",
     "@sanity/color": "^2.1.8",
     "@sanity/generate-help-url": "^3.0.0",

--- a/packages/@sanity/base/src/client/bifur.ts
+++ b/packages/@sanity/base/src/client/bifur.ts
@@ -1,8 +1,10 @@
-import type {ClientConfig, SanityClient} from '@sanity/client'
-import {fromSanityClient} from '@sanity/bifur-client'
-import {versionedClient} from './versionedClient'
+import {fromUrl} from '@sanity/bifur-client'
+import {authToken$} from '../datastores/authState'
+import {getVersionedClient} from './versionedClient'
 
-export const bifur = fromSanityClient(
-  // The global Sanity client is guaranteed to have a dataset, thus the type cast
-  versionedClient as SanityClient & {config(): ClientConfig & {dataset: string}}
-)
+const bifurVersionedClient = getVersionedClient('2022-06-30')
+const dataset = bifurVersionedClient.config().dataset
+
+const url = bifurVersionedClient.getUrl(`/socket/${dataset}`).replace(/^http/, 'ws')
+
+export const bifur = fromUrl(url, {token$: authToken$})

--- a/packages/@sanity/base/src/client/wrappedClient.ts
+++ b/packages/@sanity/base/src/client/wrappedClient.ts
@@ -11,7 +11,7 @@
  * client.fetch(...)
  * ```
  */
-import sanityClient from '@sanity/client'
+import sanityClient, {ClientConfig, SanityClient} from '@sanity/client'
 import {generateHelpUrl} from '@sanity/generate-help-url'
 import config from 'config:sanity'
 import configureClient from 'part:@sanity/base/configure-client?'
@@ -60,7 +60,7 @@ export const wrappedClient = {
     return configuredClient.clientConfig
   },
 
-  withConfig: (newConfig) => {
+  withConfig: (newConfig: Partial<ClientConfig>): SanityClient => {
     if (!newConfig || !newConfig.apiVersion) {
       throw new Error(
         `Client \`withConfig()\` called without an \`apiVersion\` - see ${generateHelpUrl(
@@ -77,7 +77,7 @@ export const wrappedClient = {
         const currentHasToken = Boolean(newClient.config().token)
         const nextHasToken = Boolean(token)
         if (currentHasToken !== nextHasToken) {
-          newClient.config({...newConfig, token})
+          newClient.config({...newConfig, token, ignoreBrowserTokenWarning: true})
         }
       })
     }

--- a/packages/@sanity/desk-tool/src/components/confirmDeleteDialog/__tests__/index.test.tsx
+++ b/packages/@sanity/desk-tool/src/components/confirmDeleteDialog/__tests__/index.test.tsx
@@ -61,6 +61,7 @@ jest.mock('part:@sanity/base/client', () => {
     clone: () => mockClient,
     fetch: () => Promise.resolve(null),
     request: () => Promise.resolve(null),
+    getUrl: (path: string) => `https://mock-project-id.api.sanity.io/v1${path}`,
     observable: {
       listen: () => NEVER,
       fetch: () => EMPTY,

--- a/test/mockBifurClient.ts
+++ b/test/mockBifurClient.ts
@@ -13,3 +13,7 @@ const mockBifurClient = {
 export function fromSanityClient() {
   return mockBifurClient
 }
+
+export function fromUrl() {
+  return mockBifurClient
+}

--- a/test/mockClient.ts
+++ b/test/mockClient.ts
@@ -26,6 +26,7 @@ const mockClient = {
   clone: () => mockClient,
   fetch: () => Promise.resolve(null),
   request: () => Promise.resolve(null),
+  getUrl: (path: string) => `https://mock-project-id.api.sanity.io/v1${path}`,
   observable: {
     listen: () => NEVER,
   },


### PR DESCRIPTION
### Description

The browser `WebSocket` API does not support specifying HTTP headers to the initial HTTP connection. This means we cannot send the `Authorization` header that we normally do for non-cookie authentication methods, meaning anything over the bifur socket (such as presence) fails to work.

We recently implemented support for sending authorization credentials through the first frame to the socket (only available on `v2022-06-30` and higher), and have released a new version of the bifur client to allow for retrieving the token through an observable.

This PR upgrades the bifur client, and provides the `authToken$` observable as an option, which ensures the client authorizes before sending any subscribe/requests to the server.

### What to review

- That the presence feature works as intended using both cookies (chrome) and cookieless (brave, safari)
- That there are no excessive connection attempts against the `/socket` endpoint

### Notes for release

- Added support for the presence feature when not using cookies for authentication
