### PR TITLE
fix(form): show fields without groups only when 'All fields' is selected

### DIFF
--- a/dev/test-studio/schema/debug/fieldGroups.js
+++ b/dev/test-studio/schema/debug/fieldGroups.js
@@ -22,6 +22,11 @@ export default {
   ],
   fields: [
     {name: 'field1', type: 'string', group: 'group1'},
+    {
+      type: 'string',
+      name: 'noGroup',
+      title: 'This field has no group and shall only show up in "All fields"',
+    },
     {name: 'field2', type: 'string', group: 'group2'},
     {
       name: 'field3',

--- a/packages/sanity/src/core/form/store/formState.ts
+++ b/packages/sanity/src/core/form/store/formState.ts
@@ -45,15 +45,20 @@ type PrimitiveSchemaType = BooleanSchemaType | NumberSchemaType | StringSchemaTy
 function isFieldEnabledByGroupFilter(
   // the groups config for the "enclosing object" type
   groupsConfig: FormFieldGroup[],
-  fieldGroup: string | string[],
+  fieldGroup: string | string[] | undefined,
   selectedGroup: FormFieldGroup
 ) {
   if (selectedGroup.name === ALL_FIELDS_GROUP.name) {
     return true
   }
 
+  // "all fields" is not the selected group and the field has no group config, so it should be hidden
+  if (fieldGroup === undefined) {
+    return false
+  }
+
   // if there's no group config for the object type, all fields are visible
-  if (groupsConfig.length === 0) {
+  if (groupsConfig.length === 0 && selectedGroup.name === ALL_FIELDS_GROUP.name) {
     return true
   }
 
@@ -554,9 +559,8 @@ function prepareObjectInputState<T>(
       return [
         {
           hidden: fieldMember === null,
-          inSelectedGroup: fieldSet.field.group
-            ? isFieldEnabledByGroupFilter(groups, fieldSet.field.group, selectedGroup)
-            : true,
+          inSelectedGroup: isFieldEnabledByGroupFilter(groups, fieldSet.field.group, selectedGroup),
+
           group: fieldSet.field.group,
           member: fieldMember,
         },


### PR DESCRIPTION
### Description
Fixes  #4471 

### What to review

#### Before

Repro case here: https://test-studio-1pw7fq0uj.sanity.build/test/content/input-debug;field-groups;fieldGroups;d2e9132c-81d3-4cfd-a380-4b49ab88a2b6
Note that two fields without any group config appears in all groups:
- This field has no group and shall only show up in "All fields"
- Array With Field Groups

#### After

With fix applied: https://test-studio-git-fix-first-field-group-bug.sanity.build/test/content/input-debug;field-groups;fieldGroups;d2e9132c-81d3-4cfd-a380-4b49ab88a2b6

Note that the two fields now only appear in "All fields"

### Notes for release

- Fixes a bug that made fields without a group appear in all groups