### PR TITLE
Fix fallback render issue with custom PT-styles

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/text/Style.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/Style.tsx
@@ -1,12 +1,14 @@
 import {Text} from '@sanity/ui'
 import {BlockStyleRenderProps} from '@sanity/portable-text-editor'
 import React, {useCallback, useMemo} from 'react'
-import {TEXT_STYLES} from './textStyles'
+import {Normal as FallbackComponent, TEXT_STYLES} from './textStyles'
 
 export const Style = (props: BlockStyleRenderProps) => {
   const {block, focused, children, selected, type, value} = props
   const DefaultComponent = useMemo(
-    () => (block.style && TEXT_STYLES[block.style] ? TEXT_STYLES[block.style] : TEXT_STYLES[0]),
+    () =>
+      (block.style && TEXT_STYLES[block.style] ? TEXT_STYLES[block.style] : TEXT_STYLES[0]) ||
+      FallbackComponent,
     [block.style]
   )
 

--- a/packages/sanity/src/core/form/types/definitionExtensions.ts
+++ b/packages/sanity/src/core/form/types/definitionExtensions.ts
@@ -286,20 +286,20 @@ declare module '@sanity/types' {
     /**
      * @beta
      */
-    component: ComponentType<BlockDecoratorProps>
+    component?: ComponentType<BlockDecoratorProps>
   }
 
   export interface BlockStyleDefinition {
     /**
      * @beta
      */
-    component: ComponentType<BlockStyleProps>
+    component?: ComponentType<BlockStyleProps>
   }
   export interface BlockListDefinition {
     /**
      * @beta
      */
-    component: ComponentType<BlockListItemProps>
+    component?: ComponentType<BlockListItemProps>
   }
 
   export interface BlockAnnotationDefinition {


### PR DESCRIPTION
### Description

We recently introduced a regression where a custom style in the PT-input  would error if no render component was defined for that custom style. 

Before (v3.0.6) we rendered the Normal style in that case, and we should continue to do that in order to no break this behaviour unnecessary.

Also there was a goof which removed the optionality of the `.component?` schema prop for that style (also relevant for decorators and list items).

Regression commits:
https://github.com/sanity-io/sanity/commit/0902fa59ab0b2648ad1e80a01ba86cfc7e000820
https://github.com/sanity-io/sanity/commit/f1152f740a3427cb4eaeb731402d031dd0377437

### Notes for release

Fixed a regression where a custom style in the portable text input would not fallback to be rendered as the normal style without defining a rendering-component for that style.