### PR TITLE
fix(core): intent links not focusing correctly

### DIFF
--- a/packages/sanity/src/core/form/components/EditPortal.tsx
+++ b/packages/sanity/src/core/form/components/EditPortal.tsx
@@ -14,6 +14,7 @@ interface Props {
   children?: ReactNode
   // eslint-disable-next-line camelcase
   legacy_referenceElement: HTMLElement | null
+  autofocus?: boolean
 }
 
 export function EditPortal(props: Props): React.ReactElement {
@@ -25,6 +26,7 @@ export function EditPortal(props: Props): React.ReactElement {
     onClose,
     type,
     width,
+    autofocus,
   } = props
   const [documentScrollElement, setDocumentScrollElement] = useState<HTMLDivElement | null>(null)
 
@@ -44,7 +46,7 @@ export function EditPortal(props: Props): React.ReactElement {
           onClose={onClose}
           width={width}
           contentRef={setDocumentScrollElement}
-          __unstable_autoFocus
+          __unstable_autoFocus={autofocus}
         >
           {contents}
         </Dialog>

--- a/packages/sanity/src/core/form/inputs/ObjectInput/ObjectInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ObjectInput/ObjectInput.tsx
@@ -20,7 +20,6 @@ export const ObjectInput = memo(function ObjectInput(props: ObjectInputProps) {
     level,
     value,
     id,
-    path,
     onFieldGroupSelect,
   } = props
 
@@ -67,7 +66,8 @@ export const ObjectInput = memo(function ObjectInput(props: ObjectInputProps) {
             groups={groups}
             inputId={id}
             onClick={onFieldGroupSelect}
-            shouldAutoFocus={path.length === 0}
+            // autofocus is taken care of either by focusPath or focusFirstDescendant in the parent component
+            shouldAutoFocus={false}
           />
         </FieldGroupTabsWrapper>
       ) : null}

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -108,10 +108,18 @@ export function PortableTextInput(props: PortableTextInputProps) {
 
   // Set as active whenever we have focus inside the editor.
   useEffect(() => {
-    if (hasFocus || focusPath.length > 1) {
+    if (focused || hasFocus || focusPath.length) {
       setIsActive(true)
     }
-  }, [hasFocus, focusPath])
+  }, [hasFocus, focusPath, focused])
+
+  // Set focused if the focusPath includes the path
+  useEffect(() => {
+    if (focused) {
+      setIsActive(true)
+      setHasFocus(true)
+    }
+  }, [focused])
 
   // Scroll into view when focused
   useEffect(() => {
@@ -256,14 +264,13 @@ export function PortableTextInput(props: PortableTextInputProps) {
       debounce(
         (sel: EditorSelection) => {
           if (sel && hasFocus) {
-            const fullPath = path.concat(sel.focus.path)
-            onPathFocus(fullPath)
+            onPathFocus(sel.focus.path)
           }
         },
         500,
         {trailing: true, leading: false}
       ),
-    [hasFocus, onPathFocus, path]
+    [hasFocus, onPathFocus]
   )
 
   // Handle editor changes

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -113,6 +113,15 @@ export function PortableTextInput(props: PortableTextInputProps) {
     }
   }, [hasFocus, focusPath])
 
+  // Scroll into view when focused
+  useEffect(() => {
+    if (hasFocus && innerElementRef.current) {
+      scrollIntoView(innerElementRef.current, {
+        scrollMode: 'if-needed',
+      })
+    }
+  }, [hasFocus])
+
   const toast = useToast()
   const portableTextMemberItemsRef: React.MutableRefObject<PortableTextMemberItem[]> = useRef([])
 
@@ -335,7 +344,7 @@ export function PortableTextInput(props: PortableTextInputProps) {
         scrollMode: 'if-needed',
       })
     }
-  }, [focused, hasFocus, hasOpenItem])
+  }, [hasFocus, hasOpenItem])
 
   return (
     <Box ref={innerElementRef}>

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
@@ -231,6 +231,7 @@ export function GridItem<Item extends ObjectItem = ObjectItem>(props: GridItemPr
           width={parentSchemaType?.options?.modal?.width ?? 1}
           id={value._key}
           onClose={onClose}
+          autofocus={focused}
           legacy_referenceElement={previewCardRef.current}
         >
           {children}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
@@ -217,6 +217,7 @@ export function PreviewItem<Item extends ObjectItem = ObjectItem>(props: Preview
           width={parentSchemaType?.options?.modal?.width ?? 1}
           id={value._key}
           onClose={onClose}
+          autofocus={focused}
           legacy_referenceElement={previewCardRef.current}
         >
           {children}

--- a/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
@@ -367,7 +367,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   const formStateRef = useRef(formState)
   formStateRef.current = formState
 
-  const handleOpenPath = useCallback(
+  const setOpenPath = useCallback(
     (path: Path) => {
       const ops = getExpandOperations(formStateRef.current!, path)
       ops.forEach((op) => {
@@ -405,7 +405,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     onBlur: handleBlur,
     onChange: handleChange,
     onFocus: handleFocus,
-    onPathOpen: handleOpenPath,
+    onPathOpen: setOpenPath,
     onHistoryClose: handleHistoryClose,
     onHistoryOpen: handleHistoryOpen,
     onInspectClose: handleInspectClose,
@@ -450,10 +450,11 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
 
   // Reset `focusPath` when `documentId` or `params.path` changes
   useEffect(() => {
-    // Reset focus path
-    setFocusPath(params.path ? pathFromString(params.path) : [])
-    onSetOpenPath([])
-  }, [params.path, documentId])
+    // Reset focus path when url params path changes
+    const pathFromUrl = params.path ? pathFromString(params.path) : []
+    setFocusPath(pathFromUrl)
+    setOpenPath(pathFromUrl)
+  }, [params.path, documentId, setOpenPath])
 
   return (
     <DocumentPaneContext.Provider value={documentPane}>{children}</DocumentPaneContext.Provider>

--- a/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
@@ -2,7 +2,7 @@ import React, {memo, useCallback, useEffect, useMemo, useRef, useState} from 're
 import {ObjectSchemaType, Path, SanityDocument, SanityDocumentLike} from '@sanity/types'
 import {omit} from 'lodash'
 import {useToast} from '@sanity/ui'
-import {fromString as pathFromString} from '@sanity/util/paths'
+import {fromString as pathFromString, resolveKeyedPath} from '@sanity/util/paths'
 import isHotkey from 'is-hotkey'
 import {isActionEnabled} from '@sanity/schema/_internal'
 import {usePaneRouter} from '../../components'
@@ -450,11 +450,13 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
 
   // Reset `focusPath` when `documentId` or `params.path` changes
   useEffect(() => {
-    // Reset focus path when url params path changes
-    const pathFromUrl = params.path ? pathFromString(params.path) : []
-    setFocusPath(pathFromUrl)
-    setOpenPath(pathFromUrl)
-  }, [params.path, documentId, setOpenPath])
+    if (ready && params.path) {
+      const pathFromUrl = resolveKeyedPath(formStateRef.current?.value, pathFromString(params.path))
+      // Reset focus path when url params path changes
+      setFocusPath(pathFromUrl)
+      setOpenPath(pathFromUrl)
+    }
+  }, [params.path, documentId, setOpenPath, ready])
 
   return (
     <DocumentPaneContext.Provider value={documentPane}>{children}</DocumentPaneContext.Provider>

--- a/packages/sanity/src/desk/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/documentViews/FormView.tsx
@@ -106,8 +106,14 @@ export function FormView(props: FormViewProps) {
   const formRef = useRef<null | HTMLDivElement>(null)
 
   useEffect(() => {
-    focusFirstDescendant(formRef.current!)
-  }, [])
+    // Only focus on the first descendant if there is not already a focus path
+    // This is to avoid stealing focus from intent links
+    if (ready && !formState?.focusPath.length) {
+      focusFirstDescendant(formRef.current!)
+    }
+    // We only want to run it on first mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ready])
 
   // const after = useMemo(
   //   () =>


### PR DESCRIPTION
### Description

Intent links do not focus on the correct path, this is because the FormView is automatically focusing on the first child regardless of what the intent link has set, this means even thought the focusPath gets set correctly from the path but when the form loads, it overrides the focusPath from where it should be to the first element in the form.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->
Testing different scenarios, like inputs, arrays, objects. Note that currently it does not open up Dialogs if the focus is nested inside a Dialog, not sure if it should?

- [X] Focus path failing to apply: `%2Cpath%3DshortTitle`
https://test-studio-git-bug-sc-32395intent-link-errors-edit-mode-dep.sanity.build/test/content/input-standard;textsTest;32f38606-26f2-4df9-be97-10754ae5d45a%2Cpath%3Drows15

- [X] Fails on objects, like slugs: `%2Cpath%3Dslug.current`
✅ https://test-studio-git-bug-sc-32395intent-link-errors-edit-mode-dep.sanity.build/test/content/input-standard;slugsTest;fbf7b473-edd8-4bcd-b93f-b4a7d0ccc2f8%2Cpath%3Dnested.nestedInner.slug
❌ https://test-studio-git-bug-sc-32395intent-link-errors-edit-mode-dep.sanity.build/test/content/input-standard;slugsTest;fbf7b473-edd8-4bcd-b93f-b4a7d0ccc2f8%2Cpath%3Dnested.nestedInner.slug.current

- [X] Toggle inputs: `%2Cpath%3DincludeInSitemap` works on v2 `%2Cpath%3DincludeInSitemap`
https://test-studio-git-bug-sc-32395intent-link-errors-edit-mode-dep.sanity.build/test/content/input-standard;booleansTest;8624098d-ecdf-4d24-92c7-597356ab3389%2Cpath%3DswitchShort

- ~~[ ] TagInput: doesn't work for a specific tag: `%2Cpath%3Dcategories%5B0%5D` 
https://test-studio-git-bug-sc-32395intent-link-errors-edit-mode-dep.sanity.build/test/content/input-standard;arraysTest;3d11c034-70a6-4b12-aaf1-b4d593ec9fdf%2Cpath%3Dtags%5B0%5D~~ Not fixing this iteration
   - [X] nor the general tag input: `%2Cpath%3Dcategories`
   https://test-studio-git-bug-sc-32395intent-link-errors-edit-mode-dep.sanity.build/test/content/input-standard;arraysTest;3d11c034-70a6-4b12-aaf1-b4d593ec9fdf%2Cpath%3Dtags 

- [X] Select input: `%2Cpath%3Drelation` works on v2 `%2Cpath%3Drelation`
https://test-studio-git-bug-sc-32395intent-link-errors-edit-mode-dep.sanity.build/test/content/input-standard;stringsTest;a0318d72-38cf-4a36-816a-1b3ee208d3f0%2Cpath%3DlistWithKeys

- [X] Resolve dialog: `%2Cpath%3Dschedule%5B0%5D.title`
https://test-studio-git-bug-sc-32395intent-link-errors-edit-mode-dep.sanity.build/test/content/input-standard;arraysTest;18db9a51-b3fe-4843-94a6-c5a2ba6ac039%2Cpath%3DarrayOfMultipleTypes[0].title

- [X] Fails on fieldsets `%2Cpath%3DseoTitle` but works on v2 `%2Cpath%3DseoTitle` and note that it even expands the collapsed fieldset for you
https://test-studio-git-bug-sc-32395intent-link-errors-edit-mode-dep.sanity.build/test/content/input-standard;objectsTest;14916a0b-5b61-4650-beda-94ca9b886e90%2Cpath%3Drecursive.recursive.fieldWithObjectType.field1
  - [X] Works on fieldsets but does not expand collapsed fieldset
  https://test-studio-git-bug-sc-32395intent-link-errors-edit-mode-dep.sanity.build/test/content/input-standard;objectsTest;14916a0b-5b61-4650-beda-94ca9b886e90%2Cpath%3DcollapsibleObject.field1

- ~~[ ] Fails on image inputs but works on v2: `%2Cpath%3DseoImage`
https://test-studio-git-bug-sc-32395intent-link-errors-edit-mode-dep.sanity.build/test/content/input-standard;imagesTest;6a2f0a14-0b52-4022-9194-647eb3fc1ee1%2Cpath%3DimageWithAdditionalFields~~ Not fixing this iteration

- [X] Portable text struggles: `%2Cpath%3Dblurb%5B0%5D.children%5B0%5D.text` - On v2 it partially works: Is able to activate the editor (no "Click to activate" overlay on mouse hover), and also scrolls it into view. But it doesn't give the editor focus, using the tab key shows no focus were set at all. Mouse interaction required to start typing: `%2Cpath%3Dblurb%5B0%5D.children%5B0%5D.text`
https://test-studio-git-bug-sc-32395intent-link-errors-edit-mode-dep.sanity.build/test/content/input-standard;portable-text;blocksTest;832585fd-8f28-4b08-ab0c-5f30f9b00d83%2Cpath%3Drecursive.blocks
  - [ ] ~~Focusing on specific child~~ Not fixing this iteration
https://test-studio-git-bug-sc-32395intent-link-errors-edit-mode-dep.sanity.build/test/content/input-standard;portable-text;blocksTest;832585fd-8f28-4b08-ab0c-5f30f9b00d83%2Cpath%3Drecursive.blocks%5B0%5D.children%5B0%5D.text

- ~~[ ] Alternative path encoding (using _key=="string" instead of number indexes): Same result for v3 `%2Cpath%3Dblurb%5B_key==%22e54dd975a733%22%5D.children%5B_key==%226c997c5fdfd9%22%5D.text` and v2 `%2Cpath%3Dblurb%5B_key==%22e54dd975a733%22%5D.children%5B_key==%226c997c5fdfd9%22%5D.text`~~ Not fixing this iteration


### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

Fixes intent links to focus on the correct location
