### PR TITLE
refactor(core)!: rename document action `modal` prop to `dialog`

### DIFF
--- a/dev/test-studio/documentActions/actions/TestConfirmDialogAction.tsx
+++ b/dev/test-studio/documentActions/actions/TestConfirmDialogAction.tsx
@@ -5,15 +5,15 @@ import React, {useCallback, useMemo, useState} from 'react'
 
 export const TestConfirmDialogAction: DocumentActionComponent = (props) => {
   const {onComplete} = props
-  const [modalOpen, setDialogOpen] = useState(false)
+  const [dialogOpen, setDialogOpen] = useState(false)
   const {push: pushToast} = useToast()
 
   const handleOpen = useCallback(() => {
-    if (!modalOpen) {
+    if (!dialogOpen) {
       setDialogOpen(true)
       pushToast({closable: true, title: '[confirm] Opened'})
     }
-  }, [modalOpen, pushToast])
+  }, [dialogOpen, pushToast])
 
   const handleClose = useCallback(() => {
     setDialogOpen(false)
@@ -33,20 +33,20 @@ export const TestConfirmDialogAction: DocumentActionComponent = (props) => {
     onComplete()
   }, [onComplete, pushToast])
 
-  const modal: DocumentActionDescription['modal'] = useMemo(
+  const dialog: DocumentActionDescription['dialog'] = useMemo(
     () =>
-      modalOpen && {
+      dialogOpen && {
         type: 'confirm',
         tone: 'positive',
         content: (
           <>
             <Text>
-              This is the <code>confirm</code> modal
+              This is the <code>confirm</code> dialog
             </Text>
             <Button onClick={handleClose} text="Close" />
           </>
         ),
-        message: 'Test confirm modal',
+        message: 'Test confirm dialog',
         onCancel: handleCancel,
         onConfirm: handleConfirm,
         cancelButtonIcon: CloseCircleIcon,
@@ -54,14 +54,14 @@ export const TestConfirmDialogAction: DocumentActionComponent = (props) => {
         confirmButtonIcon: CheckmarkCircleIcon,
         confirmButtonText: 'Yes',
       },
-    [modalOpen, handleCancel, handleClose, handleConfirm]
+    [dialogOpen, handleCancel, handleClose, handleConfirm]
   )
 
   return {
     tone: 'positive',
-    modal,
+    dialog,
     onHandle: handleOpen,
-    label: 'Test confirm modal',
+    label: 'Test confirm dialog',
     shortcut: 'mod+p',
   }
 }

--- a/dev/test-studio/documentActions/actions/TestModalDialogAction.tsx
+++ b/dev/test-studio/documentActions/actions/TestModalDialogAction.tsx
@@ -5,7 +5,7 @@ import React, {useCallback, useMemo, useState} from 'react'
 
 export const TestModalDialogAction: DocumentActionComponent = (props) => {
   const {onComplete} = props
-  const [modalOpen, setDialogOpen] = useState(false)
+  const [dialogOpen, setDialogOpen] = useState(false)
   const {push: pushToast} = useToast()
 
   const handleOpen = useCallback(() => {
@@ -19,9 +19,9 @@ export const TestModalDialogAction: DocumentActionComponent = (props) => {
     onComplete()
   }, [onComplete, pushToast])
 
-  const modal: DocumentActionDescription['modal'] = useMemo(
+  const dialog: DocumentActionDescription['dialog'] = useMemo(
     () =>
-      modalOpen && {
+      dialogOpen && {
         type: 'dialog',
         content: (
           <Text>
@@ -38,11 +38,11 @@ export const TestModalDialogAction: DocumentActionComponent = (props) => {
         showCloseButton: false,
         width: 'medium',
       },
-    [modalOpen, handleClose]
+    [dialogOpen, handleClose]
   )
 
   return {
-    modal,
+    dialog,
     icon: CopyIcon,
     label: 'Test dialog modal',
     onHandle: handleOpen,

--- a/dev/test-studio/documentActions/actions/TestPopoverDialogAction.tsx
+++ b/dev/test-studio/documentActions/actions/TestPopoverDialogAction.tsx
@@ -5,7 +5,7 @@ import React, {useCallback, useMemo, useState} from 'react'
 
 export const TestPopoverDialogAction: DocumentActionComponent = (props) => {
   const {onComplete} = props
-  const [modalOpen, setDialogOpen] = useState(false)
+  const [dialogOpen, setDialogOpen] = useState(false)
   const {push: pushToast} = useToast()
 
   const handleOpen = useCallback(() => {
@@ -19,27 +19,27 @@ export const TestPopoverDialogAction: DocumentActionComponent = (props) => {
     onComplete()
   }, [onComplete, pushToast])
 
-  const modal: DocumentActionDescription['modal'] = useMemo(
+  const dialog: DocumentActionDescription['dialog'] = useMemo(
     () =>
-      modalOpen && {
+      dialogOpen && {
         type: 'popover',
         content: (
           <Stack padding={4} space={4}>
             <Text>
-              This is the <code>popover</code> modal
+              This is the <code>popover</code> dialog
             </Text>
             <Button onClick={handleClose} text="Close" />
           </Stack>
         ),
         onClose: handleClose,
       },
-    [modalOpen, handleClose]
+    [dialogOpen, handleClose]
   )
 
   return {
-    modal,
+    dialog,
     icon: LaunchIcon,
-    label: 'Test popover modal',
+    label: 'Test popover dialog',
     onHandle: handleOpen,
   }
 }

--- a/packages/sanity/src/core/config/document/actions.ts
+++ b/packages/sanity/src/core/config/document/actions.ts
@@ -37,7 +37,7 @@ export interface DocumentActionComponent extends ActionComponent<DocumentActionP
 }
 
 /** @beta */
-export interface DocumentActionConfirmModalProps {
+export interface DocumentActionConfirmDialogProps {
   type: 'confirm'
   tone?: ButtonTone
   message: React.ReactNode
@@ -50,8 +50,8 @@ export interface DocumentActionConfirmModalProps {
 }
 
 /** @beta */
-export interface DocumentActionDialogModalProps {
-  type: 'dialog'
+export interface DocumentActionModalDialogProps {
+  type?: 'dialog'
   content: React.ReactNode
   /**
    * @beta
@@ -70,22 +70,25 @@ export interface DocumentActionDialogModalProps {
 }
 
 /** @beta */
-export interface DocumentActionPopoverModalProps {
+export interface DocumentActionPopoverDialogProps {
   type: 'popover'
   content: React.ReactNode
   onClose: () => void
 }
 
 /** @beta */
-export type DocumentActionModalProps =
-  | DocumentActionConfirmModalProps
-  | DocumentActionPopoverModalProps
-  | DocumentActionDialogModalProps
+export type DocumentActionDialogProps =
+  | DocumentActionConfirmDialogProps
+  | DocumentActionPopoverDialogProps
+  | DocumentActionModalDialogProps
 
 /** @beta */
 export interface DocumentActionDescription {
   tone?: ButtonTone
-  modal?: DocumentActionModalProps | false | null
+  dialog?: DocumentActionDialogProps | false | null
+  // @todo: remove the following types for v3 GA
+  /** @deprecated Use `dialog` */
+  modal?: never
   disabled?: boolean
   icon?: React.ReactNode | React.ComponentType
   label: string
@@ -93,3 +96,29 @@ export interface DocumentActionDescription {
   shortcut?: string | null
   title?: React.ReactNode
 }
+
+// @todo: remove the following types for v3 GA
+
+/**
+ * @beta
+ * @deprecated Use `DocumentActionDialogProps` instead
+ */
+export type DocumentActionModalProps = DocumentActionDialogProps
+
+/**
+ * @beta
+ * @deprecated Use `DocumentActionConfirmDialogProps` instead
+ */
+export type DocumentActionConfirmModalProps = DocumentActionConfirmDialogProps
+
+/**
+ * @beta
+ * @deprecated Use `DocumentActionPopoverDialogProps` instead
+ */
+export type DocumentActionPopoverModalProps = DocumentActionPopoverDialogProps
+
+/**
+ * @beta
+ * @deprecated Use `DocumentActionModalDialogProps` instead
+ */
+export type DocumentActionDialogModalProps = DocumentActionModalDialogProps

--- a/packages/sanity/src/desk/__workshop__/DocumentStateStory.tsx
+++ b/packages/sanity/src/desk/__workshop__/DocumentStateStory.tsx
@@ -104,17 +104,17 @@ function Debug(props: {documentId: string; documentType: string}) {
           </Stack>
 
           {documentActions.items.map((actionItem, idx) => {
-            if (actionItem?.modal && actionItem.modal.type === 'dialog') {
+            if (actionItem?.dialog && actionItem.dialog.type === 'dialog') {
               return (
                 <Dialog
-                  footer={actionItem.modal.footer}
-                  header={actionItem.modal.header}
+                  footer={actionItem.dialog.footer}
+                  header={actionItem.dialog.header}
                   id={`document-action-modal-${idx}`}
                   key={idx}
                   // eslint-disable-next-line react/jsx-handler-names
-                  onClose={actionItem.modal.onClose}
+                  onClose={actionItem.dialog.onClose}
                 >
-                  <Box padding={4}>{actionItem.modal.content}</Box>
+                  <Box padding={4}>{actionItem.dialog.content}</Box>
                 </Dialog>
               )
             }

--- a/packages/sanity/src/desk/documentActions/DeleteAction.tsx
+++ b/packages/sanity/src/desk/documentActions/DeleteAction.tsx
@@ -71,7 +71,7 @@ export const DeleteAction: DocumentActionComponent = ({id, type, draft, onComple
     label: isDeleting ? 'Deleting…' : 'Delete',
     shortcut: 'Ctrl+Alt+D',
     onHandle: handle,
-    modal: isConfirmDialogOpen && {
+    dialog: isConfirmDialogOpen && {
       type: 'dialog',
       onClose: onComplete,
       content: (

--- a/packages/sanity/src/desk/documentActions/DiscardChangesAction.tsx
+++ b/packages/sanity/src/desk/documentActions/DiscardChangesAction.tsx
@@ -42,7 +42,7 @@ export const DiscardChangesAction: DocumentActionComponent = ({
     setConfirmDialogOpen(true)
   }, [])
 
-  const modal: DocumentActionModalProps | false = useMemo(
+  const dialog: DocumentActionModalProps | false = useMemo(
     () =>
       isConfirmDialogOpen && {
         type: 'confirm',
@@ -83,7 +83,7 @@ export const DiscardChangesAction: DocumentActionComponent = ({
       '',
     label: 'Discard changes',
     onHandle: handle,
-    modal,
+    dialog,
   }
 }
 

--- a/packages/sanity/src/desk/documentActions/HistoryRestoreAction.tsx
+++ b/packages/sanity/src/desk/documentActions/HistoryRestoreAction.tsx
@@ -1,6 +1,6 @@
 import {RestoreIcon} from '@sanity/icons'
 import React, {useCallback, useMemo, useState} from 'react'
-import {DocumentActionComponent, DocumentActionModalProps, useDocumentOperation} from 'sanity'
+import {DocumentActionComponent, DocumentActionDialogProps, useDocumentOperation} from 'sanity'
 import {useRouter} from 'sanity/router'
 
 /** @internal */
@@ -19,7 +19,7 @@ export const HistoryRestoreAction: DocumentActionComponent = ({id, type, revisio
     setConfirmDialogOpen(true)
   }, [])
 
-  const modal: DocumentActionModalProps | null = useMemo(() => {
+  const dialog: DocumentActionDialogProps | null = useMemo(() => {
     if (isConfirmDialogOpen) {
       return {
         type: 'confirm',
@@ -43,7 +43,7 @@ export const HistoryRestoreAction: DocumentActionComponent = ({id, type, revisio
       ? "You can't restore to the initial version"
       : 'Restore to this version',
     icon: RestoreIcon,
-    modal,
+    dialog,
     disabled: isRevisionInitialVersion,
   }
 }

--- a/packages/sanity/src/desk/documentActions/UnpublishAction.tsx
+++ b/packages/sanity/src/desk/documentActions/UnpublishAction.tsx
@@ -3,11 +3,11 @@ import React, {useCallback, useMemo, useState} from 'react'
 import {ConfirmDeleteDialog} from '../components'
 import {
   DocumentActionComponent,
-  DocumentActionModalProps,
   InsufficientPermissionsMessage,
   useDocumentPairPermissions,
   useCurrentUser,
   useDocumentOperation,
+  DocumentActionModalDialogProps,
 } from 'sanity'
 
 const DISABLED_REASON_TITLE = {
@@ -42,7 +42,7 @@ export const UnpublishAction: DocumentActionComponent = ({
     onComplete()
   }, [onComplete, unpublish])
 
-  const modal: DocumentActionModalProps | null = useMemo(() => {
+  const dialog: DocumentActionModalDialogProps | null = useMemo(() => {
     if (isConfirmDialogOpen) {
       return {
         type: 'dialog',
@@ -90,7 +90,7 @@ export const UnpublishAction: DocumentActionComponent = ({
       ? DISABLED_REASON_TITLE[unpublish.disabled as keyof typeof DISABLED_REASON_TITLE]
       : '',
     onHandle: () => setConfirmDialogOpen(true),
-    modal,
+    dialog,
   }
 }
 

--- a/packages/sanity/src/desk/panes/document/keyboardShortcuts/DocumentActionShortcuts.tsx
+++ b/packages/sanity/src/desk/panes/document/keyboardShortcuts/DocumentActionShortcuts.tsx
@@ -3,7 +3,12 @@ import React, {useCallback, useMemo, useState} from 'react'
 import {ActionStateDialog} from '../statusBar'
 import {Pane, RenderActionCollectionState} from '../../../components'
 import {useDocumentPane} from '../useDocumentPane'
-import {DocumentActionDescription, DocumentActionProps, LegacyLayerProvider} from 'sanity'
+import {
+  DocumentActionDescription,
+  DocumentActionDialogProps,
+  DocumentActionProps,
+  LegacyLayerProvider,
+} from 'sanity'
 
 export interface KeyboardShortcutResponderProps {
   actionsBoxElement: HTMLElement | null
@@ -67,9 +72,12 @@ function KeyboardShortcutResponder(
     <Pane id={id} onKeyDown={handleKeyDown} tabIndex={-1} {...rest} ref={rootRef}>
       {children}
 
-      {activeAction && activeAction.modal && (
+      {activeAction && (activeAction.dialog || activeAction.modal) && (
         <LegacyLayerProvider zOffset="paneFooter">
-          <ActionStateDialog modal={activeAction.modal} referenceElement={actionsBoxElement} />
+          <ActionStateDialog
+            dialog={(activeAction.dialog || activeAction.modal) as DocumentActionDialogProps}
+            referenceElement={actionsBoxElement}
+          />
         </LegacyLayerProvider>
       )}
     </Pane>

--- a/packages/sanity/src/desk/panes/document/statusBar/ActionMenuButton.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/ActionMenuButton.tsx
@@ -22,7 +22,7 @@ import React, {
 } from 'react'
 import {isValidElementType} from 'react-is'
 import {ActionStateDialog} from './ActionStateDialog'
-import {DocumentActionDescription, LegacyLayerProvider} from 'sanity'
+import {DocumentActionDescription, DocumentActionDialogProps, LegacyLayerProvider} from 'sanity'
 
 export interface ActionMenuButtonProps {
   actionStates: DocumentActionDescription[]
@@ -83,9 +83,12 @@ export function ActionMenuButton(props: ActionMenuButtonProps) {
         ref={setReferenceElement}
       />
 
-      {currentAction && currentAction.modal && (
+      {currentAction && (currentAction.dialog || currentAction.modal) && (
         <LegacyLayerProvider zOffset="paneFooter">
-          <ActionStateDialog modal={currentAction.modal} referenceElement={referenceElement} />
+          <ActionStateDialog
+            dialog={(currentAction.dialog || currentAction.modal) as DocumentActionDialogProps}
+            referenceElement={referenceElement}
+          />
         </LegacyLayerProvider>
       )}
     </>

--- a/packages/sanity/src/desk/panes/document/statusBar/ActionStateDialog.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/ActionStateDialog.tsx
@@ -3,31 +3,31 @@ import React, {useId} from 'react'
 import {ConfirmDialog} from './dialogs/ConfirmDialog'
 import {ModalDialog} from './dialogs/ModalDialog'
 import {PopoverDialog} from './dialogs/PopoverDialog'
-import {DocumentActionModalProps} from 'sanity'
+import {DocumentActionDialogProps} from 'sanity'
 
 export interface ActionStateDialogProps {
-  modal: DocumentActionModalProps
+  dialog: DocumentActionDialogProps
   referenceElement?: HTMLElement | null
 }
 
 export function ActionStateDialog(props: ActionStateDialogProps) {
-  const {modal, referenceElement = null} = props
+  const {dialog, referenceElement = null} = props
   const modalId = useId()
 
-  if (modal.type === 'confirm') {
-    return <ConfirmDialog modal={modal} referenceElement={referenceElement} />
+  if (dialog.type === 'confirm') {
+    return <ConfirmDialog dialog={dialog} referenceElement={referenceElement} />
   }
 
-  if (modal.type === 'dialog') {
-    return <ModalDialog modal={modal} />
+  if (dialog.type === 'popover') {
+    return <PopoverDialog dialog={dialog} referenceElement={referenceElement} />
   }
 
-  if (modal.type === 'popover') {
-    return <PopoverDialog modal={modal} referenceElement={referenceElement} />
+  if (dialog.type === 'dialog' || !dialog.type) {
+    return <ModalDialog dialog={dialog} />
   }
 
   // @todo: add validation?
-  const unknownModal: any = modal
+  const unknownModal: any = dialog
 
   // eslint-disable-next-line no-console
   console.warn(`Unsupported modal type ${unknownModal.type}`)

--- a/packages/sanity/src/desk/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -5,7 +5,7 @@ import {HistoryRestoreAction} from '../../../documentActions'
 import {useDocumentPane} from '../useDocumentPane'
 import {ActionMenuButton} from './ActionMenuButton'
 import {ActionStateDialog} from './ActionStateDialog'
-import {DocumentActionDescription} from 'sanity'
+import {DocumentActionDescription, DocumentActionDialogProps} from 'sanity'
 
 interface DocumentStatusBarActionsInnerProps {
   disabled: boolean
@@ -64,8 +64,11 @@ function DocumentStatusBarActionsInner(props: DocumentStatusBarActionsInnerProps
         </Box>
       )}
 
-      {firstActionState && firstActionState.modal && (
-        <ActionStateDialog modal={firstActionState.modal} referenceElement={buttonElement} />
+      {firstActionState && (firstActionState.dialog || firstActionState.modal) && (
+        <ActionStateDialog
+          dialog={(firstActionState.dialog || firstActionState.modal) as DocumentActionDialogProps}
+          referenceElement={buttonElement}
+        />
       )}
     </Flex>
   )

--- a/packages/sanity/src/desk/panes/document/statusBar/dialogs/ConfirmDialog.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/dialogs/ConfirmDialog.tsx
@@ -10,17 +10,17 @@ import {
 } from '@sanity/ui'
 import React, {useCallback, useState} from 'react'
 import {POPOVER_FALLBACK_PLACEMENTS} from './constants'
-import {DocumentActionConfirmModalProps} from 'sanity'
+import {DocumentActionConfirmDialogProps} from 'sanity'
 
 export function ConfirmDialog(props: {
-  modal: DocumentActionConfirmModalProps
+  dialog: DocumentActionConfirmDialogProps
   referenceElement: HTMLElement | null
 }) {
-  const {modal, referenceElement} = props
+  const {dialog, referenceElement} = props
 
   return (
     <Popover
-      content={<ConfirmDialogContent modal={modal} />}
+      content={<ConfirmDialogContent dialog={dialog} />}
       fallbackPlacements={POPOVER_FALLBACK_PLACEMENTS}
       open
       placement="top"
@@ -31,8 +31,8 @@ export function ConfirmDialog(props: {
   )
 }
 
-function ConfirmDialogContent(props: {modal: DocumentActionConfirmModalProps}) {
-  const {modal} = props
+function ConfirmDialogContent(props: {dialog: DocumentActionConfirmDialogProps}) {
+  const {dialog} = props
   const {
     cancelButtonIcon,
     cancelButtonText,
@@ -43,7 +43,7 @@ function ConfirmDialogContent(props: {modal: DocumentActionConfirmModalProps}) {
     onCancel,
     onConfirm,
     tone,
-  } = modal
+  } = dialog
   const {isTopLayer} = useLayer()
   const [element, setElement] = useState<HTMLElement | null>(null)
 

--- a/packages/sanity/src/desk/panes/document/statusBar/dialogs/ModalDialog.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/dialogs/ModalDialog.tsx
@@ -1,32 +1,32 @@
 import {Box, Dialog} from '@sanity/ui'
 import React, {useId} from 'react'
 import {DIALOG_WIDTH_TO_UI_WIDTH} from './constants'
-import {DocumentActionDialogModalProps, LegacyLayerProvider} from 'sanity'
+import {DocumentActionModalDialogProps, LegacyLayerProvider} from 'sanity'
 
-export function ModalDialog(props: {modal: DocumentActionDialogModalProps}) {
-  const {modal} = props
-  const modalId = useId()
+export function ModalDialog(props: {dialog: DocumentActionModalDialogProps}) {
+  const {dialog} = props
+  const dialogId = useId()
 
-  const footer = modal.footer && (
+  const footer = dialog.footer && (
     <Box paddingX={4} paddingY={3}>
-      {modal.footer}
+      {dialog.footer}
     </Box>
   )
 
   return (
     <LegacyLayerProvider zOffset="fullscreen">
       <Dialog
-        __unstable_hideCloseButton={modal.showCloseButton === false}
+        __unstable_hideCloseButton={dialog.showCloseButton === false}
         footer={footer}
-        header={modal.header}
-        id={modalId}
+        header={dialog.header}
+        id={dialogId}
         // eslint-disable-next-line react/jsx-handler-names
-        onClose={modal.onClose}
+        onClose={dialog.onClose}
         // eslint-disable-next-line react/jsx-handler-names
-        onClickOutside={modal.onClose}
-        width={modal.width === undefined ? 1 : DIALOG_WIDTH_TO_UI_WIDTH[modal.width]}
+        onClickOutside={dialog.onClose}
+        width={dialog.width === undefined ? 1 : DIALOG_WIDTH_TO_UI_WIDTH[dialog.width]}
       >
-        <Box padding={4}>{modal.content}</Box>
+        <Box padding={4}>{dialog.content}</Box>
       </Dialog>
     </LegacyLayerProvider>
   )

--- a/packages/sanity/src/desk/panes/document/statusBar/dialogs/PopoverDialog.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/dialogs/PopoverDialog.tsx
@@ -1,17 +1,17 @@
 import {Popover, useClickOutside, useGlobalKeyDown, useLayer} from '@sanity/ui'
 import React, {useCallback, useState} from 'react'
 import {POPOVER_FALLBACK_PLACEMENTS} from './constants'
-import {DocumentActionPopoverModalProps} from 'sanity'
+import {DocumentActionPopoverDialogProps} from 'sanity'
 
 export function PopoverDialog(props: {
-  modal: DocumentActionPopoverModalProps
+  dialog: DocumentActionPopoverDialogProps
   referenceElement: HTMLElement | null
 }) {
-  const {modal, referenceElement} = props
+  const {dialog, referenceElement} = props
 
   return (
     <Popover
-      content={<PopoverDialogContent modal={modal} />}
+      content={<PopoverDialogContent dialog={dialog} />}
       fallbackPlacements={POPOVER_FALLBACK_PLACEMENTS}
       open
       placement="top"
@@ -22,9 +22,9 @@ export function PopoverDialog(props: {
   )
 }
 
-function PopoverDialogContent(props: {modal: DocumentActionPopoverModalProps}) {
-  const {modal} = props
-  const {content, onClose} = modal
+function PopoverDialogContent(props: {dialog: DocumentActionPopoverDialogProps}) {
+  const {dialog} = props
+  const {content, onClose} = dialog
   const {isTopLayer} = useLayer()
   const [element, setElement] = useState<HTMLElement | null>(null)
 


### PR DESCRIPTION
### Description

**BREAKING CHANGE**: Document actions has a `modal` prop which in v2 was named `dialog`. In this version, we are reverting this back to `dialog`, since it is a more correct term for the feature. To align with this change, we are also renaming types that are coupled to it.

For now, this is a backwards compatible change, but before we launch v3 into General Availability (GA), the support for `modal` will be removed.

### What to review

- That document actions still work as expected (default + custom)
- That the names of types and props make sense

### Notes for release

- **BREAKING CHANGE:** Renamed the `modal` property to `dialog` for document actions. This makes them backwards compatible with v2 document actions, and is a more correct term for the feature.