### PR TITLE
Correct exports field for `nodenext` module resolution

### DIFF
--- a/packages/@sanity/types/package.json
+++ b/packages/@sanity/types/package.json
@@ -7,6 +7,7 @@
   "module": "./lib/index.js",
   "exports": {
     ".": {
+      "types": "./lib/dts/src/index.d.ts",
       "source": "./src/index.ts",
       "require": "./lib/index.cjs",
       "default": "./lib/index.js"


### PR DESCRIPTION
### Description
Adds the existing type definition to the named `exports` field in the `package.json` file for `@sanity/types`, in order to solve #3761. This should stop type errors from being thrown when Typescript's `nodenext` module resolution is used.

### What to review
In order to reproduce the type error:
1. Create a new v3 Sanity studio project.
2. Add a new type definition with the `defineField` or `defineType` type helpers.
3. Update the moduleResolution compiler option to `nodenext`.
4. `defineField` and `defineType` input throw a type error: `Module '"sanity"' has no exported member 'defineType'.`

This PR should correct the above type errors.

### Notes for release
Add named export for typescript types.