### PR TITLE
fix(core): add max height to popover

### DIFF
--- a/dev/test-studio/schema/standard/portableText/simpleBlock.tsx
+++ b/dev/test-studio/schema/standard/portableText/simpleBlock.tsx
@@ -45,7 +45,53 @@ export default defineType({
         defineArrayMember({
           type: 'block',
           marks: {
-            annotations: [linkType, myStringType],
+            annotations: [
+              {
+                name: 'link',
+                type: 'object',
+                title: 'link',
+                fields: [
+                  {
+                    name: 'url',
+                    type: 'url',
+                    validation: (Rule) =>
+                      Rule.regex(/https:\/\/(www\.|)(portabletext\.org|sanity\.io)\/.*/gi, {
+                        name: 'internal url',
+                        invert: true,
+                      }).warning(
+                        `This is not an external link. Consider using internal links instead.`
+                      ),
+                  },
+                ],
+              },
+              {
+                name: 'internalLink',
+                type: 'object',
+                title: 'Internal link',
+                fields: [
+                  {
+                    name: 'reference',
+                    type: 'reference',
+                    to: [{type: 'book'}],
+                  },
+                  {
+                    name: 'reference1',
+                    type: 'reference',
+                    to: [{type: 'author'}],
+                  },
+                  {
+                    name: 'reference2',
+                    type: 'reference',
+                    to: [{type: 'author'}],
+                  },
+                  {
+                    name: 'reference3',
+                    type: 'reference',
+                    to: [{type: 'author'}],
+                  },
+                ],
+              },
+            ],
           },
           of: [
             {type: 'image', name: 'image'},

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.styles.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.styles.ts
@@ -1,4 +1,4 @@
-import {Box, Container, Popover} from '@sanity/ui'
+import {Box, Container, Flex, Popover} from '@sanity/ui'
 import styled from 'styled-components'
 
 export const RootPopover = styled(Popover)`
@@ -17,6 +17,9 @@ export const ContentContainer = styled(Container)`
     display: flex;
   }
   direction: column;
+`
+export const ModalWrapper = styled(Flex)`
+  max-height: 300px;
 `
 
 export const ContentScrollerBox = styled(Box)`

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
@@ -10,6 +10,7 @@ import {
   ContentContainer,
   ContentHeaderBox,
   ContentScrollerBox,
+  ModalWrapper,
   RootPopover,
 } from './PopoverModal.styles'
 
@@ -67,7 +68,7 @@ function Content(props: PopoverEditDialogProps) {
 
   return (
     <ContentContainer width={width}>
-      <Flex direction="column" flex={1}>
+      <ModalWrapper direction="column" flex={1}>
         <ContentHeaderBox padding={1}>
           <Flex align="center">
             <Box flex={1} padding={2}>
@@ -82,7 +83,7 @@ function Content(props: PopoverEditDialogProps) {
             <Box padding={3}>{props.children}</Box>
           </PresenceOverlay>
         </ContentScrollerBox>
-      </Flex>
+      </ModalWrapper>
     </ContentContainer>
   )
 }


### PR DESCRIPTION
### Description
The popover for annotation links were not scrollable due to the height of it being the entire document pane height. I could not find an optimal fix for this issue and all input is highly appreciated, but setting a `max-height` to the popover will at least make it more user friendly and scrollable. 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
That the annotations popover is scrollable so that all references are accessible. 

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fixes issue where annotation popovers were not scrollable in PTE. 
<!--
A description of the change(s) that should be used in the release notes.
-->
