### PR TITLE
refactor: re-order methods in fieldpresence to reduce deadcode removal on next

### DIFF
--- a/packages/sanity/src/core/presence/FieldPresence.tsx
+++ b/packages/sanity/src/core/presence/FieldPresence.tsx
@@ -16,48 +16,6 @@ import {useReporter} from './overlay/tracker'
 import {FormNodePresence} from './types'
 
 /** @internal */
-export interface FieldPresenceProps {
-  presence: FormNodePresence[]
-  maxAvatars: number
-}
-
-/** @internal */
-export const FieldPresence = DISABLE_OVERLAY
-  ? FieldPresenceWithoutOverlay
-  : FieldPresenceWithOverlay
-
-/** @internal */
-export function FieldPresenceWithOverlay(props: FieldPresenceProps) {
-  const contextPresence = useContext(FormFieldPresenceContext)
-  const {presence = contextPresence, maxAvatars = DEFAULT_MAX_AVATARS_FIELDS} = props
-  const ref = React.useRef(null)
-
-  useReporter(useId(), () => ({presence, element: ref.current!, maxAvatars: maxAvatars}))
-
-  const minWidth = -AVATAR_DISTANCE + (AVATAR_SIZE + AVATAR_DISTANCE) * props.maxAvatars
-
-  return (
-    <FlexWrapper
-      justify="flex-end"
-      ref={ref}
-      style={{minWidth: minWidth, minHeight: AVATAR_SIZE}}
-    />
-  )
-}
-
-/** @internal */
-export function FieldPresenceWithoutOverlay(props: FieldPresenceProps) {
-  const contextPresence = useContext(FormFieldPresenceContext)
-  const {presence = contextPresence, maxAvatars = DEFAULT_MAX_AVATARS_FIELDS} = props
-
-  if (!presence.length) {
-    return null
-  }
-
-  return <FieldPresenceInner presence={presence} maxAvatars={maxAvatars} />
-}
-
-/** @internal */
 export interface FieldPresenceInnerProps {
   maxAvatars?: number
   presence: FormNodePresence[]
@@ -134,3 +92,45 @@ export const FieldPresenceInner = memo(function FieldPresenceInner({
     </FlexWrapper>
   )
 })
+
+/** @internal */
+export interface FieldPresenceProps {
+  presence: FormNodePresence[]
+  maxAvatars: number
+}
+
+/** @internal */
+export function FieldPresenceWithOverlay(props: FieldPresenceProps) {
+  const contextPresence = useContext(FormFieldPresenceContext)
+  const {presence = contextPresence, maxAvatars = DEFAULT_MAX_AVATARS_FIELDS} = props
+  const ref = React.useRef(null)
+
+  useReporter(useId(), () => ({presence, element: ref.current!, maxAvatars: maxAvatars}))
+
+  const minWidth = -AVATAR_DISTANCE + (AVATAR_SIZE + AVATAR_DISTANCE) * props.maxAvatars
+
+  return (
+    <FlexWrapper
+      justify="flex-end"
+      ref={ref}
+      style={{minWidth: minWidth, minHeight: AVATAR_SIZE}}
+    />
+  )
+}
+
+/** @internal */
+export function FieldPresenceWithoutOverlay(props: FieldPresenceProps) {
+  const contextPresence = useContext(FormFieldPresenceContext)
+  const {presence = contextPresence, maxAvatars = DEFAULT_MAX_AVATARS_FIELDS} = props
+
+  if (!presence.length) {
+    return null
+  }
+
+  return <FieldPresenceInner presence={presence} maxAvatars={maxAvatars} />
+}
+
+/** @internal */
+export const FieldPresence = DISABLE_OVERLAY
+  ? FieldPresenceWithoutOverlay
+  : FieldPresenceWithOverlay


### PR DESCRIPTION
### Description

There is an issue with Vercel/Next where after they've made changes to their configuration keys (specifically `swcMinify` is now set to default to true) that causes issues with some parts of the code. 
This change came after a bug report came over the `FieldPresenceWithOverlay` was not found when running `start` but was fine when running the `dev` command). 

After speaking with @stipsan , he realised - from other bugs exactly like this one - that this is Next recognises that the method `FieldPresenceWithOverlay` is not being called anywhere so it can remove it completely. Changing the order of the methods should help reduce the amount of times that we run into this issue in the future.

Vercel/Next have also been made aware that this is happening.

### What to review

The code is exactly the same, I've only moved the code that is called on other methods over to the top (so if method `a` calls `b`, b is instantiated before `a` and not after)

