### PR TITLE
[v2] fix(desk): attempt to resolve missing document type automatically

### DIFF
--- a/packages/@sanity/structure/src/Document.ts
+++ b/packages/@sanity/structure/src/Document.ts
@@ -4,6 +4,7 @@ import {ChildResolver} from './ChildResolver'
 import {SerializeOptions, Serializable, Child, DocumentNode, EditorNode} from './StructureNodes'
 import {SerializeError, HELP_URL} from './SerializeError'
 import {SchemaType} from './parts/Schema'
+import {resolveTypeForDocument} from './util/resolveTypeForDocument'
 import {validateId} from './util/validateId'
 import {View, ViewBuilder, maybeSerializeView} from './views/View'
 import {form} from './views'
@@ -12,15 +13,19 @@ import {
   DocumentFragmentResolveOptions,
 } from './userDefinedStructure'
 
-const resolveDocumentChild: ChildResolver = (itemId, {params, path}) => {
-  const {type} = params
+const resolveDocumentChild: ChildResolver = async (itemId, {params, path}) => {
+  let type = params.type
 
   const parentPath = path.slice(0, path.length - 1)
   const currentSegment = path[path.length - 1]
 
   if (!type) {
+    type = await resolveTypeForDocument(itemId)
+  }
+
+  if (!type) {
     throw new SerializeError(
-      `Invalid link. Your link must contain a \`type\`.`,
+      `Failed to resolve document, and no type provided in parameters.`,
       parentPath,
       currentSegment
     )

--- a/packages/@sanity/structure/src/DocumentList.ts
+++ b/packages/@sanity/structure/src/DocumentList.ts
@@ -4,7 +4,7 @@ import {
 } from '@sanity/initial-value-templates'
 import {SchemaType, getDefaultSchema} from './parts/Schema'
 import {isActionEnabled} from './parts/documentActionUtils'
-import {structureClient} from './parts/Client'
+import {resolveTypeForDocument} from './util/resolveTypeForDocument'
 import {SortItem} from './Sort'
 import {SerializeError, HELP_URL} from './SerializeError'
 import {SerializeOptions, Child} from './StructureNodes'
@@ -17,15 +17,6 @@ import {
   GenericListInput,
 } from './GenericList'
 import {DocumentBuilder, getDefaultDocumentNode} from './Document'
-
-const resolveTypeForDocument = (id: string): Promise<string | undefined> => {
-  const query = '*[_id in [$documentId, $draftId]]._type'
-  const documentId = id.replace(/^drafts\./, '')
-  const draftId = `drafts.${documentId}`
-  return structureClient
-    .fetch(query, {documentId, draftId}, {tag: 'structure.resolve-type'})
-    .then((types) => types[0])
-}
 
 const validateFilter = (spec: PartialDocumentList, options: SerializeOptions) => {
   const filter = spec.options!.filter.trim()

--- a/packages/@sanity/structure/src/util/resolveTypeForDocument.ts
+++ b/packages/@sanity/structure/src/util/resolveTypeForDocument.ts
@@ -1,0 +1,15 @@
+import {structureClient} from '../parts/Client'
+
+export async function resolveTypeForDocument(id: string): Promise<string | undefined> {
+  const query = '*[_id in [$documentId, $draftId]]._type'
+  const documentId = id.replace(/^drafts\./, '')
+  const draftId = `drafts.${documentId}`
+
+  const types = await structureClient.fetch(
+    query,
+    {documentId, draftId},
+    {tag: 'structure.resolve-type'}
+  )
+
+  return types[0]
+}


### PR DESCRIPTION
### Description

This is a 2.x backport of #4244 that fixes the same issue

Builds on #4246 because the failing tests were driving me mad.

[sc-30793]

### What to review

- Example URL that fails in `next`: https://test-studio-git-2x-next.sanity.build/test/desk/author;grrm;fed42f93-66c5-4a47-a4dd-2a03c965a021%2CparentRefPath%3DfavoriteBooks%5B_key%3D%3D%2297724180be7c%22%5D
- Should now resolve in preview build: https://test-studio-git-fix-structure-auto-resolve-type-2x.sanity.build/test/desk/author;grrm;fed42f93-66c5-4a47-a4dd-2a03c965a021%2CparentRefPath%3DfavoriteBooks%5B_key%3D%3D%2297724180be7c%22%5D

### Notes for release

- Fixes an issue where the desk tool might crash if expanding a referenced document before its type was resolved
