### PR TITLE
fix(config): respect `unstable_clientFactory`

### DIFF
--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-nested-callbacks */
 
-import {SanityClient} from '@sanity/client'
+import createClient, {SanityClient} from '@sanity/client'
 import {map, shareReplay} from 'rxjs/operators'
 import {CurrentUser, Schema} from '@sanity/types'
 import {studioTheme} from '@sanity/ui'
@@ -88,10 +88,12 @@ export function prepareConfig(config: Config): PreparedConfig {
       const sources = [rootSource as SourceOptions, ...nestedSources]
 
       const resolvedSources = sources.map((source): InternalSource => {
+        const clientFactory = source.unstable_clientFactory || createClient
+
         const projectId = source.projectId
         const dataset = source.dataset
 
-        const auth = source.auth || createAuthStore({dataset, projectId})
+        const auth = source.auth || createAuthStore({clientFactory, dataset, projectId})
 
         let schemaTypes
         try {

--- a/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
@@ -1,4 +1,4 @@
-import createClient, {SanityClient} from '@sanity/client'
+import {ClientConfig as SanityClientConfig, SanityClient} from '@sanity/client'
 import {defer} from 'rxjs'
 import {map, shareReplay, startWith, switchMap} from 'rxjs/operators'
 import {memoize} from 'lodash'
@@ -19,6 +19,7 @@ export interface AuthProvider {
 
 /** @internal */
 export interface AuthStoreOptions {
+  clientFactory: (options: SanityClientConfig) => SanityClient
   projectId: string
   dataset: string
   /**
@@ -137,6 +138,7 @@ const getCurrentUser = async (
  * @internal
  */
 export function _createAuthStore({
+  clientFactory,
   projectId,
   dataset,
   loginMethod = 'dual',
@@ -159,7 +161,7 @@ export function _createAuthStore({
     // // see above
     // debounce(() => firstMessage),
     map((token) =>
-      createClient({
+      clientFactory({
         projectId,
         dataset,
         apiVersion: '2021-06-07',
@@ -198,7 +200,7 @@ export function _createAuthStore({
 
   async function handleCallbackUrl() {
     if (sessionId && loginMethod === 'dual') {
-      const requestClient = createClient({
+      const requestClient = clientFactory({
         projectId,
         dataset,
         useCdn: true,
@@ -231,7 +233,7 @@ export function _createAuthStore({
   }
 
   async function logout() {
-    const requestClient = createClient({
+    const requestClient = clientFactory({
       projectId,
       dataset,
       useCdn: true,


### PR DESCRIPTION

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Brings back support for `unstable_clientFactory`:

```ts
import {defineConfig} from 'sanity'
import {createFakeClient} from './fake/sanityClient'

const sanityConfig = defineConfig({
  unstable_clientFactory: () => createFakeClient(),

  projectId: 'test',
  dataset: 'test',
})
```

This makes the Config API support mocking the client without using a test framework like `jest` – but instead through simple dependency injection. This means we can test rendering of Sanity components in UI Workshop (and similar) without having to rely on a connection to the Sanity backend.
