### PR TITLE
fix(form/inputs): fix issues with custom style component rendering 

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/text/Style.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/Style.tsx
@@ -1,10 +1,9 @@
-import {Text} from '@sanity/ui'
 import {BlockStyleRenderProps} from '@sanity/portable-text-editor'
 import React, {useCallback, useMemo} from 'react'
-import {Normal as FallbackComponent, TEXT_STYLES} from './textStyles'
+import {Custom as CustomStyle, Normal as FallbackComponent, TEXT_STYLES} from './textStyles'
 
 export const Style = (props: BlockStyleRenderProps) => {
-  const {block, focused, children, selected, type, value} = props
+  const {block, focused, children, selected, type} = props
   const DefaultComponent = useMemo(
     () =>
       (block.style && TEXT_STYLES[block.style] ? TEXT_STYLES[block.style] : TEXT_STYLES[0]) ||
@@ -16,23 +15,22 @@ export const Style = (props: BlockStyleRenderProps) => {
     () => <DefaultComponent>{children}</DefaultComponent>,
     [DefaultComponent, children]
   )
-  const _renderDefault = useCallback(() => defaultRendered, [defaultRendered])
+
+  const renderDefault = useCallback(() => defaultRendered, [defaultRendered])
 
   const CustomComponent = type.component
   if (CustomComponent) {
     return (
-      <Text data-testid={`text-style--${value}`}>
-        <CustomComponent
-          block={block}
-          title={type.title}
-          value={type.value}
-          selected={selected}
-          focused={focused}
-          renderDefault={_renderDefault}
-        >
-          {children}
-        </CustomComponent>
-      </Text>
+      <CustomComponent
+        block={block}
+        title={type.title}
+        value={type.value}
+        selected={selected}
+        focused={focused}
+        renderDefault={renderDefault}
+      >
+        <CustomStyle data-testid={`text-style--${block.style}`}>{children}</CustomStyle>
+      </CustomComponent>
     )
   }
   return defaultRendered

--- a/packages/sanity/src/core/form/inputs/PortableText/text/Style.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/Style.tsx
@@ -1,6 +1,6 @@
-import {BlockStyleRenderProps} from '@sanity/portable-text-editor'
 import React, {useCallback, useMemo} from 'react'
-import {Custom as CustomStyle, Normal as FallbackComponent, TEXT_STYLES} from './textStyles'
+import {BlockStyleRenderProps} from '@sanity/portable-text-editor'
+import {Normal as FallbackComponent, TEXT_STYLES, TextContainer} from './textStyles'
 
 export const Style = (props: BlockStyleRenderProps) => {
   const {block, focused, children, selected, type} = props
@@ -29,7 +29,7 @@ export const Style = (props: BlockStyleRenderProps) => {
         focused={focused}
         renderDefault={renderDefault}
       >
-        <CustomStyle data-testid={`text-style--${block.style}`}>{children}</CustomStyle>
+        <TextContainer data-testid={`text-style--${block.style}`}>{children}</TextContainer>
       </CustomComponent>
     )
   }

--- a/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.styles.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.styles.ts
@@ -34,6 +34,8 @@ function textBlockStyle(props: TextBlockStyleProps & {theme: Theme}) {
       right: -${space[1]}px;
       border-radius: ${radius[2]}px;
       background-color: var(--marker-bg-color);
+      // This is to make sure the marker is always behind the text
+      z-index: -1;
     }
 
     &[data-markers] {

--- a/packages/sanity/src/core/form/inputs/PortableText/text/textStyles.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/textStyles.tsx
@@ -10,6 +10,12 @@ export const TextContainer = styled.div`
   display: block;
 `
 
+/**
+ * Component for wrapping children inside a user's custom style component.
+ * This ensures that we have a TextContainer there (see comment above).
+ */
+export const Custom = ({children}: TextStyleProps) => <TextContainer>{children}</TextContainer>
+
 export const Normal = ({children, ...rest}: TextStyleProps) => (
   <Text data-testid="text-style--normal" {...rest}>
     <TextContainer>{children}</TextContainer>

--- a/packages/sanity/src/core/form/inputs/PortableText/text/textStyles.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/textStyles.tsx
@@ -5,53 +5,70 @@ import styled from 'styled-components'
 type TextStyleProps = Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'ref'>
 type BlockQuoteStyleProps = Omit<React.HTMLProps<HTMLQuoteElement>, 'as' | 'ref'>
 
-// Without this container, editing with Android breaks due to how Text is styled via responsiveFont in @sanity/ui
+/**
+ * Without this container, editing with Android breaks due to how Text is styled via `responsiveFont` in `@sanity/ui`
+ */
 export const TextContainer = styled.div`
   display: block;
 `
 
 /**
- * Component for wrapping children inside a user's custom style component.
- * This ensures that we have a TextContainer there (see comment above).
+ * Portable Text Input built in style
  */
-export const Custom = ({children}: TextStyleProps) => <TextContainer>{children}</TextContainer>
-
 export const Normal = ({children, ...rest}: TextStyleProps) => (
   <Text data-testid="text-style--normal" {...rest}>
     <TextContainer>{children}</TextContainer>
   </Text>
 )
 
+/**
+ * Styled component for Portable Text 'h1' style
+ */
 export const Heading1 = ({children, ...rest}: TextStyleProps) => (
   <Heading as="h1" data-testid="text-style--h1" size={5} {...rest}>
     <TextContainer>{children}</TextContainer>
   </Heading>
 )
 
+/**
+ * Styled component for Portable Text 'h2' style
+ */
 export const Heading2 = ({children, ...rest}: TextStyleProps) => (
   <Heading as="h2" data-testid="text-style--h2" size={4} {...rest}>
     <TextContainer>{children}</TextContainer>
   </Heading>
 )
 
+/**
+ * Styled component for Portable Text 'h3' style
+ */
 export const Heading3 = ({children, ...rest}: TextStyleProps) => (
   <Heading as="h3" data-testid="text-style--h3" size={3} {...rest}>
     <TextContainer>{children}</TextContainer>
   </Heading>
 )
 
+/**
+ * Styled component for Portable Text 'h4' style
+ */
 export const Heading4 = ({children, ...rest}: TextStyleProps) => (
   <Heading as="h4" data-testid="text-style--h4" size={2} {...rest}>
     <TextContainer>{children}</TextContainer>
   </Heading>
 )
 
+/**
+ * Styled component for Portable Text 'h5' style
+ */
 export const Heading5 = ({children, ...rest}: TextStyleProps) => (
   <Heading as="h5" data-testid="text-style--h5" size={1} {...rest}>
     <TextContainer>{children}</TextContainer>
   </Heading>
 )
 
+/**
+ * Styled component for Portable Text 'h6' style
+ */
 export const Heading6 = ({children, ...rest}: TextStyleProps) => (
   <Heading as="h6" data-testid="text-style--h6" size={0} {...rest}>
     <TextContainer>{children}</TextContainer>
@@ -75,13 +92,18 @@ const BlockQuoteRoot = styled.blockquote`
   }
 `
 
+/**
+ * Styled component for Portable Text 'blockquote' style
+ */
 export const BlockQuote = ({children, ...rest}: TextStyleProps) => (
-  // @todo figure out props typings for BlockQuoteStyleProps
-  <BlockQuoteRoot data-testid="text-style--blockquote" {...(rest as any as BlockQuoteStyleProps)}>
+  <BlockQuoteRoot data-testid="text-style--blockquote" {...(rest as BlockQuoteStyleProps)}>
     <Text as="p">{children}</Text>
   </BlockQuoteRoot>
 )
 
+/**
+ * Portable Text built in styles.
+ */
 export const TEXT_STYLES: Record<string, React.ComponentType<TextStyleProps>> = {
   normal: Normal,
   h1: Heading1,


### PR DESCRIPTION
### Description

The background for this PR is that we needed to wrap all text content inside the Portable Text Editor as @sanity/ui text for them to render properly in the editor. When a Sanity/UI Text element was missing, the text would be impossible to put the cursor in by the mouse, and the text were hidden behind the error/warning overlay when those were displayed.

We can not require that the implementor of a custom style component knows about, or should need to care about using Sanity/UI texts in their custom components. Currently we have worked our way around t his by wrapping the custom component in a Text. But this causes issues the moment you would like to use like a Sanity/UI `Heading` in your custom component (`Text` takes presedence).

The problem turned out to be an issue with the z-index on the text block error/warning overlays (thanks @hermanwikner).
By removing the Text workaround and specifying a z-index on the overlay, everything is now working as it should. 

Notes for release:
* Fixes a styling issue with custom style components for text blocks in the Portable Text Input.
