### PR TITLE
fix(desk): use custom sort order by default and only use defaultOrdering as fallback

### DIFF
--- a/packages/sanity/src/desk/panes/documentList/DocumentListPane.tsx
+++ b/packages/sanity/src/desk/panes/documentList/DocumentListPane.tsx
@@ -59,7 +59,7 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
   // Ensure that we use the defaultOrdering value from structure builder if any as the default
   const defaultSortOrder = useMemo(() => {
     return defaultOrdering?.length > 0 ? {by: defaultOrdering} : DEFAULT_ORDERING
-  }, [])
+  }, [defaultOrdering])
 
   const [sortOrderRaw, setSortOrder] = useDeskToolSetting<SortOrder>(
     typeName,

--- a/packages/sanity/src/desk/panes/documentList/DocumentListPane.tsx
+++ b/packages/sanity/src/desk/panes/documentList/DocumentListPane.tsx
@@ -76,7 +76,6 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
   const filterIsSimpleTypeContraint = isSimpleTypeFilter(filter)
 
   const {error, fullList, handleListChange, isLoading, items, onRetry} = useDocumentList({
-    defaultOrdering,
     filter,
     params,
     sortOrder,

--- a/packages/sanity/src/desk/panes/documentList/DocumentListPane.tsx
+++ b/packages/sanity/src/desk/panes/documentList/DocumentListPane.tsx
@@ -55,10 +55,16 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
     'layout',
     defaultLayout
   )
+
+  // Ensure that we use the defaultOrdering value from structure builder if any as the default
+  const defaultSortOrder = useMemo(() => {
+    return defaultOrdering?.length > 0 ? {by: defaultOrdering} : DEFAULT_ORDERING
+  }, [])
+
   const [sortOrderRaw, setSortOrder] = useDeskToolSetting<SortOrder>(
     typeName,
     'sortOrder',
-    DEFAULT_ORDERING
+    defaultSortOrder
   )
 
   const sortWithOrderingFn =

--- a/packages/sanity/src/desk/panes/documentList/constants.ts
+++ b/packages/sanity/src/desk/panes/documentList/constants.ts
@@ -2,5 +2,5 @@ import {SortOrder} from './types'
 
 export const PARTIAL_PAGE_LIMIT = 100
 export const FULL_LIST_LIMIT = 2000
-export const DEFAULT_ORDERING: SortOrder = {by: [{field: '_createdAt', direction: 'desc'}]}
+export const DEFAULT_ORDERING: SortOrder = {by: [{field: '_updatedAt', direction: 'desc'}]}
 export const EMPTY_RECORD: Record<string, unknown> = {}

--- a/packages/sanity/src/desk/panes/documentList/useDocumentList.ts
+++ b/packages/sanity/src/desk/panes/documentList/useDocumentList.ts
@@ -29,7 +29,7 @@ interface DocumentListState {
  * @internal
  */
 export function useDocumentList(opts: UseDocumentListOpts): DocumentListState {
-  const {apiVersion, defaultOrdering, filter, params, sortOrder} = opts
+  const {apiVersion, filter, params, sortOrder} = opts
   const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
   const [fullList, setFullList] = useState(false)
   const fullListRef = useRef(fullList)
@@ -47,7 +47,7 @@ export function useDocumentList(opts: UseDocumentListOpts): DocumentListState {
     const extendedProjection = sortOrder?.extendedProjection
     const projectionFields = ['_id', '_type']
     const finalProjection = projectionFields.join(',')
-    const sortBy = defaultOrdering || sortOrder?.by || []
+    const sortBy = sortOrder?.by || []
     const limit = fullList ? FULL_LIST_LIMIT : PARTIAL_PAGE_LIMIT
     const sort = sortBy.length > 0 ? sortBy : DEFAULT_ORDERING.by
     const order = toOrderClause(sort)
@@ -62,7 +62,7 @@ export function useDocumentList(opts: UseDocumentListOpts): DocumentListState {
     }
 
     return `*[${filter}]|order(${order})[0...${limit}]{${finalProjection}}`
-  }, [defaultOrdering, filter, fullList, sortOrder])
+  }, [filter, fullList, sortOrder])
 
   const handleListChange = useCallback(
     ({toIndex}: VirtualListChangeOpts) => {

--- a/packages/sanity/src/desk/panes/documentList/useDocumentList.ts
+++ b/packages/sanity/src/desk/panes/documentList/useDocumentList.ts
@@ -2,14 +2,13 @@ import {VirtualListChangeOpts} from '@sanity/ui'
 import {useEffect, useState, useCallback, useMemo, useRef} from 'react'
 import {of} from 'rxjs'
 import {filter as filterEvents} from 'rxjs/operators'
-import {DocumentListPaneItem, QueryResult, SortOrder, SortOrderBy} from './types'
+import {DocumentListPaneItem, QueryResult, SortOrder} from './types'
 import {removePublishedWithDrafts, toOrderClause} from './helpers'
 import {DEFAULT_ORDERING, FULL_LIST_LIMIT, PARTIAL_PAGE_LIMIT} from './constants'
 import {getQueryResults} from './getQueryResults'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS, useClient} from 'sanity'
 
 interface UseDocumentListOpts {
-  defaultOrdering: SortOrderBy[]
   filter: string
   params: Record<string, unknown>
   sortOrder?: SortOrder


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Custom sorts were broken and document list would not update with the correct sort order when changing sort order from the pane menu. 

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

Make sure that ordering works as expected

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

- Fixed an issue where custom sort orders were broken