### PR TITLE
fix(core): update logo 

### DIFF
--- a/dev/test-studio/components/Branding.tsx
+++ b/dev/test-studio/components/Branding.tsx
@@ -1,6 +1,10 @@
-import {Text} from '@sanity/ui'
+import {Box, Text} from '@sanity/ui'
 import React from 'react'
 
 export function Branding() {
-  return <Text weight="bold">Test Studio&trade;</Text>
+  return (
+    <Box padding={3}>
+      <Text weight="bold">Test Studio&trade;</Text>
+    </Box>
+  )
 }

--- a/packages/sanity/src/core/studio/components/navbar/LogoButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/LogoButton.tsx
@@ -19,7 +19,7 @@ export function LogoButton(props: LogoButtonProps) {
       href={href}
       mode="bleed"
       onClick={onClick}
-      padding={3}
+      padding={0}
     >
       {children}
     </Button>

--- a/packages/sanity/src/core/studio/components/navbar/StudioLogo.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioLogo.tsx
@@ -1,4 +1,4 @@
-import {Text} from '@sanity/ui'
+import {Box, Text} from '@sanity/ui'
 import React from 'react'
 import {LogoProps} from '../../../config'
 
@@ -6,5 +6,9 @@ import {LogoProps} from '../../../config'
 export function StudioLogo(props: LogoProps) {
   const {title} = props
 
-  return <Text weight="bold">{title}</Text>
+  return (
+    <Box padding={3}>
+      <Text weight="bold">{title}</Text>
+    </Box>
+  )
 }


### PR DESCRIPTION
### Description

This pull request moves the padding from the button that wraps the logo in the navbar to the default logo component. 

**Why?**
Today, if you configure a custom logo component, the navbar often becomes unnecessarily large because you have to render the logo inside a button with padding. By removing the padding from the button that wraps the logo, it is up to the implementation of the custom logo to decide how big the logo/button should be.

### What to review

n/a

### Notes for release

The default button padding surrounding the logo component is now gone. This means that the custom logo component now fully controls the size of the navbar button. Therefore, it may be necessary to update the custom logo component with padding. Below is an example of how to reproduce the same result as before:

```tsx
import {defineConfig} from 'sanity'
import {Box} from '@sanity/ui'

function MyLogo() {
  return (
    <Box padding={3}> // <-- Wrap your custom logo with a `Box` with `padding={3}`
      <CustomLogo />
    </Box>
  )
}

export default defineConfig({
  // ... rest of config

  studio: {
    components: {
      logo: MyLogo,
    },
  },
})

```

