### PR TITLE
fix(server): configure `cacheDir` to avoid cache conflicts

### DIFF
--- a/packages/@sanity/server/src/getViteConfig.ts
+++ b/packages/@sanity/server/src/getViteConfig.ts
@@ -70,6 +70,9 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
   const staticPath = `${basePath}static`
 
   const viteConfig: InlineConfig = {
+    // Define a custom cache directory so that sanity's vite cache
+    // does not conflict with any potential local vite projects
+    cacheDir: 'node_modules/.sanity/vite',
     root: cwd,
     base: basePath,
     build: {


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Set `viteConfig.cacheDir` to a location that is different from Vite's default location: `node_modules/.vite`. This makes sure that there will not be Vite cache conflicts if you happen to use Vite for something else than `sanity` in your project.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

- Remove any `node_modules/.vite` directories.
- Run `sanity dev` & `sanity build` and make sure the cache is stored in `node_modules/.sanity/vite`.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

- Fix an issue where Vite cache could be overwritten/corrupted.