### PR TITLE
Fix focus navigation issue inside of block in PTE

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
@@ -115,6 +115,7 @@ export function BlockObject(props: BlockObjectProps) {
         onClickingEdit={openItem}
         readOnly={readOnly}
         renderPreview={renderPreview}
+        isOpen={memberItem?.member.open}
         type={type}
         value={block}
       />

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObjectPreview.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObjectPreview.tsx
@@ -32,6 +32,7 @@ interface BlockObjectPreviewProps {
   renderPreview: RenderPreviewCallback
   type: ObjectSchemaType
   value: PortableTextBlock
+  isOpen?: boolean
 }
 
 const POPOVER_PROPS: MenuButtonProps['popover'] = {
@@ -51,6 +52,7 @@ export function BlockObjectPreview(props: BlockObjectPreviewProps): ReactElement
     renderPreview,
     type,
     value,
+    isOpen,
   } = props
   const {isTopLayer} = useLayer()
   const editor = usePortableTextEditor()
@@ -85,7 +87,7 @@ export function BlockObjectPreview(props: BlockObjectPreviewProps): ReactElement
           PortableTextEditor.focus(editor)
         }
         if (event.key === 'Tab') {
-          if (menuButton.current && !isTabbing.current) {
+          if (menuButton.current && !isTabbing.current && !isOpen) {
             event.preventDefault()
             event.stopPropagation()
             menuButton.current.focus()


### PR DESCRIPTION
### Description

This fixes the tab navigation focus inside of a block within PTE

### What to review

First test:
1. In the test studio go to "Block Test"
2. Pick a document and scroll down to `With geopoints` portable text editor
3. Add geographical point -> let the modal open
4. Use tab to navigate the inputs and make sure that you can and it doesn't escape to the PTE beneath

https://user-images.githubusercontent.com/6951139/211536689-bf96256d-5046-4598-9e3b-39c8605ddbd2.mov

Second test:
1. 1. In the test studio go to "Block Test"
2. Pick a document and scroll down to `With geopoints` portable text editor
3. Add geographical point -> close the modal
4. Single click on the geopoint component (select it, but don't open it)
5. Use tab to navigate through the menu items

https://user-images.githubusercontent.com/6951139/211536988-b69a1ff5-a701-42c4-b9ef-ea6d2cb4d2fc.mov

### Notes for release

Fix focus navigation when in a component within Portable Text Editor
