### PR TITLE
fix: object reconciler

### DIFF
--- a/packages/sanity/src/core/form/store/utils/__tests__/immutableReconcile.test.ts
+++ b/packages/sanity/src/core/form/store/utils/__tests__/immutableReconcile.test.ts
@@ -108,5 +108,6 @@ test('returns new array when previous and next has different length', () => {
   const lessItems = ['a']
 
   expect(immutableReconcile(moreItems, lessItems)).not.toBe(moreItems)
+
   expect(immutableReconcile(lessItems, moreItems)).not.toBe(lessItems)
 })

--- a/packages/sanity/src/core/form/store/utils/__tests__/immutableReconcile.test.ts
+++ b/packages/sanity/src/core/form/store/utils/__tests__/immutableReconcile.test.ts
@@ -87,3 +87,26 @@ test('does not mutate any of its input', () => {
 
   expect(() => immutableReconcile(prev, next)).not.toThrow()
 })
+
+test('returns new object when previous and next has different number of keys', () => {
+  const moreKeys = {
+    key1: 'value1',
+    key2: 'value2',
+    key3: 'value3',
+  }
+  const lessKeys = {
+    key1: 'value1',
+    key2: 'value2',
+  }
+
+  expect(immutableReconcile(moreKeys, lessKeys)).not.toBe(moreKeys)
+  expect(immutableReconcile(lessKeys, moreKeys)).not.toBe(lessKeys)
+})
+
+test('returns new array when previous and next has different length', () => {
+  const moreItems = ['a', 'b']
+  const lessItems = ['a']
+
+  expect(immutableReconcile(moreItems, lessItems)).not.toBe(moreItems)
+  expect(immutableReconcile(lessItems, moreItems)).not.toBe(lessItems)
+})

--- a/packages/sanity/src/core/form/store/utils/immutableReconcile.ts
+++ b/packages/sanity/src/core/form/store/utils/immutableReconcile.ts
@@ -55,9 +55,10 @@ function _immutableReconcile<T>(
     assertType<Record<string, unknown>>(previous)
     assertType<Record<string, unknown>>(next)
 
-    let allEqual = true
+    const nextKeys = Object.keys(next)
+    let allEqual = Object.keys(previous).length === nextKeys.length
     const result: Record<string, unknown> = {}
-    for (const key of Object.keys(next)) {
+    for (const key of nextKeys) {
       if (parents.has(next[key])) {
         return next
       }


### PR DESCRIPTION
### Description

Form state now correctly updates members when hidden state changes.

Underlying issue: immutableReconcile did not account for changes in number of keys in objects,
which resulted in it considering next object unchanged when a key had been removed.
This made the code retain the previous value incorrectly.

This had the effect of associating wrong schemaTypes with member fields, when hidden function
changed state (as one observed effect).

### What to review

Evaluate the code.

This was verified in the test-studio by reproducing a reported issue related to this (observed as wrong schema passed as props to renderInput) and confirming that it fixed.
