### PR TITLE
Fix duplication of initial block in empty PTE

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -335,7 +335,7 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
       ]
     }
     return EMPTY_DECORATORS
-  }, [slateEditor.children])
+  }, [schemaTypes, slateEditor.children])
 
   // The editor
   const slateEditable = useMemo(

--- a/packages/@sanity/portable-text-editor/src/editor/PortableTextEditor.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/PortableTextEditor.tsx
@@ -99,7 +99,7 @@ export type PortableTextEditorProps = PropsWithChildren<{
 
 export interface PortableTextEditorState {
   invalidValueResolution: InvalidValueResolution | null
-  initialValue: Descendant[]
+  initialSlateEditorValue: Descendant[]
 }
 export class PortableTextEditor extends React.Component<
   PortableTextEditorProps,
@@ -135,7 +135,7 @@ export class PortableTextEditor extends React.Component<
 
     this.state = {
       invalidValueResolution: null,
-      initialValue: [], // Created in the constructor
+      initialSlateEditorValue: [], // Created in the constructor
     }
 
     // Test if we have a compiled schema type, if not, conveniently compile it
@@ -220,7 +220,7 @@ export class PortableTextEditor extends React.Component<
 
     this.state = {
       ...this.state,
-      initialValue: toSlateValue(
+      initialSlateEditorValue: toSlateValue(
         getValueOrInitialValue(props.value, [
           this.slateInstance.createPlaceholderBlock(),
         ] as PortableTextBlock[]),
@@ -256,9 +256,11 @@ export class PortableTextEditor extends React.Component<
     }
     // Sync value from props, but not when we are responding to incoming patches
     // (if this is the case, we sync the value after the incoming patches has been processed - see createWithPatches plugin)
+    const isPristineEditor =
+      !prevProps.value && this.slateInstance.children === this.state.initialSlateEditorValue
     if (
       this.props.value !== prevProps.value &&
-      (!prevProps.value || this.readOnly || !this.props.incomingPatches$)
+      (isPristineEditor || this.readOnly || !this.props.incomingPatches$)
     ) {
       this.syncValue()
     }
@@ -280,7 +282,11 @@ export class PortableTextEditor extends React.Component<
         <PortableTextEditorValueContext.Provider value={this.props.value}>
           <PortableTextEditorReadOnlyContext.Provider value={Boolean(this.props.readOnly)}>
             <PortableTextEditorSelectionContext.Provider value={this.selectionRef.current}>
-              <Slate onChange={NOOP} editor={this.slateInstance} value={this.state.initialValue}>
+              <Slate
+                onChange={NOOP}
+                editor={this.slateInstance}
+                value={this.state.initialSlateEditorValue}
+              >
                 {this.props.children}
               </Slate>
             </PortableTextEditorSelectionContext.Provider>

--- a/packages/@sanity/portable-text-editor/src/editor/PortableTextEditor.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/PortableTextEditor.tsx
@@ -99,7 +99,6 @@ export type PortableTextEditorProps = PropsWithChildren<{
 
 export interface PortableTextEditorState {
   invalidValueResolution: InvalidValueResolution | null
-  selection: EditorSelection | null
   initialValue: Descendant[]
 }
 export class PortableTextEditor extends React.Component<
@@ -119,7 +118,8 @@ export class PortableTextEditor extends React.Component<
   private editable?: EditableAPI
   private pendingPatches: Patch[] = []
   private returnedPatches: Patch[] = []
-  hasPendingLocalPatches: React.MutableRefObject<boolean | null>
+  private selectionRef: React.MutableRefObject<EditorSelection | null>
+  private hasPendingLocalPatches: React.MutableRefObject<boolean | null>
 
   constructor(props: PortableTextEditorProps) {
     super(props)
@@ -131,9 +131,10 @@ export class PortableTextEditor extends React.Component<
     this.hasPendingLocalPatches = React.createRef()
     this.hasPendingLocalPatches.current = false
 
+    this.selectionRef = React.createRef()
+
     this.state = {
       invalidValueResolution: null,
-      selection: null,
       initialValue: [], // Created in the constructor
     }
 
@@ -185,7 +186,7 @@ export class PortableTextEditor extends React.Component<
           break
         case 'selection':
           onChange(next)
-          this.setState({selection: next.selection})
+          this.selectionRef.current = next.selection
           break
         default:
           onChange(next)
@@ -278,7 +279,7 @@ export class PortableTextEditor extends React.Component<
       <PortableTextEditorContext.Provider value={this}>
         <PortableTextEditorValueContext.Provider value={this.props.value}>
           <PortableTextEditorReadOnlyContext.Provider value={Boolean(this.props.readOnly)}>
-            <PortableTextEditorSelectionContext.Provider value={this.state.selection}>
+            <PortableTextEditorSelectionContext.Provider value={this.selectionRef.current}>
               <Slate onChange={NOOP} editor={this.slateInstance} value={this.state.initialValue}>
                 {this.props.children}
               </Slate>

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPatches.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPatches.ts
@@ -118,7 +118,7 @@ export function createWithPatches({
 
       // Sync the with props.value in PortableTextEditor after we have processed batches of incoming patches.
       // This is only for consistency checking against the props.value, so it can be debounced without problems.
-      const syncValueAfterIncomingPatches = debounce(() => syncValue(), 100, {
+      const syncValueAfterIncomingPatches = debounce(() => syncValue(), 0, {
         trailing: true,
         leading: false,
       })

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPlaceholderBlock.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPlaceholderBlock.ts
@@ -1,8 +1,6 @@
 import {Transforms, Descendant} from 'slate'
 import {PortableTextMemberSchemaTypes, PortableTextSlateEditor} from '../../types/editor'
 import {debugWithName} from '../../utils/debug'
-import {withoutPatching} from '../../utils/withoutPatching'
-import {withoutSaving} from './createWithUndoRedo'
 
 const debug = debugWithName('plugin:withPlaceholderBlock')
 
@@ -38,25 +36,20 @@ export function createWithPlaceholderBlock({
     const {onChange} = editor
     // Make sure there's a placeholder block present if the editor's children become empty
     editor.onChange = () => {
+      const hadSelection = !!editor.selection
       onChange()
       if (editor.children.length === 0) {
-        const hadSelection = !!editor.selection
-        withoutPatching(editor, () => {
-          withoutSaving(editor, () => {
-            debug('Inserting placeholder block')
-            Transforms.deselect(editor)
-            Transforms.insertNodes(editor, editor.createPlaceholderBlock(), {
-              at: [0],
-            })
-            if (hadSelection) {
-              Transforms.select(editor, {
-                focus: {path: [0, 0], offset: 0},
-                anchor: {path: [0, 0], offset: 0},
-              })
-              editor.onChange()
-            }
+        debug('Inserting placeholder block')
+        Transforms.deselect(editor)
+        // Set the value directly without using transforms as we don't want this to be producing any patches
+        editor.children = [editor.createPlaceholderBlock()]
+        if (hadSelection) {
+          Transforms.select(editor, {
+            focus: {path: [0, 0], offset: 0},
+            anchor: {path: [0, 0], offset: 0},
           })
-        })
+        }
+        editor.onChange()
       }
     }
     return editor

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPlaceholderBlock.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPlaceholderBlock.ts
@@ -40,6 +40,7 @@ export function createWithPlaceholderBlock({
     editor.onChange = () => {
       onChange()
       if (editor.children.length === 0) {
+        const hadSelection = !!editor.selection
         withoutPatching(editor, () => {
           withoutSaving(editor, () => {
             debug('Inserting placeholder block')
@@ -47,11 +48,13 @@ export function createWithPlaceholderBlock({
             Transforms.insertNodes(editor, editor.createPlaceholderBlock(), {
               at: [0],
             })
-            Transforms.select(editor, {
-              focus: {path: [0, 0], offset: 0},
-              anchor: {path: [0, 0], offset: 0},
-            })
-            editor.onChange()
+            if (hadSelection) {
+              Transforms.select(editor, {
+                focus: {path: [0, 0], offset: 0},
+                anchor: {path: [0, 0], offset: 0},
+              })
+              editor.onChange()
+            }
           })
         })
       }

--- a/packages/@sanity/portable-text-editor/src/utils/patchToOperations.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/patchToOperations.ts
@@ -377,7 +377,7 @@ function isKeyedSegment(segment: PathSegment): segment is KeyedSegment {
 }
 
 // Helper function to find the last part of a patch path that has a known key
-function findLastKey(path: Path) {
+function findLastKey(path: Path): string | null {
   let key: string | null = null
 
   path

--- a/packages/@sanity/portable-text-editor/src/utils/patchToOperations.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/patchToOperations.ts
@@ -90,9 +90,12 @@ export function createPatchToOperations(
         KEY_TO_SLATE_ELEMENT.get(editor)
       ) as Descendant[]
       const posKey = findLastKey(patch.path)
-      const index = editor.children.findIndex((node, indx) => {
-        return posKey ? node._key === posKey : indx === patch.path[0]
-      })
+      const index = Math.max(
+        0,
+        editor.children.findIndex((node, indx) => {
+          return posKey ? node._key === posKey : indx === patch.path[0]
+        })
+      )
       const normalizedIdx = position === 'after' ? index + 1 : index
       debug(`Inserting blocks at path [${normalizedIdx}]`)
       debugState(editor, 'before')

--- a/packages/@sanity/portable-text-editor/test/__tests__/writingTogether.collaborative.test.ts
+++ b/packages/@sanity/portable-text-editor/test/__tests__/writingTogether.collaborative.test.ts
@@ -14,7 +14,7 @@ const initialValue: PortableTextBlock[] = [
 ]
 
 // @todo reenable when flakey tests are resolved
-describe.skip('collaborate editing', () => {
+describe('collaborate editing', () => {
   it('will have the same start value for editor A and B', async () => {
     await setDocumentValue(initialValue)
     const editors = await getEditors()
@@ -118,34 +118,7 @@ describe.skip('collaborate editing', () => {
       ]
     `)
     const selA = await editorA.getSelection()
-    expect(selA).toMatchInlineSnapshot(`
-      Object {
-        "anchor": Object {
-          "offset": 0,
-          "path": Array [
-            Object {
-              "_key": "B-2",
-            },
-            "children",
-            Object {
-              "_key": "B-3",
-            },
-          ],
-        },
-        "focus": Object {
-          "offset": 0,
-          "path": Array [
-            Object {
-              "_key": "B-2",
-            },
-            "children",
-            Object {
-              "_key": "B-3",
-            },
-          ],
-        },
-      }
-    `)
+    expect(selA).toMatchInlineSnapshot(`null`)
     await editorA.pressKey('2')
     valA = await editorA.getValue()
     valB = await editorB.getValue()


### PR DESCRIPTION
### Description

There is an issue in the PTE where if you have editor A and editor B, and A deletes all the content, a raise condition may occur:

If client B receives the deletion, and afterwards client A writes in new content - this initial block is duplicated in client B's editor and we risk a duplicate keys error in all clients as the duplicated blocks are already propagated to the document store through patching being done by client B.

The reason this happens is because we had an invalid test for equality between the server value and the editor state in the case where the editor value is longer (array) than the server value. To add to the problem there are also side effects by creating the placeholder block (a non existing block for the user to type into in an empty editor) by text operations which will produce insert patches.

The solution is to fix the equality test defect,  and to create the placeholder block without using operations  (but rather just put it straight to the editor's children) - then patch from anything there  (as opposed to creating that placeholder block by actual transformations / patches).

Related to this I also found an issue with the selection for a local client is not being reset properly when the document is emptied remotely by another client.

I also moved the stored selection in PortableTextEditor  to a ref instead, as we potentially want to use it even in a unmounted component state (we hade some occasional React dev warnings about this debugging the above issue).

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

That the duplication error is no longer reproducible.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Fixes a potential raise condition with duplicate keys when an editor deletes all the content of a portable text editor, while other clients are within that document, and then starts to type new content.

<!--
A description of the change(s) that should be used in the release notes.
-->
