### PR TITLE
Workaround weird Chrome bug related to flex layout

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/PortableText/text/TextBlock.styles.ts
+++ b/packages/@sanity/form-builder/src/inputs/PortableText/text/TextBlock.styles.ts
@@ -99,8 +99,12 @@ function textBlockStyle(props: TextBlockStyleProps & {theme: Theme}) {
 
 export const TextRoot = styled.div<TextBlockStyleProps>(textBlockStyle)
 
-export const TextBlockFlexWrapper = styled(Flex)`
+// Because of a weird bug in Google Chrome regarding the @sanity/ui Flex component and spellchecking,
+// this is set to be a Box with 'display: flex'. Using the Flex component here results in Chrome
+// using 20% CPU when idle when spellchecking is on for some reason.
+export const TextBlockFlexWrapper = styled(Box)`
   position: relative;
+  display: flex;
 `
 
 export const ListPrefixWrapper = styled.div`


### PR DESCRIPTION
### Description

There seem to be a bug in Chrome related to flex layout and spellchecking. By using a div with 'display: flex' here the spellcheck would use around 20% cpu idle. By using a Box with the same display value, the bug isn't introduced for some reason.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

That everything works as before and that the CPU idle use is gone.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Workaround Chrome bug related to spellcheck and flex layout.

<!--
A description of the change(s) that should be used in the release notes.
-->
