### PR TITLE
fix(desk): Change message shown after successfully deleting document

### DIFF
--- a/packages/sanity/src/desk/panes/document/DocumentOperationResults.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentOperationResults.tsx
@@ -26,7 +26,7 @@ function getOpSuccessTitle(op: string): string {
     return `All changes since last publish has now been discarded. The discarded draft can still be recovered from history`
   }
   if (op === 'delete') {
-    return `This document was deleted. It can still be recovered from history and if you continue editing it will be recreated.`
+    return `The document was successfully deleted`
   }
   return `Successfully performed ${op} on document`
 }


### PR DESCRIPTION
### Description
Simplifies message shown after successfully deleting document. 
Changing the copy of the toast to a longer, more descriptive explanation would provide more context but most likely would make the experience more confusing. How to retrieve a deleted document should be covered in docs instead. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Changes message shown after successfully deleting a document.
<!--
A description of the change(s) that should be used in the release notes.
-->
