### PR TITLE
fix(schema): Disallows fieldnames that are already defined

### DIFF
--- a/packages/@sanity/schema/src/sanity/validation/types/file.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/file.ts
@@ -9,6 +9,10 @@ export default (typeDef, visitorContext) => {
     problems.push(...validateFields(fields, {allowEmpty: true}))
   }
 
+  const invalidFieldNames = Array.isArray(fields)
+    ? fields?.filter((field) => field.name === 'asset')
+    : []
+
   if (
     typeDef.options &&
     typeof typeDef.options.metadata !== 'undefined' &&
@@ -20,6 +24,8 @@ export default (typeDef, visitorContext) => {
         HELP_IDS.ASSET_METADATA_FIELD_INVALID
       )
     )
+  } else if (invalidFieldNames.length > 0) {
+    problems.push(error('The name `asset` is not a valid field name for type `file`.'))
   }
 
   return {

--- a/packages/@sanity/schema/src/sanity/validation/types/image.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/image.ts
@@ -17,8 +17,10 @@ export default (typeDef, visitorContext) => {
     ? metadata.filter((meta) => autoMeta.includes(meta))
     : []
 
-  const invalidFieldNames = Array.isArray(fields)
-    ? fields?.filter((field) => field.name === 'asset')
+  const invalidFieldNames = ['asset', 'hotspot', 'crop']
+
+  const fieldsWithInvalidName = Array.isArray(fields)
+    ? fields?.filter((field) => invalidFieldNames.includes(field.name))
     : []
 
   if (typeof metadata !== 'undefined' && !Array.isArray(metadata)) {
@@ -37,8 +39,14 @@ export default (typeDef, visitorContext) => {
       )
     )
     options = {...options, metadata: metadata.filter((meta) => !autoMeta.includes(meta))}
-  } else if (invalidFieldNames.length > 0) {
-    problems.push(error('The name `asset` is not a valid field name for type `Image` .'))
+  } else if (fieldsWithInvalidName.length > 0) {
+    problems.push(
+      error(
+        `The names \`${invalidFieldNames.join(
+          '`, `'
+        )}\` are invalid field names for type \`image\`.`
+      )
+    )
   }
 
   return {

--- a/packages/@sanity/schema/src/sanity/validation/types/image.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/image.ts
@@ -17,6 +17,10 @@ export default (typeDef, visitorContext) => {
     ? metadata.filter((meta) => autoMeta.includes(meta))
     : []
 
+  const invalidFieldNames = Array.isArray(fields)
+    ? fields?.filter((field) => field.name === 'asset')
+    : []
+
   if (typeof metadata !== 'undefined' && !Array.isArray(metadata)) {
     problems.push(
       error(
@@ -33,6 +37,8 @@ export default (typeDef, visitorContext) => {
       )
     )
     options = {...options, metadata: metadata.filter((meta) => !autoMeta.includes(meta))}
+  } else if (invalidFieldNames.length > 0) {
+    problems.push(error('The name `asset` is not a valid field name for type `Image` .'))
   }
 
   return {


### PR DESCRIPTION
### Description

Link to story: https://app.shortcut.com/sanity-io/story/22859/schema-validation-disallow-already-defined-fields-on-image-file 

Schema validation: Disallows field names `'asset', 'hotspot', 'crop'` for type `Image`, and `'asset'` for type `File`. 

![Screenshot 2023-01-09 at 16 39 18](https://user-images.githubusercontent.com/44635000/211347166-44b2e486-3a3c-4508-b0e5-f4a87c69c7c1.png)

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Add invalid field names for the type `Image` or `File` in the schema to see the error message. 

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Fix(schema): Schema validation: Disallow already defined fields on `image`, `file`

<!--
A description of the change(s) that should be used in the release notes.
-->
