### PR TITLE
fix: preserve preview panes on small screens

### DIFF
--- a/packages/sanity/src/desk/components/deskTool/DeskTool.tsx
+++ b/packages/sanity/src/desk/components/deskTool/DeskTool.tsx
@@ -1,4 +1,4 @@
-import {PortalProvider, useToast, useMediaIndex} from '@sanity/ui'
+import {PortalProvider, useToast} from '@sanity/ui'
 import React, {memo, Fragment, useState, useEffect, useCallback} from 'react'
 import styled from 'styled-components'
 import isHotkey from 'is-hotkey'
@@ -9,7 +9,6 @@ import {PaneNode} from '../../types'
 import {PaneLayout} from '../pane'
 import {useDeskTool} from '../../useDeskTool'
 import {NoDocumentTypesScreen} from './NoDocumentTypesScreen'
-import {useRouter} from 'sanity/router'
 import {useSchema, _isCustomDocumentTypeDefinition} from 'sanity'
 
 interface DeskToolProps {
@@ -27,12 +26,10 @@ const isSaveHotkey = isHotkey('mod+s')
  * @internal
  */
 export const DeskTool = memo(function DeskTool({onPaneChange}: DeskToolProps) {
-  const {navigate} = useRouter()
   const {push: pushToast} = useToast()
   const schema = useSchema()
-  const mediaIndex = useMediaIndex()
   const {layoutCollapsed, setLayoutCollapsed} = useDeskTool()
-  const {paneDataItems, resolvedPanes, routerPanes} = useResolvedPanes()
+  const {paneDataItems, resolvedPanes} = useResolvedPanes()
 
   const [portalElement, setPortalElement] = useState<HTMLDivElement | null>(null)
 
@@ -47,18 +44,6 @@ export const DeskTool = memo(function DeskTool({onPaneChange}: DeskToolProps) {
       onPaneChange(resolvedPanes)
     }
   }, [onPaneChange, resolvedPanes])
-
-  // The pane layout is "collapsed" on small screens, and only shows 1 pane at a time.
-  // Remove pane siblings (i.e. split panes) as the pane layout collapses.
-  useEffect(() => {
-    if (mediaIndex > 1 || !layoutCollapsed) return
-    const hasSiblings = routerPanes.some((group) => group.length > 1)
-
-    if (!hasSiblings) return
-    const withoutSiblings = routerPanes.map((group) => [group[0]])
-
-    navigate({panes: withoutSiblings}, {replace: true})
-  }, [mediaIndex, navigate, layoutCollapsed, routerPanes])
 
   useEffect(() => {
     const handleGlobalKeyDown = (event: KeyboardEvent) => {


### PR DESCRIPTION
### Description

On small screens, and when in a "split pane" mode, like an editor pane next to a preview pane, the Desk Tool will attempt to close the "preview" pane.
It fails, and it will instead close all panes as demonstrated in this Loom: https://www.loom.com/share/ab5675cf50d0427d9eefa9d722966ae6

I assume that the original idea was that on small screens we wanted you to end up on a view like:
![Screenshot 2023-03-14 at 16 43 04](https://user-images.githubusercontent.com/81981/225057622-601cab6b-8e19-4d78-9f9e-80245c262f14.png)

As we don't support a "split pane" view on small screens, it's only ever 1 pane open and this is what a phone would see on the same URL as in the above Loom:

![Screenshot 2023-03-14 at 16 43 00](https://user-images.githubusercontent.com/81981/225057964-13476bbb-05e0-4169-a6e1-6ee2692e3341.png)

The above screenshot is what this PR will get you, instead of losing the state.
It's not super ideal, but it's better than window resizing potentially being a destructive action (as the pane collapsing is done as a URL redirect with `replace: true`, so you can't recover the previous state by hitting the back button).

### What to review

Resize the test editor from the smallest viewport allowed and back up on these two URLs to compare the before and after:
- [Before (without fix)](https://test-studio.sanity.build/test/content/author;69e3900b-5a7e-4edc-ae9f-d5d8790b4794%7C%2Cview%3Djson)
- [After (fix applied)](https://test-studio-git-bug-sc-31148panes-lost-on-resize.sanity.build/test/content/author;69e3900b-5a7e-4edc-ae9f-d5d8790b4794%7C%2Cview%3Djson)

### Notes for release

- fix: preserve preview panes on small screens