### PR TITLE
Bug/remove empty on close

### DIFF
--- a/dev/test-studio/structure/resolveStructure.ts
+++ b/dev/test-studio/structure/resolveStructure.ts
@@ -357,7 +357,8 @@ export const structure: StructureResolver = (S, {schema}) => {
           !STANDARD_PORTABLE_TEXT_INPUT_TYPES.includes(id) &&
           !PLUGIN_INPUT_TYPES.includes(id) &&
           !EXTERNAL_PLUGIN_INPUT_TYPES.includes(id) &&
-          !DEBUG_FIELD_GROUP_TYPES.includes(id)
+          !DEBUG_FIELD_GROUP_TYPES.includes(id) &&
+          !typesInOptionGroup(S, schema, 'v3').includes(id)
         )
       }),
     ])

--- a/packages/sanity/src/form/members/items/ArrayOfObjectsItem.tsx
+++ b/packages/sanity/src/form/members/items/ArrayOfObjectsItem.tsx
@@ -141,12 +141,13 @@ export function ArrayOfObjectsItem(props: MemberItemProps) {
     onPathOpen(member.item.path)
   }, [onPathOpen, member.item.path])
 
+  const isEmptyValue = !member.item.value || isEmpty(member.item.value)
   const handleClose = useCallback(() => {
-    if (!member.item.value || isEmpty(member.item.value)) {
+    if (isEmptyValue) {
       onRemove()
     }
     onPathOpen(member.item.path.slice(0, -1))
-  }, [onPathOpen, member.item.path, member.item.value, onRemove])
+  }, [onPathOpen, member.item.path, isEmptyValue, onRemove])
 
   const handleSelectFieldGroup = useCallback(
     (groupName: string) => {

--- a/packages/sanity/src/form/members/items/ArrayOfObjectsItem.tsx
+++ b/packages/sanity/src/form/members/items/ArrayOfObjectsItem.tsx
@@ -15,6 +15,7 @@ import {ensureKey} from '../../utils/ensureKey'
 import {FormCallbacksProvider, useFormCallbacks} from '../../studio/contexts/FormCallbacks'
 import {ArrayOfObjectsItemMember} from '../../store'
 import {createProtoValue} from '../../utils/createProtoValue'
+import {isEmpty} from '../../inputs/arrays/ArrayOfObjectsInput/item/helpers'
 
 /**
  * @alpha
@@ -49,6 +50,25 @@ export function ArrayOfObjectsItem(props: MemberItemProps) {
       focusRef.current?.focus()
     }
   })
+
+  const onRemove = useCallback(() => {
+    onChange(PatchEvent.from([unset([{_key: member.key}])]))
+  }, [member.key, onChange])
+
+  const onInsert = useCallback(
+    (event: {items: unknown[]; position: 'before' | 'after'}) => {
+      onChange(
+        PatchEvent.from([
+          insert(
+            event.items.map((item) => ensureKey(item)),
+            event.position,
+            [{_key: member.key}]
+          ),
+        ])
+      )
+    },
+    [member.key, onChange]
+  )
 
   const handleBlur = useCallback(() => {
     onPathBlur(member.item.path)
@@ -122,8 +142,11 @@ export function ArrayOfObjectsItem(props: MemberItemProps) {
   }, [onPathOpen, member.item.path])
 
   const handleClose = useCallback(() => {
+    if (!member.item.value || isEmpty(member.item.value)) {
+      onRemove()
+    }
     onPathOpen(member.item.path.slice(0, -1))
-  }, [onPathOpen, member.item.path])
+  }, [onPathOpen, member.item.path, member.item.value, onRemove])
 
   const handleSelectFieldGroup = useCallback(
     (groupName: string) => {
@@ -203,26 +226,6 @@ export function ArrayOfObjectsItem(props: MemberItemProps) {
   ])
 
   const renderedInput = useMemo(() => renderInput(inputProps), [inputProps, renderInput])
-
-  // const onInsert = useCallback(() => {}, [member.key])
-  const onRemove = useCallback(() => {
-    onChange(PatchEvent.from([unset([{_key: member.key}])]))
-  }, [member.key, onChange])
-
-  const onInsert = useCallback(
-    (event: {items: unknown[]; position: 'before' | 'after'}) => {
-      onChange(
-        PatchEvent.from([
-          insert(
-            event.items.map((item) => ensureKey(item)),
-            event.position,
-            [{_key: member.key}]
-          ),
-        ])
-      )
-    },
-    [member.key, onChange]
-  )
 
   const itemProps = useMemo((): ObjectItemProps => {
     return {


### PR DESCRIPTION
### Description

Restores v2 behavior: "delete on close" for empty array items.

Simply checks if the current value only contains _key and _type and if so, invokes onRemove.

Note: not tested with renderItem as it seems to be unimplemented atm?

### What to review

All the changes ;)

### Notes for release

Empty array items are removed when the edit dialog is closed.
