### PR TITLE
fix: whitelist all standard text decorators in block-tools

### DIFF
--- a/packages/@sanity/block-tools/README.md
+++ b/packages/@sanity/block-tools/README.md
@@ -68,13 +68,34 @@ This will deserialize the input html (string) into blocks.
 
 #### Params
 
+##### `html`
+
+The stringified version of the HTML you are importing
+
 ##### `blockContentType`
 
 A compiled version of the block content schema type.
-When you give this option, the deserializer will respect the schema when deserializing to blocks.
-I.e. if the schema doesn't allow h2-styles, all h2 html-elements will deserialized to normal styled blocks.
 
-##### `options`
+The deserializer will respect the schema when deserializing the HTML elements to blocks.
+
+It only supports a subset of HTML tags. Any HTML tag not in the block-tools [whitelist](https://github.com/sanity-io/sanity/blob/243b4a5686a1293a8a977574a5cabc768ec01725/packages/%40sanity/block-tools/src/constants.ts#L24-L78) will be deserialized to normal blocks/spans.
+
+For instance, if the schema doesn't allow H2 styles, all H2 HTML elements will be output like this:
+
+```js
+{
+  _type: 'block',
+  style: 'normal'
+  children: [
+    {
+      _type: 'span'
+      text: 'Hello world!'
+    }
+  ]
+}
+```
+
+##### `options` (optional)
 
 ###### `parseHtml`
 
@@ -146,7 +167,7 @@ const partialBlock = {
     },
   ],
 }
-normalizeBlock(partialBlock, {alowedDecorators: ['strong']})
+normalizeBlock(partialBlock, {allowedDecorators: ['strong']})
 ```
 
 Will produce

--- a/packages/@sanity/block-tools/src/HtmlDeserializer/rules/html.ts
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/rules/html.ts
@@ -177,7 +177,7 @@ export default function createHTMLRules(
           children: next(el.childNodes),
         }
       },
-    }, // Deal with decorators
+    }, // Deal with decorators - this is a limited set of known html elements that we know how to deserialize
     {
       deserialize(el, next) {
         const decorator = HTML_DECORATOR_TAGS[tagName(el) || '']

--- a/packages/@sanity/block-tools/src/constants.ts
+++ b/packages/@sanity/block-tools/src/constants.ts
@@ -61,6 +61,11 @@ export const HTML_DECORATOR_TAGS: Record<string, string | undefined> = {
   del: 'strike-through',
 
   code: 'code',
+  sup: 'sup',
+  sub: 'sub',
+  ins: 'ins',
+  mark: 'mark',
+  small: 'small',
 }
 
 export const HTML_LIST_ITEM_TAGS: Record<string, PartialBlock | undefined> = {

--- a/packages/@sanity/block-tools/test/fixtures/customSchema.ts
+++ b/packages/@sanity/block-tools/test/fixtures/customSchema.ts
@@ -24,6 +24,14 @@ export default Schema.compile({
         decorators: [
           {title: 'Strong', value: 'strong'},
           {title: 'Emphasis', value: 'em'},
+          {title: 'Code', value: 'code'},
+          {title: 'Strike through', value: 'strike-through'},
+          {title: 'Highlight', value: 'highlight'},
+          {title: 'Subscript', value: 'sub'},
+          {title: 'Superscript', value: 'sup'},
+          {title: 'Mark', value: 'mark'},
+          {title: 'Inserted', value: 'ins'},
+          {title: 'Small', value: 'small'},
         ],
         // Support annotating text with a reference to an author
         annotations: [

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/customSchema/input.html
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/customSchema/input.html
@@ -1,5 +1,18 @@
 <html>
   <body>
     <h6>A heading that is not allowed</h6>
+    <p>
+      <strong>Strong text but
+        <em>this is also emphasized and
+          <strike>striked</strike>
+          <sub>and subbed</sub>
+          <sup>and supped</sup>
+          <ins>and inserted</ins>
+          <mark>and marked</mark>
+          <del>and deleted</del>
+          <small>and shrunk</small>
+        </em>
+      </strong>
+    </p>
   </body>
 </html>

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/customSchema/output.json
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/customSchema/output.json
@@ -1,7 +1,8 @@
 [
   {
-    "_key": "randomKey0",
     "_type": "customBlock",
+    "markDefs": [],
+    "style": "normal",
     "children": [
       {
         "_type": "span",
@@ -9,7 +10,89 @@
         "text": "A heading that is not allowed"
       }
     ],
+    "_key": "randomKey0"
+  },
+  {
+    "_type": "customBlock",
     "markDefs": [],
-    "style": "normal"
+    "style": "normal",
+    "children": [
+      {
+        "_type": "span",
+        "marks": ["strong"],
+        "text": "Strong text but "
+      },
+      {
+        "_type": "span",
+        "marks": ["strong", "em"],
+        "text": "this is also emphasized and "
+      },
+      {
+        "_type": "span",
+        "marks": ["strong", "em", "strike-through"],
+        "text": "striked"
+      },
+      {
+        "_type": "span",
+        "marks": [],
+        "text": " "
+      },
+      {
+        "_type": "span",
+        "marks": ["strong", "em", "sub"],
+        "text": "and subbed"
+      },
+      {
+        "_type": "span",
+        "marks": [],
+        "text": " "
+      },
+      {
+        "_type": "span",
+        "marks": ["strong", "em", "sup"],
+        "text": "and supped"
+      },
+      {
+        "_type": "span",
+        "marks": [],
+        "text": " "
+      },
+      {
+        "_type": "span",
+        "marks": ["strong", "em", "ins"],
+        "text": "and inserted"
+      },
+      {
+        "_type": "span",
+        "marks": [],
+        "text": " "
+      },
+      {
+        "_type": "span",
+        "marks": ["strong", "em", "mark"],
+        "text": "and marked"
+      },
+      {
+        "_type": "span",
+        "marks": [],
+        "text": " "
+      },
+      {
+        "_type": "span",
+        "marks": ["strong", "em", "strike-through"],
+        "text": "and deleted"
+      },
+      {
+        "_type": "span",
+        "marks": [],
+        "text": " "
+      },
+      {
+        "_type": "span",
+        "marks": ["strong", "em", "small"],
+        "text": "and shrunk"
+      }
+    ],
+    "_key": "randomKey1"
   }
 ]

--- a/packages/@sanity/block-tools/test/tests/util/__snapshots__/blockContentTypeFeatures.test.ts.snap
+++ b/packages/@sanity/block-tools/test/tests/util/__snapshots__/blockContentTypeFeatures.test.ts.snap
@@ -1357,6 +1357,38 @@ Object {
       "title": "Emphasis",
       "value": "em",
     },
+    Object {
+      "title": "Code",
+      "value": "code",
+    },
+    Object {
+      "title": "Strike through",
+      "value": "strike-through",
+    },
+    Object {
+      "title": "Highlight",
+      "value": "highlight",
+    },
+    Object {
+      "title": "Subscript",
+      "value": "sub",
+    },
+    Object {
+      "title": "Superscript",
+      "value": "sup",
+    },
+    Object {
+      "title": "Mark",
+      "value": "mark",
+    },
+    Object {
+      "title": "Inserted",
+      "value": "ins",
+    },
+    Object {
+      "title": "Small",
+      "value": "small",
+    },
   ],
   "lists": Array [
     Object {
@@ -1677,6 +1709,38 @@ Object {
                       Object {
                         "title": "Emphasis",
                         "value": "em",
+                      },
+                      Object {
+                        "title": "Code",
+                        "value": "code",
+                      },
+                      Object {
+                        "title": "Strike through",
+                        "value": "strike-through",
+                      },
+                      Object {
+                        "title": "Highlight",
+                        "value": "highlight",
+                      },
+                      Object {
+                        "title": "Subscript",
+                        "value": "sub",
+                      },
+                      Object {
+                        "title": "Superscript",
+                        "value": "sup",
+                      },
+                      Object {
+                        "title": "Mark",
+                        "value": "mark",
+                      },
+                      Object {
+                        "title": "Inserted",
+                        "value": "ins",
+                      },
+                      Object {
+                        "title": "Small",
+                        "value": "small",
                       },
                     ],
                     "fields": Array [
@@ -2429,6 +2493,38 @@ Object {
                         Object {
                           "title": "Emphasis",
                           "value": "em",
+                        },
+                        Object {
+                          "title": "Code",
+                          "value": "code",
+                        },
+                        Object {
+                          "title": "Strike through",
+                          "value": "strike-through",
+                        },
+                        Object {
+                          "title": "Highlight",
+                          "value": "highlight",
+                        },
+                        Object {
+                          "title": "Subscript",
+                          "value": "sub",
+                        },
+                        Object {
+                          "title": "Superscript",
+                          "value": "sup",
+                        },
+                        Object {
+                          "title": "Mark",
+                          "value": "mark",
+                        },
+                        Object {
+                          "title": "Inserted",
+                          "value": "ins",
+                        },
+                        Object {
+                          "title": "Small",
+                          "value": "small",
                         },
                       ],
                       "fields": Array [
@@ -3192,6 +3288,38 @@ Object {
         Object {
           "title": "Emphasis",
           "value": "em",
+        },
+        Object {
+          "title": "Code",
+          "value": "code",
+        },
+        Object {
+          "title": "Strike through",
+          "value": "strike-through",
+        },
+        Object {
+          "title": "Highlight",
+          "value": "highlight",
+        },
+        Object {
+          "title": "Subscript",
+          "value": "sub",
+        },
+        Object {
+          "title": "Superscript",
+          "value": "sup",
+        },
+        Object {
+          "title": "Mark",
+          "value": "mark",
+        },
+        Object {
+          "title": "Inserted",
+          "value": "ins",
+        },
+        Object {
+          "title": "Small",
+          "value": "small",
         },
       ],
       "fields": Array [


### PR DESCRIPTION
### Description

This updates the whitelist of block-tools to allow highly requested decorators like `sup/sub`, as well as any other similar HTML elements that will "just work": `mark, ins, small` (we already had `del` in there).

It also updates the README to be more specific that we only will convert a subset of HTML elements, and adds a link to the internal whitelist.

### What to review

- Review that the docs update makes sense to you and makes it clearer what tags we whitelist
- Review the list of whitelisted decorators: Any objects to the additions?

### Notes for release

- Added support for `<sup>`, `<sub>`, `<ins>` and `<mark>` in `@sanity/block-tools`