### PR TITLE
Keep stable child presence

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
@@ -11,6 +11,7 @@ import {useMemberValidation} from '../hooks/useMemberValidation'
 import {usePortableTextMarkers} from '../hooks/usePortableTextMarkers'
 import {usePortableTextMemberItem} from '../hooks/usePortableTextMembers'
 import {debugRender} from '../debugRender'
+import {useChildPresence} from '../../../studio/contexts/Presence'
 import {EMPTY_ARRAY} from '../../../../util'
 import {AnnotationToolbarPopover} from './AnnotationToolbarPopover'
 import {Root, TooltipBox} from './Annotation.styles'
@@ -111,7 +112,11 @@ export function Annotation(props: AnnotationProps) {
     [Markers, markers, renderCustomMarkers, text, validation]
   )
 
-  const presence = memberItem?.node.presence || EMPTY_ARRAY
+  const presence = useChildPresence(path, true)
+  const rootPresence = useMemo(
+    () => presence.filter((p) => isEqual(p.path, path)),
+    [path, presence]
+  )
 
   const isOpen = Boolean(memberItem?.member.open)
   const input = memberItem?.input
@@ -133,7 +138,7 @@ export function Annotation(props: AnnotationProps) {
       open: isOpen,
       parentSchemaType: editor.schemaTypes.block,
       path: nodePath,
-      presence,
+      presence: rootPresence,
       readOnly: Boolean(readOnly),
       renderDefault: DefaultAnnotationComponent,
       schemaType,
@@ -156,9 +161,9 @@ export function Annotation(props: AnnotationProps) {
       onOpen,
       onPathFocus,
       onRemove,
-      presence,
       readOnly,
       referenceElement,
+      rootPresence,
       schemaType,
       selected,
       text,

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
@@ -15,6 +15,7 @@ import React, {
   useRef,
   useState,
 } from 'react'
+import {isEqual} from '@sanity/util/paths'
 import {PatchArg} from '../../../patch'
 import {BlockProps, RenderCustomMarkers, RenderPreviewCallback} from '../../../types'
 import {RenderBlockActionsCallback} from '../types'
@@ -27,6 +28,7 @@ import {usePortableTextMemberItem} from '../hooks/usePortableTextMembers'
 import {pathToString} from '../../../../field'
 import {debugRender} from '../debugRender'
 import {EMPTY_ARRAY} from '../../../../util'
+import {useChildPresence} from '../../../studio/contexts/Presence'
 import {
   Root,
   ChangeIndicatorWrapper,
@@ -160,7 +162,11 @@ export function BlockObject(props: BlockObjectProps) {
   const parentSchemaType = editor.schemaTypes.portableText
   const hasMarkers = Boolean(markers.length > 0)
 
-  const presence = memberItem?.node.presence || EMPTY_ARRAY
+  const presence = useChildPresence(path, true)
+  const rootPresence = useMemo(
+    () => presence.filter((p) => isEqual(p.path, path)),
+    [path, presence]
+  )
 
   // Tooltip indicating validation errors, warnings, info and markers
   const tooltipEnabled = hasError || hasWarning || hasInfo || hasMarkers
@@ -199,7 +205,7 @@ export function BlockObject(props: BlockObjectProps) {
       open: isOpen,
       parentSchemaType,
       path: nodePath,
-      presence,
+      presence: rootPresence,
       readOnly: Boolean(readOnly),
       renderDefault: DefaultBlockObjectComponent,
       renderPreview,
@@ -221,7 +227,7 @@ export function BlockObject(props: BlockObjectProps) {
       isOpen,
       parentSchemaType,
       nodePath,
-      presence,
+      rootPresence,
       readOnly,
       renderPreview,
       schemaType,

--- a/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
@@ -6,6 +6,7 @@ import {
 import {ObjectSchemaType, Path, PortableTextBlock, PortableTextChild} from '@sanity/types'
 import React, {useCallback, useEffect, useMemo, useState} from 'react'
 import {Tooltip} from '@sanity/ui'
+import {isEqual} from '@sanity/util/paths'
 import {BlockProps, RenderCustomMarkers, RenderPreviewCallback} from '../../../types'
 import {useFormBuilder} from '../../../useFormBuilder'
 import {usePortableTextMarkers} from '../hooks/usePortableTextMarkers'
@@ -13,6 +14,7 @@ import {useMemberValidation} from '../hooks/useMemberValidation'
 import {usePortableTextMemberItem} from '../hooks/usePortableTextMembers'
 import {pathToString} from '../../../../field/paths'
 import {EMPTY_ARRAY} from '../../../../util'
+import {useChildPresence} from '../../../studio/contexts/Presence'
 import {InlineObjectToolbarPopover} from './InlineObjectToolbarPopover'
 import {ObjectEditModal} from './modals/ObjectEditModal'
 import {PreviewSpan, Root, TooltipBox} from './InlineObject.styles'
@@ -89,7 +91,11 @@ export const InlineObject = (props: InlineObjectProps) => {
   const nodePath = memberItem?.node.path || EMPTY_ARRAY
   const referenceElement = memberItem?.elementRef?.current
 
-  const presence = memberItem?.node.presence || EMPTY_ARRAY
+  const presence = useChildPresence(path, true)
+  const rootPresence = useMemo(
+    () => presence.filter((p) => isEqual(p.path, path)),
+    [path, presence]
+  )
 
   const componentProps: BlockProps | undefined = useMemo(
     () => ({
@@ -106,7 +112,7 @@ export const InlineObject = (props: InlineObjectProps) => {
       member: memberItem?.member,
       parentSchemaType,
       path: nodePath,
-      presence,
+      presence: rootPresence,
       readOnly: Boolean(readOnly),
       renderDefault: DefaultInlineObjectComponent,
       renderPreview,
@@ -128,10 +134,10 @@ export const InlineObject = (props: InlineObjectProps) => {
       onPathFocus,
       onRemove,
       parentSchemaType,
-      presence,
       readOnly,
       referenceElement,
       renderPreview,
+      rootPresence,
       schemaType,
       selected,
       validation,


### PR DESCRIPTION
### Description

When using `useChildPresence` it will return a new object even though the presence data is equal.

Keep stable child presence by using immutableReconcile on them.

I have also updated the PT-input nodes to get their presence from this hook, rather than getting them from the array member item. This is also how the Array Input does it, and we get the added performance there as well.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
* That there is a new presence list only when something actually changed in the list.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Improved presence rendering performance

<!--
A description of the change(s) that should be used in the release notes.
-->
