### PR TITLE
fix(core): fix scrolling issue with documents

### DIFF
--- a/dev/test-studio/schema/debug/scrollBug.tsx
+++ b/dev/test-studio/schema/debug/scrollBug.tsx
@@ -1,0 +1,461 @@
+import {defineArrayMember, defineField, defineType, PreviewProps} from 'sanity'
+import {
+  ActivityIcon,
+  ClipboardIcon,
+  ComponentIcon,
+  ErrorOutlineIcon,
+  PackageIcon,
+  RocketIcon,
+  TrendUpwardIcon,
+} from '@sanity/icons'
+import React from 'react'
+import {Stack, Text} from '@sanity/ui'
+
+export const articleImage = defineType({
+  type: 'image',
+  name: 'articleImage',
+  title: 'Image',
+  fields: [
+    defineField({
+      type: 'string',
+      name: 'altText',
+      title: 'Alt text',
+    }),
+  ],
+})
+
+export const mockObject2 = defineType({
+  type: 'object',
+  name: 'mockObject2',
+  title: 'Details',
+  icon: PackageIcon,
+  fields: [
+    defineField({
+      type: 'text',
+      name: 'note',
+      title: 'Note',
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'note',
+    },
+    prepare: (select) => {
+      return {
+        ...select,
+        media: PackageIcon,
+      }
+    },
+  },
+})
+
+export const tidbitsTest = defineType({
+  type: 'object',
+  name: 'tidbitsItem',
+  title: 'Tidbits',
+  icon: RocketIcon,
+  fields: [
+    defineField({
+      type: 'string',
+      name: 'fact',
+      title: 'Fact',
+    }),
+    defineField({
+      type: 'string',
+      name: 'contradiction',
+      title: 'Contradiction',
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'fact',
+      subtitle: 'contradiction',
+    },
+    prepare: (select) => {
+      return {
+        ...select,
+        media: RocketIcon,
+      }
+    },
+  },
+})
+
+export const factBox = defineType({
+  type: 'object',
+  name: 'factBox',
+  title: 'Factbox',
+  icon: ErrorOutlineIcon,
+  fields: [
+    defineField({
+      type: 'string',
+      name: 'title',
+      title: 'Title',
+    }),
+    defineField({
+      type: 'string',
+      name: 'subtitle',
+      title: 'Subtitle',
+    }),
+    defineField({
+      type: 'text',
+      name: 'facts',
+      title: 'Facts',
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      subtitle: 'subtitle',
+      facts: 'facts',
+    },
+    prepare: (select) => {
+      return {
+        ...select,
+        media: ErrorOutlineIcon,
+      }
+    },
+  },
+})
+
+export const todo = defineType({
+  type: 'object',
+  name: 'todo',
+  title: 'Todo',
+  icon: ClipboardIcon,
+  fields: [
+    defineField({
+      type: 'array',
+      name: 'items',
+      title: 'Todo items',
+      of: [{type: 'string'}],
+    }),
+  ],
+  preview: {
+    select: {
+      items: 'items',
+    },
+    prepare: ({items = []}) => {
+      return {
+        title: `Todo (${items.length} items)`,
+        items,
+        media: ClipboardIcon,
+      }
+    },
+  },
+  components: {
+    preview: (props: any) => {
+      return (
+        <Stack space={2} padding={2}>
+          <Text weight="semibold">Article TODOs</Text>
+          <ul>
+            {props?.items?.map((t: string) => (
+              <li key={t}>{t}</li>
+            ))}
+          </ul>
+        </Stack>
+      )
+    },
+  },
+})
+
+export const timelineEvent = defineType({
+  type: 'object',
+  name: 'timelineEvent',
+  title: 'Timeline event',
+  icon: ActivityIcon,
+  fields: [
+    defineField({
+      type: 'string',
+      name: 'title',
+      title: 'Title',
+    }),
+    defineField({
+      type: 'string',
+      name: 'periodDescription',
+      title: 'Period description',
+    }),
+    defineField({
+      type: 'text',
+      name: 'eventDescription',
+      title: 'Event description',
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      subtitle: 'periodDescription',
+    },
+  },
+})
+
+export const timeline = defineType({
+  type: 'object',
+  name: 'timeline',
+  title: 'Timeline',
+  icon: TrendUpwardIcon,
+  fields: [
+    defineField({
+      type: 'array',
+      name: 'events',
+      title: 'Events',
+      of: [defineArrayMember({type: timelineEvent.name})],
+    }),
+  ],
+  preview: {
+    select: {
+      events: 'events',
+    },
+    prepare: ({events = []}) => {
+      return {
+        title: `Events (${events.length})`,
+        events,
+        media: TrendUpwardIcon,
+      }
+    },
+  },
+  components: {
+    preview: (props: PreviewProps & {events?: any[]}) => {
+      return (
+        <Stack space={2} padding={2}>
+          <Text weight="semibold">Timeline</Text>
+          <ul>
+            {props?.events?.map((event: {title: string; periodDescription: string}) => (
+              <li key={event?.title}>
+                {event?.title ?? 'No title'} - {event?.periodDescription ?? 'No description'}
+              </li>
+            ))}
+          </ul>
+        </Stack>
+      )
+    },
+  },
+})
+
+export const mockObject1 = defineType({
+  type: 'object',
+  name: 'mockObject1',
+  title: 'Thing',
+  icon: ComponentIcon,
+  fields: [
+    defineField({
+      type: 'string',
+      name: 'title',
+      title: 'Title',
+    }),
+    defineField({
+      type: 'text',
+      name: 'description',
+      title: 'Description',
+    }),
+    /*defineField({
+      name: 'listOfThings',
+      title: 'A list of things',
+      type: 'array',
+      of: [
+        {
+          type: 'block',
+          styles: [{title: 'Normal', value: 'normal'}],
+          lists: [],
+          marks: {
+            decorators: [{title: 'Strong', value: 'strong'}],
+            annotations: [],
+          },
+        },
+      ],
+    }),*/
+    defineField({
+      type: mockObject2.name,
+      name: 'inner',
+      title: 'Details',
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      subtitle: 'description',
+    },
+    prepare: (select) => {
+      return {
+        ...select,
+        media: ComponentIcon,
+      }
+    },
+  },
+})
+
+export const seoObject = defineType({
+  type: 'object',
+  name: 'seoObject',
+  title: 'SEO',
+  fields: [
+    defineField({
+      type: 'string',
+      name: 'seoTitle',
+      title: 'SEO title',
+    }),
+    defineField({
+      type: 'text',
+      name: 'seoDescription',
+      title: 'SEO Description',
+    }),
+    defineField({
+      type: 'array',
+      name: 'seoKeywords',
+      title: 'SEO Keywords',
+      of: [{type: 'string'}],
+    }),
+  ],
+  options: {
+    collapsible: true,
+  },
+})
+
+export const scrollBug = defineType({
+  type: 'document',
+  name: 'scrollBug',
+  title: 'Scroll bug article',
+  /*  components: {
+    input: ForceSummarizationButton,
+  },*/
+  fieldsets: [{name: 'group', title: 'SEO', options: {columns: 1}}],
+  /*  groups: [{name: 'seo', title: 'SEO'}],*/
+  preview: {
+    select: {
+      title: 'title',
+      subtitle: 'lede',
+    },
+  },
+  fields: [
+    defineField({
+      type: 'string',
+      name: 'title',
+      title: 'Title',
+      validation: (rule) => rule.required().min(3),
+    }),
+    defineField({
+      type: 'array',
+      name: 'alternateTitles',
+      title: 'Alternate titles',
+      of: [{type: 'string'}],
+    }),
+    defineField({
+      type: 'text',
+      name: 'lede',
+      title: 'Lede',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      type: articleImage.name,
+      name: 'image',
+      title: 'Cover image',
+      options: {
+        collapsible: true,
+      },
+    }),
+    defineField({
+      name: 'body',
+      type: 'array',
+      /*      components: {
+        input: (props: any) => {
+          console.log(props.value)
+          return props.renderDefault({...props, value: props.value?.slice(0, 8)})
+        },
+      },*/
+      of: [
+        defineArrayMember({
+          type: 'block',
+          //styles: [{title: 'Normal', value: 'normal'}],
+          marks: {
+            decorators: [
+              {title: 'Bold', value: 'strong'},
+              {title: 'Italic', value: 'em'},
+              {title: 'Code', value: 'code'},
+            ] as any,
+            annotations: [],
+          },
+        }),
+        {type: articleImage.name},
+        {type: 'code'},
+        {type: timeline.name},
+        {type: factBox.name},
+        {type: todo.name},
+        /*        {type: 'reference', to: [{type: 'sanity-ai.context'}]},*/
+        /*        {type: mockObject1.name},*/
+        /* {
+          type: 'object',
+          name: '$$markdown$$',
+          fields: [
+            {
+              type: 'string',
+              name: 'title',
+              title: 'Title',
+            },
+          ],
+        },*/
+      ],
+    }),
+    defineField({
+      name: 'plainBody',
+      type: 'array',
+      /*      components: {
+        input: (props: any) => {
+          console.log(props.value)
+          return props.renderDefault({...props, value: props.value?.slice(0, 8)})
+        },
+      },*/
+      of: [
+        defineArrayMember({
+          type: 'block',
+          //styles: [{title: 'Normal', value: 'normal'}],
+          marks: {
+            decorators: [
+              {title: 'Bold', value: 'strong'},
+              {title: 'Italic', value: 'em'},
+              {title: 'Code', value: 'code'},
+            ] as any,
+            annotations: [],
+          },
+        }),
+      ],
+    }),
+    defineField({
+      name: 'alternateTakes',
+      type: 'array',
+      title: 'Alternate takes',
+      of: [defineArrayMember({type: factBox.name}), defineArrayMember({type: timeline.name})],
+    }),
+    defineField({
+      type: factBox.name,
+      name: 'heroFactbox',
+      title: 'Hero factbox',
+      options: {
+        collapsible: true,
+        collapsed: true,
+      },
+    }),
+    defineField({
+      name: 'topics',
+      type: 'array',
+      title: 'Topics',
+      of: [{type: 'string'}],
+    }),
+    defineField({
+      name: 'number',
+      type: 'array',
+      title: 'Numbers',
+      of: [{type: 'number'}],
+    }),
+    defineField({
+      type: 'reference',
+      name: 'ref',
+      title: 'Ref',
+      to: [{type: 'scrollBug'}],
+    }),
+    defineField({
+      type: seoObject.name,
+      name: 'seo',
+      title: 'SEO',
+      //group: 'seo',
+    }),
+  ],
+})

--- a/dev/test-studio/schema/index.ts
+++ b/dev/test-studio/schema/index.ts
@@ -30,6 +30,7 @@ import {v3docs} from './docs/v3'
 import {demos3d} from './demos/3d'
 
 // Test documents for debugging
+import * as scrollBugTypes from './debug/scrollBug'
 import actions from './debug/actions'
 import button from './debug/button'
 import conditionalFields from './debug/conditionalFields'
@@ -215,6 +216,7 @@ export const schemaTypes = [
   reservedFieldNames,
   review,
   richTextObject,
+  ...Object.values(scrollBugTypes),
   select,
   simpleBlock,
   simpleBlockNote,

--- a/dev/test-studio/structure/constants.ts
+++ b/dev/test-studio/structure/constants.ts
@@ -71,6 +71,7 @@ export const DEBUG_INPUT_TYPES = [
   'uploadsTest',
   'validationTest',
   'allNativeInputComponents',
+  'scrollBug',
 ]
 
 export const CI_INPUT_TYPES = ['conditionalFieldset', 'validationCI']

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/PreviewReferenceValue.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/PreviewReferenceValue.tsx
@@ -40,6 +40,7 @@ export function PreviewReferenceValue(props: {
               layout: 'default',
               schemaType: refType,
               value: stub,
+              skipVisibilityCheck: true,
             })}
           </Box>
           <Box>

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
@@ -178,6 +178,8 @@ export function PreviewItem<Item extends ObjectItem = ObjectItem>(props: Preview
           schemaType: props.schemaType,
           value: props.value,
           layout: 'default',
+          // Don't do visibility check for virtualized items as the calculation will be incorrect causing it to scroll
+          skipVisibilityCheck: true,
         })}
         {resolvingInitialValue && (
           <Card


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Fixes an issue where the document would automatically scroll when a user is not scrolling. From investigation, the reason that happens is when the element first measured it gets stored in a cache but if the element's height changes then there is a code in react-virtual that is to fix the delta by doing a scroll.

https://github.com/TanStack/virtual/blob/623ac63988f16e6ea6755d8b2e190c123134501c/packages/virtual-core/src/index.ts#L653-L672

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

To fix the issue we are making sure that the preview items in the virtualized list are not hidden when outside of the scroll window so it doesn't keep changing heights based on scrolling. There is still an issue if you have a new reference autocomplete and you get to a specific height it would do a scroll, we will probably fix that in future PR and probably investigate the library logic for a more future proofing fix.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

Fixes an issue with documents would automatically scroll