### PR TITLE
 feat(form): add correct field level UI

### DIFF
--- a/packages/sanity/src/form/studio/inputResolver/helpers.ts
+++ b/packages/sanity/src/form/studio/inputResolver/helpers.ts
@@ -1,6 +1,38 @@
 import {SchemaType} from '@sanity/types'
 import {get} from 'lodash'
+import {ArrayFieldProps, ObjectFieldProps} from '../../types'
 
 export function getOption(type: SchemaType, optionName: string) {
   return get(type.options, optionName)
+}
+
+const PSEUDO_OBJECTS = ['array', 'file', 'image', 'reference']
+const HIDDEN_FIELDS = ['asset', 'crop', 'hotspot', '_ref', '_weak']
+
+export function getObjectFieldLevel(field: ObjectFieldProps): number {
+  const {type, fields, options} = field.schemaType
+  const fieldType = type?.name || ''
+
+  const isPseudoObject = PSEUDO_OBJECTS.includes(fieldType)
+
+  const hasVisibleFields = fields?.filter((f) => !HIDDEN_FIELDS.includes(f.name)).length > 0
+  const hasListOptions = options?.list?.length > 0
+
+  if (hasVisibleFields || hasListOptions || !isPseudoObject) {
+    return field.level
+  }
+
+  return 0
+}
+
+export function getArrayFieldLevel(field: ArrayFieldProps): number {
+  const {options} = field.schemaType
+
+  const hasListOptions = (options?.list || [])?.length > 0
+
+  if (hasListOptions) {
+    return field.level
+  }
+
+  return 0
 }

--- a/packages/sanity/src/form/studio/inputResolver/inputResolver.tsx
+++ b/packages/sanity/src/form/studio/inputResolver/inputResolver.tsx
@@ -26,6 +26,8 @@ import {resolveArrayInput} from './resolveArrayInput'
 import {resolveStringInput} from './resolveStringInput'
 import {resolveNumberInput} from './resolveNumberInput'
 import {defaultInputs} from './defaultInputs'
+import {getArrayFieldLevel, getObjectFieldLevel} from './helpers'
+import {isObjectField} from '../../utils/asserters'
 
 function resolveComponentFromTypeVariants(
   type: SchemaType
@@ -106,10 +108,12 @@ function PrimitiveField(field: FieldProps) {
 }
 
 function ObjectOrArrayField(field: ObjectFieldProps | ArrayFieldProps) {
+  const level = isObjectField(field) ? getObjectFieldLevel(field) : getArrayFieldLevel(field)
+
   return (
     <FormFieldSet
       data-testid={`field-${field.inputId}`}
-      level={field.level}
+      level={level}
       title={field.title}
       description={field.description}
       collapsed={field.collapsed}
@@ -132,9 +136,12 @@ function ImageOrFileField(field: ObjectFieldProps) {
   const presence = hotspotField?.open
     ? field.presence
     : field.presence.concat(hotspotField?.field.presence || [])
+
+  const level = getObjectFieldLevel(field)
+
   return (
     <FormFieldSet
-      level={field.level}
+      level={level}
       title={field.title}
       description={field.description}
       collapsed={field.collapsed}


### PR DESCRIPTION
### Description
This PR adds logic to determine when a field should have the "level UI" (that is, padding to left + border). 

### What to review
Do the level UI appear on places where it is expected? (Tip: compare with v2)

### Notes for release
feat(form): add correct field level UI 

