### PR TITLE
fix(core, desk): add accessible labels to presence indicators, publish status, and review changes

### DIFF
--- a/packages/sanity/src/core/components/userAvatar/UserAvatar.tsx
+++ b/packages/sanity/src/core/components/userAvatar/UserAvatar.tsx
@@ -97,6 +97,7 @@ const StaticUserAvatar = forwardRef(function StaticUserAvatar(
       ref={ref}
       size={typeof size === 'string' ? LEGACY_TO_UI_AVATAR_SIZES[size] : size}
       status={status}
+      title={user?.displayName}
     />
   )
 })

--- a/packages/sanity/src/core/presence/DocumentPreviewPresence.tsx
+++ b/packages/sanity/src/core/presence/DocumentPreviewPresence.tsx
@@ -70,7 +70,7 @@ export function DocumentPreviewPresence(props: DocumentPreviewPresenceProps) {
   return (
     <Tooltip content={tooltipContent} {...PRESENCE_MENU_POPOVER_PROPS}>
       <AvatarStackCard scheme={selected ? invertedScheme : undefined} $selected={selected}>
-        <AvatarStack maxLength={2}>
+        <AvatarStack maxLength={2} aria-label={getTooltipText(uniqueUsers)}>
           {uniqueUsers.map((item) => (
             <UserAvatar key={item.user.id} user={item.user} />
           ))}

--- a/packages/sanity/src/desk/components/PublishedStatus.tsx
+++ b/packages/sanity/src/desk/components/PublishedStatus.tsx
@@ -8,6 +8,7 @@ import {TextWithTone} from 'sanity'
 export function PublishedStatus(props: {document?: PreviewValue | Partial<SanityDocument> | null}) {
   const {document} = props
   const updatedAt = document && '_updatedAt' in document && document._updatedAt
+  const statusLabel = document ? 'Published' : 'Not published'
 
   return (
     <Tooltip
@@ -25,7 +26,7 @@ export function PublishedStatus(props: {document?: PreviewValue | Partial<Sanity
       }
     >
       <TextWithTone tone="positive" dimmed={!document} muted={!document} size={1}>
-        <PublishIcon />
+        <PublishIcon aria-label={statusLabel} />
       </TextWithTone>
     </Tooltip>
   )

--- a/packages/sanity/src/desk/panes/document/inspectors/changes/ChangesInspector.tsx
+++ b/packages/sanity/src/desk/panes/document/inspectors/changes/ChangesInspector.tsx
@@ -74,7 +74,7 @@ export function ChangesInspector(props: DocumentInspectorProps): ReactElement {
 
           <Box flex="none">
             <DiffTooltip annotations={changeAnnotations} description="Changes by" portal>
-              <AvatarStack maxLength={4}>
+              <AvatarStack maxLength={4} aria-label="Changes by">
                 {changeAnnotations.map(({author}) => (
                   <UserAvatar key={author} user={author} />
                 ))}

--- a/packages/sanity/src/desk/panes/document/statusBar/sparkline/PublishStatus.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/sparkline/PublishStatus.tsx
@@ -19,11 +19,22 @@ const Root = styled(Flex)`
 export function PublishStatus(props: PublishStatusProps) {
   const {collapsed, disabled, lastPublished, lastUpdated, liveEdit} = props
 
+  // Label with abbreviations and suffix
   const lastPublishedTimeAgo = useTimeAgo(lastPublished || '', {minimal: true, agoSuffix: true})
+  // Label with abbreviation and no suffix
   const lastPublishedTime = useTimeAgo(lastPublished || '', {minimal: true})
 
+  // Label with abbreviations and suffix
   const lastUpdatedTimeAgo = useTimeAgo(lastUpdated || '', {minimal: true, agoSuffix: true})
+  // Label with abbreviation and no suffix
   const lastUpdatedTime = useTimeAgo(lastUpdated || '', {minimal: true})
+
+  // Accessible labels without abbreviations or suffixes
+  const a11yUpdatedAgo = useTimeAgo(lastUpdated || '', {minimal: false, agoSuffix: true})
+  const a11yPublishedAgo = useTimeAgo(lastPublished || '', {minimal: false, agoSuffix: true})
+  const a11yLabel = liveEdit
+    ? `Last updated ${a11yUpdatedAgo}`
+    : `Last published ${a11yPublishedAgo}`
 
   return (
     <Root align="center" data-ui="SessionLayout" sizing="border">
@@ -34,9 +45,16 @@ export function PublishStatus(props: PublishStatusProps) {
           <Stack padding={3} space={3}>
             <Text size={1}>
               {liveEdit ? (
-                <>Last updated {lastUpdated ? lastUpdatedTimeAgo : lastPublishedTimeAgo}</>
+                <>
+                  Last updated{' '}
+                  <abbr aria-label={lastUpdated ? a11yUpdatedAgo : a11yPublishedAgo}>
+                    {lastUpdated ? lastUpdatedTimeAgo : lastPublishedTimeAgo}
+                  </abbr>
+                </>
               ) : (
-                <>Last published {lastPublishedTimeAgo}</>
+                <>
+                  Last published <abbr aria-label={a11yPublishedAgo}>{lastPublishedTimeAgo}</abbr>
+                </>
               )}
             </Text>
           </Stack>
@@ -47,17 +65,22 @@ export function PublishStatus(props: PublishStatusProps) {
           tone={liveEdit ? 'critical' : 'positive'}
           tabIndex={-1}
           disabled={disabled}
+          aria-label={a11yLabel}
         >
           <Flex align="center">
             <Box marginRight={collapsed ? 0 : 3}>
-              <Text size={2}>{liveEdit ? <PlayIcon /> : <PublishIcon />}</Text>
+              <Text size={2} aria-hidden="true">
+                {liveEdit ? <PlayIcon /> : <PublishIcon />}
+              </Text>
             </Box>
             {!collapsed && (
               <Text size={1} weight="medium">
                 {liveEdit ? (
-                  <>{lastUpdated ? lastUpdatedTime : lastPublishedTime}</>
+                  <abbr aria-label={a11yLabel}>
+                    {lastUpdated ? lastUpdatedTime : lastPublishedTime}
+                  </abbr>
                 ) : (
-                  lastPublishedTime
+                  <abbr aria-label={a11yLabel}>{lastPublishedTime}</abbr>
                 )}
               </Text>
             )}

--- a/packages/sanity/src/desk/panes/document/statusBar/sparkline/ReviewChangesButton/ReviewChangesButton.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/sparkline/ReviewChangesButton/ReviewChangesButton.tsx
@@ -16,6 +16,7 @@ const ReviewButton = React.forwardRef(function ReviewButton(
   const {collapsed, status, lastUpdated, ...rest} = props
   const lastUpdatedTime = useTimeAgo(lastUpdated || '', {minimal: true})
   const lastUpdatedTimeAgo = useTimeAgo(lastUpdated || '', {minimal: true, agoSuffix: true})
+  const a11yUpdatedAgo = useTimeAgo(lastUpdated || '', {minimal: false, agoSuffix: true})
 
   const buttonProps: ButtonProps = useMemo(() => {
     if (status === 'syncing') {
@@ -55,7 +56,7 @@ const ReviewButton = React.forwardRef(function ReviewButton(
             Review changes
           </Text>
           <Text size={1} muted>
-            Changes saved {lastUpdatedTimeAgo}
+            Changes saved <abbr aria-label={a11yUpdatedAgo}>{lastUpdatedTimeAgo}</abbr>
           </Text>
         </Stack>
       }
@@ -67,9 +68,10 @@ const ReviewButton = React.forwardRef(function ReviewButton(
         {...rest}
         data-testid="review-changes-button"
         ref={ref}
+        aria-label="Review changes"
       >
         <Flex align="center">
-          <Box marginRight={collapsed ? 0 : 3}>
+          <Box marginRight={collapsed ? 0 : 3} aria-hidden="true">
             <Text>
               <AnimatedStatusIcon status={status} />
             </Text>


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Currently when a screen reader is using Sanity, no labels are read out about presence indicators, or understandable document status timestamps. This fixes that to some extent.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

Test the with a screen reader where possible.
1. Navigate to a document
2. Use the document sparkline or pane header to get information about the document

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
Fixed various accessibility label issues in the desk tool