### PR TITLE
fix(types): add `hidden` property to `FieldGroupDefinition`

### DIFF
--- a/packages/@sanity/types/src/schema/definition/type/common.ts
+++ b/packages/@sanity/types/src/schema/definition/type/common.ts
@@ -16,6 +16,7 @@ export type FieldsetDefinition = {
 export type FieldGroupDefinition = {
   name: string
   title?: string
+  hidden?: ConditionalProperty
   icon?: ComponentType | ReactNode
   default?: boolean
 }


### PR DESCRIPTION
### Description

When building out _siteSettings.tsx_ and adding `hidden` to `groups` a TypeScript error is introduced:

> Type '{ title: string; name: string; hidden: () => boolean; }' is not assignable to type 'FieldGroupDefinition'.
  Object literal may only specify known properties, and 'hidden' does not exist in type 'FieldGroupDefinition'.ts(2322

Screenshot:

![Screen Shot 2023-02-24 at 11 25 28 AM](https://user-images.githubusercontent.com/3289032/221246724-db70abed-40f1-41d1-9920-fd7e8a8a7574.png)

Code example:

```
import { defineField, defineType } from 'sanity';

export default defineType({
  name: 'siteSettings',
  title: 'Site Settings',
  type: 'document',
  groups: [
    { title: 'General', name: 'general', default: true },
    { title: 'Menu', name: 'menu' },
    { title: 'Footer', name: 'footer-settings' },
    { title: 'Default Meta Data', name: 'default-meta-data' },
    {
      title: 'foo bar',
      name: 'foobar',
      hidden: () => {
        return !window.org.dataset.startsWith('foo'); // <=== error is here
      }
    },
    { title: 'Default Pages', name: 'default-pages' }
  ],
  // removed code
  ]
});
```

and this should resolve the TypeScript error.