### PR TITLE
Refactor block type render callbacks

### DIFF
--- a/packages/@sanity/types/src/schema/definition/schemaDefinition.ts
+++ b/packages/@sanity/types/src/schema/definition/schemaDefinition.ts
@@ -116,6 +116,7 @@ export interface TypeAliasDefinition<
   components?: {
     annotation?: ComponentType<any>
     block?: ComponentType<any>
+    inlineBlock?: ComponentType<any>
     diff?: ComponentType<any>
     field?: ComponentType<any>
     input?: ComponentType<any>

--- a/packages/@sanity/types/src/schema/definition/type/block.ts
+++ b/packages/@sanity/types/src/schema/definition/type/block.ts
@@ -51,7 +51,7 @@ export interface BlockDefinition extends BaseSchemaDefinition {
   styles?: BlockStyleDefinition[]
   lists?: BlockListDefinition[]
   marks?: BlockMarksDefinition
-  of?: ArrayOfType[]
+  of?: ArrayOfType<'object' | 'reference'>[]
   initialValue?: InitialValueProperty<any, any[]>
   options?: BlockOptions
   validation?: ValidationBuilder<BlockRule, any[]>

--- a/packages/sanity/src/core/form/types/definitionExtensions.test.ts
+++ b/packages/sanity/src/core/form/types/definitionExtensions.test.ts
@@ -3,6 +3,7 @@
 
 import {
   CrossDatasetReferenceValue,
+  defineArrayMember,
   defineField,
   defineType,
   FileValue,
@@ -150,6 +151,17 @@ describe('definitionExtensions', () => {
           preview: (props: string) => null,
         },
       })
+    })
+  })
+
+  it('should extend components for block .of and .components', () => {
+    defineArrayMember({
+      type: 'block',
+      name: 'test',
+      of: [{type: 'author', components: {inlineBlock: () => null}}],
+      components: {
+        block: () => null,
+      },
     })
   })
 

--- a/packages/sanity/src/core/form/types/definitionExtensions.ts
+++ b/packages/sanity/src/core/form/types/definitionExtensions.ts
@@ -38,10 +38,11 @@ import {
  * @beta
  */
 export interface ArrayOfObjectsComponents {
-  annotation?: ComponentType<any>
-  block?: ComponentType<any>
+  annotation?: ComponentType<BlockAnnotationProps>
+  block?: ComponentType<BlockProps>
   diff?: ComponentType<any>
   field?: ComponentType<ArrayFieldProps>
+  inlineBlock?: ComponentType<BlockProps>
   input?: ComponentType<ArrayOfObjectsInputProps>
   item?: ComponentType<ObjectItemProps>
   preview?: ComponentType<PreviewProps>
@@ -106,8 +107,11 @@ export interface DocumentComponents {
  * @beta
  */
 export interface FileComponents {
+  annotation?: ComponentType<BlockAnnotationProps>
+  block?: ComponentType<BlockProps>
   diff?: ComponentType<any>
   field?: ComponentType<ObjectFieldProps<FileValue>>
+  inlineBlock?: ComponentType<BlockProps>
   input?: ComponentType<ObjectInputProps<FileValue>>
   item?: ComponentType<ObjectItemProps<FileValue & ObjectItem>>
   preview?: ComponentType<PreviewProps>
@@ -117,8 +121,11 @@ export interface FileComponents {
  * @beta
  */
 export interface GeopointComponents {
+  annotation?: ComponentType<BlockAnnotationProps>
+  block?: ComponentType<BlockProps>
   diff?: ComponentType<any>
   field?: ComponentType<ObjectFieldProps<GeopointValue>>
+  inlineBlock?: ComponentType<BlockProps>
   input?: ComponentType<ObjectInputProps<GeopointValue>>
   item?: ComponentType<ObjectItemProps<GeopointValue & ObjectItem>>
   preview?: ComponentType<PreviewProps>
@@ -128,8 +135,11 @@ export interface GeopointComponents {
  * @beta
  */
 export interface ImageComponents {
+  annotation?: ComponentType<BlockAnnotationProps>
+  block?: ComponentType<BlockProps>
   diff?: ComponentType<any>
   field?: ComponentType<ObjectFieldProps<ImageValue>>
+  inlineBlock?: ComponentType<BlockProps>
   input?: ComponentType<ObjectInputProps<ImageValue>>
   item?: ComponentType<ObjectItemProps<ImageValue & ObjectItem>>
   preview?: ComponentType<PreviewProps>
@@ -150,10 +160,11 @@ export interface NumberComponents {
  * @beta
  */
 export interface ObjectComponents {
-  annotation?: ComponentType<any>
-  block?: ComponentType<any>
+  annotation?: ComponentType<BlockAnnotationProps>
+  block?: ComponentType<BlockProps>
   diff?: ComponentType<any>
   field?: ComponentType<ObjectFieldProps>
+  inlineBlock?: ComponentType<BlockProps>
   input?: ComponentType<ObjectInputProps>
   item?: ComponentType<ObjectItemProps>
   preview?: ComponentType<PreviewProps>
@@ -163,10 +174,11 @@ export interface ObjectComponents {
  * @beta
  */
 export interface ReferenceComponents {
-  annotation?: ComponentType<any>
-  block?: ComponentType<any>
+  annotation?: ComponentType<BlockAnnotationProps>
+  block?: ComponentType<BlockProps>
   diff?: ComponentType<any>
   field?: ComponentType<ObjectFieldProps<ReferenceValue>>
+  inlineBlock?: ComponentType<BlockProps>
   input?: ComponentType<ReferenceInputProps>
   item?: ComponentType<ObjectItemProps<ReferenceValue & ObjectItem>>
   preview?: ComponentType<PreviewProps>
@@ -176,10 +188,11 @@ export interface ReferenceComponents {
  * @beta
  */
 export interface CrossDatasetReferenceComponents {
-  annotation?: ComponentType<any>
-  block?: ComponentType<any>
+  annotation?: ComponentType<BlockAnnotationProps>
+  block?: ComponentType<BlockProps>
   diff?: ComponentType<any>
   field?: ComponentType<ObjectFieldProps<CrossDatasetReferenceValue>>
+  inlineBlock?: ComponentType<BlockProps>
   input?: ComponentType<CrossDatasetReferenceInputProps>
   item?: ComponentType<ObjectItemProps<CrossDatasetReferenceValue & ObjectItem>>
   preview?: ComponentType<PreviewProps>
@@ -273,26 +286,20 @@ declare module '@sanity/types' {
     /**
      * @beta
      */
-    components?: {
-      item?: ComponentType<BlockDecoratorProps>
-    }
+    component: ComponentType<BlockDecoratorProps>
   }
 
   export interface BlockStyleDefinition {
     /**
      * @beta
      */
-    components?: {
-      item?: ComponentType<BlockStyleProps>
-    }
+    component: ComponentType<BlockStyleProps>
   }
   export interface BlockListDefinition {
     /**
      * @beta
      */
-    components?: {
-      item?: ComponentType<BlockListItemProps>
-    }
+    component: ComponentType<BlockListItemProps>
   }
 
   export interface BlockAnnotationDefinition {


### PR DESCRIPTION
### Description

This will introduce a couple of changes to the block type render callbacks.

* Pure block type render callbacks (decorators, styles, lists) now only has a `.component` on it's definition, as opposed to `.compoments.item`. This is because there will be only one, and we better want to differentiate between these and general Studio type render callbacks (like for objects etc).

* The block types `.lists` definition is now validated by the schema validator.
