### PR TITLE
fix(cli): maintain old pluralization behavior on graphql gen1 schemas

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/graphql/gen1/generateTypeQueries.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/gen1/generateTypeQueries.ts
@@ -6,7 +6,9 @@ import {isNonUnion} from '../helpers'
 function pluralizeTypeName(name: string): string {
   const words = startCase(name).split(' ')
   const last = words[words.length - 1]
-  const plural = pluralize(last.toLowerCase())
+  // `pluralize` previously incorrectly cased the S to uppercase after numbers,
+  // which we need to maintain for backwards compatibility
+  const plural = pluralize(last.toLowerCase()).replace(/(\d)s$/g, '$1S')
   words[words.length - 1] = upperFirst(plural)
   return words.join('')
 }


### PR DESCRIPTION
### Description

We upgraded the `pluralize` module from v7 to v8 in studio v3 (technically speaking we replaced it with pluralize-esm, but the implementation mirrors pluralize v8), which seems to have changed a somewhat odd behavior where numbers would be suffixed with an uppercase S instead of the expected lowercase s.

To maintain backwards compatibility, we should make sure we match this old behavior. This PR addresses this. We do encourage moving to newer GraphQL API generations, since they are more featureful and do not make assumptions about pluralization, but we should still try to maintain gen1 as long as it is still in use.

### What to review

- That code change makes sense (replace any digit followed by a lowercase S at the end of the string with the same digit, followed by a capital S)

### Notes for release

- Fixed a bug where GraphQL generation 1 schemas might use a new pluralization pattern for type names ending with a number

