### PR TITLE
feat(dashboard): add sections to dashboard feed

### DIFF
--- a/dev/test-studio/parts/dashboardConfig.js
+++ b/dev/test-studio/parts/dashboardConfig.js
@@ -1,6 +1,13 @@
 export default {
   widgets: [
     {
+      name: 'sanity-tutorials',
+      layout: {
+        width: 'full',
+        height: 'full',
+      },
+    },
+    {
       type: '__experimental_group',
       widgets: [
         {name: 'dummy', options: {children: 'A'}},
@@ -8,12 +15,6 @@ export default {
         {name: 'dummy', options: {children: 'C'}},
         {name: 'dummy', options: {children: 'D'}},
       ],
-    },
-    {
-      name: 'sanity-tutorials',
-      layout: {
-        width: 'full',
-      },
     },
     {name: 'document-list'},
     {name: 'document-list', options: {title: 'Last edited', order: '_updatedAt desc'}},

--- a/packages/@sanity/dashboard/src/dashboardConfig.js
+++ b/packages/@sanity/dashboard/src/dashboardConfig.js
@@ -1,3 +1,13 @@
 export default {
-  widgets: [{name: 'sanity-tutorials'}, {name: 'project-info'}, {name: 'project-users'}],
+  widgets: [
+    {
+      name: 'sanity-tutorials',
+      layout: {
+        width: 'full',
+        height: 'full',
+      },
+    },
+    {name: 'project-info'},
+    {name: 'project-users'},
+  ],
 }

--- a/packages/@sanity/dashboard/src/widgets/sanityTutorials/Tutorial.js
+++ b/packages/@sanity/dashboard/src/widgets/sanityTutorials/Tutorial.js
@@ -1,8 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import {Card, Box, Heading, Flex, Text, Stack} from '@sanity/ui'
-import {PlayIcon} from '@sanity/icons'
+import {Card, Box, Flex, Text, Stack} from '@sanity/ui'
 import styled from 'styled-components'
+
+// eslint-disable-next-line no-useless-escape
+const youtubeRegex = /youtu(?:.*\/v\/|.*v\=|\.be\/)([A-Za-z0-9_-]{11})/
 
 const PlayIconBox = styled(Box)`
   position: absolute;
@@ -38,6 +40,8 @@ const PosterCard = styled(Card)`
   width: 100%;
   padding-bottom: calc(9 / 16 * 100%);
   position: relative;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 `
 
 const Poster = styled.img`
@@ -48,19 +52,45 @@ const Poster = styled.img`
   width: 100%;
   object-fit: cover;
   display: block;
+  border-radius: inherit;
 
   &:not([src]) {
     display: none;
   }
 `
+const YoutubeContainer = styled(Card)`
+  position: relative;
+  padding-bottom: 56.25%;
+  overflow: hidden;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 
+  iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+`
+const YoutubeEmbed = ({embedId}) => (
+  <YoutubeContainer radius={3}>
+    <iframe
+      width="853"
+      height="480"
+      src={`https://www.youtube.com/embed/${embedId}`}
+      frameBorder="0"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowFullScreen
+    />
+  </YoutubeContainer>
+)
 class Tutorial extends React.PureComponent {
   static propTypes = {
     title: PropTypes.string.isRequired,
     posterURL: PropTypes.string,
     href: PropTypes.string.isRequired,
     showPlayIcon: PropTypes.bool,
-    presenterName: PropTypes.string.isRequired,
     presenterSubtitle: PropTypes.string.isRequired,
   }
   static defaultProps = {
@@ -69,48 +99,65 @@ class Tutorial extends React.PureComponent {
   }
 
   render() {
-    const {title, posterURL, showPlayIcon, href, presenterName, presenterSubtitle} = this.props
+    const {title, posterURL, showPlayIcon, href, presenterSubtitle} = this.props
 
-    return (
+    const isYoutube = showPlayIcon && href && href.match(youtubeRegex)
+
+    return isYoutube ? (
+      <Card
+        space={2}
+        sizing="border"
+        flex={1}
+        radius={3}
+        style={{position: 'relative'}}
+        border
+        paddingBottom={2}
+      >
+        <Stack space={2} height="fill">
+          <YoutubeEmbed embedId={href.match(youtubeRegex)[1]} />
+          <Stack space={3} flex={1} padding={2}>
+            <Text as="h3" size={1} weight="bold">
+              {title}
+            </Text>
+            {presenterSubtitle && (
+              <Text size={1} muted>
+                {presenterSubtitle}
+              </Text>
+            )}
+          </Stack>
+        </Stack>
+      </Card>
+    ) : (
       <Root flex={1}>
         <Card
           sizing="border"
           flex={1}
-          padding={2}
-          radius={2}
+          radius={3}
           as="a"
           href={href}
           target="_blank"
           rel="noopener noreferrer"
           style={{position: 'relative'}}
+          border
+          paddingBottom={2}
         >
-          <Flex direction="column" style={{height: '100%'}}>
+          <Stack space={2} height="fill">
             {posterURL && (
-              <PosterCard marginBottom={1}>
+              <PosterCard radius={3}>
                 <Poster src={posterURL} />
-                {showPlayIcon && (
-                  <PlayIconBox display="flex">
-                    <Text align="center">
-                      <PlayIcon />
-                    </Text>
-                  </PlayIconBox>
-                )}
               </PosterCard>
             )}
-            <Flex direction="column" justify="space-between" paddingY={2} flex={1}>
-              <Heading as="h3" size={1}>
+            <Stack space={3} flex={1} padding={2}>
+              <Text as="h3" size={1} weight="bold">
                 {title}
-              </Heading>
-              <Box marginTop={4}>
-                <Stack space={2} flex={1}>
-                  <Text size={1}>{presenterName}</Text>
-                  <Text size={0} style={{opacity: 0.7}}>
-                    {presenterSubtitle}
-                  </Text>
-                </Stack>
-              </Box>
-            </Flex>
-          </Flex>
+              </Text>
+              {presenterSubtitle && (
+                <Text size={1} muted>
+                  {presenterSubtitle}
+                </Text>
+              )}
+            </Stack>
+          </Stack>
         </Card>
       </Root>
     )


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

- Adds support for sections of videos in dashboard feeds, and changes the layout from a horizontally scrollable dashboard widget to a full width grid.

<img width="1792" alt="Screenshot 2022-07-15 at 10 34 16" src="https://user-images.githubusercontent.com/25737281/179951500-ef0a9c99-66fe-4f6b-a3d8-6c006a6f6579.png">



### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

- Make sure layout is working and feeds are rendered without breakage.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
- Updated UI of dashboard feeds
