### PR TITLE
fix(core): fix document title not working

### DIFF
--- a/dev/test-studio/structure/resolveStructure.ts
+++ b/dev/test-studio/structure/resolveStructure.ts
@@ -9,7 +9,7 @@ import {
   JoystickIcon,
 } from '@sanity/icons'
 import {uuid} from '@sanity/uuid'
-import {DocumentStore, SanityDocument} from 'sanity'
+import {DocumentStore, SanityDocument, Schema} from 'sanity'
 import {ItemChild, StructureBuilder, StructureResolver} from 'sanity/desk'
 import {map} from 'rxjs/operators'
 import {Observable, timer} from 'rxjs'
@@ -42,7 +42,7 @@ export const structure: StructureResolver = (S, {schema, documentStore}) => {
               S.listItem()
                 .id('documentStore')
                 .title('Document store')
-                .child(documentStoreDrivenChild(S, documentStore)),
+                .child(documentStoreDrivenChild(S, schema, documentStore)),
               S.listItem()
                 .id('randomObservable')
                 .title('Random observable')
@@ -393,6 +393,7 @@ export const structure: StructureResolver = (S, {schema, documentStore}) => {
 
 function documentStoreDrivenChild(
   S: StructureBuilder,
+  schema: Schema,
   documentStore: DocumentStore
 ): Observable<ItemChild> {
   return documentStore
@@ -403,9 +404,11 @@ function documentStoreDrivenChild(
     )
     .pipe(
       map((docs: SanityDocument[]) => {
+        // Only include document types that exist in the current schema
+        const filteredDocs = docs.filter((doc) => schema.has(doc._type))
         return S.list()
           .title('Some recently edited documents')
-          .items(docs.map((doc) => S.documentListItem().schemaType(doc._type).id(doc._id)))
+          .items(filteredDocs.map((doc) => S.documentListItem().schemaType(doc._type).id(doc._id)))
       })
     )
 }

--- a/packages/@sanity/cli/typings/getIt.d.ts
+++ b/packages/@sanity/cli/typings/getIt.d.ts
@@ -1,7 +1,0 @@
-declare module 'get-it' {
-  export const getIt: any
-}
-
-declare module 'get-it/middleware' {
-  export const promise: any
-}

--- a/packages/sanity/src/desk/panes/document/documentPanel/header/DocumentHeaderTitle.test.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/header/DocumentHeaderTitle.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react'
+import {render} from '@testing-library/react'
+import {useDocumentPane} from '../../useDocumentPane'
+import {DocumentPaneContextValue} from '../../DocumentPaneContext'
+import {DocumentHeaderTitle} from './DocumentHeaderTitle'
+import {unstable_useValuePreview as useValuePreview} from 'sanity'
+
+jest.mock('../../useDocumentPane')
+jest.mock('sanity')
+
+describe('DocumentHeaderTitle', () => {
+  const mockUseDocumentPane = useDocumentPane as jest.MockedFunction<typeof useDocumentPane>
+  const mockUseValuePreview = useValuePreview as jest.MockedFunction<typeof useValuePreview>
+
+  const defaultProps = {
+    connectionState: 'connected',
+    schemaType: {title: 'Test Schema', name: 'testSchema'},
+    value: {title: 'Test Value'},
+  }
+
+  const defaultValue = {
+    isLoading: false,
+  }
+
+  beforeEach(() => {
+    mockUseDocumentPane.mockReturnValue(defaultProps as unknown as DocumentPaneContextValue)
+    mockUseValuePreview.mockReturnValue({...defaultValue, error: undefined, value: undefined})
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should render without crashing', () => {
+    const {getByText} = render(<DocumentHeaderTitle />)
+    expect(getByText('Untitled')).toBeInTheDocument()
+  })
+
+  it('should return an empty fragment when connectionState is not "connected"', () => {
+    mockUseDocumentPane.mockReturnValue({
+      ...defaultProps,
+      connectionState: 'connecting',
+    } as unknown as DocumentPaneContextValue)
+    const {container} = render(<DocumentHeaderTitle />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('should return the title if it is provided', () => {
+    mockUseDocumentPane.mockReturnValue({
+      ...defaultProps,
+      title: 'Test Title',
+    } as unknown as DocumentPaneContextValue)
+    const {getByText} = render(<DocumentHeaderTitle />)
+    expect(getByText('Test Title')).toBeInTheDocument()
+  })
+
+  it('should return "New {schemaType?.title || schemaType?.name}" if documentValue is not provided', () => {
+    mockUseDocumentPane.mockReturnValue({
+      ...defaultProps,
+      value: null,
+    } as unknown as DocumentPaneContextValue)
+    const {getByText} = render(<DocumentHeaderTitle />)
+    expect(getByText('New Test Schema')).toBeInTheDocument()
+  })
+
+  it('should return the value.title if value is provided and no error occurred', () => {
+    mockUseValuePreview.mockReturnValue({
+      ...defaultValue,
+      error: undefined,
+      value: {title: 'Test Preview Value'},
+    })
+    const {getByText} = render(<DocumentHeaderTitle />)
+    expect(getByText('Test Preview Value')).toBeInTheDocument()
+  })
+
+  it('should return "Untitled" if value is not provided and no error occurred', () => {
+    mockUseValuePreview.mockReturnValue({...defaultValue, error: undefined, value: undefined})
+    const {getByText} = render(<DocumentHeaderTitle />)
+    expect(getByText('Untitled')).toBeInTheDocument()
+  })
+
+  it('should return "Error: {error.message}" if an error occurred while getting the preview value', () => {
+    mockUseValuePreview.mockReturnValue({
+      ...defaultValue,
+      error: new Error('Test Error'),
+      value: undefined,
+    })
+    const {getByText} = render(<DocumentHeaderTitle />)
+    expect(getByText('Error: Test Error')).toBeInTheDocument()
+  })
+
+  it('should call useValuePreview hook with the correct arguments', () => {
+    render(<DocumentHeaderTitle />)
+    expect(mockUseValuePreview).toHaveBeenCalledWith({
+      enabled: true,
+      schemaType: defaultProps.schemaType,
+      value: defaultProps.value,
+    })
+  })
+
+  it('should display the value returned by useValuePreview hook correctly when no error occurs', () => {
+    mockUseValuePreview.mockReturnValue({
+      ...defaultValue,
+      error: undefined,
+      value: {title: 'Test Preview Value'},
+    })
+    const {getByText} = render(<DocumentHeaderTitle />)
+    expect(getByText('Test Preview Value')).toBeInTheDocument()
+  })
+})

--- a/packages/sanity/src/desk/panes/document/documentPanel/header/DocumentHeaderTitle.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/header/DocumentHeaderTitle.tsx
@@ -16,19 +16,17 @@ export function DocumentHeaderTitle(): ReactElement {
     return <></>
   }
 
+  if (title) {
+    return <>{title}</>
+  }
+
   if (!documentValue) {
     return <>New {schemaType?.title || schemaType?.name}</>
   }
 
-  if (subscribed) {
-    if (error) {
-      return <>Error: {error.message}</>
-    }
-
-    return (
-      <>{value?.title || <span style={{color: 'var(--card-muted-fg-color)'}}>Untitled</span>}</>
-    )
+  if (error) {
+    return <>Error: {error.message}</>
   }
 
-  return <>{title}</>
+  return <>{value?.title || <span style={{color: 'var(--card-muted-fg-color)'}}>Untitled</span>}</>
 }

--- a/perf/queries.ts
+++ b/perf/queries.ts
@@ -7,6 +7,6 @@ export const branchDeploymentsQuery = `*[_type=='branch' && name == $branch] {
 } {
   "deployments": [
     ...*[_type == 'deployment' && name=="performance-studio" && status=="succeeded" && (branch._ref in [^.branchId])],
-    *[_type == 'deployment' && name=="performance-studio" && status=="succeeded" && (branch._ref in [^.baseBranchId])][0]
+    *[_type == 'deployment' && name=="performance-studio" && status=="succeeded" && (branch._ref in [^.baseBranchId])] | order(_createdAt desc)[0]
     ]
-} [count(deployments) > 0].deployments[] | order(_createdAt asc) [0...$count] {_id, deploymentId, url, label}`
+} [count(deployments) > 0].deployments[] | order(_createdAt desc) [0...$count] {_id, deploymentId, url, label}`

--- a/perf/tests/arrayOf1kReferenceItems.test.ts
+++ b/perf/tests/arrayOf1kReferenceItems.test.ts
@@ -3,7 +3,7 @@ import {PerformanceTestProps} from '../runner/types'
 import {KNOWN_TEST_IDS} from '../runner/utils/testIds'
 
 export default {
-  id: KNOWN_TEST_IDS['array-of-1k-string-items'],
+  id: KNOWN_TEST_IDS['array-of-1k-reference-items'],
   name: 'Performance test of array with 1k reference items',
   description: `
   This test measures the general performance of an array with 1k reference items.


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Fixes an issue where the document title was not displaying when defined in the desk structure.

fixes #4079
fixes #4261 

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

Mimics logic from v2 https://github.com/sanity-io/sanity/blob/d57c92d0c00f70666234391fb9625ce6352ef05e/packages/%40sanity/desk-tool/src/panes/document/documentPanel/header/DocumentHeaderTitle.tsx#L22-L24

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

- Fixes an issue where the document title was not displaying when defined in the desk structure.  