### PR TITLE
fix(cli): fix asset check in human previews

### DIFF
--- a/packages/@sanity/cli/templates/getting-started-dashboard/components/views/components/gridList.jsx
+++ b/packages/@sanity/cli/templates/getting-started-dashboard/components/views/components/gridList.jsx
@@ -20,7 +20,7 @@ export function GridList({heading, items = []}) {
       <Grid columns={2} gap={5}>
         {items.map((item) => (
           <Box key={item._id}>
-            {item?.image && (
+            {item?.image?.asset && (
               <Card radius={6} marginBottom={2} overflow="hidden">
                 <Image width="200" src={urlFor(item.image).width(200).height(200)} alt="" />
               </Card>

--- a/packages/@sanity/cli/templates/getting-started-pets/components/views/components/gridList.jsx
+++ b/packages/@sanity/cli/templates/getting-started-pets/components/views/components/gridList.jsx
@@ -20,7 +20,7 @@ export function GridList({heading, items = []}) {
       <Grid columns={2} gap={5}>
         {items.map((item) => (
           <Box key={item._id}>
-            {item?.image && (
+            {item?.image?.asset && (
               <Card radius={6} marginBottom={2} overflow="hidden">
                 <Image width="200" src={urlFor(item.image).width(200).height(200)} alt="" />
               </Card>


### PR DESCRIPTION
### Description

This fixes an issue where human previews will crash when a referenced pet has a draft with no picture attached.

![image](https://user-images.githubusercontent.com/10508/184637870-f00c99b8-6526-40ce-aa87-ec925ddad334.png)

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

n/a
