### PR TITLE
fix: bump `scroll-into-view-if-needed` for better ESM support

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -183,7 +183,7 @@
     "rxjs-etc": "^10.6.0",
     "rxjs-exhaustmap-with-trailing": "^1.2.0",
     "sanity-diff-patch": "^1.0.9",
-    "scroll-into-view-if-needed": "^2.2.29",
+    "scroll-into-view-if-needed": "^3.0.3",
     "semver": "^7.3.5",
     "shallow-equals": "^1.0.0",
     "speakingurl": "^14.0.1",

--- a/packages/sanity/src/core/form/hooks/useScrollIntoViewOnFocusWithin.ts
+++ b/packages/sanity/src/core/form/hooks/useScrollIntoViewOnFocusWithin.ts
@@ -2,8 +2,6 @@ import {useCallback} from 'react'
 import scrollIntoView from 'scroll-into-view-if-needed'
 import {useDidUpdate} from './useDidUpdate'
 
-const SCROLL_OPTIONS = {scrollMode: 'if-needed'} as const
-
 /**
  * A hook to help make sure the parent element of a value edited in a dialog (or "out of band") stays
  visible in the background
@@ -19,7 +17,7 @@ export function useScrollIntoViewOnFocusWithin(
     useCallback(
       (hadFocus, hasFocus) => {
         if (elementRef.current && !hadFocus && hasFocus) {
-          scrollIntoView(elementRef.current, SCROLL_OPTIONS)
+          scrollIntoView(elementRef.current, {scrollMode: 'always'})
         }
       },
       [elementRef]


### PR DESCRIPTION
Help with native ESM support, `scroll-into-view-if-needed@v3` implements `pkg.exports`.