### PR TITLE
fix(sanity): disable group tabs when review changes pane is open

### DIFF
--- a/packages/sanity/src/core/form/inputs/ObjectInput/ObjectInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ObjectInput/ObjectInput.tsx
@@ -64,9 +64,9 @@ export const ObjectInput = memo(function ObjectInput(props: ObjectInputProps) {
       {groups.length > 0 ? (
         <FieldGroupTabsWrapper $level={level} data-testid="field-groups">
           <FieldGroupTabs
+            groups={groups}
             inputId={id}
             onClick={onFieldGroupSelect}
-            groups={groups}
             shouldAutoFocus={path.length === 0}
           />
         </FieldGroupTabsWrapper>

--- a/packages/sanity/src/core/form/inputs/ObjectInput/fieldGroups/FieldGroupTabs.tsx
+++ b/packages/sanity/src/core/form/inputs/ObjectInput/fieldGroups/FieldGroupTabs.tsx
@@ -5,11 +5,11 @@ import {FormFieldGroup} from '../../../store'
 import {GroupOption, GroupTab} from './GroupTab'
 
 interface FieldGroupTabsProps {
-  inputId?: string
-  groups: FormFieldGroup[]
-  shouldAutoFocus?: boolean
-  onClick?: (name: string) => void
   disabled?: boolean
+  groups: FormFieldGroup[]
+  inputId?: string
+  onClick?: (name: string) => void
+  shouldAutoFocus?: boolean
 }
 
 const Root = styled(ElementQuery)`
@@ -44,7 +44,7 @@ const GroupTabs = ({
           <GroupTab
             aria-controls={`${inputId}-field-group-fields`}
             autoFocus={shouldAutoFocus && group.selected}
-            disabled={disabled}
+            disabled={disabled || group.disabled}
             icon={group?.icon}
             key={`${inputId}-${group.name}-tab`}
             name={group.name}
@@ -60,11 +60,11 @@ const GroupTabs = ({
 
 /* For small screens, use Select from Sanity UI  */
 const GroupSelect = ({
+  disabled,
   groups,
   inputId,
   onSelect,
   shouldAutoFocus = true,
-  disabled,
 }: Omit<FieldGroupTabsProps, 'onClick'> & {onSelect: (name: string) => void}) => {
   const handleSelect = useCallback(
     (event: React.ChangeEvent<HTMLSelectElement>) => {
@@ -75,24 +75,24 @@ const GroupSelect = ({
 
   return (
     <Select
-      fontSize={2}
-      onChange={handleSelect}
-      muted
-      data-testid="field-group-select"
       aria-label="Field groups"
       autoFocus={shouldAutoFocus}
+      data-testid="field-group-select"
       disabled={disabled}
+      fontSize={2}
+      muted
+      onChange={handleSelect}
       value={groups.find((g) => g.selected)?.name}
     >
       {groups.map((group) => {
         // Separate hidden in order to resolve it to a boolean type
         return (
           <GroupOption
-            key={`${inputId}-${group.name}-tab`}
             aria-controls={`${inputId}-field-group-fields`}
-            selected={Boolean(group.selected)}
             disabled={group.disabled}
+            key={`${inputId}-${group.name}-tab`}
             name={group.name}
+            selected={Boolean(group.selected)}
             title={group.title || group.name}
           />
         )
@@ -102,8 +102,8 @@ const GroupSelect = ({
 }
 
 export const FieldGroupTabs = React.memo(function FieldGroupTabs({
-  onClick,
   disabled = false,
+  onClick,
   ...props
 }: FieldGroupTabsProps) {
   const handleClick = useCallback(

--- a/packages/sanity/src/core/form/store/types/nodes.ts
+++ b/packages/sanity/src/core/form/store/types/nodes.ts
@@ -55,6 +55,7 @@ export interface ObjectArrayFormNode<
   groups: FormFieldGroup[]
   /** @beta */
   members: ObjectMember[]
+  changesOpen?: boolean
 }
 
 /** @internal */

--- a/packages/sanity/src/core/form/store/useFormState.ts
+++ b/packages/sanity/src/core/form/store/useFormState.ts
@@ -32,6 +32,7 @@ export function useFormState<
     openPath,
     presence,
     validation,
+    changesOpen,
   }: {
     fieldGroupState?: StateTree<string> | undefined
     collapsedFieldSets?: StateTree<boolean> | undefined
@@ -42,6 +43,7 @@ export function useFormState<
     focusPath: Path
     presence: FormNodePresence[]
     validation: ValidationMarker[]
+    changesOpen?: boolean
   }
 ): FormState<T, S> | null {
   // note: feel free to move these state pieces out of this hook
@@ -70,6 +72,7 @@ export function useFormState<
       currentUser,
       presence,
       validation,
+      changesOpen,
     }) as ObjectFormNode<T, S> // TODO: remove type cast
 
     const reconciled = immutableReconcile(prev.current, next)
@@ -88,5 +91,6 @@ export function useFormState<
     currentUser,
     presence,
     validation,
+    changesOpen,
   ])
 }

--- a/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
@@ -299,8 +299,9 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     collapsedPaths,
     presence,
     validation,
-    collapsedFieldSets: collapsedFieldSets,
+    collapsedFieldSets,
     fieldGroupState,
+    changesOpen,
   })
 
   const formStateRef = useRef(formState)


### PR DESCRIPTION
### Description
The document group tabs should be disabled when the review changes pane is open.

### What to review
- Code review
- Should work for nested tabs

### Notes for release
fix(sanity): disable group tabs when review changes pane is open