### PR TITLE
Fix React 18 issue with PT-input

### DIFF
--- a/packages/sanity/src/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/form/inputs/PortableText/PortableTextInput.tsx
@@ -267,6 +267,10 @@ export function PortableTextInput(props: PortableTextInputProps) {
   // Handle editor changes
   const handleEditorChange = useCallback(
     (change: EditorChange): void => {
+      // With React 18 it can happen that we still receive changes after the editor has unmounted.
+      if (!editorRef.current) {
+        return
+      }
       switch (change.type) {
         case 'mutation':
           onChange(toFormPatches(change.patches))


### PR DESCRIPTION
Is seems like the PortableTextInput with React 18 is able to receive events from the PortableTextEditor even though it is unmounted and cleaned up at the time we receive the event inside PortableTextInput.

By checking the editorRef there before sending the patches, we can avoid that DocumentPane crashes at least when it receives the mutation.

I am however not sure if this is symtom of that something else is wrong, or it is just some of the things to expect with React 18.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->
