### PR TITLE
refactor(portable-text-editor): ignore void edits

### DIFF
--- a/packages/@sanity/portable-text-editor/src/utils/__tests__/patchToOperations.test.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/__tests__/patchToOperations.test.ts
@@ -46,11 +46,11 @@ const createDefaultValue = (): Descendant[] => [
 
 describe('operationToPatches', () => {
   beforeEach(() => {
-    editor.children = createDefaultValue()
     editor.onChange()
   })
 
   it('makes the correct operations for block objects', () => {
+    editor.children = createDefaultValue()
     const patches = [
       {type: 'unset', path: [{_key: 'c01739b0d03b'}, 'hotspot'], origin: 'remote'},
       {type: 'unset', path: [{_key: 'c01739b0d03b'}, 'crop'], origin: 'remote'},
@@ -87,6 +87,126 @@ describe('operationToPatches', () => {
               "_ref": "image-f52f71bc1df46e080dabe43a8effe8ccfb5f21de-4032x3024-png",
               "_type": "reference",
             },
+          },
+        },
+      ]
+    `)
+  })
+  it('will not create patches for insertion inside object blocks', () => {
+    editor.children = [
+      {
+        _type: 'someType',
+        _key: 'c01739b0d03b',
+        children: [
+          {
+            _key: 'c01739b0d03b-void-child',
+            _type: 'span',
+            text: '',
+            marks: [],
+          },
+        ],
+        __inline: false,
+        value: {
+          asset: {
+            _ref: 'image-f52f71bc1df46e080dabe43a8effe8ccfb5f21de-4032x3024-png',
+            _type: 'reference',
+          },
+          nestedArray: [],
+        },
+      },
+    ]
+    const patches = [
+      {type: 'insert', path: [{_key: 'c01739b0d03b'}, 'nestedArray', -1], origin: 'remote'},
+    ] as Patch[]
+    const snapShot = fromSlateValue(editor.children, schemaTypes.block.name)
+    patches.forEach((p) => {
+      patchToOperations(editor, p, patches, snapShot)
+    })
+    expect(editor.children).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "__inline": false,
+          "_key": "c01739b0d03b",
+          "_type": "someType",
+          "children": Array [
+            Object {
+              "_key": "c01739b0d03b-void-child",
+              "_type": "span",
+              "marks": Array [],
+              "text": "",
+            },
+          ],
+          "value": Object {
+            "asset": Object {
+              "_ref": "image-f52f71bc1df46e080dabe43a8effe8ccfb5f21de-4032x3024-png",
+              "_type": "reference",
+            },
+            "nestedArray": Array [],
+          },
+        },
+      ]
+    `)
+  })
+  it('will not create patches for removal inside object blocks', () => {
+    editor.children = [
+      {
+        _type: 'someType',
+        _key: 'c01739b0d03b',
+        children: [
+          {
+            _key: 'c01739b0d03b-void-child',
+            _type: 'span',
+            text: '',
+            marks: [],
+          },
+        ],
+        __inline: false,
+        value: {
+          asset: {
+            _ref: 'image-f52f71bc1df46e080dabe43a8effe8ccfb5f21de-4032x3024-png',
+            _type: 'reference',
+          },
+          nestedArray: [
+            {
+              _key: 'foo',
+              _type: 'nestedValue',
+            },
+          ],
+        },
+      },
+    ]
+    const patches = [
+      {type: 'unset', path: [{_key: 'c01739b0d03b'}, 'nestedArray', 0], origin: 'remote'},
+    ] as Patch[]
+    const snapShot = fromSlateValue(editor.children, schemaTypes.block.name)
+    patches.forEach((p) => {
+      patchToOperations(editor, p, patches, snapShot)
+    })
+    expect(editor.children).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "__inline": false,
+          "_key": "c01739b0d03b",
+          "_type": "someType",
+          "children": Array [
+            Object {
+              "_key": "c01739b0d03b-void-child",
+              "_type": "span",
+              "marks": Array [],
+              "text": "",
+            },
+          ],
+          "value": Object {
+            "asset": Object {
+              "_ref": "image-f52f71bc1df46e080dabe43a8effe8ccfb5f21de-4032x3024-png",
+              "_type": "reference",
+            },
+            "nestedArray": Array [
+              Object {
+                "_key": "foo",
+                "_type": "nestedValue",
+              },
+            ],
           },
         },
       ]

--- a/packages/@sanity/portable-text-editor/src/utils/patchToOperations.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/patchToOperations.ts
@@ -347,12 +347,6 @@ export function createPatchToOperations(
       debugState(editor, 'after')
       return true
     }
-    // Inside block objects - patch block and set it again
-    if (!editor.isTextBlock(block)) {
-      const newBlock = applyAll([block], [patch])[0]
-      Transforms.setNodes(editor, newBlock, {at: [blockIndex]})
-      return true
-    }
     return false
   }
 


### PR DESCRIPTION
### Description
Values inside void objects (block objects or inline blocks) are not the editor's responsibility to deal with, and the data doesn't interfere with the editor's selection state.

Just ignore these kind of patches. They are not edited by the editor.

`useSyncValue` will make sure to update this content when it's changed anyway.

Started out by making a failing test for this which is now passing.

There are no issues with this with normal usage of the editor, however if you send external patches to the document, the editor might crash because how it acts these patches.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

* That all regular text editing operations works as they should (should be covered by tests pretty good).


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Doesn't need to be mentioned I think. Doesn't affect normal/expected usage.

<!--
A description of the change(s) that should be used in the release notes.
-->
