### PR TITLE
fix: add the node folder to the npm publish allowlist

### DIFF
--- a/packages/groq/package.json
+++ b/packages/groq/package.json
@@ -45,6 +45,7 @@
   "types": "./lib/dts/src/groq.d.ts",
   "files": [
     "lib",
+    "node",
     "src"
   ],
   "scripts": {


### PR DESCRIPTION
### Description

The #4085 doesn't work because I forgot to add `node` to the `pkg.files` list, so the fix isn't included in the published package on npm 😭 

### Notes for release

- fix: the `groq` hotfix in `v3.2.1` is missing from npm as since it's not declared in the `pkg.files` allowlist. It's included now in `v3.2.2`. But since publishing JS is a bit like quantum physics it might still be missing. If that's the case then by the time you read this message we'll already be working on a `v3.2.3` release 🫣
