### PR TITLE
fix(core): add readonly prop to RefenceInput

### DIFF
--- a/dev/test-studio/schema/standard/references.ts
+++ b/dev/test-studio/schema/standard/references.ts
@@ -23,6 +23,7 @@ export default defineType({
       type: 'reference',
       description: 'Some description',
       to: {type: 'referenceTest'},
+      readOnly: () => true,
     },
     {
       name: 'selfOrEmpty',

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/CreateButton.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/CreateButton.tsx
@@ -12,6 +12,7 @@ interface Props extends ComponentProps<typeof Button> {
   createOptions: CreateReferenceOption[]
   menuRef?: React.RefObject<HTMLDivElement>
   onCreate: (option: CreateReferenceOption) => void
+  readOnly?: boolean
 }
 
 function ConditionalTooltip(
@@ -47,7 +48,15 @@ export function CreateButton(props: Props) {
 
   return createOptions.length > 1 ? (
     <MenuButton
-      button={<Button {...rest} text="Create new…" mode="ghost" icon={AddIcon} />}
+      button={
+        <Button
+          {...rest}
+          disabled={props.readOnly}
+          text="Create new…"
+          mode="ghost"
+          icon={AddIcon}
+        />
+      }
       id={id}
       menu={
         <Menu ref={props.menuRef}>
@@ -83,7 +92,7 @@ export function CreateButton(props: Props) {
       {...rest}
       text="Create new"
       mode="ghost"
-      disabled={!createOptions[0].permission.granted}
+      disabled={!createOptions[0].permission.granted || props.readOnly}
       onClick={() => onCreate(createOptions[0])}
       icon={AddIcon}
     />

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
@@ -283,9 +283,10 @@ export function ReferenceInput(props: ReferenceInputProps) {
             referenceElement={autocompletePopoverReferenceElementRef.current}
             options={hits}
             radius={1}
-            placeholder="Type to search"
+            // eslint-disable-next-line no-negated-condition
+            placeholder={!readOnly ? 'Type to search' : ''}
             onKeyDown={handleAutocompleteKeyDown}
-            readOnly={loadableReferenceInfo.isLoading}
+            readOnly={loadableReferenceInfo.isLoading || readOnly}
             onQueryChange={handleQueryChange}
             searchString={searchState.searchString}
             onChange={handleChange}

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
@@ -283,8 +283,7 @@ export function ReferenceInput(props: ReferenceInputProps) {
             referenceElement={autocompletePopoverReferenceElementRef.current}
             options={hits}
             radius={1}
-            // eslint-disable-next-line no-negated-condition
-            placeholder={!readOnly ? 'Type to search' : ''}
+            placeholder="Type to search"
             onKeyDown={handleAutocompleteKeyDown}
             readOnly={loadableReferenceInfo.isLoading || readOnly}
             onQueryChange={handleQueryChange}
@@ -297,9 +296,10 @@ export function ReferenceInput(props: ReferenceInputProps) {
             openButton={{onClick: handleAutocompleteOpenButtonClick}}
           />
 
-          {!readOnly && createOptions.length > 0 && (
+          {createOptions.length > 0 && (
             <CreateButton
               id={`${id}-selectTypeMenuButton`}
+              readOnly={readOnly}
               createOptions={createOptions}
               onCreate={handleCreateNew}
               onKeyDown={handleCreateButtonKeyDown}


### PR DESCRIPTION
### Description
An empty read-only reference field should not show the dropdown and be able to set a reference. It should be read-only for an empty field as well.

https://user-images.githubusercontent.com/44635000/214015457-2dda9a5c-74e2-479c-83db-7f590629afb1.mov

https://github.com/sanity-io/sanity/issues/3947

Added `readOnly` field for the `ReferenceAutocomplete`.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
- Make sure that it truly is read-only for the field - both when empty and when there is a reference

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fixes bug where the read-only reference field was not read-only for empty field

<!--
A description of the change(s) that should be used in the release notes.
-->
