### PR TITLE
refactor(desk): remove support for documentAction.modal

### DIFF
--- a/packages/sanity/src/desk/documentActions/DiscardChangesAction.tsx
+++ b/packages/sanity/src/desk/documentActions/DiscardChangesAction.tsx
@@ -4,7 +4,7 @@ import {ResetIcon} from '@sanity/icons'
 import React, {useCallback, useMemo, useState} from 'react'
 import {
   DocumentActionComponent,
-  DocumentActionModalProps,
+  DocumentActionDialogProps,
   InsufficientPermissionsMessage,
   useCurrentUser,
   useDocumentOperation,
@@ -42,7 +42,7 @@ export const DiscardChangesAction: DocumentActionComponent = ({
     setConfirmDialogOpen(true)
   }, [])
 
-  const dialog: DocumentActionModalProps | false = useMemo(
+  const dialog: DocumentActionDialogProps | false = useMemo(
     () =>
       isConfirmDialogOpen && {
         type: 'confirm',

--- a/packages/sanity/src/desk/panes/document/keyboardShortcuts/DocumentActionShortcuts.tsx
+++ b/packages/sanity/src/desk/panes/document/keyboardShortcuts/DocumentActionShortcuts.tsx
@@ -3,12 +3,7 @@ import React, {useCallback, useMemo, useState} from 'react'
 import {ActionStateDialog} from '../statusBar'
 import {Pane, RenderActionCollectionState} from '../../../components'
 import {useDocumentPane} from '../useDocumentPane'
-import {
-  DocumentActionDescription,
-  DocumentActionDialogProps,
-  DocumentActionProps,
-  LegacyLayerProvider,
-} from 'sanity'
+import {DocumentActionDescription, DocumentActionProps, LegacyLayerProvider} from 'sanity'
 
 export interface KeyboardShortcutResponderProps {
   actionsBoxElement: HTMLElement | null
@@ -72,12 +67,9 @@ function KeyboardShortcutResponder(
     <Pane id={id} onKeyDown={handleKeyDown} tabIndex={-1} {...rest} ref={rootRef}>
       {children}
 
-      {activeAction && (activeAction.dialog || activeAction.modal) && (
+      {activeAction && activeAction.dialog && (
         <LegacyLayerProvider zOffset="paneFooter">
-          <ActionStateDialog
-            dialog={(activeAction.dialog || activeAction.modal) as DocumentActionDialogProps}
-            referenceElement={actionsBoxElement}
-          />
+          <ActionStateDialog dialog={activeAction.dialog} referenceElement={actionsBoxElement} />
         </LegacyLayerProvider>
       )}
     </Pane>

--- a/packages/sanity/src/desk/panes/document/statusBar/ActionMenuButton.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/ActionMenuButton.tsx
@@ -22,7 +22,7 @@ import React, {
 } from 'react'
 import {isValidElementType} from 'react-is'
 import {ActionStateDialog} from './ActionStateDialog'
-import {DocumentActionDescription, DocumentActionDialogProps, LegacyLayerProvider} from 'sanity'
+import {DocumentActionDescription, LegacyLayerProvider} from 'sanity'
 
 export interface ActionMenuButtonProps {
   actionStates: DocumentActionDescription[]
@@ -83,12 +83,9 @@ export function ActionMenuButton(props: ActionMenuButtonProps) {
         ref={setReferenceElement}
       />
 
-      {currentAction && (currentAction.dialog || currentAction.modal) && (
+      {currentAction && currentAction.dialog && (
         <LegacyLayerProvider zOffset="paneFooter">
-          <ActionStateDialog
-            dialog={(currentAction.dialog || currentAction.modal) as DocumentActionDialogProps}
-            referenceElement={referenceElement}
-          />
+          <ActionStateDialog dialog={currentAction.dialog} referenceElement={referenceElement} />
         </LegacyLayerProvider>
       )}
     </>

--- a/packages/sanity/src/desk/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -5,7 +5,7 @@ import {HistoryRestoreAction} from '../../../documentActions'
 import {useDocumentPane} from '../useDocumentPane'
 import {ActionMenuButton} from './ActionMenuButton'
 import {ActionStateDialog} from './ActionStateDialog'
-import {DocumentActionDescription, DocumentActionDialogProps} from 'sanity'
+import {DocumentActionDescription} from 'sanity'
 
 interface DocumentStatusBarActionsInnerProps {
   disabled: boolean
@@ -64,11 +64,8 @@ function DocumentStatusBarActionsInner(props: DocumentStatusBarActionsInnerProps
         </Box>
       )}
 
-      {firstActionState && (firstActionState.dialog || firstActionState.modal) && (
-        <ActionStateDialog
-          dialog={(firstActionState.dialog || firstActionState.modal) as DocumentActionDialogProps}
-          referenceElement={buttonElement}
-        />
+      {firstActionState && firstActionState.dialog && (
+        <ActionStateDialog dialog={firstActionState.dialog} referenceElement={buttonElement} />
       )}
     </Flex>
   )


### PR DESCRIPTION
This will remove support for `.modal` in documentActions and only use `.dialog`.

See commit 24fb475bbc225a740bb2e8dcb553659d5b3afeb5

