### PR TITLE
fix(portable-text-editor): ignore void edits inside markDefs

### DIFF
--- a/packages/@sanity/portable-text-editor/src/utils/__tests__/patchToOperations.test.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/__tests__/patchToOperations.test.ts
@@ -92,7 +92,7 @@ describe('operationToPatches', () => {
       ]
     `)
   })
-  it('will not create patches for insertion inside object blocks', () => {
+  it('will not create operations for insertion inside object blocks', () => {
     editor.children = [
       {
         _type: 'someType',
@@ -147,7 +147,7 @@ describe('operationToPatches', () => {
       ]
     `)
   })
-  it('will not create patches for removal inside object blocks', () => {
+  it('will not create operations for removal inside object blocks', () => {
     editor.children = [
       {
         _type: 'someType',
@@ -208,6 +208,90 @@ describe('operationToPatches', () => {
               },
             ],
           },
+        },
+      ]
+    `)
+  })
+  it('will not create operations for setting data inside object blocks', () => {
+    editor.children = [
+      {
+        _key: '1335959d4d03',
+        _type: 'block',
+        children: [
+          {
+            _key: '9bd868adcd6b',
+            _type: 'span',
+            marks: [],
+            text: '1 ',
+          },
+          {
+            _key: '6f75d593f3fc',
+            _type: 'span',
+            marks: ['11de7fcea659'],
+            text: '2',
+          },
+          {
+            _key: '033618a7f081',
+            _type: 'span',
+            marks: [],
+            text: ' 3',
+          },
+        ],
+        markDefs: [
+          {
+            _key: '11de7fcea659',
+            _type: 'link',
+          },
+        ],
+        style: 'normal',
+      },
+    ]
+    const patches = [
+      {
+        type: 'set',
+        path: [{_key: 'c01739b0d03b'}, 'markDefs'],
+        origin: 'remote',
+        value: {href: 'http://www.test.com'},
+      },
+    ] as Patch[]
+    const snapShot = fromSlateValue(editor.children, schemaTypes.block.name)
+    patches.forEach((p) => {
+      patchToOperations(editor, p, patches, snapShot)
+    })
+    expect(editor.children).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "_key": "1335959d4d03",
+          "_type": "block",
+          "children": Array [
+            Object {
+              "_key": "9bd868adcd6b",
+              "_type": "span",
+              "marks": Array [],
+              "text": "1 ",
+            },
+            Object {
+              "_key": "6f75d593f3fc",
+              "_type": "span",
+              "marks": Array [
+                "11de7fcea659",
+              ],
+              "text": "2",
+            },
+            Object {
+              "_key": "033618a7f081",
+              "_type": "span",
+              "marks": Array [],
+              "text": " 3",
+            },
+          ],
+          "markDefs": Array [
+            Object {
+              "_key": "11de7fcea659",
+              "_type": "link",
+            },
+          ],
+          "style": "normal",
         },
       ]
     `)

--- a/packages/@sanity/portable-text-editor/src/utils/patchToOperations.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/patchToOperations.ts
@@ -154,7 +154,15 @@ export function createPatchToOperations(
     })
     debug('blockIndex', blockIndex)
     const block = blockIndex > -1 ? editor.children[blockIndex] : undefined
-    const childIndex = editor.isTextBlock(block)
+    const isTextBlock = editor.isTextBlock(block)
+
+    // Ignore patches targeting nested void data, like 'markDefs'
+    if (isTextBlock && patch.path.length > 2 && patch.path[1] !== 'children') {
+      debug('Ignoring setting void value')
+      return false
+    }
+
+    const childIndex = isTextBlock
       ? block.children.findIndex((node: PortableTextChild, indx: number) => {
           return isKeyedSegment(patch.path[2])
             ? node._key === patch.path[2]._key
@@ -167,7 +175,6 @@ export function createPatchToOperations(
       value = {}
       value[patch.path[3]] = patch.value
     }
-    const isTextBlock = editor.isTextBlock(block)
     if (isTextBlock) {
       debug(`Setting nodes at ${JSON.stringify(patch.path)} - ${JSON.stringify(targetPath)}`)
       debug('Value to set', JSON.stringify(value, null, 2))


### PR DESCRIPTION
### Description

There was a problem where creating and inserting a value into a text annotation object would error on a listening editor.

Values inside `markDefs` (void) objects of regular text blocks are not the editor's responsibility to deal with here. So if a nested path inside a text block is anything else than `children` in the second segment, just ignore it.

`useSyncValue` will make sure to update this content when it's changed.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

* That adding a text annotation with a value (link with href val.) will not crash an editor that have the same document and editor opened.


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

* Fix an issue where creating a text annotation and inserting a value inside it, would make a listening text editor crash.

<!--
A description of the change(s) that should be used in the release notes.
-->
