### PR TITLE
fix(core): prevent number primitive fields from triggering change callbacks when numbers are out of range

### DIFF
--- a/packages/sanity/src/core/form/members/object/fields/PrimitiveField.test.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/PrimitiveField.test.tsx
@@ -173,6 +173,28 @@ describe('PrimitiveField', () => {
       expect(input).toBeInstanceOf(HTMLInputElement)
       expect(input.value).toEqual('1.00')
     })
+
+    it('wont trigger `onChange` callbacks when number input values are out of range', () => {
+      // Given
+      const {formCallbacks, member, TestWrapper} = setupTest('number', undefined)
+
+      const {getByTestId} = render(
+        <PrimitiveField
+          member={member}
+          renderInput={defaultRenderInput}
+          renderField={defaultRenderField}
+        />,
+        {wrapper: TestWrapper}
+      )
+
+      // When
+      const input = getByTestId('number-input') as HTMLInputElement
+      userEvent.paste(input!, (Number.MIN_SAFE_INTEGER - 1).toString())
+      userEvent.paste(input!, (Number.MAX_SAFE_INTEGER + 1).toString())
+
+      // Then
+      expect(formCallbacks.onChange).toBeCalledTimes(0)
+    })
   })
 })
 

--- a/packages/sanity/src/core/form/members/object/fields/PrimitiveField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/PrimitiveField.tsx
@@ -55,6 +55,9 @@ export function PrimitiveField(props: {
       let inputValue: number | string | boolean = event.currentTarget.value
       if (isNumberSchemaType(member.field.schemaType)) {
         inputValue = event.currentTarget.valueAsNumber
+        if (inputValue > Number.MAX_SAFE_INTEGER || inputValue < Number.MIN_SAFE_INTEGER) {
+          return
+        }
       } else if (isBooleanSchemaType(member.field.schemaType)) {
         inputValue = event.currentTarget.checked
       }


### PR DESCRIPTION
## Description

This PR updates `PrimitiveField` and prevents `onChange` callbacks when number values exceeds safe ranges in JS (`Number.MAX_SAFE_INTEGER` and `Number.MIN_SAFE_INTEGER` respectively)

Currently, entering an integer outside the ranges in a `number` field will crash the studio.

## What to review

- Entering large or small values outside this range in `number` fields will no longer cause its `onChange` callbacks to trigger – meaning the input won't update with the out of range value. In these cases, we don't store an intermediate value or show any sort of validation error.
- There's existing precedence for this in the studio – [primitives within arrays do this same check](https://github.com/sanity-io/sanity/blob/next/packages/sanity/src/core/form/members/array/items/ArrayOfPrimitivesItem.tsx#L68-L70), so this is just replicating that behaviour for number fields.

## Notes for release

Fixes an issue where out of range integers in number fields could crash the studio