### PR TITLE
Improve PT-input focus tracking

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -283,22 +283,28 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
     [change$, onPaste, portableTextEditor, schemaTypes, slateEditor]
   )
 
-  const handleOnFocus = useCallback(() => {
-    const selection = PortableTextEditor.getSelection(portableTextEditor)
-    change$.next({type: 'focus'})
-    const newSelection = PortableTextEditor.getSelection(portableTextEditor)
-    // If the selection is the same, emit it explicitly here as there is no actual onChange event triggered.
-    if (selection === newSelection) {
-      change$.next({
-        type: 'selection',
-        selection,
-      })
-    }
-  }, [change$, portableTextEditor])
+  const handleOnFocus: React.FocusEventHandler<HTMLDivElement> = useCallback(
+    (event) => {
+      const selection = PortableTextEditor.getSelection(portableTextEditor)
+      change$.next({type: 'focus', event})
+      const newSelection = PortableTextEditor.getSelection(portableTextEditor)
+      // If the selection is the same, emit it explicitly here as there is no actual onChange event triggered.
+      if (selection === newSelection) {
+        change$.next({
+          type: 'selection',
+          selection,
+        })
+      }
+    },
+    [change$, portableTextEditor]
+  )
 
-  const handleOnBlur = useCallback(() => {
-    change$.next({type: 'blur'})
-  }, [change$])
+  const handleOnBlur: React.FocusEventHandler<HTMLDivElement> = useCallback(
+    (event) => {
+      change$.next({type: 'blur', event})
+    },
+    [change$]
+  )
 
   const handleOnBeforeInput = useCallback(
     (event: Event) => {

--- a/packages/@sanity/portable-text-editor/src/editor/hooks/useSyncValue.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/hooks/useSyncValue.ts
@@ -250,7 +250,7 @@ function _updateBlock(
     currentBlock.children.forEach((currentBlockChild, currentBlockChildIndex) => {
       const oldBlockChild = oldBlock.children[currentBlockChildIndex]
       const isChildChanged = !isEqual(currentBlockChild, oldBlockChild)
-      const isTextChanged = !isEqual(currentBlockChild.text, oldBlockChild.text)
+      const isTextChanged = !isEqual(currentBlockChild.text, oldBlockChild?.text)
       const path = [currentBlockIndex, currentBlockChildIndex]
       if (isChildChanged) {
         // Update if this is the same child

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithEditableAPI.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithEditableAPI.ts
@@ -392,17 +392,20 @@ export function createWithEditableAPI(
               editor.onChange()
               return
             }
+            if (options?.mode === 'blocks') {
+              debug(`Deleting blocks touched by selection`)
+            } else {
+              debug(`Deleting children touched by selection`)
+            }
             const nodes = Editor.nodes(editor, {
               at: range,
               match: (node) => {
                 if (options?.mode === 'blocks') {
-                  debug(`Deleting blocks touched by selection`)
                   return (
                     editor.isTextBlock(node) ||
                     (!editor.isTextBlock(node) && SlateElement.isElement(node))
                   )
                 }
-                debug(`Deleting children touched by selection`)
                 return (
                   node._type === types.span.name || // Text children
                   (!editor.isTextBlock(node) && SlateElement.isElement(node)) // inline blocks

--- a/packages/@sanity/portable-text-editor/src/types/editor.ts
+++ b/packages/@sanity/portable-text-editor/src/types/editor.ts
@@ -17,6 +17,7 @@ import {
 import {Subject, Observable} from 'rxjs'
 import {Descendant, Node as SlateNode, Operation as SlateOperation} from 'slate'
 import {ReactEditor} from '@sanity/slate-react'
+import {FocusEvent} from 'react'
 import type {Patch} from '../types/patch'
 import {PortableTextEditor} from '../editor/PortableTextEditor'
 
@@ -217,6 +218,7 @@ export type SelectionChange = {
 /** @beta */
 export type FocusChange = {
   type: 'focus'
+  event: FocusEvent<HTMLDivElement, Element>
 }
 
 /** @beta */
@@ -228,6 +230,7 @@ export type UnsetChange = {
 /** @beta */
 export type BlurChange = {
   type: 'blur'
+  event: FocusEvent<HTMLDivElement, Element>
 }
 
 /** @beta */

--- a/packages/sanity/src/core/form/inputs/PortableText/BlockActions.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/BlockActions.tsx
@@ -1,5 +1,5 @@
 import {PortableTextEditor, usePortableTextEditor} from '@sanity/portable-text-editor'
-import React, {useCallback, useMemo} from 'react'
+import React, {useMemo} from 'react'
 import styled from 'styled-components'
 import {PortableTextBlock} from '@sanity/types'
 import {PatchArg} from '../../patch'
@@ -36,18 +36,9 @@ export function BlockActions(props: BlockActionsProps) {
     return undefined
   }, [renderBlockActions, block, editor, onChange, decoratorValues])
 
-  // Take focus away from the editor so dealing with block actions doesn't interfere with the editor focus
-  const handleClick = useCallback(() => {
-    PortableTextEditor.blur(editor)
-  }, [editor])
-
   // Don't render anything if the renderBlockActions function returns null.
   // Note that if renderBlockComponent is a React class, this will never be the case.
   if (!blockActions) return null
 
-  return (
-    <Root contentEditable={false} onKeyDown={handleClick} onMouseDown={handleClick}>
-      {blockActions}
-    </Root>
-  )
+  return <Root contentEditable={false}>{blockActions}</Root>
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -252,7 +252,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     (annotationProps: BlockAnnotationRenderProps) => {
       const {
         children,
-        focused: aFocused,
+        focused: editorNodeFocused,
         path: aPath,
         selected,
         schemaType: aSchemaType,
@@ -261,7 +261,8 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       return (
         <Annotation
           boundaryElement={boundaryElement}
-          focused={aFocused}
+          focused={Boolean(focused)}
+          editorNodeFocused={editorNodeFocused}
           onItemClose={onItemClose}
           onItemOpen={onItemOpen}
           onPathFocus={onPathFocus}
@@ -276,7 +277,16 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
         </Annotation>
       )
     },
-    [boundaryElement, onItemClose, onItemOpen, onPathFocus, path, readOnly, renderCustomMarkers]
+    [
+      boundaryElement,
+      focused,
+      onItemClose,
+      onItemOpen,
+      onPathFocus,
+      path,
+      readOnly,
+      renderCustomMarkers,
+    ]
   )
 
   const editorNode = useMemo(

--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -284,7 +284,6 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       <Editor
         hasFocus={hasFocus}
         hotkeys={editorHotkeys}
-        initialSelection={null}
         isActive={isActive}
         isFullscreen={isFullscreen}
         onItemOpen={onItemOpen}

--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -1,6 +1,5 @@
 import React, {useState, useMemo, useCallback} from 'react'
 import {
-  EditorSelection,
   OnCopyFn,
   OnPasteFn,
   usePortableTextEditor,
@@ -45,6 +44,7 @@ export type PortableTextEditorElement = HTMLDivElement | HTMLSpanElement | null
 export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunctions'>) {
   const {
     changed,
+    focused,
     focusPath = EMPTY_ARRAY,
     hasFocus,
     hotkeys,
@@ -92,16 +92,6 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
 
   const _renderBlockActions = !!value && renderBlockActions ? renderBlockActions : undefined
   const _renderCustomMarkers = !!value && renderCustomMarkers ? renderCustomMarkers : undefined
-
-  const initialSelection = useMemo((): EditorSelection => {
-    return focusPath.length > 0
-      ? {
-          anchor: {path: focusPath, offset: 0},
-          focus: {path: focusPath, offset: 0},
-        }
-      : null
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []) // only initial!
 
   const [portalElement, setPortalElement] = useState<HTMLDivElement | null>(null)
 
@@ -294,7 +284,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       <Editor
         hasFocus={hasFocus}
         hotkeys={editorHotkeys}
-        initialSelection={initialSelection}
+        initialSelection={null}
         isActive={isActive}
         isFullscreen={isFullscreen}
         onItemOpen={onItemOpen}
@@ -314,21 +304,20 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
 
     // Keep only stable ones here!
     [
-      hasFocus,
+      boundaryElement,
       editorHotkeys,
-      initialSelection,
+      handleToggleFullscreen,
+      hasFocus,
       isActive,
       isFullscreen,
-      onItemOpen,
       onCopy,
+      onItemOpen,
       onPaste,
-      handleToggleFullscreen,
       path,
       readOnly,
       renderAnnotation,
       renderBlock,
       renderChild,
-      boundaryElement,
     ]
   )
 
@@ -346,7 +335,6 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
 
   // Scroll to the DOM element of the "opened" portable text member when relevant.
   useTrackFocusPath({
-    editorRootPath: path,
     focusPath,
     boundaryElement: boundaryElement || undefined,
     onItemClose,
@@ -357,7 +345,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       <ActivateOnFocus onActivate={onActivate} isOverlayActive={!isActive}>
         <ChangeIndicator
           disabled={isFullscreen}
-          hasFocus={hasFocus}
+          hasFocus={Boolean(focused)}
           isChanged={changed}
           path={path}
         >

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -12,7 +12,6 @@ import {
   usePortableTextEditor,
   RenderStyleFunction,
   RenderListItemFunction,
-  usePortableTextEditorSelection,
 } from '@sanity/portable-text-editor'
 import {Path} from '@sanity/types'
 import {BoundaryElementProvider, useBoundaryElement, useGlobalKeyDown, useLayer} from '@sanity/ui'
@@ -87,7 +86,6 @@ export function Editor(props: EditorProps) {
   const {isTopLayer} = useLayer()
   const editableRef = useRef<HTMLDivElement | null>(null)
   const editor = usePortableTextEditor()
-  const selection = usePortableTextEditorSelection()
 
   const {element: boundaryElement} = useBoundaryElement()
 
@@ -112,18 +110,13 @@ export function Editor(props: EditorProps) {
   const scrollSelectionIntoView = useScrollSelectionIntoView(scrollElement)
 
   // Restore the React editor selection and focus when toggling fullscreen
-  // Note that the selection itself is not part of the dependencies here (use the last known from the PTE instance)
   useEffect(() => {
-    if (selection) {
-      PortableTextEditor.select(editor, selection)
-    }
     if (hasFocus) {
       PortableTextEditor.focus(editor)
     } else {
       PortableTextEditor.blur(editor)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editor, isFullscreen]) // skip selection dep.
+  }, [editor, hasFocus, isFullscreen])
 
   const editable = useMemo(
     () => (
@@ -160,11 +153,9 @@ export function Editor(props: EditorProps) {
 
   const handleToolBarOnMemberOpen = useCallback(
     (relativePath: Path) => {
-      PortableTextEditor.blur(editor)
-      const fullPath = path.concat(relativePath)
-      onItemOpen(fullPath)
+      onItemOpen(path.concat(relativePath))
     },
-    [editor, onItemOpen, path]
+    [onItemOpen, path]
   )
 
   return (

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -109,14 +109,21 @@ export function Editor(props: EditorProps) {
 
   const scrollSelectionIntoView = useScrollSelectionIntoView(scrollElement)
 
-  // Restore the React editor selection and focus when toggling fullscreen
+  // Re-focus/blur the editor when toggling fullscreen.
+  // The hasFocus is kept in ref so focus or blur is called only
+  // when `isFullscreen` changes (and not when `hasFocus` changes)
+  // This is important to avoid focus/blur loops when opening up
+  // object blocks for editing where the form focus and
+  // the editor selection share the same path.
+  const focusRef = useRef(hasFocus)
   useEffect(() => {
-    if (hasFocus) {
+    focusRef.current = hasFocus
+  }, [hasFocus])
+  useEffect(() => {
+    if (focusRef.current) {
       PortableTextEditor.focus(editor)
-    } else {
-      PortableTextEditor.blur(editor)
     }
-  }, [editor, hasFocus, isFullscreen])
+  }, [editor, isFullscreen])
 
   const editable = useMemo(
     () => (

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -1,4 +1,4 @@
-import {PortableTextBlock} from '@sanity/types'
+import {Path, PortableTextBlock} from '@sanity/types'
 import {
   EditorChange,
   Patch as EditorPatch,

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -4,7 +4,6 @@ import {
   Patch as EditorPatch,
   PortableTextEditor,
   InvalidValue,
-  EditorSelection,
   Patch,
 } from '@sanity/portable-text-editor'
 import React, {
@@ -16,10 +15,10 @@ import React, {
   useImperativeHandle,
   createRef,
   ReactNode,
+  startTransition,
 } from 'react'
 import {Subject} from 'rxjs'
 import {Box, useToast} from '@sanity/ui'
-import {debounce} from 'lodash'
 import {FormPatch, SANITY_PATCH_TYPE} from '../../patch'
 import {ArrayOfObjectsItemMember, ObjectFormNode} from '../../store'
 import type {PortableTextInputProps} from '../../types'
@@ -52,6 +51,7 @@ export interface PortableTextMemberItem {
  */
 export function PortableTextInput(props: PortableTextInputProps) {
   const {
+    elementProps,
     focused,
     focusPath,
     hotkeys,
@@ -59,17 +59,18 @@ export function PortableTextInput(props: PortableTextInputProps) {
     members,
     onChange,
     onCopy,
-    onPathFocus,
     onInsert,
     onPaste,
+    onPathFocus,
     path,
     readOnly,
     renderBlockActions,
     renderCustomMarkers,
     schemaType,
     value,
-    elementProps,
   } = props
+
+  const {onBlur} = elementProps
 
   // Make the PTE focusable from the outside
   useImperativeHandle(elementProps.ref, () => ({
@@ -86,16 +87,6 @@ export function PortableTextInput(props: PortableTextInputProps) {
   const [invalidValue, setInvalidValue] = useState<InvalidValue | null>(null)
   const [isFullscreen, setIsFullscreen] = useState(false)
   const [isActive, setIsActive] = useState(false)
-
-  // Let formState decide if we are focused or not.
-  const hasFocus = Boolean(focused) || focusPath.length > 0
-
-  // Set active if focused
-  useEffect(() => {
-    if (hasFocus) {
-      setIsActive(true)
-    }
-  }, [hasFocus])
 
   const toast = useToast()
   const portableTextMemberItemsRef: React.MutableRefObject<PortableTextMemberItem[]> = useRef([])
@@ -224,21 +215,14 @@ export function PortableTextInput(props: PortableTextInputProps) {
     return items
   }, [members, props])
 
-  // Sets the focusPath from editor selection (when typing, moving the cursor, clicking around)
-  // This doesn't need to be immediate, so debounce it as it impacts performance.
-  const setFocusPathDebounced = useMemo(
-    () =>
-      debounce(
-        (sel: EditorSelection) => {
-          if (sel) {
-            onPathFocus(sel.focus.path)
-          }
-        },
-        500,
-        {trailing: true, leading: true}
-      ),
-    [onPathFocus]
-  )
+  const hasFocus = focused || isEditorFocusablePath(focusPath)
+
+  // Set active if focused
+  useEffect(() => {
+    if (hasFocus) {
+      setIsActive(true)
+    }
+  }, [hasFocus])
 
   // Handle editor changes
   const handleEditorChange = useCallback(
@@ -248,10 +232,19 @@ export function PortableTextInput(props: PortableTextInputProps) {
           onChange(toFormPatches(change.patches))
           break
         case 'selection':
-          setFocusPathDebounced(change.selection)
+          // This doesn't need to be immediate,
+          // call through startTransition
+          startTransition(() => {
+            if (change.selection) {
+              onPathFocus(change.selection.focus.path)
+            }
+          })
           break
         case 'focus':
           setIsActive(true)
+          break
+        case 'blur':
+          onBlur(change.event)
           break
         case 'undo':
         case 'redo':
@@ -269,7 +262,7 @@ export function PortableTextInput(props: PortableTextInputProps) {
         default:
       }
     },
-    [onChange, toast, setFocusPathDebounced]
+    [onBlur, onChange, onPathFocus, toast]
   )
 
   useEffect(() => {
@@ -345,4 +338,9 @@ export function PortableTextInput(props: PortableTextInputProps) {
 
 function toFormPatches(patches: any) {
   return patches.map((p: Patch) => ({...p, patchType: SANITY_PATCH_TYPE})) as FormPatch[]
+}
+
+// Return true if the path directly points to something focusable in the editor
+function isEditorFocusablePath(path: Path) {
+  return path.length === 1 || (path.length === 3 && path[1] === 'children')
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
@@ -1,56 +1,88 @@
-import {PortableTextEditor, usePortableTextEditor} from '@sanity/portable-text-editor'
+import {
+  PortableTextEditor,
+  usePortableTextEditor,
+  usePortableTextEditorSelection,
+} from '@sanity/portable-text-editor'
 import {Path} from '@sanity/types'
 import {useEffect} from 'react'
 import scrollIntoView from 'scroll-into-view-if-needed'
+import {isEqual} from '@sanity/util/paths'
 import {usePortableTextMemberItems} from './usePortableTextMembers'
 
 interface Props {
   focusPath: Path
   boundaryElement?: HTMLElement
-  editorRootPath: Path
   onItemClose: () => void
 }
 
 // This hook will track the focusPath and make sure editor content is visible and focused accordingly.
 export function useTrackFocusPath(props: Props): void {
-  const {focusPath, editorRootPath, boundaryElement, onItemClose} = props
+  const {focusPath, boundaryElement, onItemClose} = props
   const portableTextMemberItems = usePortableTextMemberItems()
   const editor = usePortableTextEditor()
+  const selection = usePortableTextEditorSelection()
 
   useEffect(() => {
-    // Don't do anything if no internal focusPath
+    // Don't do anything if no focusPath
     if (focusPath.length === 0) {
       return
     }
-    // Find the most specific opened member item and scroll to it
-    const memberItem = portableTextMemberItems
-      .filter((item) => item.member.open)
-      .sort((a, b) => b.member.item.path.length - a.member.item.path.length)[0]
-    if (memberItem && memberItem.elementRef?.current) {
+
+    // Don't do anything if the selection focus path already is the focusPath
+    if (selection?.focus.path && isEqual(selection.focus.path, focusPath)) {
+      return
+    }
+
+    // Find the opened member item
+    const openItem = portableTextMemberItems.find((m) => m.member.open)
+
+    if (openItem && openItem.elementRef?.current) {
       if (boundaryElement) {
-        // Scroll the boundary element into view
+        // Scroll the boundary element into view (the scrollable element itself)
         scrollIntoView(boundaryElement, {
           scrollMode: 'if-needed',
         })
+        // Scroll the member into view (the member within the scroll-boundary)
+        scrollIntoView(openItem.elementRef?.current, {
+          scrollMode: 'if-needed',
+          boundary: boundaryElement,
+        })
       }
-      // Make a selection in the editor
-      PortableTextEditor.select(editor, {
-        anchor: {path: focusPath, offset: 0},
-        focus: {path: focusPath, offset: 0},
-      })
-      if (memberItem.kind === 'textBlock') {
-        PortableTextEditor.focus(editor)
-        // "auto-close" regular text blocks or they get sticky here when trying to focus on an other field
-        // There is no natural way of closing them (however opening something else would close them)
-        onItemClose()
+      // If the focusPath i targeting a text block (with focusPath on the block itself),
+      // ensure that an editor selection is pointing to it's first child and then focus the editor.
+      if (openItem.kind === 'textBlock') {
+        const path =
+          focusPath.length === 3 && focusPath[1] === 'children'
+            ? focusPath // focusPath pointing to known span
+            : [
+                focusPath[0],
+                'children',
+                (Array.isArray(openItem.node.value?.children) &&
+                  openItem.node.value?.children[0]._key && {
+                    _key: openItem.node.value?.children[0]._key,
+                  }) ||
+                  0,
+              ] // unknown span (just a block key given as focusPath), select the first span
+
+        // Make an editor selection unless we are focusing into a annotation (markDefs) or inside inline object
+        if (path.length === 3 && focusPath[1] !== 'markDefs' && focusPath.length < 4) {
+          PortableTextEditor.select(editor, {
+            anchor: {path, offset: 0},
+            focus: {path, offset: 0},
+          })
+          // Focus the editor if focusing directly on block or child
+          if (focusPath.length === 1 || (focusPath.length === 3 && focusPath[1] === 'children')) {
+            PortableTextEditor.focus(editor)
+          }
+        }
       }
     }
   }, [
     boundaryElement,
     editor,
-    editorRootPath.length,
     focusPath,
     onItemClose,
     portableTextMemberItems,
+    selection?.focus.path,
   ])
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
@@ -41,11 +41,15 @@ export function useTrackFocusPath(props: Props): void {
         // Scroll the boundary element into view (the scrollable element itself)
         scrollIntoView(boundaryElement, {
           scrollMode: 'if-needed',
+          block: 'start',
+          inline: 'start',
         })
         // Scroll the member into view (the member within the scroll-boundary)
-        scrollIntoView(openItem.elementRef?.current, {
+        scrollIntoView(openItem.elementRef.current, {
           scrollMode: 'if-needed',
           boundary: boundaryElement,
+          block: 'start',
+          inline: 'start',
         })
       }
       // If the focusPath i targeting a text block (with focusPath on the block itself),

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
@@ -52,32 +52,30 @@ export function useTrackFocusPath(props: Props): void {
           inline: 'start',
         })
       }
+      const isBlockFocusPath = focusPath.length === 1
+      const isChildFocusPath = focusPath.length === 3 && focusPath[1] === 'children'
       // If the focusPath i targeting a text block (with focusPath on the block itself),
       // ensure that an editor selection is pointing to it's first child and then focus the editor.
       if (openItem.kind === 'textBlock') {
-        const path =
-          focusPath.length === 3 && focusPath[1] === 'children'
-            ? focusPath // focusPath pointing to known span
-            : [
-                focusPath[0],
-                'children',
-                (Array.isArray(openItem.node.value?.children) &&
-                  openItem.node.value?.children[0]._key && {
-                    _key: openItem.node.value?.children[0]._key,
-                  }) ||
-                  0,
-              ] // unknown span (just a block key given as focusPath), select the first span
+        const path = isChildFocusPath
+          ? focusPath // focusPath pointing to known span
+          : [
+              focusPath[0],
+              'children',
+              (Array.isArray(openItem.node.value?.children) &&
+                openItem.node.value?.children[0]._key && {
+                  _key: openItem.node.value?.children[0]._key,
+                }) ||
+                0,
+            ] // unknown span (just a block key given as focusPath), select the first span
 
-        // Make an editor selection unless we are focusing into a annotation (markDefs) or inside inline object
-        if (path.length === 3 && focusPath[1] !== 'markDefs' && focusPath.length < 4) {
+        // Make an editor selection if we have a child path, and not have focus inside of it
+        if (isBlockFocusPath || isChildFocusPath) {
           PortableTextEditor.select(editor, {
             anchor: {path, offset: 0},
             focus: {path, offset: 0},
           })
-          // Focus the editor if focusing directly on block or child
-          if (focusPath.length === 1 || (focusPath.length === 3 && focusPath[1] === 'children')) {
-            PortableTextEditor.focus(editor)
-          }
+          PortableTextEditor.focus(editor)
         }
       }
     }

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
@@ -1,7 +1,8 @@
 import {PortableTextEditor, usePortableTextEditor} from '@sanity/portable-text-editor'
 import {ObjectSchemaType, Path, PortableTextObject} from '@sanity/types'
 import {Tooltip} from '@sanity/ui'
-import React, {ComponentType, useCallback, useMemo} from 'react'
+import React, {ComponentType, useCallback, useMemo, useState} from 'react'
+import {isEqual} from '@sanity/util/paths'
 import {pathToString} from '../../../../field'
 import {BlockAnnotationProps, RenderCustomMarkers} from '../../../types'
 import {DefaultMarkers} from '../_legacyDefaultParts/Markers'
@@ -111,7 +112,7 @@ export function Annotation(props: AnnotationProps) {
   const isOpen = Boolean(memberItem?.member.open)
   const input = memberItem?.input
   const nodePath = memberItem?.node.path || EMPTY_ARRAY
-  const referenceElement = memberItem?.elementRef?.current
+  const referenceElement = spanElm
 
   const componentProps = useMemo(
     (): BlockAnnotationProps => ({
@@ -154,7 +155,6 @@ export function Annotation(props: AnnotationProps) {
       referenceElement,
       schemaType,
       selected,
-      spanElm,
       text,
       validation,
       value,

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
@@ -52,7 +52,7 @@ export function Annotation(props: AnnotationProps) {
     () => path.slice(0, path.length - 2).concat(['markDefs', {_key: value._key}]),
     [path, value._key]
   )
-  const [spanElm, setSpanElm] = useState<HTMLSpanElement | null>(null)
+  const [spanElement, setSpanElement] = useState<HTMLSpanElement | null>(null)
   const spanPath: Path = useMemo(() => path.slice(path.length - 3, path.length), [path])
   const memberItem = usePortableTextMemberItem(pathToString(markDefPath))
   const {validation} = useMemberValidation(memberItem?.node)
@@ -112,7 +112,7 @@ export function Annotation(props: AnnotationProps) {
   const isOpen = Boolean(memberItem?.member.open)
   const input = memberItem?.input
   const nodePath = memberItem?.node.path || EMPTY_ARRAY
-  const referenceElement = spanElm
+  const referenceElement = spanElement
 
   const componentProps = useMemo(
     (): BlockAnnotationProps => ({
@@ -170,7 +170,7 @@ export function Annotation(props: AnnotationProps) {
       if (memberItem?.elementRef) {
         memberItem.elementRef.current = elm
       }
-      setSpanElm(elm) // update state here so the reference element is available on first render
+      setSpanElement(elm) // update state here so the reference element is available on first render
     },
     [memberItem]
   )

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
@@ -19,6 +19,7 @@ import {ObjectEditModal} from './modals/ObjectEditModal'
 interface AnnotationProps {
   boundaryElement: HTMLElement | null
   children: React.ReactElement
+  editorNodeFocused: boolean
   focused: boolean
   onItemClose: () => void
   onItemOpen: (path: Path) => void
@@ -35,6 +36,7 @@ export function Annotation(props: AnnotationProps) {
   const {
     boundaryElement,
     children,
+    editorNodeFocused,
     focused,
     onItemClose,
     onItemOpen,
@@ -64,9 +66,10 @@ export function Annotation(props: AnnotationProps) {
     if (memberItem) {
       // Take focus away from the editor so that it doesn't propagate a new focusPath and interfere here.
       PortableTextEditor.blur(editor)
+      onPathFocus(memberItem.node.focusPath) // Set the focus path to be the markDef here as we currently have focus on the text node
       onItemOpen(memberItem.node.path)
     }
-  }, [editor, onItemOpen, memberItem])
+  }, [editor, memberItem, onItemOpen, onPathFocus])
 
   const onClose = useCallback(() => {
     onItemClose()
@@ -117,6 +120,7 @@ export function Annotation(props: AnnotationProps) {
 
   const componentProps = useMemo(
     (): BlockAnnotationProps => ({
+      __unstable_textElementFocus: editorNodeFocused, // Is there focus on the related text element for this object?
       __unstable_boundaryElement: boundaryElement || undefined,
       __unstable_referenceElement: referenceElement || undefined,
       children: input,
@@ -141,6 +145,7 @@ export function Annotation(props: AnnotationProps) {
     [
       boundaryElement,
       editor.schemaTypes.block,
+      editorNodeFocused,
       focused,
       input,
       isOpen,
@@ -195,23 +200,21 @@ export const DefaultAnnotationComponent = (props: BlockAnnotationProps) => {
     __unstable_boundaryElement,
     __unstable_referenceElement,
     children,
+    focused,
     markers,
     onClose,
     onOpen,
     onRemove,
     open,
-    path,
     readOnly,
     schemaType,
     textElement,
     validation,
-    value,
   } = props
   const isLink = schemaType.name === 'link'
   const hasError = validation.filter((v) => v.level === 'error').length > 0
   const hasWarning = validation.filter((v) => v.level === 'warning').length > 0
   const hasMarkers = markers.length > 0
-  const autofocus = isEqual(path.slice(-2), ['markDefs', {_key: value._key}])
 
   const toneKey = useMemo(() => {
     if (hasError) {
@@ -250,7 +253,7 @@ export const DefaultAnnotationComponent = (props: BlockAnnotationProps) => {
           boundaryElement={__unstable_boundaryElement}
           defaultType="popover"
           onClose={onClose}
-          autofocus={autofocus}
+          autofocus={focused}
           referenceElement={__unstable_referenceElement}
           schemaType={schemaType}
         >

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
@@ -240,8 +240,8 @@ export const DefaultAnnotationComponent = (props: BlockAnnotationProps) => {
       <AnnotationToolbarPopover
         referenceElement={__unstable_referenceElement}
         boundaryElement={__unstable_boundaryElement}
-        onEdit={onOpen}
-        onDelete={onRemove}
+        onOpen={onOpen}
+        onRemove={onRemove}
         title={schemaType.title || schemaType.name}
       />
       {open && (

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
@@ -253,7 +253,7 @@ export const DefaultAnnotationComponent = (props: BlockAnnotationProps) => {
           boundaryElement={__unstable_boundaryElement}
           defaultType="popover"
           onClose={onClose}
-          autofocus={focused}
+          autoFocus={focused}
           referenceElement={__unstable_referenceElement}
           schemaType={schemaType}
         >

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
@@ -199,16 +199,18 @@ export const DefaultAnnotationComponent = (props: BlockAnnotationProps) => {
     onOpen,
     onRemove,
     open,
-    focused,
+    path,
     readOnly,
     schemaType,
     textElement,
     validation,
+    value,
   } = props
   const isLink = schemaType.name === 'link'
   const hasError = validation.filter((v) => v.level === 'error').length > 0
   const hasWarning = validation.filter((v) => v.level === 'warning').length > 0
   const hasMarkers = markers.length > 0
+  const autofocus = isEqual(path.slice(-2), ['markDefs', {_key: value._key}])
 
   const toneKey = useMemo(() => {
     if (hasError) {
@@ -247,7 +249,7 @@ export const DefaultAnnotationComponent = (props: BlockAnnotationProps) => {
           boundaryElement={__unstable_boundaryElement}
           defaultType="popover"
           onClose={onClose}
-          autofocus={focused}
+          autofocus={autofocus}
           referenceElement={__unstable_referenceElement}
           schemaType={schemaType}
         >

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
@@ -62,6 +62,7 @@ export function Annotation(props: AnnotationProps) {
 
   const onOpen = useCallback(() => {
     if (memberItem) {
+      // Take focus away from the editor so that it doesn't propagate a new focusPath and interfere here.
       PortableTextEditor.blur(editor)
       onItemOpen(memberItem.node.path)
     }

--- a/packages/sanity/src/core/form/inputs/PortableText/object/AnnotationToolbarPopover.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/AnnotationToolbarPopover.tsx
@@ -22,14 +22,14 @@ const POPOVER_FALLBACK_PLACEMENTS: PopoverProps['fallbackPlacements'] = ['top', 
 
 interface AnnotationToolbarPopoverProps {
   boundaryElement?: HTMLElement
-  onDelete: () => void
-  onEdit: () => void
+  onOpen: () => void
+  onRemove: () => void
   referenceElement?: HTMLElement
   title: string
 }
 
 export function AnnotationToolbarPopover(props: AnnotationToolbarPopoverProps) {
-  const {boundaryElement, onDelete, onEdit, referenceElement, title} = props
+  const {boundaryElement, onOpen, onRemove, referenceElement, title} = props
   const [popoverOpen, setPopoverOpen] = useState<boolean>(false)
   const [cursorRect, setCursorRect] = useState<DOMRect | null>(null)
   const [selection, setSelection] = useState<{
@@ -119,13 +119,13 @@ export function AnnotationToolbarPopover(props: AnnotationToolbarPopoverProps) {
 
   const handleEditButtonClicked = useCallback(() => {
     setPopoverOpen(false)
-    onEdit()
-  }, [onEdit])
+    onOpen()
+  }, [onOpen])
 
   const handleRemoveButtonClicked = useCallback(() => {
     setPopoverOpen(false)
-    onDelete()
-  }, [onDelete])
+    onRemove()
+  }, [onRemove])
 
   useEffect(() => {
     if (!popoverOpen) {

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
@@ -99,9 +99,11 @@ export function BlockObject(props: BlockObjectProps) {
   const handleMouseOut = useCallback(() => setReviewChangesHovered(false), [])
 
   const onOpen = useCallback(() => {
-    PortableTextEditor.blur(editor)
-    onItemOpen(path)
-  }, [editor, onItemOpen, path])
+    if (memberItem) {
+      PortableTextEditor.blur(editor)
+      onItemOpen(memberItem.node.path)
+    }
+  }, [editor, onItemOpen, memberItem])
 
   const onClose = useCallback(() => {
     onItemClose()

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
@@ -6,7 +6,16 @@ import {
 } from '@sanity/portable-text-editor'
 import {ObjectSchemaType, Path, PortableTextBlock, isImage} from '@sanity/types'
 import {Tooltip, Flex, ResponsivePaddingProps, Box} from '@sanity/ui'
-import React, {ComponentType, PropsWithChildren, useCallback, useMemo, useState} from 'react'
+import React, {
+  ComponentType,
+  PropsWithChildren,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import {isEqual} from '@sanity/util/paths'
 import {PatchArg} from '../../../patch'
 import {BlockProps, RenderCustomMarkers, RenderPreviewCallback} from '../../../types'
 import {RenderBlockActionsCallback} from '../types'

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
@@ -15,7 +15,6 @@ import React, {
   useRef,
   useState,
 } from 'react'
-import {isEqual} from '@sanity/util/paths'
 import {PatchArg} from '../../../patch'
 import {BlockProps, RenderCustomMarkers, RenderPreviewCallback} from '../../../types'
 import {RenderBlockActionsCallback} from '../types'
@@ -104,7 +103,7 @@ export function BlockObject(props: BlockObjectProps) {
       PortableTextEditor.blur(editor)
       onItemOpen(memberItem.node.path)
     }
-  }, [editor, onItemOpen, memberItem])
+  }, [editor, memberItem, onItemOpen])
 
   const onClose = useCallback(() => {
     onItemClose()
@@ -317,11 +316,10 @@ export const DefaultBlockObjectComponent = (props: BlockProps) => {
     onOpen,
     onRemove,
     open,
-    path,
     readOnly,
     renderPreview,
-    selected,
     schemaType,
+    selected,
     value,
     validation,
   } = props
@@ -331,7 +329,6 @@ export const DefaultBlockObjectComponent = (props: BlockProps) => {
   const hasWarning = validation.filter((v) => v.level === 'warning').length > 0
   const hasMarkers = Boolean(markers.length > 0)
   const tone = selected || focused ? 'primary' : 'default'
-  const autofocus = isEqual(path.slice(-1), [{_key: value._key}])
 
   const handleDoubleClickToOpen = useCallback(
     (e: React.MouseEvent<Element, MouseEvent>) => {
@@ -380,7 +377,7 @@ export const DefaultBlockObjectComponent = (props: BlockProps) => {
           boundaryElement={__unstable_boundaryElement}
           defaultType="dialog"
           onClose={onClose}
-          autofocus={autofocus}
+          autofocus={focused}
           schemaType={schemaType}
           referenceElement={__unstable_referenceElement}
         >

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
@@ -116,8 +116,13 @@ export function BlockObject(props: BlockObjectProps) {
     if (isDeleting.current) {
       return
     }
-    PortableTextEditor.delete(editor, selfSelection, {mode: 'blocks'})
-    isDeleting.current = true
+    try {
+      PortableTextEditor.delete(editor, selfSelection, {mode: 'blocks'})
+    } catch (err) {
+      console.error(err)
+    } finally {
+      isDeleting.current = true
+    }
   }, [editor, selfSelection])
 
   // Focus the editor if this object is removed because it was deleted.

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
@@ -176,7 +176,6 @@ export function BlockObject(props: BlockObjectProps) {
       children: input,
       focused,
       markers,
-      nodeFocused: memberItem?.node.focused,
       onClose,
       onOpen,
       onPathFocus,
@@ -300,8 +299,8 @@ export const DefaultBlockObjectComponent = (props: BlockProps) => {
     onClose,
     onOpen,
     onRemove,
-    nodeFocused,
     open,
+    path,
     readOnly,
     renderPreview,
     selected,
@@ -315,6 +314,7 @@ export const DefaultBlockObjectComponent = (props: BlockProps) => {
   const hasWarning = validation.filter((v) => v.level === 'warning').length > 0
   const hasMarkers = Boolean(markers.length > 0)
   const tone = selected || focused ? 'primary' : 'default'
+  const autofocus = isEqual(path.slice(-1), [{_key: value._key}])
 
   const handleDoubleClickToOpen = useCallback(
     (e: React.MouseEvent<Element, MouseEvent>) => {
@@ -363,7 +363,7 @@ export const DefaultBlockObjectComponent = (props: BlockProps) => {
           boundaryElement={__unstable_boundaryElement}
           defaultType="dialog"
           onClose={onClose}
-          autofocus={nodeFocused}
+          autofocus={autofocus}
           schemaType={schemaType}
           referenceElement={__unstable_referenceElement}
         >

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
@@ -100,6 +100,7 @@ export function BlockObject(props: BlockObjectProps) {
 
   const onOpen = useCallback(() => {
     if (memberItem) {
+      // Take focus away from the editor so that it doesn't propagate a new focusPath and interfere here.
       PortableTextEditor.blur(editor)
       onItemOpen(memberItem.node.path)
     }

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
@@ -377,7 +377,7 @@ export const DefaultBlockObjectComponent = (props: BlockProps) => {
           boundaryElement={__unstable_boundaryElement}
           defaultType="dialog"
           onClose={onClose}
-          autofocus={focused}
+          autoFocus={focused}
           schemaType={schemaType}
           referenceElement={__unstable_referenceElement}
         >

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObjectActionsMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObjectActionsMenu.tsx
@@ -83,6 +83,15 @@ export function BlockObjectActionsMenu(props: BlockObjectActionsMenuProps): Reac
     )
   )
 
+  const handleDelete = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      event.preventDefault()
+      event.stopPropagation()
+      onRemove()
+    },
+    [onRemove]
+  )
+
   return (
     <Flex>
       <Box flex={1}>{children}</Box>
@@ -110,7 +119,7 @@ export function BlockObjectActionsMenu(props: BlockObjectActionsMenuProps): Reac
                 {readOnly && <MenuItem icon={EyeOpenIcon} onClick={onOpen} text="View" />}
                 {!readOnly && <MenuItem icon={EditIcon} onClick={onOpen} text="Edit" />}
                 {!readOnly && (
-                  <MenuItem icon={TrashIcon} onClick={onRemove} text="Delete" tone="critical" />
+                  <MenuItem icon={TrashIcon} onClick={handleDelete} text="Delete" tone="critical" />
                 )}
               </>
             </Menu>

--- a/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
@@ -280,7 +280,7 @@ export const DefaultInlineObjectComponent = (props: BlockProps) => {
           boundaryElement={__unstable_boundaryElement}
           defaultType="popover"
           onClose={onClose}
-          autofocus={focused}
+          autoFocus={focused}
           referenceElement={__unstable_referenceElement}
           schemaType={schemaType}
         >

--- a/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
@@ -6,6 +6,7 @@ import {
 import {ObjectSchemaType, Path, PortableTextBlock, PortableTextChild} from '@sanity/types'
 import React, {useCallback, useEffect, useMemo, useState} from 'react'
 import {Tooltip} from '@sanity/ui'
+import {isEqual} from '@sanity/util/paths'
 import {BlockProps, RenderCustomMarkers, RenderPreviewCallback} from '../../../types'
 import {useFormBuilder} from '../../../useFormBuilder'
 import {usePortableTextMarkers} from '../hooks/usePortableTextMarkers'
@@ -192,6 +193,7 @@ export const DefaultInlineObjectComponent = (props: BlockProps) => {
     onOpen,
     onRemove,
     open,
+    path,
     readOnly,
     renderPreview,
     schemaType,
@@ -239,6 +241,8 @@ export const DefaultInlineObjectComponent = (props: BlockProps) => {
     setPopoverOpen(false)
   }, [])
 
+  const autofocus = isEqual(path.slice(-2), ['children', {_key: value._key}])
+
   return (
     <>
       <Root
@@ -279,7 +283,7 @@ export const DefaultInlineObjectComponent = (props: BlockProps) => {
           boundaryElement={__unstable_boundaryElement}
           defaultType="popover"
           onClose={onClose}
-          autofocus={focused}
+          autofocus={autofocus}
           referenceElement={__unstable_referenceElement}
           schemaType={schemaType}
         >

--- a/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
@@ -57,22 +57,31 @@ export const InlineObject = (props: InlineObjectProps) => {
   const parentSchemaType = editor.schemaTypes.block
   const CustomComponent = schemaType.components?.inlineBlock
   const hasMarkers = markers.length > 0
+  const selfSelection = useMemo(
+    (): EditorSelection => ({
+      anchor: {path: relativePath, offset: 0},
+      focus: {path: relativePath, offset: 0},
+    }),
+    [relativePath]
+  )
 
   const onRemove = useCallback(() => {
-    const sel: EditorSelection = {
-      focus: {path: relativePath, offset: 0},
-      anchor: {path: relativePath, offset: 0},
-    }
-    PortableTextEditor.delete(editor, sel, {mode: 'children'})
-    // Focus will not stick unless this is done through a timeout when deleted through clicking the menu button.
-    setTimeout(() => PortableTextEditor.focus(editor))
-  }, [editor, relativePath])
+    PortableTextEditor.delete(editor, selfSelection, {mode: 'children'})
+    PortableTextEditor.focus(editor)
+  }, [selfSelection, editor])
 
   const onOpen = useCallback(() => {
     if (memberItem) {
-      onItemOpen(memberItem?.node.path)
+      PortableTextEditor.blur(editor)
+      onItemOpen(memberItem.node.path)
     }
-  }, [memberItem, onItemOpen])
+  }, [editor, onItemOpen, memberItem])
+
+  const onClose = useCallback(() => {
+    onItemClose()
+    PortableTextEditor.select(editor, selfSelection)
+    PortableTextEditor.focus(editor)
+  }, [onItemClose, editor, selfSelection])
 
   const isOpen = Boolean(memberItem?.member.open)
   const input = memberItem?.input
@@ -87,7 +96,7 @@ export const InlineObject = (props: InlineObjectProps) => {
       __unstable_referenceElement: referenceElement || undefined,
       children: input,
       focused,
-      onClose: onItemClose,
+      onClose,
       onOpen,
       onPathFocus,
       onRemove,
@@ -183,7 +192,6 @@ export const DefaultInlineObjectComponent = (props: BlockProps) => {
     onOpen,
     onRemove,
     open,
-    path,
     readOnly,
     renderPreview,
     schemaType,
@@ -191,7 +199,6 @@ export const DefaultInlineObjectComponent = (props: BlockProps) => {
     validation,
     value,
   } = props
-  const editor = usePortableTextEditor()
   const hasMarkers = markers.length > 0
   const [popoverOpen, setPopoverOpen] = useState<boolean>(false)
   const popoverTitle = schemaType?.title || schemaType.name
@@ -230,8 +237,7 @@ export const DefaultInlineObjectComponent = (props: BlockProps) => {
 
   const onClosePopover = useCallback(() => {
     setPopoverOpen(false)
-    PortableTextEditor.focus(editor)
-  }, [editor])
+  }, [])
 
   return (
     <>
@@ -273,7 +279,7 @@ export const DefaultInlineObjectComponent = (props: BlockProps) => {
           boundaryElement={__unstable_boundaryElement}
           defaultType="popover"
           onClose={onClose}
-          path={path}
+          autofocus={focused}
           referenceElement={__unstable_referenceElement}
           schemaType={schemaType}
         >

--- a/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
@@ -123,7 +123,7 @@ export const InlineObject = (props: InlineObjectProps) => {
       markers,
       memberItem?.member,
       nodePath,
-      onItemClose,
+      onClose,
       onOpen,
       onPathFocus,
       onRemove,

--- a/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
@@ -6,7 +6,6 @@ import {
 import {ObjectSchemaType, Path, PortableTextBlock, PortableTextChild} from '@sanity/types'
 import React, {useCallback, useEffect, useMemo, useState} from 'react'
 import {Tooltip} from '@sanity/ui'
-import {isEqual} from '@sanity/util/paths'
 import {BlockProps, RenderCustomMarkers, RenderPreviewCallback} from '../../../types'
 import {useFormBuilder} from '../../../useFormBuilder'
 import {usePortableTextMarkers} from '../hooks/usePortableTextMarkers'
@@ -194,7 +193,6 @@ export const DefaultInlineObjectComponent = (props: BlockProps) => {
     onOpen,
     onRemove,
     open,
-    path,
     readOnly,
     renderPreview,
     schemaType,
@@ -242,8 +240,6 @@ export const DefaultInlineObjectComponent = (props: BlockProps) => {
     setPopoverOpen(false)
   }, [])
 
-  const autofocus = isEqual(path.slice(-2), ['children', {_key: value._key}])
-
   return (
     <>
       <Root
@@ -284,7 +280,7 @@ export const DefaultInlineObjectComponent = (props: BlockProps) => {
           boundaryElement={__unstable_boundaryElement}
           defaultType="popover"
           onClose={onClose}
-          autofocus={autofocus}
+          autofocus={focused}
           referenceElement={__unstable_referenceElement}
           schemaType={schemaType}
         >

--- a/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
@@ -73,6 +73,7 @@ export const InlineObject = (props: InlineObjectProps) => {
 
   const onOpen = useCallback(() => {
     if (memberItem) {
+      // Take focus away from the editor so that it doesn't propagate a new focusPath and interfere here.
       PortableTextEditor.blur(editor)
       onItemOpen(memberItem.node.path)
     }

--- a/packages/sanity/src/core/form/inputs/PortableText/object/InlineObjectToolbarPopover.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/InlineObjectToolbarPopover.tsx
@@ -59,9 +59,14 @@ export function InlineObjectToolbarPopover(props: InlineObjectToolbarPopoverProp
       }
       event.preventDefault()
       event.stopPropagation()
-      onDelete(event)
-      if (deleteButtonRef.current) {
-        deleteButtonRef.current.disabled = true
+      try {
+        onDelete(event)
+      } catch (err) {
+        console.error(err)
+      } finally {
+        if (deleteButtonRef.current) {
+          deleteButtonRef.current.disabled = true
+        }
       }
     },
     [onDelete]

--- a/packages/sanity/src/core/form/inputs/PortableText/object/InlineObjectToolbarPopover.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/InlineObjectToolbarPopover.tsx
@@ -1,4 +1,4 @@
-import React, {useRef, useCallback, useMemo} from 'react'
+import React, {useRef, useCallback, useMemo, MouseEvent} from 'react'
 import {
   Box,
   Button,
@@ -34,6 +34,7 @@ export function InlineObjectToolbarPopover(props: InlineObjectToolbarPopoverProp
   const {onClosePopover, onEdit, onDelete, referenceElement, boundaryElement, title, open} = props
   const {sanity} = useTheme()
   const editButtonRef = useRef<HTMLButtonElement | null>(null)
+  const deleteButtonRef = useRef<HTMLButtonElement | null>(null)
   const popoverScheme = sanity.color.dark ? 'light' : 'dark'
 
   // Close floating toolbar on Escape
@@ -49,6 +50,21 @@ export function InlineObjectToolbarPopover(props: InlineObjectToolbarPopoverProp
       },
       [onClosePopover]
     )
+  )
+
+  const handleDelete = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      if (deleteButtonRef.current?.disabled) {
+        return
+      }
+      event.preventDefault()
+      event.stopPropagation()
+      onDelete(event)
+      if (deleteButtonRef.current) {
+        deleteButtonRef.current.disabled = true
+      }
+    },
+    [onDelete]
   )
 
   const popoverContent = useMemo(
@@ -69,17 +85,18 @@ export function InlineObjectToolbarPopover(props: InlineObjectToolbarPopoverProp
             alt="Edit object"
           />
           <Button
+            ref={deleteButtonRef}
             icon={TrashIcon}
             mode="bleed"
             padding={2}
-            onClick={onDelete}
+            onClick={handleDelete}
             tone="critical"
             alt="Remove object"
           />
         </Inline>
       </Box>
     ),
-    [onDelete, onEdit, title]
+    [handleDelete, onEdit, title]
   )
 
   return (

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/DialogModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/DialogModal.tsx
@@ -9,11 +9,11 @@ interface DefaultEditDialogProps {
   onClose: () => void
   title: string | React.ReactNode
   width?: ModalWidth
-  autofocus?: boolean
+  autoFocus?: boolean
 }
 
 export function DefaultEditDialog(props: DefaultEditDialogProps) {
-  const {onClose, children, title, width = 1, autofocus} = props
+  const {onClose, children, title, width = 1, autoFocus} = props
   const dialogId = useId()
   // This seems to work with regular refs as well, but it might be safer to use state.
   const [contentElement, setContentElement] = useState<HTMLDivElement | null>(null)
@@ -27,7 +27,7 @@ export function DefaultEditDialog(props: DefaultEditDialogProps) {
       portal="default"
       width={width}
       contentRef={setContentElement}
-      __unstable_autoFocus={autofocus}
+      __unstable_autoFocus={autoFocus}
     >
       <PresenceOverlay margins={[0, 0, 1, 0]}>
         <VirtualizerScrollInstanceProvider scrollElement={contentElement}>

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/DialogModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/DialogModal.tsx
@@ -9,10 +9,11 @@ interface DefaultEditDialogProps {
   onClose: () => void
   title: string | React.ReactNode
   width?: ModalWidth
+  autofocus?: boolean
 }
 
 export function DefaultEditDialog(props: DefaultEditDialogProps) {
-  const {onClose, children, title, width = 1} = props
+  const {onClose, children, title, width = 1, autofocus} = props
   const dialogId = useId()
   // This seems to work with regular refs as well, but it might be safer to use state.
   const [contentElement, setContentElement] = useState<HTMLDivElement | null>(null)
@@ -26,6 +27,7 @@ export function DefaultEditDialog(props: DefaultEditDialogProps) {
       portal="default"
       width={width}
       contentRef={setContentElement}
+      __unstable_autoFocus={autofocus}
     >
       <PresenceOverlay margins={[0, 0, 1, 0]}>
         <VirtualizerScrollInstanceProvider scrollElement={contentElement}>

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx
@@ -3,11 +3,9 @@ import {
   PortableTextEditor,
   usePortableTextEditor,
 } from '@sanity/portable-text-editor'
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
-import {ObjectSchemaType, Path} from '@sanity/types'
+import React, {useCallback, useMemo, useRef} from 'react'
+import {ObjectSchemaType} from '@sanity/types'
 import {_getModalOption} from '../helpers'
-import {pathToString} from '../../../../../field'
-import {usePortableTextMemberItem} from '../../hooks/usePortableTextMembers'
 import {DefaultEditDialog} from './DialogModal'
 import {PopoverEditDialog} from './PopoverModal'
 
@@ -16,49 +14,22 @@ export function ObjectEditModal(props: {
   children: React.ReactNode
   defaultType: 'dialog' | 'popover'
   onClose: () => void
-  path: Path
   referenceElement: HTMLElement | undefined
   schemaType: ObjectSchemaType
+  autofocus?: boolean
 }) {
-  const {onClose, defaultType, referenceElement, boundaryElement, schemaType, path} = props
-  const editor = usePortableTextEditor()
-  const firstElementIsFocused = useRef(false)
+  const {onClose, defaultType, referenceElement, boundaryElement, schemaType, autofocus} = props
 
   const schemaModalOption = useMemo(() => _getModalOption(schemaType), [schemaType])
   const modalType = schemaModalOption?.type || defaultType
 
   const modalTitle = <>Edit {schemaType.title}</>
 
-  // The initial editor selection when opening the object
-  const initialSelection = useRef<EditorSelection | null>(PortableTextEditor.getSelection(editor))
-
-  const memberItem = usePortableTextMemberItem(pathToString(path))
-
   const handleClose = useCallback(() => {
-    PortableTextEditor.select(editor, initialSelection.current)
     onClose()
-  }, [editor, onClose])
+  }, [onClose])
 
   const modalWidth = schemaModalOption?.width
-
-  // Set focus on the first field
-  useEffect(() => {
-    if (firstElementIsFocused.current) {
-      return
-    }
-    const firstFieldMember = memberItem?.member.item.members.find((m) => m.kind === 'field')
-    if (firstFieldMember && firstFieldMember.kind === 'field') {
-      setTimeout(() => {
-        const firstFieldElm = document.getElementById(
-          firstFieldMember.field.id
-        ) as HTMLElement | null
-        if (firstFieldElm) {
-          firstFieldElm.focus()
-        }
-      }, 0)
-      firstElementIsFocused.current = true
-    }
-  }, [memberItem])
 
   if (modalType === 'popover') {
     return (
@@ -75,7 +46,12 @@ export function ObjectEditModal(props: {
   }
 
   return (
-    <DefaultEditDialog onClose={handleClose} title={modalTitle} width={modalWidth}>
+    <DefaultEditDialog
+      onClose={handleClose}
+      title={modalTitle}
+      width={modalWidth}
+      autofocus={autofocus}
+    >
       {props.children}
     </DefaultEditDialog>
   )

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx
@@ -1,22 +1,17 @@
-import {
-  EditorSelection,
-  PortableTextEditor,
-  usePortableTextEditor,
-} from '@sanity/portable-text-editor'
-import React, {useCallback, useMemo, useRef} from 'react'
+import React, {useCallback, useMemo} from 'react'
 import {ObjectSchemaType} from '@sanity/types'
 import {_getModalOption} from '../helpers'
 import {DefaultEditDialog} from './DialogModal'
 import {PopoverEditDialog} from './PopoverModal'
 
 export function ObjectEditModal(props: {
+  autofocus?: boolean
   boundaryElement: HTMLElement | undefined
   children: React.ReactNode
   defaultType: 'dialog' | 'popover'
   onClose: () => void
   referenceElement: HTMLElement | undefined
   schemaType: ObjectSchemaType
-  autofocus?: boolean
 }) {
   const {onClose, defaultType, referenceElement, boundaryElement, schemaType, autofocus} = props
 
@@ -34,6 +29,7 @@ export function ObjectEditModal(props: {
   if (modalType === 'popover') {
     return (
       <PopoverEditDialog
+        autofocus={autofocus}
         boundaryElement={boundaryElement}
         onClose={handleClose}
         referenceElement={referenceElement}

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx
@@ -5,7 +5,7 @@ import {DefaultEditDialog} from './DialogModal'
 import {PopoverEditDialog} from './PopoverModal'
 
 export function ObjectEditModal(props: {
-  autofocus?: boolean
+  autoFocus?: boolean
   boundaryElement: HTMLElement | undefined
   children: React.ReactNode
   defaultType: 'dialog' | 'popover'
@@ -13,7 +13,7 @@ export function ObjectEditModal(props: {
   referenceElement: HTMLElement | undefined
   schemaType: ObjectSchemaType
 }) {
-  const {onClose, defaultType, referenceElement, boundaryElement, schemaType, autofocus} = props
+  const {onClose, defaultType, referenceElement, boundaryElement, schemaType, autoFocus} = props
 
   const schemaModalOption = useMemo(() => _getModalOption(schemaType), [schemaType])
   const modalType = schemaModalOption?.type || defaultType
@@ -29,7 +29,7 @@ export function ObjectEditModal(props: {
   if (modalType === 'popover') {
     return (
       <PopoverEditDialog
-        autofocus={autofocus}
+        autoFocus={autoFocus}
         boundaryElement={boundaryElement}
         onClose={handleClose}
         referenceElement={referenceElement}
@@ -46,7 +46,7 @@ export function ObjectEditModal(props: {
       onClose={handleClose}
       title={modalTitle}
       width={modalWidth}
-      autofocus={autofocus}
+      autoFocus={autoFocus}
     >
       {props.children}
     </DefaultEditDialog>

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
@@ -16,7 +16,7 @@ import {
 } from './PopoverModal.styles'
 
 interface PopoverEditDialogProps {
-  autofocus?: boolean
+  autoFocus?: boolean
   boundaryElement?: PortableTextEditorElement
   children: React.ReactNode
   onClose: () => void
@@ -53,7 +53,7 @@ export function PopoverEditDialog(props: PopoverEditDialogProps) {
 }
 
 function Content(props: PopoverEditDialogProps) {
-  const {onClose, referenceElement, width = 0, title, boundaryElement, autofocus} = props
+  const {onClose, referenceElement, width = 0, title, boundaryElement, autoFocus} = props
 
   useGlobalKeyDown(
     useCallback(
@@ -82,7 +82,7 @@ function Content(props: PopoverEditDialogProps) {
               </Box>
 
               <Button
-                autoFocus={Boolean(autofocus)}
+                autoFocus={Boolean(autoFocus)}
                 icon={CloseIcon}
                 mode="bleed"
                 onClick={onClose}

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
@@ -16,6 +16,7 @@ import {
 } from './PopoverModal.styles'
 
 interface PopoverEditDialogProps {
+  autofocus?: boolean
   boundaryElement?: PortableTextEditorElement
   children: React.ReactNode
   onClose: () => void
@@ -52,7 +53,7 @@ export function PopoverEditDialog(props: PopoverEditDialogProps) {
 }
 
 function Content(props: PopoverEditDialogProps) {
-  const {onClose, referenceElement, width = 0, title, boundaryElement} = props
+  const {onClose, referenceElement, width = 0, title, boundaryElement, autofocus} = props
 
   useGlobalKeyDown(
     useCallback(
@@ -80,7 +81,13 @@ function Content(props: PopoverEditDialogProps) {
                 <Text weight="semibold">{title}</Text>
               </Box>
 
-              <Button icon={CloseIcon} mode="bleed" onClick={onClose} padding={2} />
+              <Button
+                autoFocus={Boolean(autofocus)}
+                icon={CloseIcon}
+                mode="bleed"
+                onClick={onClose}
+                padding={2}
+              />
             </Flex>
           </ContentHeaderBox>
           <ContentScrollerBox flex={1}>

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/InsertMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/InsertMenu.tsx
@@ -2,10 +2,10 @@ import React, {memo, useCallback, useMemo} from 'react'
 import {AddIcon} from '@sanity/icons'
 import {Button, PopoverProps} from '@sanity/ui'
 import {PortableTextEditor, usePortableTextEditor} from '@sanity/portable-text-editor'
+import {upperFirst} from 'lodash'
 import {CollapseMenu, CollapseMenuButton} from '../../../../components/collapseMenu'
 import {BlockItem} from './types'
 import {useFocusBlock} from './hooks'
-import {upperFirst} from 'lodash'
 
 const CollapseMenuMemo = memo(CollapseMenu)
 

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/hooks.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/hooks.ts
@@ -41,9 +41,9 @@ export function useActionGroups({
   const editor = usePortableTextEditor()
 
   const handleInsertAnnotation = useCallback(
-    async (type: ObjectSchemaType) => {
-      const initialValue = await resolveInitialValue(type)
-      const paths = PortableTextEditor.addAnnotation(editor, type as FIXME, initialValue)
+    async (schemaType: ObjectSchemaType) => {
+      const initialValue = await resolveInitialValue(schemaType)
+      const paths = PortableTextEditor.addAnnotation(editor, schemaType, initialValue)
       if (paths && paths.markDefPath) {
         onMemberOpen(paths.markDefPath)
       }

--- a/packages/sanity/src/core/form/types/blockProps.ts
+++ b/packages/sanity/src/core/form/types/blockProps.ts
@@ -57,7 +57,7 @@ export interface BlockAnnotationProps {
   __unstable_boundaryElement?: HTMLElement // Boundary element for the annotation, typically a scroll container
   __unstable_referenceElement?: HTMLElement // Reference element representing the annotation in the DOM
   children?: ReactNode | undefined
-  focused: boolean
+  focused: boolean // Whether the annotation data object has form focus
   markers: PortableTextMarker[]
   onClose: () => void
   onOpen: () => void
@@ -70,7 +70,7 @@ export interface BlockAnnotationProps {
   readOnly: boolean
   renderDefault: (props: BlockAnnotationProps) => React.ReactElement
   schemaType: ObjectSchemaType
-  selected: boolean
+  selected: boolean // Whether the object is selected in the editor
   textElement: ReactElement
   validation: FormNodeValidation[]
   value: PortableTextObject
@@ -81,7 +81,7 @@ export interface BlockProps {
   __unstable_boundaryElement?: HTMLElement // Boundary element for the block, typically a scroll container
   __unstable_referenceElement?: HTMLElement // Reference element representing the block in the DOM
   children?: ReactNode | undefined
-  focused: boolean
+  focused: boolean // Whether the object has form focus
   markers: PortableTextMarker[]
   onClose: () => void
   onOpen: () => void
@@ -95,7 +95,7 @@ export interface BlockProps {
   renderDefault: (props: BlockProps) => React.ReactElement
   renderPreview: RenderPreviewCallback
   schemaType: ObjectSchemaType
-  selected: boolean
+  selected: boolean // Whether the object is selected in the editor
   validation: FormNodeValidation[]
   value: PortableTextBlock
 }

--- a/packages/sanity/src/core/form/types/blockProps.ts
+++ b/packages/sanity/src/core/form/types/blockProps.ts
@@ -56,6 +56,7 @@ export interface BlockListItemProps {
 export interface BlockAnnotationProps {
   __unstable_boundaryElement?: HTMLElement // Boundary element for the annotation, typically a scroll container
   __unstable_referenceElement?: HTMLElement // Reference element representing the annotation in the DOM
+  __unstable_textElementFocus?: boolean // Wether the related text element (in the editor) has selection focus. Differs from form state focus.
   children?: ReactNode | undefined
   focused: boolean // Whether the annotation data object has form focus
   markers: PortableTextMarker[]

--- a/packages/sanity/src/core/form/types/blockProps.ts
+++ b/packages/sanity/src/core/form/types/blockProps.ts
@@ -13,9 +13,8 @@ import {
 } from '@sanity/types'
 import {ReactElement, ReactNode} from 'react'
 import {FormNodePresence} from '../../presence'
-import {ArrayOfObjectsItemMember, ObjectArrayFormNode, PortableTextMarker} from '../..'
+import {PortableTextMarker} from '../..'
 import {RenderPreviewCallback} from './renderCallback'
-import {ObjectItem} from './itemProps'
 
 /** @beta */
 export interface BlockDecoratorProps {


### PR DESCRIPTION
### Description

The PT-input is doing focusPath tracking in some situations when it should not, which can cause issues when editing embedded objects inside through the dialogs. There was a recent regression where the selection was not handled well when creating new links in particular.

Also when deleting block objects or inline objects with the mouse through menus, the focus was lost and not properly put back into the editor after the element was deleted. This is now fixed by preventing the default on that menu item click.

There is also an issue with autofocus on the embedded data forms. This is now following the same pattern as elsewhere in the studio (using `autofocus` with React). Autofocus will be triggered when the `focusPath` matches exact with the node in question (so pointing directly to, but not into a embedded object).

All the changes from https://github.com/sanity-io/sanity/pull/4487 are also present and superseded by this PR.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
* That we don't put selection and focus back in the editor when an object is being edited or opened interfering with the editing experience.
* That studio links pointing to content inside a PT-input is properly selected, focused and scrolled to (play with presence)
* That the selection is correct when toggling fullscreen in the PT-input
* That clicking on top navigation validation items for the PT-input is properly selected, focused and scrolled to inside the PT-input
* That when using the mouse to remove block objects or inline objects from the menu on the node, that the selection and focus is correct (back in the editor) for object blocks, inline objects and annotations.
* That the first element in the dialogs for object blocks, inline objects and annotations is selected when first opening them up


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Improve how focus and selection is handled and tracked in the PT-Input. 

<!--
A description of the change(s) that should be used in the release notes.
-->
