### PR TITLE
fix(cli): skip v3 init prompt in unattended mode

### DIFF
--- a/packages/@sanity/cli/src/commands/init/initCommand.ts
+++ b/packages/@sanity/cli/src/commands/init/initCommand.ts
@@ -75,6 +75,7 @@ export const initCommand: CliCommandDefinition<InitFlags> = {
   action: async (args, context) => {
     const {output, chalk, prompt} = context
     const [type] = args.argsWithoutOptions
+    const unattended = args.extOptions.y || args.extOptions.yes
 
     const warn = (msg: string) => output.warn(chalk.yellow.bgBlack(msg))
 
@@ -109,10 +110,12 @@ export const initCommand: CliCommandDefinition<InitFlags> = {
     warn('╰────────────────────────────────────────────────────────────╯')
     warn('') // Newline to separate from other output
 
-    const continueV3Init = await prompt.single({
-      message: 'Continue creating a Sanity Studio v3 project?',
-      type: 'confirm',
-    })
+    const continueV3Init = unattended
+      ? true
+      : await prompt.single({
+          message: 'Continue creating a Sanity Studio v3 project?',
+          type: 'confirm',
+        })
 
     // Fall back
     if (!continueV3Init) {


### PR DESCRIPTION
### Description

When running the CLI `init` command in unattended mode (`sanity init --yes ...`), we don't want any prompt to appear, instead defaulting to whatever the default is. The prompt introduced after the v3 launch which suggests running `npm create sanity` did not respect this mode, and stopped at the prompt.

This PR makes it bypass the prompt (but show the warning) if passing `--yes`.

### What to review

`~/path/to/sanity/packages/@sanity/cli/bin/sanity init --yes --dataset=test --project=ppsg7ml5 --output-path=~/some-path` does not show prompt (requires building first (`yarn build`))

### Notes for release

- Resolves issue where unattended mode (`--yes` flag) for `sanity init` would still show a confirmation prompt about running a v2-like CLI command
