### PR TITLE
fix(default-layout): apply offset on search spinner wrapping element

### DIFF
--- a/packages/@sanity/default-layout/src/navbar/search/components/SearchHeader.tsx
+++ b/packages/@sanity/default-layout/src/navbar/search/components/SearchHeader.tsx
@@ -12,9 +12,12 @@ interface SearchHeaderProps {
 }
 
 const AlignedSpinner = styled(Spinner)`
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  margin-top: 4.5px;
   svg {
     width: 20px;
-    vertical-align: bottom !important;
   }
 `
 


### PR DESCRIPTION
### Description

Ensures that the spinner within the search header offsets the wrapping element and not the containing SVG.

This is to counter a recent update in `@sanity/ui` that now animates the spinner's wrapping element.