### PR TITLE
fix(core/form/inputs): fix rendering regression for PT-input

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -199,9 +199,13 @@ export function PortableTextInput(props: PortableTextInputProps) {
       }
 
       if (existingItem) {
+        // Only update the input if the node is open or the value has changed
+        // This is a performance optimization.
+        if (item.member.open || existingItem.node.value !== item.node.value) {
+          existingItem.input = input
+        }
         existingItem.member = item.member
         existingItem.node = item.node
-        existingItem.input = input
         return existingItem
       }
 

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
@@ -1,7 +1,7 @@
 import {PortableTextEditor, usePortableTextEditor} from '@sanity/portable-text-editor'
 import {ObjectSchemaType, Path, PortableTextObject} from '@sanity/types'
 import {Tooltip} from '@sanity/ui'
-import React, {ComponentType, useCallback, useMemo, useRef} from 'react'
+import React, {ComponentType, useCallback, useMemo} from 'react'
 import {pathToString} from '../../../../field'
 import {BlockAnnotationProps, RenderCustomMarkers} from '../../../types'
 import {DefaultMarkers} from '../_legacyDefaultParts/Markers'
@@ -99,14 +99,15 @@ export function Annotation(props: AnnotationProps) {
   const presence = memberItem?.node.presence || EMPTY_ARRAY
 
   const isOpen = Boolean(memberItem?.member.open)
-  const inputRef = useRef(memberItem?.input)
-  inputRef.current = memberItem?.input // Update at every render as other Annotation props updates
+  const input = memberItem?.input
+  const nodePath = memberItem?.node.path || EMPTY_ARRAY
+  const referenceElement = memberItem?.elementRef?.current
 
   const componentProps = useMemo(
     (): BlockAnnotationProps => ({
       __unstable_boundaryElement: boundaryElement || undefined,
-      __unstable_referenceElement: memberItem?.elementRef?.current || undefined,
-      children: inputRef.current,
+      __unstable_referenceElement: referenceElement || undefined,
+      children: input,
       focused,
       markers,
       onClose,
@@ -115,7 +116,7 @@ export function Annotation(props: AnnotationProps) {
       onRemove,
       open: isOpen,
       parentSchemaType: editor.schemaTypes.block,
-      path: memberItem?.node.path || path,
+      path: nodePath,
       presence,
       readOnly: Boolean(readOnly),
       renderDefault: DefaultAnnotationComponent,
@@ -129,18 +130,18 @@ export function Annotation(props: AnnotationProps) {
       boundaryElement,
       editor.schemaTypes.block,
       focused,
-      inputRef,
+      input,
       isOpen,
       markers,
       markersToolTip,
-      memberItem,
+      nodePath,
       onClose,
       onOpen,
       onPathFocus,
       onRemove,
-      path,
       presence,
       readOnly,
+      referenceElement,
       schemaType,
       selected,
       text,

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
@@ -6,14 +6,7 @@ import {
 } from '@sanity/portable-text-editor'
 import {ObjectSchemaType, Path, PortableTextBlock} from '@sanity/types'
 import {Tooltip, Flex, ResponsivePaddingProps, Box} from '@sanity/ui'
-import React, {
-  ComponentType,
-  PropsWithChildren,
-  useCallback,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
+import React, {ComponentType, PropsWithChildren, useCallback, useMemo, useState} from 'react'
 import {PatchArg} from '../../../patch'
 import {BlockProps, RenderCustomMarkers, RenderPreviewCallback} from '../../../types'
 import {RenderBlockActionsCallback} from '../types'
@@ -150,15 +143,16 @@ export function BlockObject(props: BlockObjectProps) {
   )
 
   const isOpen = Boolean(memberItem?.member.open)
-  const inputRef = useRef(memberItem?.input)
-  inputRef.current = memberItem?.input // Update at every render as other BlockObjectProps updates
+  const input = memberItem?.input
+  const nodePath = memberItem?.node.path || EMPTY_ARRAY
+  const referenceElement = memberItem?.elementRef?.current
 
   const CustomComponent = schemaType.components?.block as ComponentType<BlockProps> | undefined
   const componentProps: BlockProps = useMemo(
     () => ({
       __unstable_boundaryElement: boundaryElement || undefined,
-      __unstable_referenceElement: memberItem?.elementRef?.current || undefined,
-      children: inputRef.current,
+      __unstable_referenceElement: referenceElement || undefined,
+      children: input,
       focused,
       markers,
       onClose,
@@ -167,7 +161,7 @@ export function BlockObject(props: BlockObjectProps) {
       onRemove,
       open: isOpen,
       parentSchemaType,
-      path: memberItem?.node.path || EMPTY_ARRAY,
+      path: nodePath,
       presence,
       readOnly: Boolean(readOnly),
       renderDefault: DefaultBlockObjectComponent,
@@ -179,16 +173,17 @@ export function BlockObject(props: BlockObjectProps) {
     }),
     [
       boundaryElement,
+      referenceElement,
+      input,
       focused,
-      isOpen,
       markers,
-      memberItem?.elementRef,
-      memberItem?.node.path,
       onClose,
       onOpen,
       onPathFocus,
       onRemove,
+      isOpen,
       parentSchemaType,
+      nodePath,
       presence,
       readOnly,
       renderPreview,

--- a/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
@@ -4,7 +4,7 @@ import {
   usePortableTextEditor,
 } from '@sanity/portable-text-editor'
 import {ObjectSchemaType, Path, PortableTextBlock, PortableTextChild} from '@sanity/types'
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import React, {useCallback, useEffect, useMemo, useState} from 'react'
 import {Tooltip} from '@sanity/ui'
 import {BlockProps, RenderCustomMarkers, RenderPreviewCallback} from '../../../types'
 import {useFormBuilder} from '../../../useFormBuilder'
@@ -75,17 +75,17 @@ export const InlineObject = (props: InlineObjectProps) => {
   }, [memberItem, onItemOpen])
 
   const isOpen = Boolean(memberItem?.member.open)
-
-  const inputRef = useRef(memberItem?.input)
-  inputRef.current = memberItem?.input // Update at every render as other Annotation props updates
+  const input = memberItem?.input
+  const nodePath = memberItem?.node.path || EMPTY_ARRAY
+  const referenceElement = memberItem?.elementRef?.current
 
   const presence = memberItem?.node.presence || EMPTY_ARRAY
 
   const componentProps: BlockProps | undefined = useMemo(
     () => ({
       __unstable_boundaryElement: boundaryElement || undefined,
-      __unstable_referenceElement: memberItem?.elementRef?.current || undefined,
-      children: inputRef.current,
+      __unstable_referenceElement: referenceElement || undefined,
+      children: input,
       focused,
       onClose: onItemClose,
       onOpen,
@@ -95,7 +95,7 @@ export const InlineObject = (props: InlineObjectProps) => {
       markers,
       member: memberItem?.member,
       parentSchemaType,
-      path: memberItem?.member.item.path || EMPTY_ARRAY,
+      path: nodePath,
       presence,
       readOnly: Boolean(readOnly),
       renderDefault: DefaultInlineObjectComponent,
@@ -108,10 +108,11 @@ export const InlineObject = (props: InlineObjectProps) => {
     [
       boundaryElement,
       focused,
-      inputRef,
+      input,
       isOpen,
       markers,
-      memberItem,
+      memberItem?.member,
+      nodePath,
       onItemClose,
       onOpen,
       onPathFocus,
@@ -119,6 +120,7 @@ export const InlineObject = (props: InlineObjectProps) => {
       parentSchemaType,
       presence,
       readOnly,
+      referenceElement,
       renderPreview,
       schemaType,
       selected,


### PR DESCRIPTION
### Description

There was a rendering regression from v3.11.2 in 75dfb9ca1bbb6bc21cad9c8139e4a9d87f9522ad where nested PT-inputs (PT in PT) would not properly update their form inputs. It was probably a bit naive to use refs like that. 😔 

This will revert the use of refs for the input in the PT node components, and let the PortableTextInput figure out if we need to re-render their inputs instead.

I have added a condition that will only re-render the input if the member is open _or_ it's value has changed.

This way we keep the intended performance optimisations by not render all the object inputs with every cycle,
but making sure we do so initially, when the object is open, or it's value has changed.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
* [Set this constant](https://github.com/sanity-io/sanity/blob/next/packages/sanity/src/core/form/inputs/PortableText/debugRender.ts#L1) to true then write some Portable Text. The only colour that should change is the current block you're typing in, or where a new presence or value is made.
* That custom block rendering is able to render the inputs at any time even when displayed directly in the block rendering of the PT-input.
```
        {
          type: 'image',
          name: 'image',
          components: {
            block: (props: BlockProps) => <div contentEditable={false}>{props.children}</div>,
            // props.children here is the input
          },
        },
```
* That one can edit a PT annotation in a nested Portable Text Input (PT block object containing a new PT-input on one of it's properties).


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Fix a recent regression from v3.11.2 with the PT-input where text annotations inside nested PT-inputs could not properly be edited.

<!--
A description of the change(s) that should be used in the release notes.
-->
