### PR TITLE
fix(form): missing icon in field group

### DIFF
--- a/packages/sanity/src/form/inputs/ObjectInput/fieldGroups/FieldGroupTabs.tsx
+++ b/packages/sanity/src/form/inputs/ObjectInput/fieldGroups/FieldGroupTabs.tsx
@@ -42,14 +42,15 @@ const GroupTabs = ({
       .map((group) => {
         return (
           <GroupTab
-            key={`${inputId}-${group.name}-tab`}
             aria-controls={`${inputId}-field-group-fields`}
-            onClick={onClick}
-            name={group.name}
-            title={group.title || group.name}
-            selected={Boolean(group.selected)}
             autoFocus={shouldAutoFocus && group.selected}
             disabled={disabled}
+            icon={group?.icon}
+            key={`${inputId}-${group.name}-tab`}
+            name={group.name}
+            onClick={onClick}
+            selected={Boolean(group.selected)}
+            title={group.title || group.name}
           />
         )
       })

--- a/packages/sanity/src/form/inputs/ObjectInput/fieldGroups/GroupTab.tsx
+++ b/packages/sanity/src/form/inputs/ObjectInput/fieldGroups/GroupTab.tsx
@@ -2,13 +2,14 @@ import React, {forwardRef} from 'react'
 import {Tab} from '@sanity/ui'
 
 interface GroupType {
-  name: string
-  title: string
-  onClick?: (value: string) => void
-  autoFocus?: boolean
-  selected: boolean
   'aria-controls': string
+  autoFocus?: boolean
   disabled?: boolean
+  icon?: React.ComponentType
+  name: string
+  onClick?: (value: string) => void
+  selected: boolean
+  title: string
 }
 
 export const GroupTab = forwardRef(function GroupTab(

--- a/packages/sanity/src/form/store/formState.ts
+++ b/packages/sanity/src/form/store/formState.ts
@@ -5,6 +5,7 @@ import {
   ArraySchemaType,
   BooleanSchemaType,
   CurrentUser,
+  FieldGroup,
   isArrayOfObjectsSchemaType,
   isArraySchemaType,
   isObjectSchemaType,
@@ -39,7 +40,7 @@ import {FieldError} from './types/memberErrors'
 
 type PrimitiveSchemaType = BooleanSchemaType | NumberSchemaType | StringSchemaType
 
-const ALL_FIELDS_GROUP = {
+const ALL_FIELDS_GROUP: FieldGroup = {
   name: 'all-fields',
   title: 'All fields',
   hidden: false,
@@ -499,9 +500,10 @@ function prepareObjectInputState<T>(
       ? []
       : [
           {
+            icon: group?.icon,
             name: group.name,
-            title: group.title,
             selected,
+            title: group.title,
           },
         ]
   })


### PR DESCRIPTION
### Description

This PR fixes so that the icon configured in the schema for a field group is displayed. Example:

```js
  groups: [
    {
      name: 'group',
      title: 'Group',
      icon: CogIcon
    },
  ]
```

### What to review

Make sure that the icon configured for a field group is displayed on the group tab.

### Notes for release

fix(form): missing icon in field group