### PR TITLE
chore(test-studio): enable source-maps

### DIFF
--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -6,7 +6,7 @@
     "build": "run-s workshop:build sanity:build",
     "clean": "rimraf .sanity dist",
     "dev": "run-p workshop:dev sanity:dev",
-    "sanity:build": "../.bin/sanity build",
+    "sanity:build": "../.bin/sanity build --source-maps",
     "sanity:dev": "../.bin/sanity dev",
     "start": "../.bin/sanity start",
     "workshop:build": "node -r esbuild-register scripts/workshop/build.ts",


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Enables source maps for test studio in vercel, helpful for debugging issues.

![Screenshot 2023-04-18 at 12 34 34 PM](https://user-images.githubusercontent.com/6476108/232844675-1945130b-b050-483c-898f-60c70e84f53e.png)

Debugger in vercel 🙌 

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

Does it make sense to make source-maps an env variable and add it to vercel as a build env. Or is that too much effort for little gain? 

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

N/A (internal) 
