### PR TITLE
Ensure image previews in PT have an `alt` attribute

### DIFF
--- a/packages/@sanity/base/src/preview/components/SanityDefaultPreview.tsx
+++ b/packages/@sanity/base/src/preview/components/SanityDefaultPreview.tsx
@@ -104,7 +104,7 @@ export default class SanityDefaultPreview extends React.PureComponent<SanityDefa
     const imageUrl = value.imageUrl
     if (isString(imageUrl)) {
       const assetUrl = assetUrlBuilder(imageUrl.split('?')[0], dimensions)
-      return <img src={assetUrl} alt={isString(value.title) ? value.title : undefined} />
+      return <img src={assetUrl} alt={isString(value.title) ? value.title : ''} />
     }
     return undefined
   }


### PR DESCRIPTION
Editors can add images to portable text content. If they don’t add an alternative text to these images, these are rendered without an `alt` attribute. A missing `alt` attribute will trigger some screen-readers to read out the full URL of the image asset, which is undesired.

Related WCAG 2.1 criterion: [1.1.1: Non-text Content](https://www.w3.org/WAI/WCAG21/quickref/?versions=2.1#non-text-content)

---

I _think_ I found the right place, but it wasn’t easy because I have no idea how the Portable Text editor works under the hood. If I did hit the target, the problem occurs because we set `undefined` as a value for the `alt` prop, instead of an empty string. This causes React not to render the attribute at all.
