### PR TITLE
feat(config): allow specifying `apiHost` for source

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -110,6 +110,16 @@ export default defineConfig([
     basePath: '/playground',
   },
   {
+    name: 'staging',
+    title: 'Staging',
+    subtitle: 'Staging dataset',
+    projectId: 'exx11uqh',
+    dataset: 'playground',
+    plugins: [sharedSettings()],
+    basePath: '/staging',
+    apiHost: 'https://api.sanity.work',
+  },
+  {
     name: 'custom-components',
     title: 'Test Studio',
     subtitle: 'Components API playground',

--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -103,10 +103,9 @@ export function prepareConfig(
       const resolvedSources = sources.map((source): InternalSource => {
         const clientFactory = source.unstable_clientFactory || createClient
 
-        const projectId = source.projectId
-        const dataset = source.dataset
+        const {projectId, dataset, apiHost} = source
 
-        const auth = source.auth || createAuthStore({clientFactory, dataset, projectId})
+        const auth = source.auth || createAuthStore({clientFactory, dataset, projectId, apiHost})
 
         let schemaTypes
         try {

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -247,8 +247,26 @@ export interface WorkspaceOptions extends SourceOptions {
 /** @beta */
 export interface SourceOptions extends PluginOptions {
   title?: string
+
+  /**
+   * Project ID for this source
+   */
   projectId: string
+
+  /**
+   * Dataset name for this source
+   */
   dataset: string
+
+  /**
+   * API hostname used for requests. Generally used for custom CNAMEs, allowing businesses to use
+   * their own domain for API requests. Must include protocol:
+   * eg `https://sanityapi.mycompany.com`
+   *
+   * Note that (currently) the project ID will be prepended to the passed URL, so the above
+   * example would end up as: `https://<projectId>.sanityapi.mycompany.com`
+   */
+  apiHost?: string
 
   /** @internal */
   auth?: AuthStore


### PR DESCRIPTION
### Description

This PR allows users to configure a custom API host for each source (usually for the entire studio, but it makes sense to do it on a source level, which workspaces inherit from). Enables the use of custom CNAMEs, which some of our customers have, as well as for testing purposes.

### What to review

- Specifying API host makes studio use the configured host. Prefixes with project ID.
- Code makes sense

### Notes for release

- A custom API hostname can now be configured for the studio through the `apiHost` configuration parameter. Note that the  configured API host must behave the same as Sanity's API, thus this is mostly useful for CNAMEs.
