### PR TITLE
refactor: use named export for schema package

### DIFF
--- a/packages/@sanity/block-tools/README.md
+++ b/packages/@sanity/block-tools/README.md
@@ -13,7 +13,7 @@ sanity exec path/to/script.js
 Let's start with a complete example:
 
 ```js
-import Schema from '@sanity/schema'
+import {Schema} from '@sanity/schema'
 import {htmlToBlocks} from '@sanity/block-tools'
 
 // Start with compiling a schema we can work against

--- a/packages/@sanity/block-tools/test/fixtures/customSchema.ts
+++ b/packages/@sanity/block-tools/test/fixtures/customSchema.ts
@@ -1,4 +1,4 @@
-import Schema from '@sanity/schema'
+import {Schema} from '@sanity/schema'
 
 export default Schema.compile({
   name: 'withCustomBlockType',

--- a/packages/@sanity/block-tools/test/fixtures/defaultSchema.ts
+++ b/packages/@sanity/block-tools/test/fixtures/defaultSchema.ts
@@ -1,4 +1,4 @@
-import Schema from '@sanity/schema'
+import {Schema} from '@sanity/schema'
 
 export default Schema.compile({
   name: 'withDefaultBlockType',

--- a/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditorTester.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditorTester.tsx
@@ -1,5 +1,5 @@
 import React, {ForwardedRef, forwardRef, useCallback, useEffect} from 'react'
-import Schema from '@sanity/schema'
+import {Schema} from '@sanity/schema'
 
 import {defineArrayMember, defineField} from '@sanity/types'
 import {PortableTextEditor, PortableTextEditable} from '../../index'

--- a/packages/@sanity/portable-text-editor/src/utils/schema.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/schema.ts
@@ -1,4 +1,4 @@
-import Schema from '@sanity/schema'
+import {Schema} from '@sanity/schema'
 
 export function compileType(rawType: any) {
   return Schema.compile({

--- a/packages/@sanity/schema/example/test.js
+++ b/packages/@sanity/schema/example/test.js
@@ -1,5 +1,5 @@
 import assert from 'assert'
-import Schema from '../src/legacy/Schema'
+import {Schema} from '../src/legacy/Schema'
 import schemaDef from './schema-def'
 
 const schema = new Schema(schemaDef)

--- a/packages/@sanity/schema/src/_exports/index.ts
+++ b/packages/@sanity/schema/src/_exports/index.ts
@@ -1,2 +1,5 @@
-export {default} from '../legacy/Schema'
+import {Schema as NamedSchema, DeprecatedDefaultSchema} from '../legacy/Schema'
+
+export default DeprecatedDefaultSchema
+export const Schema = NamedSchema
 export {type SchemaValidationResult} from '../sanity/typedefs'

--- a/packages/@sanity/schema/src/legacy/Schema.ts
+++ b/packages/@sanity/schema/src/legacy/Schema.ts
@@ -41,7 +41,7 @@ function compileRegistry(schemaDef) {
 /**
  * @beta
  */
-export default class Schema {
+export class Schema {
   _original: {name: string; types: any[]}
   _registry: {[typeName: string]: any}
 
@@ -68,5 +68,25 @@ export default class Schema {
 
   getTypeNames(): string[] {
     return Object.keys(this._registry)
+  }
+}
+
+/**
+ * @deprecated Use `import {Schema} from "@sanity/schema"` instead
+ */
+export class DeprecatedDefaultSchema extends Schema {
+  static compile(schemaDef: any): Schema {
+    return new DeprecatedDefaultSchema(schemaDef)
+  }
+
+  constructor(schemaDef: any) {
+    super(schemaDef)
+
+    const stack = new Error(
+      'The default export of `@sanity/schema` is deprecated. Use `import {Schema} from "@sanity/schema"` instead.'
+    ).stack.replace(/^Error/, 'Warning')
+
+    // eslint-disable-next-line no-console
+    console.warn(stack)
   }
 }

--- a/packages/@sanity/schema/test/legacy/schemas.test.ts
+++ b/packages/@sanity/schema/test/legacy/schemas.test.ts
@@ -1,4 +1,4 @@
-import Schema from '../../src/legacy/Schema'
+import {Schema} from '../../src/legacy/Schema'
 
 import rawSchemas from './fixtures/schemas'
 

--- a/packages/@sanity/validation/test/createSchema.ts
+++ b/packages/@sanity/validation/test/createSchema.ts
@@ -1,4 +1,4 @@
-import SchemaBuilder from '@sanity/schema'
+import {Schema as SchemaBuilder} from '@sanity/schema'
 import {validateSchema, groupProblems} from '@sanity/schema/_internal'
 import {Schema} from '@sanity/types'
 

--- a/packages/@sanity/validation/test/infer.test.ts
+++ b/packages/@sanity/validation/test/infer.test.ts
@@ -1,5 +1,5 @@
 import {SanityClient} from '@sanity/client'
-import SchemaBuilder from '@sanity/schema'
+import {Schema as SchemaBuilder} from '@sanity/schema'
 import {ObjectSchemaType, Rule, SanityDocument} from '@sanity/types'
 import inferFromSchema from '../src/inferFromSchema'
 import validateDocument from '../src/validateDocument'

--- a/packages/sanity/src/_internal/cli/actions/graphql/extractFromSanitySchema.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/extractFromSanitySchema.ts
@@ -10,7 +10,7 @@ import type {
   IntrinsicTypeName,
 } from '@sanity/types'
 import {generateHelpUrl} from '@sanity/generate-help-url'
-import Schema from '@sanity/schema'
+import {Schema} from '@sanity/schema'
 import oneline from 'oneline'
 import * as helpUrls from './helpUrls'
 import {SchemaError} from './SchemaError'

--- a/packages/sanity/src/core/form/__workshop__/_common/data.ts
+++ b/packages/sanity/src/core/form/__workshop__/_common/data.ts
@@ -1,4 +1,4 @@
-import Schema from '@sanity/schema'
+import {Schema} from '@sanity/schema'
 import type {Schema as SchemaSchema} from '@sanity/types'
 import {keyBy, mapValues} from 'lodash'
 import getSimpleDummySchema from './schema/simpleDummySchema'

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/__tests__/ReferenceInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/__tests__/ReferenceInput.test.tsx
@@ -1,6 +1,6 @@
 import {render} from '@testing-library/react'
 import React, {forwardRef, useImperativeHandle} from 'react'
-import Schema from '@sanity/schema'
+import {Schema} from '@sanity/schema'
 import {LayerProvider, studioTheme, ThemeProvider, ToastProvider} from '@sanity/ui'
 import {of} from 'rxjs'
 import {noop} from 'lodash'

--- a/packages/sanity/src/core/form/store/__tests__/collapsible.test.ts
+++ b/packages/sanity/src/core/form/store/__tests__/collapsible.test.ts
@@ -1,4 +1,4 @@
-import Schema from '@sanity/schema'
+import {Schema} from '@sanity/schema'
 import {ObjectSchemaType, Path} from '@sanity/types'
 import {pathToString} from '../../../field'
 import {prepareFormState} from '../formState'

--- a/packages/sanity/src/core/form/store/__tests__/equality.test.ts
+++ b/packages/sanity/src/core/form/store/__tests__/equality.test.ts
@@ -1,5 +1,5 @@
 import {ConditionalProperty} from '@sanity/types'
-import Schema from '@sanity/schema'
+import {Schema} from '@sanity/schema'
 import {prepareFormState} from '../formState'
 import {DEFAULT_PROPS} from './shared'
 

--- a/packages/sanity/src/core/form/store/__tests__/members.hidden.test.ts
+++ b/packages/sanity/src/core/form/store/__tests__/members.hidden.test.ts
@@ -1,4 +1,4 @@
-import Schema from '@sanity/schema'
+import {Schema} from '@sanity/schema'
 import {ConditionalProperty, ObjectSchemaType} from '@sanity/types'
 import {prepareFormState} from '../formState'
 import {DEFAULT_PROPS} from './shared'

--- a/packages/sanity/src/core/schema/createSchema.ts
+++ b/packages/sanity/src/core/schema/createSchema.ts
@@ -1,4 +1,4 @@
-import SchemaBuilder, {type SchemaValidationResult} from '@sanity/schema'
+import {Schema as SchemaBuilder, type SchemaValidationResult} from '@sanity/schema'
 import {validateSchema, groupProblems} from '@sanity/schema/_internal'
 import {Schema} from '@sanity/types'
 import {inferFromSchema as inferValidation} from '@sanity/validation'

--- a/packages/sanity/src/core/search/weighted/createWeightedSearch.test.ts
+++ b/packages/sanity/src/core/search/weighted/createWeightedSearch.test.ts
@@ -1,4 +1,4 @@
-import Schema from '@sanity/schema'
+import {Schema} from '@sanity/schema'
 import {renderHook} from '@testing-library/react'
 import {defer, lastValueFrom, of} from 'rxjs'
 import type {SearchTerms} from '..'

--- a/packages/sanity/src/core/studio/components/navbar/search/datastores/recentSearches.test.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/datastores/recentSearches.test.ts
@@ -1,4 +1,4 @@
-import Schema from '@sanity/schema'
+import {Schema} from '@sanity/schema'
 import type {CurrentUser, ObjectSchemaType} from '@sanity/types'
 import type {SearchTerms} from '../../../../../search'
 import {filterDefinitions} from '../definitions/defaultFilters'

--- a/packages/sanity/src/core/studio/components/navbar/search/utils/createFieldDefinitions.test.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/utils/createFieldDefinitions.test.tsx
@@ -1,4 +1,4 @@
-import Schema from '@sanity/schema'
+import {Schema} from '@sanity/schema'
 import React from 'react'
 import {filterDefinitions} from '../definitions/defaultFilters'
 import {createFieldDefinitions, MAX_OBJECT_TRAVERSAL_DEPTH} from './createFieldDefinitions'

--- a/packages/sanity/src/core/studio/components/navbar/search/utils/filterUtils.test.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/utils/filterUtils.test.ts
@@ -1,4 +1,4 @@
-import Schema from '@sanity/schema'
+import {Schema} from '@sanity/schema'
 import {SearchableType} from '../../../../../search'
 import {filterDefinitions} from '../definitions/defaultFilters'
 import {operatorDefinitions} from '../definitions/operators/defaultOperators'

--- a/packages/sanity/src/core/templates/__tests__/schema.ts
+++ b/packages/sanity/src/core/templates/__tests__/schema.ts
@@ -1,4 +1,4 @@
-import SchemaBuilder from '@sanity/schema'
+import {Schema as SchemaBuilder} from '@sanity/schema'
 import {Schema} from '@sanity/types'
 
 const Icon = () => null

--- a/packages/sanity/src/desk/panes/documentList/__tests__/helpers.test.ts
+++ b/packages/sanity/src/desk/panes/documentList/__tests__/helpers.test.ts
@@ -1,4 +1,4 @@
-import Schema from '@sanity/schema'
+import {Schema} from '@sanity/schema'
 import {ObjectSchemaType} from '@sanity/types'
 import {applyOrderingFunctions, fieldExtendsType} from '../helpers'
 

--- a/packages/sanity/test/cli/graphql/fixtures/test-studio.ts
+++ b/packages/sanity/test/cli/graphql/fixtures/test-studio.ts
@@ -1,4 +1,4 @@
-import Schema from '@sanity/schema'
+import {Schema} from '@sanity/schema'
 
 export default Schema.compile({
   types: [


### PR DESCRIPTION
### Description

We want to move away from default exports, as they are hard to work with in a dual CommonJS/ESM environment. The schema package currently only exposes the `Schema` class on the default export. This PR moves the default Schema class export to a _named_ export (`Schema`), _and_ introduces a "deprecated" class for the default export, which only exists to warn about the deprecated default export.

I decided to warn with a stack trace to make it easier to find where the warning is appearing from.

### Notes for release

- Use named export for the `@sanity/schema` module - the default export is now deprecated and will give a warning when used
