### PR TITLE
fix: corrected object level indentation for slug and alias types

### DIFF
--- a/dev/test-studio/schema/index.ts
+++ b/dev/test-studio/schema/index.ts
@@ -18,8 +18,8 @@ import simpleBlockNote from './standard/portableText/simpleBlockNote'
 import simpleBlockNoteBody from './standard/portableText/simpleBlockNoteBody'
 import simpleBlockNoteUrl from './standard/portableText/simpleBlockNoteUrl'
 import spotifyEmbed from './standard/portableText/spotifyEmbed'
-import references from './standard/references'
-import slugs from './standard/slugs'
+import references, {referenceAlias} from './standard/references'
+import slugs, {slugAlias} from './standard/slugs'
 import strings from './standard/strings'
 import texts from './standard/texts'
 import urls from './standard/urls'
@@ -200,6 +200,7 @@ export const schemaTypes = [
   recursiveObjectTest,
   recursivePopover,
   references,
+  referenceAlias,
   crossDatasetReference,
   crossDatasetSubtype,
   circularCrossDatasetReferenceTest,
@@ -213,6 +214,7 @@ export const schemaTypes = [
   simpleBlockNoteUrl,
   simpleArrayOfObjects,
   slugs,
+  slugAlias,
   species,
   spotifyEmbed,
   strings,

--- a/dev/test-studio/schema/standard/references.ts
+++ b/dev/test-studio/schema/standard/references.ts
@@ -1,6 +1,14 @@
 import {SyncIcon} from '@sanity/icons'
 import {defineField, defineType} from 'sanity'
 
+export const referenceAlias = defineType({
+  type: 'reference',
+  name: 'reference-alias',
+  title: 'Reference alias',
+  description: 'This is a reference alias type',
+  to: {type: 'referenceTest'},
+})
+
 export default defineType({
   name: 'referenceTest',
   type: 'document',
@@ -15,6 +23,10 @@ export default defineType({
       type: 'reference',
       description: 'Some description',
       to: {type: 'referenceTest'},
+    },
+    {
+      name: 'aliasRef',
+      type: referenceAlias.name,
     },
     {
       title: 'Reference to book or author',

--- a/dev/test-studio/schema/standard/slugs.ts
+++ b/dev/test-studio/schema/standard/slugs.ts
@@ -1,5 +1,11 @@
 import {defineType} from 'sanity'
 
+export const slugAlias = {
+  name: 'slug-alias',
+  type: 'slug',
+  title: 'Slug alias',
+}
+
 export default defineType({
   name: 'slugsTest',
   type: 'document',
@@ -31,6 +37,10 @@ export default defineType({
         source: 'title',
         maxLength: 96,
       },
+    },
+    {
+      name: 'slugAlias',
+      type: slugAlias.name,
     },
     {
       name: 'noSource',
@@ -118,6 +128,17 @@ export default defineType({
               return encodeURI(`${type.name}_${value}`).toLocaleLowerCase()
             },
           },
+        },
+        {
+          name: 'nestedInner',
+          type: 'object',
+          fields: [
+            {
+              name: 'slug',
+              type: 'slug',
+              description: 'Level indentation check',
+            },
+          ],
         },
       ],
     },

--- a/packages/sanity/src/form/store/formState.ts
+++ b/packages/sanity/src/form/store/formState.ts
@@ -37,6 +37,7 @@ import {ArrayOfObjectsFormNode, ArrayOfPrimitivesFormNode, ObjectFormNode} from 
 import {FormFieldGroup} from './types/fieldGroup'
 import {getCollapsedWithDefaults} from './utils/getCollapsibleOptions'
 import {FieldError} from './types/memberErrors'
+import {getFieldLevel} from '../studio/inputResolver/helpers'
 
 type PrimitiveSchemaType = BooleanSchemaType | NumberSchemaType | StringSchemaType
 
@@ -117,7 +118,8 @@ function prepareFieldMember(props: {
 }): ObjectMember | null {
   const {parent, field, index} = props
   const fieldPath = pathFor([...parent.path, field.name])
-  const fieldLevel = parent.level + 1
+  const fieldLevel = getFieldLevel(field.type, parent.level + 1)
+
   const parentValue = parent.value
   const parentComparisonValue = parent.comparisonValue
   if (!isAcceptedObjectValue(parentValue)) {

--- a/packages/sanity/src/form/studio/inputResolver/helpers.test.ts
+++ b/packages/sanity/src/form/studio/inputResolver/helpers.test.ts
@@ -1,0 +1,108 @@
+/* eslint max-nested-callbacks: */
+
+import {getObjectFieldLevel, type PartialObjectFieldProps} from './helpers'
+
+type SchemaSnippet = PartialObjectFieldProps['schemaType']
+type SchemaTest = SchemaSnippet & {description: string}
+
+const noIndentation: SchemaTest[] = [
+  {description: 'any array', name: 'array'},
+  {description: 'file without additional fields', name: 'file', fields: [{name: 'asset'}]},
+  {
+    description: 'image without additional fields',
+    name: 'image',
+    fields: [{name: 'asset'}, {name: 'crop'}, {name: 'hotspot'}],
+  },
+  {description: 'any reference', name: 'reference', fields: [{name: '_ref'}, {name: '_weak'}]},
+  {description: 'any slug', name: 'slug', fields: [{name: 'current'}]},
+]
+
+const hasIndentation: SchemaTest[] = [
+  {description: 'string without list', name: 'string'},
+  {description: 'string with empty list', name: 'string', options: {list: []}},
+  {description: 'string with list', name: 'string', options: {list: ['dummy']}},
+
+  {description: 'number with list', name: 'number', options: {list: [1]}},
+  {description: 'number without list', name: 'number'},
+  {description: 'number with empty list', name: 'number', options: {list: []}},
+
+  {description: 'object with (visible) fields', name: 'object', fields: [{name: 'title'}]},
+  {description: 'object with no fields', name: 'object', fields: []},
+  {
+    description: 'file with additional fields',
+    name: 'file',
+    fields: [{name: 'caption'}, {name: 'asset'}],
+  },
+  {
+    description: 'image with additional fields',
+    name: 'image',
+    fields: [{name: 'caption'}, {name: 'asset'}, {name: 'crop'}, {name: 'hotspot'}],
+  },
+]
+
+function createBaseType(snippet: SchemaSnippet): SchemaSnippet {
+  return {
+    ...snippet,
+    type: snippet,
+  }
+}
+
+function createAlias(snippet: SchemaSnippet): SchemaSnippet {
+  const parentType = createBaseType(snippet)
+  const alias = {
+    ...parentType,
+    name: `${parentType.name}-alias`,
+    type: parentType,
+  }
+  // schemas seem to self-reference first, then recurse
+  return {
+    ...alias,
+    type: alias,
+  }
+}
+
+describe('inputResolver/helpers', () => {
+  describe('getObjectFieldLevel', () => {
+    const GREATER_THAN_ZERO = 5
+
+    noIndentation.forEach((schemaSnippet) => {
+      describe('types without indentation', () => {
+        it(`should return level 0 for ${schemaSnippet.description}`, () => {
+          const field = {schemaType: createBaseType(schemaSnippet), level: GREATER_THAN_ZERO}
+          const baseLevel = getObjectFieldLevel(field)
+          expect(baseLevel).toEqual(0)
+        })
+
+        it(`should return level 0 for ${schemaSnippet.description} alias`, () => {
+          const field = {
+            schemaType: createAlias(schemaSnippet),
+            level: GREATER_THAN_ZERO,
+          }
+          const aliasLevel = getObjectFieldLevel(field)
+          expect(aliasLevel).toEqual(0)
+        })
+      })
+    })
+
+    describe('types with indentation', () => {
+      hasIndentation.forEach((schemaSnippet) => {
+        it(`should return level > 0 for ${schemaSnippet.name}`, () => {
+          const field = {schemaType: createBaseType(schemaSnippet), level: GREATER_THAN_ZERO}
+          const baseLevel = getObjectFieldLevel(field)
+          expect(baseLevel).toEqual(GREATER_THAN_ZERO)
+        })
+
+        it(`should return level > 0 for ${schemaSnippet.name} alias`, () => {
+          const field = {
+            schemaType: createAlias(schemaSnippet),
+            level: GREATER_THAN_ZERO,
+          }
+          const aliasLevel = getObjectFieldLevel(field)
+          expect(aliasLevel).toEqual(GREATER_THAN_ZERO)
+        })
+      })
+    })
+  })
+})
+
+export {}

--- a/packages/sanity/src/form/studio/inputResolver/helpers.ts
+++ b/packages/sanity/src/form/studio/inputResolver/helpers.ts
@@ -1,6 +1,6 @@
-import {SchemaType} from '@sanity/types'
+import {ObjectSchemaType, SchemaType} from '@sanity/types'
 import {get} from 'lodash'
-import {ArrayFieldProps, ObjectFieldProps} from '../../types'
+import {ArrayFieldProps} from '../../types'
 
 export function getOption(type: SchemaType, optionName: string) {
   return get(type.options, optionName)
@@ -9,15 +9,30 @@ export function getOption(type: SchemaType, optionName: string) {
 const PSEUDO_OBJECTS = ['array', 'file', 'image', 'reference']
 const HIDDEN_FIELDS = ['asset', 'crop', 'hotspot', '_ref', '_weak']
 const NO_LEVEL_LAYOUTS = ['tags']
+const NO_LEVEL_TYPES = ['slug']
 
-export function getObjectFieldLevel(field: ObjectFieldProps): number {
+type PartialObjectSchema = Pick<ObjectSchemaType, 'name' | 'options'> & {
+  type?: PartialObjectSchema
+  fields?: {name: string}[]
+}
+
+export interface PartialObjectFieldProps {
+  schemaType: PartialObjectSchema
+  level: number
+}
+
+export function getObjectFieldLevel(field: PartialObjectFieldProps): number {
   const {type, fields, options} = field.schemaType
-  const fieldType = type?.name || ''
+  const rootType = getRootType(type)
+  const fieldType = rootType?.name || ''
+
+  if (NO_LEVEL_TYPES.includes(fieldType)) {
+    return 0
+  }
 
   const isPseudoObject = PSEUDO_OBJECTS.includes(fieldType)
-
-  const hasVisibleFields = fields?.filter((f) => !HIDDEN_FIELDS.includes(f.name)).length > 0
-  const hasListOptions = options?.list?.length > 0
+  const hasVisibleFields = (fields?.filter((f) => !HIDDEN_FIELDS.includes(f.name)).length ?? 0) > 0
+  const hasListOptions = (options?.list?.length ?? 0) > 0
 
   if (hasVisibleFields || hasListOptions || !isPseudoObject) {
     return field.level
@@ -37,4 +52,11 @@ export function getArrayFieldLevel(field: ArrayFieldProps): number {
   }
 
   return 0
+}
+
+function getRootType(schemaType?: PartialObjectSchema): PartialObjectSchema | undefined {
+  if (!schemaType?.type) {
+    return schemaType
+  }
+  return getRootType(schemaType.type)
 }

--- a/packages/sanity/src/form/studio/inputResolver/inputResolver.tsx
+++ b/packages/sanity/src/form/studio/inputResolver/inputResolver.tsx
@@ -21,14 +21,12 @@ import * as is from '../../utils/is'
 import {FormField, FormFieldSet} from '../../components/formField'
 import {PreviewProps} from '../../../components/previews'
 import {SanityPreview} from '../../../preview'
-import {isObjectField} from '../../utils/asserters'
 import {ChangeIndicator} from '../../../components/changeIndicators'
 import {resolveReferenceInput} from './resolveReferenceInput'
 import {resolveArrayInput} from './resolveArrayInput'
 import {resolveStringInput} from './resolveStringInput'
 import {resolveNumberInput} from './resolveNumberInput'
 import {defaultInputs} from './defaultInputs'
-import {getArrayFieldLevel, getObjectFieldLevel} from './helpers'
 
 function resolveComponentFromTypeVariants(
   type: SchemaType
@@ -115,12 +113,10 @@ function PrimitiveField(field: FieldProps) {
 }
 
 function ObjectOrArrayField(field: ObjectFieldProps | ArrayFieldProps) {
-  const level = isObjectField(field) ? getObjectFieldLevel(field) : getArrayFieldLevel(field)
-
   return (
     <FormFieldSet
       data-testid={`field-${field.inputId}`}
-      level={level}
+      level={field.level}
       title={field.title}
       description={field.description}
       collapsed={field.collapsed}
@@ -144,11 +140,9 @@ function ImageOrFileField(field: ObjectFieldProps) {
     ? field.presence
     : field.presence.concat(hotspotField?.field.presence || [])
 
-  const level = getObjectFieldLevel(field)
-
   return (
     <FormFieldSet
-      level={level}
+      level={field.level}
       title={field.title}
       description={field.description}
       collapsed={field.collapsed}


### PR DESCRIPTION
### Description

Slug had level indentation. This is now removed.
The code that handled level indentation for objects did not account for recursive alias types. This is now added.

Moved the resolution of levels into formState so that this behaves equally in all components.
Should also be a tiny pref boost, since we dont have to recalculate level every render.

Added a test-suit to try to account for most codepaths.

#### Before
![image](https://user-images.githubusercontent.com/835514/190131923-22de75b1-1bb9-4708-be22-d69cada6a943.png)

![image](https://user-images.githubusercontent.com/835514/190132015-d5bfd618-a42e-4d14-88b8-dec2d0e4291d.png)

#### After
![image](https://user-images.githubusercontent.com/835514/190132070-84433f4a-e774-497b-8b56-be0ee406d694.png)

![image](https://user-images.githubusercontent.com/835514/190132178-813b1d45-c3ce-47f1-a3a8-2c4fa82bf886.png)

### What to review

Evaluate the tests-cases.

![image](https://user-images.githubusercontent.com/835514/190131292-9bceb6d8-663d-4d68-8302-2cd942db6519.png)

Is the move from components to formState ok?

Can be tested in the studio: added alias for slug and reference. 

### Notes for release

Slug no longer has indentation next to the input.
