### PR TITLE
chore(typings): remove `get-it` overrides

### DIFF
--- a/packages/@sanity/cli/typings/getIt.d.ts
+++ b/packages/@sanity/cli/typings/getIt.d.ts
@@ -1,7 +1,0 @@
-declare module 'get-it' {
-  export const getIt: any
-}
-
-declare module 'get-it/middleware' {
-  export const promise: any
-}


### PR DESCRIPTION
### Description

The `get-it` package is now shipping with typings, so it shouldn't be necessary to provide them here.

### What to review

If TypeScript builds then we're in the clear.

### Notes for release

N/A - internals only
