### PR TITLE
Add boundary provider for nested content inside PT-input dialogs

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/DialogModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/DialogModal.tsx
@@ -1,5 +1,5 @@
-import React, {useId, useRef} from 'react'
-import {Box, Dialog} from '@sanity/ui'
+import React, {useId, useRef, useState} from 'react'
+import {BoundaryElementProvider, Box, Dialog} from '@sanity/ui'
 import {PresenceOverlay} from '../../../../../presence'
 import {ModalWidth} from './types'
 
@@ -12,22 +12,25 @@ interface DefaultEditDialogProps {
 
 export function DefaultEditDialog(props: DefaultEditDialogProps) {
   const {onClose, children, title, width = 1} = props
-  const dialogRef = useRef<HTMLDivElement | null>(null)
   const dialogId = useId()
+  // This seems to work with regular refs as well, but it might be safer to use state.
+  const [contentElement, setContentElement] = useState<HTMLDivElement | null>(null)
 
   return (
-    <Dialog
-      header={title}
-      id={dialogId}
-      onClickOutside={onClose}
-      onClose={onClose}
-      portal="default"
-      width={width}
-      ref={dialogRef}
-    >
-      <PresenceOverlay margins={[0, 0, 1, 0]}>
-        <Box padding={4}>{children}</Box>
-      </PresenceOverlay>
-    </Dialog>
+    <BoundaryElementProvider element={contentElement}>
+      <Dialog
+        header={title}
+        id={dialogId}
+        onClickOutside={onClose}
+        onClose={onClose}
+        portal="default"
+        width={width}
+        contentRef={setContentElement}
+      >
+        <PresenceOverlay margins={[0, 0, 1, 0]}>
+          <Box padding={4}>{children}</Box>
+        </PresenceOverlay>
+      </Dialog>
+    </BoundaryElementProvider>
   )
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
@@ -1,7 +1,16 @@
 /* eslint-disable react/no-unused-prop-types */
 
 import {CloseIcon} from '@sanity/icons'
-import {Box, Button, Flex, PopoverProps, Text, useClickOutside, useGlobalKeyDown} from '@sanity/ui'
+import {
+  BoundaryElementProvider,
+  Box,
+  Button,
+  Flex,
+  PopoverProps,
+  Text,
+  useClickOutside,
+  useGlobalKeyDown,
+} from '@sanity/ui'
 import React, {useCallback, useEffect, useState} from 'react'
 import {PresenceOverlay} from '../../../../../presence'
 import {PortableTextEditorElement} from '../../Compositor'
@@ -66,24 +75,31 @@ function Content(props: PopoverEditDialogProps) {
 
   useClickOutside(onClose, referenceElement ? [referenceElement] : [], boundaryElement)
 
-  return (
-    <ContentContainer width={width}>
-      <ModalWrapper direction="column" flex={1}>
-        <ContentHeaderBox padding={1}>
-          <Flex align="center">
-            <Box flex={1} padding={2}>
-              <Text weight="semibold">{title}</Text>
-            </Box>
+  // This seems to work with regular refs as well, but it might be safer to use state.
+  const [contentElement, setContentElement] = useState<HTMLDivElement | null>(null)
 
-            <Button icon={CloseIcon} mode="bleed" onClick={onClose} padding={2} />
-          </Flex>
-        </ContentHeaderBox>
-        <ContentScrollerBox flex={1}>
-          <PresenceOverlay margins={[0, 0, 1, 0]}>
-            <Box padding={3}>{props.children}</Box>
-          </PresenceOverlay>
-        </ContentScrollerBox>
-      </ModalWrapper>
-    </ContentContainer>
+  return (
+    <BoundaryElementProvider element={contentElement}>
+      <ContentContainer width={width}>
+        <ModalWrapper direction="column" flex={1}>
+          <ContentHeaderBox padding={1}>
+            <Flex align="center">
+              <Box flex={1} padding={2}>
+                <Text weight="semibold">{title}</Text>
+              </Box>
+
+              <Button icon={CloseIcon} mode="bleed" onClick={onClose} padding={2} />
+            </Flex>
+          </ContentHeaderBox>
+          <ContentScrollerBox flex={1}>
+            <PresenceOverlay margins={[0, 0, 1, 0]}>
+              <Box padding={3} ref={setContentElement}>
+                {props.children}
+              </Box>
+            </PresenceOverlay>
+          </ContentScrollerBox>
+        </ModalWrapper>
+      </ContentContainer>
+    </BoundaryElementProvider>
   )
 }


### PR DESCRIPTION
### Description

Wrap PT-input dialog content in a own boundary element provider, so that content inside can use the dialog content container as the boundary element (as opposed to the editor boundary itself).

This is needed to correctly calculate the height of it for virtual array lists which will use the closest boundary for this.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review


That long arrays will correctly show when loaded inside a PT-input modal (both popover and regular dialogs).


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Fix issue where arrays inputs inside dialogs inside the Portable Text input would not properly render.

<!--
A description of the change(s) that should be used in the release notes.
-->
