### PR TITLE
fix(portable-text-editor): use editor relativePath for PTE API methods

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -176,21 +176,22 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       } = blockProps
       return (
         <BlockObject
+          boundaryElement={boundaryElement || undefined}
           focused={blockFocused}
           isFullscreen={isFullscreen}
           onChange={onChange}
-          onItemOpen={onItemOpen}
           onItemClose={onItemClose}
+          onItemOpen={onItemOpen}
           onItemRemove={onItemRemove}
           onPathFocus={onPathFocus}
           path={path.concat(blockPath)}
           readOnly={readOnly}
-          renderPreview={renderPreview}
+          relativePath={blockPath}
           renderBlockActions={_renderBlockActions}
           renderCustomMarkers={_renderCustomMarkers}
-          boundaryElement={boundaryElement || undefined}
-          selected={blockSelected}
+          renderPreview={renderPreview}
           schemaType={blockSchemaType}
+          selected={blockSelected}
           value={blockValue}
         />
       )
@@ -239,17 +240,18 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       }
       return (
         <InlineObject
+          boundaryElement={boundaryElement || undefined}
           focused={childFocused}
-          onPathFocus={onPathFocus}
           onItemClose={onItemClose}
           onItemOpen={onItemOpen}
+          onPathFocus={onPathFocus}
           path={path.concat(childPath)}
           readOnly={readOnly}
+          relativePath={childPath}
           renderCustomMarkers={renderCustomMarkers}
           renderPreview={renderPreview}
-          boundaryElement={boundaryElement || undefined}
-          selected={selected}
           schemaType={childSchemaType}
+          selected={selected}
           value={child}
         />
       )

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObjectActionsMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObjectActionsMenu.tsx
@@ -24,7 +24,6 @@ import {IntentLink} from 'sanity/router'
 
 interface BlockObjectActionsMenuProps extends PropsWithChildren {
   focused: boolean
-  isActive?: boolean
   isOpen?: boolean
   onOpen: () => void
   onRemove: () => void
@@ -40,7 +39,7 @@ const POPOVER_PROPS: MenuButtonProps['popover'] = {
 }
 
 export function BlockObjectActionsMenu(props: BlockObjectActionsMenuProps): ReactElement {
-  const {children, focused, isActive, isOpen, onOpen, onRemove, readOnly, value} = props
+  const {children, focused, isOpen, onOpen, onRemove, readOnly, value} = props
   const menuButtonId = useId()
   const menuButton = useRef<HTMLButtonElement | null>(null)
   const isTabbing = useRef<boolean>(false)
@@ -105,7 +104,7 @@ export function BlockObjectActionsMenu(props: BlockObjectActionsMenuProps): Reac
               iconRight={EllipsisVerticalIcon}
               mode="bleed"
               paddingX={2}
-              tabIndex={isActive ? 0 : 1}
+              tabIndex={focused ? 0 : 1}
             />
           }
           ref={menuButton}

--- a/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
@@ -20,15 +20,16 @@ import {PreviewSpan, Root, TooltipBox} from './InlineObject.styles'
 interface InlineObjectProps {
   boundaryElement?: HTMLElement
   focused: boolean
-  selected: boolean
-  path: Path
   onItemClose: () => void
-  onPathFocus: (path: Path) => void
   onItemOpen: (path: Path) => void
+  onPathFocus: (path: Path) => void
+  path: Path
   readOnly?: boolean
+  relativePath: Path
   renderCustomMarkers?: RenderCustomMarkers
   renderPreview: RenderPreviewCallback
   schemaType: ObjectSchemaType
+  selected: boolean
   value: PortableTextChild
 }
 
@@ -41,10 +42,11 @@ export const InlineObject = (props: InlineObjectProps) => {
     onPathFocus,
     path,
     readOnly,
+    relativePath,
     renderCustomMarkers,
     renderPreview,
-    selected,
     schemaType,
+    selected,
     value,
   } = props
   const {Markers} = useFormBuilder().__internal.components
@@ -57,11 +59,14 @@ export const InlineObject = (props: InlineObjectProps) => {
   const hasMarkers = markers.length > 0
 
   const onRemove = useCallback(() => {
-    const sel: EditorSelection = {focus: {path, offset: 0}, anchor: {path, offset: 0}}
+    const sel: EditorSelection = {
+      focus: {path: relativePath, offset: 0},
+      anchor: {path: relativePath, offset: 0},
+    }
     PortableTextEditor.delete(editor, sel, {mode: 'children'})
     // Focus will not stick unless this is done through a timeout when deleted through clicking the menu button.
     setTimeout(() => PortableTextEditor.focus(editor))
-  }, [editor, path])
+  }, [editor, relativePath])
 
   const onOpen = useCallback(() => {
     if (memberItem) {


### PR DESCRIPTION
The PTE would not know about the full studio paths, only relative to the editor itself. Use these when calling .delete
