### PR TITLE
fix(desk-tool): add full timestamp tooltip to timeline items

### DIFF
--- a/packages/@sanity/desk-tool/package.json
+++ b/packages/@sanity/desk-tool/package.json
@@ -43,6 +43,7 @@
     "@sanity/ui": "^0.37.21",
     "@sanity/util": "2.33.2",
     "@sanity/uuid": "^3.0.1",
+    "date-fns": "^2.16.1",
     "framer-motion": "^5.3.3",
     "hashlru": "^2.1.0",
     "is-hotkey": "^0.1.6",

--- a/packages/@sanity/desk-tool/src/panes/document/timeline/timelineItem.styled.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/timeline/timelineItem.styled.tsx
@@ -1,4 +1,4 @@
-import {Text, Box, MenuItem, Theme, Flex} from '@sanity/ui'
+import {Text, Box, MenuItem, Theme, Flex, rem} from '@sanity/ui'
 import styled, {css} from 'styled-components'
 import {TimelineItemState} from './types'
 
@@ -112,4 +112,9 @@ export const IconBox = styled(Box)`
 
 export const EventLabel = styled(Text)`
   text-transform: capitalize;
+`
+
+export const TimestampBox = styled(Box)`
+  min-width: 1rem;
+  margin-left: ${({theme}) => `-${rem(theme.sanity.space[1])}`};
 `

--- a/packages/@sanity/desk-tool/src/panes/document/timeline/timelineItem.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/timeline/timelineItem.tsx
@@ -1,12 +1,12 @@
-import React, {useCallback, createElement, useState} from 'react'
+import React, {useCallback, createElement, useState, useMemo} from 'react'
 import {useTimeAgo} from '@sanity/base/hooks'
 import {Chunk, ChunkType} from '@sanity/field/diff'
-import {Box, Flex, Stack, Text, ButtonTone} from '@sanity/ui'
+import {Box, Flex, Stack, Text, ButtonTone, Tooltip} from '@sanity/ui'
+import {format} from 'date-fns'
 import {formatTimelineEventLabel, getTimelineEventIconComponent} from './helpers'
 import {TimelineItemState} from './types'
 import {UserAvatarStack} from './userAvatarStack'
-
-import {EventLabel, IconBox, IconWrapper, Root} from './timelineItem.styled'
+import {EventLabel, IconBox, IconWrapper, Root, TimestampBox} from './timelineItem.styled'
 
 const TIMELINE_ITEM_EVENT_TONE: Record<ChunkType | 'withinSelection', ButtonTone> = {
   initial: 'primary',
@@ -33,6 +33,12 @@ export function TimelineItem(props: {
   const iconComponent = getTimelineEventIconComponent(type)
   const authorUserIds = Array.from(chunk.authors)
   const timeAgo = useTimeAgo(timestamp, {minimal: true})
+  const formattedTimestamp = useMemo(() => {
+    const parsedDate = new Date(timestamp)
+    const formattedDate = format(parsedDate, 'MMM d, yyyy, hh:mm a')
+
+    return formattedDate
+  }, [timestamp])
 
   const isSelected = state === 'selected'
   const isWithinSelection = state === 'withinSelection'
@@ -49,52 +55,65 @@ export function TimelineItem(props: {
   )
 
   return (
-    <Root
-      data-ui="timelineItem"
-      radius={2}
-      data-chunk-id={chunk.id}
-      paddingY={0}
-      paddingX={2}
-      tone={
-        isHovered || isSelected || isWithinSelection ? 'default' : TIMELINE_ITEM_EVENT_TONE[type]
+    <Tooltip
+      portal
+      placement="left"
+      fallbackPlacements={['bottom']}
+      content={
+        <Stack padding={3} space={3}>
+          <Text size={1}>{formattedTimestamp}</Text>
+        </Stack>
       }
-      pressed={isWithinSelection}
-      state={state}
-      selected={isSelected}
-      isHovered={isHovered}
-      disabled={state === 'disabled'}
-      data-selection-bottom={isSelectionBottom}
-      data-selection-top={isSelectionTop}
-      onClick={handleClick}
     >
-      <div
-        // eslint-disable-next-line react/jsx-no-bind
-        onMouseEnter={() => setHovered(true)}
-        // eslint-disable-next-line react/jsx-no-bind
-        onMouseLeave={() => setHovered(false)}
+      <Root
+        data-ui="timelineItem"
+        radius={2}
+        data-chunk-id={chunk.id}
+        paddingY={0}
+        paddingX={2}
+        tone={
+          isHovered || isSelected || isWithinSelection ? 'default' : TIMELINE_ITEM_EVENT_TONE[type]
+        }
+        pressed={isWithinSelection}
+        state={state}
+        selected={isSelected}
+        isHovered={isHovered}
+        disabled={state === 'disabled'}
+        data-selection-bottom={isSelectionBottom}
+        data-selection-top={isSelectionTop}
+        onClick={handleClick}
       >
-        <Flex align="stretch">
-          <IconWrapper align="center">
-            <IconBox padding={2}>
-              <Text size={2}>{iconComponent && createElement(iconComponent)}</Text>
-            </IconBox>
-          </IconWrapper>
+        <div
+          // eslint-disable-next-line react/jsx-no-bind
+          onMouseEnter={() => setHovered(true)}
+          // eslint-disable-next-line react/jsx-no-bind
+          onMouseLeave={() => setHovered(false)}
+        >
+          <Flex align="stretch">
+            <IconWrapper align="center">
+              <IconBox padding={2}>
+                <Text size={2}>{iconComponent && createElement(iconComponent)}</Text>
+              </IconBox>
+            </IconWrapper>
 
-          <Stack space={2} margin={2}>
-            <Box>
-              <EventLabel size={1} weight="medium">
-                {formatTimelineEventLabel(type) || <code>{type}</code>}
-              </EventLabel>
-            </Box>
-            <Text size={0} muted>
-              {timeAgo}
-            </Text>
-          </Stack>
-          <Flex flex={1} justify="flex-end" align="center">
-            <UserAvatarStack maxLength={3} userIds={authorUserIds} />
+            <Stack space={2} margin={2}>
+              <Box>
+                <EventLabel size={1} weight="medium">
+                  {formatTimelineEventLabel(type) || <code>{type}</code>}
+                </EventLabel>
+              </Box>
+              <TimestampBox paddingX={1}>
+                <Text size={0} muted>
+                  {timeAgo}
+                </Text>
+              </TimestampBox>
+            </Stack>
+            <Flex flex={1} justify="flex-end" align="center">
+              <UserAvatarStack maxLength={3} userIds={authorUserIds} />
+            </Flex>
           </Flex>
-        </Flex>
-      </div>
-    </Root>
+        </div>
+      </Root>
+    </Tooltip>
   )
 }


### PR DESCRIPTION
### Description

This adds the full change timestamp to a tooltip when you hover over the relative time stamp in the version timeline.

https://user-images.githubusercontent.com/10508/190409236-557b0d86-1115-448e-b9ed-32e36a080bad.mp4

Closes #3251

### What to review

- Is this the best UI solution?

### Notes for release

- Added full timestamp to version timeline
