### PR TITLE
fix(sanity): remove `constrainSize` property

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/text/AnnotationToolbarPopover.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/AnnotationToolbarPopover.tsx
@@ -165,8 +165,6 @@ export function AnnotationToolbarPopover(props: AnnotationToolbarPopoverProps) {
 
   return (
     <ToolbarPopover
-      boundaryElement={scrollElement}
-      constrainSize
       content={
         <Box padding={1}>
           <Inline space={1}>
@@ -197,7 +195,7 @@ export function AnnotationToolbarPopover(props: AnnotationToolbarPopoverProps) {
       fallbackPlacements={POPOVER_FALLBACK_PLACEMENTS}
       open={open}
       placement="top"
-      portal="editor"
+      portal="default"
       referenceElement={cursorElement}
       scheme={popoverScheme}
     />


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Fixes an issue with PTE annotation toolbar getting `overflow: auto` when it shouldn't.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/406933/197472992-452bb967-b502-46f1-a60a-f6c20858c98c.png) | ![image](https://user-images.githubusercontent.com/406933/197473175-50e7ca17-9a2d-43ec-8cec-84650b590ebf.png) |