### PR TITLE
perf(form-builder): skip passing parent for schema types with no conditional fields

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ObjectInput/ObjectInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ObjectInput/ObjectInput.tsx
@@ -26,7 +26,7 @@ import {isTrueIsh, omitDeprecatedRole} from '../../utils/common'
 import {ObjectInputField} from './ObjectInputField'
 import {UnknownFields} from './UnknownFields'
 import {ObjectFieldSet} from './ObjectFieldSet'
-import {getCollapsedWithDefaults} from './utils'
+import {getCollapsedWithDefaults, hasConditionalFields} from './utils'
 import {FieldGroupTabs} from './fieldGroups'
 import {FieldGroupTabsWrapper} from './ObjectInput.styled'
 
@@ -230,7 +230,7 @@ export const ObjectInput = memo(
             key={`field-${field.name}`}
           >
             <ObjectInputField
-              parent={value}
+              parent={hasConditionalFields(field.type) ? value : undefined}
               field={field}
               value={fieldValue}
               onChange={handleFieldChange}

--- a/packages/@sanity/form-builder/src/inputs/ObjectInput/utils.ts
+++ b/packages/@sanity/form-builder/src/inputs/ObjectInput/utils.ts
@@ -1,4 +1,8 @@
-import {ObjectSchemaTypeWithOptions} from '@sanity/types'
+import {ObjectSchemaTypeWithOptions, SchemaType} from '@sanity/types'
+
+export function hasConditionalFields(type: SchemaType) {
+  return typeof type.readOnly === 'function' || typeof type.hidden === 'function'
+}
 
 interface CollapsibleOptions {
   collapsible: boolean


### PR DESCRIPTION
### Description
This optimizes field rendering by not passing the parent value to fields that has no conditional callbacks. In certain cases this improves rerendering speed with about 20%.

### What to review

- Verify that conditional fields works like before

### Notes for release

- Don't pass parent object to fields with no conditional callbacks
