### PR TITLE
fix(core): remove button to convert to reference for arrays

### DIFF
--- a/packages/sanity/src/core/form/inputs/InvalidValueInput/InvalidValueInput.tsx
+++ b/packages/sanity/src/core/form/inputs/InvalidValueInput/InvalidValueInput.tsx
@@ -6,6 +6,7 @@ import {Details} from '../../components/Details'
 import {isDev} from '../../../environment'
 import {converters as CONVERTERS, ValueConverter} from './converters'
 import {UntypedValueInput} from './UntypedValueInput'
+import {isPlainObject} from 'lodash'
 
 interface Converter extends ValueConverter {
   from: string
@@ -59,7 +60,7 @@ export const InvalidValueInput = forwardRef(
       [value, actualType, validTypes]
     )
 
-    if (typeof value === 'object' && value !== null && !('_type' in value)) {
+    if (isPlainObject(value) && !('_type' in (value as object))) {
       return (
         <UntypedValueInput
           value={value as Record<string, unknown>}


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

When converting from array of references to a singular reference convert to reference would show which would convert it incorrectly making the document invalid

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

~I still kept `typeof value === 'object'` check to keep typescript happy~

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

Remove convert to reference button when converting array of references to singular reference