### PR TITLE
fix: add 'checkbox' layout to array schema options

### DIFF
--- a/packages/@sanity/types/src/schema/definition/type/array.ts
+++ b/packages/@sanity/types/src/schema/definition/type/array.ts
@@ -7,12 +7,12 @@ import {BaseSchemaDefinition, TitledListValue} from './common'
 export interface ArrayOptions<V = unknown> {
   list?: TitledListValue<V>[] | V[]
   /**
-   * layout: 'tags' only works for string array
-   * layout: 'grid' only works for arrays with objects
+   * layout: 'tags' and 'checkbox' only apply to arrays of strings
+   * layout: 'grid' only apply to arrays of objects
    */
   // inferring the array.of value for ArrayDefinition cause too much code-noise and was removed.
   // Since we don't have the type-info needed here, we allow values
-  layout?: 'tags' | 'grid'
+  layout?: 'tags' | 'checkbox' | 'grid'
   direction?: 'horizontal' | 'vertical'
   sortable?: boolean
   modal?: {type?: 'dialog' | 'popover'; width?: number | 'auto'}


### PR DESCRIPTION
### Description

The Type for Array schema's `options.layout` was missing `checkbox`
https://www.sanity.io/docs/array-type#options

### What to review

That Simeon did this correctly as he doesn't do PR's often

### Notes for release

Add `checkbox` as a valid option for the Array schema type's `options.layout` Type