### PR TITLE
refactor(form): fix issue with hiding a field group that only have fieldsets

### DIFF
--- a/dev/test-studio/schema/debug/fieldGroupsWithFieldsets.js
+++ b/dev/test-studio/schema/debug/fieldGroupsWithFieldsets.js
@@ -1,0 +1,54 @@
+import {CogIcon} from '@sanity/icons'
+
+export default {
+  name: 'fieldGroupsWithFieldsets',
+  title: 'Field groups with all fields inside fieldsets',
+  type: 'document',
+  groups: [
+    {
+      name: 'group1',
+      title: 'Group 1',
+      icon: CogIcon,
+    },
+    {
+      name: 'group2',
+      title: 'Group 2',
+    },
+  ],
+  fieldsets: [
+    {name: 'fieldset1', title: 'Fieldset 1', options: {collapsed: true}},
+    {name: 'fieldset2', title: 'Fieldset 2', options: {collapsed: true}},
+  ],
+  fields: [
+    {
+      name: 'group1fieldset1',
+      type: 'string',
+      group: 'group1',
+      fieldset: 'fieldset1',
+    },
+    {
+      name: 'noGroupFieldset1',
+      type: 'string',
+      validation: (r) => r.required(),
+      fieldset: 'fieldset1',
+    },
+    {
+      name: 'group1fieldset2',
+      type: 'string',
+      group: 'group1',
+      fieldset: 'fieldset2',
+    },
+    {
+      name: 'group2fieldset1',
+      type: 'string',
+      group: 'group2',
+      fieldset: 'fieldset1',
+    },
+    {
+      name: 'group2fieldset2',
+      type: 'string',
+      group: 'group2',
+      fieldset: 'fieldset2',
+    },
+  ],
+}

--- a/dev/test-studio/schema/index.ts
+++ b/dev/test-studio/schema/index.ts
@@ -106,6 +106,7 @@ import validationTest from './ci/validationCI'
 import crossDatasetReference, {crossDatasetSubtype} from './standard/crossDatasetReference'
 import {circularCrossDatasetReferenceTest} from './debug/circularCrossDatasetReference'
 import {allNativeInputComponents} from './debug/allNativeInputComponents'
+import fieldGroupsWithFieldsets from './debug/fieldGroupsWithFieldsets'
 
 // @todo temporary, until code input is v3 compatible
 const codeInputType = {
@@ -244,6 +245,7 @@ export const schemaTypes = [
   fieldGroupsDefault,
   fieldGroupsMany,
   fieldGroupsWithValidation,
+  fieldGroupsWithFieldsets,
   fieldGroupsWithFieldsetsAndValidation,
   allNativeInputComponents,
   ...v3docs.types,

--- a/dev/test-studio/structure/constants.ts
+++ b/dev/test-studio/structure/constants.ts
@@ -80,6 +80,7 @@ export const DEBUG_FIELD_GROUP_TYPES = [
   'fieldGroupsDefault',
   'fieldGroupsMany',
   'fieldGroupsWithValidation',
+  'fieldGroupsWithFieldsets',
   'fieldGroupsWithFieldsetsAndValidation',
 ]
 

--- a/packages/sanity/src/core/form/inputs/ObjectInput/__tests__/ObjectInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/ObjectInput/__tests__/ObjectInput.test.tsx
@@ -147,6 +147,8 @@ describe('basic examples', () => {
               open: false,
               collapsible: true,
               key: 'first-field',
+              inSelectedGroup: false,
+              groups: [],
               index: 0,
               field: {
                 schemaType,

--- a/packages/sanity/src/core/form/members/object/fields/PrimitiveField.test.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/PrimitiveField.test.tsx
@@ -207,6 +207,8 @@ function setupTest(type: string, value: string | number | boolean | undefined) {
     collapsed: false,
     collapsible: false,
     open: true,
+    groups: [],
+    inSelectedGroup: false,
     field: {
       id: 'id',
       schemaType: {

--- a/packages/sanity/src/core/form/store/formState.ts
+++ b/packages/sanity/src/core/form/store/formState.ts
@@ -25,7 +25,13 @@ import {getFieldLevel} from '../studio/inputResolver/helpers'
 import {FIXME} from '../../FIXME'
 import {FormNodePresence} from '../../presence'
 
-import {ObjectArrayFormNode, PrimitiveFormNode, StateTree} from './types'
+import {
+  FieldSetMember,
+  HiddenField,
+  ObjectArrayFormNode,
+  PrimitiveFormNode,
+  StateTree,
+} from './types'
 import {resolveConditionalProperty} from './conditional-property'
 import {ALL_FIELDS_GROUP, MAX_FIELD_DEPTH} from './constants'
 import {getItemType, getPrimitiveItemType} from './utils/getItemType'
@@ -114,9 +120,12 @@ function isChangedValue(value: any, comparisonValue: any) {
  */
 function prepareFieldMember(props: {
   field: ObjectField
-  parent: RawState<ObjectSchemaType, unknown>
+  parent: RawState<ObjectSchemaType, unknown> & {
+    groups: FormFieldGroup[]
+    selectedGroup: FormFieldGroup
+  }
   index: number
-}): ObjectMember | null {
+}): ObjectMember | HiddenField | null {
   const {parent, field, index} = props
   const fieldPath = pathFor([...parent.path, field.name])
   const fieldLevel = getFieldLevel(field.type, parent.level + 1)
@@ -129,11 +138,19 @@ function prepareFieldMember(props: {
     throw new Error('Unexpected non-object value')
   }
 
+  const normalizedFieldGroupNames = field.group ? castArray(field.group) : []
+  const inSelectedGroup = isFieldEnabledByGroupFilter(
+    parent.groups,
+    field.group,
+    parent.selectedGroup
+  )
+
   if (isObjectSchemaType(field.type)) {
     const fieldValue = parentValue?.[field.name]
     const fieldComparisonValue = isRecord(parentComparisonValue)
       ? parentComparisonValue?.[field.name]
       : undefined
+
     if (!isAcceptedObjectValue(fieldValue)) {
       return {
         kind: 'error',
@@ -147,6 +164,27 @@ function prepareFieldMember(props: {
         },
       }
     }
+
+    const conditionalPropertyContext = {
+      value: fieldValue,
+      parent: parent.value,
+      document: parent.document,
+      currentUser: parent.currentUser,
+    }
+    const hidden = resolveConditionalProperty(field.type.hidden, conditionalPropertyContext)
+
+    if (hidden) {
+      return {
+        kind: 'hidden',
+        key: `field-${field.name}`,
+        name: field.name,
+        index: index,
+      }
+    }
+
+    // readonly is inherited
+    const readOnly =
+      parent.readOnly || resolveConditionalProperty(field.type.readOnly, conditionalPropertyContext)
 
     // todo: consider requiring a _type annotation for object values on fields as well
     // if (resolvedValueType !== field.type.name) {
@@ -182,11 +220,12 @@ function prepareFieldMember(props: {
       openPath: parent.openPath,
       collapsedPaths: scopedCollapsedPaths,
       collapsedFieldSets: scopedCollapsedFieldsets,
-      readOnly: parent.readOnly,
+      readOnly,
       changesOpen: parent.changesOpen,
     })
 
     if (inputState === null) {
+      // if inputState is null is either because we reached max field depth or if it has no visible members
       return null
     }
 
@@ -200,6 +239,10 @@ function prepareFieldMember(props: {
       key: `field-${field.name}`,
       name: field.name,
       index: index,
+
+      inSelectedGroup,
+      groups: normalizedFieldGroupNames,
+
       open: startsWith(fieldPath, parent.openPath),
       field: inputState,
       collapsed,
@@ -313,6 +356,9 @@ function prepareFieldMember(props: {
 
         open: startsWith(fieldPath, parent.openPath),
 
+        inSelectedGroup,
+        groups: normalizedFieldGroupNames,
+
         collapsible: false,
         collapsed: false,
         // note: this is what we actually end up passing down as to the next input component
@@ -379,6 +425,9 @@ function prepareFieldMember(props: {
         name: field.name,
         index: index,
 
+        inSelectedGroup,
+        groups: normalizedFieldGroupNames,
+
         open: startsWith(fieldPath, parent.openPath),
 
         // todo: consider support for collapsible arrays
@@ -427,8 +476,10 @@ function prepareFieldMember(props: {
       key: `field-${field.name}`,
       name: field.name,
       index: index,
-
       open: startsWith(fieldPath, parent.openPath),
+
+      inSelectedGroup,
+      groups: normalizedFieldGroupNames,
 
       // todo: consider support for collapsible primitive fields
       collapsible: false,
@@ -461,16 +512,6 @@ interface RawState<SchemaType, T> {
   changesOpen?: boolean
 }
 
-/**
- * This allows us to give the field members an intermediate state in order to render field groups correctly in cases where all members in a field group is hidden
- */
-export interface InternalFormStateMember {
-  hidden: boolean
-  // if it's hidden and in the currently selected group, it should still be excluded from its group
-  inSelectedGroup: boolean
-  group?: string | string[]
-  member: ObjectMember | null
-}
 function prepareObjectInputState<T>(
   props: RawState<ObjectSchemaType, T>,
   enableHiddenCheck?: false
@@ -493,18 +534,6 @@ function prepareObjectInputState<T>(
     document: props.document,
     currentUser: props.currentUser,
   }
-
-  const hidden =
-    enableHiddenCheck &&
-    resolveConditionalProperty(props.schemaType.hidden, conditionalPropertyContext)
-
-  if (hidden) {
-    return null
-  }
-
-  const objectIsReadOnly =
-    props.readOnly ||
-    resolveConditionalProperty(props.schemaType.readOnly, conditionalPropertyContext)
 
   const schemaTypeGroupConfig = props.schemaType.groups || []
   const defaultGroupName = (schemaTypeGroupConfig.find((g) => g.default) || ALL_FIELDS_GROUP)?.name
@@ -534,12 +563,6 @@ function prepareObjectInputState<T>(
 
   const selectedGroup = groups.find((group) => group.selected)!
 
-  const parentProps: RawState<ObjectSchemaType, unknown> = {
-    ...props,
-    hidden,
-    readOnly: objectIsReadOnly,
-  }
-
   // note: this is needed because not all object types gets a ´fieldsets´ property during schema parsing.
   // ideally members should be normalized as part of the schema parsing and not here
   const normalizedSchemaMembers: typeof props.schemaType.fieldsets = props.schemaType.fieldsets
@@ -547,84 +570,76 @@ function prepareObjectInputState<T>(
     : props.schemaType.fields.map((field) => ({single: true, field}))
 
   // create a members array for the object
-  const members = normalizedSchemaMembers.flatMap((fieldSet, index): InternalFormStateMember[] => {
-    if (fieldSet.single) {
+  const members = normalizedSchemaMembers.flatMap(
+    (fieldSet, index): (ObjectMember | HiddenField)[] => {
       // "single" means not part of a fieldset
-      const fieldMember = prepareFieldMember({
-        field: fieldSet.field,
-        parent: parentProps,
-        index,
+      if (fieldSet.single) {
+        const field = fieldSet.field
+
+        const fieldMember = prepareFieldMember({
+          field: field,
+          parent: {...props, groups, selectedGroup},
+          index,
+        })
+
+        return fieldMember ? [fieldMember] : []
+      }
+
+      // it's an actual fieldset
+      const fieldsetFieldNames = fieldSet.fields.map((f) => f.name)
+      const fieldsetHidden = resolveConditionalProperty(fieldSet.hidden, {
+        currentUser: props.currentUser,
+        document: props.document,
+        parent: props.value,
+        value: pick(props.value, fieldsetFieldNames),
       })
+
+      const fieldsetReadOnly = resolveConditionalProperty(fieldSet.readOnly, {
+        currentUser: props.currentUser,
+        document: props.document,
+        parent: props.value,
+        value: pick(props.value, fieldsetFieldNames),
+      })
+
+      const fieldsetMembers = fieldSet.fields.flatMap(
+        (field): (FieldMember | FieldError | HiddenField)[] => {
+          const hidden = resolveConditionalProperty(field.type.hidden, conditionalPropertyContext)
+
+          if (fieldsetHidden || hidden) {
+            return [
+              {
+                kind: 'hidden',
+                key: `field-${field.name}`,
+                name: field.name,
+                index: index,
+              },
+            ]
+          }
+
+          // readonly is inherited
+          const readOnly = props.readOnly || fieldsetReadOnly
+          const fieldMember = prepareFieldMember({
+            field: field,
+            parent: {...props, readOnly, hidden, groups, selectedGroup},
+            index,
+          }) as FieldMember | FieldError
+
+          return fieldMember ? [fieldMember] : []
+        }
+      )
+
+      const defaultCollapsedState = getCollapsedWithDefaults(fieldSet.options, props.level)
+
+      const collapsed =
+        (props.collapsedFieldSets?.children || {})[fieldSet.name]?.value ??
+        defaultCollapsedState.collapsed
 
       return [
         {
-          hidden: fieldMember === null,
-          inSelectedGroup: isFieldEnabledByGroupFilter(groups, fieldSet.field.group, selectedGroup),
-
-          group: fieldSet.field.group,
-          member: fieldMember,
-        },
-      ]
-    }
-
-    // it's an actual fieldset
-    const fieldsetFieldNames = fieldSet.fields.map((f) => f.name)
-    const fieldsetHidden = resolveConditionalProperty(fieldSet.hidden, {
-      currentUser: props.currentUser,
-      document: props.document,
-      parent: props.value,
-      value: pick(props.value, fieldsetFieldNames),
-    })
-
-    const fieldsetReadOnly = resolveConditionalProperty(fieldSet.readOnly, {
-      currentUser: props.currentUser,
-      document: props.document,
-      parent: props.value,
-      value: pick(props.value, fieldsetFieldNames),
-    })
-
-    const fieldsetMembers = fieldSet.fields.flatMap((field): (FieldMember | FieldError)[] => {
-      const fieldState = prepareFieldMember({
-        field,
-        parent: parentProps,
-        index,
-        // the explicit type cast here is ok - we know that a fieldset can not have fieldsets
-      }) as FieldMember | FieldError | null
-
-      if (fieldState?.kind === 'error') {
-        return [fieldState]
-      }
-
-      if (fieldState === null) {
-        return []
-      }
-
-      const fieldStateWithReadOnly = {
-        ...fieldState,
-        field: {
-          ...fieldState.field,
-          readOnly: objectIsReadOnly || fieldState.field.readOnly || fieldsetReadOnly,
-        },
-      }
-
-      return [fieldStateWithReadOnly]
-    })
-    const defaultCollapsedState = getCollapsedWithDefaults(fieldSet.options, props.level)
-
-    const collapsed =
-      (props.collapsedFieldSets?.children || {})[fieldSet.name]?.value ??
-      defaultCollapsedState.collapsed
-
-    return [
-      {
-        hidden: fieldsetHidden || fieldsetMembers.length === 0,
-        inSelectedGroup: fieldSet.group
-          ? isFieldEnabledByGroupFilter(groups, fieldSet.group, selectedGroup)
-          : true,
-        group: [],
-        member: {
           kind: 'fieldSet',
           key: `fieldset-${fieldSet.name}`,
+          _inSelectedGroup: isFieldEnabledByGroupFilter(groups, fieldSet.group, selectedGroup),
+          groups: fieldSet.group ? castArray(fieldSet.group) : [],
           fieldSet: {
             path: pathFor(props.path.concat(fieldSet.name)),
             name: fieldSet.name,
@@ -632,15 +647,17 @@ function prepareObjectInputState<T>(
             description: fieldSet.description,
             hidden: false,
             level: props.level + 1,
-            members: fieldsetMembers,
+            members: fieldsetMembers.filter(
+              (member): member is FieldMember => member.kind !== 'hidden'
+            ),
             collapsible: defaultCollapsedState?.collapsible,
             collapsed,
             columns: fieldSet?.options?.columns,
           },
         },
-      },
-    ]
-  })
+      ]
+    }
+  )
 
   const hasFieldGroups = schemaTypeGroupConfig.length > 0
 
@@ -650,10 +667,9 @@ function prepareObjectInputState<T>(
     .filter((item) => isEqual(item.path, props.path))
     .map((v) => ({level: v.level, message: v.item.message, path: v.path}))
 
-  const visibleMembers = members
-    .filter((memberWithHiddenState) => memberWithHiddenState.inSelectedGroup)
-    .map((m) => m.member)
-    .filter(isNonNullable)
+  const visibleMembers = members.filter(
+    (member): member is ObjectMember => member.kind !== 'hidden'
+  )
 
   // Return null here only when enableHiddenCheck, or we end up with array members that have 'item: null' when they
   // really should not be. One example is when a block object inside the PT-input have a type with one single hidden field.
@@ -662,27 +678,60 @@ function prepareObjectInputState<T>(
     return null
   }
 
-  // Disable all groups except the "all fields" group when the review changes pane is open.
-  const _groups = hasFieldGroups
+  const visibleGroups = hasFieldGroups
     ? groups.flatMap((group) => {
+        // The "all fields" group is always visible
         if (group.name === ALL_FIELDS_GROUP.name) {
           return group
         }
-        const hasMembers = members.some((memberWithHiddenState) => {
+        const hasVisibleMembers = visibleMembers.some((member) => {
+          if (member.kind === 'error') {
+            return false
+          }
+          if (member.kind === 'field') {
+            return member.groups.includes(group.name)
+          }
+
           return (
-            !memberWithHiddenState.hidden &&
-            castArray(memberWithHiddenState.group).includes(group.name)
+            member.groups.includes(group.name) ||
+            member.fieldSet.members.some(
+              (fieldsetMember) =>
+                fieldsetMember.kind !== 'error' && fieldsetMember.groups.includes(group.name)
+            )
           )
         })
-        return hasMembers ? group : []
+        return hasVisibleMembers ? group : []
       })
     : []
+
+  const filtereredMembers = visibleMembers.flatMap(
+    (member): (FieldError | FieldMember | FieldSetMember)[] => {
+      if (member.kind === 'error') {
+        return [member]
+      }
+      if (member.kind === 'field') {
+        return member.inSelectedGroup ? [member] : []
+      }
+
+      const filteredFieldsetMembers: ObjectMember[] = member.fieldSet.members.filter(
+        (fieldsetMember) => fieldsetMember.kind !== 'field' || fieldsetMember.inSelectedGroup
+      )
+      return filteredFieldsetMembers.length > 0
+        ? [
+            {
+              ...member,
+              fieldSet: {...member.fieldSet, members: filteredFieldsetMembers},
+            } as FieldSetMember,
+          ]
+        : []
+    }
+  )
 
   return {
     value: props.value as Record<string, unknown> | undefined,
     changed: isChangedValue(props.value, props.comparisonValue),
     schemaType: props.schemaType,
-    readOnly: props.readOnly || objectIsReadOnly,
+    readOnly: props.readOnly,
     path: props.path,
     id: toString(props.path),
     level: props.level,
@@ -693,8 +742,8 @@ function prepareObjectInputState<T>(
     // this is currently needed by getExpandOperations which needs to know about hidden members
     // (e.g. members not matching current group filter) in order to determine what to expand
     _allMembers: members,
-    members: visibleMembers,
-    groups: _groups,
+    members: filtereredMembers,
+    groups: visibleGroups,
   }
 }
 

--- a/packages/sanity/src/core/form/store/types/members.ts
+++ b/packages/sanity/src/core/form/store/types/members.ts
@@ -56,6 +56,18 @@ export interface FieldMember<Node extends BaseFormNode = BaseFormNode> {
   collapsible: boolean | undefined
   open: boolean
 
+  /**
+   * @internal
+   * Whether this field is in the selected group
+   */
+  inSelectedGroup: boolean
+
+  /**
+   * @internal
+   * Names of the field groups this field is part of
+   */
+  groups: string[]
+
   /** @beta */
   field: Node
 }
@@ -64,6 +76,10 @@ export interface FieldMember<Node extends BaseFormNode = BaseFormNode> {
 export interface FieldSetMember {
   kind: 'fieldSet'
   key: string
+
+  // if it's hidden and in the currently selected group, it should still be excluded from its group
+  _inSelectedGroup: boolean
+  groups: string[]
 
   /** @beta */
   fieldSet: FieldsetState

--- a/packages/sanity/src/core/form/store/types/nodes.ts
+++ b/packages/sanity/src/core/form/store/types/nodes.ts
@@ -10,7 +10,6 @@ import {
 } from '@sanity/types'
 import {ObjectItem} from '../../types'
 import {FormNodePresence} from '../../../presence'
-import {InternalFormStateMember} from '../formState'
 import {ArrayOfObjectsMember, ArrayOfPrimitivesMember, ObjectMember} from './members'
 import {FormFieldGroup} from './fieldGroup'
 
@@ -32,6 +31,14 @@ export interface BaseFormNode<T = unknown, S extends SchemaType = SchemaType> {
   changed: boolean
 }
 
+/** @internal */
+export interface HiddenField {
+  kind: 'hidden'
+  key: string
+  name: string
+  index: number
+}
+
 /** @public */
 export interface ObjectFormNode<
   T = {[key in string]: unknown},
@@ -43,7 +50,7 @@ export interface ObjectFormNode<
   /** @beta */
   members: ObjectMember[]
   /** @internal */
-  _allMembers: InternalFormStateMember[]
+  _allMembers: (ObjectMember | HiddenField)[]
 }
 
 /** @public */
@@ -60,7 +67,7 @@ export interface ObjectArrayFormNode<
   members: ObjectMember[]
 
   /** @internal */
-  _allMembers: InternalFormStateMember[]
+  _allMembers: ObjectMember[]
   changesOpen?: boolean
 }
 

--- a/packages/sanity/src/core/form/store/utils/getExpandOperations.ts
+++ b/packages/sanity/src/core/form/store/utils/getExpandOperations.ts
@@ -76,15 +76,6 @@ function getObjectFieldsetAndFieldGroupOperations(
   // extract the field name for the current level we're looking at
   const [fieldName, ...tail] = path
 
-  /**
-   * When this function is called as a result of clicking the validation button whilst Group 2 is selected:
-   * - `path` reflects the path of the field with the validation error
-   * - `node.members` appears to reflect the state of available nodes whilst group 2 is selected
-   * - the field specified by `path` isn't visible in Group 2
-   * - as such, we're unable to find the fieldsetMember, and this resolves to undefined
-   * - since `fieldsetMember` is undefined, the `expandFieldSet` operation is never added
-   * - as such, the studio will select 'all fields' but wont expand the fieldset
-   */
   const fieldsetMember = node._allMembers.find(
     (member): member is FieldSetMember =>
       member.kind === 'fieldSet' &&

--- a/packages/sanity/src/core/form/store/utils/getExpandOperations.ts
+++ b/packages/sanity/src/core/form/store/utils/getExpandOperations.ts
@@ -76,8 +76,16 @@ function getObjectFieldsetAndFieldGroupOperations(
   // extract the field name for the current level we're looking at
   const [fieldName, ...tail] = path
 
-  // check if we can find the field inside a fieldset
-  const fieldsetMember = node.members.find(
+  /**
+   * When this function is called as a result of clicking the validation button whilst Group 2 is selected:
+   * - `path` reflects the path of the field with the validation error
+   * - `node.members` appears to reflect the state of available nodes whilst group 2 is selected
+   * - the field specified by `path` isn't visible in Group 2
+   * - as such, we're unable to find the fieldsetMember, and this resolves to undefined
+   * - since `fieldsetMember` is undefined, the `expandFieldSet` operation is never added
+   * - as such, the studio will select 'all fields' but wont expand the fieldset
+   */
+  const fieldsetMember = node._allMembers.find(
     (member): member is FieldSetMember =>
       member.kind === 'fieldSet' &&
       member.fieldSet.members.some(

--- a/packages/sanity/src/core/form/store/utils/getExpandOperations.ts
+++ b/packages/sanity/src/core/form/store/utils/getExpandOperations.ts
@@ -89,7 +89,7 @@ function getObjectFieldsetAndFieldGroupOperations(
   const members = fieldsetMember
     ? fieldsetMember.fieldSet.members
     : // Note: we need to use the internal `_allMembers` array here instead of members since hidden/collapsed members are omitted from members
-      node._allMembers.map((formStateMember) => formStateMember.member)
+      node._allMembers
 
   // look for the field inside the members array
   const fieldMember = members.find(


### PR DESCRIPTION
### Description

As described in #4432, when a field group only has fieldsets, the group becomes hidden.
 
### What to review
#### Before
When a field group has fieldsets only, it disappears. Reproducible here: https://test-studio-cbwgkvfea.sanity.build/test/content/input-debug;field-groups;fieldGroupsWithFieldsets;96fcdb05-ed51-41b7-a189-94eae745eae2%2Ctemplate%3DfieldGroupsWithFieldsets

#### After
The same case as above with the fix from this PR applied: https://test-studio-git-fix-fieldset-field-group-bug.sanity.build/test/content/input-debug;field-groups;fieldGroupsWithFieldsets;96fcdb05-ed51-41b7-a189-94eae745eae2

In particular, the following cases should hold true after these changes:
- Fields inside fieldsets should be filtered based on the currently active field group
- A field group should be selectable even if it consists entirely of fieldsets
- If a fieldset has no fields in the active group, it should be hidden
- If all fields (both in fields and fieldsets) in the active group are hidden, the field group should be hidden
- Validation and conditional fields should work as usual


### Notes for release

- Fixes an issue causing field groups with only fieldsets to be hidden
