### PR TITLE
feat(server): print error on process.env usage in development

### DIFF
--- a/packages/@sanity/server/src/getViteConfig.ts
+++ b/packages/@sanity/server/src/getViteConfig.ts
@@ -96,6 +96,7 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     resolve: {
       alias: getAliases({monorepo}),
     },
+    define: mode === 'development' ? {'process.env': getProcessEnvProxy()} : {},
   }
 
   if (mode === 'production') {
@@ -150,4 +151,14 @@ export function finalizeViteConfig(config: InlineConfig): InlineConfig {
       },
     },
   }
+}
+
+function getProcessEnvProxy() {
+  return `new Proxy({}, {
+    get: (target, key) => {
+      if (key.indexOf('SANITY_STUDIO_') === 0) {
+        console.warn('process.env is not available - use "import.meta.env.' + key + '" instead')
+      }
+    }
+  })`
 }


### PR DESCRIPTION
### Description

Note: I am not 100% confident that this is a good idea, but I can't think of a better approach.

When migrating from Sanity v2 to v3, users might attempt to use the `process.env.SANITY_STUDIO_` approach for getting environment variable values. However, we are using Vite, and it instead uses `import.meta.env.SANITY_STUDIO_` for the same purpose.

We have a couple of options here:
- Leave it as-is, crashing when attempting to access `process`
- Declare all `SANITY_STUDIO_` prefixed env variables both in `import.meta.env` _and_ `process.env`
- Implement a proxy/object with getters at `process.env` that warns/errors on use

This PR uses the last approach, but as I wrote in the opening notes; I am not convinced it is a good idea. It leads to the side effect that `process` and `process.env` gets defined, which _might_ have unintended consequences.

Open for discussion.

### What to review

- Is this a good idea?
- Would it be better to just document the change?
- Would it be better to check this differently? (esbuild plugin?)
