### PR TITLE
Feat/v3/poc component props

### DIFF
--- a/packages/@sanity/types/src/schema/definition/type/common.ts
+++ b/packages/@sanity/types/src/schema/definition/type/common.ts
@@ -28,13 +28,6 @@ export interface BaseSchemaDefinition {
   hidden?: ConditionalProperty
   readOnly?: ConditionalProperty
   icon?: ComponentType | ReactNode
-  components?: {
-    diff?: ComponentType<any> // @todo: use `DiffProps` here
-    field?: ComponentType<any> // @todo: use `FieldProps` here
-    input?: ComponentType<any> // @todo: use `InputProps` here
-    item?: ComponentType<any> // @todo: use `ItemProps` here
-    preview?: ComponentType<any> // @todo: use `PreviewProps` here
-  }
   validation?: unknown
   initialValue?: unknown
 }

--- a/packages/sanity/src/core/index.ts
+++ b/packages/sanity/src/core/index.ts
@@ -1,3 +1,5 @@
+export type {SchemaComponents} from './schemaComponentsExtension'
+
 export * from './FIXME'
 export * from './changeIndicators'
 export * from './components'

--- a/packages/sanity/src/core/schemaComponentsExtension.ts
+++ b/packages/sanity/src/core/schemaComponentsExtension.ts
@@ -1,0 +1,18 @@
+import {ComponentType} from 'react'
+import {FieldProps, InputProps, ItemProps} from './form'
+import {DiffProps} from './field'
+import {PreviewProps} from './components'
+
+export interface SchemaComponents {
+  diff?: ComponentType<DiffProps>
+  field?: ComponentType<FieldProps>
+  input?: ComponentType<InputProps>
+  item?: ComponentType<ItemProps>
+  preview?: ComponentType<PreviewProps>
+}
+
+declare module '@sanity/types' {
+  export interface BaseSchemaDefinition {
+    components?: SchemaComponents
+  }
+}


### PR DESCRIPTION
PoC on how we can augment `@sanity/types` from `sanity` to avoid moving component props around.