### PR TITLE
fix(core): fix image and file upload

### DIFF
--- a/dev/test-studio/schema/standard/arrays.tsx
+++ b/dev/test-studio/schema/standard/arrays.tsx
@@ -447,6 +447,17 @@ export default defineType({
       ],
     },
     {
+      name: 'fileArray',
+      title: 'File array (with defaults)',
+      type: 'array',
+      of: [
+        {
+          title: 'File',
+          type: 'file',
+        },
+      ],
+    },
+    {
       name: 'polymorphicGridArray',
       title: 'Polymorphic grid array',
       description: 'An array of multiple types. options: {layout: "grid"}',

--- a/dev/test-studio/schema/standard/objects.tsx
+++ b/dev/test-studio/schema/standard/objects.tsx
@@ -21,6 +21,16 @@ export const myObject = defineType({
       type: 'string',
       title: 'Second',
     },
+    {
+      name: 'third',
+      type: 'image',
+      title: 'Image',
+    },
+    {
+      name: 'fourth',
+      type: 'file',
+      title: 'File',
+    },
   ],
 })
 
@@ -78,6 +88,16 @@ export default defineType({
           type: 'number',
           title: 'Number 2',
           name: 'number2',
+        },
+        {
+          type: 'image',
+          title: 'Image 1',
+          name: 'image1',
+        },
+        {
+          name: 'file',
+          type: 'file',
+          title: 'File',
         },
       ],
     },


### PR DESCRIPTION
### Description

Regression from #4495
The current issue was that the image and file inputs were not being able to upload (the data was uploaded but then immediately reset)

This was caused because the `handleChange` method is being called more than once in both of the components mentioned (image and file) which makes it that at the point where it gets to the check in `ObjectFields`, the `member.field.value` wasn't up to date.

**I have tested and made sure that there are no issues when using image and file inputs within arrays**

### What to review

Object input (with string, files and images):
- [On simple object (Obj Name), removing the value unsets the object input](https://test-studio-hp8fumvew.sanity.build/test/content/input-debug;empty;85909e44-4e17-4dd1-adf3-117681e59a7e)
- [On object with multiple values (Object with columns), removing all values unsets the whole field](https://test-studio-hp8fumvew.sanity.build/test/content/input-standard;objectsTest;91476f47-f035-47d7-8577-eba51f33964f%2Cpath%3DobjectWithColumns.string1)
- [On custom object field (MyObject), removing one value unsets only the removed value](https://test-studio-hp8fumvew.sanity.build/test/content/input-standard;objectsTest;91476f47-f035-47d7-8577-eba51f33964f%2Cpath%3DmyObject.first)
- [On custom object field (MyObject), removing all values unsets the whole field](https://test-studio-hp8fumvew.sanity.build/test/content/input-standard;objectsTest;91476f47-f035-47d7-8577-eba51f33964f%2Cpath%3DmyObject.first)
- [On deeply nested object (recursive), removing separate values should have no impact on the rest](https://test-studio-hp8fumvew.sanity.build/test/content/input-standard;objectsTest;91476f47-f035-47d7-8577-eba51f33964f%2Cpath%3Drecursive.objectWithColumns.string1)
- [On deeply nested object (recursive), removing all values should have no impact on the rest](https://test-studio-hp8fumvew.sanity.build/test/content/input-standard;objectsTest;91476f47-f035-47d7-8577-eba51f33964f%2Cpath%3Drecursive.objectWithColumns.string1)

Arrays input (image and file)
- [On Image array (with defaults), upload an image, make sure it uploads. Check inspector that it's there. Remove the item. You should not be able to see the field in the inspector](https://test-studio-hp8fumvew.sanity.build/test/intent/edit/id=18db9a51-b3fe-4843-94a6-c5a2ba6ac039;path=imageArray%5B_key%3D%3D%225d3d6000da49%22%5D/)
- [On File array (with defaults), upload a file, make sure it uploads. Check inspector that it's there. Remove the item. You should not be able to see the field in the inspector](https://test-studio-hp8fumvew.sanity.build/test/intent/edit/id=18db9a51-b3fe-4843-94a6-c5a2ba6ac039;path=fileArray%5B_key%3D%3D%22ad40ffafb135%22%5D/)

### Notes for release

Fixes issue where image and file inputs were unable to upload data
