### PR TITLE
Allow 'dev' to be started from failed 'start' command

### DIFF
--- a/packages/@sanity/cli/src/commands/init/initCommand.ts
+++ b/packages/@sanity/cli/src/commands/init/initCommand.ts
@@ -1,4 +1,3 @@
-/* eslint-disable prettier/prettier */
 import initProject from '../../actions/init-project/initProject'
 import initPlugin from '../../actions/init-plugin/initPlugin'
 import {CliCommandDefinition} from '../../types'
@@ -75,29 +74,41 @@ export const initCommand: CliCommandDefinition<InitFlags> = {
     const warn = (msg: string) => output.warn(chalk.yellow.bgBlack(msg))
 
     if (!type) {
-      warn('╔═══════════════════════════════════════════════════════════════════════════════════════╗')
-      warn("║ \u26A0  Welcome to Sanity! Looks like you're following instructions for Sanity Studio v2,  ║")
-      warn('║    but the version you have installed is the latest, Sanity Studio v3.                ║')
-      warn('║    In Sanity Studio v3, new projects are created with [npm create sanity@latest].     ║')
-      warn('║                                                                                       ║')
-      warn('║    Learn more about Sanity Studio v3: https://www.sanity.io/help/studio-v2-vs-v3      ║')
-      warn('╚═══════════════════════════════════════════════════════════════════════════════════════╝')
+      warn(
+        '╔═══════════════════════════════════════════════════════════════════════════════════════╗'
+      )
+      warn(
+        "║ \u26A0  Welcome to Sanity! Looks like you're following instructions for Sanity Studio v2,  ║"
+      )
+      warn(
+        '║    but the version you have installed is the latest, Sanity Studio v3.                ║'
+      )
+      warn(
+        '║    In Sanity Studio v3, new projects are created with [npm create sanity@latest].     ║'
+      )
+      warn(
+        '║                                                                                       ║'
+      )
+      warn(
+        '║    Learn more about Sanity Studio v3: https://www.sanity.io/help/studio-v2-vs-v3      ║'
+      )
+      warn(
+        '╚═══════════════════════════════════════════════════════════════════════════════════════╝'
+      )
       warn('') // Newline to separate from other output
       const runInitResponse = await prompt.single({
         message: 'Continue creating a Sanity Studio v3 project?',
         type: 'confirm',
       })
       if (runInitResponse) {
-        return initProject(args, context).then(
-          (res) => {
-            warn('╔═══════════════════════════════════════════════════════════════════════════╗')
-            warn("║ \u24D8  To learn how commands have changed from Studio v2 to v3, check:        ║")
-            warn('║    https://www.sanity.io/help/studio-v2-vs-v3                             ║')
-            warn('╚═══════════════════════════════════════════════════════════════════════════╝')
-            warn('') // Newline to separate from other output
-            return res
-          }
-        )
+        return initProject(args, context).then((res) => {
+          warn('╔═══════════════════════════════════════════════════════════════════════════╗')
+          warn('║ \u24D8  To learn how commands have changed from Studio v2 to v3, check:        ║')
+          warn('║    https://www.sanity.io/help/studio-v2-vs-v3                             ║')
+          warn('╚═══════════════════════════════════════════════════════════════════════════╝')
+          warn('') // Newline to separate from other output
+          return res
+        })
       }
     }
 

--- a/packages/@sanity/cli/src/commands/init/initCommand.ts
+++ b/packages/@sanity/cli/src/commands/init/initCommand.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import initProject from '../../actions/init-project/initProject'
 import initPlugin from '../../actions/init-plugin/initPlugin'
 import {CliCommandDefinition} from '../../types'
@@ -68,11 +69,36 @@ export const initCommand: CliCommandDefinition<InitFlags> = {
   signature: '',
   description: 'Initialize a new Sanity studio project',
   helpText,
-  action: (args, context) => {
+  action: async (args, context) => {
+    const {output, chalk, prompt} = context
     const [type] = args.argsWithoutOptions
+    const warn = (msg: string) => output.warn(chalk.yellow.bgBlack(msg))
 
     if (!type) {
-      return initProject(args, context)
+      warn('╔═══════════════════════════════════════════════════════════════════════════════════════╗')
+      warn("║ \u26A0  Welcome to Sanity! Looks like you're following instructions for Sanity Studio v2,  ║")
+      warn('║    but the version you have installed is the latest, Sanity Studio v3.                ║')
+      warn('║    In Sanity Studio v3, new projects are created with [npm create sanity@latest].     ║')
+      warn('║                                                                                       ║')
+      warn('║    Learn more about Sanity Studio v3: https://www.sanity.io/help/studio-v2-vs-v3      ║')
+      warn('╚═══════════════════════════════════════════════════════════════════════════════════════╝')
+      warn('') // Newline to separate from other output
+      const runInitResponse = await prompt.single({
+        message: 'Continue creating a Sanity Studio v3 project?',
+        type: 'confirm',
+      })
+      if (runInitResponse) {
+        return initProject(args, context).then(
+          (res) => {
+            warn('╔═══════════════════════════════════════════════════════════════════════════╗')
+            warn("║ \u24D8  To learn how commands have changed from Studio v2 to v3, check:        ║")
+            warn('║    https://www.sanity.io/help/studio-v2-vs-v3                             ║')
+            warn('╚═══════════════════════════════════════════════════════════════════════════╝')
+            warn('') // Newline to separate from other output
+            return res
+          }
+        )
+      }
     }
 
     if (type === 'plugin') {

--- a/packages/sanity/src/_internal/cli/commands/dev/devCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/dev/devCommand.ts
@@ -29,7 +29,7 @@ const devCommand: CliCommandDefinition = {
   helpText,
 }
 
-async function getDevAction() {
+export async function getDevAction() {
   // NOTE: in dev-mode we want to include from `src` so we need to use `.ts` extension
   // NOTE: this `if` statement is not included in the output bundle
   if (__DEV__) {

--- a/packages/sanity/src/_internal/cli/commands/start/startCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/start/startCommand.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import type {CliCommandArguments, CliCommandContext, CliCommandDefinition} from '@sanity/cli'
 import type {StartPreviewServerCommandFlags} from '../../actions/preview/previewAction'
 import {getDevAction} from '../dev/devCommand'

--- a/packages/sanity/src/_internal/cli/commands/start/startCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/start/startCommand.ts
@@ -1,4 +1,3 @@
-/* eslint-disable prettier/prettier */
 import type {CliCommandArguments, CliCommandContext, CliCommandDefinition} from '@sanity/cli'
 import type {StartPreviewServerCommandFlags} from '../../actions/preview/previewAction'
 import {getDevAction} from '../dev/devCommand'


### PR DESCRIPTION
### Description

`npm run start`

![image](https://user-images.githubusercontent.com/373403/205953345-052ef4a8-f262-493f-a6c1-acd45446723a.png)

`npm run init`

![image](https://user-images.githubusercontent.com/373403/205953522-b790f2c8-938d-4b39-8323-11180b75978f.png)

![image](https://user-images.githubusercontent.com/373403/205955577-297bc88c-f9c9-4ba7-a3e6-5f2d4c7e84a6.png)

