### PR TITLE
fix(core): add readOnly check for ReferenceAutocomplete dropdown

### DIFF
--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Cache node modules
         id: cache-node-modules
-        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d # v3
+        uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 # v3
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
 
       - name: Cache node modules
         id: cache-node-modules

--- a/.github/workflows/lintChanged.yml
+++ b/.github/workflows/lintChanged.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Cache node modules
         id: cache-node-modules
-        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d # v3
+        uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 # v3
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/lintChanged.yml
+++ b/.github/workflows/lintChanged.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
 
       - name: Cache node modules
         id: cache-node-modules

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -16,7 +16,7 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v4.0.0
+      - uses: dessant/lock-threads@c1b35aecc5cdb1a34539d14196df55838bb2f836 # v4.0.0
         with:
           github-token: ${{ github.token }}
           exclude-issue-created-before: '2022-11-01T00:00:00Z' 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
 
       - name: Setup node
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Cache node modules
         id: cache-node-modules
-        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d # v3
+        uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 # v3
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
 
       - name: Setup node
-        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
         with:
           node-version: ${{ matrix.node }}
 

--- a/dev/test-studio/sanity.cli.ts
+++ b/dev/test-studio/sanity.cli.ts
@@ -15,6 +15,18 @@ export default defineCliConfig({
   vite(viteConfig: UserConfig): UserConfig {
     return {
       ...viteConfig,
+      // server: {
+      //   ...viteConfig.server,
+      //   ...{
+      //     // Listen on all addresses, including LAN and public addresses
+      //     host: true,
+      //     // Specify server port
+      //     port: 3333,
+      //     // Exit if port is already in use,
+      //     // instead of automatically trying the next available port
+      //     strictPort: true,
+      //   },
+      // },
       build: {
         ...viteConfig.build,
         rollupOptions: {

--- a/dev/test-studio/schema/standard/references.ts
+++ b/dev/test-studio/schema/standard/references.ts
@@ -23,6 +23,7 @@ export default defineType({
       type: 'reference',
       description: 'Some description',
       to: {type: 'referenceTest'},
+      readOnly: () => true,
     },
     {
       name: 'selfOrEmpty',

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceAutocomplete.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceAutocomplete.tsx
@@ -18,6 +18,7 @@ export const ReferenceAutocomplete = forwardRef(function ReferenceAutocomplete(
     referenceElement: HTMLDivElement | null
     searchString?: string
     portalRef?: React.RefObject<HTMLDivElement>
+    readOnly?: boolean
   },
   ref: React.ForwardedRef<HTMLInputElement>
 ) {

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
@@ -273,38 +273,40 @@ export function ReferenceInput(props: ReferenceInputProps) {
             </Text>
           </Alert>
         ) : null}
-        <AutocompleteContainer ref={autocompletePopoverReferenceElementRef}>
-          <ReferenceAutocomplete
-            {...elementProps}
-            onFocus={handleFocus}
-            onBlur={handleBlur}
-            data-testid="autocomplete"
-            loading={searchState.isLoading}
-            referenceElement={autocompletePopoverReferenceElementRef.current}
-            options={hits}
-            radius={1}
-            placeholder="Type to search"
-            onKeyDown={handleAutocompleteKeyDown}
-            readOnly={loadableReferenceInfo.isLoading}
-            onQueryChange={handleQueryChange}
-            searchString={searchState.searchString}
-            onChange={handleChange}
-            filterOption={NO_FILTER}
-            renderOption={renderOption as any}
-            renderValue={renderValue}
-            value={value?._ref}
-            openButton={{onClick: handleAutocompleteOpenButtonClick}}
-          />
-
-          {!readOnly && createOptions.length > 0 && (
-            <CreateButton
-              id={`${id}-selectTypeMenuButton`}
-              createOptions={createOptions}
-              onCreate={handleCreateNew}
-              onKeyDown={handleCreateButtonKeyDown}
+        {!readOnly && (
+          <AutocompleteContainer ref={autocompletePopoverReferenceElementRef}>
+            <ReferenceAutocomplete
+              {...elementProps}
+              onFocus={handleFocus}
+              onBlur={handleBlur}
+              data-testid="autocomplete"
+              loading={searchState.isLoading}
+              referenceElement={autocompletePopoverReferenceElementRef.current}
+              options={hits}
+              radius={1}
+              placeholder="Type to search"
+              onKeyDown={handleAutocompleteKeyDown}
+              readOnly={loadableReferenceInfo.isLoading}
+              onQueryChange={handleQueryChange}
+              searchString={searchState.searchString}
+              onChange={handleChange}
+              filterOption={NO_FILTER}
+              renderOption={renderOption as any}
+              renderValue={renderValue}
+              value={value?._ref}
+              openButton={{onClick: handleAutocompleteOpenButtonClick}}
             />
-          )}
-        </AutocompleteContainer>
+
+            {!readOnly && createOptions.length > 0 && (
+              <CreateButton
+                id={`${id}-selectTypeMenuButton`}
+                createOptions={createOptions}
+                onCreate={handleCreateNew}
+                onKeyDown={handleCreateButtonKeyDown}
+              />
+            )}
+          </AutocompleteContainer>
+        )}
       </Stack>
     </Stack>
   )

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
@@ -253,6 +253,7 @@ export function ReferenceInput(props: ReferenceInputProps) {
       })),
     [searchState.hits]
   )
+
   return (
     <Stack space={1} data-testid="reference-input">
       <Stack space={2}>
@@ -273,20 +274,20 @@ export function ReferenceInput(props: ReferenceInputProps) {
             </Text>
           </Alert>
         ) : null}
-        {!readOnly && (
+        {
           <AutocompleteContainer ref={autocompletePopoverReferenceElementRef}>
             <ReferenceAutocomplete
               {...elementProps}
-              onFocus={handleFocus}
               onBlur={handleBlur}
               data-testid="autocomplete"
               loading={searchState.isLoading}
               referenceElement={autocompletePopoverReferenceElementRef.current}
               options={hits}
               radius={1}
-              placeholder="Type to search"
+              // eslint-disable-next-line no-negated-condition
+              placeholder={!readOnly ? 'Type to search' : ''}
               onKeyDown={handleAutocompleteKeyDown}
-              readOnly={loadableReferenceInfo.isLoading}
+              readOnly={loadableReferenceInfo.isLoading || readOnly}
               onQueryChange={handleQueryChange}
               searchString={searchState.searchString}
               onChange={handleChange}
@@ -306,7 +307,7 @@ export function ReferenceInput(props: ReferenceInputProps) {
               />
             )}
           </AutocompleteContainer>
-        )}
+        }
       </Stack>
     </Stack>
   )

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
@@ -335,7 +335,7 @@ export class BaseImageInput extends React.PureComponent<BaseImageInputProps, Bas
 
   handleFilesOver = (hoveringFiles: FileInfo[]) => {
     this.setState({
-      hoveringFiles,
+      hoveringFiles: hoveringFiles.filter((file) => file.kind !== 'string'),
     })
   }
   handleFilesOut = () => {
@@ -425,6 +425,7 @@ export class BaseImageInput extends React.PureComponent<BaseImageInputProps, Bas
     const {hoveringFiles} = this.state
 
     const acceptedFiles = hoveringFiles.filter((file) => resolveUploader(schemaType, file))
+
     const rejectedFilesCount = hoveringFiles.length - acceptedFiles.length
     const imageUrl = imageUrlBuilder
       .width(2000)

--- a/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
+++ b/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
@@ -70,7 +70,7 @@ export function ConfirmDeleteDialogBody({
   if (internalReferences?.totalCount === 0 && crossDatasetReferences?.totalCount === 0) {
     return (
       <Text as="p">
-        Are you sure you want to delete <strong>“{documentTitle}”</strong>?
+        Are you sure you want to {action} <strong>“{documentTitle}”</strong>?
       </Text>
     )
   }


### PR DESCRIPTION
### Description

An empty read-only reference field should not show the dropdown and be able to set a reference. It should be read-only for an empty field as well. 

https://user-images.githubusercontent.com/44635000/213703474-f6945a01-f1af-424f-b4e0-f8b06114b12b.mov

https://github.com/sanity-io/sanity/issues/3947

Added `readOnly` check for the dropdown.  

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
- Add `readOnly: () => true` to a reference 
- Make sure that it truly is read-only for the field - both when empty and when there is a reference 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
Fixes bug where the read-only reference field was not read-only for empty field