### PR TITLE
fix(core): only notify subscribers when `currentUser` value changes in `createAuthStore`

### DIFF
--- a/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
@@ -1,7 +1,7 @@
 import createSanityClient, {ClientConfig as SanityClientConfig, SanityClient} from '@sanity/client'
 import {defer} from 'rxjs'
-import {map, shareReplay, startWith, switchMap} from 'rxjs/operators'
-import {memoize} from 'lodash'
+import {distinctUntilChanged, map, shareReplay, startWith, switchMap} from 'rxjs/operators'
+import {isEqual, memoize} from 'lodash'
 import {CorsOriginError} from '../cors'
 import {AuthState, AuthStore} from './types'
 import {createBroadcastChannel} from './createBroadcastChannel'
@@ -196,6 +196,11 @@ export function _createAuthStore({
           authenticated: !!currentUser,
         }
       })
+    ),
+    distinctUntilChanged((prev, next) =>
+      // Only notify subscribers if the the currentUser object has changed.
+      // Using isEqual is OK since the currentUser object being a small data structure.
+      isEqual(prev.currentUser, next.currentUser)
     ),
     shareReplay(1)
   )


### PR DESCRIPTION
### Description

This PR addresses an issue discovered when two browser windows are open in the same studio at the same time, where reloading one causes the other to re-render. The solution implemented in this PR is to only notify subscribers of the authentication stream when there is a change in the `currentUser` object by using the `distinctUntilChanged` operator to compare previous and next states.


### What to review

1. Open the same studio in two different browser windows
2. Reload one of the browser windows
3. The studio in the other browser window should not re-render.

### Notes for release

n/a