### PR TITLE
fix(dashboard): use correct property for feed item keys

### DIFF
--- a/packages/@sanity/dashboard/src/widgets/sanityTutorials/SanityTutorials.js
+++ b/packages/@sanity/dashboard/src/widgets/sanityTutorials/SanityTutorials.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import {Flex, Grid, Stack, Heading, Container, Card, Text, Box, Button} from '@sanity/ui'
+import {Flex, Grid, Stack, Heading, Container, Card, Text, Button} from '@sanity/ui'
 import Tutorial from './Tutorial'
 import dataAdapter from './dataAdapter'
 
@@ -124,7 +124,7 @@ class SanityTutorials extends React.Component {
               <Heading>{title}</Heading>
               <Grid as="ul" columns={columns(items?.length)} gap={4}>
                 {items.map((feedItem) => (
-                  <Flex as="li" key={feedItem.id}>
+                  <Flex as="li" key={feedItem._id}>
                     <FeedItem feedItem={feedItem} />
                   </Flex>
                 ))}

--- a/packages/@sanity/dashboard/src/widgets/sanityTutorials/Tutorial.js
+++ b/packages/@sanity/dashboard/src/widgets/sanityTutorials/Tutorial.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import {Card, Box, Flex, Text, Stack} from '@sanity/ui'
 import styled from 'styled-components'
 
@@ -86,13 +85,6 @@ const YoutubeEmbed = ({embedId}) => (
   </YoutubeContainer>
 )
 class Tutorial extends React.PureComponent {
-  static propTypes = {
-    title: PropTypes.string.isRequired,
-    posterURL: PropTypes.string,
-    href: PropTypes.string.isRequired,
-    showPlayIcon: PropTypes.bool,
-    presenterSubtitle: PropTypes.string.isRequired,
-  }
   static defaultProps = {
     posterURL: null,
     showPlayIcon: false,


### PR DESCRIPTION
### Description

The tutorials dashboard widget prints two warnings currently - one caused by missing keys for feed items (it was using `.id` instead of `._id`, and one about a required proptype that was missing.

The widget seems to work just fine without the prop, and as we're moving away from the prop-types module I figured I might as well just remove it from use in this component.

### Notes for release

- Fixed a few warnings being emitted from the tutorials dashboard widget
