### PR TITLE
fix: actually fix the `groq` bug and include tests that prove it

### DIFF
--- a/packages/groq/node/groq.mjs
+++ b/packages/groq/node/groq.mjs
@@ -1,4 +1,4 @@
 // eslint-disable-next-line import/extensions
 import cjs from '../lib/groq.js'
 
-export default cjs.groq
+export default cjs

--- a/packages/groq/package.json
+++ b/packages/groq/package.json
@@ -54,7 +54,8 @@
     "postbuild": "run-s check:package",
     "check:package": "pkg-utils --strict --tsconfig tsconfig.lib.json",
     "clean": "rimraf lib",
-    "test": "node test/groq.test.js",
+    "pretest": "run-s build",
+    "test": "node test/groq.test.cjs && node test/groq.test.mjs ",
     "watch": "pkg-utils watch --tsconfig tsconfig.lib.json"
   },
   "engines": {

--- a/packages/groq/test/groq.test.cjs
+++ b/packages/groq/test/groq.test.cjs
@@ -1,6 +1,16 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-const assert = require('assert')
-const groq = require('../src/groq')
+'use strict'
+// Integration test for the Node.js CJS runtime
+
+const {strict: assert} = require('node:assert')
+
+const groq = require('groq')
+
+assert.equal(typeof groq, 'function')
+
+// Ensure it's possible to check what version of groq is being used
+const pkg = require('groq/package.json')
+
+assert.equal(typeof pkg.version, 'string')
 
 assert.equal(groq`foo${'bar'}`, `foo${'bar'}`)
 assert.equal(groq`${'bar'}`, `${'bar'}`)

--- a/packages/groq/test/groq.test.mjs
+++ b/packages/groq/test/groq.test.mjs
@@ -1,0 +1,19 @@
+// Integration test for the Node.js ESM runtime
+
+import {strict as assert} from 'node:assert'
+
+import groq from 'groq'
+// Ensure it's possible to check what version of groq being used
+import pkg from 'groq/package.json' assert {type: 'json'}
+
+assert.equal(typeof groq, 'function')
+assert.equal(typeof pkg.version, 'string')
+
+assert.equal(groq`foo${'bar'}`, `foo${'bar'}`)
+assert.equal(groq`${'bar'}`, `${'bar'}`)
+assert.equal(groq``, ``)
+assert.equal(groq`${'foo'}`, `${'foo'}`)
+assert.equal(groq`${/foo/}bar`, `${/foo/}bar`)
+assert.equal(groq`${'foo'}bar${347}`, `${'foo'}bar${347}`)
+assert.equal(groq`${'foo'}bar${347}${/qux/}`, `${'foo'}bar${347}${/qux/}`)
+assert.equal(groq`${'foo'}${347}qux`, `${'foo'}${347}qux`)


### PR DESCRIPTION
### Description

Third time's the charm.

### Notes for release

- fix: issue in the Node.js runtime wrapper causing the `groq` tagged template literal to sometimes be undefined
