### PR TITLE
fix(desk-tool): show correct action message in unpublish dialog

### DIFF
--- a/packages/@sanity/desk-tool/src/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
+++ b/packages/@sanity/desk-tool/src/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
@@ -77,7 +77,7 @@ export function ConfirmDeleteDialogBody({
   if (internalReferences?.totalCount === 0 && crossDatasetReferences?.totalCount === 0) {
     return (
       <Text as="p">
-        Are you sure you want to delete <strong>“{documentTitle}”</strong>?
+        Are you sure you want to {action} <strong>“{documentTitle}”</strong>?
       </Text>
     )
   }


### PR DESCRIPTION
### Description

This fixes the message in the confirm delete dialog when unpublishing.

![image](https://user-images.githubusercontent.com/10508/182327054-7820e9c2-a905-4e88-b12d-f98c405cc479.png)

### What to review

1. Go to any published document
2. Select the Unpublish action
3. It should read _Are you sure you want to unpublish <document title>?_

### Notes for release

- Fixed the message in the confirm delete dialog when unpublishing
