### PR TITLE
fix(desk): remove path param from url after initially read

### DIFF
--- a/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
@@ -451,12 +451,15 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   // Reset `focusPath` when `documentId` or `params.path` changes
   useEffect(() => {
     if (ready && params.path) {
-      const pathFromUrl = resolveKeyedPath(formStateRef.current?.value, pathFromString(params.path))
+      const {path, ...restParams} = params
+      const pathFromUrl = resolveKeyedPath(formStateRef.current?.value, pathFromString(path))
       // Reset focus path when url params path changes
       setFocusPath(pathFromUrl)
       setOpenPath(pathFromUrl)
+      // remove the `path`-param from url after we have consumed it as the initial focus path
+      paneRouter.setParams(restParams)
     }
-  }, [params.path, documentId, setOpenPath, ready])
+  }, [params, documentId, setOpenPath, ready, paneRouter])
 
   return (
     <DocumentPaneContext.Provider value={documentPane}>{children}</DocumentPaneContext.Provider>


### PR DESCRIPTION
### Description

When following a intent link or a link to a field/input at a specific path in the Studio (e.g from presence menu or through Visual Editing), the path remains in the url. This means that if you reload the page, you are taken (likely surprisingly) back to the path you arrived at initially. This PR fixes that by clearing the path parameter from the URL after it's been set as the initial focus path.

### What to review
#### Old behavior:
- Go to https://test-studio.sanity.build/test/content/input-standard;objectsTest;cc5c90bd-1184-44ae-9a94-d3395ac7ebec%2Cpath%3Drecursive.recursive.events%255B_key%253D%253D%25220123f5fdca78%2522%255D.where
- Move around in the document, make some edits
- Reload page
- You're back to the field you arrived at earlier

#### New behavior:
- Go to https://test-studio-git-fix-remove-initial-path-param.sanity.build/test/content/input-standard;objectsTest;cc5c90bd-1184-44ae-9a94-d3395ac7ebec%2Cpath%3Drecursive.recursive.events%255B_key%253D%253D%25220123f5fdca78%2522%255D.where
- Move around in the document, make some edits
- Reload page
- It behaves as if you opened the document as usual

### Notes for release

- When following a link to a document field, the field path is now cleared from the url after initial load