### PR TITLE
feat(cli): provide unresolved cross-dataset references for GraphQL APIs

### DIFF
--- a/packages/@sanity/schema/src/legacy/types/crossDatasetReference.ts
+++ b/packages/@sanity/schema/src/legacy/types/crossDatasetReference.ts
@@ -16,7 +16,19 @@ export const WEAK_FIELD = {
   type: 'boolean',
 }
 
-const REFERENCE_FIELDS = [REF_FIELD, WEAK_FIELD]
+const DATASET_FIELD = {
+  name: '_dataset',
+  title: 'Target dataset',
+  type: 'string',
+}
+
+const PROJECT_ID_FIELD = {
+  name: '_projectId',
+  title: 'Target project ID',
+  type: 'string',
+}
+
+const REFERENCE_FIELDS = [REF_FIELD, WEAK_FIELD, DATASET_FIELD, PROJECT_ID_FIELD]
 
 const OVERRIDABLE_FIELDS = [...DEFAULT_OVERRIDEABLE_FIELDS]
 

--- a/packages/sanity/src/_internal/cli/actions/graphql/extractFromSanitySchema.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/extractFromSanitySchema.ts
@@ -22,13 +22,26 @@ import type {
   ConvertedUnion,
 } from './types'
 
-const skipTypes = ['document', 'reference', 'crossDatasetReference']
+const skipTypes = ['document', 'reference']
 const allowedJsonTypes = ['object', 'array']
 const disallowedCustomizedMembers = ['object', 'array', 'image', 'file', 'block']
 const disabledBlockFields = ['markDefs']
 const scalars = ['string', 'number', 'boolean']
 
 function getBaseType(baseSchema: CompiledSchema, typeName: IntrinsicTypeName): SchemaType {
+  if (typeName === 'crossDatasetReference') {
+    return Schema.compile({
+      types: (baseSchema._original?.types || []).concat([
+        {
+          name: `__placeholder__`,
+          type: 'crossDatasetReference',
+          // Just needs _something_ to refer to, doesn't matter what
+          to: [{type: 'sanity.imageAsset'}],
+        },
+      ]),
+    }).get('__placeholder__')
+  }
+
   return Schema.compile({
     types: (baseSchema._original?.types || []).concat([
       {name: `__placeholder__`, type: typeName, options: {hotspot: true}},
@@ -46,8 +59,7 @@ function isBaseType(type: SchemaType): boolean {
     type.name !== type.jsonType &&
     allowedJsonTypes.includes(type.jsonType) &&
     !skipTypes.includes(type.name) &&
-    !isReference(type) &&
-    !isCrossDatasetReference(type)
+    !isReference(type)
   )
 }
 

--- a/packages/sanity/test/cli/graphql/__snapshots__/extract.test.ts.snap
+++ b/packages/sanity/test/cli/graphql/__snapshots__/extract.test.ts.snap
@@ -252,6 +252,45 @@ Object {
       "description": undefined,
       "fields": Array [
         Object {
+          "description": undefined,
+          "fieldName": "_dataset",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_projectId",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_ref",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_weak",
+          "type": "Boolean",
+        },
+      ],
+      "kind": "Type",
+      "name": "CrossDatasetReference",
+      "originalName": "crossDatasetReference",
+      "type": "Object",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
           "description": "Date the document was created",
           "fieldName": "_createdAt",
           "isNullable": true,

--- a/packages/sanity/test/cli/graphql/__snapshots__/gen2.test.ts.snap
+++ b/packages/sanity/test/cli/graphql/__snapshots__/gen2.test.ts.snap
@@ -846,6 +846,111 @@ Object {
       "name": "ColorSorting",
     },
     Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_dataset",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_projectId",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_ref",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_weak",
+          "type": "Boolean",
+        },
+      ],
+      "kind": "Type",
+      "name": "CrossDatasetReference",
+      "originalName": "crossDatasetReference",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_dataset",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_projectId",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_ref",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_weak",
+          "isReference": undefined,
+          "type": "BooleanFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "CrossDatasetReferenceFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_dataset",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_projectId",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_ref",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_weak",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "CrossDatasetReferenceSorting",
+    },
+    Object {
       "fields": Array [
         Object {
           "description": "Checks if the value is equal to the given input.",

--- a/packages/sanity/test/cli/graphql/__snapshots__/gen3.test.ts.snap
+++ b/packages/sanity/test/cli/graphql/__snapshots__/gen3.test.ts.snap
@@ -888,6 +888,111 @@ Object {
       "name": "ColorSorting",
     },
     Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_dataset",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_projectId",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_ref",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_weak",
+          "type": "Boolean",
+        },
+      ],
+      "kind": "Type",
+      "name": "CrossDatasetReference",
+      "originalName": "crossDatasetReference",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_dataset",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_projectId",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_ref",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_weak",
+          "isReference": undefined,
+          "type": "BooleanFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "CrossDatasetReferenceFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_dataset",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_projectId",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_ref",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_weak",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "CrossDatasetReferenceSorting",
+    },
+    Object {
       "fields": Array [
         Object {
           "description": "Checks if the value is equal to the given input.",


### PR DESCRIPTION
### Description

While we do not currently support _resolving_ cross-dataset references in the GraphQL API, there is still a case to be made for retrieving the reference value so users may manually fetch the content. This also unblocks deploying APIs for schemas that uses cross-dataset references.

### What to review

- Specifying dataset/project fields do not have any negative side effects on the studio side

### Notes for release

- Allow fetching unresolved cross-dataset references through GraphQL API
