### PR TITLE
fix: ensure lodash is optimized in every monorepo package

### DIFF
--- a/package.config.ts
+++ b/package.config.ts
@@ -1,3 +1,4 @@
+import {optimizeLodashImports} from '@optimize-lodash/rollup-plugin'
 import {defineConfig} from '@sanity/pkg-utils'
 
 export default defineConfig({
@@ -16,4 +17,7 @@ export default defineConfig({
   },
   legacyExports: true,
   minify: false,
+  rollup: {
+    plugins: [optimizeLodashImports()],
+  },
 })

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@babel/preset-env": "^7.19.1",
     "@babel/preset-react": "^7.18.6",
     "@babel/preset-typescript": "^7.18.6",
+    "@optimize-lodash/rollup-plugin": "^4.0.1",
     "@rexxars/babel-plugin-inline-json-import": "^0.3.4",
     "@sanity/client": "^3.4.1",
     "@sanity/pkg-utils": "^1.17.3",

--- a/packages/@sanity/block-tools/.depcheckignore.json
+++ b/packages/@sanity/block-tools/.depcheckignore.json
@@ -1,3 +1,3 @@
 {
-  "ignore": ["@sanity/pkg-utils"]
+  "ignore": ["@optimize-lodash/rollup-plugin", "@sanity/pkg-utils"]
 }

--- a/packages/@sanity/cli/.depcheckignore.json
+++ b/packages/@sanity/cli/.depcheckignore.json
@@ -1,6 +1,7 @@
 {
   "ignore": [
     "@babel/parser",
+    "@optimize-lodash/rollup-plugin",
     "@sanity/asset-utils",
     "@sanity/base",
     "@sanity/color",

--- a/packages/@sanity/diff/.depcheckignore.json
+++ b/packages/@sanity/diff/.depcheckignore.json
@@ -1,3 +1,3 @@
 {
-  "ignore": ["@sanity/pkg-utils"]
+  "ignore": ["@optimize-lodash/rollup-plugin", "@sanity/pkg-utils"]
 }

--- a/packages/@sanity/mutator/.depcheckignore.json
+++ b/packages/@sanity/mutator/.depcheckignore.json
@@ -1,3 +1,3 @@
 {
-  "ignore": ["@sanity/pkg-utils"]
+  "ignore": ["@optimize-lodash/rollup-plugin", "@sanity/pkg-utils"]
 }

--- a/packages/@sanity/portable-text-editor/.depcheckignore.json
+++ b/packages/@sanity/portable-text-editor/.depcheckignore.json
@@ -1,3 +1,3 @@
 {
-  "ignore": ["@sanity/pkg-utils"]
+  "ignore": ["@optimize-lodash/rollup-plugin", "@sanity/pkg-utils"]
 }

--- a/packages/@sanity/schema/.depcheckignore.json
+++ b/packages/@sanity/schema/.depcheckignore.json
@@ -1,3 +1,3 @@
 {
-  "ignore": ["@sanity/pkg-utils"]
+  "ignore": ["@optimize-lodash/rollup-plugin", "@sanity/pkg-utils"]
 }

--- a/packages/@sanity/server/.depcheckignore.json
+++ b/packages/@sanity/server/.depcheckignore.json
@@ -1,3 +1,3 @@
 {
-  "ignore": ["@sanity/pkg-utils", "styled-components"]
+  "ignore": ["@optimize-lodash/rollup-plugin", "@sanity/pkg-utils", "styled-components"]
 }

--- a/packages/@sanity/types/.depcheckignore.json
+++ b/packages/@sanity/types/.depcheckignore.json
@@ -1,6 +1,7 @@
 {
   "ignore": [
     "@juggle/resize-observer",
+    "@optimize-lodash/rollup-plugin",
     "@popperjs/core",
     "@rexxars/react-sortable-hoc",
     "@sanity/bifur-client",

--- a/packages/@sanity/util/.depcheckignore.json
+++ b/packages/@sanity/util/.depcheckignore.json
@@ -1,3 +1,3 @@
 {
-  "ignore": ["@sanity/pkg-utils"]
+  "ignore": ["@optimize-lodash/rollup-plugin", "@sanity/pkg-utils"]
 }

--- a/packages/@sanity/validation/.depcheckignore.json
+++ b/packages/@sanity/validation/.depcheckignore.json
@@ -1,3 +1,3 @@
 {
-  "ignore": ["@sanity/pkg-utils"]
+  "ignore": ["@optimize-lodash/rollup-plugin", "@sanity/pkg-utils"]
 }

--- a/packages/@sanity/vision/.depcheckignore.json
+++ b/packages/@sanity/vision/.depcheckignore.json
@@ -1,3 +1,3 @@
 {
-  "ignore": ["@sanity/pkg-utils"]
+  "ignore": ["@optimize-lodash/rollup-plugin", "@sanity/pkg-utils"]
 }

--- a/packages/groq/.depcheckignore.json
+++ b/packages/groq/.depcheckignore.json
@@ -1,3 +1,3 @@
 {
-  "ignore": ["@sanity/pkg-utils"]
+  "ignore": ["@optimize-lodash/rollup-plugin", "@sanity/pkg-utils"]
 }

--- a/packages/sanity/.depcheckignore.json
+++ b/packages/sanity/.depcheckignore.json
@@ -1,3 +1,3 @@
 {
-  "ignore": ["@sanity/pkg-utils", "globby", "read-pkg-up", "sanity"]
+  "ignore": ["@optimize-lodash/rollup-plugin", "@sanity/pkg-utils", "globby", "read-pkg-up", "sanity"]
 }

--- a/packages/sanity/package.config.ts
+++ b/packages/sanity/package.config.ts
@@ -1,14 +1,8 @@
-import {optimizeLodashImports} from '@optimize-lodash/rollup-plugin'
 import {defineConfig} from '@sanity/pkg-utils'
 import baseConfig from '../../package.config'
 
 export default defineConfig({
   ...baseConfig,
-
-  rollup: {
-    ...baseConfig.rollup,
-    plugins: [optimizeLodashImports()],
-  },
 
   exports: (prevExports) => ({
     ...prevExports,

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -198,7 +198,6 @@
     "yargs": "^17.3.0"
   },
   "devDependencies": {
-    "@optimize-lodash/rollup-plugin": "^4.0.1",
     "@sanity/ui-workshop": "^1.0.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",


### PR DESCRIPTION
### Description

The fix in #3974 were not sufficient. 

Running this:

```js
const {renderStudio} = await import('https://esm.sh/sanity@3.1.0')
```
Throws:
```js
Uncaught SyntaxError: The requested module '/v99/lodash@4.17.21/es2022/lodash.js' does not provide an export named 'flatMap' (at schema.js:formatted:2:178)
```
This is because only `sanity` is optimizing lodash imports, and other packages [like `@sanity/schema` aren't](https://unpkg.com/browse/@sanity/schema@3.1.0/lib/_exports/index.esm.js).

### What to review

Since it's just an optimisation step it shouldn't break any existing behaviour or introduce new behaviour, beyond a smaller bundle size.

### Notes for release

- fix: optimize lodash imports in the rest of the monorepo packages (`@sanity/schema` and more)