### PR TITLE
fix(validation): Remove recursive validation check for annotations in PTE

### DIFF
--- a/packages/@sanity/validation/src/validateDocument.ts
+++ b/packages/@sanity/validation/src/validateDocument.ts
@@ -210,36 +210,6 @@ function validateItemObservable({
     )
   }
 
-  // markDefs also do no run nested validation if the parent object is undefined
-  // for a similar reason to arrays
-  const shouldRunNestedValidationForMarkDefs =
-    isPortableTextTextBlock(value) && value.markDefs?.length && isBlockSchemaType(type)
-
-  if (shouldRunNestedValidationForMarkDefs) {
-    const [spanChildrenField] = type.fields
-    const spanType = spanChildrenField.type.of.find(isSpanSchemaType)
-
-    const annotations = (spanType?.annotations || []).reduce<Map<string, SchemaType>>(
-      (acc, annotationType) => {
-        acc.set(annotationType.name, annotationType)
-        return acc
-      },
-      new Map()
-    )
-
-    nestedChecks = nestedChecks.concat(
-      (value.markDefs || []).map((markDef) =>
-        validateItemObservable({
-          ...restOfContext,
-          parent: value,
-          value: markDef,
-          path: path.concat(['markDefs', {_key: markDef._key}]),
-          type: annotations.get(markDef._type),
-        })
-      )
-    )
-  }
-
   return defer(() => merge([...selfChecks, ...nestedChecks])).pipe(
     mergeMap((validateNode) => concat(idle(), validateNode), 40),
     mergeAll(),


### PR DESCRIPTION
### Description
During the v3 work, the type for annotations were changed to be arrays. 
The check where validation is added to arrays will therefore include annotations as well now, and a separate check for annotations are not necessary. By removing this check for annotations, the validation messages are now only shown once. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
That validation for annotations work as expected and are now duplicated anymore. 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fixes bug where validation messages on annotations were shown twice. 
<!--
A description of the change(s) that should be used in the release notes.
-->
