### PR TITLE
Fix re-rendering issues

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
@@ -1,7 +1,7 @@
 import {PortableTextEditor, usePortableTextEditor} from '@sanity/portable-text-editor'
 import {ObjectSchemaType, Path, PortableTextObject} from '@sanity/types'
 import {Tooltip} from '@sanity/ui'
-import React, {ComponentType, useCallback, useMemo} from 'react'
+import React, {ComponentType, useCallback, useMemo, useRef} from 'react'
 import {pathToString} from '../../../../field'
 import {BlockAnnotationProps, RenderCustomMarkers} from '../../../types'
 import {DefaultMarkers} from '../_legacyDefaultParts/Markers'
@@ -99,13 +99,14 @@ export function Annotation(props: AnnotationProps) {
   const presence = memberItem?.node.presence?.length ? memberItem.node.presence : EMPTY_ARRAY
 
   const isOpen = Boolean(memberItem?.member.open)
-  const input = memberItem?.input
+  const inputRef = useRef(memberItem?.input)
+  inputRef.current = memberItem?.input // Update at every render as other Annotation props updates
 
   const componentProps = useMemo(
     (): BlockAnnotationProps => ({
       __unstable_boundaryElement: boundaryElement || undefined,
       __unstable_referenceElement: memberItem?.elementRef?.current || undefined,
-      children: input,
+      children: inputRef.current,
       focused,
       markers,
       onClose,
@@ -128,7 +129,7 @@ export function Annotation(props: AnnotationProps) {
       boundaryElement,
       editor.schemaTypes.block,
       focused,
-      input,
+      inputRef,
       isOpen,
       markers,
       markersToolTip,

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
@@ -96,7 +96,7 @@ export function Annotation(props: AnnotationProps) {
     [Markers, markers, renderCustomMarkers, text, validation]
   )
 
-  const presence = memberItem?.node.presence?.length ? memberItem.node.presence : EMPTY_ARRAY
+  const presence = memberItem?.node.presence || EMPTY_ARRAY
 
   const isOpen = Boolean(memberItem?.member.open)
   const inputRef = useRef(memberItem?.input)

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
@@ -96,7 +96,11 @@ export function Annotation(props: AnnotationProps) {
     [Markers, markers, renderCustomMarkers, text, validation]
   )
 
-  const presence = memberItem?.node.presence || EMPTY_ARRAY
+  const presence =
+    memberItem?.node.presence && memberItem?.node.presence.length > 0
+      ? memberItem.node.presence
+      : EMPTY_ARRAY
+
   const isOpen = Boolean(memberItem?.member.open)
   const input = memberItem?.input
 

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
@@ -96,10 +96,7 @@ export function Annotation(props: AnnotationProps) {
     [Markers, markers, renderCustomMarkers, text, validation]
   )
 
-  const presence =
-    memberItem?.node.presence && memberItem?.node.presence.length > 0
-      ? memberItem.node.presence
-      : EMPTY_ARRAY
+  const presence = memberItem?.node.presence?.length ? memberItem.node.presence : EMPTY_ARRAY
 
   const isOpen = Boolean(memberItem?.member.open)
   const input = memberItem?.input

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
@@ -123,7 +123,10 @@ export function BlockObject(props: BlockObjectProps) {
   const parentSchemaType = editor.schemaTypes.portableText
   const hasMarkers = Boolean(markers.length > 0)
 
-  const presence = memberItem?.node.presence || EMPTY_ARRAY
+  const presence =
+    memberItem?.node.presence && memberItem?.node.presence.length > 0
+      ? memberItem.node.presence
+      : EMPTY_ARRAY
 
   // Tooltip indicating validation errors, warnings, info and markers
   const tooltipEnabled = hasError || hasWarning || hasInfo || hasMarkers

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
@@ -123,10 +123,7 @@ export function BlockObject(props: BlockObjectProps) {
   const parentSchemaType = editor.schemaTypes.portableText
   const hasMarkers = Boolean(markers.length > 0)
 
-  const presence =
-    memberItem?.node.presence && memberItem?.node.presence.length > 0
-      ? memberItem.node.presence
-      : EMPTY_ARRAY
+  const presence = memberItem?.node.presence?.length ? memberItem.node.presence : EMPTY_ARRAY
 
   // Tooltip indicating validation errors, warnings, info and markers
   const tooltipEnabled = hasError || hasWarning || hasInfo || hasMarkers

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
@@ -130,7 +130,7 @@ export function BlockObject(props: BlockObjectProps) {
   const parentSchemaType = editor.schemaTypes.portableText
   const hasMarkers = Boolean(markers.length > 0)
 
-  const presence = memberItem?.node.presence?.length ? memberItem.node.presence : EMPTY_ARRAY
+  const presence = memberItem?.node.presence || EMPTY_ARRAY
 
   // Tooltip indicating validation errors, warnings, info and markers
   const tooltipEnabled = hasError || hasWarning || hasInfo || hasMarkers

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
@@ -6,7 +6,14 @@ import {
 } from '@sanity/portable-text-editor'
 import {ObjectSchemaType, Path, PortableTextBlock} from '@sanity/types'
 import {Tooltip, Flex, ResponsivePaddingProps, Box} from '@sanity/ui'
-import React, {ComponentType, PropsWithChildren, useCallback, useMemo, useState} from 'react'
+import React, {
+  ComponentType,
+  PropsWithChildren,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import {PatchArg} from '../../../patch'
 import {BlockProps, RenderCustomMarkers, RenderPreviewCallback} from '../../../types'
 import {RenderBlockActionsCallback} from '../types'
@@ -143,14 +150,15 @@ export function BlockObject(props: BlockObjectProps) {
   )
 
   const isOpen = Boolean(memberItem?.member.open)
-  const input = memberItem?.input
+  const inputRef = useRef(memberItem?.input)
+  inputRef.current = memberItem?.input // Update at every render as other BlockObjectProps updates
 
   const CustomComponent = schemaType.components?.block as ComponentType<BlockProps> | undefined
   const componentProps: BlockProps = useMemo(
     () => ({
       __unstable_boundaryElement: boundaryElement || undefined,
       __unstable_referenceElement: memberItem?.elementRef?.current || undefined,
-      children: input,
+      children: inputRef.current,
       focused,
       markers,
       onClose,
@@ -172,7 +180,6 @@ export function BlockObject(props: BlockObjectProps) {
     [
       boundaryElement,
       focused,
-      input,
       isOpen,
       markers,
       memberItem?.elementRef,

--- a/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
@@ -76,7 +76,10 @@ export const InlineObject = (props: InlineObjectProps) => {
 
   const isOpen = Boolean(memberItem?.member.open)
   const input = memberItem?.input
-  const presence = memberItem?.node.presence || EMPTY_ARRAY
+  const presence =
+    memberItem?.node.presence && memberItem?.node.presence.length > 0
+      ? memberItem.node.presence
+      : EMPTY_ARRAY
 
   const componentProps: BlockProps | undefined = useMemo(
     () => ({

--- a/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
@@ -76,11 +76,7 @@ export const InlineObject = (props: InlineObjectProps) => {
 
   const isOpen = Boolean(memberItem?.member.open)
   const input = memberItem?.input
-  const presence =
-    memberItem?.node.presence && memberItem?.node.presence.length > 0
-      ? memberItem.node.presence
-      : EMPTY_ARRAY
-
+  const presence = memberItem?.node.presence?.length ? memberItem.node.presence : EMPTY_ARRAY
   const componentProps: BlockProps | undefined = useMemo(
     () => ({
       __unstable_boundaryElement: boundaryElement || undefined,

--- a/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
@@ -4,7 +4,7 @@ import {
   usePortableTextEditor,
 } from '@sanity/portable-text-editor'
 import {ObjectSchemaType, Path, PortableTextBlock, PortableTextChild} from '@sanity/types'
-import React, {useCallback, useEffect, useMemo, useState} from 'react'
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {Tooltip} from '@sanity/ui'
 import {BlockProps, RenderCustomMarkers, RenderPreviewCallback} from '../../../types'
 import {useFormBuilder} from '../../../useFormBuilder'
@@ -75,13 +75,17 @@ export const InlineObject = (props: InlineObjectProps) => {
   }, [memberItem, onItemOpen])
 
   const isOpen = Boolean(memberItem?.member.open)
-  const input = memberItem?.input
-  const presence = memberItem?.node.presence?.length ? memberItem.node.presence : EMPTY_ARRAY
+
+  const inputRef = useRef(memberItem?.input)
+  inputRef.current = memberItem?.input // Update at every render as other Annotation props updates
+
+  const presence = memberItem?.node.presence || EMPTY_ARRAY
+
   const componentProps: BlockProps | undefined = useMemo(
     () => ({
       __unstable_boundaryElement: boundaryElement || undefined,
       __unstable_referenceElement: memberItem?.elementRef?.current || undefined,
-      children: input,
+      children: inputRef.current,
       focused,
       onClose: onItemClose,
       onOpen,
@@ -104,7 +108,7 @@ export const InlineObject = (props: InlineObjectProps) => {
     [
       boundaryElement,
       focused,
-      input,
+      inputRef,
       isOpen,
       markers,
       memberItem,

--- a/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.tsx
@@ -147,7 +147,7 @@ export function TextBlock(props: TextBlockProps) {
 
   const isOpen = Boolean(memberItem?.member.open)
   const parentSchemaType = editor.schemaTypes.portableText
-  const presence = memberItem?.node.presence?.length ? memberItem.node.presence : EMPTY_ARRAY
+  const presence = memberItem?.node.presence || EMPTY_ARRAY
 
   const CustomComponent = schemaType.components?.block as ComponentType<BlockProps> | undefined
   const componentProps: BlockProps = useMemo(

--- a/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.tsx
@@ -147,10 +147,7 @@ export function TextBlock(props: TextBlockProps) {
 
   const isOpen = Boolean(memberItem?.member.open)
   const parentSchemaType = editor.schemaTypes.portableText
-  const presence =
-    memberItem?.node.presence && memberItem?.node.presence.length > 0
-      ? memberItem.node.presence
-      : EMPTY_ARRAY
+  const presence = memberItem?.node.presence?.length ? memberItem.node.presence : EMPTY_ARRAY
 
   const CustomComponent = schemaType.components?.block as ComponentType<BlockProps> | undefined
   const componentProps: BlockProps = useMemo(

--- a/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.tsx
@@ -147,7 +147,10 @@ export function TextBlock(props: TextBlockProps) {
 
   const isOpen = Boolean(memberItem?.member.open)
   const parentSchemaType = editor.schemaTypes.portableText
-  const presence = memberItem?.node.presence || EMPTY_ARRAY
+  const presence =
+    memberItem?.node.presence && memberItem?.node.presence.length > 0
+      ? memberItem.node.presence
+      : EMPTY_ARRAY
 
   const CustomComponent = schemaType.components?.block as ComponentType<BlockProps> | undefined
   const componentProps: BlockProps = useMemo(

--- a/packages/sanity/src/core/form/members/object/fields/ArrayOfObjectsField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/ArrayOfObjectsField.tsx
@@ -89,6 +89,9 @@ export function ArrayOfObjectsField(props: {
     [member.field.path, onPathBlur]
   )
 
+  const valueRef = useRef(member.field.value)
+  valueRef.current = member.field.value
+
   const handleChange = useCallback(
     (event: PatchEvent | PatchArg) => {
       const patches = PatchEvent.from(event).patches
@@ -99,7 +102,7 @@ export function ArrayOfObjectsField(props: {
 
       if (isRemovingLastItem) {
         // apply the patch to the current value
-        const result = applyAll(member.field.value || [], patches)
+        const result = applyAll(valueRef.current || [], patches)
 
         // if the result is an empty array
         if (Array.isArray(result) && !result.length) {
@@ -111,7 +114,7 @@ export function ArrayOfObjectsField(props: {
       // otherwise apply the patch
       onChange(PatchEvent.from(event).prepend(setIfMissing([])).prefixAll(member.name))
     },
-    [onChange, member.name, member.field.value]
+    [onChange, member.name, valueRef]
   )
   const resolveInitialValue = useResolveInitialValueForType()
 

--- a/packages/sanity/src/core/form/members/object/fields/ArrayOfObjectsField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/ArrayOfObjectsField.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useMemo, useRef} from 'react'
+import React, {useCallback, useEffect, useMemo, useRef} from 'react'
 import {Path, SchemaType} from '@sanity/types'
 import {map, tap} from 'rxjs/operators'
 import {Subscription} from 'rxjs'
@@ -90,7 +90,9 @@ export function ArrayOfObjectsField(props: {
   )
 
   const valueRef = useRef(member.field.value)
-  valueRef.current = member.field.value
+  useEffect(() => {
+    valueRef.current = member.field.value
+  }, [member.field.value])
 
   const handleChange = useCallback(
     (event: PatchEvent | PatchArg) => {
@@ -102,10 +104,10 @@ export function ArrayOfObjectsField(props: {
 
       if (isRemovingLastItem) {
         // apply the patch to the current value
-        const result = applyAll(valueRef.current || [], patches)
+        valueRef.current = applyAll(valueRef.current || [], patches)
 
         // if the result is an empty array
-        if (Array.isArray(result) && !result.length) {
+        if (Array.isArray(valueRef.current) && !valueRef.current.length) {
           // then unset the array field
           onChange(PatchEvent.from(unset([member.name])))
           return

--- a/packages/sanity/src/core/form/store/formState.ts
+++ b/packages/sanity/src/core/form/store/formState.ts
@@ -20,7 +20,7 @@ import {castArray, isEqual as _isEqual, pick} from 'lodash'
 import {isEqual, pathFor, startsWith, toString, trimChildPath} from '@sanity/util/paths'
 import {resolveTypeName} from '@sanity/util/content'
 
-import {isNonNullable, isRecord} from '../../util'
+import {EMPTY_ARRAY, isNonNullable, isRecord} from '../../util'
 import {getFieldLevel} from '../studio/inputResolver/helpers'
 import {FIXME} from '../../FIXME'
 import {FormNodePresence} from '../../presence'
@@ -661,7 +661,8 @@ function prepareObjectInputState<T>(
 
   const hasFieldGroups = schemaTypeGroupConfig.length > 0
 
-  const presence = props.presence.filter((item) => isEqual(item.path, props.path))
+  const filteredPresence = props.presence.filter((item) => isEqual(item.path, props.path))
+  const presence = filteredPresence.length ? filteredPresence : EMPTY_ARRAY
 
   const validation = props.validation
     .filter((item) => isEqual(item.path, props.path))
@@ -775,7 +776,8 @@ function prepareArrayOfPrimitivesInputState<T extends (boolean | string | number
   // Todo: improve error handling at the parent level so that the value here is either undefined or an array
   const items = Array.isArray(props.value) ? props.value : []
 
-  const presence = props.presence.filter((item) => isEqual(item.path, props.path))
+  const filteredPresence = props.presence.filter((item) => isEqual(item.path, props.path))
+  const presence = filteredPresence.length ? filteredPresence : EMPTY_ARRAY
   const validation = props.validation
     .filter((item) => isEqual(item.path, props.path))
     .map((v) => ({level: v.level, message: v.item.message, path: v.path}))
@@ -824,7 +826,8 @@ function prepareArrayOfObjectsInputState<T extends {_key: string}[]>(
   // Todo: improve error handling at the parent level so that the value here is either undefined or an array
   const items = Array.isArray(props.value) ? props.value : []
 
-  const presence = props.presence.filter((item) => isEqual(item.path, props.path))
+  const filteredPresence = props.presence.filter((item) => isEqual(item.path, props.path))
+  const presence = filteredPresence.length ? filteredPresence : EMPTY_ARRAY
   const validation = props.validation
     .filter((item) => isEqual(item.path, props.path))
     .map((v) => ({level: v.level, message: v.item.message, path: v.path}))
@@ -1010,7 +1013,8 @@ function prepareArrayOfPrimitivesMember(props: {
 function preparePrimitiveInputState<SchemaType extends PrimitiveSchemaType>(
   props: RawState<SchemaType, unknown>
 ): PrimitiveFormNode {
-  const presence = props.presence.filter((item) => isEqual(item.path, props.path))
+  const filteredPresence = props.presence.filter((item) => isEqual(item.path, props.path))
+  const presence = filteredPresence.length ? filteredPresence : EMPTY_ARRAY
 
   const validation = props.validation
     .filter((item) => isEqual(item.path, props.path))


### PR DESCRIPTION
### Description

Both `onChange` and `onItemRemove` sent in to an `arrayOfObjects` input will be a new object every time an array item changes because it's callback is dependent on the field value.

Use a `ref` for this dependency instead. This also fixes the instability of `onItemRemove` which again is dependent on the `onChange` callback.

I have also fixed a snag with presence causing re-rendering for the PT-input as they are new empty arrays each time presence is returned back. Use the same empty array object in this case.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

* [Set this constant](https://github.com/sanity-io/sanity/blob/fix/re-rendering-issue/packages/sanity/src/core/form/inputs/PortableText/debugRender.ts#L1) to true then write some Portable Text. The only colour that should change is the current block you're typing in, or where a new presence is made.


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Improved performance for arrays and portable text inputs.

<!--
A description of the change(s) that should be used in the release notes.
-->
