### PR TITLE
Fix issue with PTE merge operation not producing unset patch

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPatches.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPatches.ts
@@ -234,7 +234,7 @@ export function createWithPatches({
       if (
         !editorWasEmpty &&
         editorIsEmpty &&
-        ['set_node', 'remove_text', 'remove_node'].includes(operation.type)
+        ['merge_node', 'set_node', 'remove_text', 'remove_node'].includes(operation.type)
       ) {
         patches = [...patches, unset([])]
         change$.next({

--- a/packages/@sanity/portable-text-editor/test/__tests__/writingTogether.collaborative.test.ts
+++ b/packages/@sanity/portable-text-editor/test/__tests__/writingTogether.collaborative.test.ts
@@ -683,4 +683,46 @@ describe('collaborate editing', () => {
       focus: {path: [{_key: '26901064a3c9'}, 'children', {_key: 'ef4627c1c11b'}], offset: 16},
     })
   })
+  it('will not result in duplicate keys when overwriting some partial bold text line, as the only content in the editor', async () => {
+    const [editorA, editorB] = await getEditors()
+    await editorA.insertText('Hey')
+    await editorA.toggleMark()
+    await editorA.insertText('there')
+    const valA = await editorA.getValue()
+    if (!valA || !Array.isArray(valA[0].children)) {
+      throw new Error('Unexpected value')
+    }
+    await editorA.setSelection({
+      anchor: {
+        path: [{_key: valA[0]._key}, 'children', {_key: valA[0].children[0]._key}],
+        offset: 0,
+      },
+      focus: {
+        path: [{_key: valA[0]._key}, 'children', {_key: valA[0].children[1]._key}],
+        offset: 5,
+      },
+    })
+    await editorA.insertText('1')
+    const newValA = await editorA.getValue()
+    expect(newValA).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "_key": "A-0",
+          "_type": "block",
+          "children": Array [
+            Object {
+              "_key": "A-1",
+              "_type": "span",
+              "marks": Array [],
+              "text": "1",
+            },
+          ],
+          "markDefs": Array [],
+          "style": "normal",
+        },
+      ]
+    `)
+    const valB = await editorB.getValue()
+    expect(newValA).toEqual(valB)
+  })
 })

--- a/packages/@sanity/portable-text-editor/test/setup/collaborative.jest.env.ts
+++ b/packages/@sanity/portable-text-editor/test/setup/collaborative.jest.env.ts
@@ -272,7 +272,13 @@ export default class CollaborationEnvironment extends NodeEnvironment {
 
               await page.keyboard.up('b')
               await page.keyboard.up(metaKey)
-              await waitForRevision()
+              const selection = await selectionHandle.evaluate((node) =>
+                node instanceof HTMLElement && node.innerText ? JSON.parse(node.innerText) : null
+              )
+              // Don't wait for a new revision unless something was actually selected
+              if (selection && !isEqual(selection.anchor, selection.focus)) {
+                await waitForRevision()
+              }
             },
             focus: async () => {
               await editableHandle.focus()


### PR DESCRIPTION
### Description

There is a bug in the Portable Text Editor, where if you write only one sentence in the editor, mark half of it bold, then select all and (over)write something, it will produce two duplicate blocks as a result giving a "duplicate key error".

The reason is that `merge_node` isn't included in the list of operations that potentially can make the editor empty and should lead to a unset patch being produced.

In detail:

The follow operations are done:

1. The text is set to empty in both of the spans.
2. The mark is removed from the second span.
3. The now empty identical spans are merged into one single empty span, that equals to an empty editor.
4. The merge_node operation made the editor "empty", and a unset patch should be produced.

Since the unset patch is never produced, the insert patch is produces correctly afterwards will then duplicate the block.

Also added a test for this.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

That https://github.com/sanity-io/sanity/issues/4415 is no longer happening.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Fixed a bug in the Portable Text Input which could duplicate single sentence content with mixed marks in the editor when overwritten by another text.

<!--
A description of the change(s) that should be used in the release notes.
-->
