### PR TITLE
fix(core): uploaded images popover display

### DIFF
--- a/packages/sanity/src/core/form/studio/assetSource/AssetThumb.tsx
+++ b/packages/sanity/src/core/form/studio/assetSource/AssetThumb.tsx
@@ -45,17 +45,25 @@ const Root = styled.div`
   position: relative;
   display: inherit;
 `
-
 const MenuContainer = styled.div`
   box-sizing: border-box;
   position: absolute;
   z-index: 2;
-  display: none;
   top: 3px;
   right: 3px;
 
-  ${Root}:hover & {
+  & button {
+    display: none;
+  }
+
+  & button[data-selected] {
     display: block;
+  }
+
+  ${Root}:hover & {
+    button {
+      display: block;
+    }
   }
 `
 


### PR DESCRIPTION
### Description
There was a bug with the dropdown of uploaded images. It wasn't possible to access the dropdown to delete uploaded images. 

https://user-images.githubusercontent.com/44635000/210981806-110dca30-4c52-4c62-9199-af5e33c12279.mp4

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Try to delete an uploaded image. Make sure the dropdown works as intended. 

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fix(core): uploaded images popover accessibility 
<!--
A description of the change(s) that should be used in the release notes.
-->
