### PR TITLE
fix(core):  unset objects when no values in patch when empty value

### DIFF
--- a/packages/sanity/src/core/form/members/object/fields/ObjectField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/ObjectField.tsx
@@ -66,7 +66,6 @@ export const ObjectField = function ObjectField(props: {
   const handleChange = useCallback(
     (event: PatchEvent | PatchArg) => {
       const isRoot = member.field.path.length === 0
-      // if the patch is an unset patch that targets an item in the array (as opposed to unsetting a field somewhere deeper)
       const patches = PatchEvent.from(event).patches
       // if the patch is an unset patch that targets an item in the array (as opposed to unsetting a field somewhere deeper)
       const isRemovingLastItem = patches.some(

--- a/packages/sanity/src/core/form/members/object/fields/ObjectField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/ObjectField.tsx
@@ -67,7 +67,7 @@ export const ObjectField = function ObjectField(props: {
     (event: PatchEvent | PatchArg) => {
       const isRoot = member.field.path.length === 0
       const patches = PatchEvent.from(event).patches
-      // if the patch is an unset patch that targets an item in the array (as opposed to unsetting a field somewhere deeper)
+      // if the patch is an unset patch that targets a field in the object (as opposed to unsetting a field somewhere deeper)
       const isRemovingLastItem = patches.some(
         (patch) => patch.type === 'unset' && patch.path.length === 1
       )

--- a/packages/sanity/src/core/form/members/object/fields/ObjectField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/ObjectField.tsx
@@ -81,9 +81,9 @@ export const ObjectField = function ObjectField(props: {
 
           // only run this if the result is an empty object with only _type
           if (result && result._type && Object.keys(result).length === 1) {
-            // The value has a _type key, but the type name from schema is 'object',
-            // but _type: 'object' is implicit so we should fix it by removing it
-            // this happens, for example, when a type is made of objects
+            // this happens, for example, when a type is made of objects and all values from
+            // that object were removed except the _type key
+            // by removing the _type key completely it allows for the field to be completely removed
             onChange(PatchEvent.from(unset(['_type'])).prefixAll(member.name))
           }
 


### PR DESCRIPTION
### Description

A bug was reported (like #4285) where objects weren't being unset when the values were removed. Now the object input will remove itself completely from a patch if it identifies that it should

### What to review

- [On simple object (Obj Name), removing the value unsets the object input](https://test-studio-git-bug-sc-32671.sanity.build/test/content/input-debug;empty;85909e44-4e17-4dd1-adf3-117681e59a7e)
- [On object with multiple values (Object with columns), removing one value unsets only the removed value](https://test-studio-git-bug-sc-32671.sanity.build/test/content/input-standard;objectsTest;91476f47-f035-47d7-8577-eba51f33964f%2Cpath%3DobjectWithColumns.string1)
- [On object with multiple values (Object with columns), removing all values unsets the whole field](https://test-studio-git-bug-sc-32671.sanity.build/test/content/input-standard;objectsTest;91476f47-f035-47d7-8577-eba51f33964f%2Cpath%3DobjectWithColumns.string1)
- [On custom object field (MyObject), removing one value unsets only the removed value](https://test-studio-git-bug-sc-32671.sanity.build/test/content/input-standard;objectsTest;91476f47-f035-47d7-8577-eba51f33964f%2Cpath%3DmyObject.first)
- [On custom object field (MyObject), removing all values unsets the whole field](https://test-studio-git-bug-sc-32671.sanity.build/test/content/input-standard;objectsTest;91476f47-f035-47d7-8577-eba51f33964f%2Cpath%3DmyObject.first)
- [On deeply nested object (recursive), removing separate values should have no impact on the rest](https://test-studio-git-bug-sc-32671.sanity.build/test/content/input-standard;objectsTest;91476f47-f035-47d7-8577-eba51f33964f%2Cpath%3Drecursive.objectWithColumns.string1)
- [On deeply nested object (recursive), removing all values should have no impact on the rest](https://test-studio-git-bug-sc-32671.sanity.build/test/content/input-standard;objectsTest;91476f47-f035-47d7-8577-eba51f33964f%2Cpath%3Drecursive.objectWithColumns.string1)

### Notes for release

Fixes an issue where an object field’s value is not set to undefined when the last item is removed