### PR TITLE
fix(desk): timeline button focus ring

### DIFF
--- a/packages/sanity/src/desk/components/pane/PaneHeader.tsx
+++ b/packages/sanity/src/desk/components/pane/PaneHeader.tsx
@@ -49,7 +49,7 @@ export const PaneHeader = forwardRef(function PaneHeader(
             <Layout
               onClick={handleLayoutClick}
               padding={2}
-              paddingBottom={tabs || subActions ? 1 : 2}
+              paddingBottom={tabs || subActions ? 0 : 2}
               sizing="border"
               style={layoutStyle}
             >
@@ -80,7 +80,7 @@ export const PaneHeader = forwardRef(function PaneHeader(
               <Flex
                 align="center"
                 hidden={collapsed}
-                paddingTop={0}
+                paddingTop={1}
                 paddingRight={2}
                 paddingBottom={2}
                 paddingLeft={3}


### PR DESCRIPTION
### Description

This PR fixes the focus ring on the timeline button which was partially hidden.

<img width="781" alt="Screen Shot 2022-10-19 at 11 17 32" src="https://user-images.githubusercontent.com/15094168/196651173-af5d3a2f-7812-4231-8ce7-692818280e20.png">

### What to review

n/a

### Notes for release

fix(desk): timeline button focus ring