### PR TITLE
fix(cli): use more recent version ranges for new projects

### DIFF
--- a/packages/@sanity/cli/src/studioDependencies.ts
+++ b/packages/@sanity/cli/src/studioDependencies.ts
@@ -2,16 +2,16 @@ export const studioDependencies = {
   // Dependencies for a default Sanity installation
   dependencies: {
     // Official studio dependencies
-    sanity: '^3.0.0',
+    sanity: '^3.9.0',
 
     // Official studio plugin dependencies
-    '@sanity/vision': '^3.0.0',
+    '@sanity/vision': '^3.9.0',
 
     // Non-Sanity dependencies
     react: '^18.2.0',
     'react-dom': '^18.2.0',
     'react-is': '^18.2.0', // Peer dependency of styled-components
-    'styled-components': '^5.2.0',
+    'styled-components': '^5.3.9',
   },
 
   devDependencies: {


### PR DESCRIPTION
### Description

_Note: This is not a complete fix, but will _mitigate_ problems until we can properly fix it._

pnpm 8 has switched resolution to use the _lowest_ matching version when installing dependencies. This is apparently done for performance reasons, but creates problems for us since it means pnpm users will get Sanity 3.0.0 instead of the latest. The same goes for other root-level dependencies.

There is no flag to set resolution mode, and installing a pnpmrc seems a little invasive, so I think the real solution is to resolve the latest (compatible) version of dependencies upon install and write that to the project `package.json`. Until we can get around to that, this will at least bring versions up to a much more recent version of Sanity, and avoids a number of react hooks warning on the dev server startup when using pnpm.
