### PR TITLE
fix(desk): add full timestamp tooltip to timeline items

### DIFF
--- a/packages/sanity/src/desk/panes/document/timeline/__workshop__/DefaultStory.tsx
+++ b/packages/sanity/src/desk/panes/document/timeline/__workshop__/DefaultStory.tsx
@@ -1,0 +1,54 @@
+import React, {useMemo} from 'react'
+import {Box, Card, Inline, Stack, Text} from '@sanity/ui'
+import {DeskToolProvider} from '../../../../DeskToolProvider'
+import type {DocumentPaneNode} from '../../../../types'
+import {DocumentPaneProvider} from '../../DocumentPaneProvider'
+import {TimelineMenu} from '../timelineMenu'
+
+const DOCUMENT_ID = 'test'
+const DOCUMENT_TYPE = 'author'
+
+export default function DefaultStory() {
+  const pane: DocumentPaneNode = useMemo(
+    () => ({
+      id: DOCUMENT_ID,
+      options: {
+        id: DOCUMENT_ID,
+        type: DOCUMENT_TYPE,
+      },
+      type: 'document',
+      title: 'Workshop',
+    }),
+    []
+  )
+
+  return (
+    <DeskToolProvider>
+      <DocumentPaneProvider index={0} itemId={DOCUMENT_ID} pane={pane} paneKey={DOCUMENT_ID}>
+        <Box padding={2}>
+          <Stack space={2}>
+            <Card padding={3} shadow={1} tone="primary">
+              <Stack space={3}>
+                <Inline space={1}>
+                  <Text size={1} weight="medium">
+                    Document ID:
+                  </Text>
+                  <Text size={1}>{DOCUMENT_ID}</Text>
+                </Inline>
+                <Inline space={1}>
+                  <Text size={1} weight="medium">
+                    Document Type:
+                  </Text>
+                  <Text size={1}>{DOCUMENT_TYPE}</Text>
+                </Inline>
+              </Stack>
+            </Card>
+            <Card padding={2}>
+              <TimelineMenu chunk={null} mode="rev" />
+            </Card>
+          </Stack>
+        </Box>
+      </DocumentPaneProvider>
+    </DeskToolProvider>
+  )
+}

--- a/packages/sanity/src/desk/panes/document/timeline/__workshop__/DefaultStory.tsx
+++ b/packages/sanity/src/desk/panes/document/timeline/__workshop__/DefaultStory.tsx
@@ -1,5 +1,5 @@
-import React, {useMemo} from 'react'
 import {Box, Card, Inline, Stack, Text} from '@sanity/ui'
+import React from 'react'
 import {DeskToolProvider} from '../../../../DeskToolProvider'
 import type {DocumentPaneNode} from '../../../../types'
 import {DocumentPaneProvider} from '../../DocumentPaneProvider'
@@ -7,24 +7,20 @@ import {TimelineMenu} from '../timelineMenu'
 
 const DOCUMENT_ID = 'test'
 const DOCUMENT_TYPE = 'author'
+const PANE: DocumentPaneNode = {
+  id: DOCUMENT_ID,
+  options: {
+    id: DOCUMENT_ID,
+    type: DOCUMENT_TYPE,
+  },
+  type: 'document',
+  title: 'Workshop',
+}
 
 export default function DefaultStory() {
-  const pane: DocumentPaneNode = useMemo(
-    () => ({
-      id: DOCUMENT_ID,
-      options: {
-        id: DOCUMENT_ID,
-        type: DOCUMENT_TYPE,
-      },
-      type: 'document',
-      title: 'Workshop',
-    }),
-    []
-  )
-
   return (
     <DeskToolProvider>
-      <DocumentPaneProvider index={0} itemId={DOCUMENT_ID} pane={pane} paneKey={DOCUMENT_ID}>
+      <DocumentPaneProvider index={0} itemId={DOCUMENT_ID} pane={PANE} paneKey={DOCUMENT_ID}>
         <Box padding={2}>
           <Stack space={2}>
             <Card padding={3} shadow={1} tone="primary">

--- a/packages/sanity/src/desk/panes/document/timeline/__workshop__/index.ts
+++ b/packages/sanity/src/desk/panes/document/timeline/__workshop__/index.ts
@@ -1,0 +1,14 @@
+import {defineScope} from '@sanity/ui-workshop'
+import {lazy} from 'react'
+
+export default defineScope({
+  name: 'sanity/desk/documentTimelineMenu',
+  title: 'Document Timeline Menu',
+  stories: [
+    {
+      name: 'default',
+      title: 'Default',
+      component: lazy(() => import('./DefaultStory')),
+    },
+  ],
+})

--- a/packages/sanity/src/desk/panes/document/timeline/timelineItem.styled.tsx
+++ b/packages/sanity/src/desk/panes/document/timeline/timelineItem.styled.tsx
@@ -1,4 +1,4 @@
-import {Text, Box, MenuItem, Theme, Flex} from '@sanity/ui'
+import {Text, Box, MenuItem, Theme, Flex, rem} from '@sanity/ui'
 import styled, {css} from 'styled-components'
 import {TimelineItemState} from './types'
 
@@ -112,4 +112,9 @@ export const IconBox = styled(Box)`
 
 export const EventLabel = styled(Text)`
   text-transform: capitalize;
+`
+
+export const TimestampBox = styled(Box)`
+  min-width: 1rem;
+  margin-left: ${({theme}) => `-${rem(theme.sanity.space[1])}`};
 `

--- a/packages/sanity/src/desk/panes/document/timeline/timelineItem.tsx
+++ b/packages/sanity/src/desk/panes/document/timeline/timelineItem.tsx
@@ -1,10 +1,11 @@
-import React, {useCallback, createElement, useState} from 'react'
-import {Box, Flex, Stack, Text, ButtonTone} from '@sanity/ui'
+import React, {useCallback, createElement, useMemo, useState} from 'react'
+import {Box, ButtonTone, Flex, Stack, Text, Tooltip} from '@sanity/ui'
+import {format} from 'date-fns'
 import {formatTimelineEventLabel, getTimelineEventIconComponent} from './helpers'
 import {TimelineItemState} from './types'
 import {UserAvatarStack} from './userAvatarStack'
 
-import {EventLabel, IconBox, IconWrapper, Root} from './timelineItem.styled'
+import {EventLabel, IconBox, IconWrapper, Root, TimestampBox} from './timelineItem.styled'
 import {ChunkType, Chunk, useTimeAgo} from 'sanity'
 
 const TIMELINE_ITEM_EVENT_TONE: Record<ChunkType | 'withinSelection', ButtonTone> = {
@@ -32,6 +33,12 @@ export function TimelineItem(props: {
   const iconComponent = getTimelineEventIconComponent(type)
   const authorUserIds = Array.from(chunk.authors)
   const timeAgo = useTimeAgo(timestamp, {minimal: true})
+  const formattedTimestamp = useMemo(() => {
+    const parsedDate = new Date(timestamp)
+    const formattedDate = format(parsedDate, 'MMM d, yyyy, hh:mm a')
+
+    return formattedDate
+  }, [timestamp])
 
   const isSelected = state === 'selected'
   const isWithinSelection = state === 'withinSelection'
@@ -48,52 +55,65 @@ export function TimelineItem(props: {
   )
 
   return (
-    <Root
-      data-ui="timelineItem"
-      radius={2}
-      data-chunk-id={chunk.id}
-      paddingY={0}
-      paddingX={2}
-      tone={
-        isHovered || isSelected || isWithinSelection ? 'default' : TIMELINE_ITEM_EVENT_TONE[type]
+    <Tooltip
+      portal
+      placement="left"
+      fallbackPlacements={['bottom']}
+      content={
+        <Stack padding={3} space={3}>
+          <Text size={1}>{formattedTimestamp}</Text>
+        </Stack>
       }
-      pressed={isWithinSelection}
-      state={state}
-      selected={isSelected}
-      isHovered={isHovered}
-      disabled={state === 'disabled'}
-      data-selection-bottom={isSelectionBottom}
-      data-selection-top={isSelectionTop}
-      onClick={handleClick}
     >
-      <div
-        // eslint-disable-next-line react/jsx-no-bind
-        onMouseEnter={() => setHovered(true)}
-        // eslint-disable-next-line react/jsx-no-bind
-        onMouseLeave={() => setHovered(false)}
+      <Root
+        data-ui="timelineItem"
+        radius={2}
+        data-chunk-id={chunk.id}
+        paddingY={0}
+        paddingX={2}
+        tone={
+          isHovered || isSelected || isWithinSelection ? 'default' : TIMELINE_ITEM_EVENT_TONE[type]
+        }
+        pressed={isWithinSelection}
+        state={state}
+        selected={isSelected}
+        isHovered={isHovered}
+        disabled={state === 'disabled'}
+        data-selection-bottom={isSelectionBottom}
+        data-selection-top={isSelectionTop}
+        onClick={handleClick}
       >
-        <Flex align="stretch">
-          <IconWrapper align="center">
-            <IconBox padding={2}>
-              <Text size={2}>{iconComponent && createElement(iconComponent)}</Text>
-            </IconBox>
-          </IconWrapper>
+        <div
+          // eslint-disable-next-line react/jsx-no-bind
+          onMouseEnter={() => setHovered(true)}
+          // eslint-disable-next-line react/jsx-no-bind
+          onMouseLeave={() => setHovered(false)}
+        >
+          <Flex align="stretch">
+            <IconWrapper align="center">
+              <IconBox padding={2}>
+                <Text size={2}>{iconComponent && createElement(iconComponent)}</Text>
+              </IconBox>
+            </IconWrapper>
 
-          <Stack space={2} margin={2}>
-            <Box>
-              <EventLabel size={1} weight="medium">
-                {formatTimelineEventLabel(type) || <code>{type}</code>}
-              </EventLabel>
-            </Box>
-            <Text size={0} muted>
-              {timeAgo}
-            </Text>
-          </Stack>
-          <Flex flex={1} justify="flex-end" align="center">
-            <UserAvatarStack maxLength={3} userIds={authorUserIds} />
+            <Stack space={2} margin={2}>
+              <Box>
+                <EventLabel size={1} weight="medium">
+                  {formatTimelineEventLabel(type) || <code>{type}</code>}
+                </EventLabel>
+              </Box>
+              <TimestampBox paddingX={1}>
+                <Text size={0} muted>
+                  {timeAgo}
+                </Text>
+              </TimestampBox>
+            </Stack>
+            <Flex flex={1} justify="flex-end" align="center">
+              <UserAvatarStack maxLength={3} userIds={authorUserIds} />
+            </Flex>
           </Flex>
-        </Flex>
-      </div>
-    </Root>
+        </div>
+      </Root>
+    </Tooltip>
   )
 }

--- a/packages/sanity/src/desk/panes/document/timeline/timelineItem.tsx
+++ b/packages/sanity/src/desk/panes/document/timeline/timelineItem.tsx
@@ -54,6 +54,7 @@ export function TimelineItem(props: {
     [onSelect, chunk]
   )
 
+  // @todo: ensure that tooltips are correctly displayed when navigating the parent <Menu> component with the keyboard.
   return (
     <Root
       data-ui="timelineItem"

--- a/packages/sanity/src/desk/panes/document/timeline/timelineItem.tsx
+++ b/packages/sanity/src/desk/panes/document/timeline/timelineItem.tsx
@@ -55,39 +55,39 @@ export function TimelineItem(props: {
   )
 
   return (
-    <Tooltip
-      portal
-      placement="left"
-      fallbackPlacements={['bottom']}
-      content={
-        <Stack padding={3} space={3}>
-          <Text size={1}>{formattedTimestamp}</Text>
-        </Stack>
+    <Root
+      data-ui="timelineItem"
+      radius={2}
+      data-chunk-id={chunk.id}
+      padding={0}
+      tone={
+        isHovered || isSelected || isWithinSelection ? 'default' : TIMELINE_ITEM_EVENT_TONE[type]
       }
+      pressed={isWithinSelection}
+      state={state}
+      selected={isSelected}
+      isHovered={isHovered}
+      disabled={state === 'disabled'}
+      data-selection-bottom={isSelectionBottom}
+      data-selection-top={isSelectionTop}
+      onClick={handleClick}
     >
-      <Root
-        data-ui="timelineItem"
-        radius={2}
-        data-chunk-id={chunk.id}
-        paddingY={0}
-        paddingX={2}
-        tone={
-          isHovered || isSelected || isWithinSelection ? 'default' : TIMELINE_ITEM_EVENT_TONE[type]
+      <Tooltip
+        portal
+        placement="left"
+        fallbackPlacements={['bottom']}
+        content={
+          <Stack padding={3} space={3}>
+            <Text size={1}>{formattedTimestamp}</Text>
+          </Stack>
         }
-        pressed={isWithinSelection}
-        state={state}
-        selected={isSelected}
-        isHovered={isHovered}
-        disabled={state === 'disabled'}
-        data-selection-bottom={isSelectionBottom}
-        data-selection-top={isSelectionTop}
-        onClick={handleClick}
       >
-        <div
+        <Box
           // eslint-disable-next-line react/jsx-no-bind
           onMouseEnter={() => setHovered(true)}
           // eslint-disable-next-line react/jsx-no-bind
           onMouseLeave={() => setHovered(false)}
+          paddingX={2}
         >
           <Flex align="stretch">
             <IconWrapper align="center">
@@ -112,8 +112,8 @@ export function TimelineItem(props: {
               <UserAvatarStack maxLength={3} userIds={authorUserIds} />
             </Flex>
           </Flex>
-        </div>
-      </Root>
-    </Tooltip>
+        </Box>
+      </Tooltip>
+    </Root>
   )
 }

--- a/packages/sanity/src/desk/panes/document/timeline/timelineMenu.tsx
+++ b/packages/sanity/src/desk/panes/document/timeline/timelineMenu.tsx
@@ -1,6 +1,5 @@
 import {SelectIcon} from '@sanity/icons'
 import {useClickOutside, Button, Popover, Placement, useGlobalKeyDown} from '@sanity/ui'
-import isHotkey from 'is-hotkey'
 import {upperFirst} from 'lodash'
 import React, {useCallback, useState} from 'react'
 import styled from 'styled-components'
@@ -14,8 +13,6 @@ interface TimelineMenuProps {
   mode: 'rev' | 'since'
   placement?: Placement
 }
-
-const isEscape = isHotkey('escape')
 
 const Root = styled(Popover)`
   & > div {
@@ -59,11 +56,12 @@ export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {
 
   const handleGlobalKeyDown = useCallback(
     (event: KeyboardEvent) => {
-      if (isEscape(event)) {
+      if (open && (event.key === 'Escape' || event.key === 'Tab')) {
         handleClose()
+        button?.focus()
       }
     },
-    [handleClose]
+    [button, handleClose, open]
   )
 
   useClickOutside(handleClickOutside, [menuContent, button])

--- a/packages/sanity/src/desk/panes/document/timeline/timelineMenu.tsx
+++ b/packages/sanity/src/desk/panes/document/timeline/timelineMenu.tsx
@@ -1,5 +1,6 @@
 import {SelectIcon} from '@sanity/icons'
-import {useClickOutside, Button, Popover, Placement} from '@sanity/ui'
+import {useClickOutside, Button, Popover, Placement, useGlobalKeyDown} from '@sanity/ui'
+import isHotkey from 'is-hotkey'
 import {upperFirst} from 'lodash'
 import React, {useCallback, useState} from 'react'
 import styled from 'styled-components'
@@ -13,6 +14,8 @@ interface TimelineMenuProps {
   mode: 'rev' | 'since'
   placement?: Placement
 }
+
+const isEscape = isHotkey('escape')
 
 const Root = styled(Popover)`
   & > div {
@@ -54,7 +57,17 @@ export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {
     handleClose()
   }, [handleClose])
 
+  const handleGlobalKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (isEscape(event)) {
+        handleClose()
+      }
+    },
+    [handleClose]
+  )
+
   useClickOutside(handleClickOutside, [menuContent, button])
+  useGlobalKeyDown(handleGlobalKeyDown)
 
   const selectRev = useCallback(
     (revChunk: Chunk) => {


### PR DESCRIPTION
### Description

V3 port of #3628 with a few minor differences:
- Tooltips are now correctly nested inside (and not around) `MenuItem` components
  - This was previously causing an issue where tooltips were appearing immediately when the Menu was opened, and other odd side-effects (tooltip not appearing on hover)
- History timeline menu can now be dismissed with ESC
- Added workshop story

### Notes for release

- The document history timeline now displays full dates in tooltips on hover