### PR TITLE
fix(sanity): fix controls for custom block components preview

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObjectPreview.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObjectPreview.tsx
@@ -57,7 +57,7 @@ export function BlockObjectPreview(props: BlockObjectPreviewProps): ReactElement
   const menuButtonId = useId() || ''
   const menuButton = useRef<HTMLButtonElement | null>(null)
   const isTabbing = useRef<boolean>(false)
-  const isCustomPreviewComponent = Boolean((type.preview as FIXME)?.component)
+  const isCustomPreviewComponent = Boolean(type?.components?.preview)
   const isImageType = is('image', type)
 
   const referenceLink = useMemo(


### PR DESCRIPTION
### Description

When a PTE object block has a custom `components.preview`, the dot-menu disappears. This fixes the check that adds the wrapper around the preview.

This is reproducible by adding a block to a PTE input with the following schema:
```ts
defineField({
  type: 'object',
  name: 'testPreview',
  fields: [
    {
      title: 'Title',
      name: 'title',
      type: 'string',
    },
  ],
  preview: {
    select: {
      title: 'title',
    },
  },
  components: {
    preview: () => <div>Yolo</div>,
  },
})
```

### What to review

- That the UI looks correct when you have a custom `components.preview` for a block preview

### Notes for release

- Fixed missing block action menu around custom block object previews
