### PR TITLE
fix(core): fix crash when history does not include valid user information

### DIFF
--- a/packages/sanity/src/core/store/_legacy/user/userStore.ts
+++ b/packages/sanity/src/core/store/_legacy/user/userStore.ts
@@ -10,6 +10,14 @@ export interface UserStoreOptions {
   currentUser: CurrentUser | null
 }
 
+const INTERNAL_USER_IDS: User[] = [
+  {
+    id: '<system>',
+    displayName: 'Sanity',
+    imageUrl: 'https://public.sanity.io/logos/favicon-192.png',
+  },
+]
+
 /** @beta */
 export interface UserStore {
   getUser(userId: string): Promise<User | null>
@@ -55,6 +63,8 @@ export function createUserStore({client: _client, currentUser}: UserStoreOptions
   if (userFromCurrentUser?.id) {
     userLoader.prime(userFromCurrentUser.id, userFromCurrentUser)
   }
+
+  INTERNAL_USER_IDS.forEach((user) => userLoader.prime(user.id, user))
 
   return {
     getUser: (userId) => userLoader.load(userId),


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

When a dataset is copied without history it stores userId as `<system>` which is not a valid userId. This change fixes studio to show a dummy user information when invalid ids are present.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

- Does the logic make sense? Can it be simplified? 
    -  I created a new variable for storing invalid userIds, it might be a little over engineered for now but it allows flexibility to handle similar cases in the future.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

Fix crash in studio when viewing history for dataset that is copied without history
