### PR TITLE
fix(core): ensure filter function on reference field is always fired when menu is opened

### DIFF
--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
@@ -149,7 +149,6 @@ export function ReferenceInput(props: ReferenceInputProps) {
     (inputValue$: Observable<string | null>) => {
       return inputValue$.pipe(
         filter(nonNullable),
-        distinctUntilChanged(),
         switchMap((searchString) =>
           concat(
             of({isLoading: true}),


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->
Previously, when a reference field with a filter function was opened, the function would only be triggered on the first occasion. However, with this fix, the filter function will be executed every time the select menu is opened.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

Ensures that the filter function of a reference field is always executed upon opening of the select menu. 