### PR TITLE
fix(SSR): handle `scheme` & `onSchemeChange` props edge cases

### DIFF
--- a/dev/test-next-studio/.depcheckignore.json
+++ b/dev/test-next-studio/.depcheckignore.json
@@ -1,0 +1,3 @@
+{
+  "ignore": ["styled-components", "react", "react-dom", "sanity"]
+}

--- a/dev/test-next-studio/.gitignore
+++ b/dev/test-next-studio/.gitignore
@@ -1,0 +1,2 @@
+.next
+.vscode

--- a/dev/test-next-studio/app/Studio.tsx
+++ b/dev/test-next-studio/app/Studio.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+/* eslint-disable react/react-in-jsx-scope */
+
+import {useMemo} from 'react'
+import {defineConfig, Studio, StudioProps} from 'sanity'
+import {deskTool} from 'sanity/desk'
+
+export default function StudioRoot({
+  basePath,
+  scheme,
+  unstable_globalStyles,
+  unstable_noAuthBoundary,
+}: {basePath: string} & Pick<
+  StudioProps,
+  'scheme' | 'unstable_noAuthBoundary' | 'unstable_globalStyles'
+>) {
+  const config = useMemo(
+    () =>
+      defineConfig({
+        basePath,
+        plugins: [deskTool()],
+        projectId: 'ppsg7ml5',
+        dataset: 'test',
+        schema: {
+          types: [
+            {
+              type: 'document',
+              name: 'post',
+              title: 'Post',
+              fields: [
+                {
+                  type: 'string',
+                  name: 'title',
+                  title: 'Title',
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    [basePath]
+  )
+
+  return (
+    <div id="sanity">
+      <Studio
+        config={config}
+        scheme={scheme}
+        unstable_globalStyles={unstable_globalStyles}
+        unstable_noAuthBoundary={unstable_noAuthBoundary}
+      />
+    </div>
+  )
+}

--- a/dev/test-next-studio/app/app-defaults/[[...path]]/page.tsx
+++ b/dev/test-next-studio/app/app-defaults/[[...path]]/page.tsx
@@ -1,0 +1,7 @@
+/* eslint-disable react/react-in-jsx-scope */
+
+import Studio from '../../Studio'
+
+export default function StudioPage() {
+  return <Studio basePath="/app-defaults" />
+}

--- a/dev/test-next-studio/app/app-global-styles/[[...path]]/page.tsx
+++ b/dev/test-next-studio/app/app-global-styles/[[...path]]/page.tsx
@@ -1,0 +1,7 @@
+/* eslint-disable react/react-in-jsx-scope */
+
+import Studio from '../../Studio'
+
+export default function StudioPage() {
+  return <Studio basePath="/app-global-styles" unstable_globalStyles />
+}

--- a/dev/test-next-studio/app/app-no-auth-boundary/[[...path]]/page.tsx
+++ b/dev/test-next-studio/app/app-no-auth-boundary/[[...path]]/page.tsx
@@ -1,0 +1,7 @@
+/* eslint-disable react/react-in-jsx-scope */
+
+import Studio from '../../Studio'
+
+export default function StudioPage() {
+  return <Studio basePath="/app-no-auth-boundary" unstable_noAuthBoundary />
+}

--- a/dev/test-next-studio/app/app-scheme-dark/[[...path]]/page.tsx
+++ b/dev/test-next-studio/app/app-scheme-dark/[[...path]]/page.tsx
@@ -1,0 +1,7 @@
+/* eslint-disable react/react-in-jsx-scope */
+
+import Studio from '../../Studio'
+
+export default function StudioPage() {
+  return <Studio basePath="/app-scheme-dark" scheme="dark" />
+}

--- a/dev/test-next-studio/app/app-scheme-light/[[...path]]/page.tsx
+++ b/dev/test-next-studio/app/app-scheme-light/[[...path]]/page.tsx
@@ -1,0 +1,7 @@
+/* eslint-disable react/react-in-jsx-scope */
+
+import Studio from '../../Studio'
+
+export default function StudioPage() {
+  return <Studio basePath="/app-scheme-light" scheme="light" />
+}

--- a/dev/test-next-studio/app/app-scheme-system/[[...path]]/page.tsx
+++ b/dev/test-next-studio/app/app-scheme-system/[[...path]]/page.tsx
@@ -1,0 +1,7 @@
+/* eslint-disable react/react-in-jsx-scope */
+
+import Studio from '../../Studio'
+
+export default function StudioPage() {
+  return <Studio basePath="/app-scheme-system" scheme="system" />
+}

--- a/dev/test-next-studio/app/global.css
+++ b/dev/test-next-studio/app/global.css
@@ -1,0 +1,12 @@
+html, body {
+  margin: 0;
+  padding: 0;
+}
+
+#sanity {
+  height: 100vh;
+  max-height: 100dvh;
+  overscroll-behavior: none;
+  -webkit-font-smoothing: antialiased;
+  overflow: auto;
+}

--- a/dev/test-next-studio/app/layout.tsx
+++ b/dev/test-next-studio/app/layout.tsx
@@ -1,0 +1,14 @@
+/* eslint-disable react/react-in-jsx-scope */
+// eslint-disable-next-line import/no-unassigned-import
+import './global.css'
+import StyledComponentsRegistry from './registry'
+
+export default function RootLayout({children}: {children: React.ReactNode}) {
+  return (
+    <html lang="en">
+      <body>
+        <StyledComponentsRegistry>{children}</StyledComponentsRegistry>
+      </body>
+    </html>
+  )
+}

--- a/dev/test-next-studio/app/page.tsx
+++ b/dev/test-next-studio/app/page.tsx
@@ -1,0 +1,43 @@
+/* eslint-disable react/react-in-jsx-scope */
+import Link from 'next/link'
+
+const links = [
+  // appDir
+  ['/app-defaults', '/app with defaults'],
+  ['/app-scheme-system', '/app with `scheme` hardcoded to `system`'],
+  ['/app-scheme-light', '/app with `scheme` hardcoded to `light`'],
+  ['/app-scheme-dark', '/app with `scheme` hardcoded to `dark`'],
+  ['/app-global-styles', '/app with `unstable_globalStyles`'],
+  ['/app-no-auth-boundary', '/app with `unstable_noAuthBoundary`'],
+  // good old pages
+  ['/pages-defaults', '/pages with defaults'],
+  ['/pages-scheme-system', '/pages with `scheme` hardcoded to `system`'],
+  ['/pages-scheme-light', '/pages with `scheme` hardcoded to `light`'],
+  ['/pages-scheme-dark', '/pages with `scheme` hardcoded to `dark`'],
+  ['/pages-global-styles', '/pages with `unstable_globalStyles`'],
+  ['/pages-no-auth-boundary', '/pages with `unstable_noAuthBoundary`'],
+]
+
+export default function Page() {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        height: '100vh',
+        maxHeight: '100dvh',
+        width: '100vw',
+        maxWidth: '100dvw',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <ul>
+        {links.map(([href, text]) => (
+          <li key={href}>
+            <Link href={href}>{text}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/dev/test-next-studio/app/registry.tsx
+++ b/dev/test-next-studio/app/registry.tsx
@@ -1,0 +1,28 @@
+// https://beta.nextjs.org/docs/styling/css-in-js#styled-components
+
+'use client'
+
+import React, {useState} from 'react'
+import {useServerInsertedHTML} from 'next/navigation'
+import {ServerStyleSheet, StyleSheetManager} from 'styled-components'
+
+export default function StyledComponentsRegistry({children}: {children: React.ReactNode}) {
+  // Only create stylesheet once with lazy initial state
+  // x-ref: https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
+  const [styledComponentsStyleSheet] = useState(() => new ServerStyleSheet())
+
+  useServerInsertedHTML(() => {
+    const styles = styledComponentsStyleSheet.getStyleElement()
+    // @ts-expect-error -- clearTag exists but `@types/styled-components` is missing its definitions
+    styledComponentsStyleSheet.instance.clearTag()
+    return styles
+  })
+
+  if (typeof window !== 'undefined') return children as JSX.Element
+
+  return (
+    <StyleSheetManager sheet={styledComponentsStyleSheet.instance}>
+      {children as React.ReactNode}
+    </StyleSheetManager>
+  )
+}

--- a/dev/test-next-studio/next-env.d.ts
+++ b/dev/test-next-studio/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/dev/test-next-studio/next.config.mjs
+++ b/dev/test-next-studio/next.config.mjs
@@ -1,0 +1,5 @@
+// eslint-disable-next-line tsdoc/syntax
+/** @type {import('next').NextConfig} */
+export default {
+  experimental: {appDir: true},
+}

--- a/dev/test-next-studio/package.json
+++ b/dev/test-next-studio/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "sanity-test-next-studio",
+  "version": "3.6.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "^13.2.4",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "sanity": "3.7.0",
+    "styled-components": "^5.2.0"
+  }
+}

--- a/dev/test-next-studio/pages/_app.tsx
+++ b/dev/test-next-studio/pages/_app.tsx
@@ -1,0 +1,10 @@
+/* eslint-disable react/react-in-jsx-scope */
+
+import type {AppProps} from 'next/app'
+
+// eslint-disable-next-line import/no-unassigned-import
+import '../app/global.css'
+
+export default function App({Component, pageProps}: AppProps) {
+  return <Component {...pageProps} />
+}

--- a/dev/test-next-studio/pages/_document.tsx
+++ b/dev/test-next-studio/pages/_document.tsx
@@ -1,0 +1,25 @@
+/* eslint-disable react/react-in-jsx-scope */
+import Document, {type DocumentContext} from 'next/document'
+import {ServerStyleSheet} from 'styled-components'
+
+export default class ServerStyleSheetDocument extends Document {
+  static async getInitialProps(ctx: DocumentContext) {
+    const sheet = new ServerStyleSheet()
+    const originalRenderPage = ctx.renderPage
+
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanceApp: (App) => (props) => sheet.collectStyles(<App {...props} />),
+        })
+
+      const initialProps = await Document.getInitialProps(ctx)
+      return {
+        ...initialProps,
+        styles: [initialProps.styles, sheet.getStyleElement()],
+      }
+    } finally {
+      sheet.seal()
+    }
+  }
+}

--- a/dev/test-next-studio/pages/pages-defaults/[[...path]].tsx
+++ b/dev/test-next-studio/pages/pages-defaults/[[...path]].tsx
@@ -1,0 +1,7 @@
+/* eslint-disable react/react-in-jsx-scope */
+
+import Studio from '../../app/Studio'
+
+export default function StudioPage() {
+  return <Studio basePath="/pages-defaults" />
+}

--- a/dev/test-next-studio/pages/pages-global-styles/[[...path]].tsx
+++ b/dev/test-next-studio/pages/pages-global-styles/[[...path]].tsx
@@ -1,0 +1,7 @@
+/* eslint-disable react/react-in-jsx-scope */
+
+import Studio from '../../app/Studio'
+
+export default function StudioPage() {
+  return <Studio basePath="/pages-global-styles" unstable_globalStyles />
+}

--- a/dev/test-next-studio/pages/pages-no-auth-boundary/[[...path]].tsx
+++ b/dev/test-next-studio/pages/pages-no-auth-boundary/[[...path]].tsx
@@ -1,0 +1,7 @@
+/* eslint-disable react/react-in-jsx-scope */
+
+import Studio from '../../app/Studio'
+
+export default function StudioPage() {
+  return <Studio basePath="/pages-no-auth-boundary" unstable_noAuthBoundary />
+}

--- a/dev/test-next-studio/pages/pages-scheme-dark/[[...path]].tsx
+++ b/dev/test-next-studio/pages/pages-scheme-dark/[[...path]].tsx
@@ -1,0 +1,7 @@
+/* eslint-disable react/react-in-jsx-scope */
+
+import Studio from '../../app/Studio'
+
+export default function StudioPage() {
+  return <Studio basePath="/pages-scheme-dark" scheme="dark" />
+}

--- a/dev/test-next-studio/pages/pages-scheme-light/[[...path]].tsx
+++ b/dev/test-next-studio/pages/pages-scheme-light/[[...path]].tsx
@@ -1,0 +1,7 @@
+/* eslint-disable react/react-in-jsx-scope */
+
+import Studio from '../../app/Studio'
+
+export default function StudioPage() {
+  return <Studio basePath="/pages-scheme-light" scheme="light" />
+}

--- a/dev/test-next-studio/pages/pages-scheme-system/[[...path]].tsx
+++ b/dev/test-next-studio/pages/pages-scheme-system/[[...path]].tsx
@@ -1,0 +1,7 @@
+/* eslint-disable react/react-in-jsx-scope */
+
+import Studio from '../../app/Studio'
+
+export default function StudioPage() {
+  return <Studio basePath="/pages-scheme-system" scheme="system" />
+}

--- a/dev/test-next-studio/tsconfig.json
+++ b/dev/test-next-studio/tsconfig.json
@@ -1,0 +1,37 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "strictNullChecks": true
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@types/mkdirp": "^1.0.2",
     "@types/node": "^14.18.9",
     "@types/react": "^18.0.25",
-    "@types/styled-components": "^5.1.16",
+    "@types/styled-components": "^5.1.26",
     "@types/tmp": "^0.2.3",
     "@types/yargs": "^17.0.7",
     "@typescript-eslint/eslint-plugin": "^5.5.0",

--- a/packages/sanity/src/core/studio/Studio.test.tsx
+++ b/packages/sanity/src/core/studio/Studio.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * SSR Hydration is hard to get right.
+ * It's not a concern when using `sanity dev`, `sanity build` or `sanity deploy` as we ship a client-only application
+ * that does not perform any attempt of hydration.
+ * However, when using `<Studio />` embedded into a library like Remix or Next.js, then:
+ * 1. The server will render as much as it can (including the Studio), in a single render pass.
+ *    It's a single pass, code like useEffect, or state setters etc won't trigger a state update or a re-render.
+ * 2. The client will then take over, and use the `hydrateRoot` API (https://beta.reactjs.org/apis/react-dom/client/hydrateRoot) which will skip the first render pass and not attempt to produce any HTML or mutate the DOM.
+ *    Instead, it will attempt to reuse the existing DOM and only attach event listeners.
+ * 3. It's critical that the server and client renders are identical, otherwise the client can in worst case scenarios attach event handlers to the wrong elements.
+ *    It may also break `styled-components` hydration, which results elements getting wrong styling, or no styling at all.
+ * 4. In development mode React will attempt to detect if there's a mismatch and warn, in production however it opts for speed and skips this check to enable fast hydration.
+ *
+ * The purpose of this testing suite is to guarantee that `<Studio />` is fully compatible the APIs that are used for hydration:
+ * a) https://beta.reactjs.org/apis/react-dom/client/hydrateRoot
+ * b) https://beta.reactjs.org/apis/react-dom/server/renderToString
+ * c) https://styled-components.com/docs/advanced#server-side-rendering
+ */
+
+import React from 'react'
+import {renderToString, renderToStaticMarkup} from 'react-dom/server'
+import {ServerStyleSheet} from 'styled-components'
+import {act} from 'react-dom/test-utils'
+import {hydrateRoot} from 'react-dom/client'
+import {SanityClient} from '@sanity/client'
+import {createMockAuthStore} from '../store/_legacy/authStore/createMockAuthStore'
+import {createMockSanityClient} from '../../../test/mocks/mockSanityClient'
+import {Studio} from './Studio'
+
+const client = createMockSanityClient() as any as SanityClient
+const config = {
+  projectId: 'test',
+  dataset: 'test',
+  auth: createMockAuthStore({client, currentUser: null}),
+}
+
+jest.mock('./components/navbar/NewDocumentButton')
+jest.mock('./components/navbar/presence/PresenceMenu')
+
+describe('Studio', () => {
+  it(`SSR to static markup doesn't throw or warn`, () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation()
+    const sheet = new ServerStyleSheet()
+    try {
+      const html = renderToStaticMarkup(sheet.collectStyles(<Studio config={config} />))
+      expect(html).toMatchInlineSnapshot(
+        `"<div data-ui=\\"Flex\\" data-scheme=\\"light\\" data-tone=\\"default\\" class=\\"sc-pyfCe fzrBED sc-hBxehG bwfbFf sc-pyfCe gGSiJt sc-csuSiG dmYLsz\\"><div data-ui=\\"Text\\" class=\\"sc-bcXHqe jJiwyv\\"><span>Loading…</span></div><div data-ui=\\"Spinner\\" class=\\"sc-bcXHqe jJiwyv sc-eDWCr eLlbHT\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\"></path></svg></span></div></div>"`
+      )
+    } finally {
+      sheet.seal()
+    }
+
+    expect(console.error).not.toHaveBeenCalled()
+
+    spy.mockReset()
+    spy.mockRestore()
+  })
+  it(`SSR to markup for hydration doesn't throw`, () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation()
+    const sheet = new ServerStyleSheet()
+    try {
+      const html = renderToString(sheet.collectStyles(<Studio config={config} />))
+      expect(html).toMatchInlineSnapshot(
+        `"<div data-ui=\\"Flex\\" data-scheme=\\"light\\" data-tone=\\"default\\" class=\\"sc-pyfCe fzrBED sc-hBxehG bwfbFf sc-pyfCe gGSiJt sc-csuSiG dmYLsz\\"><div data-ui=\\"Text\\" class=\\"sc-bcXHqe jJiwyv\\"><span>Loading…</span></div><div data-ui=\\"Spinner\\" class=\\"sc-bcXHqe jJiwyv sc-eDWCr eLlbHT\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\"></path></svg></span></div></div>"`
+      )
+    } finally {
+      sheet.seal()
+    }
+
+    expect(console.error).not.toHaveBeenCalled()
+
+    spy.mockReset()
+    spy.mockRestore()
+  })
+  it('SSR hydrateRoot finishes without warnings', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation()
+    const node = document.createElement('div')
+    document.body.appendChild(node)
+    const sheet = new ServerStyleSheet()
+    try {
+      const html = renderToString(sheet.collectStyles(<Studio config={config} />))
+      node.innerHTML = html
+      expect(html).toMatchInlineSnapshot(
+        `"<div data-ui=\\"Flex\\" data-scheme=\\"light\\" data-tone=\\"default\\" class=\\"sc-pyfCe fzrBED sc-hBxehG bwfbFf sc-pyfCe gGSiJt sc-csuSiG dmYLsz\\"><div data-ui=\\"Text\\" class=\\"sc-bcXHqe jJiwyv\\"><span>Loading…</span></div><div data-ui=\\"Spinner\\" class=\\"sc-bcXHqe jJiwyv sc-eDWCr eLlbHT\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\"></path></svg></span></div></div>"`
+      )
+      document.head.innerHTML += sheet.getStyleTags()
+
+      act(() => hydrateRoot(node, <Studio config={config} />))
+    } finally {
+      sheet.seal()
+    }
+
+    expect(console.error).not.toHaveBeenCalled()
+
+    spy.mockReset()
+    spy.mockRestore()
+  })
+})

--- a/packages/sanity/src/core/studio/Studio.tsx
+++ b/packages/sanity/src/core/studio/Studio.tsx
@@ -1,6 +1,6 @@
-import {ThemeColorSchemeKey} from '@sanity/ui'
 import React, {ReactElement} from 'react'
 import {Config} from '../config'
+import type {StudioThemeColorSchemeKey} from '../theme/types'
 import {GlobalStyle} from './GlobalStyle'
 import {RouterHistory} from './router'
 import {useLayoutComponent} from './studio-components-hooks'
@@ -10,8 +10,64 @@ import {StudioProvider} from './StudioProvider'
 export interface StudioProps {
   config: Config
   basePath?: string
-  onSchemeChange?: (nextScheme: ThemeColorSchemeKey) => void
-  scheme?: ThemeColorSchemeKey
+  /**
+   * Useful for scenarios where the Studio is embedded in another app,
+   * and the surrounding app also implements light and dark color schemes.
+   *
+   * The callback is fired whenever the user selects a new color scheme in the "Appearance" menu in the top-right dropdown.
+   * It also fires on first render with its initial value if you don't provide a `scheme` prop.
+   *
+   * If the user selects "System" in the "Appearance" menu, the callback will be fired with `"system"` as the scheme.
+   * To resolve `"system"` to the same color scheme as the Studio use the `usePrefersDark` hook from `@sanity/ui`:
+   *
+   * ```tsx
+   * import {usePrefersDark} from '@sanity/ui'
+   * import {Studio} from 'sanity'
+   *
+   * export default function StudioPage() {
+   *   const prefersDark = usePrefersDark()
+   *   const [_scheme, setScheme] = useState('system')
+   *   const prefersScheme = prefersDark ? 'dark' : 'light'
+   *   const scheme = _scheme === 'system' ? prefersScheme : _scheme
+   *
+   *   return (
+   *     <AppLayout scheme={scheme}>
+   *       <Studio config={config} onSchemeChange={setScheme} />
+   *     </AppLayout>
+   *   )
+   * }
+   * ```
+   *
+   * @beta
+   */
+  onSchemeChange?: (nextScheme: StudioThemeColorSchemeKey) => void
+  /**
+   * By default the Studio handles the color scheme itself, but you can provide a color scheme to use.
+   * If you only define `scheme` then the top-right "Appearance" dropdown menu will be hidden,
+   * and the Studio will stay in sync with the `scheme` prop.
+   *
+   * You may setup two-way sync and re-enable the "Appearance" dropdown menu by also providing an `onSchemeChange` callback:
+   * ```tsx
+   * import {Studio} from 'sanity'
+   * import {useSession} from 'your-app'
+   *
+   * export default function StudioPage() {
+   *   const session = useSession()
+   *   // Overrides the default scheme to be what's in the app user session
+   *   const [_scheme, setScheme] = useState(session.scheme)
+   *   const scheme = _scheme === 'system' ? session.scheme : _scheme
+   *
+   *   return (
+   *     <AppLayout scheme={scheme}>
+   *       <Studio config={config} scheme={scheme} onSchemeChange={setScheme} />
+   *     </AppLayout>
+   *   )
+   * }
+   * ```
+   *
+   * @beta
+   */
+  scheme?: StudioThemeColorSchemeKey
   /** @beta */
   unstable_history?: RouterHistory
   /** @beta */
@@ -28,10 +84,25 @@ function StudioLayout() {
 
 /** @beta */
 export function Studio(props: StudioProps): ReactElement {
-  const {unstable_globalStyles: globalStyles, ...restProps} = props
+  const {
+    basePath,
+    config,
+    onSchemeChange,
+    scheme,
+    unstable_globalStyles: globalStyles,
+    unstable_history,
+    unstable_noAuthBoundary,
+  } = props
 
   return (
-    <StudioProvider {...restProps}>
+    <StudioProvider
+      basePath={basePath}
+      config={config}
+      onSchemeChange={onSchemeChange}
+      scheme={scheme}
+      unstable_history={unstable_history}
+      unstable_noAuthBoundary={unstable_noAuthBoundary}
+    >
       {globalStyles && <GlobalStyle />}
       <StudioLayout />
     </StudioProvider>

--- a/packages/sanity/src/core/studio/StudioProvider.tsx
+++ b/packages/sanity/src/core/studio/StudioProvider.tsx
@@ -1,5 +1,5 @@
 import {ToastProvider} from '@sanity/ui'
-import React, {Fragment, useMemo} from 'react'
+import React from 'react'
 import Refractor from 'react-refractor'
 import bash from 'refractor/lang/bash'
 import javascript from 'refractor/lang/javascript'
@@ -47,9 +47,10 @@ export function StudioProvider({
   unstable_history: history,
   unstable_noAuthBoundary: noAuthBoundary,
 }: StudioProviderProps) {
-  const ConditionalAuthBoundary = useMemo(
-    () => (noAuthBoundary ? Fragment : AuthBoundary),
-    [noAuthBoundary]
+  const _children = (
+    <WorkspaceLoader LoadingComponent={LoadingScreen} ConfigErrorsComponent={ConfigErrorsScreen}>
+      <ResourceCacheProvider>{children}</ResourceCacheProvider>
+    </WorkspaceLoader>
   )
 
   return (
@@ -65,18 +66,17 @@ export function StudioProvider({
             >
               <StudioThemeProvider>
                 <UserColorManagerProvider>
-                  <ConditionalAuthBoundary
-                    LoadingComponent={LoadingScreen}
-                    AuthenticateComponent={AuthenticateScreen}
-                    NotAuthenticatedComponent={NotAuthenticatedScreen}
-                  >
-                    <WorkspaceLoader
+                  {noAuthBoundary ? (
+                    _children
+                  ) : (
+                    <AuthBoundary
                       LoadingComponent={LoadingScreen}
-                      ConfigErrorsComponent={ConfigErrorsScreen}
+                      AuthenticateComponent={AuthenticateScreen}
+                      NotAuthenticatedComponent={NotAuthenticatedScreen}
                     >
-                      <ResourceCacheProvider>{children}</ResourceCacheProvider>
-                    </WorkspaceLoader>
-                  </ConditionalAuthBoundary>
+                      {_children}
+                    </AuthBoundary>
+                  )}
                 </UserColorManagerProvider>
               </StudioThemeProvider>
             </ActiveWorkspaceMatcher>

--- a/packages/sanity/src/core/studio/StudioThemeProvider.tsx
+++ b/packages/sanity/src/core/studio/StudioThemeProvider.tsx
@@ -3,23 +3,32 @@
 import React from 'react'
 import {ThemeProvider, LayerProvider} from '@sanity/ui'
 import {useActiveWorkspace} from './activeWorkspaceMatcher'
-import {ColorSchemeContext, useColorScheme} from './colorScheme'
+import {ColorSchemeSetValueContext, ColorSchemeValueContext} from './colorScheme'
 
 interface StudioThemeProviderProps {
-  children: React.ReactChild
+  children: React.ReactNode
 }
 
 /** @internal */
 export function StudioThemeProvider({children}: StudioThemeProviderProps) {
   const theme = useActiveWorkspace().activeWorkspace.theme
-  const colorScheme = useColorScheme()
-  const scheme = theme.__legacy ? (theme.__dark ? 'dark' : 'light') : colorScheme.scheme
+
+  if (theme.__legacy) {
+    const scheme = theme.__dark ? 'dark' : 'light'
+    return (
+      <ColorSchemeSetValueContext.Provider value={false}>
+        <ColorSchemeValueContext.Provider value={scheme}>
+          <ThemeProvider scheme={scheme} theme={theme} tone="transparent">
+            <LayerProvider>{children}</LayerProvider>
+          </ThemeProvider>
+        </ColorSchemeValueContext.Provider>
+      </ColorSchemeSetValueContext.Provider>
+    )
+  }
 
   return (
-    <ColorSchemeContext.Provider value={{...colorScheme, scheme}}>
-      <ThemeProvider scheme={scheme} theme={theme} tone="transparent">
-        <LayerProvider>{children}</LayerProvider>
-      </ThemeProvider>
-    </ColorSchemeContext.Provider>
+    <ThemeProvider theme={theme} tone="transparent">
+      <LayerProvider>{children}</LayerProvider>
+    </ThemeProvider>
   )
 }

--- a/packages/sanity/src/core/studio/colorScheme.tsx
+++ b/packages/sanity/src/core/studio/colorScheme.tsx
@@ -1,54 +1,57 @@
-import React, {createContext, useCallback, useContext, useEffect, useMemo, useState} from 'react'
+import React, {createContext, useContext, useEffect, useMemo, useSyncExternalStore} from 'react'
 import {studioTheme, ThemeColorSchemeKey, ThemeProvider, usePrefersDark} from '@sanity/ui'
 import {DesktopIcon, MoonIcon, SunIcon} from '@sanity/icons'
+import type {StudioThemeColorSchemeKey} from '../theme/types'
 
-const LOCAL_STORAGE_KEY = 'sanityStudio:ui:colorScheme'
+/**
+ * Used to keep track of the internal value, which can be "system" in addition to "light" and "dark"
+ * @internal
+ */
+export const ColorSchemeValueContext = createContext<StudioThemeColorSchemeKey | null>(null)
 
-function localStorageManager() {
-  const supportsLocalStorage = typeof window !== 'undefined' && window.localStorage
-
-  function getItem(key: string) {
-    return supportsLocalStorage ? window.localStorage.getItem(key) : undefined
-  }
-
-  function setItem(key: string, value: string) {
-    return supportsLocalStorage ? window.localStorage.setItem(key, value) : undefined
-  }
-
-  function removeItem(key: string) {
-    return supportsLocalStorage ? window.localStorage.removeItem(key) : undefined
-  }
-
-  return {getItem, setItem, removeItem}
-}
+/**
+ * The setter for ColorSchemeValueContext, in a separate context to avoid unnecessary re-renders
+ * If set to false then the UI should adjust to reflect that the Studio can't change the color scheme
+ * @internal
+ */
+export const ColorSchemeSetValueContext = createContext<
+  ((nextScheme: StudioThemeColorSchemeKey) => void) | false | null
+>(null)
 
 /** @internal */
-export const ColorSchemeContext = createContext<{
-  /** The current color scheme */
-  scheme: ThemeColorSchemeKey
-  /** Set the color scheme and store it in local storage */
-  setScheme: (colorScheme: ThemeColorSchemeKey) => void
-  /** A boolean indicating whether the user is using the system color scheme */
-  usingSystemScheme: boolean
-  /** Clear the stored color scheme from local storage and use the system color scheme */
-  clearStoredScheme: () => void
-  /** The color scheme options */
-  colorSchemeOptions: ColorSchemeOption[]
-} | null>(null)
+function useSystemScheme(): ThemeColorSchemeKey {
+  const prefersDark = usePrefersDark()
+  return prefersDark ? 'dark' : 'light'
+}
+
+function ColorThemeProvider({
+  children,
+  scheme: _scheme,
+}: {
+  children: React.ReactNode
+  scheme: StudioThemeColorSchemeKey
+}) {
+  const systemScheme = useSystemScheme()
+  const scheme = _scheme === 'system' ? systemScheme : _scheme
+
+  return (
+    <ThemeProvider scheme={scheme} theme={studioTheme}>
+      {/* Note: this is a fallback ThemeProvider that is for any components */}
+      {/* that may render before the StudioThemeProvider renders. this is */}
+      {/* required because the StudioThemeProvider has a dependence on the */}
+      {/* active workspace provided via the ActiveWorkspaceMatcher */}
+      {children}
+    </ThemeProvider>
+  )
+}
+
+const LOCAL_STORAGE_KEY = 'sanityStudio:ui:colorScheme'
 
 /** @internal */
 export interface ColorSchemeProviderProps {
   children: React.ReactNode
-  onSchemeChange?: (nextScheme: ThemeColorSchemeKey) => void
-  scheme?: ThemeColorSchemeKey
-}
-
-interface ColorSchemeOption {
-  icon: React.ComponentType
-  name: 'light' | 'dark' | 'system'
-  onSelect: () => void
-  selected: boolean
-  title: string
+  onSchemeChange?: (nextScheme: StudioThemeColorSchemeKey) => void
+  scheme?: StudioThemeColorSchemeKey
 }
 
 /** @internal */
@@ -57,107 +60,176 @@ export function ColorSchemeProvider({
   onSchemeChange,
   scheme: schemeProp,
 }: ColorSchemeProviderProps) {
-  const {getItem, setItem, removeItem} = useMemo(() => localStorageManager(), [])
+  if (schemeProp) {
+    return (
+      <ColorSchemeCustomProvider scheme={schemeProp} onSchemeChange={onSchemeChange}>
+        {children}
+      </ColorSchemeCustomProvider>
+    )
+  }
 
-  // The system color scheme
-  const prefersDark = usePrefersDark()
-  const systemScheme = prefersDark ? 'dark' : 'light'
-
-  // The color scheme stored in local storage
-  const storedScheme = getItem?.(LOCAL_STORAGE_KEY) as ThemeColorSchemeKey | undefined
-
-  // A state indicating whether the user is using the system color scheme (mainly used to reflect what the user has selected in the UI)
-  const [usingSystemScheme, setUsingSystemScheme] = useState<boolean>(!storedScheme)
-
-  // The initial scheme to use
-  const initialScheme = (schemeProp || storedScheme || systemScheme) as ThemeColorSchemeKey
-  const [scheme, setScheme] = useState<ThemeColorSchemeKey>(initialScheme)
-
-  // Store the scheme in local storage when it changes (unless it's the system scheme)
-  const handleSetScheme = useCallback(
-    (nextScheme: ThemeColorSchemeKey) => {
-      // Safety check to make sure we only store valid scheme keys
-      if (nextScheme === 'dark' || nextScheme === 'light') {
-        setItem?.(LOCAL_STORAGE_KEY, nextScheme)
-        setScheme(nextScheme)
-        onSchemeChange?.(nextScheme)
-        setUsingSystemScheme(false)
-      }
-    },
-    [onSchemeChange, setItem]
+  return (
+    <ColorSchemeLocalStorageProvider onSchemeChange={onSchemeChange}>
+      {children}
+    </ColorSchemeLocalStorageProvider>
   )
+}
 
-  // Remove the stored scheme from local storage and set the scheme to the system scheme
-  const clearStoredScheme = useCallback(() => {
-    removeItem?.(LOCAL_STORAGE_KEY)
-    setScheme(systemScheme)
-    onSchemeChange?.(systemScheme)
-    setUsingSystemScheme(true)
-  }, [onSchemeChange, removeItem, systemScheme])
+/**
+ * Uses useSyncExternalStore to ensure that localStorage is accessed in a SSR hydration compatible way
+ * @internal
+ */
+export function ColorSchemeLocalStorageProvider({
+  children,
+  onSchemeChange,
+}: Pick<ColorSchemeProviderProps, 'children' | 'onSchemeChange'>) {
+  const store = useMemo(() => {
+    let snapshot: StudioThemeColorSchemeKey
+    const subscribers = new Set<() => void>()
 
-  // React to changes in the system settings.
-  // If the user doesn't have a stored scheme in local storage, use the system scheme.
-  useEffect(() => {
-    if (!storedScheme) {
-      setScheme(systemScheme)
-      setUsingSystemScheme(true)
+    return {
+      subscribe: (onStoreChange: () => void) => {
+        if (!snapshot) {
+          snapshot = getScheme(localStorage.getItem(LOCAL_STORAGE_KEY)) || 'system'
+        }
+        subscribers.add(onStoreChange)
+        return () => {
+          subscribers.delete(onStoreChange)
+        }
+      },
+      getSnapshot: () => snapshot,
+      setSnapshot: (nextScheme: StudioThemeColorSchemeKey) => {
+        snapshot = getScheme(nextScheme)
+        for (const subscription of subscribers) {
+          subscription()
+        }
+      },
+      // Only called during server-side rendering, and hydration if using hydrateRoot
+      // https://beta.reactjs.org/apis/react/useSyncExternalStore#adding-support-for-server-rendering
+      getServerSnapshot: () => 'system',
     }
-  }, [onSchemeChange, storedScheme, systemScheme])
+  }, [])
+  const scheme = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getServerSnapshot)
 
-  const colorSchemeOptions = useMemo(() => {
-    const options: ColorSchemeOption[] = [
+  useEffect(() => {
+    if (typeof onSchemeChange === 'function') {
+      onSchemeChange(scheme)
+    }
+    localStorage.setItem(LOCAL_STORAGE_KEY, scheme)
+  }, [onSchemeChange, scheme])
+
+  return (
+    <ColorSchemeSetValueContext.Provider value={store.setSnapshot}>
+      <ColorSchemeValueContext.Provider value={scheme}>
+        <ColorThemeProvider scheme={scheme}>{children}</ColorThemeProvider>
+      </ColorSchemeValueContext.Provider>
+    </ColorSchemeSetValueContext.Provider>
+  )
+}
+
+function getScheme(scheme: unknown): StudioThemeColorSchemeKey {
+  switch (scheme) {
+    case 'dark':
+    case 'light':
+      return scheme
+    default:
+      return 'system'
+  }
+}
+
+/**
+ * If the `scheme` prop is provided we don't need to setup any logic to handle localStorage
+ * @internal
+ */
+export function ColorSchemeCustomProvider({
+  children,
+  onSchemeChange,
+  scheme,
+}: Pick<ColorSchemeProviderProps, 'children' | 'onSchemeChange'> & {
+  scheme: StudioThemeColorSchemeKey
+}) {
+  return (
+    <ColorSchemeSetValueContext.Provider
+      value={typeof onSchemeChange === 'function' ? onSchemeChange : false}
+    >
+      <ColorSchemeValueContext.Provider value={scheme}>
+        <ColorThemeProvider scheme={scheme}>{children}</ColorThemeProvider>
+      </ColorSchemeValueContext.Provider>
+    </ColorSchemeSetValueContext.Provider>
+  )
+}
+
+/** @alpha */
+export function useColorSchemeSetValue() {
+  const setValue = useContext(ColorSchemeSetValueContext)
+  if (setValue === null) throw new Error('Could not find `ColorSchemeSetValueContext` context')
+  return setValue
+}
+
+/** @internal */
+export function _useColorSchemeInternalValue(): StudioThemeColorSchemeKey {
+  const value = useContext(ColorSchemeValueContext)
+  if (value === null) throw new Error('Could not find `ColorSchemeValueContext` context')
+  return value
+}
+
+/** @alpha */
+export function useColorSchemeValue(): ThemeColorSchemeKey {
+  const scheme = _useColorSchemeInternalValue()
+  const systemScheme = useSystemScheme()
+  return scheme === 'system' ? systemScheme : scheme
+}
+
+/**
+ * @deprecated Use `useColorSchemeValue` or `useColorSchemeSetValue` instead
+ * @internal
+ */
+export function useColorScheme() {
+  const scheme = useColorSchemeValue()
+  const setScheme = useColorSchemeSetValue()
+  return useMemo(() => ({scheme, setScheme}), [scheme, setScheme])
+}
+
+interface ColorSchemeOption {
+  icon: React.ComponentType
+  label: string
+  name: StudioThemeColorSchemeKey
+  onSelect: () => void
+  selected: boolean
+  title: string
+}
+/**
+ * @internal
+ */
+export function useColorSchemeOptions(setScheme: (nextScheme: StudioThemeColorSchemeKey) => void) {
+  const scheme = _useColorSchemeInternalValue()
+
+  return useMemo(() => {
+    return [
       {
         title: 'System',
         name: 'system',
-        selected: usingSystemScheme,
-        onSelect: clearStoredScheme,
+        label: 'Use system appearance',
+        selected: scheme === 'system',
+        onSelect: () => setScheme('system'),
         icon: DesktopIcon,
       },
       {
         title: 'Dark',
         name: 'dark',
-        selected: scheme === 'dark' && !usingSystemScheme,
-        onSelect: () => handleSetScheme('dark'),
+        label: 'Use dark appearance',
+        selected: scheme === 'dark',
+        onSelect: () => setScheme('dark'),
         icon: MoonIcon,
       },
       {
         title: 'Light',
         name: 'light',
-        selected: scheme === 'light' && !usingSystemScheme,
-        onSelect: () => handleSetScheme('light'),
+        label: 'Use light appearance',
+        selected: scheme === 'light',
+        onSelect: () => setScheme('light'),
         icon: SunIcon,
       },
-    ]
-
-    return options
-  }, [clearStoredScheme, handleSetScheme, scheme, usingSystemScheme])
-
-  const colorScheme = useMemo(
-    () => ({
-      scheme,
-      setScheme: handleSetScheme,
-      usingSystemScheme,
-      clearStoredScheme,
-      colorSchemeOptions,
-    }),
-    [clearStoredScheme, colorSchemeOptions, handleSetScheme, scheme, usingSystemScheme]
-  )
-  return (
-    <ColorSchemeContext.Provider value={colorScheme}>
-      {/* Note: this is a fallback ThemeProvider that is for any components */}
-      {/* that may render before the StudioThemeProvider renders. this is */}
-      {/* required because the StudioThemeProvider has a dependence on the */}
-      {/* active workspace provided via the ActiveWorkspaceMatcher */}
-      <ThemeProvider scheme={scheme} theme={studioTheme} tone="transparent">
-        {children}
-      </ThemeProvider>
-    </ColorSchemeContext.Provider>
-  )
-}
-
-/** @internal */
-export function useColorScheme() {
-  const value = useContext(ColorSchemeContext)
-  if (!value) throw new Error('Could not find `colorScheme` context')
-  return value
+    ] satisfies ColorSchemeOption[]
+  }, [scheme, setScheme])
 }

--- a/packages/sanity/src/core/studio/components/navbar/NavDrawer.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/NavDrawer.tsx
@@ -1,4 +1,4 @@
-import {Layer, Card, Flex, Text, Box, Button, Stack, Label, useRootTheme} from '@sanity/ui'
+import {Layer, Card, Flex, Text, Box, Button, Stack, Label} from '@sanity/ui'
 import {
   CheckmarkIcon,
   CloseIcon,
@@ -17,8 +17,8 @@ import {Tool} from '../../../config'
 import {useToolMenuComponent} from '../../studio-components-hooks'
 import {UserAvatar} from '../../../components'
 import {useWorkspaces} from '../../workspaces'
-import {useColorScheme} from '../../colorScheme'
-import {StudioTheme} from '../../../theme'
+import {useColorSchemeOptions, useColorSchemeSetValue} from '../../colorScheme'
+import {StudioThemeColorSchemeKey} from '../../../theme'
 import {userHasRole} from '../../../util/userHasRole'
 import {WorkspaceMenuButton} from './workspace'
 
@@ -71,6 +71,40 @@ const InnerCard = styled(motion(Card))`
   overflow: auto;
 `
 
+function AppearanceMenu({setScheme}: {setScheme: (nextScheme: StudioThemeColorSchemeKey) => void}) {
+  // Subscribe to just what we need, if the menu isn't shown then we're not subscribed to these contexts
+  const options = useColorSchemeOptions(setScheme)
+
+  return (
+    <>
+      <Card borderTop flex="none" padding={3} overflow="auto">
+        <Box padding={2}>
+          <Label size={1} muted>
+            Appearance
+          </Label>
+        </Box>
+
+        <Stack as="ul" marginTop={1} space={1}>
+          {options.map(({icon, label, name, onSelect, selected, title}) => (
+            <Stack as="li" key={name}>
+              <Button
+                aria-label={label}
+                icon={icon}
+                iconRight={selected && <CheckmarkIcon />}
+                justify="flex-start"
+                mode="bleed"
+                onClick={onSelect}
+                selected={selected}
+                text={title}
+              />
+            </Stack>
+          ))}
+        </Stack>
+      </Card>
+    </>
+  )
+}
+
 interface NavDrawerProps {
   activeToolName?: string
   isOpen: boolean
@@ -81,10 +115,9 @@ interface NavDrawerProps {
 export const NavDrawer = memo(function NavDrawer(props: NavDrawerProps) {
   const {activeToolName, isOpen, onClose, tools} = props
 
-  const {colorSchemeOptions} = useColorScheme()
+  const setScheme = useColorSchemeSetValue()
   const {auth, currentUser, projectId} = useWorkspace()
   const workspaces = useWorkspaces()
-  const theme = useRootTheme().theme as StudioTheme
   const ToolMenu = useToolMenuComponent()
 
   const isAdmin = Boolean(currentUser && userHasRole(currentUser, 'administrator'))
@@ -169,31 +202,7 @@ export const NavDrawer = memo(function NavDrawer(props: NavDrawerProps) {
 
                 {/* Theme picker and Manage */}
                 <Flex direction="column">
-                  <Card borderTop flex="none" padding={3} overflow="auto">
-                    <Box padding={2}>
-                      <Label size={1} muted>
-                        Appearance
-                      </Label>
-                    </Box>
-
-                    <Stack as="ul" marginTop={1} space={1}>
-                      {!theme.__legacy &&
-                        colorSchemeOptions.map((option) => (
-                          <Stack as="li" key={option.name}>
-                            <Button
-                              aria-label={`Use ${option} appearance`}
-                              icon={option.icon}
-                              iconRight={option.selected && <CheckmarkIcon />}
-                              justify="flex-start"
-                              mode="bleed"
-                              onClick={() => option.onSelect()}
-                              selected={option.selected}
-                              text={option.title}
-                            />
-                          </Stack>
-                        ))}
-                    </Stack>
-                  </Card>
+                  {setScheme && <AppearanceMenu setScheme={setScheme} />}
                   <Card borderTop flex="none" padding={3}>
                     <Stack as="ul" space={1}>
                       <Stack as="li">

--- a/packages/sanity/src/core/studio/components/navbar/userMenu/UserMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/userMenu/UserMenu.tsx
@@ -21,16 +21,19 @@ import {
   Stack,
   Text,
   Tooltip,
-  useRootTheme,
 } from '@sanity/ui'
 import React, {useMemo} from 'react'
 import styled from 'styled-components'
 import {UserAvatar} from '../../../../components'
 import {getProviderTitle} from '../../../../store'
-import {StudioTheme} from '../../../../theme'
-import {userHasRole} from '../../../../util/userHasRole'
-import {useColorScheme} from '../../../colorScheme'
+import {type StudioThemeColorSchemeKey} from '../../../../theme'
+import {
+  useColorSchemeOptions,
+  useColorSchemeSetValue,
+  useColorSchemeValue,
+} from '../../../colorScheme'
 import {useWorkspace} from '../../../workspace'
+import {userHasRole} from '../../../../util/userHasRole'
 import {LoginProviderLogo} from './LoginProviderLogo'
 
 const AVATAR_SIZE = 1
@@ -46,11 +49,39 @@ const AvatarBox = styled(Box)`
   min-height: ${({theme}) => theme.sanity.avatar.sizes[AVATAR_SIZE].size}px;
 `
 
+function AppearanceMenu({setScheme}: {setScheme: (nextScheme: StudioThemeColorSchemeKey) => void}) {
+  // Subscribe to just what we need, if the menu isn't shown then we're not subscribed to these contexts
+  const options = useColorSchemeOptions(setScheme)
+
+  return (
+    <>
+      <MenuDivider />
+
+      <Box padding={2}>
+        <Label size={1} muted>
+          Appearance
+        </Label>
+      </Box>
+
+      {options.map(({icon, label, name, onSelect, selected, title}) => (
+        <MenuItem
+          key={name}
+          aria-label={label}
+          icon={icon}
+          onClick={onSelect}
+          pressed={selected}
+          text={title}
+          iconRight={selected && <CheckmarkIcon />}
+        />
+      ))}
+    </>
+  )
+}
+
 export function UserMenu() {
-  const {colorSchemeOptions} = useColorScheme()
   const {currentUser, projectId, auth} = useWorkspace()
-  const {scheme} = useColorScheme()
-  const theme = useRootTheme().theme as StudioTheme
+  const scheme = useColorSchemeValue()
+  const setScheme = useColorSchemeSetValue()
 
   const isAdmin = Boolean(currentUser && userHasRole(currentUser, 'administrator'))
   const providerTitle = getProviderTitle(currentUser?.provider)
@@ -117,18 +148,7 @@ export function UserMenu() {
               </Stack>
             </Flex>
           </Card>
-          {!theme.__legacy &&
-            colorSchemeOptions.map((option) => (
-              <MenuItem
-                aria-label={`Use ${option} appearance`}
-                icon={option.icon}
-                iconRight={option.selected && <CheckmarkIcon />}
-                key={option.name}
-                onClick={() => option.onSelect()}
-                pressed={option.selected}
-                text={option.title}
-              />
-            ))}
+          {setScheme && <AppearanceMenu setScheme={setScheme} />}
 
           <MenuDivider />
 

--- a/packages/sanity/src/core/theme/types.ts
+++ b/packages/sanity/src/core/theme/types.ts
@@ -1,4 +1,4 @@
-import {RootTheme} from '@sanity/ui'
+import type {RootTheme, ThemeColorSchemeKey} from '@sanity/ui'
 
 /** @public */
 export interface StudioTheme extends RootTheme {
@@ -7,3 +7,9 @@ export interface StudioTheme extends RootTheme {
   /** @internal */
   __legacy?: boolean
 }
+
+/**
+ * Used to specify light or dark mode, or to respect system settings (prefers-color-scheme media query) use 'system'
+ * @public
+ */
+export type StudioThemeColorSchemeKey = ThemeColorSchemeKey | 'system'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2876,70 +2876,140 @@
   resolved "https://registry.yarnpkg.com/@next/env/-/env-12.3.4.tgz#c787837d36fcad75d72ff8df6b57482027d64a47"
   integrity sha512-H/69Lc5Q02dq3o+dxxy5O/oNxFsZpdL6WREtOOtOM1B/weonIwDXkekr1KV5DPVPr12IHFPrMrcJQ6bgPMfn7A==
 
+"@next/env@13.2.4":
+  version "13.2.4"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-13.2.4.tgz#8b763700262b2445140a44a8c8d088cef676dbae"
+  integrity sha512-+Mq3TtpkeeKFZanPturjcXt+KHfKYnLlX6jMLyCrmpq6OOs4i1GqBOAauSkii9QeKCMTYzGppar21JU57b/GEA==
+
 "@next/swc-android-arm-eabi@12.3.4":
   version "12.3.4"
   resolved "https://registry.yarnpkg.com/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.4.tgz#fd1c2dafe92066c6120761c6a39d19e666dc5dd0"
   integrity sha512-cM42Cw6V4Bz/2+j/xIzO8nK/Q3Ly+VSlZJTa1vHzsocJRYz8KT6MrreXaci2++SIZCF1rVRCDgAg5PpqRibdIA==
+
+"@next/swc-android-arm-eabi@13.2.4":
+  version "13.2.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.2.4.tgz#758d0403771e549f9cee71cbabc0cb16a6c947c0"
+  integrity sha512-DWlalTSkLjDU11MY11jg17O1gGQzpRccM9Oes2yTqj2DpHndajrXHGxj9HGtJ+idq2k7ImUdJVWS2h2l/EDJOw==
 
 "@next/swc-android-arm64@12.3.4":
   version "12.3.4"
   resolved "https://registry.yarnpkg.com/@next/swc-android-arm64/-/swc-android-arm64-12.3.4.tgz#11a146dae7b8bca007239b21c616e83f77b19ed4"
   integrity sha512-5jf0dTBjL+rabWjGj3eghpLUxCukRhBcEJgwLedewEA/LJk2HyqCvGIwj5rH+iwmq1llCWbOky2dO3pVljrapg==
 
+"@next/swc-android-arm64@13.2.4":
+  version "13.2.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-android-arm64/-/swc-android-arm64-13.2.4.tgz#834d586523045110d5602e0c8aae9028835ac427"
+  integrity sha512-sRavmUImUCf332Gy+PjIfLkMhiRX1Ez4SI+3vFDRs1N5eXp+uNzjFUK/oLMMOzk6KFSkbiK/3Wt8+dHQR/flNg==
+
 "@next/swc-darwin-arm64@12.3.4":
   version "12.3.4"
   resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.4.tgz#14ac8357010c95e67327f47082af9c9d75d5be79"
   integrity sha512-DqsSTd3FRjQUR6ao0E1e2OlOcrF5br+uegcEGPVonKYJpcr0MJrtYmPxd4v5T6UCJZ+XzydF7eQo5wdGvSZAyA==
+
+"@next/swc-darwin-arm64@13.2.4":
+  version "13.2.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.2.4.tgz#5006fca179a36ef3a24d293abadec7438dbb48c6"
+  integrity sha512-S6vBl+OrInP47TM3LlYx65betocKUUlTZDDKzTiRDbsRESeyIkBtZ6Qi5uT2zQs4imqllJznVjFd1bXLx3Aa6A==
 
 "@next/swc-darwin-x64@12.3.4":
   version "12.3.4"
   resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.4.tgz#e7dc63cd2ac26d15fb84d4d2997207fb9ba7da0f"
   integrity sha512-PPF7tbWD4k0dJ2EcUSnOsaOJ5rhT3rlEt/3LhZUGiYNL8KvoqczFrETlUx0cUYaXe11dRA3F80Hpt727QIwByQ==
 
+"@next/swc-darwin-x64@13.2.4":
+  version "13.2.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-13.2.4.tgz#6549c7c04322766acc3264ccdb3e1b43fcaf7946"
+  integrity sha512-a6LBuoYGcFOPGd4o8TPo7wmv5FnMr+Prz+vYHopEDuhDoMSHOnC+v+Ab4D7F0NMZkvQjEJQdJS3rqgFhlZmKlw==
+
 "@next/swc-freebsd-x64@12.3.4":
   version "12.3.4"
   resolved "https://registry.yarnpkg.com/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.4.tgz#fe7ceec58746fdf03f1fcb37ec1331c28e76af93"
   integrity sha512-KM9JXRXi/U2PUM928z7l4tnfQ9u8bTco/jb939pdFUHqc28V43Ohd31MmZD1QzEK4aFlMRaIBQOWQZh4D/E5lQ==
+
+"@next/swc-freebsd-x64@13.2.4":
+  version "13.2.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.2.4.tgz#0bbe28979e3e868debc2cc06e45e186ce195b7f4"
+  integrity sha512-kkbzKVZGPaXRBPisoAQkh3xh22r+TD+5HwoC5bOkALraJ0dsOQgSMAvzMXKsN3tMzJUPS0tjtRf1cTzrQ0I5vQ==
 
 "@next/swc-linux-arm-gnueabihf@12.3.4":
   version "12.3.4"
   resolved "https://registry.yarnpkg.com/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.4.tgz#d7016934d02bfc8bd69818ffb0ae364b77b17af7"
   integrity sha512-3zqD3pO+z5CZyxtKDTnOJ2XgFFRUBciOox6EWkoZvJfc9zcidNAQxuwonUeNts6Xbm8Wtm5YGIRC0x+12YH7kw==
 
+"@next/swc-linux-arm-gnueabihf@13.2.4":
+  version "13.2.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.2.4.tgz#1d28d2203f5a7427d6e7119d7bcb5fc40959fb3e"
+  integrity sha512-7qA1++UY0fjprqtjBZaOA6cas/7GekpjVsZn/0uHvquuITFCdKGFCsKNBx3S0Rpxmx6WYo0GcmhNRM9ru08BGg==
+
 "@next/swc-linux-arm64-gnu@12.3.4":
   version "12.3.4"
   resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.4.tgz#43a7bc409b03487bff5beb99479cacdc7bd29af5"
   integrity sha512-kiX0vgJGMZVv+oo1QuObaYulXNvdH/IINmvdZnVzMO/jic/B8EEIGlZ8Bgvw8LCjH3zNVPO3mGrdMvnEEPEhKA==
+
+"@next/swc-linux-arm64-gnu@13.2.4":
+  version "13.2.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.2.4.tgz#eb26448190948cdf4c44b8f34110a3ecea32f1d0"
+  integrity sha512-xzYZdAeq883MwXgcwc72hqo/F/dwUxCukpDOkx/j1HTq/J0wJthMGjinN9wH5bPR98Mfeh1MZJ91WWPnZOedOg==
 
 "@next/swc-linux-arm64-musl@12.3.4":
   version "12.3.4"
   resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.4.tgz#4d1db6de6dc982b974cd1c52937111e3e4a34bd3"
   integrity sha512-EETZPa1juczrKLWk5okoW2hv7D7WvonU+Cf2CgsSoxgsYbUCZ1voOpL4JZTOb6IbKMDo6ja+SbY0vzXZBUMvkQ==
 
+"@next/swc-linux-arm64-musl@13.2.4":
+  version "13.2.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.2.4.tgz#c4227c0acd94a420bb14924820710e6284d234d3"
+  integrity sha512-8rXr3WfmqSiYkb71qzuDP6I6R2T2tpkmf83elDN8z783N9nvTJf2E7eLx86wu2OJCi4T05nuxCsh4IOU3LQ5xw==
+
 "@next/swc-linux-x64-gnu@12.3.4":
   version "12.3.4"
   resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.4.tgz#c3b414d77bab08b35f7dd8943d5586f0adb15e38"
   integrity sha512-4csPbRbfZbuWOk3ATyWcvVFdD9/Rsdq5YHKvRuEni68OCLkfy4f+4I9OBpyK1SKJ00Cih16NJbHE+k+ljPPpag==
+
+"@next/swc-linux-x64-gnu@13.2.4":
+  version "13.2.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.2.4.tgz#6bcb540944ee9b0209b33bfc23b240c2044dfc3e"
+  integrity sha512-Ngxh51zGSlYJ4EfpKG4LI6WfquulNdtmHg1yuOYlaAr33KyPJp4HeN/tivBnAHcZkoNy0hh/SbwDyCnz5PFJQQ==
 
 "@next/swc-linux-x64-musl@12.3.4":
   version "12.3.4"
   resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.4.tgz#187a883ec09eb2442a5ebf126826e19037313c61"
   integrity sha512-YeBmI+63Ro75SUiL/QXEVXQ19T++58aI/IINOyhpsRL1LKdyfK/35iilraZEFz9bLQrwy1LYAR5lK200A9Gjbg==
 
+"@next/swc-linux-x64-musl@13.2.4":
+  version "13.2.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.2.4.tgz#ce21e43251eaf09a09df39372b2c3e38028c30ff"
+  integrity sha512-gOvwIYoSxd+j14LOcvJr+ekd9fwYT1RyMAHOp7znA10+l40wkFiMONPLWiZuHxfRk+Dy7YdNdDh3ImumvL6VwA==
+
 "@next/swc-win32-arm64-msvc@12.3.4":
   version "12.3.4"
   resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.4.tgz#89befa84e453ed2ef9a888f375eba565a0fde80b"
   integrity sha512-Sd0qFUJv8Tj0PukAYbCCDbmXcMkbIuhnTeHm9m4ZGjCf6kt7E/RMs55Pd3R5ePjOkN7dJEuxYBehawTR/aPDSQ==
+
+"@next/swc-win32-arm64-msvc@13.2.4":
+  version "13.2.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.2.4.tgz#68220063d8e5e082f5465498675640dedb670ff1"
+  integrity sha512-q3NJzcfClgBm4HvdcnoEncmztxrA5GXqKeiZ/hADvC56pwNALt3ngDC6t6qr1YW9V/EPDxCYeaX4zYxHciW4Dw==
 
 "@next/swc-win32-ia32-msvc@12.3.4":
   version "12.3.4"
   resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.4.tgz#cb50c08f0e40ead63642a7f269f0c8254261f17c"
   integrity sha512-rt/vv/vg/ZGGkrkKcuJ0LyliRdbskQU+91bje+PgoYmxTZf/tYs6IfbmgudBJk6gH3QnjHWbkphDdRQrseRefQ==
 
+"@next/swc-win32-ia32-msvc@13.2.4":
+  version "13.2.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.2.4.tgz#7c120ab54a081be9566df310bed834f168252990"
+  integrity sha512-/eZ5ncmHUYtD2fc6EUmAIZlAJnVT2YmxDsKs1Ourx0ttTtvtma/WKlMV5NoUsyOez0f9ExLyOpeCoz5aj+MPXw==
+
 "@next/swc-win32-x64-msvc@12.3.4":
   version "12.3.4"
   resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.4.tgz#d28ea15a72cdcf96201c60a43e9630cd7fda168f"
   integrity sha512-DQ20JEfTBZAgF8QCjYfJhv2/279M6onxFjdG/+5B0Cyj00/EdBxiWb2eGGFgQhrBbNv/lsvzFbbi0Ptf8Vw/bg==
+
+"@next/swc-win32-x64-msvc@13.2.4":
+  version "13.2.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.2.4.tgz#5abda92fe12b9829bf7951c4a221282c56041144"
+  integrity sha512-0MffFmyv7tBLlji01qc0IaPP/LVExzvj7/R5x1Jph1bTAIj4Vu81yFQWHHQAP6r4ff9Ukj1mBK6MDNVXm7Tcvw==
 
 "@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
   version "5.1.1-v1"
@@ -4111,6 +4181,13 @@
   dependencies:
     tslib "^2.4.0"
 
+"@swc/helpers@0.4.14":
+  version "0.4.14"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.4.14.tgz#1352ac6d95e3617ccb7c1498ff019654f1e12a74"
+  integrity sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==
+  dependencies:
+    tslib "^2.4.0"
+
 "@tanstack/react-virtual@3.0.0-beta.53":
   version "3.0.0-beta.53"
   resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.0.0-beta.53.tgz#328877a2d51b4aee533846e37f9992a66904e56b"
@@ -4791,7 +4868,7 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
-"@types/styled-components@^5.1.16":
+"@types/styled-components@^5.1.26":
   version "5.1.26"
   resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-5.1.26.tgz#5627e6812ee96d755028a98dae61d28e57c233af"
   integrity sha512-KuKJ9Z6xb93uJiIyxo/+ksS7yLjS1KzG6iv5i78dhVg/X3u5t1H7juRWqVmodIdz6wGVaIApo1u01kmFRdJHVw==
@@ -6653,6 +6730,11 @@ cli-width@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
   integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
+
+client-only@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
+  integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
 
 cliui@^7.0.2:
   version "7.0.4"
@@ -13387,6 +13469,31 @@ next@^12.1.0:
     "@next/swc-win32-ia32-msvc" "12.3.4"
     "@next/swc-win32-x64-msvc" "12.3.4"
 
+next@^13.2.4:
+  version "13.2.4"
+  resolved "https://registry.yarnpkg.com/next/-/next-13.2.4.tgz#2363330392b0f7da02ab41301f60857ffa7f67d6"
+  integrity sha512-g1I30317cThkEpvzfXujf0O4wtaQHtDCLhlivwlTJ885Ld+eOgcz7r3TGQzeU+cSRoNHtD8tsJgzxVdYojFssw==
+  dependencies:
+    "@next/env" "13.2.4"
+    "@swc/helpers" "0.4.14"
+    caniuse-lite "^1.0.30001406"
+    postcss "8.4.14"
+    styled-jsx "5.1.1"
+  optionalDependencies:
+    "@next/swc-android-arm-eabi" "13.2.4"
+    "@next/swc-android-arm64" "13.2.4"
+    "@next/swc-darwin-arm64" "13.2.4"
+    "@next/swc-darwin-x64" "13.2.4"
+    "@next/swc-freebsd-x64" "13.2.4"
+    "@next/swc-linux-arm-gnueabihf" "13.2.4"
+    "@next/swc-linux-arm64-gnu" "13.2.4"
+    "@next/swc-linux-arm64-musl" "13.2.4"
+    "@next/swc-linux-x64-gnu" "13.2.4"
+    "@next/swc-linux-x64-musl" "13.2.4"
+    "@next/swc-win32-arm64-msvc" "13.2.4"
+    "@next/swc-win32-ia32-msvc" "13.2.4"
+    "@next/swc-win32-x64-msvc" "13.2.4"
+
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
@@ -17356,6 +17463,13 @@ styled-jsx@5.0.7:
   version "5.0.7"
   resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-5.0.7.tgz#be44afc53771b983769ac654d355ca8d019dff48"
   integrity sha512-b3sUzamS086YLRuvnaDigdAewz1/EFYlHpYBP5mZovKEdQQOIIYq8lApylub3HHZ6xFjV051kkGU7cudJmrXEA==
+
+styled-jsx@5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-5.1.1.tgz#839a1c3aaacc4e735fed0781b8619ea5d0009d1f"
+  integrity sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==
+  dependencies:
+    client-only "0.0.1"
 
 stylehacks@^5.1.1:
   version "5.1.1"


### PR DESCRIPTION
### Description

Fixes SSR hydration mismatch bugs caused by `ColorSchemeProvider` reading from localStorage (`const storedScheme = getItem?.(LOCAL_STORAGE_KEY) as ThemeColorSchemeKey | undefined`) during render. Rewritten to use `useSyncExternalStore` and other patterns we use for solving this in `@sanity/ui` with hooks like `usePrefersDark` and `useMediaIndex`.
Also rewrites `colorScheme.tsx` internals to break `ColorSchemeContext` into smaller, separate contexts to speed up re-renders. In [Themer](https://themer.sanity.build/) the slow path is sometimes extremely noticeable, but now it's far less of a problem.

And finally, the `<StudioProvider scheme={"light" | "dark"}>` works as expected. And support for `<StudioProvider scheme="system">` is added. Like before, setting the `scheme` prop acts as an initial value.

But if you add `onSchemeChange` it now acts as "controlled" and the appearance menu is hidden, in the same way it's hidden if you use a legacy color theme.

### What to review

Check the new `dev/test-next-studio` for tests that demonstrate the hydration errors are fixed (there's no console warnings or errors 🎉 ).


### Notes for release

fix(SSR): hydration mismatch bugs related to the `scheme` and `onSchemeChange` props on `<Studio />` are fixed!
