### PR TITLE
fix(base): skip cross dataset validation on mutations

### DIFF
--- a/packages/@sanity/base/src/datastores/document/document-pair/checkoutPair.ts
+++ b/packages/@sanity/base/src/datastores/document/document-pair/checkoutPair.ts
@@ -50,6 +50,9 @@ function commitMutations(mutationParams: MutatorMutation['params']) {
     visibility: 'async',
     returnDocuments: false,
     tag: 'document.commit',
+    // This makes sure the studio doesn't crash when a draft is crated
+    // because someone deleted a referenced document in the target dataset
+    skipCrossDatasetReferenceValidation: true,
   })
 }
 


### PR DESCRIPTION
### Description

This change disables cross dataset validation on mutations in the studio. This is mainly done to prevent the studio crashing because the mutation fails when 1) There is a cross dataset in the document being mutated 2) The document referenced has been deleted in the target dataset.

### What to review

- That a document with a cross dataset reference where the document has been deleted won't crash the studio anymore

### Notes for release

- Fix a edge case where a cross dataset reference to a deleted document would prevent you changing the document with the reference

_This is a port from v3 of PR #3846_