### PR TITLE
fix(core): change design for clickable present users in dropdown

### DIFF
--- a/packages/sanity/src/core/components/UserAvatar.tsx
+++ b/packages/sanity/src/core/components/UserAvatar.tsx
@@ -14,6 +14,7 @@ export interface UserAvatarProps {
   tone?: 'navbar'
   user: User | string
   withTooltip?: boolean
+  blur?: boolean
 }
 
 const symbols = /[^\p{Alpha}\p{White_Space}]/gu
@@ -76,7 +77,7 @@ const StaticUserAvatar = forwardRef(function StaticUserAvatar(
   props: Omit<UserAvatarProps, 'user'> & {user: User},
   ref: React.ForwardedRef<HTMLDivElement>
 ) {
-  const {user, animateArrowFrom, position, size, status, tone} = props
+  const {user, animateArrowFrom, position, size, status, tone, blur} = props
   const [imageLoadError, setImageLoadError] = useState<null | Error>(null)
   const userColor = useUserColor(user.id)
   const imageUrl = imageLoadError ? undefined : user?.imageUrl
@@ -89,6 +90,7 @@ const StaticUserAvatar = forwardRef(function StaticUserAvatar(
       data-legacy-tone={tone}
       initials={user?.displayName && nameToInitials(user.displayName)}
       src={imageUrl}
+      style={{opacity: blur ? '0.5' : '1'}}
       onImageLoadError={setImageLoadError}
       ref={ref}
       size={typeof size === 'string' ? LEGACY_TO_UI_AVATAR_SIZES[size] : size}

--- a/packages/sanity/src/core/components/UserAvatar.tsx
+++ b/packages/sanity/src/core/components/UserAvatar.tsx
@@ -14,7 +14,6 @@ export interface UserAvatarProps {
   tone?: 'navbar'
   user: User | string
   withTooltip?: boolean
-  blur?: boolean
 }
 
 const symbols = /[^\p{Alpha}\p{White_Space}]/gu
@@ -77,7 +76,7 @@ const StaticUserAvatar = forwardRef(function StaticUserAvatar(
   props: Omit<UserAvatarProps, 'user'> & {user: User},
   ref: React.ForwardedRef<HTMLDivElement>
 ) {
-  const {user, animateArrowFrom, position, size, status, tone, blur} = props
+  const {user, animateArrowFrom, position, size, status, tone} = props
   const [imageLoadError, setImageLoadError] = useState<null | Error>(null)
   const userColor = useUserColor(user.id)
   const imageUrl = imageLoadError ? undefined : user?.imageUrl
@@ -90,7 +89,6 @@ const StaticUserAvatar = forwardRef(function StaticUserAvatar(
       data-legacy-tone={tone}
       initials={user?.displayName && nameToInitials(user.displayName)}
       src={imageUrl}
-      style={{opacity: blur ? '0.5' : '1'}}
       onImageLoadError={setImageLoadError}
       ref={ref}
       size={typeof size === 'string' ? LEGACY_TO_UI_AVATAR_SIZES[size] : size}

--- a/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
@@ -98,16 +98,23 @@ export function PresenceMenu(props: PresenceMenuProps) {
       menu={
         <StyledMenu padding={1}>
           {hasPresence && (
-            <Stack space={2}>
-              {presence.map((item) => (
-                <PresenceMenuItem
-                  focused={focusedId === item.user.id}
-                  key={item.user.id}
-                  onFocus={handleItemFocus}
-                  presence={item}
-                />
-              ))}
-            </Stack>
+            <>
+              <Box margin={2}>
+                <Text muted size={1} weight="semibold">
+                  SEE WHERE THEY ARE
+                </Text>
+              </Box>
+              <Stack space={2}>
+                {presence.map((item) => (
+                  <PresenceMenuItem
+                    focused={focusedId === item.user.id}
+                    key={item.user.id}
+                    onFocus={handleItemFocus}
+                    presence={item}
+                  />
+                ))}
+              </Stack>
+            </>
           )}
 
           {!hasPresence && (

--- a/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
@@ -99,23 +99,16 @@ export function PresenceMenu(props: PresenceMenuProps) {
       menu={
         <StyledMenu padding={1}>
           {hasPresence && (
-            <>
-              <Box paddingX={2} paddingY={3}>
-                <Label muted size={1}>
-                  SEE WHERE THEY ARE
-                </Label>
-              </Box>
-              <Stack space={2}>
-                {presence.map((item) => (
-                  <PresenceMenuItem
-                    focused={focusedId === item.user.id}
-                    key={item.user.id}
-                    onFocus={handleItemFocus}
-                    presence={item}
-                  />
-                ))}
-              </Stack>
-            </>
+            <Stack>
+              {presence.map((item) => (
+                <PresenceMenuItem
+                  focused={focusedId === item.user.id}
+                  key={item.user.id}
+                  onFocus={handleItemFocus}
+                  presence={item}
+                />
+              ))}
+            </Stack>
           )}
 
           {!hasPresence && (

--- a/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
@@ -4,7 +4,6 @@ import {
   Box,
   Button,
   Card,
-  Label,
   Menu,
   MenuButton,
   MenuDivider,

--- a/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
@@ -4,6 +4,7 @@ import {
   Box,
   Button,
   Card,
+  Label,
   Menu,
   MenuButton,
   MenuDivider,
@@ -99,10 +100,10 @@ export function PresenceMenu(props: PresenceMenuProps) {
         <StyledMenu padding={1}>
           {hasPresence && (
             <>
-              <Box margin={2}>
-                <Text muted size={1} weight="semibold">
+              <Box paddingX={2} paddingY={3}>
+                <Label muted size={1}>
                   SEE WHERE THEY ARE
-                </Text>
+                </Label>
               </Box>
               <Stack space={2}>
                 {presence.map((item) => (

--- a/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenuItem.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenuItem.tsx
@@ -1,7 +1,7 @@
 import React, {forwardRef, memo, useCallback, useEffect, useMemo, useState} from 'react'
 import {orderBy} from 'lodash'
 import * as PathUtils from '@sanity/util/paths'
-import {Box, Card, Flex, MenuItem, Text} from '@sanity/ui'
+import {Box, Card, Flex, MenuItem, Stack, Text} from '@sanity/ui'
 import styled from 'styled-components'
 import {GlobalPresence} from '../../../../store'
 import {UserAvatar} from '../../../../components'
@@ -72,7 +72,8 @@ export const PresenceMenuItem = memo(function PresenceMenuItem(props: PresenceLi
       as={lastActiveLocation ? LinkComponent : 'div'}
       data-as={lastActiveLocation ? 'a' : 'div'}
       onFocus={handleFocus}
-      padding={4}
+      paddingY={hasLink ? 4 : 3}
+      paddingLeft={4}
       paddingRight={3}
       ref={setMenuItemElement}
     >
@@ -88,6 +89,13 @@ export const PresenceMenuItem = memo(function PresenceMenuItem(props: PresenceLi
 
         <Box flex={1} marginLeft={4}>
           <Text textOverflow="ellipsis">{presence.user.displayName}</Text>
+          {!hasLink && (
+            <Stack paddingTop={2}>
+              <Text size={0} muted textOverflow="ellipsis">
+                Not in a document
+              </Text>
+            </Stack>
+          )}
         </Box>
       </Flex>
     </MenuItem>

--- a/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenuItem.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenuItem.tsx
@@ -2,7 +2,6 @@ import React, {forwardRef, memo, useCallback, useEffect, useMemo, useState} from
 import {orderBy} from 'lodash'
 import * as PathUtils from '@sanity/util/paths'
 import {Box, Card, Flex, MenuItem, Text} from '@sanity/ui'
-import {LinkIcon} from '@sanity/icons'
 import styled from 'styled-components'
 import {GlobalPresence} from '../../../../store'
 import {UserAvatar} from '../../../../components'
@@ -79,20 +78,12 @@ export const PresenceMenuItem = memo(function PresenceMenuItem(props: PresenceLi
     >
       <Flex align="center">
         <AvatarCard>
-          <UserAvatar size={1} key={presence.user.id} user={presence.user} />
+          <UserAvatar size={1} key={presence.user.id} user={presence.user} blur={!hasLink} />
         </AvatarCard>
 
         <Box flex={1} marginLeft={4}>
           <Text textOverflow="ellipsis">{presence.user.displayName}</Text>
         </Box>
-
-        {hasLink && (
-          <Box marginLeft={3}>
-            <Text>
-              <LinkIcon />
-            </Text>
-          </Box>
-        )}
       </Flex>
     </MenuItem>
   )

--- a/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenuItem.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenuItem.tsx
@@ -1,7 +1,7 @@
 import React, {forwardRef, memo, useCallback, useEffect, useMemo, useState} from 'react'
 import {orderBy} from 'lodash'
 import * as PathUtils from '@sanity/util/paths'
-import {Box, Card, Flex, MenuItem, Stack, Text} from '@sanity/ui'
+import {Card, Flex, MenuItem, Stack, Text} from '@sanity/ui'
 import styled from 'styled-components'
 import {GlobalPresence} from '../../../../store'
 import {UserAvatar} from '../../../../components'
@@ -87,16 +87,14 @@ export const PresenceMenuItem = memo(function PresenceMenuItem(props: PresenceLi
           />
         </AvatarCard>
 
-        <Box flex={1} marginLeft={4}>
+        <Stack space={2} marginLeft={4}>
           <Text textOverflow="ellipsis">{presence.user.displayName}</Text>
           {!hasLink && (
-            <Stack paddingTop={2}>
-              <Text size={0} muted textOverflow="ellipsis">
-                Not in a document
-              </Text>
-            </Stack>
+            <Text size={0} muted textOverflow="ellipsis">
+              Not in a document
+            </Text>
           )}
-        </Box>
+        </Stack>
       </Flex>
     </MenuItem>
   )

--- a/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenuItem.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenuItem.tsx
@@ -78,7 +78,12 @@ export const PresenceMenuItem = memo(function PresenceMenuItem(props: PresenceLi
     >
       <Flex align="center">
         <AvatarCard>
-          <UserAvatar size={1} key={presence.user.id} user={presence.user} blur={!hasLink} />
+          <UserAvatar
+            size={1}
+            key={presence.user.id}
+            user={presence.user}
+            status={hasLink ? 'editing' : 'inactive'}
+          />
         </AvatarCard>
 
         <Box flex={1} marginLeft={4}>


### PR DESCRIPTION
### Description
The LinkIcon for clickable users in the presence menu has been replaced with a new design. The users that are not clickable are now greyed out and has text under. Users that can be clicked on, are not. 

![Screenshot 2023-02-06 at 11 24 05](https://user-images.githubusercontent.com/44635000/216947266-d791430c-d584-4ff9-86ea-9056114c3c8e.png)

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Click on the presence menu and make sure users that have a presence can be clicked on. 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Design change of the presence menu where non-clickable users are greyed out
<!--
A description of the change(s) that should be used in the release notes.
-->
