### PR TITLE
fix(pte): duplication in pte, backport to v2 from v3 fix

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPatches.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPatches.ts
@@ -114,7 +114,7 @@ export function createWithPatches({
 
       // Sync the with props.value in PortableTextEditor after we have processed batches of incoming patches.
       // This is only for consistency checking against the props.value, so it can be debounced without problems.
-      const syncValueAfterIncomingPatches = debounce(() => syncValue(), 100, {
+      const syncValueAfterIncomingPatches = debounce(() => syncValue(), 0, {
         trailing: true,
         leading: false,
       })

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPlaceholderBlock.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPlaceholderBlock.ts
@@ -39,22 +39,20 @@ export function createWithPlaceholderBlock({
     const {onChange} = editor
     // Make sure there's a placeholder block present if the editor's children become empty
     editor.onChange = () => {
+      const hadSelection = !!editor.selection
       onChange()
       if (editor.children.length === 0) {
-        withoutPatching(editor, () => {
-          withoutSaving(editor, () => {
-            debug('Inserting placeholder block')
-            Transforms.deselect(editor)
-            Transforms.insertNodes(editor, editor.createPlaceholderBlock(), {
-              at: [0],
-            })
-            Transforms.select(editor, {
-              focus: {path: [0, 0], offset: 0},
-              anchor: {path: [0, 0], offset: 0},
-            })
-            editor.onChange()
+        debug('Inserting placeholder block')
+        Transforms.deselect(editor)
+        // Set the value directly without using transforms as we don't want this to be producing any patches
+        editor.children = [editor.createPlaceholderBlock()]
+        if (hadSelection) {
+          Transforms.select(editor, {
+            focus: {path: [0, 0], offset: 0},
+            anchor: {path: [0, 0], offset: 0},
           })
-        })
+        }
+        editor.onChange()
       }
     }
     return editor

--- a/packages/@sanity/portable-text-editor/src/utils/patchToOperations.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/patchToOperations.ts
@@ -90,9 +90,12 @@ export function createPatchToOperations(
         KEY_TO_SLATE_ELEMENT.get(editor)
       ) as Descendant[]
       const posKey = findLastKey(patch.path)
-      const index = editor.children.findIndex((node, indx) => {
-        return posKey ? node._key === posKey : indx === patch.path[0]
-      })
+      const index = Math.max(
+        0,
+        editor.children.findIndex((node, indx) => {
+          return posKey ? node._key === posKey : indx === patch.path[0]
+        })
+      )
       const normalizedIdx = position === 'after' ? index + 1 : index
       debug(`Inserting blocks at path [${normalizedIdx}]`)
       debugState(editor, 'before')
@@ -378,7 +381,7 @@ function isKeyedSegment(segment: PathSegment): segment is KeyedSegment {
 }
 
 // Helper function to find the last part of a patch path that has a known key
-function findLastKey(path: Path) {
+function findLastKey(path: Path): string | null {
   let key: string | null = null
 
   path

--- a/packages/@sanity/portable-text-editor/test/__tests__/writingTogether.collaborative.test.ts
+++ b/packages/@sanity/portable-text-editor/test/__tests__/writingTogether.collaborative.test.ts
@@ -120,34 +120,7 @@ describe('collaborate editing', () => {
       ]
     `)
     const selA = await editorA.getSelection()
-    expect(selA).toMatchInlineSnapshot(`
-      Object {
-        "anchor": Object {
-          "offset": 0,
-          "path": Array [
-            Object {
-              "_key": "randomKey0",
-            },
-            "children",
-            Object {
-              "_key": "randomKey1",
-            },
-          ],
-        },
-        "focus": Object {
-          "offset": 0,
-          "path": Array [
-            Object {
-              "_key": "randomKey0",
-            },
-            "children",
-            Object {
-              "_key": "randomKey1",
-            },
-          ],
-        },
-      }
-    `)
+    expect(selA).toMatchInlineSnapshot(`null`)
     await editorA.pressKey('2')
     valA = await editorB.getValue()
     valB = await editorB.getValue()


### PR DESCRIPTION
### Description
This is a backporting of the fix that was done for v3 (https://github.com/sanity-io/sanity/pull/4049) 

There is an issue in the PTE where if you have editor A and editor B, and A deletes all the content, a raise condition may occur:

If client B receives the deletion, and afterwards client A writes in new content - this initial block is duplicated in client B's editor and we risk a duplicate keys error in all clients as the duplicated blocks are already propagated to the document store through patching being done by client B.

The reason this happens is because we had an invalid test for equality between the server value and the editor state in the case where the editor value is longer (array) than the server value. To add to the problem there are also side effects by creating the placeholder block (a non existing block for the user to type into in an empty editor) by text operations which will produce insert patches.

The solution is to fix the equality test defect, and to create the placeholder block without using operations (but rather just put it straight to the editor's children) - then patch from anything there (as opposed to creating that placeholder block by actual transformations / patches).

Related to this I also found an issue with the selection for a local client is not being reset properly when the document is emptied remotely by another client.

I also moved the stored selection in PortableTextEditor to a ref instead, as we potentially want to use it even in a unmounted component state (we hade some occasional React dev warnings about this debugging the above issue).

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

That the duplication error is no longer reproducible.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fixes a potential raise condition with duplicate keys when an editor deletes all the content of a portable text editor, while other clients are within that document, and then starts to type new content.
<!--
A description of the change(s) that should be used in the release notes.
-->
