### PR TITLE
fix(form): pass the correct data to conditional fields contained inside fieldsets

### DIFF
--- a/packages/sanity/src/core/form/store/formState.ts
+++ b/packages/sanity/src/core/form/store/formState.ts
@@ -603,9 +603,7 @@ function prepareObjectInputState<T>(
 
       const fieldsetMembers = fieldSet.fields.flatMap(
         (field): (FieldMember | FieldError | HiddenField)[] => {
-          const hidden = resolveConditionalProperty(field.type.hidden, conditionalPropertyContext)
-
-          if (fieldsetHidden || hidden) {
+          if (fieldsetHidden) {
             return [
               {
                 kind: 'hidden',
@@ -615,14 +613,13 @@ function prepareObjectInputState<T>(
               },
             ]
           }
-
           // readonly is inherited
           const readOnly = props.readOnly || fieldsetReadOnly
           const fieldMember = prepareFieldMember({
             field: field,
-            parent: {...props, readOnly, hidden, groups, selectedGroup},
+            parent: {...props, readOnly, groups, selectedGroup},
             index,
-          }) as FieldMember | FieldError
+          }) as FieldMember | FieldError | HiddenField
 
           return fieldMember ? [fieldMember] : []
         }


### PR DESCRIPTION
### Description

Currently, conditional fields on fields contained inside fieldsets doesn't get passed the correct arguments. Instead of getting the current field value, it receives the parent's field values.

### What to review

- Make sure fields + field groups and conditional fields works as they should

### Notes for release

- Fixes a bug that made conditional field callbacks inside fieldsets to get passed a wrong parent value
