### PR TITLE
fix: migrate class components to functions+hooks

### DIFF
--- a/packages/sanity/src/_exports/form.ts
+++ b/packages/sanity/src/_exports/form.ts
@@ -74,7 +74,6 @@ export type {FIXME_SanityDocument} from '../form/store/formState' // eslint-disa
 export type {
   HashFocusManagerChildArgs,
   HashFocusManagerProps,
-  HashFocusManagerState,
   SimpleFocusManagerProps,
   SimpleFocusManagerState,
 } from '../form/studio'

--- a/packages/sanity/src/form/inputs/files/ImageToolInput/imagetool/ImageLoader.tsx
+++ b/packages/sanity/src/form/inputs/files/ImageToolInput/imagetool/ImageLoader.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+/* eslint-disable @typescript-eslint/no-shadow */
+import {useEffect, useState, type ReactElement} from 'react'
 
 interface ImageLoaderProps {
   src: string
@@ -6,59 +7,36 @@ interface ImageLoaderProps {
     isLoading: boolean
     image: HTMLImageElement | null
     error: Error | null
-  }) => React.ReactNode
-}
-interface ImageLoaderState {
-  isLoading: boolean
-  image: HTMLImageElement | null
-  error: Error | null
+  }) => ReactElement | null
 }
 
-export class ImageLoader extends React.Component<ImageLoaderProps, ImageLoaderState> {
-  state: ImageLoaderState = {
-    isLoading: true,
-    image: null,
-    error: null,
-  }
+export function ImageLoader(props: ImageLoaderProps) {
+  const {src, children} = props
+  const [isLoading, setIsLoading] = useState(true)
+  const [image, setImage] = useState<HTMLImageElement | null>(null)
+  const [error, setError] = useState<Error | null>(null)
 
-  UNSAFE_componentWillMount() {
-    this.loadImage(this.props.src)
-  }
+  useEffect(() => {
+    setImage(null)
+    setError(null)
+    setIsLoading(true)
 
-  loadImage(src: string) {
     const image = new Image()
-    this.setState({
-      image: null,
-      error: null,
-    })
 
     image.onload = () => {
-      this.setState({
-        image: image,
-        error: null,
-        isLoading: false,
-      })
+      setImage(image)
+      setError(null)
+      setIsLoading(false)
     }
 
     image.onerror = () => {
-      this.setState({
-        error: new Error(`Could not load image from ${JSON.stringify(this.props.src)}`),
-        isLoading: false,
-      })
+      setError(new Error(`Could not load image from ${JSON.stringify(src)}`))
+      setIsLoading(false)
     }
 
     image.referrerPolicy = 'strict-origin-when-cross-origin'
     image.src = src
-  }
+  }, [src])
 
-  UNSAFE_componentWillReceiveProps(nextProps: ImageLoaderProps) {
-    if (nextProps.src !== this.props.src) {
-      this.loadImage(nextProps.src)
-    }
-  }
-
-  render() {
-    const {error, image, isLoading} = this.state
-    return this.props.children({image, error, isLoading})
-  }
+  return children({image, error, isLoading})
 }

--- a/packages/sanity/src/form/studio/focusManagers/HashFocusManager.ts
+++ b/packages/sanity/src/form/studio/focusManagers/HashFocusManager.ts
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-unused-prop-types */
 
 import {Path} from '@sanity/types'
-import React from 'react'
+import React, {useCallback, useEffect, useState} from 'react'
 import {decodePath, encodePath} from '../../utils/path'
 
 export type HashFocusManagerChildArgs = {
@@ -17,10 +17,6 @@ export interface HashFocusManagerProps {
   children: (arg0: HashFocusManagerChildArgs) => any
 }
 
-export interface HashFocusManagerState {
-  focusPath: Array<any>
-}
-
 function getHash() {
   return decodeURIComponent(document.location.hash.substring(1))
 }
@@ -33,39 +29,25 @@ function getPathFromHash() {
 /**
  * An example of how to sync focus path through document.location.hash
  */
-export class HashFocusManager extends React.Component<
-  HashFocusManagerProps,
-  HashFocusManagerState
-> {
-  state = {
-    focusPath: getPathFromHash(),
-  }
+export function HashFocusManager(props: HashFocusManagerProps) {
+  const {children} = props
+  const [focusPath, setFocusPath] = useState(() => getPathFromHash())
 
-  componentDidMount() {
-    window.addEventListener('hashchange', this.handleHashChange, false)
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('hashchange', this.handleHashChange, false)
-  }
-
-  handleHashChange = () => {
-    this.setState({focusPath: getPathFromHash()})
-  }
-
-  handleFocus = (focusPath: Path) => {
+  const handleBlur = useCallback(() => {
+    // setFocusPath([])
+  }, [])
+  // eslint-disable-next-line @typescript-eslint/no-shadow
+  const handleFocus = useCallback((focusPath: Path) => {
     document.location.hash = encodePath(focusPath)
-  }
+  }, [])
 
-  handleBlur = () => {
-    // this.setState({focusPath: []})
-  }
+  useEffect(() => {
+    const handleHashChange = () => {
+      setFocusPath(getPathFromHash())
+    }
+    window.addEventListener('hashchange', handleHashChange, false)
+    return () => window.removeEventListener('hashchange', handleHashChange, false)
+  }, [])
 
-  render() {
-    return this.props.children({
-      onBlur: this.handleBlur,
-      onFocus: this.handleFocus,
-      focusPath: this.state.focusPath,
-    })
-  }
+  return children({onBlur: handleBlur, onFocus: handleFocus, focusPath})
 }


### PR DESCRIPTION
### Description

Converts problematic class components to function components with hooks to make them ready for React 18 concurrent features. With this PR there's no longer any components left in our codebase that uses `UNSAFE_` prefixed legacy lifecycle hooks.
