### PR TITLE
fix: allow use of `Rule.valueOfField` inside fields using `defineField`

### DIFF
--- a/packages/@sanity/types/src/schema/definition/type/array.ts
+++ b/packages/@sanity/types/src/schema/definition/type/array.ts
@@ -1,3 +1,4 @@
+import {FieldReference} from '../../../validation'
 import {RuleDef, ValidationBuilder} from '../../ruleBuilder'
 import {InitialValueProperty, SchemaValidationValue} from '../../types'
 import {IntrinsicDefinitions, TypeAliasDefinition, IntrinsicTypeName} from '../schemaDefinition'
@@ -20,9 +21,9 @@ export interface ArrayOptions<V = unknown> {
 
 /** @public */
 export interface ArrayRule<Value> extends RuleDef<ArrayRule<Value>, Value> {
-  min: (length: number) => ArrayRule<Value>
-  max: (length: number) => ArrayRule<Value>
-  length: (length: number) => ArrayRule<Value>
+  min: (length: number | FieldReference) => ArrayRule<Value>
+  max: (length: number | FieldReference) => ArrayRule<Value>
+  length: (length: number | FieldReference) => ArrayRule<Value>
   unique: () => ArrayRule<Value>
 }
 

--- a/packages/@sanity/types/src/schema/definition/type/date.ts
+++ b/packages/@sanity/types/src/schema/definition/type/date.ts
@@ -1,3 +1,4 @@
+import {FieldReference} from '../../../validation'
 import {RuleDef, ValidationBuilder} from '../../ruleBuilder'
 import {InitialValueProperty} from '../../types'
 import {BaseSchemaDefinition} from './common'
@@ -8,16 +9,15 @@ export interface DateOptions {
 }
 
 /** @public */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface DateRule extends RuleDef<DateRule, string> {
   /**
    * @param minDate - Minimum date (inclusive). minDate should be in ISO 8601 format.
    */
-  min: (minDate: string) => DateRule
+  min: (minDate: string | FieldReference) => DateRule
   /**
    * @param maxDate - Maximum date (inclusive). maxDate should be in ISO 8601 format.
    */
-  max: (maxDate: string) => DateRule
+  max: (maxDate: string | FieldReference) => DateRule
 }
 
 /** @public */

--- a/packages/@sanity/types/src/schema/definition/type/datetime.ts
+++ b/packages/@sanity/types/src/schema/definition/type/datetime.ts
@@ -1,3 +1,4 @@
+import {FieldReference} from '../../../validation'
 import {RuleDef, ValidationBuilder} from '../../ruleBuilder'
 import {InitialValueProperty} from '../../types'
 import {BaseSchemaDefinition} from './common'
@@ -10,16 +11,15 @@ export interface DatetimeOptions {
 }
 
 /** @public */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface DatetimeRule extends RuleDef<DatetimeRule, string> {
   /**
    * @param minDate - Minimum date (inclusive). minDate should be in ISO 8601 format.
    */
-  min: (minDate: string) => DatetimeRule
+  min: (minDate: string | FieldReference) => DatetimeRule
   /**
    * @param maxDate - Maximum date (inclusive). maxDate should be in ISO 8601 format.
    */
-  max: (maxDate: string) => DatetimeRule
+  max: (maxDate: string | FieldReference) => DatetimeRule
 }
 
 /** @public */

--- a/packages/@sanity/types/src/schema/definition/type/geopoint.ts
+++ b/packages/@sanity/types/src/schema/definition/type/geopoint.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 import {RuleDef, ValidationBuilder} from '../../ruleBuilder'
 import {InitialValueProperty} from '../../types'
 import {BaseSchemaDefinition} from './common'

--- a/packages/@sanity/types/src/schema/definition/type/number.ts
+++ b/packages/@sanity/types/src/schema/definition/type/number.ts
@@ -1,3 +1,4 @@
+import {FieldReference} from '../../../validation'
 import {RuleDef, ValidationBuilder} from '../../ruleBuilder'
 import {InitialValueProperty} from '../../types'
 import {BaseSchemaDefinition, EnumListProps} from './common'
@@ -8,12 +9,12 @@ export interface NumberOptions extends EnumListProps<number> {}
 
 /** @public */
 export interface NumberRule extends RuleDef<NumberRule, number> {
-  min: (minNumber: number) => NumberRule
-  max: (maxNumber: number) => NumberRule
-  lessThan: (limit: number) => NumberRule
-  greaterThan: (limit: number) => NumberRule
+  min: (minNumber: number | FieldReference) => NumberRule
+  max: (maxNumber: number | FieldReference) => NumberRule
+  lessThan: (limit: number | FieldReference) => NumberRule
+  greaterThan: (limit: number | FieldReference) => NumberRule
   integer: () => NumberRule
-  precision: (limit: number) => NumberRule
+  precision: (limit: number | FieldReference) => NumberRule
   positive: () => NumberRule
   negative: () => NumberRule
 }

--- a/packages/@sanity/types/src/schema/definition/type/string.ts
+++ b/packages/@sanity/types/src/schema/definition/type/string.ts
@@ -1,3 +1,4 @@
+import {FieldReference} from '../../../validation'
 import {RuleDef, ValidationBuilder} from '../../ruleBuilder'
 import {InitialValueProperty} from '../../types'
 import {BaseSchemaDefinition, EnumListProps} from './common'
@@ -8,9 +9,9 @@ export interface StringOptions extends EnumListProps<string> {}
 
 /** @public */
 export interface StringRule extends RuleDef<StringRule, string> {
-  min: (minNumber: number) => StringRule
-  max: (maxNumber: number) => StringRule
-  length: (exactLength: number) => StringRule
+  min: (minNumber: number | FieldReference) => StringRule
+  max: (maxNumber: number | FieldReference) => StringRule
+  length: (exactLength: number | FieldReference) => StringRule
   uppercase: () => StringRule
   lowercase: () => StringRule
   regex(pattern: RegExp, name: string, options: {name?: string; invert?: boolean}): StringRule

--- a/packages/@sanity/types/src/schema/test/array.test.ts
+++ b/packages/@sanity/types/src/schema/test/array.test.ts
@@ -178,6 +178,19 @@ describe('array types', () => {
       },
     })
   })
+
+  it('should support Rule.valueOfField calls inside defineField', () => {
+    const arrayField: ArrayDefinition = defineField({
+      type: 'array',
+      name: 'defineField-defined',
+      description: 'field defined with defineField, containing validation using Rule.valueOfField',
+      of: [{type: 'string'}],
+      validation: (Rule) => {
+        const fieldRef = Rule.valueOfField('some-other-field')
+        return Rule.min(fieldRef).max(fieldRef).length(fieldRef)
+      },
+    })
+  })
 })
 
 export {}

--- a/packages/@sanity/types/src/schema/test/date.test.ts
+++ b/packages/@sanity/types/src/schema/test/date.test.ts
@@ -4,7 +4,7 @@
  * use of ts-expect-error serves the same purpose - TypeScript is the testrunner here
  */
 import {DateDefinition, StringDefinition} from '../definition'
-import {defineType} from '../types'
+import {defineField, defineType} from '../types'
 
 describe('date types', () => {
   describe('defineType', () => {
@@ -35,6 +35,18 @@ describe('date types', () => {
 
       // @ts-expect-error date is not assignable to string
       const notAssignableToString: StringDefinition = dateDef
+    })
+  })
+
+  it('should support Rule.valueOfField calls inside defineField', () => {
+    const dateField: DateDefinition = defineField({
+      type: 'date',
+      name: 'defineField-defined',
+      description: 'field defined with defineField, containing validation using Rule.valueOfField',
+      validation: (Rule) => {
+        const fieldRef = Rule.valueOfField('some-other-field')
+        return Rule.min(fieldRef).max(fieldRef)
+      },
     })
   })
 })

--- a/packages/@sanity/types/src/schema/test/datetime.test.ts
+++ b/packages/@sanity/types/src/schema/test/datetime.test.ts
@@ -4,7 +4,7 @@
  * use of ts-expect-error serves the same purpose - TypeScript is the testrunner here
  */
 import {DatetimeDefinition} from '../definition'
-import {defineType} from '../types'
+import {defineField, defineType} from '../types'
 
 describe('datetime types', () => {
   describe('defineType', () => {
@@ -39,6 +39,18 @@ describe('datetime types', () => {
 
       // @ts-expect-error datetime is not assignable to string
       const notAssignableToString: StringDefinition = datetimeDef
+    })
+  })
+
+  it('should support Rule.valueOfField calls inside defineField', () => {
+    const datetimeField: DatetimeDefinition = defineField({
+      type: 'datetime',
+      name: 'defineField-defined',
+      description: 'field defined with defineField, containing validation using Rule.valueOfField',
+      validation: (Rule) => {
+        const fieldRef = Rule.valueOfField('some-other-field')
+        return Rule.min(fieldRef).max(fieldRef)
+      },
     })
   })
 })

--- a/packages/@sanity/types/src/schema/test/number.test.ts
+++ b/packages/@sanity/types/src/schema/test/number.test.ts
@@ -4,7 +4,7 @@
  * use of ts-expect-error serves the same purpose - TypeScript is the testrunner here
  */
 import {NumberDefinition, StringDefinition} from '../definition'
-import {defineType} from '../types'
+import {defineField, defineType} from '../types'
 
 describe('number types', () => {
   describe('defineType', () => {
@@ -45,6 +45,22 @@ describe('number types', () => {
 
       // @ts-expect-error number is not assignable to string
       const notAssignableToString: StringDefinition = numberDef
+    })
+  })
+
+  it('should support Rule.valueOfField calls inside defineField', () => {
+    const numberField: NumberDefinition = defineField({
+      type: 'number',
+      name: 'defineField-defined',
+      description: 'field defined with defineField, containing validation using Rule.valueOfField',
+      validation: (Rule) => {
+        const fieldRef = Rule.valueOfField('some-other-field')
+        return Rule.min(fieldRef)
+          .max(fieldRef)
+          .lessThan(fieldRef)
+          .greaterThan(fieldRef)
+          .precision(fieldRef)
+      },
     })
   })
 })

--- a/packages/@sanity/types/src/schema/test/string.test.ts
+++ b/packages/@sanity/types/src/schema/test/string.test.ts
@@ -131,6 +131,19 @@ describe('string types', () => {
         },
       })
     })
+
+    it('should support Rule.valueOfField calls', () => {
+      const stringField: StringDefinition = defineField({
+        type: 'string',
+        name: 'defineField-defined',
+        description:
+          'field defined with defineField, containing validation using Rule.valueOfField',
+        validation: (Rule) => {
+          const fieldRef = Rule.valueOfField('some-other-field')
+          return Rule.min(fieldRef).max(fieldRef).max(length)
+        },
+      })
+    })
   })
 })
 

--- a/packages/@sanity/types/src/validation/types.ts
+++ b/packages/@sanity/types/src/validation/types.ts
@@ -5,7 +5,6 @@ import type {SanityDocument} from '../documents'
 import type {ValidationMarker} from '../markers'
 import {SlugSchemaType} from '../schema'
 import {SlugParent} from '../slug'
-import {PortableTextBlock} from '../portableText'
 
 /** @public */
 export type RuleTypeConstraint = 'Array' | 'Boolean' | 'Date' | 'Number' | 'Object' | 'String'
@@ -141,10 +140,10 @@ export interface Rule {
   custom<T = unknown>(fn: CustomValidator<T>): Rule
   min(len: number | FieldReference): Rule
   max(len: number | FieldReference): Rule
-  length(len: number): Rule
+  length(len: number | FieldReference): Rule
   valid(value: unknown | unknown[]): Rule
   integer(): Rule
-  precision(limit: number): Rule
+  precision(limit: number | FieldReference): Rule
   positive(): Rule
   negative(): Rule
   greaterThan(num: number | FieldReference): Rule


### PR DESCRIPTION
### Description

Currently, the following schema definition is allowed by TypeScript:
```ts
const product = defineType({
  name: "product",
  type: "document",
  fields: [
    {
      name: "compareAtPrice",
      type: "number",
      validation: (Rule) => Rule.greaterThan(Rule.valueOfField("price")),
    },
    // ...
  ],
})
```

But the following, with only the addition of the `defineField` call, is not allowed*:
```ts
const product = defineType({
  name: "product",
  type: "document",
  fields: [
    defineField({
      name: "compareAtPrice",
      type: "number",
      validation: (Rule) => Rule.greaterThan(Rule.valueOfField("price")),
    }),
    // ...
  ],
})
```
<details><summary><i>* There are cases where that same call is allowed, such as under a `defineConfig` or `definePlugin` call</i></summary>

  ```ts
  const config = defineConfig({
    // ...
    schema: {
      types: [
        {
          type: "document",
          name: "mydoc",
          fields: [
            defineField({
              type: "string",
              name: "mystring",
              validation: (Rule) =>
                Rule.max(Rule.valueOfField("some-other-field")),
            }),
          ],
        },
      ],
    },
  });
  ```

</details>

This PR updates the types used in validation rules such that TypeScript no longer considers use of `Rule.valueOfField()` results as invalid arguments to functions that accept field references. I also updated the signature for `Rule.length` and `Rule.precision` calls to reflect the fact that those can accept field references as well.

### What to review

I added TypeScript test cases to go with each change. You can undo a couple of the type changes locally and see that a type error occurs in the corresponding test case.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
- Fixes type issue where calling `Rule.valueOfField` inside validation defined in `defineField` resulted in type errors.
- The typing for validation rules `Rule.length` and `Rule.precision` now allows referencing values from other fields with `Rule.valueOfField`