### PR TITLE
fix(form-builder): remove distinctUntilChanged function from handleQueryChange in referenceInput

### DIFF
--- a/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/@sanity/form-builder/src/inputs/ReferenceInput/ReferenceInput.tsx
@@ -261,7 +261,9 @@ export const ReferenceInput = forwardRef(function ReferenceInput(
   const handleQueryChange = useObservableCallback((inputValue$: Observable<string | null>) => {
     return inputValue$.pipe(
       filter(nonNullable),
-      distinctUntilChanged(),
+      //This prevents a filter in a reference from updating when the dependent reference are updated.
+      //Worst case by removing - the function will be called when you enter the same string.
+      //distinctUntilChanged(),
       switchMap((searchString) =>
         concat(
           of({isLoading: true}),


### PR DESCRIPTION


### Description

Removed the `distinctUntilChanged` function call from the `handleQueryChange` in the `ReferenceInput` to fix the issue of filtering not being updated when the parent component is changed. 

Link to issue: https://github.com/sanity-io/sanity/issues/3217

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

The book reference dropdown is updated when the decade is changed without the need of a hard refresh. 
ie try to go from 1980 to 10 (there are actual books for these decades to show) 

![Screenshot 2022-11-24 at 17 25 50](https://user-images.githubusercontent.com/44635000/203830643-f39e9c21-b79f-4ce5-82fe-4d75e9376bd9.png)

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
fix(form-build): Fix reference filtering updas
<!--
A description of the change(s) that should be used in the release notes.
-->
