### PR TITLE
chore: fix v2 build

### DIFF
--- a/packages/@sanity/base/src/datastores/user/createUserStore.ts
+++ b/packages/@sanity/base/src/datastores/user/createUserStore.ts
@@ -64,7 +64,6 @@ function fetchCurrentUser(): Observable<CurrentUser | null> {
     const currentUserPromise = authenticationFetcher.getCurrentUser()
     userLoader.prime(
       'me',
-      // @ts-expect-error although not reflected in typings, priming with a promise is indeed supported, see https://github.com/graphql/dataloader/issues/235#issuecomment-692495153 and this PR for fixing it https://github.com/graphql/dataloader/pull/252
       currentUserPromise.then((u) => (u ? normalizeOwnUser(u) : null))
     )
     return currentUserPromise

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -10,7 +10,7 @@
     "build": "npm run build:lib && npm run package-yarn && npm run pack",
     "build:lib": "babel src --copy-files --out-dir lib",
     "clean": "rimraf lib dest",
-    "pack": "node scripts/pack.js",
+    "pack": "patch-package && node scripts/pack.js",
     "package-yarn": "node -r @babel/register src/scripts/package-yarn.js",
     "prebuild": "npm run clean",
     "prepublishOnly": "npm run build"
@@ -72,6 +72,7 @@
     "osenv": "^0.1.4",
     "p-filter": "^2.1.0",
     "p-timeout": "^2.0.1",
+    "patch-package": "^6.2.2",
     "promise-props-recursive": "^1.0.0",
     "resolve-from": "^4.0.0",
     "rimraf": "^2.7.1",
@@ -79,7 +80,7 @@
     "semver-compare": "^1.0.0",
     "split2": "^3.2.2",
     "validate-npm-package-name": "^3.0.0",
-    "webpack": "^4.14.0",
+    "webpack": "^4.46.0",
     "which": "^1.3.0",
     "xdg-basedir": "^3.0.0"
   }

--- a/packages/@sanity/cli/patches/webpack++terser-webpack-plugin+1.4.5.patch
+++ b/packages/@sanity/cli/patches/webpack++terser-webpack-plugin+1.4.5.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/webpack/node_modules/terser-webpack-plugin/dist/index.js b/node_modules/webpack/node_modules/terser-webpack-plugin/dist/index.js
+index 6268f6b..f4aa0e8 100644
+--- a/node_modules/webpack/node_modules/terser-webpack-plugin/dist/index.js
++++ b/node_modules/webpack/node_modules/terser-webpack-plugin/dist/index.js
+@@ -214,7 +214,7 @@ class TerserPlugin {
+               // eslint-disable-next-line global-require
+               'terser-webpack-plugin': require('../package.json').version,
+               'terser-webpack-plugin-options': this.options,
+-              hash: _crypto.default.createHash('md4').update(input).digest('hex')
++              hash: _crypto.default.createHash('md5').update(input).digest('hex')
+             };
+             task.cacheKeys = this.options.cacheKeys(defaultCacheKeys, file);
+           }

--- a/packages/@sanity/cli/patches/webpack+4.46.0.patch
+++ b/packages/@sanity/cli/patches/webpack+4.46.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/webpack/lib/util/createHash.js b/node_modules/webpack/lib/util/createHash.js
+index 64de510..52c9ca6 100644
+--- a/node_modules/webpack/lib/util/createHash.js
++++ b/node_modules/webpack/lib/util/createHash.js
+@@ -132,6 +132,7 @@ module.exports = algorithm => {
+ 		case "debug":
+ 			return new DebugHash();
+ 		default:
+-			return new BulkUpdateDecorator(require("crypto").createHash(algorithm));
++			const algo = algorithm === 'md4' ? 'md5' : algorithm;
++			return new BulkUpdateDecorator(require("crypto").createHash(algo));
+ 	}
+ };

--- a/packages/@sanity/import/package.json
+++ b/packages/@sanity/import/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@sanity/client": "^3.3.3",
-    "nock": "^9.0.5",
+    "nock": "^13.3.0",
     "rimraf": "^2.7.1"
   },
   "repository": {


### PR DESCRIPTION
### Description

This PR fixes a few build issue in the v2 branch:
- The CLI cannot be built on recent versions of node because of webpack using md4, which has been removed from OpenSSL in later versions. I've added the `patch-package` dependency and patches needed to replace the hashes with md5. We only use it for building the CLI, so it is a devtooling issue only.
- The dataloader dependency has fixed their typings, so a `ts-expect-error` comment was now giving errors, as it no longer produced an error
- Node 18 was complaining when running tests, with the error "The "stream" argument must be an instance of Stream. Received an instance of Socket". I eventually managed to narrow it down to the `nock` dependency, which I've upgraded. This fixed the issue, and it is still compatible with node 12 (the lowest version we support on v2)

### Notes for release

Nothing, this is build tooling related only.
