### PR TITLE
fix: apply `config.form.image.directUploads`

### DIFF
--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -491,7 +491,7 @@ function resolveSource({
         directUploads:
           // TODO: consider refactoring this to `noDirectUploads` or similar
           // default value for this is `true`
-          config.form?.file?.directUploads === undefined ? true : config.form.file.directUploads,
+          config.form?.image?.directUploads === undefined ? true : config.form.image.directUploads,
       },
     },
 


### PR DESCRIPTION
### Description

The official [Custom Asset Sources guide for turning off file uploads and only use external sources doesn't work](https://www.sanity.io/docs/custom-asset-sources#8a7448076430:~:text=directUploads%3A%20false%2C). It's because internally we have a typo causing `config.form.file.directUploads` to apply for `image` while it should only apply to `file`.

### What to review

A config like:
```js
import {defineConfig} from 'sanity'
import {deskTool} from 'sanity/desk'
import {unsplashAssetSource} from 'sanity-plugin-asset-source-unsplash'
import {schemaTypes} from './schemas'

export default defineConfig({
  name: 'default',
  projectId: '<projectId>',
  dataset: 'production',
  plugins: [deskTool()],
  form: {
    image: {
      assetSources: () => [unsplashAssetSource],
      directUploads: false,
    },
  },
  schema: {
    types: schemaTypes,
  },
})
```
should now disable the Upload button:
<img width="226" alt="image" src="https://user-images.githubusercontent.com/81981/208961907-e3c7a340-f90f-4ece-afc0-c871ea1bd00a.png">


### Notes for release

- fix: apply `config.form.image.directUploads` correctly
