### PR TITLE
feat: add 'workspace' to conditional readOnly + hidden context

### DIFF
--- a/dev/test-studio/schema/author.ts
+++ b/dev/test-studio/schema/author.ts
@@ -1,5 +1,5 @@
 import {UserIcon as icon} from '@sanity/icons'
-import {Rule} from 'sanity'
+import {defineField, Rule} from 'sanity'
 
 const AUTHOR_ROLES = [
   {value: 'developer', title: 'Developer'},
@@ -41,6 +41,16 @@ export default {
       title: 'Name',
       type: 'string',
       validation: (rule: Rule) => rule.required(),
+    },
+    defineField({
+      name: 'workspaceConditionalHidden',
+      type: 'string',
+      hidden: (context) => context.workspace.dataset === 'hideMe',
+    }),
+    {
+      name: 'workspaceConditionalReadOnly',
+      type: 'string',
+      readOnly: (context) => context.workspace.dataset === 'hideMe',
     },
     {
       name: 'bestFriend',

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -106,6 +106,7 @@ export interface ConditionalPropertyCallbackContext {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   value: any
   currentUser: Omit<CurrentUser, 'role'> | null
+  workspace: any
 }
 
 /** @public */

--- a/packages/sanity/src/core/field/conditional-property/useConditionalProperty.tsx
+++ b/packages/sanity/src/core/field/conditional-property/useConditionalProperty.tsx
@@ -1,5 +1,7 @@
 import {SanityDocument, ConditionalProperty} from '@sanity/types'
+import {Workspace} from '../../config'
 import {useCurrentUser} from '../../store'
+import {useWorkspace} from '../../studio'
 import {useUnique} from '../../util'
 import {useCheckCondition} from './utils'
 
@@ -23,12 +25,14 @@ const useConditionalProperty = (props: ConditionalPropertyProps): boolean => {
   const {checkProperty = false, checkPropertyKey, document, parent, value: valueProp} = props
   const value = useUnique(valueProp)
   const currentUser = useCurrentUser()
+  const workspace = useWorkspace()
 
   const isPropertyTruthy = useCheckCondition(checkProperty, checkPropertyKey, {
     currentUser,
     document,
     parent,
     value,
+    workspace,
   })
 
   return isPropertyTruthy

--- a/packages/sanity/src/core/field/conditional-property/utils.tsx
+++ b/packages/sanity/src/core/field/conditional-property/utils.tsx
@@ -16,7 +16,7 @@ export function useCheckCondition(
   checkPropertyName: string,
   context: ConditionalPropertyCallbackContext
 ): boolean {
-  const {currentUser, document, parent, value} = context
+  const {currentUser, document, parent, value, workspace} = context
 
   const didWarn = useRef(false)
 
@@ -33,6 +33,7 @@ export function useCheckCondition(
         parent,
         value,
         currentUser,
+        workspace,
       })
     } catch (err) {
       console.error(
@@ -55,5 +56,5 @@ export function useCheckCondition(
     }
 
     return isTrueIsh
-  }, [checkProperty, document, parent, value, currentUser, checkPropertyName])
+  }, [checkProperty, document, parent, value, currentUser, workspace, checkPropertyName])
 }

--- a/packages/sanity/src/core/form/store/conditional-property/resolveConditionalProperty.ts
+++ b/packages/sanity/src/core/form/store/conditional-property/resolveConditionalProperty.ts
@@ -1,18 +1,20 @@
 /* eslint-disable no-nested-ternary */
 import {ConditionalProperty, CurrentUser} from '@sanity/types'
+import {Workspace} from '../../../config'
 
 export interface ConditionalPropertyCallbackContext {
   parent?: unknown
   document?: Record<string, unknown>
   currentUser: Omit<CurrentUser, 'role'> | null
   value: unknown
+  workspace: Workspace
 }
 
 export function resolveConditionalProperty(
   property: ConditionalProperty,
   context: ConditionalPropertyCallbackContext
 ) {
-  const {currentUser, document, parent, value} = context
+  const {currentUser, document, parent, value, workspace} = context
 
   if (typeof property === 'boolean' || property === undefined) {
     return Boolean(property)
@@ -24,6 +26,7 @@ export function resolveConditionalProperty(
       parent,
       value,
       currentUser,
+      workspace,
     }) === true // note: we can't strictly "trust" the return value here, so the conditional property should probably be typed as unknown
   )
 }

--- a/packages/sanity/src/core/form/store/formState.ts
+++ b/packages/sanity/src/core/form/store/formState.ts
@@ -24,6 +24,7 @@ import {isRecord} from '../../util'
 import {getFieldLevel} from '../studio/inputResolver/helpers'
 import {FIXME} from '../../FIXME'
 import {FormNodePresence} from '../../presence'
+import {Workspace} from '../../config'
 import {ObjectArrayFormNode, PrimitiveFormNode, StateTree} from './types'
 import {resolveConditionalProperty} from './conditional-property'
 import {ALL_FIELDS_GROUP, MAX_FIELD_DEPTH} from './constants'
@@ -162,6 +163,7 @@ function prepareFieldMember(props: {
     const inputState = prepareObjectInputState({
       schemaType: field.type,
       currentUser: parent.currentUser,
+      workspace: parent.workspace,
       parent: parent.value,
       document: parent.document,
       value: fieldValue,
@@ -273,12 +275,14 @@ function prepareFieldMember(props: {
           parent: parent.value,
           document: parent.document,
           currentUser: parent.currentUser,
+          workspace: parent.workspace,
         })
 
       const fieldState = prepareArrayOfObjectsInputState({
         schemaType: field.type,
         parent: parent.value,
         currentUser: parent.currentUser,
+        workspace: parent.workspace,
         document: parent.document,
         value: fieldValue,
         changed: isChangedValue(fieldValue, fieldComparisonValue),
@@ -341,6 +345,7 @@ function prepareFieldMember(props: {
           parent: parent.value,
           document: parent.document,
           currentUser: parent.currentUser,
+          workspace: parent.workspace,
         })
 
       const fieldState = prepareArrayOfPrimitivesInputState({
@@ -349,6 +354,7 @@ function prepareFieldMember(props: {
         schemaType: field.type,
         parent: parent.value,
         currentUser: parent.currentUser,
+        workspace: parent.workspace,
         document: parent.document,
         value: fieldValue,
         fieldGroupState,
@@ -395,6 +401,7 @@ function prepareFieldMember(props: {
       parent: parent.value,
       document: parent.document,
       currentUser: parent.currentUser,
+      workspace: parent.workspace,
     }
 
     // note: we *only* want to call the conditional props here, as it's handled by the prepare<Object|Array>InputProps otherwise
@@ -439,6 +446,7 @@ interface RawState<SchemaType, T> {
   changed?: boolean
   document: FIXME_SanityDocument
   currentUser: Omit<CurrentUser, 'role'> | null
+  workspace: Workspace
   parent?: unknown
   hidden?: boolean
   readOnly?: boolean
@@ -476,6 +484,7 @@ function prepareObjectInputState<T>(
     parent: props.parent,
     document: props.document,
     currentUser: props.currentUser,
+    workspace: props.workspace,
   }
 
   const hidden =
@@ -552,6 +561,7 @@ function prepareObjectInputState<T>(
       document: props.document,
       parent: props.value,
       value: pick(props.value, fieldsetFieldNames),
+      workspace: props.workspace,
     })
 
     if (fieldsetHidden) {
@@ -563,6 +573,7 @@ function prepareObjectInputState<T>(
       document: props.document,
       parent: props.value,
       value: pick(props.value, fieldsetFieldNames),
+      workspace: props.workspace,
     })
 
     const fieldsetMembers = fieldSet.fields.flatMap((field): (FieldMember | FieldError)[] => {
@@ -671,6 +682,7 @@ function prepareArrayOfPrimitivesInputState<T extends (boolean | string | number
     parent: props.parent,
     document: props.document,
     currentUser: props.currentUser,
+    workspace: props.workspace,
   }
 
   const hidden = resolveConditionalProperty(props.schemaType.hidden, conditionalPropertyContext)
@@ -721,6 +733,7 @@ function prepareArrayOfObjectsInputState<T extends {_key: string}[]>(
     parent: props.parent,
     document: props.document,
     currentUser: props.currentUser,
+    workspace: props.workspace,
   }
   const hidden = resolveConditionalProperty(props.schemaType.hidden, conditionalPropertyContext)
 
@@ -801,6 +814,7 @@ function prepareArrayOfObjectsMember(props: {
     parent: props.parent,
     document: parent.document,
     currentUser: parent.currentUser,
+    workspace: parent.workspace,
   }
   const readOnly =
     parent.readOnly ||
@@ -826,6 +840,7 @@ function prepareArrayOfObjectsMember(props: {
       focusPath: parent.focusPath,
       openPath: parent.openPath,
       currentUser: parent.currentUser,
+      workspace: parent.workspace,
       collapsedPaths: scopedCollapsedPaths,
       collapsedFieldSets: scopedCollapsedFieldsets,
       presence: parent.presence,
@@ -896,6 +911,7 @@ function prepareArrayOfPrimitivesMember(props: {
       parent: parent.value,
       document: parent.document,
       currentUser: parent.currentUser,
+      workspace: parent.workspace,
     })
 
   const item = preparePrimitiveInputState({

--- a/packages/sanity/src/core/form/store/useFormState.ts
+++ b/packages/sanity/src/core/form/store/useFormState.ts
@@ -5,6 +5,7 @@ import {useLayoutEffect, useMemo, useRef} from 'react'
 import {pathFor} from '@sanity/util/paths'
 import {FormNodePresence} from '../../presence'
 import {useCurrentUser} from '../../store'
+import {useWorkspace} from '../../studio'
 import {StateTree, ObjectFormNode} from './types'
 import {prepareFormState, FIXME_SanityDocument} from './formState'
 import {immutableReconcile} from './utils/immutableReconcile'
@@ -50,6 +51,7 @@ export function useFormState<
 ): FormState<T, S> | null {
   // note: feel free to move these state pieces out of this hook
   const currentUser = useCurrentUser()
+  const workspace = useWorkspace()
 
   const prev = useRef<DocumentFormNode | null>(null)
 
@@ -73,6 +75,7 @@ export function useFormState<
       path: pathFor([]),
       level: 0,
       currentUser,
+      workspace,
       presence,
       validation,
       changesOpen,
@@ -96,5 +99,6 @@ export function useFormState<
     presence,
     validation,
     changesOpen,
+    workspace,
   ])
 }


### PR DESCRIPTION
### Description

Adds the current `workspace` to the context parameter in `readOnly` and `hidden` functions.

### What to review

That there aren’t missing places for this sort of conditional logic. This probably shouldn't be merged until it's in other places that share the same context object like desk structure, rule.custom validations, etc.

Also the current workspace object is so big (it includes schema, theme, and more) that it might not be a good idea to include all of it – or some trimmed-down version.

### Notes for release

Adds the current `workspace` to the context parameter in `readOnly` and `hidden` functions.