### PR TITLE
Fix issue with PTE-undo/redo shared history

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithUndoRedo.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithUndoRedo.ts
@@ -21,7 +21,6 @@ import * as DMP from 'diff-match-patch'
 import type {Patch} from '../../types/patch'
 import {PatchObservable, PortableTextSlateEditor} from '../../types/editor'
 import {debugWithName} from '../../utils/debug'
-import {isPatching} from '../../utils/withoutPatching'
 
 const debug = debugWithName('plugin:withUndoRedo')
 // eslint-disable-next-line new-cap
@@ -36,9 +35,6 @@ const isMerging = (editor: Editor): boolean | undefined => {
 }
 
 const isSaving = (editor: Editor): boolean | undefined => {
-  if (!isPatching(editor)) {
-    return false
-  }
   return SAVING.get(editor)
 }
 


### PR DESCRIPTION
### Description

There is an issue with the undo/redo functions for the Portable Text Editor that leads to a invalid undo/redo history for users that are within the same document at the same time.

We should not be considering the `isPatching` state here in the undo/redo plugin, as the code that produces the unwanted operations are properly  scoped with  the `withoutSaving` scope elsewhere in the code. This would exclude them from the history, as the intention of this removed return originally was - and is the way it should be.

By returning this state there, the `isSaving` test could get stuck in a state where we are returning the previous value from `isSaving`. This is what happened when we had actual remote patching going on causing local operations to be missed.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

That if you are two users writing on the same document, your undo/redo history will work acceptably.


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Fixed issue with shared undo/redo history for the Portable Text Input

<!--
A description of the change(s) that should be used in the release notes.
-->
