### PR TITLE
Fix Spinner misalignments

### DIFF
--- a/dev/design-studio/package.json
+++ b/dev/design-studio/package.json
@@ -31,7 +31,7 @@
     "@sanity/logos": "^1.1.15",
     "@sanity/structure": "2.33.2",
     "@sanity/types": "2.33.2",
-    "@sanity/ui": "^0.37.21",
+    "@sanity/ui": "^0.37.22",
     "@sanity/vision": "2.33.3",
     "prop-types": "^15.6.0",
     "react": "17.0.1",

--- a/dev/example-studio/package.json
+++ b/dev/example-studio/package.json
@@ -29,7 +29,7 @@
     "@sanity/icons": "^1.3.4",
     "@sanity/language-filter": "2.33.2",
     "@sanity/portable-text-editor": "3.0.0-v3-pte.80+7ad1a80c1e",
-    "@sanity/ui": "^0.37.21",
+    "@sanity/ui": "^0.37.22",
     "@sanity/vision": "2.33.3",
     "bio-pv": "^1.8.1",
     "date-fns": "^2.16.1",

--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -36,7 +36,7 @@
     "@sanity/production-preview": "2.33.2",
     "@sanity/studio-hints": "2.33.2",
     "@sanity/types": "2.33.2",
-    "@sanity/ui": "^0.37.21",
+    "@sanity/ui": "^0.37.22",
     "@sanity/util": "2.33.2",
     "@sanity/uuid": "^3.0.1",
     "@sanity/vision": "2.33.3",

--- a/dev/workshop/package.json
+++ b/dev/workshop/package.json
@@ -16,7 +16,7 @@
     "type-check": "tsc -b"
   },
   "dependencies": {
-    "@sanity/ui": "^0.37.21",
+    "@sanity/ui": "^0.37.22",
     "@sanity/ui-workshop": "^0.4.16",
     "qs": "^6.10.1",
     "react": "17.0.1",

--- a/examples/ecommerce-studio/package.json
+++ b/examples/ecommerce-studio/package.json
@@ -26,7 +26,7 @@
     "@sanity/default-login": "2.33.3",
     "@sanity/desk-tool": "2.33.3",
     "@sanity/form-builder": "2.33.3",
-    "@sanity/ui": "^0.37.21",
+    "@sanity/ui": "^0.37.22",
     "prop-types": "^15.6.0",
     "react": "17.0.1",
     "react-barcode": "^1.3.2",

--- a/packages/@sanity/base/package.json
+++ b/packages/@sanity/base/package.json
@@ -58,7 +58,7 @@
     "@sanity/structure": "2.33.2",
     "@sanity/transaction-collator": "2.33.2",
     "@sanity/types": "2.33.2",
-    "@sanity/ui": "^0.37.21",
+    "@sanity/ui": "^0.37.22",
     "@sanity/util": "2.33.2",
     "@sanity/validation": "2.33.2",
     "boundless-arrow-key-navigation": "^1.1.0",

--- a/packages/@sanity/code-input/package.json
+++ b/packages/@sanity/code-input/package.json
@@ -25,7 +25,7 @@
     "@sanity/form-builder": "2.33.3",
     "@sanity/icons": "^1.3.4",
     "@sanity/types": "2.33.2",
-    "@sanity/ui": "^0.37.21",
+    "@sanity/ui": "^0.37.22",
     "@sanity/util": "2.33.2",
     "ace-builds": "^1.4.13",
     "react-ace": "^9.5.0"

--- a/packages/@sanity/color-input/package.json
+++ b/packages/@sanity/color-input/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@sanity/icons": "^1.3.4",
-    "@sanity/ui": "^0.37.21",
+    "@sanity/ui": "^0.37.22",
     "lodash": "^4.17.15",
     "react-color": "^2.13.8"
   },

--- a/packages/@sanity/dashboard/package.json
+++ b/packages/@sanity/dashboard/package.json
@@ -23,7 +23,7 @@
     "@sanity/icons": "^1.3.4",
     "@sanity/image-url": "^1.0.1",
     "@sanity/types": "2.33.2",
-    "@sanity/ui": "^0.37.21",
+    "@sanity/ui": "^0.37.22",
     "lodash": "^4.17.15",
     "rxjs": "^6.5.3"
   },

--- a/packages/@sanity/dashboard/src/widgets/projectUsers/ProjectUsers.js
+++ b/packages/@sanity/dashboard/src/widgets/projectUsers/ProjectUsers.js
@@ -1,9 +1,13 @@
+// @todo: remove the following line when part imports has been removed from this file
+///<reference types="@sanity/types/parts" />
+
 import React from 'react'
 import {map, switchMap} from 'rxjs/operators'
-import {Stack, Spinner, Card, Box, Text, Button} from '@sanity/ui'
+import {Stack, Card, Box, Text, Button} from '@sanity/ui'
 import {RobotIcon} from '@sanity/icons'
 import styled from 'styled-components'
 import {DefaultPreview} from '@sanity/base/components'
+import Spinner from 'part:@sanity/components/loading/spinner'
 import {versionedClient} from '../../versionedClient'
 import {DashboardWidget} from '../../'
 import {userStore} from '../../legacyParts'
@@ -134,16 +138,9 @@ class ProjectUsers extends React.PureComponent {
         }
       >
         {isLoading && (
-          <Box paddingY={5} paddingX={2}>
-            <Stack space={4}>
-              <Text align="center" muted size={1}>
-                <Spinner />
-              </Text>
-              <Text align="center" size={1} muted>
-                Loading items...
-              </Text>
-            </Stack>
-          </Box>
+          <Card padding={4}>
+            <Spinner center message="Loading..." />
+          </Card>
         )}
 
         {!isLoading && (

--- a/packages/@sanity/default-layout/package.json
+++ b/packages/@sanity/default-layout/package.json
@@ -39,7 +39,7 @@
     "@sanity/icons": "^1.3.4",
     "@sanity/image-url": "^1.0.1",
     "@sanity/logos": "^1.1.15",
-    "@sanity/ui": "^0.37.21",
+    "@sanity/ui": "^0.37.22",
     "@sanity/util": "2.33.2",
     "debug": "^3.2.7",
     "is-hotkey": "^0.1.6",

--- a/packages/@sanity/default-layout/src/navbar/search/components/SearchHeader.tsx
+++ b/packages/@sanity/default-layout/src/navbar/search/components/SearchHeader.tsx
@@ -1,7 +1,7 @@
-import {CloseIcon, ControlsIcon, SearchIcon} from '@sanity/icons'
-import {Box, Button, Card, Flex, Spinner, studioTheme, Theme} from '@sanity/ui'
+import {CloseIcon, ControlsIcon, SearchIcon, SpinnerIcon} from '@sanity/icons'
+import {Box, Button, Card, Flex, studioTheme, Theme} from '@sanity/ui'
 import React, {Dispatch, SetStateAction, useCallback, useEffect, useRef, useState} from 'react'
-import styled from 'styled-components'
+import styled, {keyframes} from 'styled-components'
 import {useSearchState} from '../contexts/search'
 import {supportsTouch} from '../utils/supportsTouch'
 import {CustomTextInput} from './CustomTextInput'
@@ -11,15 +11,17 @@ interface SearchHeaderProps {
   setHeaderInputRef: Dispatch<SetStateAction<HTMLInputElement | null>>
 }
 
-// @todo: remove hardcoded margin once <Spinner /> alignment within <TextInput /> icons is fixed
-const AlignedSpinner = styled(Spinner)`
-  align-items: center;
-  display: flex;
-  justify-content: center;
-  margin-top: 4.5px;
-  svg {
-    width: 20px;
+const rotate = keyframes`
+  from {
+    transform: rotate(0deg);
   }
+  to {
+    transform: rotate(360deg);
+  }
+`
+
+const AnimatedSpinnerIcon = styled(SpinnerIcon)`
+  animation: ${rotate} 500ms linear infinite;
 `
 
 const FilterBox = styled(Box)`
@@ -96,7 +98,7 @@ export function SearchHeader({onClose, setHeaderInputRef}: SearchHeaderProps) {
             border={false}
             clearButton={!!terms.query}
             fontSize={2}
-            icon={loading ? <AlignedSpinner /> : SearchIcon}
+            icon={loading ? AnimatedSpinnerIcon : SearchIcon}
             onChange={handleQueryChange}
             onClear={handleQueryClear}
             placeholder="Search"

--- a/packages/@sanity/default-login/package.json
+++ b/packages/@sanity/default-login/package.json
@@ -23,7 +23,7 @@
     "@sanity/client": "^3.3.3",
     "@sanity/generate-help-url": "^3.0.0",
     "@sanity/logos": "^1.1.15",
-    "@sanity/ui": "^0.37.21",
+    "@sanity/ui": "^0.37.22",
     "prop-types": "^15.6.0",
     "rxjs": "^6.5.3"
   },

--- a/packages/@sanity/default-login/src/CorsCheck.js
+++ b/packages/@sanity/default-login/src/CorsCheck.js
@@ -53,11 +53,9 @@ export default function CorsCheck() {
 
   if (isLoading) {
     return (
-      <Container width={4} padding={4} height="fill">
-        <Flex align="center" justify="center" height="fill">
-          <Text>
-            <Spinner />
-          </Text>
+      <Container width={4} height="fill">
+        <Flex justify="center" height="fill">
+          <Spinner />
         </Flex>
       </Container>
     )

--- a/packages/@sanity/desk-tool/package.json
+++ b/packages/@sanity/desk-tool/package.json
@@ -40,7 +40,7 @@
     "@sanity/react-hooks": "2.33.3",
     "@sanity/structure": "2.33.2",
     "@sanity/types": "2.33.2",
-    "@sanity/ui": "^0.37.21",
+    "@sanity/ui": "^0.37.22",
     "@sanity/util": "2.33.2",
     "@sanity/uuid": "^3.0.1",
     "framer-motion": "^5.3.3",

--- a/packages/@sanity/field/package.json
+++ b/packages/@sanity/field/package.json
@@ -45,7 +45,7 @@
     "@sanity/image-url": "^1.0.1",
     "@sanity/react-hooks": "2.33.3",
     "@sanity/types": "2.33.2",
-    "@sanity/ui": "^0.37.21",
+    "@sanity/ui": "^0.37.22",
     "@sanity/util": "2.33.2",
     "diff-match-patch": "^1.0.4",
     "lodash": "^4.17.15",

--- a/packages/@sanity/form-builder/package.json
+++ b/packages/@sanity/form-builder/package.json
@@ -42,7 +42,7 @@
     "@sanity/portable-text-editor": "3.0.0-v3-pte.80+7ad1a80c1e",
     "@sanity/schema": "2.33.2",
     "@sanity/types": "2.33.2",
-    "@sanity/ui": "^0.37.21",
+    "@sanity/ui": "^0.37.22",
     "@sanity/util": "2.33.2",
     "@sanity/uuid": "^3.0.1",
     "attr-accept": "^1.1.0",

--- a/packages/@sanity/google-maps-input/package.json
+++ b/packages/@sanity/google-maps-input/package.json
@@ -22,7 +22,7 @@
     "@sanity/field": "2.33.3",
     "@sanity/icons": "^1.3.4",
     "@sanity/types": "2.33.2",
-    "@sanity/ui": "^0.37.21",
+    "@sanity/ui": "^0.37.22",
     "lodash": "^4.17.15",
     "rxjs": "^6.5.3"
   },

--- a/packages/@sanity/language-filter/package.json
+++ b/packages/@sanity/language-filter/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@sanity/icons": "^1.3.4",
     "@sanity/types": "2.33.2",
-    "@sanity/ui": "^0.37.21",
+    "@sanity/ui": "^0.37.22",
     "lodash": "^4.17.15",
     "rxjs": "^6.5.3"
   },

--- a/packages/@sanity/studio-hints/package.json
+++ b/packages/@sanity/studio-hints/package.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "@sanity/icons": "^1.3.4",
-    "@sanity/ui": "^0.37.21"
+    "@sanity/ui": "^0.37.22"
   },
   "devDependencies": {
     "rimraf": "^2.7.1"

--- a/packages/@sanity/studio-hints/src/components/HintsPackage.js
+++ b/packages/@sanity/studio-hints/src/components/HintsPackage.js
@@ -109,18 +109,21 @@ export default class HintsPackage extends React.PureComponent {
         </span>
       )
     }
-
     if (isLoading) {
       return (
-        <Flex justify="center" align="center" paddingX={4} paddingY={5} flex={1}>
-          <Stack space={3}>
-            <Text size={1} muted align="center">
-              <Spinner />
-            </Text>
-            <Text size={1} muted>
-              Loading hints
-            </Text>
-          </Stack>
+        <Flex
+          justify="center"
+          align="center"
+          paddingX={4}
+          paddingY={5}
+          flex={1}
+          direction="column"
+          gap={3}
+        >
+          <Spinner muted />
+          <Text size={1} muted>
+            Loading hints
+          </Text>
         </Flex>
       )
     }

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@juggle/resize-observer": "^3.3.1",
     "@sanity/icons": "^1.3.4",
-    "@sanity/ui": "^0.37.21",
+    "@sanity/ui": "^0.37.22",
     "classnames": "^2.2.5",
     "codemirror": "^5.47.0",
     "is-hotkey": "^0.1.6",


### PR DESCRIPTION
### Description

This will upgrade `@sanity/ui` to ` 0.37.22` and take care of some Spinner issues.

With the current performance optimization  done in `@sanity/ui` for Spinner animations, some spinners in the Studio code aligned wrong when animated. This was due to them being wrapped in a Text node.

I have updated all occurrences of this (I think) by implementing them according to the updated documentation at https://www.sanity.io/ui/docs/primitive/spinner#examples

For the ProjectUser dashboard widget I have used the Spinner Sanity-part to better align them with plugin code elsewhere.

For the Seach bar spinner I have used the spinner icon from `@sanity/icons` as the TextInput from `@sanity/ui` is expecting an icon and not a component. Then put on the same animation as `@sanity/ui` uses for its spinner.



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

That all spinners inside the studio looks good.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Doesn't need to be mentioned as this problem doesn't affect any production code and needed to be done in order to upgrade `@sanity/ui`.

<!--
A description of the change(s) that should be used in the release notes.
-->
