### PR TITLE
refactor(core): move color scheme logic to consuming UI components

### DIFF
--- a/packages/sanity/src/core/field/diff/components/DiffCard.tsx
+++ b/packages/sanity/src/core/field/diff/components/DiffCard.tsx
@@ -4,6 +4,7 @@ import {Card, rem} from '@sanity/ui'
 import styled from 'styled-components'
 import {getAnnotationAtPath, useAnnotationColor} from '../annotations'
 import {Annotation, Diff} from '../../types'
+import {useDefaultTintKeys} from '../../utils/useDefaultTintKeys'
 import {DiffTooltip} from './DiffTooltip'
 
 /** @internal */
@@ -91,6 +92,7 @@ export const DiffCard = forwardRef(function DiffCard(
     [annotationProp, diff, path]
   )
 
+  const {bg, fg} = useDefaultTintKeys()
   const color = useAnnotationColor(annotation)
 
   const element = (
@@ -103,8 +105,8 @@ export const DiffCard = forwardRef(function DiffCard(
       radius={1}
       style={{
         ...style,
-        backgroundColor: color.background,
-        color: color.text,
+        backgroundColor: color.tints[bg].hex,
+        color: color.tints[fg].hex,
       }}
     >
       {children}

--- a/packages/sanity/src/core/field/diff/components/DiffTooltip.tsx
+++ b/packages/sanity/src/core/field/diff/components/DiffTooltip.tsx
@@ -5,6 +5,7 @@ import {LegacyLayerProvider, UserAvatar} from '../../../components'
 import {useTimeAgo} from '../../../hooks'
 import {useUser} from '../../../store'
 import {AnnotationDetails, Diff} from '../../types'
+import {useDefaultTintKeys} from '../../utils/useDefaultTintKeys'
 import {getAnnotationAtPath, useAnnotationColor} from '../annotations'
 
 /** @internal */
@@ -72,6 +73,7 @@ function DiffTooltipWithAnnotation(props: DiffTooltipWithAnnotationsProps) {
 function AnnotationItem({annotation}: {annotation: AnnotationDetails}) {
   const {author, timestamp} = annotation
   const [user] = useUser(author)
+  const {bg, fg} = useDefaultTintKeys()
   const color = useAnnotationColor(annotation)
   const timeAgo = useTimeAgo(timestamp, {minimal: true})
 
@@ -81,14 +83,14 @@ function AnnotationItem({annotation}: {annotation: AnnotationDetails}) {
         align="center"
         paddingRight={3}
         style={{
-          backgroundColor: color.background,
-          color: color.text,
+          backgroundColor: color.tints[bg].hex,
+          color: color.tints[fg].hex,
           borderRadius: 'calc(23px / 2)',
         }}
       >
         <UserAvatar user={author} />
         <Inline paddingLeft={2}>
-          <Text muted size={1} style={{color: color.text}}>
+          <Text muted size={1} style={{color: color.tints[fg].hex}}>
             {user ? user.displayName : 'Loading…'}
           </Text>
         </Inline>

--- a/packages/sanity/src/core/field/types/boolean/preview/BooleanPreview.tsx
+++ b/packages/sanity/src/core/field/types/boolean/preview/BooleanPreview.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {UserColor} from '../../../../user-color'
 import {FieldPreviewComponent} from '../../../preview'
+import {useDefaultTintKeys} from '../../../utils/useDefaultTintKeys'
 
 type BooleanProps = {
   checked: boolean | undefined | null
@@ -17,27 +18,36 @@ export const BooleanPreview: FieldPreviewComponent<boolean> = function BooleanPr
 }
 
 export function Checkbox({checked, color}: BooleanProps) {
+  const {bg, fg} = useDefaultTintKeys()
+
   return (
     <svg
       width="17"
       height="17"
       viewBox="0 0 17 17"
       xmlns="http://www.w3.org/2000/svg"
-      fill={color?.background}
+      fill={color?.tints[bg].hex}
     >
       <rect x="0" y="0" width="17" height="17" rx="2.5" />
       {typeof checked === 'undefined' && (
-        <path d="M4.07996 8.5H12.92" stroke={color?.text} strokeWidth="2" />
+        <path d="M4.07996 8.5H12.92" stroke={color?.tints[fg].hex} strokeWidth="2" />
       )}
-      {checked && <path d="M3.5 8L7 11.5L13.5 5" stroke={color?.text} strokeWidth="2" />}
+      {checked && <path d="M3.5 8L7 11.5L13.5 5" stroke={color?.tints[fg].hex} strokeWidth="2" />}
     </svg>
   )
 }
 
 export function Switch({checked, color}: BooleanProps) {
+  const {bg, border} = useDefaultTintKeys()
+
   return (
     <svg width="38" height="22" viewBox="0 0 38 22" xmlns="http://www.w3.org/2000/svg">
-      <rect width="38" height="22" rx="11" fill={checked ? color?.border : color?.background} />
+      <rect
+        width="38"
+        height="22"
+        rx="11"
+        fill={checked ? color?.tints[border].hex : color?.tints[bg].hex}
+      />
       {typeof checked === 'undefined' && (
         <rect x="11" y="3" width="16" height="16" rx="8" fill="white" />
       )}

--- a/packages/sanity/src/core/field/types/image/diff/HotspotCropSVG.tsx
+++ b/packages/sanity/src/core/field/types/image/diff/HotspotCropSVG.tsx
@@ -2,6 +2,7 @@ import {Image, ImageCrop, ImageHotspot} from '@sanity/types'
 import React from 'react'
 import {DiffTooltip, useDiffAnnotationColor} from '../../../diff'
 import {ObjectDiff} from '../../../types'
+import {useDefaultTintKeys} from '../../../utils/useDefaultTintKeys'
 import {hexToRgba} from './helpers'
 
 interface HotspotCropSVGProps {
@@ -19,6 +20,7 @@ export function HotspotCropSVG(
   const {crop, diff, hash, hotspot, width = 100, height = 100, ...restProps} = props
   const cropColor = useDiffAnnotationColor(diff, 'crop')
   const hotspotColor = useDiffAnnotationColor(diff, 'hotspot')
+  const {border} = useDefaultTintKeys()
 
   return (
     <svg
@@ -50,9 +52,9 @@ export function HotspotCropSVG(
           <g>
             <CropSVG
               crop={crop}
-              fill={hexToRgba(cropColor.border, 0.25)}
+              fill={hexToRgba(cropColor.tints[border].hex, 0.25)}
               mask={hotspot ? `url(#mask-hotspot-${hash})` : undefined}
-              stroke={cropColor.border}
+              stroke={cropColor.tints[border].hex}
               strokeWidth={1}
               width={width}
               height={height}
@@ -66,8 +68,8 @@ export function HotspotCropSVG(
           <g>
             <HotspotSVG
               hotspot={hotspot}
-              fill={hexToRgba(hotspotColor.border, 0.25)}
-              stroke={hotspotColor.border}
+              fill={hexToRgba(hotspotColor.tints[border].hex, 0.25)}
+              stroke={hotspotColor.tints[border].hex}
               strokeWidth={1}
               width={width}
               height={height}

--- a/packages/sanity/src/core/field/types/portableText/diff/components/Annotation.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/Annotation.tsx
@@ -8,6 +8,7 @@ import {ChangeList, DiffContext, DiffTooltip, useDiffAnnotationColor} from '../.
 import {ObjectDiff} from '../../../../types'
 import {isEmptyObject} from '../helpers'
 import {ConnectorContext, useReportedValues} from '../../../../../changeIndicators'
+import {useDefaultTintKeys} from '../../../../utils/useDefaultTintKeys'
 import {InlineBox, InlineText, PopoverContainer, PreviewContainer} from './styledComponents'
 
 interface AnnotationProps {
@@ -90,9 +91,11 @@ function AnnnotationWithDiff({
   const {path: fullPath} = useContext(DiffContext)
   const [popoverElement, setPopoverElement] = useState<HTMLDivElement | null>(null)
   const color = useDiffAnnotationColor(diff, [])
+  const {bg, fg} = useDefaultTintKeys()
+
   const style = useMemo(
-    () => (color ? {background: color.background, color: color.text} : {}),
-    [color]
+    () => (color ? {backgroundColor: color.tints[bg].hex, color: color.tints[fg].hex} : {}),
+    [bg, color, fg]
   )
   const isRemoved = diff.action === 'removed'
   const [open, setOpen] = useState(false)

--- a/packages/sanity/src/core/field/types/portableText/diff/components/Block.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/Block.tsx
@@ -5,6 +5,7 @@ import {DiffContext, DiffTooltip, useDiffAnnotationColor} from '../../../../diff
 import {isHeader} from '../helpers'
 import {PortableTextDiff} from '../types'
 import {ConnectorContext} from '../../../../../changeIndicators'
+import {useDefaultTintKeys} from '../../../../utils/useDefaultTintKeys'
 import Blockquote from './Blockquote'
 import Header from './Header'
 import Paragraph from './Paragraph'
@@ -18,6 +19,7 @@ export default function Block(props: {
 }): JSX.Element {
   const {diff, block, children} = props
   const color = useDiffAnnotationColor(diff, EMPTY_PATH)
+  const {bg, fg} = useDefaultTintKeys()
   const {path: fullPath} = useContext(DiffContext)
   const {onSetFocus} = useContext(ConnectorContext)
   const isRemoved = diff.action === 'removed'
@@ -52,7 +54,7 @@ export default function Block(props: {
   ) {
     fromStyle = diff?.origin?.fromValue?.style
 
-    const style = color ? {background: color.background, color: color.text} : {}
+    const style = color ? {backgroundColor: color.tints[bg].hex, color: color.tints[fg].hex} : {}
 
     returned = (
       <Card

--- a/packages/sanity/src/core/field/types/portableText/diff/components/InlineObject.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/InlineObject.tsx
@@ -15,6 +15,7 @@ import {ObjectDiff} from '../../../../types'
 import {isEmptyObject} from '../helpers'
 import {ConnectorContext, useReportedValues} from '../../../../../changeIndicators'
 import {Preview} from '../../../../../preview/components/Preview'
+import {useDefaultTintKeys} from '../../../../utils/useDefaultTintKeys'
 import {InlineBox, InlineText, PopoverContainer, PreviewContainer} from './styledComponents'
 
 interface InlineObjectProps {
@@ -80,9 +81,10 @@ function InlineObjectWithDiff({
   const {path: fullPath} = useContext(DiffContext)
   const {onSetFocus} = useContext(ConnectorContext)
   const color = useDiffAnnotationColor(diff, [])
+  const {bg, fg} = useDefaultTintKeys()
   const style = useMemo(
-    () => (color ? {background: color.background, color: color.text} : {}),
-    [color]
+    () => (color ? {backgroundColor: color.tints[bg].hex, color: color.tints[fg].hex} : {}),
+    [bg, color, fg]
   )
   const [open, setOpen] = useState(false)
   const emptyObject = object && isEmptyObject(object)

--- a/packages/sanity/src/core/field/utils/useDefaultTintKeys.ts
+++ b/packages/sanity/src/core/field/utils/useDefaultTintKeys.ts
@@ -1,0 +1,20 @@
+import {ColorTintKey} from '@sanity/color'
+import {useColorScheme} from '../../studio'
+
+interface DefaultTintKeysHookValue {
+  bg: ColorTintKey
+  border: ColorTintKey
+  fg: ColorTintKey
+}
+
+/** @internal */
+export function useDefaultTintKeys(): DefaultTintKeysHookValue {
+  const {scheme} = useColorScheme()
+  const isDarkScheme = scheme === 'dark'
+
+  return {
+    bg: isDarkScheme ? '900' : '100',
+    border: isDarkScheme ? '700' : '300',
+    fg: isDarkScheme ? '200' : '700',
+  }
+}

--- a/packages/sanity/src/core/user-color/__tests__/userColorManager.test.ts
+++ b/packages/sanity/src/core/user-color/__tests__/userColorManager.test.ts
@@ -32,7 +32,6 @@ const colors: UserColorManagerOptions['colors'] = hues.reduce<UserColorManagerOp
 const options: UserColorManagerOptions = {
   currentUserColor: 'blue',
   colors,
-  scheme: 'light',
 }
 
 describe('user color manager', () => {

--- a/packages/sanity/src/core/user-color/provider.tsx
+++ b/packages/sanity/src/core/user-color/provider.tsx
@@ -1,5 +1,4 @@
 import React, {useMemo} from 'react'
-import {useColorScheme} from '../studio'
 import {UserColorManagerContext} from './context'
 import {UserColorManager} from './types'
 import {createUserColorManager} from './manager'
@@ -15,11 +14,9 @@ export function UserColorManagerProvider({
   children,
   manager: managerFromProps,
 }: UserColorManagerProviderProps): React.ReactElement {
-  const {scheme} = useColorScheme()
-
   const manager = useMemo(() => {
-    return managerFromProps || createUserColorManager({scheme})
-  }, [managerFromProps, scheme])
+    return managerFromProps || createUserColorManager()
+  }, [managerFromProps])
 
   return (
     <UserColorManagerContext.Provider value={manager}>{children}</UserColorManagerContext.Provider>

--- a/packages/sanity/src/core/user-color/types.ts
+++ b/packages/sanity/src/core/user-color/types.ts
@@ -13,9 +13,6 @@ export type UserId = string
 /** @internal */
 export interface UserColor {
   name: ColorHueKey
-  background: HexColor
-  border: HexColor
-  text: HexColor
   tints: ColorTints
 }
 


### PR DESCRIPTION
### Description
This pull request moves color scheme logic from the color manager to the consuming UI components of the color manager. 

### What to review
- Make sure that colors used by the color manager looks good

### Notes for release

Move color scheme logic from the color manager to the consuming UI components
