### PR TITLE
Fix document pane title bug

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/document/documentPanel/header/DocumentHeaderTitle.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/documentPanel/header/DocumentHeaderTitle.tsx
@@ -13,7 +13,7 @@ function renderTitle({title}: SanityDocument) {
 }
 
 export function DocumentHeaderTitle() {
-  const {connectionState, documentSchema, title, value} = useDocumentPane()
+  const {connectionState, documentSchema, title, value, ready} = useDocumentPane()
 
   if (connectionState !== 'connected') {
     return <></>
@@ -27,9 +27,9 @@ export function DocumentHeaderTitle() {
     return <>New {documentSchema?.title || documentSchema?.name}</>
   }
 
-  return (
+  return ready ? (
     <PreviewFields document={value} layout="inline" type={documentSchema} fields={PREVIEW_FIELDS}>
       {renderTitle}
     </PreviewFields>
-  )
+  ) : null
 }

--- a/packages/@sanity/react-hooks/src/useEditState.ts
+++ b/packages/@sanity/react-hooks/src/useEditState.ts
@@ -23,6 +23,6 @@ export function useEditState(
         )
       )
     }
-    return documentStore.pair.editState(publishedDocId, docTypeName)
+    return base
   }, [publishedDocId, docTypeName, priority]) as EditStateFor
 }


### PR DESCRIPTION
### Description

This will fix an issue where the documentPane would render its Title preview for the document before it's ready in the Pane.

This bug has probably not been seen before because it has always been rendered synchronous with editState in DocumentPaneProvider. 


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

That the header preview for the document renders correctly and no longer is displaying a "Untitled" over the ghost title rendering.


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Doesn't need to mentioned as this bug is not yet released

<!--
A description of the change(s) that should be used in the release notes.
-->
