### PR TITLE
Restore PTE selection in placeholder block

### DIFF
--- a/packages/@sanity/portable-text-editor/src/utils/patchToOperations.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/patchToOperations.ts
@@ -257,10 +257,18 @@ export function createPatchToOperations(
     if (patch.path.length === 0) {
       debug(`Removing everything`)
       debugState(editor, 'before')
+      const previousSelection = editor.selection
       Transforms.deselect(editor)
       editor.children.forEach((c, i) => {
         Transforms.removeNodes(editor, {at: [i]})
       })
+      Transforms.insertNodes(editor, editor.createPlaceholderBlock())
+      if (previousSelection) {
+        Transforms.select(editor, {
+          anchor: {path: [0, 0], offset: 0},
+          focus: {path: [0, 0], offset: 0},
+        })
+      }
       debugState(editor, 'after')
       return true
     }

--- a/packages/@sanity/portable-text-editor/test/__tests__/writingTogether.collaborative.test.ts
+++ b/packages/@sanity/portable-text-editor/test/__tests__/writingTogether.collaborative.test.ts
@@ -62,7 +62,7 @@ describe('collaborate editing', () => {
     })
   })
 
-  it('will reset the value when someone deletes everything, and when they start to type again, they will produce their own respective blocks.', async () => {
+  it.only('will reset the value when someone deletes everything, and when they start to type again, they will produce their own respective blocks.', async () => {
     await setDocumentValue(initialValue)
     const [editorA, editorB] = await getEditors()
     await editorA.setSelection({
@@ -101,11 +101,11 @@ describe('collaborate editing', () => {
     expect(valA).toMatchInlineSnapshot(`
       Array [
         Object {
-          "_key": "B-4",
+          "_key": "B-6",
           "_type": "block",
           "children": Array [
             Object {
-              "_key": "B-3",
+              "_key": "B-5",
               "_type": "span",
               "marks": Array [],
               "text": "1",
@@ -152,11 +152,11 @@ describe('collaborate editing', () => {
     expect(valB).toMatchInlineSnapshot(`
       Array [
         Object {
-          "_key": "B-4",
+          "_key": "B-6",
           "_type": "block",
           "children": Array [
             Object {
-              "_key": "B-3",
+              "_key": "B-5",
               "_type": "span",
               "marks": Array [],
               "text": "12",

--- a/packages/@sanity/portable-text-editor/test/__tests__/writingTogether.collaborative.test.ts
+++ b/packages/@sanity/portable-text-editor/test/__tests__/writingTogether.collaborative.test.ts
@@ -62,7 +62,7 @@ describe('collaborate editing', () => {
     })
   })
 
-  it.only('will reset the value when someone deletes everything, and when they start to type again, they will produce their own respective blocks.', async () => {
+  it('will reset the value when someone deletes everything, and when they start to type again, they will produce their own respective blocks.', async () => {
     await setDocumentValue(initialValue)
     const [editorA, editorB] = await getEditors()
     await editorA.setSelection({

--- a/packages/@sanity/portable-text-editor/test/setup/collaborative.jest.env.ts
+++ b/packages/@sanity/portable-text-editor/test/setup/collaborative.jest.env.ts
@@ -287,6 +287,7 @@ export default class CollaborationEnvironment extends NodeEnvironment {
                   editorId,
                 })
               )
+              await delay(200)
               await waitForSelection(selection)
             },
             async getValue(): Promise<PortableTextBlock[] | undefined> {


### PR DESCRIPTION
### Description

There is an issue in the PTE where if several users are typing and one editor deletes all the content, a set selection in another editor is nullified in a non-clear way and as observed in the CI will randomly fail on these kind of tests.

Not a big real world problem probably, but very disruptive when these tests randomly fails unrelated to anyone's changes and there are unexpected things happening.

The symptom was that the test framework's `waitForNewSelection` would timeout while waiting for a new selection that never came. The reason it doesn't fail (on a fast computer) is that the safety-mechanism in `useSyncValue` will later make this happen anyway (though a tad bit later) making it just in time for the test to be true at that particular time. I think this is why it's never been a problem locally for me, but chronically so on the CI server.

I have also identified another thing related to how we set the test selections. When the tests want to set a certain selection in a test editor, we must wait a little for the IPC message to be received by the editor first, before we test for the applied new selection. This was also randomly failing on the CI (sometimes it would reach the client before the test proceeded I think). This is only relevant to how we set state in these tests, and not affect the editor code itself.
 
BTW: all this was uncovered and helped fixed by using Firefox with Playwright which is a bit interesting!


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

That tests are not flaky:

* Add runs to this [CI-job](https://github.com/sanity-io/sanity/actions/runs/4747799000) and see if some of the collaborative tests for the PTE are failing randomly. So far it has been looking good, and I haven't been able to get a failed run.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Doesn't need to be mentioned. Fixed most of all a CI  and internal DX problem.

<!--
A description of the change(s) that should be used in the release notes.
-->
