### PR TITLE
fix(desk): compare selected on sortOrderRaw instead of sortOrder

### DIFF
--- a/dev/test-studio/schema/standard/numbers.ts
+++ b/dev/test-studio/schema/standard/numbers.ts
@@ -66,4 +66,16 @@ export default defineType({
       readOnly: true,
     },
   ],
+  orderings: [
+    {name: 'asc', title: 'Asc', by: [{field: 'myNumberField', direction: 'asc'}]},
+    {name: 'desc', title: 'Desc', by: [{field: 'myNumberField', direction: 'desc'}]},
+    {
+      title: 'Title',
+      name: 'title',
+      by: [
+        {field: 'title', direction: 'asc'},
+        {field: 'myNumberField', direction: 'asc'},
+      ],
+    },
+  ],
 })

--- a/packages/sanity/src/desk/panes/documentList/DocumentListPane.tsx
+++ b/packages/sanity/src/desk/panes/documentList/DocumentListPane.tsx
@@ -33,10 +33,10 @@ function useShallowUnique<ValueType>(value: ValueType): ValueType {
 
 const addSelectedStateToMenuItems = (options: {
   menuItems?: PaneMenuItem[]
-  sortOrder?: SortOrder
+  sortOrderRaw?: SortOrder
   layout?: GeneralPreviewLayoutKey
 }) => {
-  const {menuItems, sortOrder, layout} = options
+  const {menuItems, sortOrderRaw, layout} = options
 
   return menuItems?.map((item) => {
     if (item.params?.layout) {
@@ -46,17 +46,10 @@ const addSelectedStateToMenuItems = (options: {
       }
     }
 
-    if (item?.params?.extendedProjection) {
-      return {
-        ...item,
-        selected: sortOrder?.extendedProjection === item?.params?.extendedProjection,
-      }
-    }
-
     if (item?.params?.by) {
       return {
         ...item,
-        selected: isEqual(sortOrder?.by, item?.params?.by || EMPTY_ARRAY),
+        selected: isEqual(sortOrderRaw?.by, item?.params?.by || EMPTY_ARRAY),
       }
     }
 
@@ -121,7 +114,7 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
     () =>
       addSelectedStateToMenuItems({
         menuItems,
-        sortOrder,
+        sortOrderRaw,
         layout,
       }),
     [layout, menuItems, sortOrder]


### PR DESCRIPTION
### Description
When adding selected state based on `extendedProjection`, it could cause several sort orderings to be selected, as these are not unique. Two sort orderings can have the same `extendedProjection` if they are sorting by the same field. 

This PR removes selected state based on `extendedProjection` and is only based on `sortOrderRaw` instead of `sortOrder`. 
This is necessary as a `sortOrder` based on type `string` field includes a `mapWith` prop, while the `item.params` does not add the `mapWith` prop, hence the `isEqual` check will fail and a sort option by a `string` will never be selected. 


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Make sure the correct sorting option is highlighted in the dropdown menu for sorting document lists. 

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fixes issue where several sorting options could be selected concurrently in dropdown. 
<!--
A description of the change(s) that should be used in the release notes.
-->
