### PR TITLE
fix(schema): validate that object has no standalone block fields

### DIFF
--- a/packages/@sanity/schema/src/sanity/validateSchema.test.ts
+++ b/packages/@sanity/schema/src/sanity/validateSchema.test.ts
@@ -1,0 +1,48 @@
+import {validateSchema} from './validateSchema'
+
+describe('object validation', () => {
+  test('validate standalone blocks', () => {
+    const result = validateSchema([
+      {
+        title: 'Valid object',
+        name: 'validObject',
+        type: 'object',
+        fields: [
+          {
+            title: 'Blocks',
+            name: 'blocks',
+            type: 'array',
+            of: [{type: 'block'}],
+          },
+        ],
+      },
+      {
+        title: 'Invalid object',
+        name: 'invalidObject',
+        type: 'object',
+        fields: [
+          {
+            name: 'field1',
+            title: 'Block 1',
+            type: 'block',
+          },
+          {
+            name: 'field2',
+            title: 'Block 2',
+            type: 'block',
+          },
+        ],
+      },
+    ])
+
+    const validObjectResult = result.get('validObject')
+    expect(validObjectResult._problems).toHaveLength(0)
+
+    const invalidObjectResult = result.get('invalidObject')
+    expect(invalidObjectResult._problems).toHaveLength(1)
+    expect(invalidObjectResult._problems[0]).toMatchObject({
+      severity: 'error',
+      helpId: 'schema-standalone-block-type',
+    })
+  })
+})

--- a/packages/@sanity/schema/src/sanity/validation/createValidationResult.ts
+++ b/packages/@sanity/schema/src/sanity/validation/createValidationResult.ts
@@ -28,6 +28,7 @@ export const HELP_IDS = {
   ASSET_METADATA_FIELD_INVALID: 'asset-metadata-field-invalid',
   CROSS_DATASET_REFERENCE_INVALID: 'cross-dataset-reference-invalid',
   DEPRECATED_BLOCKEDITOR_KEY: 'schema-deprecated-blockeditor-key',
+  STANDALONE_BLOCK_TYPE: 'schema-standalone-block-type',
 }
 
 function createValidationResult(

--- a/packages/@sanity/schema/src/sanity/validation/types/object.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/object.ts
@@ -117,6 +117,20 @@ export function validateFields(fields: any, options = {allowEmpty: false}) {
     problems.push(error('Object should have at least one field', HELP_IDS.OBJECT_FIELDS_INVALID))
   }
 
+  const standaloneBlockFields = fields
+    .filter((field) => field.type === 'block')
+    .map((field) => `"${field.name}"`)
+
+  if (standaloneBlockFields.length > 0) {
+    const fmtFields = standaloneBlockFields.join(', ')
+    problems.push(
+      error(
+        `Invalid standalone block field(s) ${fmtFields}. Block content must be defined as an array of blocks`,
+        HELP_IDS.STANDALONE_BLOCK_TYPE
+      )
+    )
+  }
+
   return problems
 }
 


### PR DESCRIPTION
### Description

This PR fixes addresses the issue #4152, in which Sanity Studio accepts standalone `block` fields, but crashes when trying to render the "edit form". The PR enhances the `object` validation to also check for these fields, and adds a problem when at least one such field is found.

This PR also introduces a new "help id" `STANDALONE_BLOCK_TYPE`. A new help page with the slug `schema-standalone-block-type` needs to be created. 

### What to review

* No schema validation issue when an `object`/`document` has no standalone `block` fields.
* Schema validation issues a problem when an `object`/`document` has 1 or more standalone `block` fields.

I tested it with the following `document`:

```
{
  title: 'Document with blocks',
  name: 'docBlocks',
  type: 'document',
  fields: [
    {
      title: 'Title',
      name: 'title',
      type: 'string',
    },
    {
      title: 'Blocks',
      name: 'blocks',
      type: 'array',
      of: [{type: 'block'}],
    },
    // {
    //   name: 'field1',
    //   title: 'Block 1',
    //   type: 'block',
    // },
    // {
    //   name: 'field2',
    //   title: 'Block 2',
    //   type: 'block',
    // },
  ],
}
```

When `field1` is present:

<img width="702" alt="Screenshot 2023-02-22 at 21 17 00" src="https://user-images.githubusercontent.com/424015/220752992-8627d2b1-f0fa-4bb2-9371-18ec41ea371e.png">

When both `field1` and `field2` are present:

<img width="685" alt="Screenshot 2023-02-22 at 21 16 28" src="https://user-images.githubusercontent.com/424015/220753023-012aaa61-d927-4c18-ba18-ce03cb0347af.png">

### Notes for release

Something along the lines of:

> Introduces a missing `object` validation to prevent standalone `block` fields to exist.
