### PR TITLE
fix(tests): make sure cli tests don't crash if no token specified

### DIFF
--- a/packages/@sanity/cli/test/shared/globalSetup.ts
+++ b/packages/@sanity/cli/test/shared/globalSetup.ts
@@ -29,6 +29,13 @@ import {
 const SYMLINK_SCRIPT = path.resolve(__dirname, '../../../../../scripts/symlinkDependencies.js')
 
 export default async function globalSetup(): Promise<void> {
+  // Write a file with the test id, so it can be shared across workers
+  const localHost = hostname().toLowerCase().split('.')[0]
+  const testId = `${localHost}-${process.ppid || process.pid}`
+
+  await mkdir(baseTestPath, {recursive: true})
+  await writeFile(testIdPath, testId, 'utf8')
+
   if (!cliUserToken) {
     console.warn('\nNo SANITY_CI_CLI_AUTH_TOKEN set, skipping CLI tests')
     return
@@ -39,12 +46,6 @@ export default async function globalSetup(): Promise<void> {
     console.warn('Must have built the CLI with `npm run build` before running integration tests')
     return
   }
-
-  // Write a file with the test id, so it can be shared across workers
-  const localHost = hostname().toLowerCase().split('.')[0]
-  const testId = `${localHost}-${process.ppid || process.pid}`
-  await mkdir(baseTestPath, {recursive: true})
-  await writeFile(testIdPath, testId, 'utf8')
 
   // Do these things in parallel to save time
   await Promise.all([


### PR DESCRIPTION
### Description

Running the @sanity/cli tests locally without a `SANITY_CI_CLI_AUTH_TOKEN` specified currently triggers a bunch of test failures due to a missing tempdir, for example:
```
 ● Test suite failed to run

    ENOENT: no such file or directory, open '/var/folders/0f/4jx7p3354q7f86_z629rjf440000gn/T/sanity-cli-test/test-id.txt'

      3 |
      4 | describeCliTest('CLI: `sanity dataset`', () => {
    > 5 |   describe.each(studioVersions)('%s', (version) => {
        |                                ^
      6 |     const testRunArgs = getTestRunArgs(version)
      7 |
      8 |     testConcurrent('dataset create', async () => {

      at test/dataset.test.ts:5:32
      at Object.<anonymous> (test/dataset.test.ts:4:16)
```

This PR addresses it by making sure we create the tempdir before returning from the globalSetup. It seems to fixes it, but there might be better ways around it.

### What to review
- Make sure CLI tests work locally without a `SANITY_CI_CLI_AUTH_TOKEN` set

### Notes for release

n/a - internal only
