### PR TITLE
chore(typings): prepare for react 18 by using stricter typings

### DIFF
--- a/dev/test-studio/schema/debug/components/CustomInputWithDefaultPresence.tsx
+++ b/dev/test-studio/schema/debug/components/CustomInputWithDefaultPresence.tsx
@@ -13,7 +13,7 @@ export const CustomInputWithDefaultPresence = React.forwardRef(
     // const {onFocus, readOnly} = inputProps
 
     const handleRootFocus = useCallback(
-      (event) => {
+      (event: any) => {
         if (event.currentTarget.element === ref) onFocus(event)
       },
       [onFocus, ref]

--- a/dev/test-studio/schema/debug/components/CustomInputWithDialogOverlay.tsx
+++ b/dev/test-studio/schema/debug/components/CustomInputWithDialogOverlay.tsx
@@ -20,7 +20,7 @@ export const CustomInputWithDialogOverlay = React.forwardRef(function CustomInpu
   const {focusPath, level = 0, onBlur, onChange, onFocus, presence, schemaType, value} = props
 
   const handleFieldChange = React.useCallback(
-    (field, fieldPatchEvent) => {
+    (field: any, fieldPatchEvent: any) => {
       // Whenever the field input emits a patch event, we need to make sure to each of the included patches
       // are prefixed with its field name, e.g. going from:
       // {path: [], set: <nextvalue>} to {path: [<fieldName>], set: <nextValue>}

--- a/dev/test-studio/schema/debug/components/CustomObjectSelectInput.tsx
+++ b/dev/test-studio/schema/debug/components/CustomObjectSelectInput.tsx
@@ -26,7 +26,7 @@ export const CustomObjectSelectInput = React.forwardRef(function CustomObjectSel
   const [inputId] = useState(() => String(++objectSelectInputIdx))
 
   const handleChange = useCallback(
-    (evt) => {
+    (evt: any) => {
       onChange(
         evt.target.value ? set(items.find((item) => item.value === evt.target.value)) : unset()
       )

--- a/dev/test-studio/schema/standard/portableText/LinkAnnotationInput.tsx
+++ b/dev/test-studio/schema/standard/portableText/LinkAnnotationInput.tsx
@@ -41,11 +41,12 @@ export const LinkAnnotationInput = (props: LinkAnnotationInputProps) => {
   const exclude = [urlField?.name, referenceArticleField?.name]
   const otherFields = type.fields.filter((f) => !exclude.includes(f.name))
   const getFieldValidation = useCallback(
-    (fieldName) => validation.filter((marker) => PathUtils.startsWith([fieldName], marker.path)),
+    (fieldName: any) =>
+      validation.filter((marker) => PathUtils.startsWith([fieldName], marker.path)),
     [validation]
   )
   const handleFieldChange = useCallback(
-    (field, fieldPatchEvent) => {
+    (field: any, fieldPatchEvent: any) => {
       const patchEvent = fieldPatchEvent
         .prefixAll(field.name)
         .prepend(setIfMissing({_type: type.name}))

--- a/dev/test-studio/workshop/useLocationStore.ts
+++ b/dev/test-studio/workshop/useLocationStore.ts
@@ -63,7 +63,7 @@ export function useLocationStore(props: {baseUrl?: string} = {}): WorkshopLocati
     [baseUrl, navigateUrl]
   )
 
-  const subscribe = useCallback((subscriber) => {
+  const subscribe = useCallback((subscriber: any) => {
     subscribersRef.current.push(subscriber)
 
     return () => {

--- a/packages/@sanity/cli/templates/shopify/components/inputs/PlaceholderString.tsx
+++ b/packages/@sanity/cli/templates/shopify/components/inputs/PlaceholderString.tsx
@@ -33,7 +33,7 @@ const PlaceholderStringInput = forwardRef((props: Props, ref: RefObject<HTMLInpu
 
   const handleChange = useCallback(
     // useCallback will help with performance
-    (event) => {
+    (event: any) => {
       const inputValue = event.currentTarget.value // get current value
 
       // if the value exists, set the data, if not, unset the data

--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -126,7 +126,7 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
   }, [readOnly, slateEditor, withHotKeys, withInsertData])
 
   const renderElement = useCallback(
-    (eProps) => (
+    (eProps: any) => (
       <Element
         {...eProps}
         portableTextFeatures={portableTextFeatures}
@@ -140,7 +140,7 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
   )
 
   const renderLeaf = useCallback(
-    (lProps) => {
+    (lProps: any) => {
       if (renderPlaceholder && lProps.leaf.placeholder && lProps.text.text === '') {
         return (
           <>

--- a/packages/@sanity/portable-text-editor/src/editor/PortableTextEditor.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/PortableTextEditor.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {PropsWithChildren} from 'react'
 import {ArraySchemaType, Path} from '@sanity/types'
 import {Subscription, Subject, defer, of, EMPTY, Observable, OperatorFunction} from 'rxjs'
 import {concatMap, share, switchMap, tap} from 'rxjs/operators'
@@ -46,7 +46,7 @@ const debug = debugWithName('component:PortableTextEditor')
  *
  * @public
  */
-export interface PortableTextEditorProps {
+export type PortableTextEditorProps = PropsWithChildren<{
   /**
    * Function that gets called when the editor changes the value
    */
@@ -82,7 +82,7 @@ export interface PortableTextEditorProps {
    * adjusting editor selections on concurrent editing and similar
    */
   incomingPatches$?: PatchObservable
-}
+}>
 
 /**
  * @internal

--- a/packages/@sanity/types/src/schema/preview.ts
+++ b/packages/@sanity/types/src/schema/preview.ts
@@ -1,4 +1,4 @@
-import type {ReactNode} from 'react'
+import type {ReactNode, ElementType} from 'react'
 import type {SortOrdering} from './types'
 
 export interface PrepareViewOptions {
@@ -6,10 +6,10 @@ export interface PrepareViewOptions {
 }
 
 export interface PreviewValue {
-  title?: ReactNode
-  subtitle?: ReactNode
-  description?: ReactNode
-  media?: ReactNode
+  title?: ReactNode | ElementType
+  subtitle?: ReactNode | ElementType
+  description?: ReactNode | ElementType
+  media?: ReactNode | ElementType
   imageUrl?: string
 }
 

--- a/packages/sanity/src/components/collapseMenu/CollapseMenu.tsx
+++ b/packages/sanity/src/components/collapseMenu/CollapseMenu.tsx
@@ -121,7 +121,7 @@ export const CollapseMenu = forwardRef(function CollapseMenu(
   )
 
   const isInMenu = useCallback(
-    (childKey) => menuOptionsArray.some((o) => o.key === childKey),
+    (childKey: any) => menuOptionsArray.some((o) => o.key === childKey),
     [menuOptionsArray]
   )
 

--- a/packages/sanity/src/components/collapseMenu/CollapseMenuButton.tsx
+++ b/packages/sanity/src/components/collapseMenu/CollapseMenuButton.tsx
@@ -1,19 +1,17 @@
 import {Button, ButtonProps, TooltipProps} from '@sanity/ui'
 import React, {forwardRef} from 'react'
 
-export interface CommonProps extends Omit<ButtonProps, 'text' | 'icon' | 'iconRight'> {
+export interface CommonProps extends Omit<ButtonProps, 'text' | 'iconRight'> {
   as?: React.ElementType | keyof JSX.IntrinsicElements
   dividerBefore?: boolean
   focused?: boolean
   tooltipProps?: TooltipProps
   tooltipText?: React.ReactNode
-  icon?: React.ReactNode
 }
 export interface CollapseMenuButtonProps extends CommonProps {
   collapsedProps?: Omit<CommonProps, 'text'>
   expandedProps?: CommonProps
-  icon: React.ReactNode
-  text: React.ReactNode
+  text: ButtonProps['text']
 }
 
 export const CollapseMenuButton = forwardRef(function CollapseMenuButton(

--- a/packages/sanity/src/components/previews/_common/Media.tsx
+++ b/packages/sanity/src/components/previews/_common/Media.tsx
@@ -43,7 +43,7 @@ function renderMedia(props: {
     media?: string
     mediaString?: string
   }
-}) {
+}): React.ReactNode {
   const {dimensions, layout, media, styles} = props
 
   if (isValidElementType(media)) {

--- a/packages/sanity/src/components/previews/general/DefaultPreview.tsx
+++ b/packages/sanity/src/components/previews/general/DefaultPreview.tsx
@@ -88,7 +88,7 @@ export function DefaultPreview(props: DefaultPreviewProps) {
         <Media
           dimensions={DEFAULT_MEDIA_DIMENSIONS}
           layout="default"
-          media={media}
+          media={media as any}
           styles={styles}
         />
       )}

--- a/packages/sanity/src/components/previews/general/DetailPreview.tsx
+++ b/packages/sanity/src/components/previews/general/DetailPreview.tsx
@@ -69,7 +69,9 @@ export function DetailPreview(props: DetailPreviewProps) {
 
   return (
     <RootFlex data-testid="detail-preview">
-      {media !== false && <Media dimensions={mediaDimensions} layout="detail" media={media} />}
+      {media !== false && (
+        <Media dimensions={mediaDimensions} layout="detail" media={media as any} />
+      )}
 
       <Box flex={1} paddingLeft={media === false ? 1 : 2}>
         <Flex align="center" data-testid="detail-preview__header">

--- a/packages/sanity/src/components/previews/general/MediaPreview.tsx
+++ b/packages/sanity/src/components/previews/general/MediaPreview.tsx
@@ -75,7 +75,7 @@ export function MediaPreview(props: MediaPreviewProps) {
               border={withBorder}
               dimensions={mediaDimensions}
               layout="media"
-              media={media}
+              media={media as any}
               radius={withRadius ? 1 : 0}
               responsive
             />

--- a/packages/sanity/src/components/previews/helpers.tsx
+++ b/packages/sanity/src/components/previews/helpers.tsx
@@ -3,12 +3,10 @@ import {isValidElementType} from 'react-is'
 import {PreviewLayoutKey, PreviewMediaDimensions} from './types'
 
 export function renderPreviewMedia<Layout = PreviewLayoutKey>(
-  value:
-    | React.ReactNode
-    | React.ComponentType<{layout: Layout; dimensions: PreviewMediaDimensions}>,
+  value: React.ReactNode | React.ElementType<{layout: Layout; dimensions: PreviewMediaDimensions}>,
   layout: Layout,
   dimensions: PreviewMediaDimensions
-) {
+): React.ReactNode {
   if (isValidElementType(value)) {
     return createElement(value, {layout, dimensions})
   }
@@ -17,14 +15,15 @@ export function renderPreviewMedia<Layout = PreviewLayoutKey>(
     return <div>{value}</div>
   }
 
-  return value
+  // @todo: find out why `value` isn't infered as `React.ReactNode` here
+  return value as any
 }
 
 export function renderPreviewNode<Layout = PreviewLayoutKey>(
-  value: React.ReactNode | React.ComponentType<{layout: Layout}>,
+  value: React.ReactNode | React.ElementType<{layout: Layout}>,
   layout: Layout,
   fallbackNode?: React.ReactNode
-) {
+): React.ReactNode {
   if (typeof value === 'string') {
     return value
   }
@@ -33,5 +32,6 @@ export function renderPreviewNode<Layout = PreviewLayoutKey>(
     return createElement(value, {layout})
   }
 
-  return value || fallbackNode
+  // @todo: find out why `value` isn't infered as `React.ReactNode` here
+  return (value as any) || fallbackNode
 }

--- a/packages/sanity/src/components/previews/portableText/BlockImagePreview.tsx
+++ b/packages/sanity/src/components/previews/portableText/BlockImagePreview.tsx
@@ -43,13 +43,15 @@ export function BlockImagePreview(props: BlockImagePreviewProps) {
       <Stack>
         <HeaderFlex paddingLeft={2} paddingRight={1} paddingY={1}>
           <Stack flex={1} space={2}>
-            <Text size={1} textOverflow="ellipsis" weight="semibold">
-              {title || fallbackTitle}
-            </Text>
+            {(title || fallbackTitle) && (
+              <Text size={1} textOverflow="ellipsis" weight="semibold">
+                {title ? renderPreviewNode(title as any, 'block') : fallbackTitle}
+              </Text>
+            )}
 
             {subtitle && (
               <Text muted size={1} textOverflow="ellipsis">
-                {renderPreviewNode(subtitle, 'block')}
+                {renderPreviewNode(subtitle as any, 'block')}
               </Text>
             )}
           </Stack>
@@ -57,11 +59,11 @@ export function BlockImagePreview(props: BlockImagePreviewProps) {
           <Flex gap={1} paddingLeft={1}>
             {status && (
               <Box paddingX={2} paddingY={3}>
-                {renderPreviewNode(status, 'block')}
+                {renderPreviewNode(status as any, 'block')}
               </Box>
             )}
 
-            {actions}
+            {actions as any}
           </Flex>
         </HeaderFlex>
 
@@ -76,7 +78,7 @@ export function BlockImagePreview(props: BlockImagePreviewProps) {
             border={false}
             dimensions={mediaDimensions}
             layout="blockImage"
-            media={media}
+            media={media as any}
             radius={0}
             responsive
           />
@@ -86,7 +88,7 @@ export function BlockImagePreview(props: BlockImagePreviewProps) {
       {description && (
         <Box paddingX={2} paddingY={3}>
           <Text muted size={1}>
-            {renderPreviewNode(description, 'block')}
+            {renderPreviewNode(description as any, 'block')}
           </Text>
         </Box>
       )}

--- a/packages/sanity/src/components/previews/portableText/BlockPreview.tsx
+++ b/packages/sanity/src/components/previews/portableText/BlockPreview.tsx
@@ -33,12 +33,11 @@ export function BlockPreview(props: PreviewProps<'block'>) {
   return (
     <Stack data-testid="block-preview" space={1}>
       <HeaderFlex data-testid="block-preview__header">
-        {media && <Media dimensions={mediaDimensions} layout="block" media={media} />}
+        {media && <Media dimensions={mediaDimensions} layout="block" media={media as any} />}
 
         <Box flex={1} paddingLeft={media ? 2 : 1}>
           <Text size={1} textOverflow="ellipsis" weight="semibold">
-            {title && renderPreviewNode(title, 'block')}
-            {!title && <>Untitled</>}
+            {title ? renderPreviewNode(title, 'block') : 'Untitled'}
           </Text>
 
           {subtitle && (
@@ -65,7 +64,7 @@ export function BlockPreview(props: PreviewProps<'block'>) {
             </Box>
           )}
 
-          {actions}
+          {actions as any}
         </Flex>
       </HeaderFlex>
 

--- a/packages/sanity/src/components/previews/template/TemplatePreview.tsx
+++ b/packages/sanity/src/components/previews/template/TemplatePreview.tsx
@@ -1,18 +1,19 @@
-import React from 'react'
+import React, {createElement, isValidElement} from 'react'
+import {isValidElementType} from 'react-is'
 import {Box, Flex, rem, Stack, Text, TextSkeleton} from '@sanity/ui'
 import styled from 'styled-components'
 import {getDevicePixelRatio} from 'use-device-pixel-ratio'
 import {PreviewMediaDimensions} from '../types'
-import {Media} from '../_common/Media'
+import {Media, MediaProps} from '../_common/Media'
 import {PREVIEW_MEDIA_SIZE} from '../constants'
 
 export interface TemplatePreviewProps {
-  description?: React.ReactNode | React.FunctionComponent<unknown>
+  description?: React.ReactNode
   isPlaceholder?: boolean
-  media?: React.ReactNode | React.FunctionComponent<unknown>
+  media?: MediaProps['media']
   mediaDimensions?: PreviewMediaDimensions
-  subtitle?: React.ReactNode | React.FunctionComponent<{layout: 'default'}>
-  title?: React.ReactNode | React.FunctionComponent<unknown>
+  subtitle?: React.ElementType<{layout: 'default'}> | React.ReactNode
+  title?: React.ElementType<{layout: 'default'}> | React.ReactNode
 }
 
 const DEFAULT_MEDIA_DIMENSION: PreviewMediaDimensions = {
@@ -76,14 +77,19 @@ export function TemplatePreview(props: TemplatePreviewProps) {
     <Root>
       <HeaderFlex>
         <Stack flex={1} space={2}>
-          <Text textOverflow="ellipsis">
-            {typeof title !== 'function' && title}
-            {typeof title === 'function' && title({layout: 'default'})}
-          </Text>
+          {isValidElementType(title) && (
+            <Text textOverflow="ellipsis">{createElement(title, {layout: 'default'})}</Text>
+          )}
+          {isValidElement(title) && <Text textOverflow="ellipsis">{title}</Text>}
 
-          {subtitle && (
+          {isValidElementType(subtitle) && (
             <Text muted size={1} textOverflow="ellipsis">
-              {(typeof subtitle === 'function' && subtitle({layout: 'default'})) || subtitle}
+              {createElement(subtitle, {layout: 'default'})}
+            </Text>
+          )}
+          {isValidElement(subtitle) && (
+            <Text muted size={1} textOverflow="ellipsis">
+              {subtitle}
             </Text>
           )}
         </Stack>

--- a/packages/sanity/src/components/rovingFocus/useRovingFocus.ts
+++ b/packages/sanity/src/components/rovingFocus/useRovingFocus.ts
@@ -79,7 +79,7 @@ export function useRovingFocus(props: RovingFocusProps): undefined {
    * Handle increment/decrement of focusedIndex
    */
   const handleKeyDown = useCallback(
-    (event) => {
+    (event: any) => {
       if (pause) {
         return
       }

--- a/packages/sanity/src/desk/__workshop__/ResolvePanesStory.tsx
+++ b/packages/sanity/src/desk/__workshop__/ResolvePanesStory.tsx
@@ -20,7 +20,7 @@ const testPaths: RouterPanes[] = [
 
 export default function ResolvePanesStoryWrapper() {
   return (
-    <DeskToolProvider structure={useCallback((S) => S.list().title('Content'), [])}>
+    <DeskToolProvider structure={useCallback((S: any) => S.list().title('Content'), [])}>
       <ResolvePanesStory />
     </DeskToolProvider>
   )

--- a/packages/sanity/src/desk/actions/GetHookCollectionState.tsx
+++ b/packages/sanity/src/desk/actions/GetHookCollectionState.tsx
@@ -48,7 +48,7 @@ export function GetHookCollectionState<T, K>(props: GetHookCollectionStateProps<
     trailing: true,
   })
 
-  const handleNext = useCallback((id, hookState) => {
+  const handleNext = useCallback((id: any, hookState: any) => {
     if (hookState === null) {
       delete statesRef.current[id]
     } else {
@@ -58,7 +58,7 @@ export function GetHookCollectionState<T, K>(props: GetHookCollectionStateProps<
   }, [])
 
   const handleReset = useCallback(
-    (id) => {
+    (id: any) => {
       setKeys((currentKeys) => ({...currentKeys, [id]: (currentKeys[id] || 0) + 1}))
 
       if (onReset) {

--- a/packages/sanity/src/desk/components/ReferringDocumentsList.tsx
+++ b/packages/sanity/src/desk/components/ReferringDocumentsList.tsx
@@ -39,7 +39,7 @@ function DocumentPreviewLink(props: DocumentPreviewLinkProps) {
   const schemaType = schema.get(document._type)
 
   const handleClick = useCallback(
-    (event) => {
+    (event: any) => {
       if (event.shiftKey || event.metaKey) return
       event.preventDefault()
       router.navigateIntent(intent.action, intent.params)

--- a/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
+++ b/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
@@ -45,7 +45,7 @@ export function ConfirmDeleteDialogBody({
   const toast = useToast()
 
   const renderPreviewItem = useCallback(
-    (item) => {
+    (item: any) => {
       const type = schema.get(item._type)
       if (type) {
         return <ReferencePreviewLink type={type} value={item} onClick={onReferenceLinkClick} />

--- a/packages/sanity/src/desk/components/pane/PaneDivider.tsx
+++ b/packages/sanity/src/desk/components/pane/PaneDivider.tsx
@@ -63,7 +63,7 @@ export function PaneDivider({
   const [dragging, setDragging] = useState(false)
 
   const handleMouseDown = useCallback(
-    (event) => {
+    (event: any) => {
       if (!element) return
 
       setDragging(true)

--- a/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
@@ -206,7 +206,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     patch.execute(toMutationPatches(event.patches), initialValue.value)
   }
 
-  const handleChange = useCallback((event) => patchRef.current(event), [])
+  const handleChange = useCallback((event: any) => patchRef.current(event), [])
 
   const handleHistoryClose = useCallback(() => {
     paneRouter.setParams({...params, since: undefined})

--- a/packages/sanity/src/desk/panes/document/keyboardShortcuts/DocumentActionShortcuts.tsx
+++ b/packages/sanity/src/desk/panes/document/keyboardShortcuts/DocumentActionShortcuts.tsx
@@ -40,7 +40,7 @@ function KeyboardShortcutResponder(
   const activeAction = states[activeIndex]
 
   const handleKeyDown = useCallback(
-    (event) => {
+    (event: any) => {
       const matchingStates = states.filter(
         (state) => state.shortcut && isHotkey(state.shortcut, event)
       )

--- a/packages/sanity/src/desk/panes/document/statusBar/dialogs/ConfirmDialog.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/dialogs/ConfirmDialog.tsx
@@ -52,7 +52,7 @@ function ConfirmDialogContent(props: {modal: DocumentActionConfirmModalProps}) {
   }, [isTopLayer, onCancel])
 
   const handleGlobalKeyDown = useCallback(
-    (event) => {
+    (event: any) => {
       if (event.key === 'Escape' && isTopLayer) onCancel()
     },
     [isTopLayer, onCancel]

--- a/packages/sanity/src/desk/panes/document/statusBar/dialogs/PopoverDialog.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/dialogs/PopoverDialog.tsx
@@ -33,7 +33,7 @@ function PopoverDialogContent(props: {modal: DocumentActionPopoverModalProps}) {
   }, [isTopLayer, onClose])
 
   const handleGlobalKeyDown = useCallback(
-    (event) => {
+    (event: any) => {
       if (event.key === 'Escape' && isTopLayer) onClose()
     },
     [isTopLayer, onClose]

--- a/packages/sanity/src/field/__workshop__/ChangeListStory.tsx
+++ b/packages/sanity/src/field/__workshop__/ChangeListStory.tsx
@@ -73,7 +73,7 @@ export default function ChangeListStory() {
     [nameDiff]
   )
 
-  const FieldWrapper = useCallback((_props) => {
+  const FieldWrapper = useCallback((_props: any) => {
     // console.log('props', _props)
     return <Card>{_props.children}</Card>
   }, [])

--- a/packages/sanity/src/field/__workshop__/ChangeResolverStory.tsx
+++ b/packages/sanity/src/field/__workshop__/ChangeResolverStory.tsx
@@ -71,7 +71,7 @@ export default function ChangeResolverStory() {
     [nameDiff, schemaType]
   )
 
-  const FieldWrapper = useCallback((_props) => {
+  const FieldWrapper = useCallback((_props: any) => {
     // console.log('props', _props)
     return <Card>{_props.children}</Card>
   }, [])

--- a/packages/sanity/src/field/types/portableText/diff/components/Annotation.tsx
+++ b/packages/sanity/src/field/types/portableText/diff/components/Annotation.tsx
@@ -127,7 +127,7 @@ function AnnnotationWithDiff({
   }, [isEditing, myPath, onSetFocus, open])
 
   const handleOpenPopup = useCallback(
-    (event) => {
+    (event: any) => {
       event.stopPropagation()
       setOpen(true)
       if (!isRemoved) {

--- a/packages/sanity/src/field/types/portableText/diff/components/Block.tsx
+++ b/packages/sanity/src/field/types/portableText/diff/components/Block.tsx
@@ -24,7 +24,7 @@ export default function Block(props: {
   let returned = children
 
   const handleClick = useCallback(
-    (event) => {
+    (event: any) => {
       event.stopPropagation()
 
       if (!isRemoved) {

--- a/packages/sanity/src/field/types/portableText/diff/components/InlineObject.tsx
+++ b/packages/sanity/src/field/types/portableText/diff/components/InlineObject.tsx
@@ -101,7 +101,7 @@ function InlineObjectWithDiff({
   }, [isEditing])
 
   const handleOpenPopup = useCallback(
-    (event) => {
+    (event: any) => {
       event.stopPropagation()
       setOpen(true)
       if (!isRemoved) {

--- a/packages/sanity/src/form/__workshop__/FormBuilderStory.tsx
+++ b/packages/sanity/src/form/__workshop__/FormBuilderStory.tsx
@@ -36,7 +36,7 @@ export default function FormBuilderStory() {
   }, [])
 
   const handleChange = useCallback(
-    (patches) => {
+    (patches: any) => {
       patch.execute(patches, initialValue.value)
     },
     [patch, initialValue.value]

--- a/packages/sanity/src/form/__workshop__/_common/FilterFieldInput.tsx
+++ b/packages/sanity/src/form/__workshop__/_common/FilterFieldInput.tsx
@@ -21,7 +21,7 @@ export const FilterFieldInput = React.forwardRef(function FilterFieldInput(
   const {value, onChange, onFilter} = props
 
   const handleChange = useCallback(
-    (event) => {
+    (event: any) => {
       onChange(event.target.value)
     },
     [onChange]

--- a/packages/sanity/src/form/__workshop__/_common/TypeTester.tsx
+++ b/packages/sanity/src/form/__workshop__/_common/TypeTester.tsx
@@ -79,7 +79,7 @@ export function TypeTester({readOnly}: TypeTesterProps) {
   }, [focusedInput])
 
   const handleHighlightMouseOver = useCallback(
-    (event) => {
+    (event: any) => {
       if (event.type === 'mouseover') {
         focusedInput!.classList.add(HIGHLIGHT_CLASSNAME)
       }

--- a/packages/sanity/src/form/__workshop__/example.tsx
+++ b/packages/sanity/src/form/__workshop__/example.tsx
@@ -68,17 +68,17 @@ export default function ExampleStory() {
     // setDocumentValue((currentDocumentValue) => patcher.apply(currentDocumentValue))
   }, [])
   const handleBlur = useCallback(() => setFocused(false), [])
-  const handleFocus = useCallback((path) => {
+  const handleFocus = useCallback((path: any) => {
     setFocusPath(path)
     setFocused(true)
   }, [])
-  const handleChangeFieldFilterSource = useCallback((value) => {
+  const handleChangeFieldFilterSource = useCallback((value: any) => {
     const handledValue = value && value.length > 0 ? value : ``
 
     setFieldFilterSource(handledValue)
   }, [])
   const handleChangeFieldFilter = useCallback(
-    (value) => {
+    (value: any) => {
       setFieldFilterValue(value)
       toast.push({
         status: 'success',

--- a/packages/sanity/src/form/inputs/CrossDatasetReferenceInput/CrossDatasetReferenceInput.tsx
+++ b/packages/sanity/src/form/inputs/CrossDatasetReferenceInput/CrossDatasetReferenceInput.tsx
@@ -117,7 +117,7 @@ export function CrossDatasetReferenceInput(props: CrossDatasetReferenceInputProp
   }, [onChange])
 
   const handleAutocompleteKeyDown = useCallback(
-    (event) => {
+    (event: any) => {
       // escape
       if (event.keyCode === 27) {
         onFocusPath?.([])
@@ -166,7 +166,7 @@ export function CrossDatasetReferenceInput(props: CrossDatasetReferenceInputProp
   const errors = useMemo(() => validation.filter((item) => item.level === 'error'), [validation])
 
   const handleFocus = useCallback(
-    (event) => {
+    (event: any) => {
       if (onFocusPath && event.currentTarget === elementProps.ref.current) {
         onFocusPath([])
       }
@@ -175,7 +175,7 @@ export function CrossDatasetReferenceInput(props: CrossDatasetReferenceInputProp
   )
 
   const handleAutocompleteFocus = useCallback(
-    (event) => {
+    (event: any) => {
       if (onFocusPath && event.currentTarget === elementProps.ref.current) {
         onFocusPath(REF_PATH)
       }
@@ -233,7 +233,7 @@ export function CrossDatasetReferenceInput(props: CrossDatasetReferenceInputProp
     null
 
   const renderOption = useCallback(
-    (option) => {
+    (option: any) => {
       return (
         <PreviewCard forwardedAs="button" type="button" radius={2}>
           <Box paddingX={3} paddingY={1}>

--- a/packages/sanity/src/form/inputs/DateInputs/CommonDateTimeInput.tsx
+++ b/packages/sanity/src/form/inputs/DateInputs/CommonDateTimeInput.tsx
@@ -48,7 +48,7 @@ export const CommonDateTimeInput = React.forwardRef(function CommonDateTimeInput
   }, [value])
 
   const handleDatePickerInputChange = React.useCallback(
-    (event) => {
+    (event: any) => {
       const nextInputValue = event.currentTarget.value
       const result = nextInputValue === '' ? null : parseInputValue(nextInputValue)
 

--- a/packages/sanity/src/form/inputs/DateInputs/base/DatePicker.tsx
+++ b/packages/sanity/src/form/inputs/DateInputs/base/DatePicker.tsx
@@ -14,7 +14,7 @@ export const DatePicker = React.forwardRef(function DatePicker(
   const [focusedDate, setFocusedDay] = React.useState<Date>()
 
   const handleSelect = React.useCallback(
-    (nextDate) => {
+    (nextDate: any) => {
       onChange(nextDate)
       setFocusedDay(undefined)
     },

--- a/packages/sanity/src/form/inputs/DateInputs/base/DateTimeInput.tsx
+++ b/packages/sanity/src/form/inputs/DateInputs/base/DateTimeInput.tsx
@@ -36,7 +36,7 @@ export const DateTimeInput = forwardRef(function DateTimeInput(
     forwardedRef.current?.select()
   }, [forwardedRef])
 
-  const handleKeyUp = useCallback((e) => {
+  const handleKeyUp = useCallback((e: any) => {
     if (e.key === 'Escape') {
       setPickerOpen(false)
     }

--- a/packages/sanity/src/form/inputs/DateInputs/base/LazyTextInput.tsx
+++ b/packages/sanity/src/form/inputs/DateInputs/base/LazyTextInput.tsx
@@ -24,12 +24,12 @@ export const LazyTextInput = React.forwardRef(function LazyTextInput(
 ) {
   const [inputValue, setInputValue] = React.useState<string>()
 
-  const handleChange = React.useCallback((event) => {
+  const handleChange = React.useCallback((event: any) => {
     setInputValue(event.currentTarget.value)
   }, [])
 
   const checkEvent = React.useCallback(
-    (event) => {
+    (event: any) => {
       const currentValue = event.currentTarget.value
       if (currentValue !== `${value}`) {
         if (onChange) {
@@ -42,7 +42,7 @@ export const LazyTextInput = React.forwardRef(function LazyTextInput(
   )
 
   const handleBlur = React.useCallback(
-    (e) => {
+    (e: any) => {
       checkEvent(e)
       if (onBlur) {
         onBlur(e)

--- a/packages/sanity/src/form/inputs/DateInputs/base/calendar/Calendar.tsx
+++ b/packages/sanity/src/form/inputs/DateInputs/base/calendar/Calendar.tsx
@@ -109,7 +109,7 @@ export const Calendar = forwardRef(function Calendar(
   }, [ref])
 
   const handleKeyDown = useCallback(
-    (event) => {
+    (event: any) => {
       if (!ARROW_KEYS.includes(event.key)) {
         return
       }

--- a/packages/sanity/src/form/inputs/InvalidValueInput/InvalidValueInput.tsx
+++ b/packages/sanity/src/form/inputs/InvalidValueInput/InvalidValueInput.tsx
@@ -48,7 +48,7 @@ export const InvalidValueInput = forwardRef(
     }, [onChange])
 
     const handleConvertTo = useCallback(
-      (converted) => {
+      (converted: any) => {
         onChange(PatchEvent.from(set(converted)))
       },
       [onChange]

--- a/packages/sanity/src/form/inputs/ObjectInput/UnknownFields.tsx
+++ b/packages/sanity/src/form/inputs/ObjectInput/UnknownFields.tsx
@@ -20,7 +20,7 @@ export function UnknownFields(props: Props) {
   const fieldsLen = fieldNames.length
 
   const handleUnsetClick = useCallback(
-    (fieldName) => {
+    (fieldName: any) => {
       onChange(unset([fieldName]))
     },
     [onChange]

--- a/packages/sanity/src/form/inputs/ObjectInput/fieldGroups/FieldGroupTabs.tsx
+++ b/packages/sanity/src/form/inputs/ObjectInput/fieldGroups/FieldGroupTabs.tsx
@@ -107,7 +107,7 @@ export const FieldGroupTabs = React.memo(function FieldGroupTabs({
   ...props
 }: FieldGroupTabsProps) {
   const handleClick = useCallback(
-    (groupName) => {
+    (groupName: any) => {
       onClick?.(groupName)
     },
     [onClick]

--- a/packages/sanity/src/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/form/inputs/PortableText/Compositor.tsx
@@ -176,7 +176,7 @@ export function Compositor(props: InputProps) {
   )
 
   const renderChild = useCallback(
-    (child, childType, attributes, defaultRender) => {
+    (child: any, childType: any, attributes: any, defaultRender: any) => {
       const isSpan = child._type === ptFeatures.types.span.name
       if (isSpan) {
         return defaultRender(child)
@@ -206,7 +206,7 @@ export function Compositor(props: InputProps) {
   )
 
   const renderAnnotation = useCallback(
-    (annotation, annotationType, attributes, defaultRender) => {
+    (annotation: any, annotationType: any, attributes: any, defaultRender: any) => {
       return (
         <Annotation
           attributes={attributes}

--- a/packages/sanity/src/form/inputs/PortableText/__workshop__/_common/TestInput.tsx
+++ b/packages/sanity/src/form/inputs/PortableText/__workshop__/_common/TestInput.tsx
@@ -65,7 +65,7 @@ export function TestInput(props: TestInputProps) {
     setFocusPath([])
   }, [])
 
-  const onChange = useCallback((event) => {
+  const onChange = useCallback((event: any) => {
     setValue((prevValue) => applyAll(prevValue, event.patches))
   }, [])
 

--- a/packages/sanity/src/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/form/inputs/PortableText/object/BlockObject.tsx
@@ -76,7 +76,7 @@ export function BlockObject(props: BlockObjectProps) {
   }, [onOpenItem, memberItem])
 
   const handleDoubleClickToOpen = useCallback(
-    (e) => {
+    (e: any) => {
       e.preventDefault()
       e.stopPropagation()
       PortableTextEditor.blur(editor)
@@ -86,7 +86,7 @@ export function BlockObject(props: BlockObjectProps) {
   )
 
   const handleDelete = useCallback(
-    (e) => {
+    (e: any) => {
       e.stopPropagation()
       e.preventDefault()
       const sel: EditorSelection = {focus: {path, offset: 0}, anchor: {path, offset: 0}}

--- a/packages/sanity/src/form/inputs/PortableText/toolbar/types.ts
+++ b/packages/sanity/src/form/inputs/PortableText/toolbar/types.ts
@@ -4,7 +4,7 @@ import {ObjectSchemaType} from '@sanity/types'
 
 export interface BlockItem {
   handle: () => void
-  icon: React.ComponentType
+  icon: React.ElementType
   inline: boolean
   key: string
   type: ObjectSchemaType
@@ -13,14 +13,14 @@ export interface BlockItem {
 export interface BlockStyleItem {
   key: string
   style: string
-  styleComponent?: React.ComponentType
+  styleComponent?: React.ElementType
   title: string
 }
 
 export interface PTEToolbarAction {
   type: 'annotation' | 'format' | 'listStyle'
   disabled: boolean
-  icon?: React.ComponentType | string
+  icon?: React.ElementType | string
   handle: (active?: boolean) => void
   hotkeys?: string[]
   key: string

--- a/packages/sanity/src/form/inputs/ReferenceInput/ArrayItemReferenceInput.tsx
+++ b/packages/sanity/src/form/inputs/ReferenceInput/ArrayItemReferenceInput.tsx
@@ -203,7 +203,7 @@ export function ArrayItemReferenceInput(props: Props) {
   }, [onChange])
 
   const handlePreviewKeyPress = useCallback(
-    (event) => {
+    (event: any) => {
       if (event.key !== 'Enter' && event.key !== 'Space') {
         // enable "search for reference"-mode
         onFocusPath(['_ref'])
@@ -220,7 +220,7 @@ export function ArrayItemReferenceInput(props: Props) {
   }, [onChange, onFocusPath, value?._ref])
 
   const handleAutocompleteKeyDown = useCallback(
-    (event) => {
+    (event: any) => {
       // escape
       if (event.keyCode === 27) {
         handleCancelEdit()
@@ -230,7 +230,7 @@ export function ArrayItemReferenceInput(props: Props) {
   )
 
   const getReferenceInfoMemo = useCallback(
-    (id) => getReferenceInfo(id, type),
+    (id: any) => getReferenceInfo(id, type),
     [getReferenceInfo, type]
   )
 
@@ -283,7 +283,7 @@ export function ArrayItemReferenceInput(props: Props) {
   const pressed = selectedState === 'pressed'
   const selected = selectedState === 'selected'
   const handleFocus = useCallback(
-    (event) => {
+    (event: any) => {
       if (event.currentTarget === forwardedRef.current) {
         elementProps.onFocus(event)
       }
@@ -292,7 +292,7 @@ export function ArrayItemReferenceInput(props: Props) {
   )
 
   const handleAutocompleteFocus = useCallback(
-    (event) => {
+    (event: any) => {
       if (onFocusPath && event.currentTarget === forwardedRef.current) {
         onFocusPath(['_ref'])
       }
@@ -343,7 +343,7 @@ export function ArrayItemReferenceInput(props: Props) {
   const inputId = useId()
 
   const handleCreateButtonKeyDown = useCallback(
-    (e) => {
+    (e: any) => {
       if (e.key === 'Escape') {
         forwardedRef.current?.focus()
       }
@@ -352,7 +352,7 @@ export function ArrayItemReferenceInput(props: Props) {
   )
 
   const renderOption = useCallback(
-    (option) => {
+    (option: any) => {
       const id = option.hit.draft?._id || option.hit.published?._id
 
       return (
@@ -627,8 +627,8 @@ export function ArrayItemReferenceInput(props: Props) {
         >
           <Stack space={3}>
             <Text as="p" muted size={1}>
-              <strong>{loadableReferenceInfo.result?.preview.published?.title}</strong> is published
-              and this reference should now be{' '}
+              <strong>{loadableReferenceInfo.result?.preview.published?.title as any}</strong> is
+              published and this reference should now be{' '}
               {type.weak ? <>finalized</> : <>converted to a strong reference</>}.
             </Text>
             <Button

--- a/packages/sanity/src/form/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/sanity/src/form/inputs/ReferenceInput/ReferenceInput.tsx
@@ -159,7 +159,7 @@ export function ReferenceInput(props: ReferenceInputProps) {
   }, [onChange])
 
   const handlePreviewKeyPress = useCallback(
-    (event) => {
+    (event: any) => {
       if (event.key !== 'Enter' && event.key !== 'Space') {
         // enable "search for reference"-mode
         onFocusPath(['_ref'])
@@ -169,7 +169,7 @@ export function ReferenceInput(props: ReferenceInputProps) {
   )
 
   const handleAutocompleteKeyDown = useCallback(
-    (event) => {
+    (event: any) => {
       // escape
       if (event.keyCode === 27) {
         onFocusPath([])
@@ -179,7 +179,7 @@ export function ReferenceInput(props: ReferenceInputProps) {
   )
 
   const getReferenceInfoMemo = useCallback(
-    (id) => getReferenceInfo(id, schemaType),
+    (id: any) => getReferenceInfo(id, schemaType),
     [getReferenceInfo, schemaType]
   )
 
@@ -279,7 +279,7 @@ export function ReferenceInput(props: ReferenceInputProps) {
   const inputId = useId()
 
   const handleCreateButtonKeyDown = useCallback(
-    (e) => {
+    (e: any) => {
       if (e.key === 'Escape') {
         forwardedRef?.current?.focus()
       }
@@ -288,7 +288,7 @@ export function ReferenceInput(props: ReferenceInputProps) {
   )
 
   const renderOption = useCallback(
-    (option) => {
+    (option: any) => {
       const id = option.hit.draft?._id || option.hit.published?._id
 
       return (
@@ -507,8 +507,8 @@ export function ReferenceInput(props: ReferenceInputProps) {
               >
                 <Stack space={3}>
                   <Text as="p" muted size={1}>
-                    <strong>{loadableReferenceInfo.result?.preview.published?.title}</strong> is
-                    published and this reference should now be{' '}
+                    <strong>{loadableReferenceInfo.result?.preview.published?.title as any}</strong>{' '}
+                    is published and this reference should now be{' '}
                     {schemaType.weak ? <>finalized</> : <>converted to a strong reference</>}.
                   </Text>
                   <Button

--- a/packages/sanity/src/form/inputs/SelectInput.tsx
+++ b/packages/sanity/src/form/inputs/SelectInput.tsx
@@ -35,7 +35,7 @@ export function SelectInput(props: StringInputProps) {
   const isRadio = schemaType.options && schemaType.options.layout === 'radio'
 
   const itemFromOptionValue = useCallback(
-    (optionValue) => {
+    (optionValue: any) => {
       const index = Number(optionValue)
 
       return items[index]
@@ -44,7 +44,7 @@ export function SelectInput(props: StringInputProps) {
   )
 
   const optionValueFromItem = useCallback(
-    (item) => {
+    (item: any) => {
       return String(items.indexOf(item))
     },
     [items]

--- a/packages/sanity/src/form/inputs/Slug/SlugInput.tsx
+++ b/packages/sanity/src/form/inputs/Slug/SlugInput.tsx
@@ -36,7 +36,7 @@ export function SlugInput(props: SlugInputProps) {
   const errors = useMemo(() => validation.filter((item) => item.level === 'error'), [validation])
 
   const updateSlug = useCallback(
-    (nextSlug) => {
+    (nextSlug: any) => {
       if (!nextSlug) {
         onChange(PatchEvent.from(unset([])))
         return
@@ -68,7 +68,7 @@ export function SlugInput(props: SlugInputProps) {
   const isUpdating = generateState?.status === 'pending'
 
   const handleChange = React.useCallback(
-    (event) => updateSlug(event.currentTarget.value),
+    (event: any) => updateSlug(event.currentTarget.value),
     [updateSlug]
   )
 

--- a/packages/sanity/src/form/inputs/arrays/ArrayOfObjectsInput/item/ItemWithMissingType.tsx
+++ b/packages/sanity/src/form/inputs/arrays/ArrayOfObjectsInput/item/ItemWithMissingType.tsx
@@ -21,7 +21,7 @@ export function ItemWithMissingType(props: Props) {
 
   useClickOutside(() => setShowDetails(false), [popoverRef])
 
-  const handleKeyDown = React.useCallback((e) => {
+  const handleKeyDown = React.useCallback((e: any) => {
     if (e.key === 'Escape' || e.key === 'Tab') {
       setShowDetails(false)
     }

--- a/packages/sanity/src/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesFunctions.tsx
+++ b/packages/sanity/src/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesFunctions.tsx
@@ -15,7 +15,7 @@ export function ArrayOfPrimitivesFunctions<
   const menuButtonId = useId()
 
   const insertItem = React.useCallback(
-    (itemType) => {
+    (itemType: any) => {
       onAppendItem(onCreateValue(itemType))
     },
     [onCreateValue, onAppendItem]

--- a/packages/sanity/src/form/inputs/arrays/common/ArrayFunctions.tsx
+++ b/packages/sanity/src/form/inputs/arrays/common/ArrayFunctions.tsx
@@ -15,7 +15,7 @@ export function DefaultArrayInputFunctions<
   const menuButtonId = useId()
 
   const insertItem = React.useCallback(
-    (itemType) => {
+    (itemType: any) => {
       const item = onCreateValue(itemType)
 
       onAppendItem(item)

--- a/packages/sanity/src/form/inputs/files/ImageInput/ImageActionsMenu.tsx
+++ b/packages/sanity/src/form/inputs/files/ImageInput/ImageActionsMenu.tsx
@@ -24,7 +24,7 @@ export function ImageActionsMenu(props: Props) {
   }, [onMenuOpen])
 
   const handleGlobalKeyDown = useCallback(
-    (e) => {
+    (e: any) => {
       if (e.key === 'Escape') {
         onMenuOpen(false)
         menuButtonRef?.focus()

--- a/packages/sanity/src/form/inputs/files/ImageToolInput/ImageToolInput.tsx
+++ b/packages/sanity/src/form/inputs/files/ImageToolInput/ImageToolInput.tsx
@@ -80,7 +80,7 @@ export function ImageToolInput(props: ImageToolInputProps) {
   })
 
   const handleChangeEnd = useCallback(
-    (finalValue) => {
+    (finalValue: any) => {
       if (readOnly) {
         return
       }

--- a/packages/sanity/src/form/members/fields/ArrayOfObjectsField.tsx
+++ b/packages/sanity/src/form/members/fields/ArrayOfObjectsField.tsx
@@ -128,7 +128,7 @@ export function ArrayOfObjectsField(props: {
   )
 
   const handlePrependItem = useCallback(
-    (item) => {
+    (item: any) => {
       onChange(
         PatchEvent.from([setIfMissing([]), insert([ensureKey(item)], 'before', [0])]).prefixAll(
           member.name
@@ -138,7 +138,7 @@ export function ArrayOfObjectsField(props: {
     [member.name, onChange]
   )
   const handleAppendItem = useCallback(
-    (item) => {
+    (item: any) => {
       onChange(
         PatchEvent.from([setIfMissing([]), insert([ensureKey(item)], 'after', [-1])]).prefixAll(
           member.name

--- a/packages/sanity/src/form/studio/DefaultAssetSource/AssetThumb.tsx
+++ b/packages/sanity/src/form/studio/DefaultAssetSource/AssetThumb.tsx
@@ -90,7 +90,7 @@ export const AssetThumb = React.memo(function AssetThumb(props: AssetProps) {
   }, [setShowUsageDialog])
 
   const handleDeleteError = useCallback(
-    (error) => {
+    (error: any) => {
       toast.push({
         closable: true,
         status: 'error',

--- a/packages/sanity/src/form/studio/DefaultAssetSource/DefaultSource.tsx
+++ b/packages/sanity/src/form/studio/DefaultAssetSource/DefaultSource.tsx
@@ -83,7 +83,7 @@ const DefaultAssetSource = function DefaultAssetSource(
   )
 
   const handleDeleteFinished = useCallback(
-    (id) => {
+    (id: any) => {
       // eslint-disable-next-line max-nested-callbacks
       setAssets((prevState) => prevState.filter((asset) => asset._id !== id))
     },
@@ -91,7 +91,7 @@ const DefaultAssetSource = function DefaultAssetSource(
   )
 
   const select = useCallback(
-    (id) => {
+    (id: any) => {
       const selected = assets.find((doc) => doc._id === id)
 
       if (selected) {
@@ -129,7 +129,7 @@ const DefaultAssetSource = function DefaultAssetSource(
   }, [onClose])
 
   const handleFetchNextPage = useCallback(
-    (event) => {
+    (event: any) => {
       event.preventDefault()
       fetchPage(++currentPageNumber.current)
     },

--- a/packages/sanity/src/form/studio/inputs/reference/StudioReferenceInput.tsx
+++ b/packages/sanity/src/form/studio/inputs/reference/StudioReferenceInput.tsx
@@ -170,7 +170,7 @@ export function StudioReferenceInput(props: StudioReferenceInputProps) {
   }, [disableNew, initialValueTemplateItems, schemaType.to])
 
   const getReferenceInfo = useCallback(
-    (id, _type) => adapter.getReferenceInfo(documentPreviewStore, id, _type),
+    (id: any, _type: any) => adapter.getReferenceInfo(documentPreviewStore, id, _type),
     [documentPreviewStore]
   )
 

--- a/packages/sanity/src/presence/overlay/RegionsWithIntersections.tsx
+++ b/packages/sanity/src/presence/overlay/RegionsWithIntersections.tsx
@@ -63,7 +63,7 @@ export const RegionsWithIntersections = forwardRef(function RegionsWithIntersect
     >
   >({})
 
-  const onIntersection = useCallback((id, entry) => {
+  const onIntersection = useCallback((id: any, entry: any) => {
     setIntersections((current) => ({...current, [id]: entry}))
   }, [])
 

--- a/packages/sanity/src/presence/overlay/StickyOverlay.tsx
+++ b/packages/sanity/src/presence/overlay/StickyOverlay.tsx
@@ -146,7 +146,7 @@ export function StickyOverlay(props: Props) {
   )
 
   const renderCallback = React.useCallback(
-    (regionsWithIntersectionDetails: RegionWithIntersectionDetails[], containerWidth) => {
+    (regionsWithIntersectionDetails: RegionWithIntersectionDetails[], containerWidth: any) => {
       const grouped = group(
         regionsWithIntersectionDetails.filter((item) => item.region.presence.length > 0)
       )

--- a/packages/sanity/src/preview/components/SanityDefaultPreview.tsx
+++ b/packages/sanity/src/preview/components/SanityDefaultPreview.tsx
@@ -2,13 +2,14 @@ import {DocumentIcon} from '@sanity/icons'
 import imageUrlBuilder from '@sanity/image-url'
 import {ImageUrlFitMode, isImage, isReference} from '@sanity/types'
 import React, {
-  ComponentType,
   createElement,
+  ElementType,
   isValidElement,
   ReactElement,
   useCallback,
   useMemo,
 } from 'react'
+import {isValidElementType} from 'react-is'
 import {PreviewProps} from '../../components/previews'
 import {useClient} from '../../hooks'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
@@ -22,7 +23,7 @@ function FallbackIcon() {
 
 export interface SanityDefaultPreviewProps extends Omit<PreviewProps, 'value'> {
   error?: Error | null
-  icon?: ComponentType | false
+  icon?: ElementType | false
   value?: unknown
 }
 
@@ -42,7 +43,7 @@ export function SanityDefaultPreview(props: SanityDefaultPreviewProps): ReactEle
   const imageBuilder = useMemo(() => imageUrlBuilder(client), [client])
 
   const component = (_previewComponents[layout || 'default'] ||
-    _previewComponents.default) as ComponentType<PreviewProps>
+    _previewComponents.default) as ElementType<PreviewProps>
 
   const {_upload, value} = useMemo(() => {
     return valueProp ? _extractUploadState(valueProp) : {_upload: undefined, value: undefined}
@@ -100,7 +101,7 @@ export function SanityDefaultPreview(props: SanityDefaultPreviewProps): ReactEle
       return false
     }
 
-    if (typeof mediaProp === 'function') {
+    if (isValidElementType(mediaProp)) {
       return mediaProp
     }
 

--- a/packages/sanity/src/preview/components/SanityPreview.tsx
+++ b/packages/sanity/src/preview/components/SanityPreview.tsx
@@ -62,7 +62,7 @@ export function SanityPreview(props: SanityPreviewProps & {style?: CSSProperties
         error,
         isPlaceholder: !value,
         layout,
-        media: isImage(valueProp) ? valueProp : value?.media,
+        media: isImage(valueProp) ? (valueProp as any) : value?.media,
         schemaType,
         subtitle: value?.subtitle,
         title: value?.title,

--- a/packages/sanity/src/preview/components/_resolvePreviewComponent.ts
+++ b/packages/sanity/src/preview/components/_resolvePreviewComponent.ts
@@ -1,13 +1,16 @@
 import {SchemaType} from '@sanity/types'
-import {ComponentType} from 'react'
+import {ElementType} from 'react'
 import {PreviewProps} from '../../components/previews'
 import {SanityDefaultPreview} from './SanityDefaultPreview'
 
-export function _resolvePreviewComponent(type: SchemaType): ComponentType<
+type PreviewElementType = ElementType<
   PreviewProps & {
-    icon?: ComponentType
+    icon?: React.ElementType
     schemaType?: SchemaType
   }
-> {
-  return type.components?.preview || SanityDefaultPreview
+>
+
+export function _resolvePreviewComponent(type: SchemaType): PreviewElementType {
+  // @todo: find out why `type.components?.preview` isn't inferred as `PreviewElementType`
+  return (type.components?.preview as any) || SanityDefaultPreview
 }

--- a/packages/sanity/src/studio/components/navbar/search/SearchField.tsx
+++ b/packages/sanity/src/studio/components/navbar/search/SearchField.tsx
@@ -39,7 +39,7 @@ export function SearchField(props: SearchFieldProps) {
   }, [fullScreen, onSearchItemClick])
 
   const renderOption = useCallback(
-    (option) => {
+    (option: any) => {
       const {data} = option.payload
       const documentId = data.hit._id
       const documentType = data.hit._type
@@ -58,7 +58,7 @@ export function SearchField(props: SearchFieldProps) {
   )
 
   const renderPopoverFullscreen = useCallback(
-    (popoverProps, ref) => {
+    (popoverProps: any, ref: any) => {
       if (!popoverProps.hidden && results.error) {
         return (
           <SearchFullscreenContent tone="critical">
@@ -111,7 +111,7 @@ export function SearchField(props: SearchFieldProps) {
   )
 
   const renderPopover = useCallback(
-    (popoverProps, ref) => {
+    (popoverProps: any, ref: any) => {
       if (!popoverProps.hidden && results.error) {
         return (
           <SearchPopoverContent


### PR DESCRIPTION
### Description

Relates to #3612 but only does the legwork to fix typing errors caused by the stricter definitions in `@types/react@18`.
This only matters for the internal codebase and in this PR everything is still react `v17`.