### PR TITLE
bug(dashboard): fix typo in banner, open link in new pane

### DIFF
--- a/packages/@sanity/dashboard/src/widgets/sanityTutorials/SanityTutorials.js
+++ b/packages/@sanity/dashboard/src/widgets/sanityTutorials/SanityTutorials.js
@@ -67,7 +67,6 @@ class SanityTutorials extends React.Component {
 
   render() {
     const {title = 'Learn about Sanity', feedItems} = this.state
-    const {templateRepoId} = this.props
 
     // Filter out items and sections for layout purposes
     const sections = feedItems.filter((i) => i._type === 'feedSection')
@@ -95,9 +94,7 @@ class SanityTutorials extends React.Component {
                     tone="primary"
                     as="a"
                     target="_blank"
-                    href={`https://www.sanity.io/docs?ref=studio-dashboard-${
-                      templateRepoId || 'plugin'
-                    }`}
+                    href="https://www.sanity.io/docs?ref=studio-dashboard"
                     text="Go to docs"
                   />
                 </Stack>

--- a/packages/@sanity/dashboard/src/widgets/sanityTutorials/SanityTutorials.js
+++ b/packages/@sanity/dashboard/src/widgets/sanityTutorials/SanityTutorials.js
@@ -81,9 +81,9 @@ class SanityTutorials extends React.Component {
           <Card tone="primary" padding={4} radius={2} border marginTop={4}>
             <Flex direction={['column', 'column', 'row']}>
               <Stack space={4} flex={1} paddingRight={[0, 0, 4]}>
-                <Heading>Getting started Guide</Heading>
+                <Heading>Getting started guide</Heading>
                 <Text>
-                  It’s time to learn how to build schemas, create content and connect it with other
+                  It's time to learn how to build schemas, create content, and connect it to other
                   applications.
                 </Text>
               </Stack>
@@ -94,8 +94,11 @@ class SanityTutorials extends React.Component {
                     paddingX={5}
                     tone="primary"
                     as="a"
-                    href={`https://www.sanity.io/docs?ref=dashboard-${templateRepoId || 'plugin'}`}
-                    text="Go go docs"
+                    target="_blank"
+                    href={`https://www.sanity.io/docs?ref=studio-dashboard-${
+                      templateRepoId || 'plugin'
+                    }`}
+                    text="Go to docs"
                   />
                 </Stack>
               </Flex>


### PR DESCRIPTION
### Description
Fixed typos in the dashboard banner. 
The link to docs now open in a new pane. 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->
<img width="1081" alt="Screenshot 2022-08-08 at 11 12 00" src="https://user-images.githubusercontent.com/44635000/183383839-b486a7b5-3a2a-452a-bf7f-3239e4628426.png">

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->
Check the link to the docs and the text in the banner. 

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
- Fixed typo in dashboard banner 