### PR TITLE
fix: avoid scroll on `overflow: hidden`

### DIFF
--- a/dev/design-studio/package.json
+++ b/dev/design-studio/package.json
@@ -33,7 +33,7 @@
     "@sanity/color": "^2.1.20",
     "@sanity/icons": "^2.3.0",
     "@sanity/logos": "^2.0.2",
-    "@sanity/ui": "^1.3.0",
+    "@sanity/ui": "^1.3.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "sanity": "3.10.1",

--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -24,7 +24,7 @@
     "@sanity/image-url": "^1.0.2",
     "@sanity/portable-text-editor": "3.10.1",
     "@sanity/types": "3.10.1",
-    "@sanity/ui": "^1.3.0",
+    "@sanity/ui": "^1.3.3",
     "@sanity/ui-workshop": "^1.0.0",
     "@sanity/util": "3.10.1",
     "@sanity/uuid": "^3.0.1",

--- a/examples/ecommerce-studio/package.json
+++ b/examples/ecommerce-studio/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@sanity/cli": "3.10.1",
-    "@sanity/ui": "^1.3.0",
+    "@sanity/ui": "^1.3.3",
     "react": "^18.2.0",
     "react-barcode": "^1.4.1",
     "react-dom": "^18.2.0",

--- a/packages/@sanity/cli/templates/shopify/components/media/ColorTheme.tsx
+++ b/packages/@sanity/cli/templates/shopify/components/media/ColorTheme.tsx
@@ -20,6 +20,7 @@ const StyledSpan = styled.span<StyledSpanProps>(({background}) => {
     height: 100%;
     justify-content: center;
     overflow: hidden;
+    overflow: clip;
     width: 100%;
   `
 })

--- a/packages/@sanity/portable-text-editor/package.json
+++ b/packages/@sanity/portable-text-editor/package.json
@@ -75,7 +75,7 @@
     "slate": "0.81.1"
   },
   "devDependencies": {
-    "@sanity/ui": "^1.3.0",
+    "@sanity/ui": "^1.3.3",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@types/debug": "^4.1.5",

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -67,7 +67,7 @@
     "@rexxars/react-split-pane": "^0.1.93",
     "@sanity/color": "^2.1.20",
     "@sanity/icons": "^2.3.0",
-    "@sanity/ui": "^1.3.0",
+    "@sanity/ui": "^1.3.3",
     "@uiw/react-codemirror": "^4.11.4",
     "hashlru": "^2.3.0",
     "is-hotkey": "^0.1.6",

--- a/packages/@sanity/vision/src/codemirror/VisionCodeMirror.styled.tsx
+++ b/packages/@sanity/vision/src/codemirror/VisionCodeMirror.styled.tsx
@@ -6,6 +6,7 @@ export const EditorRoot = styled.div`
   box-sizing: border-box;
   height: 100%;
   overflow: hidden;
+  overflow: clip;
   position: relative;
   display: flex;
 

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -151,7 +151,7 @@
     "@sanity/portable-text-editor": "3.10.1",
     "@sanity/schema": "3.10.1",
     "@sanity/types": "3.10.1",
-    "@sanity/ui": "^1.3.0",
+    "@sanity/ui": "^1.3.3",
     "@sanity/util": "3.10.1",
     "@sanity/uuid": "^3.0.1",
     "@sanity/validation": "3.10.1",

--- a/packages/sanity/src/core/components/previews/_common/Media.styled.ts
+++ b/packages/sanity/src/core/components/previews/_common/Media.styled.ts
@@ -22,6 +22,7 @@ export const MediaWrapper = styled.span<{
     border-radius: ${({theme}) => rem(theme.sanity.radius[$radius])};
     display: flex;
     overflow: hidden;
+    overflow: clip;
     align-items: center;
     justify-content: center;
 

--- a/packages/sanity/src/core/components/previews/general/DetailPreview.styled.ts
+++ b/packages/sanity/src/core/components/previews/general/DetailPreview.styled.ts
@@ -43,6 +43,7 @@ export const DescriptionText = styled(Text)(({theme}) => {
       /* Multi-line text overflow */
       display: -webkit-box;
       overflow: hidden;
+      overflow: clip;
       text-overflow: ellipsis;
       -webkit-line-clamp: ${maxLines};
       -webkit-box-orient: vertical;

--- a/packages/sanity/src/core/components/previews/portableText/InlinePreview.styled.tsx
+++ b/packages/sanity/src/core/components/previews/portableText/InlinePreview.styled.tsx
@@ -69,6 +69,7 @@ export const TextSpan = styled(Text).attrs({forwardedAs: 'span'})(({theme}: {the
       white-space: nowrap;
       text-overflow: ellipsis;
       overflow: hidden;
+      overflow: clip;
     }
   `
 })

--- a/packages/sanity/src/core/components/progress/LinearProgress.tsx
+++ b/packages/sanity/src/core/components/progress/LinearProgress.tsx
@@ -7,6 +7,7 @@ const STROKE_WIDTH = 0.5
 
 const Root = styled(Card)`
   overflow: hidden;
+  overflow: clip;
 `
 
 const Bar = styled(Card)(({theme}: {theme: Theme}) => {

--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.styles.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.styles.tsx
@@ -18,6 +18,7 @@ export const Root = styled.div(({theme}) => {
 
     & [data-wrapper] {
       overflow: hidden;
+      overflow: clip;
       position: relative;
       z-index: 1;
       padding: ${input.border.width}px;

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
@@ -21,6 +21,7 @@ export const ToolbarCard = styled(Card)`
 export const EditableCard = styled(Card)`
   position: relative;
   overflow: hidden;
+  overflow: clip;
 
   & > [data-portal] {
     position: absolute;
@@ -64,6 +65,7 @@ export const EditableWrapper = styled(Card)<{$isFullscreen: boolean; $readOnly?:
   width: 100%;
   counter-reset: ${TEXT_LEVELS.map((l) => createListName(l)).join(' ')};
   overflow: hidden;
+  overflow: clip;
 
   & > div {
     height: 100%;

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.styles.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.styles.ts
@@ -9,6 +9,7 @@ export const RootPopover = styled(Popover)`
 
   & > div {
     overflow: hidden;
+    overflow: clip;
   }
 `
 
@@ -19,8 +20,8 @@ export const ContentContainer = styled(Container)`
   direction: column;
 `
 /*
-Setting a static max-height here to avoid scrolling issue. 
-Calculating a dynamic height to make the popover more responsive is complex, as the popover can switch top/bottom placement, 
+Setting a static max-height here to avoid scrolling issue.
+Calculating a dynamic height to make the popover more responsive is complex, as the popover can switch top/bottom placement,
 with different height requirements.
 */
 export const ModalWrapper = styled(Flex)`

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImagePreview.styled.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImagePreview.styled.tsx
@@ -7,6 +7,7 @@ export const RatioBox = styled(Card)`
   position: relative;
   width: 100%;
   overflow: hidden;
+  overflow: clip;
   min-height: 3.75rem;
   max-height: 20rem;
 

--- a/packages/sanity/src/core/form/inputs/files/common/FileInputButton/styles.ts
+++ b/packages/sanity/src/core/form/inputs/files/common/FileInputButton/styles.ts
@@ -17,6 +17,7 @@ export const FileButton = styled(Button).attrs({forwardedAs: 'label'})(
 
       & input {
         overflow: hidden;
+        overflow: clip;
         top: 0;
         left: 0;
         width: 100%;

--- a/packages/sanity/src/core/form/inputs/files/common/FileInputMenuItem/FileInputMenuItem.styled.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/FileInputMenuItem/FileInputMenuItem.styled.tsx
@@ -18,6 +18,7 @@ export const FileButton = styled(MenuItem)(({theme}: {theme: Theme}) => {
 
     & input {
       overflow: hidden;
+      overflow: clip;
       top: 0;
       left: 0;
       width: 100%;

--- a/packages/sanity/src/core/form/inputs/files/common/UploadProgress.styled.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/UploadProgress.styled.tsx
@@ -9,6 +9,7 @@ export const CardWrapper = styled(Card)`
 export const FlexWrapper = styled(Flex)`
   text-overflow: ellipsis;
   overflow: hidden;
+  overflow: clip;
 `
 
 export const LeftSection = styled(Stack)`
@@ -22,6 +23,7 @@ export const CodeWrapper = styled(Code)`
 
   code {
     overflow: hidden;
+    overflow: clip;
     text-overflow: ellipsis;
     position: relative;
     max-width: 200px;

--- a/packages/sanity/src/core/presence/overlay/RegionsWithIntersections.styled.tsx
+++ b/packages/sanity/src/core/presence/overlay/RegionsWithIntersections.styled.tsx
@@ -22,6 +22,7 @@ export const OverlayWrapper = styled.div`
 
 export const RegionWrapper = css`
   overflow: hidden;
+  overflow: clip;
   pointer-events: none;
   position: absolute;
 `

--- a/packages/sanity/src/core/studio/StudioLayout.tsx
+++ b/packages/sanity/src/core/studio/StudioLayout.tsx
@@ -21,6 +21,7 @@ const SearchFullscreenPortalCard = styled(Card)`
   height: 100%;
   left: 0;
   overflow: hidden;
+  overflow: clip;
   position: fixed;
   top: 0;
   width: 100%;

--- a/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.style.ts
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.style.ts
@@ -10,6 +10,7 @@ export const StyledPopover = styled(Popover)(() => {
       border-radius: ${({theme}) => theme.sanity.radius[3]}px;
       position: relative;
       overflow: hidden;
+      overflow: clip;
     }
   `
 })

--- a/packages/sanity/src/core/studio/components/navbar/search/SearchDialog.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/SearchDialog.tsx
@@ -21,6 +21,7 @@ interface SearchDialogProps {
 const InnerCard = styled(Card)`
   flex-direction: column;
   overflow: hidden;
+  overflow: clip;
   pointer-events: all;
   position: relative;
 `
@@ -29,6 +30,7 @@ const SearchDialogBox = styled(Box)`
   height: 100%;
   left: 0;
   overflow: hidden;
+  overflow: clip;
   pointer-events: none;
   position: fixed;
   top: 0;

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/FilterPopoverContent.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/FilterPopoverContent.tsx
@@ -15,6 +15,7 @@ const ContainerFlex = styled(Flex)`
   max-width: 480px;
   min-width: 150px;
   overflow: hidden;
+  overflow: clip;
   width: 100%;
 `
 

--- a/packages/sanity/src/core/studio/screens/CorsOriginErrorScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/CorsOriginErrorScreen.tsx
@@ -12,6 +12,7 @@ export const ScreenReaderLabel = styled.label`
   clip-path: inset(50%);
   height: 1px;
   overflow: hidden;
+  overflow: clip;
   position: absolute;
   white-space: nowrap;
   width: 1px;

--- a/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.styles.tsx
+++ b/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.styles.tsx
@@ -65,6 +65,7 @@ export const ReferencesCard = styled(Card).attrs({
   flex: 'auto',
 })`
   overflow: hidden;
+  overflow: clip;
   min-height: 150px;
 `
 

--- a/packages/sanity/src/desk/components/pane/PaneHeader.styles.tsx
+++ b/packages/sanity/src/desk/components/pane/PaneHeader.styles.tsx
@@ -45,6 +45,7 @@ export const TabsBox = styled(Box)(({theme}: {theme: Theme}) => {
   return css`
     margin: -${space[2]}px 0 -${space[2]}px -${space[3]}px;
     overflow: hidden;
+    overflow: clip;
     position: relative;
 
     & > div {

--- a/packages/sanity/src/desk/panes/document/documentPanel/ReferenceChangedBanner.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/ReferenceChangedBanner.tsx
@@ -19,6 +19,7 @@ const Root = styled(Card)`
 const TextOneLine = styled(Text)`
   & > * {
     overflow: hidden;
+    overflow: clip;
     white-space: nowrap;
     text-overflow: ellipsis;
   }

--- a/packages/sanity/src/desk/panes/document/timeline/timelineMenu.tsx
+++ b/packages/sanity/src/desk/panes/document/timeline/timelineMenu.tsx
@@ -18,6 +18,7 @@ interface TimelineMenuProps {
 
 const Root = styled(Popover)`
   overflow: hidden;
+  overflow: clip;
 `
 
 export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3982,10 +3982,10 @@
     segmented-property "^3.0.3"
     vite "^4.1.1"
 
-"@sanity/ui@^1", "@sanity/ui@^1.0.0", "@sanity/ui@^1.3.0":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@sanity/ui/-/ui-1.3.2.tgz#8afa08da88cd84d910c50f958389b249654f8943"
-  integrity sha512-wI+XW/C7C3ZqpC2OyvEYRdU0fetT5OSSfpmiBia00dej8wygu5u3KzspPcrXFpWbPkUEdvcJjQyDEY6LMQqs8w==
+"@sanity/ui@^1", "@sanity/ui@^1.0.0", "@sanity/ui@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@sanity/ui/-/ui-1.3.3.tgz#ec3b9aeb8be79f53d94406bbf80c806af1a47e7f"
+  integrity sha512-fp5eyc6U760Mvg6wmiv0wOnX/uiPpFoPf4Ne9cJX6X80mk2/u2pOkXCuMuhfXmty3KP7uPZxkapD8atd7BaWIw==
   dependencies:
     "@floating-ui/react-dom" "1.1.1"
     "@sanity/color" "^2.2.3"


### PR DESCRIPTION
### Description

When `overflow: hidden` browsers turn off scrollbars and the user can no longer scroll. But it can still be scrolled if the APIs `.focus()` and `.scrollIntoView`, as well as with other native browser behaviour as browsers still consider them scrolling boxes.

This video demonstrates how `overflow: hidden` is being scrolled into breaking the Studio layout when opening an edit intent link on iOS Safari that ends up in a field inside a dialog. 

https://user-images.githubusercontent.com/81981/236252831-515d3752-6957-465d-9e25-84b7544ace06.mp4

What makes matters worse is that since `overflow: hidden` disables user scroll the user can't recover from this broken state in a lot of cases. And there are many other ways it can break the layout and UI.

The new `overflow: clip` fixes this and turns of all scrolling. By adding it after `overflow: hidden` it's applied in browsers that support it, while those who don't continue to use `overflow: hidden`.

~~As [`@sanity/ui`](https://github.com/sanity-io/ui/pull/1098) also need a fix this PR is in draft status. Once `@sanity/ui` is published with the fix I'll update this PR and move it out of draft.~~

It's out! PR ready ☺️ 

### What to review

That what happens in the video no longer happens. No matter what triggers the soft keyboard on iOS and Android in dialogs or other initially hidden, or below-the-fold elements, shouldn't be able to break the layout.

### Notes for release

fix: edit intent links that result in iOS softkeyboards to open while opening dialogs no longer breaks the layout.
