### PR TITLE
fix(form): prevent autofocus on array dialogs where focus is on a deeper value

### DIFF
--- a/packages/sanity/src/core/form/components/EditPortal.tsx
+++ b/packages/sanity/src/core/form/components/EditPortal.tsx
@@ -14,6 +14,7 @@ interface Props {
   children?: ReactNode
   // eslint-disable-next-line camelcase
   legacy_referenceElement: HTMLElement | null
+  autofocus?: boolean
 }
 
 export function EditPortal(props: Props): React.ReactElement {
@@ -25,6 +26,7 @@ export function EditPortal(props: Props): React.ReactElement {
     onClose,
     type,
     width,
+    autofocus,
   } = props
   const [documentScrollElement, setDocumentScrollElement] = useState<HTMLDivElement | null>(null)
 
@@ -44,7 +46,7 @@ export function EditPortal(props: Props): React.ReactElement {
           onClose={onClose}
           width={width}
           contentRef={setDocumentScrollElement}
-          __unstable_autoFocus
+          __unstable_autoFocus={autofocus}
         >
           {contents}
         </Dialog>

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
@@ -231,6 +231,7 @@ export function GridItem<Item extends ObjectItem = ObjectItem>(props: GridItemPr
           width={parentSchemaType?.options?.modal?.width ?? 1}
           id={value._key}
           onClose={onClose}
+          autofocus={focused}
           legacy_referenceElement={previewCardRef.current}
         >
           {children}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
@@ -217,6 +217,7 @@ export function PreviewItem<Item extends ObjectItem = ObjectItem>(props: Preview
           width={parentSchemaType?.options?.modal?.width ?? 1}
           id={value._key}
           onClose={onClose}
+          autofocus={focused}
           legacy_referenceElement={previewCardRef.current}
         >
           {children}

--- a/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
@@ -367,7 +367,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   const formStateRef = useRef(formState)
   formStateRef.current = formState
 
-  const handleOpenPath = useCallback(
+  const setOpenPath = useCallback(
     (path: Path) => {
       const ops = getExpandOperations(formStateRef.current!, path)
       ops.forEach((op) => {
@@ -405,7 +405,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     onBlur: handleBlur,
     onChange: handleChange,
     onFocus: handleFocus,
-    onPathOpen: handleOpenPath,
+    onPathOpen: setOpenPath,
     onHistoryClose: handleHistoryClose,
     onHistoryOpen: handleHistoryOpen,
     onInspectClose: handleInspectClose,
@@ -450,10 +450,11 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
 
   // Reset `focusPath` when `documentId` or `params.path` changes
   useEffect(() => {
-    // Reset focus path
-    setFocusPath(params.path ? pathFromString(params.path) : [])
-    onSetOpenPath([])
-  }, [params.path, documentId])
+    // Reset focus path when url params path changes
+    const pathFromUrl = params.path ? pathFromString(params.path) : []
+    setFocusPath(pathFromUrl)
+    setOpenPath(pathFromUrl)
+  }, [params.path, documentId, setOpenPath])
 
   return (
     <DocumentPaneContext.Provider value={documentPane}>{children}</DocumentPaneContext.Provider>


### PR DESCRIPTION
### Description

This will skip autofocus on first interactive descendant when opening dialogs to edit array objects unless focus is on  the object itself. Prevents an issue causing focus to be set on the close button even if the focus path mandated focus to be set at a node deeper down in the hierarchy.

### What to review
Open 
http://test-studio-git-bug-sc-32395fix-array-dialog-autofocus.sanity.build/test/content/input-debug;focusTest;b99a1ee9-c8be-4248-9104-259b9fade2a3%2Cpath%3DsomeArray%5B_key%3D%3D"ee65a8923ed5"%5D.focusTest.someArray%5B_key%3D%3D"3c9e353346e4"%5D.focusTest.someObject.first and observe that the right field inside the dialog gets focused

Here's `next` for comparison: 
https://test-studio.sanity.build/test/content/input-debug;focusTest;b99a1ee9-c8be-4248-9104-259b9fade2a3%2Cpath%3DsomeArray%5B_key%3D%3D"ee65a8923ed5"%5D.focusTest.someArray%5B_key%3D%3D"3c9e353346e4"%5D.focusTest.someObject.first


### Notes for release

- Fixes an issue causing focus to be set on wrong element when  deep linking to a field inside an array
