### PR TITLE
fix(core): remove uploaded image from hoveringFiles

### DIFF
--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
@@ -335,7 +335,7 @@ export class BaseImageInput extends React.PureComponent<BaseImageInputProps, Bas
 
   handleFilesOver = (hoveringFiles: FileInfo[]) => {
     this.setState({
-      hoveringFiles,
+      hoveringFiles: hoveringFiles.filter((file) => file.kind !== 'string'),
     })
   }
   handleFilesOut = () => {
@@ -425,6 +425,7 @@ export class BaseImageInput extends React.PureComponent<BaseImageInputProps, Bas
     const {hoveringFiles} = this.state
 
     const acceptedFiles = hoveringFiles.filter((file) => resolveUploader(schemaType, file))
+
     const rejectedFilesCount = hoveringFiles.length - acceptedFiles.length
     const imageUrl = imageUrlBuilder
       .width(2000)


### PR DESCRIPTION
### Description

Dragging image lead to unexpected behaviors. 
When dragging an uploaded image, an unexpected error message occurred (see video). 

https://user-images.githubusercontent.com/44635000/213460396-2f1e8dc9-083f-4151-b4c4-04cf528ea6ce.mov

By removing the file kind of `string` from the `hoveringFiles` array, the current image that is uploaded is excluded and does not trigger the error message when hovering. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

- Add an image to an image input.
- Drag the same image over the image input.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
Fixes error message triggering when hovering already uploaded image. 