### PR TITLE
bug(desk-tool): add a pollInterval in useReferringDocuments hook to avoid spamming 404 in documentPane

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/document/DocumentPaneProvider.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/DocumentPaneProvider.tsx
@@ -58,7 +58,7 @@ export const DocumentPaneProvider = memo(({children, index, pane, paneKey}: Prop
   const {markers: markersRaw} = useValidationStatus(documentId, documentType)
   const connectionState = useConnectionState(documentId, documentType)
   const documentSchema = schema.get(documentType)
-  const {totalCount} = useReferringDocuments(options.id)
+  const {totalCount} = useReferringDocuments(options.id, 1000 * 60)
   const documentIsReferenced = totalCount > 0
   const value: Partial<SanityDocument> =
     editState?.draft || editState?.published || initialValue.value


### PR DESCRIPTION
### Description
Shortcut link: https://app.shortcut.com/sanity-io/story/22548/v2-30-3-new-reference-check-throws-repeated-404s-on-draft-docs-without-published-version-new-docs 

In order to avoid firing `404s `every 5 seconds, a prop was added to the `useReferringDocuments` hook.
The default is now 5 seconds.  
When the hook is used for a document pane, the interval is set to 1 minute. This means that the `404` will be thrown every minute. The error is still valid - the document that is not published should get this error. Once the document is published, the error will disappear. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Create a new reference without publishing. 
Reference this unpublished document from another document. Open the unpublished document and check the console for errors. 

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
bug(desk-tool): add a pollInterval in useReferringDocuments hook to avoid spamming 404 