### PR TITLE
fix(cli): reintroduce deprecated graphql deployment flags

### DIFF
--- a/packages/@sanity/cli/test/graphql.test.ts
+++ b/packages/@sanity/cli/test/graphql.test.ts
@@ -25,7 +25,7 @@ describeCliTest('CLI: `sanity graphql`', () => {
       expect(result.stdout).toContain('https://')
       expect(result.code).toBe(0)
 
-      const [graphqlUrl] = result.stdout.match(/(https:\/\/.*(\s|$))/) || []
+      const [graphqlUrl] = result.stdout.match(/(https:\/\/.*(\s|$))/) || ['']
       expect(graphqlUrl.startsWith('https://')).toBeTruthy()
 
       const response = await request(graphqlUrl, {

--- a/packages/sanity/src/_internal/cli/actions/graphql/getGraphQLAPIs.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/getGraphQLAPIs.ts
@@ -60,5 +60,9 @@ function isModernCliConfig(config: CliCommandContext): config is CliV3CommandCon
 }
 
 function serialize<T>(obj: T): T {
-  return JSON.parse(JSON.stringify(obj))
+  try {
+    return JSON.parse(JSON.stringify(obj))
+  } catch (cause) {
+    throw new Error(`Failed to serialize CLI configuration`, {cause})
+  }
 }

--- a/packages/sanity/src/_internal/cli/actions/graphql/getGraphQLAPIs.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/getGraphQLAPIs.ts
@@ -45,7 +45,7 @@ function getApisWithSchemaTypes(cliContext: CliCommandContext): Promise<TypeReso
     const rootDir = path.dirname(rootPkgPath)
     const workerPath = path.join(rootDir, 'lib', '_internal', 'cli', 'threads', 'getGraphQLAPIs.js')
     const worker = new Worker(workerPath, {
-      workerData: {cliConfig: serialize(cliConfig), cliConfigPath, workDir},
+      workerData: {cliConfig: serialize(cliConfig || {}), cliConfigPath, workDir},
     })
     worker.on('message', resolve)
     worker.on('error', reject)

--- a/packages/sanity/src/_internal/cli/commands/graphql/deployGraphQLAPICommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/graphql/deployGraphQLAPICommand.ts
@@ -6,15 +6,29 @@ Options
   --force Deploy API without confirming breaking changes
   --api <api-id> Only deploy API with this ID. Can be specified multiple times.
 
+The following options will override any setting from the CLI configuration file
+(sanity.cli.js/sanity.cli.ts) - and applies to ALL defined APIs defined in that
+configuration file. Tread with caution!
+
+  --tag Deploy API(s) to given tag (defaults to 'default')
+  --dataset <name> Deploy API for the given dataset
+  --generation <gen1|gen2|gen3> API generation to deploy (defaults to 'gen3')
+  --non-null-document-fields Use non-null document fields (_id, _type etc)
+  --playground Enable GraphQL playground for easier debugging
+  --no-playground Disable GraphQL playground
+
 Examples
   # Deploy all defined GraphQL APIs
   sanity graphql deploy
 
-  # Validate defined GraphQL APIs and check for breaking changes
+  # Validate defined GraphQL APIs, check for breaking changes, skip deploy
   sanity graphql deploy --dry-run
 
   # Deploy only the GraphQL APIs with the IDs "staging" and "ios"
   sanity graphql deploy --api staging --api ios
+
+  # Deploy all defined GraphQL APIs, overriding any playground setting
+  sanity graphql deploy --playground
 `
 
 const deployGraphQLAPICommand: CliCommandDefinition = {


### PR DESCRIPTION
### Description

This PR reintroduces the `--playground`, `--generation` and `--non-null-document-fields` flags for the `sanity graphql deploy` command. While they ideally should still be configured in `sanity.cli.ts`, it seemed somewhat arbitrary which flags we allowed and did not allow.

With a hopefully clear message during deployment, we will allow using these flags, but indicate that they apply to _all_ defined GraphQL APIs.

While researching this, I also discovered that we were requiring a `projectId` and `dataset` to be defined in the CLI configuration, which is unnecessary as we are extracting this from the studio source configuration anyway. I have thus removed this requirement, which also means you can run `sanity graphql deploy` without a CLI configuration file present - same as in v2.

### What to review

- `sanity graphql deploy` still works (`npx sanity graphql deploy` in `examples/blog-studio` for instance)
- Flags can be used
- Code makes sense

### Notes for release

- Reintroduced the `--playground`, `--generation` and `--non-null-document-fields` flags for `sanity graphql deploy`
- Fixed an issue where a CLI configuration file was _required_ in order to deploy a GraphQL API

