### PR TITLE
fix(form): broken array grid layout

### DIFF
--- a/packages/sanity/src/form/inputs/arrays/ArrayOfObjectsInput/ArrayInput.tsx
+++ b/packages/sanity/src/form/inputs/arrays/ArrayOfObjectsInput/ArrayInput.tsx
@@ -274,7 +274,7 @@ export class ArrayInput extends React.PureComponent<ArrayInputProps> {
           onRemove={itemProps.onRemove}
           onFocus={itemProps.onFocus}
           index={itemProps.index}
-          schemaType={itemProps.schemaType}
+          schemaType={schemaType}
           insertableTypes={schemaType.of}
           value={itemProps.value as _ArrayInput_ArrayMember}
           focused={itemProps.focused}


### PR DESCRIPTION
### Description

This PR fixes so that the array items are rendered in a grid layout when the schema type has `options: { layout: 'grid'}`.

### Notes for release

fix(form): fix broken array grid layout
