### PR TITLE
Allow for skipping visibility in preview element (fix flickering issue)

### DIFF
--- a/dev/test-studio/components/formComponents.tsx
+++ b/dev/test-studio/components/formComponents.tsx
@@ -1,11 +1,64 @@
-import React from 'react'
-import {Card} from '@sanity/ui'
-import {definePlugin, InputProps, FieldProps, ItemProps, PreviewProps} from 'sanity'
+import React, {useState} from 'react'
+import {Card, Stack, Button, Text} from '@sanity/ui'
+import {definePlugin, InputProps, FieldProps, ItemProps, Preview} from 'sanity'
 
 export function Input(props: InputProps) {
+  const [count, setCount] = useState(0)
+
   return (
     <Card data-testid="input-config-component" padding={2} border tone="primary">
-      {props.renderDefault(props)}
+      <Stack space={2}>
+        <Button onClick={() => setCount((c) => c + 1)} text={`Re-render: ${count}`} />{' '}
+        <Text>Default - no skip</Text>
+        <Preview
+          key={`default-no-${count.toString()}`}
+          layout="default"
+          value={props.value}
+          schemaType={props.schemaType}
+        />
+        <Text>Default - with skip</Text>
+        <Preview
+          key={`default-${count.toString()}`}
+          layout="default"
+          value={props.value}
+          schemaType={props.schemaType}
+          __internal_skip_visibility_check
+        />
+        <Text>No Layout - no skip</Text>
+        <Preview
+          key={`no-layout-no-${count.toString()}`}
+          value={props.value}
+          schemaType={props.schemaType}
+        />
+        <Text>No Layout - with skip</Text>
+        <Preview
+          key={`no-layout-${count.toString()}`}
+          value={props.value}
+          schemaType={props.schemaType}
+          __internal_skip_visibility_check
+        />
+        <Text>Block</Text>
+        <Preview
+          key={`block-${count.toString()}`}
+          layout="block"
+          value={props.value}
+          schemaType={props.schemaType}
+        />
+        <Text>Block Image</Text>
+        <Preview
+          key={`blockImage-${count.toString()}`}
+          layout="blockImage"
+          value={props.value}
+          schemaType={props.schemaType}
+        />
+        <Text>inline</Text>
+        <Preview
+          key={`inline-${count.toString()}`}
+          layout="inline"
+          value={props.value}
+          schemaType={props.schemaType}
+        />
+      </Stack>
     </Card>
   )
 }
@@ -21,14 +74,6 @@ export function Field(props: FieldProps) {
 export function Item(props: ItemProps) {
   return (
     <Card data-testid="item-config-component" padding={2} border tone="positive">
-      {props.renderDefault(props)}
-    </Card>
-  )
-}
-
-export function Preview(props: PreviewProps) {
-  return (
-    <Card data-testid="preview-config-component" padding={2} border tone="critical">
       {props.renderDefault(props)}
     </Card>
   )

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -132,7 +132,6 @@ export default defineConfig([
         input: Input,
         field: Field,
         item: Item,
-        preview: Preview,
       },
     },
     studio: {

--- a/packages/sanity/src/core/form/types/renderCallback.ts
+++ b/packages/sanity/src/core/form/types/renderCallback.ts
@@ -49,6 +49,7 @@ export interface RenderPreviewCallbackProps<TLayoutKey = PreviewLayoutKey> {
   withShadow?: boolean
   schemaType: SchemaType
   style?: CSSProperties
+  __internal_skip_visibility_check?: boolean
 }
 
 /** @beta */

--- a/packages/sanity/src/core/preview/components/PreviewLoader.tsx
+++ b/packages/sanity/src/core/preview/components/PreviewLoader.tsx
@@ -33,7 +33,7 @@ export function PreviewLoader(
   const isPTE = layout && ['inline', 'block', 'blockImage'].includes(layout)
 
   // Subscribe to visibility
-  const visibility = useVisibility({
+  const isVisible = useVisibility({
     // NOTE: disable when PTE preview
     element: isPTE ? null : element,
     hideDelay: _HIDE_DELAY,
@@ -41,7 +41,7 @@ export function PreviewLoader(
 
   // Subscribe document preview value
   const preview = useValuePreview({
-    enabled: isPTE || visibility,
+    enabled: isPTE || isVisible,
     schemaType,
     value,
   })

--- a/packages/sanity/src/core/preview/components/PreviewLoader.tsx
+++ b/packages/sanity/src/core/preview/components/PreviewLoader.tsx
@@ -27,7 +27,15 @@ export function PreviewLoader(
     component: ComponentType<Omit<PreviewProps, 'renderDefault'>>
   }
 ): ReactElement {
-  const {layout, value, component, style: styleProp, schemaType, ...restProps} = props
+  const {
+    layout,
+    value,
+    component,
+    style: styleProp,
+    schemaType,
+    __internal_skip_visibility_check,
+    ...restProps
+  } = props
 
   const [element, setElement] = useState<HTMLDivElement | null>(null)
   const isPTE = layout && ['inline', 'block', 'blockImage'].includes(layout)
@@ -41,7 +49,7 @@ export function PreviewLoader(
 
   // Subscribe document preview value
   const preview = useValuePreview({
-    enabled: isPTE || isVisible,
+    enabled: __internal_skip_visibility_check || isPTE || isVisible,
     schemaType,
     value,
   })

--- a/packages/sanity/src/core/preview/components/PreviewLoader.tsx
+++ b/packages/sanity/src/core/preview/components/PreviewLoader.tsx
@@ -38,18 +38,20 @@ export function PreviewLoader(
   } = props
 
   const [element, setElement] = useState<HTMLDivElement | null>(null)
-  const isPTE = layout && ['inline', 'block', 'blockImage'].includes(layout)
+  const shouldSkipVisbility =
+    (layout && ['inline', 'block', 'blockImage'].includes(layout)) ||
+    __internal_skip_visibility_check
 
   // Subscribe to visibility
   const isVisible = useVisibility({
     // NOTE: disable when PTE preview
-    element: isPTE ? null : element,
+    element: shouldSkipVisbility ? null : element,
     hideDelay: _HIDE_DELAY,
   })
 
   // Subscribe document preview value
   const preview = useValuePreview({
-    enabled: __internal_skip_visibility_check || isPTE || isVisible,
+    enabled: shouldSkipVisbility || isVisible,
     schemaType,
     value,
   })


### PR DESCRIPTION
### Description

A bug was reported where someone using the `<preview>`  with the default layout was getting a flickering when there was a re-render. The data was the same, but the interface flickered. The original use case was in a drag and drop situation where the re-render made sense to exist. The example below is a simple way of reproducing it.

The error:

https://user-images.githubusercontent.com/6951139/233350609-7c684353-88c8-4b6e-a21e-84042749b584.mov

*The solution* that I arrived to was after trying different things. The main issue is that because a re-render is happening, the ref of the element in the preview is changed so the visibilty needs to be re-rendered multiple times. After looking at the way that the fetching of the data (when necessary) and the visibility were set up there wasn't any indication that they were slow (they were all miliseconds fast). 

The best solution for this particular issue, after discussing with Bjørge and trying different solution was to allow for an internal prop that can skip the visibility. We already have an exception when it comes to some `layouts` (`isPTE` renamed to `shouldSkipVisbility`), this just adds an external way to allow users to use it.

The error and fix:

https://user-images.githubusercontent.com/6951139/233351365-8c8f2745-380e-4ddf-b166-ea172765d274.mov

### What to review

1. In the test-studio, go to the Components API playground workspace (`custom-components/content/book`)
2. Go into any of the books and press the re-render to check behavior in different layouts

### Notes for release

n/a internal updates tooling
