### PR TITLE
fix(core): `useFormValue` lagging one iteration behind

### DIFF
--- a/packages/sanity/src/core/form/useFormValue.ts
+++ b/packages/sanity/src/core/form/useFormValue.ts
@@ -1,8 +1,4 @@
-import {Path, SanityDocument} from '@sanity/types'
-import {isEqual} from 'lodash'
-import {useEffect, useMemo, useState} from 'react'
-import {Subject} from 'rxjs'
-import {distinctUntilChanged, map} from 'rxjs/operators'
+import {Path} from '@sanity/types'
 import {getValueAtPath} from '../field'
 import {useUnique} from '../util'
 import {useFormBuilder} from './useFormBuilder'
@@ -12,30 +8,7 @@ import {useFormBuilder} from './useFormBuilder'
  */
 export function useFormValue(path: Path): unknown {
   const uniquePath = useUnique(path)
-  const {getDocument, patchChannel} = useFormBuilder().__internal
-  const documentValueSubject = useMemo(() => new Subject<SanityDocument | undefined>(), [])
-  const documentValue$ = useMemo(() => documentValueSubject.asObservable(), [documentValueSubject])
-  const [value, setValue] = useState(() => getValueAtPath(getDocument(), uniquePath))
+  const {value} = useFormBuilder()
 
-  // Subscribe to all document changes
-  useEffect(
-    () => patchChannel.subscribe(() => documentValueSubject.next(getDocument())),
-    [documentValueSubject, getDocument, patchChannel]
-  )
-
-  // Subscribe to value at `path`
-  useEffect(() => {
-    const value$ = documentValue$.pipe(
-      map((documentValue) =>
-        uniquePath.length === 0 ? documentValue : getValueAtPath(documentValue, uniquePath)
-      ),
-      distinctUntilChanged((x, y) => isEqual(x, y))
-    )
-
-    const sub = value$.subscribe(setValue)
-
-    return () => sub.unsubscribe()
-  }, [documentValue$, uniquePath])
-
-  return value
+  return getValueAtPath(value, uniquePath)
 }


### PR DESCRIPTION
### Description

This PR simplifies and fixes an issue with `useFormValue` hook lagging one iteration behind

### What to review

Test the hook and make sure you get value that is up to date

### Notes for release

Fix issue with `useFormValue` lagging one iteration behind