### PR TITLE
chore(server): add more debug logging

### DIFF
--- a/packages/@sanity/server/src/devServer.ts
+++ b/packages/@sanity/server/src/devServer.ts
@@ -25,6 +25,7 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
   const {cwd, httpPort, httpHost, basePath: base, reactStrictMode, vite: extendViteConfig} = options
 
   const startTime = Date.now()
+  debug('Writing Sanity runtime files')
   await writeSanityRuntime({cwd, reactStrictMode, watch: true})
 
   debug('Resolving vite config')
@@ -36,6 +37,7 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
   })
 
   if (extendViteConfig) {
+    debug('Extending vite config using user-specified function')
     viteConfig = extendViteConfig(viteConfig)
   }
 
@@ -43,6 +45,7 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
   const server = await createServer(viteConfig)
   const info = server.config.logger.info
 
+  debug('Listening on specified port')
   await server.listen()
 
   const startupDuration = Date.now() - startTime

--- a/packages/@sanity/server/src/previewServer.ts
+++ b/packages/@sanity/server/src/previewServer.ts
@@ -2,7 +2,9 @@ import fs from 'fs'
 import path from 'path'
 import chalk from 'chalk'
 import {InlineConfig, preview} from 'vite'
-import {debug} from './debug'
+import {debug as serverDebug} from './debug'
+
+const debug = serverDebug.extend('preview')
 
 export interface PreviewServer {
   urls: {local: string[]; network: string[]}

--- a/packages/@sanity/server/src/runtime.ts
+++ b/packages/@sanity/server/src/runtime.ts
@@ -1,7 +1,7 @@
 import fs from 'fs/promises'
 import path from 'path'
 import chokidar from 'chokidar'
-import {debug} from './debug'
+import {debug as serverDebug} from './debug'
 import {getEntryModule} from './getEntryModule'
 import {getSanityStudioConfigPath} from './sanityConfig'
 import {loadSanityMonorepo} from './sanityMonorepo'
@@ -10,6 +10,8 @@ import {
   getPossibleDocumentComponentLocations,
   renderDocument,
 } from './renderDocument'
+
+const debug = serverDebug.extend('runtime')
 
 export interface RuntimeOptions {
   cwd: string
@@ -29,6 +31,7 @@ export async function writeSanityRuntime({
   reactStrictMode,
   watch,
 }: RuntimeOptions): Promise<void> {
+  debug('Resolving Sanity monorepo information')
   const monorepo = await loadSanityMonorepo(cwd)
   const runtimeDir = path.join(cwd, '.sanity', 'runtime')
 

--- a/packages/@sanity/server/src/sanityConfig.ts
+++ b/packages/@sanity/server/src/sanityConfig.ts
@@ -1,5 +1,8 @@
 import path from 'path'
 import fs from 'fs/promises'
+import {debug as serverDebug} from './debug'
+
+const debug = serverDebug.extend('config')
 
 /**
  * Resolves the path to the studio configuration file with the following extensions,
@@ -18,6 +21,7 @@ export async function getSanityStudioConfigPath(studioRootPath: string): Promise
     path.join(studioRootPath, 'sanity.config.tsx'),
   ]
 
+  debug('Looking for configuration file in %d possible locations', configPaths.length)
   const configs = await Promise.all(
     configPaths.map(async (configPath) => ({
       path: configPath,
@@ -25,8 +29,10 @@ export async function getSanityStudioConfigPath(studioRootPath: string): Promise
     }))
   )
 
-  // No config file exists?
   const availableConfigs = configs.filter((config) => config.exists)
+  debug('Found %d available configuration files', availableConfigs.length)
+
+  // No config file exists?
   if (availableConfigs.length === 0) {
     console.warn('No `sanity.config.js`/`sanity.config.ts` found - using default studio config')
     return path.resolve(__dirname, './default-config.js')


### PR DESCRIPTION
### Description

Basically just adds more logging using the `debug` module, in order to more easily probe what is going wrong or is slow in certain cases. Should be fairly uncontroversial.

### What to review

- `sanity build`, `sanity dev`, `sanity preview` works

