### PR TITLE
feature(core): show to-blockstyle in pt-diff

### DIFF
--- a/packages/sanity/src/core/field/types/portableText/diff/components/Block.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/Block.tsx
@@ -68,7 +68,9 @@ export default function Block(props: {
             annotations={[diff.origin.fields.style?.annotation]}
             diff={diff.origin.fields.style}
           >
-            <Text size={0}>Changed block style from '{fromStyle}'</Text>
+            <Text size={0}>
+              Changed block style from '{fromStyle}' to '{block.style}'
+            </Text>
           </DiffTooltip>
           <Box style={style}>{returned}</Box>
         </Stack>


### PR DESCRIPTION
When block styles are changed, show both from and to style in the history diff:

![image](https://user-images.githubusercontent.com/373403/228466401-47ad0ffe-5e83-4602-ad9e-2ca1b602e578.png)

They are not 1:1 represented in the diff preview in visual size, so it's hard to know what it changed to.

### Notes for release
* Show name of block style a block changed into in review changes panel.