### PR TITLE
fix: direct link to add cors origin

### DIFF
--- a/packages/sanity/src/core/studio/screens/CorsOriginErrorScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/CorsOriginErrorScreen.tsx
@@ -34,50 +34,23 @@ export function CorsOriginErrorScreen(props: CorsOriginErrorScreenProps) {
 
   return (
     <Card height="fill">
-      <Dialog
-        id="cors-error-dialog"
-        header="Configure API access"
-        width={1}
-        footer={
-          <Stack paddingX={3} paddingY={2}>
-            <Button
-              as="a"
-              href={corsUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              text="Add origin"
-              tone="primary"
-            />
-          </Stack>
-        }
-      >
+      <Dialog id="cors-error-dialog" header="Before you continue..." width={1}>
         <Stack paddingX={4} paddingY={5} space={4}>
           <Text>
-            It looks like you're trying to connect to the Content Lake API from this origin:
+            To access your content, you need to{' '}
+            <b>add the following URLas an allowed CORS origin</b> to your Sanity project.
           </Text>
 
           <TextInput value={origin} readOnly />
 
-          <Text>
-            However it's not in the{' '}
-            <a
-              href="https://www.sanity.io/docs/front-ends/cors"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              list over allowed CORS origins
-            </a>{' '}
-            for{' '}
-            <a
-              href={`https://sanity.io/manage/project/${projectId}`}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              your project.
-            </a>
-          </Text>
-
-          <Text>Add it now to proceed loading your studio.</Text>
+          <Button
+            as="a"
+            href={corsUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            text="Add CORS origin"
+            tone="primary"
+          />
         </Stack>
       </Dialog>
     </Card>

--- a/packages/sanity/src/core/studio/screens/CorsOriginErrorScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/CorsOriginErrorScreen.tsx
@@ -17,10 +17,6 @@ export const ScreenReaderLabel = styled.label`
   width: 1px;
 `
 
-export const LaunchIconWrapper = styled.span`
-  margin-left: 0.75rem;
-`
-
 export function CorsOriginErrorScreen(props: CorsOriginErrorScreenProps) {
   const {projectId} = props
 
@@ -58,12 +54,12 @@ export function CorsOriginErrorScreen(props: CorsOriginErrorScreenProps) {
           <TextInput value={origin} readOnly />
 
           <Button as="a" href={corsUrl} target="_blank" rel="noopener noreferrer" tone="primary">
-            <Text align="center">
-              Continue
-              <LaunchIconWrapper>
+            <Flex align="center" justify="center" gap={3}>
+              <Text weight="medium">Continue</Text>
+              <Text weight="medium">
                 <LaunchIcon />
-              </LaunchIconWrapper>
-            </Text>
+              </Text>
+            </Flex>
           </Button>
         </Stack>
       </Dialog>

--- a/packages/sanity/src/core/studio/screens/CorsOriginErrorScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/CorsOriginErrorScreen.tsx
@@ -9,18 +9,15 @@ export function CorsOriginErrorScreen(props: CorsOriginErrorScreenProps) {
   const {projectId} = props
 
   const origin = window.location.origin
+  const projectURL = `https://sanity.io/manage/project/${projectId}`
   const corsUrl = useMemo(() => {
-    // const url = new URL(`http://localhost:3000/manage/project/${projectId}/api`)
-    const url = new URL(
-      `https://manage-git-feat-sc-25721cors.sanity.build/manage/project/${projectId}/api`
-    )
-    // const url = new URL(`https://sanity.io/manage/project/${projectId}/api`)
+    const url = new URL(`${projectURL}/api`)
     url.searchParams.set('cors', 'add')
     url.searchParams.set('origin', origin)
     url.searchParams.set('credentials', '')
 
     return url.toString()
-  }, [origin, projectId])
+  }, [origin, projectURL])
 
   useEffect(() => {
     const handleFocus = () => {
@@ -37,8 +34,12 @@ export function CorsOriginErrorScreen(props: CorsOriginErrorScreenProps) {
       <Dialog id="cors-error-dialog" header="Before you continue..." width={1}>
         <Stack paddingX={4} paddingY={5} space={4}>
           <Text>
-            To access your content, you need to{' '}
-            <b>add the following URLas an allowed CORS origin</b> to your Sanity project.
+            To access your content, you need to <b>add the following URL as a CORS origin</b> to
+            your{' '}
+            <a href={projectURL} target="_blank" rel="noreferrer">
+              Sanity project
+            </a>
+            .
           </Text>
 
           <TextInput value={origin} readOnly />
@@ -48,7 +49,7 @@ export function CorsOriginErrorScreen(props: CorsOriginErrorScreenProps) {
             href={corsUrl}
             target="_blank"
             rel="noopener noreferrer"
-            text="Add CORS origin"
+            text="Continue"
             tone="primary"
           />
         </Stack>

--- a/packages/sanity/src/core/studio/screens/CorsOriginErrorScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/CorsOriginErrorScreen.tsx
@@ -1,5 +1,5 @@
-import {Card, Dialog, Stack, Button, Text} from '@sanity/ui'
-import React, {useCallback} from 'react'
+import {Card, Dialog, Stack, Button, Text, TextInput} from '@sanity/ui'
+import React, {useEffect, useMemo} from 'react'
 
 interface CorsOriginErrorScreenProps {
   projectId?: string
@@ -8,49 +8,76 @@ interface CorsOriginErrorScreenProps {
 export function CorsOriginErrorScreen(props: CorsOriginErrorScreenProps) {
   const {projectId} = props
 
-  const corsUrl = `https://sanity.io/manage/project/${projectId}/settings/api`
   const origin = window.location.origin
+  const corsUrl = useMemo(() => {
+    // const url = new URL(`http://localhost:3000/manage/project/${projectId}/api`)
+    const url = new URL(
+      `https://manage-git-feat-sc-25721cors.sanity.build/manage/project/${projectId}/api`
+    )
+    // const url = new URL(`https://sanity.io/manage/project/${projectId}/api`)
+    url.searchParams.set('cors', 'add')
+    url.searchParams.set('origin', origin)
+    url.searchParams.set('credentials', '')
 
-  const handleRetry = useCallback(() => {
-    window.location.reload()
+    return url.toString()
+  }, [origin, projectId])
+
+  useEffect(() => {
+    const handleFocus = () => {
+      window.location.reload()
+    }
+    window.addEventListener('focus', handleFocus)
+    return () => {
+      window.removeEventListener('focus', handleFocus)
+    }
   }, [])
 
   return (
     <Card height="fill">
       <Dialog
         id="cors-error-dialog"
-        header="Error"
+        header="Configure API access"
         width={1}
         footer={
           <Stack paddingX={3} paddingY={2}>
-            <Button text="Retry" onClick={handleRetry} />
+            <Button
+              as="a"
+              href={corsUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              text="Add origin"
+              tone="primary"
+            />
           </Stack>
         }
       >
         <Stack paddingX={4} paddingY={5} space={4}>
           <Text>
-            It looks like the error is being caused by the current origin (<code>{origin}</code>)
-            not being allowed for this project.
+            It looks like you're trying to connect to the Content Lake API from this origin:
           </Text>
 
-          <Text>
-            If you are a project administrator or developer, you can head to{' '}
-            <a rel="noopener noreferrer" target="_blank" href={corsUrl}>
-              the project management
-            </a>{' '}
-            interface to configure CORS origins for this project.
-          </Text>
+          <TextInput value={origin} readOnly />
 
           <Text>
+            However it's not in the{' '}
             <a
               href="https://www.sanity.io/docs/front-ends/cors"
               target="_blank"
               rel="noopener noreferrer"
             >
-              Read more about CORS Origins
+              list over allowed CORS origins
+            </a>{' '}
+            for{' '}
+            <a
+              href={`https://sanity.io/manage/project/${projectId}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              your project.
             </a>
-            .
           </Text>
+
+          <Text>Add it now to proceed loading your studio.</Text>
         </Stack>
       </Dialog>
     </Card>

--- a/packages/sanity/src/core/studio/screens/CorsOriginErrorScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/CorsOriginErrorScreen.tsx
@@ -1,23 +1,38 @@
-import {Card, Dialog, Stack, Button, Text, TextInput} from '@sanity/ui'
+import {Card, Dialog, Stack, Button, Text, TextInput, Inline, Flex, Box} from '@sanity/ui'
 import React, {useEffect, useMemo} from 'react'
+import {LaunchIcon} from '@sanity/icons'
+import styled from 'styled-components'
 
 interface CorsOriginErrorScreenProps {
   projectId?: string
 }
 
+export const ScreenReaderLabel = styled.label`
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+`
+
+export const LaunchIconWrapper = styled.span`
+  margin-left: 0.75rem;
+`
+
 export function CorsOriginErrorScreen(props: CorsOriginErrorScreenProps) {
   const {projectId} = props
 
   const origin = window.location.origin
-  const projectURL = `https://sanity.io/manage/project/${projectId}`
   const corsUrl = useMemo(() => {
-    const url = new URL(`${projectURL}/api`)
+    const url = new URL(`https://sanity.io/manage/project/${projectId}/api`)
     url.searchParams.set('cors', 'add')
     url.searchParams.set('origin', origin)
     url.searchParams.set('credentials', '')
 
     return url.toString()
-  }, [origin, projectURL])
+  }, [origin, projectId])
 
   useEffect(() => {
     const handleFocus = () => {
@@ -35,23 +50,21 @@ export function CorsOriginErrorScreen(props: CorsOriginErrorScreenProps) {
         <Stack paddingX={4} paddingY={5} space={4}>
           <Text>
             To access your content, you need to <b>add the following URL as a CORS origin</b> to
-            your{' '}
-            <a href={projectURL} target="_blank" rel="noreferrer">
-              Sanity project
-            </a>
-            .
+            your Sanity project.
           </Text>
 
+          {/* added for accessibility */}
+          <ScreenReaderLabel aria-hidden="true">CORS URL to be added</ScreenReaderLabel>
           <TextInput value={origin} readOnly />
 
-          <Button
-            as="a"
-            href={corsUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            text="Continue"
-            tone="primary"
-          />
+          <Button as="a" href={corsUrl} target="_blank" rel="noopener noreferrer" tone="primary">
+            <Text align="center">
+              Continue
+              <LaunchIconWrapper>
+                <LaunchIcon />
+              </LaunchIconWrapper>
+            </Text>
+          </Button>
         </Stack>
       </Dialog>
     </Card>

--- a/packages/sanity/src/core/studio/screens/CorsOriginErrorScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/CorsOriginErrorScreen.tsx
@@ -1,4 +1,4 @@
-import {Card, Dialog, Stack, Button, Text, TextInput, Inline, Flex, Box} from '@sanity/ui'
+import {Card, Dialog, Stack, Button, Text, TextInput, Flex} from '@sanity/ui'
 import React, {useEffect, useMemo} from 'react'
 import {LaunchIcon} from '@sanity/icons'
 import styled from 'styled-components'


### PR DESCRIPTION
### Description

Simplifies the CORS error dialog to reduce technical language, and adds a "Add origin" CTA that takes you to a [new flow in manage](https://github.com/sanity-io/manage/pull/291). The new flow prefills the CORS information for you and gives the user a "Confirm" CTA at the end. Pressing it closes the popup window.
Upon return a `winow.onfocus` handler automatically retries.

This means that the happy path for resolving a CORS problem becomes:
1. User sees the CORS error dialog, and clicks on CTA.
2. A new window opens in manage, explaining what is about to happen, and the user clicks "Confirm".
3. The origin is added and the window closes, and the Studio loads automatically.

### What to review

Try the flow on origins we don't allow: `cd dev/test-studio && yarn sanity:dev --port 3030`.
You should see the error, clicking on "Add origin" should let you do so, and show an error message in Manage if you don't have admin rights.

Live test link: https://test-studio-no-cors.vercel.app/

You can also test it locally by replacing the cors URL with `https://manage-git-feat-sc-25721cors.sanity.build/manage/project/${projectId}/api`

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
