### PR TITLE
fix(form): improve focus handling for image and file inputs

### DIFF
--- a/packages/sanity/src/core/form/inputs/files/FileInput/FileActionsMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/FileActionsMenu.tsx
@@ -76,8 +76,6 @@ export function FileActionsMenu(props: Props) {
     <Flex wrap="nowrap" justify="space-between" align="center">
       <Card
         as={muted || disabled ? undefined : 'button'}
-        tabIndex={disabled ? undefined : 0}
-        __unstable_focusRing
         radius={2}
         padding={2}
         tone="inherit"


### PR DESCRIPTION
### Description
This includes a couple of improvements for image and file inputs with regards to focus handling:

  - Makes sure image and file fields support deep linking + scroll to through focus path (fixes deep linking + validation)
  - Fixes a bug breaking the ability to paste a file into a file field that has a value (we currently had two focusable elements in a file field that had a value (the preview wrapper + the FileTarget)

### What to review
Make sure deep linking (either via intent link w/path, from presence menu or validation menu) works
- Deep linking to file field from intent link: https://test-studio-git-fix-improve-asset-inputs-focus.sanity.build/test/intent/edit/id=66890ca9-0354-4a16-9ec0-e25ff5679295;path=FileWithTwoAccept/
- Deep linking to image field from intent link: https://test-studio-git-fix-improve-asset-inputs-focus.sanity.build/test/intent/edit/id=6a2f0a14-0b52-4022-9194-647eb3fc1ee1;path=noAssetSource/

### Notes for release
- Makes sure image and file fields support deep linking
- Fixes a bug that broke the ability to paste a file into a file field that already has got a value
