### PR TITLE
Replace Puppeteer with Playwright for PTE-tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Check formatting
         run: yarn check:format
 
+      - name: Install Playwright
+        run: npx playwright install --with-deps
+
       - name: Check type system
         # If TypeScript project references is set up properly, `tsc --build` should work right after dependencies
         # has been installed, no extra build/compile step required
@@ -70,12 +73,6 @@ jobs:
         run: yarn depcheck
         env:
           NODE_OPTIONS: --max_old_space_size=8192
-
-      # (for puppeteer tests)
-      - name: Install Chrome
-        uses: browser-actions/setup-chrome@latest
-        with:
-          chrome-version: stable
 
       - name: Test
         id: test

--- a/packages/@sanity/portable-text-editor/package.json
+++ b/packages/@sanity/portable-text-editor/package.json
@@ -97,7 +97,7 @@
     "jest-environment-jsdom": "^27.3.1",
     "jest-environment-node": "^27.1.0",
     "node-ipc": "^9.2.0",
-    "puppeteer": "^19.3.0",
+    "playwright": "^1.30.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rimraf": "^3.0.2",

--- a/packages/@sanity/portable-text-editor/test/setup/globals.jest.ts
+++ b/packages/@sanity/portable-text-editor/test/setup/globals.jest.ts
@@ -1,5 +1,4 @@
 import {PortableTextBlock} from '@sanity/types'
-import {KeyInput} from 'puppeteer'
 import {EditorSelection} from '../../src'
 
 export {}
@@ -12,7 +11,7 @@ type Editor = {
   getSelection: () => Promise<EditorSelection | null>
   getValue: () => Promise<Value>
   insertText: (text: string) => Promise<void>
-  pressKey: (keyName: KeyInput, times?: number) => Promise<void>
+  pressKey: (keyName: string, times?: number) => Promise<void>
   redo: () => void
   setSelection: (selection: EditorSelection | null) => Promise<void>
   testId: string

--- a/packages/@sanity/portable-text-editor/test/ws-server/index.ts
+++ b/packages/@sanity/portable-text-editor/test/ws-server/index.ts
@@ -39,7 +39,8 @@ const sub = messages.subscribe((next) => {
 })
 
 ipc.config.id = 'socketServer'
-ipc.config.retry = 1500
+ipc.config.retry = 5000
+ipc.config.networkPort = 3002
 ipc.config.silent = true
 
 ipc.serveNet(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14465,6 +14465,18 @@ pkg-up@^3.1.0:
   dependencies:
     find-up "^3.0.0"
 
+playwright-core@1.30.0:
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.30.0.tgz#de987cea2e86669e3b85732d230c277771873285"
+  integrity sha512-7AnRmTCf+GVYhHbLJsGUtskWTE33SwMZkybJ0v6rqR1boxq2x36U7p1vDRV7HO2IwTZgmycracLxPEJI49wu4g==
+
+playwright@^1.30.0:
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.30.0.tgz#b1d7be2d45d97fbb59f829f36f521f12010fe072"
+  integrity sha512-ENbW5o75HYB3YhnMTKJLTErIBExrSlX2ZZ1C/FzmHjUYIfxj/UnI+DWpQr992m+OQVSg0rCExAOlRwB+x+yyIg==
+  dependencies:
+    playwright-core "1.30.0"
+
 please-upgrade-node@^3.2.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz"


### PR DESCRIPTION
### Description

This will replace Puppeteer with Playwright for doing the PTE collaboration tests as we are moving on to Playwright now anyway.

* Added Playwright as dep. removed Puppeteer.
* Added Github Action step to install Playwright deps on CI.
* Re-wrote the collaborative test Jest environment to use Puppeteer.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Please note that this PR is not targeting the `next` branch, but the `refactor/pte-various` - a working branch for a larger refactoring where I'll merge PR's limited in scope for easier reviewing - like this one.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Doesn't need to mentioned. Internal dev stuff.

<!--
A description of the change(s) that should be used in the release notes.
-->
