### PR TITLE
fix(core): fix typings to reflect that the second argument to patch.execute is optional

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operations/patch.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operations/patch.ts
@@ -2,7 +2,7 @@ import {isLiveEditEnabled} from '../utils/isLiveEditEnabled'
 import {OperationImpl} from './types'
 
 // todo: we could also consider exposing 'mutate' directly
-export const patch: OperationImpl<[patches: any[], initialDocument: Record<string, any>]> = {
+export const patch: OperationImpl<[patches: any[], initialDocument?: Record<string, any>]> = {
   disabled: (): false => false,
   execute: (
     {schema, snapshots, idPair, draft, published, typeName},

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operations/types.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operations/types.ts
@@ -31,7 +31,7 @@ export interface OperationsAPI {
   publish:
     | Operation<[], 'LIVE_EDIT_ENABLED' | 'ALREADY_PUBLISHED' | 'NO_CHANGES'>
     | GuardedOperation
-  patch: Operation<[patches: Patch[], initialDocument: Record<string, any>]> | GuardedOperation
+  patch: Operation<[patches: Patch[], initialDocument?: Record<string, any>]> | GuardedOperation
   discardChanges: Operation<[], 'NO_CHANGES' | 'NOT_PUBLISHED'> | GuardedOperation
   unpublish: Operation<[], 'LIVE_EDIT_ENABLED' | 'NOT_PUBLISHED'> | GuardedOperation
   duplicate: Operation<[documentId: string], 'NOTHING_TO_DUPLICATE'> | GuardedOperation


### PR DESCRIPTION
### Description
As per the types it currently looks like providing a second argument to `patch.execute` is required when it isn't (passing `undefined` works because `{...undefined}` is valid)

This PR fixes modifies the typings to reflect this.

### Notes for release

- Changed typings of `patch.execute()` to reflect that the second argument is optional