### PR TITLE
chore(perf): support passing a comma-separated list of test-ids when running perf suite

### DIFF
--- a/perf/cli.ts
+++ b/perf/cli.ts
@@ -18,6 +18,7 @@ async function main(args: {
   tagsOnly?: boolean
   pattern?: string
   local?: boolean
+  testIds?: string
   count?: string
   label?: string
 }) {
@@ -95,6 +96,7 @@ async function main(args: {
   return run({
     testFiles,
     deployments,
+    testIds: args.testIds ? args.testIds.split(',') : undefined,
     perfStudioClient,
     studioMetricsClient,
     registerHelpersFile: require.resolve(`${__dirname}/tests/helpers/register.ts`),
@@ -129,6 +131,10 @@ const {values: args} = parseArgs({
     pattern: {
       type: 'string',
       short: 'p',
+    },
+    testIds: {
+      type: 'string',
+      short: 'i',
     },
     count: {
       type: 'string',

--- a/perf/runner/runner.ts
+++ b/perf/runner/runner.ts
@@ -97,6 +97,7 @@ export async function run({
   perfStudioClient,
   deployments,
   testFiles,
+  testIds,
   registerHelpersFile,
   headless,
   iterations = 1,
@@ -106,16 +107,19 @@ export async function run({
   perfStudioClient: SanityClient
   deployments: Deployment[]
   testFiles: string[]
+  testIds?: string[]
   registerHelpersFile: string
   headless?: boolean
   iterations?: number
   token: string
 }) {
-  const testModules = await Promise.all(
-    testFiles.map((testModule) =>
-      import(testModule).then((module) => module.default as PerformanceTestProps)
+  const testModules = (
+    await Promise.all(
+      testFiles.map((testModule) =>
+        import(testModule).then((module) => module.default as PerformanceTestProps)
+      )
     )
-  )
+  ).filter((test) => !testIds || testIds.includes(test.id))
   // Start by syncing test documents
   await Promise.all(
     testModules.map((test) =>


### PR DESCRIPTION


### Description

Adds support for specifying a comma separated list of test-ids to run when running the performance tests

Example:
```
yarn perf:test --tagsOnly --count=10 --testIds=deeply-nested-objects-test,large-document-editing
```

### What to review
Does it make sense?

### Notes for release

n/a internal tooling