### PR TITLE
refactor(portable-text-editor): improve onPaste typings

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -8,6 +8,7 @@ import {
   useSlate,
 } from '@sanity/slate-react'
 import {noop} from 'lodash'
+import {PortableTextBlock} from '@sanity/types'
 import {
   EditorChange,
   EditorSelection,
@@ -271,7 +272,9 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
             return
           }
           if (result && result.insert) {
-            slateEditor.insertFragment(toSlateValue(result.insert, {schemaTypes}))
+            slateEditor.insertFragment(
+              toSlateValue(result.insert as PortableTextBlock[], {schemaTypes})
+            )
             change$.next({type: 'loading', isLoading: false})
             return
           }

--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -26,7 +26,7 @@ import {
 import {HotkeyOptions} from '../types/options'
 import {fromSlateValue, isEqualToEmptyEditor, toSlateValue} from '../utils/values'
 import {normalizeSelection} from '../utils/selection'
-import {toSlateRange} from '../utils/ranges'
+import {toPortableTextRange, toSlateRange} from '../utils/ranges'
 import {debugWithName} from '../utils/debug'
 import {usePortableTextEditorReadOnlyStatus} from './hooks/usePortableTextReadOnly'
 import {usePortableTextEditorKeyGenerator} from './hooks/usePortableTextEditorKeyGenerator'
@@ -250,11 +250,14 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
       }
       // Resolve it as promise (can be either async promise or sync return value)
       new Promise<OnPasteResult>((resolve) => {
+        const value = PortableTextEditor.getValue(portableTextEditor)
+        const ptRange = toPortableTextRange(value, slateEditor.selection, schemaTypes)
+        const path = ptRange?.focus.path || []
         resolve(
           onPaste({
             event,
-            value: PortableTextEditor.getValue(portableTextEditor),
-            path: slateEditor.selection?.focus.path || [],
+            value,
+            path,
             schemaTypes,
           })
         )

--- a/packages/@sanity/portable-text-editor/src/types/editor.ts
+++ b/packages/@sanity/portable-text-editor/src/types/editor.ts
@@ -13,6 +13,7 @@ import {
   PortableTextSpan,
   PortableTextTextBlock,
   SpanSchemaType,
+  TypedObject,
 } from '@sanity/types'
 import {Subject, Observable} from 'rxjs'
 import {Descendant, Node as SlateNode, Operation as SlateOperation} from 'slate'
@@ -303,19 +304,22 @@ export type EditorChanges = Subject<EditorChange>
 /** @beta */
 export type OnPasteResult =
   | {
-      insert?: PortableTextBlock[]
+      insert?: TypedObject[]
       path?: Path
     }
   | undefined
 export type OnPasteResultOrPromise = OnPasteResult | Promise<OnPasteResult>
 
 /** @beta */
-export type OnPasteFn = (arg0: {
+export interface PasteData {
   event: React.ClipboardEvent
   path: Path
   schemaTypes: PortableTextMemberSchemaTypes
   value: PortableTextBlock[] | undefined
-}) => OnPasteResultOrPromise
+}
+
+/** @beta */
+export type OnPasteFn = (data: PasteData) => OnPasteResultOrPromise
 
 /** @beta */
 export type OnBeforeInputFn = (event: Event) => void


### PR DESCRIPTION
### Description

This will improve the DX a bit on the `PortableTextEditor` `onPaste` prop which is reused by the `PortableTextInput`

First I noticed this function is being called with the wrong path value.  This is supposed to be a keyed PortableText path (and not a Slate path)

Then there was a too strictly typed property on the callback function, it was typed to `PortableTextBlock` which will require a `_key` which isn't needed here. Use `TypedObject` which is the correct one.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

* That the path is called with the correct relative keyed path where the focus is at.
* That one are able to write this without TS-error:
```ts
const onPaste: PortableTextInputProps['onPaste'] = ({event, schemaTypes}) => {
  return {
    // Only a type is required here
    insert: [
      {
        _type: 'myType',
        foo: 'bar',
      },
    ],
  }
}

```

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Improve typings on PortableTextInputProps and fix incorrect `path` value for `onPaste` callback function

<!--
A description of the change(s) that should be used in the release notes.
-->
