### PR TITLE
fix(router): resolve intent resolver regression since `v3.7.1`

### DIFF
--- a/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.tsx
+++ b/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.tsx
@@ -1,8 +1,8 @@
 import {escapeRegExp, isEqual} from 'lodash'
-import React, {useCallback, useEffect, useMemo, useRef} from 'react'
+import React, {useEffect, useMemo, useRef} from 'react'
 import {useSyncExternalStoreWithSelector} from 'use-sync-external-store/with-selector'
 import type {Tool, Workspace} from '../../config'
-import {createRouter, type RouterHistory} from '../router'
+import {createRouter, type RouterStateEvent, type RouterHistory} from '../router'
 import {decodeUrlState, resolveDefaultState, resolveIntentState} from '../router/helpers'
 import {useRouterHistory} from '../router/RouterHistoryContext'
 import {type Router, RouterProvider, type RouterState} from 'sanity/router'
@@ -20,39 +20,30 @@ export function WorkspaceRouterProvider({
 }: WorkspaceRouterProviderProps) {
   const {basePath, tools} = workspace
   const history = useRouterHistory()
-
-  const handleNavigate = useCallback(
-    (opts: {path: string; replace?: boolean}) => {
-      if (opts.replace) {
-        history.replace(opts.path)
-      } else {
-        history.push(opts.path)
-      }
-    },
-    [history]
-  )
   const router = useMemo(() => createRouter({basePath, tools}), [basePath, tools])
-  const state = useRouterStateFromWorkspaceHistory(history, router, tools)
+  const [state, onNavigate] = useRouterFromWorkspaceHistory(history, router, tools)
 
   // `state` is only null if the Studio is somehow rendering in SSR or using hydrateRoot in combination with `unstable_noAuthBoundary`.
   // Which makes this loading condition extremely rare, most of the time it'll render `RouteProvider` right away.
   if (!state) return <LoadingComponent />
 
   return (
-    <RouterProvider onNavigate={handleNavigate} router={router} state={state}>
+    <RouterProvider onNavigate={onNavigate} router={router} state={state}>
       {children}
     </RouterProvider>
   )
 }
 
+type HandleNavigate = (opts: {path: string; replace?: boolean}) => void
+
 /**
  * @internal
  */
-function useRouterStateFromWorkspaceHistory(
+function useRouterFromWorkspaceHistory(
   history: RouterHistory,
   router: Router,
   tools: Tool[]
-): RouterState | null {
+): [RouterState | null, HandleNavigate] {
   // React will only re-subscribe if store.subscribe changes identity, so by memoizing the whole store
   // we ensure that if any of the dependencies used by store.selector changes, we'll re-subscribe.
   // If we don't, we risk hot reload seeing stale workspace configs as the user is editing them.
@@ -83,26 +74,14 @@ function useRouterStateFromWorkspaceHistory(
     store.selector,
     isEqual
   )
-
+  /**
+   * As `prevEvent` needs to be referenced in `onNavigate`, it's important to use a React Ref when reading from it.
+   * The `onNavigate` callback is the backbone which all the router operations are built upon, implemented in `RouterProvider`.
+   * This includes `navigateUrl`, 'mavigate' and 'navigateIntent'. If we didn't use a React Ref, for example maybe use `useState` instead, then this would mean that every time `prevEvent` got a new value
+   * it would trigger a React re-render, which would give `onNavigate` a new identity. Which means all components that use `useRouter` would re-render just so that
+   * the callback will "see" the latest `preEvent` value. This is a very expensive operation, and we want to avoid it.
+   */
   const prevEvent = useRef(event)
-  // Handles redirects to intents, e.g. `/test/intent/create/template=codeTest;type=codeTest/` -> `/test/content/input-plugin;codeTest;c7e1aa3e-5555-40f5-b0af-c7309df6edcc%2Ctemplate%3DcodeTest`
-  // eslint-disable-next-line consistent-return
-  useEffect(() => {
-    if (event?.type === 'state' && event.state?.intent) {
-      const redirectState = resolveIntentState(
-        tools,
-        prevEvent.current?.type === 'state' ? prevEvent.current.state : {},
-        event.state
-      )
-
-      if (redirectState?.type === 'state') {
-        history.replace(router.encode(redirectState.state))
-        // Since we are calling history.replace here, a new event will be received immediately and we want to preserve prevEvent
-        return undefined
-      }
-    }
-    prevEvent.current = event
-  }, [event, history, router, tools])
 
   // Handles redirects from the root base path to the default tool, e.g. `/` -> `/desk`
   useEffect(() => {
@@ -114,5 +93,64 @@ function useRouterStateFromWorkspaceHistory(
     }
   }, [event?.state, event?.type, history, router, tools])
 
-  return event?.state ?? null
+  // Handles redirects to intents, e.g. `/test/intent/create/template=codeTest;type=codeTest/` -> `/test/content/input-plugin;codeTest;c7e1aa3e-5555-40f5-b0af-c7309df6edcc%2Ctemplate%3DcodeTest`
+  // eslint-disable-next-line consistent-return
+  useEffect(() => {
+    const resolvedIntent = maybeResolveIntent(event, router, tools, prevEvent)
+    // If resolvedIntent is truthy then we have a redirect to perform. Most of the time it'll be `null`
+    if (resolvedIntent) {
+      // console.debug('useEffect about to resolve intent URL to %o', resolvedIntent)
+      history.replace(resolvedIntent)
+    } else {
+      // console.debug('Syncing prevEvent.current to %o', event)
+      /**
+       * Sync the prevEvent ref with the current event, in a way that ensures the above side-effect is idemptotent.
+       * Idempotent means that if this hook is called multiple times, before the `history` state updates with the result of calling `history.replace` above,
+       * then the `prevEvent` ref remains the same until the `history` state has updated.
+       */
+      prevEvent.current = event
+    }
+  }, [event, history, router, tools])
+
+  const handleNavigate = useMemo<HandleNavigate>(() => {
+    // This is using useMemo instead of useCallback just so we can track if it's called an abnormal amount of times
+    // console.debug('handleNavigate useMemo called (should optimally only happen once)')
+    // console.count('handleNavigate')
+    return ({path, replace}) => {
+      // Handle intent resolving early, so we avoid rendering intermediate states in the workspace root, as it otherwise resolves intents in useEffect handlers
+      const predictedEvent = store.selector(path)
+      const resolvedIntent = maybeResolveIntent(predictedEvent, router, tools, prevEvent)
+      const resolvedPath = typeof resolvedIntent === 'string' ? resolvedIntent : path
+
+      if (replace) {
+        history.replace(resolvedPath)
+      } else {
+        history.push(resolvedPath)
+      }
+    }
+  }, [history, router, store, tools])
+
+  return [event?.state ?? null, handleNavigate]
+}
+
+// Handles intent resolving, both on navigate events (onClick and such), as well as onLoad by useEffect
+function maybeResolveIntent(
+  event: RouterStateEvent | null,
+  router: Router,
+  tools: Tool[],
+  prevEvent: React.MutableRefObject<RouterStateEvent | null>
+): string | null {
+  if (event?.type === 'state' && event.state?.intent) {
+    const redirectState = resolveIntentState(
+      tools,
+      prevEvent.current?.type === 'state' ? prevEvent.current.state : {},
+      event.state
+    )
+
+    if (redirectState?.type === 'state') {
+      return router.encode(redirectState.state)
+    }
+  }
+
+  return null
 }

--- a/packages/sanity/src/router/RouterProvider.tsx
+++ b/packages/sanity/src/router/RouterProvider.tsx
@@ -52,15 +52,7 @@ export interface RouterProviderProps {
  * @public
  */
 export function RouterProvider(props: RouterProviderProps): React.ReactElement {
-  // TODO: can we do nested routes?
   const {onNavigate, router: routerProp, state} = props
-
-  const navigateUrl = useCallback(
-    (opts: {path: string; replace?: boolean}) => {
-      onNavigate(opts)
-    },
-    [onNavigate]
-  )
 
   const resolveIntentLink = useCallback(
     (intentName: string, parameters?: IntentParameters): string => {
@@ -79,28 +71,28 @@ export function RouterProvider(props: RouterProviderProps): React.ReactElement {
 
   const navigate = useCallback(
     (nextState: Record<string, unknown>, options: NavigateOptions = {}) => {
-      navigateUrl({path: resolvePathFromState(nextState), replace: options.replace})
+      onNavigate({path: resolvePathFromState(nextState), replace: options.replace})
     },
-    [navigateUrl, resolvePathFromState]
+    [onNavigate, resolvePathFromState]
   )
 
   const navigateIntent = useCallback(
     (intentName: string, params?: IntentParameters, options: NavigateOptions = {}) => {
-      navigateUrl({path: resolveIntentLink(intentName, params), replace: options.replace})
+      onNavigate({path: resolveIntentLink(intentName, params), replace: options.replace})
     },
-    [navigateUrl, resolveIntentLink]
+    [onNavigate, resolveIntentLink]
   )
 
   const router: RouterContextValue = useMemo(
     () => ({
       navigate,
       navigateIntent,
-      navigateUrl,
+      navigateUrl: onNavigate,
       resolveIntentLink,
       resolvePathFromState,
       state,
     }),
-    [navigate, navigateIntent, navigateUrl, resolveIntentLink, resolvePathFromState, state]
+    [navigate, navigateIntent, onNavigate, resolveIntentLink, resolvePathFromState, state]
   )
 
   return <RouterContext.Provider value={router}>{props.children}</RouterContext.Provider>


### PR DESCRIPTION
### Description

The router refactor in #4282, released with [`v3.7.1`](https://github.com/sanity-io/sanity/releases/tag/v3.7.1) introduced a regression bug in intent link resolving.
The regression manifests itself when trying to create a new document, or navigating to a search result from the navbar, as demonstrated in this video:


https://user-images.githubusercontent.com/81981/229625967-efa1a7dd-d8d5-43a0-9197-47e926e34296.mp4

The reason why this happens is because the old router used to eagerly resolve intent links during render. The new router changed this flow to resolving them inside a `useEffect` flow so that React renders no longer have side-effects during render.
This means that when links are clicked there's an intermediary loading state that causes everything to unmount and remount, as demonstrated in the video above.
The fix solves this by adding intent resolving to the `onNavigate` handler in addition to the existing `useEffect`. Since `onNavigate` is called in response to user events such as clicking on an search result link, or a "create new..." button, it's safe to resolve intents here.
And by resolving them early we avoid the intermediary render state and unmounts only happen if the intent link resolves to a different tool or another pane tree that don't have a shared parent.


### What to review

The video below demonstrates how the intent links no longer causes dramatic unmounts, context is preserved and the UI no longer changes more than it absolutely needs to in order to resolve the intent.
There are some commented out `console.debug` calls, please ignore them as I intend to make a follow up PR after this one that resolves other router bugs I found. Priority 1 is to get a release that fixes the regression introduced in `v3.7.1` while the follow-up PR might take longer to create as it'll deal with long standing bugs, not recent regressions.



### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
