### PR TITLE
Add alt text field for main image in blog schema

### DIFF
--- a/packages/@sanity/cli/templates/blog/schemas/post.js
+++ b/packages/@sanity/cli/templates/blog/schemas/post.js
@@ -32,6 +32,12 @@ export default {
       },
     },
     {
+      name: 'mainImageAlternative',
+      title: 'Alternative text for main image',
+      type: 'string',
+      description: 'Describe what is on this image',
+    },
+    {
       name: 'categories',
       title: 'Categories',
       type: 'array',


### PR DESCRIPTION
### Description

The blog schema has a field for a main image, but no field to provide alternative text for that image. This change adds that.

This is from a suggestion by a community member and I feel it makes for a sensible default.

### What to review

Would this be a useful property and is it added in a satisfactory way?

### Notes for release

- The main image field in the blog schema now includes an alternative text field.

<!--
A description of the change(s) that should be used in the release notes.
-->
