### PR TITLE
fix: pass `readOnly` to select element

### DIFF
--- a/packages/sanity/src/core/form/inputs/SelectInput.tsx
+++ b/packages/sanity/src/core/form/inputs/SelectInput.tsx
@@ -86,12 +86,14 @@ export function SelectInput(props: StringInputProps) {
       direction={schemaType.options?.direction || 'vertical'}
       customValidity={validationError}
       onChange={handleChange}
+      readOnly={readOnly}
     />
   ) : (
     <Select
       {...elementProps}
       customValidity={validationError}
       value={optionValueFromItem(currentItem)}
+      readOnly={readOnly}
       onChange={handleSelectChange}
     >
       {[EMPTY_ITEM, ...items].map((item, i) => (


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Pass on `readOnly` property to the `Select` element.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

Check that read only works as intended for string input with select layout.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

Bugfix: pass `readOnly` to select element