### PR TITLE
fix(cli): skip dataset validation in unattended mode when provided

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -471,7 +471,7 @@ export default async function initSanity(
     aclMode?: string
     defaultConfig?: boolean
   }) {
-    if (opts.dataset && isCI) {
+    if (opts.dataset && (isCI || unattended)) {
       return {datasetName: opts.dataset}
     }
 


### PR DESCRIPTION
### Description
We have mostly supported unattended mode when you provide project name and -y flag to the cli, but a quirk in the `getOrCreateDataset` implementation required a login for this step, even if a dataset name was provided on the cli params.

This change skips verifying dataset name through API if provided as a parameter option to the CLI and in unattended mode, reflecting the behaviour already there for "CI mode" and also the existing behaviuor of `getOrCreateProject`

### What to review

That the behaviour is as expected through the cli with -y, --project and --dataset while logged out

### Notes for release
Enable fully unattended Studio init through cli when`project`, `dataset` and `y` flag is set