### PR TITLE
fix(desk-tool): fix: earlier revision not appearing in form

### DIFF
--- a/packages/sanity/src/core/form/store/useFormState.ts
+++ b/packages/sanity/src/core/form/store/useFormState.ts
@@ -32,6 +32,7 @@ export function useFormState<
     openPath,
     presence,
     validation,
+    readOnly,
     changesOpen,
   }: {
     fieldGroupState?: StateTree<string> | undefined
@@ -44,6 +45,7 @@ export function useFormState<
     presence: FormNodePresence[]
     validation: ValidationMarker[]
     changesOpen?: boolean
+    readOnly?: boolean
   }
 ): FormState<T, S> | null {
   // note: feel free to move these state pieces out of this hook
@@ -67,6 +69,7 @@ export function useFormState<
       comparisonValue,
       focusPath,
       openPath,
+      readOnly,
       path: pathFor([]),
       level: 0,
       currentUser,

--- a/packages/sanity/src/desk/panes/document/DocumentPaneContext.ts
+++ b/packages/sanity/src/desk/panes/document/DocumentPaneContext.ts
@@ -14,8 +14,10 @@ import {
   DocumentBadgeComponent,
   DocumentFormNode,
   DocumentLanguageFilterComponent,
+  DocumentPermission,
   EditStateFor,
   PatchEvent,
+  PermissionCheckResult,
   StateTree,
   Timeline,
   TimelineController,
@@ -71,6 +73,8 @@ export interface DocumentPaneContextValue {
   value: SanityDocumentLike
   views: View[]
   formState: DocumentFormNode | null
+  permissions?: PermissionCheckResult | null
+  isPermissionsLoading: boolean
   unstable_languageFilter: DocumentLanguageFilterComponent[]
 }
 

--- a/packages/sanity/src/desk/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/DocumentPanel.tsx
@@ -39,17 +39,17 @@ const Scroller = styled(ScrollContainer)<{$disabled: boolean}>(({$disabled}) => 
 
 export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
   const {footerHeight, isInspectOpen, rootElement} = props
-  const schema = useSchema()
   const {
     activeViewId,
     displayed,
     documentId,
-    documentType,
     editState,
     value,
     views,
     ready,
     schemaType,
+    permissions,
+    isPermissionsLoading,
   } = useDocumentPane()
   const {collapsed: layoutCollapsed} = usePaneLayout()
   const parentPortal = usePortal()
@@ -60,21 +60,6 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
   const [documentScrollElement, setDocumentScrollElement] = useState<HTMLDivElement | null>(null)
 
   const requiredPermission = value._createdAt ? 'update' : 'create'
-  const liveEdit = useMemo(
-    () => Boolean(schema.get(documentType)?.liveEdit),
-    [documentType, schema]
-  )
-  const docId = value._id ? value._id : 'dummy-id'
-  const docPermissionsInput = useMemo(() => {
-    return {
-      ...value,
-      _id: liveEdit ? getPublishedId(docId) : getDraftId(docId),
-    }
-  }, [liveEdit, value, docId])
-  const [permissions, isPermissionsLoading] = useDocumentValuePermissions({
-    document: docPermissionsInput,
-    permission: requiredPermission,
-  })
 
   const activeView = useMemo(
     () => views.find((view) => view.id === activeViewId) || views[0] || {type: 'form'},
@@ -154,7 +139,6 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
                 hidden={formViewHidden}
                 key={documentId + (ready ? '_ready' : '_pending')}
                 margins={margins}
-                granted={Boolean(permissions?.granted)}
               />
               {activeViewNode}
             </Scroller>


### PR DESCRIPTION
This is a cherry pick of https://github.com/sanity-io/sanity/pull/3759 into `v3`, plus a fix for a v3-only issue with forms not becoming `readOnly` based on external factors like "viewing an older revision", or "current user has no access to edit".
