### PR TITLE
Connect the review changes button and its tooltip

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/document/statusBar/sparkline/ReviewChangesButton/ReviewChangesButton.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/statusBar/sparkline/ReviewChangesButton/ReviewChangesButton.tsx
@@ -48,6 +48,7 @@ const ReviewButton = React.forwardRef(function ReviewButton(
     <Tooltip
       portal
       disabled={status !== 'changes'}
+      id="review-changes-button"
       content={
         <Stack padding={3} space={3}>
           <Text size={1} weight="semibold">
@@ -62,6 +63,7 @@ const ReviewButton = React.forwardRef(function ReviewButton(
         justify="flex-start"
         tone={buttonProps?.tone}
         {...rest}
+        aria-describedby="review-changes-button"
         data-testid="review-changes-button"
         ref={ref}
       >


### PR DESCRIPTION

At the moment, the “review changes” button which indicates the edit status of the open document, is not semantically connected to the tooltip it triggers. This pull-request intends to address this by creating a relationship between both nodes using `aria-describedby`. 

<img width="197" alt="Screenshot 2022-08-26 at 13 21 41" src="https://user-images.githubusercontent.com/1889710/186892883-a9900091-ec56-483d-831f-44c4fefce60f.png">


**However**, this is not a perfect fix, because the tooltip is being added and removed from the DOM, but the `aria-describedby` attribute is not. This causes the toggle to reference an unknown ID with `aria-describedby` when the tooltip is not visible (since it’s the only time it’s actually in the DOM).

A simple fix for that would be for the toggle to be able to know if the tooltip is currently visible, but that doesn’t appear to be possible with the current tooltip component. I feel like the latter would benefit from a proper rewrite to use a hook or render props to convey its state to the toggle but that’s for another day.

After discussion with @hidde, we agreed that this would be marginally better than the current situation since some assistive technologies can pick up that newly formed relationship (but not all, due to the aforementioned issue).