### PR TITLE
fix(core): clear unused references in an array when clicked outside

### DIFF
--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
@@ -3,8 +3,7 @@
 
 import React, {KeyboardEvent, FocusEvent, useCallback, useRef, useState, useMemo} from 'react'
 import {concat, Observable, of} from 'rxjs'
-
-import {catchError, distinctUntilChanged, filter, map, scan, switchMap, tap} from 'rxjs/operators'
+import {catchError, filter, map, scan, switchMap, tap} from 'rxjs/operators'
 import {Box, Button, Stack, Text, useToast} from '@sanity/ui'
 import {useObservableCallback} from 'react-rx'
 import {uuid} from '@sanity/uuid'
@@ -14,6 +13,7 @@ import {Alert} from '../../components/Alert'
 import {PreviewCard} from '../../../components'
 import {getPublishedId, isNonNullable} from '../../../util'
 import {useDidUpdate} from '../../hooks/useDidUpdate'
+import {useOnClickOutside} from '../../hooks/useOnClickOutside'
 import {useReferenceInput} from './useReferenceInput'
 import {
   CreateReferenceOption,
@@ -26,6 +26,7 @@ import {useReferenceInfo} from './useReferenceInfo'
 import {CreateButton} from './CreateButton'
 import {ReferenceAutocomplete} from './ReferenceAutocomplete'
 import {AutocompleteContainer} from './AutocompleteContainer'
+import {useReferenceItemRef} from './useReferenceItemRef'
 
 const StyledPreviewCard = styled(PreviewCard)`
   /* this is a hack to avoid layout jumps while previews are loading
@@ -62,6 +63,7 @@ export function ReferenceInput(props: ReferenceInputProps) {
     renderPreview,
     path,
     elementProps,
+    focusPath,
   } = props
 
   const {getReferenceInfo} = useReferenceInput({
@@ -129,6 +131,12 @@ export function ReferenceInput(props: ReferenceInputProps) {
   const handleClear = useCallback(() => {
     onChange(unset())
   }, [onChange])
+
+  const handleCancelEdit = useCallback(() => {
+    if (!value?._ref) {
+      handleClear()
+    }
+  }, [handleClear, value?._ref])
 
   const handleAutocompleteKeyDown = useCallback(
     (event: KeyboardEvent) => {
@@ -239,7 +247,7 @@ export function ReferenceInput(props: ReferenceInputProps) {
     !value?._strengthenOnPublish &&
     value?._weak
 
-  useDidUpdate(props.focusPath?.[0] === '_ref', (hadFocusAtRef, hasFocusAtRef) => {
+  useDidUpdate(focusPath?.[0] === '_ref', (hadFocusAtRef, hasFocusAtRef) => {
     if (!hadFocusAtRef && hasFocusAtRef) {
       elementProps.ref.current?.focus()
     }
@@ -252,8 +260,31 @@ export function ReferenceInput(props: ReferenceInputProps) {
       })),
     [searchState.hits]
   )
+
+  const isEditing = focusPath.length === 1 && (focusPath[0] === '_ref' || focusPath[0] === '$')
+
+  // --- click outside handling
+  const {menuRef, containerRef} = useReferenceItemRef()
+  const clickOutsideBoundaryRef = useRef<HTMLDivElement>(null)
+  const autoCompletePortalRef = useRef<HTMLDivElement>(null)
+  const createButtonMenuPortalRef = useRef<HTMLDivElement>(null)
+  useOnClickOutside(
+    [
+      containerRef,
+      clickOutsideBoundaryRef,
+      autoCompletePortalRef,
+      createButtonMenuPortalRef,
+      menuRef,
+    ],
+    () => {
+      if (isEditing) {
+        handleCancelEdit()
+      }
+    }
+  )
+
   return (
-    <Stack space={1} data-testid="reference-input">
+    <Stack space={1} data-testid="reference-input" ref={clickOutsideBoundaryRef}>
       <Stack space={2}>
         {isWeakRefToNonexistent ? (
           <Alert
@@ -292,6 +323,7 @@ export function ReferenceInput(props: ReferenceInputProps) {
             renderOption={renderOption as any}
             renderValue={renderValue}
             openButton={{onClick: handleAutocompleteOpenButtonClick}}
+            portalRef={autoCompletePortalRef}
           />
 
           {createOptions.length > 0 && (
@@ -301,6 +333,7 @@ export function ReferenceInput(props: ReferenceInputProps) {
               createOptions={createOptions}
               onCreate={handleCreateNew}
               onKeyDown={handleCreateButtonKeyDown}
+              menuRef={createButtonMenuPortalRef}
             />
           )}
         </AutocompleteContainer>

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
@@ -261,7 +261,7 @@ export function ReferenceInput(props: ReferenceInputProps) {
     [searchState.hits]
   )
 
-  const isEditing = focusPath.length === 1 && (focusPath[0] === '_ref' || focusPath[0] === '$')
+  const isEditing = focusPath.length === 1 && focusPath[0] === '_ref'
 
   // --- click outside handling
   const {menuRef, containerRef} = useReferenceItemRef()

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
@@ -41,6 +41,7 @@ import {PreviewReferenceValue} from './PreviewReferenceValue'
 import {useReferenceInput} from './useReferenceInput'
 import {ReferenceLinkCard} from './ReferenceLinkCard'
 import {IntentLink} from 'sanity/router'
+import {ReferenceItemRefProvider} from './ReferenceItemRefProvider'
 
 export interface ReferenceItemValue extends Omit<ObjectItem, '_type'>, Omit<Reference, '_key'> {}
 
@@ -102,6 +103,8 @@ export function ReferenceItem<Item extends ReferenceItemValue = ReferenceItemVal
   const insertableTypes = parentSchemaType.of
 
   const elementRef = useRef<HTMLDivElement | null>(null)
+  const menuRef = useRef<HTMLDivElement | null>(null)
+  const containerRef = useRef<HTMLDivElement | null>(null)
 
   const {EditReferenceLink, getReferenceInfo, selectedState, isCurrentDocumentLiveEdit} =
     useReferenceInput({
@@ -191,7 +194,7 @@ export function ReferenceItem<Item extends ReferenceItemValue = ReferenceItemVal
             button={<Button paddingY={3} paddingX={2} mode="bleed" icon={EllipsisVerticalIcon} />}
             id={`${inputId}-menuButton`}
             menu={
-              <Menu>
+              <Menu ref={menuRef}>
                 {!readOnly && (
                   <>
                     <MenuItem text="Remove" tone="critical" icon={TrashIcon} onClick={onRemove} />
@@ -331,73 +334,76 @@ export function ReferenceItem<Item extends ReferenceItemValue = ReferenceItemVal
   )
 
   const item = (
-    <RowLayout
-      dragHandle={sortable}
-      presence={
-        !isEditing && presence.length > 0 && <FieldPresence presence={presence} maxAvatars={1} />
-      }
-      validation={
-        !isEditing && validation.length > 0 && <FormFieldValidationStatus validation={validation} />
-      }
-      menu={menu}
-      footer={isEditing ? undefined : issues}
-      tone={isEditing ? undefined : tone}
-      focused={focused}
-    >
-      {isEditing ? (
-        <Box padding={1}>
-          <FormFieldSet
-            title={schemaType.title}
-            description={schemaType.description}
-            __unstable_presence={presence}
-            validation={validation}
-          >
-            {children}
-          </FormFieldSet>
-        </Box>
-      ) : (
-        <ReferenceLinkCard
-          as={EditReferenceLink}
-          tone="inherit"
-          radius={2}
-          documentId={value?._ref}
-          documentType={refType?.name}
-          disabled={resolvingInitialValue}
-          paddingX={2}
-          paddingY={1}
-          __unstable_focusRing
-          selected={selected}
-          pressed={pressed}
-          data-selected={selected ? true : undefined}
-          data-pressed={pressed ? true : undefined}
-          {...elementProps}
-        >
-          <PreviewReferenceValue
-            value={value}
-            referenceInfo={loadableReferenceInfo}
-            renderPreview={renderPreview}
-            type={schemaType}
-          />
-          {resolvingInitialValue && (
-            <Card
-              style={INITIAL_VALUE_CARD_STYLE}
-              tone="transparent"
-              radius={2}
-              as={Flex}
-              // @ts-expect-error composed from as={Flex}
-              justify="center"
+    <ReferenceItemRefProvider menuRef={menuRef} containerRef={containerRef}>
+      <RowLayout
+        dragHandle={sortable}
+        presence={
+          !isEditing && presence.length > 0 && <FieldPresence presence={presence} maxAvatars={1} />
+        }
+        validation={
+          !isEditing &&
+          validation.length > 0 && <FormFieldValidationStatus validation={validation} />
+        }
+        menu={menu}
+        footer={isEditing ? undefined : issues}
+        tone={isEditing ? undefined : tone}
+        focused={focused}
+      >
+        {isEditing ? (
+          <Box padding={1} ref={containerRef}>
+            <FormFieldSet
+              title={schemaType.title}
+              description={schemaType.description}
+              __unstable_presence={presence}
+              validation={validation}
             >
-              <Flex align="center" justify="center" padding={3}>
-                <Box marginX={3}>
-                  <Spinner muted />
-                </Box>
-                <Text>Resolving initial value…</Text>
-              </Flex>
-            </Card>
-          )}
-        </ReferenceLinkCard>
-      )}
-    </RowLayout>
+              {children}
+            </FormFieldSet>
+          </Box>
+        ) : (
+          <ReferenceLinkCard
+            as={EditReferenceLink}
+            tone="inherit"
+            radius={2}
+            documentId={value?._ref}
+            documentType={refType?.name}
+            disabled={resolvingInitialValue}
+            paddingX={2}
+            paddingY={1}
+            __unstable_focusRing
+            selected={selected}
+            pressed={pressed}
+            data-selected={selected ? true : undefined}
+            data-pressed={pressed ? true : undefined}
+            {...elementProps}
+          >
+            <PreviewReferenceValue
+              value={value}
+              referenceInfo={loadableReferenceInfo}
+              renderPreview={renderPreview}
+              type={schemaType}
+            />
+            {resolvingInitialValue && (
+              <Card
+                style={INITIAL_VALUE_CARD_STYLE}
+                tone="transparent"
+                radius={2}
+                as={Flex}
+                // @ts-expect-error composed from as={Flex}
+                justify="center"
+              >
+                <Flex align="center" justify="center" padding={3}>
+                  <Box marginX={3}>
+                    <Spinner muted />
+                  </Box>
+                  <Text>Resolving initial value…</Text>
+                </Flex>
+              </Card>
+            )}
+          </ReferenceLinkCard>
+        )}
+      </RowLayout>
+    </ReferenceItemRefProvider>
   )
   return (
     <ChangeIndicator path={path} isChanged={changed} hasFocus={Boolean(focused)}>

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItemRefProvider.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItemRefProvider.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import {type ReferenceItemRef, ReferenceItemRefContext} from './useReferenceItemRef'
+
+/**
+ * @internal
+ */
+interface ReferenceItemRefProviderProps extends ReferenceItemRef {
+  children: React.ReactNode
+}
+
+/**
+ *
+ * @internal
+ */
+export function ReferenceItemRefProvider(props: ReferenceItemRefProviderProps) {
+  const {menuRef, containerRef} = props
+
+  return (
+    <ReferenceItemRefContext.Provider value={{menuRef, containerRef}}>
+      {props.children}
+    </ReferenceItemRefContext.Provider>
+  )
+}

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/useReferenceItemRef.ts
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/useReferenceItemRef.ts
@@ -1,0 +1,30 @@
+import {createContext, type MutableRefObject, useContext} from 'react'
+
+/**
+ * @internal
+ */
+export interface ReferenceItemRef {
+  menuRef: MutableRefObject<HTMLDivElement | null>
+  containerRef: MutableRefObject<HTMLDivElement | null>
+}
+
+/**
+ * This is a way to store ref of the menu as well as the container of the ReferenceItem
+ * so it can be used down the tree for clickOutside handling
+ * @internal
+ */
+export const ReferenceItemRefContext = createContext<ReferenceItemRef | null>(null)
+
+/**
+ * @internal
+ */
+export function useReferenceItemRef(): ReferenceItemRef {
+  const ref = useContext(ReferenceItemRefContext)
+  if (!ref) {
+    // The input may not always be wrapped in a reference item.
+    // For example in the case of a singular reference input.
+    // To prevent the function from crashing, default values are returned in such cases.
+    return {menuRef: {current: null}, containerRef: {current: null}}
+  }
+  return ref
+}


### PR DESCRIPTION
### Description

This PR fixes issue where unused references don't clear when clicked outside which works in v2. This second attempt makes sure that the options menu works as intended and does not trigger cancel when clicking on actions like duplicate, etc.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

https://user-images.githubusercontent.com/6476108/231271452-62208359-e99e-40c4-abd5-624e919b5cfe.mov

The solution to fix this isn't ideal IMO but it is the only way I can think this could work. Since the ReferenceInput and ReferenceItem don't necessarily have a strict parent child relation and the menu popover is located in the ReferenceItem the only way for ReferenceInput to know if that is being clicked is when a ref is shared using context.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
Fixes issue where unused references in array were not cleared when clicking outside