### PR TITLE
Add an accessible name to the presence menu button

### DIFF
--- a/packages/@sanity/default-layout/src/navbar/presence/PresenceMenu.tsx
+++ b/packages/@sanity/default-layout/src/navbar/presence/PresenceMenu.tsx
@@ -45,7 +45,7 @@ const PRESENCE_MENU_POPOVER_PROPS: MenuButtonProps['popover'] = {
 }
 
 export function PresenceMenu(props: PresenceMenuProps) {
-  const {collapse, maxAvatars, projectId} = props
+  const {collapse, maxAvatars, projectId, label = "Who is here"} = props
   const presence = useGlobalPresence()
   const hasPresence = presence.length > 0
 
@@ -56,9 +56,10 @@ export function PresenceMenu(props: PresenceMenuProps) {
           icon={UsersIcon}
           mode="bleed"
           statusTone={hasPresence ? 'positive' : undefined}
+          aria-label={label}
         />
       ) : (
-        <Button mode="bleed" padding={1}>
+        <Button mode="bleed" padding={1} aria-label={label}>
           <AvatarStackCard>
             <AvatarStack maxLength={maxAvatars}>
               {presence.map((item) => (


### PR DESCRIPTION
The button that opens the presence menu (where one can see who else is interacting with the current document) does not have any accessible name. This is a problem for people using screen-readers. This pull-request addresses this issue by adding a customizable label.

<img width="1792" alt="Screenshot 2022-08-26 at 13 33 05" src="https://user-images.githubusercontent.com/1889710/186894683-bad95742-af55-4898-a45a-d219439560a6.png">

Related WCAG 2.1 SC: [4.1.2 Name, Role and Value](https://www.w3.org/WAI/WCAG21/quickref/?versions=2.1#name-role-value)