### PR TITLE
fix(core): fix crash when history does not include valid user information

### DIFF
--- a/packages/@sanity/base/src/datastores/user/createUserStore.ts
+++ b/packages/@sanity/base/src/datastores/user/createUserStore.ts
@@ -39,6 +39,14 @@ import {consumeSessionId} from './sessionId'
 const debug = debugIt('sanity:userstore')
 const client = sanityClient.withConfig({apiVersion: '2021-06-07'})
 
+const INTERNAL_USERS: User[] = [
+  {
+    id: '<system>',
+    displayName: 'Sanity',
+    imageUrl: 'https://public.sanity.io/logos/favicon-192.png',
+  },
+]
+
 // Consume any session ID as early as possible (before mount) so we can remove it from the URL
 let sid: string | null = consumeSessionId()
 const projectId = config.api.projectId
@@ -55,6 +63,8 @@ const userLoader = new DataLoader(
     batchScheduleFn: (cb) => raf(cb),
   }
 )
+
+INTERNAL_USERS.forEach((user) => userLoader.prime(user.id, user))
 
 const debugRoles$ = debugRolesParam$.pipe(map(getDebugRolesByNames))
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

When a dataset is copied without history it stores userId as <system> which is not a valid userId. This change fixes studio to show a dummy user information when invalid ids are present.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

Making change to v2 version

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

Fix crash in studio when viewing history for dataset that is copied without history