### PR TITLE
fix(core): popover wrap button to allow replacing uploaded image

### DIFF
--- a/packages/sanity/src/core/form/inputs/files/FileInput/FileActionsMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/FileActionsMenu.tsx
@@ -15,7 +15,7 @@ type Props = {
   onMenuOpen: (flag: boolean) => void
 }
 
-export function FileDetails(props: Props) {
+export function FileActionsMenu(props: Props) {
   const {originalFilename, size, children, muted, disabled, onClick, isMenuOpen, onMenuOpen} = props
 
   const [menuElement, setMenuRef] = useState<HTMLDivElement | null>(null)

--- a/packages/sanity/src/core/form/inputs/files/FileInput/FileInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/FileInput.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable no-undef, import/no-unresolved */
+/* eslint-disable import/no-unresolved,react/jsx-handler-names, react/display-name, react/no-this-in-sfc */
 
 import React, {ReactNode} from 'react'
 import {Observable, Subscription} from 'rxjs'
@@ -41,7 +41,7 @@ import {ImperativeToast} from '../../../../components'
 import {ChangeIndicator} from '../../../../changeIndicators'
 import {FIXME} from '../../../../FIXME'
 import {CardOverlay, FlexContainer} from './styles'
-import {FileDetails} from './FileDetails'
+import {FileActionsMenu} from './FileActionsMenu'
 import {FileSkeleton} from './FileSkeleton'
 import {InvalidFileWarning} from './InvalidFileWarning'
 
@@ -430,7 +430,7 @@ export class BaseFileInput extends React.PureComponent<BaseFileInputProps, BaseF
           }
 
           return (
-            <FileDetails
+            <FileActionsMenu
               size={size}
               originalFilename={filename}
               muted={!readOnly}
@@ -447,7 +447,7 @@ export class BaseFileInput extends React.PureComponent<BaseFileInputProps, BaseF
                 accept={accept}
                 directUploads={directUploads}
               />
-            </FileDetails>
+            </FileActionsMenu>
           )
         }}
       </WithReferencedAsset>

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageActionsMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageActionsMenu.tsx
@@ -1,9 +1,7 @@
-import React, {MouseEventHandler, ReactNode} from 'react'
+import React, {MouseEventHandler, ReactNode, useState} from 'react'
 import {EllipsisVerticalIcon, CropIcon} from '@sanity/icons'
-import {Button, Inline, Menu, MenuButton, MenuButtonProps} from '@sanity/ui'
+import {Button, Inline, Menu, MenuButton, Popover, useClickOutside} from '@sanity/ui'
 import styled from 'styled-components'
-
-const POPOVER_PROPS: MenuButtonProps['popover'] = {portal: true, constrainSize: true}
 
 export const MenuActionsWrapper = styled(Inline)`
   position: absolute;
@@ -17,10 +15,29 @@ interface ImageActionsMenuProps {
   setHotspotButtonElement: (element: HTMLButtonElement | null) => void
   setMenuButtonElement: (element: HTMLButtonElement | null) => void
   showEdit: boolean
+  isMenuOpen: boolean
+  onMenuOpen: (flag: boolean) => void
 }
 
 export function ImageActionsMenu(props: ImageActionsMenuProps) {
-  const {onEdit, children, showEdit, setHotspotButtonElement, setMenuButtonElement} = props
+  const {
+    onEdit,
+    children,
+    showEdit,
+    setHotspotButtonElement,
+    setMenuButtonElement,
+    onMenuOpen,
+    isMenuOpen,
+  } = props
+
+  const [menuElement, setMenuRef] = useState<HTMLDivElement | null>(null)
+
+  const handleClick = React.useCallback(() => onMenuOpen(true), [onMenuOpen])
+
+  useClickOutside(
+    React.useCallback(() => onMenuOpen(false), [onMenuOpen]),
+    [menuElement]
+  )
 
   return (
     <MenuActionsWrapper data-buttons space={1} padding={2}>
@@ -37,16 +54,17 @@ export function ImageActionsMenu(props: ImageActionsMenuProps) {
 
       <MenuButton
         button={
-          <Button
-            aria-label="Open image options menu"
-            data-testid="options-menu-button"
-            icon={EllipsisVerticalIcon}
-            mode="ghost"
-          />
+          <Popover content={<Menu ref={setMenuRef}>{children}</Menu>} portal open={isMenuOpen}>
+            <Button
+              aria-label="Open image options menu"
+              data-testid="options-menu-button"
+              icon={EllipsisVerticalIcon}
+              mode="ghost"
+              onClick={handleClick}
+            />
+          </Popover>
         }
         id="image-actions-menu"
-        menu={<Menu>{children}</Menu>}
-        popover={POPOVER_PROPS}
         ref={setMenuButtonElement}
       />
     </MenuActionsWrapper>

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageActionsMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageActionsMenu.tsx
@@ -1,6 +1,6 @@
 import React, {MouseEventHandler, ReactNode, useState} from 'react'
 import {EllipsisVerticalIcon, CropIcon} from '@sanity/icons'
-import {Button, Inline, Menu, MenuButton, Popover, useClickOutside} from '@sanity/ui'
+import {Button, Inline, Menu, Popover, useClickOutside} from '@sanity/ui'
 import styled from 'styled-components'
 
 export const MenuActionsWrapper = styled(Inline)`
@@ -13,22 +13,13 @@ interface ImageActionsMenuProps {
   children: ReactNode
   onEdit: MouseEventHandler<HTMLButtonElement>
   setHotspotButtonElement: (element: HTMLButtonElement | null) => void
-  setMenuButtonElement: (element: HTMLButtonElement | null) => void
   showEdit: boolean
   isMenuOpen: boolean
   onMenuOpen: (flag: boolean) => void
 }
 
 export function ImageActionsMenu(props: ImageActionsMenuProps) {
-  const {
-    onEdit,
-    children,
-    showEdit,
-    setHotspotButtonElement,
-    setMenuButtonElement,
-    onMenuOpen,
-    isMenuOpen,
-  } = props
+  const {onEdit, children, showEdit, setHotspotButtonElement, onMenuOpen, isMenuOpen} = props
 
   const [menuElement, setMenuRef] = useState<HTMLDivElement | null>(null)
 
@@ -52,21 +43,21 @@ export function ImageActionsMenu(props: ImageActionsMenuProps) {
         />
       )}
 
-      <MenuButton
-        button={
-          <Popover content={<Menu ref={setMenuRef}>{children}</Menu>} portal open={isMenuOpen}>
-            <Button
-              aria-label="Open image options menu"
-              data-testid="options-menu-button"
-              icon={EllipsisVerticalIcon}
-              mode="ghost"
-              onClick={handleClick}
-            />
-          </Popover>
-        }
+      <Popover
         id="image-actions-menu"
-        ref={setMenuButtonElement}
-      />
+        content={<Menu ref={setMenuRef}>{children}</Menu>}
+        portal
+        open={isMenuOpen}
+        constrainSize
+      >
+        <Button
+          aria-label="Open image options menu"
+          data-testid="options-menu-button"
+          icon={EllipsisVerticalIcon}
+          mode="ghost"
+          onClick={handleClick}
+        />
+      </Popover>
     </MenuActionsWrapper>
   )
 }

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
@@ -83,8 +83,8 @@ type FileInfo = {
   type: string // mime type
   kind: string // 'file' or 'string'
 }
-/** @internal */
-export interface BaseImageInputState {
+
+interface BaseImageInputState {
   isUploading: boolean
   selectedAssetSource: AssetSource | null
   // Metadata about files currently over the drop area
@@ -172,7 +172,7 @@ export class BaseImageInput extends React.PureComponent<BaseImageInputProps, Bas
     return uploader ? [{type: schemaType, uploader}] : []
   }
 
-  uploadFirstAccepted(files: globalThis.File[]) {
+  uploadFirstAccepted(files: File[]) {
     const {schemaType, resolveUploader} = this.props
 
     const match = files
@@ -726,8 +726,6 @@ export class BaseImageInput extends React.PureComponent<BaseImageInputProps, Bas
 
     // todo: convert this to a functional component and use this with useCallback
     //  it currently has to return a new function on every render in order to pick up state from this component
-    // eslint-disable react/display-name
-    // eslint-disable react/no-this-in-sfc
     return (inputProps: Omit<InputProps, 'renderDefault'>) => (
       <>
         {isStale && (

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
@@ -141,10 +141,6 @@ export class BaseImageInput extends React.PureComponent<BaseImageInputProps, Bas
     this._assetElementRef = el
   }
 
-  setMenuButtonElement = (el: HTMLButtonElement | null) => {
-    this.setState({menuButtonElement: el})
-  }
-
   setHotspotButtonElement = (el: HTMLButtonElement | null) => {
     this.setState({hotspotButtonElement: el})
   }
@@ -518,7 +514,6 @@ export class BaseImageInput extends React.PureComponent<BaseImageInputProps, Bas
               onEdit={this.handleOpenDialog}
               showEdit={showAdvancedEditButton}
               setHotspotButtonElement={this.setHotspotButtonElement}
-              setMenuButtonElement={this.setMenuButtonElement}
               onMenuOpen={(isOpen) => this.setState({isMenuOpen: isOpen})}
               isMenuOpen={this.state.isMenuOpen}
             >

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
@@ -1,4 +1,5 @@
-/* eslint-disable import/no-unresolved,react/jsx-handler-names */
+/* eslint-disable react/jsx-no-bind */
+/* eslint-disable import/no-unresolved,react/jsx-handler-names, react/display-name, react/no-this-in-sfc */
 
 import {
   Box,
@@ -82,8 +83,8 @@ type FileInfo = {
   type: string // mime type
   kind: string // 'file' or 'string'
 }
-
-type BaseImageInputState = {
+/** @internal */
+export interface BaseImageInputState {
   isUploading: boolean
   selectedAssetSource: AssetSource | null
   // Metadata about files currently over the drop area
@@ -91,6 +92,7 @@ type BaseImageInputState = {
   isStale: boolean
   hotspotButtonElement: HTMLButtonElement | null
   menuButtonElement: HTMLButtonElement | null
+  isMenuOpen: boolean
 }
 
 type Focusable = {
@@ -119,6 +121,7 @@ export class BaseImageInput extends React.PureComponent<BaseImageInputProps, Bas
     isStale: false,
     hotspotButtonElement: null,
     menuButtonElement: null,
+    isMenuOpen: false,
   }
 
   constructor(props: BaseImageInputProps) {
@@ -169,7 +172,7 @@ export class BaseImageInput extends React.PureComponent<BaseImageInputProps, Bas
     return uploader ? [{type: schemaType, uploader}] : []
   }
 
-  uploadFirstAccepted(files: File[]) {
+  uploadFirstAccepted(files: globalThis.File[]) {
     const {schemaType, resolveUploader} = this.props
 
     const match = files
@@ -179,6 +182,8 @@ export class BaseImageInput extends React.PureComponent<BaseImageInputProps, Bas
     if (match) {
       this.uploadWith(match.uploader!, match.file)
     }
+
+    this.setState({isMenuOpen: false})
   }
 
   uploadWith = (uploader: Uploader, file: File, assetDocumentProps: UploadOptions = {}) => {
@@ -363,7 +368,6 @@ export class BaseImageInput extends React.PureComponent<BaseImageInputProps, Bas
   handleSelectFiles = (files: File[]) => {
     const {directUploads, readOnly} = this.props
     const {hoveringFiles} = this.state
-
     if (directUploads && !readOnly) {
       this.uploadFirstAccepted(files)
     } else if (hoveringFiles.length > 0) {
@@ -471,6 +475,7 @@ export class BaseImageInput extends React.PureComponent<BaseImageInputProps, Bas
           icon={SearchIcon}
           text="Select"
           onClick={() => {
+            this.setState({isMenuOpen: false})
             this.handleSelectImageFromAssetSource(assetSources[0])
           }}
           disabled={readOnly}
@@ -485,6 +490,7 @@ export class BaseImageInput extends React.PureComponent<BaseImageInputProps, Bas
             key={assetSource.name}
             text={assetSource.title}
             onClick={() => {
+              this.setState({isMenuOpen: false})
               this.handleSelectImageFromAssetSource(assetSource)
             }}
             icon={assetSource.icon || ImageIcon}
@@ -513,6 +519,8 @@ export class BaseImageInput extends React.PureComponent<BaseImageInputProps, Bas
               showEdit={showAdvancedEditButton}
               setHotspotButtonElement={this.setHotspotButtonElement}
               setMenuButtonElement={this.setMenuButtonElement}
+              onMenuOpen={(isOpen) => this.setState({isMenuOpen: isOpen})}
+              isMenuOpen={this.state.isMenuOpen}
             >
               <ActionsMenu
                 onUpload={this.handleSelectFiles}
@@ -557,6 +565,7 @@ export class BaseImageInput extends React.PureComponent<BaseImageInputProps, Bas
                     key={assetSource.name}
                     text={assetSource.title}
                     onClick={() => {
+                      this.setState({isMenuOpen: false})
                       this.handleSelectImageFromAssetSource(assetSource)
                     }}
                     icon={assetSource.icon || ImageIcon}
@@ -579,6 +588,7 @@ export class BaseImageInput extends React.PureComponent<BaseImageInputProps, Bas
         icon={SearchIcon}
         mode="ghost"
         onClick={() => {
+          this.setState({isMenuOpen: false})
           this.handleSelectImageFromAssetSource(assetSources[0])
         }}
         data-testid="file-input-browse-button"
@@ -716,6 +726,8 @@ export class BaseImageInput extends React.PureComponent<BaseImageInputProps, Bas
 
     // todo: convert this to a functional component and use this with useCallback
     //  it currently has to return a new function on every render in order to pick up state from this component
+    // eslint-disable react/display-name
+    // eslint-disable react/no-this-in-sfc
     return (inputProps: Omit<InputProps, 'renderDefault'>) => (
       <>
         {isStale && (


### PR DESCRIPTION
### Description

Fixed issue where when an image was uploaded, it was not possible to upload a new image to replace the existing one. This had to do with the popover disappearing after clicking on `Upload` in the dropdown menu, resulting in a `No file chosen` error. 

Also renamed `FileDetails` to `FileActionsMenu` to match the similar file used for `Image` uploads, as these files have similar functions for uploading files/images.  


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Go to an `Image` field and try to upload a new image, overwriting an existing image that is uploaded. 


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Fixed issue with replacing an image in an `Image` field. 

<!--
A description of the change(s) that should be used in the release notes.
-->
