### PR TITLE
fix(desk): attempt to resolve missing document type automatically

### DIFF
--- a/packages/sanity/src/desk/structureBuilder/DocumentList.ts
+++ b/packages/sanity/src/desk/structureBuilder/DocumentList.ts
@@ -1,6 +1,6 @@
 import {SchemaType, SortOrderingItem} from '@sanity/types'
-import {SanityClient} from '@sanity/client'
 import {ComposeIcon} from '@sanity/icons'
+import {resolveTypeForDocument} from './util/resolveTypeForDocument'
 import {SerializeError, HELP_URL} from './SerializeError'
 import {SerializeOptions, Child} from './StructureNodes'
 import {ChildResolver, ChildResolverOptions, ItemChild} from './ChildResolver'
@@ -12,24 +12,7 @@ import {
 } from './GenericList'
 import {DocumentBuilder} from './Document'
 import {StructureContext} from './types'
-import {DEFAULT_STUDIO_CLIENT_OPTIONS, InitialValueTemplateItem, SourceClientOptions} from 'sanity'
-
-const resolveTypeForDocument = async (
-  getClient: (options: SourceClientOptions) => SanityClient,
-  id: string
-): Promise<string | undefined> => {
-  const query = '*[_id in [$documentId, $draftId]]._type'
-  const documentId = id.replace(/^drafts\./, '')
-  const draftId = `drafts.${documentId}`
-
-  const types = await getClient(DEFAULT_STUDIO_CLIENT_OPTIONS).fetch(
-    query,
-    {documentId, draftId},
-    {tag: 'structure.resolve-type'}
-  )
-
-  return types[0]
-}
+import {InitialValueTemplateItem} from 'sanity'
 
 const validateFilter = (spec: PartialDocumentList, options: SerializeOptions) => {
   const filter = spec.options?.filter.trim() || ''

--- a/packages/sanity/src/desk/structureBuilder/util/resolveTypeForDocument.ts
+++ b/packages/sanity/src/desk/structureBuilder/util/resolveTypeForDocument.ts
@@ -1,0 +1,24 @@
+import type {SanityClient} from '@sanity/client'
+import {
+  DEFAULT_STUDIO_CLIENT_OPTIONS,
+  getDraftId,
+  getPublishedId,
+  type SourceClientOptions,
+} from 'sanity'
+
+export async function resolveTypeForDocument(
+  getClient: (options: SourceClientOptions) => SanityClient,
+  id: string
+): Promise<string | undefined> {
+  const query = '*[_id in [$documentId, $draftId]]._type'
+  const documentId = getPublishedId(id)
+  const draftId = getDraftId(id)
+
+  const types = await getClient(DEFAULT_STUDIO_CLIENT_OPTIONS).fetch(
+    query,
+    {documentId, draftId},
+    {tag: 'structure.resolve-type'}
+  )
+
+  return types[0]
+}


### PR DESCRIPTION
### Description

In some cases, a link will be generated that does not include a document type (because only the document ID is loaded until the document type has been resolved, for instance). When following the link, if the default document child resolver was used, it would throw an error. This PR improves on the situation by attempting to resolve the document type. If we're unable to find the document, we still throw - but otherwise we can recover from this state.

[sc-30793]

### What to review

- Example URL that fails in `next`: https://test-studio.sanity.build/test/content/author;grrm;fed42f93-66c5-4a47-a4dd-2a03c965a021%2CparentRefPath%3DfavoriteBooks%5B_key%3D%3D%2297724180be7c%22%5D
- Should now resolve in preview build: https://test-studio-git-fix-structure-auto-resolve-type.sanity.build/test/content/author;grrm;fed42f93-66c5-4a47-a4dd-2a03c965a021%2CparentRefPath%3DfavoriteBooks%5B_key%3D%3D%2297724180be7c%22%5D

### Notes for release

- Fixes an issue where the desk tool might crash if expanding a referenced document before its type was resolved
