### PR TITLE
fix(datastores): memoize edit state in document store instance

### DIFF
--- a/packages/sanity/src/datastores/document/document-pair/editState.ts
+++ b/packages/sanity/src/datastores/document/document-pair/editState.ts
@@ -4,7 +4,6 @@ import {Observable} from 'rxjs'
 import {map, publishReplay, refCount, startWith} from 'rxjs/operators'
 import {HistoryStore} from '../../history'
 import {IdPair} from '../types'
-import {memoize} from '../utils/createMemoizer'
 import {operationArgs} from './operationArgs'
 import {isLiveEditEnabled} from './utils/isLiveEditEnabled'
 
@@ -18,37 +17,34 @@ export interface EditStateFor {
   ready: boolean
 }
 
-export const editState = memoize(
-  (
-    ctx: {
-      client: SanityClient
-      historyStore: HistoryStore
-      schema: Schema
-    },
-    idPair: IdPair,
-    typeName: string
-  ): Observable<EditStateFor> => {
-    const liveEdit = isLiveEditEnabled(ctx.schema, typeName)
-    return operationArgs(ctx, idPair, typeName).pipe(
-      map(({snapshots}) => ({
-        id: idPair.publishedId,
-        type: typeName,
-        draft: snapshots.draft,
-        published: snapshots.published,
-        liveEdit,
-        ready: true,
-      })),
-      startWith({
-        id: idPair.publishedId,
-        type: typeName,
-        draft: null,
-        published: null,
-        liveEdit,
-        ready: false,
-      }),
-      publishReplay(1),
-      refCount()
-    )
+export const editState = (
+  ctx: {
+    client: SanityClient
+    historyStore: HistoryStore
+    schema: Schema
   },
-  (_ctx, idPair, typeName) => idPair.publishedId + typeName
-)
+  idPair: IdPair,
+  typeName: string
+): Observable<EditStateFor> => {
+  const liveEdit = isLiveEditEnabled(ctx.schema, typeName)
+  return operationArgs(ctx, idPair, typeName).pipe(
+    map(({snapshots}) => ({
+      id: idPair.publishedId,
+      type: typeName,
+      draft: snapshots.draft,
+      published: snapshots.published,
+      liveEdit,
+      ready: true,
+    })),
+    startWith({
+      id: idPair.publishedId,
+      type: typeName,
+      draft: null,
+      published: null,
+      liveEdit,
+      ready: false,
+    }),
+    publishReplay(1),
+    refCount()
+  )
+}

--- a/packages/sanity/src/datastores/document/document-store.ts
+++ b/packages/sanity/src/datastores/document/document-store.ts
@@ -74,7 +74,8 @@ export function createDocumentStore({
 
   const caches = {
     pair: {
-      editOperations: new Map(),
+      editOperations: new Map<string, Observable<OperationsAPI>>(),
+      editState: new Map<string, Observable<EditStateFor>>(),
     },
   }
 
@@ -104,15 +105,26 @@ export function createDocumentStore({
       editOperations(publishedId, type) {
         const cache = caches.pair.editOperations
         const key = `${publishedId}:${type}`
-
-        if (!cache.has(key)) {
-          cache.set(key, editOperations(ctx, getIdPairFromPublished(publishedId), type))
+        const cached = cache.get(key)
+        if (cached) {
+          return cached
         }
 
-        return cache.get(key)
+        const ops = editOperations(ctx, getIdPairFromPublished(publishedId), type)
+        cache.set(key, ops)
+        return ops
       },
       editState(publishedId, type) {
-        return editState(ctx, getIdPairFromPublished(publishedId), type)
+        const cache = caches.pair.editState
+        const key = `${publishedId}:${type}`
+        const cached = cache.get(key)
+        if (cached) {
+          return cached
+        }
+
+        const state = editState(ctx, getIdPairFromPublished(publishedId), type)
+        cache.set(key, state)
+        return state
       },
       operationEvents(publishedId, type) {
         return operationEvents(getIdPairFromPublished(publishedId), type)


### PR DESCRIPTION
### Description

There is some global memoization going on in the document pair datastore utils. This isn't great:
1. Global state is a side effect. It can be hard to test these utils properly, and it could lead to memory leaks.
2. The keys used in the memoization is insufficient. For the edit state, it does not take into account changes in the schema - for instance `liveEdit`. It also does not take the source into account (projectId/dataset), which could lead to trouble in cases where document IDs and type names are shared (think production vs staging).

I want us to clean up all of these globally memoized things, but I figured I would open this initially so we could discuss/verify the approach.

The document store is already memoized with a key on `client, documentPreviewStore, historyStore, schema`, and I implemented a cache local to the document store for the edit state in particular. It looks like the listener gets unsubscribed as it should when constructing the document pair.

Thoughts? Is this the way to go, or should we address this differently?

### What to review

- Change in memoization
- To see the before/after:
  - `cd dev/starter-next-studio && yarn dev` - navigate to a document, then open `Studio.tsx` and change the schema type to be `liveEdit: true`. Watch how the footer does not reflect the change. Checkout this branch and try the same, and see it reflected.

### Notes for release

- Fixed certain schema properties not being reflected after a hot-module reload in Next.js/Webpack
