### PR TITLE
fix(form): Allow fractional part of a number to have leading zeros

### DIFF
--- a/packages/sanity/src/core/form/inputs/NumberInput.tsx
+++ b/packages/sanity/src/core/form/inputs/NumberInput.tsx
@@ -31,6 +31,7 @@ export function NumberInput(props: NumberInputProps) {
       pattern={onlyPositiveNumber ? '[d]*' : undefined}
       max={Number.MAX_SAFE_INTEGER}
       min={Number.MIN_SAFE_INTEGER}
+      data-testid="number-input"
     />
   )
 }

--- a/packages/sanity/src/core/form/members/object/fields/PrimitiveField.test.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/PrimitiveField.test.tsx
@@ -1,0 +1,206 @@
+// eslint-disable-next-line import/no-unassigned-import
+import '@testing-library/jest-dom/extend-expect'
+import {render} from '@testing-library/react'
+import React, {PropsWithChildren} from 'react'
+import {ThemeProvider, studioTheme, LayerProvider} from '@sanity/ui'
+import userEvent from '@testing-library/user-event'
+import {FieldMember} from '../../../store'
+import {
+  defaultRenderField,
+  defaultRenderInput,
+  FormCallbacksProvider,
+  FormCallbacksValue,
+} from '../../../studio'
+import {PatchEvent, set} from '../../../patch'
+import {FIXME} from '../../../../FIXME'
+import {PrimitiveField} from './PrimitiveField'
+
+describe('PrimitiveField', () => {
+  describe('number', () => {
+    it('render empty input when given no valud', () => {
+      // Given
+      const {member, formCallbacks} = setupTest('number', undefined)
+
+      // When
+      const {getByTestId} = render(
+        <ThemeProvider theme={studioTheme}>
+          <LayerProvider>
+            <FormCallbacksProvider {...formCallbacks}>
+              <PrimitiveField
+                member={member}
+                renderInput={defaultRenderInput}
+                renderField={defaultRenderField}
+              />
+            </FormCallbacksProvider>
+          </LayerProvider>
+        </ThemeProvider>
+      )
+
+      // Then
+      const input = getByTestId('number-input') as HTMLInputElement
+      expect(input).toBeInstanceOf(HTMLInputElement)
+      expect(input.value).toEqual('')
+    })
+
+    it('render given initial number when mounted', () => {
+      // Given
+      const {member, TestWrapper} = setupTest('number', 42)
+
+      // When
+      const {getByTestId} = render(
+        <PrimitiveField
+          member={member}
+          renderInput={defaultRenderInput}
+          renderField={defaultRenderField}
+        />,
+        {wrapper: TestWrapper}
+      )
+
+      // Then
+      const input = getByTestId('number-input') as HTMLInputElement
+      expect(input).toBeInstanceOf(HTMLInputElement)
+      expect(input.value).toEqual('42')
+    })
+
+    it('calls `onChange` callback when the input changes', () => {
+      // Given
+      const {member, formCallbacks, TestWrapper} = setupTest('number', undefined)
+
+      const {getByTestId} = render(
+        <PrimitiveField
+          member={member}
+          renderInput={defaultRenderInput}
+          renderField={defaultRenderField}
+        />,
+        {wrapper: TestWrapper}
+      )
+
+      // When
+      userEvent.type(getByTestId('number-input'), '1.01')
+
+      // Then
+      expect(formCallbacks.onChange).toHaveBeenNthCalledWith(
+        1,
+        PatchEvent.from(set(1)).prefixAll(member.name)
+      )
+      expect(formCallbacks.onChange).toHaveBeenNthCalledWith(
+        2,
+        PatchEvent.from(set(1)).prefixAll(member.name)
+      )
+      expect(formCallbacks.onChange).toHaveBeenNthCalledWith(
+        3,
+        PatchEvent.from(set(1.01)).prefixAll(member.name)
+      )
+    })
+
+    it('updates input value when field is updated with a new value', () => {
+      // Given
+      const {member, TestWrapper} = setupTest('number', 1)
+
+      const {getByTestId, rerender} = render(
+        <PrimitiveField
+          member={member}
+          renderInput={defaultRenderInput}
+          renderField={defaultRenderField}
+        />,
+        {wrapper: TestWrapper}
+      )
+
+      // When
+      member.field.value = 42
+
+      rerender(
+        <PrimitiveField
+          member={member}
+          renderInput={defaultRenderInput}
+          renderField={defaultRenderField}
+        />
+      )
+
+      // Then
+      const input = getByTestId('number-input') as HTMLInputElement
+      expect(input).toBeInstanceOf(HTMLInputElement)
+      expect(input.value).toEqual('42')
+    })
+
+    it('keeps input value when field value is updated with a "simplified" version of the current input', () => {
+      // Given
+      const {member, TestWrapper} = setupTest('number', 1)
+
+      const {getByTestId, rerender} = render(
+        <PrimitiveField
+          member={member}
+          renderInput={defaultRenderInput}
+          renderField={defaultRenderField}
+        />,
+        {wrapper: TestWrapper}
+      )
+
+      // When
+      userEvent.type(getByTestId('number-input'), '.00')
+      member.field.value = 1
+
+      rerender(
+        <PrimitiveField
+          member={member}
+          renderInput={defaultRenderInput}
+          renderField={defaultRenderField}
+        />
+      )
+
+      // Then
+      const input = getByTestId('number-input') as HTMLInputElement
+      expect(input).toBeInstanceOf(HTMLInputElement)
+      expect(input.value).toEqual('1.00')
+    })
+  })
+})
+
+function setupTest(type: string, value: string | number | boolean | undefined) {
+  const member: FieldMember = {
+    kind: 'field',
+    key: 'key',
+    name: 'name',
+    index: 0,
+    collapsed: false,
+    collapsible: false,
+    open: true,
+    field: {
+      id: 'id',
+      schemaType: {
+        name: type,
+        jsonType: type as FIXME,
+      },
+      level: 1,
+      path: ['id'],
+      presence: [],
+      validation: [],
+      value,
+      readOnly: false,
+      focused: false,
+      changed: false,
+    },
+  }
+
+  const formCallbacks: FormCallbacksValue = {
+    onChange: jest.fn(),
+    onPathFocus: jest.fn(),
+    onPathBlur: jest.fn(),
+    onPathOpen: jest.fn(),
+    onSetPathCollapsed: jest.fn(),
+    onSetFieldSetCollapsed: jest.fn(),
+    onFieldGroupSelect: jest.fn(),
+  }
+
+  function TestWrapper({children}: PropsWithChildren) {
+    return (
+      <ThemeProvider theme={studioTheme}>
+        <LayerProvider>
+          <FormCallbacksProvider {...formCallbacks}>{children}</FormCallbacksProvider>
+        </LayerProvider>
+      </ThemeProvider>
+    )
+  }
+
+  return {member, formCallbacks, TestWrapper}
+}


### PR DESCRIPTION
### Description

This PR addresses the issue #4192. In which is impossible to type numbers that have leading zeros in their fractional part, e.g. `1.0001`.

This happens because every input change re-renders the form using a "normalized" value. For the case of a number, that is `HTMLInputElement. valueAsNumber`, which will happily parse a string of value `"1.000"` into the number `1`.

The first commit adds a few unit tests around the `PrimitiveField` component, to establish some base ground for refactoring. It also includes a test that captures this behaviour, and which fails without the proposed fix.

The second commit implements the fix, by introducing a piece of local state to hold the input value, as typed. On re-renders, this value is only updated if the underlying number differs from the component incoming prop.

(I haven't added tests for the `ArrayOfPrimitivesItem` component. If this proposed solution is accepted, and if you think it's valuable, I can definitely add them!)

Here's a video demonstrating the result of the proposed fix:

https://user-images.githubusercontent.com/424015/221186323-4b0584a8-f42b-420b-a606-aab851fbc9c1.mov

### What to review

It's important to verify that `PrimitiveField` and `ArrayOfPrimitivesItem` still work as expected for `boolean` and `string` values.

### Notes for release

Something along the lines of:

> Allow fractional part of a number to have leading zeros.
