### PR TITLE
fix(cli): specify 2.x version ranges for dependencies

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/bootstrapTemplate.js
+++ b/packages/@sanity/cli/src/actions/init-project/bootstrapTemplate.js
@@ -1,10 +1,8 @@
 import path from 'path'
 import chalk from 'chalk'
 import fse from 'fs-extra'
-import {union, difference} from 'lodash'
 import debug from '../../debug'
 import versionRanges from '../../versionRanges'
-import resolveLatestVersions from '../../util/resolveLatestVersions'
 import {createPackageManifest, createSanityManifest} from './createManifest'
 import templates from './templates'
 
@@ -30,20 +28,7 @@ export default async (opts, context) => {
   spinner.succeed()
 
   // Merge global and template-specific plugins and dependencies
-  const allModules = Object.assign({}, versionRanges.core, template.dependencies || {})
-  const modules = union(Object.keys(versionRanges.core), Object.keys(template.dependencies || {}))
-
-  // Resolve latest versions of Sanity-dependencies
-  spinner = output.spinner('Resolving latest module versions').start()
-  const firstParty = modules.filter(isFirstParty)
-  const thirdParty = difference(modules, firstParty)
-  const firstPartyVersions = await resolveLatestVersions(firstParty, {asRange: true})
-  const thirdPartyVersions = thirdParty.reduce((acc, dep) => {
-    acc[dep] = allModules[dep]
-    return acc
-  }, {})
-  const dependencies = Object.assign({}, firstPartyVersions, thirdPartyVersions)
-  spinner.succeed()
+  const dependencies = Object.assign({}, versionRanges.core, template.dependencies || {})
 
   // Now create a package manifest (`package.json`) with the merged dependencies
   spinner = output.spinner('Creating default project files').start()
@@ -96,8 +81,4 @@ export default async (opts, context) => {
       }
     }
   }
-}
-
-function isFirstParty(pkg) {
-  return pkg.indexOf('@sanity/') === 0
 }

--- a/packages/@sanity/cli/src/versionRanges.js
+++ b/packages/@sanity/cli/src/versionRanges.js
@@ -1,13 +1,13 @@
 export default {
   // Dependencies for a default Sanity installation
   core: {
-    '@sanity/base': 'latest',
-    '@sanity/core': 'latest',
-    '@sanity/default-layout': 'latest',
-    '@sanity/default-login': 'latest',
-    '@sanity/desk-tool': 'latest',
-    '@sanity/eslint-config-studio': 'latest',
-    '@sanity/vision': 'latest',
+    '@sanity/base': '^2.0.0',
+    '@sanity/core': '^2.0.0',
+    '@sanity/default-layout': '^2.0.0',
+    '@sanity/default-login': '^2.0.0',
+    '@sanity/desk-tool': '^2.0.0',
+    '@sanity/eslint-config-studio': '^2.0.0',
+    '@sanity/vision': '^2.0.0',
     eslint: '^8.6.0',
     'prop-types': '^15.7',
     react: '^17.0',


### PR DESCRIPTION
### Description

When bootstrapping new studios using the Sanity v2 CLI, you currently get the following error:
> Error: No "sanity.json" file found in plugin "@sanity/vision"

This is caused by the CLI installing the v3 version of `@sanity/vision`, because we specify that we want `latest`. Theoretically all the other dependencies have the same issue - the only reason they work is because we no longer use these modules in v3, and so `latest` still points to the v2 version.

This PR changes to use version ranges (`^2.0.0`) for everything (and drops resolving the latest version, since it is irrelevant), which should ensure that even if we _do_ release new versions of these packages, it won't break anything in v2 studios.

[sc-28222]

### What to review

- You are able to bootstrap new v2 studios with v2 dependencies

To test:

- Check out the branch
- Use node 14
- Install dependencies (`yarn`)
- Build the monorepo (`yarn build`)
- Initialize a new project (`~/path/to/monorepo/packages/@sanity/cli/bin/sanity init`)
- Check that it installs dependencies and you can run `sanity start`

Note: CI fails because of this exact issue, ironically.

### Notes for release

- Fixed issue where new v2 studios failed to be created because of the incorrect `@sanity/vision` version being installed
