### PR TITLE
fix(core): list virtualization is broken inside modals

### DIFF
--- a/packages/sanity/src/core/components/popoverDialog/PopoverDialog.tsx
+++ b/packages/sanity/src/core/components/popoverDialog/PopoverDialog.tsx
@@ -46,7 +46,7 @@ interface PopoverDialogProps {
   onClose: () => void
   referenceElement: PopoverProps['referenceElement']
   width: ResponsiveWidthProps['width']
-  containerRef?: React.RefObject<HTMLDivElement>
+  containerRef?: React.Dispatch<React.SetStateAction<HTMLDivElement | null>>
 }
 
 /** @internal */

--- a/packages/sanity/src/core/components/popoverDialog/PopoverDialog.tsx
+++ b/packages/sanity/src/core/components/popoverDialog/PopoverDialog.tsx
@@ -46,11 +46,12 @@ interface PopoverDialogProps {
   onClose: () => void
   referenceElement: PopoverProps['referenceElement']
   width: ResponsiveWidthProps['width']
+  containerRef?: React.RefObject<HTMLDivElement>
 }
 
 /** @internal */
 export function PopoverDialog(props: PopoverDialogProps) {
-  const {children, header, onClose, referenceElement, width} = props
+  const {children, header, onClose, referenceElement, containerRef, width} = props
 
   const handleClose = useCallback(() => {
     onClose()
@@ -60,7 +61,7 @@ export function PopoverDialog(props: PopoverDialogProps) {
   }, [onClose, referenceElement])
 
   const content = (
-    <PopoverContainer width={width}>
+    <PopoverContainer width={width} ref={containerRef}>
       <TrapFocus autoFocus>
         <Stack>
           <StickyLayer>

--- a/packages/sanity/src/core/form/components/EditPortal.tsx
+++ b/packages/sanity/src/core/form/components/EditPortal.tsx
@@ -1,4 +1,4 @@
-import React, {type ReactNode, useRef} from 'react'
+import React, {type ReactNode, useState} from 'react'
 import {BoundaryElementProvider, Box, Dialog, ResponsiveWidthProps} from '@sanity/ui'
 import {PresenceOverlay} from '../../presence'
 import {PopoverDialog} from '../../components'
@@ -26,7 +26,7 @@ export function EditPortal(props: Props): React.ReactElement {
     type,
     width,
   } = props
-  const documentScrollElement = useRef<HTMLDivElement>(null)
+  const [documentScrollElement, setDocumentScrollElement] = useState<HTMLDivElement | null>(null)
 
   const contents = (
     <PresenceOverlay margins={PRESENCE_MARGINS}>
@@ -36,14 +36,15 @@ export function EditPortal(props: Props): React.ReactElement {
 
   if (type === 'dialog') {
     return (
-      <BoundaryElementProvider element={documentScrollElement.current}>
+      <BoundaryElementProvider element={documentScrollElement}>
         <Dialog
           header={header}
           id={id || ''}
           onClickOutside={onClose}
           onClose={onClose}
           width={width}
-          contentRef={documentScrollElement}
+          contentRef={setDocumentScrollElement}
+          __unstable_autoFocus
         >
           {contents}
         </Dialog>
@@ -52,13 +53,13 @@ export function EditPortal(props: Props): React.ReactElement {
   }
 
   return (
-    <BoundaryElementProvider element={documentScrollElement.current}>
+    <BoundaryElementProvider element={documentScrollElement}>
       <PopoverDialog
         header={header}
         onClose={onClose}
         referenceElement={referenceElement}
         width={width}
-        containerRef={documentScrollElement}
+        containerRef={setDocumentScrollElement}
       >
         {contents}
       </PopoverDialog>

--- a/packages/sanity/src/core/form/components/EditPortal.tsx
+++ b/packages/sanity/src/core/form/components/EditPortal.tsx
@@ -1,5 +1,5 @@
-import React, {ReactNode, useCallback} from 'react'
-import {Box, Dialog, Layer, ResponsiveWidthProps} from '@sanity/ui'
+import React, {type ReactNode, useRef} from 'react'
+import {BoundaryElementProvider, Box, Dialog, ResponsiveWidthProps} from '@sanity/ui'
 import {PresenceOverlay} from '../../presence'
 import {PopoverDialog} from '../../components'
 
@@ -26,6 +26,7 @@ export function EditPortal(props: Props): React.ReactElement {
     type,
     width,
   } = props
+  const documentScrollElement = useRef<HTMLDivElement>(null)
 
   const contents = (
     <PresenceOverlay margins={PRESENCE_MARGINS}>
@@ -35,26 +36,32 @@ export function EditPortal(props: Props): React.ReactElement {
 
   if (type === 'dialog') {
     return (
-      <Dialog
-        header={header}
-        id={id || ''}
-        onClickOutside={onClose}
-        onClose={onClose}
-        width={width}
-      >
-        {contents}
-      </Dialog>
+      <BoundaryElementProvider element={documentScrollElement.current}>
+        <Dialog
+          header={header}
+          id={id || ''}
+          onClickOutside={onClose}
+          onClose={onClose}
+          width={width}
+          contentRef={documentScrollElement}
+        >
+          {contents}
+        </Dialog>
+      </BoundaryElementProvider>
     )
   }
 
   return (
-    <PopoverDialog
-      header={header}
-      onClose={onClose}
-      referenceElement={referenceElement}
-      width={width}
-    >
-      {contents}
-    </PopoverDialog>
+    <BoundaryElementProvider element={documentScrollElement.current}>
+      <PopoverDialog
+        header={header}
+        onClose={onClose}
+        referenceElement={referenceElement}
+        width={width}
+        containerRef={documentScrollElement}
+      >
+        {contents}
+      </PopoverDialog>
+    </BoundaryElementProvider>
   )
 }


### PR DESCRIPTION
### Description

fixes #4396 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

When virtualized list is inside the modal it does not render all the content

Before
![Screenshot 2023-04-21 at 10 17 42 AM](https://user-images.githubusercontent.com/6476108/233659522-8f52552e-34c2-4c54-9367-7dc4588f50e2.png)

After
![Screenshot 2023-04-21 at 10 17 56 AM](https://user-images.githubusercontent.com/6476108/233659552-0a8ea4df-8183-4a00-ae1a-5ac02afd00b1.png)

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

Since the virtualized list always looks for the scroll element that is on the DocumentPanel, when it is inside it is still using the DocumentPanel to get the offset. The change that is made is to wrap the EditPortal in BoundaryElement, since that would be the closet parent it would use the scroll reference from it to set the correct top offset.

❓Are there other instances that you can think of that would have similar issues where arrays are not rendered inside DocumentPanel and have their own scroll positioning?

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

Fixes virtualized list not rendering properly when inside a modal
