### PR TITLE
fix(core): components API execution order

### DIFF
--- a/packages/sanity/src/core/config/components/useMiddlewareComponents.ts
+++ b/packages/sanity/src/core/config/components/useMiddlewareComponents.ts
@@ -43,17 +43,21 @@ export function useMiddlewareComponents<T extends {}>(props: {
   const {defaultComponent, pick} = props
 
   return useMemo(() => {
-    // 1. Flatten the config tree into a list of configs
-    const flattened = flattenConfig(options, [])
+    // Flatten the config tree into a list of configs
+    const flattened = [...flattenConfig(options, [])]
 
-    // 2. Pick the middleware components from the configs
+    // Since the middleware chain is executed backwards, we need to reverse the list of configs here.
+    // This is important because we want the order of the Components API to be consistent with the order of the other APIs.
+    flattened.reverse()
+
+    // Pick the middleware components from the configs
     const pickedComponents = flattened.map(({config}) => pick(config))
 
-    // 3: Since we try to pick the components in all configs, some results may be undefined.
+    // Since we try to pick the components in all configs, some results may be undefined.
     // Therefore, we filter these values out before passing the result to the middleware creator.
     const result = pickedComponents.filter(Boolean)
 
-    // 4. Create the middleware component
+    // Create the middleware component
     return _createMiddlewareComponent(defaultComponent, result)
   }, [defaultComponent, options, pick])
 }


### PR DESCRIPTION
### Description

This PR fixes an issue in the components API. Since middleware chain in the components API is executed backwards, we need to reverse the list of configs before passing it to the middleware creator. This is important because we want the order of the components API to be consistent with the order of the other APIs.

### What to review

Make sure that the order of the components API is consistent with other APIs and that it works as expected. 

### Notes for release

Fix components API execution order
