### PR TITLE
ci(github): drop node 14 from test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [14, 16, 18]
+        node: [16, 18]
         experimental: [false]
         # include:
         #   - os: windows-latest


### PR DESCRIPTION
### Description
Node 14 went [EOL](https://nodejs.dev/en/about/releases/) 2023-04-30 so let's drop it form our test matrix. We should probably add v19 or v20 once adoption starts picking up.

### Notes for release
- Drop Node 14.x from CI test matrix