### PR TITLE
feat(core): add new `documentIdEquals` utility method

### DIFF
--- a/packages/sanity/src/core/util/draftUtils.test.ts
+++ b/packages/sanity/src/core/util/draftUtils.test.ts
@@ -1,5 +1,5 @@
 import {SanityDocument} from '@sanity/types'
-import {collate, removeDupes} from './draftUtils'
+import {collate, documentIdEquals, removeDupes} from './draftUtils'
 
 test('collate()', () => {
   const foo = {_type: 'foo', _id: 'foo'}
@@ -21,4 +21,18 @@ test('removeDupes()', () => {
   const baz = {_type: 'foo', _id: 'baz'} as SanityDocument
 
   expect(removeDupes([foo, fooDraft, barDraft, baz])).toEqual([fooDraft, barDraft, baz])
+})
+
+test.each([
+  ['full equality, published', 'agot', 'agot', true],
+  ['full equality, drafts', 'drafts.agot', 'drafts.agot', true],
+  ['lhs draft, rhs published', 'drafts.agot', 'agot', true],
+  ['rhs draft, lhs published', 'agot', 'drafts.agot', true],
+  ['differing documents', 'agot', 'adwd', false],
+  ['differing documents, draft lhs', 'drafts.agot', 'adwd', false],
+  ['differing documents, draft rhs', 'agot', 'drafts.adwd', false],
+  ['lhs non-draft prefix, otherwise equality', 'notes.agot', 'agot', false],
+  ['rhs non-draft prefix, otherwise equality', 'agot', 'notes.agot', false],
+])('documentIdEquals(): %s', (_, documentId, equalsDocumentId, shouldEqual) => {
+  expect(documentIdEquals(documentId, equalsDocumentId)).toEqual(shouldEqual)
 })

--- a/packages/sanity/src/core/util/draftUtils.ts
+++ b/packages/sanity/src/core/util/draftUtils.ts
@@ -15,6 +15,29 @@ export type PublishedId = Opaque<string, 'publishedId'>
 export const DRAFTS_FOLDER = 'drafts'
 const DRAFTS_PREFIX = `${DRAFTS_FOLDER}.`
 
+/**
+ * Checks if the document ID `documentId` has the same ID as `equalsDocumentId`,
+ * if you discard the draft status of the given IDs. Examples:
+ *
+ * @example
+ * Draft vs published document ID, but representing the same document:
+ * ```
+ * // Prints "true":
+ * console.log(documentIdEquals('drafts.agot', 'agot'));
+ * ```
+ * @example
+ * Different documents:
+ * ```
+ * // Prints "false":
+ * console.log(documentIdEquals('hp-tcos', 'hp-hbp'));
+ * ```
+ *
+ * @public
+ */
+export function documentIdEquals(documentId: string, equalsDocumentId: string): boolean {
+  return getPublishedId(documentId) === getPublishedId(equalsDocumentId)
+}
+
 /** @internal */
 export function isDraft(document: SanityDocument): boolean {
   return isDraftId(document._id)


### PR DESCRIPTION
### Description

Quite often I find myself needing to see if two documents/document IDs are the same, if you disregard their draft status. While you can use `getPublishedId()` manually and compare the two, it is _just_ a bit too repetetive for my taste. This PR adds a new `documentIdEquals()` method which does this comparison. I'm not sure on naming. Other alternatives could be:

- `documentIdsAreEqual()`
- `documentIdsEqual()`
- `documentIdsRepresentSameDocument()`
- `documentIdsAreEqualIfYouDisregardTheirPublishedStatus` (yes that was a joke)

Another alternative would be to just live with having to do the `getPublishedId()` calls manually, but in this case we should at least make the method public (it is currently set as internal).

### What to review

- Naming
- Implementation
- Tests

### Notes for release

- Added a new `documentIdEquals` utility method for checking equality of two document IDs, disregarding the draft/published status
