### PR TITLE
fix(form-builder): make sure to forward ref for object input with tabs

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ObjectInput/ObjectInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ObjectInput/ObjectInput.tsx
@@ -72,7 +72,7 @@ const DEFAULT_FILTER_FIELD = () => true
 // disable eslint false positive
 // eslint-disable-next-line react/display-name
 export const ObjectInput = memo(
-  forwardRef(function ObjectInput(props: Props, forwardedRef: ForwardedRef<HTMLDivElement>) {
+  forwardRef(function ObjectInput(fieldProps: Props, forwardedRef: ForwardedRef<HTMLDivElement>) {
     const {
       type,
       presence = EMPTY_PRESENCE,
@@ -87,7 +87,7 @@ export const ObjectInput = memo(
       onBlur,
       compareValue,
       filterField = DEFAULT_FILTER_FIELD,
-    } = props
+    } = fieldProps
 
     const {value: currentUser} = useCurrentUser()
     const {changesOpen} = useReviewChanges()

--- a/packages/@sanity/form-builder/src/inputs/ObjectInput/ObjectInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ObjectInput/ObjectInput.tsx
@@ -466,6 +466,7 @@ export const ObjectInput = memo(
               onClick={handleSelectTab}
               selectedName={selectedFieldGroupName}
               groups={filterGroups}
+              ref={forwardedRef}
               shouldAutoFocus={
                 level === 0 && (focusPath.length === 0 || focusPath[0] === FOCUS_TERMINATOR)
               }

--- a/packages/@sanity/form-builder/src/inputs/ObjectInput/fieldGroups/FieldGroupTabs.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ObjectInput/fieldGroups/FieldGroupTabs.tsx
@@ -1,3 +1,5 @@
+/* This is disabled to work around a bug with eslint-plugin-react */
+/* eslint-disable react/no-unused-prop-types */
 import React, {ForwardedRef, forwardRef, useCallback} from 'react'
 import {ElementQuery, Select, TabList} from '@sanity/ui'
 import {FieldGroup} from '@sanity/types/src'

--- a/packages/@sanity/form-builder/src/inputs/ObjectInput/fieldGroups/FieldGroupTabs.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ObjectInput/fieldGroups/FieldGroupTabs.tsx
@@ -1,8 +1,8 @@
-import React, {useCallback, useEffect, useMemo, useState} from 'react'
+import React, {ForwardedRef, forwardRef, useCallback} from 'react'
 import {ElementQuery, Select, TabList} from '@sanity/ui'
 import {FieldGroup} from '@sanity/types/src'
 import styled from 'styled-components'
-import {GroupTab, GroupOption} from './GroupTab'
+import {GroupOption, GroupTab} from './GroupTab'
 
 interface FieldGroupTabsProps {
   inputId: string
@@ -30,39 +30,38 @@ const Root = styled(ElementQuery)`
     display: block;
   }
 `
-
 /* For medium to large screens, use TabList and Tab from Sanity UI  */
-const GroupTabs = ({
-  inputId,
-  groups,
-  onClick,
-  selectedName,
-  shouldAutoFocus = true,
-  disabled,
-}: FieldGroupTabsProps) => (
-  <TabList space={2} data-testid="field-group-tabs">
-    {groups
-      .map((group) => {
-        const {fields, ...restGroup} = group
+// disable eslint false positive
+// eslint-disable-next-line react/display-name
+const GroupTabs = forwardRef(
+  (
+    {inputId, groups, onClick, selectedName, shouldAutoFocus = true, disabled}: FieldGroupTabsProps,
+    forwardedRef: ForwardedRef<HTMLButtonElement>
+  ) => (
+    <TabList space={2} data-testid="field-group-tabs" ref={forwardedRef}>
+      {groups
+        .map((group) => {
+          const {fields, ...restGroup} = group
 
-        if (!fields || fields.length === 0) {
-          return null
-        }
-        return (
-          <GroupTab
-            key={`${inputId}-${group.name}-tab`}
-            aria-controls={`${inputId}-field-group-fields`}
-            onClick={onClick}
-            selected={selectedName === group.name ?? group.default}
-            autoFocus={selectedName === group.name && shouldAutoFocus}
-            parent={groups}
-            disabled={disabled}
-            {...restGroup}
-          />
-        )
-      })
-      .filter(Boolean)}
-  </TabList>
+          if (!fields || fields.length === 0) {
+            return null
+          }
+          return (
+            <GroupTab
+              key={`${inputId}-${group.name}-tab`}
+              aria-controls={`${inputId}-field-group-fields`}
+              onClick={onClick}
+              selected={selectedName === group.name ?? group.default}
+              autoFocus={selectedName === group.name && shouldAutoFocus}
+              parent={groups}
+              disabled={disabled}
+              {...restGroup}
+            />
+          )
+        })
+        .filter(Boolean)}
+    </TabList>
+  )
 )
 
 /* For small screens, use Select from Sanity UI  */
@@ -114,24 +113,27 @@ const GroupSelect = ({
   )
 }
 
-export const FieldGroupTabs = React.memo(function FieldGroupTabs({
-  onClick,
-  disabled = false,
-  ...props
-}: FieldGroupTabsProps) {
-  const {groups} = props
+// disable eslint false positive
+// eslint-disable-next-line react/display-name
+export const FieldGroupTabs = React.memo(
+  forwardRef(function FieldGroupTabs(
+    {onClick, disabled = false, ...props}: FieldGroupTabsProps,
+    forwardedRef: ForwardedRef<any>
+  ) {
+    const {groups} = props
 
-  const handleClick = useCallback(
-    (groupName) => {
-      onClick(groupName)
-    },
-    [onClick]
-  )
+    const handleClick = useCallback(
+      (groupName) => {
+        onClick(groupName)
+      },
+      [onClick]
+    )
 
-  return (
-    <Root data-testid="field-group-root">
-      <GroupTabs {...props} disabled={disabled} onClick={handleClick} />
-      <GroupSelect {...props} disabled={disabled} onSelect={handleClick} />
-    </Root>
-  )
-})
+    return (
+      <Root data-testid="field-group-root">
+        <GroupTabs {...props} ref={forwardedRef} disabled={disabled} onClick={handleClick} />
+        <GroupSelect {...props} disabled={disabled} onSelect={handleClick} />
+      </Root>
+    )
+  })
+)


### PR DESCRIPTION
### Description

This change fixes the console warning _The input component for type "fieldGroups" has no associated ref element..._ for document types with field groups.

The bug is that that all inputs need to set the ref to an actual element, but in the case of field groups we didn't forward the ref anywhere. The ref is now set on the tab list.

### What to review

- Go to test studio and document type with field groups
- See that console warning _The input component for type "fieldGroups" has no associated ref element...._ is not triggered any more

### Notes for release

- Fixed a bug where we didn't forward the ref for object input with tabs, causing console warnings
