### PR TITLE
fix: allow URL imports in `sanity.config.ts`

### DIFF
--- a/packages/@sanity/server/src/vite/plugin-sanity-build-entries.ts
+++ b/packages/@sanity/server/src/vite/plugin-sanity-build-entries.ts
@@ -52,7 +52,10 @@ export function sanityBuildEntries(options: {
         for (const key of entryFile.imports) {
           // Traverse all CSS assets that isn't loaded by the runtime and
           // need <link> tags in the HTML template
-          css.push(...bundle[key].viteMetadata.importedCss)
+          const importedCss = bundle[key]?.viteMetadata?.importedCss
+          if (importedCss) {
+            css.push(...importedCss)
+          }
         }
       }
 


### PR DESCRIPTION
### Description

Fixes a bug that is preventing the usage of URL imports atm.
Link to reproduction: https://github.com/sanity-io/themer/pull/37

If you add an URL import to `sanity.config.ts`:
```ts
import { createConfig } from 'sanity'
import { theme } from 'https://themer.sanity.build/api/hues?preset=verdant'

export default createConfig({
  // ...
  theme,
})
```
You'll get this error:
```bash
TypeError: Cannot read properties of undefined (reading 'viteMetadata')
--
at Object.generateBundle (/node_modules/@sanity/server/lib/vite/plugin-sanity-build-entries.js:78:35)
at /node_modules/rollup/dist/es/shared/rollup.js:22695:37
```

The reason it happens is Vite doesn't populate `viteMetadata` on its `entryFiles.imports` for URL imports. 
This makes sense, as they're evaluated at runtime instead of at build time thus how should Vite know what the URL import is pulling in?

This PR fixes the bug/assumption 😌 