### PR TITLE
fix(cli): exit if user does not confirm v3 init continuation

### DIFF
--- a/packages/@sanity/cli/src/commands/init/initCommand.ts
+++ b/packages/@sanity/cli/src/commands/init/initCommand.ts
@@ -72,57 +72,61 @@ export const initCommand: CliCommandDefinition<InitFlags> = {
     const {output, chalk, prompt} = context
     const [type] = args.argsWithoutOptions
     const warn = (msg: string) => output.warn(chalk.yellow.bgBlack(msg))
-    if (!type) {
-      if (!args.argv.includes('--from-create')) {
-        warn(
-          '╔═══════════════════════════════════════════════════════════════════════════════════════╗'
-        )
-        warn(
-          "║ \u26A0  Welcome to Sanity! Looks like you're following instructions for Sanity Studio v2,  ║"
-        )
-        warn(
-          '║    but the version you have installed is the latest, Sanity Studio v3.                ║'
-        )
-        warn(
-          '║    In Sanity Studio v3, new projects are created with [npm create sanity@latest].     ║'
-        )
-        warn(
-          '║                                                                                       ║'
-        )
-        warn(
-          '║    Learn more about Sanity Studio v3: https://www.sanity.io/help/studio-v2-vs-v3      ║'
-        )
-        warn(
-          '╚═══════════════════════════════════════════════════════════════════════════════════════╝'
-        )
-        warn('') // Newline to separate from other output
-        const runInitResponse = await prompt.single({
-          message: 'Continue creating a Sanity Studio v3 project?',
-          type: 'confirm',
-        })
-        if (runInitResponse) {
-          return initProject(args, context).then((res) => {
-            warn('╔═══════════════════════════════════════════════════════════════════════════╗')
-            warn(
-              '║ \u24D8  To learn how commands have changed from Studio v2 to v3, check:        ║'
-            )
-            warn('║    https://www.sanity.io/help/studio-v2-vs-v3                             ║')
-            warn('╚═══════════════════════════════════════════════════════════════════════════╝')
-            warn('') // Newline to separate from other output
-            return res
-          })
-        }
-      }
-      return initProject(args, context)
-    }
 
+    // `sanity init plugin`
     if (type === 'plugin') {
       return context.sanityMajorVersion === 2
         ? initPlugin(args, context)
         : Promise.reject(new Error(`'sanity init plugin' is not available in modern studios`))
     }
 
-    return Promise.reject(new Error(`Unknown init type "${type}"`))
+    // `sanity init whatever`
+    if (type) {
+      return Promise.reject(new Error(`Unknown init type "${type}"`))
+    }
+
+    // `npm create sanity` (regular v3 init)
+    if (args.argv.includes('--from-create')) {
+      return initProject(args, context)
+    }
+
+    // `sanity init` (v2 style)
+    warn('╭────────────────────────────────────────────────────────────╮')
+    warn('│                                                            │')
+    warn("│  Welcome to Sanity! It looks like you're following         │")
+    warn('│  instructions for Sanity Studio v2, but the version you    │')
+    warn('│  have installed is the latest - Sanity Studio v3.          │')
+    warn('│                                                            │')
+    warn('│  In Sanity Studio v3, new projects are created by running  │')
+    warn('│  [npm create sanity@latest]. For more information, see     │')
+    warn('│   https://www.sanity.io/help/studio-v2-vs-v3               │')
+    warn('│                                                            │')
+    warn('╰────────────────────────────────────────────────────────────╯')
+    warn('') // Newline to separate from other output
+
+    const continueV3Init = await prompt.single({
+      message: 'Continue creating a Sanity Studio v3 project?',
+      type: 'confirm',
+    })
+
+    // Fall back
+    if (!continueV3Init) {
+      // Indicate that the operation did not succeed as expected
+      // eslint-disable-next-line no-process-exit
+      process.exit(1)
+    }
+
+    const returnVal = await initProject(args, context)
+
+    warn('╭────────────────────────────────────────────────────────────╮')
+    warn('│                                                            │')
+    warn('│  To learn how commands have changed from Studio v2 to v3,  │')
+    warn('│  see https://www.sanity.io/help/studio-v2-vs-v3            │')
+    warn('│                                                            │')
+    warn('╰────────────────────────────────────────────────────────────╯')
+    warn('') // Newline to separate from other output
+
+    return returnVal
   },
 }
 


### PR DESCRIPTION
### Description

When running `sanity init` with the v3 CLI, you will be prompted with a warning indicating you're following v2 installation instructions, and a confirmation prompt will ask the user whether or not to continue initing with a v3 studio. When answering "no" on this dialog, the CLI still continues the init process as if answering yes, however.

This PR fixes this issue, and also adjusts the border look of the message/warning dialog to match branding guideline. Also reduces the amount of nested code - apologies for hard to read diff, but code shouldn't be too hard to follow.

### What to review

- `sanity init` will show prompt
  - answering no will exit
  - answering yes will continue

### Notes for release

- Fixed an issue where answering "no" when being asked whether or not to create a new v3 project would not actually stop the init process
