### PR TITLE
feat: add array schema validation when using tags layout with list

### DIFF
--- a/packages/@sanity/schema/src/sanity/validation/types/array.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/array.ts
@@ -106,6 +106,14 @@ export default (typeDef, visitorContext) => {
     )
   }
 
+  if (typeDef?.options?.list && typeDef?.options?.layout === 'tags') {
+    problems.push(
+      warning(
+        'Found array member declaration with both tags layout and a list of predefined values. If you want to display a list of predefined values, remove the tags layout from `options`.'
+      )
+    )
+  }
+
   return {
     ...typeDef,
     of: of.map(visitorContext.visit),

--- a/packages/sanity/src/form/studio/inputResolver/resolveArrayInput.ts
+++ b/packages/sanity/src/form/studio/inputResolver/resolveArrayInput.ts
@@ -30,13 +30,13 @@ export function hasOptionsList(type: ArraySchemaType): boolean {
 }
 
 export function resolveArrayInput(type: ArraySchemaType): ComponentType<any> {
+  if (isStringArray(type) && isTagsArray(type)) {
+    return TagsArrayInput
+  }
+
   // Schema provides predefines list
   if (hasOptionsList(type)) {
     return OptionsArray
-  }
-
-  if (isStringArray(type) && isTagsArray(type)) {
-    return TagsArrayInput
   }
 
   // Special component for array of primitive values


### PR DESCRIPTION
### Description
This PR adds:
- Schema validation when using `layout: 'tags'` together with a `list` with predefined values
- Renders the `TagsArrayInput` before `OptionsArray`. I think this is more expected behaviour.

### What to review
- Configure an array with tags layout + a list in `options` and the warning should appear in the list of configuration issues 
- Does the copy make sense?

### Notes for release
feat: add array schema validation when using tags layout with list
