### PR TITLE
feature(schema): backward compatibility for breaking changes in block…

### DIFF
--- a/packages/@sanity/schema/src/sanity/validation/createValidationResult.ts
+++ b/packages/@sanity/schema/src/sanity/validation/createValidationResult.ts
@@ -27,6 +27,7 @@ export const HELP_IDS = {
   SLUG_SLUGIFY_FN_RENAMED: 'slug-slugifyfn-renamed',
   ASSET_METADATA_FIELD_INVALID: 'asset-metadata-field-invalid',
   CROSS_DATASET_REFERENCE_INVALID: 'cross-dataset-reference-invalid',
+  DEPRECATED_BLOCKEDITOR_KEY: 'schema-deprecated-blockeditor-key',
 }
 
 function createValidationResult(

--- a/packages/@sanity/schema/src/sanity/validation/types/block.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/block.ts
@@ -1,6 +1,6 @@
 import {omit, isPlainObject} from 'lodash'
 import humanizeList from 'humanize-list'
-import {error, warning} from '../createValidationResult'
+import {error, HELP_IDS, warning} from '../createValidationResult'
 import {isJSONTypeOf} from '../utils/isJSONTypeOf'
 
 const getTypeOf = (thing) => (Array.isArray(thing) ? 'array' : typeof thing)
@@ -197,7 +197,8 @@ function validateStyles(styles, visitorContext, problems) {
     if (typeof style.blockEditor !== 'undefined') {
       problems.push(
         warning(
-          `Style has deprecated key "blockEditor", please refer to the documentation on how to configure the block type for version 3.`
+          `Style has deprecated key "blockEditor", please refer to the documentation on how to configure the block type for version 3.`,
+          HELP_IDS.DEPRECATED_BLOCKEDITOR_KEY
         )
       )
       // TODO remove this backward compatibility at some point.
@@ -245,7 +246,8 @@ function validateDecorators(decorators, visitorContext, problems) {
     if (typeof decorator.blockEditor !== 'undefined') {
       problems.push(
         warning(
-          `Decorator "${name}" has deprecated key "blockEditor", please refer to the documentation on how to configure the block type for version 3.`
+          `Decorator "${name}" has deprecated key "blockEditor", please refer to the documentation on how to configure the block type for version 3.`,
+          HELP_IDS.DEPRECATED_BLOCKEDITOR_KEY
         )
       )
       // TODO remove this backward compatibility at some point.
@@ -278,7 +280,8 @@ function validateAnnotations(annotations, visitorContext, problems) {
     if (typeof annotation.blockEditor !== 'undefined') {
       problems.push(
         warning(
-          `Annotation has deprecated key "blockEditor", please refer to the documentation on how to configure the block type for version 3.`
+          `Annotation has deprecated key "blockEditor", please refer to the documentation on how to configure the block type for version 3.`,
+          HELP_IDS.DEPRECATED_BLOCKEDITOR_KEY
         )
       )
       // TODO remove this backward compatibility at some point.


### PR DESCRIPTION
### Description

This will keep backward compatibility for breaking changes in the block schema introduced in v3 since launch date in order not to break the contract for semantic releases.

It will allow using the old config keys for decorators, styles and annotations, but will produce a warning about them being deprecated.

