### PR TITLE
fix(core): add fieldset within field to expandOperation

### DIFF
--- a/dev/test-studio/schema/debug/fieldGroupsWithFieldsetsAndValidation.js
+++ b/dev/test-studio/schema/debug/fieldGroupsWithFieldsetsAndValidation.js
@@ -1,0 +1,76 @@
+export default {
+  name: 'fieldGroupsWithFieldsetsAndValidation',
+  title: 'With fieldsets and validation',
+  type: 'document',
+  groups: [
+    {name: 'group1', title: 'Group 1'},
+    {name: 'group2', title: 'Group 2'},
+  ],
+  fieldsets: [{name: 'fieldset1', title: 'Fieldset 1', options: {collapsed: true}}],
+  fields: [
+    {
+      name: 'title',
+      type: 'string',
+      group: 'group1',
+    },
+    {
+      name: 'field1',
+      type: 'string',
+      group: 'group2',
+      description: 'Required',
+      fieldset: 'fieldset1',
+      validation: (Rule) => Rule.required(),
+    },
+    {name: 'field2', type: 'string', group: 'group1'},
+    {name: 'field3', type: 'string', group: ['group1', 'group2']},
+    {
+      name: 'object1',
+      type: 'object',
+      options: {collapsible: true, collapsed: true},
+      group: 'group1',
+      fields: [
+        {
+          name: 'groupField1',
+          type: 'string',
+        },
+        {
+          name: 'groupField2',
+          description: 'Required',
+          type: 'string',
+          validation: (Rule) => Rule.required(),
+        },
+        {
+          name: 'object2',
+          type: 'object',
+
+          options: {collapsible: true, collapsed: true},
+          fieldsets: [{name: 'fieldset2', title: 'Fieldset 2', options: {collapsed: true}}],
+          fields: [
+            {
+              name: 'groupField3',
+              type: 'string',
+            },
+            {
+              name: 'groupField4',
+              description: 'Required',
+              type: 'string',
+              validation: (Rule) => Rule.required(),
+            },
+            {
+              name: 'groupField5',
+              type: 'string',
+              fieldset: 'fieldset2',
+            },
+            {
+              name: 'groupField6',
+              description: 'Required',
+              type: 'string',
+              fieldset: 'fieldset2',
+              validation: (Rule) => Rule.required(),
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}

--- a/dev/test-studio/schema/index.ts
+++ b/dev/test-studio/schema/index.ts
@@ -80,6 +80,7 @@ import fieldGroups from './debug/fieldGroups'
 import fieldGroupsDefault from './debug/fieldGroupsDefault'
 import fieldGroupsMany from './debug/fieldGroupsMany'
 import fieldGroupsWithValidation from './debug/fieldGroupsWithValidation'
+import fieldGroupsWithFieldsetsAndValidation from './debug/fieldGroupsWithFieldsetsAndValidation'
 
 // Test documents with official plugin inputs
 import code from './plugins/code'
@@ -243,6 +244,7 @@ export const schemaTypes = [
   fieldGroupsDefault,
   fieldGroupsMany,
   fieldGroupsWithValidation,
+  fieldGroupsWithFieldsetsAndValidation,
   allNativeInputComponents,
   ...v3docs.types,
   ...demos3d.types,

--- a/dev/test-studio/schema/standard/objects.tsx
+++ b/dev/test-studio/schema/standard/objects.tsx
@@ -145,7 +145,9 @@ export default defineType({
               name: 'nested2',
               title: 'nested2',
               type: 'object',
-              fields: [{name: 'ge', title: 'hello', type: 'string'}],
+              fields: [
+                {name: 'ge', title: 'hello', type: 'string', validation: (Rule) => Rule.required()},
+              ],
               options: {collapsible: true, collapsed: true},
             },
           ],

--- a/dev/test-studio/structure/constants.ts
+++ b/dev/test-studio/structure/constants.ts
@@ -80,6 +80,7 @@ export const DEBUG_FIELD_GROUP_TYPES = [
   'fieldGroupsDefault',
   'fieldGroupsMany',
   'fieldGroupsWithValidation',
+  'fieldGroupsWithFieldsetsAndValidation',
 ]
 
 export const EXTERNAL_PLUGIN_INPUT_TYPES = ['markdownTest', 'muxVideoPost']

--- a/packages/sanity/src/core/form/store/types/asserters.ts
+++ b/packages/sanity/src/core/form/store/types/asserters.ts
@@ -1,7 +1,13 @@
-import {BaseFormNode, ObjectFormNode} from './nodes'
-import {isObjectSchemaType} from '@sanity/types'
+import {isArrayOfObjectsSchemaType, isObjectSchemaType} from '@sanity/types'
+import {ArrayOfObjectsFormNode, BaseFormNode, ObjectFormNode} from './nodes'
 
 /** @internal */
 export function isObjectFormNode(formNode: BaseFormNode): formNode is ObjectFormNode {
   return isObjectSchemaType(formNode.schemaType)
+}
+/** @internal */
+export function isArrayOfObjectsFormNode(
+  formNode: BaseFormNode
+): formNode is ArrayOfObjectsFormNode {
+  return isArrayOfObjectsSchemaType(formNode.schemaType)
 }

--- a/packages/sanity/src/core/form/store/types/nodes.ts
+++ b/packages/sanity/src/core/form/store/types/nodes.ts
@@ -29,6 +29,7 @@ export interface BaseFormNode<T = unknown, S extends SchemaType = SchemaType> {
   readOnly?: boolean
   focused?: boolean
   changed: boolean
+  members?: ObjectMember[]
 }
 
 /** @public */

--- a/packages/sanity/src/core/form/store/types/nodes.ts
+++ b/packages/sanity/src/core/form/store/types/nodes.ts
@@ -10,6 +10,7 @@ import {
 } from '@sanity/types'
 import {ObjectItem} from '../../types'
 import {FormNodePresence} from '../../../presence'
+import {InternalFormStateMember} from '../formState'
 import {ArrayOfObjectsMember, ArrayOfPrimitivesMember, ObjectMember} from './members'
 import {FormFieldGroup} from './fieldGroup'
 
@@ -29,7 +30,6 @@ export interface BaseFormNode<T = unknown, S extends SchemaType = SchemaType> {
   readOnly?: boolean
   focused?: boolean
   changed: boolean
-  members?: ObjectMember[]
 }
 
 /** @public */
@@ -42,6 +42,8 @@ export interface ObjectFormNode<
   groups: FormFieldGroup[]
   /** @beta */
   members: ObjectMember[]
+  /** @internal */
+  _allMembers: InternalFormStateMember[]
 }
 
 /** @public */
@@ -56,6 +58,9 @@ export interface ObjectArrayFormNode<
   groups: FormFieldGroup[]
   /** @beta */
   members: ObjectMember[]
+
+  /** @internal */
+  _allMembers: InternalFormStateMember[]
   changesOpen?: boolean
 }
 

--- a/packages/sanity/src/core/form/store/utils/getExpandOperations.ts
+++ b/packages/sanity/src/core/form/store/utils/getExpandOperations.ts
@@ -3,12 +3,14 @@ import {castArray} from 'lodash'
 import {
   ArrayOfObjectsFormNode,
   ArrayOfObjectsItemMember,
+  BaseFormNode,
   FieldMember,
   FieldSetMember,
   ObjectFormNode,
 } from '../types'
-import {isMemberArrayOfObjects} from '../../members/object/fields/asserters'
+import {isMemberArrayOfObjects, isMemberObject} from '../../members/object/fields/asserters'
 import {ALL_FIELDS_GROUP} from '../constants'
+import {isArrayOfObjectsFormNode, isObjectFormNode} from '../types/asserters'
 
 /** @internal */
 export interface ExpandPathOperation {
@@ -37,16 +39,45 @@ export type ExpandOperation =
 
 /**
  * This takes a form state and returns a list of operations required to open a node at a particular path
- * @param state - The form state
+ * @param node - The base form node (i.e. the form state node for the _document_)
  * @param path - The path to open
  *
  * @internal
  */
-export function getExpandOperations(state: ObjectFormNode, path: Path): ExpandOperation[] {
-  // start at the root and make sure all groups/paths are expanded/activated along the way
-  const [fieldName, ...rest] = path
+export function getExpandOperations(node: BaseFormNode, path: Path): ExpandOperation[] {
+  return [
+    // make sure to expand all intermediate paths
+    ...path.map((p, i): ExpandPathOperation => ({type: 'expandPath', path: path.slice(0, i + 1)})),
+    // make sure to expand all fieldsets and selects the groups that includes the intermediate nodes
+    ...getFieldsetAndFieldGroupOperations(node, path),
+  ]
+}
+function getFieldsetAndFieldGroupOperations(node: BaseFormNode, path: Path) {
+  if (path.length === 0) {
+    return []
+  }
 
-  const fieldsetMember = state.members.find(
+  if (isObjectFormNode(node)) {
+    return getObjectFieldsetAndFieldGroupOperations(node, path)
+  }
+  if (isArrayOfObjectsFormNode(node)) {
+    return getArrayFieldsetAndFieldGroupOperations(node, path)
+  }
+  return []
+}
+
+function getObjectFieldsetAndFieldGroupOperations(
+  node: ObjectFormNode,
+  path: Path
+): (ExpandFieldSetOperation | SetActiveGroupOperation)[] {
+  if (path.length === 0) {
+    return []
+  }
+  // extract the field name for the current level we're looking at
+  const [fieldName, ...tail] = path
+
+  // check if we can find the field inside a fieldset
+  const fieldsetMember = node.members.find(
     (member): member is FieldSetMember =>
       member.kind === 'fieldSet' &&
       member.fieldSet.members.some(
@@ -54,63 +85,61 @@ export function getExpandOperations(state: ObjectFormNode, path: Path): ExpandOp
       )
   )
 
-  const ops: ExpandOperation[] = [{type: 'expandPath', path}]
-  if (fieldsetMember) {
-    ops.push({type: 'expandFieldSet', path: fieldsetMember.fieldSet.path})
-  }
+  // if we found the field in a fieldset we need to recurse into this fieldset's members, otherwise we can use the node's members
+  const members = fieldsetMember
+    ? fieldsetMember.fieldSet.members
+    : // Note: we need to use the internal `_allMembers` array here instead of members since hidden/collapsed members are omitted from members
+      node._allMembers.map((formStateMember) => formStateMember.member)
 
-  const fieldMember = state.members.find(
-    (member): member is FieldMember => member.kind === 'field' && member.name === fieldName
+  // look for the field inside the members array
+  const fieldMember = members.find(
+    (member): member is FieldMember =>
+      member !== null && member.kind === 'field' && member.name === fieldName
   )
 
-  const fieldMemberFieldSet = fieldMember?.field?.members?.find(
-    (member): member is FieldSetMember =>
-      member.kind === 'fieldSet' &&
-      member.fieldSet.members.some((field): field is FieldMember => field.kind === 'field')
-  )
-
-  const schemaField = state.schemaType.fields.find((field) => field.name === fieldName)
-  const selectedGroupName = state.groups.find((group) => group.selected)?.name
-  const defaultGroupName = (state.schemaType.groups || []).find((group) => group.default)?.name
+  // Group handling
+  const schemaField = node.schemaType.fields.find((field) => field.name === fieldName)
+  const selectedGroupName = node.groups.find((group) => group.selected)?.name
+  const defaultGroupName = (node.schemaType.groups || []).find((group) => group.default)?.name
   const inSelectedGroup =
     selectedGroupName &&
     (selectedGroupName === ALL_FIELDS_GROUP.name ||
       (schemaField && castArray(schemaField.group).includes(selectedGroupName)))
 
+  const ops: (ExpandFieldSetOperation | SetActiveGroupOperation)[] = []
+
   if (!inSelectedGroup) {
     ops.push({
       type: 'setSelectedGroup',
-      path: state.path,
+      path: node.path,
       groupName: defaultGroupName || ALL_FIELDS_GROUP.name,
     })
   }
 
+  if (fieldsetMember) {
+    // the field is inside a fieldset, make sure we expand it too
+    ops.push({type: 'expandFieldSet', path: fieldsetMember.fieldSet.path})
+  }
+
   if (fieldMember) {
-    ops.push({type: 'expandPath', path: fieldMember.field.path})
-    //If a fieldset exists within a field, this needs to expanded
-    if (fieldMemberFieldSet) {
-      ops.push({type: 'expandFieldSet', path: fieldMemberFieldSet.fieldSet.path})
+    if (isMemberArrayOfObjects(fieldMember)) {
+      ops.push(...getArrayFieldsetAndFieldGroupOperations(fieldMember.field, tail))
+    } else if (isMemberObject(fieldMember)) {
+      ops.push(...getObjectFieldsetAndFieldGroupOperations(fieldMember.field, tail))
     }
   }
 
-  if (fieldMember && fieldMember.field.members) {
-    ops.push({type: 'expandFieldSet', path: fieldMember.field.members})
-  }
-
-  if (rest.length === 0) {
-    return ops
-  }
-
-  if (fieldMember && isMemberArrayOfObjects(fieldMember)) {
-    return ops.concat([
-      {type: 'expandPath', path: fieldMember.field.path},
-      ...expandArrayPath(fieldMember.field, rest),
-    ])
-  }
   return ops
 }
 
-function expandArrayPath(state: ArrayOfObjectsFormNode, path: Path): ExpandOperation[] {
+function getArrayFieldsetAndFieldGroupOperations(
+  state: ArrayOfObjectsFormNode,
+  path: Path
+): (ExpandFieldSetOperation | SetActiveGroupOperation)[] {
+  if (path.length === 0) {
+    return []
+  }
+
   // start at the root and make sure all groups/paths are expanded/activated along the way
   const [segment, ...rest] = path
   if (!isKeySegment(segment)) {
@@ -125,5 +154,5 @@ function expandArrayPath(state: ArrayOfObjectsFormNode, path: Path): ExpandOpera
     // tried to open a member that does not exist in the form state - it's likely hidden
     return []
   }
-  return [{type: 'expandPath', path: path}, ...getExpandOperations(foundMember.item, rest)]
+  return getFieldsetAndFieldGroupOperations(foundMember.item, rest)
 }

--- a/packages/sanity/src/core/form/store/utils/getExpandOperations.ts
+++ b/packages/sanity/src/core/form/store/utils/getExpandOperations.ts
@@ -63,6 +63,12 @@ export function getExpandOperations(state: ObjectFormNode, path: Path): ExpandOp
     (member): member is FieldMember => member.kind === 'field' && member.name === fieldName
   )
 
+  const fieldMemberFieldSet = fieldMember?.field?.members?.find(
+    (member): member is FieldSetMember =>
+      member.kind === 'fieldSet' &&
+      member.fieldSet.members.some((field): field is FieldMember => field.kind === 'field')
+  )
+
   const schemaField = state.schemaType.fields.find((field) => field.name === fieldName)
   const selectedGroupName = state.groups.find((group) => group.selected)?.name
   const defaultGroupName = (state.schemaType.groups || []).find((group) => group.default)?.name
@@ -81,6 +87,14 @@ export function getExpandOperations(state: ObjectFormNode, path: Path): ExpandOp
 
   if (fieldMember) {
     ops.push({type: 'expandPath', path: fieldMember.field.path})
+    //If a fieldset exists within a field, this needs to expanded
+    if (fieldMemberFieldSet) {
+      ops.push({type: 'expandFieldSet', path: fieldMemberFieldSet.fieldSet.path})
+    }
+  }
+
+  if (fieldMember && fieldMember.field.members) {
+    ops.push({type: 'expandFieldSet', path: fieldMember.field.members})
   }
 
   if (rest.length === 0) {

--- a/packages/sanity/src/core/form/studio/FormBuilder.tsx
+++ b/packages/sanity/src/core/form/studio/FormBuilder.tsx
@@ -17,7 +17,7 @@ import {useFormCallbacks} from './contexts/FormCallbacks'
  * @alpha
  */
 export interface FormBuilderProps
-  extends Omit<ObjectFormNode, 'level' | 'path' | 'presence' | 'validation'> {
+  extends Omit<ObjectFormNode, 'level' | 'path' | 'presence' | 'validation' | '_allMembers'> {
   /**
    * @internal Considered internal – do not use.
    */

--- a/packages/sanity/src/core/form/types/inputProps.ts
+++ b/packages/sanity/src/core/form/types/inputProps.ts
@@ -46,7 +46,7 @@ export interface ObjectInputProps<
   T = Record<string, any>,
   S extends ObjectSchemaType = ObjectSchemaType
 > extends BaseInputProps,
-    ObjectFormNode<T, S> {
+    Omit<ObjectFormNode<T, S>, '_allMembers'> {
   /** @beta */
   groups: FormFieldGroup[]
 


### PR DESCRIPTION
### Description
Validation error would not focus fields in collapsed fieldsets that existed within a field. 
This was due to the fieldset not being found and expanded within the `getExpandOperations.ts`. 
By adding a fieldset within a field to the expand operation, the field can get focused when clicking the validation error. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Make sure that all validation error links works as expected, especially within a field and a fieldset within a field. 

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Fixes bug where validation error would not focus on collapsed fieldset
<!--
A description of the change(s) that should be used in the release notes.
-->
