### PR TITLE
fix(core): handle 403 responses when calling `userStore.getUser()`

### DIFF
--- a/packages/sanity/src/core/store/_legacy/user/__tests__/userStore.test.ts
+++ b/packages/sanity/src/core/store/_legacy/user/__tests__/userStore.test.ts
@@ -1,0 +1,31 @@
+import {SanityClient} from '@sanity/client'
+import {createUserStore} from '../userStore'
+
+export class HttpError extends Error {
+  statusCode?: number
+}
+
+// Mock client which always throws 403 Forbidden errors on `request`
+const client = {
+  request: jest.fn(() => {
+    const error = new HttpError('Forbidden')
+    error.statusCode = 403
+    throw error
+  }),
+  withConfig: () => client,
+} as unknown as SanityClient
+
+const userStore = createUserStore({client, currentUser: null})
+
+describe('userStore', () => {
+  describe('getUser()', () => {
+    it(`resolves with null on 403 responses`, async () => {
+      await expect(userStore.getUser('foo')).resolves.toEqual(null)
+    })
+  })
+  describe('getUsers()', () => {
+    it(`resolves with an empty array on 403 responses`, async () => {
+      await expect(userStore.getUsers(['foo', 'bar'])).resolves.toStrictEqual([])
+    })
+  })
+})


### PR DESCRIPTION
## Description

This PR ensures that `userStore.getUser()` catches 403 responses - needed when trying to fetch users when your current role doesn't have access to _project members_. Previously, this was crashing the studio when opening document history changes.

This only really affects `<UserAvatar>`, and the reason why presence doesn't crash in these instances is that it uses `DataLoader.loadMany()` under the hood, which handles responses containing errors a little differently ([they always resolve](https://github.com/graphql/dataloader#loadmanykeys)).

This is a quick fix, and in future we could potentially look to obviate these requests entirely if your role doesn't have sufficient access.

## What to review

Opening document history shouldn't crash the studio when accessing the studio with a role that does not have read access to either:
- Project members
- Project details

## Notes for release

Fixes an issue where the studio may crash when accessing history changes with reduced permissions.