### PR TITLE
fix(desk): place null/undefined values at bottom in groq query when sorting

### DIFF
--- a/dev/test-studio/structure/resolveStructure.ts
+++ b/dev/test-studio/structure/resolveStructure.ts
@@ -9,7 +9,7 @@ import {
   JoystickIcon,
 } from '@sanity/icons'
 import {uuid} from '@sanity/uuid'
-import {DocumentStore, SanityDocument} from 'sanity'
+import {DocumentStore, SanityDocument, Schema} from 'sanity'
 import {ItemChild, StructureBuilder, StructureResolver} from 'sanity/desk'
 import {map} from 'rxjs/operators'
 import {Observable, timer} from 'rxjs'
@@ -42,7 +42,7 @@ export const structure: StructureResolver = (S, {schema, documentStore}) => {
               S.listItem()
                 .id('documentStore')
                 .title('Document store')
-                .child(documentStoreDrivenChild(S, documentStore)),
+                .child(documentStoreDrivenChild(S, schema, documentStore)),
               S.listItem()
                 .id('randomObservable')
                 .title('Random observable')
@@ -393,6 +393,7 @@ export const structure: StructureResolver = (S, {schema, documentStore}) => {
 
 function documentStoreDrivenChild(
   S: StructureBuilder,
+  schema: Schema,
   documentStore: DocumentStore
 ): Observable<ItemChild> {
   return documentStore
@@ -403,9 +404,11 @@ function documentStoreDrivenChild(
     )
     .pipe(
       map((docs: SanityDocument[]) => {
+        // Only include document types that exist in the current schema
+        const filteredDocs = docs.filter((doc) => schema.has(doc._type))
         return S.list()
           .title('Some recently edited documents')
-          .items(docs.map((doc) => S.documentListItem().schemaType(doc._type).id(doc._id)))
+          .items(filteredDocs.map((doc) => S.documentListItem().schemaType(doc._type).id(doc._id)))
       })
     )
 }

--- a/packages/@sanity/cli/typings/getIt.d.ts
+++ b/packages/@sanity/cli/typings/getIt.d.ts
@@ -1,7 +1,0 @@
-declare module 'get-it' {
-  export const getIt: any
-}
-
-declare module 'get-it/middleware' {
-  export const promise: any
-}

--- a/packages/sanity/src/desk/panes/documentList/useDocumentList.ts
+++ b/packages/sanity/src/desk/panes/documentList/useDocumentList.ts
@@ -53,6 +53,15 @@ export function useDocumentList(opts: UseDocumentListOpts): DocumentListState {
 
     if (extendedProjection) {
       const firstProjection = projectionFields.concat(extendedProjection).join(',')
+
+      if (order.includes('desc')) {
+        return [
+          `*[${filter}] {${firstProjection}}`,
+          `order(select( ${extendedProjection} == null => 1, 0) asc, ${extendedProjection} desc) [0...${limit}]`,
+          `{${finalProjection}}`,
+        ].join('|')
+      }
+
       return [
         `*[${filter}] {${firstProjection}}`,
         `order(${order}) [0...${limit}]`,


### PR DESCRIPTION
### Description
`null | undefined` sorting values would be get sorted to the top when a field was sorted `desc`. These values should be ordered at the bottom. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
When adding custom sorting in `desc` order, the `null | undefined` values will be ordered at the bottom. 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fixes bug where `undefined | null` appeared at top when sorting documents in `desc` order
<!--
A description of the change(s) that should be used in the release notes.
-->
