### PR TITLE
fix(form): check for invalid image/file values, provide reset option

### DIFF
--- a/packages/@sanity/import/package.json
+++ b/packages/@sanity/import/package.json
@@ -25,7 +25,7 @@
     "ndjson"
   ],
   "dependencies": {
-    "@sanity/asset-utils": "^1.2.3",
+    "@sanity/asset-utils": "^1.2.5",
     "@sanity/generate-help-url": "^3.0.0",
     "@sanity/mutator": "3.0.0-dev-preview.12",
     "@sanity/uuid": "^3.0.1",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -97,7 +97,7 @@
     "@portabletext/types": "^1.0.3",
     "@reach/auto-id": "^0.13.2",
     "@rexxars/react-json-inspector": "^8.0.1",
-    "@sanity/asset-utils": "^1.2.3",
+    "@sanity/asset-utils": "^1.2.5",
     "@sanity/bifur-client": "^0.0.8",
     "@sanity/block-tools": "3.0.0-dev-preview.12",
     "@sanity/cli": "3.0.0-dev-preview.12",

--- a/packages/sanity/src/form/inputs/files/FileInput/InvalidFileWarning.tsx
+++ b/packages/sanity/src/form/inputs/files/FileInput/InvalidFileWarning.tsx
@@ -1,0 +1,36 @@
+import {ResetIcon, WarningOutlineIcon} from '@sanity/icons'
+import {Card, Flex, Box, Text, Stack, Button} from '@sanity/ui'
+import React from 'react'
+import styled from 'styled-components'
+
+type Props = {
+  onClearValue?: () => void
+}
+
+const ButtonWrapper = styled(Button)`
+  width: 100%;
+`
+
+export function InvalidFileWarning({onClearValue}: Props) {
+  return (
+    <Card tone="caution" padding={4} border radius={2}>
+      <Flex gap={4} marginBottom={4}>
+        <Box>
+          <Text size={1}>
+            <WarningOutlineIcon />
+          </Text>
+        </Box>
+        <Stack space={3}>
+          <Text size={1} weight="semibold">
+            Invalid file value
+          </Text>
+          <Text size={1}>
+            The value of this field is not a valid file. Resetting this field will let you choose a
+            new file.
+          </Text>
+        </Stack>
+      </Flex>
+      <ButtonWrapper icon={ResetIcon} text="Reset value" onClick={onClearValue} mode="ghost" />
+    </Card>
+  )
+}

--- a/packages/sanity/src/form/inputs/files/ImageInput/InvalidImageWarning.tsx
+++ b/packages/sanity/src/form/inputs/files/ImageInput/InvalidImageWarning.tsx
@@ -1,0 +1,36 @@
+import {ResetIcon, WarningOutlineIcon} from '@sanity/icons'
+import {Card, Flex, Box, Text, Stack, Button} from '@sanity/ui'
+import React from 'react'
+import styled from 'styled-components'
+
+type Props = {
+  onClearValue?: () => void
+}
+
+const ButtonWrapper = styled(Button)`
+  width: 100%;
+`
+
+export function InvalidImageWarning({onClearValue}: Props) {
+  return (
+    <Card tone="caution" padding={4} border radius={2}>
+      <Flex gap={4} marginBottom={4}>
+        <Box>
+          <Text size={1}>
+            <WarningOutlineIcon />
+          </Text>
+        </Box>
+        <Stack space={3}>
+          <Text size={1} weight="semibold">
+            Invalid image value
+          </Text>
+          <Text size={1}>
+            The value of this field is not a valid image. Resetting this field will let you choose a
+            new image.
+          </Text>
+        </Stack>
+      </Flex>
+      <ButtonWrapper icon={ResetIcon} text="Reset value" onClick={onClearValue} mode="ghost" />
+    </Card>
+  )
+}

--- a/packages/sanity/src/form/inputs/files/common/ActionsMenu.tsx
+++ b/packages/sanity/src/form/inputs/files/common/ActionsMenu.tsx
@@ -11,8 +11,8 @@ interface Props {
   onReset: MouseEventHandler<HTMLDivElement>
   accept: string
   directUploads?: boolean
-  downloadUrl: string
-  copyUrl: string
+  downloadUrl?: string
+  copyUrl?: string
 }
 
 export function ActionsMenu(props: Props) {
@@ -21,7 +21,7 @@ export function ActionsMenu(props: Props) {
   const {push: pushToast} = useToast()
 
   const handleCopyURL = useCallback(() => {
-    navigator.clipboard.writeText(copyUrl)
+    navigator.clipboard.writeText(copyUrl || '')
     pushToast({closable: true, status: 'success', title: 'The url is copied to the clipboard'})
   }, [pushToast, copyUrl])
 
@@ -44,9 +44,9 @@ export function ActionsMenu(props: Props) {
       />
       {browse}
 
-      <MenuDivider />
-      <MenuItem as="a" icon={DownloadIcon} text="Download" href={downloadUrl} />
-      <MenuItem icon={ClipboardIcon} text="Copy URL" onClick={handleCopyURL} />
+      {(downloadUrl || copyUrl) && <MenuDivider />}
+      {downloadUrl && <MenuItem as="a" icon={DownloadIcon} text="Download" href={downloadUrl} />}
+      {copyUrl && <MenuItem icon={ClipboardIcon} text="Copy URL" onClick={handleCopyURL} />}
 
       <MenuDivider />
       <MenuItem

--- a/yarn.lock
+++ b/yarn.lock
@@ -3026,10 +3026,10 @@
     colors "~1.2.1"
     string-argv "~0.3.1"
 
-"@sanity/asset-utils@^1.2.3":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@sanity/asset-utils/-/asset-utils-1.2.3.tgz#a90c7895c6506405d64c2363db131923ba1fa6ef"
-  integrity sha512-0eOR0D6zcqd6nEmAGIJ93ibRGO6ocYzQ5aEuyYvngHy5MDDjUfC821UnF/YPIcxiMXg2DLDjWd4EPt9F8frKNQ==
+"@sanity/asset-utils@^1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@sanity/asset-utils/-/asset-utils-1.2.5.tgz#85b306b98593fbb1243ecd0402bfb349f9e37f3e"
+  integrity sha512-t1WetjlVR4hH6ppxN9KGK7her+qUJvm9f9ZTXXhhbzG0ntvajaG/tgFMFSlkm8MWVrwOm1Va/Gb6L0nPiFkMdw==
 
 "@sanity/bifur-client@^0.0.8":
   version "0.0.8"


### PR DESCRIPTION
### Description

When an incorrect value is set for an image/file `asset` field, the inputs crash because it expects the shape to be correct. This PR upgrades the asset utils in order to use some looser type checks, and uses these to ensure the image asset is correct. If not, it will show a warning with a reset option, which unset the `asset` field. On images, it will also unset `crop` and `hotspot` since they are likely invalid for whatever image is selected next.

I also made the action menu for file/images more forgiving of a missing `copyUrl`/`downloadUrl` - automatically hiding these options if the values are undefined.

Screenshot:
![image](https://user-images.githubusercontent.com/48200/184018475-cdaf6180-9b7b-4594-822c-1ff30cba3f65.png)

### How to reproduce
- Change an image field to an object, and include an `asset` field which is a reference to something that is not an image
- Use the input to select a non-image reference
- Switch back to an image type, removing the `asset` field

### Notes for release

- Fixed an issue where incorrect image and file shapes (references to non-assets) would crash the studio

