### PR TITLE
fix(core): capitalize type name if item type lacks title in pte

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/InsertMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/InsertMenu.tsx
@@ -5,6 +5,7 @@ import {PortableTextEditor, usePortableTextEditor} from '@sanity/portable-text-e
 import {CollapseMenu, CollapseMenuButton} from '../../../../components/collapseMenu'
 import {BlockItem} from './types'
 import {useFocusBlock} from './hooks'
+import {upperFirst} from 'lodash'
 
 const CollapseMenuMemo = memo(CollapseMenu)
 
@@ -30,10 +31,7 @@ export const InsertMenu = memo(function InsertMenu(props: InsertMenuProps) {
 
   const children = useMemo(() => {
     return items.map((item) => {
-      const title =
-        item.type.title ||
-        (item?.type.type?.name !== undefined &&
-          item?.type.type?.name.charAt(0).toUpperCase() + item?.type.type?.name.slice(1))
+      const title = item.type.title || upperFirst(item.type.name)
 
       return (
         <CollapseMenuButton

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/InsertMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/InsertMenu.tsx
@@ -30,7 +30,10 @@ export const InsertMenu = memo(function InsertMenu(props: InsertMenuProps) {
 
   const children = useMemo(() => {
     return items.map((item) => {
-      const title = item.type.title || item.type.type?.name
+      const title =
+        item.type.title ||
+        (item?.type.type?.name !== undefined &&
+          item?.type.type?.name.charAt(0).toUpperCase() + item?.type.type?.name.slice(1))
 
       return (
         <CollapseMenuButton


### PR DESCRIPTION
### Description
In schema, when a field only has a `name` the `title` is automatically generated and should be uppercase in the PTE. 
Before: 
![image](https://user-images.githubusercontent.com/44635000/232015987-07648ab1-0819-4441-b013-da5ccd424190.png)


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Make sure that if a field in PTE does not have a `title` field, the automatically generated title is uppercase. 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fixes automatically generated title in PTE to be uppercase. 
<!--
A description of the change(s) that should be used in the release notes.
-->
