### PR TITLE
fix(desk): missing icon in default structure

### DIFF
--- a/packages/sanity/src/desk/structureBuilder/ListItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/ListItem.ts
@@ -106,6 +106,12 @@ export class ListItemBuilder implements Serializable<ListItem> {
   }
 
   getSchemaType(): PartialListItem['schemaType'] {
+    const schemaType = this.spec.schemaType
+
+    if (typeof schemaType === 'string') {
+      return this._context.schema.get(schemaType)
+    }
+
     return this.spec.schemaType
   }
 


### PR DESCRIPTION
### Description
This PR fixes a problem where a default structure does not show any icons.

### What to review

1. Start the `clean-studio` with `yarn dev:clean-studio`
2. Go to `examples/clean-studio` and add a schema to `sanity.config.ts`:

```js
  schema: {
    types: [
      {
        type: 'document',
        title: 'Document',
        name: 'doc',
        icon: CogIcon,
        fields: [
          {
            name: 'string',
            type: 'string',
            title: 'String',
          },
        ],
      },
    ],
  }
  ```
  
  3. The icon should be displayed.
<img width="373" alt="Screenshot 2022-08-17 at 17 38 49" src="https://user-images.githubusercontent.com/15094168/185182279-f08637d9-fcbc-4a88-a139-c569e7cdc689.png">

### Notes for release
fix(desk): missing icon in default structure
