### PR TITLE
fix: allow global studio base path

### DIFF
--- a/packages/@sanity/cli/test/__fixtures__/static-basepath/index.html
+++ b/packages/@sanity/cli/test/__fixtures__/static-basepath/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Sanity Static, Base Pathed</title>
+  </head>
+  <body>
+    <h1>This is static, served from a base path.</h1>
+    <script type="module" src="/some-base-path/static/sanity-a3cc3d86.js"></script>
+  </body>
+</html>

--- a/packages/@sanity/cli/test/__fixtures__/static-root-basepath/index.html
+++ b/packages/@sanity/cli/test/__fixtures__/static-root-basepath/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Sanity Static, Root Path</title>
+  </head>
+  <body>
+    <h1>This is static, served from a root base path.</h1>
+    <script type="module" src="/static/sanity-a3cc3d86.js"></script>
+  </body>
+</html>

--- a/packages/@sanity/cli/test/__fixtures__/v3/package.json
+++ b/packages/@sanity/cli/test/__fixtures__/v3/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "sanity": "3.0.0-dev-preview.20",
+    "sanity": "^3.0.0",
     "styled-components": "^5.2.0"
   }
 }

--- a/packages/@sanity/cli/test/__fixtures__/v3/sanity.cli.ts
+++ b/packages/@sanity/cli/test/__fixtures__/v3/sanity.cli.ts
@@ -1,15 +1,7 @@
 import {defineCliConfig} from 'sanity/cli'
 
 export default defineCliConfig({
-  api: {
-    projectId: 'aeysrmym',
-    dataset: 'production',
-  },
-
-  graphql: [
-    {
-      playground: false,
-      workspace: 'default', // @todo remove
-    },
-  ],
+  api: {projectId: 'aeysrmym', dataset: 'production'},
+  project: {basePath: '/config-base-path'},
+  graphql: [{playground: false}],
 })

--- a/packages/@sanity/cli/test/__fixtures__/v3/sanity.config.ts
+++ b/packages/@sanity/cli/test/__fixtures__/v3/sanity.config.ts
@@ -4,7 +4,6 @@ import {MyLogo} from './components/MyLogo'
 import {schema} from './schema'
 
 export default defineConfig({
-  name: 'default', // @todo remove
   projectId: 'aeysrmym',
   dataset: 'production',
   plugins: [deskTool()],

--- a/packages/@sanity/cli/test/build.test.ts
+++ b/packages/@sanity/cli/test/build.test.ts
@@ -5,6 +5,8 @@ import {describeCliTest, testConcurrent} from './shared/describe'
 
 describeCliTest('CLI: `sanity build` / `sanity deploy`', () => {
   describe.each(studioVersions)('%s', (version) => {
+    const testConcurrentV3 = version === 'v3' ? testConcurrent : test.skip
+
     // Builds can take a bit of time with lots of concurrent tasks and slow CIs
     jest.setTimeout(120 * 1000)
 
@@ -41,13 +43,65 @@ describeCliTest('CLI: `sanity build` / `sanity deploy`', () => {
             throw new Error('Could not find Sanity CSS entry file (-[hash].css)')
           }
 
-          const builtHtml = await readFile(path.join(studioPath, 'out/index.html'), 'utf8')
+          const builtHtml = await readFile(path.join(studioPath, 'out', 'index.html'), 'utf8')
           const builtJs = await readFile(path.join(studioPath, 'out', 'static', jsPath), 'utf8')
           const builtCss = await readFile(path.join(studioPath, 'out', 'static', cssPath), 'utf8')
           expect(builtHtml).toContain('id="sanity"')
           expect(builtJs).toMatch(/getElementById\(['"]sanity['"]\)/)
           expect(builtCss).toMatch(/background:\s*green/)
         }
+      },
+      120 * 1000
+    )
+
+    testConcurrentV3(
+      'build with base path environment variable',
+      async () => {
+        // Build to a different output directory to avoid conflicting with
+        // `sanity deploy` / `sanity start` / `sanity build` tests
+        const result = await runSanityCmdCommand(version, ['build', 'out-basepath', '-y'], {
+          env: {SANITY_STUDIO_BASEPATH: '/custom-base-path'},
+        })
+        expect(result.code).toBe(0)
+
+        const builtHtml = await readFile(
+          path.join(studioPath, 'out-basepath', 'index.html'),
+          'utf8'
+        )
+        expect(builtHtml).toContain('id="sanity"')
+        expect(builtHtml).toContain('src="/custom-base-path/static/sanity')
+      },
+      120 * 1000
+    )
+
+    testConcurrentV3(
+      'build with base path from config',
+      async () => {
+        const result = await runSanityCmdCommand(version, ['build', 'out-config', '-y'])
+        expect(result.code).toBe(0)
+
+        const builtHtml = await readFile(path.join(studioPath, 'out-config', 'index.html'), 'utf8')
+        expect(builtHtml).toContain('id="sanity"')
+        expect(builtHtml).toContain('src="/config-base-path/static/sanity')
+      },
+      120 * 1000
+    )
+
+    testConcurrentV3(
+      'build with base path from environment, overriding config file',
+      async () => {
+        const result = await runSanityCmdCommand(version, ['build', 'out-env', '-y'], {
+          env: {SANITY_STUDIO_BASEPATH: '/env-base-path'},
+        })
+        expect(result.code).toBe(0)
+
+        const builtHtml = await readFile(path.join(studioPath, 'out-env', 'index.html'), 'utf8')
+        expect(builtHtml).toContain('id="sanity"')
+        expect(builtHtml).toContain('src="/env-base-path/static/sanity')
+
+        expect(result.stderr).toContain(
+          `Overriding configured base path (/config-base-path) with value from environment variable (/env-base-path)`
+        )
       },
       120 * 1000
     )

--- a/packages/@sanity/cli/test/dev.test.ts
+++ b/packages/@sanity/cli/test/dev.test.ts
@@ -7,7 +7,7 @@ describeCliTest('CLI: `sanity dev`', () => {
   describe.each(studioVersions)('%s', (version) => {
     test('start', async () => {
       const testRunArgs = getTestRunArgs(version)
-      const startHtml = await testServerCommand({
+      const {html: startHtml} = await testServerCommand({
         command: version === 'v2' ? 'start' : 'dev',
         port: testRunArgs.port,
         cwd: path.join(studiosPath, version),

--- a/packages/@sanity/cli/test/preview.test.ts
+++ b/packages/@sanity/cli/test/preview.test.ts
@@ -27,12 +27,11 @@ describeCliTest('CLI: `sanity preview`', () => {
       expect(previewHtml).toContain('<h1>This is static.</h1>')
     })
 
-    // Disable this for now as this has become a prompt now.
-    // testConcurrent('start (hint for new `dev` command)', async () => {
-    //   const result = await runSanityCmdCommand('v3', ['start'])
-    //   const error = result.stderr.trim()
-    //   expect(error).toContain('`sanity start` aliases `sanity preview`')
-    //   expect(error).toContain('to start the development server')
-    // })
+    testConcurrent('start (hint for new `dev` command)', async () => {
+      const result = await runSanityCmdCommand('v3', ['start'])
+      const error = result.stderr.trim()
+      expect(error).toContain('command is used to preview static builds')
+      expect(error).toContain('sanity dev')
+    })
   })
 })

--- a/packages/@sanity/cli/test/preview.test.ts
+++ b/packages/@sanity/cli/test/preview.test.ts
@@ -29,7 +29,7 @@ describeCliTest('CLI: `sanity preview`', () => {
       expect(previewHtml).toContain('<h1>This is static, served from a base path.</h1>')
       expect(stdout).toContain('Using resolved base path from static build')
       expect(stdout).toContain('/some-base-path')
-      expect(stdout).toContain('http://localhost:3456/some-base-path')
+      expect(stdout).toContain(':3456/some-base-path')
     })
 
     testConcurrent('preview (root basepath)', async () => {

--- a/packages/@sanity/cli/test/shared/environment.ts
+++ b/packages/@sanity/cli/test/shared/environment.ts
@@ -68,7 +68,6 @@ export const testClient = new SanityClient({
 export const getTestRunArgs = (version: string) => {
   const testId = getTestId()
   return {
-    sourceStudioPath: path.join(__dirname, '..', '__fixtures__', `${version}-studio`),
     corsOrigin: `https://${testId}-${version}.sanity.build`,
     sourceDataset: 'production',
     dataset: `${testId}-${version}`,

--- a/packages/@sanity/cli/test/shared/environment.ts
+++ b/packages/@sanity/cli/test/shared/environment.ts
@@ -86,7 +86,7 @@ export const getTestRunArgs = (version: string) => {
 export function runSanityCmdCommand(
   version: string,
   args: string[],
-  options = {}
+  options: {env?: Record<string, string | undefined>} = {}
 ): Promise<{
   code: number | null
   stdout: string
@@ -94,8 +94,8 @@ export function runSanityCmdCommand(
 }> {
   return exec(process.argv[0], [cliBinPath, ...args], {
     cwd: path.join(studiosPath, version),
-    env: sanityEnv,
     ...options,
+    env: {...sanityEnv, ...options.env},
   })
 }
 

--- a/packages/@sanity/cli/test/shared/globalSetup.ts
+++ b/packages/@sanity/cli/test/shared/globalSetup.ts
@@ -50,19 +50,24 @@ export default async function globalSetup(): Promise<void> {
   await Promise.all([
     packCli().then((packedFilePath) => installAndVerifyPackedCli({packedFilePath})),
     prepareCliInstall(),
-    prepareStaticFixture(),
+    prepareStaticFixtures(),
     prepareStudios(),
     prepareCliAuth(cliConfigPath),
     prepareDatasets(),
   ])
 }
 
-async function prepareStaticFixture() {
-  const sourcePath = path.join(fixturesPath, 'static')
-  const destinationPath = path.join(baseTestPath, 'static')
+async function prepareStaticFixtures() {
+  const dirs = ['static', 'static-basepath', 'static-root-basepath']
+  const jobs = dirs.map((dir) => ({
+    sourcePath: path.join(fixturesPath, dir),
+    destinationPath: path.join(baseTestPath, dir),
+  }))
 
-  await mkdir(destinationPath, {recursive: true})
-  await copy(`${sourcePath}/**`, destinationPath, {dereference: true})
+  for (const {sourcePath, destinationPath} of jobs) {
+    await mkdir(destinationPath, {recursive: true})
+    await copy(`${sourcePath}/**`, destinationPath, {dereference: true})
+  }
 }
 
 function prepareStudios() {

--- a/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
@@ -1,9 +1,9 @@
 import path from 'path'
 import {promisify} from 'util'
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore This may not yet be built.
 import chalk from 'chalk'
 import rimrafCallback from 'rimraf'
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore This may not yet be built.
 import type {CliCommandArguments, CliCommandContext} from '@sanity/cli'
 import {buildStaticFiles, ChunkModule, ChunkStats} from '../../server'
 import {checkStudioDependencyVersions} from '../../util/checkStudioDependencyVersions'
@@ -75,15 +75,15 @@ export default async function buildSanityStudio(
     spin.succeed()
   }
 
-  const basePath =
+  const specifiedBasePath =
     // Allow `sanity deploy` to override base path
-    overrides?.basePath ||
+    overrides?.basePath ??
     // Environment variables
-    process.env.SANITY_STUDIO_BASEPATH ||
+    process.env.SANITY_STUDIO_BASEPATH ??
     // `sanity.cli.ts`
-    cliConfig?.project?.basePath ||
-    // Fallback
-    '/'
+    cliConfig?.project?.basePath
+
+  const basePath = specifiedBasePath || '/'
 
   spin = output.spinner('Build Sanity Studio').start()
 

--- a/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
@@ -75,6 +75,16 @@ export default async function buildSanityStudio(
     spin.succeed()
   }
 
+  const basePath =
+    // Allow `sanity deploy` to override base path
+    overrides?.basePath ||
+    // Environment variables
+    process.env.SANITY_STUDIO_BASEPATH ||
+    // `sanity.cli.ts`
+    cliConfig?.project?.basePath ||
+    // Fallback
+    '/'
+
   spin = output.spinner('Build Sanity Studio').start()
 
   try {
@@ -82,7 +92,7 @@ export default async function buildSanityStudio(
     const bundle = await buildStaticFiles({
       cwd: workDir,
       outputDir,
-      basePath: overrides?.basePath || cliConfig?.project?.basePath || '/',
+      basePath,
       sourceMap: Boolean(flags['source-maps']),
       minify: Boolean(flags.minify),
       vite: cliConfig && 'vite' in cliConfig ? cliConfig.vite : undefined,

--- a/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
@@ -64,6 +64,28 @@ export default async function buildSanityStudio(
     })
   }
 
+  // Determine base path for built studio
+  let basePath = '/'
+  const envBasePath = process.env.SANITY_STUDIO_BASEPATH
+  const configBasePath = cliConfig?.project?.basePath
+
+  // Allow `sanity deploy` to override base path
+  if (overrides?.basePath) {
+    basePath = overrides.basePath
+  } else if (envBasePath) {
+    // Environment variable (SANITY_STUDIO_BASEPATH)
+    basePath = envBasePath
+  } else if (configBasePath) {
+    // `sanity.cli.ts`
+    basePath = configBasePath
+  }
+
+  if (envBasePath && configBasePath) {
+    output.warn(
+      `Overriding configured base path (${configBasePath}) with value from environment variable (${envBasePath})`
+    )
+  }
+
   let spin
 
   if (shouldClean) {
@@ -74,16 +96,6 @@ export default async function buildSanityStudio(
     spin.text = `Clean output folder (${cleanDuration.toFixed()}ms)`
     spin.succeed()
   }
-
-  const specifiedBasePath =
-    // Allow `sanity deploy` to override base path
-    overrides?.basePath ??
-    // Environment variables
-    process.env.SANITY_STUDIO_BASEPATH ??
-    // `sanity.cli.ts`
-    cliConfig?.project?.basePath
-
-  const basePath = specifiedBasePath || '/'
 
   spin = output.spinner('Build Sanity Studio').start()
 

--- a/packages/sanity/src/_internal/cli/commands/dev/devCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/dev/devCommand.ts
@@ -29,7 +29,12 @@ const devCommand: CliCommandDefinition = {
   helpText,
 }
 
-export async function getDevAction() {
+export async function getDevAction(): Promise<
+  (
+    args: CliCommandArguments<StartDevServerCommandFlags>,
+    context: CliCommandContext
+  ) => Promise<void>
+> {
   // NOTE: in dev-mode we want to include from `src` so we need to use `.ts` extension
   // NOTE: this `if` statement is not included in the output bundle
   if (__DEV__) {

--- a/packages/sanity/src/_internal/cli/commands/start/startCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/start/startCommand.ts
@@ -1,5 +1,6 @@
 import type {CliCommandArguments, CliCommandContext, CliCommandDefinition} from '@sanity/cli'
 import type {StartPreviewServerCommandFlags} from '../../actions/preview/previewAction'
+import {isInteractive} from '../../util/isInteractive'
 import {getDevAction} from '../dev/devCommand'
 
 const helpText = `
@@ -51,14 +52,20 @@ const startCommand: CliCommandDefinition = {
       error(err.message)
       error('\n')
 
-      const shouldRunDevServer = await prompt.single({
-        message: 'Do you want to start a development server instead?',
-        type: 'confirm',
-      })
+      const shouldRunDevServer =
+        isInteractive &&
+        (await prompt.single({
+          message: 'Do you want to start a development server instead?',
+          type: 'confirm',
+        }))
 
       if (shouldRunDevServer) {
         const devAction = await getDevAction()
         await devAction(args, context)
+      } else {
+        // Indicate that this isn't an expected exit
+        // eslint-disable-next-line no-process-exit
+        process.exit(1)
       }
     }
   },

--- a/packages/sanity/src/_internal/cli/server/buildStaticFiles.ts
+++ b/packages/sanity/src/_internal/cli/server/buildStaticFiles.ts
@@ -51,7 +51,7 @@ export async function buildStaticFiles(
   debug('Resolving vite config')
   let viteConfig = await getViteConfig({
     cwd,
-    basePath: ensureTrailingSlash(basePath || '/'),
+    basePath,
     outputDir,
     minify,
     sourceMap,

--- a/packages/sanity/src/_internal/cli/server/buildStaticFiles.ts
+++ b/packages/sanity/src/_internal/cli/server/buildStaticFiles.ts
@@ -3,6 +3,7 @@ import fs from 'fs/promises'
 import {constants as fsConstants} from 'fs'
 import {build, InlineConfig} from 'vite'
 import readPkgUp from 'read-pkg-up'
+import {ensureTrailingSlash} from '../util/ensureTrailingSlash'
 import {finalizeViteConfig, getViteConfig} from './getViteConfig'
 import {generateWebManifest} from './webManifest'
 import {writeSanityRuntime} from './runtime'
@@ -169,8 +170,4 @@ async function writeWebManifest(basePath: string, destDir: string): Promise<void
   await fs
     .writeFile(path.join(destDir, 'manifest.webmanifest'), content, 'utf8')
     .catch(skipIfExistsError)
-}
-
-function ensureTrailingSlash(urlPath: string) {
-  return urlPath.endsWith('/') ? urlPath : `${urlPath}/`
 }

--- a/packages/sanity/src/_internal/cli/server/buildStaticFiles.ts
+++ b/packages/sanity/src/_internal/cli/server/buildStaticFiles.ts
@@ -45,12 +45,12 @@ export async function buildStaticFiles(
   } = options
 
   debug('Writing Sanity runtime files')
-  await writeSanityRuntime({cwd, reactStrictMode: false, watch: false})
+  await writeSanityRuntime({cwd, reactStrictMode: false, watch: false, basePath})
 
   debug('Resolving vite config')
   let viteConfig = await getViteConfig({
     cwd,
-    basePath,
+    basePath: ensureTrailingSlash(basePath || '/'),
     outputDir,
     minify,
     sourceMap,
@@ -169,4 +169,8 @@ async function writeWebManifest(basePath: string, destDir: string): Promise<void
   await fs
     .writeFile(path.join(destDir, 'manifest.webmanifest'), content, 'utf8')
     .catch(skipIfExistsError)
+}
+
+function ensureTrailingSlash(urlPath: string) {
+  return urlPath.endsWith('/') ? urlPath : `${urlPath}/`
 }

--- a/packages/sanity/src/_internal/cli/server/devServer.ts
+++ b/packages/sanity/src/_internal/cli/server/devServer.ts
@@ -22,7 +22,7 @@ export interface DevServer {
 }
 
 export async function startDevServer(options: DevServerOptions): Promise<DevServer> {
-  const {cwd, httpPort, httpHost, basePath = '/', reactStrictMode, vite: extendViteConfig} = options
+  const {cwd, httpPort, httpHost, basePath, reactStrictMode, vite: extendViteConfig} = options
 
   const startTime = Date.now()
   debug('Writing Sanity runtime files')

--- a/packages/sanity/src/_internal/cli/server/devServer.ts
+++ b/packages/sanity/src/_internal/cli/server/devServer.ts
@@ -22,15 +22,15 @@ export interface DevServer {
 }
 
 export async function startDevServer(options: DevServerOptions): Promise<DevServer> {
-  const {cwd, httpPort, httpHost, basePath: base, reactStrictMode, vite: extendViteConfig} = options
+  const {cwd, httpPort, httpHost, basePath = '/', reactStrictMode, vite: extendViteConfig} = options
 
   const startTime = Date.now()
   debug('Writing Sanity runtime files')
-  await writeSanityRuntime({cwd, reactStrictMode, watch: true})
+  await writeSanityRuntime({cwd, reactStrictMode, watch: true, basePath})
 
   debug('Resolving vite config')
   let viteConfig = await getViteConfig({
-    basePath: base || '/',
+    basePath,
     mode: 'development',
     server: {port: httpPort, host: httpHost},
     cwd,

--- a/packages/sanity/src/_internal/cli/server/devServer.ts
+++ b/packages/sanity/src/_internal/cli/server/devServer.ts
@@ -49,7 +49,7 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
   await server.listen()
 
   const startupDuration = Date.now() - startTime
-  const url = `http://${httpHost || 'localhost'}:${httpPort || '3333'}`
+  const url = `http://${httpHost || 'localhost'}:${httpPort || '3333'}${basePath}`
   info(
     `Sanity Studio ` +
       `using ${chalk.cyan(`vite@${require('vite/package.json').version}`)} ` +

--- a/packages/sanity/src/_internal/cli/server/getEntryModule.ts
+++ b/packages/sanity/src/_internal/cli/server/getEntryModule.ts
@@ -7,7 +7,7 @@ import studioConfig from %STUDIO_CONFIG_LOCATION%
 renderStudio(
   document.getElementById("sanity"),
   studioConfig,
-  %STUDIO_REACT_STRICT_MODE%
+  {reactStrictMode: %STUDIO_REACT_STRICT_MODE%, basePath: %STUDIO_BASE_PATH%}
 )
 `
 
@@ -21,18 +21,20 @@ const studioConfig = {missingConfigFile: true}
 renderStudio(
   document.getElementById("sanity"),
   studioConfig,
-  %STUDIO_REACT_STRICT_MODE%
+  {reactStrictMode: %STUDIO_REACT_STRICT_MODE%, basePath: %STUDIO_BASE_PATH%}
 )
 `
 
 export function getEntryModule(options: {
   reactStrictMode: boolean
   relativeConfigLocation: string | null
+  basePath?: string
 }): string {
-  const {reactStrictMode, relativeConfigLocation} = options
+  const {reactStrictMode, relativeConfigLocation, basePath} = options
   const sourceModule = relativeConfigLocation ? entryModule : noConfigEntryModule
 
   return sourceModule
     .replace(/%STUDIO_REACT_STRICT_MODE%/, JSON.stringify(Boolean(reactStrictMode)))
     .replace(/%STUDIO_CONFIG_LOCATION%/, JSON.stringify(relativeConfigLocation))
+    .replace(/%STUDIO_BASE_PATH%/, JSON.stringify(basePath || '/'))
 }

--- a/packages/sanity/src/_internal/cli/server/getViteConfig.ts
+++ b/packages/sanity/src/_internal/cli/server/getViteConfig.ts
@@ -18,7 +18,7 @@ export interface ViteOptions {
 
   /**
    * Base path (eg under where to serve the app - `/studio` or similar)
-   * Will be normalized by `getViteConfig` to ensure it starts and end with a `/`
+   * Will be normalized to ensure it starts and ends with a `/`
    */
   basePath?: string
 

--- a/packages/sanity/src/_internal/cli/server/previewServer.ts
+++ b/packages/sanity/src/_internal/cli/server/previewServer.ts
@@ -1,4 +1,4 @@
-import fs from 'fs'
+import fs from 'fs/promises'
 import path from 'path'
 import chalk from 'chalk'
 import {InlineConfig, preview} from 'vite'
@@ -14,7 +14,6 @@ export interface PreviewServer {
 export interface PreviewServerOptions {
   root: string
   cwd: string
-  basePath: string
 
   httpPort: number
   httpHost?: string
@@ -23,21 +22,29 @@ export interface PreviewServerOptions {
 }
 
 export async function startPreviewServer(options: PreviewServerOptions): Promise<PreviewServer> {
-  const {httpPort, httpHost, basePath: base, root} = options
+  const {httpPort, httpHost, root} = options
   const startTime = Date.now()
 
-  // eslint-disable-next-line no-sync
-  if (!fs.existsSync(path.join(root, 'index.html'))) {
-    const err = new Error(
+  const indexPath = path.join(root, 'index.html')
+  let basePath: string | undefined
+  try {
+    const index = await fs.readFile(indexPath, 'utf8')
+    basePath = tryResolveBasePathFromIndex(index)
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      throw err
+    }
+
+    const error = new Error(
       `Could not find a production build in the '${root}' directory. Try building your studio app with 'sanity build' before starting the preview server.`
     )
-    err.name = 'BUILD_NOT_FOUND'
-    throw err
+    error.name = 'BUILD_NOT_FOUND'
+    throw error
   }
 
   const previewConfig: InlineConfig = {
     root,
-    base: base || '/',
+    base: basePath || '/',
     configFile: false,
     preview: {
       port: httpPort,
@@ -52,8 +59,15 @@ export async function startPreviewServer(options: PreviewServerOptions): Promise
 
   debug('Creating vite server')
   const server = await preview(previewConfig)
+  const warn = server.config.logger.warn
   const info = server.config.logger.info
   const url = server.resolvedUrls.local[0]
+
+  if (typeof basePath === 'undefined') {
+    warn('Could not determine base path from index.html, using "/" as default')
+  } else if (basePath && basePath !== '/') {
+    info(`Using resolved base path from static build: ${chalk.cyan(basePath)}`)
+  }
 
   const startupDuration = Date.now() - startTime
 
@@ -71,4 +85,23 @@ export async function startPreviewServer(options: PreviewServerOptions): Promise
         server.httpServer.close((err) => (err ? reject(err) : resolve()))
       ),
   }
+}
+
+function tryResolveBasePathFromIndex(index: string): string | undefined {
+  // <script ... src="/some-base-path/static/sanity-a3cc3d86.js"></script>
+  const basePath = index.match(/<script[^>]+src="(.*?)\/static\/sanity-/)?.[1]
+
+  // We _expect_ to be able to find the base path. If we can't, we should warn.
+  // Note that we're checking for `undefined` here, since an empty string is a
+  // valid base path.
+  if (typeof basePath === 'undefined') {
+    return undefined
+  }
+
+  // In the case of an empty base path, we still want to return `/` to indicate
+  // that we _found_ the basepath - it just happens to be empty. Eg:
+  // <script ... src = "/static/sanity-a3cc3d86.js"></script>
+  // Which differs from not being able to find the script tag at all, in which
+  // case we'll want to show a warning to indicate that it is an abnormality.
+  return basePath === '' ? '/' : basePath
 }

--- a/packages/sanity/src/_internal/cli/server/previewServer.ts
+++ b/packages/sanity/src/_internal/cli/server/previewServer.ts
@@ -36,7 +36,7 @@ export async function startPreviewServer(options: PreviewServerOptions): Promise
     }
 
     const error = new Error(
-      `Could not find a production build in the '${root}' directory. Try building your studio app with 'sanity build' before starting the preview server.`
+      `Could not find a production build in the '${root}' directory.\nTry building your studio app with 'sanity build' before starting the preview server.`
     )
     error.name = 'BUILD_NOT_FOUND'
     throw error

--- a/packages/sanity/src/_internal/cli/server/previewServer.ts
+++ b/packages/sanity/src/_internal/cli/server/previewServer.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import chalk from 'chalk'
 import {InlineConfig, preview} from 'vite'
 import {debug as serverDebug} from './debug'
+import {sanityBasePathRedirectPlugin} from './vite/plugin-sanity-basepath-redirect'
 
 const debug = serverDebug.extend('preview')
 
@@ -45,6 +46,7 @@ export async function startPreviewServer(options: PreviewServerOptions): Promise
   const previewConfig: InlineConfig = {
     root,
     base: basePath || '/',
+    plugins: [sanityBasePathRedirectPlugin(basePath)],
     configFile: false,
     preview: {
       port: httpPort,

--- a/packages/sanity/src/_internal/cli/server/renderDocument.ts
+++ b/packages/sanity/src/_internal/cli/server/renderDocument.ts
@@ -38,7 +38,7 @@ ${generateHelpUrl('custom-document-component')}
 `.trim()
 
 interface DocumentProps {
-  basePath?: string
+  basePath: string
   entryPath?: string
   css?: string[]
 }

--- a/packages/sanity/src/_internal/cli/server/renderDocument.ts
+++ b/packages/sanity/src/_internal/cli/server/renderDocument.ts
@@ -38,6 +38,7 @@ ${generateHelpUrl('custom-document-component')}
 `.trim()
 
 interface DocumentProps {
+  basePath?: string
   entryPath?: string
   css?: string[]
 }

--- a/packages/sanity/src/_internal/cli/server/runtime.ts
+++ b/packages/sanity/src/_internal/cli/server/runtime.ts
@@ -17,6 +17,7 @@ export interface RuntimeOptions {
   cwd: string
   reactStrictMode: boolean
   watch: boolean
+  basePath?: string
 }
 
 /**
@@ -30,6 +31,7 @@ export async function writeSanityRuntime({
   cwd,
   reactStrictMode,
   watch,
+  basePath,
 }: RuntimeOptions): Promise<void> {
   debug('Resolving Sanity monorepo information')
   const monorepo = await loadSanityMonorepo(cwd)
@@ -44,7 +46,10 @@ export async function writeSanityRuntime({
       await renderDocument({
         studioRootPath: cwd,
         monorepo,
-        props: {entryPath: `/${path.relative(cwd, path.join(runtimeDir, 'app.js'))}`},
+        props: {
+          entryPath: `/${path.relative(cwd, path.join(runtimeDir, 'app.js'))}`,
+          basePath: basePath || '/',
+        },
       })
     )
 
@@ -68,6 +73,6 @@ export async function writeSanityRuntime({
 
   await fs.writeFile(
     path.join(runtimeDir, 'app.js'),
-    getEntryModule({reactStrictMode, relativeConfigLocation})
+    getEntryModule({reactStrictMode, relativeConfigLocation, basePath})
   )
 }

--- a/packages/sanity/src/_internal/cli/server/vite/plugin-sanity-basepath-redirect.ts
+++ b/packages/sanity/src/_internal/cli/server/vite/plugin-sanity-basepath-redirect.ts
@@ -1,0 +1,25 @@
+import type {Plugin} from 'vite'
+
+export function sanityBasePathRedirectPlugin(basePath: string | undefined): Plugin {
+  return {
+    name: 'sanity/server/sanity-base-path-redirect',
+    apply: 'serve',
+    configurePreviewServer(vitePreviewServer) {
+      return () => {
+        if (!basePath) {
+          return
+        }
+
+        vitePreviewServer.middlewares.use((req, res, next) => {
+          if (req.url !== '/') {
+            next()
+            return
+          }
+
+          res.writeHead(302, {Location: basePath})
+          res.end()
+        })
+      }
+    },
+  }
+}

--- a/packages/sanity/src/_internal/cli/server/vite/plugin-sanity-build-entries.ts
+++ b/packages/sanity/src/_internal/cli/server/vite/plugin-sanity-build-entries.ts
@@ -86,6 +86,7 @@ export function sanityBuildEntries(options: {
           monorepo,
           studioRootPath: cwd,
           props: {
+            basePath,
             entryPath,
             css,
           },

--- a/packages/sanity/src/_internal/cli/util/ensureTrailingSlash.ts
+++ b/packages/sanity/src/_internal/cli/util/ensureTrailingSlash.ts
@@ -1,0 +1,11 @@
+/**
+ * Ensures that the given path ends with a `/`, and does not add an
+ * additional one if it already does
+ *
+ * @param path - The path to ensure has a trailing slash
+ * @returns A path with a trailing slash
+ * @internal
+ */
+export function ensureTrailingSlash(path: string): string {
+  return path.endsWith('/') ? path : `${path}/`
+}

--- a/packages/sanity/src/_internal/cli/util/isInteractive.ts
+++ b/packages/sanity/src/_internal/cli/util/isInteractive.ts
@@ -1,0 +1,3 @@
+/* eslint-disable no-process-env */
+export const isInteractive =
+  process.stdout.isTTY && process.env.TERM !== 'dumb' && !('CI' in process.env)

--- a/packages/sanity/src/_internal/cli/util/servers.ts
+++ b/packages/sanity/src/_internal/cli/util/servers.ts
@@ -1,4 +1,5 @@
 import type {CliConfig} from '@sanity/cli'
+import {ensureTrailingSlash} from './ensureTrailingSlash'
 
 export function gracefulServerDeath(
   command: 'start' | 'dev' | 'preview',
@@ -59,7 +60,7 @@ export function getSharedServerConfig({
   )
 
   const basePath = ensureTrailingSlash(
-    env.SANITY_STUDIO_BASEPATH || cliConfig?.project?.basePath || '/'
+    env.SANITY_STUDIO_BASEPATH ?? (cliConfig?.project?.basePath || '/')
   )
 
   return {
@@ -78,8 +79,4 @@ function toInt(value: string | number | undefined, defaultValue: number): number
 
   const intVal = parseInt(`${value}`, 10)
   return Number.isFinite(intVal) ? intVal : defaultValue
-}
-
-function ensureTrailingSlash(path: string) {
-  return path.endsWith('/') ? path : `${path}/`
 }

--- a/packages/sanity/src/_internal/cli/util/servers.ts
+++ b/packages/sanity/src/_internal/cli/util/servers.ts
@@ -58,7 +58,9 @@ export function getSharedServerConfig({
     3333
   )
 
-  const basePath = env.SANITY_STUDIO_BASEPATH || cliConfig?.project?.basePath || '/'
+  const basePath = ensureTrailingSlash(
+    env.SANITY_STUDIO_BASEPATH || cliConfig?.project?.basePath || '/'
+  )
 
   return {
     cwd: workDir,
@@ -76,4 +78,8 @@ function toInt(value: string | number | undefined, defaultValue: number): number
 
   const intVal = parseInt(`${value}`, 10)
   return Number.isFinite(intVal) ? intVal : defaultValue
+}
+
+function ensureTrailingSlash(path: string) {
+  return path.endsWith('/') ? path : `${path}/`
 }

--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -69,7 +69,10 @@ function normalizeIcon(
  *
  * @internal
  */
-export function prepareConfig(config: Config | MissingConfigFile): PreparedConfig {
+export function prepareConfig(
+  config: Config | MissingConfigFile,
+  options?: {basePath?: string}
+): PreparedConfig {
   if (!Array.isArray(config) && 'missingConfigFile' in config) {
     throw new ConfigResolutionError({
       name: '',
@@ -78,6 +81,7 @@ export function prepareConfig(config: Config | MissingConfigFile): PreparedConfi
     })
   }
 
+  const rootPath = getRootPath(options?.basePath)
   const workspaceOptions: WorkspaceOptions[] | [SingleWorkspace] = Array.isArray(config)
     ? config
     : [config]
@@ -165,7 +169,7 @@ export function prepareConfig(config: Config | MissingConfigFile): PreparedConfi
       const workspaceSummary: WorkspaceSummary = {
         type: 'workspace-summary',
         auth: resolvedSources[0].auth,
-        basePath: rootSource.basePath || '/',
+        basePath: joinBasePath(rootPath, rootSource.basePath),
         dataset: rootSource.dataset,
         schema: resolvedSources[0].schema,
         icon: normalizeIcon(
@@ -532,4 +536,48 @@ function resolveSource({
   }
 
   return source
+}
+
+/**
+ * Validate and normalize the `basePath` option.
+ * The root path will be used to prepend workspace-specific base paths.
+ * For instance, a `/studio` root path is joined with `/design` to become `/studio/design`.
+ *
+ * @param basePath - The base path to validate. If not set, an empty string will be returned.
+ * @returns A normalized string
+ * @throws ConfigResolutionError if the basePath is invalid
+ * @internal
+ */
+function getRootPath(basePath?: string) {
+  const rootPath = basePath || ''
+  if (typeof rootPath !== 'string' || (rootPath.length > 0 && !rootPath.startsWith('/'))) {
+    throw new ConfigResolutionError({
+      name: '',
+      type: 'options',
+      causes: ['basePath must be a string, and must start with a slash'],
+    })
+  }
+
+  // Since we'll be appending other base paths, we don't want to end up with double slashes
+  return rootPath === '/' ? '' : rootPath
+}
+
+/**
+ * Join the root path of the studio with a workspace base path
+ *
+ * @param rootPath - The root path to prepend to the base path
+ * @param basePath - The base path of the workspace (can be empty)
+ * @returns A normalized and joined, complete base path for a workspace
+ * @internal
+ */
+function joinBasePath(rootPath: string, basePath?: string) {
+  const joined = [rootPath, basePath || '']
+    // Remove leading/trailing slashes
+    .map((path) => path.replace(/^\/+/g, '').replace(/\/+$/g, ''))
+    // Remove empty segments
+    .filter(Boolean)
+    // Join the segments
+    .join('/')
+
+  return `/${joined}`
 }

--- a/packages/sanity/src/core/studio/Studio.tsx
+++ b/packages/sanity/src/core/studio/Studio.tsx
@@ -9,6 +9,7 @@ import {StudioProvider} from './StudioProvider'
 /** @beta */
 export interface StudioProps {
   config: Config
+  basePath?: string
   onSchemeChange?: (nextScheme: ThemeColorSchemeKey) => void
   scheme?: ThemeColorSchemeKey
   /** @beta */

--- a/packages/sanity/src/core/studio/StudioProvider.tsx
+++ b/packages/sanity/src/core/studio/StudioProvider.tsx
@@ -41,6 +41,7 @@ export interface StudioProviderProps extends StudioProps {
 export function StudioProvider({
   children,
   config,
+  basePath,
   onSchemeChange,
   scheme,
   unstable_history: history,
@@ -56,7 +57,7 @@ export function StudioProvider({
       <ToastProvider paddingY={7} zOffset={Z_OFFSET.toast}>
         <ErrorLogger />
         <StudioErrorBoundary>
-          <WorkspacesProvider config={config}>
+          <WorkspacesProvider config={config} basePath={basePath}>
             <ActiveWorkspaceMatcher
               unstable_history={history}
               NotFoundComponent={NotFoundScreen}

--- a/packages/sanity/src/core/studio/renderStudio.tsx
+++ b/packages/sanity/src/core/studio/renderStudio.tsx
@@ -3,25 +3,53 @@ import {createRoot} from 'react-dom/client'
 import type {Config} from '../config'
 import {Studio} from './Studio'
 
+interface RenderStudioOptions {
+  basePath?: string
+  reactStrictMode?: boolean
+}
+
+/**
+ * @internal
+ * @deprecated Use `renderStudio(rootElement, config, {reactStrictMode: true})` instead
+ */
+export function renderStudio(
+  rootElement: HTMLElement | null,
+  config: Config,
+  options: boolean
+): () => void
+
+/** @internal */
+export function renderStudio(rootElement: HTMLElement | null, config: Config): () => void
+
 /** @internal */
 export function renderStudio(
   rootElement: HTMLElement | null,
   config: Config,
-  reactStrictMode = false
+  options: RenderStudioOptions
+): () => void
+
+/** @internal */
+export function renderStudio(
+  rootElement: HTMLElement | null,
+  config: Config,
+  options: RenderStudioOptions | boolean = false
 ): () => void {
   if (!rootElement) {
     throw new Error('Missing root element to mount application into')
   }
+
+  const opts = typeof options === 'boolean' ? {reactStrictMode: options} : options
+  const {reactStrictMode = false, basePath} = opts
 
   const root = createRoot(rootElement)
 
   root.render(
     reactStrictMode ? (
       <StrictMode>
-        <Studio config={config} unstable_globalStyles />
+        <Studio config={config} basePath={basePath} unstable_globalStyles />
       </StrictMode>
     ) : (
-      <Studio config={config} unstable_globalStyles />
+      <Studio config={config} basePath={basePath} unstable_globalStyles />
     )
   )
 

--- a/packages/sanity/src/core/studio/workspaces/WorkspacesProvider.tsx
+++ b/packages/sanity/src/core/studio/workspaces/WorkspacesProvider.tsx
@@ -6,10 +6,11 @@ import {WorkspacesContext} from './WorkspacesContext'
 export interface WorkspacesProviderProps {
   config: Config
   children: React.ReactNode
+  basePath?: string
 }
 
 /** @internal */
-export function WorkspacesProvider({config, children}: WorkspacesProviderProps) {
-  const {workspaces} = useMemo(() => prepareConfig(config), [config])
+export function WorkspacesProvider({config, children, basePath}: WorkspacesProviderProps) {
+  const {workspaces} = useMemo(() => prepareConfig(config, {basePath}), [config, basePath])
   return <WorkspacesContext.Provider value={workspaces}>{children}</WorkspacesContext.Provider>
 }


### PR DESCRIPTION
### Description

There is a `basePath` option in the CLI configuration (`project.basePath`) which is also available through an environment variable (`SANITY_STUDIO_BASEPATH`). This wasn't properly threaded through to all locations, so the built javascript bundles (and preview server) did not respect it properly.

This PR addresses two separate points:

1. Makes sure the configured base path is threaded through to the correct server/build configuration
2. Prepends the configured studio basepath (if any) to the workspace base paths

I'm slightly unsure how I feel about the second point here. I do feel like you would expect the tooling to take it into account if configured, instead of having to manually configure all your workspaces to manually include it? But theoretically we could also leave it up to the user, as we do now. It is a bit of double-configuration, however, and unless you are using an environment variable to configure it, you need to define it more than once.

One could also discuss _where_ the application of the "root path" belongs - I've currently added it to `prepareConfig`, which applies it while normalizing base paths, but theoretically this could also be done earlier in the process - but then we'd need to account for single vs multiple workspaces in several locations, which I was hoping to avoid.

Would love opinions on this! 
 
Fixes #3972

### What to review

- Code
- `sanity build` + `sanity preview` with and without a configured base path (either through `sanity.cli.ts` (`project.basePath`) or through environment variable (`SANITY_STUDIO_BASEPATH`))
- `sanity dev` with and without configured base path

It's probably easiest to review this one commit at a time, since it deals with two slightly different things (build tooling vs automatically applying base path to workspaces)

### Notes for release

- Fixes an issue where a configured studio-wide `basePath` would not be respected in build output, and workspaces would have to manually include the prefix in each workspace base path