### PR TITLE
fix: log inability to fetch user for avatars, prevent studio crash

### DIFF
--- a/packages/sanity/src/core/store/user/hooks.ts
+++ b/packages/sanity/src/core/store/user/hooks.ts
@@ -6,7 +6,14 @@ import {UserStore, useUserStore} from '../_legacy'
 import {createHookFromObservableFactory, LoadingTuple} from '../../util'
 
 const useUserViaUserStore = createHookFromObservableFactory(
-  ([userStore, userId]: [UserStore, string]) => from(userStore.getUser(userId))
+  ([userStore, userId]: [UserStore, string]) => {
+    return from(
+      userStore.getUser(userId).catch((err) => {
+        console.error(err)
+        return null
+      })
+    )
+  }
 )
 
 /** @internal */


### PR DESCRIPTION
### Handle getUser error from UserStore

Adding a catch + console.error log when failing to fetch user information. This situation happens when using `unstable_noAuthBoundary` as the studio is trying to get avatars for users (for viewing document diffs and history) but there is no valid session and the backend returns a 401. Rather than crash the studio this will log the error and return `null` for the user which was already written as a potential return type.

### What to review

Try using `unstable_noAuthBoundary` in the studio and verify the studio doesn't unexpectedly stop when viewing document history/diffs.

### Notes for release

Gracefully handle when user data is unavailable for document history/diffing
