### PR TITLE
chore(CI): create yarn lockfile maintenance action

### DIFF
--- a/.github/workflows/prettier-if-needed.yml
+++ b/.github/workflows/prettier-if-needed.yml
@@ -46,7 +46,7 @@ jobs:
           key: prettier-${{ hashFiles('yarn.lock') }}
       - run: yarn prettier --write
       - name: GitHub blocks PRs from automation that alter workflows in any way
-        run: git restore .github/workflows
+        run: git restore .github/workflows yarn.lock
       - uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1
         id: generate-token
         with:

--- a/.github/workflows/yarn-if-needed.yml
+++ b/.github/workflows/yarn-if-needed.yml
@@ -1,0 +1,42 @@
+---
+name: Yarn lockfile
+
+on:
+  push:
+    branches: [next]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    name: Is yarn.lock in sync? 🤔
+    runs-on: ubuntu-latest
+    # workflow_dispatch always lets you select the branch ref, even though in this case we only ever want to run the action on `main` thus we need an if check
+    if: ${{ github.ref_name == 'next' }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          cache: yarn
+          node-version: lts/*
+      - run: yarn install --ignore-scripts
+      - uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.ECOSPARK_APP_ID }}
+          private_key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
+      - uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4
+        with:
+          author: github-actions <41898282+github-actions[bot]@users.noreply.github.com>
+          body: I ran `yarn install --ignore-scripts` 🧑‍💻
+          branch: actions/yarn-if-needed
+          commit-message: 'chore(deps): lock file maintenance'
+          labels: 🤖 bot
+          title: 'chore(deps): lock file maintenance'
+          token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
### Description

On this `prettier-if-needed.yml` PR: https://github.com/sanity-io/sanity/pull/4369
I noticed it committed a change to `yarn.lock`, which is odd. It shouldn't. 
I ran `yarn` myself on `git checkout origin next` and can confirm the lockfile is currently out of sync. 
This can happen due to PR queues and how merge conflicts or ordering happens.
In any case this PR introduces an action that will create a PR that fixes `yarn.lock` whenever needed.
The benefit of this is to avoid multiple PRs now changing `yarn.lock` as authors run `yarn` locally and the lockfile is currently stale in `next`.

### What to review

I didn't commit a fixed `yarn.lock` on purpose so that we can test if the bot works and is able to fix the currently stale `yarn.lock` on `next`.
Merging this PR should also trigger the prettier bot to auto-close: https://github.com/sanity-io/sanity/pull/4369

### Notes for release

- N/A
