### PR TITLE
docs: add docblock for useClient hook

### DIFF
--- a/packages/sanity/src/core/hooks/useClient.ts
+++ b/packages/sanity/src/core/hooks/useClient.ts
@@ -2,7 +2,24 @@ import type {SanityClient} from '@sanity/client'
 import type {SourceClientOptions} from '../config'
 import {useSource} from '../studio'
 
-/** @beta */
+/**
+ * React hook that returns a configured Sanity client instance based on the given configuration.
+ * Automatically uses the correct project and dataset based on the current active workspace.
+ *
+ * @public
+ * @param clientOptions - Options for the client. Specifying
+ *   {@link https://www.sanity.io/docs/api-versioning | apiVersion} is required in order to
+ *   prevent breaking changes if studio changes the API version used in other places.
+ * @returns A configured Sanity client instance
+ * @remarks The client instance is automatically memoized based on API version
+ * @example Instantiating a client
+ * ```ts
+ * function MyComponent() {
+ *   const client = useClient({apiVersion: '2021-06-07'})
+ *   // ... do something with client instance ...
+ * }
+ * ```
+ */
 export function useClient(clientOptions?: SourceClientOptions): SanityClient {
   const source = useSource()
   if (!clientOptions) {


### PR DESCRIPTION
### Description

I figured since we already talked about this and I had an example ready, I might as well _actually_ add the docblock ;) 

### Notes for release

- Marked the `useClient()` hook as public (stable)
