### PR TITLE
Fix PT-input fullscreen issue

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/PortableText/Compositor.styles.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Compositor.styles.tsx
@@ -51,7 +51,4 @@ export const ExpandedLayer = styled(Layer)`
   left: 0;
   right: 0;
   bottom: 0;
-  &:not([data-fullscreen]) {
-    position: relative;
-  }
 `

--- a/packages/@sanity/form-builder/src/inputs/PortableText/Compositor.tsx
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/Compositor.tsx
@@ -392,15 +392,6 @@ export function Compositor(props: InputProps) {
     [portal.element, portalElement, wrapperElement]
   )
 
-  const editorLayer = useMemo(
-    () => (
-      <Portal __unstable_name={isFullscreen ? 'expanded' : 'collapsed'}>
-        <ExpandedLayer data-fullscreen={isFullscreen ? '' : undefined}>{children}</ExpandedLayer>
-      </Portal>
-    ),
-    [children, isFullscreen]
-  )
-
   return (
     <PortalProvider __unstable_elements={portalElements}>
       <ActivateOnFocus
@@ -416,7 +407,9 @@ export function Compositor(props: InputProps) {
         >
           <Root data-focused={hasFocus ? '' : undefined} data-read-only={readOnly ? '' : undefined}>
             <div data-wrapper="" ref={setWrapperElement}>
-              {editorLayer}
+              <Portal __unstable_name={isFullscreen ? 'expanded' : 'collapsed'}>
+                {isFullscreen ? <ExpandedLayer>{children}</ExpandedLayer> : children}
+              </Portal>
             </div>
             <div data-border="" />
           </Root>


### PR DESCRIPTION
### Description

This will fix an issue when closing modals from PT that contains a nested PT-editor when pressing `ESC`.

There was an attempt to always render the ExtendedLayer wrapped around the fullscreen version of the PT-input in order to optimize rendering. This seems not to actually give any particular performance wins though.

By only including the ExtendedLayer when in fullscreen fixes the issue described above as the `isTopLayer` get's the correct value now.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

That everything closes as expected using `ESC` on modals and fullscreen mode in the PT-input.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Fix an issue where Portable Text Input modals including a nested PT-input didn't close properly when pressing `ESC`.

<!--
A description of the change(s) that should be used in the release notes.
-->
