### PR TITLE
fix(core): hide style select when there is only one option

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/Toolbar.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/Toolbar.tsx
@@ -79,6 +79,7 @@ const InnerToolbar = memo(function InnerToolbar({
   const rootElementRect = useElementRect(rootElement)
 
   const collapsed = rootElementRect ? rootElementRect?.width < 400 : false
+  const showBlockStyleSelect = blockStyles.length > 1
 
   useRovingFocus({
     rootElement: rootElement,
@@ -86,11 +87,13 @@ const InnerToolbar = memo(function InnerToolbar({
 
   return (
     <RootFlex align="center" ref={setRootElement}>
-      <StyleSelectFlex flex={collapsed ? 1 : undefined}>
-        <StyleSelectBox padding={isFullscreen ? 2 : 1}>
-          <BlockStyleSelect disabled={disabled} items={blockStyles} />
-        </StyleSelectBox>
-      </StyleSelectFlex>
+      {showBlockStyleSelect && (
+        <StyleSelectFlex flex={collapsed ? 1 : undefined}>
+          <StyleSelectBox padding={isFullscreen ? 2 : 1}>
+            <BlockStyleSelect disabled={disabled} items={blockStyles} />
+          </StyleSelectBox>
+        </StyleSelectFlex>
+      )}
 
       <Flex flex={1}>
         {showActionMenu && (


### PR DESCRIPTION
### Description

This PR fixes so that the block style select in PTE is only visible when there is more than one option.

### What to review

Make sure that the block style select is visible when there is more than one option and hidden when there is only one option.

### Notes for release

Only show the block style select in the portable text editor when there is more than one option
