### PR TITLE
feat(cli): prefix commands if using npx

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.js
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.js
@@ -16,11 +16,13 @@ import getProjectDefaults from '../../util/getProjectDefaults'
 import createProject from '../project/createProject'
 import login from '../login/login'
 import dynamicRequire from '../../util/dynamicRequire'
+import {prefixCommand} from '../../util/isNpx'
 import promptForDatasetName from './promptForDatasetName'
 import bootstrapTemplate from './bootstrapTemplate'
 import templates from './templates'
 
 /* eslint-disable no-process-env */
+const commandPrefix = prefixCommand()
 const isCI = process.env.CI
 const sanityEnv = process.env.SANITY_INTERNAL_ENV
 const environment = sanityEnv ? sanityEnv : process.env.NODE_ENV
@@ -188,7 +190,7 @@ export default async function initSanity(args, context) {
     const hasNodeModules = await fse.pathExists(path.join(workDir, 'node_modules'))
     if (hasNodeModules) {
       print('Skipping installation of dependencies since node_modules exists.')
-      print('Run sanity install to reinstall dependencies')
+      print(`Run ${commandPrefix} install to reinstall dependencies`)
     } else {
       try {
         await yarn(['install'], {...output, rootDir: workDir})
@@ -274,14 +276,14 @@ export default async function initSanity(args, context) {
 
         print('')
         print('If you want to delete the imported data, use')
-        print(`\t${chalk.cyan(`sanity dataset delete ${datasetName}`)}`)
+        print(`\t${chalk.cyan(`${commandPrefix} dataset delete ${datasetName}`)}`)
         print('and create a new clean dataset with')
-        print(`\t${chalk.cyan(`sanity dataset create <name>`)}\n`)
+        print(`\t${chalk.cyan(`${commandPrefix} dataset create <name>`)}\n`)
       }
     } else {
       debug('Skipping configcheck since `@sanity/core` could not be found')
       shouldPrintImportCommand = shouldImport
-      importCmd = `sanity dataset import ${template.datasetUrl} ${datasetName}`
+      importCmd = `${commandPrefix} dataset import ${template.datasetUrl} ${datasetName}`
     }
 
     // See if the template has a success message handler and print it
@@ -294,26 +296,26 @@ export default async function initSanity(args, context) {
   if (isCurrentDir && shouldPrintImportCommand) {
     print(`\n${chalk.green('Success!')} Now, use these commands to continue:\n`)
     print(`First: ${chalk.cyan(importCmd)} - to import the sample data`)
-    print(`Then:  ${chalk.cyan('sanity start')} - to run Sanity Studio\n`)
+    print(`Then:  ${chalk.cyan(`${commandPrefix} start`)} - to run Sanity Studio\n`)
   } else if (isCurrentDir) {
     print(`\n${chalk.green('Success!')} Now, use this command to continue:\n`)
-    print(`${chalk.cyan('sanity start')} - to run Sanity Studio\n`)
+    print(`${chalk.cyan(`${commandPrefix} start`)} - to run Sanity Studio\n`)
   } else if (shouldPrintImportCommand) {
     print(`\n${chalk.green('Success!')} Now, use these commands to continue:\n`)
     print(`First: ${chalk.cyan(`cd ${outputPath}`)} - to enter project’s directory`)
     print(`Then:  ${chalk.cyan(importCmd)}`)
     print(`       (to import the sample data)`)
-    print(`Lastly: ${chalk.cyan('sanity start')} - to run Sanity Studio\n`)
+    print(`Lastly: ${chalk.cyan(`${commandPrefix} start`)} - to run Sanity Studio\n`)
   } else {
     print(`\n${chalk.green('Success!')} Now, use these commands to continue:\n`)
     print(`First: ${chalk.cyan(`cd ${outputPath}`)} - to enter project’s directory`)
-    print(`Then:  ${chalk.cyan('sanity start')} - to run Sanity Studio\n`)
+    print(`Then:  ${chalk.cyan(`${commandPrefix} start`)} - to run Sanity Studio\n`)
   }
 
   print(`Other helpful commands`)
-  print(`sanity docs - to open the documentation in a browser`)
-  print(`sanity manage - to open the project settings in a browser`)
-  print(`sanity help - to explore the CLI manual`)
+  print(`${commandPrefix} docs - to open the documentation in a browser`)
+  print(`${commandPrefix} manage - to open the project settings in a browser`)
+  print(`${commandPrefix} help - to explore the CLI manual`)
 
   if (successMessage) {
     print(`\n${successMessage}`)

--- a/packages/@sanity/cli/src/commands/codemod/codemodCommand.js
+++ b/packages/@sanity/cli/src/commands/codemod/codemodCommand.js
@@ -1,8 +1,12 @@
 /* eslint-disable no-process-exit, no-sync */
+import {prefixCommand} from '../../util/isNpx'
+
 const childProcess = require('child_process')
 const path = require('path')
 const fs = require('fs')
 const mods = require('../../actions/codemod/mods')
+
+const commandPrefix = prefixCommand()
 
 const helpText = `
 Runs a given code modification script on the current studio folder.
@@ -16,11 +20,11 @@ Options
 
 Examples
   # Show available code mods
-  sanity codemod
+  ${commandPrefix} codemod
 
   # Run codemod to transform react-icons imports from v2 style to v3 style,
   # but only as a dry-run (do not write the files)
-  sanity codemod reactIconsV3 --dry
+  ${commandPrefix} codemod reactIconsV3 --dry
 
 `
 

--- a/packages/@sanity/cli/src/commands/debug/debugCommand.js
+++ b/packages/@sanity/cli/src/commands/debug/debugCommand.js
@@ -1,4 +1,7 @@
+import {prefixCommand} from '../../util/isNpx'
 import printDebugInfo from './printDebugInfo'
+
+const commandPrefix = prefixCommand()
 
 const help = `
 Used to find information about the Sanity environment, and to debug Sanity-related issues.
@@ -8,10 +11,10 @@ Options
 
 Examples
   # Show information about the user, project, and local/global Sanity environment
-  sanity debug
+  ${commandPrefix} debug
 
   # Include API keys in the output
-  sanity debug --secrets
+  ${commandPrefix} debug --secrets
 `
 
 export default {

--- a/packages/@sanity/cli/src/commands/init/initCommand.js
+++ b/packages/@sanity/cli/src/commands/init/initCommand.js
@@ -1,5 +1,8 @@
 import initProject from '../../actions/init-project/initProject'
 import initPlugin from '../../actions/init-plugin/initPlugin'
+import {prefixCommand} from '../../util/isNpx'
+
+const commandPrefix = prefixCommand()
 
 const helpText = `
 Options
@@ -19,23 +22,23 @@ Options
 
 Examples
   # Initialize a new project, prompt for required information along the way
-  sanity init
+  ${commandPrefix} init
 
   # Initialize a new plugin
-  sanity init plugin
+  ${commandPrefix} init plugin
 
   # Initialize a new project with a public dataset named "production"
-  sanity init --dataset-default
+  ${commandPrefix} init --dataset-default
 
   # Initialize a project with the given project ID and dataset to the given path
-  sanity init -y --project abc123 --dataset production --output-path ~/myproj
+  ${commandPrefix} init -y --project abc123 --dataset production --output-path ~/myproj
 
   # Initialize a project with the given project ID and dataset using the moviedb
   # template to the given path
-  sanity init -y --project abc123 --dataset staging --template moviedb --output-path .
+  ${commandPrefix} init -y --project abc123 --dataset staging --template moviedb --output-path .
 
   # Create a brand new project with name "Movies Unlimited"
-  sanity init -y \\
+  ${commandPrefix} init -y \\
     --create-project "Movies Unlimited" \\
     --dataset moviedb \\
     --visibility private \\

--- a/packages/@sanity/cli/src/commands/login/loginCommand.js
+++ b/packages/@sanity/cli/src/commands/login/loginCommand.js
@@ -1,4 +1,7 @@
 import login from '../../actions/login/login'
+import {prefixCommand} from '../../util/isNpx'
+
+const commandPrefix = prefixCommand()
 
 const helpText = `
 Options
@@ -6,10 +9,10 @@ Options
 
 Examples
   # Login against the Sanity.io API
-  sanity login
+  ${commandPrefix} login
 
   # Login with SAML SSO
-  sanity login --sso org-slug
+  ${commandPrefix} login --sso org-slug
 `
 export default {
   name: 'login',

--- a/packages/@sanity/cli/src/commands/projects/listProjectsCommand.js
+++ b/packages/@sanity/cli/src/commands/projects/listProjectsCommand.js
@@ -1,4 +1,8 @@
+import {prefixCommand} from '../../util/isNpx'
+
 const {size, sortBy} = require('lodash')
+
+const commandPrefix = prefixCommand()
 
 const headings = ['id', 'members', 'name', 'url', 'created']
 const helpText = `
@@ -8,10 +12,10 @@ Options
 
 Examples
   # List projects
-  sanity projects list
+  ${commandPrefix} projects list
 
   # List projects sorted by member count, ascending
-  sanity projects list --sort=members --order=asc
+  ${commandPrefix} projects list --sort=members --order=asc
 `
 
 const defaultFlags = {

--- a/packages/@sanity/cli/src/commands/upgrade/upgradeCommand.js
+++ b/packages/@sanity/cli/src/commands/upgrade/upgradeCommand.js
@@ -1,4 +1,7 @@
+import {prefixCommand} from '../../util/isNpx'
 import upgradeDependencies from './upgradeDependencies'
+
+const commandPrefix = prefixCommand()
 
 const helpText = `
 Upgrades installed Sanity studio modules to the latest available version within
@@ -13,16 +16,16 @@ Options
 
 Examples
   # Upgrade modules to the latest semver compatible versions
-  sanity upgrade
+  ${commandPrefix} upgrade
 
   # Update to the latest within the 2.2 range
-  sanity upgrade --range 2.2.x
+  ${commandPrefix} upgrade --range 2.2.x
 
   # Update to the latest semver compatible versions and pin the versions
-  sanity upgrade --save-exact
+  ${commandPrefix} upgrade --save-exact
 
   # Update to the latest 'canary' npm tag
-  sanity upgrade --tag canary
+  ${commandPrefix} upgrade --tag canary
 `
 
 export default {

--- a/packages/@sanity/cli/src/util/generateCommandsDocumentation.js
+++ b/packages/@sanity/cli/src/util/generateCommandsDocumentation.js
@@ -1,5 +1,8 @@
 import {padEnd} from 'lodash'
 import noSuchCommandText from './noSuchCommandText'
+import {prefixCommand} from './isNpx'
+
+const commandPrefix = prefixCommand()
 
 /**
  * Generate documentation for all commands within a given group
@@ -17,12 +20,15 @@ export function generateCommandsDocumentation(commandGroups, group = 'default') 
   const prefix = group === 'default' ? '' : ` ${group}`
 
   const rows = [
-    `usage: sanity${prefix} [--default] [-v|--version] [-d|--debug] [-h|--help] <command> [<args>]`,
+    `usage: ${commandPrefix}${prefix} [--default] [-v|--version] [-d|--debug] [-h|--help] <command> [<args>]`,
     '',
     'Commands:',
   ]
     .concat(commands.map((cmd) => `   ${padEnd(cmd.name, cmdLength + 1)} ${cmd.description}`))
-    .concat(['', `See 'sanity help${prefix} <command>' for specific information on a subcommand.`])
+    .concat([
+      '',
+      `See '${commandPrefix} help${prefix} <command>' for specific information on a subcommand.`,
+    ])
 
   return rows.join('\n')
 }
@@ -41,7 +47,7 @@ export function generateCommandDocumentation(command, group, subCommand) {
 
   const cmdParts = [group || command.name, subCommand].filter(Boolean).join(' ')
   return [
-    `usage: sanity ${cmdParts} ${command.signature}`,
+    `usage: ${commandPrefix} ${cmdParts} ${command.signature}`,
     '',
     `   ${command.description}`,
     '',

--- a/packages/@sanity/cli/src/util/isNpx.js
+++ b/packages/@sanity/cli/src/util/isNpx.js
@@ -1,0 +1,6 @@
+const isNpx =
+  process.argv.some((segment) => segment.includes('_npx')) ||
+  process.env.npm_lifecycle_event === 'npx'
+
+export const prefixCommand = (command = '') =>
+  (isNpx ? `npx @sanity/cli ${command}` : `sanity ${command}`).trim()


### PR DESCRIPTION
### Description

This adds `npx` detection to the CLI, so all the help text will show the correct version of commands based on if you are using npx or not.

If running with npx it will look like this:

<img width="822" alt="image" src="https://user-images.githubusercontent.com/10508/188588628-ef410383-cb5c-4854-a6cc-41f57736c1dc.png">

If running the `sanity` command as normal, it will look like this:

<img width="840" alt="image" src="https://user-images.githubusercontent.com/10508/188588816-0e2c3dd8-08fb-4201-bece-fa46fdfc0552.png">

After doing research on the canonical way to detect `npx`, I ended up with a naive approach that checks if the folder that npx uses (`_npx`) is listed in `process.argv` or `process.env.npm_lifecycle_event` is `npx`. I have observed either when when testing.

### What to review

- Test that all the commands display either versions depending on if you use `npx` or not

### Notes for release

- CLI help text will now prefix commands with `npx @sanity/cli` instead of `sanity` if you are using `npx`
