### PR TITLE
feat(cli): add `--force` flag to `sanity dataset delete` command

### DIFF
--- a/packages/@sanity/core/src/commands/dataset/deleteDatasetCommand.js
+++ b/packages/@sanity/core/src/commands/dataset/deleteDatasetCommand.js
@@ -1,12 +1,30 @@
+import yargs from 'yargs/yargs'
+import {hideBin} from 'yargs/helpers'
 import validateDatasetName from '../../actions/dataset/validateDatasetName'
+
+const helpText = `
+Options
+  --force Do not prompt for delete confirmation - forcefully delete
+
+Examples
+  sanity dataset delete
+  sanity dataset delete my-dataset
+  sanity dataset delete my-dataset --force
+`
+
+function parseCliFlags(args) {
+  return yargs(hideBin(args.argv || process.argv).slice(2)).option('force', {type: 'boolean'}).argv
+}
 
 export default {
   name: 'delete',
   group: 'dataset',
+  helpText,
   signature: '[datasetName]',
   description: 'Delete a dataset within your project',
   action: async (args, context) => {
     const {apiClient, prompt, output} = context
+    const {force} = parseCliFlags(args)
     const [ds] = args.argsWithoutOptions
     if (!ds) {
       throw new Error('Dataset name must be provided')
@@ -18,20 +36,21 @@ export default {
       throw dsError
     }
 
-    await prompt.single({
-      type: 'input',
-      message:
-        'Are you ABSOLUTELY sure you want to delete this dataset?\n  Type the name of the dataset to confirm delete:',
-      filter: (input) => `${input}`.trim(),
-      validate: (input) => {
-        return input === dataset || 'Incorrect dataset name. Ctrl + C to cancel delete.'
-      },
-    })
-
-    return apiClient()
-      .datasets.delete(dataset)
-      .then(() => {
-        output.print('Dataset deleted successfully')
+    if (force) {
+      output.warn(`'--force' used: skipping confirmation, deleting dataset "${dataset}"`)
+    } else {
+      await prompt.single({
+        type: 'input',
+        message:
+          'Are you ABSOLUTELY sure you want to delete this dataset?\n  Type the name of the dataset to confirm delete:',
+        filter: (input) => `${input}`.trim(),
+        validate: (input) => {
+          return input === dataset || 'Incorrect dataset name. Ctrl + C to cancel delete.'
+        },
       })
+    }
+
+    await apiClient().datasets.delete(dataset)
+    output.print('Dataset deleted successfully')
   },
 }


### PR DESCRIPTION
### Description

Adds a new `--force` flag to the dataset delete command, in order to aid automation.

The reparsing of the CLI args is done to work around an issue where `sanity dataset delete --force foo` would treat the `force` flag as a string flag instead of a boolean flag and fail.

### What to review

- That `sanity dataset delete my-dataset` still works and prompts for the name
- That `sanity dataset delete my-dataset --force` skips the prompt and deletes

### Notes for release

- Added a new `--force` flag to the `sanity dataset delete` command
