### PR TITLE
fix(core): fix focus issues when a new reference field is added

### DIFF
--- a/packages/sanity/src/core/form/hooks/__tests__/useDidUpdate.test.ts
+++ b/packages/sanity/src/core/form/hooks/__tests__/useDidUpdate.test.ts
@@ -1,0 +1,125 @@
+/* eslint-disable max-nested-callbacks */
+import {renderHook} from '@testing-library/react'
+import {StrictMode} from 'react'
+import {useDidUpdate} from '../useDidUpdate'
+
+describe('useDidUpdate', () => {
+  describe('Normal Mode', () => {
+    it('calls the didUpdate callback when the value changes', () => {
+      const previousValue = {foo: 'bar'}
+      const currentValue = {foo: 'baz'}
+      const didUpdate = jest.fn()
+
+      const {rerender} = renderHook(({value}) => useDidUpdate(value, didUpdate), {
+        initialProps: {value: previousValue},
+      })
+
+      // The first time, didUpdate should be called
+      expect(didUpdate).toHaveBeenCalledTimes(1)
+
+      rerender({value: currentValue})
+
+      expect(didUpdate).toHaveBeenCalledWith(previousValue, currentValue)
+    })
+
+    it('calls the compare function when it is passed', () => {
+      const previousValue = {foo: 'bar'}
+      const currentValue = {foo: 'baz'}
+      const compare = jest.fn(() => false)
+      const didUpdate = jest.fn()
+
+      const {rerender} = renderHook(({value}) => useDidUpdate(value, didUpdate, compare), {
+        initialProps: {value: previousValue},
+      })
+
+      // The first time, didUpdate and compare should be called
+      expect(didUpdate).toHaveBeenCalledTimes(1)
+      expect(compare).toHaveBeenCalledTimes(1)
+
+      rerender({value: currentValue})
+
+      expect(compare).toHaveBeenCalledWith(previousValue, currentValue)
+      expect(didUpdate).toHaveBeenCalledWith(previousValue, currentValue)
+    })
+
+    it('does not call the didUpdate callback when the value does not change', () => {
+      const previousValue = {foo: 'bar'}
+      const currentValue = {foo: 'bar'}
+      const didUpdate = jest.fn()
+
+      const {rerender} = renderHook(({value}) => useDidUpdate(value, didUpdate), {
+        initialProps: {value: previousValue},
+      })
+
+      // The first time, didUpdate should be called
+      expect(didUpdate).toHaveBeenCalledTimes(1)
+
+      didUpdate.mockClear()
+
+      rerender({value: currentValue})
+
+      expect(didUpdate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Strict mode', () => {
+    it('calls the didUpdate callback when the value changes', () => {
+      const previousValue = {foo: 'bar'}
+      const currentValue = {foo: 'baz'}
+      const didUpdate = jest.fn()
+
+      const {rerender} = renderHook(({value}) => useDidUpdate(value, didUpdate), {
+        initialProps: {value: previousValue},
+        wrapper: StrictMode,
+      })
+
+      // The first time, didUpdate should be called. StrictMode runs hooks twice https://react.dev/reference/react/StrictMode#strictmode
+      expect(didUpdate).toHaveBeenCalledTimes(2)
+
+      rerender({value: currentValue})
+
+      expect(didUpdate).toHaveBeenCalledWith(previousValue, currentValue)
+    })
+
+    it('calls the compare function when it is passed', () => {
+      const previousValue = {foo: 'bar'}
+      const currentValue = {foo: 'baz'}
+      const compare = jest.fn(() => false)
+      const didUpdate = jest.fn()
+
+      const {rerender} = renderHook(({value}) => useDidUpdate(value, didUpdate, compare), {
+        initialProps: {value: previousValue},
+        wrapper: StrictMode,
+      })
+
+      // The first time, didUpdate should be called. StrictMode runs hooks twice https://react.dev/reference/react/StrictMode#strictmode
+      expect(didUpdate).toHaveBeenCalledTimes(2)
+      expect(compare).toHaveBeenCalledTimes(2)
+
+      rerender({value: currentValue})
+
+      expect(compare).toHaveBeenCalledWith(previousValue, currentValue)
+      expect(didUpdate).toHaveBeenCalledWith(previousValue, currentValue)
+    })
+
+    it('does not call the didUpdate callback when the value does not change', () => {
+      const previousValue = {foo: 'bar'}
+      const currentValue = {foo: 'bar'}
+      const didUpdate = jest.fn()
+
+      const {rerender} = renderHook(({value}) => useDidUpdate(value, didUpdate), {
+        initialProps: {value: previousValue},
+        wrapper: StrictMode,
+      })
+
+      // The first time, didUpdate should be called. StrictMode runs hooks twice https://react.dev/reference/react/StrictMode#strictmode
+      expect(didUpdate).toHaveBeenCalledTimes(2)
+
+      didUpdate.mockClear()
+
+      rerender({value: currentValue})
+
+      expect(didUpdate).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/sanity/src/core/form/hooks/__tests__/useOnClickOutside.test.tsx
+++ b/packages/sanity/src/core/form/hooks/__tests__/useOnClickOutside.test.tsx
@@ -1,0 +1,67 @@
+import {render, renderHook} from '@testing-library/react'
+import React, {createRef} from 'react'
+import {useOnClickOutside} from '../useOnClickOutside'
+
+describe('useOnClickOutside', () => {
+  it('calls the handler when clicking outside of the refs', () => {
+    const handler = jest.fn()
+    const ref1 = createRef<HTMLDivElement>()
+    const ref2 = createRef<HTMLDivElement>()
+
+    render(
+      <div>
+        <div ref={ref1} />
+        <div ref={ref2} />
+      </div>
+    )
+
+    renderHook(() => {
+      useOnClickOutside([ref1, ref2], handler)
+      return {ref1, ref2}
+    })
+
+    // Create an element to represent the click target outside of the refs
+    const target = document.createElement('div')
+    document.body.appendChild(target)
+
+    // Simulate a click event on the target element
+    const event = new MouseEvent('mousedown', {bubbles: true})
+    target.dispatchEvent(event)
+
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    // Clean up the target element
+    document.body.removeChild(target)
+  })
+
+  it('does not call the handler when clicking inside of the refs', () => {
+    const handler = jest.fn()
+    const ref1 = createRef<HTMLDivElement>()
+    const ref2 = createRef<HTMLDivElement>()
+
+    render(
+      <div>
+        <div ref={ref1} />
+        <div ref={ref2} />
+      </div>
+    )
+
+    const {result} = renderHook(() => {
+      useOnClickOutside([ref1, ref2], handler)
+      return {ref1, ref2}
+    })
+
+    // Create an element to represent a click target inside one of the refs
+    const target = document.createElement('div')
+    result.current.ref1.current?.appendChild(target)
+
+    // Simulate a click event on the target element
+    const event = new MouseEvent('mousedown', {bubbles: true})
+    target.dispatchEvent(event)
+
+    expect(handler).not.toHaveBeenCalled()
+
+    // Clean up the target element
+    result.current.ref1.current?.removeChild(target)
+  })
+})

--- a/packages/sanity/src/core/form/hooks/__tests__/usePrevious.test.ts
+++ b/packages/sanity/src/core/form/hooks/__tests__/usePrevious.test.ts
@@ -1,0 +1,31 @@
+import {renderHook} from '@testing-library/react'
+import {usePrevious} from '../usePrevious'
+
+describe('usePrevious', () => {
+  it('should return undefined on the first render', () => {
+    const {result} = renderHook(() => usePrevious('test'))
+    expect(result.current).toBeNull()
+  })
+
+  it('should return the previous value on the next render', () => {
+    const {result, rerender} = renderHook(({value}) => usePrevious(value), {
+      initialProps: {value: 'test'},
+    })
+
+    rerender({value: 'updated'})
+    expect(result.current).toEqual('test')
+
+    rerender({value: 'changed'})
+    expect(result.current).toEqual('updated')
+  })
+
+  it('should return the initial value if provided', () => {
+    const {result, rerender} = renderHook(({value}) => usePrevious(value, 'initial'), {
+      initialProps: {value: 'test'},
+    })
+    expect(result.current).toEqual('initial')
+
+    rerender({value: 'updated'})
+    expect(result.current).toEqual('test')
+  })
+})

--- a/packages/sanity/src/core/form/hooks/__tests__/useScrollIntoViewOnFocusWithin.test.ts
+++ b/packages/sanity/src/core/form/hooks/__tests__/useScrollIntoViewOnFocusWithin.test.ts
@@ -1,0 +1,101 @@
+import {renderHook} from '@testing-library/react'
+import scrollIntoView from 'scroll-into-view-if-needed'
+import * as useDidUpdate from '../useDidUpdate'
+import {useScrollIntoViewOnFocusWithin} from '../useScrollIntoViewOnFocusWithin'
+
+jest.mock('scroll-into-view-if-needed', () => jest.fn())
+
+describe('useScrollIntoViewOnFocusWithin', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('should scroll when hasFocusWithin is true', () => {
+    const elementRef = {current: document.createElement('div')}
+    const hasFocusWithin = true
+    const useDidUpdateSpy = jest.spyOn(useDidUpdate, 'useDidUpdate')
+
+    renderHook(() => useScrollIntoViewOnFocusWithin(elementRef, hasFocusWithin))
+
+    expect(useDidUpdateSpy).toHaveBeenCalledTimes(1)
+    expect(useDidUpdateSpy.mock.calls[0][0]).toBe(hasFocusWithin)
+    expect(scrollIntoView).toHaveBeenCalledTimes(1)
+  })
+
+  test('should scroll when hasFocusWithin changes from false to true', () => {
+    const elementRef = {current: document.createElement('div')}
+    const hasFocusWithin = false
+    const useDidUpdateSpy = jest.spyOn(useDidUpdate, 'useDidUpdate')
+
+    const {rerender} = renderHook(
+      (props) => useScrollIntoViewOnFocusWithin(elementRef, props.hasFocusWithin),
+      {
+        initialProps: {hasFocusWithin},
+      }
+    )
+
+    expect(useDidUpdateSpy).toHaveBeenCalledTimes(1)
+    expect(useDidUpdateSpy.mock.calls[0][0]).toBe(hasFocusWithin)
+    expect(scrollIntoView).not.toHaveBeenCalled()
+
+    // clear all mocks
+    jest.clearAllMocks()
+
+    const newHasFocusWithin = true
+    rerender({hasFocusWithin: newHasFocusWithin})
+    expect(useDidUpdateSpy).toHaveBeenCalledTimes(1)
+    expect(useDidUpdateSpy.mock.calls[0][0]).toBe(newHasFocusWithin)
+    expect(scrollIntoView).toHaveBeenCalledTimes(1)
+    expect(scrollIntoView).toHaveBeenCalledWith(elementRef.current, {scrollMode: 'always'})
+  })
+
+  test('should not scroll when hasFocusWithin changes from true to false', () => {
+    const elementRef = {current: document.createElement('div')}
+    const hasFocusWithin = true
+    const useDidUpdateSpy = jest.spyOn(useDidUpdate, 'useDidUpdate')
+
+    const {rerender} = renderHook(
+      (props) => useScrollIntoViewOnFocusWithin(elementRef, props.hasFocusWithin),
+      {
+        initialProps: {hasFocusWithin},
+      }
+    )
+
+    expect(useDidUpdateSpy).toHaveBeenCalledTimes(1)
+    expect(useDidUpdateSpy.mock.calls[0][0]).toBe(hasFocusWithin)
+    expect(scrollIntoView).toHaveBeenCalledTimes(1)
+
+    jest.clearAllMocks()
+
+    const newHasFocusWithin = false
+    rerender({hasFocusWithin: newHasFocusWithin})
+    expect(useDidUpdateSpy).toHaveBeenCalledTimes(1)
+    expect(useDidUpdateSpy.mock.calls[0][0]).toBe(newHasFocusWithin)
+    expect(scrollIntoView).not.toHaveBeenCalled()
+  })
+
+  test('should not scroll when hasFocusWithin has not changed', () => {
+    const elementRef = {current: document.createElement('div')}
+    const hasFocusWithin = true
+    const useDidUpdateSpy = jest.spyOn(useDidUpdate, 'useDidUpdate')
+
+    const {rerender} = renderHook(
+      (props) => useScrollIntoViewOnFocusWithin(elementRef, props.hasFocusWithin),
+      {
+        initialProps: {hasFocusWithin},
+      }
+    )
+
+    expect(useDidUpdateSpy).toHaveBeenCalledTimes(1)
+    expect(useDidUpdateSpy.mock.calls[0][0]).toBe(hasFocusWithin)
+    expect(scrollIntoView).toHaveBeenCalledTimes(1)
+
+    jest.clearAllMocks()
+
+    const newHasFocusWithin = true
+    rerender({hasFocusWithin: newHasFocusWithin})
+    expect(useDidUpdateSpy).toHaveBeenCalledTimes(1)
+    expect(useDidUpdateSpy.mock.calls[0][0]).toBe(newHasFocusWithin)
+    expect(scrollIntoView).not.toHaveBeenCalled()
+  })
+})

--- a/packages/sanity/src/core/form/hooks/useDidUpdate.ts
+++ b/packages/sanity/src/core/form/hooks/useDidUpdate.ts
@@ -1,4 +1,4 @@
-import {useEffect, useRef} from 'react'
+import {useEffect} from 'react'
 import shallowEquals from 'shallow-equals'
 import {usePrevious} from './usePrevious'
 

--- a/packages/sanity/src/core/form/hooks/useDidUpdate.ts
+++ b/packages/sanity/src/core/form/hooks/useDidUpdate.ts
@@ -26,13 +26,8 @@ export function useDidUpdate<T>(
   didUpdate: (previous: T | undefined, current: T | undefined) => void,
   compare: (previous: T | undefined, current: T) => boolean = shallowEquals
 ): void {
-  const previous = usePrevious<T>(current)
-  const initial = useRef<boolean>(true)
+  const previous = usePrevious<T | undefined>(current)
   useEffect(() => {
-    if (initial.current) {
-      initial.current = false
-      return
-    }
     if (!compare(previous, current)) {
       didUpdate(previous, current)
     }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->
The issues are related to when an application is not running in strict mode. This is important because in [StrictMode](https://react.dev/reference/react/StrictMode#strictmode) every effect gets runs twice but when not using strict mode, i.e in production the hook only gets called once. 

Issue 1: When a new reference item is created the focus is not set into the AutoComplete
Issue 2: In a virtualized list if there is a validation error clicking on the error on top of the document panel does not scroll to the validation error

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

The way to review this PR is looking at the tests first and if the assertions makes sense.
I have added tests for `usePrevious`, `useOnClickOutside` and `useScrollIntoViewOnFocusWithin` hooks while I was in the folder without any change to the existing hooks. 

#### Whats Changed

`useUpdate` Hook: Currently the hook checks for an initial mount and does not run the compare function when it's an initial mount. The hook also utilized `usePrevious` hook to store the previous value. This is an issue because when array of reference field is created it is by default focused, i.e (focused = true) and that does not change until a user interaction occurs. See code before

https://github.com/sanity-io/sanity/blob/c6464400f2d971982668c1e66d53fd05944e6bb5/packages/sanity/src/core/form/members/object/fields/ArrayOfObjectsField.tsx#L60-L64

Since the value it is listening for does not change and it ignores the first render you run into situation where previous and the current value becomes the same and it never fires the compare function in the file above hence never focusing on the input field.

❓Does this change affect anything that I overlooked? From my testing this does not seem to be an issue and is helping with scroll issues where it was previously not working

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

- Fixes issue where unused references are cleared on clicking outside
- Fixes issue where the validation error is not focused when clicking on error in the panel