### PR TITLE
refactor: rename `createConfig` to `defineConfig`

### DIFF
--- a/cypress/integration/config/studioComponentsApi.test.js
+++ b/cypress/integration/config/studioComponentsApi.test.js
@@ -3,7 +3,7 @@ describe('Config: studio components', () => {
     cy.visit('custom-components/content')
   })
 
-  describe('createConfig', () => {
+  describe('defineConfig', () => {
     it('default layout is displayed inside renderLayout component', () => {
       cy.get('[data-testid="test-layout-config"]')
         .find('[data-testid="studio-layout"]')
@@ -31,21 +31,21 @@ describe('Config: studio components', () => {
   })
 
   describe('createPlugin', () => {
-    it('custom layout in createConfig is displayed inside renderLayout component', () => {
+    it('custom layout in defineConfig is displayed inside renderLayout component', () => {
       cy.get('[data-testid="test-layout-plugin"]')
         .find('[data-testid="test-layout-config"]')
         .find('[data-testid="studio-layout"]')
         .should('be.visible')
     })
 
-    it('custom navbar in createConfig is displayed inside renderNavbar component', () => {
+    it('custom navbar in defineConfig is displayed inside renderNavbar component', () => {
       cy.get('[data-testid="test-navbar-plugin"]')
         .find('[data-testid="test-navbar-config"]')
         .find('[data-testid="navbar"]')
         .should('be.visible')
     })
 
-    it('custom tool menu in createConfig is displayed inside renderToolMenu component', () => {
+    it('custom tool menu in defineConfig is displayed inside renderToolMenu component', () => {
       cy.get('[data-testid="test-tool-menu-plugin"]')
         .find('[data-testid="test-tool-menu-config"]')
         .find('[data-testid="tool-collapse-menu"]')

--- a/dev/design-studio/sanity.config.ts
+++ b/dev/design-studio/sanity.config.ts
@@ -1,11 +1,11 @@
-import {createConfig} from 'sanity'
+import {defineConfig} from 'sanity'
 import {deskTool} from 'sanity/desk'
 import {templates} from './templates'
 import {themePreviewTool} from './plugins/theme-preview-tool'
 import {schemaTypes} from './schemaTypes'
 import {structure} from './structure'
 
-export default createConfig({
+export default defineConfig({
   plugins: [
     deskTool({structure}),
     themePreviewTool(),

--- a/dev/starter-cra-studio/src/Studio.js
+++ b/dev/starter-cra-studio/src/Studio.js
@@ -1,10 +1,10 @@
 /* eslint-disable react/jsx-filename-extension */
 /* eslint-disable react/react-in-jsx-scope */
 
-import {createConfig, Studio} from 'sanity'
+import {defineConfig, Studio} from 'sanity'
 import {deskTool} from 'sanity/desk'
 
-const config = createConfig({
+const config = defineConfig({
   plugins: [deskTool()],
   name: 'default',
   projectId: 'ppsg7ml5',

--- a/dev/starter-next-studio/components/Studio.tsx
+++ b/dev/starter-next-studio/components/Studio.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/react-in-jsx-scope */
 
 import {useMemo} from 'react'
-import {createConfig, Studio} from 'sanity'
+import {defineConfig, Studio} from 'sanity'
 import {deskTool} from 'sanity/desk'
 
 const wrapperStyles = {height: '100vh', width: '100vw'}
@@ -9,7 +9,7 @@ const wrapperStyles = {height: '100vh', width: '100vw'}
 export default function StudioRoot({basePath}: {basePath: string}) {
   const config = useMemo(
     () =>
-      createConfig({
+      defineConfig({
         basePath,
         plugins: [deskTool()],
         title: 'Next.js Starter',

--- a/dev/starter-studio/sanity.cli.ts
+++ b/dev/starter-studio/sanity.cli.ts
@@ -1,6 +1,6 @@
-import {createCliConfig} from 'sanity/cli'
+import {defineCliConfig} from 'sanity/cli'
 
-export default createCliConfig({
+export default defineCliConfig({
   api: {
     projectId: 'ppsg7ml5',
     dataset: 'test',

--- a/dev/starter-studio/sanity.config.ts
+++ b/dev/starter-studio/sanity.config.ts
@@ -1,7 +1,7 @@
-import {createConfig} from 'sanity'
+import {defineConfig} from 'sanity'
 import {deskTool} from 'sanity/desk'
 
-export default createConfig({
+export default defineConfig({
   dataset: 'test',
   plugins: [deskTool()],
   name: 'default',

--- a/dev/strict-studio/sanity.config.ts
+++ b/dev/strict-studio/sanity.config.ts
@@ -1,8 +1,8 @@
-import {createConfig} from 'sanity'
+import {defineConfig} from 'sanity'
 import {deskTool} from 'sanity/desk'
 import {schemaTypes} from './schema'
 
-export default createConfig({
+export default defineConfig({
   plugins: [deskTool()],
   title: 'Strict',
   name: 'default',

--- a/dev/test-studio/components/studioComponents.tsx
+++ b/dev/test-studio/components/studioComponents.tsx
@@ -1,8 +1,8 @@
 import React, {createContext, useContext} from 'react'
 import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
-import {LogoProps, NavbarProps, LayoutProps, createPlugin, ToolMenuProps} from 'sanity'
+import {LogoProps, NavbarProps, LayoutProps, definePlugin, ToolMenuProps} from 'sanity'
 
-export const studioComponentsPlugin = createPlugin({
+export const studioComponentsPlugin = definePlugin({
   name: 'studio-components-plugin',
   studio: {
     components: {
@@ -51,7 +51,7 @@ export function CustomNavbar(props: NavbarProps) {
         <Flex align="center" gap={4}>
           <Text weight="semibold" size={1}>
             This banner is rendered with <code>{`components.navbar`}</code> in{' '}
-            <code>{`createConfig`}</code>
+            <code>{`defineConfig`}</code>
           </Text>
         </Flex>
       </Card>

--- a/dev/test-studio/sanity.cli.ts
+++ b/dev/test-studio/sanity.cli.ts
@@ -1,8 +1,8 @@
 import path from 'path'
-import {createCliConfig} from 'sanity/cli'
+import {defineCliConfig} from 'sanity/cli'
 import {UserConfig} from 'vite'
 
-export default createCliConfig({
+export default defineCliConfig({
   api: {
     projectId: 'ppsg7ml5',
     dataset: 'test',

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -1,6 +1,6 @@
 import {BookIcon} from '@sanity/icons'
 import {visionTool} from '@sanity/vision'
-import {createConfig, createPlugin} from 'sanity'
+import {defineConfig, definePlugin} from 'sanity'
 import {deskTool} from 'sanity/desk'
 import {muxInput} from 'sanity-plugin-mux-input'
 import {imageAssetSource} from './assetSources'
@@ -23,7 +23,7 @@ import {googleTheme} from './themes/google'
 import {vercelTheme} from './themes/vercel'
 import {theme as tailwindTheme} from 'https://themer.sanity.build/api/hues?preset=tw-cyan&default=64748b&primary=d946ef;lightest:fdf4ff;darkest:701a75&transparent=6b7180;darkest:111826&positive=43d675;400;lightest:f8fafc&caution=f59e09;300;lightest:fffbeb;darkest:783510&critical=f43f5e;lightest:fef1f2;darkest:881337&lightest=ffffff&darkest=0f172a'
 
-const sharedSettings = createPlugin({
+const sharedSettings = definePlugin({
   name: 'sharedSettings',
   schema: {
     types: schemaTypes,
@@ -74,7 +74,7 @@ const sharedSettings = createPlugin({
   ],
 })
 
-export default createConfig([
+export default defineConfig([
   {
     name: 'default',
     title: 'Test Studio',

--- a/examples/blog-studio/sanity.config.ts
+++ b/examples/blog-studio/sanity.config.ts
@@ -1,8 +1,8 @@
-import {createConfig} from 'sanity'
+import {defineConfig} from 'sanity'
 import {deskTool} from 'sanity/desk'
 import {schemaTypes} from '../../packages/@sanity/cli/templates/blog/schemas'
 
-export default createConfig({
+export default defineConfig({
   name: 'default',
   title: 'Blog studio example',
 

--- a/examples/clean-studio/sanity.config.ts
+++ b/examples/clean-studio/sanity.config.ts
@@ -1,8 +1,8 @@
-import {createConfig} from 'sanity'
+import {defineConfig} from 'sanity'
 import {deskTool} from 'sanity/desk'
 import {schemaTypes} from '../../packages/@sanity/cli/templates/clean/schemas'
 
-export default createConfig({
+export default defineConfig({
   name: 'default',
   title: 'Clean studio',
 

--- a/examples/ecommerce-studio/sanity.config.ts
+++ b/examples/ecommerce-studio/sanity.config.ts
@@ -1,9 +1,9 @@
-import {createConfig} from 'sanity'
+import {defineConfig} from 'sanity'
 import {deskTool} from 'sanity/desk'
 import {schemaTypes} from '../../packages/@sanity/cli/templates/ecommerce/schemas'
 import {barcodeInput} from './plugins/barcode-input'
 
-export default createConfig({
+export default defineConfig({
   name: 'default',
   title: 'Sanity E-commerce example studio',
 

--- a/examples/movies-studio/sanity.config.ts
+++ b/examples/movies-studio/sanity.config.ts
@@ -1,11 +1,11 @@
-import {createConfig} from 'sanity'
+import {defineConfig} from 'sanity'
 import {deskTool} from 'sanity/desk'
 import {googleMapsInput} from '@sanity/google-maps-input'
 
 import {schemaTypes} from '../../packages/@sanity/cli/templates/moviedb/schemas'
 import {BrandLogo} from './components/BrandLogo'
 
-export default createConfig({
+export default defineConfig({
   name: 'default',
   title: 'Movies Unlimited',
 

--- a/packages/@sanity/cli/src/actions/init-project/createCliConfig.ts
+++ b/packages/@sanity/cli/src/actions/init-project/createCliConfig.ts
@@ -3,9 +3,9 @@ import * as parser from 'recast/parsers/typescript'
 import traverse from '@babel/traverse'
 
 const defaultTemplate = `
-import {createCliConfig} from 'sanity/cli'
+import {defineCliConfig} from 'sanity/cli'
 
-export default createCliConfig({
+export default defineCliConfig({
   api: {
     projectId: '%projectId%',
     dataset: '%dataset%'

--- a/packages/@sanity/cli/src/actions/init-project/createStudioConfig.ts
+++ b/packages/@sanity/cli/src/actions/init-project/createStudioConfig.ts
@@ -3,11 +3,11 @@ import * as parser from 'recast/parsers/typescript'
 import traverse from '@babel/traverse'
 
 const defaultTemplate = `
-import {createConfig} from 'sanity'
+import {defineConfig} from 'sanity'
 import {deskTool} from 'sanity/desk'
 import {schemaTypes} from './schemas'
 
-export default createConfig({
+export default defineConfig({
   name: '%sourceName%',
   title: '%projectName%',
 

--- a/packages/@sanity/cli/src/actions/init-project/templates/ecommerce.ts
+++ b/packages/@sanity/cli/src/actions/init-project/templates/ecommerce.ts
@@ -1,12 +1,12 @@
 import type {ProjectTemplate} from '../initProject'
 
 const configTemplate = `
-import {createConfig} from 'sanity'
+import {defineConfig} from 'sanity'
 import {deskTool} from 'sanity/desk'
 import {barcodeInput} from './plugins/barcode
 import {schemaTypes} from './schemas'
 
-export default createConfig({
+export default defineConfig({
   name: '%sourceName%',
   title: '%projectName%',
 

--- a/packages/@sanity/cli/src/actions/init-project/templates/get-started.ts
+++ b/packages/@sanity/cli/src/actions/init-project/templates/get-started.ts
@@ -1,12 +1,12 @@
 import type {ProjectTemplate} from '../initProject'
 
 const configTemplate = `
-import {createConfig} from 'sanity'
+import {defineConfig} from 'sanity'
 import {deskTool} from 'sanity/desk'
 import {tutorialLayout} from './plugins/tutorial'
 import {schemaTypes} from './schemas'
 
-export default createConfig({
+export default defineConfig({
   name: '%sourceName%',
   title: '%projectName%',
 

--- a/packages/@sanity/cli/src/actions/init-project/templates/moviedb.ts
+++ b/packages/@sanity/cli/src/actions/init-project/templates/moviedb.ts
@@ -1,12 +1,12 @@
 import type {ProjectTemplate} from '../initProject'
 
 const configTemplate = `
-import {createConfig} from 'sanity'
+import {defineConfig} from 'sanity'
 import {deskTool} from 'sanity/desk'
 //import {googleMapsInput} from '@sanity/google-maps-input'
 import {schemaTypes} from './schemas'
 
-export default createConfig({
+export default defineConfig({
   name: '%sourceName%',
   title: '%projectName%',
 

--- a/packages/@sanity/cli/src/actions/init-project/templates/shopify.ts
+++ b/packages/@sanity/cli/src/actions/init-project/templates/shopify.ts
@@ -4,14 +4,14 @@ import type {ProjectTemplate} from '../initProject'
 // @todo new document structure
 // @todo document actions
 const configTemplate = `
-import {createConfig} from 'sanity'
+import {defineConfig} from 'sanity'
 import {deskTool} from 'sanity/desk'
 import {dashboard} from '@sanity/dashboard'
 import {media} from 'sanity-plugin-media'
 import {structure} from './deskStructure'
 import {schemaTypes} from './schemas'
 
-export default createConfig({
+export default defineConfig({
   plugins: [
     deskTool({structure}),
     media(),

--- a/packages/@sanity/cli/src/config.ts
+++ b/packages/@sanity/cli/src/config.ts
@@ -1,5 +1,14 @@
 import type {CliConfig} from './types'
 
+/** @beta */
+export function defineCliConfig(config: CliConfig): CliConfig {
+  return config
+}
+
+/**
+ * @deprecated Use `defineCliConfig` instead
+ * @beta
+ */
 export function createCliConfig(config: CliConfig): CliConfig {
   return config
 }

--- a/packages/@sanity/cli/src/util/getCliConfig.ts
+++ b/packages/@sanity/cli/src/util/getCliConfig.ts
@@ -145,7 +145,7 @@ function importConfig(filePath: string): CliConfig | null {
 
     return 'default' in config ? config.default : config
   } catch (err) {
-    // If attempting to import `createCliConfig` or similar from `sanity/cli`,
+    // If attempting to import `defineCliConfig` or similar from `sanity/cli`,
     // accept the fact that it might not be installed. Instead, let the CLI
     // give a warning about the `sanity` module not being installed
     if (err.code === 'MODULE_NOT_FOUND' && err.message.includes('sanity/cli')) {

--- a/packages/@sanity/cli/test/__fixtures__/v3/sanity.cli.ts
+++ b/packages/@sanity/cli/test/__fixtures__/v3/sanity.cli.ts
@@ -1,6 +1,6 @@
-import {createCliConfig} from 'sanity/cli'
+import {defineCliConfig} from 'sanity/cli'
 
-export default createCliConfig({
+export default defineCliConfig({
   api: {
     projectId: 'aeysrmym',
     dataset: 'production',

--- a/packages/@sanity/cli/test/__fixtures__/v3/sanity.config.ts
+++ b/packages/@sanity/cli/test/__fixtures__/v3/sanity.config.ts
@@ -1,9 +1,9 @@
-import {createConfig} from 'sanity'
+import {defineConfig} from 'sanity'
 import {deskTool} from 'sanity/desk'
 import {MyLogo} from './components/MyLogo'
 import {schema} from './schema'
 
-export default createConfig({
+export default defineConfig({
   name: 'default', // @todo remove
   projectId: 'aeysrmym',
   dataset: 'production',

--- a/packages/@sanity/vision/README.md
+++ b/packages/@sanity/vision/README.md
@@ -17,10 +17,10 @@ Vision is a plugin for Sanity Studio for testing GROQ queries. It features:
 
 ```ts
 // `sanity.config.ts` / `sanity.config.js`:
-import {createConfig} from 'sanity'
+import {defineConfig} from 'sanity'
 import {visionTool} from '@sanity/vision'
 
-export default createConfig({
+export default defineConfig({
   // ...
   plugins: [
     visionTool({
@@ -38,12 +38,12 @@ If you only want the tool available in development (eg not in deployed studios),
 
 ```ts
 // `sanity.config.ts` / `sanity.config.js`:
-import {createConfig, isDev} from 'sanity'
+import {defineConfig, isDev} from 'sanity'
 import {visionTool} from '@sanity/vision'
 
 const devOnlyPlugins = [visionTool()]
 
-export default createConfig({
+export default defineConfig({
   // ...
   plugins: [
     // ... your other plugins here ...

--- a/packages/sanity/exports/cli.ts
+++ b/packages/sanity/exports/cli.ts
@@ -1,3 +1,3 @@
-export {createCliConfig, getCliClient} from '@sanity/cli'
+export {createCliConfig, defineCliConfig, getCliClient} from '@sanity/cli'
 
 export type {CliClientOptions, CliConfig} from '@sanity/cli'

--- a/packages/sanity/src/core/config/__tests__/createPlugin.test.ts
+++ b/packages/sanity/src/core/config/__tests__/createPlugin.test.ts
@@ -1,4 +1,4 @@
-import {createPlugin} from '../createPlugin'
+import {createPlugin} from '../definePlugin'
 
 describe('createPlugin', () => {
   it.todo('normalizes its input to a function')

--- a/packages/sanity/src/core/config/__tests__/resolveConfigProperty.test.ts
+++ b/packages/sanity/src/core/config/__tests__/resolveConfigProperty.test.ts
@@ -1,5 +1,5 @@
 import {resolveConfigProperty} from '../resolveConfigProperty'
-import {createPlugin} from '../createPlugin'
+import {createPlugin} from '../definePlugin'
 
 describe('resolveConfigProperty', () => {
   it('traverses configs and returns a resolved configuration property', () => {

--- a/packages/sanity/src/core/config/createConfig.ts
+++ b/packages/sanity/src/core/config/createConfig.ts
@@ -1,6 +1,0 @@
-import type {Config} from './types'
-
-/** @beta */
-export function createConfig<T extends Config>(config: T): T {
-  return config
-}

--- a/packages/sanity/src/core/config/defineConfig.ts
+++ b/packages/sanity/src/core/config/defineConfig.ts
@@ -1,0 +1,14 @@
+import type {Config} from './types'
+
+/** @beta */
+export function defineConfig<T extends Config>(config: T): T {
+  return config
+}
+
+/**
+ * @deprecated Use `defineConfig` instead
+ * @beta
+ */
+export function createConfig<T extends Config>(config: T): T {
+  return defineConfig(config)
+}

--- a/packages/sanity/src/core/config/definePlugin.ts
+++ b/packages/sanity/src/core/config/definePlugin.ts
@@ -18,7 +18,7 @@ function validatePlugin(pluginResult: PluginOptions) {
 }
 
 /** @beta */
-export function createPlugin<TOptions = void>(
+export function definePlugin<TOptions = void>(
   arg: PluginFactory<TOptions> | PluginOptions
 ): Plugin<TOptions> {
   if (typeof arg === 'function') {
@@ -36,4 +36,14 @@ export function createPlugin<TOptions = void>(
 
   validatePlugin(arg)
   return () => arg
+}
+
+/**
+ * @deprecated Use `definePlugin` instead
+ * @beta
+ */
+export function createPlugin<TOptions = void>(
+  arg: PluginFactory<TOptions> | PluginOptions
+): Plugin<TOptions> {
+  return definePlugin(arg)
 }

--- a/packages/sanity/src/core/config/document/actions.ts
+++ b/packages/sanity/src/core/config/document/actions.ts
@@ -20,10 +20,10 @@ export interface DocumentActionComponent extends ActionComponent<DocumentActionP
    * with another. E.g.:
    *
    * ```js
-   * import {createConfig} from 'sanity'
+   * import {defineConfig} from 'sanity'
    * import {MyPublishAction} from '...'
    *
-   * export default createConfig({
+   * export default defineConfig({
    *   document: {
    *     actions: (prev) =>
    *       prev.map((previousAction) =>

--- a/packages/sanity/src/core/config/index.ts
+++ b/packages/sanity/src/core/config/index.ts
@@ -1,5 +1,5 @@
-export * from './createConfig'
-export * from './createPlugin'
+export * from './defineConfig'
+export * from './definePlugin'
 export * from './document'
 export * from './types'
 export * from './prepareConfig'

--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -57,7 +57,7 @@ function normalizeIcon(
 }
 
 /**
- * Takes in a config (created from the `createConfig` function) and returns
+ * Takes in a config (created from the `defineConfig` function) and returns
  * an array of `WorkspaceSummary`. Note: this only partially resolves a config.
  *
  * For usage inside the Studio, it's preferred to pull the pre-resolved

--- a/packages/sanity/src/core/form/inputs/PortableText/__workshop__/defaultSchema/Story.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__workshop__/defaultSchema/Story.tsx
@@ -8,7 +8,7 @@ import {createPatchChannel} from '../../../../patch/PatchChannel'
 import {ArrayOfObjectsMember} from '../../../../store'
 import {applyAll} from '../../../../patch/applyPatch'
 import {FormPatch, PatchEvent} from '../../../../patch'
-import {createConfig} from '../../../../../config'
+import {defineConfig} from '../../../../../config'
 import {StudioProvider} from '../../../../../studio'
 import {useSchema} from '../../../../../hooks'
 import {valueOptions, values} from './values'
@@ -19,7 +19,7 @@ const ptType = {
   of: [{type: 'block'}],
 }
 
-const config = createConfig({
+const config = defineConfig({
   name: 'test',
   dataset: 'test',
   projectId: 'test',

--- a/packages/sanity/src/core/form/types/definitionExtensions.test.ts
+++ b/packages/sanity/src/core/form/types/definitionExtensions.test.ts
@@ -11,7 +11,7 @@ import {
   ReferenceValue,
   SlugValue,
 } from '@sanity/types'
-import {createConfig} from '../../config'
+import {defineConfig} from '../../config'
 import {PreviewProps} from '../../components'
 import {
   ArrayOfObjectsInputProps,
@@ -190,7 +190,7 @@ describe('definitionExtensions', () => {
       const components: ArrayOfObjectsComponents | undefined = type.components
 
       // ensure we can assign this to config.schema.types
-      createConfig({
+      defineConfig({
         name: 'test',
         projectId: 'test',
         dataset: 'test',
@@ -237,7 +237,7 @@ describe('definitionExtensions', () => {
       const components: BlockComponents | undefined = type.components
 
       // ensure we can assign this to config.schema.types
-      createConfig({
+      defineConfig({
         name: 'test',
         projectId: 'test',
         dataset: 'test',

--- a/packages/sanity/src/core/store/_legacy/document/hooks/__tests__/useDocumentType.test.tsx
+++ b/packages/sanity/src/core/store/_legacy/document/hooks/__tests__/useDocumentType.test.tsx
@@ -1,14 +1,14 @@
 import type {SanityClient} from '@sanity/client'
-import {act, renderHook, waitFor} from '@testing-library/react'
+import {renderHook, waitFor} from '@testing-library/react'
 import {asyncScheduler, defer, of} from 'rxjs'
 import {delay, observeOn, tap} from 'rxjs/operators'
 import {createMockSanityClient} from '../../../../../../../test/mocks/mockSanityClient'
 import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
-import {createConfig} from '../../../../../config'
+import {defineConfig} from '../../../../../config'
 import {useDocumentType} from '../useDocumentType'
 
 function createWrapperComponent(client: SanityClient) {
-  const config = createConfig({
+  const config = defineConfig({
     projectId: 'foo',
     dataset: 'test',
   })

--- a/packages/sanity/src/core/studio/components/navbar/__workshop__/ChangelogDialogStory.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/__workshop__/ChangelogDialogStory.tsx
@@ -39,7 +39,7 @@ const changelog = [
           {
             _key: '527d1e404b08',
             _type: 'code',
-            code: "import {createConfig} from 'sanity'\nimport {deskTool} from 'sanity/desk'\nimport {schemaTypes} from './schema/schema'\n\nexport default createConfig({\n  name: 'default',\n  title: 'My Cool Project',\n  projectId: 'my-project-id',\n  dataset: 'production',\n  plugins: [\n    deskTool(),\n  ],\n  schema: {\n    types: schemaTypes,\n  },\n})",
+            code: "import {defineConfig} from 'sanity'\nimport {deskTool} from 'sanity/desk'\nimport {schemaTypes} from './schema/schema'\n\nexport default defineConfig({\n  name: 'default',\n  title: 'My Cool Project',\n  projectId: 'my-project-id',\n  dataset: 'production',\n  plugins: [\n    deskTool(),\n  ],\n  schema: {\n    types: schemaTypes,\n  },\n})",
             language: 'javascript',
           },
         ],

--- a/packages/sanity/src/core/studio/components/navbar/__workshop__/NavbarStory.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/__workshop__/NavbarStory.tsx
@@ -10,7 +10,7 @@ import {Card} from '@sanity/ui'
 import {useBoolean, useString} from '@sanity/ui-workshop'
 import React, {createContext, useMemo, useState} from 'react'
 import styled from 'styled-components'
-import {createConfig, Tool} from '../../../../config'
+import {defineConfig, Tool} from '../../../../config'
 import {isNonNullable} from '../../../../util/isNonNullable'
 import {isTruthy} from '../../../../util/isTruthy'
 import {useNavbarComponent} from '../../../studio-components-hooks'
@@ -46,7 +46,7 @@ export default function NavbarStory() {
   const tools = useTools()
   const config = useMemo(
     () =>
-      createConfig({
+      defineConfig({
         // The same id as in the test-studio sanity.config.ts
         projectId: 'ppsg7ml5',
         dataset: 'production',

--- a/packages/sanity/src/core/theme/_legacy/theme.ts
+++ b/packages/sanity/src/core/theme/_legacy/theme.ts
@@ -13,9 +13,9 @@ import {LegacyThemeProps} from './types'
  *
  * @example
  * ```tsx
- * import {buildLegacyTheme, createConfig} from 'sanity'
+ * import {buildLegacyTheme, defineConfig} from 'sanity'
  *
- * export default createConfig({
+ * export default defineConfig({
  *   // project configuration ...
  *
  *   // Customize theming


### PR DESCRIPTION
### Description

To align better with other frameworks and our own methods (`defineType`, `defineField` et all), we want to change from `createConfig` to `defineConfig` (and `defineCliConfig` instead of `createCliConfig`). This PR makes this backwards compatible - we're only deprecating the old `create` methods. Prior to GA release, they will be removed.

### Notes for release

- `createConfig` renamed to `defineConfig`, and `createCliConfig` renamed to `defineCliConfig`
