### PR TITLE
fix(portable-text-editor): show editable when invalid value

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -398,7 +398,7 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
   if (!portableTextEditor) {
     return null
   }
-  return hasInvalidValue ? null : (
+  return (
     <SlateEditable
       {...restProps}
       autoFocus={false}


### PR DESCRIPTION
Always show the editable also when there is an invalid value.

This is making a better experience when choosing to ignore the validation error for a PT text block.

The invalid value is now removed from the greater value when displayed in the editor, making it possible to still edit everything else if you choose to. This was not previously possible, but became possible with the introduction of the useSyncValue hook. Enabling this behaviour now.

Note that you have to explicitly ignore a warning in order to continue editing on the remaining value.

### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
