### PR TITLE
fix(structure): resolve schema type from template if possible

### DIFF
--- a/packages/@sanity/structure/src/DocumentList.ts
+++ b/packages/@sanity/structure/src/DocumentList.ts
@@ -1,4 +1,7 @@
-import {getParameterlessTemplatesBySchemaType} from '@sanity/initial-value-templates'
+import {
+  getParameterlessTemplatesBySchemaType,
+  getTemplateById,
+} from '@sanity/initial-value-templates'
 import {SchemaType, getDefaultSchema} from './parts/Schema'
 import {isActionEnabled} from './parts/documentActionUtils'
 import {structureClient} from './parts/Client'
@@ -44,7 +47,11 @@ const resolveDocumentChildForItem: ChildResolver = (
   options: ChildResolverOptions
 ): ItemChild | Promise<ItemChild> | undefined => {
   const parentItem = options.parent as DocumentList
-  const type = parentItem.schemaTypeName || resolveTypeForDocument(itemId)
+  const template = options.params?.template ? getTemplateById(options.params.template) : undefined
+  const type = template
+    ? template.schemaType
+    : parentItem.schemaTypeName || resolveTypeForDocument(itemId)
+
   return Promise.resolve(type).then((schemaType) =>
     schemaType
       ? getDefaultDocumentNode({schemaType, documentId: itemId})


### PR DESCRIPTION
### Description

When resolving the child of a document pane, it tries to either use the defined schema type for that pane to open a document pane as a child, or falls back to inferring it from the query. However, in some cases a type is not inferable from the query, in which case we fall back to resolving the type from the document ID. This can  _still_ fail however, in the case where you are creating a _new_ document - the document does not exist and as such you don't know which type to use, and will get an error. In many cases however, we explicitly tell the pane which _template_ to use - and a template has an associated schema type.

This PR checks for the presence of a template parameter, looks it up and uses its schema type.

### What to review

That document panes still work - both single-document type panes, panes with many different types, creating new documents through the pane menu etc.

### Notes for release

- Fixes an issue where the desk tool would not be able to infer the document type for new documents created from a document pane that displayed several different types
