### PR TITLE
fix(perf-runner): add support for running tests against recent tags only

### DIFF
--- a/perf/queries.ts
+++ b/perf/queries.ts
@@ -10,3 +10,10 @@ export const branchDeploymentsQuery = `*[_type=='branch' && name == $branch] {
     *[_type == 'deployment' && name=="performance-studio" && status=="succeeded" && (branch._ref in [^.baseBranchId])] | order(_createdAt desc)[0]
     ]
 } [count(deployments) > 0].deployments[] | order(_createdAt desc) [0...$count] {_id, deploymentId, url, label}`
+
+export const tagsDeploymentsQuery = `*[_type=='tag'] | order(_createdAt desc) {
+  name,
+  commit,
+  _createdAt,
+  "deployments": *[_type == 'deployment' && name=="performance-studio" && status=="succeeded" && defined(meta.githubCommitSha) && meta.githubCommitSha==^.commit]
+} [count(deployments) > 0].deployments[] | order(_createdAt desc) [0...$count] {_id, deploymentId, url, label}`

--- a/perf/queries.ts
+++ b/perf/queries.ts
@@ -12,8 +12,8 @@ export const branchDeploymentsQuery = `*[_type=='branch' && name == $branch] {
 } [count(deployments) > 0].deployments[] | order(_createdAt desc) [0...$count] {_id, deploymentId, url, label}`
 
 export const tagsDeploymentsQuery = `*[_type=='tag'] | order(_createdAt desc) {
-  name,
+  "tagName": name,
   commit,
   _createdAt,
-  "deployments": *[_type == 'deployment' && name=="performance-studio" && status=="succeeded" && defined(meta.githubCommitSha) && meta.githubCommitSha==^.commit]
-} [count(deployments) > 0].deployments[] | order(_createdAt desc) [0...$count] {_id, deploymentId, url, label}`
+  "deployment": *[_type == 'deployment' && name=="performance-studio" && status=="succeeded" && defined(meta.githubCommitSha) && meta.githubCommitSha==^.commit] | order(_createdAt desc)[0]
+} [defined(deployment)] | order(deployment._createdAt desc) [0...$count] {...deployment, "label": tagName} {_id, deploymentId, url, label}`


### PR DESCRIPTION
### Description
Small change that adds support for running perf tests against --count recent tags (typically releases).

For example, to run the perf tests against the 5 most recent tags: `yarn perf:test --tagsOnly --count=5`

Note: The copy edits are mainly to make the output more accurate (it's no longer just "branch" or "branches))

### What to review
Check that the code makes change

### Notes for release

n/a: internal tooling