### PR TITLE
fix(structure): fix regression with initialValueTemplates being overridden

### DIFF
--- a/packages/@sanity/structure/src/DocumentList.ts
+++ b/packages/@sanity/structure/src/DocumentList.ts
@@ -181,6 +181,12 @@ export class DocumentListBuilder extends GenericListBuilder<
     const builder = new DocumentListBuilder()
     builder.spec = {...this.spec, ...(withSpec || {})}
 
+    // Since initialValueTemplatesSpecified is only set in the constructor, we need to
+    // manually copy it over to not override initialValueTemplates below
+    if (this.initialValueTemplatesSpecified) {
+      builder.initialValueTemplatesSpecified = true
+    }
+
     if (!this.initialValueTemplatesSpecified) {
       builder.spec.initialValueTemplates = inferInitialValueTemplates(builder.spec)
     }


### PR DESCRIPTION
### Description

Before you could chain more methods after calling `initialValueTemplates()` on `S.documentList()`, but this seems to have broken at some point.

Example:
```js
S.documentList()
  .title("Docs")
  .menuItems([])
  .menuItemGroups([])
  .initialValueTemplates([])
  .defaultOrdering([{ field: "title", direction: "asc" }])
```

Here `.defaultOrdering()` would reset `initialValueTemplates` because `.clone()` was called under the hood, and a new `DocumentListBuilder` instance was created. However `initialValueTemplatesSpecified` was only set in the constructor, and at that point the spec was not passed yet.

This fixes the 

#### Questions
- `initialValueTemplatesSpecified` is protected. Is the change in this PR the best way to do it? We could pass the spec in the constructor instead, but the current typing doesn't allow it.

### What to review

- That you are able to set `.initialValueTemplates([])` and call additional methods

### Notes for release

- Fixed issue with `initialValueTemplates()` being overridden if you called other methods after it
