### PR TITLE
fix: unable to navigate back to mounted url

### DIFF
--- a/packages/sanity/src/router/RouterProvider.tsx
+++ b/packages/sanity/src/router/RouterProvider.tsx
@@ -1,5 +1,4 @@
-import {isEqual} from 'lodash'
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import React, {useCallback, useMemo} from 'react'
 import {RouterContext} from './RouterContext'
 import {IntentParameters, RouterContextValue, NavigateOptions, Router, RouterState} from './types'
 
@@ -54,9 +53,7 @@ export interface RouterProviderProps {
  */
 export function RouterProvider(props: RouterProviderProps): React.ReactElement {
   // TODO: can we do nested routes?
-  const {onNavigate, router: routerProp, state: stateProp} = props
-  const [state, setState] = useState<RouterState>(stateProp)
-  const stateRef = useRef(state)
+  const {onNavigate, router: routerProp, state} = props
 
   const navigateUrl = useCallback(
     (opts: {path: string; replace?: boolean}) => {
@@ -105,16 +102,6 @@ export function RouterProvider(props: RouterProviderProps): React.ReactElement {
     }),
     [navigate, navigateIntent, navigateUrl, resolveIntentLink, resolvePathFromState, state]
   )
-
-  // Update state as new `state` prop comes in
-  useEffect(() => {
-    const prevState = stateRef.current
-    const nextState = stateProp
-
-    if (!isEqual(nextState, prevState)) {
-      setState(nextState)
-    }
-  }, [stateProp])
 
   return <RouterContext.Provider value={router}>{props.children}</RouterContext.Provider>
 }


### PR DESCRIPTION
### Description

Whichever URL Studio v3 is mounted with can't be navigated back to.
This is due to `stateRef.current` never being updated inside `RouterProvider`.
This PR refactors it to pass down the router state as is, as its parent router is already doing the `isEqual` checks needed.
The `useEffect` + `useState` loop in `RouterProvider` creates extra rerender cycles and slows down route changes to no benefit.

### What to review

#### Repro bug
1. Open [workshop](https://test-studio-git-v3.sanity.build/test/workshop?scheme=dark&value=eJyrrgUAAXUA%2BQ%3D%3D).
2. Click Content.
3. Click on Workshop.
4. You're still seeing the `Content` tool, even though the URL pathname is now `/test/workshop`.

#### Repro fix
1. Open [workshop](https://test-studio-git-v3-fix-sticky-routing.sanity.build/test/workshop?scheme=dark&value=eJyrrgUAAXUA%2BQ%3D%3D).
2. Click Content.
3. Click on Workshop.
4. You're now seeing the `Workshop` tool, and the URL pathname is `/test/workshop`.

### Notes for release

- Fix issue where the router couldn't navigate back to the tool it initially loaded with.
