### PR TITLE
fix(desk): Change hardcoded delete word in action dialog to the correct action

### DIFF
--- a/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
+++ b/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
@@ -70,7 +70,7 @@ export function ConfirmDeleteDialogBody({
   if (internalReferences?.totalCount === 0 && crossDatasetReferences?.totalCount === 0) {
     return (
       <Text as="p">
-        Are you sure you want to delete <strong>“{documentTitle}”</strong>?
+        Are you sure you want to {action} <strong>“{documentTitle}”</strong>?
       </Text>
     )
   }


### PR DESCRIPTION
### Description
The action dialog should say "unpublish" and not "delete" when you unpublish a document. 
Changed to use `action` instead of hardcoded `delete`.

https://github.com/sanity-io/sanity/issues/4063

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Try to unpublish/delete document and see that the text is correct. 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
