### PR TITLE
fix(portable-text-editor): remove unsafe prev state

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithUndoRedo.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithUndoRedo.ts
@@ -400,10 +400,9 @@ const shouldClear = (op: Operation): boolean => {
 }
 
 export function withoutSaving(editor: Editor, fn: () => void): void {
-  const prev = isSaving(editor)
   SAVING.set(editor, false)
   fn()
-  SAVING.set(editor, prev)
+  SAVING.set(editor, true)
 }
 
 function createSelectOperation(editor: Editor): SelectionOperation {

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithUndoRedo.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithUndoRedo.ts
@@ -21,7 +21,6 @@ import * as DMP from 'diff-match-patch'
 import type {Patch} from '../../types/patch'
 import {PatchObservable, PortableTextSlateEditor} from '../../types/editor'
 import {debugWithName} from '../../utils/debug'
-import {isPatching} from '../../utils/withoutPatching'
 
 const debug = debugWithName('plugin:withUndoRedo')
 // eslint-disable-next-line new-cap
@@ -36,9 +35,6 @@ const isMerging = (editor: Editor): boolean | undefined => {
 }
 
 const isSaving = (editor: Editor): boolean | undefined => {
-  if (!isPatching(editor)) {
-    return false
-  }
   return SAVING.get(editor)
 }
 


### PR DESCRIPTION
### Description

Using prev state here leads to errors in the history stack when remote patches are coming in and using this scope.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
