### PR TITLE
fix: ignore blocks inside list items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,10 @@ jspm_packages
 # macOS finder cache file
 .DS_Store
 
+# Intellij
+.idea
+*.iml
+
 # VS Code settings
 .vscode
 

--- a/packages/@sanity/block-tools/src/HtmlDeserializer/rules/html.ts
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/rules/html.ts
@@ -91,7 +91,7 @@ export default function createHTMLRules(blockContentType, options: any = {}) {
           return undefined
         }
         // Don't add blocks into list items
-        if (el.parentNode && tagName(el) === 'li') {
+        if (el.parentNode && tagName(el.parentNode) === 'li') {
           return next(el.childNodes)
         }
         // If style is not supported, return a defaultBlockType

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/lists/input.html
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/lists/input.html
@@ -22,6 +22,10 @@
         <li>
           <a href="/">Link</a>
         </li>
+        <li>
+          <p>p in li.</p>
+          <h1>block children are still <strong>processed.</strong></h1>
+        </li>
       </ul>
   </body>
 </html>

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/lists/output.json
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/lists/output.json
@@ -126,5 +126,27 @@
       }
     ],
     "style": "normal"
+  },
+  {
+    "_key": "randomKey8",
+    "_type": "block",
+    "children": [
+      {
+        "_key": "randomKey80",
+        "_type": "span",
+        "marks": [],
+        "text": "p in li. block children are still "
+      },
+      {
+        "_key": "randomKey81",
+        "_type": "span",
+        "marks": ["strong"],
+        "text": "processed."
+      }
+    ],
+    "level": 1,
+    "listItem": "bullet",
+    "markDefs": [],
+    "style": "normal"
   }
 ]


### PR DESCRIPTION
### Description

This fixes a bug where p-tags (and other block elements) inside li elements where incorrectly hoisted out of the li element.

With this change blocks are ignored, and block children are added directly to the listItem instead.

### What to review

Testcase should cover the changes introduced; from the code comment it seems like this usecase was already accounted for, but was checking element tag name instead of parent tag name.

### Notes for release

[@sanity/block-tools] Blocks inside list items are now ignored. Child element will be added directly to the list item instead.