### PR TITLE
fix(preview): fix array selection on previews

### DIFF
--- a/packages/sanity/src/core/preview/createPathObserver.ts
+++ b/packages/sanity/src/core/preview/createPathObserver.ts
@@ -106,7 +106,13 @@ function observePaths(
   const next = Object.keys(leads).reduce((res: Record<string, unknown>, head) => {
     const tails = leads[head].filter((tail) => tail.length > 0)
     if (tails.length === 0) {
-      res[head] = isRecord(value) ? (value as Record<string, unknown>)[head] : undefined
+      if (isRecord(value)) {
+        res[head] = (value as Record<string, unknown>)[head]
+      } else if (Array.isArray(value)) {
+        res[head] = (value as any)[head]
+      } else {
+        res[head] = undefined
+      }
     } else {
       res[head] = observePaths((value as any)[head], tails, observeFields, apiConfig)
     }


### PR DESCRIPTION
### Description

This PR addresses the issue #4078.

When computing previews, the code navigates and resolves a chain of paths from a root value. But a preview path resolved value is set to `undefined` if an array property is the last element of its chain. This PR fixes that by allowing arrays' properties to be resolved.

### What to review

Although the patch is small, there's a lot of context around this, and I'm not sure if I missed something.

I used the following test documents to check if arrays are correctly resolved when at a "leaf position" or in the middle of the path. And also testing when their contents are primitive values, nested objects or references to other documents. 

```typescript
defineType({
  title: 'Test document',
  name: 'testDocument',
  type: 'document',
  fields: [
    {
      name: 'title',
      title: 'Title',
      type: 'string',
    },
    {
      name: 'strings',
      title: 'Strings',
      type: 'array',
      of: [{type: 'string'}],
    },
    {
      name: 'objects',
      title: 'Objects',
      type: 'array',
      of: [
        {
          type: 'object',
          fields: [
            {
              name: 'title',
              title: 'Title',
              type: 'string',
            },
            {
              name: 'strings',
              title: 'Strings',
              type: 'array',
              of: [{type: 'string'}],
            },
          ],
        },
      ],
    },
    {
      name: 'refs',
      title: 'References',
      type: 'array',
      of: [
        {
          type: 'reference',
          to: {type: 'innerDocument'},
        },
      ],
    },
  ],
  preview: {
    select: {
      title: 'title',
      stringCount: 'strings.length',
      objCount: 'objects.length',
      refCount: 'refs.length',
      firstString: 'strings.0',
      secondString: 'strings.1',
      firstObjTitle: 'objects.0.title',
      firstRefTitle: 'refs.0.title',
    },
    prepare({title, stringCount, objCount, firstString, secondString, firstObjTitle, refCount, firstRefTitle}) {
      return {
        title: `${title} ${firstString} ${secondString} ${firstObjTitle} ${firstRefTitle}`,
        subtitle: `${stringCount} ${objCount} ${refCount}`,
      }
    },
  },
})

defineType({
  title: 'Inner document',
  name: 'innerDocument',
  type: 'document',
  fields: [
    {
      name: 'title',
      title: 'Title',
      type: 'string',
    },
    {
      name: 'strings',
      title: 'Strings',
      type: 'array',
      of: [{type: 'string'}],
    },
  ],
})
```

### Notes for release

Something along the lines of:

> Fixed a preview bug which prevented array properties to be used at the end of a preview path.
