### PR TITLE
fix: move presence menu to leftmost position in navbar

### DIFF
--- a/packages/sanity/src/studio/components/navbar/Navbar.tsx
+++ b/packages/sanity/src/studio/components/navbar/Navbar.tsx
@@ -279,6 +279,10 @@ export function Navbar(props: NavbarProps) {
           {shouldRender.brandingCenter && <Box marginX={1}>{brandingComponent}</Box>}
 
           <Flex align="center">
+            <Box marginRight={1}>
+              <PresenceMenu collapse={shouldRender.collapsedPresenceMenu} />
+            </Box>
+
             {shouldRender.changelog && (
               <Box marginRight={1}>
                 <ChangelogButton />
@@ -290,10 +294,6 @@ export function Navbar(props: NavbarProps) {
                 <ConfigIssuesButton />
               </Box>
             )}
-
-            <Box marginRight={1}>
-              <PresenceMenu collapse={shouldRender.collapsedPresenceMenu} />
-            </Box>
 
             {shouldRender.tools && (
               <Box>


### PR DESCRIPTION
### Description

This is done because the number of people present changes over time, causing occasional "jumping" when people enter/exit. With the changelog/warning button to the left of the presence menu, you can end up in situations where you click on the wrong thing by accident, since the layout shifts. It also causes less of a layout shift on update.

### What to review

That things still look alright, and that you agree that this makes sense.

### Notes for release

Probably not worth mentioning.
