### PR TITLE
fix(core): add readOnly prop to sortable array items

### DIFF
--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
@@ -113,7 +113,7 @@ export function ReferenceItem<Item extends ReferenceItemValue = ReferenceItemVal
     inputProps: {onChange, focusPath, onPathFocus, renderPreview, elementProps},
   } = props
 
-  const sortable = parentSchemaType.options?.sortable !== false
+  const sortable = !readOnly && parentSchemaType.options?.sortable !== false
   const insertableTypes = parentSchemaType.of
 
   const elementRef = useRef<HTMLDivElement | null>(null)

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
@@ -94,7 +94,7 @@ export function GridItem<Item extends ObjectItem = ObjectItem>(props: GridItemPr
     inputProps: {renderPreview},
   } = props
 
-  const sortable = parentSchemaType.options?.sortable !== false
+  const sortable = !readOnly && parentSchemaType.options?.sortable !== false
   const insertableTypes = parentSchemaType.of
 
   const previewCardRef = useRef<FIXME | null>(null)

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
@@ -78,7 +78,7 @@ export function PreviewItem<Item extends ObjectItem = ObjectItem>(props: Preview
     inputProps: {renderPreview},
   } = props
 
-  const sortable = parentSchemaType.options?.sortable !== false
+  const sortable = !readOnly && parentSchemaType.options?.sortable !== false
   const insertableTypes = parentSchemaType.of
 
   const previewCardRef = useRef<HTMLDivElement | null>(null)


### PR DESCRIPTION
### Description
It was possible to sort arrays and publish even when `readOnly` was set. Fixed by adding the prop `readOnly` to `sortable`. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Add `readOnly` prop to an array and make sure it is not sortable. 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Disables sorting of arrays when `readOnly` is set. 
<!--
A description of the change(s) that should be used in the release notes.
-->
