### PR TITLE
fix(form/inputs): fix issues with opening annotations in the PT-input

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -281,7 +281,6 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
           onPathFocus={onPathFocus}
           path={path.concat(aPath)}
           readOnly={readOnly}
-          relativePath={aPath}
           renderCustomMarkers={renderCustomMarkers}
           schemaType={aSchemaType}
           selected={selected}

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
@@ -24,7 +24,6 @@ interface AnnotationProps {
   onPathFocus: (path: Path) => void
   path: Path
   readOnly?: boolean
-  relativePath: Path
   renderCustomMarkers?: RenderCustomMarkers
   selected: boolean
   schemaType: ObjectSchemaType
@@ -41,7 +40,6 @@ export function Annotation(props: AnnotationProps) {
     onPathFocus,
     path,
     readOnly,
-    relativePath,
     renderCustomMarkers,
     schemaType,
     selected,
@@ -50,8 +48,8 @@ export function Annotation(props: AnnotationProps) {
   const {Markers = DefaultMarkers} = useFormBuilder().__internal.components
   const editor = usePortableTextEditor()
   const markDefPath: Path = useMemo(
-    () => path.slice(0, relativePath.length - 1).concat(['markDefs', {_key: value._key}]),
-    [path, relativePath, value._key]
+    () => path.slice(0, path.length - 2).concat(['markDefs', {_key: value._key}]),
+    [path, value._key]
   )
   const memberItem = usePortableTextMemberItem(pathToString(markDefPath))
   const {validation} = useMemberValidation(memberItem?.node)


### PR DESCRIPTION
### Description

This fixes a recent regression where annotations within nested content (inside array items or simiar) was unable to be edited (it would not open the popover toolbar).

This happened because the path created for the `block.markDefs` object was sliced incorrectly, and it the member item with the element reference for the popovers could not be resolved, neither could the item be opened correctly by using said path.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
* That objects can be properly edited within a PT-input that is nested inside other content (like array items).

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Fix issue where Portable Text annotations within nested content could not be properly edited.

<!--
A description of the change(s) that should be used in the release notes.
-->
