### PR TITLE
fix: define types path for exports

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -18,31 +18,37 @@
   "module": "./lib/esm/_exports/index.js",
   "exports": {
     ".": {
+      "types": "./lib/dts/src/_exports/index.d.ts",
       "source": "./src/_exports/index.ts",
       "require": "./lib/cjs/_exports/index.js",
       "default": "./lib/esm/_exports/index.js"
     },
     "./_unstable": {
+      "types": "./lib/dts/src/_exports/_unstable.d.ts",
       "source": "./src/_exports/_unstable.ts",
       "require": "./lib/cjs/_exports/_unstable.js",
       "default": "./lib/esm/_exports/_unstable.js"
     },
     "./_internal": {
+      "types": "./lib/dts/src/_exports/_internal.d.ts",
       "source": "./src/_exports/_internal.ts",
       "require": "./lib/cjs/_exports/_internal.js",
       "default": "./lib/esm/_exports/_internal.js"
     },
     "./cli": {
+      "types": "./lib/dts/src/_exports/cli.d.ts",
       "source": "./src/_exports/cli.ts",
       "require": "./lib/cjs/_exports/cli.js",
       "default": "./lib/esm/_exports/cli.js"
     },
     "./desk": {
+      "types": "./lib/dts/src/_exports/desk.d.ts",
       "source": "./src/_exports/desk.ts",
       "require": "./lib/cjs/_exports/desk.js",
       "default": "./lib/esm/_exports/desk.js"
     },
     "./form": {
+      "types": "./lib/dts/src/_exports/form.d.ts",
       "source": "./src/_exports/form.ts",
       "require": "./lib/cjs/_exports/form.js",
       "default": "./lib/esm/_exports/form.js"


### PR DESCRIPTION
### Description

Projects that uses ES Modules and typescript (eg declares `type: 'module'` in `package.json`), as well as has typescript settings of `"module": "ESNext"` and `"moduleResolution": "Node16"` (not sure if _all_ of these are needed, but you get the point) will currently fail to resolve type definitions when importing from the `sanity` package. This is because the `exports` field is used, and resolves to the ESM build, which does not have a sibling `.d.ts` file. By declaring a `types` entry for each export, it is able to resolve it as expected.  

Note that the types entry must be first, as noted here: https://www.typescriptlang.org/docs/handbook/esm-node.html

### What to review

That the included patch does not have unintended side effects.

### Notes for release

- Make typescript definitions for the `sanity` package work in TypeScript projects using Node 16 module resolution
