### PR TITLE
fix(desk-tool) invalidate form state between different document types

### DIFF
--- a/dev/test-studio/schema/debug/fieldGroups.js
+++ b/dev/test-studio/schema/debug/fieldGroups.js
@@ -53,5 +53,33 @@ export default {
       ],
     },
     {name: 'field5', type: 'string', group: 'group3'},
+    {
+      name: 'arrayWithFieldGroups',
+      type: 'array',
+      of: [
+        {type: 'fieldGroups'},
+        {
+          type: 'object',
+          groups: [
+            {name: 'group21', title: 'Group 2 / group 1'},
+            {name: 'group22', title: 'Group 2 / group 2'},
+          ],
+          fields: [
+            {
+              type: 'string',
+              name: 'group21',
+              group: 'group21',
+              title: 'string in group 1 in group 2',
+            },
+            {
+              type: 'string',
+              name: 'group22',
+              group: 'group22',
+              title: 'string in group 2 in group 2',
+            },
+          ],
+        },
+      ],
+    },
   ],
 }

--- a/dev/test-studio/structure/resolveStructure.ts
+++ b/dev/test-studio/structure/resolveStructure.ts
@@ -219,7 +219,16 @@ export const structure: StructureResolver = (S, {schema, documentStore}) => {
 
               // A "singleton" which should use a default preview
               S.documentListItem().id('jrr-tolkien').schemaType('author'),
-
+              S.listItem()
+                .id('field-groups-test-1')
+                .title('Field groups test 1')
+                .child(S.document().documentId('field-groups-test-1').schemaType('fieldGroups')),
+              S.listItem()
+                .id('field-groups-test-2')
+                .title('Field groups test 2')
+                .child(
+                  S.document().documentId('field-groups-test-2').schemaType('fieldGroupsMany')
+                ),
               S.listItem()
                 .title('Deep')
                 .child(

--- a/packages/sanity/src/desk/panes/document/DocumentPane.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentPane.tsx
@@ -138,7 +138,12 @@ function DocumentPaneInner(props: DocumentPaneProviderProps) {
   }
 
   return (
-    <DocumentPaneProvider {...providerProps}>
+    <DocumentPaneProvider
+      // this needs to be here to avoid formState from being re-used across (incompatible) document types
+      // see https://github.com/sanity-io/sanity/discussions/3794 for a description of the problem
+      key={documentType}
+      {...providerProps}
+    >
       {/* NOTE: this is a temporary location for this provider until we */}
       {/* stabilize the reference input options formally in the form builder */}
       {/* eslint-disable-next-line react/jsx-pascal-case */}


### PR DESCRIPTION
### Description

This supersedes #4038 and fixes the root cause of the issue described in https://github.com/sanity-io/sanity/discussions/3794

Background: when switching between documents, form state like expanded/collapsed state, field group selection etc. is preserved. This means that e.g. the field groups you have selected in one document will be kept selected if you switch to another document of the same type. This is argueably a _feature_ and makes it easier to edit a field that is normally hidden behind field groups across many documents without having to drill down into the field group every time you go to the next document (That said, I can see that it is can also be a bit _unexpected_ behavior).

In any case, when switching between two documents of _different_ types, this can in some cases trigger the error described in https://github.com/sanity-io/sanity/discussions/3794 because the field groups structure doesn't match between the two schemas. This PR fixes the issue by making sure we force the document pane provider to unmount + remount when the document type changes.

Thoughts?

### What to review
- 9d9cbc348282e0555599ad1faef9809ff0cae3a3 includes a repro case that can be tested on https://test-studio-8dbh5k252.sanity.build/test/content/custom;field-groups-test-1. It should crash if you do some field groups selections and toggle between "Field groups test 1" and "Field groups test 2"
- 9fdeaf1530b21ef0945e2a3deefa0c6c5c9ac866 includes the fix and should not crash when following the above instructions. Can be tested here: http://test-studio-jmqec7x2d.sanity.build/test/content/custom;field-groups-test-1

### Notes for release

- Fixes an issue that in certain situations caused the Studio to crash when switching between documents of different types
