### PR TITLE
chore(cli): fix basePath test flakiness

### DIFF
--- a/packages/@sanity/cli/test/build.test.ts
+++ b/packages/@sanity/cli/test/build.test.ts
@@ -99,7 +99,7 @@ describeCliTest('CLI: `sanity build` / `sanity deploy`', () => {
         })
         expect(result.code).toBe(0)
 
-        const files = await readdir(path.join(studioPath, 'out', 'static'))
+        const files = await readdir(path.join(studioPath, 'out-basepath', 'static'))
         const builtHtml = await readFile(
           path.join(studioPath, 'out-basepath', 'index.html'),
           'utf8'


### PR DESCRIPTION
### Description

I was reading the css file from wrong directory so based on if v2 test run first or not it would fail. Now that it is reading the files from correct directory it should not fail flakily 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->


### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
N/A