### PR TITLE
fix(core): invalid reference link

### DIFF
--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceField.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceField.tsx
@@ -25,10 +25,10 @@ import {useScrollIntoViewOnFocusWithin} from '../../hooks/useScrollIntoViewOnFoc
 import {useDidUpdate} from '../../hooks/useDidUpdate'
 import {set, unset} from '../../patch'
 import {AlertStrip} from '../../components/AlertStrip'
-import {ReferencePreviewCard} from './ReferenceItem'
 import {useReferenceInput} from './useReferenceInput'
 import {useReferenceInfo} from './useReferenceInfo'
 import {PreviewReferenceValue} from './PreviewReferenceValue'
+import {ReferenceLinkCard} from './ReferenceLinkCard'
 import {IntentLink} from 'sanity/router'
 
 interface ReferenceFieldProps extends Omit<ObjectFieldProps, 'renderDefault'> {
@@ -257,6 +257,7 @@ export function ReferenceField(props: ReferenceFieldProps) {
       ),
     [handleClear, handleReplace, inputId, OpenLink, readOnly, value?._ref]
   )
+
   return (
     <FormField
       level={props.level}
@@ -271,19 +272,17 @@ export function ReferenceField(props: ReferenceFieldProps) {
         <Card shadow={1} radius={1} padding={1} tone={tone}>
           <Stack space={1}>
             <Flex gap={1} align="center">
-              <ReferencePreviewCard
+              <ReferenceLinkCard
                 flex={1}
-                forwardedAs={EditReferenceLink as any}
+                as={EditReferenceLink}
                 tone="inherit"
                 radius={2}
-                data-as="a"
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 documentId={value?._ref}
                 documentType={refType?.name}
                 paddingX={2}
                 paddingY={1}
                 __unstable_focusRing
-                style={{position: 'relative'}}
                 selected={selected}
                 pressed={pressed}
                 data-selected={selected ? true : undefined}
@@ -295,7 +294,7 @@ export function ReferenceField(props: ReferenceFieldProps) {
                   renderPreview={renderPreview}
                   type={schemaType}
                 />
-              </ReferencePreviewCard>
+              </ReferenceLinkCard>
               <Box>{menu}</Box>
             </Flex>
             {footer}

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import {
   Box,
   Button,
@@ -22,7 +23,6 @@ import {
   SyncIcon as ReplaceIcon,
   TrashIcon,
 } from '@sanity/icons'
-import styled from 'styled-components'
 import {ObjectItem, ObjectItemProps} from '../../types'
 import {useScrollIntoViewOnFocusWithin} from '../../hooks/useScrollIntoViewOnFocusWithin'
 import {useDidUpdate} from '../../hooks/useDidUpdate'
@@ -39,6 +39,7 @@ import {InsertMenu} from '../arrays/ArrayOfObjectsInput/InsertMenu'
 import {useReferenceInfo} from './useReferenceInfo'
 import {PreviewReferenceValue} from './PreviewReferenceValue'
 import {useReferenceInput} from './useReferenceInput'
+import {ReferenceLinkCard} from './ReferenceLinkCard'
 
 export interface ReferenceItemValue extends Omit<ObjectItem, '_type'>, Omit<Reference, '_key'> {}
 
@@ -74,22 +75,6 @@ const INITIAL_VALUE_CARD_STYLE = {
   height: '100%',
   opacity: 0.6,
 } as const
-
-export const ReferencePreviewCard = styled(Card)`
-  /* this is a hack to avoid layout jumps while previews are loading
-     there's probably better ways of solving this */
-  min-height: 35px;
-
-  /* TextWithTone uses its own logic to set color, and we therefore need */
-  /* to override this logic in order to set the correct color in different states */
-  &[data-selected],
-  &[data-pressed],
-  &:active {
-    [data-ui='TextWithTone'] {
-      color: inherit;
-    }
-  }
-`
 
 export function ReferenceItem<Item extends ReferenceItemValue = ReferenceItemValue>(
   props: ReferenceItemProps<Item>
@@ -350,18 +335,16 @@ export function ReferenceItem<Item extends ReferenceItemValue = ReferenceItemVal
           </FormFieldSet>
         </Box>
       ) : (
-        <ReferencePreviewCard
-          forwardedAs={EditReferenceLink as any}
+        <ReferenceLinkCard
+          as={EditReferenceLink}
           tone="inherit"
           radius={2}
-          data-as="a"
           documentId={value?._ref}
           documentType={refType?.name}
           disabled={resolvingInitialValue}
           paddingX={2}
           paddingY={1}
           __unstable_focusRing
-          style={{position: 'relative'}}
           selected={selected}
           pressed={pressed}
           data-selected={selected ? true : undefined}
@@ -391,7 +374,7 @@ export function ReferenceItem<Item extends ReferenceItemValue = ReferenceItemVal
               </Flex>
             </Card>
           )}
-        </ReferencePreviewCard>
+        </ReferenceLinkCard>
       )}
     </RowLayout>
   )

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceLinkCard.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceLinkCard.tsx
@@ -1,0 +1,49 @@
+import React, {forwardRef} from 'react'
+import styled from 'styled-components'
+import {Card, CardProps} from '@sanity/ui'
+
+export const StyledCard = styled(Card)`
+  /* this is a hack to avoid layout jumps while previews are loading
+     there's probably better ways of solving this */
+  min-height: 35px;
+  position: relative;
+
+  /* TextWithTone uses its own logic to set color, and we therefore need */
+  /* to override this logic in order to set the correct color in different states */
+  &[data-selected],
+  &[data-pressed],
+  &:active {
+    [data-ui='TextWithTone'] {
+      color: inherit;
+    }
+  }
+`
+
+interface ReferenceLinkCardProps extends CardProps {
+  as: any
+  documentId: string
+  documentType: string | undefined
+}
+
+export const ReferenceLinkCard = forwardRef(function ReferenceLinkCard(
+  props: ReferenceLinkCardProps & React.HTMLProps<HTMLElement>,
+  ref: React.ForwardedRef<HTMLElement>
+) {
+  const {documentType, as: asProp, ...restProps} = props
+  const dataAs = documentType ? 'a' : undefined
+
+  // If the child link is clicked without a document type, an error will be thrown.
+  // This usually happens when the link is clicked before the document type has been resolved.
+  // In this case, we don't want to pass the `as` prop to the Card component, as it will throw an error.
+  const as = documentType ? asProp : 'div'
+
+  return (
+    <StyledCard
+      {...restProps}
+      data-as={dataAs}
+      documentType={documentType}
+      forwardedAs={as}
+      ref={ref}
+    />
+  )
+})


### PR DESCRIPTION
### Description

This PR fixes an issue where an error is thrown if a reference link is clicked while it is loading.

### What to review

Click a reference link when it is loading. An error should not be thrown.

### Notes for release

n/a