### PR TITLE
fix(form): use most specific title for schema type in modal header

### DIFF
--- a/packages/@sanity/schema/src/legacy/types/blocks/block.ts
+++ b/packages/@sanity/schema/src/legacy/types/blocks/block.ts
@@ -25,6 +25,7 @@ const INHERITED_FIELDS = [
 
 const BLOCK_CORE = {
   name: 'block',
+  title: 'Block',
   type: null,
   jsonType: 'object',
 }

--- a/packages/@sanity/schema/src/legacy/types/blocks/span.ts
+++ b/packages/@sanity/schema/src/legacy/types/blocks/span.ts
@@ -15,6 +15,7 @@ const INHERITED_FIELDS = [
 
 const SPAN_CORE = {
   name: 'span',
+  title: 'Span',
   type: null,
   jsonType: 'object',
 }

--- a/packages/@sanity/schema/src/legacy/types/boolean.ts
+++ b/packages/@sanity/schema/src/legacy/types/boolean.ts
@@ -6,6 +6,7 @@ const OVERRIDABLE_FIELDS = [...DEFAULT_OVERRIDEABLE_FIELDS]
 
 const BOOLEAN_CORE = {
   name: 'boolean',
+  title: 'Boolean',
   type: null,
   jsonType: 'boolean',
 }

--- a/packages/@sanity/schema/src/legacy/types/document.ts
+++ b/packages/@sanity/schema/src/legacy/types/document.ts
@@ -2,6 +2,7 @@ import {ObjectType} from './object'
 
 const DOCUMENT_CORE = {
   name: 'document',
+  title: 'Document',
   type: null,
   jsonType: 'object',
 }

--- a/packages/@sanity/schema/src/legacy/types/file.ts
+++ b/packages/@sanity/schema/src/legacy/types/file.ts
@@ -14,6 +14,7 @@ const OVERRIDABLE_FIELDS = [...DEFAULT_OVERRIDEABLE_FIELDS]
 
 const FILE_CORE = {
   name: 'file',
+  title: 'File',
   type: null,
   jsonType: 'object',
 }

--- a/packages/@sanity/schema/src/legacy/types/image.ts
+++ b/packages/@sanity/schema/src/legacy/types/image.ts
@@ -9,6 +9,7 @@ const OVERRIDABLE_FIELDS = [...DEFAULT_OVERRIDEABLE_FIELDS]
 
 const IMAGE_CORE = {
   name: 'image',
+  title: 'Image',
   type: null,
   jsonType: 'object',
 }

--- a/packages/@sanity/schema/src/legacy/types/number.ts
+++ b/packages/@sanity/schema/src/legacy/types/number.ts
@@ -6,6 +6,7 @@ const OVERRIDABLE_FIELDS = [...DEFAULT_OVERRIDEABLE_FIELDS]
 
 const NUMBER_CORE = {
   name: 'number',
+  title: 'Number',
   type: null,
   jsonType: 'number',
 }

--- a/packages/@sanity/schema/src/legacy/types/object.ts
+++ b/packages/@sanity/schema/src/legacy/types/object.ts
@@ -19,6 +19,7 @@ export const ObjectType = {
   get() {
     return {
       name: 'object',
+      title: 'Object',
       type: null,
       jsonType: 'object',
     }

--- a/packages/@sanity/schema/src/legacy/types/reference.ts
+++ b/packages/@sanity/schema/src/legacy/types/reference.ts
@@ -22,6 +22,7 @@ const OVERRIDABLE_FIELDS = [...DEFAULT_OVERRIDEABLE_FIELDS]
 
 const REFERENCE_CORE = {
   name: 'reference',
+  title: 'Reference',
   type: null,
   jsonType: 'object',
 }

--- a/packages/@sanity/schema/src/legacy/types/string.ts
+++ b/packages/@sanity/schema/src/legacy/types/string.ts
@@ -6,6 +6,7 @@ const OVERRIDABLE_FIELDS = [...DEFAULT_OVERRIDEABLE_FIELDS]
 
 const STRING_CORE = {
   name: 'string',
+  title: 'String',
   type: null,
   jsonType: 'string',
 }

--- a/packages/@sanity/schema/src/legacy/types/text.ts
+++ b/packages/@sanity/schema/src/legacy/types/text.ts
@@ -6,6 +6,7 @@ const OVERRIDABLE_FIELDS = [...DEFAULT_OVERRIDEABLE_FIELDS, 'rows']
 
 const TEXT_CORE = {
   name: 'text',
+  title: 'Text',
   type: null,
   jsonType: 'string',
 }

--- a/packages/sanity/src/form/inputs/arrays/ArrayOfObjectsInput/ArrayInput.tsx
+++ b/packages/sanity/src/form/inputs/arrays/ArrayOfObjectsInput/ArrayInput.tsx
@@ -17,6 +17,7 @@ import {Subscription} from 'rxjs'
 import {randomKey, resolveTypeName} from '@sanity/util/content'
 import {SanityClient} from '@sanity/client'
 import {Uploader, UploaderResolver, UploadEvent} from '../../../studio/uploads/types'
+import {getSchemaTypeTitle} from '../../../../schema/helpers'
 import {isDev} from '../../../../environment'
 import {Alert} from '../../../components/Alert'
 import {Details} from '../../../components/Details'
@@ -264,6 +265,8 @@ export class ArrayInput extends React.PureComponent<ArrayInputProps> {
     if (isReferenceSchemaType(itemProps.schemaType)) {
       return itemProps.children
     }
+
+    const typeTitle = getSchemaTypeTitle(itemProps.schemaType)
     return (
       <>
         <ArrayItem
@@ -287,7 +290,7 @@ export class ArrayInput extends React.PureComponent<ArrayInputProps> {
           {itemProps.open ? (
             <Dialog
               width={1}
-              header={`Edit ${itemProps.schemaType.title}`}
+              header={`Edit ${typeTitle}`}
               id={`${id}-item-${itemProps.key}-dialog`}
               onClose={itemProps.onClose}
             >

--- a/packages/sanity/src/schema/helpers.ts
+++ b/packages/sanity/src/schema/helpers.ts
@@ -1,0 +1,22 @@
+import type {SchemaType} from '@sanity/types'
+
+/**
+ * Get the most specific defined title of a schema type
+ * If not set directly on the given type, it will traverse up the tree until it
+ * finds one, falling back to the _name_ of the type.
+ *
+ * @param type - The schema type to get the title of
+ * @returns A title, alternatively the schema type _name_
+ * @internal
+ */
+export function getSchemaTypeTitle(type: SchemaType): string {
+  if (typeof type.title === 'string') {
+    return type.title
+  }
+
+  if (type.type) {
+    return getSchemaTypeTitle(type.type)
+  }
+
+  return type.name || type.jsonType
+}


### PR DESCRIPTION
### Description

When the schema type used for array members did not have a title, it displayed `Edit undefined` in the header. This PR makes it look up the most specific title in the schema type chain, falling back to the schema type name when unable to go any further. 

I also investigated a bit and it looks like `file` and `image` etc never had a title. Was this intentional? I've added titles to all the base schema types - maybe _that_ is the real fix here? Let me know if that is a bad idea, or if we should drop the title lookup helper and just stick with the titles in the schema definitions 👍  

Before:
![image](https://user-images.githubusercontent.com/48200/184022552-58ae1e85-5bcd-4212-8e47-b987cf02d962.png)

After:
![image](https://user-images.githubusercontent.com/48200/184022637-86ba3e8c-33f5-4398-b902-a80ce5c40673.png)

### Notes for release

- Fixed a bug where object modals would sometimes display "Edit undefined" in the header
