### PR TITLE
fix(core): editing reference input in PTE does not show value

### DIFF
--- a/dev/test-studio/schema/debug/ptReference.ts
+++ b/dev/test-studio/schema/debug/ptReference.ts
@@ -1,0 +1,24 @@
+import {defineType} from 'sanity'
+
+export default defineType({
+  name: 'ptReference',
+  title: 'Portable Text Reference',
+  type: 'document',
+  fields: [
+    {
+      name: 'body',
+      title: 'Body',
+      type: 'array',
+      of: [
+        {
+          type: 'block',
+          marks: {
+            annotations: [{type: 'reference', to: {type: 'author'}}],
+          },
+          of: [{type: 'reference', to: {type: 'author'}}],
+        },
+        {type: 'reference', to: {type: 'author'}},
+      ],
+    },
+  ],
+})

--- a/dev/test-studio/schema/index.ts
+++ b/dev/test-studio/schema/index.ts
@@ -107,6 +107,7 @@ import crossDatasetReference, {crossDatasetSubtype} from './standard/crossDatase
 import {circularCrossDatasetReferenceTest} from './debug/circularCrossDatasetReference'
 import {allNativeInputComponents} from './debug/allNativeInputComponents'
 import fieldGroupsWithFieldsets from './debug/fieldGroupsWithFieldsets'
+import ptReference from './debug/ptReference'
 
 // @todo temporary, until code input is v3 compatible
 const codeInputType = {
@@ -203,6 +204,7 @@ export const schemaTypes = [
   previewSelectBugRepro,
   ptAllTheBellsAndWhistlesType,
   ptCustomMarkersTestType,
+  ptReference,
   radio,
   readOnly,
   recursive,

--- a/dev/test-studio/structure/constants.ts
+++ b/dev/test-studio/structure/constants.ts
@@ -72,6 +72,7 @@ export const DEBUG_INPUT_TYPES = [
   'validationTest',
   'allNativeInputComponents',
   'scrollBug',
+  'ptReference',
 ]
 
 export const CI_INPUT_TYPES = ['conditionalFieldset', 'validationCI']

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
@@ -324,6 +324,7 @@ export function ReferenceInput(props: ReferenceInputProps) {
             renderValue={renderValue}
             openButton={{onClick: handleAutocompleteOpenButtonClick}}
             portalRef={autoCompletePortalRef}
+            value={value?._ref}
           />
 
           {createOptions.length > 0 && (

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
@@ -192,8 +192,7 @@ export function ReferenceItem<Item extends ReferenceItemValue = ReferenceItemVal
     } else {
       onPathFocus(['_ref'])
     }
-    onChange(unset(['_ref']))
-  }, [hasRef, isEditing, onChange, onPathFocus])
+  }, [hasRef, isEditing, onPathFocus])
 
   const menu = useMemo(
     () =>

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
@@ -186,6 +186,15 @@ export function ReferenceItem<Item extends ReferenceItemValue = ReferenceItemVal
     [refType?.name, value?._ref]
   )
 
+  const handleReplace = useCallback(() => {
+    if (hasRef && isEditing) {
+      onPathFocus([])
+    } else {
+      onPathFocus(['_ref'])
+    }
+    onChange(unset(['_ref']))
+  }, [hasRef, isEditing, onChange, onPathFocus])
+
   const menu = useMemo(
     () =>
       readOnly ? null : (
@@ -201,9 +210,7 @@ export function ReferenceItem<Item extends ReferenceItemValue = ReferenceItemVal
                     <MenuItem
                       text={hasRef && isEditing ? 'Cancel replace' : 'Replace'}
                       icon={hasRef && isEditing ? CloseIcon : ReplaceIcon}
-                      onClick={
-                        hasRef && isEditing ? () => onPathFocus([]) : () => onPathFocus(['_ref'])
-                      }
+                      onClick={handleReplace}
                     />
                     <MenuItem text="Duplicate" icon={DuplicateIcon} onClick={handleDuplicate} />
                     <InsertMenu onInsert={handleInsert} types={insertableTypes} />
@@ -231,11 +238,11 @@ export function ReferenceItem<Item extends ReferenceItemValue = ReferenceItemVal
       onRemove,
       hasRef,
       isEditing,
+      handleReplace,
       handleDuplicate,
       handleInsert,
       insertableTypes,
       OpenLink,
-      onPathFocus,
     ]
   )
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This reverts the change in #4105 where it fixes an issue where clicking Replace in reference inputs would still retain the search query. This is because the change broke reference inputs in PTE. 

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->
Following scenario work
1. Editing reference field in PTE shows correct value
2. ~In an array list clicking on replace removes the current value from the input~ We will tackle this in future iteration as fixing the above issue is more critical

Does the code change make sense?

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

- Fixes an issue where editing reference inputs in Portable Text Editor does not show current value