### PR TITLE
fix: only show "document published" toast once

### DIFF
--- a/packages/sanity/src/desk/panes/document/DocumentOperationResults.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentOperationResults.tsx
@@ -1,5 +1,5 @@
 import {useToast} from '@sanity/ui'
-import React, {memo, useEffect} from 'react'
+import React, {memo, useEffect, useRef} from 'react'
 import {useDocumentPane} from './useDocumentPane'
 import {useDocumentOperationEvent} from 'sanity'
 
@@ -37,9 +37,10 @@ export const DocumentOperationResults = memo(function DocumentOperationResults()
   const {push: pushToast} = useToast()
   const {documentId, documentType} = useDocumentPane()
   const event: any = useDocumentOperationEvent(documentId, documentType)
+  const prevEvent = useRef(event)
 
   useEffect(() => {
-    if (!event) return
+    if (!event || event === prevEvent.current) return
 
     if (event.type === 'error') {
       pushToast({
@@ -63,6 +64,8 @@ export const DocumentOperationResults = memo(function DocumentOperationResults()
         title: getOpSuccessTitle(event.op),
       })
     }
+
+    prevEvent.current = event
   }, [event, pushToast])
 
   return null


### PR DESCRIPTION
### Description

Prevents toasts that have already been fired from being fired again.

### What to review

See if push toasts work as they should.

### Notes for release

Toast notifications no longer fire more than once for the same event.
