### PR TITLE
feat(cli): add `--no-open` flag to login command

### DIFF
--- a/packages/@sanity/cli/src/actions/login/login.js
+++ b/packages/@sanity/cli/src/actions/login/login.js
@@ -11,7 +11,7 @@ import {getCliToken} from '../../util/clientWrapper'
 
 export default async function login(args, context) {
   const {prompt, output, apiClient} = context
-  const {sso, experimental, provider: specifiedProvider} = args.extOptions
+  const {sso, experimental, open: openFlag, provider: specifiedProvider} = args.extOptions
   const previousToken = getCliToken()
   const hasExistingToken = Boolean(previousToken)
 
@@ -38,14 +38,17 @@ export default async function login(args, context) {
   providerUrl.query.label = `${os.hostname()} / ${os.platform()}`
   const loginUrl = urlParser.format(providerUrl)
 
-  const shouldLaunchBrowser = canLaunchBrowser()
+  const shouldLaunchBrowser = canLaunchBrowser() && openFlag !== false
   const actionText = shouldLaunchBrowser ? 'Opening browser at' : 'Please open a browser at'
 
   output.print(`\n${actionText} ${loginUrl}\n`)
   const spin = output
     .spinner('Waiting for browser login to complete... Press Ctrl + C to cancel')
     .start()
-  open(loginUrl, {wait: false})
+
+  if (shouldLaunchBrowser) {
+    open(loginUrl, {wait: false})
+  }
 
   // Wait for a success/error on the listener channel
   let token

--- a/packages/@sanity/cli/src/commands/login/loginCommand.js
+++ b/packages/@sanity/cli/src/commands/login/loginCommand.js
@@ -6,6 +6,8 @@ const commandPrefix = prefixCommand()
 const helpText = `
 Options
   --sso <slug> Authenticate against a third-party identity provider
+  --provider <providerId> Authenticate against a specific provider
+  --no-open Do not open a browser window to log in, only print URL
 
 Examples
   # Login against the Sanity.io API
@@ -13,6 +15,9 @@ Examples
 
   # Login with SAML SSO
   ${commandPrefix} login --sso org-slug
+
+  # Login with GitHub provider, but do not open a browser window automatically
+  ${commandPrefix} login --provider github --no-open
 `
 export default {
   name: 'login',


### PR DESCRIPTION
### Description

Adds a new `--no-open` flag (technically also `--open`, but that is the default behavior) to the `sanity login` command, which is useful in certain situations such as automation. Also documents the `--provider <id>` option, which is also useful for automation.

### What to review

- That `sanity login` still opens a browser by default
- That `sanity login --no-open` does not open browser, but prints login URL to screen

### Notes for release

- Added a new `--no-open` flag to the `sanity login` command in order to suppress the opening of browser automatically

