### PR TITLE
feat(export): check sha1 hash first

### DIFF
--- a/packages/@sanity/export/src/AssetHandler.js
+++ b/packages/@sanity/export/src/AssetHandler.js
@@ -167,13 +167,13 @@ class AssetHandler {
     const remoteSha1 = stream.headers['x-sanity-sha1']
     const remoteMd5 = stream.headers['x-sanity-md5']
     const hasHash = Boolean(remoteSha1 || remoteMd5)
-    const method = md5 ? 'md5' : 'sha1'
+    const method = sha1 ? 'sha1' : 'md5'
 
     let differs = false
-    if (remoteMd5 && md5) {
-      differs = remoteMd5 !== md5
-    } else if (remoteSha1 && sha1) {
+    if (remoteSha1 && sha1) {
       differs = remoteSha1 !== sha1
+    } else if (remoteMd5 && md5) {
+      differs = remoteMd5 !== md5
     }
 
     if (differs && attemptNum < 3) {


### PR DESCRIPTION
### Description

Swap the logic for validating assets to prefer sha1 validation. This is to address an issue where the md5 of an asset is being misreported.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Dataset export works
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
