### PR TITLE
fix(desk): focusFirst in document and dialog behavior

### DIFF
--- a/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
@@ -442,7 +442,8 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   useEffect(() => {
     // Reset focus path
     setFocusPath(params.path ? pathFromString(params.path) : [])
-  }, [documentId, params.path])
+    onSetOpenPath([])
+  }, [params.path, documentId])
 
   return (
     <DocumentPaneContext.Provider value={documentPane}>{children}</DocumentPaneContext.Provider>

--- a/packages/sanity/src/desk/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/documentViews/FormView.tsx
@@ -1,8 +1,7 @@
 /* eslint-disable no-nested-ternary */
 
-import {isActionEnabled} from '@sanity/schema/_internal'
-import {Box, Container, Flex, Spinner, Text} from '@sanity/ui'
-import React, {useCallback, useEffect, useMemo} from 'react'
+import {Box, Container, Flex, Spinner, Text, focusFirstDescendant} from '@sanity/ui'
+import React, {useEffect, useMemo, useRef} from 'react'
 import {tap} from 'rxjs/operators'
 import {useDocumentPane} from '../../useDocumentPane'
 import {Delay} from '../../../../components/Delay'
@@ -11,7 +10,6 @@ import {
   DocumentMutationEvent,
   DocumentRebaseEvent,
   FormBuilder,
-  PatchEvent,
   PatchMsg,
   PresenceOverlay,
   createPatchChannel,
@@ -105,6 +103,12 @@ export function FormView(props: FormViewProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasRev])
 
+  const formRef = useRef<null | HTMLDivElement>(null)
+
+  useEffect(() => {
+    focusFirstDescendant(formRef.current!)
+  }, [])
+
   // const after = useMemo(
   //   () =>
   //     Array.isArray(afterEditorComponents) &&
@@ -125,7 +129,7 @@ export function FormView(props: FormViewProps) {
       width={1}
     >
       <PresenceOverlay margins={margins}>
-        <Box as="form" onSubmit={preventDefault}>
+        <Box as="form" onSubmit={preventDefault} ref={formRef}>
           {ready ? (
             formState === null ? (
               <Box padding={2}>


### PR DESCRIPTION
### Description
Adds focus to the first field when opening a document. This will be the case even if the field is `readOnly`. 
This also fixes the issue of a dialog in an array being open even after switching documents. It will also make the presence update when a user navigates to a document. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
- Open a document and see that the first field is focused. 
Also: 
- Open an array item popover in an array with `modal.type popover`
- Open another document from the document list
- Reopen the original document from the document list
- The popover is should not still be open

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Adds focus to the first field in a document, close dialog when navigating documents
<!--
A description of the change(s) that should be used in the release notes.
-->
