### PR TITLE
fix(form): fix focus issue with reference fields

### DIFF
--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceField.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceField.tsx
@@ -76,7 +76,7 @@ export function ReferenceField(props: ReferenceFieldProps) {
   useDidUpdate(focused, (hadFocus, hasFocus) => {
     if (!hadFocus && hasFocus && elementRef.current) {
       // Note: if editing an inline item, focus is handled by the item input itself and no ref is being set
-      elementRef.current?.focus()
+      elementRef.current.focus()
     }
   })
 
@@ -285,6 +285,7 @@ export function ReferenceField(props: ReferenceFieldProps) {
                 __unstable_focusRing
                 selected={selected}
                 pressed={pressed}
+                ref={elementRef}
                 data-selected={selected ? true : undefined}
                 data-pressed={pressed ? true : undefined}
               >


### PR DESCRIPTION
### Description
Clicking a validation error for - or following a deep link to - a reference field that _has_ a value doesn't trigger focus/scroll to the field currently. This PR should fix the issue by forwarding the ref to the preview element. This ref was not being forwarded to any element, which most certainly must have been an oversight.

### What to review

Go for example to [this document](https://test-studio-git-feature-sc-32690clicking-validation-erro-7859b4.sanity.build/test/content/input-debug;scrollBug;5010321f-a700-41bb-af9d-c2c35944e361) and click on the validation error for the reference, and see that it scrolls to the reference field

For comparison: Here's the [same document](https://test-studio.sanity.build/test/content/input-debug;scrollBug;5010321f-a700-41bb-af9d-c2c35944e361) in `next`

### Notes for release
- Fixes a bug with reference fields not receiving focus when clicking a validation error or following a link to the field
