### PR TITLE
fix(desk-tool): fix issue with history pane not showing the earlier version

### DIFF
--- a/packages/@sanity/desk-tool/src/panes/document/DocumentPaneContext.ts
+++ b/packages/@sanity/desk-tool/src/panes/document/DocumentPaneContext.ts
@@ -17,6 +17,7 @@ export interface DocumentPaneContextValue {
   compareValue: Partial<SanityDocument> | null
   connectionState: 'connecting' | 'reconnecting' | 'connected'
   displayed: Partial<SanityDocument> | null
+  historyValue: Partial<SanityDocument> | null
   documentId: string
   documentIdRaw: string
   documentSchema: DocumentSchema | null

--- a/packages/@sanity/desk-tool/src/panes/document/DocumentPaneProvider.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/DocumentPaneProvider.tsx
@@ -116,6 +116,13 @@ export const DocumentPaneProvider = memo(({children, index, pane, paneKey}: Prop
     : editState?.published || null
   const ready = connectionState === 'connected' && editState.ready
   const viewOlderVersion = historyController.onOlderRevision()
+
+  const historyValue: Partial<SanityDocument> | null = useMemo(
+    () => (viewOlderVersion ? historyController.displayed() : null),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [historyController, params.rev, params.since, viewOlderVersion]
+  )
+
   const displayed: Partial<SanityDocument> | null = useMemo(
     () => (viewOlderVersion ? historyController.displayed() : value),
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -228,6 +235,7 @@ export const DocumentPaneProvider = memo(({children, index, pane, paneKey}: Prop
       compareValue,
       connectionState,
       displayed,
+      historyValue,
       documentId,
       documentIdRaw,
       documentSchema,
@@ -271,6 +279,7 @@ export const DocumentPaneProvider = memo(({children, index, pane, paneKey}: Prop
       displayed,
       documentId,
       documentIdRaw,
+      historyValue,
       documentSchema,
       documentType,
       focusPath,

--- a/packages/@sanity/desk-tool/src/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/@sanity/desk-tool/src/panes/document/documentPanel/documentViews/FormView.tsx
@@ -55,12 +55,13 @@ export function FormView(props: FormViewProps) {
     handleFocus,
     historyController,
     initialValue,
+    historyValue,
     markers,
     ready,
     changesOpen,
   } = useDocumentPane()
   const editState = useEditState(documentId, documentType)
-  const value = editState.draft || editState.published || initialValue
+  const value = historyValue || editState.draft || editState.published || initialValue
   const presence = useDocumentPresence(documentId, {ignoreLastActiveUpdates: true})
   const {revTime: rev} = historyController
   const [{filterField}, setFilterField] = useState<FormViewState>(INITIAL_STATE)


### PR DESCRIPTION
### Description

Fixes a regression introduced in [v2.34.2](https://github.com/sanity-io/sanity/releases/tag/v2.34.2) that broke the revision history selector by making it always show the current version of the document.

### What to review

- Make sure navigating throuigh revision history will display the selected revision

### Notes for release

- Fixes a bug causing revision history selector to always display the current version instead of the selected revision