### PR TITLE
fix(form): pass layout option from array input

### DIFF
--- a/packages/sanity/src/form/inputs/arrays/ArrayOfObjectsInput/ArrayInput.tsx
+++ b/packages/sanity/src/form/inputs/arrays/ArrayOfObjectsInput/ArrayInput.tsx
@@ -277,7 +277,8 @@ export class ArrayInput extends React.PureComponent<ArrayInputProps> {
           onRemove={itemProps.onRemove}
           onFocus={itemProps.onFocus}
           index={itemProps.index}
-          schemaType={schemaType}
+          schemaType={itemProps.schemaType}
+          layout={schemaType.options?.layout}
           insertableTypes={schemaType.of}
           value={itemProps.value as _ArrayInput_ArrayMember}
           focused={itemProps.focused}

--- a/packages/sanity/src/form/inputs/arrays/ArrayOfObjectsInput/item/ArrayItem.tsx
+++ b/packages/sanity/src/form/inputs/arrays/ArrayOfObjectsInput/item/ArrayItem.tsx
@@ -16,6 +16,7 @@ export interface ArrayItemProps {
   children: React.ReactNode
   focused?: boolean
   changed: boolean
+  layout?: 'grid'
   index: number
   insertableTypes: SchemaType[]
   onClick: () => void
@@ -43,6 +44,7 @@ export const ArrayItem = memo(function ArrayItem(props: ArrayItemProps) {
     open,
     path,
     onClick,
+    layout,
     readOnly,
     presence = [],
     validation = [],
@@ -73,7 +75,7 @@ export const ArrayItem = memo(function ArrayItem(props: ArrayItemProps) {
   const options = schemaType.options || {}
   const isSortable = !readOnly && options.sortable !== false
 
-  const isGrid = schemaType.options?.layout === 'grid'
+  const isGrid = layout === 'grid'
   const ItemComponent = isGrid ? CellItem : RowItem
 
   const isReference = schemaType && isReferenceSchemaType(schemaType)


### PR DESCRIPTION
### Description

This change introduces an layout option to the array item component and passes it from the array schema type where it's configured

### What to review
Make sure arrays configured with grid layout still works, and that the regression introduced by the previous change is fixed

### Notes for release

N/A