### PR TITLE
feat(cli): use typescript by default for new projects

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -186,7 +186,7 @@ export default async function initSanity(
   }
 
   // Use typescript?
-  let useTypeScript = false
+  let useTypeScript = true
   if (typeof cliFlags.typescript === 'boolean') {
     useTypeScript = cliFlags.typescript
   } else if (!unattended) {

--- a/packages/@sanity/cli/src/actions/init-project/prompts.ts
+++ b/packages/@sanity/cli/src/actions/init-project/prompts.ts
@@ -4,7 +4,7 @@ export function promptForTypeScript(prompt: CliPrompter): Promise<boolean> {
   return prompt.single({
     type: 'confirm',
     message: 'Do you want to use TypeScript?',
-    default: false,
+    default: true,
   })
 }
 

--- a/packages/@sanity/cli/src/commands/init/initCommand.ts
+++ b/packages/@sanity/cli/src/commands/init/initCommand.ts
@@ -17,7 +17,7 @@ Options
   --project-plan <name> Optionally select a plan for a new project
   --coupon <name> Optionally select a coupon for a new project (cannot be used with --project-plan)
   --reconfigure Reconfigure Sanity studio in current folder with new project/dataset
-  --typescript Use TypeScript for template files
+  --no-typescript Do not use TypeScript for template files
 
 Examples
   # Initialize a new project, prompt for required information along the way


### PR DESCRIPTION
### Description

After a lot of discussion, we've decided that we should be encouraging the use of typescript for new projects. This PR changes the default from javascript to typescript. People will still be prompted, but the default choice is to use typescript. You can use `--no-typescript` to explicitly opt out, should you want to (`--typescript` still works as before, skipping the prompt).

### What to review

- Initializing new projects works as before, but the default in the typescript prompt is "yes"
- `--no-typescript` works as expected

### Notes for release

- New projects now use TypeScript by default
