### PR TITLE
fix: remove muted prop from text inside every tooltip in the studio

### DIFF
--- a/packages/@sanity/base/src/components/previews/general/MediaPreview.tsx
+++ b/packages/@sanity/base/src/components/previews/general/MediaPreview.tsx
@@ -57,7 +57,7 @@ export function MediaPreview(props: MediaPreviewProps) {
         )}
 
         {subtitle && (
-          <Text align="center" muted size={1}>
+          <Text align="center" size={1}>
             {typeof subtitle === 'function' ? subtitle({layout: 'media'}) : subtitle}
           </Text>
         )}

--- a/packages/@sanity/cli/templates/getting-started-dashboard/components/views/components/metadataList.jsx
+++ b/packages/@sanity/cli/templates/getting-started-dashboard/components/views/components/metadataList.jsx
@@ -63,9 +63,7 @@ function ImageAndCaption({image, caption}) {
     <Tooltip
       content={
         <Box padding={2}>
-          <Text muted size={1}>
-            {caption}
-          </Text>
+          <Text size={1}>{caption}</Text>
         </Box>
       }
       portal

--- a/packages/@sanity/cli/templates/getting-started-pets/components/views/components/metadataList.jsx
+++ b/packages/@sanity/cli/templates/getting-started-pets/components/views/components/metadataList.jsx
@@ -63,9 +63,7 @@ function ImageAndCaption({image, caption}) {
     <Tooltip
       content={
         <Box padding={2}>
-          <Text muted size={1}>
-            {caption}
-          </Text>
+          <Text size={1}>{caption}</Text>
         </Box>
       }
       portal

--- a/packages/@sanity/desk-tool/src/components/paneItem/ReferencedDocTooltip.tsx
+++ b/packages/@sanity/desk-tool/src/components/paneItem/ReferencedDocTooltip.tsx
@@ -9,7 +9,7 @@ export function ReferencedDocTooltip({totalReferenceCount}: {totalReferenceCount
         <Tooltip
           content={
             <Box padding={2}>
-              <Text muted size={1}>
+              <Text size={1}>
                 Referenced by {totalReferenceCount}
                 {totalReferenceCount === 1 ? ' document' : ' documents'}
               </Text>

--- a/packages/@sanity/desk-tool/src/panes/document/statusBar/sparkline/PublishStatus.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/statusBar/sparkline/PublishStatus.tsx
@@ -31,7 +31,7 @@ export function PublishStatus(props: PublishStatusProps) {
         portal
         content={
           <Stack padding={3} space={3}>
-            <Text size={1} muted>
+            <Text size={1}>
               {liveEdit ? (
                 <>Last updated {lastUpdated ? lastUpdatedTimeAgo : lastPublishedTimeAgo}</>
               ) : (

--- a/packages/@sanity/desk-tool/src/panes/document/statusBar/sparkline/ReviewChangesButton/ReviewChangesButton.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/statusBar/sparkline/ReviewChangesButton/ReviewChangesButton.tsx
@@ -53,9 +53,7 @@ const ReviewButton = React.forwardRef(function ReviewButton(
           <Text size={1} weight="semibold">
             Review changes
           </Text>
-          <Text size={1} muted>
-            Changes saved {lastUpdatedTimeAgo}
-          </Text>
+          <Text size={1}>Changes saved {lastUpdatedTimeAgo}</Text>
         </Stack>
       }
     >

--- a/packages/@sanity/field/src/diff/components/DiffTooltip.tsx
+++ b/packages/@sanity/field/src/diff/components/DiffTooltip.tsx
@@ -40,7 +40,7 @@ function DiffTooltipWithAnnotation(props: DiffTooltipWithAnnotationsProps) {
 
   const content = (
     <Stack padding={3} space={2}>
-      <Label size={1} style={{textTransform: 'uppercase'}} muted>
+      <Label size={1} style={{textTransform: 'uppercase'}}>
         {description}
       </Label>
       <Stack space={2}>
@@ -95,7 +95,7 @@ function AnnotationItem({annotation}: {annotation: AnnotationDetails}) {
           </Text>
         </Inline>
       </Flex>
-      <Text as="time" muted size={1} dateTime={timestamp}>
+      <Text as="time" size={1} dateTime={timestamp}>
         {timeAgo}
       </Text>
     </Inline>

--- a/packages/@sanity/form-builder/src/inputs/CrossDatasetReferenceInput/CrossDatasetReferencePreview.tsx
+++ b/packages/@sanity/form-builder/src/inputs/CrossDatasetReferenceInput/CrossDatasetReferencePreview.tsx
@@ -24,7 +24,7 @@ function UnavailableMessage(props: {icon: ComponentType; children: ReactNode; ti
         </Text>
 
         <Box marginTop={3}>
-          <Text as="p" muted size={1}>
+          <Text as="p" size={1}>
             {props.children}
           </Text>
         </Box>

--- a/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/item/RowItem.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/ArrayOfObjectsInput/item/RowItem.tsx
@@ -160,7 +160,7 @@ export const RowItem = React.forwardRef(function RegularItem(
               <Tooltip
                 content={
                   <Box padding={2}>
-                    <Text muted size={1}>
+                    <Text size={1}>
                       This item is missing the required <code>_key</code> property.
                     </Text>
                   </Box>

--- a/packages/@sanity/form-builder/src/inputs/arrays/common/ArrayFunctions.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/common/ArrayFunctions.tsx
@@ -48,9 +48,7 @@ export default function ArrayFunctions<MemberType>(
         portal
         content={
           <Box padding={2} sizing="border">
-            <Text size={1} muted>
-              This field is read-only
-            </Text>
+            <Text size={1}>This field is read-only</Text>
           </Box>
         }
       >

--- a/packages/@sanity/form-builder/src/inputs/arrays/common/ArrayFunctions.tsx
+++ b/packages/@sanity/form-builder/src/inputs/arrays/common/ArrayFunctions.tsx
@@ -8,15 +8,20 @@ import PatchEvent from '../../../PatchEvent'
 
 // These are the props any implementation of the ArrayFunctions part will receive
 export interface ArrayFunctionsProps<SchemaType extends ArraySchemaType, MemberType> {
+  /* eslint-disable react/no-unused-prop-types */
   className?: string
   type: SchemaType
   children?: ReactNode
+  /* eslint-disable react/no-unused-prop-types */
   value?: MemberType[]
   readOnly: boolean | null
   onAppendItem: (itemValue: MemberType) => void
+  /* eslint-disable react/no-unused-prop-types */
   onPrependItem: (itemValue: MemberType) => void
+  /* eslint-disable react/no-unused-prop-types */
   onFocusItem: (item: MemberType, index: number) => void
   onCreateValue: (type: SchemaType) => MemberType
+  /* eslint-disable react/no-unused-prop-types */
   onChange: (event: PatchEvent) => void
 }
 


### PR DESCRIPTION
### Description
Link to shortcut ticket: https://app.shortcut.com/sanity-io/story/22481/sanity-ui-tooltip-text-contrast-not-matching-a11y-requirements

Removed the muted prop in text in every tooltip in the studio to increase contrast of text in a tooltip

### What to review
Test all the tooltips and make sure that the text is no longer black.
<img width="287" alt="Screenshot 2022-08-24 at 12 16 46" src="https://user-images.githubusercontent.com/44635000/186614282-45b2a4f9-328a-4fa7-a1e2-ce116fdb009a.png">
<img width="347" alt="Screenshot 2022-08-24 at 12 05 52" src="https://user-images.githubusercontent.com/44635000/186614326-306d730b-ae97-457d-b1d6-8b015815eb97.png">

As stated in the shortcut ticket: the hotkeys will **not** be black and this is intentional 
<img width="268" alt="Screenshot 2022-08-24 at 12 16 39" src="https://user-images.githubusercontent.com/44635000/186614436-0482645a-4d72-448f-8279-b142600b9928.png">


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
fix: change text color in tooltips from gray to black