### PR TITLE
fix(core): improve read only visibility of tags array

### DIFF
--- a/packages/sanity/src/core/form/components/tagInput/tagInput.tsx
+++ b/packages/sanity/src/core/form/components/tagInput/tagInput.tsx
@@ -5,7 +5,7 @@ import styled, {css} from 'styled-components'
 import type {CSSObject} from 'styled-components'
 import {focusRingBorderStyle, focusRingStyle} from './styles'
 
-const Root = styled(Box)((props: {theme: Theme}): CSSObject => {
+const Root = styled(Card)((props: {theme: Theme}): CSSObject => {
   const {theme} = props
   const {focusRing, input, radius} = theme.sanity
   const color = theme.sanity.color.input
@@ -15,7 +15,6 @@ const Root = styled(Box)((props: {theme: Theme}): CSSObject => {
     position: 'relative',
     borderRadius: `${radius[1]}px`,
     color: color.default.enabled.fg,
-    backgroundColor: color.default.enabled.bg,
     boxShadow: focusRingBorderStyle({
       color: color.default.enabled.border,
       width: input.border.width,
@@ -120,6 +119,11 @@ const Placeholder = styled(Box)((props: {theme: Theme}) => {
     --card-fg-color: ${color.default.enabled.placeholder};
   `
 })
+
+const TagBox = styled(Box)`
+  // This is needed to make textOverflow="ellipsis" work properly for the Text primitive
+  max-width: 100%;
+`
 
 export const TagInput = forwardRef(
   (
@@ -232,6 +236,7 @@ export const TagInput = forwardRef(
         data-read-only={readOnly ? '' : undefined}
         data-ui="TagInput"
         onPointerDown={handleRootPointerDown}
+        overflow="auto"
         padding={1}
         ref={rootRef}
       >
@@ -244,15 +249,15 @@ export const TagInput = forwardRef(
         <div className="content">
           {value.map((tag, tagIndex) => (
             // eslint-disable-next-line react/no-array-index-key
-            <div key={`tag-${tagIndex}`}>
+            <TagBox key={`tag-${tagIndex}`}>
               <Tag
                 enabled={enabled}
                 index={tagIndex}
-                muted={disabled}
+                muted={!enabled}
                 onRemove={handleTagRemove}
                 tag={tag}
               />
-            </div>
+            </TagBox>
           ))}
 
           <div key="tag-input">
@@ -293,7 +298,9 @@ function Tag(props: {
     <Card data-ui="Tag" padding={1} radius={2} tone="transparent">
       <Flex align="center">
         <Box flex={1} padding={1}>
-          <Text muted={muted}>{tag.value}</Text>
+          <Text muted={muted} textOverflow="ellipsis">
+            {tag.value}
+          </Text>
         </Box>
 
         {enabled && (

--- a/packages/sanity/src/core/form/inputs/__workshop__/TagInputStory.tsx
+++ b/packages/sanity/src/core/form/inputs/__workshop__/TagInputStory.tsx
@@ -1,0 +1,27 @@
+import {Container, Flex} from '@sanity/ui'
+import {useBoolean} from '@sanity/ui-workshop'
+import React, {useCallback, useState} from 'react'
+import {TagInput} from '../../components/tagInput'
+
+interface Tag {
+  value: string
+}
+
+const INITIAL_VALUE: Tag[] = [{value: 'foo'}, {value: 'bar'}, {value: 'baz'}]
+
+export default function TagInputStory() {
+  const readOnly = useBoolean('readOnly', false)
+  const [tags, setTags] = useState<Tag[]>(INITIAL_VALUE)
+
+  const handleChange = useCallback((nextValue: Tag[]) => {
+    setTags(nextValue)
+  }, [])
+
+  return (
+    <Flex align="center" height="fill">
+      <Container width={1} padding={4}>
+        <TagInput value={tags} onChange={handleChange} readOnly={readOnly} />
+      </Container>
+    </Flex>
+  )
+}

--- a/packages/sanity/src/core/form/inputs/__workshop__/index.ts
+++ b/packages/sanity/src/core/form/inputs/__workshop__/index.ts
@@ -1,0 +1,14 @@
+import {defineScope} from '@sanity/ui-workshop'
+import {lazy} from 'react'
+
+export default defineScope({
+  name: 'sanity/form/inputs',
+  title: 'Inputs',
+  stories: [
+    {
+      name: 'tag-input',
+      title: 'TagInput',
+      component: lazy(() => import('./TagInputStory')),
+    },
+  ],
+})


### PR DESCRIPTION
### Description

This PR improves the read only visibility of the tags input array.
<img width="920" alt="tags" src="https://user-images.githubusercontent.com/15094168/212072726-1ab998fb-475c-4432-b4c4-4cafdae71b8b.png">

### What to review

- Does the UI look good?

### Notes for release

Improve read only visibility of tags array input
