### PR TITLE
fix(desk): silence warning about animating stroke dash offset

### DIFF
--- a/packages/sanity/src/desk/panes/document/statusBar/sparkline/ReviewChangesButton/AnimatedStatusIcon.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/sparkline/ReviewChangesButton/AnimatedStatusIcon.tsx
@@ -62,7 +62,7 @@ const root = {
 const circle = {
   syncing: {
     strokeDasharray: '0, 0, 23, 3, 23, 3',
-    strokeDashoffset: '10',
+    strokeDashoffset: 10,
     opacity: 1,
     transition: {
       duration: 0,
@@ -70,7 +70,7 @@ const circle = {
   },
   saved: {
     strokeDasharray: '0, 0, 23, 0, 23, 0',
-    strokeDashoffset: '10',
+    strokeDashoffset: 10,
     opacity: 1,
     transition: {
       duration: 0.2,
@@ -78,7 +78,7 @@ const circle = {
   },
   changes: {
     strokeDasharray: '0, 60, 23, 0, 23, 0',
-    strokeDashoffset: '0',
+    strokeDashoffset: 0,
     opacity: 0,
     transition: {
       duration: 0.5,


### PR DESCRIPTION
### Description

Framer motion gives a warning saying it cannot animate string values (`strokeDashoffset`). This PR changes the prop from a string to a number, which prevents this warning from being printed.

### What to review

- That the animated syncing/saved indicator still looks as it is supposed to

### Notes for release

- Silenced a warning about animating a string property
