### PR TITLE
fix(desk-tool): check for valid resize observer entry before use

### DIFF
--- a/packages/@sanity/desk-tool/src/components/paneItem/ReferencedDocHeading.tsx
+++ b/packages/@sanity/desk-tool/src/components/paneItem/ReferencedDocHeading.tsx
@@ -32,7 +32,7 @@ export function ReferencedDocHeading(props: ReferenceDocHeadingProps) {
   // Ideally, this would automatically be handled by `@sanity/ui`.
   const handleResize = useCallback(
     (e: ResizeObserverEntry[]) => {
-      if (!hidePopover) {
+      if (!hidePopover && e?.[0]?.borderBoxSize?.[0]?.inlineSize) {
         setTitleBoxSize(Math.floor(e[0].borderBoxSize[0].inlineSize))
       }
     },


### PR DESCRIPTION
### Description

We implemented a hack in order to trigger the "this document is referenced" popover to move properly on DOM changes that causes the parent to reposition. Unfortunately, I did not test this properly on older versions of Safari, which apparently doesn't work. This PR checks for the presence of the property before attempting to use it.

Fixes #3587

### What to review

- That the popover still repositions as expected

### Notes for release

- Fixed an issue where older versions of Safari might crash when opening a referenced document
