### PR TITLE
fix(core): array popover editing improvements

### DIFF
--- a/packages/sanity/src/core/components/popoverDialog/PopoverContainer.tsx
+++ b/packages/sanity/src/core/components/popoverDialog/PopoverContainer.tsx
@@ -1,0 +1,40 @@
+import {
+  Container,
+  ContainerProps,
+  rem,
+  ResponsiveWidthStyleProps,
+  Theme,
+  useArrayProp,
+  _responsive,
+} from '@sanity/ui'
+import React, {Ref} from 'react'
+import styled from 'styled-components'
+
+// This is a workaround to make sure that the Container gets the correct width when used inside a popover.
+// The default Container uses `maxWidth` which doesn't work well with popovers because the popover
+// calculates its width based on the content width.
+const StyledContainer = styled(Container)((props: ResponsiveWidthStyleProps & {theme: Theme}) => {
+  const {theme} = props
+  const {container, media} = theme.sanity
+
+  return _responsive(media, props.$width, (val) => ({
+    // Make sure that the Container gets the correct width when used inside a popover.
+    width: val === 'auto' ? 'none' : rem(container[val]),
+    // Make sure that the Container width is constrained by available space.
+    maxWidth: '100%',
+  }))
+})
+
+interface PopoverContainerProps extends ContainerProps {
+  children: React.ReactNode
+}
+
+export const PopoverContainer = React.forwardRef(function PopoverContainer(
+  props: PopoverContainerProps,
+  ref: Ref<HTMLDivElement>
+) {
+  const {width, ...restProps} = props
+  const widthArr = useArrayProp(width)
+
+  return <StyledContainer {...restProps} data-ui="PopoverContainer" $width={widthArr} ref={ref} />
+})

--- a/packages/sanity/src/core/components/popoverDialog/PopoverDialog.tsx
+++ b/packages/sanity/src/core/components/popoverDialog/PopoverDialog.tsx
@@ -2,63 +2,91 @@ import {CloseIcon} from '@sanity/icons'
 import {
   Box,
   Button,
-  Card,
-  Container,
   Flex,
-  focusFirstDescendant,
+  Layer,
   Popover,
   PopoverProps,
   ResponsiveWidthProps,
+  Stack,
   Text,
+  Theme,
 } from '@sanity/ui'
-import React, {HTMLProps, useEffect, useRef} from 'react'
+import React, {useCallback} from 'react'
+import styled, {css} from 'styled-components'
+import TrapFocus from 'react-focus-lock'
+import {PopoverContainer} from './PopoverContainer'
+
+const StyledPopover = styled(Popover)(() => {
+  return css`
+    // Make the popover scrollable if it overflows the viewport
+    [data-ui='Popover__wrapper'] {
+      overflow: auto;
+    }
+  `
+})
+
+// This layer is sticky so that the header is always visible when scrolling
+const StickyLayer = styled(Layer)((props: {theme: Theme}) => {
+  const radii = props.theme.sanity.radius[3]
+
+  return css`
+    position: sticky;
+    top: 0;
+    width: 100%;
+    background: var(--card-bg-color);
+    border-bottom: 1px solid var(--card-border-color);
+    border-top-left-radius: ${radii}px;
+    border-top-right-radius: ${radii}px;
+  `
+})
+
+interface PopoverDialogProps {
+  children: React.ReactNode
+  header?: React.ReactNode
+  onClose: () => void
+  referenceElement: PopoverProps['referenceElement']
+  width: ResponsiveWidthProps['width']
+}
 
 /** @internal */
-export function PopoverDialog(
-  props: Omit<PopoverProps, 'content' | 'width'> &
-    Omit<HTMLProps<HTMLDivElement>, 'ref' | 'width'> & {
-      header?: React.ReactNode
-      onClose: () => void
-      width?: ResponsiveWidthProps['width']
-    }
-) {
-  const {children, header, onClose, width, ...restProps} = props
-  const containerRef = useRef<HTMLDivElement | null>(null)
+export function PopoverDialog(props: PopoverDialogProps) {
+  const {children, header, onClose, referenceElement, width} = props
 
-  useEffect(() => {
-    focusFirstDescendant(containerRef.current!)
-  }, [])
+  const handleClose = useCallback(() => {
+    onClose()
+
+    // Set focus to the reference element when closing
+    referenceElement?.focus()
+  }, [onClose, referenceElement])
+
+  const content = (
+    <PopoverContainer width={width}>
+      <TrapFocus autoFocus>
+        <Stack>
+          <StickyLayer>
+            <Box padding={2} paddingLeft={3}>
+              <Flex align="center" gap={2}>
+                <Box flex={1}>
+                  <Text textOverflow="ellipsis" weight="semibold">
+                    {header}
+                  </Text>
+                </Box>
+
+                <Button icon={CloseIcon} mode="bleed" onClick={handleClose} />
+              </Flex>
+            </Box>
+          </StickyLayer>
+
+          {children}
+        </Stack>
+      </TrapFocus>
+    </PopoverContainer>
+  )
 
   // Note: if you come here to attempt to add support for Escape to close and/or clickOutside to close, please read this first:
   //  - Escape must work with nested dialogs/popover. So if you have an array inside here that opens its items in another a popover,
   //    hitting escape should only close the topmost dialog
   //  - clickOutside needs to work through portals. So if you have an array inside here that opens its items in a dialog/portal,
   //    any clicks inside such dialogs or portals should not cause _this_ popover to close
-  return (
-    <Popover
-      {...restProps}
-      open
-      portal
-      padding={1}
-      content={
-        <Container width={width} ref={containerRef}>
-          <Flex direction="column">
-            <Card padding={1} flex="none">
-              <Flex align="center">
-                <Box padding={2} flex={1}>
-                  <Text weight="semibold">{header}</Text>
-                </Box>
-                <Box>
-                  <Button mode="bleed" icon={CloseIcon} onClick={onClose} />
-                </Box>
-              </Flex>
-            </Card>
-            <Card flex={1} overflow="auto">
-              {children}
-            </Card>
-          </Flex>
-        </Container>
-      }
-    />
-  )
+  return <StyledPopover constrainSize content={content} open referenceElement={referenceElement} />
 }

--- a/packages/sanity/src/core/form/components/EditPortal.tsx
+++ b/packages/sanity/src/core/form/components/EditPortal.tsx
@@ -26,23 +26,29 @@ export function EditPortal(props: Props): React.ReactElement {
     legacy_referenceElement: referenceElement,
     header,
   } = props
+
   const contents = (
     <PresenceOverlay margins={PRESENCE_MARGINS}>
       <Box padding={4}>{children}</Box>
     </PresenceOverlay>
   )
-  return type === 'dialog' ? (
-    <Layer>
-      <Dialog width={width} id={id || ''} onClose={onClose} header={header}>
-        {contents}
-      </Dialog>
-    </Layer>
-  ) : (
+
+  if (type === 'dialog') {
+    return (
+      <Layer>
+        <Dialog header={header} onClose={onClose} id={id || ''} width={width}>
+          {contents}
+        </Dialog>
+      </Layer>
+    )
+  }
+
+  return (
     <PopoverDialog
-      width={width}
+      header={header}
       onClose={onClose}
       referenceElement={referenceElement}
-      header={header}
+      width={width}
     >
       {contents}
     </PopoverDialog>


### PR DESCRIPTION
### Description
This pull request addresses several problems with the popover editing feature for array items.

**Context**
It is possible to configure an array field to use a popover instead of a dialog for editing items, as shown in the following code example:

```js
{
  type: 'array',
  name: 'myArray',
  options: {
    modal: {type: 'popover', width: 2}, // <-- 👈 edit inside a popover instead of a dialog
  },
  of: [
    // fields...
  ]
}
```

**List of fixes:**
- Ensures that the width property functions as intended (currently the popover does not respect `width`)
- Restores focus on the array item upon closing the popover
- Traps focus within the popover content
- Includes a sticky header in the popover + header UI fixes
- Constrains the popover's size to the boundary element (i.e the form view)
- Makes the popover scrollable
- General user interface improvements

**Note:** There is currently an issue where the popover flashes and is difficult to use when an image input is rendered inside the popover and the width is set to `width: 'auto'`. It is likely that this is an issue that should be addressed in the Sanity UI library rather than in the Studio. However, this will be treated as a separate issue.

### What to review

Please review the list of fixes above. While there are many areas that could be improved when it comes to popover editing in arrays, this pull request focuses on addressing the most critical issues.

### Notes for release

n/a
