### PR TITLE
test(cli): use `--detach` for dataset copy for faster runs

### DIFF
--- a/packages/@sanity/cli/test/datasetCopy.test.ts
+++ b/packages/@sanity/cli/test/datasetCopy.test.ts
@@ -15,6 +15,7 @@ describeCliTest('CLI: `sanity dataset copy`', () => {
         'production',
         testRunArgs.datasetCopy,
         '--skip-history',
+        '--detach',
       ])
       expect(result.stdout).toMatch(/job .*? started/i)
       expect(result.code).toBe(0)


### PR DESCRIPTION
### Description

Small change - dataset copying is one of the slower things we can test, but logically the only thing we want to test is that the commands can be run and spawns their tasks - not that the actual dataset copying completes. This changes to use the `--detach` flag, which immediately returns once the job has been registered with the backend.


### What to review

Tests pass, that we cant think of any side effects

### Notes for release

None