### PR TITLE
feat(form): future-proof patch types

### DIFF
--- a/packages/sanity/src/form/inputs/CrossDatasetReferenceInput/__tests__/CrossDatasetReferenceInput.test.tsx
+++ b/packages/sanity/src/form/inputs/CrossDatasetReferenceInput/__tests__/CrossDatasetReferenceInput.test.tsx
@@ -338,6 +338,7 @@ describe('user interaction happy paths', () => {
     expect(onChange).toHaveBeenCalledTimes(1)
     expect(onChange.mock.calls[0]).toEqual([
       {
+        patchType: Symbol.for('sanity.patch'),
         path: [],
         type: 'unset',
       },

--- a/packages/sanity/src/form/inputs/DateInputs/__tests__/__snapshots__/DateInput.test.tsx.snap
+++ b/packages/sanity/src/form/inputs/DateInputs/__tests__/__snapshots__/DateInput.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`emits onChange on correct format if a valid value has been typed 1`] = 
 Array [
   Array [
     Object {
+      "patchType": Symbol(sanity.patch),
       "path": Array [],
       "type": "set",
       "value": "2021-03-28",

--- a/packages/sanity/src/form/inputs/DateInputs/__tests__/__snapshots__/DateTimeInput.test.tsx.snap
+++ b/packages/sanity/src/form/inputs/DateInputs/__tests__/__snapshots__/DateTimeInput.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`emits onChange on correct format if a valid value has been typed 1`] = 
 Array [
   Array [
     Object {
+      "patchType": Symbol(sanity.patch),
       "path": Array [],
       "type": "set",
       "value": "2021-03-28T17:23:00.000Z",

--- a/packages/sanity/src/form/patch/patch.ts
+++ b/packages/sanity/src/form/patch/patch.ts
@@ -1,7 +1,5 @@
-/* eslint-disable camelcase */
-
-import {Path, PathSegment} from '@sanity/types'
-import {
+import type {Path, PathSegment} from '@sanity/types'
+import type {
   FormSetIfMissingPatch,
   FormInsertPatch,
   FormInsertPatchPosition,
@@ -11,8 +9,11 @@ import {
   FormDecPatch,
 } from './types'
 
+export const SANITY_PATCH_TYPE = Symbol.for('sanity.patch')
+
 export function setIfMissing(value: any, path: Path = []): FormSetIfMissingPatch {
   return {
+    patchType: SANITY_PATCH_TYPE,
     type: 'setIfMissing',
     path,
     value,
@@ -25,6 +26,7 @@ export function insert(
   path: Path = []
 ): FormInsertPatch {
   return {
+    patchType: SANITY_PATCH_TYPE,
     type: 'insert',
     path,
     position,
@@ -33,19 +35,19 @@ export function insert(
 }
 
 export function set(value: any, path: Path = []): FormSetPatch {
-  return {type: 'set', path, value}
+  return {patchType: SANITY_PATCH_TYPE, type: 'set', path, value}
 }
 
 export function unset(path: Path = []): FormUnsetPatch {
-  return {type: 'unset', path}
+  return {patchType: SANITY_PATCH_TYPE, type: 'unset', path}
 }
 
 export function inc(amount = 1, path: Path = []): FormIncPatch {
-  return {type: 'inc', path, value: amount}
+  return {patchType: SANITY_PATCH_TYPE, type: 'inc', path, value: amount}
 }
 
 export function dec(amount = 1, path: Path = []): FormDecPatch {
-  return {type: 'dec', path, value: amount}
+  return {patchType: SANITY_PATCH_TYPE, type: 'dec', path, value: amount}
 }
 
 export function prefixPath<T extends {path: Path}>(patch: T, segment: PathSegment): T {

--- a/packages/sanity/src/form/patch/types.ts
+++ b/packages/sanity/src/form/patch/types.ts
@@ -1,6 +1,19 @@
-/* eslint-disable camelcase */
+import type {Path} from '@sanity/types'
 
-import {Path} from '@sanity/types'
+/**
+ * @alpha
+ */
+export interface FormPatchBase {
+  /**
+   * A property used to identify this as a Sanity patch type, eg "set", "unset", "insert", etc.
+   * This allows us to potentially introduce new patch types in the future without breaking
+   * existing code. This is an internal property/implementation detail and should not be used by
+   * consumers.
+   *
+   * @internal
+   */
+  patchType: symbol
+}
 
 /**
  * @alpha
@@ -20,7 +33,7 @@ export type FormPatchOrigin = 'remote' | 'local' | 'internal'
 /**
  * @alpha
  */
-export type FormSetPatch = {
+export interface FormSetPatch extends FormPatchBase {
   path: Path
   type: 'set'
   origin?: FormPatchOrigin
@@ -30,7 +43,7 @@ export type FormSetPatch = {
 /**
  * @alpha
  */
-export type FormIncPatch = {
+export interface FormIncPatch extends FormPatchBase {
   path: Path
   type: 'inc'
   origin?: FormPatchOrigin
@@ -40,7 +53,7 @@ export type FormIncPatch = {
 /**
  * @alpha
  */
-export type FormDecPatch = {
+export interface FormDecPatch extends FormPatchBase {
   path: Path
   type: 'dec'
   origin?: FormPatchOrigin
@@ -50,7 +63,7 @@ export type FormDecPatch = {
 /**
  * @alpha
  */
-export type FormSetIfMissingPatch = {
+export interface FormSetIfMissingPatch extends FormPatchBase {
   path: Path
   origin?: FormPatchOrigin
   type: 'setIfMissing'
@@ -60,7 +73,7 @@ export type FormSetIfMissingPatch = {
 /**
  * @alpha
  */
-export type FormUnsetPatch = {
+export interface FormUnsetPatch extends FormPatchBase {
   path: Path
   origin?: FormPatchOrigin
   type: 'unset'
@@ -74,7 +87,7 @@ export type FormInsertPatchPosition = 'before' | 'after'
 /**
  * @alpha
  */
-export type FormInsertPatch = {
+export interface FormInsertPatch extends FormPatchBase {
   path: Path
   origin?: FormPatchOrigin
   type: 'insert'
@@ -85,7 +98,7 @@ export type FormInsertPatch = {
 /**
  * @alpha
  */
-export type FormDiffMatchPatch = {
+export interface FormDiffMatchPatch extends FormPatchBase {
   path: Path
   type: 'diffMatchPatch'
   origin?: FormPatchOrigin

--- a/packages/sanity/src/form/utils/mutationPatch.ts
+++ b/packages/sanity/src/form/utils/mutationPatch.ts
@@ -1,5 +1,6 @@
 import {arrayToJSONMatchPath} from '@sanity/mutator'
 import {flatten} from 'lodash'
+import {SANITY_PATCH_TYPE} from '../patch'
 import type {FormPatchOrigin, FormPatch} from '../patch/types'
 import {decodePath} from './path'
 
@@ -95,6 +96,16 @@ function toFormBuilderPatches(origin: FormPatchOrigin, patch: MutationPatch): Fo
 }
 
 function toMutationPatch(patch: FormPatch): MutationPatch {
+  if (patch.patchType !== SANITY_PATCH_TYPE && patch.type) {
+    throw new Error(
+      `Patch is missing "patchType" - import and use "${patch.type}()" from "sanity/form"`
+    )
+  } else if (patch.patchType !== SANITY_PATCH_TYPE) {
+    throw new Error(
+      `Patch is missing "patchType" - import and use the patch method helpers from "sanity/form"`
+    )
+  }
+
   const matchPath = arrayToJSONMatchPath(patch.path || [])
   if (patch.type === 'insert') {
     const {position, items} = patch


### PR DESCRIPTION
### Description

We might want to provide alternative ways of specifying patches in the future. By adding a `patchType` symbol to the patches returned by our patch helpers, we can future-proof that we can differentiate between a "patch helper generated" patch and an arbitrary value.

Wasn't quite sure about the naming on this one - open to suggestions.

### Notes for release

Probably not worth mentioning.
