### PR TITLE
fix(datastores): add missing request tag prefix

### DIFF
--- a/packages/sanity/src/datastores/authStore/createAuthStore.ts
+++ b/packages/sanity/src/datastores/authStore/createAuthStore.ts
@@ -130,6 +130,7 @@ export function _createAuthStore({
         useCdn: false,
         ...(token && {token}),
         withCredentials: true,
+        requestTagPrefix: 'sanity.studio',
       })
     ),
     switchMap((client) =>
@@ -154,6 +155,7 @@ export function _createAuthStore({
         useCdn: true,
         withCredentials: true,
         apiVersion: '2021-06-07',
+        requestTagPrefix: 'sanity.studio',
       })
 
       // try to get the current user by using the cookie credentials
@@ -186,6 +188,7 @@ export function _createAuthStore({
       useCdn: true,
       withCredentials: true,
       apiVersion: '2021-06-07',
+      requestTagPrefix: 'sanity.studio',
     })
 
     clearToken(projectId)


### PR DESCRIPTION
### Description

Fixes an issue where the v3 studio did not specify a request tag prefix, so requests would not have the `sanity.studio` prefix for tags.

### What to review

That requests from the studio have the `sanity.studio` prefix on their `tag` query parameter.

### Notes for release

- Fixed an issue where requests from the studio would not have the `sanity.studio` prefix
