### PR TITLE
fix(form-builder): check for invalid image/file values, provide reset option

### DIFF
--- a/packages/@sanity/base/package.json
+++ b/packages/@sanity/base/package.json
@@ -44,7 +44,7 @@
     "@juggle/resize-observer": "^3.3.1",
     "@popperjs/core": "^2.5.4",
     "@reach/auto-id": "^0.13.2",
-    "@sanity/asset-utils": "^1.2.0",
+    "@sanity/asset-utils": "^1.2.5",
     "@sanity/bifur-client": "^0.3.0",
     "@sanity/client": "^3.3.3",
     "@sanity/color": "^2.1.14",

--- a/packages/@sanity/base/src/preview/components/SanityDefaultPreview.tsx
+++ b/packages/@sanity/base/src/preview/components/SanityDefaultPreview.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import imageUrlBuilder from '@sanity/image-url'
+import {isImageSource} from '@sanity/asset-utils'
 import {ImageUrlFitMode, SanityDocument} from '@sanity/types'
 import {DocumentIcon} from '@sanity/icons'
 import {assetUrlBuilder} from '../../assets'
@@ -129,7 +130,12 @@ export default class SanityDefaultPreview extends React.PureComponent<SanityDefa
     }
 
     // If the asset is on media
-    if (isRecord(value.media) && value.media._type === 'reference' && value.media._ref) {
+    if (
+      isRecord(value.media) &&
+      value.media._type === 'reference' &&
+      value.media._ref &&
+      isImageSource(media)
+    ) {
       return this.renderMedia
     }
 
@@ -139,7 +145,7 @@ export default class SanityDefaultPreview extends React.PureComponent<SanityDefa
     }
 
     // Handle sanity image
-    if (isRecord(media) && media.asset) {
+    if (isRecord(media) && media.asset && isImageSource(media)) {
       return this.renderMedia
     }
 

--- a/packages/@sanity/default-layout/package.json
+++ b/packages/@sanity/default-layout/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@portabletext/react": "^1.0.0",
     "@reach/auto-id": "^0.13.2",
-    "@sanity/asset-utils": "^1.2.0",
+    "@sanity/asset-utils": "^1.2.5",
     "@sanity/base": "2.31.0",
     "@sanity/client": "^3.3.3",
     "@sanity/generate-help-url": "^3.0.0",

--- a/packages/@sanity/field/package.json
+++ b/packages/@sanity/field/package.json
@@ -36,7 +36,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sanity/asset-utils": "^1.2.0",
+    "@sanity/asset-utils": "^1.2.5",
     "@sanity/base": "2.31.0",
     "@sanity/client": "^3.3.3",
     "@sanity/color": "^2.1.14",

--- a/packages/@sanity/field/src/types/file/diff/FileFieldDiff.tsx
+++ b/packages/@sanity/field/src/types/file/diff/FileFieldDiff.tsx
@@ -3,8 +3,10 @@
 
 import FileIcon from 'part:@sanity/base/file-icon'
 import React, {useMemo} from 'react'
-import {Box, Card, Flex, Text} from '@sanity/ui'
+import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
 import styled from 'styled-components'
+import {isFileSource} from '@sanity/asset-utils'
+import {WarningOutlineIcon} from '@sanity/icons'
 import {
   DiffComponent,
   DiffCard,
@@ -42,6 +44,8 @@ export const FileFieldDiff: DiffComponent<ObjectDiff<File>> = ({diff, schemaType
   const toAsset = toValue?.asset
   const prev = useRefValue<FileAsset>(fromAsset?._ref)
   const next = useRefValue<FileAsset>(toAsset?._ref)
+  const fromInvalid = fromAsset?._ref && !isFileSource(fromAsset?._ref)
+  const toInvalid = toAsset?._ref && !isFileSource(toAsset?._ref)
 
   const changedFields = Object.keys(fields).filter(
     (name) => fields[name].isChanged && name !== '_type'
@@ -65,27 +69,55 @@ export const FileFieldDiff: DiffComponent<ObjectDiff<File>> = ({diff, schemaType
 
   const from = prev && (
     <DiffCard as="del" diff={diff} path="asset._ref" style={cardStyles}>
-      <MetaInfo title={prev.originalFilename || 'Untitled'} icon={FileIcon}>
-        <Text size={0} style={{color: 'inherit'}}>{`${roundedPrevSize}MB`}</Text>
-      </MetaInfo>
+      {fromInvalid && (
+        <Card tone="caution" padding={4} paddingRight={2} border radius={2}>
+          <Stack space={3}>
+            <Text size={1}>
+              <WarningOutlineIcon />
+            </Text>
+            <Text size={1} weight="semibold">
+              Invalid file value
+            </Text>
+          </Stack>
+        </Card>
+      )}
+      {!fromInvalid && (
+        <MetaInfo title={prev.originalFilename || 'Untitled'} icon={FileIcon}>
+          <Text size={0} style={{color: 'inherit'}}>{`${roundedPrevSize}MB`}</Text>
+        </MetaInfo>
+      )}
     </DiffCard>
   )
 
   const to = next && (
     <DiffCard as="ins" diff={diff} path="asset._ref" style={cardStyles}>
-      <MetaInfo title={next.originalFilename || 'Untitled'} icon={FileIcon}>
-        <Flex align="center">
-          <Text size={0} style={{color: 'inherit'}}>{`${roundedNextSize}MB`}</Text>
-          {pctDiff !== 0 && (
-            <Card radius={2} padding={1} as={SizeDiff} marginLeft={2}>
-              <Text size={0} data-number={pctDiff > 0 ? 'positive' : 'negative'}>
-                {pctDiff > 0 && '+'}
-                {pctDiff}%
-              </Text>
-            </Card>
-          )}
-        </Flex>
-      </MetaInfo>
+      {toInvalid && (
+        <Card tone="caution" padding={4} paddingRight={2} border radius={2}>
+          <Stack space={3}>
+            <Text size={1}>
+              <WarningOutlineIcon />
+            </Text>
+            <Text size={1} weight="semibold">
+              Invalid file value
+            </Text>
+          </Stack>
+        </Card>
+      )}
+      {!toInvalid && (
+        <MetaInfo title={next.originalFilename || 'Untitled'} icon={FileIcon}>
+          <Flex align="center">
+            <Text size={0} style={{color: 'inherit'}}>{`${roundedNextSize}MB`}</Text>
+            {pctDiff !== 0 && (
+              <Card radius={2} padding={1} as={SizeDiff} marginLeft={2}>
+                <Text size={0} data-number={pctDiff > 0 ? 'positive' : 'negative'}>
+                  {pctDiff > 0 && '+'}
+                  {pctDiff}%
+                </Text>
+              </Card>
+            )}
+          </Flex>
+        </MetaInfo>
+      )}
     </DiffCard>
   )
 

--- a/packages/@sanity/field/src/types/image/diff/ImagePreview.tsx
+++ b/packages/@sanity/field/src/types/image/diff/ImagePreview.tsx
@@ -3,10 +3,15 @@
 
 import React, {SyntheticEvent} from 'react'
 import {useDocumentValues} from '@sanity/base/hooks'
-import {getImageDimensions, isDefaultCrop, isDefaultHotspot} from '@sanity/asset-utils'
+import {
+  getImageDimensions,
+  isDefaultCrop,
+  isDefaultHotspot,
+  isImageSource,
+} from '@sanity/asset-utils'
 import imageUrlBuilder from '@sanity/image-url'
-import {ImageIcon} from '@sanity/icons'
-import {Box, Card, Flex, Text} from '@sanity/ui'
+import {ImageIcon, WarningOutlineIcon} from '@sanity/icons'
+import {Box, Card, Flex, Text, Stack} from '@sanity/ui'
 import styled from 'styled-components'
 import {hues} from '@sanity/color'
 import {versionedClient} from '../../../versionedClient'
@@ -93,6 +98,24 @@ export function ImagePreview(props: ImagePreviewProps): React.ReactElement {
   const {id, action, diff, hotspot, crop, is} = props
   const [imageError, setImageError] = React.useState<SyntheticEvent<HTMLImageElement, Event>>()
   const {value: asset} = useDocumentValues<MinimalAsset>(id, ASSET_FIELDS)
+
+  if (!isImageSource(id)) {
+    return (
+      <Flex direction="column" height="fill" flex={1}>
+        <Card tone="caution" padding={4} paddingRight={2} border radius={2}>
+          <Stack space={3}>
+            <Text size={1}>
+              <WarningOutlineIcon />
+            </Text>
+            <Text size={1} weight="semibold">
+              Invalid image value
+            </Text>
+          </Stack>
+        </Card>
+      </Flex>
+    )
+  }
+
   const dimensions = getImageDimensions(id)
 
   // undefined = still loading, null = its gone

--- a/packages/@sanity/form-builder/package.json
+++ b/packages/@sanity/form-builder/package.json
@@ -30,6 +30,7 @@
     "@reach/auto-id": "^0.13.2",
     "@sanity/base": "2.31.0",
     "@sanity/block-tools": "2.31.0",
+    "@sanity/asset-utils": "^1.2.5",
     "@sanity/client": "^3.3.3",
     "@sanity/color": "^2.1.14",
     "@sanity/generate-help-url": "^3.0.0",

--- a/packages/@sanity/form-builder/src/inputs/files/FileInput/FileInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/FileInput/FileInput.tsx
@@ -20,6 +20,7 @@ import {
 import {ImageIcon, SearchIcon} from '@sanity/icons'
 import {Box, Button, Card, Dialog, Menu, MenuButton, MenuItem, ToastParams} from '@sanity/ui'
 import {PresenceOverlay, FormFieldPresence} from '@sanity/base/presence'
+import {isFileSource} from '@sanity/asset-utils'
 import {WithReferencedAsset} from '../../../utils/WithReferencedAsset'
 import {Uploader, UploaderResolver, UploadOptions} from '../../../sanity/uploads/types'
 import PatchEvent, {setIfMissing, unset} from '../../../PatchEvent'
@@ -37,6 +38,7 @@ import {CardOverlay, FlexContainer} from './styles'
 import {FileInputField} from './FileInputField'
 import {FileDetails} from './FileDetails'
 import {FileSkeleton} from './FileSkeleton'
+import {InvalidFileWarning} from './InvalidFileWarning'
 
 type Field = {
   name: string
@@ -155,9 +157,14 @@ export default class FileInput extends React.PureComponent<Props, FileInputState
     this.setState({isStale: true})
   }
 
+  handleClearField = () => {
+    this.props.onChange(PatchEvent.from(unset(['asset'])))
+  }
+
   handleSelectFiles = (files: DOMFile[]) => {
-    const {directUploads, readOnly} = this.props
+    const {directUploads, readOnly, value} = this.props
     const {hoveringFiles} = this.state
+
     if (directUploads && !readOnly) {
       this.uploadFirstAccepted(files)
     } else if (hoveringFiles.length > 0) {
@@ -689,6 +696,9 @@ export default class FileInput extends React.PureComponent<Props, FileInputState
     }
 
     const hasValueOrUpload = Boolean(value?._upload || value?.asset)
+    const hasInvalidFile =
+      value && typeof value.asset !== 'undefined' && !value?._upload && !isFileSource(value)
+
     return (
       <>
         <ImperativeToast ref={this.setToast} />
@@ -718,7 +728,7 @@ export default class FileInput extends React.PureComponent<Props, FileInputState
                 value={value?.asset?._ref}
               >
                 {/* not uploading */}
-                {!value?._upload && (
+                {!value?._upload && !hasInvalidFile && (
                   <FileTarget
                     tabIndex={0}
                     disabled={Boolean(readOnly)}
@@ -740,6 +750,8 @@ export default class FileInput extends React.PureComponent<Props, FileInputState
                       : null}
                   </FileTarget>
                 )}
+
+                {hasInvalidFile && <InvalidFileWarning onClearValue={this.handleClearField} />}
 
                 {/* uploading */}
                 {value?._upload && this.renderUploadState(value._upload)}

--- a/packages/@sanity/form-builder/src/inputs/files/FileInput/FileInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/FileInput/FileInput.tsx
@@ -58,6 +58,7 @@ export type Props = {
   type: FileSchemaType
   level: number
   onChange: (event: PatchEvent) => void
+  // eslint-disable-next-line react/no-unused-prop-types
   resolveUploader: UploaderResolver
   observeAsset: (documentId: string) => Observable<FileAsset>
   onBlur: () => void

--- a/packages/@sanity/form-builder/src/inputs/files/FileInput/InvalidFileWarning.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/FileInput/InvalidFileWarning.tsx
@@ -1,0 +1,36 @@
+import {ResetIcon, WarningOutlineIcon} from '@sanity/icons'
+import {Card, Flex, Box, Text, Stack, Button} from '@sanity/ui'
+import React from 'react'
+import styled from 'styled-components'
+
+type Props = {
+  onClearValue?: () => void
+}
+
+const ButtonWrapper = styled(Button)`
+  width: 100%;
+`
+
+export function InvalidFileWarning({onClearValue}: Props) {
+  return (
+    <Card tone="caution" padding={4} border radius={2}>
+      <Flex gap={4} marginBottom={4}>
+        <Box>
+          <Text size={1}>
+            <WarningOutlineIcon />
+          </Text>
+        </Box>
+        <Stack space={3}>
+          <Text size={1} weight="semibold">
+            Invalid file value
+          </Text>
+          <Text size={1}>
+            The value of this field is not a valid file. Resetting this field will let you choose a
+            new file.
+          </Text>
+        </Stack>
+      </Flex>
+      <ButtonWrapper icon={ResetIcon} text="Reset value" onClick={onClearValue} mode="ghost" />
+    </Card>
+  )
+}

--- a/packages/@sanity/form-builder/src/inputs/files/ImageInput/InvalidImageWarning.tsx
+++ b/packages/@sanity/form-builder/src/inputs/files/ImageInput/InvalidImageWarning.tsx
@@ -1,0 +1,36 @@
+import {ResetIcon, WarningOutlineIcon} from '@sanity/icons'
+import {Card, Flex, Box, Text, Stack, Button} from '@sanity/ui'
+import React from 'react'
+import styled from 'styled-components'
+
+type Props = {
+  onClearValue?: () => void
+}
+
+const ButtonWrapper = styled(Button)`
+  width: 100%;
+`
+
+export function InvalidImageWarning({onClearValue}: Props) {
+  return (
+    <Card tone="caution" padding={4} border radius={2}>
+      <Flex gap={4} marginBottom={4}>
+        <Box>
+          <Text size={1}>
+            <WarningOutlineIcon />
+          </Text>
+        </Box>
+        <Stack space={3}>
+          <Text size={1} weight="semibold">
+            Invalid image value
+          </Text>
+          <Text size={1}>
+            The value of this field is not a valid image. Resetting this field will let you choose a
+            new image.
+          </Text>
+        </Stack>
+      </Flex>
+      <ButtonWrapper icon={ResetIcon} text="Reset value" onClick={onClearValue} mode="ghost" />
+    </Card>
+  )
+}

--- a/packages/@sanity/import/package.json
+++ b/packages/@sanity/import/package.json
@@ -25,7 +25,7 @@
     "ndjson"
   ],
   "dependencies": {
-    "@sanity/asset-utils": "^1.2.0",
+    "@sanity/asset-utils": "^1.2.5",
     "@sanity/generate-help-url": "^3.0.0",
     "@sanity/mutator": "2.29.3",
     "@sanity/uuid": "^3.0.1",


### PR DESCRIPTION
### Description

(Backport of v3 fix in [#3502](https://github.com/sanity-io/sanity/pull/3502))

> When an incorrect value is set for an image/file `asset` field, the inputs crash because it expects the shape to be correct. This PR upgrades the asset utils in order to use some looser type checks, and uses these to ensure the image asset is correct. If not, it will show a warning with a reset option, which unset the `asset` field. On images, it will also unset `crop` and `hotspot` since they are likely invalid for whatever image is selected next.

> I also made the action menu for file/images more forgiving of a missing `copyUrl`/`downloadUrl` - automatically hiding these options if the values are undefined.

In addition to the v3 fix I have updated the diff previews to handle invalid values.

Updated image input: 

![image](https://user-images.githubusercontent.com/10508/186442883-07a2bda5-bfd6-4405-83b5-f0f72314b4a0.png)

Update image diff: 

![image](https://user-images.githubusercontent.com/10508/186442949-170f493c-2604-4718-9fc3-76b54c846887.png)

Update file input: 

![image](https://user-images.githubusercontent.com/10508/186442708-737b33cd-7e78-41b2-b07c-f87121af2760.png)

Updated file diff: 

![image](https://user-images.githubusercontent.com/10508/186442650-7cb3a98b-f984-4871-bad7-7aca8e86b7dc.png)

### How to reproduce
- Change an image field to an object, and include an `asset` field which is a reference to something that is not an image
- Use the input to select a non-image reference
- Switch back to an image type, removing the `asset` field

### Notes for release

- Fixed an issue where incorrect image and file shapes (references to non-assets) would crash the studio and display invalid diffs