### PR TITLE
feat: legacy theming

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -19,6 +19,8 @@ import {
   studioComponentsPlugin,
 } from './components/studioComponents'
 import {Field, formComponentsPlugin, Input, Item, Preview} from './components/formComponents'
+import {googleTheme} from './themes/google'
+import {vercelTheme} from './themes/vercel'
 
 const sharedSettings = createPlugin({
   name: 'sharedSettings',
@@ -84,6 +86,34 @@ export default createConfig([
         logo: Branding,
       },
     },
+  },
+  {
+    name: 'google-theme',
+    title: 'Google Colors',
+    projectId: 'ppsg7ml5',
+    dataset: 'test',
+    plugins: [sharedSettings()],
+    basePath: '/google',
+    studio: {
+      components: {
+        logo: Branding,
+      },
+    },
+    theme: googleTheme,
+  },
+  {
+    name: 'vercel-theme',
+    title: 'Vercel Colors',
+    projectId: 'ppsg7ml5',
+    dataset: 'test',
+    plugins: [sharedSettings()],
+    basePath: '/vercel',
+    studio: {
+      components: {
+        logo: Branding,
+      },
+    },
+    theme: vercelTheme,
   },
   {
     name: 'playground',

--- a/dev/test-studio/themes/google.ts
+++ b/dev/test-studio/themes/google.ts
@@ -1,0 +1,44 @@
+import {buildLegacyTheme} from 'sanity'
+
+const props = {
+  '--google-white': '#fff',
+  '--google-black': '#1a1a1a',
+  '--google-blue': '#4285f4',
+  '--google-red': '#db4437',
+  '--google-yellow': '#f4b400',
+  '--google-green': '#0f9d58',
+}
+
+export const googleTheme = buildLegacyTheme({
+  /* Base theme colors */
+  '--black': props['--google-black'],
+  '--white': props['--google-white'],
+
+  '--gray': '#666',
+  '--gray-base': '#666',
+
+  '--component-bg': props['--google-white'],
+  '--component-text-color': props['--google-black'],
+
+  /* Brand */
+  '--brand-primary': props['--google-blue'],
+
+  // Default button
+  '--default-button-color': '#666',
+  '--default-button-primary-color': props['--google-blue'],
+  '--default-button-success-color': props['--google-green'],
+  '--default-button-warning-color': props['--google-yellow'],
+  '--default-button-danger-color': props['--google-red'],
+
+  /* State */
+  '--state-info-color': props['--google-blue'],
+  '--state-success-color': props['--google-green'],
+  '--state-warning-color': props['--google-yellow'],
+  '--state-danger-color': props['--google-red'],
+
+  /* Navbar */
+  '--main-navigation-color': props['--google-black'],
+  '--main-navigation-color--inverted': props['--google-white'],
+
+  '--focus-color': props['--google-blue'],
+})

--- a/dev/test-studio/themes/vercel.ts
+++ b/dev/test-studio/themes/vercel.ts
@@ -1,0 +1,61 @@
+import {buildLegacyTheme} from 'sanity'
+
+const color = {
+  'geist-foreground': '#000',
+  'geist-background': '#fff',
+  'geist-success': '#2276fc',
+  'geist-error': '#f03e2f',
+  'geist-warning': '#f5a623',
+  'geist-warning-lighter': '#ffefcf',
+  'geist-highlight-purple': '#f81ce5',
+
+  'accents-1': '#fafafa',
+  'accents-2': '#eaeaea',
+  'accents-3': '#999',
+  'accents-4': '#888',
+  'accents-5': '#666',
+  'accents-6': '#444',
+  'accents-7': '#333',
+  'accents-8': '#111',
+}
+
+const legacyTheme = buildLegacyTheme({
+  // Base
+  '--black': color['geist-background'],
+  '--white': color['geist-background'],
+
+  // Gray
+  '--gray-base': color['accents-5'],
+  '--gray': color['accents-5'],
+
+  '--component-bg': color['geist-background'],
+  '--component-text-color': color['geist-foreground'],
+
+  // Brand
+  '--brand-primary': color['geist-foreground'],
+
+  // Main navigation
+  '--main-navigation-color': color['geist-background'],
+  '--main-navigation-color--inverted': color['geist-foreground'],
+
+  // Default button
+  '--default-button-color': color['geist-foreground'],
+  '--default-button-primary-color': color['geist-highlight-purple'],
+  '--default-button-success-color': color['geist-success'],
+  '--default-button-warning-color': color['geist-warning'],
+  '--default-button-danger-color': color['geist-error'],
+
+  // State
+  '--state-success-color': color['geist-success'],
+  '--state-info-color': color['geist-highlight-purple'],
+  '--state-warning-color': color['geist-warning'],
+  '--state-danger-color': color['geist-error'],
+
+  // Focus
+  '--focus-color': color['geist-highlight-purple'],
+})
+
+export const vercelTheme = {
+  ...legacyTheme,
+  // space: legacyTheme.space.map((v) => v * 2),
+}

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -164,6 +164,7 @@
     "open": "^8.4.0",
     "pirates": "^4.0.0",
     "pluralize-esm": "^9.0.2",
+    "polished": "^4.2.2",
     "pretty-ms": "^7.0.1",
     "raf": "^3.4.1",
     "react-copy-to-clipboard": "^5.0.4",

--- a/packages/sanity/src/core/studio/StudioThemeProvider.tsx
+++ b/packages/sanity/src/core/studio/StudioThemeProvider.tsx
@@ -1,7 +1,9 @@
+/* eslint-disable no-nested-ternary */
+
 import React from 'react'
 import {ThemeProvider, LayerProvider} from '@sanity/ui'
 import {useActiveWorkspace} from './activeWorkspaceMatcher'
-import {useColorScheme} from './colorScheme'
+import {ColorSchemeContext, useColorScheme} from './colorScheme'
 
 interface StudioThemeProviderProps {
   children: React.ReactChild
@@ -10,11 +12,14 @@ interface StudioThemeProviderProps {
 /** @internal */
 export function StudioThemeProvider({children}: StudioThemeProviderProps) {
   const theme = useActiveWorkspace().activeWorkspace.theme
-  const {scheme} = useColorScheme()
+  const colorScheme = useColorScheme()
+  const scheme = theme.__legacy ? (theme.__dark ? 'dark' : 'light') : colorScheme.scheme
 
   return (
-    <ThemeProvider scheme={scheme} theme={theme} tone="transparent">
-      <LayerProvider>{children}</LayerProvider>
-    </ThemeProvider>
+    <ColorSchemeContext.Provider value={{...colorScheme, scheme}}>
+      <ThemeProvider scheme={scheme} theme={theme} tone="transparent">
+        <LayerProvider>{children}</LayerProvider>
+      </ThemeProvider>
+    </ColorSchemeContext.Provider>
   )
 }

--- a/packages/sanity/src/core/studio/colorScheme.tsx
+++ b/packages/sanity/src/core/studio/colorScheme.tsx
@@ -1,7 +1,8 @@
 import React, {createContext, useContext, useEffect, useMemo, useState} from 'react'
 import {studioTheme, ThemeColorSchemeKey, ThemeProvider, usePrefersDark} from '@sanity/ui'
 
-const ColorSchemeContext = createContext<{
+/** @internal */
+export const ColorSchemeContext = createContext<{
   scheme: ThemeColorSchemeKey
   setScheme: (colorScheme: ThemeColorSchemeKey) => void
 } | null>(null)

--- a/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
@@ -9,6 +9,7 @@ import {
   Tooltip,
   useGlobalKeyDown,
   useMediaIndex,
+  useRootTheme,
 } from '@sanity/ui'
 import React, {useCallback, useState, useMemo, useEffect, useRef, useContext} from 'react'
 import {startCase} from 'lodash'
@@ -19,6 +20,7 @@ import {useColorScheme} from '../../colorScheme'
 import {useWorkspaces} from '../../workspaces'
 import {NavbarContext} from '../../StudioLayout'
 import {useLogoComponent, useToolMenuComponent} from '../../studio-components-hooks'
+import {StudioTheme} from '../../../theme'
 import {UserMenu} from './userMenu'
 import {NewDocumentButton} from './NewDocumentButton'
 import {PresenceMenu} from './presence'
@@ -68,6 +70,7 @@ const LeftFlex = styled(Flex)`
 /** @beta */
 export function StudioNavbar() {
   const {name, tools, ...workspace} = useWorkspace()
+  const theme = useRootTheme().theme as StudioTheme
   const workspaces = useWorkspaces()
   const routerState = useRouterState()
   const {scheme} = useColorScheme()
@@ -163,7 +166,7 @@ export function StudioNavbar() {
         data-ui="Navbar"
         padding={2}
         scheme="dark"
-        shadow={scheme === 'dark' ? 1 : undefined}
+        shadow={theme.__legacy || scheme === 'dark' ? 1 : undefined}
         sizing="border"
       >
         <Flex align="center" justify="space-between">

--- a/packages/sanity/src/core/studio/components/navbar/userMenu/UserMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/userMenu/UserMenu.tsx
@@ -13,11 +13,13 @@ import {
   Stack,
   Text,
   Tooltip,
+  useRootTheme,
 } from '@sanity/ui'
 import React, {useCallback, useMemo} from 'react'
 import styled from 'styled-components'
 import {UserAvatar} from '../../../../components'
 import {getProviderTitle} from '../../../../store'
+import {StudioTheme} from '../../../../theme'
 import {useColorScheme} from '../../../colorScheme'
 import {useWorkspace} from '../../../workspace'
 import {LoginProviderLogo} from './LoginProviderLogo'
@@ -33,6 +35,7 @@ const AvatarBox = styled(Box)`
 
 export function UserMenu() {
   const {currentUser, projectId, auth} = useWorkspace()
+  const theme = useRootTheme().theme as StudioTheme
   const {scheme, setScheme} = useColorScheme()
 
   const providerTitle = getProviderTitle(currentUser?.provider)
@@ -103,13 +106,17 @@ export function UserMenu() {
             </Flex>
           </Card>
 
-          <MenuDivider />
+          {!theme?.__legacy && (
+            <>
+              <MenuDivider />
 
-          <MenuItem
-            icon={scheme === 'dark' ? SunIcon : MoonIcon}
-            onClick={handleToggleScheme}
-            text={scheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
-          />
+              <MenuItem
+                icon={scheme === 'dark' ? SunIcon : MoonIcon}
+                onClick={handleToggleScheme}
+                text={scheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+              />
+            </>
+          )}
 
           <MenuDivider />
 

--- a/packages/sanity/src/core/theme/_legacy/color.ts
+++ b/packages/sanity/src/core/theme/_legacy/color.ts
@@ -1,0 +1,635 @@
+import {hues} from '@sanity/color'
+import {createColorTheme, rgba, ThemeColorSchemes} from '@sanity/ui'
+import {_multiply, _screen, _isDark} from './helpers'
+import {LegacyPalette} from './palette'
+import {LegacyTones} from './tones'
+import {LegacyThemeTints} from './types'
+
+const NEUTRAL_TONES = ['default', 'transparent']
+
+export function buildColor(
+  legacyPalette: LegacyPalette,
+  legacyTones: LegacyTones
+): ThemeColorSchemes {
+  return createColorTheme({
+    base: ({dark: navbar, name}) => {
+      const stateTones = navbar ? legacyTones.state.navbar : legacyTones.state.default
+      const dark = stateTones.dark
+      const blend = navbar ? _screen : _multiply
+      const tints = stateTones[name] || stateTones.default
+
+      if (name === 'default') {
+        const skeletonFrom = stateTones.default[100]
+
+        return {
+          fg: stateTones.fg,
+          bg: stateTones.bg,
+          border: stateTones.default[200],
+          focusRing: legacyPalette.focus.base,
+          shadow: {
+            outline: rgba(stateTones.default[500], 0.4),
+            umbra: rgba(dark ? legacyPalette.black : stateTones.default[500], 0.2),
+            penumbra: rgba(dark ? legacyPalette.black : stateTones.default[500], 0.14),
+            ambient: rgba(dark ? legacyPalette.black : stateTones.default[500], 0.12),
+          },
+          skeleton: {
+            from: skeletonFrom,
+            to: rgba(skeletonFrom, 0.5),
+          },
+        }
+      }
+
+      if (name === 'transparent') {
+        const bg = tints[50]
+        const skeletonFrom = blend(bg, tints[100])
+
+        return {
+          fg: tints[900],
+          bg,
+          border: tints[300],
+          focusRing: legacyPalette.focus.base,
+          shadow: {
+            outline: rgba(tints[500], dark ? 0.2 : 0.4),
+            umbra: rgba(dark ? legacyPalette.black : tints[500], 0.2),
+            penumbra: rgba(dark ? legacyPalette.black : tints[500], 0.14),
+            ambient: rgba(dark ? legacyPalette.black : tints[500], 0.12),
+          },
+          skeleton: {
+            from: skeletonFrom,
+            to: rgba(skeletonFrom, 0.5),
+          },
+        }
+      }
+
+      const bg = tints[50]
+      const skeletonFrom = blend(bg, tints[100])
+
+      return {
+        fg: tints[900],
+        bg,
+        border: tints[200],
+        focusRing: tints[500],
+        shadow: {
+          outline: rgba(tints[500], dark ? 0.2 : 0.4),
+          umbra: rgba(dark ? legacyPalette.black : tints[500], 0.2),
+          penumbra: rgba(dark ? legacyPalette.black : tints[500], 0.14),
+          ambient: rgba(dark ? legacyPalette.black : tints[500], 0.12),
+        },
+        skeleton: {
+          from: skeletonFrom,
+          to: rgba(skeletonFrom, 0.5),
+        },
+      }
+    },
+
+    solid: ({base, dark: navbar, name, state, tone}) => {
+      const buttonTones = navbar ? legacyTones.button.navbar : legacyTones.button.default
+      const dark = buttonTones.dark
+      const blend = dark ? _screen : _multiply
+      const blendInvert = dark ? _multiply : _screen
+      const defaultTints = buttonTones[name] || buttonTones.default
+      const isNeutral = NEUTRAL_TONES.includes(name) && NEUTRAL_TONES.includes(tone)
+      let tints = buttonTones[tone === 'default' ? name : tone] || defaultTints
+
+      if (state === 'disabled') {
+        tints = defaultTints
+
+        const bg = blend(base.bg, tints[200])
+        const skeletonFrom = blendInvert(bg, tints[800])
+
+        return {
+          bg,
+          border: blend(base.bg, tints[200]),
+          fg: blend(base.bg, buttonTones.bg),
+          muted: {
+            fg: blend(base.bg, tints[50]),
+          },
+          accent: {
+            fg: blend(base.bg, tints[50]),
+          },
+          link: {
+            fg: blend(base.bg, tints[50]),
+          },
+          code: {
+            bg,
+            fg: blend(base.bg, tints[50]),
+          },
+          skeleton: {
+            from: skeletonFrom,
+            to: rgba(skeletonFrom, 0.5),
+          },
+        }
+      }
+
+      if (state === 'hovered') {
+        const bg = blend(base.bg, tints[600])
+        const skeletonFrom = blendInvert(bg, tints[800])
+
+        return {
+          bg,
+          border: blend(base.bg, tints[600]),
+          fg: blend(base.bg, buttonTones.bg),
+          muted: {
+            fg: blend(base.bg, tints[200]),
+          },
+          accent: {
+            fg: blendInvert(bg, buttonTones.critical[300]),
+          },
+          link: {
+            fg: blendInvert(bg, buttonTones.primary[200]),
+          },
+          code: {
+            bg: blend(bg, tints[50]),
+            fg: blend(base.bg, tints[200]),
+          },
+          skeleton: {
+            from: skeletonFrom,
+            to: rgba(skeletonFrom, 0.5),
+          },
+        }
+      }
+
+      if (state === 'pressed') {
+        const bg = blend(base.bg, tints[800])
+        const skeletonFrom = blendInvert(bg, tints[800])
+
+        return {
+          bg,
+          border: blend(base.bg, tints[800]),
+          fg: blend(base.bg, buttonTones.bg),
+          muted: {
+            fg: blend(base.bg, tints[200]),
+          },
+          accent: {
+            fg: blendInvert(bg, buttonTones.critical[300]),
+          },
+          link: {
+            fg: blendInvert(bg, buttonTones.primary[200]),
+          },
+          code: {
+            bg: blend(bg, tints[50]),
+            fg: blend(base.bg, tints[200]),
+          },
+          skeleton: {
+            from: skeletonFrom,
+            to: rgba(skeletonFrom, 0.5),
+          },
+        }
+      }
+
+      if (state === 'selected') {
+        if (isNeutral) {
+          tints = buttonTones.primary
+        }
+
+        const bg = blend(base.bg, tints[800])
+        const skeletonFrom = blendInvert(bg, tints[800])
+
+        return {
+          bg,
+          border: blend(base.bg, tints[800]),
+          fg: blend(base.bg, buttonTones.bg),
+          muted: {
+            fg: blend(base.bg, tints[200]),
+          },
+          accent: {
+            fg: blendInvert(bg, buttonTones.critical[300]),
+          },
+          link: {
+            fg: blendInvert(bg, buttonTones.primary[200]),
+          },
+          code: {
+            bg: blend(bg, tints[50]),
+            fg: blend(base.bg, tints[200]),
+          },
+          skeleton: {
+            from: skeletonFrom,
+            to: rgba(skeletonFrom, 0.5),
+          },
+        }
+      }
+
+      const bg = blend(base.bg, tints[500])
+      const skeletonFrom = blendInvert(bg, tints[800])
+
+      return {
+        bg,
+        border: blend(base.bg, tints[500]),
+        fg: blend(base.bg, buttonTones.bg),
+        muted: {
+          fg: blend(base.bg, tints[100]),
+        },
+        accent: {
+          fg: blendInvert(bg, buttonTones.critical[200]),
+        },
+        link: {
+          fg: blendInvert(bg, buttonTones.primary[100]),
+        },
+        code: {
+          bg: blend(bg, tints[50]),
+          fg: blend(base.bg, tints[100]),
+        },
+        skeleton: {
+          from: skeletonFrom,
+          to: rgba(skeletonFrom, 0.5),
+        },
+      }
+    },
+
+    muted: ({base, dark: navbar, name, state, tone}) => {
+      const stateTones = navbar ? legacyTones.state.navbar : legacyTones.state.default
+      const dark = stateTones.dark
+      const blend = dark ? _screen : _multiply
+      const defaultTints = stateTones[name] || stateTones.default
+      const isNeutral = NEUTRAL_TONES.includes(name) && NEUTRAL_TONES.includes(tone)
+
+      let tints: LegacyThemeTints = stateTones[tone === 'default' ? name : tone] || defaultTints
+
+      if (state === 'disabled') {
+        tints = defaultTints
+
+        const bg = base.bg
+        const skeletonFrom = blend(bg, tints[100])
+
+        return {
+          bg,
+          border: blend(base.bg, tints[50]),
+          fg: blend(base.bg, tints[200]),
+          muted: {
+            fg: blend(bg, tints[100]),
+          },
+          accent: {
+            fg: blend(bg, tints[100]),
+          },
+          link: {
+            fg: blend(bg, tints[100]),
+          },
+          code: {
+            bg,
+            fg: blend(bg, tints[100]),
+          },
+          skeleton: {
+            from: skeletonFrom,
+            to: rgba(skeletonFrom, 0.5),
+          },
+        }
+      }
+
+      if (state === 'hovered') {
+        const bg = blend(base.bg, tints[50])
+        const skeletonFrom = blend(bg, tints[100])
+
+        return {
+          bg,
+          border: blend(bg, tints[100]),
+          fg: blend(base.bg, tints[900]),
+          muted: {
+            fg: blend(base.bg, tints[600]),
+          },
+          accent: {
+            fg: blend(base.bg, stateTones.critical[500]),
+          },
+          link: {
+            fg: blend(base.bg, stateTones.primary[600]),
+          },
+          code: {
+            bg: blend(bg, tints[50]),
+            fg: blend(base.bg, tints[600]),
+          },
+          skeleton: {
+            from: skeletonFrom,
+            to: rgba(skeletonFrom, 0.5),
+          },
+        }
+      }
+
+      if (state === 'pressed') {
+        if (isNeutral) {
+          tints = stateTones.primary
+        }
+
+        const bg = blend(base.bg, tints[100])
+        const skeletonFrom = blend(bg, tints[100])
+
+        return {
+          bg,
+          border: blend(bg, tints[100]),
+          fg: blend(base.bg, tints[800]),
+          muted: {
+            fg: blend(base.bg, tints[600]),
+          },
+          accent: {
+            fg: blend(bg, stateTones.critical[500]),
+          },
+          link: {
+            fg: blend(bg, stateTones.primary[600]),
+          },
+          code: {
+            bg: blend(bg, tints[50]),
+            fg: blend(bg, tints[600]),
+          },
+          skeleton: {
+            from: skeletonFrom,
+            to: rgba(skeletonFrom, 0.5),
+          },
+        }
+      }
+
+      if (state === 'selected') {
+        if (isNeutral) {
+          tints = stateTones.primary
+        }
+
+        const bg = blend(base.bg, tints[100])
+        const skeletonFrom = blend(bg, tints[100])
+
+        return {
+          bg,
+          border: blend(bg, tints[100]),
+          fg: blend(bg, tints[800]),
+          muted: {
+            fg: blend(bg, tints[600]),
+          },
+          accent: {
+            fg: blend(bg, stateTones.critical[500]),
+          },
+          link: {
+            fg: blend(bg, stateTones.primary[600]),
+          },
+          code: {
+            bg: blend(bg, tints[50]),
+            fg: blend(bg, tints[600]),
+          },
+          skeleton: {
+            from: skeletonFrom,
+            to: rgba(skeletonFrom, 0.5),
+          },
+        }
+      }
+
+      const bg = base.bg
+      const skeletonFrom = blend(base.bg, tints[100])
+
+      return {
+        bg,
+        border: blend(bg, tints[100]),
+        fg: blend(bg, tints[700]),
+        muted: {
+          fg: blend(bg, tints[600]),
+        },
+        accent: {
+          fg: blend(bg, stateTones.critical[500]),
+        },
+        link: {
+          fg: blend(bg, stateTones.primary[600]),
+        },
+        code: {
+          bg: blend(bg, tints[50]),
+          fg: blend(bg, tints[600]),
+        },
+        skeleton: {
+          from: skeletonFrom,
+          to: rgba(skeletonFrom, 0.5),
+        },
+      }
+    },
+
+    button: ({base, mode, muted, solid}) => {
+      if (mode === 'bleed') {
+        return {
+          enabled: {
+            ...muted.enabled,
+            border: muted.enabled.bg,
+          },
+          hovered: {
+            ...muted.hovered,
+            border: muted.hovered.bg,
+          },
+          pressed: {
+            ...muted.pressed,
+            border: muted.pressed.bg,
+          },
+          selected: {
+            ...muted.selected,
+            border: muted.selected.bg,
+          },
+          disabled: {
+            ...muted.disabled,
+            border: muted.disabled.bg,
+          },
+        }
+      }
+
+      if (mode === 'ghost') {
+        return {
+          ...solid,
+          enabled: {
+            ...muted.enabled,
+            border: base.border,
+          },
+          disabled: muted.disabled,
+        }
+      }
+
+      return solid
+    },
+
+    card: ({base, dark: navbar, muted, name, solid, state}) => {
+      if (state === 'hovered') {
+        return muted[name].hovered
+      }
+
+      if (state === 'disabled') {
+        return muted[name].disabled
+      }
+
+      const isNeutral = NEUTRAL_TONES.includes(name)
+      const stateTones = navbar ? legacyTones.state.navbar : legacyTones.state.default
+      const tints: LegacyThemeTints = stateTones[name] || stateTones.default
+
+      const dark = stateTones.dark
+      const blend = dark ? _screen : _multiply
+
+      if (state === 'pressed') {
+        if (isNeutral) {
+          return muted.primary.pressed
+        }
+
+        return muted[name].pressed
+      }
+
+      if (state === 'selected') {
+        if (isNeutral) {
+          return solid.primary.enabled
+        }
+
+        return solid[name].enabled
+      }
+
+      const bg = base.bg
+      const skeletonFrom = blend(base.bg, tints[dark ? 900 : 100])
+
+      return {
+        bg,
+        fg: base.fg,
+        border: base.border,
+        muted: {
+          fg: blend(base.bg, tints[dark ? 400 : 600]),
+        },
+        accent: {
+          fg: blend(base.bg, stateTones.critical[dark ? 400 : 500]),
+        },
+        link: {
+          fg: blend(base.bg, stateTones.primary[dark ? 400 : 600]),
+        },
+        code: {
+          bg: blend(base.bg, tints[dark ? 950 : 50]),
+          fg: tints[dark ? 400 : 600],
+        },
+        skeleton: {
+          from: skeletonFrom,
+          to: rgba(skeletonFrom, 0.5),
+        },
+      }
+    },
+
+    input: ({base, dark: navbar, mode, state}) => {
+      const stateTones = navbar ? legacyTones.state.navbar : legacyTones.state.default
+      const dark = stateTones.dark
+      const blend = dark ? _screen : _multiply
+
+      if (mode === 'invalid') {
+        const tints = stateTones.critical
+
+        return {
+          bg: blend(base.bg, tints[50]),
+          fg: blend(base.bg, tints[700]),
+          border: blend(base.bg, tints[200]),
+          placeholder: blend(base.bg, tints[400]),
+        }
+      }
+
+      if (state === 'hovered') {
+        return {
+          bg: base.bg,
+          fg: base.fg,
+          border: blend(base.bg, hues.gray[300].hex),
+          placeholder: blend(base.bg, hues.gray[400].hex),
+        }
+      }
+
+      if (state === 'disabled') {
+        return {
+          bg: blend(base.bg, hues.gray[50].hex),
+          fg: blend(base.bg, hues.gray[200].hex),
+          border: blend(base.bg, hues.gray[100].hex),
+          placeholder: blend(base.bg, hues.gray[100].hex),
+        }
+      }
+
+      if (state === 'readOnly') {
+        return {
+          bg: blend(base.bg, hues.gray[50].hex),
+          fg: blend(base.bg, hues.gray[800].hex),
+          border: blend(base.bg, hues.gray[200].hex),
+          placeholder: blend(base.bg, hues.gray[400].hex),
+        }
+      }
+
+      return {
+        bg: base.bg,
+        fg: base.fg,
+        border: base.border,
+        placeholder: blend(base.bg, hues.gray[700].hex),
+      }
+    },
+
+    selectable: ({base, muted, tone, solid, state}) => {
+      if (state === 'enabled') {
+        return {
+          ...muted[tone].enabled,
+          bg: base.bg,
+        }
+      }
+
+      if (state === 'pressed') {
+        if (tone === 'default') {
+          return muted.primary.pressed
+        }
+
+        return muted[tone].pressed
+      }
+
+      if (state === 'selected') {
+        if (tone === 'default') {
+          return solid.primary.enabled
+        }
+
+        return solid[tone].enabled
+      }
+
+      if (state === 'disabled') {
+        return {
+          ...muted[tone].disabled,
+          bg: base.bg,
+        }
+      }
+
+      return muted[tone][state]
+    },
+
+    spot: ({base, key}) => {
+      const dark = _isDark(base.bg, base.fg)
+      const blend = dark ? _screen : _multiply
+
+      return blend(base.bg, hues[key][dark ? 400 : 500].hex)
+    },
+
+    syntax: ({base, dark: navbar}) => {
+      const stateTones = navbar ? legacyTones.state.navbar : legacyTones.state.default
+      const dark = stateTones.dark
+      const blend = dark ? _screen : _multiply
+      const mainShade = 600
+      const secondaryShade = 400
+
+      return {
+        atrule: blend(base.bg, hues.purple[mainShade].hex),
+        attrName: blend(base.bg, stateTones.positive[mainShade]),
+        attrValue: blend(base.bg, stateTones.caution[mainShade]),
+        attribute: blend(base.bg, stateTones.caution[mainShade]),
+        boolean: blend(base.bg, hues.purple[mainShade].hex),
+        builtin: blend(base.bg, hues.purple[mainShade].hex),
+        cdata: blend(base.bg, stateTones.caution[mainShade]),
+        char: blend(base.bg, stateTones.caution[mainShade]),
+        class: blend(base.bg, hues.orange[mainShade].hex),
+        className: blend(base.bg, hues.cyan[mainShade].hex),
+        comment: blend(base.bg, stateTones.default[secondaryShade]),
+        constant: blend(base.bg, hues.purple[mainShade].hex),
+        deleted: blend(base.bg, stateTones.critical[mainShade]),
+        doctype: blend(base.bg, stateTones.default[secondaryShade]),
+        entity: blend(base.bg, stateTones.critical[mainShade]),
+        function: blend(base.bg, stateTones.positive[mainShade]),
+        hexcode: blend(base.bg, stateTones.primary[mainShade]),
+        id: blend(base.bg, hues.purple[mainShade].hex),
+        important: blend(base.bg, hues.purple[mainShade].hex),
+        inserted: blend(base.bg, stateTones.caution[mainShade]),
+        keyword: blend(base.bg, hues.magenta[mainShade].hex),
+        number: blend(base.bg, hues.purple[mainShade].hex),
+        operator: blend(base.bg, hues.magenta[mainShade].hex),
+        prolog: blend(base.bg, stateTones.default[secondaryShade]),
+        property: blend(base.bg, stateTones.primary[mainShade]),
+        pseudoClass: blend(base.bg, stateTones.caution[mainShade]),
+        pseudoElement: blend(base.bg, stateTones.caution[mainShade]),
+        punctuation: blend(base.bg, stateTones.default[mainShade]),
+        regex: blend(base.bg, stateTones.primary[mainShade]),
+        selector: blend(base.bg, stateTones.critical[mainShade]),
+        string: blend(base.bg, stateTones.caution[mainShade]),
+        symbol: blend(base.bg, hues.purple[mainShade].hex),
+        tag: blend(base.bg, stateTones.critical[mainShade]),
+        unit: blend(base.bg, hues.orange[mainShade].hex),
+        url: blend(base.bg, stateTones.critical[mainShade]),
+        variable: blend(base.bg, stateTones.critical[mainShade]),
+      }
+    },
+  })
+}

--- a/packages/sanity/src/core/theme/_legacy/fonts.ts
+++ b/packages/sanity/src/core/theme/_legacy/fonts.ts
@@ -1,0 +1,24 @@
+import {studioTheme as defaults, ThemeFonts} from '@sanity/ui'
+import {LegacyThemeProps} from './types'
+
+export function buildFonts(cssCustomProperties: LegacyThemeProps): ThemeFonts {
+  return {
+    ...defaults.fonts,
+    code: {
+      ...defaults.fonts.code,
+      family: cssCustomProperties['--font-family-monospace'] || defaults.fonts.code.family,
+    },
+    heading: {
+      ...defaults.fonts.heading,
+      family: cssCustomProperties['--font-family-base'] || defaults.fonts.code.family,
+    },
+    label: {
+      ...defaults.fonts.label,
+      family: cssCustomProperties['--font-family-base'] || defaults.fonts.code.family,
+    },
+    text: {
+      ...defaults.fonts.text,
+      family: cssCustomProperties['--font-family-base'] || defaults.fonts.code.family,
+    },
+  }
+}

--- a/packages/sanity/src/core/theme/_legacy/helpers.ts
+++ b/packages/sanity/src/core/theme/_legacy/helpers.ts
@@ -1,0 +1,61 @@
+import {parseColor, rgbToHex, screen, multiply} from '@sanity/ui'
+import {getLuminance, mix, parseToRgb, rgb} from 'polished'
+import {LegacyThemeTints} from './types'
+
+/**
+ * @internal
+ */
+export function _buildTints(bg: string, mid: string, fg: string): LegacyThemeTints {
+  return {
+    50: mix(0.1, mid, bg),
+    100: mix(0.2, mid, bg),
+    200: mix(0.4, mid, bg),
+    300: mix(0.6, mid, bg),
+    400: mix(0.8, mid, bg),
+    500: mid,
+    600: mix(0.8, mid, fg),
+    700: mix(0.6, mid, fg),
+    800: mix(0.4, mid, fg),
+    900: mix(0.2, mid, fg),
+    950: mix(0.1, mid, fg),
+  }
+}
+
+/**
+ * @internal
+ */
+export function _toHex(color: string): string {
+  const {red, green, blue} = parseToRgb(color)
+  return rgb(red, green, blue)
+}
+
+/**
+ * @internal
+ */
+export function _isDark(bg: string, fg: string): boolean {
+  return getLuminance(bg) < getLuminance(fg)
+}
+
+/**
+ * Blend two colors using the "screen" blend mode
+ * @internal
+ */
+export function _multiply(bg: string, fg: string): string {
+  const b = parseColor(bg)
+  const s = parseColor(fg)
+  const hex = rgbToHex(multiply(b, s))
+
+  return hex
+}
+
+/**
+ * Blend two colors using the "screen" blend mode
+ * @internal
+ */
+export function _screen(bg: string, fg: string): string {
+  const b = parseColor(bg)
+  const s = parseColor(fg)
+  const hex = rgbToHex(screen(b, s))
+
+  return hex
+}

--- a/packages/sanity/src/core/theme/_legacy/index.ts
+++ b/packages/sanity/src/core/theme/_legacy/index.ts
@@ -1,0 +1,2 @@
+export * from './theme'
+export * from './types'

--- a/packages/sanity/src/core/theme/_legacy/palette.ts
+++ b/packages/sanity/src/core/theme/_legacy/palette.ts
@@ -1,0 +1,102 @@
+import {_toHex} from './helpers'
+import {LegacyThemeProps} from './types'
+
+export interface LegacyPalette {
+  black: string
+  component: {
+    bg: string
+    fg: string
+  }
+  defaultButton: {
+    default: {
+      base: string
+    }
+    primary: {
+      base: string
+    }
+    success: {
+      base: string
+    }
+    warning: {
+      base: string
+    }
+    danger: {
+      base: string
+    }
+  }
+  focus: {
+    base: string
+  }
+  gray: {
+    base: string
+  }
+  mainNavigation: {
+    bg: string
+    fg: string
+  }
+  state: {
+    info: {
+      fg: string
+    }
+    success: {
+      fg: string
+    }
+    warning: {
+      fg: string
+    }
+    danger: {
+      fg: string
+    }
+  }
+}
+
+export function buildLegacyPalette(cssCustomProperties: LegacyThemeProps): LegacyPalette {
+  return {
+    black: _toHex(cssCustomProperties['--black']),
+    component: {
+      bg: _toHex(cssCustomProperties['--component-bg']),
+      fg: _toHex(cssCustomProperties['--component-text-color']),
+    },
+    defaultButton: {
+      default: {
+        base: _toHex(cssCustomProperties['--default-button-color']),
+      },
+      primary: {
+        base: _toHex(cssCustomProperties['--default-button-primary-color']),
+      },
+      success: {
+        base: _toHex(cssCustomProperties['--default-button-success-color']),
+      },
+      warning: {
+        base: _toHex(cssCustomProperties['--default-button-warning-color']),
+      },
+      danger: {
+        base: _toHex(cssCustomProperties['--default-button-danger-color']),
+      },
+    },
+    focus: {
+      base: _toHex(cssCustomProperties['--focus-color']),
+    },
+    gray: {
+      base: _toHex(cssCustomProperties['--gray-base']),
+    },
+    mainNavigation: {
+      bg: _toHex(cssCustomProperties['--main-navigation-color']),
+      fg: _toHex(cssCustomProperties['--main-navigation-color--inverted']),
+    },
+    state: {
+      info: {
+        fg: _toHex(cssCustomProperties['--state-info-color']),
+      },
+      success: {
+        fg: _toHex(cssCustomProperties['--state-success-color']),
+      },
+      warning: {
+        fg: _toHex(cssCustomProperties['--state-warning-color']),
+      },
+      danger: {
+        fg: _toHex(cssCustomProperties['--state-danger-color']),
+      },
+    },
+  }
+}

--- a/packages/sanity/src/core/theme/_legacy/theme.ts
+++ b/packages/sanity/src/core/theme/_legacy/theme.ts
@@ -1,0 +1,120 @@
+import {black, blue, gray, green, red, white, yellow} from '@sanity/color'
+import {studioTheme as defaults} from '@sanity/ui'
+import {StudioTheme} from '../types'
+import {buildColor} from './color'
+import {buildFonts} from './fonts'
+import {_isDark} from './helpers'
+import {buildLegacyPalette} from './palette'
+import {buildLegacyTones} from './tones'
+import {LegacyThemeProps} from './types'
+
+/**
+ * Build a Sanity UI theme from legacy CSS properties.
+ *
+ * @example
+ * ```tsx
+ * import {buildLegacyTheme, createConfig} from 'sanity'
+ *
+ * export default createConfig({
+ *   // project configuration ...
+ *
+ *   // Customize theming
+ *   theme: buildLegacyTheme({
+ *     '--black': '#000',
+ *     '--gray': '#777',
+ *     '--focus-color': '#00f',
+ *   })
+ * })
+ * ```
+ *
+ * @public
+ */
+export function buildLegacyTheme(partialLegacyTheme: Partial<LegacyThemeProps>): StudioTheme {
+  const legacyTheme = resolveLegacyTheme(partialLegacyTheme)
+  const legacyPalette = buildLegacyPalette(legacyTheme)
+  const legacyTones = buildLegacyTones(legacyPalette)
+
+  const color = buildColor(legacyPalette, legacyTones)
+  const fonts = buildFonts(legacyTheme)
+
+  return {
+    __dark: _isDark(color.light.default.base.bg, color.light.default.base.fg),
+    __legacy: true,
+    ...defaults,
+    color,
+    focusRing: {
+      offset: -1,
+      width: 2,
+    },
+    fonts,
+    media: [
+      parseInt(legacyTheme['--screen-medium-break'], 10) || 512,
+      parseInt(legacyTheme['--screen-default-break'], 10) || 640,
+      parseInt(legacyTheme['--screen-large-break'], 10) || 960,
+      parseInt(legacyTheme['--screen-xlarge-break'], 10) || 1600,
+    ],
+  }
+}
+
+const defaultCustomProperties: LegacyThemeProps = {
+  '--font-family-monospace': defaults.fonts.code.family,
+  '--font-family-base': defaults.fonts.text.family,
+
+  '--black': black.hex,
+  '--white': white.hex,
+
+  // Brand
+  '--brand-primary': blue[500].hex,
+
+  // Component
+  '--component-bg': white.hex,
+  '--component-text-color': black.hex,
+
+  // Gray
+  '--gray': gray[500].hex,
+  '--gray-base': gray[500].hex,
+
+  // Default button
+  '--default-button-color': gray[500].hex,
+  '--default-button-danger-color': red[500].hex,
+  '--default-button-primary-color': blue[500].hex,
+  '--default-button-success-color': green[500].hex,
+  '--default-button-warning-color': yellow[500].hex,
+
+  // Focus
+  '--focus-color': blue[500].hex,
+
+  // Screen
+  '--screen-medium-break': '512px',
+  '--screen-default-break': '640px',
+  '--screen-large-break': '960px',
+  '--screen-xlarge-break': '1600px',
+
+  // State
+  '--state-info-color': blue[500].hex,
+  '--state-success-color': green[500].hex,
+  '--state-warning-color': yellow[500].hex,
+  '--state-danger-color': red[500].hex,
+
+  // Navbar
+  '--main-navigation-color': black.hex,
+  '--main-navigation-color--inverted': white.hex,
+}
+
+function resolveLegacyTheme(legacyTheme: Partial<LegacyThemeProps>): LegacyThemeProps {
+  const props: LegacyThemeProps = {
+    ...defaultCustomProperties,
+    ...legacyTheme,
+  }
+
+  // Update properties (order matters)
+  props['--focus-color'] = legacyTheme['--focus-color'] || props['--brand-primary']
+  props['--default-button-primary-color'] =
+    legacyTheme['--default-button-primary-color'] || props['--brand-primary']
+  props['--main-navigation-color'] = legacyTheme['--main-navigation-color'] || props['--black']
+  props['--main-navigation-color--inverted'] =
+    legacyTheme['--main-navigation-color--inverted'] || props['--white']
+  props['--state-info-color'] = legacyTheme['--brand-primary'] || props['--brand-primary']
+
+  return props
+}

--- a/packages/sanity/src/core/theme/_legacy/tones.ts
+++ b/packages/sanity/src/core/theme/_legacy/tones.ts
@@ -1,0 +1,213 @@
+import {_buildTints, _isDark} from './helpers'
+import {LegacyThemeTints} from './types'
+import {LegacyPalette} from './palette'
+
+export interface LegacyTones {
+  button: {
+    default: {
+      bg: string
+      fg: string
+      dark: boolean
+
+      default: LegacyThemeTints
+      transparent: LegacyThemeTints
+      primary: LegacyThemeTints
+      positive: LegacyThemeTints
+      caution: LegacyThemeTints
+      critical: LegacyThemeTints
+    }
+
+    navbar: {
+      bg: string
+      fg: string
+      dark: boolean
+
+      default: LegacyThemeTints
+      transparent: LegacyThemeTints
+      primary: LegacyThemeTints
+      positive: LegacyThemeTints
+      caution: LegacyThemeTints
+      critical: LegacyThemeTints
+    }
+  }
+
+  state: {
+    default: {
+      bg: string
+      fg: string
+      dark: boolean
+
+      default: LegacyThemeTints
+      transparent: LegacyThemeTints
+      primary: LegacyThemeTints
+      positive: LegacyThemeTints
+      caution: LegacyThemeTints
+      critical: LegacyThemeTints
+    }
+
+    navbar: {
+      bg: string
+      fg: string
+      dark: boolean
+
+      default: LegacyThemeTints
+      transparent: LegacyThemeTints
+      primary: LegacyThemeTints
+      positive: LegacyThemeTints
+      caution: LegacyThemeTints
+      critical: LegacyThemeTints
+    }
+  }
+}
+
+export function buildLegacyTones(legacyPalette: LegacyPalette): LegacyTones {
+  return {
+    state: {
+      default: {
+        bg: legacyPalette.component.bg,
+        fg: legacyPalette.component.fg,
+        dark: _isDark(legacyPalette.component.bg, legacyPalette.component.fg),
+        default: _buildTints(
+          legacyPalette.component.bg,
+          legacyPalette.gray.base,
+          legacyPalette.component.fg
+        ),
+        transparent: _buildTints(
+          legacyPalette.component.bg,
+          legacyPalette.gray.base,
+          legacyPalette.component.fg
+        ),
+        primary: _buildTints(
+          legacyPalette.component.bg,
+          legacyPalette.state.info.fg,
+          legacyPalette.component.fg
+        ),
+        positive: _buildTints(
+          legacyPalette.component.bg,
+          legacyPalette.state.success.fg,
+          legacyPalette.component.fg
+        ),
+        caution: _buildTints(
+          legacyPalette.component.bg,
+          legacyPalette.state.warning.fg,
+          legacyPalette.component.fg
+        ),
+        critical: _buildTints(
+          legacyPalette.component.bg,
+          legacyPalette.state.danger.fg,
+          legacyPalette.component.fg
+        ),
+      },
+      navbar: {
+        bg: legacyPalette.mainNavigation.bg,
+        fg: legacyPalette.mainNavigation.fg,
+        dark: _isDark(legacyPalette.mainNavigation.bg, legacyPalette.mainNavigation.fg),
+
+        default: _buildTints(
+          legacyPalette.mainNavigation.bg,
+          legacyPalette.gray.base,
+          legacyPalette.mainNavigation.fg
+        ),
+        transparent: _buildTints(
+          legacyPalette.mainNavigation.bg,
+          legacyPalette.gray.base,
+          legacyPalette.mainNavigation.fg
+        ),
+        primary: _buildTints(
+          legacyPalette.mainNavigation.bg,
+          legacyPalette.state.info.fg,
+          legacyPalette.mainNavigation.fg
+        ),
+        positive: _buildTints(
+          legacyPalette.mainNavigation.bg,
+          legacyPalette.state.success.fg,
+          legacyPalette.mainNavigation.fg
+        ),
+        caution: _buildTints(
+          legacyPalette.mainNavigation.bg,
+          legacyPalette.state.warning.fg,
+          legacyPalette.mainNavigation.fg
+        ),
+        critical: _buildTints(
+          legacyPalette.mainNavigation.bg,
+          legacyPalette.state.danger.fg,
+          legacyPalette.mainNavigation.fg
+        ),
+      },
+    },
+    button: {
+      default: {
+        bg: legacyPalette.component.bg,
+        fg: legacyPalette.component.fg,
+        dark: _isDark(legacyPalette.component.bg, legacyPalette.component.fg),
+
+        default: _buildTints(
+          legacyPalette.component.bg,
+          legacyPalette.defaultButton.default.base,
+          legacyPalette.component.fg
+        ),
+        transparent: _buildTints(
+          legacyPalette.component.bg,
+          legacyPalette.defaultButton.default.base,
+          legacyPalette.component.fg
+        ),
+        primary: _buildTints(
+          legacyPalette.component.bg,
+          legacyPalette.defaultButton.primary.base,
+          legacyPalette.component.fg
+        ),
+        positive: _buildTints(
+          legacyPalette.component.bg,
+          legacyPalette.defaultButton.success.base,
+          legacyPalette.component.fg
+        ),
+        caution: _buildTints(
+          legacyPalette.component.bg,
+          legacyPalette.defaultButton.warning.base,
+          legacyPalette.component.fg
+        ),
+        critical: _buildTints(
+          legacyPalette.component.bg,
+          legacyPalette.defaultButton.danger.base,
+          legacyPalette.component.fg
+        ),
+      },
+      navbar: {
+        bg: legacyPalette.mainNavigation.bg,
+        fg: legacyPalette.mainNavigation.fg,
+        dark: _isDark(legacyPalette.mainNavigation.bg, legacyPalette.mainNavigation.fg),
+
+        default: _buildTints(
+          legacyPalette.mainNavigation.bg,
+          legacyPalette.defaultButton.default.base,
+          legacyPalette.mainNavigation.fg
+        ),
+        transparent: _buildTints(
+          legacyPalette.mainNavigation.bg,
+          legacyPalette.defaultButton.default.base,
+          legacyPalette.mainNavigation.fg
+        ),
+        primary: _buildTints(
+          legacyPalette.mainNavigation.bg,
+          legacyPalette.defaultButton.primary.base,
+          legacyPalette.mainNavigation.fg
+        ),
+        positive: _buildTints(
+          legacyPalette.mainNavigation.bg,
+          legacyPalette.defaultButton.success.base,
+          legacyPalette.mainNavigation.fg
+        ),
+        caution: _buildTints(
+          legacyPalette.mainNavigation.bg,
+          legacyPalette.defaultButton.warning.base,
+          legacyPalette.mainNavigation.fg
+        ),
+        critical: _buildTints(
+          legacyPalette.mainNavigation.bg,
+          legacyPalette.defaultButton.danger.base,
+          legacyPalette.mainNavigation.fg
+        ),
+      },
+    },
+  }
+}

--- a/packages/sanity/src/core/theme/_legacy/types.ts
+++ b/packages/sanity/src/core/theme/_legacy/types.ts
@@ -1,0 +1,43 @@
+import {ColorTintKey} from '@sanity/color'
+
+/** @internal */
+// eslint-disable-next-line no-unused-vars
+export type LegacyThemeTints = {[key in ColorTintKey]: string}
+
+/** @public */
+export interface LegacyThemeProps {
+  '--font-family-monospace': string
+  '--font-family-base': string
+
+  '--black': string
+  '--white': string
+
+  '--brand-primary': string
+
+  '--component-bg': string
+  '--component-text-color': string
+
+  '--default-button-color': string
+  '--default-button-primary-color': string
+  '--default-button-success-color': string
+  '--default-button-warning-color': string
+  '--default-button-danger-color': string
+
+  '--focus-color': string
+
+  '--gray-base': string
+  '--gray': string
+
+  '--main-navigation-color': string
+  '--main-navigation-color--inverted': string
+
+  '--state-info-color': string
+  '--state-success-color': string
+  '--state-warning-color': string
+  '--state-danger-color': string
+
+  '--screen-medium-break': string
+  '--screen-default-break': string
+  '--screen-large-break': string
+  '--screen-xlarge-break': string
+}

--- a/packages/sanity/src/core/theme/index.ts
+++ b/packages/sanity/src/core/theme/index.ts
@@ -1,6 +1,7 @@
 import {studioTheme} from '@sanity/ui'
 import {StudioTheme} from './types'
 
+export * from './_legacy'
 export * from './types'
 
 /** @internal */

--- a/packages/sanity/src/core/theme/types.ts
+++ b/packages/sanity/src/core/theme/types.ts
@@ -1,4 +1,9 @@
 import {RootTheme} from '@sanity/ui'
 
-/** @beta */
-export type StudioTheme = RootTheme
+/** @public */
+export interface StudioTheme extends RootTheme {
+  /** @internal */
+  __dark?: boolean
+  /** @internal */
+  __legacy?: boolean
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1276,6 +1276,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.17.8":
+  version "7.19.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.4.tgz#a42f814502ee467d55b38dd1c256f53a7b885c78"
+  integrity sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.18.10", "@babel/template@^7.3.3":
   version "7.18.10"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.10.tgz#6f9134835970d1dbf0835c0d100c9f38de0c5e71"
@@ -14164,6 +14171,13 @@ pluralize-esm@^9.0.2:
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/pluralize-esm/-/pluralize-esm-9.0.2.tgz#8715866666dc6bb09bded995fdfbb2a78f8031db"
   integrity sha512-QKTZKGfBbpRyD4w5rRP7yNTjUNFy0VFwE55AAYHjp5oWveQYtbR61gF3WyIs4Z2Wzjz5CFBd+XUm4aN8Jh5o1Q==
+
+polished@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-4.2.2.tgz#2529bb7c3198945373c52e34618c8fe7b1aa84d1"
+  integrity sha512-Sz2Lkdxz6F2Pgnpi9U5Ng/WdWAUZxmHrNPoVlm3aAemxoy2Qy7LGjQg4uf8qKelDAUW94F4np3iH2YPf2qefcQ==
+  dependencies:
+    "@babel/runtime" "^7.17.8"
 
 popmotion@11.0.3:
   version "11.0.3"


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Move logic from v2 for creating a Sanity UI theme object based on a record of CSS variables.

You can now use `buildLegacyTheme` to generate a Sanity UI theme:

```ts
import {buildLegacyTheme, createConfig} from 'sanity'

export default createConfig({
  // project configuration ...

  // Customize theming
  theme: buildLegacyTheme({
    '--black': '#000',
    '--gray': '#777',
    '--focus-color': '#00f',
  })
})
```

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

- Open the [Test Studio](https://test-studio-git-feat-legacy-theme.sanity.build/test/content)
- Open the Google workspace
- Open the Vercel workspace
- Check that colors and contrasts look reasonable and good enough
- Check that light/dark mode switching is NOT supported for legacy themes

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

- Use `buildLegacyTheme()` to migrate your theme from v2 => v3. NOTE: this will disable light/dark mode switching.
