### PR TITLE
fix(server): handle jsx in `.js` files

### DIFF
--- a/packages/@sanity/server/src/renderDocument.ts
+++ b/packages/@sanity/server/src/renderDocument.ts
@@ -114,11 +114,17 @@ function renderDocumentFromWorkerData() {
   // Require hook #2
   // Use `esbuild` to allow JSX/TypeScript and modern JS features
   // eslint-disable-next-line import/no-unassigned-import
-  require('esbuild-register/register')
+  const {unregister} = require('esbuild-register/dist/node').register({
+    target: `node${process.version.slice(1)}`,
+    loader: 'tsx',
+  })
 
   const html = getDocumentHtml(studioRootPath, props)
 
   parentPort.postMessage({type: 'result', html})
+
+  // Be polite and clean up after esbuild-register
+  unregister()
 }
 
 function getDocumentHtml(studioRootPath: string, props?: DocumentProps): string {

--- a/packages/@sanity/server/src/renderDocument.ts
+++ b/packages/@sanity/server/src/renderDocument.ts
@@ -179,7 +179,10 @@ function tryLoadDocumentComponent(studioRootPath: string) {
         path: componentPath,
       }
     } catch (err) {
-      // Allow this to fail
+      // Allow "not found" errors
+      if (err.code !== 'MODULE_NOT_FOUND') {
+        throw err
+      }
     }
   }
 


### PR DESCRIPTION
### Description

When using a custom `_document.js` file, the esbuild loader did not handle JSX. This was made worse by the importer silently swallowing all errors, instead of just the "not found" ones.

This PR tells esbuild to use the tsx loader even for .js files, and will throw an error on any error that is not "module not found" - eg syntax errors and such.

### What to review

- Custom `_document.js`/`_document.tsx` files work as expected

### Notes for release

- Fixed a bug where a custom `_document.js` with JSX would not work, and syntax errors would silently be swallowed

