### PR TITLE
feat: implement custom components API

### DIFF
--- a/cypress/integration/config/componentsApi.test.js
+++ b/cypress/integration/config/componentsApi.test.js
@@ -1,0 +1,21 @@
+describe('Config: components API', () => {
+  beforeEach(() => {
+    cy.visit('custom-components/content')
+  })
+
+  it('default layout is displayed inside renderLayout component', () => {
+    cy.get('[data-testid="custom-studio-layout"]')
+      .find('[data-testid="studio-layout"]')
+      .should('be.visible')
+  })
+
+  it('default tool menu is displayed inside renderToolMenu component', () => {
+    cy.get('[data-testid="custom-tool-menu"]')
+      .find('[data-testid="tool-collapse-menu"]')
+      .should('be.visible')
+  })
+
+  it('custom logo is displayed using renderLogo with context value from renderLayout', () => {
+    cy.get('[data-testid="custom-logo"]').contains('Context value')
+  })
+})

--- a/dev/test-studio/components/customComponents.tsx
+++ b/dev/test-studio/components/customComponents.tsx
@@ -1,0 +1,69 @@
+import React, {createContext, useContext} from 'react'
+import {Box, Button, Card, Stack, Text} from '@sanity/ui'
+import {LogoProps} from 'sanity'
+import {RobotIcon} from '@sanity/icons'
+
+// Layout
+const TitleContext = createContext<string>('')
+const useTitleContext = () => useContext(TitleContext)
+
+export function CustomLayout({children}: {children: React.ReactNode}) {
+  return (
+    <TitleContext.Provider value="Context value">
+      <Box height="fill" data-testid="custom-studio-layout">
+        {children}
+      </Box>
+    </TitleContext.Provider>
+  )
+}
+
+// Logo
+export function CustomLogo(props: LogoProps) {
+  const {onClick, href} = props
+  const title = useTitleContext()
+
+  return (
+    <Button
+      as="a"
+      fontSize={1}
+      data-testid="custom-logo"
+      href={href}
+      icon={RobotIcon}
+      mode="ghost"
+      onClick={onClick}
+      padding={3}
+      text={title}
+      tone="primary"
+    />
+  )
+}
+
+// Navbar
+export function CustomNavbar({children}: {children: React.ReactNode}) {
+  return (
+    <Stack>
+      <Card padding={4} tone="primary">
+        <Text weight="semibold" size={1}>
+          This banner is rendered with <code>{`renderNavbar`}</code> in{' '}
+          <code>{`createConfig`}</code>
+        </Text>
+      </Card>
+      {children}
+    </Stack>
+  )
+}
+
+export function CustomToolMenu({children}: {children: React.ReactNode}) {
+  return (
+    <Card
+      data-testid="custom-tool-menu"
+      paddingX={1}
+      radius={2}
+      shadow={1}
+      sizing="border"
+      tone="primary"
+    >
+      {children}
+    </Card>
+  )
+}

--- a/dev/test-studio/components/navbar/ToolMenu.tsx
+++ b/dev/test-studio/components/navbar/ToolMenu.tsx
@@ -3,17 +3,17 @@ import React from 'react'
 import {ToolMenuProps, ToolLink} from 'sanity'
 
 export function ToolMenu(props: ToolMenuProps) {
-  const {context, tools, closeDrawer} = props
+  const {context, tools, closeSidebar} = props
 
   return (
-    <Flex gap={3} direction={context === 'drawer' ? 'column' : 'row'}>
+    <Flex gap={3} direction={context === 'sidebar' ? 'column' : 'row'}>
       {tools.map((tool) => (
         <ToolLink key={tool.name} name={tool.name}>
           {tool.title}
         </ToolLink>
       ))}
 
-      {context === 'drawer' && <Button text="Close drawer" onClick={closeDrawer} />}
+      {context === 'topbar' && <Button text="Close drawer" onClick={closeSidebar} />}
     </Flex>
   )
 }

--- a/dev/test-studio/sanity.config.tsx
+++ b/dev/test-studio/sanity.config.tsx
@@ -1,4 +1,5 @@
 //import {codeInput} from '@sanity/code-input'
+import React from 'react'
 import {BookIcon} from '@sanity/icons'
 import {visionTool} from '@sanity/vision'
 import {createConfig, createPlugin} from 'sanity'
@@ -11,6 +12,7 @@ import {languageFilter} from './plugins/language-filter'
 import {schemaTypes} from './schema'
 import {defaultDocumentNode, newDocumentOptions, structure} from './structure'
 import {workshopTool} from './workshop'
+import {CustomLogo, CustomLayout, CustomNavbar, CustomToolMenu} from './components/customComponents'
 
 const sharedSettings = createPlugin({
   name: 'sharedSettings',
@@ -18,16 +20,7 @@ const sharedSettings = createPlugin({
     types: schemaTypes,
     templates: resolveInitialValueTemplates,
   },
-  // navbar: {
-  //   components: {
-  //     ToolMenu: ToolMenu,
-  //   },
-  // },
   form: {
-    // unstable: {
-    //   CustomMarkers,
-    //   Markers,
-    // },
     image: {
       assetSources: [imageAssetSource],
     },
@@ -37,12 +30,7 @@ const sharedSettings = createPlugin({
     newDocumentOptions,
   },
   plugins: [
-    // codeInput(),
     deskTool({
-      // TODO:
-      // components: {
-      //   LanguageFilter,
-      // },
       icon: BookIcon,
       name: 'content',
       title: 'Content',
@@ -93,5 +81,20 @@ export default createConfig([
     dataset: 'playground',
     plugins: [sharedSettings()],
     basePath: '/playground',
+  },
+  {
+    name: 'custom-components',
+    title: 'Test Studio (custom-components)',
+    logo: Branding,
+    projectId: 'ppsg7ml5',
+    dataset: 'test',
+    plugins: [sharedSettings()],
+    basePath: '/custom-components',
+    studio: {
+      renderLayout: (props, next) => <CustomLayout>{next(props)}</CustomLayout>,
+      renderLogo: (props) => <CustomLogo {...props} />,
+      renderNavbar: (props, next) => <CustomNavbar>{next(props)}</CustomNavbar>,
+      renderToolMenu: (props, next) => <CustomToolMenu>{next(props)}</CustomToolMenu>,
+    },
   },
 ])

--- a/packages/sanity/src/_exports/_unstable.ts
+++ b/packages/sanity/src/_exports/_unstable.ts
@@ -203,8 +203,6 @@ export type {
 
 export * from '../schema'
 
-export type {ToolMenuProps} from '../studio'
-
 export type {
   ArrayFieldDefinition,
   FieldDefinition,

--- a/packages/sanity/src/_exports/index.ts
+++ b/packages/sanity/src/_exports/index.ts
@@ -197,6 +197,8 @@ export {
 } from '../studio'
 
 export type {
+  LogoProps,
+  NavbarProps,
   SourceProviderProps,
   StudioProps,
   StudioProviderProps,

--- a/packages/sanity/src/components/collapseMenu/CollapseMenu.tsx
+++ b/packages/sanity/src/components/collapseMenu/CollapseMenu.tsx
@@ -76,6 +76,7 @@ export const CollapseMenu = forwardRef(function CollapseMenu(
     gap,
     menuButtonProps,
     onMenuClose,
+    ...rest
   } = props
   const [rootEl, setRootEl] = useState<HTMLDivElement | null>(null)
   const [hiddenRowEl, setHiddenRowEl] = useState<HTMLDivElement | null>(null)
@@ -169,7 +170,14 @@ export const CollapseMenu = forwardRef(function CollapseMenu(
   }
 
   return (
-    <OuterFlex align="center" data-ui="CollapseMenu" overflow="hidden" sizing="border" ref={ref}>
+    <OuterFlex
+      align="center"
+      data-ui="CollapseMenu"
+      overflow="hidden"
+      sizing="border"
+      ref={ref}
+      {...rest}
+    >
       <RootFlex direction="column" flex={1} justify="center" ref={setRootEl}>
         {/* Content */}
         <RowFlex gap={gap}>

--- a/packages/sanity/src/config/components/_createRenderComponent.ts
+++ b/packages/sanity/src/config/components/_createRenderComponent.ts
@@ -1,0 +1,85 @@
+import React, {createElement, ReactNode} from 'react'
+import {StudioLayout} from '../../studio'
+import {Navbar, ToolMenu, DefaultLogo} from '../../studio/components'
+import {_RenderMiddleware} from '../form/_types'
+import {PluginOptions, RenderComponentCallback, SourceOptions} from '../types'
+
+const DEFAULT_COMPONENTS: Record<ComponentNames, React.ElementType> = {
+  Layout: StudioLayout,
+  Logo: DefaultLogo,
+  Navbar: Navbar,
+  ToolMenu: ToolMenu,
+}
+
+const RENDER_CALLBACK_NAMES: Record<ComponentNames, RenderCallbackNames> = {
+  Layout: 'renderLayout',
+  Logo: 'renderLogo',
+  Navbar: 'renderNavbar',
+  ToolMenu: 'renderToolMenu',
+}
+
+type FIXME = ReactNode
+
+type ComponentNames = 'Layout' | 'Logo' | 'Navbar' | 'ToolMenu'
+
+type RenderCallbackNames = 'renderLayout' | 'renderLogo' | 'renderNavbar' | 'renderToolMenu'
+
+type MiddlewaresType<T> = _RenderMiddleware<T, RenderComponentCallback<T>>[]
+
+interface CreateRenderComponentProps {
+  componentName: ComponentNames
+  config: SourceOptions
+}
+
+function _collectMiddleware<T>(
+  middlewares: MiddlewaresType<T>,
+  plugins: PluginOptions[],
+  renderCallbackName: RenderCallbackNames
+) {
+  for (const plugin of plugins) {
+    if (plugin.plugins) {
+      _collectMiddleware(middlewares, plugin.plugins, renderCallbackName)
+    }
+
+    if (plugin.studio?.[renderCallbackName]) {
+      middlewares.push(plugin.studio[renderCallbackName] as RenderComponentCallback<T>)
+    }
+  }
+}
+
+/**
+ * @internal
+ */
+export function _createRenderComponent<T>({
+  componentName,
+  config,
+}: CreateRenderComponentProps): RenderComponentCallback<T> {
+  return (props) => {
+    const middlewares: MiddlewaresType<T> = []
+
+    const renderCallbackName = RENDER_CALLBACK_NAMES[componentName]
+
+    if (config.plugins) {
+      _collectMiddleware(middlewares, config.plugins, renderCallbackName)
+    }
+
+    if (config.studio?.[renderCallbackName]) {
+      middlewares.push(config.studio[renderCallbackName] as RenderComponentCallback<T>)
+    }
+
+    const _defaultItem = (itemProps: T): FIXME =>
+      createElement(DEFAULT_COMPONENTS[componentName], itemProps)
+
+    let next = _defaultItem
+
+    for (const middleware of middlewares) {
+      const defaultRender = next
+
+      next = (itemProps: T) => {
+        return middleware(itemProps, defaultRender) || defaultRender(itemProps)
+      }
+    }
+
+    return next(props)
+  }
+}

--- a/packages/sanity/src/config/components/index.ts
+++ b/packages/sanity/src/config/components/index.ts
@@ -1,0 +1,1 @@
+export * from './_createRenderComponent'

--- a/packages/sanity/src/config/prepareConfig.ts
+++ b/packages/sanity/src/config/prepareConfig.ts
@@ -13,6 +13,7 @@ import {InitialValueTemplateItem, Template, TemplateResponse} from '../templates
 import {isNonNullable} from '../util'
 import {defaultFileAssetSources, defaultImageAssetSources} from '../form/defaults'
 import {validateWorkspaces} from '../studio/workspaces/validateWorkspaces'
+import {LogoProps, NavbarProps, ToolMenuProps} from '../studio/components'
 import {
   Config,
   PreparedConfig,
@@ -45,6 +46,7 @@ import {_createRenderField} from './form/_renderField'
 import {_createRenderInput} from './form/_renderInput'
 import {_createRenderItem} from './form/_renderItem'
 import {_createRenderPreview} from './form/_renderPreview'
+import {_createRenderComponent} from './components'
 
 type InternalSource = WorkspaceSummary['__internal']['sources'][number]
 
@@ -453,6 +455,25 @@ function resolveSource({
           // default value for this is `true`
           config.form?.file?.directUploads === undefined ? true : config.form.file.directUploads,
       },
+    },
+
+    studio: {
+      renderLayout: _createRenderComponent<unknown>({
+        componentName: 'Layout',
+        config,
+      }),
+      renderLogo: _createRenderComponent<LogoProps>({
+        componentName: 'Logo',
+        config,
+      }),
+      renderNavbar: _createRenderComponent<NavbarProps>({
+        componentName: 'Navbar',
+        config,
+      }),
+      renderToolMenu: _createRenderComponent<ToolMenuProps>({
+        componentName: 'ToolMenu',
+        config,
+      }),
     },
 
     __internal: {

--- a/packages/sanity/src/config/types.ts
+++ b/packages/sanity/src/config/types.ts
@@ -31,7 +31,7 @@ import type {Router, RouterState} from '../router'
 import type {DocumentActionComponent} from '../desk/actions'
 import type {DocumentBadgeComponent} from '../desk/badges'
 import {PreviewProps} from '../components/previews'
-import {ToolMenuProps} from '../studio/components/navbar/tools/ToolMenu'
+import {LogoProps, NavbarProps, ToolMenuProps} from '../studio/components'
 
 /**
  * @alpha
@@ -48,6 +48,28 @@ export interface SanityAuthConfig {
 }
 
 export type AssetSourceResolver = ComposableOption<AssetSource[], ConfigContext>
+
+export type RenderComponentCallback<T> = (props: T) => ReactNode
+
+// Component API
+export type RenderLayoutCallback = RenderComponentCallback<unknown>
+export type RenderLogoCallback = RenderComponentCallback<LogoProps>
+export type RenderNavbarCallback = RenderComponentCallback<NavbarProps>
+export type RenderToolMenuCallback = RenderComponentCallback<ToolMenuProps>
+
+interface StudioConfigOptions {
+  renderLayout: RenderLayoutCallback
+  renderLogo: RenderLogoCallback
+  renderNavbar: RenderNavbarCallback
+  renderToolMenu: RenderToolMenuCallback
+}
+
+interface StudioPluginOptions {
+  renderLayout?: (props: unknown, next: RenderLayoutCallback) => ReactNode
+  renderLogo?: (props: LogoProps, next: RenderLogoCallback) => ReactNode
+  renderNavbar?: (props: NavbarProps, next: RenderComponentCallback<NavbarProps>) => ReactNode
+  renderToolMenu?: (props: ToolMenuProps, next: RenderToolMenuCallback) => ReactNode
+}
 
 /**
  * @alpha
@@ -203,6 +225,7 @@ export interface PluginOptions {
   document?: DocumentPluginOptions
   tools?: Tool[] | ComposableOption<Tool[], ConfigContext>
   form?: SanityFormConfig
+  studio?: StudioPluginOptions
 }
 
 export type ConfigPropertyReducer<TValue, TContext> = (
@@ -320,6 +343,9 @@ export interface Source {
       Markers?: FormBuilderMarkersComponent
     }
   }
+
+  studio: StudioConfigOptions
+
   __internal: {
     bifur: BifurClient
     staticInitialValueTemplateItems: InitialValueTemplateItem[]

--- a/packages/sanity/src/studio/Studio.tsx
+++ b/packages/sanity/src/studio/Studio.tsx
@@ -1,8 +1,15 @@
 import React from 'react'
 import {StudioProvider, StudioProviderProps} from './StudioProvider'
-import {StudioLayout} from './StudioLayout'
+import {useWorkspace} from './workspace'
 
 export type StudioProps = Omit<StudioProviderProps, 'children'>
+
+function StudioLayout() {
+  const {renderLayout} = useWorkspace().studio
+  const layout = renderLayout(undefined)
+
+  return <>{layout}</>
+}
 
 export function Studio(props: StudioProps) {
   return (

--- a/packages/sanity/src/studio/StudioLayout.tsx
+++ b/packages/sanity/src/studio/StudioLayout.tsx
@@ -4,7 +4,6 @@ import React, {createElement, Suspense, useCallback, useEffect, useMemo, useStat
 import styled from 'styled-components'
 import {useHotModuleReload} from 'use-hot-module-reload'
 import {RouteScope, useRouter} from '../router'
-import {Navbar} from './components'
 import {NoToolsScreen} from './screens/NoToolsScreen'
 import {ToolNotFoundScreen} from './screens/ToolNotFoundScreen'
 import {useWorkspace} from './workspace'
@@ -18,7 +17,7 @@ const SearchFullscreenPortalCard = styled(Card)`
 
 export function StudioLayout() {
   const {state: routerState} = useRouter()
-  const {name, title, tools} = useWorkspace()
+  const {name, title, tools, studio} = useWorkspace()
   const activeToolName = typeof routerState.tool === 'string' ? routerState.tool : undefined
   const activeTool = tools.find((tool) => tool.name === activeToolName)
   const [toolError, setToolError] = useState<{error: Error; info: React.ErrorInfo} | null>(null)
@@ -50,12 +49,19 @@ export function StudioLayout() {
   useEffect(resetToolError, [activeToolName, resetToolError])
   useHotModuleReload(resetToolError)
 
+  const navbarProps = useMemo(
+    () => ({
+      onSearchOpenChange: handleSearchOpenChange,
+      fullscreenSearchPortalEl: fullscreenSearchPortalEl,
+    }),
+    [fullscreenSearchPortalEl, handleSearchOpenChange]
+  )
+
+  const navbar = studio.renderNavbar(navbarProps)
+
   return (
-    <Flex data-ui="ToolScreen" direction="column" height="fill">
-      <Navbar
-        onSearchOpenChange={handleSearchOpenChange}
-        fullscreenSearchPortalEl={fullscreenSearchPortalEl}
-      />
+    <Flex data-ui="ToolScreen" direction="column" height="fill" data-testid="studio-layout">
+      {navbar}
 
       {tools.length === 0 && <NoToolsScreen />}
 

--- a/packages/sanity/src/studio/components/navbar/DefaultLogo.tsx
+++ b/packages/sanity/src/studio/components/navbar/DefaultLogo.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import {Button, Text} from '@sanity/ui'
+
+export interface LogoProps {
+  href: string
+  onClick: React.MouseEventHandler<HTMLElement>
+  title: string
+}
+
+export function DefaultLogo(props: LogoProps) {
+  const {title, href, onClick} = props
+
+  return (
+    <Button aria-label={title} as="a" href={href} mode="bleed" onClick={onClick} padding={3}>
+      <Text weight="bold">{title}</Text>
+    </Button>
+  )
+}

--- a/packages/sanity/src/studio/components/navbar/NavDrawer.tsx
+++ b/packages/sanity/src/studio/components/navbar/NavDrawer.tsx
@@ -1,12 +1,12 @@
 import {Layer, Card, Flex, Text, Box, Button, Stack, useGlobalKeyDown} from '@sanity/ui'
 import {CloseIcon, LeaveIcon} from '@sanity/icons'
-import React, {memo, useEffect, useState} from 'react'
+import React, {memo, useEffect, useMemo, useState} from 'react'
 import styled from 'styled-components'
 import {UserAvatar} from '../../../components/UserAvatar'
 import {useWorkspace} from '../../workspace'
 import {useRovingFocus} from '../../../components/rovingFocus'
 import {Tool} from '../../../config'
-import {ToolMenu as DefaultToolMenu} from './tools/ToolMenu'
+import {ToolMenuProps} from './tools/ToolMenu'
 import {WorkspaceMenuButton} from './workspace'
 
 const Root = styled(Layer)`
@@ -61,10 +61,7 @@ export const NavDrawer = memo(function NavDrawer(props: NavDrawerProps) {
   const [closeButtonElement, setCloseButtonElement] = useState<HTMLButtonElement | null>(null)
   const [innerCardElement, setInnerCardElement] = useState<HTMLDivElement | null>(null)
   const tabIndex = isOpen ? 0 : -1
-
-  const {currentUser, navbar, auth} = useWorkspace()
-
-  const {ToolMenu = DefaultToolMenu} = navbar?.components || {}
+  const {auth, currentUser, studio} = useWorkspace()
 
   useRovingFocus({
     rootElement: innerCardElement,
@@ -82,6 +79,19 @@ export const NavDrawer = memo(function NavDrawer(props: NavDrawerProps) {
       closeButtonElement?.focus()
     }
   }, [closeButtonElement, isOpen])
+
+  const toolMenuProps: ToolMenuProps = useMemo(
+    () => ({
+      activeToolName: activeToolName,
+      closeSidebar: onClose,
+      context: 'sidebar',
+      isSidebarOpen: isOpen,
+      tools: tools,
+    }),
+    [activeToolName, isOpen, onClose, tools]
+  )
+
+  const toolMenu = studio.renderToolMenu(toolMenuProps)
 
   return (
     <Root>
@@ -126,13 +136,7 @@ export const NavDrawer = memo(function NavDrawer(props: NavDrawerProps) {
         </Card>
 
         <Box flex="auto" overflow="auto" padding={[3, 3, 4]}>
-          <ToolMenu
-            activeToolName={activeToolName}
-            closeDrawer={onClose}
-            context="drawer"
-            isDrawerOpen={isOpen}
-            tools={tools}
-          />
+          {toolMenu}
         </Box>
 
         {auth.logout && (

--- a/packages/sanity/src/studio/components/navbar/index.ts
+++ b/packages/sanity/src/studio/components/navbar/index.ts
@@ -1,1 +1,3 @@
+export * from './DefaultLogo'
 export * from './Navbar'
+export * from './tools'

--- a/packages/sanity/src/studio/components/navbar/tools/ToolCollapseMenu.tsx
+++ b/packages/sanity/src/studio/components/navbar/tools/ToolCollapseMenu.tsx
@@ -63,7 +63,12 @@ export function ToolCollapseMenu(props: ToolCollapseMenuProps) {
   )
 
   return (
-    <CollapseMenu gap={1} menuButtonProps={menuButtonProps} ref={setCollapseMenuEl}>
+    <CollapseMenu
+      data-testid="tool-collapse-menu"
+      gap={1}
+      menuButtonProps={menuButtonProps}
+      ref={setCollapseMenuEl}
+    >
       {children}
     </CollapseMenu>
   )

--- a/packages/sanity/src/studio/components/navbar/tools/ToolMenu.tsx
+++ b/packages/sanity/src/studio/components/navbar/tools/ToolMenu.tsx
@@ -5,17 +5,17 @@ import {ToolVerticalMenu} from './ToolVerticalMenu'
 
 export interface ToolMenuProps {
   activeToolName?: string
-  context: 'drawer' | 'topbar'
-  isDrawerOpen: boolean
+  closeSidebar: () => void
+  context: 'sidebar' | 'topbar'
+  isSidebarOpen: boolean
   tools: Tool[]
-  closeDrawer: () => void
 }
 
 export function ToolMenu(props: ToolMenuProps) {
-  const {context, isDrawerOpen, ...restProps} = props
+  const {context, isSidebarOpen, ...restProps} = props
 
-  if (context === 'drawer') {
-    return <ToolVerticalMenu isVisible={isDrawerOpen} {...restProps} />
+  if (context === 'sidebar') {
+    return <ToolVerticalMenu isVisible={isSidebarOpen} {...restProps} />
   }
 
   return <ToolCollapseMenu {...restProps} />

--- a/packages/sanity/src/studio/components/navbar/tools/index.ts
+++ b/packages/sanity/src/studio/components/navbar/tools/index.ts
@@ -1,1 +1,2 @@
-export * from './ToolCollapseMenu'
+export * from './ToolMenu'
+export * from './ToolLink'

--- a/packages/sanity/src/studio/index.ts
+++ b/packages/sanity/src/studio/index.ts
@@ -1,5 +1,4 @@
-export * from './components/navbar/tools/ToolMenu'
-export * from './components/navbar/tools/ToolLink'
+export * from './components/navbar'
 
 export * from './Studio'
 export * from './StudioLayout'


### PR DESCRIPTION
### Description

This PR implements render callbacks for components. The render callbacks is intended to be used when you want to replace, modify or wrap components in studio. Example:

```js
const config = createConfig({
  ...,
  studio: {
    renderLayout: (props, next) => <ContextProvider>{props(next)}</ContextProvider>,
    renderNavbar: (props, next) => (
      <Stack>
        <Banner />
        {props(next)}
      </Stack>
    ),
    renderLogo: () => <MyLogo />,
  }
})
```

### What to review

- Make sure that the render callbacks works as expected
- General code review

### Notes for release

feat: implement custom components API