### PR TITLE
fix(form): skip autofocus on field groups

### DIFF
--- a/packages/sanity/src/core/form/inputs/ObjectInput/ObjectInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ObjectInput/ObjectInput.tsx
@@ -20,7 +20,6 @@ export const ObjectInput = memo(function ObjectInput(props: ObjectInputProps) {
     level,
     value,
     id,
-    path,
     onFieldGroupSelect,
   } = props
 
@@ -67,7 +66,8 @@ export const ObjectInput = memo(function ObjectInput(props: ObjectInputProps) {
             groups={groups}
             inputId={id}
             onClick={onFieldGroupSelect}
-            shouldAutoFocus={path.length === 0}
+            // autofocus is taken care of either by focusPath or focusFirstDescendant in the parent component
+            shouldAutoFocus={false}
           />
         </FieldGroupTabsWrapper>
       ) : null}

--- a/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
@@ -367,7 +367,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   const formStateRef = useRef(formState)
   formStateRef.current = formState
 
-  const handleOpenPath = useCallback(
+  const setOpenPath = useCallback(
     (path: Path) => {
       const ops = getExpandOperations(formStateRef.current!, path)
       ops.forEach((op) => {
@@ -405,7 +405,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     onBlur: handleBlur,
     onChange: handleChange,
     onFocus: handleFocus,
-    onPathOpen: handleOpenPath,
+    onPathOpen: setOpenPath,
     onHistoryClose: handleHistoryClose,
     onHistoryOpen: handleHistoryOpen,
     onInspectClose: handleInspectClose,
@@ -450,10 +450,11 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
 
   // Reset `focusPath` when `documentId` or `params.path` changes
   useEffect(() => {
-    // Reset focus path
-    setFocusPath(params.path ? pathFromString(params.path) : [])
-    onSetOpenPath([])
-  }, [params.path, documentId])
+    // Reset focus path when url params path changes
+    const pathFromUrl = params.path ? pathFromString(params.path) : []
+    setFocusPath(pathFromUrl)
+    setOpenPath(pathFromUrl)
+  }, [params.path, documentId, setOpenPath])
 
   return (
     <DocumentPaneContext.Provider value={documentPane}>{children}</DocumentPaneContext.Provider>


### PR DESCRIPTION
### Description

Since focus is Studio forms are managed by the focus path (or, in some cases, by calling focusFirstDescendant on the container element), we can skip autofocus for field groups, preventing it from stealing focus in cases where focusPath mandates that focus should be set elsewhere.

### What to review

When deep linking to a field contained inside a field group, make sure that the field group button itself doesn't steal focus

### Notes for release

- Fixed an issue that caused field group buttons to steal focus when deep linking into a Studio value