### PR TITLE
fix(desk): close document actions dialog when changing document

### DIFF
--- a/packages/sanity/src/desk/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -72,7 +72,7 @@ function DocumentStatusBarActionsInner(props: DocumentStatusBarActionsInnerProps
 }
 
 export const DocumentStatusBarActions = memo(function DocumentStatusBarActions() {
-  const {actions, connectionState, editState} = useDocumentPane()
+  const {actions, connectionState, documentId, editState} = useDocumentPane()
   // const [isMenuOpen, setMenuOpen] = useState(false)
   // const handleMenuOpen = useCallback(() => setMenuOpen(true), [])
   // const handleMenuClose = useCallback(() => setMenuOpen(false), [])
@@ -98,6 +98,8 @@ export const DocumentStatusBarActions = memo(function DocumentStatusBarActions()
           // onMenuClose={handleMenuClose}
           showMenu={actions.length > 1}
           states={states}
+          // Use document ID as key to make sure that the actions state is reset when the document changes
+          key={documentId}
         />
       )}
     </RenderActionCollectionState>


### PR DESCRIPTION
### Description

This PR fixes an issue with document actions dialog staying open after navigating to another document.

### What to review

1. Go to a document
2. Open e.g the delete document dialog
3. Navigate to a another document
4. The dialog should close

### Notes for release

n/a
