### PR TITLE
fix(desk): referenced document title ellipsis

### DIFF
--- a/packages/@sanity/desk-tool/src/components/paneItem/ReferencedDocHeading.tsx
+++ b/packages/@sanity/desk-tool/src/components/paneItem/ReferencedDocHeading.tsx
@@ -42,9 +42,11 @@ export function ReferencedDocHeading(props: ReferenceDocHeadingProps) {
   if (hidePopover) {
     return (
       <Flex>
-        <TitleText tabIndex={0} textOverflow="ellipsis" weight="semibold">
-          {title}
-        </TitleText>
+        <Box paddingBottom={3}>
+          <TitleText tabIndex={0} textOverflow="ellipsis" weight="semibold">
+            {title}
+          </TitleText>
+        </Box>
         <ReferencedDocTooltip totalReferenceCount={totalReferenceCount} />
       </Flex>
     )
@@ -68,9 +70,11 @@ export function ReferencedDocHeading(props: ReferenceDocHeadingProps) {
         <Flex>
           {/* This empty div is added to prevent a jump of the popover pointer once the title is rendered */}
           <div ref={documentTitleRef}>{''}</div>
-          <TitleText tabIndex={0} textOverflow="ellipsis" weight="semibold">
-            <Box marginBottom={2}>{title}</Box>
-          </TitleText>
+          <Box marginBottom={3}>
+            <TitleText tabIndex={0} textOverflow="ellipsis" weight="semibold">
+              {title}
+            </TitleText>
+          </Box>
           <ReferencedDocTooltip totalReferenceCount={totalReferenceCount} />
         </Flex>
       </ObserveElementResize>

--- a/packages/@sanity/desk-tool/src/components/paneItem/ReferencedDocTooltip.tsx
+++ b/packages/@sanity/desk-tool/src/components/paneItem/ReferencedDocTooltip.tsx
@@ -4,7 +4,7 @@ import {LinkIcon} from '@sanity/icons'
 
 export function ReferencedDocTooltip({totalReferenceCount}: {totalReferenceCount?: number}) {
   return (
-    <Box marginLeft={2}>
+    <Box marginLeft={2} marginRight={4}>
       <Text>
         <Tooltip
           content={


### PR DESCRIPTION
### Description

Shortcut link: https://app.shortcut.com/sanity-io/story/22722/document-title-ellipsis-broken

Fixed the bug where the document title ellipsis did not work for referenced documents.
<img width="791" alt="Screenshot 2022-08-11 at 13 08 43" src="https://user-images.githubusercontent.com/44635000/184120391-234e52aa-23d7-4e07-88bb-f7bd75680aff.png">


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Write a long title for a document. Make sure the title and icons in the header works as expected.


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
fix(desk): add ellipsis for referenced document title