### PR TITLE
Remove unnecessary tabindex attribute

### DIFF
--- a/packages/@sanity/desk-tool/src/components/pane/PaneHeader.tsx
+++ b/packages/@sanity/desk-tool/src/components/pane/PaneHeader.tsx
@@ -74,7 +74,7 @@ export const PaneHeader = forwardRef(function PaneHeader(
                   <ReferencedDocHeading totalReferenceCount={totalReferenceCount} title={title} />
                 ) : (
                   <Box paddingBottom={3}>
-                    <TitleText tabIndex={0} textOverflow="ellipsis" weight="semibold">
+                    <TitleText textOverflow="ellipsis" weight="semibold">
                       {title}
                     </TitleText>
                   </Box>


### PR DESCRIPTION
There is no reason for that title to be focusable. It’s not an interactive element and should not have a `tabindex` attribute.

If it needs to be focused programmatically (which it shouldn’t but we never know), `tabindex="-1"` should be used instead so it remains focusable via `.focus()`. Let me know if I should update the PR. :)