### PR TITLE
fix: persist split panes on reload

### DIFF
--- a/packages/sanity/src/desk/components/deskTool/DeskTool.tsx
+++ b/packages/sanity/src/desk/components/deskTool/DeskTool.tsx
@@ -1,4 +1,4 @@
-import {PortalProvider, useToast} from '@sanity/ui'
+import {PortalProvider, useToast, useMediaIndex} from '@sanity/ui'
 import React, {memo, Fragment, useState, useEffect, useCallback} from 'react'
 import styled from 'styled-components'
 import isHotkey from 'is-hotkey'
@@ -30,6 +30,7 @@ export const DeskTool = memo(function DeskTool({onPaneChange}: DeskToolProps) {
   const {navigate} = useRouter()
   const {push: pushToast} = useToast()
   const schema = useSchema()
+  const mediaIndex = useMediaIndex()
   const {layoutCollapsed, setLayoutCollapsed} = useDeskTool()
   const {paneDataItems, resolvedPanes, routerPanes} = useResolvedPanes()
 
@@ -50,14 +51,14 @@ export const DeskTool = memo(function DeskTool({onPaneChange}: DeskToolProps) {
   // The pane layout is "collapsed" on small screens, and only shows 1 pane at a time.
   // Remove pane siblings (i.e. split panes) as the pane layout collapses.
   useEffect(() => {
-    if (!layoutCollapsed) return
+    if (mediaIndex > 1 || !layoutCollapsed) return
     const hasSiblings = routerPanes.some((group) => group.length > 1)
 
     if (!hasSiblings) return
     const withoutSiblings = routerPanes.map((group) => [group[0]])
 
     navigate({panes: withoutSiblings}, {replace: true})
-  }, [navigate, layoutCollapsed, routerPanes])
+  }, [mediaIndex, navigate, layoutCollapsed, routerPanes])
 
   useEffect(() => {
     const handleGlobalKeyDown = (event: KeyboardEvent) => {


### PR DESCRIPTION
### Description

Fixes a long standing bug where if you reload the page when in split view the extra panes are closed

Before: https://test-studio-git-v3.sanity.build/test/content/author;grrm%7C%2Cview%3Djson
After: https://test-studio-git-bug-sc-25678split-pane-urls.sanity.build/test/content/author;grrm%7C%2Cview%3Djson

### Notes for release

- Split panes persists on page reloads. And can be linked to.
