### PR TITLE
fix: `clientFactory` should be optional

### DIFF
--- a/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
@@ -1,4 +1,4 @@
-import {ClientConfig as SanityClientConfig, SanityClient} from '@sanity/client'
+import createSanityClient, {ClientConfig as SanityClientConfig, SanityClient} from '@sanity/client'
 import {defer} from 'rxjs'
 import {map, shareReplay, startWith, switchMap} from 'rxjs/operators'
 import {memoize} from 'lodash'
@@ -19,7 +19,7 @@ export interface AuthProvider {
 
 /** @internal */
 export interface AuthStoreOptions {
-  clientFactory: (options: SanityClientConfig) => SanityClient
+  clientFactory?: (options: SanityClientConfig) => SanityClient
   projectId: string
   dataset: string
   /**
@@ -138,7 +138,7 @@ const getCurrentUser = async (
  * @internal
  */
 export function _createAuthStore({
-  clientFactory,
+  clientFactory: clientFactoryOption,
   projectId,
   dataset,
   loginMethod = 'dual',
@@ -148,6 +148,8 @@ export function _createAuthStore({
   // a new client will be created from it, otherwise, it'll only trigger a retry
   // for cookie-based auth
   const {broadcast, messages} = createBroadcastChannel<string | null>(`dual_mode_auth_${projectId}`)
+
+  const clientFactory = clientFactoryOption ?? createSanityClient
 
   // // TODO: there is currently a bug where the AuthBoundary flashes the
   // // `NotAuthenticatedComponent` on the first load after a login with


### PR DESCRIPTION
### Description

There was a regression in 3.1.0 where `clientFactory` was added to the `createAuthStore` options. This option should be optional. Addresses and closes https://github.com/sanity-io/sanity/issues/4007.
