### PR TITLE
fix(core): fix deleting invalid reference items in array

### DIFF
--- a/packages/sanity/src/core/form/members/object/fields/ArrayOfObjectsField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/ArrayOfObjectsField.tsx
@@ -235,9 +235,9 @@ export function ArrayOfObjectsField(props: {
         uploadSubscriptions.current[itemKey].unsubscribe()
         delete uploadSubscriptions.current[itemKey]
       }
-      handleChange([unset(member.field.path.concat({_key: itemKey}))])
+      handleChange([unset([{_key: itemKey}])])
     },
-    [handleChange, member.field.path]
+    [handleChange]
   )
 
   const handleFocusChildPath = useCallback(


### PR DESCRIPTION
### Description
Fixes invalid reference type in array fields
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->
Not sure if this is the correct way to fix it but seems like it since 
https://github.com/sanity-io/sanity/blob/next/packages/sanity/src/core/form/members/object/fields/ArrayOfObjectsField.tsx#L93 

the `handleChange` function is adding the name prefix so it should avoid double prefixing

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
Fixes deleting invalid reference items in array fields