### PR TITLE
feat(core): store selected scheme in local storage

### DIFF
--- a/packages/sanity/src/core/studio/colorScheme.tsx
+++ b/packages/sanity/src/core/studio/colorScheme.tsx
@@ -1,10 +1,34 @@
 import React, {createContext, useContext, useEffect, useMemo, useState} from 'react'
 import {studioTheme, ThemeColorSchemeKey, ThemeProvider, usePrefersDark} from '@sanity/ui'
 
+const LOCAL_STORAGE_KEY = 'sanityStudio:ui:colorScheme'
+
+function localStorageManager() {
+  const supportsLocalStorage = typeof window !== 'undefined' && window.localStorage
+
+  function getItem(key: string) {
+    return supportsLocalStorage ? window.localStorage.getItem(key) : undefined
+  }
+
+  function setItem(key: string, value: string) {
+    return supportsLocalStorage ? window.localStorage.setItem(key, value) : undefined
+  }
+
+  function removeItem(key: string) {
+    return supportsLocalStorage ? window.localStorage.removeItem(key) : undefined
+  }
+
+  return {getItem, setItem, removeItem}
+}
+
+type StudioAppearance = ThemeColorSchemeKey | 'system'
+
 /** @internal */
 export const ColorSchemeContext = createContext<{
   scheme: ThemeColorSchemeKey
+  appearance: StudioAppearance
   setScheme: (colorScheme: ThemeColorSchemeKey) => void
+  setAppearance: (appearance: StudioAppearance) => void
 } | null>(null)
 
 /** @internal */
@@ -15,22 +39,50 @@ export interface ColorSchemeProviderProps {
 }
 
 /** @internal */
-export function ColorSchemeProvider({
-  children,
-  onSchemeChange,
-  scheme: schemeProp,
-}: ColorSchemeProviderProps) {
+export function ColorSchemeProvider(props: ColorSchemeProviderProps) {
+  const {children, onSchemeChange, scheme: schemeProp} = props
+  const {getItem, setItem, removeItem} = useMemo(() => localStorageManager(), [])
+
+  // Read the stored scheme from local storage
+  const storedScheme = getItem?.(LOCAL_STORAGE_KEY) as ThemeColorSchemeKey | undefined
+
+  // Get the system scheme
   const prefersDark = usePrefersDark()
-  const [scheme, setScheme] = useState<ThemeColorSchemeKey>(schemeProp || 'light')
+  const systemScheme = prefersDark ? 'dark' : 'light'
 
-  // if the preferred color scheme changes, then react to this change
+  // If there is a stored scheme, that means the user has set the appearance to "dark" or "light" and we should use that scheme
+  // If there is no stored scheme, that means that the user has set the appearance to "system" or nothing at all, so we should use the system scheme
+  const initialAppearance = (storedScheme ? storedScheme : 'system') as StudioAppearance
+  const [appearance, setAppearance] = useState<StudioAppearance>(initialAppearance)
+
+  // Set the initial scheme based on the schemeProp, stored scheme or system scheme
+  const initialScheme = (schemeProp || storedScheme || systemScheme) as ThemeColorSchemeKey
+  const [scheme, setScheme] = useState<ThemeColorSchemeKey>(initialScheme)
+
+  // React to appearance changes and update the scheme accordingly
   useEffect(() => {
-    const nextScheme = prefersDark ? 'dark' : 'light'
-    setScheme(nextScheme)
-    onSchemeChange?.(nextScheme)
-  }, [onSchemeChange, prefersDark])
+    // If the appearance is set to "system", remove the stored scheme from local storage to allow system settings to take over
+    if (appearance == 'system') {
+      setScheme(systemScheme)
+      onSchemeChange?.(systemScheme)
+      removeItem?.(LOCAL_STORAGE_KEY)
+    } else {
+      // If the appearance is set to "dark" or "light", set the scheme to "dark" or "light" respectively and store the scheme in local storage
+      setScheme(appearance)
+      onSchemeChange?.(appearance)
+      setItem?.(LOCAL_STORAGE_KEY, appearance)
+    }
+  }, [appearance, onSchemeChange, prefersDark, removeItem, setItem, systemScheme])
 
-  const colorScheme = useMemo(() => ({scheme, setScheme}), [scheme])
+  const colorScheme = useMemo(
+    () => ({
+      appearance,
+      scheme,
+      setAppearance,
+      setScheme,
+    }),
+    [appearance, scheme]
+  )
 
   return (
     <ColorSchemeContext.Provider value={colorScheme}>

--- a/packages/sanity/src/core/studio/components/navbar/userMenu/UserMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/userMenu/UserMenu.tsx
@@ -1,4 +1,4 @@
-import {SunIcon, MoonIcon, LeaveIcon, ChevronDownIcon, CogIcon} from '@sanity/icons'
+import {SunIcon, MoonIcon, LeaveIcon, ChevronDownIcon, CogIcon, DesktopIcon} from '@sanity/icons'
 import {
   Box,
   Button,
@@ -15,7 +15,7 @@ import {
   Tooltip,
   useRootTheme,
 } from '@sanity/ui'
-import React, {useCallback, useMemo} from 'react'
+import React, {useMemo} from 'react'
 import styled from 'styled-components'
 import {UserAvatar} from '../../../../components'
 import {getProviderTitle} from '../../../../store'
@@ -40,7 +40,7 @@ const AvatarBox = styled(Box)`
 export function UserMenu() {
   const {currentUser, projectId, auth} = useWorkspace()
   const theme = useRootTheme().theme as StudioTheme
-  const {scheme, setScheme} = useColorScheme()
+  const {scheme, appearance, setAppearance} = useColorScheme()
 
   const providerTitle = getProviderTitle(currentUser?.provider)
 
@@ -53,10 +53,6 @@ export function UserMenu() {
     }),
     [scheme]
   )
-
-  const handleToggleScheme = useCallback(() => {
-    setScheme(scheme === 'dark' ? 'light' : 'dark')
-  }, [scheme, setScheme])
 
   return (
     <MenuButton
@@ -114,10 +110,33 @@ export function UserMenu() {
             <>
               <MenuDivider />
 
+              <Box padding={2}>
+                <Label size={1} muted>
+                  Color scheme
+                </Label>
+              </Box>
+
               <MenuItem
-                icon={scheme === 'dark' ? SunIcon : MoonIcon}
-                onClick={handleToggleScheme}
-                text={scheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+                icon={DesktopIcon}
+                // eslint-disable-next-line react/jsx-no-bind
+                onClick={() => setAppearance('system')}
+                pressed={appearance === 'system'}
+                text="System"
+              />
+
+              <MenuItem
+                icon={MoonIcon}
+                // eslint-disable-next-line react/jsx-no-bind
+                onClick={() => setAppearance('dark')}
+                pressed={appearance === 'dark'}
+                text="Dark"
+              />
+              <MenuItem
+                icon={SunIcon}
+                // eslint-disable-next-line react/jsx-no-bind
+                onClick={() => setAppearance('light')}
+                pressed={appearance === 'light'}
+                text="Light"
               />
             </>
           )}


### PR DESCRIPTION
### Description

This PR implements so that the chosen color scheme is saved in local storage and reused on the next visit, and the default color scheme is "system" until the user chooses something else.

### What to review

Make sure that you get the expected color scheme

### Notes for release

Store selected scheme in local storage