### PR TITLE
fix: string array issues

### DIFF
--- a/dev/test-studio/schema/standard/arrays.tsx
+++ b/dev/test-studio/schema/standard/arrays.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import {ImageIcon, OlistIcon} from '@sanity/icons'
-import {defineType} from 'sanity'
+import {defineField, defineType} from 'sanity'
 
 export const topLevelArrayType = defineType({
   name: 'topLevelArrayType',
@@ -33,6 +33,17 @@ export const topLevelPrimitiveArrayType = defineType({
   ],
 })
 
+const predefinedStringArray = defineField({
+  name: 'predefinedStringArray',
+  title: 'Array of strings',
+  description: 'First field in object is string with list options',
+  type: 'array',
+  of: [{type: 'string'}],
+  options: {
+    list: [{title: 'Cats', value: 'cats4ever'}, {title: 'Dogs', value: 'dogs4ever'}, 'Horses'],
+  },
+})
+
 export default defineType({
   name: 'arraysTest',
   type: 'document',
@@ -50,19 +61,7 @@ export default defineType({
       type: 'array',
       of: [{type: 'reference', to: [{type: 'author'}]}],
     },
-    {
-      name: 'predefinedStringArray',
-      title: 'Array of strings',
-      description: 'First field in object is string with list options',
-      type: 'array',
-      of: [{type: 'string'}],
-      options: {
-        list: [
-          {title: 'Cats', value: 'cats4ever'},
-          {title: 'Dogs', value: 'dogs4ever'},
-        ],
-      },
-    },
+    predefinedStringArray,
     {
       name: 'objectArrayWithPrefinedStringField',
       title: 'Array of objects',

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -156,7 +156,7 @@ export namespace Schema {
   export interface ArrayOptions<TValue = unknown> {
     sortable?: boolean
     layout?: 'tags' | 'grid'
-    list?: Array<{title: string; value: TValue}>
+    list?: Array<{title: string; value: TValue} | string>
     modal?: {type?: 'dialog' | 'popover'; width?: number | 'auto'}
   }
 

--- a/packages/sanity/src/form/inputs/arrays/OptionsArrayInput/OptionsArrayInput.tsx
+++ b/packages/sanity/src/form/inputs/arrays/OptionsArrayInput/OptionsArrayInput.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import {get} from 'lodash'
-import {isTitledListValue} from '@sanity/types'
+import {get, startCase} from 'lodash'
 import {Box, Checkbox, Flex, Text} from '@sanity/ui'
 import {resolveTypeName} from '@sanity/util/content'
 import {set, unset} from '../../../patch'
@@ -109,7 +108,7 @@ export class OptionsArrayInput extends React.PureComponent<OptionsArrayInputProp
             const optionType = this.getMemberTypeOfItem(option)
             const checked = inArray(value || [], resolveValueWithLegacyOptionsSupport(option))
             const disabled = !optionType
-            const isTitled = isTitledListValue(option)
+            const title = option?.title || startCase(option?.value) || option
 
             return (
               <Item index={index} isGrid={isGrid} key={index}>
@@ -124,9 +123,9 @@ export class OptionsArrayInput extends React.PureComponent<OptionsArrayInputProp
                   />
 
                   {optionType &&
-                    (isTitled ? (
+                    (title ? (
                       <Box padding={2}>
-                        <Text>{option.title}</Text>
+                        <Text>{title}</Text>
                       </Box>
                     ) : (
                       <Box marginLeft={2}>

--- a/packages/sanity/src/form/studio/inputResolver/helpers.ts
+++ b/packages/sanity/src/form/studio/inputResolver/helpers.ts
@@ -8,6 +8,7 @@ export function getOption(type: SchemaType, optionName: string) {
 
 const PSEUDO_OBJECTS = ['array', 'file', 'image', 'reference']
 const HIDDEN_FIELDS = ['asset', 'crop', 'hotspot', '_ref', '_weak']
+const NO_LEVEL_LAYOUTS = ['tags']
 
 export function getObjectFieldLevel(field: ObjectFieldProps): number {
   const {type, fields, options} = field.schemaType
@@ -29,8 +30,9 @@ export function getArrayFieldLevel(field: ArrayFieldProps): number {
   const {options} = field.schemaType
 
   const hasListOptions = (options?.list || [])?.length > 0
+  const isNoLevelLayout = NO_LEVEL_LAYOUTS.includes(options?.layout || '')
 
-  if (hasListOptions) {
+  if (hasListOptions && !isNoLevelLayout) {
     return field.level
   }
 


### PR DESCRIPTION
### Description

This PR fixes:
- Render tags input when an array has `options: {layout: 'tags'}`
- Update form field UI for tags array (no border or padding to the left of the field)
- Make it possible to have strings in addition to an object with `title` and `value` in `options.list`. E.g:
```
  options: {
    list: [{title: 'Title', value: 'value'}, 'Hello'],
  }
```
### What to review
Test that the above mentioned fixes works

### Notes for release

fix: string array issues
