### PR TITLE
chore(default-layout): re-enable search sorting

### DIFF
--- a/packages/@sanity/default-layout/src/navbar/search/components/SearchResults.tsx
+++ b/packages/@sanity/default-layout/src/navbar/search/components/SearchResults.tsx
@@ -104,7 +104,7 @@ export function SearchResults({
   return (
     <SearchResultsFlex direction="column">
       {/* Sort menu */}
-      {/* {hasSearchResults && <SortMenu small={small} />} */}
+      {hasSearchResults && <SortMenu small={small} />}
 
       {/* Results */}
       <SearchResultsInnerFlex $loading={result.loading} aria-busy={result.loading} flex={1}>


### PR DESCRIPTION
# Description

One-liner to re-enable sort menu in search results! (Now clear to display)

# Notes for release

## Search updates

Order search results by relevance, created and last updated date.
