### PR TITLE
fix: `@sanity/vision` includes `react` in bundle

### DIFF
--- a/packages/@sanity/vision/README.md
+++ b/packages/@sanity/vision/README.md
@@ -11,7 +11,7 @@ Vision is a plugin for Sanity Studio for testing GROQ queries. It features:
 
 ## Installation
 
-`npm install --save @sanity/vision`
+`npm install --save-exact @sanity/vision@dev-preview`
 
 ### Configuring
 

--- a/packages/@sanity/vision/package.config.ts
+++ b/packages/@sanity/vision/package.config.ts
@@ -1,4 +1,4 @@
 import {defineConfig} from '@sanity/pkg-utils'
 import baseConfig from '../../../package.config'
 
-export default defineConfig({...baseConfig, external: ['sanity']})
+export default defineConfig({...baseConfig, external: (external) => [...external, 'sanity']})


### PR DESCRIPTION
### Description

When using `@sanity/vision` outside the monorepo it throws this error and crashes:
![image](https://user-images.githubusercontent.com/81981/195626700-471af227-cbe3-42e2-b880-2766d2517214.png)
Running it on localhost also throws this warning:
```
next-dev.js:28 Warning: Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:
1. You might have mismatching versions of React and the renderer (such as React DOM)
2. You might be breaking the Rules of Hooks
3. You might have more than one copy of React in the same app
See https://reactjs.org/link/invalid-hook-call for tips about how to debug and fix this problem.
```
This is due to `@sanity/vision` bundling react instead of treating it as an external.

Related PR in `@sanity/pkg-utils` that changes `config.external: string[]` to merge in `pkg.dependencies` and `pkg.peerDependencies` instead of overriding them: https://github.com/sanity-io/pkg-utils/pull/1

### What to review

Run `yarn build` in `cd packages/@sanity/vision` and inspect `./dist`. The should all be small files as everything declared in `dependencies` and `peerDependencies` in its `package.json` should be excluded from the bundles.

### Notes for release

- `@sanity/vision` no longer bundles `react` and other dependencies that are declared in `dependencies` and `peerDependencies`.
