### PR TITLE
fix(portable-text-editor): make deprecated property non-enumerable

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/components/Element.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/components/Element.tsx
@@ -182,24 +182,32 @@ export const Element: FunctionComponent<ElementProps> = ({
         )
       }
     }
-    const renderProps: BlockRenderProps = {
-      children: renderedBlock,
-      editorElementRef: blockRef,
-      focused,
-      level,
-      listItem: isListItem ? element.listItem : undefined,
-      path: blockPath,
-      selected,
-      style,
-      schemaType: schemaTypes.block,
-      get type() {
-        console.warn("Property 'type' is deprecated, use 'schemaType' instead.")
-        return schemaTypes.block
+    const renderProps: Omit<BlockRenderProps, 'type'> = Object.defineProperty(
+      {
+        children: renderedBlock,
+        editorElementRef: blockRef,
+        focused,
+        level,
+        listItem: isListItem ? element.listItem : undefined,
+        path: blockPath,
+        selected,
+        style,
+        schemaType: schemaTypes.block,
+        value,
       },
-      value,
-    }
+      'type',
+      {
+        enumerable: false,
+        get() {
+          console.warn("Property 'type' is deprecated, use 'schemaType' instead.")
+          return schemaTypes.block
+        },
+      }
+    )
 
-    const propsOrDefaultRendered = renderBlock ? renderBlock(renderProps) : children
+    const propsOrDefaultRendered = renderBlock
+      ? renderBlock(renderProps as BlockRenderProps)
+      : children
     return (
       <div key={element._key} {...attributes} className={className} spellCheck={spellCheck}>
         <DraggableBlock element={element} readOnly={readOnly} blockRef={blockRef}>
@@ -221,21 +229,29 @@ export const Element: FunctionComponent<ElementProps> = ({
     schemaTypes.block.name,
     KEY_TO_VALUE_ELEMENT.get(editor)
   )[0]
-  const renderedBlockFromProps =
-    renderBlock &&
-    renderBlock({
-      children: <ObjectNode value={value} />,
-      editorElementRef: blockRef,
-      focused,
-      path: blockPath,
-      schemaType,
-      selected,
-      get type() {
-        console.warn("Property 'type' is deprecated, use 'schemaType' instead.")
-        return schemaType
+  let renderedBlockFromProps
+  if (renderBlock) {
+    const _props: Omit<BlockRenderProps, 'type'> = Object.defineProperty(
+      {
+        children: <ObjectNode value={value} />,
+        editorElementRef: blockRef,
+        focused,
+        path: blockPath,
+        schemaType,
+        selected,
+        value: block,
       },
-      value: block,
-    })
+      'type',
+      {
+        enumerable: false,
+        get() {
+          console.warn("Property 'type' is deprecated, use 'schemaType' instead.")
+          return schemaType
+        },
+      }
+    )
+    renderedBlockFromProps = renderBlock(_props as BlockRenderProps)
+  }
   return (
     <div key={element._key} {...attributes} className={className}>
       {children}

--- a/packages/@sanity/portable-text-editor/src/editor/components/Leaf.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/components/Leaf.tsx
@@ -15,6 +15,9 @@ import {
   PortableTextMemberSchemaTypes,
   RenderAnnotationFunction,
   RenderDecoratorFunction,
+  BlockDecoratorRenderProps,
+  BlockAnnotationRenderProps,
+  BlockChildRenderProps,
 } from '../../types/editor'
 import {debugWithName} from '../../utils/debug'
 import {DefaultAnnotation} from '../nodes/DefaultAnnotation'
@@ -165,19 +168,26 @@ export const Leaf = (props: LeafProps) => {
       marks.forEach((mark) => {
         const schemaType = schemaTypes.decorators.find((dec) => dec.value === mark)
         if (schemaType && renderDecorator) {
-          returnedChildren = renderDecorator({
-            children: returnedChildren,
-            editorElementRef: spanRef,
-            focused,
-            path,
-            selected,
-            schemaType,
-            get type() {
-              console.warn("Property 'type' is deprecated, use 'schemaType' instead.")
-              return schemaType
+          const _props: Omit<BlockDecoratorRenderProps, 'type'> = Object.defineProperty(
+            {
+              children: returnedChildren,
+              editorElementRef: spanRef,
+              focused,
+              path,
+              selected,
+              schemaType,
+              value: mark,
             },
-            value: mark,
-          })
+            'type',
+            {
+              enumerable: false,
+              get() {
+                console.warn("Property 'type' is deprecated, use 'schemaType' instead.")
+                return schemaType
+              },
+            }
+          )
+          returnedChildren = renderDecorator(_props as BlockDecoratorRenderProps)
         }
       })
 
@@ -186,23 +196,29 @@ export const Leaf = (props: LeafProps) => {
           const schemaType = schemaTypes.annotations.find((t) => t.name === annotation._type)
           if (schemaType) {
             if (renderAnnotation) {
+              const _props: Omit<BlockAnnotationRenderProps, 'type'> = Object.defineProperty(
+                {
+                  block,
+                  children: returnedChildren,
+                  editorElementRef: spanRef,
+                  focused,
+                  path,
+                  selected,
+                  schemaType,
+                  value: annotation,
+                },
+                'type',
+                {
+                  enumerable: false,
+                  get() {
+                    console.warn("Property 'type' is deprecated, use 'schemaType' instead.")
+                    return schemaType
+                  },
+                }
+              )
+
               returnedChildren = (
-                <span ref={spanRef}>
-                  {renderAnnotation({
-                    block,
-                    children: returnedChildren,
-                    editorElementRef: spanRef,
-                    focused,
-                    path,
-                    selected,
-                    schemaType,
-                    get type() {
-                      console.warn("Property 'type' is deprecated, use 'schemaType' instead.")
-                      return schemaType
-                    },
-                    value: annotation,
-                  })}
-                </span>
+                <span ref={spanRef}>{renderAnnotation(_props as BlockAnnotationRenderProps)}</span>
               )
             } else {
               returnedChildren = (
@@ -218,20 +234,27 @@ export const Leaf = (props: LeafProps) => {
         const child = block.children.find((_child) => _child._key === leaf._key) // Ensure object equality
         if (child) {
           const defaultRendered = <>{returnedChildren}</>
-          returnedChildren = renderChild({
-            annotations,
-            children: defaultRendered,
-            editorElementRef: spanRef,
-            focused,
-            path,
-            schemaType: schemaTypes.span,
-            selected,
-            get type() {
-              console.warn("Property 'type' is deprecated, use 'schemaType' instead.")
-              return schemaTypes.span
+          const _props: Omit<BlockChildRenderProps, 'type'> = Object.defineProperty(
+            {
+              annotations,
+              children: defaultRendered,
+              editorElementRef: spanRef,
+              focused,
+              path,
+              schemaType: schemaTypes.span,
+              selected,
+              value: child,
             },
-            value: child,
-          })
+            'type',
+            {
+              enumerable: false,
+              get() {
+                console.warn("Property 'type' is deprecated, use 'schemaType' instead.")
+                return schemaTypes.span
+              },
+            }
+          )
+          returnedChildren = renderChild(_props as BlockChildRenderProps)
         }
       }
     }


### PR DESCRIPTION
### Description

These deprecated properties must be non-enumerable or the warning will be triggered when spreading props.
