### PR TITLE
fix(core/form/inputs): use isImage asserter to determine image preview

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
@@ -4,7 +4,7 @@ import {
   EditorSelection,
   usePortableTextEditor,
 } from '@sanity/portable-text-editor'
-import {ObjectSchemaType, Path, PortableTextBlock} from '@sanity/types'
+import {ObjectSchemaType, Path, PortableTextBlock, isImage} from '@sanity/types'
 import {Tooltip, Flex, ResponsivePaddingProps, Box} from '@sanity/ui'
 import React, {ComponentType, PropsWithChildren, useCallback, useMemo, useState} from 'react'
 import {PatchArg} from '../../../patch'
@@ -287,7 +287,8 @@ export const DefaultBlockObjectComponent = (props: BlockProps) => {
     value,
     validation,
   } = props
-  const isImagePreview = schemaType.name === 'image'
+
+  const isImagePreview = isImage(schemaType)
   const hasError = validation.filter((v) => v.level === 'error').length > 0
   const hasWarning = validation.filter((v) => v.level === 'warning').length > 0
   const hasMarkers = Boolean(markers.length > 0)


### PR DESCRIPTION
### Description

The determination of using image preview for object blocks in the PT-input is a bit naive and doesn't take custom named image types into account.

Use the `isImage` type asserter from `sanity` instead to determine this which is the correct way.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

That the correct image preview is made inside the PT-input for image blocks.

Custom named image types like this should be asserted correctly too: `{type: 'myBigImageType', name: 'Big image'}`


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

* Improve how image blocks in the Portable Text Input is rendered for custom named image types.

<!--
A description of the change(s) that should be used in the release notes.
-->
