### PR TITLE
chore: add script for setting npm `latest` tag on v2 modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "publish-canary": "RELEASE_TAG=canary npm run publish-tag",
     "publish-current-branch": "RELEASE_TAG=`git rev-parse --abbrev-ref HEAD | sed 's/\\//\\_/g'` npm run publish-tag",
     "publish-tag": "RELEASE_TAG=\"${RELEASE_TAG:-canary}\"; npm run build && lerna publish --canary --force-publish --no-git-tag-version --dist-tag=$RELEASE_TAG --preid=$RELEASE_TAG --exact",
+    "postpublish": "node scripts/setLatestForV2OnlyModules.js",
     "package": "npm run package-yarn && npm run package-cli",
     "package-cli": "(cd packages/@sanity/cli && npm run pack)",
     "package-yarn": "(cd packages/@sanity/cli && npm run package-yarn)",

--- a/scripts/setLatestForV2OnlyModules.js
+++ b/scripts/setLatestForV2OnlyModules.js
@@ -1,0 +1,48 @@
+/* eslint-disable no-sync, no-console, import/no-dynamic-require */
+const fs = require('fs')
+const path = require('path')
+const execa = require('execa')
+const semver = require('semver')
+
+main()
+
+async function main() {
+  const pkgsPath = path.join(__dirname, '..', 'packages', '@sanity')
+  const pkgs = fs
+    .readdirSync(pkgsPath)
+    .filter((pkg) => fs.statSync(path.join(pkgsPath, pkg)).isDirectory())
+
+  for (const pkg of pkgs) {
+    const pkgName = `@sanity/${pkg}`
+    const latestVersion = (await execa('npm', ['show', pkgName, 'version'])).stdout.trim()
+
+    // For 3.x modules, we want to keep that as latest
+    if (!latestVersion.startsWith('2.')) {
+      continue
+    }
+
+    // If on 2.x range, check if the in-repo version is newer than what is published as `latest`.
+    // This happens because we publish blindly with `--tag v2`, but for modules that were removed
+    // in v3, we actually want the latest 2.x version to be the latest version.
+    const localVersion = require(path.join(pkgsPath, pkg, 'package.json')).version
+    if (
+      !localVersion ||
+      !localVersion.startsWith('2.') ||
+      semver.gte(latestVersion, localVersion)
+    ) {
+      console.log('%s is at latest already, skipping', pkgName)
+      continue
+    }
+
+    console.log(
+      '%s is newer locally (%s) than latest (%s) - adjusting `latest` tag',
+      pkgName,
+      localVersion,
+      latestVersion
+    )
+
+    console.log(
+      (await execa('npm', ['dist-tag', 'add', `${pkgName}@${localVersion}`, 'latest'])).stdout
+    )
+  }
+}


### PR DESCRIPTION
### Description

When we run a v2 release, we now set the npm dist tag to `v2`. This is fine for the modules that are present in both v2 and v3, such as `@sanity/cli`, but it is unfortunate that new versions of 2.x modules are not set as `latest`.

This PR introduces a script which loops through all the modules in the `@sanity` packages folder, runs `npm view <pkgName> version` on them to see what the `latest` tag is set to on npm, and if that version is in the 2.x range, _and_ a _newer_ version is available locally (and is on the 2.x range) - it will set the `latest` tag on the npm module to the local version.

Kind of hacky, but think it should do the trick.

Also set this up as a post-publish task. 

### Notes for release

Nothing. Transparent for the end user.
