### PR TITLE
test(cli): reduce dangling entity cleanup threhold to 16 hours

### DIFF
--- a/packages/@sanity/cli/test/shared/globalSetup.ts
+++ b/packages/@sanity/cli/test/shared/globalSetup.ts
@@ -140,12 +140,14 @@ async function prepareDatasets() {
     const datasets = [args.documentsDataset, args.graphqlDataset, args.aclDataset]
 
     await Promise.all(
-      datasets.map((ds) =>
-        client.datasets.create(ds, {aclMode: 'public'}).catch((err) => {
+      datasets.map((ds) => {
+        // eslint-disable-next-line no-console
+        console.log(`Creating dataset ${ds}...`)
+        return client.datasets.create(ds, {aclMode: 'public'}).catch((err) => {
           err.message = `Failed to create dataset "${ds}":\n${err.message}`
           throw err
         })
-      )
+      })
     )
   }
 }

--- a/packages/@sanity/cli/test/shared/globalTeardown.ts
+++ b/packages/@sanity/cli/test/shared/globalTeardown.ts
@@ -25,10 +25,8 @@ export default async function globalTeardown(): Promise<void> {
   await rm(baseTestPath, {recursive: true, force: true})
 
   // Very hacky, but good enough for now:
-  // Force a cleanup of dangling entities left over from previous test runs every once in a while
-  if (Math.random() < 0.7) {
-    await cleanupDangling()
-  }
+  // Force a cleanup of dangling entities left over from previous test runs
+  await cleanupDangling()
 }
 
 function getErrorWarner(entity: string, id: string) {


### PR DESCRIPTION
### Description

There are a few dangling entities left by the tests, mainly dataset copy jobs. To increase the likelyhood of these getting cleaned up, this PR makes sure that the dangling cleanup is _always_ run, instead of 70% of the time. In addition, the threshold for deleting old entities is lowered from 48h to 16h. To have the required precision for this, I needed to change the format from using dates (`20220131` to rounded unix timestamps (`168262061`). 

Note: This may interrupt ongoing CI jobs - but feel like a workaround for that case was not worth it.

### What to review

Cleanup logic looks sane.

### Notes for release

None.
