### PR TITLE
feat(types): add missing `Geopoint` data type

### DIFF
--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -762,3 +762,30 @@ export interface ImageSchemaType extends Omit<ObjectSchemaType, 'options'> {
     sources?: AssetSource[]
   }
 }
+
+/**
+ * Geographical point representing a pair of latitude and longitude coordinates,
+ * stored as degrees, in the World Geodetic System 1984 (WGS 84) format. Also
+ * includes an optional `alt` property representing the altitude in meters.
+ */
+export interface Geopoint {
+  /**
+   * Type of the object. Must be `geopoint`.
+   */
+  _type: 'geopoint'
+
+  /**
+   * Latitude in degrees
+   */
+  lat: number
+
+  /**
+   * Longitude in degrees
+   */
+  lng: number
+
+  /**
+   * Altitude in meters
+   */
+  alt?: number
+}


### PR DESCRIPTION
### Description

Adds a typescript interface for the `Geopoint` data type that is represented by the [geopoint](https://www.sanity.io/docs/geopoint-type) schema type.

### What to review

- Comments and shape seems correct and does not contain typos

### Notes for release

- Add and export `Geopoint` typescript interface
