### PR TITLE
feat(dashboard): add docs banner to sanity tutorials widget

### DIFF
--- a/packages/@sanity/dashboard/src/widgets/sanityTutorials/SanityTutorials.js
+++ b/packages/@sanity/dashboard/src/widgets/sanityTutorials/SanityTutorials.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import {Flex, Grid, Stack, Heading, Container} from '@sanity/ui'
+import {Flex, Grid, Stack, Heading, Container, Card, Text, Box, Button} from '@sanity/ui'
 import Tutorial from './Tutorial'
 import dataAdapter from './dataAdapter'
 
@@ -76,7 +76,30 @@ class SanityTutorials extends React.Component {
 
     return (
       <Container width={4}>
-        <Stack space={5} paddingBottom={4}>
+        <Stack space={6} paddingBottom={4}>
+          <Card tone="primary" padding={4} radius={2} border marginTop={4}>
+            <Flex direction={['column', 'column', 'row']}>
+              <Stack space={4} flex={1} paddingRight={[0, 0, 4]}>
+                <Heading>Getting started Guide</Heading>
+                <Text>
+                  It’s time to learn how to build schemas, create content and connect it with other
+                  applications.
+                </Text>
+              </Stack>
+              <Flex paddingTop={[4, 4, 0]} align="center">
+                <Stack flex={1}>
+                  <Button
+                    paddingY={3}
+                    paddingX={5}
+                    tone="primary"
+                    as="a"
+                    href="https://www.sanity.io/docs"
+                    text="Go go docs"
+                  />
+                </Stack>
+              </Flex>
+            </Flex>
+          </Card>
           {sections &&
             sections?.length > 0 &&
             sections.map((section) => {

--- a/packages/@sanity/dashboard/src/widgets/sanityTutorials/SanityTutorials.js
+++ b/packages/@sanity/dashboard/src/widgets/sanityTutorials/SanityTutorials.js
@@ -67,6 +67,7 @@ class SanityTutorials extends React.Component {
 
   render() {
     const {title = 'Learn about Sanity', feedItems} = this.state
+    const {templateRepoId} = this.props
 
     // Filter out items and sections for layout purposes
     const sections = feedItems.filter((i) => i._type === 'feedSection')
@@ -93,7 +94,7 @@ class SanityTutorials extends React.Component {
                     paddingX={5}
                     tone="primary"
                     as="a"
-                    href="https://www.sanity.io/docs"
+                    href={`https://www.sanity.io/docs?ref=dashboard-${templateRepoId || 'plugin'}`}
                     text="Go go docs"
                   />
                 </Stack>


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This adds a banner at the top of the sanity tutorials videos with a CTA to our docs site.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

- Start the test studio and make sure everything works as it should in the dashboard with the banner/

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

n/a