### PR TITLE
fix(hooks): short-circuit invalid dates in `useTimeAgo` hook

### DIFF
--- a/packages/sanity/src/hooks/useTimeAgo.ts
+++ b/packages/sanity/src/hooks/useTimeAgo.ts
@@ -48,9 +48,19 @@ export function useTimeAgo(time: Date | string, {minimal, agoSuffix}: TimeAgoOpt
 }
 
 function formatRelativeTime(date: Date | string, opts: TimeAgoOpts = {}): TimeSpec {
-  const now = Date.now()
   const parsedDate = date instanceof Date ? date : new Date(date)
 
+  // Invalid date? Return empty timestamp and inifinite refresh interval, to save us from
+  // continuously trying to format an invalid date. The `useEffect` calls in the hook will
+  // trigger a re-evaluation of the timestamp when the date changes, so this is safe.
+  if (!parsedDate.getTime()) {
+    return {
+      timestamp: '',
+      refreshInterval: +Infinity,
+    }
+  }
+
+  const now = Date.now()
   const diffMonths = differenceInMonths(now, parsedDate)
   const diffYears = differenceInYears(now, parsedDate)
 


### PR DESCRIPTION
### Description

In some cases we're sending an empty or invalid string to the `useTimeAgo` hook - usually because of the rule of invocation on hooks - we can't conditionally call it, so if we don't have a date to pass it, we still need to call it. 

The result of this is that we would return "just now" as the timestamp, and every 5 seconds would update the value with... the same value. This is not ideal, since it causes more re-renders than necessary.

This PR instead returns an empty string (could debate whether or not this is the right choice, but showing "just now" also seems incorrect in my opinion), and an infinite refresh interval, meaning no timer will be set to update it while the date is invalid.

### Notes for release

None. Transparent for end users.
