### PR TITLE
fix(form): set focus according to focus path on inputs inside block objects

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -283,22 +283,28 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
     [change$, onPaste, portableTextEditor, schemaTypes, slateEditor]
   )
 
-  const handleOnFocus = useCallback(() => {
-    const selection = PortableTextEditor.getSelection(portableTextEditor)
-    change$.next({type: 'focus'})
-    const newSelection = PortableTextEditor.getSelection(portableTextEditor)
-    // If the selection is the same, emit it explicitly here as there is no actual onChange event triggered.
-    if (selection === newSelection) {
-      change$.next({
-        type: 'selection',
-        selection,
-      })
-    }
-  }, [change$, portableTextEditor])
+  const handleOnFocus: React.FocusEventHandler<HTMLDivElement> = useCallback(
+    (event) => {
+      const selection = PortableTextEditor.getSelection(portableTextEditor)
+      change$.next({type: 'focus', event})
+      const newSelection = PortableTextEditor.getSelection(portableTextEditor)
+      // If the selection is the same, emit it explicitly here as there is no actual onChange event triggered.
+      if (selection === newSelection) {
+        change$.next({
+          type: 'selection',
+          selection,
+        })
+      }
+    },
+    [change$, portableTextEditor]
+  )
 
-  const handleOnBlur = useCallback(() => {
-    change$.next({type: 'blur'})
-  }, [change$])
+  const handleOnBlur: React.FocusEventHandler<HTMLDivElement> = useCallback(
+    (event) => {
+      change$.next({type: 'blur', event})
+    },
+    [change$]
+  )
 
   const handleOnBeforeInput = useCallback(
     (event: Event) => {

--- a/packages/@sanity/portable-text-editor/src/editor/hooks/useSyncValue.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/hooks/useSyncValue.ts
@@ -250,7 +250,7 @@ function _updateBlock(
     currentBlock.children.forEach((currentBlockChild, currentBlockChildIndex) => {
       const oldBlockChild = oldBlock.children[currentBlockChildIndex]
       const isChildChanged = !isEqual(currentBlockChild, oldBlockChild)
-      const isTextChanged = !isEqual(currentBlockChild.text, oldBlockChild.text)
+      const isTextChanged = !isEqual(currentBlockChild.text, oldBlockChild?.text)
       const path = [currentBlockIndex, currentBlockChildIndex]
       if (isChildChanged) {
         // Update if this is the same child

--- a/packages/@sanity/portable-text-editor/src/types/editor.ts
+++ b/packages/@sanity/portable-text-editor/src/types/editor.ts
@@ -17,6 +17,7 @@ import {
 import {Subject, Observable} from 'rxjs'
 import {Descendant, Node as SlateNode, Operation as SlateOperation} from 'slate'
 import {ReactEditor} from '@sanity/slate-react'
+import {FocusEvent} from 'react'
 import type {Patch} from '../types/patch'
 import {PortableTextEditor} from '../editor/PortableTextEditor'
 
@@ -217,6 +218,7 @@ export type SelectionChange = {
 /** @beta */
 export type FocusChange = {
   type: 'focus'
+  event: FocusEvent<HTMLDivElement, Element>
 }
 
 /** @beta */
@@ -228,6 +230,7 @@ export type UnsetChange = {
 /** @beta */
 export type BlurChange = {
   type: 'blur'
+  event: FocusEvent<HTMLDivElement, Element>
 }
 
 /** @beta */

--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -1,6 +1,5 @@
 import React, {useState, useMemo, useCallback} from 'react'
 import {
-  EditorSelection,
   OnCopyFn,
   OnPasteFn,
   usePortableTextEditor,
@@ -45,6 +44,7 @@ export type PortableTextEditorElement = HTMLDivElement | HTMLSpanElement | null
 export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunctions'>) {
   const {
     changed,
+    focused,
     focusPath = EMPTY_ARRAY,
     hasFocus,
     hotkeys,
@@ -92,16 +92,6 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
 
   const _renderBlockActions = !!value && renderBlockActions ? renderBlockActions : undefined
   const _renderCustomMarkers = !!value && renderCustomMarkers ? renderCustomMarkers : undefined
-
-  const initialSelection = useMemo((): EditorSelection => {
-    return focusPath.length > 0
-      ? {
-          anchor: {path: focusPath, offset: 0},
-          focus: {path: focusPath, offset: 0},
-        }
-      : null
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []) // only initial!
 
   const [portalElement, setPortalElement] = useState<HTMLDivElement | null>(null)
 
@@ -294,7 +284,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       <Editor
         hasFocus={hasFocus}
         hotkeys={editorHotkeys}
-        initialSelection={initialSelection}
+        initialSelection={null}
         isActive={isActive}
         isFullscreen={isFullscreen}
         onItemOpen={onItemOpen}
@@ -314,21 +304,20 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
 
     // Keep only stable ones here!
     [
-      hasFocus,
+      boundaryElement,
       editorHotkeys,
-      initialSelection,
+      handleToggleFullscreen,
+      hasFocus,
       isActive,
       isFullscreen,
-      onItemOpen,
       onCopy,
+      onItemOpen,
       onPaste,
-      handleToggleFullscreen,
       path,
       readOnly,
       renderAnnotation,
       renderBlock,
       renderChild,
-      boundaryElement,
     ]
   )
 
@@ -346,7 +335,6 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
 
   // Scroll to the DOM element of the "opened" portable text member when relevant.
   useTrackFocusPath({
-    editorRootPath: path,
     focusPath,
     boundaryElement: boundaryElement || undefined,
     onItemClose,
@@ -357,7 +345,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       <ActivateOnFocus onActivate={onActivate} isOverlayActive={!isActive}>
         <ChangeIndicator
           disabled={isFullscreen}
-          hasFocus={hasFocus}
+          hasFocus={Boolean(focused)}
           isChanged={changed}
           path={path}
         >

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -112,18 +112,13 @@ export function Editor(props: EditorProps) {
   const scrollSelectionIntoView = useScrollSelectionIntoView(scrollElement)
 
   // Restore the React editor selection and focus when toggling fullscreen
-  // Note that the selection itself is not part of the dependencies here (use the last known from the PTE instance)
   useEffect(() => {
-    if (selection) {
-      PortableTextEditor.select(editor, selection)
-    }
     if (hasFocus) {
       PortableTextEditor.focus(editor)
     } else {
       PortableTextEditor.blur(editor)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editor, isFullscreen]) // skip selection dep.
+  }, [editor, hasFocus, isFullscreen])
 
   const editable = useMemo(
     () => (

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -12,7 +12,6 @@ import {
   usePortableTextEditor,
   RenderStyleFunction,
   RenderListItemFunction,
-  usePortableTextEditorSelection,
 } from '@sanity/portable-text-editor'
 import {Path} from '@sanity/types'
 import {BoundaryElementProvider, useBoundaryElement, useGlobalKeyDown, useLayer} from '@sanity/ui'
@@ -87,7 +86,6 @@ export function Editor(props: EditorProps) {
   const {isTopLayer} = useLayer()
   const editableRef = useRef<HTMLDivElement | null>(null)
   const editor = usePortableTextEditor()
-  const selection = usePortableTextEditorSelection()
 
   const {element: boundaryElement} = useBoundaryElement()
 
@@ -155,11 +153,9 @@ export function Editor(props: EditorProps) {
 
   const handleToolBarOnMemberOpen = useCallback(
     (relativePath: Path) => {
-      PortableTextEditor.blur(editor)
-      const fullPath = path.concat(relativePath)
-      onItemOpen(fullPath)
+      onItemOpen(path.concat(relativePath))
     },
-    [editor, onItemOpen, path]
+    [onItemOpen, path]
   )
 
   return (

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -103,16 +103,6 @@ export function PortableTextInput(props: PortableTextInputProps) {
   const [isFullscreen, setIsFullscreen] = useState(false)
   const [isActive, setIsActive] = useState(false)
 
-  // Let formState decide if we are focused or not.
-  const hasFocus = Boolean(focused) || focusPath.length > 0
-
-  // Set active if focused
-  useEffect(() => {
-    if (hasFocus) {
-      setIsActive(true)
-    }
-  }, [hasFocus])
-
   const toast = useToast()
   const portableTextMemberItemsRef: React.MutableRefObject<PortableTextMemberItem[]> = useRef([])
 
@@ -306,6 +296,19 @@ export function PortableTextInput(props: PortableTextInputProps) {
       }
     }
   }, [isActive])
+
+  // The editor has focus if we have selected a single block or one of it's children.
+  const hasFocus =
+    Boolean(focused) ||
+    focusPath.length === 1 ||
+    (focusPath.length === 3 && focusPath[1] === 'children')
+
+  // Set active if focused
+  useEffect(() => {
+    if (hasFocus) {
+      setIsActive(true)
+    }
+  }, [hasFocus])
 
   return (
     <Box ref={innerElementRef}>

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
@@ -1,69 +1,86 @@
-import {PortableTextEditor, usePortableTextEditor} from '@sanity/portable-text-editor'
+import {
+  PortableTextEditor,
+  usePortableTextEditor,
+  usePortableTextEditorSelection,
+} from '@sanity/portable-text-editor'
 import {Path} from '@sanity/types'
-import {useEffect, useRef} from 'react'
+import {useEffect} from 'react'
 import scrollIntoView from 'scroll-into-view-if-needed'
-import {isEqual} from 'lodash'
-import {PortableTextMemberItem} from '../PortableTextInput'
+import {isEqual} from '@sanity/util/paths'
 import {usePortableTextMemberItems} from './usePortableTextMembers'
 
 interface Props {
   focusPath: Path
   boundaryElement?: HTMLElement
-  editorRootPath: Path
   onItemClose: () => void
 }
 
 // This hook will track the focusPath and make sure editor content is visible and focused accordingly.
 export function useTrackFocusPath(props: Props): void {
-  const {focusPath, editorRootPath, boundaryElement, onItemClose} = props
+  const {focusPath, boundaryElement, onItemClose} = props
   const portableTextMemberItems = usePortableTextMemberItems()
   const editor = usePortableTextEditor()
+  const selection = usePortableTextEditorSelection()
 
   useEffect(() => {
-    // Don't do anything if no internal focusPath
+    // Don't do anything if no focusPath
     if (focusPath.length === 0) {
       return
     }
-    // Find the most specific opened member item and scroll to it
-    const memberItem = portableTextMemberItems
-      .filter((item) => item.member.open)
-      .sort((a, b) => b.member.item.path.length - a.member.item.path.length)[0]
-    if (memberItem && memberItem.elementRef?.current) {
+
+    // Don't do anything if the selection focus path already is the focusPath
+    if (selection?.focus.path && isEqual(selection.focus.path, focusPath)) {
+      return
+    }
+
+    // Find the opened member item
+    const openItem = portableTextMemberItems.find((m) => m.member.open)
+
+    if (openItem && openItem.elementRef?.current) {
       if (boundaryElement) {
-        // Scroll the boundary element into view
+        // Scroll the boundary element into view (the scrollable element itself)
         scrollIntoView(boundaryElement, {
           scrollMode: 'if-needed',
         })
-        // Scroll the member into view
-        scrollIntoView(memberItem.elementRef?.current, {
+        // Scroll the member into view (the member within the scroll-boundary)
+        scrollIntoView(openItem.elementRef?.current, {
           scrollMode: 'if-needed',
           boundary: boundaryElement,
         })
       }
-      const editorSelection = PortableTextEditor.getSelection(editor)
-      const hasSelectionInSameBlock = isEqual(editorSelection?.focus.path[0], focusPath[0])
-      // Only manipulate the editor selection if we are not in the same block as the user have currently selected.
-      // Otherwise we may interfere when the user is creating new links or inline objects that is supposed to open.
-      if (!editorSelection || !hasSelectionInSameBlock) {
-        // Make a selection in the editor
+      // If the focusPath i targeting a text block (with focusPath on the block itself),
+      // ensure that an editor selection is pointing to it's first child and then focus the editor.
+      if (openItem.kind === 'textBlock') {
+        const path =
+          focusPath.length === 3 && focusPath[1] === 'children'
+            ? focusPath // focusPath pointing to known span
+            : [
+                focusPath[0],
+                'children',
+                (Array.isArray(openItem.node.value?.children) &&
+                  openItem.node.value?.children[0]._key && {
+                    _key: openItem.node.value?.children[0]._key,
+                  }) ||
+                  0,
+              ] // unknown span (just a block key given as focusPath), select the first span
+
+        // Make an editor selection
         PortableTextEditor.select(editor, {
-          anchor: {path: focusPath, offset: 0},
-          focus: {path: focusPath, offset: 0},
+          anchor: {path, offset: 0},
+          focus: {path, offset: 0},
         })
-        if (memberItem.kind === 'textBlock') {
+        // Focus the editor
+        if (focusPath.length === 1) {
           PortableTextEditor.focus(editor)
-          // "auto-close" regular text blocks or they get sticky here when trying to focus on an other field
-          // There is no natural way of closing them (however opening something else would close them)
-          onItemClose()
         }
       }
     }
   }, [
     boundaryElement,
     editor,
-    editorRootPath.length,
     focusPath,
     onItemClose,
     portableTextMemberItems,
+    selection?.focus.path,
   ])
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
@@ -44,7 +44,7 @@ export function useTrackFocusPath(props: Props): void {
       const hasSelectionInSameBlock = isEqual(editorSelection?.focus.path[0], focusPath[0])
       // Only manipulate the editor selection if we are not in the same block as the user have currently selected.
       // Otherwise we may interfere when the user is creating new links or inline objects that is supposed to open.
-      if (!hasSelectionInSameBlock) {
+      if (!editorSelection || !hasSelectionInSameBlock) {
         // Make a selection in the editor
         PortableTextEditor.select(editor, {
           anchor: {path: focusPath, offset: 0},

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
@@ -177,7 +177,7 @@ export const DefaultAnnotationComponent = (props: BlockAnnotationProps) => {
     onOpen,
     onRemove,
     open,
-    path,
+    focused,
     readOnly,
     schemaType,
     textElement,
@@ -225,7 +225,7 @@ export const DefaultAnnotationComponent = (props: BlockAnnotationProps) => {
           boundaryElement={__unstable_boundaryElement}
           defaultType="popover"
           onClose={onClose}
-          path={path}
+          autofocus={focused}
           referenceElement={__unstable_referenceElement}
           schemaType={schemaType}
         >

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
@@ -161,6 +161,7 @@ export function BlockObject(props: BlockObjectProps) {
       children: inputRef.current,
       focused,
       markers,
+      nodeFocused: memberItem?.node.focused,
       onClose,
       onOpen,
       onPathFocus,
@@ -183,6 +184,7 @@ export function BlockObject(props: BlockObjectProps) {
       isOpen,
       markers,
       memberItem?.elementRef,
+      memberItem?.node.focused,
       memberItem?.node.path,
       onClose,
       onOpen,
@@ -283,8 +285,8 @@ export const DefaultBlockObjectComponent = (props: BlockProps) => {
     onClose,
     onOpen,
     onRemove,
+    nodeFocused,
     open,
-    path,
     readOnly,
     renderPreview,
     selected,
@@ -292,6 +294,7 @@ export const DefaultBlockObjectComponent = (props: BlockProps) => {
     value,
     validation,
   } = props
+
   const isImagePreview = schemaType.name === 'image'
   const hasError = validation.filter((v) => v.level === 'error').length > 0
   const hasWarning = validation.filter((v) => v.level === 'warning').length > 0
@@ -326,7 +329,7 @@ export const DefaultBlockObjectComponent = (props: BlockProps) => {
         {renderPreview({
           actions: (
             <BlockObjectActionsMenu
-              focused={focused}
+              blockFocused={focused}
               isOpen={open}
               onOpen={onOpen}
               onRemove={onRemove}
@@ -345,7 +348,7 @@ export const DefaultBlockObjectComponent = (props: BlockProps) => {
           boundaryElement={__unstable_boundaryElement}
           defaultType="dialog"
           onClose={onClose}
-          path={path}
+          autofocus={nodeFocused}
           schemaType={schemaType}
           referenceElement={__unstable_referenceElement}
         >

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
@@ -94,8 +94,13 @@ export function BlockObject(props: BlockObjectProps) {
 
   const onClose = useCallback(() => {
     onItemClose()
+    const sel: EditorSelection = {
+      focus: {path: relativePath, offset: 0},
+      anchor: {path: relativePath, offset: 0},
+    }
+    PortableTextEditor.select(editor, sel)
     PortableTextEditor.focus(editor)
-  }, [editor, onItemClose])
+  }, [relativePath, editor, onItemClose])
 
   const onRemove = useCallback(() => {
     const sel: EditorSelection = {
@@ -329,8 +334,8 @@ export const DefaultBlockObjectComponent = (props: BlockProps) => {
         {renderPreview({
           actions: (
             <BlockObjectActionsMenu
-              blockFocused={focused}
               isOpen={open}
+              focused={focused}
               onOpen={onOpen}
               onRemove={onRemove}
               readOnly={readOnly}

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObjectActionsMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObjectActionsMenu.tsx
@@ -23,7 +23,7 @@ import {PortableTextBlock} from '@sanity/types'
 import {IntentLink} from 'sanity/router'
 
 interface BlockObjectActionsMenuProps extends PropsWithChildren {
-  blockFocused?: boolean
+  focused: boolean
   isOpen?: boolean
   onOpen: () => void
   onRemove: () => void
@@ -39,7 +39,7 @@ const POPOVER_PROPS: MenuButtonProps['popover'] = {
 }
 
 export function BlockObjectActionsMenu(props: BlockObjectActionsMenuProps): ReactElement {
-  const {children, blockFocused, isOpen, onOpen, onRemove, readOnly, value} = props
+  const {children, focused, isOpen, onOpen, onRemove, readOnly, value} = props
   const menuButtonId = useId()
   const menuButton = useRef<HTMLButtonElement | null>(null)
   const isTabbing = useRef<boolean>(false)
@@ -67,7 +67,7 @@ export function BlockObjectActionsMenu(props: BlockObjectActionsMenuProps): Reac
   useGlobalKeyDown(
     useCallback(
       (event) => {
-        if (!blockFocused) {
+        if (!focused) {
           return
         }
         if (event.key === 'Tab') {
@@ -79,7 +79,7 @@ export function BlockObjectActionsMenu(props: BlockObjectActionsMenuProps): Reac
           }
         }
       },
-      [blockFocused, isOpen]
+      [focused, isOpen]
     )
   )
 
@@ -95,7 +95,7 @@ export function BlockObjectActionsMenu(props: BlockObjectActionsMenuProps): Reac
               iconRight={EllipsisVerticalIcon}
               mode="bleed"
               paddingX={2}
-              tabIndex={blockFocused ? 0 : 1}
+              tabIndex={focused ? 0 : 1}
             />
           }
           ref={menuButton}

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObjectActionsMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObjectActionsMenu.tsx
@@ -23,7 +23,7 @@ import {PortableTextBlock} from '@sanity/types'
 import {IntentLink} from 'sanity/router'
 
 interface BlockObjectActionsMenuProps extends PropsWithChildren {
-  focused: boolean
+  blockFocused?: boolean
   isOpen?: boolean
   onOpen: () => void
   onRemove: () => void
@@ -39,7 +39,7 @@ const POPOVER_PROPS: MenuButtonProps['popover'] = {
 }
 
 export function BlockObjectActionsMenu(props: BlockObjectActionsMenuProps): ReactElement {
-  const {children, focused, isOpen, onOpen, onRemove, readOnly, value} = props
+  const {children, blockFocused, isOpen, onOpen, onRemove, readOnly, value} = props
   const menuButtonId = useId()
   const menuButton = useRef<HTMLButtonElement | null>(null)
   const isTabbing = useRef<boolean>(false)
@@ -67,7 +67,7 @@ export function BlockObjectActionsMenu(props: BlockObjectActionsMenuProps): Reac
   useGlobalKeyDown(
     useCallback(
       (event) => {
-        if (!focused) {
+        if (!blockFocused) {
           return
         }
         if (event.key === 'Tab') {
@@ -79,7 +79,7 @@ export function BlockObjectActionsMenu(props: BlockObjectActionsMenuProps): Reac
           }
         }
       },
-      [focused, isOpen]
+      [blockFocused, isOpen]
     )
   )
 
@@ -95,7 +95,7 @@ export function BlockObjectActionsMenu(props: BlockObjectActionsMenuProps): Reac
               iconRight={EllipsisVerticalIcon}
               mode="bleed"
               paddingX={2}
-              tabIndex={focused ? 0 : 1}
+              tabIndex={blockFocused ? 0 : 1}
             />
           }
           ref={menuButton}

--- a/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
@@ -181,7 +181,6 @@ export const DefaultInlineObjectComponent = (props: BlockProps) => {
     onOpen,
     onRemove,
     open,
-    path,
     readOnly,
     renderPreview,
     schemaType,
@@ -271,7 +270,7 @@ export const DefaultInlineObjectComponent = (props: BlockProps) => {
           boundaryElement={__unstable_boundaryElement}
           defaultType="popover"
           onClose={onClose}
-          path={path}
+          autofocus={focused}
           referenceElement={__unstable_referenceElement}
           schemaType={schemaType}
         >

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/DialogModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/DialogModal.tsx
@@ -9,10 +9,11 @@ interface DefaultEditDialogProps {
   onClose: () => void
   title: string | React.ReactNode
   width?: ModalWidth
+  autofocus?: boolean
 }
 
 export function DefaultEditDialog(props: DefaultEditDialogProps) {
-  const {onClose, children, title, width = 1} = props
+  const {onClose, children, title, width = 1, autofocus} = props
   const dialogId = useId()
   // This seems to work with regular refs as well, but it might be safer to use state.
   const [contentElement, setContentElement] = useState<HTMLDivElement | null>(null)
@@ -26,6 +27,7 @@ export function DefaultEditDialog(props: DefaultEditDialogProps) {
       portal="default"
       width={width}
       contentRef={setContentElement}
+      __unstable_autoFocus={autofocus}
     >
       <PresenceOverlay margins={[0, 0, 1, 0]}>
         <VirtualizerScrollInstanceProvider scrollElement={contentElement}>

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx
@@ -3,11 +3,9 @@ import {
   PortableTextEditor,
   usePortableTextEditor,
 } from '@sanity/portable-text-editor'
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
-import {ObjectSchemaType, Path} from '@sanity/types'
+import React, {useCallback, useMemo, useRef} from 'react'
+import {ObjectSchemaType} from '@sanity/types'
 import {_getModalOption} from '../helpers'
-import {pathToString} from '../../../../../field'
-import {usePortableTextMemberItem} from '../../hooks/usePortableTextMembers'
 import {DefaultEditDialog} from './DialogModal'
 import {PopoverEditDialog} from './PopoverModal'
 
@@ -16,13 +14,12 @@ export function ObjectEditModal(props: {
   children: React.ReactNode
   defaultType: 'dialog' | 'popover'
   onClose: () => void
-  path: Path
   referenceElement: HTMLElement | undefined
   schemaType: ObjectSchemaType
+  autofocus?: boolean
 }) {
-  const {onClose, defaultType, referenceElement, boundaryElement, schemaType, path} = props
+  const {onClose, defaultType, referenceElement, boundaryElement, schemaType, autofocus} = props
   const editor = usePortableTextEditor()
-  const firstElementIsFocused = useRef(false)
 
   const schemaModalOption = useMemo(() => _getModalOption(schemaType), [schemaType])
   const modalType = schemaModalOption?.type || defaultType
@@ -32,33 +29,12 @@ export function ObjectEditModal(props: {
   // The initial editor selection when opening the object
   const initialSelection = useRef<EditorSelection | null>(PortableTextEditor.getSelection(editor))
 
-  const memberItem = usePortableTextMemberItem(pathToString(path))
-
   const handleClose = useCallback(() => {
     PortableTextEditor.select(editor, initialSelection.current)
     onClose()
   }, [editor, onClose])
 
   const modalWidth = schemaModalOption?.width
-
-  // Set focus on the first field
-  useEffect(() => {
-    if (firstElementIsFocused.current) {
-      return
-    }
-    const firstFieldMember = memberItem?.member.item.members.find((m) => m.kind === 'field')
-    if (firstFieldMember && firstFieldMember.kind === 'field') {
-      setTimeout(() => {
-        const firstFieldElm = document.getElementById(
-          firstFieldMember.field.id
-        ) as HTMLElement | null
-        if (firstFieldElm) {
-          firstFieldElm.focus()
-        }
-      }, 0)
-      firstElementIsFocused.current = true
-    }
-  }, [memberItem])
 
   if (modalType === 'popover') {
     return (
@@ -75,7 +51,12 @@ export function ObjectEditModal(props: {
   }
 
   return (
-    <DefaultEditDialog onClose={handleClose} title={modalTitle} width={modalWidth}>
+    <DefaultEditDialog
+      onClose={handleClose}
+      title={modalTitle}
+      width={modalWidth}
+      autofocus={autofocus}
+    >
       {props.children}
     </DefaultEditDialog>
   )

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/InsertMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/InsertMenu.tsx
@@ -2,10 +2,10 @@ import React, {memo, useCallback, useMemo} from 'react'
 import {AddIcon} from '@sanity/icons'
 import {Button, PopoverProps} from '@sanity/ui'
 import {PortableTextEditor, usePortableTextEditor} from '@sanity/portable-text-editor'
+import {upperFirst} from 'lodash'
 import {CollapseMenu, CollapseMenuButton} from '../../../../components/collapseMenu'
 import {BlockItem} from './types'
 import {useFocusBlock} from './hooks'
-import {upperFirst} from 'lodash'
 
 const CollapseMenuMemo = memo(CollapseMenu)
 

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/hooks.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/hooks.ts
@@ -41,9 +41,9 @@ export function useActionGroups({
   const editor = usePortableTextEditor()
 
   const handleInsertAnnotation = useCallback(
-    async (type: ObjectSchemaType) => {
-      const initialValue = await resolveInitialValue(type)
-      const paths = PortableTextEditor.addAnnotation(editor, type as FIXME, initialValue)
+    async (schemaType: ObjectSchemaType) => {
+      const initialValue = await resolveInitialValue(schemaType)
+      const paths = PortableTextEditor.addAnnotation(editor, schemaType, initialValue)
       if (paths && paths.markDefPath) {
         onMemberOpen(paths.markDefPath)
       }

--- a/packages/sanity/src/core/form/types/blockProps.ts
+++ b/packages/sanity/src/core/form/types/blockProps.ts
@@ -83,6 +83,7 @@ export interface BlockProps {
   __unstable_referenceElement?: HTMLElement // Reference element representing the block in the DOM
   children?: ReactNode | undefined
   focused: boolean
+  nodeFocused?: boolean
   markers: PortableTextMarker[]
   onClose: () => void
   onOpen: () => void
@@ -90,7 +91,6 @@ export interface BlockProps {
   onRemove: () => void
   open: boolean
   parentSchemaType: ArraySchemaType | ObjectSchemaType
-  path: Path
   presence: FormNodePresence[]
   readOnly: boolean
   renderDefault: (props: BlockProps) => React.ReactElement


### PR DESCRIPTION
### Description

Currently, if you follow a deep link to a block object field (opened in a dialog) it doesn't put focus on it, but rather sets focus on the first field inside the dialog ([repro](https://test-studio.sanity.build/test/intent/edit/id=97a43753-a8ab-46eb-81e1-33067bedf2bb;path=body%5B_key%3D%3D%22b016cc30e71e%22%5D.otherstring/) - as you can see from the url: the path points at `otherstring`)

This PR removes the logic that placed focus on first field with the following logic:

If the block itself has focus (i.e. not a child of the block), we use the default behavior of Sanity UI Dialogs (which is to place focus at the first interactive element inside the dialog, e.g. the close button if the dialog has one). If a child of the block has focus (according to the current focus path), Sanity UI dialog autofocus behavior is disabled in favor of the standard focus handling of inputs/field wrappers.


### What to review
- Make sure deep linking to fields and inputs inside blocks in portable text editor works as expected
- Here's the above mentioned url with this PR applied: https://test-studio-git-bug-sc-32925fix-dialog-autofocus.sanity.build/test/intent/edit/id=97a43753-a8ab-46eb-81e1-33067bedf2bb;path=body%5B_key%3D%3D%22b016cc30e71e%22%5D.otherstring/

### Notes for release
- Fixes an issue with focus placement when deep linking to fields contained in Portable Text blocks