### PR TITLE
feat(core): enable workspace subtitle configuration

### DIFF
--- a/dev/test-studio/components/workspaceLogos.tsx
+++ b/dev/test-studio/components/workspaceLogos.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import {useColorScheme} from 'sanity'
+
+export const VercelLogo = () => {
+  const {scheme} = useColorScheme()
+  const fill = scheme === 'dark' ? '#fff' : '#000'
+
+  return (
+    <svg
+      width="1155"
+      height="1000"
+      viewBox="0 0 1155 1000"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      style={{padding: 4, boxSizing: 'border-box'}}
+    >
+      <path d="M577.344 0L1154.69 1000H0L577.344 0Z" fill={fill} />
+    </svg>
+  )
+}
+
+export const GoogleLogo = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" height="512px" width="512px" viewBox="0 0 512 512">
+    <path fill="#4285f4" d="M386 400c45-42 65-112 53-179H260v74h102c-4 24-18 44-38 57z" />
+    <path fill="#34a853" d="M90 341a192 192 0 0 0 296 59l-62-48c-53 35-141 22-171-60z" />
+    <path fill="#fbbc02" d="M153 292c-8-25-8-48 0-73l-63-49c-23 46-30 111 0 171z" />
+    <path fill="#ea4335" d="M153 219c22-69 116-109 179-50l55-54c-78-75-230-72-297 55z" />
+  </svg>
+)
+
+export const TailwindLogo = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 54 33"
+    style={{padding: 4, boxSizing: 'border-box'}}
+  >
+    <g clipPath="url(#prefix__clip0)">
+      <path
+        fill="#38bdf8"
+        fillRule="evenodd"
+        d="M27 0c-7.2 0-11.7 3.6-13.5 10.8 2.7-3.6 5.85-4.95 9.45-4.05 2.054.513 3.522 2.004 5.147 3.653C30.744 13.09 33.808 16.2 40.5 16.2c7.2 0 11.7-3.6 13.5-10.8-2.7 3.6-5.85 4.95-9.45 4.05-2.054-.513-3.522-2.004-5.147-3.653C36.756 3.11 33.692 0 27 0zM13.5 16.2C6.3 16.2 1.8 19.8 0 27c2.7-3.6 5.85-4.95 9.45-4.05 2.054.514 3.522 2.004 5.147 3.653C17.244 29.29 20.308 32.4 27 32.4c7.2 0 11.7-3.6 13.5-10.8-2.7 3.6-5.85 4.95-9.45 4.05-2.054-.513-3.522-2.004-5.147-3.653C23.256 19.31 20.192 16.2 13.5 16.2z"
+        clipRule="evenodd"
+      />
+    </g>
+    <defs>
+      <clipPath id="prefix__clip0">
+        <path d="M0 0h54v32.4H0z" />
+      </clipPath>
+    </defs>
+  </svg>
+)

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -23,6 +23,7 @@ import {
 import {Field, formComponentsPlugin, Input, Item, Preview} from './components/formComponents'
 import {googleTheme} from './themes/google'
 import {vercelTheme} from './themes/vercel'
+import {GoogleLogo, TailwindLogo, VercelLogo} from './components/workspaceLogos'
 
 const sharedSettings = definePlugin({
   name: 'sharedSettings',
@@ -91,35 +92,9 @@ export default defineConfig([
     basePath: '/test',
   },
   {
-    name: 'google-theme',
-    title: 'Google Colors',
-    projectId: 'ppsg7ml5',
-    dataset: 'test',
-    plugins: [sharedSettings()],
-    basePath: '/google',
-    theme: googleTheme,
-  },
-  {
-    name: 'vercel-theme',
-    title: 'Vercel Colors',
-    projectId: 'ppsg7ml5',
-    dataset: 'test',
-    plugins: [sharedSettings()],
-    basePath: '/vercel',
-    theme: vercelTheme,
-  },
-  {
-    name: 'tailwind-theme',
-    title: 'Tailwind Colors',
-    projectId: 'ppsg7ml5',
-    dataset: 'test',
-    plugins: [sharedSettings()],
-    basePath: '/tailwind',
-    theme: tailwindTheme,
-  },
-  {
     name: 'playground',
-    title: 'Test Studio (playground)',
+    title: 'Test Studio',
+    subtitle: 'Playground dataset',
     projectId: 'ppsg7ml5',
     dataset: 'playground',
     plugins: [sharedSettings()],
@@ -127,7 +102,8 @@ export default defineConfig([
   },
   {
     name: 'custom-components',
-    title: 'Test Studio (custom-components)',
+    title: 'Test Studio',
+    subtitle: 'Components API playground',
     projectId: 'ppsg7ml5',
     dataset: 'test',
     plugins: [sharedSettings(), studioComponentsPlugin(), formComponentsPlugin()],
@@ -148,5 +124,35 @@ export default defineConfig([
         toolMenu: CustomToolMenu,
       },
     },
+  },
+  {
+    name: 'google-theme',
+    title: 'Google Colors',
+    projectId: 'ppsg7ml5',
+    dataset: 'test',
+    plugins: [sharedSettings()],
+    basePath: '/google',
+    theme: googleTheme,
+    icon: GoogleLogo,
+  },
+  {
+    name: 'vercel-theme',
+    title: 'Vercel Colors',
+    projectId: 'ppsg7ml5',
+    dataset: 'test',
+    plugins: [sharedSettings()],
+    basePath: '/vercel',
+    theme: vercelTheme,
+    icon: VercelLogo,
+  },
+  {
+    name: 'tailwind-theme',
+    title: 'Tailwind Colors',
+    projectId: 'ppsg7ml5',
+    dataset: 'test',
+    plugins: [sharedSettings()],
+    basePath: '/tailwind',
+    theme: tailwindTheme,
+    icon: TailwindLogo,
   },
 ])

--- a/packages/sanity/src/core/studio/components/navbar/__workshop__/WorkspacePreviewStory.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/__workshop__/WorkspacePreviewStory.tsx
@@ -1,0 +1,36 @@
+import React, {CSSProperties} from 'react'
+import {IceCreamIcon} from '@sanity/icons'
+import {Card, Flex} from '@sanity/ui'
+import {useBoolean, useSelect, useString} from '@sanity/ui-workshop'
+import {WorkspacePreview} from '../workspace'
+
+const CARD_INLINE_STYLE: CSSProperties = {
+  width: 250,
+}
+
+const STATE_OPTIONS: Record<string, 'logged-in' | 'logged-out' | 'no-access'> = {
+  'logged-in': 'logged-in',
+  'logged-out': 'logged-out',
+  'no-access': 'no-access',
+}
+
+export default function WorkspacePreviewStory() {
+  const title = useString('Title', 'Title') || ''
+  const subtitle = useString('Subtitle', 'Subtitle') || ''
+  const state = useSelect('State', STATE_OPTIONS, 'logged-in') || 'logged-in'
+  const selected = useBoolean('Selected', false) || false
+
+  return (
+    <Flex align="center" height="fill" justify="center">
+      <Card style={CARD_INLINE_STYLE}>
+        <WorkspacePreview
+          icon={IceCreamIcon}
+          selected={selected}
+          state={state}
+          subtitle={subtitle}
+          title={title}
+        />
+      </Card>
+    </Flex>
+  )
+}

--- a/packages/sanity/src/core/studio/components/navbar/__workshop__/index.ts
+++ b/packages/sanity/src/core/studio/components/navbar/__workshop__/index.ts
@@ -22,4 +22,9 @@ export default defineScope('sanity/studio/navbar', 'Navbar', [
     title: 'SearchDialog',
     component: lazy(() => import('./SearchDialogStory')),
   },
+  {
+    name: 'workspacePreview',
+    title: 'WorkspacePreview',
+    component: lazy(() => import('./WorkspacePreviewStory')),
+  },
 ])

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/WorkspaceAuth.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/WorkspaceAuth.tsx
@@ -49,7 +49,7 @@ export function WorkspaceAuth() {
               <WorkspacePreview
                 icon={selectedWorkspace.icon}
                 title={selectedWorkspace.title}
-                subtitle={selectedWorkspace.dataset}
+                subtitle={selectedWorkspace?.subtitle}
               />
             </Box>
           }
@@ -116,7 +116,7 @@ export function WorkspaceAuth() {
                 icon={workspace?.icon}
                 iconRight={ChevronRightIcon}
                 state={state}
-                subtitle={workspace.dataset}
+                subtitle={workspace?.subtitle}
                 title={workspace?.title || workspace.name}
               />
             </Card>

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
@@ -1,4 +1,4 @@
-import {AddIcon, SelectIcon} from '@sanity/icons'
+import {SelectIcon} from '@sanity/icons'
 import {
   Button,
   MenuButton,
@@ -7,7 +7,6 @@ import {
   MenuButtonProps,
   ButtonProps,
   Box,
-  Card,
   Label,
 } from '@sanity/ui'
 import React, {useMemo} from 'react'
@@ -15,7 +14,6 @@ import styled from 'styled-components'
 import {useActiveWorkspace} from '../../../activeWorkspaceMatcher'
 import {useColorScheme} from '../../../colorScheme'
 import {useWorkspaces} from '../../../workspaces'
-import {WORKSPACES_DOCS_URL} from './constants'
 import {useWorkspaceAuthStates} from './hooks'
 import {WorkspacePreview} from './WorkspacePreview'
 import {useRouter} from 'sanity/router'
@@ -23,11 +21,6 @@ import {useRouter} from 'sanity/router'
 const StyledMenu = styled(Menu)`
   max-width: 350px;
   min-width: 250px;
-`
-
-const FooterCard = styled(Card)`
-  position: sticky;
-  bottom: 0;
 `
 
 export function WorkspaceMenuButton(props: ButtonProps) {
@@ -47,7 +40,7 @@ export function WorkspaceMenuButton(props: ButtonProps) {
       button={<Button icon={SelectIcon} mode="bleed" {...props} disabled={!authStates} />}
       id="workspace-menu"
       menu={
-        <StyledMenu paddingBottom={0}>
+        <StyledMenu>
           <Box paddingX={3} paddingY={3}>
             <Label size={1} muted>
               Workspaces
@@ -88,23 +81,12 @@ export function WorkspaceMenuButton(props: ButtonProps) {
                     icon={workspace?.icon}
                     selected={workspace.name === activeWorkspace.name}
                     state={state}
-                    subtitle={workspace.dataset}
+                    subtitle={workspace?.subtitle}
                     title={workspace?.title || workspace.name}
                   />
                 </MenuItem>
               )
             })}
-
-          <FooterCard borderTop paddingY={1}>
-            <MenuItem
-              as="a"
-              href={WORKSPACES_DOCS_URL}
-              icon={AddIcon}
-              rel="noopener noreferrer"
-              target="__blank"
-              text="Add workspace"
-            />
-          </FooterCard>
         </StyledMenu>
       }
       popover={popoverProps}


### PR DESCRIPTION
### Description
This PR enables adding a `subtitle` to a workspace and removes the dataset name as the default subtitle. The subtitle is displayed in the workspace preview component which is used in the workspace menu and on the login screen.

```tsx
export default defineConfig([
  {
   ..., 
  
    subtitle: 'Subtitle 1',
    plugins: [...],
    schema: {...}
  },
  {
   ..., 

    subtitle: 'Subtitle 2',
    plugins: [...],
    schema: {...}
  }
])

```

### What to review

n/a

### Notes for release
feat(core): enable workspace subtitle configuration
