### PR TITLE
feat(sanity): implement custom components API

### DIFF
--- a/cypress/integration/config/componentsApi.test.js
+++ b/cypress/integration/config/componentsApi.test.js
@@ -1,0 +1,113 @@
+describe('Studio config: components API', () => {
+  beforeEach(() => {
+    cy.visit('/custom-components/content')
+  })
+
+  // createConfig
+  describe('createConfig', () => {
+    it('custom Layout in createConfig is displayed with default Layout', () => {
+      cy.get('[data-testid="custom-layout-config"]')
+        .find('[data-testid="studio-layout"]')
+        .should('be.visible')
+    })
+
+    it('custom Logo in createConfig is displayed with value from context in custom Layout', () => {
+      cy.get('[data-testid="navbar-root-link"]')
+        .find('[data-testid="custom-logo-config"]')
+        .should('be.visible')
+
+      cy.get('[data-testid="navbar-root-link"]')
+        .find('[data-testid="custom-logo-config"]')
+        .contains('Text from context')
+    })
+
+    it('custom Navbar in createConfig is displayed with default Navbar', () => {
+      cy.get('[data-testid="custom-navbar-config"]')
+        .find('[data-testid="navbar"]')
+        .should('be.visible')
+    })
+
+    it('custom ToolMenu in createConfig is displayed with default ToolMenu', () => {
+      cy.get('[data-testid="custom-tool-menu-config"]')
+        .find('[data-testid="tool-collapse-menu"]')
+        .should('be.visible')
+    })
+  })
+
+  // createPlugin
+  describe('createPlugin', () => {
+    it('custom Layout in createPlugin is displayed with Layout in createConfig', () => {
+      cy.get('[data-testid="custom-layout-plugin"]')
+        .find('[data-testid="custom-layout-config"]')
+        .find('[data-testid="studio-layout"]')
+        .should('be.visible')
+    })
+
+    it('custom Logo in createPlugin is displayed with Logo in createConfig', () => {
+      cy.get('[data-testid="navbar-root-link"]')
+        .find('[data-testid="custom-logo-plugin"]')
+        .find('[data-testid="custom-logo-config"]')
+        .should('be.visible')
+
+      cy.get('[data-testid="navbar-root-link"]')
+        .find('[data-testid="custom-logo-plugin"]')
+        .find('[data-testid="custom-logo-config"]')
+        .contains('Text from context')
+    })
+
+    it('custom Navbar in createPlugin is displayed with Navbar in createConfig', () => {
+      cy.get('[data-testid="custom-navbar-plugin"]')
+        .find('[data-testid="custom-navbar-config"]')
+        .find('[data-testid="navbar"]')
+        .should('be.visible')
+    })
+
+    it('custom ToolMenu in createPlugin is displayed with ToolMenu in createConfig', () => {
+      cy.get('[data-testid="custom-tool-menu-plugin"]')
+        .find('[data-testid="custom-tool-menu-config"]')
+        .find('[data-testid="tool-collapse-menu"]')
+        .should('be.visible')
+    })
+  })
+
+  // createPlugin with plugins
+  describe('createPlugin with plugins', () => {
+    it('custom Layout in createPlugin is displayed with Layout in plugin', () => {
+      cy.get('[data-testid="custom-layout-plugin-2"]')
+        .find('[data-testid="custom-layout-plugin"]')
+        .find('[data-testid="custom-layout-config"]')
+        .find('[data-testid="studio-layout"]')
+        .should('be.visible')
+    })
+
+    it('custom Logo in createPlugin is displayed with Logo in plugin', () => {
+      cy.get('[data-testid="navbar-root-link"]')
+        .find('[data-testid="custom-logo-plugin-2"]')
+        .find('[data-testid="custom-logo-plugin"]')
+        .find('[data-testid="custom-logo-config"]')
+        .should('be.visible')
+
+      cy.get('[data-testid="navbar-root-link"]')
+        .find('[data-testid="custom-logo-plugin-2"]')
+        .find('[data-testid="custom-logo-plugin"]')
+        .find('[data-testid="custom-logo-config"]')
+        .contains('Text from context')
+    })
+
+    it('custom Navbar in createPlugin is displayed with Navbar in plugin', () => {
+      cy.get('[data-testid="custom-navbar-plugin-2"]')
+        .find('[data-testid="custom-navbar-plugin"]')
+        .find('[data-testid="custom-navbar-config"]')
+        .find('[data-testid="navbar"]')
+        .should('be.visible')
+    })
+
+    it('custom ToolMenu in createPlugin is displayed with ToolMenu in plugin', () => {
+      cy.get('[data-testid="custom-tool-menu-plugin-2"]')
+        .find('[data-testid="custom-tool-menu-plugin"]')
+        .find('[data-testid="custom-tool-menu-config"]')
+        .find('[data-testid="tool-collapse-menu"]')
+        .should('be.visible')
+    })
+  })
+})

--- a/dev/test-studio/plugins/customComponents.tsx
+++ b/dev/test-studio/plugins/customComponents.tsx
@@ -1,0 +1,95 @@
+import React, {useContext, createContext} from 'react'
+import {Box, Card, Text} from '@sanity/ui'
+import {createPlugin} from 'sanity'
+
+interface ComponentProps {
+  children: React.ReactNode
+}
+
+export const customComponentsPlugin2 = createPlugin({
+  name: 'custom-components-plugin-2',
+  studio: {
+    components: {
+      Layout: ({children}) => (
+        <Box data-testid="custom-layout-plugin-2" height="fill">
+          {children}
+        </Box>
+      ),
+      Logo: ({children}) => <Box data-testid="custom-logo-plugin-2">{children}</Box>,
+      Navbar: ({children}) => <Box data-testid="custom-navbar-plugin-2">{children}</Box>,
+      ToolMenu: ({children}) => <Box data-testid="custom-tool-menu-plugin-2">{children}</Box>,
+    },
+  },
+})
+
+export const customComponentsPlugin = createPlugin({
+  name: 'custom-components-plugin',
+  plugins: [customComponentsPlugin2()],
+  studio: {
+    components: {
+      Layout: ({children}) => (
+        <Box data-testid="custom-layout-plugin" height="fill">
+          {children}
+        </Box>
+      ),
+      Logo: ({children}) => <Box data-testid="custom-logo-plugin">{children}</Box>,
+      Navbar: ({children}) => <Box data-testid="custom-navbar-plugin">{children}</Box>,
+      ToolMenu: ({children}) => <Box data-testid="custom-tool-menu-plugin">{children}</Box>,
+    },
+  },
+})
+
+// Components used in createConfig
+const LogoTextContext = createContext('')
+const useLogoText = () => useContext(LogoTextContext)
+
+export function LayoutConfigComponent(props: ComponentProps) {
+  return (
+    <LogoTextContext.Provider value={'Text from context'}>
+      <Box height="fill" data-testid="custom-layout-config">
+        {props.children}
+      </Box>
+    </LogoTextContext.Provider>
+  )
+}
+
+export function LogoConfigComponent() {
+  const text = useLogoText()
+
+  return (
+    <Text weight="semibold" size={1} data-testid="custom-logo-config">
+      {text}
+    </Text>
+  )
+}
+
+export function NavbarConfigComponent(props: ComponentProps) {
+  return (
+    <Card data-testid="custom-navbar-config">
+      <Card paddingY={4} paddingX={3} tone="primary" sizing="border">
+        <Text>
+          This is a banner from <code>{`studio.components.Navbar`}</code> in{' '}
+          <code>{`createConfig`}</code>
+        </Text>
+      </Card>
+
+      {props.children}
+    </Card>
+  )
+}
+
+export function ToolMenuConfigComponent(props: ComponentProps) {
+  return (
+    <Card
+      data-testid="custom-tool-menu-config"
+      paddingX={1}
+      radius={2}
+      scheme="light"
+      shadow={1}
+      sizing="border"
+      tone="primary"
+    >
+      {props.children}
+    </Card>
+  )
+}

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -1,14 +1,21 @@
 //import {codeInput} from '@sanity/code-input'
-import {BookIcon} from '@sanity/icons'
+import {BookIcon, RobotIcon} from '@sanity/icons'
 import {visionTool} from '@sanity/vision'
 import {createConfig, createPlugin} from 'sanity'
 import {deskTool} from 'sanity/desk'
 import {imageAssetSource} from './assetSources'
 import {Branding} from './components/Branding'
-import {CustomMarkers} from './components/formBuilder/CustomMarkers'
-import {Markers} from './components/formBuilder/Markers'
+// import {CustomMarkers} from './components/formBuilder/CustomMarkers'
+// import {Markers} from './components/formBuilder/Markers'
 import {resolveDocumentActions as documentActions} from './documentActions'
 import {resolveInitialValueTemplates} from './initialValueTemplates'
+import {
+  customComponentsPlugin,
+  LayoutConfigComponent,
+  LogoConfigComponent,
+  NavbarConfigComponent,
+  ToolMenuConfigComponent,
+} from './plugins/customComponents'
 import {languageFilter} from './plugins/language-filter'
 import {schemaTypes} from './schema'
 import {defaultDocumentNode, structure, newDocumentOptions} from './structure'
@@ -20,16 +27,7 @@ const sharedSettings = createPlugin({
     types: schemaTypes,
     templates: resolveInitialValueTemplates,
   },
-  // navbar: {
-  //   components: {
-  //     ToolMenu: ToolMenu,
-  //   },
-  // },
   form: {
-    // unstable: {
-    //   CustomMarkers,
-    //   Markers,
-    // },
     image: {
       assetSources: [imageAssetSource],
     },
@@ -39,12 +37,7 @@ const sharedSettings = createPlugin({
     newDocumentOptions,
   },
   plugins: [
-    // codeInput(),
     deskTool({
-      // TODO:
-      // components: {
-      //   LanguageFilter,
-      // },
       icon: BookIcon,
       name: 'content',
       title: 'Content',
@@ -81,19 +74,44 @@ export default createConfig([
   {
     name: 'default',
     title: 'Test Studio',
-    logo: Branding,
     projectId: 'ppsg7ml5',
     dataset: 'test',
     plugins: [sharedSettings()],
     basePath: '/test',
+    studio: {
+      components: {
+        Logo: Branding,
+      },
+    },
   },
   {
     name: 'playground',
     title: 'Test Studio (playground)',
-    logo: Branding,
     projectId: 'ppsg7ml5',
     dataset: 'playground',
     plugins: [sharedSettings()],
     basePath: '/playground',
+    studio: {
+      components: {
+        Logo: Branding,
+      },
+    },
+  },
+  {
+    name: 'custom-components',
+    title: 'Test Studio (custom-components)',
+    icon: RobotIcon,
+    projectId: 'ppsg7ml5',
+    dataset: 'test',
+    basePath: '/custom-components',
+    plugins: [sharedSettings(), customComponentsPlugin()],
+    studio: {
+      components: {
+        Layout: LayoutConfigComponent,
+        Logo: LogoConfigComponent,
+        Navbar: NavbarConfigComponent,
+        ToolMenu: ToolMenuConfigComponent,
+      },
+    },
   },
 ])

--- a/packages/sanity/src/components/collapseMenu/CollapseMenu.tsx
+++ b/packages/sanity/src/components/collapseMenu/CollapseMenu.tsx
@@ -76,6 +76,7 @@ export const CollapseMenu = forwardRef(function CollapseMenu(
     gap,
     menuButtonProps,
     onMenuClose,
+    ...rest
   } = props
   const [rootEl, setRootEl] = useState<HTMLDivElement | null>(null)
   const [hiddenRowEl, setHiddenRowEl] = useState<HTMLDivElement | null>(null)
@@ -169,7 +170,14 @@ export const CollapseMenu = forwardRef(function CollapseMenu(
   }
 
   return (
-    <OuterFlex align="center" data-ui="CollapseMenu" overflow="hidden" sizing="border" ref={ref}>
+    <OuterFlex
+      align="center"
+      data-ui="CollapseMenu"
+      overflow="hidden"
+      sizing="border"
+      ref={ref}
+      {...rest}
+    >
       <RootFlex direction="column" flex={1} justify="center" ref={setRootEl}>
         {/* Content */}
         <RowFlex gap={gap}>

--- a/packages/sanity/src/config/prepareConfig.ts
+++ b/packages/sanity/src/config/prepareConfig.ts
@@ -45,16 +45,9 @@ import {_createRenderField} from './form/_renderField'
 import {_createRenderInput} from './form/_renderInput'
 import {_createRenderItem} from './form/_renderItem'
 import {_createRenderPreview} from './form/_renderPreview'
+import {resolveComponentProperty} from './resolveComponentProperty'
 
 type InternalSource = WorkspaceSummary['__internal']['sources'][number]
-
-function normalizeLogo(
-  logo: React.ComponentType | React.ElementType | undefined
-): JSX.Element | undefined {
-  if (isValidElementType(logo)) return createElement(logo)
-  if (isValidElement(logo)) return logo
-  return undefined
-}
 
 function normalizeIcon(
   icon: React.ComponentType | React.ElementType | undefined,
@@ -163,7 +156,6 @@ export function prepareConfig(config: Config): PreparedConfig {
         basePath: rootSource.basePath || '/',
         dataset: rootSource.dataset,
         schema: resolvedSources[0].schema,
-        logo: normalizeLogo(rootSource.logo),
         icon: normalizeIcon(
           rootSource.icon,
           title,
@@ -386,6 +378,34 @@ function resolveSource({
     authenticated,
     templates,
     auth,
+    studio: {
+      components: {
+        Layout: ({children}) =>
+          resolveComponentProperty({
+            children,
+            config,
+            propertyName: 'Layout',
+          }),
+        Logo: ({children}) =>
+          resolveComponentProperty({
+            children,
+            config,
+            propertyName: 'Logo',
+          }),
+        Navbar: ({children}) =>
+          resolveComponentProperty({
+            children,
+            config,
+            propertyName: 'Navbar',
+          }),
+        ToolMenu: ({children}) =>
+          resolveComponentProperty({
+            children,
+            config,
+            propertyName: 'ToolMenu',
+          }),
+      },
+    },
     document: {
       actions: (partialContext) =>
         resolveConfigProperty({

--- a/packages/sanity/src/config/resolveComponentProperty.tsx
+++ b/packages/sanity/src/config/resolveComponentProperty.tsx
@@ -1,0 +1,51 @@
+import React, {Fragment} from 'react'
+import {
+  PluginOptions,
+  ResolveComponentReturnType,
+  SourceOptions,
+  StudioComponentOptionNames,
+} from './types'
+
+const EMPTY_ARRAY: [] = []
+
+function getComponentsFromPlugins(
+  plugins: PluginOptions[],
+  propertyName: StudioComponentOptionNames
+): (ResolveComponentReturnType | undefined)[] {
+  return plugins
+    ?.map((p) => {
+      const nested = getComponentsFromPlugins(p?.plugins || EMPTY_ARRAY, propertyName)
+
+      return [p?.studio?.components?.[propertyName], ...nested]
+    })
+    .flat()
+    .filter(Boolean)
+}
+
+interface ResolveComponentPropertyProps {
+  children: React.ReactElement
+  config: SourceOptions
+  propertyName: StudioComponentOptionNames
+}
+
+export function resolveComponentProperty(props: ResolveComponentPropertyProps) {
+  const {config, propertyName, children} = props
+  const pluginComponents = getComponentsFromPlugins(config?.plugins || EMPTY_ARRAY, propertyName)
+
+  const ConfigComponent = config.studio?.components?.[propertyName] || Fragment
+  const defaultComponent = <ConfigComponent>{children}</ConfigComponent>
+
+  if (pluginComponents.length > 0) {
+    return (
+      <Fragment>
+        {pluginComponents.reduce((prev, curr) => {
+          const CurrentPluginElement = curr || Fragment
+
+          return <CurrentPluginElement>{prev}</CurrentPluginElement>
+        }, defaultComponent)}
+      </Fragment>
+    )
+  }
+
+  return defaultComponent
+}

--- a/packages/sanity/src/config/types.ts
+++ b/packages/sanity/src/config/types.ts
@@ -11,7 +11,7 @@ import type {
 import type React from 'react'
 import type {Observable} from 'rxjs'
 import type {BifurClient} from '@sanity/bifur-client'
-import {ComponentType, ReactNode} from 'react'
+import {ComponentType, ReactElement, ReactNode} from 'react'
 import type {
   FormBuilderArrayFunctionComponent,
   FormBuilderCustomMarkersComponent,
@@ -194,6 +194,23 @@ export type DocumentBadgesResolver = ComposableOption<
   DocumentBadgesContext
 >
 
+export type StudioComponentOptionNames = 'Layout' | 'Logo' | 'Navbar' | 'ToolMenu'
+export type ResolveComponentReturnType = (props: {children: ReactElement}) => ReactElement
+
+interface StudioComponentsPluginOptions {
+  Layout?: ResolveComponentReturnType
+  Logo?: ResolveComponentReturnType
+  Navbar?: ResolveComponentReturnType
+  ToolMenu?: ResolveComponentReturnType
+}
+
+interface StudioComponentsConfigOptions {
+  Layout: ResolveComponentReturnType
+  Logo: ResolveComponentReturnType
+  Navbar: ResolveComponentReturnType
+  ToolMenu: ResolveComponentReturnType
+}
+
 export interface PluginOptions {
   name: string
   plugins?: PluginOptions[]
@@ -203,6 +220,9 @@ export interface PluginOptions {
   document?: DocumentPluginOptions
   tools?: Tool[] | ComposableOption<Tool[], ConfigContext>
   form?: SanityFormConfig
+  studio?: {
+    components?: StudioComponentsPluginOptions
+  }
 }
 
 export type ConfigPropertyReducer<TValue, TContext> = (
@@ -222,13 +242,7 @@ export type Plugin<TOptions = void> = (options: TOptions) => PluginOptions
 export interface WorkspaceOptions extends SourceOptions {
   basePath: string
   subtitle?: string
-  logo?: ComponentType
   icon?: ComponentType
-  navbar?: {
-    components?: {
-      ToolMenu: ComponentType<ToolMenuProps>
-    }
-  }
   theme?: StudioTheme
   /**
    * @alpha
@@ -296,6 +310,11 @@ export interface Source {
       props: PartialContext<_DocumentLanguageFilterContext>
     ) => _DocumentLanguageFilterComponent[]
   }
+
+  studio: {
+    components: StudioComponentsConfigOptions
+  }
+
   form: {
     file: {
       assetSources: AssetSource[]
@@ -330,7 +349,6 @@ export interface WorkspaceSummary {
   type: 'workspace-summary'
   name: string
   title: string
-  logo?: React.ReactNode
   icon: React.ReactNode
   subtitle?: string
   basePath: string
@@ -360,13 +378,7 @@ export interface Workspace extends Omit<Source, 'type'> {
   type: 'workspace'
   basePath: string
   subtitle?: string
-  logo?: React.ReactNode
   icon: React.ReactNode
-  navbar?: {
-    components?: {
-      ToolMenu?: ComponentType<ToolMenuProps>
-    }
-  }
   /**
    * @alpha
    */

--- a/packages/sanity/src/studio/StudioLayout.tsx
+++ b/packages/sanity/src/studio/StudioLayout.tsx
@@ -1,6 +1,14 @@
 import {Box, Button, Card, Code, ErrorBoundary, Flex, Heading, Spinner} from '@sanity/ui'
 import {startCase} from 'lodash'
-import React, {createElement, Suspense, useCallback, useEffect, useMemo, useState} from 'react'
+import React, {
+  createElement,
+  Fragment,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 import styled from 'styled-components'
 import {RouteScope, useRouter} from '../router'
 import {Navbar} from './components'
@@ -17,7 +25,7 @@ const SearchFullscreenPortalCard = styled(Card)`
 
 export function StudioLayout() {
   const {state: routerState} = useRouter()
-  const {name, title, tools} = useWorkspace()
+  const {name, title, tools, studio} = useWorkspace()
   const activeToolName = typeof routerState.tool === 'string' ? routerState.tool : undefined
   const activeTool = tools.find((tool) => tool.name === activeToolName)
   const [toolError, setToolError] = useState<{error: Error; info: React.ErrorInfo} | null>(null)
@@ -52,12 +60,22 @@ export function StudioLayout() {
     setToolError(null)
   }, [])
 
+  const navbar = useMemo(
+    () =>
+      studio.components.Navbar({
+        children: (
+          <Navbar
+            fullscreenSearchPortalEl={fullscreenSearchPortalEl}
+            onSearchOpenChange={handleSearchOpenChange}
+          />
+        ),
+      }),
+    [fullscreenSearchPortalEl, handleSearchOpenChange, studio.components]
+  )
+
   return (
-    <Flex data-ui="ToolScreen" direction="column" height="fill">
-      <Navbar
-        onSearchOpenChange={handleSearchOpenChange}
-        fullscreenSearchPortalEl={fullscreenSearchPortalEl}
-      />
+    <Flex data-testid="studio-layout" data-ui="ToolScreen" direction="column" height="fill">
+      {navbar}
 
       {tools.length === 0 && <NoToolsScreen />}
 

--- a/packages/sanity/src/studio/StudioLayoutWrapper.tsx
+++ b/packages/sanity/src/studio/StudioLayoutWrapper.tsx
@@ -1,0 +1,21 @@
+import React, {useMemo} from 'react'
+import {useWorkspace} from './workspace'
+
+interface StudioLayoutWrapperProps {
+  children: React.ReactNode
+}
+
+export function StudioLayoutWrapper(props: StudioLayoutWrapperProps) {
+  const {children} = props
+  const {studio} = useWorkspace()
+
+  const layout = useMemo(
+    () =>
+      studio.components.Layout({
+        children: <>{children}</>,
+      }),
+    [studio, children]
+  )
+
+  return <>{layout}</>
+}

--- a/packages/sanity/src/studio/StudioProvider.tsx
+++ b/packages/sanity/src/studio/StudioProvider.tsx
@@ -25,6 +25,7 @@ import {
 import {WorkspacesProvider} from './workspaces'
 import {AuthBoundary} from './AuthBoundary'
 import {Z_OFFSET} from './constants'
+import {StudioLayoutWrapper} from './StudioLayoutWrapper'
 
 Refractor.registerLanguage(bash)
 Refractor.registerLanguage(javascript)
@@ -75,7 +76,9 @@ export function StudioProvider({
                       LoadingComponent={LoadingScreen}
                       ConfigErrorsComponent={ConfigErrorsScreen}
                     >
-                      <ResourceCacheProvider>{children}</ResourceCacheProvider>
+                      <ResourceCacheProvider>
+                        <StudioLayoutWrapper>{children}</StudioLayoutWrapper>
+                      </ResourceCacheProvider>
                     </WorkspaceLoader>
                   </ConditionalAuthBoundary>
                 </UserColorManagerProvider>

--- a/packages/sanity/src/studio/components/navbar/NavDrawer.tsx
+++ b/packages/sanity/src/studio/components/navbar/NavDrawer.tsx
@@ -1,12 +1,12 @@
 import {Layer, Card, Flex, Text, Box, Button, Stack, useGlobalKeyDown} from '@sanity/ui'
 import {CloseIcon, LeaveIcon} from '@sanity/icons'
-import React, {memo, useEffect, useState} from 'react'
+import React, {memo, useEffect, useMemo, useState} from 'react'
 import styled from 'styled-components'
 import {UserAvatar} from '../../../components/UserAvatar'
 import {useWorkspace} from '../../workspace'
 import {useRovingFocus} from '../../../components/rovingFocus'
 import {Tool} from '../../../config'
-import {ToolMenu as DefaultToolMenu} from './tools/ToolMenu'
+import {ToolMenu, ToolMenuProps} from './tools/ToolMenu'
 import {WorkspaceMenuButton} from './workspace'
 
 const Root = styled(Layer)`
@@ -62,9 +62,7 @@ export const NavDrawer = memo(function NavDrawer(props: NavDrawerProps) {
   const [innerCardElement, setInnerCardElement] = useState<HTMLDivElement | null>(null)
   const tabIndex = isOpen ? 0 : -1
 
-  const {currentUser, navbar, auth} = useWorkspace()
-
-  const {ToolMenu = DefaultToolMenu} = navbar?.components || {}
+  const {currentUser, auth, studio} = useWorkspace()
 
   useRovingFocus({
     rootElement: innerCardElement,
@@ -82,6 +80,22 @@ export const NavDrawer = memo(function NavDrawer(props: NavDrawerProps) {
       closeButtonElement?.focus()
     }
   }, [closeButtonElement, isOpen])
+
+  const toolMenu = useMemo(
+    () =>
+      studio.components.ToolMenu({
+        children: (
+          <ToolMenu
+            activeToolName={activeToolName}
+            closeDrawer={onClose}
+            context="drawer"
+            isDrawerOpen={isOpen}
+            tools={tools}
+          />
+        ),
+      }),
+    [activeToolName, isOpen, onClose, studio.components, tools]
+  )
 
   return (
     <Root>
@@ -126,13 +140,7 @@ export const NavDrawer = memo(function NavDrawer(props: NavDrawerProps) {
         </Card>
 
         <Box flex="auto" overflow="auto" padding={[3, 3, 4]}>
-          <ToolMenu
-            activeToolName={activeToolName}
-            closeDrawer={onClose}
-            context="drawer"
-            isDrawerOpen={isOpen}
-            tools={tools}
-          />
+          {toolMenu}
         </Box>
 
         {auth.logout && (

--- a/packages/sanity/src/studio/components/navbar/tools/ToolCollapseMenu.tsx
+++ b/packages/sanity/src/studio/components/navbar/tools/ToolCollapseMenu.tsx
@@ -63,7 +63,12 @@ export function ToolCollapseMenu(props: ToolCollapseMenuProps) {
   )
 
   return (
-    <CollapseMenu gap={1} menuButtonProps={menuButtonProps} ref={setCollapseMenuEl}>
+    <CollapseMenu
+      data-testid="tool-collapse-menu"
+      gap={1}
+      menuButtonProps={menuButtonProps}
+      ref={setCollapseMenuEl}
+    >
       {children}
     </CollapseMenu>
   )

--- a/packages/sanity/src/studio/components/navbar/tools/ToolVerticalMenu.tsx
+++ b/packages/sanity/src/studio/components/navbar/tools/ToolVerticalMenu.tsx
@@ -16,7 +16,7 @@ export function ToolVerticalMenu(props: ToolVerticalMenuProps) {
 
   return useMemo(
     () => (
-      <Stack as="ul" space={[1, 2]}>
+      <Stack as="ul" space={[1, 2]} data-testid="tool-vertical-menu">
         {tools.map((tool) => {
           const title = tool?.title || startCase(tool.name) || undefined
 


### PR DESCRIPTION
### Description
This PR implements a new custom components API. It is intended to be used when you want to replace, or wrap, existing components in the studio. This PR implements support for `Layout`, `Navbar`, `ToolMenu` and `Logo` – but in the future more components will be available. Each field in `studio.components` returns `children` which is the default component. This makes it easy to e.g. add a banner above `Navbar`, or wrap `Layout` with your own React contexts. 

```ts
const config = createConfig({
  ...,
  studio: {
    components: {
      Layout: MyLayout,
      Logo: MyLogo,
      Navbar: MyNavbar,
      ToolMenu: MyToolMenu
    }
  }
})
```

Note: `children` does not always have to be the default component – it can also be the result of a previous component customisation done in e.g. a plugin. See example below:

```ts
// Plugin 1
const myFirstPlugin = createPlugin({
  name: 'my-first-plugin',
  studio: {
    components: {
      Navbar: MyFirstPluginNavbar, // <-- children here is MySecondPluginNavbar
    },
  },
})

// Plugin 2
const mySecondPlugin = createPlugin({
  name: 'my-second-plugin'.
  plugins: [myFirstPlugin()],
  studio: {
    components: {
      Navbar: MySecondPluginNavbar, // <-- children here is MyConfigNavbar
    },
  },
})

// Config
const myConfig = createConfig({
  ...,
  name: 'my-config',
  plugins: [mySecondPlugin()],
  studio: {
    components: {
      Navbar: MyConfigNavbar, // <-- children here is the default Navbar
    },
  },
})

```


### What to review
- General code review
- Do you see any risks with the implementation, e.g. performance? If so, how could this be optimised?
- Should the tests test more scenarios?
- Are there more components we should make available in this API for this PR? Or should we remove any from this PR?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
feat(sanity): implement custom components API