### PR TITLE
fix: add missing default export to `groq` for the `node` ESM wrapper

### DIFF
--- a/packages/groq/node/groq.mjs
+++ b/packages/groq/node/groq.mjs
@@ -1,0 +1,4 @@
+// eslint-disable-next-line import/extensions
+import cjs from '../lib/groq.js'
+
+export default cjs.groq

--- a/packages/groq/package.json
+++ b/packages/groq/package.json
@@ -31,7 +31,7 @@
       "source": "./src/groq.ts",
       "require": "./lib/groq.js",
       "node": {
-        "import": "./lib/groq.cjs.mjs",
+        "import": "./node/groq.mjs",
         "require": "./lib/groq.js"
       },
       "import": "./lib/groq.esm.js",


### PR DESCRIPTION
### Description

The `3.2.0` release of `groq` yesterday introduced a regression bug that breaks Node.js ESM runtimes that makes calls like these:
```js
import groq from 'groq'
// throws `TypeError: groq__WEBPACK_IMPORTED_MODULE_1__.default is not a function` in Next.js apps at runtime
```
It's because `@sanity/pkg-utils` are only able to generate re-exports that are named, default exports aren't handled:
https://unpkg.com/browse/groq@3.2.0/lib/groq.cjs.mjs

### What to review

Projects that use `import {groq} from 'next-sanity'` are unaffected as `next-sanity` is shipping its own ESM to CJS Node.js wrapper.

### Notes for release

- fix: regression in `groq@3.2.0` that is missing a default export affecting Node.js ESM runtimes.
