### PR TITLE
refactor(inputs): refactor PT-input annotation popover

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -87,7 +87,7 @@ export function Compositor(props: InputProps) {
 
   // Scroll to the DOM element of the "opened" portable text member when relevant.
   useScrollToOpenedMember({
-    hasFocus,
+    hasFormFocus: focusPath.length > 0,
     editorRootPath: path,
     scrollElement,
     onItemClose,

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -8,6 +8,8 @@ import {
   OnPasteFn,
   OnCopyFn,
   EditorSelection,
+  PortableTextEditor,
+  usePortableTextEditor,
 } from '@sanity/portable-text-editor'
 import {Path} from '@sanity/types'
 import {BoundaryElementProvider, useBoundaryElement, useGlobalKeyDown, useLayer} from '@sanity/ui'
@@ -69,6 +71,7 @@ export function Editor(props: EditorProps) {
   } = props
   const {isTopLayer} = useLayer()
   const editableRef = useRef<HTMLDivElement | null>(null)
+  const editor = usePortableTextEditor()
 
   const {element: boundaryElement} = useBoundaryElement()
 
@@ -131,11 +134,12 @@ export function Editor(props: EditorProps) {
     ]
   )
 
-  const handleToolBarOnExpand = useCallback(
+  const handleToolBarOnMemberOpen = useCallback(
     (relativePath: Path) => {
+      PortableTextEditor.blur(editor)
       onItemOpen(path.concat(relativePath))
     },
-    [onItemOpen, path]
+    [editor, onItemOpen, path]
   )
 
   return (
@@ -145,7 +149,7 @@ export function Editor(props: EditorProps) {
           <Toolbar
             isFullscreen={isFullscreen}
             hotkeys={hotkeys}
-            onExpand={handleToolBarOnExpand}
+            onMemberOpen={handleToolBarOnMemberOpen}
             readOnly={readOnly}
             onToggleFullscreen={onToggleFullscreen}
           />

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useScrollToOpenedMember.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useScrollToOpenedMember.tsx
@@ -6,7 +6,7 @@ import {usePortableTextMemberItems} from './usePortableTextMembers'
 
 interface Props {
   editorRootPath: Path
-  hasFocus: boolean
+  hasFormFocus: boolean // Wether we have focus on something in the editor's form state
   scrollElement: HTMLElement | null
   onItemClose: () => void
 }
@@ -14,7 +14,7 @@ interface Props {
 // This hook will scroll to the "opened" portable text object's editor dom node.
 // If the opened item is a regular text block, place the cursor there as well.
 export function useScrollToOpenedMember(props: Props): void {
-  const {editorRootPath, scrollElement, hasFocus, onItemClose} = props
+  const {editorRootPath, scrollElement, hasFormFocus, onItemClose} = props
   const portableTextMemberItems = usePortableTextMemberItems()
   const editor = usePortableTextEditor()
 
@@ -26,8 +26,8 @@ export function useScrollToOpenedMember(props: Props): void {
   }, [portableTextMemberItems])
 
   useEffect(() => {
-    // If the editor is already is focused, don't interfere.
-    if (hasFocus) {
+    // If the editor already has form focus, don't interfere.
+    if (hasFormFocus) {
       return
     }
     if (memberItem?.elementRef?.current) {
@@ -48,5 +48,5 @@ export function useScrollToOpenedMember(props: Props): void {
         onItemClose()
       }
     }
-  }, [editor, hasFocus, editorRootPath.length, memberItem, scrollElement, onItemClose])
+  }, [editor, hasFormFocus, editorRootPath.length, memberItem, scrollElement, onItemClose])
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/object/renderers/ObjectEditModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/renderers/ObjectEditModal.tsx
@@ -56,7 +56,10 @@ export function ObjectEditModal(props: {
   }, [firstField, memberItem])
 
   if (modalType === 'popover') {
-    return (
+    // 2022/11/18: Test if the elementRef is set before opening. On newly created annotations,
+    // this might not be true, and currently the @sanity/ui Popover code will not
+    // properly show the Popover if it's given at a later point.
+    return memberItem.elementRef?.current ? (
       <PopoverEditDialog
         elementRef={memberItem.elementRef}
         onClose={handleClose}
@@ -66,7 +69,7 @@ export function ObjectEditModal(props: {
       >
         {props.children}
       </PopoverEditDialog>
-    )
+    ) : null
   }
 
   return (

--- a/packages/sanity/src/core/form/inputs/PortableText/text/Annotation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/Annotation.tsx
@@ -66,7 +66,7 @@ const TooltipBox = styled(Box).attrs({forwardedAs: 'span'})`
 
 export const Annotation = function Annotation(props: AnnotationProps) {
   const {
-    attributes: {focused, path},
+    attributes: {path},
     children,
     onItemOpen,
     renderCustomMarkers,
@@ -163,7 +163,6 @@ export const Annotation = function Annotation(props: AnnotationProps) {
   }, [isLink, hasError, hasWarning])
 
   const hasCustomMarkers = markers.length > 0
-
   return (
     <Root
       $toneKey={toneKey}
@@ -175,7 +174,7 @@ export const Annotation = function Annotation(props: AnnotationProps) {
       onClick={readOnly ? openItem : undefined}
     >
       <span ref={memberItem?.elementRef}>{markersToolTip || text}</span>
-      {focused && !readOnly && (
+      {!readOnly && (
         <AnnotationToolbarPopover
           textElement={textElement || undefined}
           annotationElement={annotationRef.current || undefined}

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/Toolbar.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/Toolbar.tsx
@@ -23,7 +23,7 @@ interface ToolbarProps {
   hotkeys: HotkeyOptions
   isFullscreen: boolean
   readOnly?: boolean
-  onExpand: (path: Path) => void
+  onMemberOpen: (relativePath: Path) => void
   onToggleFullscreen: () => void
 }
 
@@ -147,7 +147,7 @@ const InnerToolbar = memo(function InnerToolbar({
 })
 
 export function Toolbar(props: ToolbarProps) {
-  const {hotkeys, isFullscreen, readOnly, onExpand, onToggleFullscreen} = props
+  const {hotkeys, isFullscreen, readOnly, onMemberOpen, onToggleFullscreen} = props
   const features = useFeatures()
   const editor = usePortableTextEditor()
   const selection = usePortableTextEditorSelection()
@@ -201,11 +201,10 @@ export function Toolbar(props: ToolbarProps) {
       const initialValue = await resolveInitialValue(type)
       const path = PortableTextEditor.insertBlock(editor, type as FIXME, initialValue)
       if (path) {
-        PortableTextEditor.blur(editor)
-        onExpand(path)
+        onMemberOpen(path)
       }
     },
-    [editor, onExpand, resolveInitialValue]
+    [editor, onMemberOpen, resolveInitialValue]
   )
 
   const handleInsertInline = useCallback(
@@ -213,16 +212,15 @@ export function Toolbar(props: ToolbarProps) {
       const initialValue = await resolveInitialValue(type)
       const path = PortableTextEditor.insertChild(editor, type as FIXME, initialValue)
       if (path) {
-        PortableTextEditor.blur(editor)
-        onExpand(path)
+        onMemberOpen(path)
       }
     },
-    [editor, onExpand, resolveInitialValue]
+    [editor, onMemberOpen, resolveInitialValue]
   )
 
   const actionGroups = useActionGroups({
     hotkeys,
-    onExpand,
+    onMemberOpen,
     resolveInitialValue,
     disabled: true,
   })

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/hooks.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/hooks.ts
@@ -38,12 +38,12 @@ export function useFeatures(): PortableTextFeatures {
 
 export function useActionGroups({
   hotkeys,
-  onExpand,
+  onMemberOpen,
   resolveInitialValue,
   disabled,
 }: {
   hotkeys: HotkeyOptions
-  onExpand: (path: Path) => void
+  onMemberOpen: (relativePath: Path) => void
   resolveInitialValue: (type: ObjectSchemaType) => FIXME
   disabled: boolean
 }): PTEToolbarActionGroup[] {
@@ -54,11 +54,10 @@ export function useActionGroups({
       const initialValue = await resolveInitialValue(type)
       const paths = PortableTextEditor.addAnnotation(editor, type as FIXME, initialValue)
       if (paths && paths.markDefPath) {
-        PortableTextEditor.blur(editor)
-        onExpand(paths.markDefPath)
+        onMemberOpen(paths.markDefPath)
       }
     },
-    [editor, onExpand, resolveInitialValue]
+    [editor, onMemberOpen, resolveInitialValue]
   )
 
   return useMemo(


### PR DESCRIPTION
When there is a Popover element opened in the editor, wait for the editor reference element to be set before we open it. Currently there is an issue with @sanity/ui and Floating.ui that will not open the popover properly if the reference element is given at a later time.

Also, improve `useScrollToOpenenedMember` to actually test if the form has focus, and not only the editor itself. The form value is what we want here as the editor in transition could have focus, but not form state focus (focusPath).

Also fixed an related issue where the toolbar popover for PT annotations would not properly show on newly created annotations.

Also moved some common editor blur logic to a more central place and renamed toolbar prop `onExpand` to `onOpenItem` to make it clearer what it does and easier to change the common behaviour.

### Notes for release
Fixed UI issues related to adding annotations in the Portable Text Editor.

<!--
A description of the change(s) that should be used in the release notes.
-->
