### PR TITLE
chore: upgrade moment to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@babel/preset-typescript": "^7.10.4",
     "@babel/register": "^7.7.4",
     "@babel/runtime": "7.12.13",
-    "@sanity/client": "^3.2.1",
+    "@sanity/client": "^3.2.0",
     "@types/jest": "^27.0.1",
     "@types/node": "^14.18.9",
     "@types/react": "^17.0.42",

--- a/packages/@sanity/util/package.json
+++ b/packages/@sanity/util/package.json
@@ -46,7 +46,7 @@
     "fs-extra": "^7.0.0",
     "get-random-values": "^1.2.2",
     "lodash": "^4.17.15",
-    "moment": "^2.19.1",
+    "moment": "^2.29.4",
     "resolve-from": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -28,7 +28,6 @@
     "is-hotkey": "^0.1.6",
     "json5": "^1.0.1",
     "lodash": "^4.17.15",
-    "moment": "^2.19.1",
     "query-string": "^4.3.2",
     "react-codemirror2": "^6.0.0",
     "react-json-view": "^1.21.3",

--- a/packages/@sanity/vision/src/util/calendarDate.js
+++ b/packages/@sanity/vision/src/util/calendarDate.js
@@ -1,9 +1,0 @@
-import moment from 'moment'
-
-function calendarDate(date) {
-  return moment(date).calendar(null, {
-    sameElse: 'YYYY-MM-DD HH:mm:ss',
-  })
-}
-
-export default calendarDate


### PR DESCRIPTION
### Description

- Upgrades moment dependency to latest version to silence reports of [this vulnerability](https://security.snyk.io/vuln/SNYK-JS-MOMENT-2944238). To be clear: unless developers of a sanity studio manually craft really long expressions and put into their datetime field formatting configuration, this is not an issue, but this will help prevent noise.
- Removes unused moment dependency from `@sanity/vision`
- Normalizes `@sanity/client` version to a single version across the monorepo to suppress a warning from lerna

### What to review

- That studio still works, and in particular: date/datetime fields with custom format specified

### Notes for release

- Upgraded moment.js dependency to latest version
