### PR TITLE
fix(config): throw error early if tools/template resolution fails

### DIFF
--- a/packages/sanity/src/core/config/__tests__/resolveConfig.test.ts
+++ b/packages/sanity/src/core/config/__tests__/resolveConfig.test.ts
@@ -5,6 +5,22 @@ import {createMockAuthStore} from '../../store'
 import {resolveConfig, createWorkspaceFromConfig, createSourceFromConfig} from '../resolveConfig'
 
 describe('resolveConfig', () => {
+  it('throws on invalid tools property', async () => {
+    expect.assertions(1)
+    try {
+      await resolveConfig({
+        projectId: 'ppsg7ml5',
+        dataset: 'production',
+        // @ts-expect-error should be an array
+        tools: {},
+      })
+        .pipe(first())
+        .toPromise()
+    } catch (err) {
+      expect(err.message).toMatch('Expected `tools` to an array or a function but found object')
+    }
+  })
+
   it('returns an observable that emits an array of fully resolved workspaces', async () => {
     const projectId = 'ppsg7ml5'
     const dataset = 'production'

--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -284,7 +284,11 @@ function resolveSource({
     // TODO: validate templates
     // TODO: validate that each one has a unique template ID
   } catch (e) {
-    errors.push(e)
+    throw new ConfigResolutionError({
+      name: config.name,
+      type: 'source',
+      causes: [e],
+    })
   }
 
   let tools!: Source['tools']
@@ -297,7 +301,11 @@ function resolveSource({
       reducer: toolsReducer,
     })
   } catch (e) {
-    errors.push(e)
+    throw new ConfigResolutionError({
+      name: config.name,
+      type: 'source',
+      causes: [e],
+    })
   }
 
   // In this case we want to throw an error because it is not possible to have
@@ -344,7 +352,6 @@ function resolveSource({
     if (templateErrors.length) {
       throw new ConfigResolutionError({
         name: config.name,
-        // TODO: figure out this name
         type: 'source',
         causes: templateErrors,
       })


### PR DESCRIPTION
### Description

We were attempting to collect/batch as many errors as possible before showing them. However, when resolving tools and templates, we try to access the resolved `tools` property as if we could guarantee it was a valid array. This would fail if (for instance) the `tools` property was an object instead of an array.

This PR changes to throwing early - which I don't think should be a huge step back in any way, and will fix cases where users instead got an error with message `cannot read properties of undefined (reading 'some')` and similar.

### What to review

- Resolving configuration still works as expected
- Defining an object or non-array property for `tools` will give the intended error

### Notes for release

- Fixed error where providing an invalid `tools` configuration property would not provide a readable error
