### PR TITLE
fix(cli): only require workspace name if more than 1 workspace

### DIFF
--- a/packages/sanity/src/_internal/cli/threads/getGraphQLAPIs.ts
+++ b/packages/sanity/src/_internal/cli/threads/getGraphQLAPIs.ts
@@ -71,7 +71,7 @@ function resolveGraphQLAPIsFromConfig(
 
   for (const apiDef of apiDefs) {
     const {workspace: workspaceName, source: sourceName} = apiDef
-    if (!workspaceName && workspaces.length > 0) {
+    if (!workspaceName && workspaces.length > 1) {
       throw new Error(
         'Must define `workspace` name in GraphQL API config when multiple workspaces are defined'
       )


### PR DESCRIPTION
### Description

When you want to deploy a GraphQL API, we should only require you to define a workspace name if you have multiple defined. There was a check for this, but it mistakenly checks for more than zero instead of more than one. This PR fixes this check.

### What to review

- `sanity graphql deploy` with a single workspace does not throw an error
- `sanity graphql deploy` with multiple workspaces throws an error if no `workspace` name is given in GraphQL config

### Notes for release

- Fix issue where you had to provide a workspace name to deploy GraphQL APIs, even if only a single workspace was defined
