### PR TITLE
chore(.github): add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,31 @@
+# These owners can be changed and added to in the future,
+
+# for now these are the main people that we are required to have eyes on PRs
+
+# that changed items in the given spaces
+
+# ------------- Packages
+
+# Espen owns any file in `/packages/@sanity/cli/`
+
+# directory in the root of your repository and any of its
+
+# subdirectories.
+
+/packages/@sanity/cli/ @rexxars
+
+# Bjørge owns any file in `/packages/@sanity/cli/`
+
+# directory in the root of your repository and any of its
+
+# subdirectories.
+
+/packages/sanity/src/core/form/ @bjoerge
+
+# PK owns any file in `/packages/@sanity/portable-text-editor`
+
+# directory in the root of your repository and any of its
+
+# subdirectories.
+
+/packages/@sanity/portable-text-editor/ @skogsmaskin

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@
 
 /packages/@sanity/cli/ @rexxars
 
-# Bjørge owns any file in `/packages/@sanity/cli/`
+# Bjørge owns any file in `/packages/sanity/src/core/form/`
 
 # directory in the root of your repository and any of its
 
@@ -22,10 +22,10 @@
 
 /packages/sanity/src/core/form/ @bjoerge
 
-# PK owns any file in `/packages/@sanity/portable-text-editor`
+# PK owns any file related to PTE
 
-# directory in the root of your repository and any of its
-
-# subdirectories.
+# They are spread across different directories and subdirectories
 
 /packages/@sanity/portable-text-editor/ @skogsmaskin
+/packages/sanity/src/core/field/types/portableText/ @skogsmaskin
+/packages/sanity/src/core/form/inputs/PortableText/ @skogsmaskin


### PR DESCRIPTION
### Description

Add code owners to specific parts of the monorepo in the `next` branch, this is just a beginning stage and more owners will be added as we go along.

### What to review

the owners

### Notes for release

n/a (internal only)