### PR TITLE
fix(form): update resolving of preview component

### DIFF
--- a/packages/sanity/src/form/studio/defaults.ts
+++ b/packages/sanity/src/form/studio/defaults.ts
@@ -25,5 +25,5 @@ export const defaultRenderItem: RenderItemCallback = (props) => {
 }
 
 export const defaultRenderPreview: RenderPreviewCallback = (props) => {
-  return createElement(defaultResolvePreviewComponent(props.schemaType), props)
+  return createElement(defaultResolvePreviewComponent(), props)
 }

--- a/packages/sanity/src/form/studio/inputResolver/inputResolver.tsx
+++ b/packages/sanity/src/form/studio/inputResolver/inputResolver.tsx
@@ -21,14 +21,14 @@ import * as is from '../../utils/is'
 import {FormField, FormFieldSet} from '../../components/formField'
 import {PreviewProps} from '../../../components/previews'
 import {SanityPreview} from '../../../preview'
+import {isObjectField} from '../../utils/asserters'
+import {ChangeIndicator} from '../../../components/changeIndicators'
 import {resolveReferenceInput} from './resolveReferenceInput'
 import {resolveArrayInput} from './resolveArrayInput'
 import {resolveStringInput} from './resolveStringInput'
 import {resolveNumberInput} from './resolveNumberInput'
 import {defaultInputs} from './defaultInputs'
 import {getArrayFieldLevel, getObjectFieldLevel} from './helpers'
-import {isObjectField} from '../../utils/asserters'
-import {ChangeIndicator} from '../../../components/changeIndicators'
 
 function resolveComponentFromTypeVariants(
   type: SchemaType
@@ -191,11 +191,6 @@ export function defaultResolveItemComponent(
   return NoopField
 }
 
-// TODO: add PreviewProps interface
-export function defaultResolvePreviewComponent(
-  schemaType: SchemaType
-): React.ComponentType<PreviewProps> {
-  if (schemaType.components?.preview) return schemaType.components.preview
-
-  return SanityPreview as any // TODO
+export function defaultResolvePreviewComponent(): React.ComponentType<PreviewProps> {
+  return SanityPreview as any
 }


### PR DESCRIPTION
### Description

 This PR fixes so that `SanityPreview` is always returned from `defaultResolvePreviewComponent` in `inputResolver`. This change is made because `SanityPreview` [takes care of resolving what preview component to render](https://github.com/sanity-io/sanity/blob/v3/packages/sanity/src/preview/components/SanityPreview.tsx#L25), but also performs some logic that is important for a preview component, logic that was missed before when we conditionally returned `components.preview`.

### What to review
n/a

### Notes for release

fix(form): update resolving of preview component