### PR TITLE
Refactor DocumentPaneProvider

### DIFF
--- a/packages/@sanity/desk-tool/src/actions/PublishAction.tsx
+++ b/packages/@sanity/desk-tool/src/actions/PublishAction.tsx
@@ -1,5 +1,10 @@
 import {DocumentActionComponent} from '@sanity/base'
-import {useSyncState, useDocumentOperation, useValidationStatus} from '@sanity/react-hooks'
+import {
+  useSyncState,
+  useDocumentOperation,
+  useValidationStatus,
+  useEditState,
+} from '@sanity/react-hooks'
 import {CheckmarkIcon, PublishIcon} from '@sanity/icons'
 import React, {useCallback, useEffect, useState} from 'react'
 import {
@@ -40,7 +45,8 @@ export const PublishAction: DocumentActionComponent = (props) => {
   const {publish} = useDocumentOperation(id, type)
   const validationStatus = useValidationStatus(id, type)
   const syncState = useSyncState(id, type)
-  const {changesOpen, editState, handleHistoryOpen} = useDocumentPane()
+  const {changesOpen, handleHistoryOpen, documentId, documentType} = useDocumentPane()
+  const editState = useEditState(documentId, documentType, 'low')
   const hasValidationErrors = validationStatus.markers.some((marker) => marker.level === 'error')
   // we use this to "schedule" publish after pending tasks (e.g. validation and sync) has completed
   const [publishScheduled, setPublishScheduled] = useState<boolean>(false)

--- a/packages/@sanity/desk-tool/src/panes/document/DocumentPaneContext.ts
+++ b/packages/@sanity/desk-tool/src/panes/document/DocumentPaneContext.ts
@@ -1,6 +1,5 @@
 import {DocumentActionDescription, DocumentBadgeDescription} from '@sanity/base'
 import {Marker, Path, SanityDocument} from '@sanity/types'
-import {EditStateFor} from '@sanity/base/_internal'
 import {createContext} from 'react'
 import {PaneView, PaneMenuItem, PaneMenuItemGroup} from '../../types'
 import {Controller as HistoryController} from './documentHistory/history/Controller'
@@ -18,7 +17,6 @@ export interface DocumentPaneContextValue {
   compareValue: Partial<SanityDocument> | null
   connectionState: 'connecting' | 'reconnecting' | 'connected'
   displayed: Partial<SanityDocument> | null
-  editState: EditStateFor | null
   documentId: string
   documentIdRaw: string
   documentSchema: DocumentSchema | null
@@ -35,6 +33,7 @@ export interface DocumentPaneContextValue {
   handlePaneSplit?: () => void
   historyController: HistoryController
   index: number
+  initialValue: Partial<SanityDocument>
   inspectOpen: boolean
   markers: Marker[]
   menuItems: PaneMenuItem[]

--- a/packages/@sanity/desk-tool/src/panes/document/DocumentPaneProvider.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/DocumentPaneProvider.tsx
@@ -1,7 +1,7 @@
 // @todo: remove the following line when part imports has been removed from this file
 ///<reference types="@sanity/types/parts" />
 
-import React, {memo, useCallback, useEffect, useMemo, useState} from 'react'
+import React, {memo, useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {Path, SanityDocument} from '@sanity/types'
 import {
   useConnectionState,
@@ -19,7 +19,7 @@ import resolveDocumentBadges from 'part:@sanity/base/document-badges/resolver'
 import {getPublishedId} from 'part:@sanity/base/util/draft-utils'
 import schema from 'part:@sanity/base/schema'
 import {useMemoObservable} from 'react-rx'
-import {PaneMenuItem} from '../../types'
+import {PaneMenuItem, PaneMenuItemGroup} from '../../types'
 import {useDeskTool} from '../../contexts/deskTool'
 import {usePaneRouter} from '../../contexts/paneRouter'
 import {useUnique} from '../../utils/useUnique'
@@ -36,6 +36,8 @@ import {getPreviewUrl} from './usePreviewUrl'
 declare const __DEV__: boolean
 
 const emptyObject = {} as Record<string, string | undefined>
+const emptyPath: Path = []
+const emptyMenuGroup: PaneMenuItemGroup[] = []
 
 type Props = {children: React.ReactElement} & DocumentPaneProviderProps
 
@@ -48,13 +50,13 @@ export const DocumentPaneProvider = memo(({children, index, pane, paneKey}: Prop
   const {features} = useDeskTool()
   const {push: pushToast} = useToast()
   const {options, menuItemGroups, title = null, views: viewsProp = []} = pane
-  const initialValueRaw = useInitialValue(options.id, options)
-  const initialValue = useUnique(initialValueRaw)
+  const initialValue = useInitialValue(options.id, options)
+
   const documentIdRaw = options.id
   const documentId = getPublishedId(documentIdRaw)
   const documentType = options.type
   const {patch}: any = useDocumentOperation(documentId, documentType)
-  const editState = useEditState(documentId, documentType)
+  const editState = useEditState(documentId, documentType, 'low')
   const {markers: markersRaw} = useValidationStatus(documentId, documentType)
   const connectionState = useConnectionState(documentId, documentType)
   const documentSchema = schema.get(documentType)
@@ -62,15 +64,17 @@ export const DocumentPaneProvider = memo(({children, index, pane, paneKey}: Prop
     externalPollInterval: 1000 * 60,
   })
   const totalReferenceCount = isReferencesLoading ? undefined : totalCount
-  const value: Partial<SanityDocument> =
-    editState?.draft || editState?.published || initialValue.value
+  const value: Partial<SanityDocument> = useMemo(
+    () => editState?.draft || editState?.published || initialValue.value,
+    [editState, initialValue]
+  )
   const actions = useMemo(() => (editState ? resolveDocumentActions(editState) : null), [editState])
   const badges = useMemo(() => (editState ? resolveDocumentBadges(editState) : null), [editState])
   const markers = useUnique(markersRaw)
   const views = useUnique(viewsProp)
   const params = paneRouter.params || emptyObject
   const [focusPath, setFocusPath] = useState<Path>(() =>
-    params.path ? pathFromString(params.path) : []
+    params.path ? pathFromString(params.path) : emptyPath
   )
   const activeViewId = params.view || (views[0] && views[0].id) || null
   const timeline = useMemo(() => new Timeline({publishedId: documentId, enableTrace: __DEV__}), [
@@ -145,10 +149,12 @@ export const DocumentPaneProvider = memo(({children, index, pane, paneKey}: Prop
     [documentId, setFocusPath]
   )
 
-  const handleChange = useCallback((patches) => patch.execute(patches, initialValue.value), [
-    patch,
-    initialValue.value,
-  ])
+  const patchRef = useRef(patch)
+  patchRef.current = patch
+  const handleChange = useCallback(
+    (patches) => patchRef.current.execute(patches, initialValue.value),
+    [initialValue.value]
+  )
 
   const handleHistoryClose = useCallback(() => {
     paneRouter.setParams({...params, since: undefined})
@@ -213,47 +219,89 @@ export const DocumentPaneProvider = memo(({children, index, pane, paneKey}: Prop
 
   const handleInspectClose = useCallback(() => toggleInspect(false), [toggleInspect])
 
-  const documentPane: DocumentPaneContextValue = {
-    actions,
-    activeViewId,
-    badges,
-    changesOpen,
-    compareValue,
-    connectionState,
-    displayed,
-    documentId,
-    documentIdRaw,
-    documentSchema,
-    documentType,
-    editState,
-    focusPath,
-    handleChange,
-    handleFocus,
-    handleHistoryClose,
-    handleHistoryOpen,
-    handleInspectClose,
-    handleKeyUp,
-    handleMenuAction,
-    handlePaneClose,
-    handlePaneSplit,
-    historyController,
-    index,
-    inspectOpen,
-    markers,
-    menuItems,
-    menuItemGroups: menuItemGroups || [],
-    paneKey,
-    previewUrl,
-    ready,
-    setTimelineMode,
-    setTimelineRange,
-    timeline,
-    timelineMode,
-    title,
-    totalReferenceCount,
-    value,
-    views,
-  }
+  const documentPane: DocumentPaneContextValue = useMemo(
+    () => ({
+      actions,
+      activeViewId,
+      badges,
+      changesOpen,
+      compareValue,
+      connectionState,
+      displayed,
+      documentId,
+      documentIdRaw,
+      documentSchema,
+      documentType,
+      focusPath,
+      handleChange,
+      handleFocus,
+      handleHistoryClose,
+      handleHistoryOpen,
+      handleInspectClose,
+      handleKeyUp,
+      handleMenuAction,
+      handlePaneClose,
+      handlePaneSplit,
+      historyController,
+      index,
+      initialValue: initialValue.value,
+      inspectOpen,
+      markers,
+      menuItems,
+      menuItemGroups: menuItemGroups || emptyMenuGroup,
+      paneKey,
+      previewUrl,
+      ready,
+      setTimelineMode,
+      setTimelineRange,
+      timeline,
+      timelineMode,
+      title,
+      totalReferenceCount,
+      value,
+      views,
+    }),
+    [
+      actions,
+      activeViewId,
+      badges,
+      changesOpen,
+      compareValue,
+      connectionState,
+      displayed,
+      documentId,
+      documentIdRaw,
+      documentSchema,
+      documentType,
+      focusPath,
+      handleChange,
+      handleFocus,
+      handleHistoryClose,
+      handleHistoryOpen,
+      handleInspectClose,
+      handleKeyUp,
+      handleMenuAction,
+      handlePaneClose,
+      handlePaneSplit,
+      historyController,
+      index,
+      initialValue,
+      inspectOpen,
+      markers,
+      menuItems,
+      menuItemGroups,
+      paneKey,
+      previewUrl,
+      ready,
+      setTimelineRange,
+      timeline,
+      timelineMode,
+      title,
+      totalReferenceCount,
+      value,
+      views,
+    ]
+  )
 
   useEffect(() => {
     if (connectionState === 'reconnecting') {

--- a/packages/@sanity/desk-tool/src/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/documentPanel/DocumentPanel.tsx
@@ -5,6 +5,7 @@ import {unstable_useDocumentValuePermissions as useDocumentValuePermissions} fro
 import styled, {css} from 'styled-components'
 import {SchemaType} from '@sanity/types'
 import {getPublishedId, getDraftId} from '@sanity/base/_internal'
+import {useEditState} from '@sanity/react-hooks'
 import {PaneContent} from '../../../components/pane'
 import {usePaneLayout} from '../../../components/pane/usePaneLayout'
 import {useDeskTool} from '../../../contexts/deskTool'
@@ -50,7 +51,6 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     displayed,
     documentId,
     documentSchema,
-    editState,
     value,
     views,
     ready,
@@ -63,6 +63,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
   const headerRect = useElementRect(headerElement)
   const portalRef = useRef<HTMLDivElement | null>(null)
   const [documentScrollElement, setDocumentScrollElement] = useState<HTMLDivElement | null>(null)
+  const editState = useEditState(documentId, documentType, 'low')
 
   const requiredPermission = value._createdAt ? 'update' : 'create'
   const liveEdit = useMemo(() => Boolean(getSchemaType(documentType)?.liveEdit), [documentType])

--- a/packages/@sanity/desk-tool/src/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/documentPanel/documentViews/FormView.tsx
@@ -20,6 +20,7 @@ import {ObjectField, ObjectSchemaTypeWithOptions} from '@sanity/types'
 import {useDocumentPane} from '../../useDocumentPane'
 import {Delay} from '../../../../components/Delay'
 import {useConditionalToast} from './useConditionalToast'
+import {useEditState} from '@sanity/react-hooks'
 
 interface FormViewProps {
   granted: boolean
@@ -46,8 +47,6 @@ export function FormView(props: FormViewProps) {
   const {hidden, margins, granted} = props
   const {
     compareValue,
-    displayed: value,
-    editState,
     documentId,
     documentSchema,
     documentType,
@@ -55,10 +54,13 @@ export function FormView(props: FormViewProps) {
     handleChange,
     handleFocus,
     historyController,
+    initialValue,
     markers,
     ready,
     changesOpen,
   } = useDocumentPane()
+  const editState = useEditState(documentId, documentType)
+  const value = editState.draft || editState.published || initialValue
   const presence = useDocumentPresence(documentId, {ignoreLastActiveUpdates: true})
   const {revTime: rev} = historyController
   const [{filterField}, setFilterField] = useState<FormViewState>(INITIAL_STATE)

--- a/packages/@sanity/desk-tool/src/panes/document/keyboardShortcuts/DocumentActionShortcuts.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/keyboardShortcuts/DocumentActionShortcuts.tsx
@@ -6,6 +6,7 @@ import {LegacyLayerProvider} from '@sanity/base/components'
 import {RenderActionCollectionState} from 'part:@sanity/base/actions/utils'
 import isHotkey from 'is-hotkey'
 import React, {useCallback, useState} from 'react'
+import {useEditState} from '@sanity/react-hooks'
 import {ActionStateDialog} from '../statusBar'
 import {Pane} from '../../../components/pane'
 import {useDocumentPane} from '../useDocumentPane'
@@ -93,7 +94,8 @@ export interface DocumentActionShortcutsProps {
 export const DocumentActionShortcuts = React.memo(
   (props: DocumentActionShortcutsProps & React.HTMLProps<HTMLDivElement>) => {
     const {actionsBoxElement, children, ...rest} = props
-    const {actions, editState} = useDocumentPane()
+    const {actions, documentId, documentType} = useDocumentPane()
+    const editState = useEditState(documentId, documentType, 'low')
     const [activeIndex, setActiveIndex] = useState(-1)
 
     const onActionStart = useCallback((idx: number) => {

--- a/packages/@sanity/desk-tool/src/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -5,6 +5,7 @@ import React, {memo, useCallback, useMemo, useState} from 'react'
 import {DocumentActionDescription} from '@sanity/base'
 import {Box, Flex, Tooltip, Stack, Button, Hotkeys, LayerProvider, Text, Card} from '@sanity/ui'
 import {RenderActionCollectionState} from 'part:@sanity/base/actions/utils'
+import {useEditState} from '@sanity/react-hooks'
 import {HistoryRestoreAction} from '../../../actions/HistoryRestoreAction'
 import {useDocumentPane} from '../useDocumentPane'
 import {ActionMenuButton} from './ActionMenuButton'
@@ -82,7 +83,8 @@ function DocumentStatusBarActionsInner(props: DocumentStatusBarActionsInnerProps
 }
 
 export const DocumentStatusBarActions = memo(function DocumentStatusBarActions() {
-  const {actions, connectionState, editState} = useDocumentPane()
+  const {actions, connectionState, documentId, documentType} = useDocumentPane()
+  const editState = useEditState(documentId, documentType, 'low')
   const [isMenuOpen, setMenuOpen] = useState(false)
   const handleMenuOpen = useCallback(() => setMenuOpen(true), [])
   const handleMenuClose = useCallback(() => setMenuOpen(false), [])
@@ -110,7 +112,8 @@ export const DocumentStatusBarActions = memo(function DocumentStatusBarActions()
 const historyActions = [HistoryRestoreAction]
 
 export const HistoryStatusBarActions = memo(function HistoryStatusBarActions() {
-  const {connectionState, editState, historyController} = useDocumentPane()
+  const {connectionState, historyController, documentId, documentType} = useDocumentPane()
+  const editState = useEditState(documentId, documentType, 'low')
   const revision = historyController.revTime?.id || ''
   const disabled = (editState?.draft || editState?.published || {})._rev === revision
   const actionProps = useMemo(() => ({...(editState || {}), revision}), [editState, revision])

--- a/packages/@sanity/desk-tool/src/panes/document/statusBar/sparkline/DocumentBadges.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/statusBar/sparkline/DocumentBadges.tsx
@@ -2,6 +2,7 @@
 ///<reference types="@sanity/types/parts" />
 
 import {DocumentBadgeDescription} from '@sanity/base'
+import {useEditState} from '@sanity/react-hooks'
 import {Badge, BadgeTone, Box, Inline, Text, Tooltip} from '@sanity/ui'
 import {RenderBadgeCollectionState} from 'part:@sanity/base/actions/utils'
 import React from 'react'
@@ -53,7 +54,8 @@ function DocumentBadgesInner({states}: DocumentBadgesInnerProps) {
 }
 
 export function DocumentBadges() {
-  const {badges, editState} = useDocumentPane()
+  const {badges, documentId, documentType} = useDocumentPane()
+  const editState = useEditState(documentId, documentType, 'low')
 
   if (!badges) return null
 

--- a/packages/@sanity/desk-tool/src/panes/document/statusBar/sparkline/DocumentSparkline.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/statusBar/sparkline/DocumentSparkline.tsx
@@ -1,6 +1,6 @@
 import {Box, Flex, useElementRect} from '@sanity/ui'
 import React, {useEffect, useMemo, useState, memo, useLayoutEffect} from 'react'
-import {useSyncState} from '@sanity/react-hooks'
+import {useEditState, useSyncState} from '@sanity/react-hooks'
 import {useDocumentPane} from '../../useDocumentPane'
 import {DocumentBadges} from './DocumentBadges'
 import {PublishStatus} from './PublishStatus'
@@ -14,12 +14,12 @@ export const DocumentSparkline = memo(function DocumentSparkline() {
     changesOpen,
     documentId,
     documentType,
-    editState,
     handleHistoryClose,
     handleHistoryOpen,
     historyController,
     value,
   } = useDocumentPane()
+  const editState = useEditState(documentId, documentType, 'low')
   const syncState = useSyncState(documentId, documentType)
 
   const lastUpdated = value?._updatedAt

--- a/packages/@sanity/react-hooks/src/useEditState.ts
+++ b/packages/@sanity/react-hooks/src/useEditState.ts
@@ -4,10 +4,25 @@
 import type {EditStateFor} from '@sanity/base/_internal'
 import documentStore from 'part:@sanity/base/datastore/document'
 import {useMemoObservable} from 'react-rx'
+import {merge, timer} from 'rxjs'
+import {debounce, share, skip, take} from 'rxjs/operators'
 
-export function useEditState(publishedDocId: string, docTypeName: string): EditStateFor {
-  return useMemoObservable(() => documentStore.pair.editState(publishedDocId, docTypeName), [
-    publishedDocId,
-    docTypeName,
-  ]) as EditStateFor
+export function useEditState(
+  publishedDocId: string,
+  docTypeName: string,
+  priority: 'default' | 'low' = 'default'
+): EditStateFor {
+  return useMemoObservable(() => {
+    const base = documentStore.pair.editState(publishedDocId, docTypeName).pipe(share())
+    if (priority === 'low') {
+      return merge(
+        base.pipe(take(1)),
+        base.pipe(
+          skip(1),
+          debounce(() => timer(1000))
+        )
+      )
+    }
+    return documentStore.pair.editState(publishedDocId, docTypeName)
+  }, [publishedDocId, docTypeName, priority]) as EditStateFor
 }


### PR DESCRIPTION
### Description

This will optimize the DocumentPaneProvider to use low priority editStates. Also optimized hook dependencies. Removed editState from the context, and added initialValue.

Stuff that previously got editState from the useDocumentPane hook, is now using useEditState directly instead.

This is using the low priority version most of the places, while FormView is still using the immediate one.

This refactor saves us quite a few re-renders, and makes editing a lot snappier.

Here's a sample measurement of typing speed inside a regular string field:

```
Before:

Average of 3 samples: 2975ms
Total lag: 8565ms
Sample #1: 2929ms
Sample #2: 3033ms
Sample #3: 2964ms

Average of 3 samples: 2783ms
Total lag: 8120ms
Sample #1: 2865ms
Sample #2: 2653ms
Sample #3: 2832ms


After:

Average of 3 samples: 1928ms
Total lag: 4726ms
Sample #1: 1950ms
Sample #2: 1906ms
Sample #3: 1929ms

Average of 3 samples: 1894ms
Total lag: 4535ms
Sample #1: 1865ms
Sample #2: 1892ms
Sample #3: 1925ms

```

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Better performance with the `useDocumentPane` hook making editing substantially faster.

<!--
A description of the change(s) that should be used in the release notes.
-->
