### PR TITLE
fix(block-tools): ignore blocks inside list items (#3492)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,10 @@ jspm_packages
 # macOS finder cache file
 .DS_Store
 
+# Intellij
+.idea
+*.iml
+
 # VS Code settings
 /.vscode
 

--- a/packages/@sanity/block-tools/src/HtmlDeserializer/rules/html.ts
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/rules/html.ts
@@ -111,7 +111,7 @@ export default function createHTMLRules(
           return undefined
         }
         // Don't add blocks into list items
-        if (el.parentNode && tagName(el) === 'li') {
+        if (el.parentNode && tagName(el.parentNode) === 'li') {
           return next(el.childNodes)
         }
         // If style is not supported, return a defaultBlockType

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/lists/input.html
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/lists/input.html
@@ -22,6 +22,10 @@
         <li>
           <a href="/">Link</a>
         </li>
+        <li>
+          <p>p in li.</p>
+          <h1>block children are still <strong>processed.</strong></h1>
+        </li>
       </ul>
   </body>
 </html>

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/lists/output.json
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/lists/output.json
@@ -126,5 +126,27 @@
       }
     ],
     "style": "normal"
+  },
+  {
+    "_key": "randomKey8",
+    "_type": "block",
+    "children": [
+      {
+        "_key": "randomKey80",
+        "_type": "span",
+        "marks": [],
+        "text": "p in li. block children are still "
+      },
+      {
+        "_key": "randomKey81",
+        "_type": "span",
+        "marks": ["strong"],
+        "text": "processed."
+      }
+    ],
+    "level": 1,
+    "listItem": "bullet",
+    "markDefs": [],
+    "style": "normal"
   }
 ]


### PR DESCRIPTION
This fix has [previously been released in v2](https://github.com/sanity-io/sanity/pull/3492). There's some work to add it to v3 in the [chore/sc-21163/cherry-pick-changes-for-v3-on-next](https://github.com/sanity-io/sanity/compare/chore/sc-21163/cherry-pick-changes-for-v3-on-next) branch, but it has not yet been merged.

***

This fixes a bug where p-tags (and other block elements) inside li elements where incorrectly hoisted out of the li element.

With this change blocks are ignored, and block children are added directly to the listItem instead.