### PR TITLE
chore(core): upgrade terser

### DIFF
--- a/packages/@sanity/core/package.json
+++ b/packages/@sanity/core/package.json
@@ -68,7 +68,7 @@
     "rxjs": "^6.5.3",
     "semver": "^6.2.3",
     "tar-fs": "^1.16.0",
-    "terser": "^5.7.2",
+    "terser": "^5.14.2",
     "yargs": "^16.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description

Upgrade terser to the latest version to work around a reported [vulnerability](https://security.snyk.io/vuln/SNYK-JS-TERSER-2806366).

### What to review

That `sanity deploy` works as expected and still minifies the bundle.

### Notes for release

- Upgraded terser dependency
