### PR TITLE
fix(desk): update tools and schema help links

### DIFF
--- a/packages/sanity/src/core/studio/screens/NoToolsScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/NoToolsScreen.tsx
@@ -16,13 +16,19 @@ export function NoToolsScreen() {
               </Box>
               <Stack flex={1} marginLeft={3} space={3}>
                 <Text as="h1" size={1} weight="bold">
-                  No configured tools!
+                  No configured tools
                 </Text>
                 <Text as="p" muted size={1}>
                   Please configure a tool in your Studio configuration.
                 </Text>
-                <Text as="p" hidden muted size={1}>
-                  <a href="">Learn how to add a tool &rarr;</a>
+                <Text as="p" muted size={1}>
+                  <a
+                    href="https://www.sanity.io/docs/studio-tools"
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    Learn how to add a tool &rarr;
+                  </a>
                 </Text>
               </Stack>
             </Flex>

--- a/packages/sanity/src/desk/components/deskTool/NoDocumentTypesScreen.tsx
+++ b/packages/sanity/src/desk/components/deskTool/NoDocumentTypesScreen.tsx
@@ -23,7 +23,7 @@ export function NoDocumentTypesScreen() {
                 </Text>
                 <Text as="p" muted size={1}>
                   <a
-                    href="https://beta.sanity.io/docs/platform/studio/config"
+                    href="https://www.sanity.io/docs/create-a-schema-and-configure-sanity-studio"
                     target="_blank"
                     rel="noreferrer"
                   >


### PR DESCRIPTION
### Description

This PR adds links to docs when there are no **schema** types or **tools** configured.

### What to review

Are the links correct?

### Notes for release

n/a
