### PR TITLE
fix: added context with client and schema to slugify and source options

### DIFF
--- a/dev/test-studio/schema/standard/slugs.ts
+++ b/dev/test-studio/schema/standard/slugs.ts
@@ -1,4 +1,4 @@
-import {defineType} from 'sanity'
+import {defineField, defineType} from 'sanity'
 
 export const slugAlias = {
   name: 'slug-alias',
@@ -61,17 +61,20 @@ export default defineType({
         maxLength: 96,
       },
     },
-    {
+    defineField({
       name: 'slugWithFunction',
       type: 'slug',
       title: 'Slug with function to get source',
-      description: 'This is a slug field that should update according to current title',
+      description:
+        'This is a slug field that should update according to current title joined with dataset',
       options: {
-        source: (document) => document.title,
+        source: (document, context) => {
+          return [document.title, context.dataset].filter(Boolean).join('_')
+        },
         maxLength: 96,
       },
-    },
-    {
+    }),
+    defineField({
       name: 'slugWithCustomUniqueCheck',
       type: 'slug',
       title: 'Slug with custom unique check',
@@ -79,10 +82,11 @@ export default defineType({
       options: {
         source: 'title',
         maxLength: 100,
-        isUnique: (value, options) =>
-          !/^hei/i.test(value) && options.defaultIsUnique(value, options),
+        isUnique: (value, context) => {
+          return !/^hei/i.test(value) && context.defaultIsUnique(value, context)
+        },
       },
-    },
+    }),
     {
       name: 'arrayOfSlugs',
       type: 'array',
@@ -104,12 +108,15 @@ export default defineType({
     {
       name: 'deprecatedSlugifyFnField',
       type: 'slug',
-      title: 'Slug field using deprecated "slugifyFn" option',
-      description: 'Should warn the developer about deprecated field',
+      title: 'Slug field using "slugify" option',
       options: {
         source: 'title',
-        slugify: (value) =>
-          value.toLocaleLowerCase().split('').reverse().join('').replace(/\s+/g, '-'),
+        slugify: (value, schemaType, context) => {
+          return [
+            value.toLocaleLowerCase().split('').reverse().join('').replace(/\s+/g, '-'),
+            context.dataset,
+          ].join('_')
+        },
       },
     },
     {

--- a/packages/@sanity/types/src/slug/types.ts
+++ b/packages/@sanity/types/src/slug/types.ts
@@ -1,6 +1,10 @@
+import {SanityClient} from '@sanity/client'
 import type {SlugSchemaType} from '../schema'
 import type {SanityDocument} from '../documents'
 import type {Path} from '../paths'
+import {CurrentUser} from '../user'
+import {Schema} from '../schema'
+import {SlugIsUniqueValidator} from '../validation'
 
 export interface Slug {
   _type: 'slug'
@@ -9,35 +13,30 @@ export interface Slug {
 
 export type SlugParent = Record<string, unknown> | Record<string, unknown>[]
 
-export interface SlugSourceOptions {
+export interface SlugSourceContext {
   parentPath: Path
   parent: SlugParent
+  projectId: string
+  dataset: string
+  schema: Schema
+  currentUser: CurrentUser | null
+  getClient: (options: {apiVersion: string}) => SanityClient
 }
 
 export type SlugSourceFn = (
   document: SanityDocument,
-  options: SlugSourceOptions
+  context: SlugSourceContext
 ) => string | Promise<string>
 
-export type SlugifierFn = (source: string, schemaType: SlugSchemaType) => string | Promise<string>
-
-// TODO: De-dupe with validation types
-export interface SlugUniqueOptions {
-  parent: SlugParent
-  type: SlugSchemaType
-  document: SanityDocument
-  defaultIsUnique: UniqueCheckerFn
-  path: Path
-}
-
-export type UniqueCheckerFn = (
-  slug: string,
-  options: SlugUniqueOptions
-) => boolean | Promise<boolean>
+export type SlugifierFn = (
+  source: string,
+  schemaType: SlugSchemaType,
+  context: SlugSourceContext
+) => string | Promise<string>
 
 export interface SlugOptions {
   source?: string | Path | SlugSourceFn
   maxLength?: number
   slugify?: SlugifierFn
-  isUnique?: UniqueCheckerFn
+  isUnique?: SlugIsUniqueValidator
 }

--- a/packages/@sanity/types/src/validation/types.ts
+++ b/packages/@sanity/types/src/validation/types.ts
@@ -4,6 +4,8 @@ import type {Schema, SchemaType, SchemaValidationValue} from '../schema'
 import type {SanityDocument} from '../documents'
 import type {ValidationMarker} from '../markers'
 import type {Block} from '../portableText'
+import {SlugSchemaType} from '../schema'
+import {SlugParent} from '../slug'
 
 export type RuleTypeConstraint = 'Array' | 'Boolean' | 'Date' | 'Number' | 'Object' | 'String'
 export type FieldRules = {[fieldKey: string]: SchemaValidationValue}
@@ -325,9 +327,15 @@ export type BlockValidator = (
   | true
   | Promise<ValidationError[] | ValidationError | string | true>
 
+export interface SlugValidationContext extends ValidationContext {
+  parent: SlugParent
+  type: SlugSchemaType
+  defaultIsUnique: SlugIsUniqueValidator
+}
+
 export type SlugIsUniqueValidator = (
   slug: string,
-  options: ValidationContext & {defaultIsUnique: SlugIsUniqueValidator}
+  context: SlugValidationContext
 ) => boolean | Promise<boolean>
 
 export interface NodeValidation {

--- a/packages/@sanity/validation/src/validators/slugValidator.ts
+++ b/packages/@sanity/validation/src/validators/slugValidator.ts
@@ -1,4 +1,12 @@
-import {SlugIsUniqueValidator, Path, CustomValidator, isKeyedObject} from '@sanity/types'
+import {
+  SlugIsUniqueValidator,
+  Path,
+  CustomValidator,
+  isKeyedObject,
+  SlugValidationContext,
+  SlugParent,
+  SlugSchemaType,
+} from '@sanity/types'
 import {memoize} from 'lodash'
 // import getClient from '../getClient'
 
@@ -94,7 +102,13 @@ export const slugValidator: CustomValidator = async (value, context) => {
   const options = context?.type?.options as {isUnique?: SlugIsUniqueValidator} | undefined
   const isUnique = options?.isUnique || defaultIsUnique
 
-  const wasUnique = await isUnique(slugValue, {...context, defaultIsUnique})
+  const slugContext: SlugValidationContext = {
+    ...context,
+    parent: context.parent as SlugParent,
+    type: context.type as SlugSchemaType,
+    defaultIsUnique,
+  }
+  const wasUnique = await isUnique(slugValue, slugContext)
   if (wasUnique) {
     return true
   }

--- a/packages/sanity/src/form/inputs/Slug/SlugInput.tsx
+++ b/packages/sanity/src/form/inputs/Slug/SlugInput.tsx
@@ -33,16 +33,15 @@ function getSlugSourceContext(
   return {parentPath, parent, ...context}
 }
 
-function getNewFromSource(
+// eslint-disable-next-line require-await
+async function getNewFromSource(
   source: string | Path | SlugSourceFn,
   document: SanityDocument,
   context: SlugSourceContext
-) {
-  return Promise.resolve(
-    typeof source === 'function'
-      ? source(document, context)
-      : (PathUtils.get(document, source) as string | undefined)
-  )
+): Promise<string | undefined> {
+  return typeof source === 'function'
+    ? source(document, context)
+    : (PathUtils.get(document, source) as string | undefined)
 }
 
 export function SlugInput(props: SlugInputProps) {

--- a/packages/sanity/src/form/inputs/Slug/utils/slugify.ts
+++ b/packages/sanity/src/form/inputs/Slug/utils/slugify.ts
@@ -9,16 +9,16 @@ const defaultSlugify = (value: FIXME, type: SlugSchemaType): string => {
   return value ? speakingurl(value, slugifyOpts) : ''
 }
 
-export function slugify(
+// eslint-disable-next-line require-await
+export async function slugify(
   sourceValue: FIXME,
   type: SlugSchemaType,
   context: SlugSourceContext
 ): Promise<string> {
   if (!sourceValue) {
-    return Promise.resolve(sourceValue)
+    return sourceValue
   }
 
   const slugifier = type.options?.slugify || defaultSlugify
-
-  return Promise.resolve(slugifier(sourceValue, type, context))
+  return slugifier(sourceValue, type, context)
 }

--- a/packages/sanity/src/form/inputs/Slug/utils/slugify.ts
+++ b/packages/sanity/src/form/inputs/Slug/utils/slugify.ts
@@ -1,4 +1,4 @@
-import {SlugSchemaType} from '@sanity/types'
+import {SlugSchemaType, SlugSourceContext} from '@sanity/types'
 import speakingurl from 'speakingurl'
 import {FIXME} from '../../../types'
 
@@ -9,12 +9,16 @@ const defaultSlugify = (value: FIXME, type: SlugSchemaType): string => {
   return value ? speakingurl(value, slugifyOpts) : ''
 }
 
-export function slugify(sourceValue: FIXME, type: SlugSchemaType): Promise<string> {
+export function slugify(
+  sourceValue: FIXME,
+  type: SlugSchemaType,
+  context: SlugSourceContext
+): Promise<string> {
   if (!sourceValue) {
     return Promise.resolve(sourceValue)
   }
 
   const slugifier = type.options?.slugify || defaultSlugify
 
-  return Promise.resolve(slugifier(sourceValue, type))
+  return Promise.resolve(slugifier(sourceValue, type, context))
 }

--- a/packages/sanity/src/form/inputs/Slug/utils/useSlugContext.ts
+++ b/packages/sanity/src/form/inputs/Slug/utils/useSlugContext.ts
@@ -1,0 +1,31 @@
+import {SlugSourceContext} from '@sanity/types'
+import {useMemo} from 'react'
+import {useSource} from '../../../../studio'
+import {useDataset, useProjectId, useSchema} from '../../../../hooks'
+import {useCurrentUser} from '../../../../datastores'
+
+/**
+ * @internal
+ */
+export type SlugContext = Omit<SlugSourceContext, 'parent' | 'parentPath'>
+
+/**
+ * @internal
+ */
+export function useSlugContext(): SlugContext {
+  const {getClient} = useSource()
+  const schema = useSchema()
+  const currentUser = useCurrentUser()
+  const projectId = useProjectId()
+  const dataset = useDataset()
+
+  return useMemo(() => {
+    return {
+      projectId,
+      dataset,
+      getClient,
+      schema,
+      currentUser,
+    }
+  }, [getClient, schema, currentUser, projectId, dataset])
+}


### PR DESCRIPTION
### Description

Extends the context object passed to `options.source` and `options.slugify` with getClient, schema, currentUser (and projectId and dataset for consistency with initial value context).

Also fixes the context type for `options.isUnique` which was duplicated in the definition, and missing some properties (they where available at runtime already though, via validation context).

This is primarily to make it possible to use the client when using these options; a common thing in v2.

### What to review

All the code.

### Notes for release

Slug options `source` and `slugify` are now passed a `context` parameter as the last argument. It contains `getClient`, `schema` and `currentUser`.