### PR TITLE
Various fixes related to number input when used inside arrays

### DIFF
--- a/packages/@sanity/mutator/src/patch/ImmutableAccessor.ts
+++ b/packages/@sanity/mutator/src/patch/ImmutableAccessor.ts
@@ -81,7 +81,7 @@ export class ImmutableAccessor implements Probe {
       throw new Error('setIndex only applies to arrays')
     }
 
-    if (value === this._value[i]) {
+    if (Object.is(value, this._value[i])) {
       return this
     }
 
@@ -131,7 +131,7 @@ export class ImmutableAccessor implements Probe {
       throw new Error('Unable to set attribute of non-object container')
     }
 
-    if (value === this._value[key]) {
+    if (Object.is(value, this._value[key])) {
       return this
     }
 

--- a/packages/sanity/src/core/form/inputs/NumberInput.tsx
+++ b/packages/sanity/src/core/form/inputs/NumberInput.tsx
@@ -8,7 +8,7 @@ import {NumberInputProps} from '../types'
  * @beta
  */
 export function NumberInput(props: NumberInputProps) {
-  const {schemaType, validationError, value, elementProps} = props
+  const {schemaType, validationError, elementProps} = props
 
   // Show numpad on mobile if only positive numbers is preferred
   const minRule = getValidationRule(schemaType, 'min')
@@ -29,6 +29,8 @@ export function NumberInput(props: NumberInputProps) {
       customValidity={validationError}
       placeholder={schemaType.placeholder}
       pattern={onlyPositiveNumber ? '[d]*' : undefined}
+      max={Number.MAX_SAFE_INTEGER}
+      min={Number.MIN_SAFE_INTEGER}
     />
   )
 }

--- a/packages/sanity/src/core/form/inputs/NumberInput.tsx
+++ b/packages/sanity/src/core/form/inputs/NumberInput.tsx
@@ -27,7 +27,6 @@ export function NumberInput(props: NumberInputProps) {
       step="any"
       inputMode={inputMode}
       customValidity={validationError}
-      value={value}
       placeholder={schemaType.placeholder}
       pattern={onlyPositiveNumber ? '[d]*' : undefined}
     />

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ErrorItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ErrorItem.tsx
@@ -2,21 +2,18 @@ import React, {useCallback, useId} from 'react'
 import {EllipsisVerticalIcon, TrashIcon} from '@sanity/icons'
 import {Box, Button, Menu, MenuButton, MenuItem} from '@sanity/ui'
 import {ArrayItemError} from '../../../../store'
-import {useFormCallbacks} from '../../../../studio/contexts/FormCallbacks'
-import {PatchEvent, unset} from '../../../../patch'
 import {RowLayout} from '../../layouts/RowLayout'
 import {IncompatibleItemType} from './IncompatibleItemType'
 
 const MENU_POPOVER_PROPS = {portal: true, tone: 'default'} as const
 
-export function ErrorItem(props: {member: ArrayItemError; sortable?: boolean}) {
-  const {member, sortable} = props
+export function ErrorItem(props: {
+  member: ArrayItemError
+  sortable?: boolean
+  onRemove: () => void
+}) {
+  const {member, sortable, onRemove} = props
   const id = useId()
-  const {onChange} = useFormCallbacks()
-
-  const handleRemove = useCallback(() => {
-    onChange(PatchEvent.from([unset([{_key: member.key}])]))
-  }, [onChange, member.key])
 
   return (
     <Box paddingX={1}>
@@ -29,7 +26,7 @@ export function ErrorItem(props: {member: ArrayItemError; sortable?: boolean}) {
             id={`${id}-menuButton`}
             menu={
               <Menu>
-                <MenuItem text="Remove" tone="critical" icon={TrashIcon} onClick={handleRemove} />
+                <MenuItem text="Remove" tone="critical" icon={TrashIcon} onClick={onRemove} />
               </Menu>
             }
             popover={MENU_POPOVER_PROPS}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.tsx
@@ -77,7 +77,13 @@ export function ListArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
                         renderPreview={renderPreview}
                       />
                     )}
-                    {member.kind === 'error' && <ErrorItem sortable={sortable} member={member} />}
+                    {member.kind === 'error' && (
+                      <ErrorItem
+                        sortable={sortable}
+                        member={member}
+                        onRemove={() => props.onItemRemove(member.key)}
+                      />
+                    )}
                   </Item>
                 ))}
               </List>

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
@@ -119,6 +119,7 @@ export class ArrayOfPrimitivesInput extends React.PureComponent<ArrayOfPrimitive
       readOnly,
       renderInput,
       onUpload,
+      onItemRemove,
       resolveUploader,
       elementProps,
       arrayFunctions: ArrayFunctions = ArrayOfPrimitivesFunctions,
@@ -156,7 +157,11 @@ export class ArrayOfPrimitivesInput extends React.PureComponent<ArrayOfPrimitive
                           />
                         )}
                         {member.kind === 'error' && (
-                          <ErrorItem sortable={isSortable} member={member} />
+                          <ErrorItem
+                            sortable={isSortable}
+                            member={member}
+                            onRemove={() => onItemRemove(index)}
+                          />
                         )}
                       </Item>
                     )

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ItemRow.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ItemRow.tsx
@@ -37,10 +37,6 @@ export const ItemRow = React.forwardRef(function ItemRow(
   const hasError = validation.filter((item) => item.level === 'error').length > 0
   const hasWarning = validation.filter((item) => item.level === 'warning').length > 0
 
-  const handleRemove = useCallback(() => {
-    onRemove()
-  }, [onRemove])
-
   const handleInsert = useCallback(
     (pos: 'before' | 'after', insertType: SchemaType) => {
       onInsert({position: pos, items: [getEmptyValue(insertType)]})
@@ -70,7 +66,7 @@ export const ItemRow = React.forwardRef(function ItemRow(
       popover={MENU_BUTTON_POPOVER_PROPS}
       menu={
         <Menu>
-          <MenuItem text="Remove" tone="critical" icon={TrashIcon} onClick={handleRemove} />
+          <MenuItem text="Remove" tone="critical" icon={TrashIcon} onClick={onRemove} />
 
           <MenuItem text="Duplicate" icon={DuplicateIcon} onClick={handleDuplicate} />
           <InsertMenu types={insertableTypes} onInsert={handleInsert} />

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/getEmptyValue.ts
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/getEmptyValue.ts
@@ -6,7 +6,7 @@ export function getEmptyValue(type: SchemaType): number | string | boolean {
       return ''
     }
     case 'number': {
-      return 0
+      return -0
     }
     case 'boolean': {
       return false

--- a/packages/sanity/src/core/form/members/array/items/ArrayOfPrimitivesItem.tsx
+++ b/packages/sanity/src/core/form/members/array/items/ArrayOfPrimitivesItem.tsx
@@ -53,18 +53,10 @@ export function ArrayOfPrimitivesItem(props: PrimitiveMemberItemProps) {
 
   const handleChange = useCallback(
     (event: PatchEvent | PatchArg) => {
-      const patches = PatchEvent.from(event).patches.map((patch) =>
-        // Map direct unset patches to empty value instead in order to not *remove* elements as the user clears out the value
-        // note: this creates the rather "weird" case where the input renders ´0´ when you try to clear it
-        patch.path.length === 0 && patch.type === 'unset'
-          ? set(getEmptyValue(member.item.schemaType))
-          : patch
-      )
-      onChange(PatchEvent.from(patches).prefixAll(member.index))
+      onChange(PatchEvent.from(event).prefixAll(member.index))
     },
-    [onChange, member.item.schemaType, member.index]
+    [onChange, member.index]
   )
-
   const handleNativeChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       let inputValue: number | string | boolean = event.currentTarget.value
@@ -78,9 +70,17 @@ export function ArrayOfPrimitivesItem(props: PrimitiveMemberItemProps) {
       const hasEmptyValue =
         inputValue === '' || (typeof inputValue === 'number' && isNaN(inputValue))
 
-      onChange(PatchEvent.from(hasEmptyValue ? unset() : set(inputValue)).prefixAll(member.index))
+      handleChange(
+        set(
+          hasEmptyValue
+            ? // Map direct unset patches to empty value instead in order to not *remove* elements as the user clears out the value
+              // note: this creates the rather curious case where the input renders ´0´ when you try to clear it.
+              getEmptyValue(member.item.schemaType)
+            : inputValue
+        )
+      )
     },
-    [member.index, member.item.schemaType, onChange]
+    [handleChange, member.item.schemaType]
   )
 
   const elementProps = useMemo(
@@ -90,7 +90,11 @@ export function ArrayOfPrimitivesItem(props: PrimitiveMemberItemProps) {
       id: member.item.id,
       ref: focusRef,
       onChange: handleNativeChange,
-      value: String(member.item.value || ''),
+      // this is a trick to retain type information while displaying an "empty" input
+      // if this input is used to edit items in an array of numbers, the value can't really be set to empty without
+      // either removing the item or losing type information (i.e. it can't be an empty string, because that's… a string)
+      // so the array of numbers then use the special value `-0` to represent an empty value
+      value: String(Object.is(member.item.value, -0) ? '' : member.item.value),
       readOnly: Boolean(member.item.readOnly),
       placeholder: member.item.schemaType.placeholder,
     }),

--- a/packages/sanity/src/core/form/members/array/items/ArrayOfPrimitivesItem.tsx
+++ b/packages/sanity/src/core/form/members/array/items/ArrayOfPrimitivesItem.tsx
@@ -62,6 +62,9 @@ export function ArrayOfPrimitivesItem(props: PrimitiveMemberItemProps) {
       let inputValue: number | string | boolean = event.currentTarget.value
       if (isNumberSchemaType(member.item.schemaType)) {
         inputValue = event.currentTarget.valueAsNumber
+        if (inputValue > Number.MAX_SAFE_INTEGER || inputValue < Number.MIN_SAFE_INTEGER) {
+          return
+        }
       } else if (isBooleanSchemaType(member.item.schemaType)) {
         inputValue = event.currentTarget.checked
       }

--- a/packages/sanity/src/core/form/members/object/fields/ArrayOfPrimitivesField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/ArrayOfPrimitivesField.tsx
@@ -245,9 +245,9 @@ export function ArrayOfPrimitivesField(props: {
 
   const handleRemoveItem = useCallback(
     (index: number) => {
-      handleChange(unset(member.field.path.concat(index)))
+      handleChange(unset([index]))
     },
-    [handleChange, member.field.path]
+    [handleChange]
   )
 
   const handleFocusIndex = useCallback(


### PR DESCRIPTION
### Description

Sorry for bundling several things into one PR. The commits can be reviewed one by one.

1. Fixes a bug preventing array items with an invalid type from being deleted
2. Changes from triple-equals to Object.is equality check in @sanity/mutator when checking if a patch needs applying or not (needed in next step)
3. Using a signed zero (`-0`) trick to mark number input as "empty" and render the number input with an empty string instead of a zero you can't get rid of. If the value is `-0` we pass an empty string to the number input. This allows us to retain the type information even when the field is empty. Closes #1694
4. Set the number input range to `[Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER]`. Rationale:
If you store numbers larger than what can fit in 32 bits you are likely going to get some surprises and have unintended consequences if you try to do arithmetics, so we should make it hard to do this by accident and encourage people to store large numbers as strings instead.


### What to review

- Check that number input doesn't allow numbers outside of the `[-9007199254740991, 9007199254740991]` range
- Check that adding/editing/removing of numbers in arrays works as expected.

### Notes for release

- Fixed an issue causing numeric array items to disappear when clearing the input