### PR TITLE
fix(core): explicitly set SVG size when used as preview media

### DIFF
--- a/packages/sanity/src/core/components/previews/_common/Media.styled.ts
+++ b/packages/sanity/src/core/components/previews/_common/Media.styled.ts
@@ -37,7 +37,7 @@ export const MediaWrapper = styled.span<{
     }
 
     & svg {
-      display: block;
+      flex: 1;
       font-size: calc(21 / 16 * 1em);
     }
 

--- a/packages/sanity/src/core/components/previews/_common/Media.styled.ts
+++ b/packages/sanity/src/core/components/previews/_common/Media.styled.ts
@@ -15,7 +15,6 @@ export const MediaWrapper = styled.span<{
   const iconSize = PREVIEW_ICON_SIZE[$layout]
 
   return css`
-    position: relative;
     width: ${$responsive ? '100%' : rem(width)};
     height: ${$responsive ? '100%' : rem(height)};
     min-width: ${$responsive ? undefined : rem(width)};
@@ -27,9 +26,6 @@ export const MediaWrapper = styled.span<{
     justify-content: center;
 
     & img {
-      position: absolute;
-      left: 0;
-      top: 0;
       width: 100%;
       height: 100%;
       object-fit: contain;


### PR DESCRIPTION
### Description

This PR makes small CSS adjustments to the `MediaWrapper` component used in list previews.

The first commit addresses the issue #4074, in which SVGs need to have their sizing "explicitly" defined in Safari.

The second commit takes the opportunity to do a small cleanup on the same `MediaWrapper` component, this time for images, removing "unused" CSS rules.

### What to review

This PR should not change any existing behavior, apart from making SVGs visible on list previews when using Safari.

I tested it:

* With SVGs of different view box sizes, including non-squared ones.
* With different layouts on the list component (compact and detailed view).
* On the different "lists" across Sanity Studio (e.g. array fields, references).

### Notes for release

Something along the lines of:

> Fixes usage of SVG elements inside list previews.