### PR TITLE
Fix handle change exception

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -266,10 +266,6 @@ export function PortableTextInput(props: PortableTextInputProps) {
   // Handle editor changes
   const handleEditorChange = useCallback(
     (change: EditorChange): void => {
-      // With React 18 it can happen that we still receive changes after the editor has unmounted.
-      if (!editorRef.current) {
-        return
-      }
       switch (change.type) {
         case 'mutation':
           onChange(toFormPatches(change.patches))

--- a/packages/sanity/src/desk/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/documentViews/FormView.tsx
@@ -76,9 +76,9 @@ export function FormView(props: FormViewProps) {
 
   const handleChange = useCallback(
     (patchEvent: PatchEvent) => {
-      if (!isReadOnly) _handleChange(patchEvent)
+      if (!isReadOnly && ready) _handleChange(patchEvent)
     },
-    [_handleChange, isReadOnly]
+    [_handleChange, isReadOnly, ready]
   )
 
   // useEffect(() => {


### PR DESCRIPTION
### Description

We had a bug where the FormView would throw errors when calling onChange from the PT-input while switching documents. This was quick fixed by this commit: https://github.com/sanity-io/sanity/pull/3700/commits/6f3f6ff1cfabc384f0e65e45d1eb9fd2add98bde

However, the real problem seems to be that handleChange is called for a a FormView in which the DocumentPane isn't ready yet, so checking for this inside DocumentPaneProvider seems to be the correct place to fix this with the current codebase.

I have also reverted the quick fix I did.
