### PR TITLE
fix(desk): set the form to read-only when reconnecting

### DIFF
--- a/packages/sanity/src/core/form/store/useFormState.ts
+++ b/packages/sanity/src/core/form/store/useFormState.ts
@@ -91,6 +91,7 @@ export function useFormState<
     comparisonValue,
     focusPath,
     openPath,
+    readOnly,
     currentUser,
     presence,
     validation,

--- a/packages/sanity/src/core/hooks/useConnectionState.ts
+++ b/packages/sanity/src/core/hooks/useConnectionState.ts
@@ -23,7 +23,7 @@ export function useConnectionState(publishedDocId: string, docTypeName: string):
         startWith(INITIAL as any),
         distinctUntilChanged()
       ),
-    [publishedDocId, docTypeName],
+    [documentStore.pair, publishedDocId, docTypeName],
     INITIAL
   )
 }

--- a/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
@@ -317,14 +317,28 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   const isNonExistent = !value?._id
 
   const readOnly = useMemo(() => {
+    const hasNoPermission = !isPermissionsLoading && !permissions?.granted
+    const updateActionDisabled = !isActionEnabled(schemaType!, 'update')
+    const createActionDisabled = isNonExistent && !isActionEnabled(schemaType!, 'create')
+    const reconnecting = connectionState === 'reconnecting'
+
     return (
       !ready ||
       rev !== null ||
-      (!isPermissionsLoading && !permissions?.granted) ||
-      !isActionEnabled(schemaType!, 'update') ||
-      (isNonExistent && !isActionEnabled(schemaType!, 'create'))
+      hasNoPermission ||
+      updateActionDisabled ||
+      createActionDisabled ||
+      reconnecting
     )
-  }, [isNonExistent, isPermissionsLoading, permissions?.granted, ready, rev, schemaType])
+  }, [
+    connectionState,
+    isNonExistent,
+    isPermissionsLoading,
+    permissions?.granted,
+    ready,
+    rev,
+    schemaType,
+  ])
 
   const formState = useFormState(schemaType!, {
     value: displayed,


### PR DESCRIPTION
### Description

This PR makes the form read-only when reconnecting to avoid unexpected behavior. Since the Studio is not fully functional when offline yet, this ensures that the connection is ready before allowing changes to be made.

This PR also adds missing dependencies in the `useFormState` and `useConnectionState` hooks.

### What to review

- Review the code
- Make sure that it works as expected

### Notes for release

n/a
