### PR TITLE
test(cli): resolve user email for configured test token

### DIFF
--- a/packages/@sanity/cli/test/basics.test.ts
+++ b/packages/@sanity/cli/test/basics.test.ts
@@ -1,5 +1,5 @@
 import {describeCliTest, testConcurrent} from './shared/describe'
-import {cliUserEmail, runSanityCmdCommand, studioVersions} from './shared/environment'
+import {getCliUserEmail, runSanityCmdCommand, studioVersions} from './shared/environment'
 
 describeCliTest('CLI: basic commands', () => {
   describe.each(studioVersions)('%s', (version) => {
@@ -11,7 +11,7 @@ describeCliTest('CLI: basic commands', () => {
 
     testConcurrent('debug', async () => {
       const result = await runSanityCmdCommand(version, ['debug'])
-      expect(result.stdout).toContain(cliUserEmail)
+      expect(result.stdout).toContain(await getCliUserEmail())
       expect(result.code).toBe(0)
     })
 

--- a/packages/@sanity/cli/test/exec.test.ts
+++ b/packages/@sanity/cli/test/exec.test.ts
@@ -1,5 +1,5 @@
 import {describeCliTest, testConcurrent} from './shared/describe'
-import {cliUserEmail, runSanityCmdCommand, studioVersions} from './shared/environment'
+import {getCliUserEmail, runSanityCmdCommand, studioVersions} from './shared/environment'
 
 describeCliTest('CLI: `sanity exec`', () => {
   describe.each(studioVersions)('%s', (version) => {
@@ -17,7 +17,7 @@ describeCliTest('CLI: `sanity exec`', () => {
     testConcurrent('sanity exec --with-user-token', async () => {
       const result = await runSanityCmdCommand(version, ['exec', script, '--with-user-token'])
       const data = JSON.parse(result.stdout.trim())
-      expect(data.user.email).toBe(cliUserEmail)
+      expect(data.user.email).toBe(await getCliUserEmail())
       // Check that we load from .env.development
       expect(data.env.SANITY_STUDIO_MODE).toBe('development')
       expect(result.code).toBe(0)

--- a/packages/@sanity/cli/test/shared/environment.ts
+++ b/packages/@sanity/cli/test/shared/environment.ts
@@ -6,7 +6,6 @@ import {platform, tmpdir} from 'os'
 import {createClient} from '@sanity/client'
 import which from 'which'
 
-export const cliUserEmail = 'developers+cli-ci@sanity.io'
 export const cliUserToken = (process.env.SANITY_CI_CLI_AUTH_TOKEN || '').trim()
 export const cliProjectId = 'aeysrmym'
 
@@ -66,6 +65,9 @@ export const testClient = createClient({
   useCdn: false,
   token: cliUserToken,
 })
+
+export const getCliUserEmail = (): Promise<string> =>
+  testClient.users.getById('me').then((user) => user.email)
 
 export const getTestRunArgs = (version: string) => {
   const testId = getTestId()


### PR DESCRIPTION
### Description

Current, the tests rely on running them with a specific test user token. With this change, the tests can be run as any admin user for the project. At some point we may want to make this even more configurable so external users can utilize their own projects here too, but will leave that for a separate PR.

### Notes for release

None - internal change.
