### PR TITLE
Fix/add env prefix exceptions

### DIFF
--- a/packages/sanity/src/_internal/cli/server/getStudioEnvironmentVariables.ts
+++ b/packages/sanity/src/_internal/cli/server/getStudioEnvironmentVariables.ts
@@ -42,17 +42,17 @@ export function getStudioEnvironmentVariables(
       continue
     }
 
+    if (key.startsWith(envPrefix)) {
+      studioEnv[`${prefix}${key}`] = jsonEncode
+        ? JSON.stringify(fullEnv[key] || '')
+        : fullEnv[key] || ''
+    }
+
     if (
       envsExceptedFromPrefix.includes(key) ||
       envsExceptedFromPrefix.some((env) => key.startsWith(env))
     ) {
       studioEnv[key] = jsonEncode ? JSON.stringify(fullEnv[key] || '') : fullEnv[key] || ''
-    }
-
-    if (key.startsWith(envPrefix)) {
-      studioEnv[`${prefix}${key}`] = jsonEncode
-        ? JSON.stringify(fullEnv[key] || '')
-        : fullEnv[key] || ''
     }
   }
   return studioEnv

--- a/packages/sanity/src/_internal/cli/server/getStudioEnvironmentVariables.ts
+++ b/packages/sanity/src/_internal/cli/server/getStudioEnvironmentVariables.ts
@@ -1,6 +1,9 @@
 /* eslint-disable no-process-env */
 import {loadEnv} from '@sanity/cli'
 
+/*Fill this array with envs that should not be prefixed*/
+const envsExceptedFromPrefix = ['VERCEL_ENV', 'NODE_ENV']
+
 const envPrefix = 'SANITY_STUDIO_'
 
 /**
@@ -35,6 +38,13 @@ export function getStudioEnvironmentVariables(
 
   const studioEnv: Record<string, string> = {}
   for (const key in fullEnv) {
+    if (!Object.prototype.hasOwnProperty.call(fullEnv, key)) {
+      continue
+    }
+    if (envsExceptedFromPrefix.includes(key)) {
+      studioEnv[key] = jsonEncode ? JSON.stringify(fullEnv[key] || '') : fullEnv[key] || ''
+    }
+
     if (key.startsWith(envPrefix)) {
       studioEnv[`${prefix}${key}`] = jsonEncode
         ? JSON.stringify(fullEnv[key] || '')

--- a/packages/sanity/src/_internal/cli/server/getStudioEnvironmentVariables.ts
+++ b/packages/sanity/src/_internal/cli/server/getStudioEnvironmentVariables.ts
@@ -2,7 +2,7 @@
 import {loadEnv} from '@sanity/cli'
 
 /*Fill this array with envs that should not be prefixed*/
-const envsExceptedFromPrefix = ['VERCEL_ENV', 'NODE_ENV']
+const envsExceptedFromPrefix = ['VERCEL_ENV', 'VERCEL_GIT', 'VERCEL_URL', 'NODE_ENV']
 
 const envPrefix = 'SANITY_STUDIO_'
 
@@ -41,7 +41,11 @@ export function getStudioEnvironmentVariables(
     if (!Object.prototype.hasOwnProperty.call(fullEnv, key)) {
       continue
     }
-    if (envsExceptedFromPrefix.includes(key)) {
+
+    if (
+      envsExceptedFromPrefix.includes(key) ||
+      envsExceptedFromPrefix.some((env) => key.startsWith(env))
+    ) {
       studioEnv[key] = jsonEncode ? JSON.stringify(fullEnv[key] || '') : fullEnv[key] || ''
     }
 


### PR DESCRIPTION
### Description

- I have added an array with env keys that should not be prefixed with the default prefix 'SANITY_STUDIO_'.
- This has been done because prefixed envs can cause unexpected behaviour in some cases. 
- For example the default envs from Vercel could previously only be used in the studio, when manually prefixing them with SANITY_STUDIO_.

- The tests are failing on Vercel but locally the tests pass and I can build the project. @ reviewer, can you see what is going on in the Vercel test studio?

### Steps to review
Please check and (if needed) elaborate on the `envsExceptedFromPrefix` array added in file getStudioEnvironmentVariables.


### Steps to test
- Deploy the studio on Vercel, and see if you can use `VERCEL_ENV` in stead of `SANITY_STUDIO_VERCEL_ENV`.

### Notes for release
- List of envs that should not be prefixed with 'SANITY_STUDIO_' added

