### PR TITLE
fix(cli): resolve and install latest sanity+vision dependencies

### DIFF
--- a/packages/@sanity/cli/src/studioDependencies.ts
+++ b/packages/@sanity/cli/src/studioDependencies.ts
@@ -2,10 +2,10 @@ export const studioDependencies = {
   // Dependencies for a default Sanity installation
   dependencies: {
     // Official studio dependencies
-    sanity: '^3.9.0',
+    sanity: 'latest',
 
     // Official studio plugin dependencies
-    '@sanity/vision': '^3.9.0',
+    '@sanity/vision': 'latest',
 
     // Non-Sanity dependencies
     react: '^18.2.0',
@@ -21,7 +21,7 @@ export const studioDependencies = {
     '@types/react': '^18.0.25',
     '@types/styled-components': '^5.1.26',
     eslint: '^8.6.0',
-    prettier: 'latest',
-    typescript: '^4.0.0', // Peer dependency of eslint-config-studio (implicitly)
+    prettier: '^2.8.8',
+    typescript: '^4.9.5', // Peer dependency of eslint-config-studio (implicitly)
   },
 }


### PR DESCRIPTION
### Description

Turns out the plumbing to do this was already in place.
Background: pnpm 8 has changed to resolve the _lowest matching_ version for a range. So when we specified `^3.0.0`, pnpm would _actually install_ 3.0.0. This is obviously not great when initiating a brand new project.

With this change, we resolve the latest versions, instead.

### What to review

`~/path/to/sanity/packages/@sanity/cli/bin/sanity init` bootstraps a project with the `sanity` and `@sanity/vision` dependencies in `package.json` set to the latest actual version (`^3.9.0` at the time of writing).

### Notes for release

- Fixed an issue where using pnpm to install dependencies would not install the latest available versions when creating a new project
