### PR TITLE
fix(core): fix permissions when initialValue is empty object

### DIFF
--- a/packages/sanity/src/core/templates/__tests__/resolve.test.ts
+++ b/packages/sanity/src/core/templates/__tests__/resolve.test.ts
@@ -1,5 +1,6 @@
 import {omit} from 'lodash'
 import {InitialValueResolverContext} from '@sanity/types'
+import {Schema as SchemaBuilder} from '@sanity/schema'
 import {resolveInitialValue, Template} from '../'
 import {schema} from './schema'
 
@@ -172,5 +173,78 @@ describe('resolveInitialValue', () => {
     expect(result.meta[0].categories[1]).toHaveProperty('_key')
     expect(result.meta[0].categories[0]._key).toMatch(/^[a-z0-9][a-z0-9-_]{8,30}/i)
     expect(result.meta[0].categories[1]._key).toMatch(/^[a-z0-9][a-z0-9-_]{8,30}/i)
+  })
+
+  describe('with empty initial values', () => {
+    const getTestSchema = (initialValue: unknown) =>
+      SchemaBuilder.compile({
+        name: 'empty',
+        types: [
+          {
+            name: 'author',
+            title: 'Author',
+            type: 'document',
+            initialValue,
+            fields: [
+              {
+                name: 'name',
+                type: 'string',
+              },
+              {
+                name: 'role',
+                type: 'string',
+              },
+            ],
+          },
+        ],
+      })
+
+    test('adds _type on empty objects', async () => {
+      const result = await resolveInitialValue(
+        getTestSchema({}),
+        {
+          ...example,
+          value: {},
+        },
+        {},
+        mockConfigContext
+      )
+
+      expect(result).toMatchObject({
+        _type: 'author',
+      })
+    })
+
+    test('adds _type on functions returning empty objects', async () => {
+      const result = await resolveInitialValue(
+        getTestSchema(() => ({})),
+        {
+          ...example,
+          value: {},
+        },
+        {},
+        mockConfigContext
+      )
+
+      expect(result).toMatchObject({
+        _type: 'author',
+      })
+    })
+
+    test('adds _type on functions returning Promise of empty objects', async () => {
+      const result = await resolveInitialValue(
+        getTestSchema(() => Promise.resolve({})),
+        {
+          ...example,
+          value: {},
+        },
+        {},
+        mockConfigContext
+      )
+
+      expect(result).toMatchObject({
+        _type: 'author',
+      })
+    })
   })
 })

--- a/packages/sanity/src/core/templates/resolve.ts
+++ b/packages/sanity/src/core/templates/resolve.ts
@@ -63,6 +63,11 @@ export async function resolveInitialValue(
     )
   }
 
+  // Ensure _type is set on empty objects
+  if (isRecord(resolvedValue) && !Object.keys(resolvedValue).length) {
+    resolvedValue = {_type: schemaTypeName}
+  }
+
   // validate default document initial values
   resolvedValue = validateInitialObjectValue(resolvedValue, template)
 


### PR DESCRIPTION
### Description

Adds `_type` when the initialValue is empty object when statically or in a function

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

Migrates https://github.com/sanity-io/sanity/pull/4346 to v3 as well as adds tests for it. Let me know if the test structure makes sense

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

Fixes permission issue when initialValue is set to empty object
