### PR TITLE
refactor(core): remove commented code and deal with "todo" config error screen

### DIFF
--- a/packages/sanity/src/core/studio/screens/ConfigErrorsScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/ConfigErrorsScreen.tsx
@@ -8,6 +8,7 @@ import React from 'react'
 // `
 
 export function ConfigErrorsScreen() {
+  /* This screen is not currently being used anywhere. We're keeping it as a basis for future work */
   return <>TODO: implement config errors screen</>
   // return (
   //   <Root forwardedAs={Flex}>

--- a/packages/sanity/src/core/studio/workspaceLoader/WorkspaceLoader.tsx
+++ b/packages/sanity/src/core/studio/workspaceLoader/WorkspaceLoader.tsx
@@ -158,7 +158,7 @@ function WorkspaceLoaderBoundary({ConfigErrorsComponent, ...props}: WorkspaceLoa
   // TODO: implement this
   // const errors = useMemo(() => flattenErrors(error, []), [error])
 
-  //TODO: implement config error screen
+  //TODO: implement config error screen - a story has been created for this
   // if (error instanceof ConfigResolutionError) return <ConfigErrorsComponent />
 
   // otherwise hand off to other boundaries


### PR DESCRIPTION
### Description

Cleaning up unused code that was related to a error config message.
This no longer happens as the studio lets you know what has gone wrong. Since we don't use it and the code is commented, I think it's best that we remove it!

### What to review

Double check that the removal of the code is clean and won't affect other parts of the studio

