### PR TITLE
fix(portable-text-editor): fix double paste event bug

### DIFF
--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@portabletext/react": "^1.0.6",
+    "@sanity/block-tools": "3.0.0-dev-preview.21",
     "@sanity/color": "2.1.17-next.30",
     "@sanity/icons": "1.3.7-next.30",
     "@sanity/image-url": "^1.0.1",

--- a/dev/test-studio/schema/standard/portableText/customMarkers/CustomContentInput.tsx
+++ b/dev/test-studio/schema/standard/portableText/customMarkers/CustomContentInput.tsx
@@ -1,10 +1,61 @@
-import React, {useMemo} from 'react'
+import React, {useCallback, useMemo} from 'react'
 import {PortableTextInput, PortableTextInputProps, PortableTextMarker} from 'sanity'
+import {htmlToBlocks} from '@sanity/block-tools'
+import {OnPasteFn, PortableTextBlock} from '@sanity/portable-text-editor'
 import {renderBlockActions} from './blockActions'
 import {renderCustomMarkers} from './customMarkers'
 
 export function CustomContentInput(inputProps: PortableTextInputProps) {
   const {value} = inputProps
+
+  const handlePaste: OnPasteFn = useCallback((input) => {
+    const {event, type, path} = input
+    const html = event.clipboardData.getData('text/html')
+    // check if schema has the code type
+    const hasCodeType = type.of.map(({name}) => name).includes('code')
+    if (!hasCodeType) {
+      // eslint-disable-next-line no-console
+      console.log('Run `sanity install @sanity/code-input, and add `type: "code"` to your schema.')
+    }
+    if (html && hasCodeType) {
+      const blocks = htmlToBlocks(html, type, {
+        rules: [
+          {
+            deserialize(el, next, block) {
+              if (
+                !(el instanceof HTMLElement) ||
+                (el.tagName && el.tagName.toLowerCase() !== 'pre')
+              ) {
+                return undefined
+              }
+              const code = el.children[0]
+              const childNodes =
+                code && code.tagName.toLowerCase() === 'code' ? code.childNodes : el.childNodes
+              let text = ''
+              childNodes.forEach((node) => {
+                text += node.textContent
+              })
+              /**
+               * Return this as an own block (via block helper function),
+               * instead of appending it to a default block's children
+               */
+              return block({
+                _type: 'code',
+                code: text,
+              })
+            },
+          },
+        ],
+      }) as PortableTextBlock[]
+      // Only paste this if it contains a single code block
+      if (blocks.length === 1 && blocks[0]._type !== 'code') {
+        return undefined
+      }
+      // return an insert patch
+      return {insert: blocks, path}
+    }
+    return undefined
+  }, [])
 
   // Extract markers from content
   const markers: PortableTextMarker[] = useMemo(() => {
@@ -30,6 +81,7 @@ export function CustomContentInput(inputProps: PortableTextInputProps) {
   return (
     <PortableTextInput
       {...inputProps}
+      onPaste={handlePaste}
       markers={markers}
       renderBlockActions={renderBlockActions}
       renderCustomMarkers={renderCustomMarkers}

--- a/dev/test-studio/schema/standard/portableText/customMarkers/schemaTypes.tsx
+++ b/dev/test-studio/schema/standard/portableText/customMarkers/schemaTypes.tsx
@@ -64,6 +64,7 @@ export const ptCustomMarkersTestType = defineType({
             },
           ],
         },
+        {type: 'code'},
       ],
       components: {input: CustomContentInput},
     },

--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -233,8 +233,9 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
       if (!slateEditor.selection) {
         return
       }
+      event.preventDefault()
       if (!onPaste) {
-        // no custom handling, fallback to default but prevent native handling
+        debug('Pasting normally')
         slateEditor.insertData(event.clipboardData)
         return
       }
@@ -252,7 +253,9 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
         .then((result) => {
           debug('Custom paste function from client resolved', result)
           change$.next({type: 'loading', isLoading: true})
-          if (!result) {
+          if (!result || !result.insert) {
+            debug('No result from custom paste handler, pasting normally')
+            slateEditor.insertData(event.clipboardData)
             return
           }
           if (result && result.insert) {

--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -268,7 +268,6 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
             throw result
           }
           if (result && result.insert) {
-            event.preventDefault() // Stop the chain
             slateEditor.insertFragment(toSlateValue(result.insert, {portableTextFeatures}))
             change$.next({type: 'loading', isLoading: false})
             return

--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -6,8 +6,6 @@ import {
   OnBeforeInputFn,
   OnCopyFn,
   OnPasteFn,
-  OnPasteResult,
-  OnPasteResultOrPromise,
   RenderAnnotationFunction,
   RenderBlockFunction,
   RenderChildFunction,
@@ -231,41 +229,31 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
   // Handle incoming pasting events in the editor
   const handlePaste = useCallback(
     (event: React.ClipboardEvent<HTMLDivElement>): Promise<void> | void => {
+      event.preventDefault()
       if (!slateEditor.selection) {
         return
       }
       if (!onPaste) {
         // no custom handling, fallback to default but prevent native handling
-        event.preventDefault()
         slateEditor.insertData(event.clipboardData)
         return
       }
-      const resolveOnPasteResultOrError = (): OnPasteResultOrPromise | Error => {
-        try {
-          return onPaste({
+      // Resolve it as promise (can be either async promise or sync return value)
+      Promise.resolve()
+        .then(() =>
+          onPaste({
             event,
             value: PortableTextEditor.getValue(portableTextEditor),
             path: slateEditor.selection?.focus.path || [],
             portableTextFeatures, // New key added in v.2.23.2
             type: portableTextFeatures.types.portableText, // For legacy support
           })
-        } catch (error) {
-          return error as Error
-        }
-      }
-      // Resolve it as promise (can be either async promise or sync return value)
-      const resolved: OnPasteResultOrPromise | Error = Promise.resolve(
-        resolveOnPasteResultOrError()
-      )
-      resolved
-        .then((result: OnPasteResult) => {
+        )
+        .then((result) => {
           debug('Custom paste function from client resolved', result)
           change$.next({type: 'loading', isLoading: true})
           if (!result) {
             return
-          }
-          if (result instanceof Error) {
-            throw result
           }
           if (result && result.insert) {
             slateEditor.insertFragment(toSlateValue(result.insert, {portableTextFeatures}))

--- a/packages/@sanity/portable-text-editor/src/types/editor.ts
+++ b/packages/@sanity/portable-text-editor/src/types/editor.ts
@@ -276,7 +276,6 @@ export type OnPasteResult =
       insert?: PortableTextBlock[]
       path?: Path
     }
-  | Error
   | undefined
 export type OnPasteResultOrPromise = OnPasteResult | Promise<OnPasteResult>
 

--- a/packages/@sanity/portable-text-editor/src/types/editor.ts
+++ b/packages/@sanity/portable-text-editor/src/types/editor.ts
@@ -280,7 +280,7 @@ export type OnPasteResult =
 export type OnPasteResultOrPromise = OnPasteResult | Promise<OnPasteResult>
 
 export type OnPasteFn = (arg0: {
-  event: React.SyntheticEvent
+  event: React.ClipboardEvent
   path: Path
   portableTextFeatures: PortableTextFeatures
   type: ArraySchemaType<PortableTextBlock>


### PR DESCRIPTION
### Description

Fixes an issue causing content to be inserted twice when using custom paste handler

### What to review
Refactored the code slightly to use a guard and early return to make the flow a bit easier to follow

### Notes for release

- Fixes an issue causing content to be inserted twice when using custom paste handler