### PR TITLE
Refactor block-tools package to use new PT-types

### DIFF
--- a/packages/@sanity/block-tools/src/HtmlDeserializer/index.ts
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/index.ts
@@ -1,4 +1,9 @@
-import type {ArraySchemaType, Block, MarkDefinition} from '@sanity/types'
+import type {
+  ArraySchemaType,
+  PortableTextBlock,
+  PortableTextObject,
+  PortableTextTextBlock,
+} from '@sanity/types'
 import {flatten} from 'lodash'
 import {findBlockType} from '../util/findBlockType'
 import {resolveJsType} from '../util/resolveJsType'
@@ -34,7 +39,7 @@ export default class HtmlDeserializer {
   blockContentType: ArraySchemaType
   rules: DeserializerRule[]
   parseHtml: (html: string) => HTMLElement
-  _markDefs: MarkDefinition[] = []
+  _markDefs: PortableTextObject[] = []
 
   /**
    * Create a new serializer respecting a Sanity block content type's schema
@@ -75,7 +80,7 @@ export default class HtmlDeserializer {
 
     if (this._markDefs.length > 0) {
       blocks
-        .filter((block): block is Block => block._type === 'block')
+        .filter((block): block is PortableTextTextBlock => block._type === 'block')
         .forEach((block) => {
           block.markDefs = block.markDefs || []
           block.markDefs = block.markDefs.concat(
@@ -216,7 +221,7 @@ export default class HtmlDeserializer {
           // Only apply marks if this is an actual text
           node.marks.unshift(name)
         }
-      } else if ('children' in node && Array.isArray((node as Block).children)) {
+      } else if ('children' in node && Array.isArray((node as PortableTextBlock).children)) {
         const block = node as any
         block.children = block.children.map(applyDecorator)
       }
@@ -251,7 +256,7 @@ export default class HtmlDeserializer {
           // Only apply marks if this is an actual text
           node.marks.unshift(markDef._key)
         }
-      } else if ('children' in node && Array.isArray((node as Block).children)) {
+      } else if ('children' in node && Array.isArray((node as PortableTextBlock).children)) {
         const block = node as any
         block.children = block.children.map(applyAnnotation)
       }

--- a/packages/@sanity/block-tools/src/index.ts
+++ b/packages/@sanity/block-tools/src/index.ts
@@ -1,4 +1,4 @@
-import type {ArraySchemaType, Block, Span} from '@sanity/types'
+import type {ArraySchemaType, PortableTextTextBlock} from '@sanity/types'
 import blockContentTypeFeatures from './util/blockContentTypeFeatures'
 import HtmlDeserializer from './HtmlDeserializer'
 import {normalizeBlock} from './util/normalizeBlock'
@@ -17,7 +17,7 @@ export function htmlToBlocks(
   html: string,
   blockContentType: ArraySchemaType,
   options: HtmlDeserializerOptions = {}
-): (TypedObject | Block<TypedObject | Span>)[] {
+): (TypedObject | PortableTextTextBlock)[] {
   const deserializer = new HtmlDeserializer(blockContentType, options)
   return deserializer.deserialize(html).map((block) => normalizeBlock(block))
 }

--- a/packages/@sanity/block-tools/src/types.ts
+++ b/packages/@sanity/block-tools/src/types.ts
@@ -1,8 +1,8 @@
 import type {ComponentType} from 'react'
 import type {
   ArraySchemaType,
-  MarkDefinition,
   ObjectSchemaType,
+  PortableTextObject,
   SpanSchemaType,
   TitledListValue,
 } from '@sanity/types'
@@ -67,7 +67,7 @@ export interface MinimalSpan {
 export interface MinimalBlock extends TypedObject {
   _type: 'block'
   children: TypedObject[]
-  markDefs?: string[]
+  markDefs?: TypedObject[]
   style?: string
   level?: number
   listItem?: string
@@ -81,7 +81,7 @@ export interface PlaceholderDecorator {
 
 export interface PlaceholderAnnotation {
   _type: '__annotation'
-  markDef: MarkDefinition
+  markDef: PortableTextObject
   children: TypedObject[]
 }
 

--- a/packages/@sanity/block-tools/src/util/blockContentTypeFeatures.ts
+++ b/packages/@sanity/block-tools/src/util/blockContentTypeFeatures.ts
@@ -3,10 +3,10 @@ import {
   BlockSchemaType,
   EnumListProps,
   isBlockChildrenObjectField,
+  isBlockListObjectField,
   isBlockSchemaType,
-  isListObjectField,
+  isBlockStyleObjectField,
   isObjectSchemaType,
-  isStyleObjectField,
   isTitledListValue,
   ObjectSchemaType,
   SpanSchemaType,
@@ -63,7 +63,7 @@ export default function blockContentFeatures(
 }
 
 function resolveEnabledStyles(blockType: BlockSchemaType): TitledListValue<string>[] {
-  const styleField = blockType.fields.find(isStyleObjectField)
+  const styleField = blockType.fields.find(isBlockStyleObjectField)
   if (!styleField) {
     throw new Error("A field with name 'style' is not defined in the block type (required).")
   }
@@ -81,7 +81,6 @@ function resolveEnabledStyles(blockType: BlockSchemaType): TitledListValue<strin
 
 function resolveEnabledAnnotationTypes(spanType: SpanSchemaType): ResolvedAnnotationType[] {
   return spanType.annotations.map((annotation) => ({
-    blockEditor: annotation.blockEditor,
     title: annotation.title,
     type: annotation,
     value: annotation.name,
@@ -94,7 +93,7 @@ function resolveEnabledDecorators(spanType: SpanSchemaType): TitledListValue<str
 }
 
 function resolveEnabledListItems(blockType: BlockSchemaType): TitledListValue<string>[] {
-  const listField = blockType.fields.find(isListObjectField)
+  const listField = blockType.fields.find(isBlockListObjectField)
   if (!listField) {
     throw new Error("A field with name 'list' is not defined in the block type (required).")
   }

--- a/packages/@sanity/block-tools/test/tests/util/__snapshots__/blockContentTypeFeatures.test.ts.snap
+++ b/packages/@sanity/block-tools/test/tests/util/__snapshots__/blockContentTypeFeatures.test.ts.snap
@@ -4,7 +4,6 @@ exports[`blockContentTypeFeatures will give a sane feature set for the default s
 Object {
   "annotations": Array [
     Object {
-      "blockEditor": undefined,
       "icon": undefined,
       "title": "Link",
       "type": Object {
@@ -1069,7 +1068,6 @@ exports[`blockContentTypeFeatures will give spesific features for a custom schem
 Object {
   "annotations": Array [
     Object {
-      "blockEditor": undefined,
       "icon": undefined,
       "title": "Author",
       "type": Object {


### PR DESCRIPTION
### Description

This will make the `block-tools` package use the updated porable text types from `@sanity/types`.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

No functional changes.

<!--
A description of the change(s) that should be used in the release notes.
-->
