### PR TITLE
fix(core): ensure the create new button dialog is functional on smaller breakpoints

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.tsx
@@ -51,6 +51,7 @@ export function NewDocumentButton(props: NewDocumentButtonProps) {
   const [open, setOpen] = useState<boolean>(false)
   const [searchQuery, setSearchQuery] = useState<string>('')
   const [popoverElement, setPopoverElement] = useState<HTMLDivElement | null>(null)
+  const [dialogElement, setDialogElement] = useState<HTMLDivElement | null>(null)
   const [buttonElement, setButtonElement] = useState<HTMLButtonElement | null>(null)
   const [searchInputElement, setSearchInputElement] = useState<HTMLInputElement | null>(null)
 
@@ -102,7 +103,7 @@ export function NewDocumentButton(props: NewDocumentButtonProps) {
     if (open) {
       handleClose()
     }
-  }, [buttonElement, popoverElement])
+  }, [buttonElement, dialogElement, popoverElement])
 
   const sharedListProps: NewDocumentListProps = useMemo(
     () => ({
@@ -199,6 +200,7 @@ export function NewDocumentButton(props: NewDocumentButtonProps) {
             id="create-new-document-dialog"
             onClickOutside={handleClose}
             onClose={handleClose}
+            ref={setDialogElement}
             scheme={scheme}
             width={1}
           >


### PR DESCRIPTION
### Description

This PR adds a small fix to the create new button works on smaller breakpoints.

The issue was that the `useClickOutside` hook wasn't adding the create new dialog element (present on smaller breakpoints) to its ignore list – effectively meaning every 'click' on mobile was triggering the `useClickOutside` callback and in turn, closing the modal without any effect.

### What to review

You could be able to create a new document via the new document button on mobile!

### Notes for release

Fixes an issue where the create new document dialog wasn't working on smaller breakpoints.