### PR TITLE
fix(config): include logo in resolved studio config

### DIFF
--- a/packages/sanity/src/config/prepareConfig.ts
+++ b/packages/sanity/src/config/prepareConfig.ts
@@ -49,12 +49,20 @@ import {_createRenderPreview} from './form/_renderPreview'
 type InternalSource = WorkspaceSummary['__internal']['sources'][number]
 
 function normalizeLogo(
-  logo: React.ComponentType | React.ElementType | undefined,
+  logo: React.ComponentType | React.ElementType | undefined
+): JSX.Element | undefined {
+  if (isValidElementType(logo)) return createElement(logo)
+  if (isValidElement(logo)) return logo
+  return undefined
+}
+
+function normalizeIcon(
+  icon: React.ComponentType | React.ElementType | undefined,
   title: string,
   subtitle = ''
 ): JSX.Element {
-  if (isValidElementType(logo)) return createElement(logo)
-  if (isValidElement(logo)) return logo
+  if (isValidElementType(icon)) return createElement(icon)
+  if (isValidElement(icon)) return icon
   return createDefaultIcon(title, subtitle)
 }
 
@@ -155,7 +163,8 @@ export function prepareConfig(config: Config): PreparedConfig {
         basePath: rootSource.basePath || '/',
         dataset: rootSource.dataset,
         schema: resolvedSources[0].schema,
-        icon: normalizeLogo(
+        logo: normalizeLogo(rootSource.logo),
+        icon: normalizeIcon(
           rootSource.icon,
           title,
           `${rootSource.projectId} ${rootSource.dataset}`


### PR DESCRIPTION
### Description

The `logo` config property was not getting passed on when resolving the configuration. This PR fixes this, and pre-renders (well... computes) it at the config level, so it is ever so slightly faster to render.


### What to review

That the `logo` property can be configured and is respected by the studio. The test-studio should now show "Test Studio™" instead of just "Test Studio", but in theory you should be able to put something else here. An SVG or an image etc.

### Notes for release

- Fixed an issue where a configured `logo` component for a workspace would not be respected
