### PR TITLE
String of options must return option value for the preview

### DIFF
--- a/packages/sanity/src/preview/utils/prepareForPreview.ts
+++ b/packages/sanity/src/preview/utils/prepareForPreview.ts
@@ -273,7 +273,7 @@ export function prepareForPreview(
       // Find the selected option that matches the raw value
       const selectedOption =
         listOptions && listOptions.find((opt) => opt.value === get(rawValue, selection[key]))
-      acc[key] = selectedOption ? selectedOption.title : get(rawValue, selection[key])
+      acc[key] = selectedOption ? selectedOption.value : get(rawValue, selection[key])
     } else {
       acc[key] = get(rawValue, selection[key])
     }


### PR DESCRIPTION
### Description

Consider the following type:

```
{
    type: 'string',
    name: 'tone',
    title: 'Tone',
    options: {
      list: [
        {value: 'default', title: 'Default'},
        {value: 'primary', title: 'Primary'},
        {value: 'positive', title: 'Positive'},
        {value: 'caution', title: 'Caution'},
        {value: 'critical', title: 'Critical'},
      ],
    },
  }
```
With the current code, the `options.list.title` is selected as value for the preview, which seems like a bug.

This will return the value instead, as it is in the actual data.

