### PR TITLE
fix(core): clear reference fields when replacing links, fix open in new tab links

### DIFF
--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
@@ -292,7 +292,6 @@ export function ReferenceInput(props: ReferenceInputProps) {
             filterOption={NO_FILTER}
             renderOption={renderOption as any}
             renderValue={renderValue}
-            value={value?._ref}
             openButton={{onClick: handleAutocompleteOpenButtonClick}}
           />
 


### PR DESCRIPTION
### Description
- Fixes an issue where clicking the **Open in new tab** button in reference inputs would crash the studio
  - Previously, this was using `EditReferenceLink` (`ReferenceChildLink`) which is used to handle creating links that open to the right
  - It now uses a regular `IntentLink` (similar to v2)
- Fixes an issue where clicking **Replace** in reference inputs would still retain the search query in the `ReferenceAutocomplete` component
  - `ReferenceAutocomplete` now no longer receives a `value` prop, which I believe makes sense given that the autocomplete component isn't rendered when the field has a patched value (this is also the case in v2)
  - Also removed unreachable states in the reference context menu (e.g. `value?._ref && isEditing`) as this menu will never be rendered if `isEditing = true`

### What to review
- Pressing 'replace' in a reference field with a value should clear the search string in the `Autocomplete` component, and clicking outside the `Autocomplete` component (with no changes) should revert to the field's current value
- Opening a reference in a new tab should work

### What this doesn't address
- `<ReferenceAutocomplete>` doesn't trigger `onBlur` when clicking outside of the input component. However, this only seems to happen outside of React 18 strict mode (i.e. when deployed, but not locally). 
  - CDR inputs aren't affected by this, as it makes use of a separate`onClickOutside` hook

### Notes for release

(None)