### PR TITLE
fix(vision): allow reconfiguration of vision client

### DIFF
--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -170,7 +170,11 @@ export class VisionGui extends React.PureComponent<VisionGuiProps, VisionGuiStat
     this._paramsEditorContainer = React.createRef()
     this._customApiVersionElement = React.createRef()
 
-    this._client = props.client.withConfig({apiVersion: customApiVersion || apiVersion, dataset})
+    this._client = props.client.withConfig({
+      apiVersion: customApiVersion || apiVersion,
+      dataset,
+      allowReconfigure: true,
+    })
 
     // Initial root height without header
     const bodyHeight =


### PR DESCRIPTION
### Description

Mistakenly forgot that the client passed to vision from the studio now has a frozen config, but we're attempting to mutate it when changing API versions. Since we're using `withConfig()` (which clones and applies a new config) on the passed client, it is okay to un-freeze the config of this _particular_ instance of the client.

### What to review

- That vision works inside the studio when switching between API versions

### Notes for release

- Fixes an issue where the vision plugin would fail to run queries

