### PR TITLE
feat(form): implement custom array functions

### DIFF
--- a/cypress/integration/config/formComponentsApi.test.js
+++ b/cypress/integration/config/formComponentsApi.test.js
@@ -60,6 +60,10 @@ describe('Config: form components', () => {
         .find('[data-testid="input-schema-array-primitives"]')
         .find('[data-testid="array-primitives-input"]')
         .should('be.visible')
+
+      cy.get('[data-testid="input-schema-array-primitives-custom-functions"]', {
+        timeout: TIMEOUT,
+      }).should('be.visible')
     })
 
     it('array', () => {

--- a/dev/test-studio/schema/docs/v3/form-components-api/components.tsx
+++ b/dev/test-studio/schema/docs/v3/form-components-api/components.tsx
@@ -1,7 +1,16 @@
-import React from 'react'
+import React, {useCallback} from 'react'
 import {hues} from '@sanity/color'
-import {Box, Stack, Heading, Flex, Inline, Text} from '@sanity/ui'
-import {FieldProps, InputProps, ItemProps, PreviewProps} from 'sanity'
+import {Box, Stack, Heading, Flex, Inline, Text, Grid, Button} from '@sanity/ui'
+import {
+  ArrayOfPrimitivesInputProps,
+  ArraySchemaType,
+  ArrayOfPrimitivesFunctions,
+  FieldProps,
+  ArrayInputFunctionsProps,
+  InputProps,
+  ItemProps,
+  PreviewProps,
+} from 'sanity'
 
 const COMPONENT_COLORS = {
   input: hues.blue[400].hex,
@@ -85,4 +94,22 @@ export function CustomPreview(props: PreviewProps & {testId: string}) {
       {props.renderDefault(props)}
     </Box>
   )
+}
+
+function ArrayActions(props: ArrayInputFunctionsProps<string | number | boolean, ArraySchemaType>) {
+  const handleAdd = useCallback(() => {
+    props.onItemAppend('Hello!')
+  }, [props])
+
+  return (
+    <Grid columns={1} gap={2} data-testid="input-schema-array-primitives-custom-functions">
+      <Button text="Custom array function" onClick={handleAdd} />
+
+      <ArrayOfPrimitivesFunctions {...props} />
+    </Grid>
+  )
+}
+
+export function ArrayWithCustomActions(props: ArrayOfPrimitivesInputProps) {
+  return props.renderDefault({...props, arrayFunctions: ArrayActions})
 }

--- a/dev/test-studio/schema/docs/v3/form-components-api/schema.tsx
+++ b/dev/test-studio/schema/docs/v3/form-components-api/schema.tsx
@@ -1,7 +1,14 @@
 import React from 'react'
 import {defineType} from 'sanity'
 import {structureGroupOptions} from '../../../../structure/groupByOption'
-import {FormInput, CustomField, CustomInput, CustomPreview, CustomItem} from './components'
+import {
+  FormInput,
+  CustomField,
+  CustomInput,
+  CustomPreview,
+  CustomItem,
+  ArrayWithCustomActions,
+} from './components'
 
 export const formComponentsSchema = defineType({
   type: 'document',
@@ -130,6 +137,19 @@ export const formComponentsSchema = defineType({
               title: 'Image',
             },
           ],
+        },
+      ],
+    },
+    {
+      type: 'array',
+      name: 'arrayWithCustomActions',
+      components: {
+        input: ArrayWithCustomActions,
+      },
+      of: [
+        {
+          type: 'string',
+          name: 'testString',
         },
       ],
     },

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -55,7 +55,6 @@ export interface SanityFormConfig {
    * @beta
    */
   unstable?: {
-    ArrayFunctions?: FormBuilderArrayFunctionComponent
     CustomMarkers?: FormBuilderCustomMarkersComponent
     Markers?: FormBuilderMarkersComponent
   }
@@ -355,7 +354,6 @@ export interface Source {
      * @beta
      */
     unstable?: {
-      ArrayFunctions?: FormBuilderArrayFunctionComponent
       CustomMarkers?: FormBuilderCustomMarkersComponent
       Markers?: FormBuilderMarkersComponent
     }

--- a/packages/sanity/src/core/form/FormBuilderContext.ts
+++ b/packages/sanity/src/core/form/FormBuilderContext.ts
@@ -23,7 +23,6 @@ export interface FormBuilderContextValue {
    */
   __internal: {
     components: {
-      ArrayFunctions: FormBuilderArrayFunctionComponent
       CustomMarkers: FormBuilderCustomMarkersComponent
       Markers: FormBuilderMarkersComponent
     }

--- a/packages/sanity/src/core/form/FormBuilderProvider.tsx
+++ b/packages/sanity/src/core/form/FormBuilderProvider.tsx
@@ -14,7 +14,7 @@ import {
   RenderPreviewCallback,
 } from './types'
 import {FormFieldGroup, ObjectMember, StateTree} from './store'
-import {DefaultArrayInputFunctions} from './inputs/arrays/common/ArrayFunctions'
+import {DefaultArrayFunctions} from './inputs/arrays/ArrayOfObjectsInput/DefaultArrayFunctions'
 import {DefaultMarkers} from './inputs/PortableText/_legacyDefaultParts/Markers'
 import {DefaultCustomMarkers} from './inputs/PortableText/_legacyDefaultParts/CustomMarkers'
 import {PatchChannel, PatchEvent} from './patch'
@@ -115,7 +115,7 @@ export function FormBuilderProvider(props: FormBuilderProviderProps) {
     () => ({
       patchChannel, // eslint-disable-line camelcase
       components: {
-        ArrayFunctions: unstable?.ArrayFunctions || DefaultArrayInputFunctions,
+        ArrayFunctions: DefaultArrayFunctions,
         CustomMarkers: unstable?.CustomMarkers || DefaultCustomMarkers,
         Markers: unstable?.Markers || DefaultMarkers,
       },

--- a/packages/sanity/src/core/form/FormBuilderProvider.tsx
+++ b/packages/sanity/src/core/form/FormBuilderProvider.tsx
@@ -14,7 +14,7 @@ import {
   RenderPreviewCallback,
 } from './types'
 import {FormFieldGroup, ObjectMember, StateTree} from './store'
-import {DefaultArrayFunctions} from './inputs/arrays/ArrayOfObjectsInput/DefaultArrayFunctions'
+import {ArrayOfObjectsFunctions} from './inputs/arrays/ArrayOfObjectsInput/ArrayOfObjectsFunctions'
 import {DefaultMarkers} from './inputs/PortableText/_legacyDefaultParts/Markers'
 import {DefaultCustomMarkers} from './inputs/PortableText/_legacyDefaultParts/CustomMarkers'
 import {PatchChannel, PatchEvent} from './patch'
@@ -115,7 +115,7 @@ export function FormBuilderProvider(props: FormBuilderProviderProps) {
     () => ({
       patchChannel, // eslint-disable-line camelcase
       components: {
-        ArrayFunctions: DefaultArrayFunctions,
+        ArrayFunctions: ArrayOfObjectsFunctions,
         CustomMarkers: unstable?.CustomMarkers || DefaultCustomMarkers,
         Markers: unstable?.Markers || DefaultMarkers,
       },

--- a/packages/sanity/src/core/form/inputs/TagsArrayInput.tsx
+++ b/packages/sanity/src/core/form/inputs/TagsArrayInput.tsx
@@ -3,7 +3,7 @@ import {set, unset} from '../patch'
 import {TagInput} from '../components/tagInput'
 import {ArrayOfPrimitivesInputProps} from '../types'
 
-export type TagsArrayInputProps = ArrayOfPrimitivesInputProps<string[]>
+export type TagsArrayInputProps = ArrayOfPrimitivesInputProps<string>
 
 export function TagsArrayInput(props: TagsArrayInputProps) {
   const {onChange, readOnly, value = [], elementProps} = props

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/ArrayOfObjectsFunctions.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/ArrayOfObjectsFunctions.tsx
@@ -1,19 +1,30 @@
-/* eslint-disable react/no-unused-prop-types */
-
 import {ArraySchemaType, isReferenceSchemaType} from '@sanity/types'
 import {AddIcon} from '@sanity/icons'
-import React, {useMemo, useId} from 'react'
-import {Box, Button, Grid, Menu, MenuButton, MenuItem, Tooltip, Text} from '@sanity/ui'
-import {FormArrayInputFunctionsProps, ObjectItem} from '../../../types'
+import React, {useId, useCallback} from 'react'
+import {
+  Box,
+  Button,
+  Grid,
+  Menu,
+  MenuButton,
+  MenuItem,
+  Tooltip,
+  Text,
+  MenuButtonProps,
+} from '@sanity/ui'
+import {ArrayInputFunctionsProps, ObjectItem} from '../../../types'
 
-export function DefaultArrayInputFunctions<
-  SchemaType extends ArraySchemaType,
-  Item extends ObjectItem
->(props: FormArrayInputFunctionsProps<SchemaType, Item>) {
-  const {type, readOnly, children, onValueCreate, onItemAppend} = props
+const POPOVER_PROPS: MenuButtonProps['popover'] = {constrainSize: true, portal: true}
+
+/** @beta */
+export function ArrayOfObjectsFunctions<
+  Item extends ObjectItem,
+  SchemaType extends ArraySchemaType
+>(props: ArrayInputFunctionsProps<Item, SchemaType>) {
+  const {schemaType, readOnly, children, onValueCreate, onItemAppend} = props
   const menuButtonId = useId()
 
-  const insertItem = React.useCallback(
+  const insertItem = useCallback(
     (itemType: any) => {
       const item = onValueCreate(itemType)
 
@@ -23,10 +34,8 @@ export function DefaultArrayInputFunctions<
   )
 
   const handleAddBtnClick = React.useCallback(() => {
-    insertItem(type.of[0])
-  }, [type, insertItem])
-
-  const popoverProps = useMemo(() => ({constrainSize: true, portal: true}), [])
+    insertItem(schemaType.of[0])
+  }, [schemaType, insertItem])
 
   if (readOnly) {
     return (
@@ -45,7 +54,7 @@ export function DefaultArrayInputFunctions<
             icon={AddIcon}
             mode="ghost"
             disabled
-            text={type.of.length === 1 ? 'Add item' : 'Add item...'}
+            text={schemaType.of.length === 1 ? 'Add item' : 'Add item...'}
           />
         </Grid>
       </Tooltip>
@@ -54,7 +63,7 @@ export function DefaultArrayInputFunctions<
 
   return (
     <Grid gap={1} style={{gridTemplateColumns: 'repeat(auto-fit, minmax(100px, 1fr))'}}>
-      {type.of.length === 1 ? (
+      {schemaType.of.length === 1 ? (
         <Button icon={AddIcon} mode="ghost" onClick={handleAddBtnClick} text="Add item" />
       ) : (
         <MenuButton
@@ -62,8 +71,8 @@ export function DefaultArrayInputFunctions<
           id={menuButtonId || ''}
           menu={
             <Menu>
-              {type.of.map((memberDef, i) => {
-                // Use reference icon if reference is to one type only
+              {schemaType.of.map((memberDef, i) => {
+                // Use reference icon if reference is to one schemaType only
                 const referenceIcon =
                   isReferenceSchemaType(memberDef) &&
                   (memberDef.to || []).length === 1 &&
@@ -81,7 +90,7 @@ export function DefaultArrayInputFunctions<
               })}
             </Menu>
           }
-          popover={popoverProps}
+          popover={POPOVER_PROPS}
         />
       )}
 
@@ -89,5 +98,3 @@ export function DefaultArrayInputFunctions<
     </Grid>
   )
 }
-
-DefaultArrayInputFunctions.__SANITY_INTERNAL_IMPLEMENTATION = true

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridArrayInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridArrayInput.tsx
@@ -3,10 +3,10 @@ import {Card, Stack, Text} from '@sanity/ui'
 import React, {useCallback} from 'react'
 import {Item, List} from '../../common/list'
 import {ArrayOfObjectsInputProps, ObjectItem, ObjectItemProps} from '../../../../types'
-import {DefaultArrayInputFunctions} from '../../common/ArrayFunctions'
 import {ArrayOfObjectsItem} from '../../../../members'
 import {createProtoArrayValue} from '../createProtoArrayValue'
 import {UploadTargetCard} from '../../common/UploadTargetCard'
+import {DefaultArrayFunctions} from '../DefaultArrayFunctions'
 import {GridItem} from './GridItem'
 import {ErrorItem} from './ErrorItem'
 
@@ -27,6 +27,7 @@ export function GridArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
     renderPreview,
     renderField,
     renderInput,
+    arrayFunctions: ArrayFunctions = DefaultArrayFunctions,
   } = props
 
   const handlePrepend = useCallback(
@@ -99,14 +100,14 @@ export function GridArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
         </Stack>
       </UploadTargetCard>
 
-      <DefaultArrayInputFunctions
-        type={schemaType}
-        value={value}
-        readOnly={readOnly}
+      <ArrayFunctions
+        onChange={onChange}
         onItemAppend={handleAppend}
         onItemPrepend={handlePrepend}
         onValueCreate={createProtoArrayValue}
-        onChange={onChange}
+        readOnly={readOnly}
+        schemaType={schemaType}
+        value={value}
       />
     </Stack>
   )

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridArrayInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridArrayInput.tsx
@@ -6,7 +6,7 @@ import {ArrayOfObjectsInputProps, ObjectItem, ObjectItemProps} from '../../../..
 import {ArrayOfObjectsItem} from '../../../../members'
 import {createProtoArrayValue} from '../createProtoArrayValue'
 import {UploadTargetCard} from '../../common/UploadTargetCard'
-import {DefaultArrayFunctions} from '../DefaultArrayFunctions'
+import {ArrayOfObjectsFunctions} from '../ArrayOfObjectsFunctions'
 import {GridItem} from './GridItem'
 import {ErrorItem} from './ErrorItem'
 
@@ -27,7 +27,7 @@ export function GridArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
     renderPreview,
     renderField,
     renderInput,
-    arrayFunctions: ArrayFunctions = DefaultArrayFunctions,
+    arrayFunctions: ArrayFunctions = ArrayOfObjectsFunctions,
   } = props
 
   const handlePrepend = useCallback(

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.tsx
@@ -3,11 +3,11 @@ import {Card, Stack, Text} from '@sanity/ui'
 import React, {useCallback} from 'react'
 import {Item, List} from '../../common/list'
 import {ArrayOfObjectsInputProps, ObjectItem} from '../../../../types'
-import {DefaultArrayInputFunctions} from '../../common/ArrayFunctions'
 import {ArrayOfObjectsItem} from '../../../../members'
 
 import {createProtoArrayValue} from '../createProtoArrayValue'
 import {UploadTargetCard} from '../../common/UploadTargetCard'
+import {DefaultArrayFunctions} from '../DefaultArrayFunctions'
 import {ErrorItem} from './ErrorItem'
 
 const EMPTY: [] = []
@@ -28,6 +28,7 @@ export function ListArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
     renderField,
     renderItem,
     renderInput,
+    arrayFunctions: ArrayFunctions = DefaultArrayFunctions,
   } = props
 
   const handlePrepend = useCallback(
@@ -85,14 +86,14 @@ export function ListArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
         </Stack>
       </UploadTargetCard>
 
-      <DefaultArrayInputFunctions
-        type={schemaType}
-        value={value}
-        readOnly={readOnly}
+      <ArrayFunctions
+        onChange={onChange}
         onItemAppend={handleAppend}
         onItemPrepend={handlePrepend}
         onValueCreate={createProtoArrayValue}
-        onChange={onChange}
+        readOnly={readOnly}
+        schemaType={schemaType}
+        value={value}
       />
     </Stack>
   )

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.tsx
@@ -7,7 +7,7 @@ import {ArrayOfObjectsItem} from '../../../../members'
 
 import {createProtoArrayValue} from '../createProtoArrayValue'
 import {UploadTargetCard} from '../../common/UploadTargetCard'
-import {DefaultArrayFunctions} from '../DefaultArrayFunctions'
+import {ArrayOfObjectsFunctions} from '../ArrayOfObjectsFunctions'
 import {ErrorItem} from './ErrorItem'
 
 const EMPTY: [] = []
@@ -28,7 +28,7 @@ export function ListArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
     renderField,
     renderItem,
     renderInput,
-    arrayFunctions: ArrayFunctions = DefaultArrayFunctions,
+    arrayFunctions: ArrayFunctions = ArrayOfObjectsFunctions,
   } = props
 
   const handlePrepend = useCallback(

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesFunctions.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesFunctions.tsx
@@ -1,16 +1,16 @@
 /* eslint-disable react/no-unused-prop-types */
-
 import {ArraySchemaType, isReferenceSchemaType} from '@sanity/types'
 import {AddIcon} from '@sanity/icons'
 import React, {useMemo, useId} from 'react'
 import {Box, Button, Grid, Menu, MenuButton, MenuItem, Tooltip, Text} from '@sanity/ui'
-import {FormArrayInputFunctionsProps} from '../../../types'
+import {ArrayInputFunctionsProps} from '../../../types'
 
+/** @beta */
 export function ArrayOfPrimitivesFunctions<
-  SchemaType extends ArraySchemaType,
-  MemberType extends string | boolean | number
->(props: FormArrayInputFunctionsProps<SchemaType, MemberType>) {
-  const {type, readOnly, children, onValueCreate, onItemAppend} = props
+  MemberType extends string | boolean | number,
+  SchemaType extends ArraySchemaType
+>(props: ArrayInputFunctionsProps<MemberType, SchemaType>) {
+  const {schemaType, readOnly, children, onValueCreate, onItemAppend} = props
   const menuButtonId = useId()
 
   const insertItem = React.useCallback(
@@ -21,8 +21,8 @@ export function ArrayOfPrimitivesFunctions<
   )
 
   const handleAddBtnClick = React.useCallback(() => {
-    insertItem(type.of[0])
-  }, [type, insertItem])
+    insertItem(schemaType.of[0])
+  }, [schemaType, insertItem])
 
   const popoverProps = useMemo(() => ({constrainSize: true, portal: true}), [])
 
@@ -43,7 +43,7 @@ export function ArrayOfPrimitivesFunctions<
             icon={AddIcon}
             mode="ghost"
             disabled
-            text={type.of.length === 1 ? 'Add item' : 'Add item...'}
+            text={schemaType.of.length === 1 ? 'Add item' : 'Add item...'}
           />
         </Grid>
       </Tooltip>
@@ -52,7 +52,7 @@ export function ArrayOfPrimitivesFunctions<
 
   return (
     <Grid gap={1} style={{gridTemplateColumns: 'repeat(auto-fit, minmax(100px, 1fr))'}}>
-      {type.of.length === 1 ? (
+      {schemaType.of.length === 1 ? (
         <Button icon={AddIcon} mode="ghost" onClick={handleAddBtnClick} text="Add item" />
       ) : (
         <MenuButton
@@ -60,8 +60,8 @@ export function ArrayOfPrimitivesFunctions<
           id={menuButtonId || ''}
           menu={
             <Menu>
-              {type.of.map((memberDef, i) => {
-                // Use reference icon if reference is to one type only
+              {schemaType.of.map((memberDef, i) => {
+                // Use reference icon if reference is to one schemaType only
                 const referenceIcon =
                   isReferenceSchemaType(memberDef) &&
                   (memberDef.to || []).length === 1 &&
@@ -87,5 +87,3 @@ export function ArrayOfPrimitivesFunctions<
     </Grid>
   )
 }
-
-ArrayOfPrimitivesFunctions.__SANITY_INTERNAL_IMPLEMENTATION = true

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
 import {get} from 'lodash'
-import {ArraySchemaType} from '@sanity/types'
 import {Card, Stack, Text} from '@sanity/ui'
-import {ArrayOfPrimitivesInputProps, FormArrayInputFunctionsProps} from '../../../types'
+import {ArrayOfPrimitivesInputProps} from '../../../types'
 import {Item, List} from '../common/list'
 import {PrimitiveItemProps} from '../../../types/itemProps'
 import {ArrayOfPrimitivesItem} from '../../../members'
@@ -13,7 +12,7 @@ import {getEmptyValue} from './getEmptyValue'
 import {PrimitiveValue} from './types'
 import {nearestIndexOf} from './utils/nearestIndex'
 import {ItemRow} from './ItemRow'
-import {ArrayOfPrimitivesFunctions} from './ArrayOfPrimitivesFunctions'
+import {DefaultArrayOfPrimitivesFunctions} from './DefaultArrayOfPrimitivesFunctions'
 
 // Note: this should be a class component until React provides support for a hook version of getSnapshotBeforeUpdate
 /** @public */
@@ -147,12 +146,11 @@ export class ArrayOfPrimitivesInput extends React.PureComponent<ArrayOfPrimitive
       schemaType,
       members,
       readOnly,
-      value,
-      onChange,
       renderInput,
       onUpload,
       resolveUploader,
       elementProps,
+      arrayFunctions: ArrayFunctions = DefaultArrayOfPrimitivesFunctions,
     } = this.props
 
     const isSortable = !readOnly && get(schemaType, 'options.sortable') !== false
@@ -198,14 +196,14 @@ export class ArrayOfPrimitivesInput extends React.PureComponent<ArrayOfPrimitive
           </Stack>
         </UploadTargetCard>
 
-        <ArrayOfPrimitivesFunctions
-          type={schemaType}
-          value={value}
-          readOnly={readOnly}
+        <ArrayFunctions
+          onChange={this.props.onChange}
           onItemAppend={this.handleAppend}
           onItemPrepend={this.handlePrepend}
           onValueCreate={getEmptyValue}
-          onChange={onChange}
+          readOnly={this.props.readOnly}
+          schemaType={this.props.schemaType}
+          value={this.props.value}
         />
       </Stack>
     )

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
@@ -12,7 +12,7 @@ import {getEmptyValue} from './getEmptyValue'
 import {PrimitiveValue} from './types'
 import {nearestIndexOf} from './utils/nearestIndex'
 import {ItemRow} from './ItemRow'
-import {DefaultArrayOfPrimitivesFunctions} from './DefaultArrayOfPrimitivesFunctions'
+import {ArrayOfPrimitivesFunctions} from './ArrayOfPrimitivesFunctions'
 
 // Note: this should be a class component until React provides support for a hook version of getSnapshotBeforeUpdate
 /** @public */
@@ -150,7 +150,7 @@ export class ArrayOfPrimitivesInput extends React.PureComponent<ArrayOfPrimitive
       onUpload,
       resolveUploader,
       elementProps,
-      arrayFunctions: ArrayFunctions = DefaultArrayOfPrimitivesFunctions,
+      arrayFunctions: ArrayFunctions = ArrayOfPrimitivesFunctions,
     } = this.props
 
     const isSortable = !readOnly && get(schemaType, 'options.sortable') !== false

--- a/packages/sanity/src/core/form/inputs/index.ts
+++ b/packages/sanity/src/core/form/inputs/index.ts
@@ -7,3 +7,6 @@ export * from './files/types'
 export * from './ObjectInput'
 export * from './PortableText/PortableTextInput'
 export {PortableTextInput as BlockEditor} from './PortableText/PortableTextInput'
+
+export {ArrayOfPrimitivesFunctions} from './arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesFunctions'
+export {ArrayOfObjectsFunctions} from './arrays/ArrayOfObjectsInput/ArrayOfObjectsFunctions'

--- a/packages/sanity/src/core/form/types/_transitional.ts
+++ b/packages/sanity/src/core/form/types/_transitional.ts
@@ -34,7 +34,7 @@ export interface PortableTextMarker {
  * @beta
  */
 export type FormBuilderArrayFunctionComponent = React.ComponentType<
-  FormArrayInputFunctionsProps<any, any>
+  ArrayInputFunctionsProps<unknown, ArraySchemaType>
 >
 
 /**
@@ -69,15 +69,14 @@ export type FormBuilderInputComponentMap = Record<
  *
  * @beta
  */
-export interface FormArrayInputFunctionsProps<SchemaType extends ArraySchemaType, Item> {
+export interface ArrayInputFunctionsProps<Item, SchemaType extends ArraySchemaType> {
   children?: React.ReactNode
-  className?: string
   onItemAppend: (itemValue: Item) => void
   onChange: (event: PatchEvent) => void
   onValueCreate: (type: SchemaType) => Item
   onItemPrepend: (itemValue: Item) => void
   readOnly?: boolean
-  type: SchemaType
+  schemaType: SchemaType
   value?: Item[]
 }
 

--- a/packages/sanity/src/core/form/types/inputProps.ts
+++ b/packages/sanity/src/core/form/types/inputProps.ts
@@ -13,7 +13,7 @@ import {
   SlugValue,
   StringSchemaType,
 } from '@sanity/types'
-import React, {FocusEventHandler, FormEventHandler} from 'react'
+import React, {ComponentType, FocusEventHandler, FormEventHandler} from 'react'
 import {FormPatch, PatchEvent} from '../patch'
 import {
   ArrayOfObjectsFormNode,
@@ -34,6 +34,7 @@ import {
   RenderPreviewCallback,
 } from './renderCallback'
 import {ArrayInputInsertEvent, ArrayInputMoveItemEvent, UploadEvent} from './event'
+import {ArrayInputFunctionsProps} from './_transitional'
 
 /** @beta */
 export interface BaseInputProps {
@@ -98,6 +99,9 @@ export interface ArrayOfObjectsInputProps<
   S extends ArraySchemaType = ArraySchemaType
 > extends BaseInputProps,
     ArrayOfObjectsFormNode<T[], S> {
+  /** @beta */
+  arrayFunctions?: ComponentType<ArrayInputFunctionsProps<T, S>>
+
   /** @beta */
   // Data manipulation callbacks special for array inputs
   onChange: (patch: FormPatch | FormPatch[] | PatchEvent) => void
@@ -177,10 +181,13 @@ export type ArrayOfPrimitivesElementType<T extends any[]> = T extends (infer K)[
 
 /** @beta */
 export interface ArrayOfPrimitivesInputProps<
-  T extends (string | boolean | number)[] = (string | boolean | number)[],
+  T extends string | boolean | number = string | boolean | number,
   S extends ArraySchemaType = ArraySchemaType
 > extends BaseInputProps,
-    ArrayOfPrimitivesFormNode<T, S> {
+    ArrayOfPrimitivesFormNode<T[], S> {
+  /** @beta */
+  arrayFunctions?: ComponentType<ArrayInputFunctionsProps<T, S>>
+
   // note: not a priority to support collapsible arrays right now
   onSetCollapsed: (collapsed: boolean) => void
 
@@ -188,10 +195,10 @@ export interface ArrayOfPrimitivesInputProps<
   onChange: (patch: FormPatch | FormPatch[] | PatchEvent) => void
 
   /** @beta */
-  onItemAppend: (item: ArrayOfPrimitivesElementType<T>) => void
+  onItemAppend: (item: ArrayOfPrimitivesElementType<T[]>) => void
 
   /** @beta */
-  onItemPrepend: (item: ArrayOfPrimitivesElementType<T>) => void
+  onItemPrepend: (item: ArrayOfPrimitivesElementType<T[]>) => void
 
   /** @beta */
   onItemRemove: (index: number) => void
@@ -200,7 +207,7 @@ export interface ArrayOfPrimitivesInputProps<
   onMoveItem: (event: ArrayInputMoveItemEvent) => void
 
   /** @beta */
-  onInsert: (event: {items: T; position: 'before' | 'after'; referenceIndex: number}) => void
+  onInsert: (event: {items: T[]; position: 'before' | 'after'; referenceIndex: number}) => void
 
   /** @beta */
   resolveUploader: UploaderResolver<NumberSchemaType | BooleanSchemaType | StringSchemaType>


### PR DESCRIPTION
### Description

This pull request makes it possible to configure custom array functions with an `arrayFunctions` prop. The component passed to `arrayFunctions` receives all the necessary props required to implement array functions.

Config example:
```tsx
import {createConfig, isArrayOfPrimitivesInputProps} from 'sanity'

export default createConfig({
  ...,
  
  form: {
    components: {
      input: (props) => {
        const {renderDefault}  = props

        if (isArrayOfPrimitivesInputProps(props)) {
          return renderDefault({...props, arrayFunctions: MyArrayFunctions})
        }

        return renderDefault(props)
      },
    },
  },
})
```

Schema example:
```tsx
import {ArrayOfPrimitivesInputProps} from 'sanity'

function CustomArrayInput(props: ArrayOfPrimitivesInputProps) {
  return props.renderDefault({...props, arrayFunctions: MyArrayFunctions})
}

const myDocument = {
  ...,
  
  fields: [
    {
      type: 'array',
      name: 'myArray',
      components: {
        input: CustomArrayInput,
      },
      of: [...],
    },
  ],
}
```

### Naming upates and exports
This PR exports `ArrayOfObjectsFunctions` (earlier `DefaultArrayFunctions`) and `ArrayOfPrimitivesFunctions` (earlier `DefaultArrayOfPrimitivesFunctions`) components. These exports makes it possible to render the default array function along with other customizations. 

```tsx
import {ArrayOfPrimitivesInputProps, ArraySchemaType, ArrayInputFunctionsProps} from 'sanity'

function ArrayFunctions(props: ArrayInputFunctionsProps<string | number | boolean, ArraySchemaType>) {
  const handleAdd = useCallback(() => {
    props.onItemAppend('Hello!')
  }, [props])

  return (
    <Grid columns={1} gap={2}>
      <Button text="Custom array function" onClick={handleAdd} /> {/** Custom */}

      <ArrayOfPrimitivesFunctions {...props} /> {/** Default primitives array function */}
    </Grid>
  )
}

function CustomArrayInput(props: ArrayOfPrimitivesInputProps) {
  return props.renderDefault({...props, arrayFunctions: ArrayFunctions})
}


const myDocument = {
  ...,
  
  fields: [
    {
      type: 'array',
      name: 'myArray',
      components: {
        input: CustomArrayInput,
      },
      of: [...],
    },
  ],
}
```

See summary below of name updates that this PR introduces:

**Renamed components**
`DefaultArrayOfPrimitivesFunctions` -> `ArrayOfPrimitivesFunctions`
 `DefaultArrayFunctions` -> `ArrayOfObjectsFunctions`

**Renamed types**
`FormArrayInputFunctionsProps` -> `ArrayInputFunctionsProps`

These name changes are made to unify the names of these components/types.

### What to review
- Test to configure custom array functions for an array of primitives, objects and with a grid layout. 

### Notes for release

feat(form): implement custom array functions
