### PR TITLE
fix(base): defer connection to presence client

### DIFF
--- a/packages/@sanity/base/src/client/bifur.ts
+++ b/packages/@sanity/base/src/client/bifur.ts
@@ -1,10 +1,13 @@
 import {fromUrl} from '@sanity/bifur-client'
+import {memoize} from 'lodash'
 import {authToken$} from '../datastores/authState'
 import {getVersionedClient} from './versionedClient'
 
-const bifurVersionedClient = getVersionedClient('2022-06-30')
-const dataset = bifurVersionedClient.config().dataset
+export const getBifur = memoize(() => {
+  const bifurVersionedClient = getVersionedClient('2022-06-30')
+  const dataset = bifurVersionedClient.config().dataset
 
-const url = bifurVersionedClient.getUrl(`/socket/${dataset}`).replace(/^http/, 'ws')
+  const url = bifurVersionedClient.getUrl(`/socket/${dataset}`).replace(/^http/, 'ws')
 
-export const bifur = fromUrl(url, {token$: authToken$})
+  return fromUrl(url, {token$: authToken$})
+})

--- a/packages/@sanity/base/src/datastores/presence/presence-store.ts
+++ b/packages/@sanity/base/src/datastores/presence/presence-store.ts
@@ -23,7 +23,7 @@ import {nanoid} from 'nanoid'
 import {User} from '@sanity/types'
 import userStore from '../user'
 
-import {bifur} from '../../client/bifur'
+import {getBifur} from '../../client/bifur'
 import {connectionStatus$} from '../connection-status/connection-status-store'
 import {debugParams$} from '../debugParams'
 import {
@@ -67,7 +67,7 @@ function setSessionId(id) {
 
 export const SESSION_ID = getSessionId() || setSessionId(generate())
 
-const [presenceEvents$, sendMessage] = createBifurTransport(bifur, SESSION_ID)
+const [presenceEvents$, sendMessage] = createBifurTransport(getBifur, SESSION_ID)
 
 const currentLocation$ = new BehaviorSubject<PresenceLocation[]>([])
 const locationChange$ = currentLocation$.pipe(distinctUntilChanged())


### PR DESCRIPTION
### Description

Hi all 👋 
Bjorge was kind enough to help me with a bug  regarding presence when people are in different datasets and go through the parts of the code that would be affected.

#### The bug
A project has two datasets: staging and production
User A is in a document in the production dataset and user B is in a document in the staging dataset.

User A goes to the presence menu, finds user B and attempts to travel to the document where they are only to be met with an error

<img width="688" alt="image" src="https://user-images.githubusercontent.com/6951139/188085107-5acfa184-c773-4151-b36e-81f24435c8b9.png">

#### The solution

To fix the actual navigation would be a large piece of work since the navigation/resolution of the document don't consider the dataset that the user is in. 
So, the solution for now is to hide users that are not in the same dataset and this way they won't appear on the list or be allowed to be navigated to if you are not on the same dataset as them. 

example:
public dataset on test project
<img width="1228" alt="image" src="https://user-images.githubusercontent.com/6951139/188088232-fb1e786c-e067-443e-bafe-72cddfbbb404.png">

private dataset on test project
<img width="1313" alt="image" src="https://user-images.githubusercontent.com/6951139/188088376-b74b831b-a5a9-46a8-aff3-1419ecc85151.png">

### What to review

- Double check that you can still navigate to documents from the presence menu as usual
- Double check that if a user is in a different dataset that they won't appear on the list 

### Notes for release

Presence list will now only show users that are in the same dataset as the logged in user 
