### PR TITLE
feat(server): support studio env vars through `process.env`

### DIFF
--- a/packages/sanity/src/_internal/cli/server/getStudioEnvVars.ts
+++ b/packages/sanity/src/_internal/cli/server/getStudioEnvVars.ts
@@ -1,0 +1,20 @@
+/* eslint-disable no-process-env */
+
+/**
+ * Get environment variables prefixed with SANITY_STUDIO_, as an object.
+ * Specify a `prefix` to add a prefix to the environment variable keys,
+ * eg: `getStudioEnvVars('process.env.')`
+ *
+ * @param prefix - Prefix to add to the environment variable keys
+ * @returns Object of studio environment variables
+ * @internal
+ */
+export function getStudioEnvVars(prefix = ''): Record<string, string> {
+  const studioEnv: Record<string, string> = {}
+  for (const key in process.env) {
+    if (key.startsWith('SANITY_STUDIO_')) {
+      studioEnv[`${prefix}${key}`] = JSON.stringify(process.env[key] || '')
+    }
+  }
+  return studioEnv
+}

--- a/packages/sanity/src/_internal/cli/server/getViteConfig.ts
+++ b/packages/sanity/src/_internal/cli/server/getViteConfig.ts
@@ -9,6 +9,7 @@ import {sanityBuildEntries} from './vite/plugin-sanity-build-entries'
 import {sanityDotWorkaroundPlugin} from './vite/plugin-sanity-dot-workaround'
 import {sanityRuntimeRewritePlugin} from './vite/plugin-sanity-runtime-rewrite'
 import {sanityFaviconsPlugin} from './vite/plugin-sanity-favicons'
+import {getStudioEnvVars} from './getStudioEnvVars'
 
 export interface ViteOptions {
   /**
@@ -107,7 +108,9 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
       alias: getAliases({monorepo}),
     },
     define: {
+      // eslint-disable-next-line no-process-env
       __SANITY_STAGING__: process.env.SANITY_INTERNAL_ENV === 'staging',
+      ...getStudioEnvVars('process.env.'),
     },
   }
 


### PR DESCRIPTION
### Description

Supersedes #3620 - the previous approach warned when using `process.env`, this one actually defines the environment variables as `process.env.SANITY_STUDIO_X`.

Rationale:
- There is no standard for environment variables across environments.
  - Node.js uses `process.env`.
  - Vite uses `import.meta.env`.
  - Deno uses `Deno.env`.
  - Cloudflare workers uses global variables.
- Sanitys tooling runs on Node.js. It is difficult/annoying to write things like configuration files, where they need to work on both the server/cli and on the client side.
- By defining these as `process.env.SANITY_STUDIO_X`, they are both accessible as `import.meta.env.SANITY_STUDIO_X` _and_ under `process.env`. This means that you can use the `process.env` approach in configuration files and (if you want/need to) use `import.meta.env` in code.

We should still encourage people to use environment variables only on the very "edge" of an application, eg in configuration, instead of deeply inside project code. This makes it easier to switch between environments where `process.env` might not be available.

[sc-19342]

### What to review

- See that a defined environment variable is accessible through `process.env`
  - Define a studio env var (`export SANITY_STUDIO_SOMETHING=yep`)
  - Use the env var in studio code - eg in a studio config or similar (`process.env.SANITY_STUDIO_SOMETHING`)
  - Use the env var in studio code from `import.meta.env`
- Ensure only `SANITY_STUDIO_` prefixed variables are accessible

### Notes for release

- Allow accessing studio-prefixed environment variables through `process.env`
