### PR TITLE
feat(core): store selected color scheme in local storage

### DIFF
--- a/packages/sanity/src/core/studio/colorScheme.tsx
+++ b/packages/sanity/src/core/studio/colorScheme.tsx
@@ -1,10 +1,36 @@
-import React, {createContext, useContext, useEffect, useMemo, useState} from 'react'
+import React, {createContext, useCallback, useContext, useEffect, useMemo, useState} from 'react'
 import {studioTheme, ThemeColorSchemeKey, ThemeProvider, usePrefersDark} from '@sanity/ui'
+
+const LOCAL_STORAGE_KEY = 'sanityStudio:ui:colorScheme'
+
+function localStorageManager() {
+  const supportsLocalStorage = typeof window !== 'undefined' && window.localStorage
+
+  function getItem(key: string) {
+    return supportsLocalStorage ? window.localStorage.getItem(key) : undefined
+  }
+
+  function setItem(key: string, value: string) {
+    return supportsLocalStorage ? window.localStorage.setItem(key, value) : undefined
+  }
+
+  function removeItem(key: string) {
+    return supportsLocalStorage ? window.localStorage.removeItem(key) : undefined
+  }
+
+  return {getItem, setItem, removeItem}
+}
 
 /** @internal */
 export const ColorSchemeContext = createContext<{
+  /** The current color scheme */
   scheme: ThemeColorSchemeKey
+  /** Set the color scheme and store it in local storage */
   setScheme: (colorScheme: ThemeColorSchemeKey) => void
+  /** A boolean indicating whether the user is using the system color scheme */
+  usingSystemScheme: boolean
+  /** Clear the stored color scheme from local storage and use the system color scheme */
+  clearStoredScheme: () => void
 } | null>(null)
 
 /** @internal */
@@ -20,17 +46,57 @@ export function ColorSchemeProvider({
   onSchemeChange,
   scheme: schemeProp,
 }: ColorSchemeProviderProps) {
+  const {getItem, setItem, removeItem} = useMemo(() => localStorageManager(), [])
+
+  // The system color scheme
   const prefersDark = usePrefersDark()
-  const [scheme, setScheme] = useState<ThemeColorSchemeKey>(schemeProp || 'light')
+  const systemScheme = prefersDark ? 'dark' : 'light'
 
-  // if the preferred color scheme changes, then react to this change
+  // The color scheme stored in local storage
+  const storedScheme = getItem?.(LOCAL_STORAGE_KEY) as ThemeColorSchemeKey | undefined
+
+  // A state indicating whether the user is using the system color scheme (mainly used to reflect what the user has selected in the UI)
+  const [usingSystemScheme, setUsingSystemScheme] = useState<boolean>(!storedScheme)
+
+  // The initial scheme to use
+  const initialScheme = (schemeProp || storedScheme || systemScheme) as ThemeColorSchemeKey
+  const [scheme, setScheme] = useState<ThemeColorSchemeKey>(initialScheme)
+
+  // Store the scheme in local storage when it changes (unless it's the system scheme)
+  const handleSetScheme = useCallback(
+    (nextScheme: ThemeColorSchemeKey) => {
+      // Safety check to make sure we only store valid scheme keys
+      if (nextScheme === 'dark' || nextScheme === 'light') {
+        setItem?.(LOCAL_STORAGE_KEY, nextScheme)
+        setScheme(nextScheme)
+        onSchemeChange?.(nextScheme)
+        setUsingSystemScheme(false)
+      }
+    },
+    [onSchemeChange, setItem]
+  )
+
+  // Remove the stored scheme from local storage and set the scheme to the system scheme
+  const clearStoredScheme = useCallback(() => {
+    removeItem?.(LOCAL_STORAGE_KEY)
+    setScheme(systemScheme)
+    onSchemeChange?.(systemScheme)
+    setUsingSystemScheme(true)
+  }, [onSchemeChange, removeItem, systemScheme])
+
+  // React to changes in the system settings.
+  // If the user doesn't have a stored scheme in local storage, use the system scheme.
   useEffect(() => {
-    const nextScheme = prefersDark ? 'dark' : 'light'
-    setScheme(nextScheme)
-    onSchemeChange?.(nextScheme)
-  }, [onSchemeChange, prefersDark])
+    if (!storedScheme) {
+      setScheme(systemScheme)
+      setUsingSystemScheme(true)
+    }
+  }, [onSchemeChange, storedScheme, systemScheme])
 
-  const colorScheme = useMemo(() => ({scheme, setScheme}), [scheme])
+  const colorScheme = useMemo(
+    () => ({scheme, setScheme: handleSetScheme, usingSystemScheme, clearStoredScheme}),
+    [clearStoredScheme, handleSetScheme, scheme, usingSystemScheme]
+  )
 
   return (
     <ColorSchemeContext.Provider value={colorScheme}>

--- a/packages/sanity/src/core/studio/components/navbar/userMenu/UserMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/userMenu/UserMenu.tsx
@@ -1,4 +1,12 @@
-import {SunIcon, MoonIcon, LeaveIcon, ChevronDownIcon, CogIcon} from '@sanity/icons'
+import {
+  SunIcon,
+  MoonIcon,
+  LeaveIcon,
+  ChevronDownIcon,
+  CogIcon,
+  DesktopIcon,
+  CheckmarkIcon,
+} from '@sanity/icons'
 import {
   Box,
   Button,
@@ -15,7 +23,7 @@ import {
   Tooltip,
   useRootTheme,
 } from '@sanity/ui'
-import React, {useCallback, useMemo} from 'react'
+import React, {useMemo} from 'react'
 import styled from 'styled-components'
 import {UserAvatar} from '../../../../components'
 import {getProviderTitle} from '../../../../store'
@@ -40,7 +48,7 @@ const AvatarBox = styled(Box)`
 export function UserMenu() {
   const {currentUser, projectId, auth} = useWorkspace()
   const theme = useRootTheme().theme as StudioTheme
-  const {scheme, setScheme} = useColorScheme()
+  const {scheme, setScheme, clearStoredScheme, usingSystemScheme} = useColorScheme()
 
   const providerTitle = getProviderTitle(currentUser?.provider)
 
@@ -53,10 +61,6 @@ export function UserMenu() {
     }),
     [scheme]
   )
-
-  const handleToggleScheme = useCallback(() => {
-    setScheme(scheme === 'dark' ? 'light' : 'dark')
-  }, [scheme, setScheme])
 
   return (
     <MenuButton
@@ -114,10 +118,37 @@ export function UserMenu() {
             <>
               <MenuDivider />
 
+              <Box padding={2}>
+                <Label size={1} muted>
+                  Appearance
+                </Label>
+              </Box>
+
               <MenuItem
-                icon={scheme === 'dark' ? SunIcon : MoonIcon}
-                onClick={handleToggleScheme}
-                text={scheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+                aria-label="Use system appearance"
+                icon={DesktopIcon}
+                onClick={clearStoredScheme}
+                pressed={usingSystemScheme}
+                text="System"
+                iconRight={usingSystemScheme && <CheckmarkIcon />}
+              />
+
+              <MenuItem
+                aria-label="Use dark appearance"
+                icon={MoonIcon}
+                onClick={() => setScheme('dark')}
+                pressed={scheme === 'dark' && !usingSystemScheme}
+                iconRight={scheme === 'dark' && !usingSystemScheme && <CheckmarkIcon />}
+                text="Dark"
+              />
+
+              <MenuItem
+                aria-label="Use light appearance"
+                icon={SunIcon}
+                onClick={() => setScheme('light')}
+                pressed={scheme === 'light' && !usingSystemScheme}
+                iconRight={scheme === 'light' && !usingSystemScheme && <CheckmarkIcon />}
+                text="Light"
               />
             </>
           )}

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspacePreview.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspacePreview.tsx
@@ -70,16 +70,12 @@ export function WorkspacePreview(props: WorkspacePreviewProps) {
       {(selected || iconRightComponent) && (
         <Flex align="center" gap={4} paddingLeft={3} paddingRight={2}>
           {selected && (
-            <Text size={1} muted>
+            <Text>
               <CheckmarkIcon />
             </Text>
           )}
 
-          {iconRightComponent && (
-            <Text size={1} muted>
-              {iconRightComponent}
-            </Text>
-          )}
+          {iconRightComponent && <Text muted>{iconRightComponent}</Text>}
         </Flex>
       )}
     </Flex>


### PR DESCRIPTION
### Description

This PR implements so that the selected color scheme is saved in local storage and reused on the next visit. The default color scheme is based on system settings until the user chooses otherwise.

This PR also makes some small UI updates the user menu component (see image).

### What to review

Make sure that you get the expected color scheme based on what you have selected after reloading the studio.

### Notes for release

The studio now saves the selected color scheme in local storage and uses it on next visit
