### PR TITLE
fix(form): prevent autofocus on array dialogs where focus is on a deeper value

### DIFF
--- a/packages/sanity/src/core/form/components/EditPortal.tsx
+++ b/packages/sanity/src/core/form/components/EditPortal.tsx
@@ -14,6 +14,7 @@ interface Props {
   children?: ReactNode
   // eslint-disable-next-line camelcase
   legacy_referenceElement: HTMLElement | null
+  autofocus?: boolean
 }
 
 export function EditPortal(props: Props): React.ReactElement {
@@ -25,6 +26,7 @@ export function EditPortal(props: Props): React.ReactElement {
     onClose,
     type,
     width,
+    autofocus,
   } = props
   const [documentScrollElement, setDocumentScrollElement] = useState<HTMLDivElement | null>(null)
 
@@ -44,7 +46,7 @@ export function EditPortal(props: Props): React.ReactElement {
           onClose={onClose}
           width={width}
           contentRef={setDocumentScrollElement}
-          __unstable_autoFocus
+          __unstable_autoFocus={autofocus}
         >
           {contents}
         </Dialog>

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
@@ -231,6 +231,7 @@ export function GridItem<Item extends ObjectItem = ObjectItem>(props: GridItemPr
           width={parentSchemaType?.options?.modal?.width ?? 1}
           id={value._key}
           onClose={onClose}
+          autofocus={focused}
           legacy_referenceElement={previewCardRef.current}
         >
           {children}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
@@ -217,6 +217,7 @@ export function PreviewItem<Item extends ObjectItem = ObjectItem>(props: Preview
           width={parentSchemaType?.options?.modal?.width ?? 1}
           id={value._key}
           onClose={onClose}
+          autofocus={focused}
           legacy_referenceElement={previewCardRef.current}
         >
           {children}


### PR DESCRIPTION
### Description

This will skip autofocus on first interactive descendant when opening dialogs to edit array objects unless focus is on  the object itself. Prevents an issue setting focus on the close button even if focus path mandated focus for a node deeper down in the hierarchy.

### What to review
Open %2Cpath%3DsomeArray%5B_key%3D%3D"01d8a490d0d1"%5D.focusTest.someObject.first and observe that the right field inside the dialog gets focused
Here's `next` for comparison: 


### Notes for release

- Fixes an issue causing focus to be set on wrong element when  deep linking to a field inside an array
