### PR TITLE
chore(ci): reduce PR builds

### DIFF
--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -1,6 +1,11 @@
 name: Extract, Transform & Load
 
-on: [push, pull_request]
+on:
+  # Build on pushes branches that have a PR (including drafts)
+  pull_request:
+  # Build on commits pushed to branches without a PR if it's in the allowlist
+  push:
+    branches: [next, v3]
 
 jobs:
   etl:

--- a/.github/workflows/lintChanged.yml
+++ b/.github/workflows/lintChanged.yml
@@ -1,6 +1,11 @@
 name: Lint changed files
 
-on: [push, pull_request]
+on:
+  # Build on pushes branches that have a PR (including drafts)
+  pull_request:
+  # Build on commits pushed to branches without a PR if it's in the allowlist
+  push:
+    branches: [next, v3]
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  # Build on pushes branches that have a PR (including drafts)
+  pull_request:
+  # Build on commits pushed to branches without a PR if it's in the allowlist
+  push:
+    branches: [next, v3]
 
 jobs:
   test:


### PR DESCRIPTION
### Description

Our PRs are a bit noisy atm as most CI tasks run double checks. With this it'll only run its CI things once per PR (without breaking fork PRs).