### PR TITLE
chore(vision): use react 18 compatible dependencies

### DIFF
--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -27,7 +27,7 @@
     "@sanity/ui-workshop": "^1.0.0",
     "@sanity/util": "3.0.6",
     "@sanity/uuid": "^3.0.1",
-    "@sanity/vision": "3.0.1",
+    "@sanity/vision": "3.0.6",
     "@turf/helpers": "^6.0.1",
     "@turf/points-within-polygon": "^5.1.5",
     "@types/three": "^0.144.0",

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -41,6 +41,7 @@
     "@juggle/resize-observer": "^3.3.1",
     "@lezer/highlight": "^1.0.0",
     "@rexxars/react-json-inspector": "^8.0.1",
+    "@rexxars/react-split-pane": "^0.1.93",
     "@sanity/color": "^2.1.20",
     "@sanity/icons": "^2.1.0",
     "@sanity/ui": "^1.0.0",
@@ -48,20 +49,16 @@
     "hashlru": "^2.3.0",
     "is-hotkey": "^0.1.6",
     "json5": "^1.0.1",
-    "lodash": "^4.17.21",
-    "react-split-pane": "^0.1.84"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@sanity/client": "^3.4.1",
     "react": "^18.2.0",
-    "rxjs": "^6.5.3",
     "sanity": "3.0.6",
     "styled-components": "^5.2.0"
   },
   "peerDependencies": {
-    "@sanity/client": "^3.4.1",
     "react": "^18",
-    "rxjs": "^6.5.3",
     "styled-components": "^5.2"
   },
   "repository": {

--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable complexity */
 import React, {ChangeEvent, type RefObject} from 'react'
-import SplitPane from 'react-split-pane'
+import SplitPane from '@rexxars/react-split-pane'
 import type {ListenEvent, MutationEvent, SanityClient} from '@sanity/client'
 import {PlayIcon, StopIcon, CopyIcon, ErrorOutlineIcon} from '@sanity/icons'
 import isHotkey from 'is-hotkey'
@@ -18,7 +18,6 @@ import {
   Button,
   ToastContextValue,
 } from '@sanity/ui'
-import type {Subscription} from 'rxjs'
 import {VisionCodeMirror} from '../codemirror/VisionCodeMirror'
 import {getLocalStorage, LocalStorageish} from '../util/localStorage'
 import {parseApiQueryString, ParsedApiQueryString} from '../util/parseApiQueryString'
@@ -83,6 +82,10 @@ function calculatePaneSizeOptions(rootHeight: number): PaneSizeOptions {
     minSize: Math.min(170, Math.max(170, rootHeight / 2)),
     maxSize: rootHeight > 650 ? rootHeight * 0.7 : rootHeight * 0.6,
   }
+}
+
+interface Subscription {
+  unsubscribe: () => void
 }
 
 interface VisionGuiProps extends VisionProps {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3461,6 +3461,15 @@
     debounce "1.0.0"
     md5-o-matic "^0.1.1"
 
+"@rexxars/react-split-pane@^0.1.93":
+  version "0.1.93"
+  resolved "https://registry.yarnpkg.com/@rexxars/react-split-pane/-/react-split-pane-0.1.93.tgz#d9e00eb5d91cfb49f3e8ca30f6c8d450bf85d6ff"
+  integrity sha512-Pok8zATwd5ZpWnccJeSA/JM2MPmi3D04duYtrbMNRgzeAU2ANtq3r4w7ldbjpGyfJqggqn0wDNjRqaevXqSxQg==
+  dependencies:
+    prop-types "^15.7.2"
+    react-lifecycles-compat "^3.0.4"
+    react-style-proptype "^3.2.2"
+
 "@rollup/plugin-alias@^3.1.9":
   version "3.1.9"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-alias/-/plugin-alias-3.1.9.tgz#a5d267548fe48441f34be8323fb64d1d4a1b3fdf"
@@ -3834,30 +3843,6 @@
   dependencies:
     "@types/uuid" "^8.0.0"
     uuid "^8.0.0"
-
-"@sanity/vision@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@sanity/vision/-/vision-3.0.1.tgz#87827d99c03d3a58f3196a70c00e9f5576750d3e"
-  integrity sha512-LdpEHUio4cSq3AW+6XK/FyUhbEWgVLWJC5FeJ4lActxkLn2ftnVwrXhF8uDjgGLOEPjJ3Oq4O7uWfEhPgyjhqA==
-  dependencies:
-    "@codemirror/autocomplete" "^6.1.0"
-    "@codemirror/commands" "^6.0.1"
-    "@codemirror/lang-javascript" "^6.0.2"
-    "@codemirror/language" "^6.2.1"
-    "@codemirror/search" "^6.0.1"
-    "@codemirror/view" "^6.1.1"
-    "@juggle/resize-observer" "^3.3.1"
-    "@lezer/highlight" "^1.0.0"
-    "@rexxars/react-json-inspector" "^8.0.1"
-    "@sanity/color" "^2.1.20"
-    "@sanity/icons" "^2.1.0"
-    "@sanity/ui" "^1.0.0"
-    "@uiw/react-codemirror" "^4.11.4"
-    hashlru "^2.3.0"
-    is-hotkey "^0.1.6"
-    json5 "^1.0.1"
-    lodash "^4.17.21"
-    react-split-pane "^0.1.84"
 
 "@sideway/address@^4.1.3":
   version "4.1.4"
@@ -16015,15 +16000,6 @@ react-scripts@^5.0.0:
     workbox-webpack-plugin "^6.4.1"
   optionalDependencies:
     fsevents "^2.3.2"
-
-react-split-pane@^0.1.84:
-  version "0.1.92"
-  resolved "https://registry.yarnpkg.com/react-split-pane/-/react-split-pane-0.1.92.tgz#68242f72138aed95dd5910eeb9d99822c4fc3a41"
-  integrity sha512-GfXP1xSzLMcLJI5BM36Vh7GgZBpy+U/X0no+VM3fxayv+p1Jly5HpMofZJraeaMl73b3hvlr+N9zJKvLB/uz9w==
-  dependencies:
-    prop-types "^15.7.2"
-    react-lifecycles-compat "^3.0.4"
-    react-style-proptype "^3.2.2"
 
 react-style-proptype@^3.2.2:
   version "3.2.2"


### PR DESCRIPTION
### Description

Two `@sanity/vision` related changes:
- Currently has `@sanity/client` and `rxjs` listed as peer dependencies. We are importing types using `import type`, and otherwise not using these modules directly. It is therefore not correct to flag them as peer dependencies. Additionally, studios don't install these dependencies directly, so they will give off warnings about missing dependencies, which is very unfortunate.
- `react-split-pane` does not seem to be maintained anymore, and has react 16 as its supported peer dependency range. This leads to peer dependency warnings when installing the vision plugin. It works just fine with React 18 however, so I have forked the module and updated the peer dependency range to `^18`. Ideally we should replace the library with something different, but I don't have time to address this right now.

### What to review

- That `@sanity/vision` works as expected still (should be very minor changes - if it lets you install dependencies, builds and allows us to resize the different areas of vision, it works fine)

### Notes for release

- Fixed a few peer dependency warnings in `@sanity/vision`
