### PR TITLE
fix(sanity): use schemaType passed to `renderDefault` in schema when resolving the form component

### DIFF
--- a/packages/sanity/src/core/form/form-components-hooks/components.ts
+++ b/packages/sanity/src/core/form/form-components-hooks/components.ts
@@ -25,7 +25,7 @@ function useResolveDefaultComponent<T extends {schemaType?: SchemaType}>(props: 
 
   const renderDefault = useCallback(
     (parentTypeProps: T) => {
-      if (!componentProps.schemaType?.type) {
+      if (!parentTypeProps.schemaType?.type) {
         // In theory this should not be possible, and this error should never be thrown
         throw new Error('Attempted to render form component of non-existent parent type')
       }
@@ -33,11 +33,11 @@ function useResolveDefaultComponent<T extends {schemaType?: SchemaType}>(props: 
       // The components property is removed from the schemaType object
       // in order to prevent that a component is render itself
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const {components, ...restSchemaType} = componentProps.schemaType
-      const parentTypeResolvedComponent = componentResolver(restSchemaType as SchemaType)
+      const {components, ...restSchemaType} = parentTypeProps.schemaType
+      const parentTypeResolvedComponent = componentResolver(restSchemaType)
       return createElement(parentTypeResolvedComponent, parentTypeProps)
     },
-    [componentProps.schemaType, componentResolver]
+    [componentResolver]
   )
 
   return createElement(defaultResolvedComponent, {


### PR DESCRIPTION
### Description

This PR fixes so that the schemaType passed to `renderDefault` in a schema is used when resolving the form component. This makes it possible to do stuff like below – which currently don't work:

```js
// Render string input as <select /> by adding `options.list` to the `schemaType`
{
  type: 'string',
  name: 'title',
  components: {
    input: (props) => {
      return props.renderDefault({
        ...props,
        schemaType: {
          ...props.schemaType,
          options: {
            list: ['Option 1', 'Option 2', 'Option 3'],
          },
        },
      })
    },
  },
}
```

### What to review
- Review the code
- Do you see any risks with this update?

### Notes for release
fix(sanity): use schemaType passed to `renderDefault` in schema when resolving the form component