### PR TITLE
Add strict runtime validation of array choices

### DIFF
--- a/dev/test-studio/schema/standard/arrays.tsx
+++ b/dev/test-studio/schema/standard/arrays.tsx
@@ -271,7 +271,7 @@ export default defineType({
         list: [
           {_type: 'color', title: 'Red', name: 'red'},
           {_type: 'color', title: 'Green', name: 'green', _key: 'green'},
-          1, // invalid, not defined in list
+          // 1, // invalid, not defined in list (note: this is now captured by the schema parsing step)
           {_type: 'color', title: 'Blue', name: 'blue', _key: 'blue'},
           {_type: 'color', title: 'Black', name: 'black', _key: 'black'},
         ],

--- a/packages/@sanity/schema/src/sanity/validation/createValidationResult.ts
+++ b/packages/@sanity/schema/src/sanity/validation/createValidationResult.ts
@@ -13,6 +13,7 @@ export const HELP_IDS = {
   OBJECT_FIELD_NOT_UNIQUE: 'schema-object-fields-invalid',
   OBJECT_FIELD_NAME_INVALID: 'schema-object-fields-invalid',
   OBJECT_FIELD_DEFINITION_INVALID_TYPE: 'schema-object-fields-invalid',
+  ARRAY_PREDEFINED_CHOICES_INVALID: 'schema-predefined-choices-invalid',
   ARRAY_OF_ARRAY: 'schema-array-of-array',
   ARRAY_OF_INVALID: 'schema-array-of-invalid',
   ARRAY_OF_NOT_UNIQUE: 'schema-array-of-invalid',


### PR DESCRIPTION
### Description
This adds strict validation of list of predefined options provided for array types. This means you will now get a schema error if you provide list options that are not allowed by the array declaration.

This also _removes_ support for predefined choices on the shape of `{title: 'Some title', value: {_type: 'someObjectType', ...}}` since preview is better handled by delgating to the studio preview for the type. You can still provide display title for primitive values, as explained in the [help article](https://www.sanity.io/help/schema-predefined-choices-invalid) linked to the schema compile error.

Example:

<img width="677" alt="image" src="https://user-images.githubusercontent.com/876086/197224649-f51360f4-7f41-4c63-b279-8d3495ed7c1a.png">


### What to review
- Verify that the validation makes sense
- Verify that the errors are sensible and the information provided by the help url makes sense

### Notes for release

- Added strict validation of predefined list options for array types