### PR TITLE
Improve PTE test stability

### DIFF
--- a/packages/@sanity/portable-text-editor/package.json
+++ b/packages/@sanity/portable-text-editor/package.json
@@ -25,7 +25,7 @@
     "prebuild": "run-s clean",
     "prettier": "prettier --write './**/*.{ts,tsx,js,css,html}'",
     "start": "cd ./test/ && ts-node serve",
-    "test": "jest",
+    "test": "jest --runInBand",
     "test:watch": "jest --watch",
     "watch": "pkg-utils watch --tsconfig tsconfig.lib.json"
   },

--- a/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditor.test.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditor.test.tsx
@@ -5,8 +5,7 @@
 // eslint-disable-next-line import/no-unassigned-import
 import '@testing-library/jest-dom/extend-expect'
 import React from 'react'
-import {act} from 'react-dom/test-utils'
-import {render} from '@testing-library/react'
+import {render, waitFor} from '@testing-library/react'
 import {PortableTextEditor} from '../PortableTextEditor'
 import {EditorSelection, PortableTextBlock} from '../..'
 import {PortableTextEditorTester, type} from './PortableTextEditorTester'
@@ -97,7 +96,7 @@ describe('initialization', () => {
     render(<PortableTextEditorTester onChange={onChange} type={type} value={initialValue} />)
     expect(onChange).toHaveBeenCalledWith({type: 'value', value: initialValue})
   })
-  it('takes initial selection from props', () => {
+  it('takes initial selection from props', async () => {
     const editorRef: React.RefObject<PortableTextEditor> = React.createRef()
     const initialValue = [helloBlock]
     const initialSelection: EditorSelection = {
@@ -114,18 +113,15 @@ describe('initialization', () => {
         value={initialValue}
       />
     )
-    if (!editorRef.current) {
-      throw new Error('No editor')
-    }
-    act(() => {
+    await waitFor(() => {
       if (editorRef.current) {
         PortableTextEditor.focus(editorRef.current)
+        expect(PortableTextEditor.getSelection(editorRef.current)).toEqual(initialSelection)
       }
     })
-    expect(PortableTextEditor.getSelection(editorRef.current)).toEqual(initialSelection)
   })
 
-  it('updates editor selection from new prop and keeps object equality in editor.getSelection()', () => {
+  it('updates editor selection from new prop and keeps object equality in editor.getSelection()', async () => {
     const editorRef: React.RefObject<PortableTextEditor> = React.createRef()
     const initialValue = [helloBlock]
     const initialSelection: EditorSelection = {
@@ -146,10 +142,7 @@ describe('initialization', () => {
         value={initialValue}
       />
     )
-    if (!editorRef.current) {
-      throw new Error('No editor')
-    }
-    act(() => {
+    await waitFor(() => {
       if (editorRef.current) {
         const sel = PortableTextEditor.getSelection(editorRef.current)
         PortableTextEditor.focus(editorRef.current)
@@ -169,7 +162,7 @@ describe('initialization', () => {
         value={initialValue}
       />
     )
-    act(() => {
+    await waitFor(() => {
       if (editorRef.current) {
         expect(PortableTextEditor.getSelection(editorRef.current)).toEqual(newSelection)
       }

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/__tests__/withEditableAPIDelete.test.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/__tests__/withEditableAPIDelete.test.tsx
@@ -5,7 +5,7 @@
 // eslint-disable-next-line import/no-unassigned-import
 import '@testing-library/jest-dom/extend-expect'
 import {act} from 'react-dom/test-utils'
-import {render} from '@testing-library/react'
+import {render, waitFor, screen} from '@testing-library/react'
 
 import React from 'react'
 import {PortableTextEditor} from '../../PortableTextEditor'
@@ -48,116 +48,101 @@ const initialSelection = {
 }
 
 describe('plugin:withEditableAPI: .delete()', () => {
-  it('deletes block', () => {
+  it('deletes block', async () => {
     const editorRef: React.RefObject<PortableTextEditor> = React.createRef()
     const onChange = jest.fn()
-    act(() => {
-      render(
-        <PortableTextEditorTester
-          onChange={onChange}
-          ref={editorRef}
-          type={type}
-          value={initialValue}
-        />
-      )
-    })
-    act(() => {
+    render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        type={type}
+        value={initialValue}
+      />
+    )
+    await waitFor(() => {
       if (editorRef.current) {
         PortableTextEditor.focus(editorRef.current)
         PortableTextEditor.select(editorRef.current, initialSelection)
-      }
-    })
-    act(() => {
-      if (editorRef.current) {
         PortableTextEditor.delete(
           editorRef.current,
           PortableTextEditor.getSelection(editorRef.current),
           {mode: 'blocks'}
         )
+        expect(PortableTextEditor.getValue(editorRef.current)).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "_key": "a",
+              "_type": "myTestBlockType",
+              "children": Array [
+                Object {
+                  "_key": "a1",
+                  "_type": "span",
+                  "marks": Array [],
+                  "text": "Block A",
+                },
+              ],
+              "markDefs": Array [],
+              "style": "normal",
+            },
+          ]
+        `)
       }
     })
-    expect(editorRef.current && PortableTextEditor.getValue(editorRef.current))
-      .toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "_key": "a",
-          "_type": "myTestBlockType",
-          "children": Array [
-            Object {
-              "_key": "a1",
-              "_type": "span",
-              "marks": Array [],
-              "text": "Block A",
-            },
-          ],
-          "markDefs": Array [],
-          "style": "normal",
-        },
-      ]
-    `)
   })
-  it('deletes children', () => {
+  it('deletes children', async () => {
     const editorRef: React.RefObject<PortableTextEditor> = React.createRef()
     const onChange = jest.fn()
-    act(() => {
-      render(
-        <PortableTextEditorTester
-          onChange={onChange}
-          ref={editorRef}
-          type={type}
-          value={initialValue}
-        />
-      )
-    })
-    if (!editorRef.current) {
-      throw new Error('No editor')
-    }
-    act(() => {
+    render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        type={type}
+        value={initialValue}
+      />
+    )
+
+    await waitFor(() => {
       if (editorRef.current) {
-        PortableTextEditor.focus(editorRef.current)
         PortableTextEditor.select(editorRef.current, initialSelection)
-      }
-    })
-    act(() => {
-      if (editorRef.current) {
+        PortableTextEditor.focus(editorRef.current)
         PortableTextEditor.delete(
           editorRef.current,
           PortableTextEditor.getSelection(editorRef.current),
           {mode: 'children'}
         )
+        expect(PortableTextEditor.getValue(editorRef.current)).toMatchInlineSnapshot(`
+                  Array [
+                    Object {
+                      "_key": "a",
+                      "_type": "myTestBlockType",
+                      "children": Array [
+                        Object {
+                          "_key": "a1",
+                          "_type": "span",
+                          "marks": Array [],
+                          "text": "Block A",
+                        },
+                      ],
+                      "markDefs": Array [],
+                      "style": "normal",
+                    },
+                    Object {
+                      "_key": "b",
+                      "_type": "myTestBlockType",
+                      "children": Array [
+                        Object {
+                          "_key": "1",
+                          "_type": "span",
+                          "marks": Array [],
+                          "text": "",
+                        },
+                      ],
+                      "markDefs": Array [],
+                      "style": "normal",
+                    },
+                  ]
+              `)
       }
     })
-    expect(PortableTextEditor.getValue(editorRef.current)).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "_key": "a",
-          "_type": "myTestBlockType",
-          "children": Array [
-            Object {
-              "_key": "a1",
-              "_type": "span",
-              "marks": Array [],
-              "text": "Block A",
-            },
-          ],
-          "markDefs": Array [],
-          "style": "normal",
-        },
-        Object {
-          "_key": "b",
-          "_type": "myTestBlockType",
-          "children": Array [
-            Object {
-              "_key": "1",
-              "_type": "span",
-              "marks": Array [],
-              "text": "",
-            },
-          ],
-          "markDefs": Array [],
-          "style": "normal",
-        },
-      ]
-    `)
   })
 })

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/__tests__/withPortableTextMarkModelNormalization.test.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/__tests__/withPortableTextMarkModelNormalization.test.tsx
@@ -4,7 +4,7 @@
 // eslint-disable-next-line import/no-unassigned-import
 import '@testing-library/jest-dom/extend-expect'
 import {act} from 'react-dom/test-utils'
-import {render} from '@testing-library/react'
+import {render, waitFor} from '@testing-library/react'
 
 import React from 'react'
 import {PortableTextEditor} from '../../PortableTextEditor'
@@ -12,7 +12,7 @@ import {PortableTextEditorTester, type} from '../../../editor/__tests__/Portable
 import {EditorSelection} from '../../../types/editor'
 
 describe('plugin:withPortableTextMarksModel: normalization', () => {
-  it('merges adjacent spans correctly when removing annotations', () => {
+  it('merges adjacent spans correctly when removing annotations', async () => {
     const editorRef: React.RefObject<PortableTextEditor> = React.createRef()
     const initialValue = [
       {
@@ -77,87 +77,79 @@ describe('plugin:withPortableTextMarksModel: normalization', () => {
       },
     ]
     const onChange = jest.fn()
-    act(() => {
-      render(
-        <PortableTextEditorTester
-          onChange={onChange}
-          ref={editorRef}
-          type={type}
-          value={initialValue}
-        />
-      )
-    })
-    if (!editorRef.current) {
-      throw new Error('No editor')
-    }
-    act(() => {
+    render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        type={type}
+        value={initialValue}
+      />
+    )
+    await waitFor(() => {
       if (editorRef.current) {
         PortableTextEditor.focus(editorRef.current)
         PortableTextEditor.select(editorRef.current, {
           focus: {path: [{_key: '5fc57af23597'}, 'children', {_key: '11c8c9f783a8'}], offset: 4},
           anchor: {path: [{_key: '5fc57af23597'}, 'children', {_key: '11c8c9f783a8'}], offset: 0},
         })
-      }
-    })
-    const linkType = PortableTextEditor.getPortableTextFeatures(editorRef.current).annotations.find(
-      (a) => a.type.name === 'link'
-    )?.type
-    if (!linkType) {
-      throw new Error('No link type found')
-    }
-    act(() => {
-      if (editorRef.current) {
+        const linkType = PortableTextEditor.getPortableTextFeatures(
+          editorRef.current
+          // eslint-disable-next-line max-nested-callbacks
+        ).annotations.find((a) => a.type.name === 'link')?.type
+        if (!linkType) {
+          throw new Error('No link type found')
+        }
         PortableTextEditor.removeAnnotation(editorRef.current, linkType)
+        expect(PortableTextEditor.getValue(editorRef.current)).toEqual([
+          {
+            _key: '5fc57af23597',
+            _type: 'myTestBlockType',
+            children: [
+              {
+                _key: 'be1c67c6971a',
+                _type: 'span',
+                marks: [],
+                text: 'This is a link, this is ',
+              },
+              {
+                _key: 'f3d73d3833bf',
+                _type: 'span',
+                marks: ['7b6d3d5de30c'],
+                text: 'another',
+              },
+              {
+                _key: '73b01f13c2ec',
+                _type: 'span',
+                marks: [],
+                text: ', and this is ',
+              },
+              {
+                _key: '13eb0d467c82',
+                _type: 'span',
+                marks: ['93a1d24eade0'],
+                text: 'a third',
+              },
+            ],
+            markDefs: [
+              {
+                _key: '7b6d3d5de30c',
+                _type: 'link',
+                url: '2',
+              },
+              {
+                _key: '93a1d24eade0',
+                _type: 'link',
+                url: '3',
+              },
+            ],
+            style: 'normal',
+          },
+        ])
       }
     })
-    expect(PortableTextEditor.getValue(editorRef.current)).toEqual([
-      {
-        _key: '5fc57af23597',
-        _type: 'myTestBlockType',
-        children: [
-          {
-            _key: 'be1c67c6971a',
-            _type: 'span',
-            marks: [],
-            text: 'This is a link, this is ',
-          },
-          {
-            _key: 'f3d73d3833bf',
-            _type: 'span',
-            marks: ['7b6d3d5de30c'],
-            text: 'another',
-          },
-          {
-            _key: '73b01f13c2ec',
-            _type: 'span',
-            marks: [],
-            text: ', and this is ',
-          },
-          {
-            _key: '13eb0d467c82',
-            _type: 'span',
-            marks: ['93a1d24eade0'],
-            text: 'a third',
-          },
-        ],
-        markDefs: [
-          {
-            _key: '7b6d3d5de30c',
-            _type: 'link',
-            url: '2',
-          },
-          {
-            _key: '93a1d24eade0',
-            _type: 'link',
-            url: '3',
-          },
-        ],
-        style: 'normal',
-      },
-    ])
   })
 
-  it('splits correctly when adding marks', () => {
+  it('splits correctly when adding marks', async () => {
     const editorRef: React.RefObject<PortableTextEditor> = React.createRef()
     const initialValue = [
       {
@@ -190,77 +182,68 @@ describe('plugin:withPortableTextMarksModel: normalization', () => {
       },
     ]
     const onChange = jest.fn()
-    act(() => {
-      render(
-        <PortableTextEditorTester
-          onChange={onChange}
-          ref={editorRef}
-          type={type}
-          value={initialValue}
-        />
-      )
-    })
-    if (!editorRef.current) {
-      throw new Error('No editor')
-    }
-    act(() => {
+    render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        type={type}
+        value={initialValue}
+      />
+    )
+    await waitFor(() => {
       if (editorRef.current) {
         PortableTextEditor.focus(editorRef.current)
         PortableTextEditor.select(editorRef.current, {
           focus: {path: [{_key: 'a'}, 'children', {_key: 'a1'}], offset: 0},
           anchor: {path: [{_key: 'b'}, 'children', {_key: 'b1'}], offset: 1},
         })
-      }
-    })
-    act(() => {
-      if (editorRef.current) {
         PortableTextEditor.toggleMark(editorRef.current, 'bold')
+        expect(PortableTextEditor.getValue(editorRef.current)).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "_key": "a",
+            "_type": "myTestBlockType",
+            "children": Array [
+              Object {
+                "_key": "a1",
+                "_type": "span",
+                "marks": Array [
+                  "bold",
+                ],
+                "text": "123",
+              },
+            ],
+            "markDefs": Array [],
+            "style": "normal",
+          },
+          Object {
+            "_key": "b",
+            "_type": "myTestBlockType",
+            "children": Array [
+              Object {
+                "_key": "b1",
+                "_type": "span",
+                "marks": Array [
+                  "bold",
+                ],
+                "text": "1",
+              },
+              Object {
+                "_key": "1",
+                "_type": "span",
+                "marks": Array [],
+                "text": "23",
+              },
+            ],
+            "markDefs": Array [],
+            "style": "normal",
+          },
+        ]
+      `)
       }
     })
-    expect(PortableTextEditor.getValue(editorRef.current)).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "_key": "a",
-          "_type": "myTestBlockType",
-          "children": Array [
-            Object {
-              "_key": "a1",
-              "_type": "span",
-              "marks": Array [
-                "bold",
-              ],
-              "text": "123",
-            },
-          ],
-          "markDefs": Array [],
-          "style": "normal",
-        },
-        Object {
-          "_key": "b",
-          "_type": "myTestBlockType",
-          "children": Array [
-            Object {
-              "_key": "b1",
-              "_type": "span",
-              "marks": Array [
-                "bold",
-              ],
-              "text": "1",
-            },
-            Object {
-              "_key": "1",
-              "_type": "span",
-              "marks": Array [],
-              "text": "23",
-            },
-          ],
-          "markDefs": Array [],
-          "style": "normal",
-        },
-      ]
-    `)
   })
-  it('merges children correctly when toggling marks in various ranges', () => {
+  it('merges children correctly when toggling marks in various ranges', async () => {
     const editorRef: React.RefObject<PortableTextEditor> = React.createRef()
     const initialValue = [
       {
@@ -279,125 +262,119 @@ describe('plugin:withPortableTextMarksModel: normalization', () => {
       },
     ]
     const onChange = jest.fn()
-    act(() => {
-      render(
-        <PortableTextEditorTester
-          onChange={onChange}
-          ref={editorRef}
-          type={type}
-          value={initialValue}
-        />
-      )
-    })
+    render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        type={type}
+        value={initialValue}
+      />
+    )
     if (!editorRef.current) {
       throw new Error('No editor')
     }
-    act(() => {
+    await waitFor(() => {
       if (editorRef.current) {
         PortableTextEditor.focus(editorRef.current)
         PortableTextEditor.select(editorRef.current, {
           focus: {path: [{_key: 'a'}, 'children', {_key: 'a1'}], offset: 0},
           anchor: {path: [{_key: 'a'}, 'children', {_key: 'a1'}], offset: 4},
         })
-      }
-    })
-    act(() => {
-      if (editorRef.current) {
         PortableTextEditor.toggleMark(editorRef.current, 'bold')
+        expect(PortableTextEditor.getValue(editorRef.current)).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "_key": "a",
+            "_type": "myTestBlockType",
+            "children": Array [
+              Object {
+                "_key": "a1",
+                "_type": "span",
+                "marks": Array [
+                  "bold",
+                ],
+                "text": "1234",
+              },
+            ],
+            "markDefs": Array [],
+            "style": "normal",
+          },
+        ]
+      `)
       }
     })
-    expect(PortableTextEditor.getValue(editorRef.current)).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "_key": "a",
-          "_type": "myTestBlockType",
-          "children": Array [
-            Object {
-              "_key": "a1",
-              "_type": "span",
-              "marks": Array [
-                "bold",
-              ],
-              "text": "1234",
-            },
-          ],
-          "markDefs": Array [],
-          "style": "normal",
-        },
-      ]
-    `)
-    act(() => {
+    await waitFor(() => {
       if (editorRef.current) {
         PortableTextEditor.select(editorRef.current, {
           focus: {path: [{_key: 'a'}, 'children', {_key: 'a1'}], offset: 1},
           anchor: {path: [{_key: 'a'}, 'children', {_key: 'a1'}], offset: 3},
         })
         PortableTextEditor.toggleMark(editorRef.current, 'bold')
+        expect(PortableTextEditor.getValue(editorRef.current)).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "_key": "a",
+            "_type": "myTestBlockType",
+            "children": Array [
+              Object {
+                "_key": "a1",
+                "_type": "span",
+                "marks": Array [
+                  "bold",
+                ],
+                "text": "1",
+              },
+              Object {
+                "_key": "2",
+                "_type": "span",
+                "marks": Array [],
+                "text": "23",
+              },
+              Object {
+                "_key": "1",
+                "_type": "span",
+                "marks": Array [
+                  "bold",
+                ],
+                "text": "4",
+              },
+            ],
+            "markDefs": Array [],
+            "style": "normal",
+          },
+        ]
+      `)
       }
     })
-    expect(PortableTextEditor.getValue(editorRef.current)).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "_key": "a",
-          "_type": "myTestBlockType",
-          "children": Array [
-            Object {
-              "_key": "a1",
-              "_type": "span",
-              "marks": Array [
-                "bold",
-              ],
-              "text": "1",
-            },
-            Object {
-              "_key": "2",
-              "_type": "span",
-              "marks": Array [],
-              "text": "23",
-            },
-            Object {
-              "_key": "1",
-              "_type": "span",
-              "marks": Array [
-                "bold",
-              ],
-              "text": "4",
-            },
-          ],
-          "markDefs": Array [],
-          "style": "normal",
-        },
-      ]
-    `)
-    act(() => {
+    await waitFor(() => {
       if (editorRef.current) {
         PortableTextEditor.select(editorRef.current, {
           focus: {path: [{_key: 'a'}, 'children', {_key: 'a1'}], offset: 0},
           anchor: {path: [{_key: 'a'}, 'children', {_key: '1'}], offset: 1},
         })
         PortableTextEditor.toggleMark(editorRef.current, 'bold')
+        expect(PortableTextEditor.getValue(editorRef.current)).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "_key": "a",
+            "_type": "myTestBlockType",
+            "children": Array [
+              Object {
+                "_key": "a1",
+                "_type": "span",
+                "marks": Array [],
+                "text": "1234",
+              },
+            ],
+            "markDefs": Array [],
+            "style": "normal",
+          },
+        ]
+      `)
       }
     })
-    expect(PortableTextEditor.getValue(editorRef.current)).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "_key": "a",
-          "_type": "myTestBlockType",
-          "children": Array [
-            Object {
-              "_key": "a1",
-              "_type": "span",
-              "marks": Array [],
-              "text": "1234",
-            },
-          ],
-          "markDefs": Array [],
-          "style": "normal",
-        },
-      ]
-    `)
   })
-  it('toggles marks on children with annotation marks correctly', () => {
+  it('toggles marks on children with annotation marks correctly', async () => {
     const editorRef: React.RefObject<PortableTextEditor> = React.createRef()
     const initialValue = [
       {
@@ -428,71 +405,62 @@ describe('plugin:withPortableTextMarksModel: normalization', () => {
       },
     ]
     const onChange = jest.fn()
-    act(() => {
-      render(
-        <PortableTextEditorTester
-          onChange={onChange}
-          ref={editorRef}
-          type={type}
-          value={initialValue}
-        />
-      )
-    })
-    if (!editorRef.current) {
-      throw new Error('No editor')
-    }
-    act(() => {
+    render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        type={type}
+        value={initialValue}
+      />
+    )
+    await waitFor(() => {
       if (editorRef.current) {
         PortableTextEditor.focus(editorRef.current)
         PortableTextEditor.select(editorRef.current, {
           focus: {path: [{_key: 'a'}, 'children', {_key: 'a1'}], offset: 0},
           anchor: {path: [{_key: 'a'}, 'children', {_key: 'b1'}], offset: 12},
         })
-      }
-    })
-    act(() => {
-      if (editorRef.current) {
         PortableTextEditor.toggleMark(editorRef.current, 'bold')
+        expect(PortableTextEditor.getValue(editorRef.current)).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "_key": "a",
+            "_type": "myTestBlockType",
+            "children": Array [
+              Object {
+                "_key": "a1",
+                "_type": "span",
+                "marks": Array [
+                  "abc",
+                  "bold",
+                ],
+                "text": "A link",
+              },
+              Object {
+                "_key": "a2",
+                "_type": "span",
+                "marks": Array [
+                  "bold",
+                ],
+                "text": ", not a link",
+              },
+            ],
+            "markDefs": Array [
+              Object {
+                "_key": "abc",
+                "_type": "link",
+                "href": "http://www.link.com",
+              },
+            ],
+            "style": "normal",
+          },
+        ]
+      `)
       }
     })
-    expect(PortableTextEditor.getValue(editorRef.current)).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "_key": "a",
-          "_type": "myTestBlockType",
-          "children": Array [
-            Object {
-              "_key": "a1",
-              "_type": "span",
-              "marks": Array [
-                "abc",
-                "bold",
-              ],
-              "text": "A link",
-            },
-            Object {
-              "_key": "a2",
-              "_type": "span",
-              "marks": Array [
-                "bold",
-              ],
-              "text": ", not a link",
-            },
-          ],
-          "markDefs": Array [
-            Object {
-              "_key": "abc",
-              "_type": "link",
-              "href": "http://www.link.com",
-            },
-          ],
-          "style": "normal",
-        },
-      ]
-    `)
   })
 
-  it('merges blocks correctly when containing links', () => {
+  it('merges blocks correctly when containing links', async () => {
     const editorRef: React.RefObject<PortableTextEditor> = React.createRef()
     const initialValue = [
       {
@@ -553,79 +521,74 @@ describe('plugin:withPortableTextMarksModel: normalization', () => {
       anchor: {path: [{_key: '7cd53af36712'}, 'children', {_key: '576c748e0cd2'}], offset: 0},
     }
     const onChange = jest.fn()
-    act(() => {
-      render(
-        <PortableTextEditorTester
-          onChange={onChange}
-          ref={editorRef}
-          type={type}
-          value={initialValue}
-        />
-      )
-    })
-    if (!editorRef.current) {
-      throw new Error('No editor')
-    }
-    act(() => {
+    render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        type={type}
+        value={initialValue}
+      />
+    )
+    await waitFor(() => {
       if (editorRef.current) {
         PortableTextEditor.select(editorRef.current, sel)
         PortableTextEditor.delete(editorRef.current, sel)
+        expect(PortableTextEditor.getValue(editorRef.current)).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "_key": "5fc57af23597",
+            "_type": "myTestBlockType",
+            "children": Array [
+              Object {
+                "_key": "be1c67c6971a",
+                "_type": "span",
+                "marks": Array [],
+                "text": "This is a ",
+              },
+              Object {
+                "_key": "11c8c9f783a8",
+                "_type": "span",
+                "marks": Array [
+                  "fde1fd54b544",
+                ],
+                "text": "link",
+              },
+              Object {
+                "_key": "576c748e0cd2",
+                "_type": "span",
+                "marks": Array [],
+                "text": "This is ",
+              },
+              Object {
+                "_key": "f3d73d3833bf",
+                "_type": "span",
+                "marks": Array [
+                  "7b6d3d5de30c",
+                ],
+                "text": "another",
+              },
+            ],
+            "markDefs": Array [
+              Object {
+                "_key": "fde1fd54b544",
+                "_type": "link",
+                "url": "1",
+              },
+              Object {
+                "_key": "7b6d3d5de30c",
+                "_type": "link",
+                "url": "2",
+              },
+            ],
+            "style": "normal",
+          },
+        ]
+      `)
       }
     })
-    expect(PortableTextEditor.getValue(editorRef.current)).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "_key": "5fc57af23597",
-          "_type": "myTestBlockType",
-          "children": Array [
-            Object {
-              "_key": "be1c67c6971a",
-              "_type": "span",
-              "marks": Array [],
-              "text": "This is a ",
-            },
-            Object {
-              "_key": "11c8c9f783a8",
-              "_type": "span",
-              "marks": Array [
-                "fde1fd54b544",
-              ],
-              "text": "link",
-            },
-            Object {
-              "_key": "576c748e0cd2",
-              "_type": "span",
-              "marks": Array [],
-              "text": "This is ",
-            },
-            Object {
-              "_key": "f3d73d3833bf",
-              "_type": "span",
-              "marks": Array [
-                "7b6d3d5de30c",
-              ],
-              "text": "another",
-            },
-          ],
-          "markDefs": Array [
-            Object {
-              "_key": "fde1fd54b544",
-              "_type": "link",
-              "url": "1",
-            },
-            Object {
-              "_key": "7b6d3d5de30c",
-              "_type": "link",
-              "url": "2",
-            },
-          ],
-          "style": "normal",
-        },
-      ]
-    `)
   })
 
-  it('resets markDefs when splitting a block in the beginning', () => {
+  it('resets markDefs when splitting a block in the beginning', async () => {
     const editorRef: React.RefObject<PortableTextEditor> = React.createRef()
     const initialValue = [
       {
@@ -668,79 +631,74 @@ describe('plugin:withPortableTextMarksModel: normalization', () => {
       anchor: {path: [{_key: '2f55670a03bb'}, 'children', {_key: '9f5ed7dee7ab'}], offset: 0},
     }
     const onChange = jest.fn()
-    act(() => {
-      render(
-        <PortableTextEditorTester
-          onChange={onChange}
-          ref={editorRef}
-          type={type}
-          value={initialValue}
-        />
-      )
-    })
-    if (!editorRef.current) {
-      throw new Error('No editor')
-    }
-    act(() => {
+    render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        type={type}
+        value={initialValue}
+      />
+    )
+    await waitFor(() => {
       if (editorRef.current) {
         PortableTextEditor.select(editorRef.current, sel)
         PortableTextEditor.focus(editorRef.current)
         editorRef.current.slateInstance.insertBreak()
+        expect(PortableTextEditor.getValue(editorRef.current)).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "_key": "1987f99da4a2",
+            "_type": "myTestBlockType",
+            "children": Array [
+              Object {
+                "_key": "3693e789451c",
+                "_type": "span",
+                "marks": Array [],
+                "text": "1",
+              },
+            ],
+            "markDefs": Array [],
+            "style": "normal",
+          },
+          Object {
+            "_key": "2f55670a03bb",
+            "_type": "myTestBlockType",
+            "children": Array [
+              Object {
+                "_key": "9f5ed7dee7ab",
+                "_type": "span",
+                "marks": Array [],
+                "text": "",
+              },
+            ],
+            "markDefs": Array [],
+            "style": "normal",
+          },
+          Object {
+            "_key": "2",
+            "_type": "myTestBlockType",
+            "children": Array [
+              Object {
+                "_key": "1",
+                "_type": "span",
+                "marks": Array [
+                  "bab319ad3a9d",
+                ],
+                "text": "2",
+              },
+            ],
+            "markDefs": Array [
+              Object {
+                "_key": "bab319ad3a9d",
+                "_type": "link",
+                "href": "http://www.123.com",
+              },
+            ],
+            "style": "normal",
+          },
+        ]
+      `)
       }
     })
-    expect(PortableTextEditor.getValue(editorRef.current)).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "_key": "1987f99da4a2",
-          "_type": "myTestBlockType",
-          "children": Array [
-            Object {
-              "_key": "3693e789451c",
-              "_type": "span",
-              "marks": Array [],
-              "text": "1",
-            },
-          ],
-          "markDefs": Array [],
-          "style": "normal",
-        },
-        Object {
-          "_key": "2f55670a03bb",
-          "_type": "myTestBlockType",
-          "children": Array [
-            Object {
-              "_key": "9f5ed7dee7ab",
-              "_type": "span",
-              "marks": Array [],
-              "text": "",
-            },
-          ],
-          "markDefs": Array [],
-          "style": "normal",
-        },
-        Object {
-          "_key": "2",
-          "_type": "myTestBlockType",
-          "children": Array [
-            Object {
-              "_key": "1",
-              "_type": "span",
-              "marks": Array [
-                "bab319ad3a9d",
-              ],
-              "text": "2",
-            },
-          ],
-          "markDefs": Array [
-            Object {
-              "_key": "bab319ad3a9d",
-              "_type": "link",
-              "href": "http://www.123.com",
-            },
-          ],
-          "style": "normal",
-        },
-      ]
-    `)
   })
 })

--- a/packages/@sanity/portable-text-editor/src/utils/__tests__/valueNormalization.test.tsx
+++ b/packages/@sanity/portable-text-editor/src/utils/__tests__/valueNormalization.test.tsx
@@ -4,14 +4,14 @@
 // eslint-disable-next-line import/no-unassigned-import
 import '@testing-library/jest-dom/extend-expect'
 import {act} from 'react-dom/test-utils'
-import {render} from '@testing-library/react'
+import {render, waitFor} from '@testing-library/react'
 
 import React from 'react'
 import {PortableTextEditor} from '../../editor/PortableTextEditor'
 import {PortableTextEditorTester, type} from '../../editor/__tests__/PortableTextEditorTester'
 
 describe('values: normalization', () => {
-  it("accepts incoming value with blocks without a style or markDefs prop, but doesn't leave them without them when editing them", () => {
+  it("accepts incoming value with blocks without a style or markDefs prop, but doesn't leave them without them when editing them", async () => {
     const editorRef: React.RefObject<PortableTextEditor> = React.createRef()
     const initialValue = [
       {
@@ -29,48 +29,39 @@ describe('values: normalization', () => {
       },
     ]
     const onChange = jest.fn()
-    act(() => {
-      render(
-        <PortableTextEditorTester
-          onChange={onChange}
-          ref={editorRef}
-          type={type}
-          value={initialValue}
-        />
-      )
-    })
-    if (!editorRef.current) {
-      throw new Error('No editor')
-    }
-    act(() => {
+    render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        type={type}
+        value={initialValue}
+      />
+    )
+    await waitFor(() => {
       if (editorRef.current) {
         PortableTextEditor.focus(editorRef.current)
         PortableTextEditor.select(editorRef.current, {
           focus: {path: [{_key: '5fc57af23597'}, 'children', {_key: 'be1c67c6971a'}], offset: 0},
           anchor: {path: [{_key: '5fc57af23597'}, 'children', {_key: 'be1c67c6971a'}], offset: 5},
         })
-      }
-    })
-    act(() => {
-      if (editorRef.current) {
         PortableTextEditor.toggleMark(editorRef.current, 'strong')
+        expect(PortableTextEditor.getValue(editorRef.current)).toEqual([
+          {
+            _key: '5fc57af23597',
+            _type: 'myTestBlockType',
+            children: [
+              {
+                _key: 'be1c67c6971a',
+                _type: 'span',
+                marks: ['strong'],
+                text: 'Hello',
+              },
+            ],
+            markDefs: [],
+            style: 'normal',
+          },
+        ])
       }
     })
-    expect(PortableTextEditor.getValue(editorRef.current)).toEqual([
-      {
-        _key: '5fc57af23597',
-        _type: 'myTestBlockType',
-        children: [
-          {
-            _key: 'be1c67c6971a',
-            _type: 'span',
-            marks: ['strong'],
-            text: 'Hello',
-          },
-        ],
-        markDefs: [],
-        style: 'normal',
-      },
-    ])
   })
 })

--- a/packages/@sanity/portable-text-editor/test/__tests__/selectionAdjustment.collaborative.test.ts
+++ b/packages/@sanity/portable-text-editor/test/__tests__/selectionAdjustment.collaborative.test.ts
@@ -2,8 +2,7 @@
 
 import '../setup/globals.jest'
 
-// @todo Temporarily disabled until flakey tests can be addressed in CI
-describe.skip('selection adjustment', () => {
+describe('selection adjustment', () => {
   describe('insert and unset blocks', () => {
     it('will keep A on same line if B insert above', async () => {
       await setDocumentValue([

--- a/packages/@sanity/portable-text-editor/test/__tests__/writingTogether.collaborative.test.ts
+++ b/packages/@sanity/portable-text-editor/test/__tests__/writingTogether.collaborative.test.ts
@@ -14,7 +14,7 @@ const initialValue: PortableTextBlock[] | undefined = [
 ]
 
 // @todo Temporarily disabled until flakey tests can be addressed in CI
-describe.skip('collaborate editing', () => {
+describe('collaborate editing', () => {
   it('will have the same start value for editor A and B', async () => {
     await setDocumentValue(initialValue)
     const editors = await getEditors()

--- a/packages/@sanity/portable-text-editor/test/serve.ts
+++ b/packages/@sanity/portable-text-editor/test/serve.ts
@@ -1,6 +1,6 @@
 // Start servers file for 'npm start'
 
-const globalSetup = require('./setup/globalSetup')
+import globalSetup from './setup/globalSetup'
 
 globalSetup().then(() => {
   // eslint-disable-next-line no-console

--- a/packages/@sanity/portable-text-editor/test/setup/collaborative.jest.env.ts
+++ b/packages/@sanity/portable-text-editor/test/setup/collaborative.jest.env.ts
@@ -18,9 +18,11 @@ const WEB_SERVER_ROOT_URL = 'http://localhost:3000'
 // eslint-disable-next-line no-process-env
 const DEBUG = process.env.DEBUG || false
 
-// Wait this long for selections and a new doc revision to appear on the clients
-const SELECTION_TIMEOUT_MS = 1500 // This will also be an indicator of the performance in the editor. Set it as low as possible without breaking the tests.
-const REVISION_TIMEOUT_MS = FLUSH_PATCHES_DEBOUNCE_MS + 1000 // 300 seems to be the limit for the doc patching to go full circle (increase this if tests starts to time out)
+// Wait this long for selections and a new doc revision to appear in the clients.
+const SELECTION_TIMEOUT_MS = 1500
+
+// How long to wait for a new revision to come back to the client(s) when patched through the server.
+const REVISION_TIMEOUT_MS = FLUSH_PATCHES_DEBOUNCE_MS + 1000
 
 // eslint-disable-next-line no-process-env
 const launchConfig = process.env.CI

--- a/packages/@sanity/portable-text-editor/test/setup/collaborative.jest.env.ts
+++ b/packages/@sanity/portable-text-editor/test/setup/collaborative.jest.env.ts
@@ -19,8 +19,8 @@ const WEB_SERVER_ROOT_URL = 'http://localhost:3000'
 const DEBUG = process.env.DEBUG || false
 
 // Wait this long for selections and a new doc revision to appear on the clients
-const SELECTION_TIMEOUT_MS = 1000 // This will also be an indicator of the performance in the editor. Set it as low as possible without breaking the tests.
-const REVISION_TIMEOUT_MS = FLUSH_PATCHES_DEBOUNCE_MS + 300 // 300 seems to be the limit for the doc patching to go full circle (increase this if tests starts to time out)
+const SELECTION_TIMEOUT_MS = 1500 // This will also be an indicator of the performance in the editor. Set it as low as possible without breaking the tests.
+const REVISION_TIMEOUT_MS = FLUSH_PATCHES_DEBOUNCE_MS + 1000 // 300 seems to be the limit for the doc patching to go full circle (increase this if tests starts to time out)
 
 // eslint-disable-next-line no-process-env
 const launchConfig = process.env.CI
@@ -171,7 +171,7 @@ export default class CollaborationEnvironment extends NodeEnvironment {
           const waitForNewSelection = async (selectionChangeFn: () => Promise<void>) => {
             const oldSelection = await getSelection()
             const dataVal = oldSelection ? JSON.stringify(oldSelection) : 'null'
-            selectionChangeFn() // Don't await this
+            await selectionChangeFn()
             await page.waitForSelector(`code[data-selection]:not([data-selection='${dataVal}'])`, {
               timeout: SELECTION_TIMEOUT_MS,
             })

--- a/packages/@sanity/portable-text-editor/test/tsconfig.json
+++ b/packages/@sanity/portable-text-editor/test/tsconfig.json
@@ -1,5 +1,11 @@
 {
   "extends": "../tsconfig.json",
+  "ts-node": {
+    // these options are overrides used only by ts-node
+    "compilerOptions": {
+      "module": "commonjs"
+    }
+  },
   "compilerOptions": {
     "target": "ESNext",
   }

--- a/packages/@sanity/portable-text-editor/test/web-server/app.tsx
+++ b/packages/@sanity/portable-text-editor/test/web-server/app.tsx
@@ -1,21 +1,9 @@
 import {Box, Card, Stack, studioTheme, ThemeProvider} from '@sanity/ui'
 import React, {useCallback, useMemo, useState} from 'react'
-//@todo: fixme: investigate why switching to React 18 root API breaks the test
-// import {createRoot} from 'react-dom/client'
-import {render} from 'react-dom'
 import {Subject} from 'rxjs'
 import {EditorSelection, Patch, PortableTextBlock} from '../../src'
 import {Editor} from './components/Editor'
 import {Value} from './components/Value'
-
-const rootEl = document.getElementById('root')
-if (!rootEl) {
-  throw new Error('Root element not found')
-}
-//@todo: fixme: investigate why switching to React 18 root API breaks the test
-// const root = createRoot(rootEl)
-// root.render(<App />)
-render(<App />, rootEl)
 
 export function App() {
   const incomingPatches$ = useMemo(


### PR DESCRIPTION
After upgrading to React 18, and other dependencies (i.e. new packing system) the portable-text-editor's tests have been needing some improvements.

I have done the following to better support their async nature:

* Refactor some of the tests to use `waitFor` instead of `act` from react testing library. This get rid of those warnings we have been seeing which potentially also can be a source to instability in test results.
* Run the individual tests in sync. Though each collaborative editing test websocket payload is tagged with the instance of the test and it's value is mapped to that id on the server (in order to support running in parallell), running these in parallel still seems to somehow yield different results than running them in serial mode (`jest --runInBand`). This is proven by one test that will differ between the modes. The best option for now seems to be to run these so that only one test use the test web/socket-server at the time. We already use `--runInBand` on the CI server for the root test list.
* Upped timeout limits for DOM selectors in Puppeteer. Sometimes tests seems to struggle when little CPU time is available and the test would fail with a timeout error.
