### PR TITLE
feat(desk): scope document footer dialogs to the current pane

### DIFF
--- a/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialog.tsx
+++ b/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialog.tsx
@@ -94,6 +94,8 @@ export function ConfirmDeleteDialog({
       }
       onClose={onCancel}
       onClickOutside={onCancel}
+      // Custom portal element configured in `DocumentPane` so that the dialog is scoped to the current pane
+      portal="documentPanelPortalElement"
     >
       <DialogBody>
         {crossDatasetReferences && internalReferences && !isLoading ? (

--- a/packages/sanity/src/desk/components/confirmDeleteDialog/index.tsx
+++ b/packages/sanity/src/desk/components/confirmDeleteDialog/index.tsx
@@ -24,6 +24,8 @@ function ConfirmDeleteDialogContainer(props: ConfirmDeleteDialogProps) {
         </Flex>
       }
       onClose={props.onCancel}
+      // Custom portal element configured in `DocumentPane` so that the dialog is scoped to the current pane
+      portal="documentPanelPortalElement"
     >
       <Box padding={4}>
         <Text>An error occurred while loading referencing documents.</Text>

--- a/packages/sanity/src/desk/panes/document/DocumentPane.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentPane.tsx
@@ -5,6 +5,7 @@ import {
   DialogProvider,
   DialogProviderProps,
   Flex,
+  PortalProvider,
   Stack,
   Text,
   useElementRect,
@@ -213,6 +214,9 @@ function InnerDocumentPane() {
   const [rootElement, setRootElement] = useState<HTMLDivElement | null>(null)
   const [footerElement, setFooterElement] = useState<HTMLDivElement | null>(null)
   const [actionsBoxElement, setActionsBoxElement] = useState<HTMLDivElement | null>(null)
+  const [documentPanelPortalElement, setDocumentPanelPortalElement] = useState<HTMLElement | null>(
+    null
+  )
   const footerRect = useElementRect(footerElement)
   const footerH = footerRect?.height
 
@@ -220,20 +224,27 @@ function InnerDocumentPane() {
     () => (
       <DocumentPanel
         footerHeight={footerH || null}
-        rootElement={rootElement}
         isInspectOpen={inspectOpen}
+        rootElement={rootElement}
+        setDocumentPanelPortalElement={setDocumentPanelPortalElement}
       />
     ),
     [footerH, rootElement, inspectOpen]
   )
 
+  // These providers are added because we want the dialogs in `DocumentStatusBar` to be scoped to the document pane.
+  // The portal element comes from `DocumentPanel`.
   const footer = useMemo(
     () => (
-      <PaneFooter ref={setFooterElement}>
-        <DocumentStatusBar actionsBoxRef={setActionsBoxElement} />
-      </PaneFooter>
+      <PortalProvider __unstable_elements={{documentPanelPortalElement}}>
+        <DialogProvider position={DIALOG_PROVIDER_POSITION} zOffset={zOffsets.portal}>
+          <PaneFooter ref={setFooterElement}>
+            <DocumentStatusBar actionsBoxRef={setActionsBoxElement} />
+          </PaneFooter>
+        </DialogProvider>
+      </PortalProvider>
     ),
-    []
+    [documentPanelPortalElement, zOffsets.portal]
   )
 
   const changesPanel = useMemo(() => {
@@ -318,18 +329,18 @@ function InnerDocumentPane() {
       </>
     )
   }, [
-    changesOpen,
-    changesPanel,
-    documentPanel,
-    documentType,
-    footer,
-    onConnectorSetFocus,
-    onHistoryOpen,
-    layoutCollapsed,
-    paneKey,
     schemaType,
-    value,
     zOffsets.portal,
+    layoutCollapsed,
+    changesOpen,
+    onHistoryOpen,
+    onConnectorSetFocus,
+    documentPanel,
+    changesPanel,
+    footer,
+    paneKey,
+    documentType,
+    value,
   ])
 
   const currentMinWidth = changesOpen

--- a/packages/sanity/src/desk/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/DocumentPanel.tsx
@@ -9,18 +9,13 @@ import {ReferenceChangedBanner} from './ReferenceChangedBanner'
 import {PermissionCheckBanner} from './PermissionCheckBanner'
 import {FormView} from './documentViews'
 import {DocumentPanelHeader} from './header'
-import {
-  ScrollContainer,
-  useDocumentValuePermissions,
-  useSchema,
-  getDraftId,
-  getPublishedId,
-} from 'sanity'
+import {ScrollContainer} from 'sanity'
 
 interface DocumentPanelProps {
   footerHeight: number | null
   rootElement: HTMLDivElement | null
   isInspectOpen: boolean
+  setDocumentPanelPortalElement: (el: HTMLElement | null) => void
 }
 
 const Scroller = styled(ScrollContainer)<{$disabled: boolean}>(({$disabled}) => {
@@ -38,7 +33,7 @@ const Scroller = styled(ScrollContainer)<{$disabled: boolean}>(({$disabled}) => 
 })
 
 export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
-  const {footerHeight, isInspectOpen, rootElement} = props
+  const {footerHeight, isInspectOpen, rootElement, setDocumentPanelPortalElement} = props
   const {
     activeViewId,
     displayed,
@@ -105,6 +100,13 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     if (!documentScrollElement?.scrollTo) return
     documentScrollElement.scrollTo(0, 0)
   }, [documentId, documentScrollElement])
+
+  // Pass portal element to `DocumentPane`
+  useEffect(() => {
+    if (portalElement) {
+      setDocumentPanelPortalElement(portalElement)
+    }
+  }, [portalElement, setDocumentPanelPortalElement])
 
   const inspectDialog = useMemo(() => {
     return isInspectOpen ? <InspectDialog value={displayed || value} /> : null

--- a/packages/sanity/src/desk/panes/document/statusBar/dialogs/ModalDialog.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/dialogs/ModalDialog.tsx
@@ -25,6 +25,8 @@ export function ModalDialog(props: {dialog: DocumentActionModalDialogProps}) {
         // eslint-disable-next-line react/jsx-handler-names
         onClickOutside={dialog.onClose}
         width={dialog.width === undefined ? 1 : DIALOG_WIDTH_TO_UI_WIDTH[dialog.width]}
+        // Custom portal element configured in `DocumentPane` so that the dialog is scoped to the current pane
+        portal="documentPanelPortalElement"
       >
         <Box padding={4}>{dialog.content}</Box>
       </Dialog>


### PR DESCRIPTION
### Description
Currently, document specific dialogs are rendered full screen. This PR updates so that a document's dialogs are scoped to the document's pane.

<img width="2642" alt="dialogs" src="https://user-images.githubusercontent.com/15094168/202284991-4421c789-218d-485e-84ce-affed5e7f172.png">

### What to review

Make sure that a document's dialogs are scoped to its pane.

### Notes for release

feat(desk): scope document footer dialogs to the current pane