### PR TITLE
feat(desk)!: drop `preserveInstance`, `urlParams` options on custom user panes

### DIFF
--- a/dev/test-studio/structure/resolveStructure.ts
+++ b/dev/test-studio/structure/resolveStructure.ts
@@ -92,59 +92,55 @@ export const structure: StructureResolver = (S, {schema}) => {
                 .id('component1')
                 .title('Component pane (1)')
                 .child(
-                  Object.assign(
-                    S.component(DebugPane)
-                      .id('component1')
-                      .title('Component pane #1')
-                      .options({no: 1})
-                      .menuItems([
-                        S.menuItem()
-                          .title('From Menu Item Create Intent')
-                          .intent({
-                            type: 'create',
-                            params: {type: 'author', id: `special.${uuid()}`},
-                          }),
-                        S.menuItem()
-                          .title('Also Menu Item Create Intent')
-                          .intent({
-                            type: 'create',
-                            params: {type: 'author', id: uuid()},
-                          }),
-                        S.menuItem()
-                          .title('Test 1')
-                          // eslint-disable-next-line no-alert
-                          .action(() => alert('you clicked!'))
-                          .showAsAction(true),
-                        S.menuItem()
-                          .title('Test Edit Intent (as action)')
-                          .intent({
-                            type: 'edit',
-                            params: {id: 'grrm', type: 'author'},
-                          })
-                          .icon(RocketIcon)
-                          .showAsAction(),
-                        S.menuItem().title('Should warn in console').action('shouldWarn'),
-                        S.menuItem()
-                          .title('Test Edit Intent (in menu)')
-                          .intent({
-                            type: 'edit',
-                            params: {id: 'foo-bar', type: 'author'},
-                          }),
-                      ])
-                      .child(
-                        S.component(DebugPane)
-                          .id('component1-1')
-                          .title('Component pane #1.1')
-                          .options({no: 1})
-                          .menuItems([
-                            S.menuItem().title('Test 1').action('test-1').showAsAction(true),
-                            S.menuItem().title('Test 2').action('test-2'), //.showAsAction(true),
-                          ])
-                          .child(S.document().documentId('component1-1-child').schemaType('author'))
-                      )
-                      .serialize(),
-                    {__preserveInstance: true}
-                  )
+                  S.component(DebugPane)
+                    .id('component1')
+                    .title('Component pane #1')
+                    .options({no: 1})
+                    .menuItems([
+                      S.menuItem()
+                        .title('From Menu Item Create Intent')
+                        .intent({
+                          type: 'create',
+                          params: {type: 'author', id: `special.${uuid()}`},
+                        }),
+                      S.menuItem()
+                        .title('Also Menu Item Create Intent')
+                        .intent({
+                          type: 'create',
+                          params: {type: 'author', id: uuid()},
+                        }),
+                      S.menuItem()
+                        .title('Test 1')
+                        // eslint-disable-next-line no-alert
+                        .action(() => alert('you clicked!'))
+                        .showAsAction(true),
+                      S.menuItem()
+                        .title('Test Edit Intent (as action)')
+                        .intent({
+                          type: 'edit',
+                          params: {id: 'grrm', type: 'author'},
+                        })
+                        .icon(RocketIcon)
+                        .showAsAction(),
+                      S.menuItem().title('Should warn in console').action('shouldWarn'),
+                      S.menuItem()
+                        .title('Test Edit Intent (in menu)')
+                        .intent({
+                          type: 'edit',
+                          params: {id: 'foo-bar', type: 'author'},
+                        }),
+                    ])
+                    .child(
+                      S.component(DebugPane)
+                        .id('component1-1')
+                        .title('Component pane #1.1')
+                        .options({no: 1})
+                        .menuItems([
+                          S.menuItem().title('Test 1').action('test-1').showAsAction(true),
+                          S.menuItem().title('Test 2').action('test-2'), //.showAsAction(true),
+                        ])
+                        .child(S.document().documentId('component1-1-child').schemaType('author'))
+                    )
                 ),
 
               S.listItem()

--- a/packages/sanity/src/desk/panes/userComponent/UserComponentPane.tsx
+++ b/packages/sanity/src/desk/panes/userComponent/UserComponentPane.tsx
@@ -1,6 +1,6 @@
 import React, {createElement, isValidElement, useState} from 'react'
 import {isValidElementType} from 'react-is'
-import {Pane, usePaneRouter} from '../../components'
+import {Pane} from '../../components'
 import {DeskToolPaneActionHandler} from '../../types'
 import {BaseDeskToolPaneProps} from '../types'
 import {UserComponentPaneHeader} from './UserComponentPaneHeader'
@@ -13,7 +13,6 @@ type UserComponentPaneProps = BaseDeskToolPaneProps<'component'>
  */
 export function UserComponentPane(props: UserComponentPaneProps) {
   const {index, pane, paneKey, ...restProps} = props
-  const {params} = usePaneRouter()
   const {
     child,
     component,
@@ -48,8 +47,6 @@ export function UserComponentPane(props: UserComponentPaneProps) {
             ...({ref: setRef} as any),
             child: child as any, // @todo: Fix typings
             paneKey,
-            // NOTE: this is for backwards compatibility (<= 2.20.0)
-            urlParams: params,
           })}
 
         {isValidElement(component) && component}

--- a/packages/sanity/src/desk/panes/userComponent/UserComponentPane.tsx
+++ b/packages/sanity/src/desk/panes/userComponent/UserComponentPane.tsx
@@ -22,7 +22,6 @@ export function UserComponentPane(props: UserComponentPaneProps) {
     title = '',
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     type: _unused,
-    __preserveInstance = false,
     ...restPane
   } = pane
   const [ref, setRef] = useState<{
@@ -42,14 +41,6 @@ export function UserComponentPane(props: UserComponentPaneProps) {
       <UserComponentPaneContent>
         {isValidElementType(component) &&
           createElement(component, {
-            // this forces a re-render when the router panes change. note: in
-            // theory, this shouldn't be necessary and the downstream user
-            // component could internally handle these updates, but this was done
-            // to preserve older desk tool behavior. if the experimental flag
-            // `__preserveInstance` is true, then no key will be applied.
-            ...(!__preserveInstance && {
-              key: `${restProps.itemId}-${restProps.childItemId}`,
-            }),
             ...restProps,
             ...restPane,
             // NOTE: here we're utilizing the function form of refs so setting

--- a/packages/sanity/src/desk/types.ts
+++ b/packages/sanity/src/desk/types.ts
@@ -162,15 +162,6 @@ export interface CustomComponentPaneNode extends BaseResolvedPaneNode<'component
   component: UserComponent
   options?: Record<string, unknown>
   // component: React.ComponentType<Props> | React.ReactNode
-
-  /**
-   * An experimental flag that can be used to opt out of the forced refresh when
-   * the `itemId` or `childItemId` changes. See `UserComponentPane`:
-   * https://github.com/sanity-io/sanity/commit/8340a003043edf6de3afd9ff628ce93be79978e2
-   *
-   * @beta
-   */
-  __preserveInstance?: boolean
 }
 
 export type PaneView = FormView | ComponentView


### PR DESCRIPTION
### Description

This PR introduces two breaking changes on custom user panes, since we've been wanting to get rid of these since v2. This has to be done before a GA v3 release so as not to cause another breaking change that could easily have been done in this release.

**BREAKING CHANGE**: we've been wanting to make `preserveInstance` the default behavior for custom panes for a while, but it has been a breaking change. Now that we have the ability to do so, lets reduce the complexity of things. User component panes should use `componentDidUpdate` or a `useEffect` with a dependency on the `itemId`/`childItemId` prop to react to updates.

**BREAKING CHANGE**: `urlParams` has been available through the `usePaneRouter()` hook as `params` since version 2.2.0. This commit drops this prop from being passed, since we prefer it to be retrieved through the hook instead.

### What to review

That user component panes still _work_, but do not remount on item ID changes anymore. This difference can be seen in the test studio - switch between "component pane 1" and "component pane 2". In the old version, the `Random ID` would change on every switch. In the new version, it stays the same.

Also note that the `urlParams` property is gone in the new version, but that the router still has access to it.

- Previous: https://test-studio-rfpvdjuqn.sanity.build/test/content/custom;component1
- This change: https://test-studio-eopmyw79f.sanity.build/test/content/custom;component1

### Notes for release

- BREAKING CHANGE: The `preserveInstance` option is now the default behavior for custom desk tool panes, meaning the components used needs to account for a change in `itemId`/`childItemId` and update accordingly
- BREAKING CHANGE: The `urlParams` property has been removed from custom desk tool panes - the same information has been available through the `usePaneRouter()` hook since v2.2.0 and is now the only way of retrieving the URL parameters for a pane

