### PR TITLE
fix(core): changing workspace with same document id causes error

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/consistencyStatus.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/consistencyStatus.ts
@@ -25,5 +25,9 @@ export const consistencyStatus: (
       refCount()
     )
   },
-  (_client, idPair, typeName) => idPair.publishedId + typeName
+  (client, idPair, typeName) => {
+    const config = client.config()
+
+    return `${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${typeName}`
+  }
 )

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/documentEvents.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/documentEvents.ts
@@ -10,9 +10,9 @@ import {memoizedPair} from './memoizedPair'
 export function documentEvents(
   client: SanityClient,
   idPair: IdPair,
-  typeName?: string
+  typeName: string
 ): Observable<DocumentVersionEvent> {
-  return memoizedPair(client, idPair).pipe(
+  return memoizedPair(client, idPair, typeName).pipe(
     switchMap(({draft, published}) => merge(draft.events, published.events))
   )
 }

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/documentEvents.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/documentEvents.ts
@@ -2,17 +2,18 @@ import {SanityClient} from '@sanity/client'
 import {merge, Observable} from 'rxjs'
 import {switchMap} from 'rxjs/operators'
 import {IdPair} from '../types'
+import {memoize} from '../utils/createMemoizer'
 import {DocumentVersionEvent} from './checkoutPair'
 import {memoizedPair} from './memoizedPair'
+import {memoizeKeyGen} from './memoizeKeyGen'
 
 // A stream of all events related to either published or draft, each event comes with a 'target'
 // that specifies which version (draft|published) the event is about
-export function documentEvents(
-  client: SanityClient,
-  idPair: IdPair,
-  typeName: string
-): Observable<DocumentVersionEvent> {
-  return memoizedPair(client, idPair, typeName).pipe(
-    switchMap(({draft, published}) => merge(draft.events, published.events))
-  )
-}
+export const documentEvents = memoize(
+  (client: SanityClient, idPair: IdPair, typeName: string): Observable<DocumentVersionEvent> => {
+    return memoizedPair(client, idPair, typeName).pipe(
+      switchMap(({draft, published}) => merge(draft.events, published.events))
+    )
+  },
+  memoizeKeyGen
+)

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/editState.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/editState.ts
@@ -3,8 +3,10 @@ import {combineLatest, Observable} from 'rxjs'
 import {map, publishReplay, refCount, startWith, switchMap} from 'rxjs/operators'
 import {SanityClient} from '@sanity/client'
 import {IdPair, PendingMutationsEvent} from '../types'
+import {memoize} from '../utils/createMemoizer'
 import {isLiveEditEnabled} from './utils/isLiveEditEnabled'
 import {snapshotPair} from './snapshotPair'
+import {memoizeKeyGen} from './memoizeKeyGen'
 
 interface TransactionSyncLockState {
   enabled: boolean
@@ -24,45 +26,48 @@ const LOCKED: TransactionSyncLockState = {enabled: true}
 const NOT_LOCKED: TransactionSyncLockState = {enabled: false}
 
 /** @internal */
-export const editState = (
-  ctx: {
-    client: SanityClient
-    schema: Schema
+export const editState = memoize(
+  (
+    ctx: {
+      client: SanityClient
+      schema: Schema
+    },
+    idPair: IdPair,
+    typeName: string
+  ): Observable<EditStateFor> => {
+    const liveEdit = isLiveEditEnabled(ctx.schema, typeName)
+    return snapshotPair(ctx.client, idPair, typeName).pipe(
+      switchMap((versions) =>
+        combineLatest([
+          versions.draft.snapshots$,
+          versions.published.snapshots$,
+          versions.transactionsPendingEvents$.pipe(
+            map((ev: PendingMutationsEvent) => (ev.phase === 'begin' ? LOCKED : NOT_LOCKED)),
+            startWith(NOT_LOCKED)
+          ),
+        ])
+      ),
+      map(([draftSnapshot, publishedSnapshot, transactionSyncLock]) => ({
+        id: idPair.publishedId,
+        type: typeName,
+        draft: draftSnapshot,
+        published: publishedSnapshot,
+        liveEdit,
+        ready: true,
+        transactionSyncLock,
+      })),
+      startWith({
+        id: idPair.publishedId,
+        type: typeName,
+        draft: null,
+        published: null,
+        liveEdit,
+        ready: false,
+        transactionSyncLock: null,
+      }),
+      publishReplay(1),
+      refCount()
+    )
   },
-  idPair: IdPair,
-  typeName: string
-): Observable<EditStateFor> => {
-  const liveEdit = isLiveEditEnabled(ctx.schema, typeName)
-  return snapshotPair(ctx.client, idPair, typeName).pipe(
-    switchMap((versions) =>
-      combineLatest([
-        versions.draft.snapshots$,
-        versions.published.snapshots$,
-        versions.transactionsPendingEvents$.pipe(
-          map((ev: PendingMutationsEvent) => (ev.phase === 'begin' ? LOCKED : NOT_LOCKED)),
-          startWith(NOT_LOCKED)
-        ),
-      ])
-    ),
-    map(([draftSnapshot, publishedSnapshot, transactionSyncLock]) => ({
-      id: idPair.publishedId,
-      type: typeName,
-      draft: draftSnapshot,
-      published: publishedSnapshot,
-      liveEdit,
-      ready: true,
-      transactionSyncLock,
-    })),
-    startWith({
-      id: idPair.publishedId,
-      type: typeName,
-      draft: null,
-      published: null,
-      liveEdit,
-      ready: false,
-      transactionSyncLock: null,
-    }),
-    publishReplay(1),
-    refCount()
-  )
-}
+  (ctx, idPair, typeName) => memoizeKeyGen(ctx.client, idPair, typeName)
+)

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/memoizeKeyGen.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/memoizeKeyGen.ts
@@ -1,0 +1,7 @@
+import {SanityClient} from '@sanity/client'
+import {IdPair} from '../types'
+
+export function memoizeKeyGen(client: SanityClient, idPair: IdPair, typeName: string) {
+  const config = client.config()
+  return `${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${typeName}`
+}

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/memoizedPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/memoizedPair.ts
@@ -8,18 +8,16 @@ import {checkoutPair, type Pair} from './checkoutPair'
 export const memoizedPair: (
   client: SanityClient,
   idPair: IdPair,
-  _typeName?: string
+  typeName: string
 ) => Observable<Pair> = memoize(
-  (client: SanityClient, idPair: IdPair, _typeName?: string): Observable<Pair> => {
+  (client: SanityClient, idPair: IdPair, _typeName: string): Observable<Pair> => {
     return new Observable<Pair>((subscriber) => {
       subscriber.next(checkoutPair(client, idPair))
     }).pipe(publishReplay(1), refCount())
   },
-  (client: SanityClient, idPair: IdPair, typeName?: string) => {
+  (client, idPair, typeName) => {
     const config = client.config()
 
-    return `${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${
-      typeName ?? ''
-    }`
+    return `${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${typeName}`
   }
 )

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/memoizedPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/memoizedPair.ts
@@ -4,6 +4,7 @@ import {publishReplay, refCount} from 'rxjs/operators'
 import type {IdPair} from '../types'
 import {memoize} from '../utils/createMemoizer'
 import {checkoutPair, type Pair} from './checkoutPair'
+import {memoizeKeyGen} from './memoizeKeyGen'
 
 export const memoizedPair: (
   client: SanityClient,
@@ -15,9 +16,5 @@ export const memoizedPair: (
       subscriber.next(checkoutPair(client, idPair))
     }).pipe(publishReplay(1), refCount())
   },
-  (client, idPair, typeName) => {
-    const config = client.config()
-
-    return `${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${typeName}`
-  }
+  memoizeKeyGen
 )

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/memoizedPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/memoizedPair.ts
@@ -1,9 +1,9 @@
-import {SanityClient} from '@sanity/client'
+import type {SanityClient} from '@sanity/client'
 import {Observable} from 'rxjs'
 import {publishReplay, refCount} from 'rxjs/operators'
-import {IdPair} from '../types'
+import type {IdPair} from '../types'
 import {memoize} from '../utils/createMemoizer'
-import {checkoutPair, Pair} from './checkoutPair'
+import {checkoutPair, type Pair} from './checkoutPair'
 
 export const memoizedPair: (
   client: SanityClient,
@@ -15,5 +15,11 @@ export const memoizedPair: (
       subscriber.next(checkoutPair(client, idPair))
     }).pipe(publishReplay(1), refCount())
   },
-  (_client, idPair) => idPair.publishedId
+  (client: SanityClient, idPair: IdPair, typeName?: string) => {
+    const config = client.config()
+
+    return `${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${
+      typeName ?? ''
+    }`
+  }
 )

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operationArgs.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operationArgs.ts
@@ -39,5 +39,9 @@ export const operationArgs = memoize(
       refCount()
     )
   },
-  (_ctx, idPair, typeName) => idPair.publishedId + typeName
+  (ctx, idPair, typeName) => {
+    const config = ctx.client.config()
+
+    return `${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${typeName}`
+  }
 )

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/remoteSnapshots.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/remoteSnapshots.ts
@@ -1,16 +1,17 @@
-import {SanityClient} from '@sanity/client'
-import {merge} from 'rxjs'
+import type {SanityClient} from '@sanity/client'
+import {merge, type Observable} from 'rxjs'
 import {switchMap} from 'rxjs/operators'
-import {IdPair} from '../types'
-import {memoize} from '../utils/createMemoizer'
+import type {IdPair} from '../types'
+import type {RemoteSnapshotVersionEvent} from './checkoutPair'
 import {memoizedPair} from './memoizedPair'
 
 /** @internal */
-export const remoteSnapshots = memoize(
-  (client: SanityClient, idPair: IdPair, typeName: string) => {
-    return memoizedPair(client, idPair, typeName).pipe(
-      switchMap(({published, draft}) => merge(published.remoteSnapshot$, draft.remoteSnapshot$))
-    )
-  },
-  (_client, idPair, typeName) => idPair.publishedId + typeName
-)
+export const remoteSnapshots = (
+  client: SanityClient,
+  idPair: IdPair,
+  typeName: string
+): Observable<RemoteSnapshotVersionEvent> => {
+  return memoizedPair(client, idPair, typeName).pipe(
+    switchMap(({published, draft}) => merge(published.remoteSnapshot$, draft.remoteSnapshot$))
+  )
+}

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/remoteSnapshots.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/remoteSnapshots.ts
@@ -2,16 +2,24 @@ import type {SanityClient} from '@sanity/client'
 import {merge, type Observable} from 'rxjs'
 import {switchMap} from 'rxjs/operators'
 import type {IdPair} from '../types'
+import {memoize} from '../utils/createMemoizer'
 import type {RemoteSnapshotVersionEvent} from './checkoutPair'
 import {memoizedPair} from './memoizedPair'
 
 /** @internal */
-export const remoteSnapshots = (
-  client: SanityClient,
-  idPair: IdPair,
-  typeName: string
-): Observable<RemoteSnapshotVersionEvent> => {
-  return memoizedPair(client, idPair, typeName).pipe(
-    switchMap(({published, draft}) => merge(published.remoteSnapshot$, draft.remoteSnapshot$))
-  )
-}
+export const remoteSnapshots = memoize(
+  (
+    client: SanityClient,
+    idPair: IdPair,
+    typeName: string
+  ): Observable<RemoteSnapshotVersionEvent> => {
+    return memoizedPair(client, idPair, typeName).pipe(
+      switchMap(({published, draft}) => merge(published.remoteSnapshot$, draft.remoteSnapshot$))
+    )
+  },
+  (client, idPair, typeName) => {
+    const config = client.config()
+
+    return `${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${typeName}`
+  }
+)

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/snapshotPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/snapshotPair.ts
@@ -72,5 +72,9 @@ export const snapshotPair = memoize(
       refCount()
     )
   },
-  (_client, idPair, typeName) => idPair.publishedId + typeName
+  (client, idPair, typeName) => {
+    const config = client.config()
+
+    return `${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${typeName}`
+  }
 )

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/validation.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/validation.ts
@@ -180,5 +180,9 @@ export const validation = memoize(
       refCount()
     )
   },
-  (_ctx, idPair) => idPair.publishedId
+  (ctx, idPair, typeName) => {
+    const config = ctx.client.config()
+
+    return `${config.dataset ?? ''}-${config.projectId ?? ''}-${idPair.publishedId}-${typeName}`
+  }
 )


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Fixes issue where switching workspaces and navigating to document that shares the same id causes an error and didn't show document history

Fixes #3992

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

1. Fix issue where the memoizedPair did not account for sanity client config changing
2. Fix multiple levels of memoization for the `remoteSnapshots`

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

- Fix issue when changing workspaces on documents that have same id didn't show document history
