### PR TITLE
fix(auth): use configured api hostname for auth checks

### DIFF
--- a/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
@@ -9,7 +9,7 @@ import {isEqual, memoize} from 'lodash'
 import {CorsOriginError} from '../cors'
 import {AuthState, AuthStore} from './types'
 import {createBroadcastChannel} from './createBroadcastChannel'
-import {sessionId} from './sessionId'
+import {getSessionId} from './sessionId'
 import * as storage from './storage'
 import {createLoginComponent} from './createLoginComponent'
 
@@ -212,6 +212,7 @@ export function _createAuthStore({
   )
 
   async function handleCallbackUrl() {
+    const sessionId = getSessionId()
     if (sessionId && loginMethod === 'dual') {
       const requestClient = clientFactory({
         projectId,
@@ -220,6 +221,7 @@ export function _createAuthStore({
         withCredentials: true,
         apiVersion: '2021-06-07',
         requestTagPrefix: 'sanity.studio',
+        ...hostOptions,
       })
 
       // try to get the current user by using the cookie credentials
@@ -253,6 +255,7 @@ export function _createAuthStore({
       withCredentials: true,
       apiVersion: '2021-06-07',
       requestTagPrefix: 'sanity.studio',
+      ...hostOptions,
     })
 
     clearToken(projectId)

--- a/packages/sanity/src/core/store/_legacy/authStore/sessionId.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/sessionId.ts
@@ -27,5 +27,13 @@ function consumeSessionId(): string | null {
 
 // this module consumes the session ID as a side-effect as soon as its loaded
 // to remove the session ID from the history (vs waiting to remove the sid hash
-// until react mounts)
-export const sessionId = consumeSessionId()
+// until react mounts). Once it is consumed and loaded once, we don't want to
+// keep it in-memory here, so we clear it out.
+let sessionId = consumeSessionId()
+export const getSessionId = (): string | null => {
+  const id = sessionId
+  if (id) {
+    sessionId = null
+  }
+  return id
+}


### PR DESCRIPTION
### Description

When configuring a custom API hostname to use for the studio, the current user and token exchange requests would fail, as they were not using the configured API hostname. This PR ensures all auth-related requests also use the configured API hostname.

Also did a small change to the session ID handling, in that the constant `sessionId` is no longer exported - it is now only available for consumption _once_ (using `getSessionId()`), since we should never rely on it outside of exchanging it for a token (which only happens once).

### Notes for release

- Fixed authentication when using a custom API hostname
