### PR TITLE
fix: `getting-started-pets` package spelling corrections

### DIFF
--- a/packages/@sanity/cli/templates/getting-started-pets/components/views/HumanPreview.jsx
+++ b/packages/@sanity/cli/templates/getting-started-pets/components/views/HumanPreview.jsx
@@ -18,7 +18,7 @@ const query = `* [_id == "drafts." + $id || _id == $id]{
 `
 
 /**
- * Renders thecurrently displayed document as formatted JSON as a
+ * Renders the currently displayed document as formatted JSON as a
  * simple little "webpage" using:
  * - @sanity/ui
  * - @sanity/image-url

--- a/packages/@sanity/cli/templates/getting-started-pets/components/views/ProductPreview.jsx
+++ b/packages/@sanity/cli/templates/getting-started-pets/components/views/ProductPreview.jsx
@@ -5,7 +5,7 @@ import {BlockText} from './BlockText'
 import {Layout, Picture} from './components'
 
 /**
- * Renders thecurrently displayed document as formatted JSON as a
+ * Renders the currently displayed document as formatted JSON as a
  * simple little "webpage" using:
  * - @sanity/ui
  * - @portabletext/react

--- a/packages/@sanity/cli/templates/getting-started-pets/style.css
+++ b/packages/@sanity/cli/templates/getting-started-pets/style.css
@@ -1,4 +1,4 @@
-/* Here you can add any CSS you'd like to use to override the Studio's defualt styles! */
+/* Here you can add any CSS you'd like to use to override the Studio's default styles! */
 
 :global([data-ui="PaneItem"] *:not(svg) + span) {
   box-shadow: none !important;


### PR DESCRIPTION
I noticed a couple spelling issues within the documentation when going through the getting started steps!
