### PR TITLE
feat(core): provide `getClient()` method to reference filter context

### DIFF
--- a/packages/@sanity/types/src/reference/types.ts
+++ b/packages/@sanity/types/src/reference/types.ts
@@ -1,3 +1,4 @@
+import type {SanityClient} from '@sanity/client'
 import type {Path} from '../paths'
 import type {SanityDocument} from '../documents'
 
@@ -27,11 +28,17 @@ export type ReferenceFilterSearchOptions = {
 }
 
 /** @public */
-export type ReferenceFilterResolver = (options: {
+export interface ReferenceFilterResolverContext {
   document: SanityDocument
   parent?: Record<string, unknown> | Record<string, unknown>[]
   parentPath: Path
-}) => ReferenceFilterSearchOptions | Promise<ReferenceFilterSearchOptions>
+  getClient: (options: {apiVersion: string}) => SanityClient
+}
+
+/** @public */
+export type ReferenceFilterResolver = (
+  context: ReferenceFilterResolverContext
+) => ReferenceFilterSearchOptions | Promise<ReferenceFilterSearchOptions>
 
 /** @public */
 export interface ReferenceFilterResolverOptions {


### PR DESCRIPTION
### Description

This PR adds the `getClient()` method to the context passed to reference filter resolvers.
Brings back functionality that was possible to do in v2, and does so in a way that is compatible with other v3 contexts.

[sc-25303]
[sc-25082]

### What to review

- Changes makes sense
- Client can be retrieved (try asyncFilter example on reference test type - it might not return any results, but should not crash)

### Notes for release

- Added `getClient()` method to reference filter context
