### PR TITLE
build: add `bin` directory to distribution

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -75,6 +75,7 @@
   },
   "files": [
     "_internal.js",
+    "bin",
     "cli.js",
     "desk.js",
     "lib",


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This change adds `bin` to the `files` array in `package.json`.
