### PR TITLE
feat(cli): add `--force` flag for dataset alias unlink command

### DIFF
--- a/packages/@sanity/core/src/commands/dataset/alias/aliasCommands.js
+++ b/packages/@sanity/core/src/commands/dataset/alias/aliasCommands.js
@@ -27,6 +27,7 @@ Link Alias
 Un-link Alias
   sanity dataset alias unlink
   sanity dataset alias unlink <alias-name>
+  sanity dataset alias unlink <alias-name> --force
 `
 
 export default {


### PR DESCRIPTION
### Description

Adds a new `--force` flag to the unlink command. Helps with automation.

### What to review

- `sanity dataset alias unlink :aliasName` still works and prompts for confirmation
- `sanity dataset alias unlink :aliasName --force` works and skips confirmation prompt

### Notes for release

- Added `--force` flag to the `sanity dataset alias unlink` command to skip confirmation prompt
