### PR TITLE
fix(sanity): fix icon from schema in block previews

### DIFF
--- a/packages/sanity/src/core/preview/components/SanityPreview.tsx
+++ b/packages/sanity/src/core/preview/components/SanityPreview.tsx
@@ -33,6 +33,10 @@ export function SanityPreview(props: SanityPreviewProps & {style?: CSSProperties
   const [element, setElement] = useState<HTMLDivElement | null>(null)
   const isPTE = ['inline', 'block', 'blockImage'].includes(layout)
 
+  const icon = useMemo(() => {
+    return schemaType?.icon
+  }, [schemaType])
+
   // Subscribe to visiblity
   const visibility = useVisibility({
     // NOTE: disable when PTE preview
@@ -67,6 +71,7 @@ export function SanityPreview(props: SanityPreviewProps & {style?: CSSProperties
       description: description || value?.description,
       error,
       isPlaceholder: isLoading,
+      icon,
       layout,
       media: media || value?.media,
       schemaType,
@@ -74,7 +79,19 @@ export function SanityPreview(props: SanityPreviewProps & {style?: CSSProperties
       title: title || value?.title,
       value,
     }),
-    [description, error, isLoading, layout, media, restProps, schemaType, subtitle, title, value]
+    [
+      description,
+      error,
+      icon,
+      isLoading,
+      layout,
+      media,
+      restProps,
+      schemaType,
+      subtitle,
+      title,
+      value,
+    ]
   )
 
   // Remove components property to avoid component rendering itself


### PR DESCRIPTION
### Description

This fixes rendering of icons from schema in `SanityPreview` by making sure the icon is pulled out from the schema type.

![image](https://user-images.githubusercontent.com/10508/194082293-e3eb8deb-118a-495a-bbf0-e0dda8defe43.png)


### What to review

- Does the change catch all schema types? Before we had [a special case for references](https://github.com/sanity-io/sanity/blob/817abbdf31e28180fea477070f6b96387cec751f/packages/@sanity/base/src/preview/components/RenderPreviewSnapshot.tsx#L31), do we still need that?

### Notes for release

- Fixed icons from schema in block previews
