### PR TITLE
chore(pkg-utils): support tsconfig build target

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "history-server": "^1.3.1",
     "husky": "^7.0.4",
     "jest": "^27.4.3",
+    "jsonc-parser": "^3.1.0",
     "lerna": "^4.0.0",
     "lint-staged": "^12.1.2",
     "lodash": "^4.17.21",

--- a/packages/@sanity/portable-text-editor/tsconfig.json
+++ b/packages/@sanity/portable-text-editor/tsconfig.json
@@ -7,7 +7,8 @@
     "declarationDir": "./lib/dts/",
     "rootDir": "./",
     "outDir": "./lib/dts/",
-    "jsx": "react"
+    "jsx": "react",
+    "target": "ES2019"
   },
   "references": [
     {"path": "../block-tools/tsconfig.lib.json"},

--- a/scripts/pkg-utils/bundle/rollup/options.ts
+++ b/scripts/pkg-utils/bundle/rollup/options.ts
@@ -1,8 +1,10 @@
+import fs from 'fs'
 import path from 'path'
 import {babel} from '@rollup/plugin-babel'
 import commonjs from '@rollup/plugin-commonjs'
 import json from '@rollup/plugin-json'
 import {nodeResolve} from '@rollup/plugin-node-resolve'
+import {parse} from 'jsonc-parser'
 import {InputOptions, ModuleFormat, OutputOptions} from 'rollup'
 import typescript from 'rollup-plugin-typescript2'
 import {sanityMonorepoPlugin} from '../sanityMonorepoPlugin'
@@ -20,6 +22,10 @@ export function buildOptions(opts: {
   tsconfig: string
 }): {inputOptions: InputOptions; outputOptions: OutputOptions} {
   const {babelConfig, build, cwd, external, input, target, tsconfig} = opts
+
+  const tsconfigBuf = fs.readFileSync(tsconfig)
+  const tsconfigOptions = parse(tsconfigBuf.toString())
+  const tsconfigTarget = tsconfigOptions?.compilerOptions?.target
 
   // see below for details on the options
   const inputOptions: InputOptions = {
@@ -49,7 +55,7 @@ export function buildOptions(opts: {
         tsconfigOverride: {
           compilerOptions: {
             module: 'ESNext',
-            target: 'esnext',
+            target: tsconfigTarget || 'esnext',
           },
         },
         typescript: require('typescript'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -11455,7 +11455,7 @@ json5@^2.1.2, json5@^2.1.3, json5@^2.2.0, json5@^2.2.1:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
-jsonc-parser@^3.0.0:
+jsonc-parser@^3.0.0, jsonc-parser@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.1.0.tgz#73b8f0e5c940b83d03476bc2e51a20ef0932615d"
   integrity sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg==


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

`pkg-utils bundle` will now respect the `target` defined in `tsconfig.json`. If not defined, it will default to `ESNext`.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

- Make sure that `@sanity/portable-text-editor` bundles files compatible with ES2019.
- Make sure that other packages build with the desired ES target.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

n/a
