### PR TITLE
fix(form/inputs): fix Safari issue with annotation edit popovers

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
@@ -216,7 +216,6 @@ export const DefaultAnnotationComponent = (props: BlockAnnotationProps) => {
       <AnnotationToolbarPopover
         referenceElement={__unstable_referenceElement}
         boundaryElement={__unstable_boundaryElement}
-        isEditing={open}
         onEdit={onOpen}
         onDelete={onRemove}
         title={schemaType.title || schemaType.name}


### PR DESCRIPTION
### Description

There is a regression introduced in `3.8.0` for Safari that hides the annotation edit popover when clicking to edit it. This is because Safari creates a new text range that isn't created by other browsers when clicking inside the popover on the button. This range is without focusNode and anchorNode and the popover is closed.

Fix this by requiring a focusNode to be set in the range before hiding the popover.

I also got rid of some tabbing logic that seems to no longer be needed as the content for the popovers are now rendered inside the node itself as opposed to earlier when it was rendered in a portal outside the editor.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
* That you can edit annotations in all browsers.
* That you in all the supported browsers can tab to the edit button expect for Safari (which treats tabbing order differently for some reason). This is something to look into later.


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Fix a regression where annotations could not be edited with Safari.

<!--
A description of the change(s) that should be used in the release notes.
-->
