### PR TITLE
fix: input mode for number type

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/NumberInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/NumberInput.tsx
@@ -43,7 +43,7 @@ const NumberInput = React.forwardRef(function NumberInput(
       <TextInput
         type="number"
         step="any"
-        inputMode={onlyPositiveNumber ? 'numeric' : 'text'}
+        inputMode={onlyPositiveNumber ? 'decimal' : 'text'}
         id={id}
         customValidity={errors && errors.length > 0 ? errors[0].item.message : ''}
         value={value}

--- a/packages/@sanity/form-builder/src/inputs/__tests__/NumberInput.test.tsx
+++ b/packages/@sanity/form-builder/src/inputs/__tests__/NumberInput.test.tsx
@@ -20,7 +20,7 @@ const dummyDocument = {
   _rev: '5hb8s6-k75-ip4-4bq-5ztbf3fbx',
   _type: 'numberFieldTest',
   _updatedAt: '2021-11-05T12:34:29Z',
-  num: 0,
+  num: 1,
   title: 'Hello world',
 }
 
@@ -44,5 +44,49 @@ describe('number-input', () => {
     input.value = '1.2'
     expect(input.value).toBe('1.2')
     expect(input.checkValidity()).toBe(true)
+  })
+
+  it('renders inputMode equals text if there is no min rule', () => {
+    const {inputContainer} = renderInput('input-num')
+    const input = inputContainer.querySelector('input')
+
+    input.value = '1.2'
+    expect(input.inputMode).toBe('text')
+  })
+
+  it.skip('renders inputMode equals "decimal" if there ', () => {
+    const customSchema = Schema.compile({
+      name: 'test',
+      types: [
+        {
+          name: 'book',
+          type: 'document',
+          fields: [
+            {
+              name: 'num',
+              title: 'Number',
+              type: 'number',
+              /**
+               * For some reason this throw an error:
+               *
+               * Uncaught [Error: Schema type "number"'s `validation` was not run though `inferFromSchema`]
+               */
+              validation: (Rule) => Rule.min(0),
+            },
+          ],
+        },
+      ],
+    })
+
+    const customDocumentType = customSchema.get('book')
+
+    const testId = 'input-num'
+
+    const {inputContainer} = inputTester(dummyDocument, customDocumentType, customSchema, testId)
+
+    const input = inputContainer.querySelector('input')
+
+    input.value = '1.2'
+    expect(input.inputMode).toBe('decimal')
   })
 })


### PR DESCRIPTION
### Description

Closes #3866

This PR changes the `inputMode` property to be `decimal` instead `number`. See the implantation in the open Issue.

### What to review

Check the number input.

Obs.: I tried to add an unit test to ensure this is not broken but I couldn't get the `minRule` condition working. I don't have much context for solving this kind of problem.

### Notes for release

When `type` is `number`, uses HTML `inputmode` equals `decimal` instead number. This will show up on mobile the decimal keyboard.