### PR TITLE
fix(export): allow either hash check

### DIFF
--- a/packages/@sanity/export/src/AssetHandler.js
+++ b/packages/@sanity/export/src/AssetHandler.js
@@ -169,12 +169,12 @@ class AssetHandler {
     const hasHash = Boolean(remoteSha1 || remoteMd5)
     const method = sha1 ? 'sha1' : 'md5'
 
-    let differs = false
-    if (remoteSha1 && sha1) {
-      differs = remoteSha1 !== sha1
-    } else if (remoteMd5 && md5) {
-      differs = remoteMd5 !== md5
-    }
+    // Asset validity is primarily determined by the sha1 hash. However, the sha1 hash is computed
+    // before certain processes (i.e. svg sanitization) which can result in a different hash.
+    // When the sha1 hashes don't match, fallback to using the md5 hash.
+    const sha1Differs = remoteSha1 && sha1 !== remoteSha1
+    const md5Differs = remoteMd5 && md5 !== remoteMd5
+    const differs = sha1Differs && md5Differs
 
     if (differs && attemptNum < 3) {
       debug('%s does not match downloaded asset, retrying (#%d) [%s]', method, attemptNum + 1, url)


### PR DESCRIPTION
### Description

Allows export hash check to succeed if either sha1 or md5 are the same.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Dataset export works
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
