### PR TITLE
refactor(config)!: drop `client` from config context

### DIFF
--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -118,10 +118,6 @@ export interface ConfigContext {
   dataset: string
   schema: Schema
   currentUser: CurrentUser | null
-  /**
-   * @deprecated Will be removed in the next version! Use `getClient({apiVersion: '2021-06-07'})` instead
-   */
-  client: SanityClient
   getClient: (options: SourceClientOptions) => SanityClient
 }
 

--- a/packages/sanity/src/core/config/useConfigContextFromSource.ts
+++ b/packages/sanity/src/core/config/useConfigContextFromSource.ts
@@ -11,20 +11,7 @@ import type {Source, ConfigContext} from './types'
 export function useConfigContextFromSource(source: Source): ConfigContext {
   const {projectId, dataset, schema, currentUser, getClient} = source
   return useMemo(() => {
-    const client = getClient({apiVersion: '2021-06-07'})
-    const context = Object.defineProperty(
-      {projectId, dataset, schema, currentUser, getClient, client},
-      'client',
-      {
-        get() {
-          console.warn(
-            '`configContext.client` is deprecated and will be removed in the next version! Use `configContext.getClient({apiVersion: "2021-06-07"})` instead.'
-          )
-          return client
-        },
-      }
-    )
-    return context
+    return {projectId, dataset, schema, currentUser, getClient}
   }, [projectId, dataset, schema, currentUser, getClient])
 }
 
@@ -37,6 +24,5 @@ export function useConfigContextFromSource(source: Source): ConfigContext {
  */
 export function getConfigContextFromSource(source: Source): ConfigContext {
   const {projectId, dataset, schema, currentUser, getClient} = source
-  const client = getClient({apiVersion: '2021-06-07'})
-  return {projectId, dataset, schema, currentUser, getClient, client}
+  return {projectId, dataset, schema, currentUser, getClient}
 }


### PR DESCRIPTION

### Description

**BREAKING CHANGE**: As warned in previous releases through deprecation warnings, the `client` provided through the config context was to be removed. This release pulls the trigger on that.

### What to review

Studio still works :)

### Notes for release

- BREAKING CHANGE: Dropped `client` from configuration context - use `getClient({apiVersion: '2022-06-07'})` or similar instead
