### PR TITLE
chore: upgrade rxjs to v7

### DIFF
--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -43,7 +43,7 @@
     "react-dom": "^18.2.0",
     "react-refractor": "^2.1.6",
     "refractor": "^3.6.0",
-    "rxjs": "^6.5.3",
+    "rxjs": "^7.8.0",
     "sanity": "3.1.4",
     "sanity-plugin-mux-input": "^2.0.2",
     "styled-components": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "prettier-plugin-packagejson": "^2.3.0",
     "puppeteer": "^19.3.0",
     "rimraf": "^3.0.2",
-    "rxjs": "^6.5.3",
+    "rxjs": "^7.8.0",
     "semver": "^7.3.5",
     "start-server-and-test": "^1.14.0",
     "tmp": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@babel/preset-react": "^7.18.6",
     "@babel/preset-typescript": "^7.18.6",
     "@optimize-lodash/rollup-plugin": "^4.0.1",
-    "@sanity/client": "^3.4.1",
+    "@sanity/client": "^4.0.1",
     "@sanity/pkg-utils": "^2.1.0",
     "@sanity/tsdoc-to-portable-text": "^0.4.3",
     "@sanity/uuid": "^3.0.1",

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -71,7 +71,7 @@
   "devDependencies": {
     "@rexxars/gitconfiglocal": "^3.0.1",
     "@rollup/plugin-node-resolve": "^15.0.0",
-    "@sanity/client": "^3.4.1",
+    "@sanity/client": "^4.0.1",
     "@sanity/eslint-config-studio": "^2.0.0",
     "@sanity/generate-help-url": "^3.0.0",
     "@sanity/types": "3.1.4",

--- a/packages/@sanity/import-cli/package.json
+++ b/packages/@sanity/import-cli/package.json
@@ -31,7 +31,7 @@
     "src"
   ],
   "dependencies": {
-    "@sanity/client": "^3.4.1",
+    "@sanity/client": "^4.0.1",
     "@sanity/import": "3.1.4",
     "get-it": "^5.2.1",
     "meow": "^9.0.0",

--- a/packages/@sanity/import/package.json
+++ b/packages/@sanity/import/package.json
@@ -51,7 +51,7 @@
     "tar-fs": "^2.1.1"
   },
   "devDependencies": {
-    "@sanity/client": "^3.4.1",
+    "@sanity/client": "^4.0.1",
     "nock": "^13.2.9"
   },
   "engines": {

--- a/packages/@sanity/portable-text-editor/package.json
+++ b/packages/@sanity/portable-text-editor/package.json
@@ -108,7 +108,7 @@
   },
   "peerDependencies": {
     "react": "^16.9 || ^17 || ^18",
-    "rxjs": ">=6.5.3",
+    "rxjs": ">=6.5.3 || ^7.0.0",
     "styled-components": "^5.2"
   },
   "engines": {

--- a/packages/@sanity/portable-text-editor/package.json
+++ b/packages/@sanity/portable-text-editor/package.json
@@ -101,7 +101,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rimraf": "^3.0.2",
-    "rxjs": "^6.5.3",
+    "rxjs": "^7.8.0",
     "styled-components": "^5.2.0",
     "typedoc": "^0.17.3",
     "vite": "^4.0.1"

--- a/packages/@sanity/types/package.json
+++ b/packages/@sanity/types/package.json
@@ -56,7 +56,7 @@
     "watch": "pkg-utils watch --tsconfig tsconfig.lib.json"
   },
   "dependencies": {
-    "@sanity/client": "^3.4.1",
+    "@sanity/client": "^4.0.1",
     "@types/react": "^18.0.25"
   },
   "devDependencies": {

--- a/packages/@sanity/validation/package.json
+++ b/packages/@sanity/validation/package.json
@@ -60,7 +60,7 @@
     "rxjs": "^6.5.3"
   },
   "devDependencies": {
-    "@sanity/client": "^3.4.1",
+    "@sanity/client": "^4.0.1",
     "@sanity/schema": "3.1.4"
   },
   "peerDependencies": {

--- a/packages/@sanity/validation/package.json
+++ b/packages/@sanity/validation/package.json
@@ -57,7 +57,7 @@
     "@sanity/types": "3.1.4",
     "date-fns": "^2.26.1",
     "lodash": "^4.17.21",
-    "rxjs": "^6.5.3"
+    "rxjs": "^7.8.0"
   },
   "devDependencies": {
     "@sanity/client": "^4.0.1",

--- a/packages/@sanity/validation/package.json
+++ b/packages/@sanity/validation/package.json
@@ -64,7 +64,7 @@
     "@sanity/schema": "3.1.4"
   },
   "peerDependencies": {
-    "@sanity/client": "^3.4.1"
+    "@sanity/client": "^3.4.1 || ^4.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@sanity/validation/src/validateDocument.ts
+++ b/packages/@sanity/validation/src/validateDocument.ts
@@ -10,7 +10,7 @@ import {
   isSpanSchemaType,
   isPortableTextTextBlock,
 } from '@sanity/types'
-import {concat, defer, merge, Observable, of} from 'rxjs'
+import {concat, defer, firstValueFrom, lastValueFrom, merge, Observable, of} from 'rxjs'
 import {catchError, map, mergeAll, mergeMap, toArray} from 'rxjs/operators'
 import {flatten, uniqBy} from 'lodash'
 import type {SanityClient} from '@sanity/client'
@@ -57,7 +57,7 @@ export default async function validateDocument(
   schema: Schema,
   context?: Pick<ValidationContext, 'getDocumentExists'>
 ): Promise<ValidationMarker[]> {
-  return validateDocumentObservable(getClient, doc, schema, context).toPromise()
+  return lastValueFrom(validateDocumentObservable(getClient, doc, schema, context))
 }
 
 export function validateDocumentObservable(
@@ -139,7 +139,7 @@ type ValidateItemOptions = {
 } & ExplicitUndefined<ValidationContext>
 
 export function validateItem(opts: ValidateItemOptions): Promise<ValidationMarker[]> {
-  return validateItemObservable(opts).toPromise()
+  return lastValueFrom(validateItemObservable(opts))
 }
 
 function validateItemObservable({

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -75,7 +75,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@sanity/client": "^3.4.1",
+    "@sanity/client": "^4.0.1",
     "react": "^18.2.0",
     "sanity": "3.1.4",
     "styled-components": "^5.2.0"

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -137,7 +137,7 @@
     "@sanity/bifur-client": "^0.3.0",
     "@sanity/block-tools": "3.1.4",
     "@sanity/cli": "3.1.4",
-    "@sanity/client": "^3.4.1",
+    "@sanity/client": "^4.0.1",
     "@sanity/color": "^2.1.20",
     "@sanity/diff": "3.1.4",
     "@sanity/eventsource": "^3.0.1",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -215,7 +215,7 @@
     "refractor": "^3.6.0",
     "resolve-from": "^5.0.0",
     "rimraf": "^3.0.2",
-    "rxjs": "^6.5.3",
+    "rxjs": "^7.8.0",
     "rxjs-etc": "^10.6.0",
     "rxjs-exhaustmap-with-trailing": "^1.2.0",
     "sanity-diff-patch": "^1.0.9",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -134,7 +134,7 @@
     "@portabletext/types": "^1.0.3",
     "@rexxars/react-json-inspector": "^8.0.1",
     "@sanity/asset-utils": "^1.2.5",
-    "@sanity/bifur-client": "^0.3.0",
+    "@sanity/bifur-client": "^0.3.1",
     "@sanity/block-tools": "3.1.4",
     "@sanity/cli": "3.1.4",
     "@sanity/client": "^4.0.1",

--- a/packages/sanity/src/_internal/cli/util/getStudioConfig.ts
+++ b/packages/sanity/src/_internal/cli/util/getStudioConfig.ts
@@ -2,6 +2,7 @@
 import fs from 'fs'
 import path from 'path'
 import {first} from 'rxjs/operators'
+import {firstValueFrom} from 'rxjs'
 import {mockBrowserEnvironment} from './mockBrowserEnvironment'
 import {resolveConfig, Config, Workspace} from 'sanity'
 
@@ -53,7 +54,7 @@ export async function getStudioConfig(options: {
       throw new Error('Configuration did not export expected config shape')
     }
 
-    workspaces = await resolveConfig(config).pipe(first()).toPromise()
+    workspaces = await firstValueFrom(resolveConfig(config))
   } catch (error) {
     if (cleanup) {
       cleanup()

--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -150,14 +150,15 @@ export function prepareConfig(config: Config | MissingConfigFile): PreparedConfi
           shareReplay(1)
         )
 
-        return Object.assign(source$, {
+        return {
           name: source.name,
           projectId: source.projectId,
           dataset: source.dataset,
           title: source.title || startCase(source.name),
           auth,
           schema,
-        })
+          source: source$,
+        }
       })
 
       const title = rootSource.title || startCase(rootSource.name)

--- a/packages/sanity/src/core/config/resolveConfig.ts
+++ b/packages/sanity/src/core/config/resolveConfig.ts
@@ -1,4 +1,4 @@
-import {combineLatest, Observable} from 'rxjs'
+import {combineLatest, firstValueFrom, Observable} from 'rxjs'
 import {first, map} from 'rxjs/operators'
 import {CurrentUser} from '@sanity/types'
 import {SanityClient} from '@sanity/client'
@@ -57,15 +57,15 @@ export async function createWorkspaceFromConfig(
   options: CreateWorkspaceFromConfigOptions
 ): Promise<Workspace> {
   const client = 'getClient' in options ? options.getClient({apiVersion: '2022-09-09'}) : undefined
-  const [workspace] = await resolveConfig({
-    ...options,
-    ...(client &&
-      'currentUser' in options && {
-        auth: createMockAuthStore({...options, client}),
-      }),
-  })
-    .pipe(first())
-    .toPromise()
+  const [workspace] = await firstValueFrom(
+    resolveConfig({
+      ...options,
+      ...(client &&
+        'currentUser' in options && {
+          auth: createMockAuthStore({...options, client}),
+        }),
+    })
+  )
 
   return workspace
 }

--- a/packages/sanity/src/core/preview/observeFields.ts
+++ b/packages/sanity/src/core/preview/observeFields.ts
@@ -18,6 +18,7 @@ import {
   publishReplay,
   refCount,
   share,
+  shareReplay,
   startWith,
   switchMap,
   tap,
@@ -69,8 +70,7 @@ export function create_preview_observeFields(context: {
       // events that happens in the time period after initial fetch and before the listener is established.
       const welcome$ = allEvents$.pipe(
         filter((event: any) => event.type === 'welcome'),
-        publishReplay(1),
-        refCount()
+        shareReplay({refCount: true, bufferSize: 1})
       )
 
       // This will keep the listener active forever and in turn reduce the number of initial fetches
@@ -174,15 +174,14 @@ export function create_preview_observeFields(context: {
     apiConfig: ApiConfig
   ): CachedFieldObserver {
     let latest: T | null = null
-    const changes$ = merge<T | null>(
+    const changes$ = merge(
       defer(() => (latest === null ? EMPTY : observableOf(latest))),
       (apiConfig
         ? (crossDatasetListenFields(id, fields, apiConfig) as any)
         : currentDatasetListenFields(id, fields)) as Observable<T>
     ).pipe(
       tap((v: T | null) => (latest = v)),
-      publishReplay(1),
-      refCount()
+      shareReplay({refCount: true, bufferSize: 1})
     )
 
     return {id, fields, changes$}

--- a/packages/sanity/src/core/preview/utils/props.ts
+++ b/packages/sanity/src/core/preview/utils/props.ts
@@ -1,5 +1,11 @@
-import {Observable, of as observableOf, from as observableFrom, isObservable} from 'rxjs'
-import {map, mergeAll, combineAll, switchMap, scan} from 'rxjs/operators'
+import {
+  combineLatest,
+  from as observableFrom,
+  isObservable,
+  Observable,
+  of as observableOf,
+} from 'rxjs'
+import {map, mergeAll, scan, switchMap} from 'rxjs/operators'
 import {keysOf} from './keysOf'
 
 function setKey(source: Record<string, unknown>, key: any, value: unknown) {
@@ -25,8 +31,7 @@ export function props<K extends keyof any, T>(options: {wait?: boolean} = {}) {
         })
 
         return options.wait
-          ? observableFrom(keyObservables).pipe(
-              combineAll(),
+          ? combineLatest(keyObservables).pipe(
               map((pairs) => pairs.reduce((acc, [key, value]) => setKey(acc, key, value), {}))
             )
           : observableFrom(keyObservables).pipe(

--- a/packages/sanity/src/core/search/weighted/createWeightedSearch.test.ts
+++ b/packages/sanity/src/core/search/weighted/createWeightedSearch.test.ts
@@ -1,6 +1,6 @@
 import Schema from '@sanity/schema'
 import {renderHook} from '@testing-library/react'
-import {defer, of} from 'rxjs'
+import {defer, lastValueFrom, of} from 'rxjs'
 import type {SearchTerms} from '..'
 import {useClient} from '../../hooks'
 import {getSearchableTypes} from '../common/utils'
@@ -37,18 +37,18 @@ beforeEach(() => {
 
 describe('createWeightedSearch', () => {
   it('should order hits by score by default', async () => {
-    // @todo: replace `toPromise` with `firstValueFrom` in rxjs 7+
-    const result = await search({query: 'harry', types: []} as SearchTerms).toPromise()
+    const result = await lastValueFrom(search({query: 'harry', types: []} as SearchTerms))
 
     expect(result[0].score).toEqual(10)
     expect(result[1].score).toEqual(2.5)
   })
 
   it('should not order hits by score if skipSortByScore is enabled', async () => {
-    // @todo: replace `toPromise` with `firstValueFrom` in rxjs 7+
-    const result = await search({query: 'harry', types: []} as SearchTerms, {
-      skipSortByScore: true,
-    }).toPromise()
+    const result = await lastValueFrom(
+      search({query: 'harry', types: []} as SearchTerms, {
+        skipSortByScore: true,
+      })
+    )
 
     expect(result[0].score).toEqual(2.5)
     expect(result[1].score).toEqual(10)

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/validation.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/validation.ts
@@ -1,5 +1,15 @@
 import type {SanityClient} from '@sanity/client'
-import {asyncScheduler, combineLatest, concat, defer, from, Observable, of, timer} from 'rxjs'
+import {
+  asyncScheduler,
+  combineLatest,
+  concat,
+  defer,
+  from,
+  lastValueFrom,
+  Observable,
+  of,
+  timer,
+} from 'rxjs'
 import {
   distinct,
   distinctUntilChanged,
@@ -134,12 +144,12 @@ export const validation = memoize(
     // Provided to individual validation functions to support using existence of a weakly referenced document
     // as part of the validation rule (used by references in place)
     const getDocumentExists: GetDocumentExists = ({id}) =>
-      referenceExistence$
-        .pipe(
+      lastValueFrom(
+        referenceExistence$.pipe(
           first(),
           map((referenceExistence) => referenceExistence[id])
         )
-        .toPromise()
+      )
 
     const referenceDocumentUpdates$ = referenceExistence$.pipe(
       // we'll skip the first emission since the document already gets an initial validation pass

--- a/packages/sanity/src/core/store/_legacy/grants/__tests__/createGrantsStore.test.ts
+++ b/packages/sanity/src/core/store/_legacy/grants/__tests__/createGrantsStore.test.ts
@@ -1,5 +1,6 @@
 import {SanityClient} from '@sanity/client'
 import {first} from 'rxjs/operators'
+import {firstValueFrom, lastValueFrom} from 'rxjs'
 import {createGrantsStore} from '../grantsStore'
 import {viewer} from '../debug/exampleGrants'
 
@@ -41,16 +42,16 @@ describe('checkDocumentPermission', () => {
     const {checkDocumentPermission} = createGrantsStore({client, currentUser: null})
 
     await expect(
-      checkDocumentPermission('create', {_id: 'example-id', _type: 'book'})
-        .pipe(first())
-        .toPromise()
+      firstValueFrom(checkDocumentPermission('create', {_id: 'example-id', _type: 'book'}))
     ).resolves.toEqual({
       granted: false,
       reason: 'No matching grants found',
     })
 
     await expect(
-      checkDocumentPermission('read', {_id: 'example-id', _type: 'book'}).pipe(first()).toPromise()
+      lastValueFrom(
+        checkDocumentPermission('read', {_id: 'example-id', _type: 'book'}).pipe(first())
+      )
     ).resolves.toEqual({
       granted: true,
       reason: 'Matching grant',

--- a/packages/sanity/src/core/store/_legacy/grants/__tests__/templatePermissions.test.ts
+++ b/packages/sanity/src/core/store/_legacy/grants/__tests__/templatePermissions.test.ts
@@ -3,6 +3,7 @@
 import {first} from 'rxjs/operators'
 import {SanityClient} from '@sanity/client'
 import {InitialValueResolverContext} from '@sanity/types'
+import {firstValueFrom} from 'rxjs'
 import {createMockSanityClient} from '../../../../../../test/mocks/mockSanityClient'
 import {requiresApproval} from '../debug/exampleGrants'
 import {createGrantsStore} from '../grantsStore'
@@ -50,28 +51,28 @@ describe('getTemplatePermissions', () => {
       currentUser: null,
     })
 
-    const permissions = getTemplatePermissions({
-      grantsStore,
-      schema,
-      templates,
-      templateItems: [
-        {
-          id: 'author-developer-locked',
-          templateId: 'author-developer-locked',
-          type: 'initialValueTemplateItem',
-          schemaType: 'author',
-        },
-        {
-          id: 'author-developer-unlocked',
-          templateId: 'author-developer-unlocked',
-          type: 'initialValueTemplateItem',
-          schemaType: 'author',
-        },
-      ],
-      context: {} as InitialValueResolverContext,
-    })
-      .pipe(first())
-      .toPromise()
+    const permissions = firstValueFrom(
+      getTemplatePermissions({
+        grantsStore,
+        schema,
+        templates,
+        templateItems: [
+          {
+            id: 'author-developer-locked',
+            templateId: 'author-developer-locked',
+            type: 'initialValueTemplateItem',
+            schemaType: 'author',
+          },
+          {
+            id: 'author-developer-unlocked',
+            templateId: 'author-developer-unlocked',
+            type: 'initialValueTemplateItem',
+            schemaType: 'author',
+          },
+        ],
+        context: {} as InitialValueResolverContext,
+      })
+    )
 
     await expect(permissions).resolves.toEqual([
       {

--- a/packages/sanity/src/core/studio/components/navbar/changelog/module-status/moduleStatus.test.ts
+++ b/packages/sanity/src/core/studio/components/navbar/changelog/module-status/moduleStatus.test.ts
@@ -1,5 +1,5 @@
 import type {SanityClient} from '@sanity/client'
-import {of, Observable, asyncScheduler} from 'rxjs'
+import {of, Observable, asyncScheduler, lastValueFrom} from 'rxjs'
 import React from 'react'
 import {createRoot} from 'react-dom/client'
 import {act} from 'react-dom/test-utils'
@@ -14,10 +14,12 @@ describe('module status', () => {
   test('can fetch module status from api', async () => {
     const installed = {sanity: basePkg.version}
     const mockClient = getMockClient()
-    const status = await checkModuleStatus({
-      client: mockClient,
-      moduleVersions: installed,
-    }).toPromise()
+    const status = await lastValueFrom(
+      checkModuleStatus({
+        client: mockClient,
+        moduleVersions: installed,
+      })
+    )
 
     expect(mockClient.observable.request).toHaveBeenCalledTimes(1)
     expect(status).toMatchObject({...defaults, installed})
@@ -37,7 +39,7 @@ describe('module status', () => {
       moduleVersions: installed,
     })
 
-    const [status1, status2] = await Promise.all([call1.toPromise(), call2.toPromise()])
+    const [status1, status2] = await Promise.all([lastValueFrom(call1), lastValueFrom(call2)])
 
     expect(mockClient.observable.request).toHaveBeenCalledTimes(1)
     expect(status1).toMatchObject({...defaults, installed})
@@ -48,15 +50,19 @@ describe('module status', () => {
     const installed = {sanity: '2.1338.0'}
     const mockClient = getMockClient()
 
-    const status1 = await checkModuleStatus({
-      client: mockClient,
-      moduleVersions: installed,
-    }).toPromise()
+    const status1 = await lastValueFrom(
+      checkModuleStatus({
+        client: mockClient,
+        moduleVersions: installed,
+      })
+    )
 
-    const status2 = await checkModuleStatus({
-      client: mockClient,
-      moduleVersions: installed,
-    }).toPromise()
+    const status2 = await lastValueFrom(
+      checkModuleStatus({
+        client: mockClient,
+        moduleVersions: installed,
+      })
+    )
 
     expect(mockClient.observable.request).toHaveBeenCalledTimes(1)
     expect(status1).toMatchObject({...defaults, installed})
@@ -114,7 +120,7 @@ describe('useModuleStatus', () => {
     }
 
     // Prepare in order to cache result
-    await checkModuleStatus(options).toPromise()
+    await lastValueFrom(checkModuleStatus(options))
     await nextTick()
 
     function StatusDumper() {

--- a/packages/sanity/src/desk/components/deskTool/intentResolver/utils.ts
+++ b/packages/sanity/src/desk/components/deskTool/intentResolver/utils.ts
@@ -1,6 +1,6 @@
 import {uuid} from '@sanity/uuid'
 import {first} from 'rxjs/operators'
-import {Observable} from 'rxjs'
+import {firstValueFrom, Observable} from 'rxjs'
 import {PaneResolutionError} from '../../../structureResolvers'
 import {getPublishedId, DocumentStore} from 'sanity'
 
@@ -26,9 +26,9 @@ export async function ensureDocumentIdAndType(
   if (id && type) return {id, type}
   if (!id && type) return {id: uuid(), type}
   if (id && !type) {
-    const resolvedType = await (documentStore.resolveTypeForDocument(id) as Observable<string>)
-      .pipe(first())
-      .toPromise()
+    const resolvedType = await firstValueFrom(
+      documentStore.resolveTypeForDocument(id) as Observable<string>
+    )
 
     return {id, type: resolvedType}
   }

--- a/packages/sanity/src/desk/structureResolvers/resolveIntent.ts
+++ b/packages/sanity/src/desk/structureResolvers/resolveIntent.ts
@@ -1,5 +1,5 @@
 import {omit} from 'lodash'
-import {Observable} from 'rxjs'
+import {firstValueFrom, Observable} from 'rxjs'
 import {first} from 'rxjs/operators'
 import {PaneNode, RouterPanes, RouterPaneSiblingContext, UnresolvedPaneNode} from '../types'
 import {StructureContext} from '../structureBuilder'
@@ -94,9 +94,7 @@ export async function resolveIntent(options: ResolveIntentOptions): Promise<Rout
       payload: undefined,
       structureContext,
     }
-    const resolvedPane = await resolvePane(unresolvedPane, context, flatIndex)
-      .pipe(first())
-      .toPromise()
+    const resolvedPane = await firstValueFrom(resolvePane(unresolvedPane, context, flatIndex))
 
     // if the resolved pane is a document pane and the pane's ID matches then
     // resolve the intent to the current path

--- a/packages/sanity/src/desk/types.ts
+++ b/packages/sanity/src/desk/types.ts
@@ -1,5 +1,5 @@
 import {SchemaType} from '@sanity/types'
-import {Subscribable} from 'rxjs'
+import {InteropObservable, Observable, ObservableInput, Subscribable} from 'rxjs'
 import {
   DefaultDocumentNodeResolver,
   StructureBuilder,
@@ -271,6 +271,6 @@ export type PaneNodeResolver = (id: string, context: RouterPaneSiblingContext) =
 export type UnresolvedPaneNode =
   | PaneNodeResolver
   | SerializablePaneNode
-  | Subscribable<UnresolvedPaneNode>
+  | Observable<UnresolvedPaneNode>
   | PromiseLike<UnresolvedPaneNode>
   | PaneNode

--- a/yarn.lock
+++ b/yarn.lock
@@ -3574,13 +3574,13 @@
   resolved "https://registry.yarnpkg.com/@sanity/asset-utils/-/asset-utils-1.3.0.tgz#6460cd993a2c24368a6308028f3bc57df91f131e"
   integrity sha512-uyIOtGA4Duf+68I3BSbYHY5P+WGftn3QtNJD2Pn7h9WPGYsSrWViIPebE9yRN8N0NHhYj+hDQXaMpVdjG7r+zA==
 
-"@sanity/bifur-client@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@sanity/bifur-client/-/bifur-client-0.3.0.tgz#7f225b9eb5696351de2b62881e0ed8d1d0da5e3e"
-  integrity sha512-lEjPPXcqizjXh7XgLoCVTmf71dsAqckl8cWb5OLGuD5wW4NfWL9HF/qoebkJqw6en3GNPlfJTd4x7/DRFIZYWw==
+"@sanity/bifur-client@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@sanity/bifur-client/-/bifur-client-0.3.1.tgz#9c80f31b6bfee3dbaf694e9db7d4f85dba3b79e2"
+  integrity sha512-GlY9+tUmM0Vye64BHwIYLOivuRL37ucW/sj/D9MYqBmjgBnTRrjfmg8NR7qoodZuJ5nYJ5qpGMsVIBLP4Plvnw==
   dependencies:
     nanoid "^3.1.12"
-    rxjs "^6.4.0"
+    rxjs "^7.0.0"
 
 "@sanity/client@^4.0.1":
   version "4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16349,7 +16349,7 @@ rxjs-exhaustmap-with-trailing@^1.2.0:
   resolved "https://registry.yarnpkg.com/rxjs-exhaustmap-with-trailing/-/rxjs-exhaustmap-with-trailing-1.2.0.tgz#7df3a126c7da2d7bdfb393a55017eef633dea468"
   integrity sha512-r8W/h996iXbMas7RxZyOEv9AK0fPh8jM9JyFpYLvZdpVrLKZkxUkWNPx2q9P40xHmm4QB4ayUJwXNJy8Yg6OuQ==
 
-rxjs@^6, rxjs@^6.4.0, rxjs@^6.5.3, rxjs@^6.6.0, rxjs@^6.6.3:
+rxjs@^6, rxjs@^6.4.0, rxjs@^6.6.0, rxjs@^6.6.3:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3582,16 +3582,15 @@
     nanoid "^3.1.12"
     rxjs "^6.4.0"
 
-"@sanity/client@^3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@sanity/client/-/client-3.4.1.tgz#d1bd02bafc50eb0aac8d5b6fab942da52549652f"
-  integrity sha512-WSvnroCHqboUeyY0nl71vDPKmfurXI0mtqdNDb5u8MW00CAHRyCt1+Sgy39D/g+6R35FYniV31vTSTo3ofim0A==
+"@sanity/client@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@sanity/client/-/client-4.0.1.tgz#21da3d625f76ca80e86d8f1a177b70a89514b86e"
+  integrity sha512-Sd/oGzDsZulodtjq54wOFoMSvUrNnXkvevAGmuLmO90givXHzEyMMUFSj/BmG6TV1mKigS0m6gmFDP/dalUHjg==
   dependencies:
     "@sanity/eventsource" "^4.0.0"
-    get-it "^6.1.1"
-    make-error "^1.3.0"
-    object-assign "^4.1.1"
-    rxjs "^6.0.0"
+    get-it "^7.0.2"
+    make-error "^1.3.6"
+    rxjs "^7.0.0"
 
 "@sanity/color@^2.1.20", "@sanity/color@^2.2.1":
   version "2.2.2"
@@ -9308,7 +9307,7 @@ focus-lock@^0.11.2:
   dependencies:
     tslib "^2.0.3"
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.14.7, follow-redirects@^1.2.4:
+follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.14.7, follow-redirects@^1.15.2, follow-redirects@^1.2.4:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -9383,7 +9382,7 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
-form-urlencoded@^2.0.7:
+form-urlencoded@^2.0.7, form-urlencoded@^2.0.9:
   version "2.0.9"
   resolved "https://registry.yarnpkg.com/form-urlencoded/-/form-urlencoded-2.0.9.tgz#ea07c5dbd9aa739275d53ec5c671ea069fe7d597"
   integrity sha512-fWUzNiOnYa126vFAT6TFXd1mhJrvD8IqmQ9ilZPjkLYQfaRreBr5fIUoOpPlWtqaAG64nzoE7u5zSetifab9IA==
@@ -9624,7 +9623,7 @@ get-it@^5.2.1:
     tunnel-agent "^0.6.0"
     url-parse "^1.1.9"
 
-get-it@^6.0.0, get-it@^6.1.1:
+get-it@^6.0.0:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/get-it/-/get-it-6.1.1.tgz#793100756a800808abc8f0d981ca5c7b90fe343d"
   integrity sha512-2835L9lb4NAgjAbFOMMOm2XDSgj+lWmmCQv40A5rE7zZoIdM2+yk7Ie+sBD3T5lHW/Dw5IFFHyx16oQGpAo4hQ==
@@ -9647,6 +9646,29 @@ get-it@^6.0.0, get-it@^6.1.1:
     simple-concat "^1.0.1"
     tunnel-agent "^0.6.0"
     url-parse "^1.1.9"
+
+get-it@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/get-it/-/get-it-7.0.2.tgz#67d1f5871838a40dfe31ea0a2b7e6cd69b70fb4b"
+  integrity sha512-q4d+ssYtpWzC4/qJ4aJDZ5yWl94BIGmRER7PEvYpiKCBoCoDnl1YygEvNHQ2tHbD3GVZaq3QonKGi6Puh1Hzkw==
+  dependencies:
+    "@sanity/timed-out" "^4.0.2"
+    create-error-class "^3.0.2"
+    debug "^4.3.4"
+    decompress-response "^6.0.0"
+    follow-redirects "^1.15.2"
+    form-urlencoded "^2.0.9"
+    into-stream "^3.1.0"
+    is-plain-object "^5.0.0"
+    is-retry-allowed "^1.2.0"
+    is-stream "^1.1.0"
+    nano-pubsub "^2.0.1"
+    parse-headers "^2.0.5"
+    progress-stream "^2.0.0"
+    same-origin "^0.1.1"
+    simple-concat "^1.0.1"
+    tunnel-agent "^0.6.0"
+    url-parse "^1.5.10"
 
 get-latest-version@^3.0.2:
   version "3.0.2"
@@ -11190,7 +11212,7 @@ is-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
   integrity sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==
 
-is-retry-allowed@^1.1.0:
+is-retry-allowed@^1.1.0, is-retry-allowed@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz#d778488bd0a4666a3be8a1482b9f2baafedea8b4"
   integrity sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==
@@ -12760,7 +12782,7 @@ make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@^1.1.1, make-error@^1.3.0:
+make-error@^1.1.1, make-error@^1.3.6:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -14204,7 +14226,7 @@ parse-glob@^3.0.4:
     is-extglob "^1.0.0"
     is-glob "^2.0.0"
 
-parse-headers@^2.0.0, parse-headers@^2.0.1, parse-headers@^2.0.4:
+parse-headers@^2.0.0, parse-headers@^2.0.1, parse-headers@^2.0.4, parse-headers@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/parse-headers/-/parse-headers-2.0.5.tgz#069793f9356a54008571eb7f9761153e6c770da9"
   integrity sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA==
@@ -16327,14 +16349,14 @@ rxjs-exhaustmap-with-trailing@^1.2.0:
   resolved "https://registry.yarnpkg.com/rxjs-exhaustmap-with-trailing/-/rxjs-exhaustmap-with-trailing-1.2.0.tgz#7df3a126c7da2d7bdfb393a55017eef633dea468"
   integrity sha512-r8W/h996iXbMas7RxZyOEv9AK0fPh8jM9JyFpYLvZdpVrLKZkxUkWNPx2q9P40xHmm4QB4ayUJwXNJy8Yg6OuQ==
 
-rxjs@^6, rxjs@^6.0.0, rxjs@^6.4.0, rxjs@^6.5.3, rxjs@^6.6.0, rxjs@^6.6.3:
+rxjs@^6, rxjs@^6.4.0, rxjs@^6.5.3, rxjs@^6.6.0, rxjs@^6.6.3:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^7.5.1, rxjs@^7.5.4, rxjs@^7.5.5, rxjs@^7.8.0:
+rxjs@^7.0.0, rxjs@^7.5.1, rxjs@^7.5.4, rxjs@^7.5.5, rxjs@^7.8.0:
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.0.tgz#90a938862a82888ff4c7359811a595e14e1e09a4"
   integrity sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==
@@ -18381,7 +18403,7 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==
 
-url-parse@^1.1.9, url-parse@^1.5.3:
+url-parse@^1.1.9, url-parse@^1.5.10, url-parse@^1.5.3:
   version "1.5.10"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
   integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==


### PR DESCRIPTION
### Description
This PR upgrades RxJS in various packages from v6 to v7. I think we can feel reasonably confident that everything works as before given that we know of several clients that have already been using the Studio with rxjs@7 in production. I've also done a fair share of manual testing and haven't found any issues. Also, all tests are passing.

The code modifications are done mainly to pass the type checker and to remove usage of methods that's been deprecated in rxjs@7

Note: This branch is using tagged releases of `@sanity/client` and `@sanity/bifur-client`. I will promote these to relases for on monday and update the package.json's here accordingly.

### What to review
- Make sure Studio works exactly as before 😅 

### Notes for release
- Upgrade RxJS to v7
This can in some cases cause build errors due to the Observable interface between v6 and v7 has changed. If you see an error  saying something similar to:
```
TS2322: Type 'Observable<…>' is not assignable to type 'ObservableInput<any>'. 
  Type 'Observable<…>' is not assignable to type 'Observable<any>'. 
  The types of 'source.operator.call' are incompatible between these types. 
…
```
Then the solution is to upgrade the version of rxjs used in your project or library to `7.x`