### PR TITLE
fix(form): handle number and boolean changes in `elementProps`

### DIFF
--- a/packages/sanity/src/form/inputs/BooleanInput.tsx
+++ b/packages/sanity/src/form/inputs/BooleanInput.tsx
@@ -1,9 +1,6 @@
-/* eslint-disable import/no-unresolved */
-
-import React, {useCallback} from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import {Box, Card, Checkbox, Flex, Switch} from '@sanity/ui'
-import {set} from '../patch'
 import {BooleanInputProps} from '../types'
 import {FormFieldHeaderText} from '../components/formField/FormFieldHeaderText'
 import {FormFieldStatus} from '../components/formField/FormFieldStatus'
@@ -17,15 +14,8 @@ const ZeroLineHeightBox = styled(Box)`
 `
 
 export function BooleanInput(props: BooleanInputProps) {
-  const {id, value, schemaType, readOnly, onChange, elementProps} = props
+  const {id, value, schemaType, readOnly, elementProps} = props
   const layout = schemaType.options?.layout || 'switch'
-
-  const handleChange = useCallback(
-    (event: React.SyntheticEvent<HTMLInputElement>) => {
-      onChange(set(event.currentTarget.checked))
-    },
-    [onChange]
-  )
 
   const indeterminate = typeof value !== 'boolean'
   const checked = value || false
@@ -39,7 +29,6 @@ export function BooleanInput(props: BooleanInputProps) {
           <LayoutSpecificInput
             label={schemaType.title}
             {...elementProps}
-            onChange={handleChange}
             indeterminate={indeterminate}
             checked={checked}
             style={{margin: -4}}

--- a/packages/sanity/test/form/renderInput.tsx
+++ b/packages/sanity/test/form/renderInput.tsx
@@ -82,7 +82,7 @@ export async function renderInput(props: {
   const onBlur = jest.fn()
   const onChange = jest.fn()
   const onFocus = jest.fn()
-  const onDOMChange = jest.fn()
+  const onDOMChange = jest.fn((...args) => onChange(...args))
 
   const onPathBlur = jest.fn()
   const onPathFocus = jest.fn()


### PR DESCRIPTION
### Description

The `onChange` handler of `elementProps` did not account for non-string types, emitting patches that used strings instead of number/boolean. This PR makes the change handler check the schema type for the item in question and emits patches of the corresponding type, using `valueAsNumber` for numbers and `checked` for booleans. Empty strings and `NaN` values are treated as "unset this field".

Also removes the custom `onChange` handler from the boolean input, which seems like a win?

### What to review

That all primitive inputs work as expected (numbers, strings, booleans)

### Notes for release

None, since the `elementProps` change has yet to be released.
