### PR TITLE
feat(cli): merge user vite config object

### DIFF
--- a/packages/@sanity/cli/src/types.ts
+++ b/packages/@sanity/cli/src/types.ts
@@ -3,6 +3,7 @@ import type chalk from 'chalk'
 import type {Ora} from 'ora'
 import type {SanityClient} from '@sanity/client'
 import type {Separator, DistinctQuestion, Answers, ChoiceCollection} from 'inquirer'
+import type {InlineConfig} from 'vite'
 import type {ClientRequirements} from './util/clientWrapper'
 import type {CliConfigResult} from './util/getCliConfig'
 import type {CliPackageManager} from './packageManager'
@@ -284,6 +285,5 @@ export interface CliConfig {
 
   graphql?: GraphQLAPIConfig[]
 
-  // @todo
-  vite?: (config: any) => any
+  vite?: InlineConfig | ((config: InlineConfig) => InlineConfig)
 }

--- a/packages/@sanity/cli/src/types.ts
+++ b/packages/@sanity/cli/src/types.ts
@@ -3,7 +3,7 @@ import type chalk from 'chalk'
 import type {Ora} from 'ora'
 import type {SanityClient} from '@sanity/client'
 import type {Separator, DistinctQuestion, Answers, ChoiceCollection} from 'inquirer'
-import type {InlineConfig} from 'vite'
+import type {InlineConfig, ConfigEnv} from 'vite'
 import type {ClientRequirements} from './util/clientWrapper'
 import type {CliConfigResult} from './util/getCliConfig'
 import type {CliPackageManager} from './packageManager'
@@ -285,5 +285,9 @@ export interface CliConfig {
 
   graphql?: GraphQLAPIConfig[]
 
-  vite?: InlineConfig | ((config: InlineConfig) => InlineConfig)
+  vite?: UserViteConfig
 }
+
+export type UserViteConfig =
+  | InlineConfig
+  | ((config: InlineConfig, env: ConfigEnv) => InlineConfig | Promise<InlineConfig>)

--- a/packages/@sanity/cli/typings/vite.d.ts
+++ b/packages/@sanity/cli/typings/vite.d.ts
@@ -1,0 +1,11 @@
+/* eslint-disable @typescript-eslint/no-empty-interface */
+
+/**
+ * Rely on declaration merging so that this package doesn't have
+ * to depend on `vite` directly
+ * @see UserViteConfig
+ */
+declare module 'vite' {
+  export interface InlineConfig {}
+  export interface ConfigEnv {}
+}

--- a/packages/sanity/src/_internal/cli/server/buildStaticFiles.ts
+++ b/packages/sanity/src/_internal/cli/server/buildStaticFiles.ts
@@ -1,8 +1,9 @@
 import path from 'path'
 import fs from 'fs/promises'
 import {constants as fsConstants} from 'fs'
-import {build, InlineConfig} from 'vite'
+import {build} from 'vite'
 import readPkgUp from 'read-pkg-up'
+import type {UserViteConfig} from '@sanity/cli'
 import {ensureTrailingSlash} from '../util/ensureTrailingSlash'
 import {extendViteConfigWithUserConfig, finalizeViteConfig, getViteConfig} from './getViteConfig'
 import {generateWebManifest} from './webManifest'
@@ -30,7 +31,7 @@ export interface StaticBuildOptions {
   profile?: boolean
   sourceMap?: boolean
 
-  vite?: InlineConfig | ((config: InlineConfig) => InlineConfig)
+  vite?: UserViteConfig
 }
 
 export async function buildStaticFiles(
@@ -49,18 +50,23 @@ export async function buildStaticFiles(
   await writeSanityRuntime({cwd, reactStrictMode: false, watch: false, basePath})
 
   debug('Resolving vite config')
+  const mode = 'production'
   let viteConfig = await getViteConfig({
     cwd,
     basePath,
     outputDir,
     minify,
     sourceMap,
-    mode: 'production',
+    mode,
   })
 
   // Extend Vite configuration with user-provided config
   if (extendViteConfig) {
-    viteConfig = extendViteConfigWithUserConfig(viteConfig, extendViteConfig)
+    viteConfig = await extendViteConfigWithUserConfig(
+      {command: 'build', mode},
+      viteConfig,
+      extendViteConfig
+    )
     viteConfig = finalizeViteConfig(viteConfig)
   }
 

--- a/packages/sanity/src/_internal/cli/server/buildStaticFiles.ts
+++ b/packages/sanity/src/_internal/cli/server/buildStaticFiles.ts
@@ -4,7 +4,7 @@ import {constants as fsConstants} from 'fs'
 import {build, InlineConfig} from 'vite'
 import readPkgUp from 'read-pkg-up'
 import {ensureTrailingSlash} from '../util/ensureTrailingSlash'
-import {finalizeViteConfig, getViteConfig} from './getViteConfig'
+import {extendViteConfigWithUserConfig, finalizeViteConfig, getViteConfig} from './getViteConfig'
 import {generateWebManifest} from './webManifest'
 import {writeSanityRuntime} from './runtime'
 import {debug as serverDebug} from './debug'
@@ -30,7 +30,7 @@ export interface StaticBuildOptions {
   profile?: boolean
   sourceMap?: boolean
 
-  vite?: (config: InlineConfig) => InlineConfig
+  vite?: InlineConfig | ((config: InlineConfig) => InlineConfig)
 }
 
 export async function buildStaticFiles(
@@ -58,9 +58,10 @@ export async function buildStaticFiles(
     mode: 'production',
   })
 
+  // Extend Vite configuration with user-provided config
   if (extendViteConfig) {
-    debug('Extending vite config with user-specified config')
-    viteConfig = finalizeViteConfig(extendViteConfig(viteConfig))
+    viteConfig = extendViteConfigWithUserConfig(viteConfig, extendViteConfig)
+    viteConfig = finalizeViteConfig(viteConfig)
   }
 
   // Copy files placed in /static to the built /static

--- a/packages/sanity/src/_internal/cli/server/devServer.ts
+++ b/packages/sanity/src/_internal/cli/server/devServer.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 import {createServer, InlineConfig} from 'vite'
-import {getViteConfig} from './getViteConfig'
+import {extendViteConfigWithUserConfig, getViteConfig} from './getViteConfig'
 import {debug} from './debug'
 import {writeSanityRuntime} from './runtime'
 
@@ -14,7 +14,7 @@ export interface DevServerOptions {
   projectName?: string
 
   reactStrictMode: boolean
-  vite?: (config: InlineConfig) => InlineConfig
+  vite?: InlineConfig | ((config: InlineConfig) => InlineConfig)
 }
 
 export interface DevServer {
@@ -36,9 +36,9 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
     cwd,
   })
 
+  // Extend Vite configuration with user-provided config
   if (extendViteConfig) {
-    debug('Extending vite config using user-specified function')
-    viteConfig = extendViteConfig(viteConfig)
+    viteConfig = extendViteConfigWithUserConfig(viteConfig, extendViteConfig)
   }
 
   debug('Creating vite server')

--- a/packages/sanity/src/_internal/cli/server/devServer.ts
+++ b/packages/sanity/src/_internal/cli/server/devServer.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk'
-import {createServer, InlineConfig} from 'vite'
+import {createServer} from 'vite'
+import type {UserViteConfig} from '@sanity/cli'
 import {extendViteConfigWithUserConfig, getViteConfig} from './getViteConfig'
 import {debug} from './debug'
 import {writeSanityRuntime} from './runtime'
@@ -14,7 +15,7 @@ export interface DevServerOptions {
   projectName?: string
 
   reactStrictMode: boolean
-  vite?: InlineConfig | ((config: InlineConfig) => InlineConfig)
+  vite?: UserViteConfig
 }
 
 export interface DevServer {
@@ -29,6 +30,7 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
   await writeSanityRuntime({cwd, reactStrictMode, watch: true, basePath})
 
   debug('Resolving vite config')
+  const mode = 'development'
   let viteConfig = await getViteConfig({
     basePath,
     mode: 'development',
@@ -38,7 +40,11 @@ export async function startDevServer(options: DevServerOptions): Promise<DevServ
 
   // Extend Vite configuration with user-provided config
   if (extendViteConfig) {
-    viteConfig = extendViteConfigWithUserConfig(viteConfig, extendViteConfig)
+    viteConfig = await extendViteConfigWithUserConfig(
+      {command: 'serve', mode},
+      viteConfig,
+      extendViteConfig
+    )
   }
 
   debug('Creating vite server')

--- a/packages/sanity/src/_internal/cli/server/getViteConfig.ts
+++ b/packages/sanity/src/_internal/cli/server/getViteConfig.ts
@@ -1,8 +1,9 @@
 import path from 'path'
-import {InlineConfig, mergeConfig} from 'vite'
+import {ConfigEnv, InlineConfig, mergeConfig} from 'vite'
 import viteReact from '@vitejs/plugin-react'
 import readPkgUp from 'read-pkg-up'
 import debug from 'debug'
+import {UserViteConfig} from '@sanity/cli'
 import {getAliases} from './aliases'
 import {normalizeBasePath} from './helpers'
 import {loadSanityMonorepo} from './sanityMonorepo'
@@ -174,16 +175,16 @@ export function finalizeViteConfig(config: InlineConfig): InlineConfig {
  * @returns Merged configuration
  * @internal
  */
-export function extendViteConfigWithUserConfig(
+export async function extendViteConfigWithUserConfig(
+  env: ConfigEnv,
   defaultConfig: InlineConfig,
-  userConfig: InlineConfig | ((config: InlineConfig) => InlineConfig)
-): InlineConfig {
-  // Create deep clone to avoid directly mutating
-  let config = mergeConfig(defaultConfig, {})
+  userConfig: UserViteConfig
+): Promise<InlineConfig> {
+  let config = defaultConfig
 
   if (typeof userConfig === 'function') {
     debug('Extending vite config using user-specified function')
-    config = userConfig(defaultConfig)
+    config = await userConfig(config, env)
   } else if (typeof userConfig === 'object') {
     debug('Merging vite config using user-specified object')
     config = mergeConfig(config, userConfig)

--- a/packages/sanity/src/_internal/cli/server/previewServer.ts
+++ b/packages/sanity/src/_internal/cli/server/previewServer.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk'
 import {InlineConfig, preview} from 'vite'
 import {debug as serverDebug} from './debug'
 import {sanityBasePathRedirectPlugin} from './vite/plugin-sanity-basepath-redirect'
+import {extendViteConfigWithUserConfig} from './getViteConfig'
 
 const debug = serverDebug.extend('preview')
 
@@ -19,7 +20,7 @@ export interface PreviewServerOptions {
   httpPort: number
   httpHost?: string
 
-  vite?: (config: InlineConfig) => InlineConfig
+  vite?: InlineConfig | ((config: InlineConfig) => InlineConfig)
 }
 
 export async function startPreviewServer(options: PreviewServerOptions): Promise<PreviewServer> {
@@ -59,9 +60,9 @@ export async function startPreviewServer(options: PreviewServerOptions): Promise
     },
   }
 
+  // Extend Vite configuration with user-provided config
   if (extendViteConfig) {
-    debug('Extending vite config using user-specified function')
-    previewConfig = extendViteConfig(previewConfig)
+    previewConfig = extendViteConfigWithUserConfig(previewConfig, extendViteConfig)
   }
 
   debug('Creating vite server')

--- a/packages/sanity/src/_internal/cli/server/previewServer.ts
+++ b/packages/sanity/src/_internal/cli/server/previewServer.ts
@@ -23,7 +23,7 @@ export interface PreviewServerOptions {
 }
 
 export async function startPreviewServer(options: PreviewServerOptions): Promise<PreviewServer> {
-  const {httpPort, httpHost, root} = options
+  const {httpPort, httpHost, root, vite: extendViteConfig} = options
   const startTime = Date.now()
 
   const indexPath = path.join(root, 'index.html')
@@ -43,7 +43,7 @@ export async function startPreviewServer(options: PreviewServerOptions): Promise
     throw error
   }
 
-  const previewConfig: InlineConfig = {
+  let previewConfig: InlineConfig = {
     root,
     base: basePath || '/',
     plugins: [sanityBasePathRedirectPlugin(basePath)],
@@ -57,6 +57,11 @@ export async function startPreviewServer(options: PreviewServerOptions): Promise
     build: {
       outDir: root,
     },
+  }
+
+  if (extendViteConfig) {
+    debug('Extending vite config using user-specified function')
+    previewConfig = extendViteConfig(previewConfig)
   }
 
   debug('Creating vite server')


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->
- (Fix?) Respect user configuration when running `sanity preview`
- Allow user to pass configuration object that will be merged into default Vite configuration
- Align user configuration function with Vite's API by [passing context as second argument](https://vitejs.dev/config/#conditional-config) and accept a Promise:
```ts
import {defineCliConfig} from 'sanity/cli'
import {mergeConfig} from 'vite'

export default defineCliConfig({
  // ...rest of config

  async vite(config, {command, mode}){
    const target = await getProxyTarget()

    return mergeConfig(config, {
      server: {
        proxy: {
          "/api": {
            target,
            changeOrigin: true,
            secure: false,
            rewrite: (path) => path.replace(/^\/api/, ""),
          },
        },
      },
    })
  }
})
```

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->
1. Bootstrap a new Sanity Studio v3 project, with TypeScript
2. In `sanity.config.ts` add a `vite` property to check Intellisense and add:
```ts
import {defineCliConfig} from 'sanity/cli'

export default defineCliConfig({
  // ...rest of config

  vite: {
    server: {
      open: true
    }
  }
})
```

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
