### PR TITLE
fix(errors): unify error boundaries, prevent duplicate toasts

### DIFF
--- a/packages/sanity/src/core/error/ErrorLogger.tsx
+++ b/packages/sanity/src/core/error/ErrorLogger.tsx
@@ -1,0 +1,67 @@
+import {useToast} from '@sanity/ui'
+import {useEffect} from 'react'
+import {ConfigResolutionError, SchemaError} from '../config'
+import {CorsOriginError} from '../store'
+import {globalScope} from '../util'
+
+const errorChannel = globalScope.__sanityErrorChannel
+
+/**
+ * Attaches a listener to the global error channel and displays a toast when a (unknown)
+ * error occurs. Compares the last displayed error message with the current
+ *
+ * @internal
+ */
+export function ErrorLogger(): null {
+  const {push: pushToast} = useToast()
+
+  useEffect(() => {
+    if (!errorChannel) return undefined
+
+    // errorChannel.subscribe() returns a unsubscriber function.
+    // By returning it from this `useEffect`, it'll unsubscribe on unmount.
+    return errorChannel.subscribe((msg) => {
+      // NOTE: Certain errors (such as the `ResizeObserver loop limit exceeded` error) is thrown
+      // by the browser, and does not include an `error` property. We ignore these errors.
+      if (!msg.error) {
+        return
+      }
+
+      // For errors that we "expect", eg have specific error screens for, do not push a toast
+      if (isKnownError(msg.error)) {
+        return
+      }
+
+      console.error(msg.error)
+
+      pushToast({
+        // Use the error message as the ID in order to prevent duplicates from showing
+        // A bit of a hack, but serves
+        id: msg.error.message,
+        closable: true,
+        description: msg.error.message,
+        duration: 5000,
+        title: 'Uncaught error',
+        status: 'error',
+      })
+    })
+  }, [pushToast])
+
+  return null
+}
+
+function isKnownError(err: Error): boolean {
+  if (err instanceof SchemaError) {
+    return true
+  }
+
+  if (err instanceof CorsOriginError) {
+    return true
+  }
+
+  if (err instanceof ConfigResolutionError) {
+    return true
+  }
+
+  return false
+}

--- a/packages/sanity/src/core/studio/StudioErrorBoundary.tsx
+++ b/packages/sanity/src/core/studio/StudioErrorBoundary.tsx
@@ -1,36 +1,21 @@
-import React, {useCallback, useEffect, useState} from 'react'
-import {Button, Card, Code, Container, ErrorBoundary, Heading, Stack, useToast} from '@sanity/ui'
+import React, {useCallback, useState} from 'react'
+import {Button, Card, Code, Container, ErrorBoundary, Heading, Stack} from '@sanity/ui'
 import {useHotModuleReload} from 'use-hot-module-reload'
-import {ConfigResolutionError, SchemaError} from '../config'
-import {globalScope, isRecord} from '../util'
+import {SchemaError} from '../config'
+import {isRecord} from '../util'
 import {CorsOriginError} from '../store'
 import {CorsOriginErrorScreen, SchemaErrorsScreen} from './screens'
 
 interface StudioErrorBoundaryProps {
   children: React.ReactNode
+  heading?: string
 }
 
-const errorChannel = globalScope.__sanityErrorChannel
-
-function isKnownError(err: Error): boolean {
-  if (err instanceof SchemaError) {
-    return true
-  }
-
-  if (err instanceof CorsOriginError) {
-    return true
-  }
-
-  if (err instanceof ConfigResolutionError) {
-    return true
-  }
-
-  return false
-}
-
-export function StudioErrorBoundary({children}: StudioErrorBoundaryProps) {
+export function StudioErrorBoundary({
+  children,
+  heading = 'An error occured',
+}: StudioErrorBoundaryProps) {
   const [{error}, setError] = useState<{error: unknown}>({error: null})
-  const {push: pushToast} = useToast()
 
   const message = isRecord(error) && typeof error.message === 'string' && error.message
   const stack = isRecord(error) && typeof error.stack === 'string' && error.stack
@@ -38,33 +23,6 @@ export function StudioErrorBoundary({children}: StudioErrorBoundaryProps) {
   const handleResetError = useCallback(() => setError({error: null}), [setError])
 
   useHotModuleReload(handleResetError)
-
-  useEffect(() => {
-    if (!errorChannel) return undefined
-
-    return errorChannel.subscribe((msg) => {
-      // NOTE: Certain errors (such as the `ResizeObserver loop limit exceeded` error) is thrown
-      // by the browser, and does not include an `error` property. We ignore these errors.
-      if (!msg.error) {
-        return
-      }
-
-      // For errors that we "expect", eg have specific error screens for, do not push a toast
-      if (isKnownError(msg.error)) {
-        return
-      }
-
-      console.error(msg.error)
-
-      pushToast({
-        closable: true,
-        description: msg.error.message,
-        duration: 5000,
-        title: 'Uncaught error',
-        status: 'error',
-      })
-    })
-  }, [pushToast])
 
   if (error instanceof CorsOriginError) {
     return <CorsOriginErrorScreen projectId={error?.projectId} />
@@ -74,41 +32,41 @@ export function StudioErrorBoundary({children}: StudioErrorBoundaryProps) {
     return <SchemaErrorsScreen schema={error.schema} />
   }
 
-  if (error) {
-    return (
-      <Card
-        height="fill"
-        overflow="auto"
-        paddingY={[4, 5, 6, 7]}
-        paddingX={4}
-        sizing="border"
-        tone="critical"
-      >
-        <Container width={3}>
-          <Stack space={4}>
-            {/* TODO: better error boundary */}
-
-            <Heading>An error occurred</Heading>
-
-            <div>
-              <Button onClick={handleResetError} text="Retry" tone="default" />
-            </div>
-
-            <Card border radius={2} overflow="auto" padding={4} tone="inherit">
-              <Stack space={4}>
-                {message && (
-                  <Code size={1}>
-                    <strong>Error: {message}</strong>
-                  </Code>
-                )}
-                {stack && <Code size={1}>{stack}</Code>}
-              </Stack>
-            </Card>
-          </Stack>
-        </Container>
-      </Card>
-    )
+  if (!error) {
+    return <ErrorBoundary onCatch={setError}>{children}</ErrorBoundary>
   }
 
-  return <ErrorBoundary onCatch={setError}>{children}</ErrorBoundary>
+  return (
+    <Card
+      height="fill"
+      overflow="auto"
+      paddingY={[4, 5, 6, 7]}
+      paddingX={4}
+      sizing="border"
+      tone="critical"
+    >
+      <Container width={3}>
+        <Stack space={4}>
+          {/* TODO: better error boundary */}
+
+          <Heading>{heading}</Heading>
+
+          <div>
+            <Button onClick={handleResetError} text="Retry" tone="default" />
+          </div>
+
+          <Card border radius={2} overflow="auto" padding={4} tone="inherit">
+            <Stack space={4}>
+              {message && (
+                <Code size={1}>
+                  <strong>Error: {message}</strong>
+                </Code>
+              )}
+              {stack && <Code size={1}>{stack}</Code>}
+            </Stack>
+          </Card>
+        </Stack>
+      </Container>
+    </Card>
+  )
 }

--- a/packages/sanity/src/core/studio/StudioProvider.tsx
+++ b/packages/sanity/src/core/studio/StudioProvider.tsx
@@ -7,6 +7,7 @@ import json from 'refractor/lang/json'
 import jsx from 'refractor/lang/jsx'
 import typescript from 'refractor/lang/typescript'
 import {UserColorManagerProvider} from '../user-color'
+import {ErrorLogger} from '../error/ErrorLogger'
 import {ResourceCacheProvider} from '../store'
 import {AuthBoundary} from './AuthBoundary'
 import {StudioProps} from './Studio'
@@ -53,6 +54,7 @@ export function StudioProvider({
   return (
     <ColorSchemeProvider onSchemeChange={onSchemeChange} scheme={scheme}>
       <ToastProvider paddingY={7} zOffset={Z_OFFSET.toast}>
+        <ErrorLogger />
         <StudioErrorBoundary>
           <WorkspacesProvider config={config}>
             <ActiveWorkspaceMatcher


### PR DESCRIPTION
### Description

We currently have two error boundaries - one on the studio level and one on the tool level. This _sorta_ makes sense, since by having a separate tool-level boundary, we can still move to different tools if one of them crashes (the global error boundary doesn't render any navigation bar). However, the two error boundaries look and behave differently, which isn't great.

This PR refactors things a bit:
- Moves the error logging bit (`console.error()` + pushing a toast) out of the error boundary and into its own little component (doesn't render anything, but attaches a listener using a `useEffect`). Could have been just a hook, but needs to be rendered below the toast provider in the tree, so might as well make it a component.
- Makes the studio error boundary slightly more reusable by allowing the configuration of a heading text (also refactors the conditionals to reduce the nesting of the actual rendered UI)
- Drops the custom error boundary on the tool level, instead reusing the `StudioErrorBoundary`
- Uses an `id` on the pushed toasts to prevent the same exact error message from being displayed more than once at a time (this happens in certain cases because of React re-rendering and such)

### What to review

- Still catches errors in tools and globally
- Switching tools works even if one tool crashes

### Notes for release

None. Basically transparent for the end user (slightly different look and feel, but generally the same).