### PR TITLE
refactor(timeline): use official external store with selector API

### DIFF
--- a/packages/sanity/src/core/store/_legacy/history/useTimelineSelector.ts
+++ b/packages/sanity/src/core/store/_legacy/history/useTimelineSelector.ts
@@ -1,4 +1,4 @@
-import {useSyncExternalStore} from 'react'
+import {useSyncExternalStoreWithSelector} from 'use-sync-external-store/with-selector'
 import {TimelineState, TimelineStore} from './useTimelineStore'
 
 /**
@@ -11,5 +11,10 @@ export function useTimelineSelector<ReturnValue>(
   timelineStore: TimelineStore,
   selector: (timelineState: TimelineState) => ReturnValue
 ): ReturnValue {
-  return useSyncExternalStore(timelineStore.subscribe, () => selector(timelineStore.getSnapshot()))
+  return useSyncExternalStoreWithSelector(
+    timelineStore.subscribe,
+    timelineStore.getSnapshot,
+    null,
+    selector
+  )
 }


### PR DESCRIPTION
### Description

Follows up on an issue that were flagged in https://github.com/sanity-io/sanity/pull/4347#discussion_r1166149559 but were merged without being fixed.
We shouldn't implement our own selector pattern on top of `useSyncExternalStore`.
Documentation from the React core team is still sparse, but the official docs talks about the importance of the stability of `getSnapshot` here: https://react.dev/reference/react/useSyncExternalStore#im-getting-an-error-the-result-of-getsnapshot-should-be-cached

This is further elaborated in the PR that introduces the hook used in this PR `use-sync-external-store/with-selector`: https://github.com/reactwg/react-18/discussions/86

#### Nothing is currently broken in `useTimelineSelector` so what are we fixing?
Even though all the callsites of `useTimelineSelector` is currently safe, as they just select a state slice like `(state) => state.sinceTime` it is not future proof.
If someone added a new selector that produces a new object or array when it's called then it'll no longer be stable: `(state) => ({isLoading: state.isLoading, sinceTime: state.sinceTime})` then we'd have a problem.
By using the official implementation this is supported.
We're already using this API in the router internals: https://github.com/sanity-io/sanity/blob/8b7ec690b7751dd0b77701715931e4c8ab3aeb14/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.tsx#L3

Even if we never were to use more complex selectors like above, another PR might be worked on that copypaste logic from the timeline implementation, and not be aware of the subtle ways this pattern can fail:
```ts
import {useSyncExternalStore} from 'react'

useSyncExternalStore(subscribe, () => selector(getSnapshot()))
```
And why they should probably be using:
```ts
import {useSyncExternalStoreWithSelector} from 'use-sync-external-store/with-selector'

useSyncExternalStoreWithSelector(subscribe, getSnapshot, null, selector)
```

#### Isn't `use-sync-external-store` meant for React v17?

No, it serves two purposes:
1. `use-sync-external-store/shim` most people think about this API when they see the package name. And it works on both React 17 and 18.
2. `use-sync-external-store/with-selector` far lesser known, and it's the API we're using here and it only works on React v18.

### What to review

Everything that calls `useTimelineSelector` still works the same (it does, in my testing).

### Notes for release

N/A
