### PR TITLE
fix(desk): remove restore action when revision is latest version

### DIFF
--- a/packages/sanity/src/desk/documentActions/HistoryRestoreAction.tsx
+++ b/packages/sanity/src/desk/documentActions/HistoryRestoreAction.tsx
@@ -34,6 +34,11 @@ export const HistoryRestoreAction: DocumentActionComponent = ({id, type, revisio
   }, [handleConfirm, isConfirmDialogOpen, onComplete])
 
   const isRevisionInitialVersion = revision === '@initial'
+  const isRevisionLatestVersion = revision === undefined // undefined means latest version
+
+  if (isRevisionLatestVersion) {
+    return null
+  }
 
   return {
     label: 'Restore',


### PR DESCRIPTION
### Description
This PR removes the restore document action when the revision is the latest version. Currently, the restore action is always available, even when the document cannot be restored.

<img width="843" alt="update1" src="https://user-images.githubusercontent.com/15094168/210243970-36318502-d4f0-41ca-aede-b1e1cdd7e4bd.png">

### What to review
Make sure that the restore action is not visible when revision id is the latest version

### Notes for release

n/a
