### PR TITLE
feat(desk): add `useMenuItem` to document inspector API

### DIFF
--- a/dev/test-studio/inspectors/custom/index.ts
+++ b/dev/test-studio/inspectors/custom/index.ts
@@ -4,10 +4,10 @@ import {defineDocumentInspector} from 'sanity'
 
 export const customInspector = defineDocumentInspector({
   name: 'custom',
-  menuItem: {
+  useMenuItem: () => ({
     icon: RocketIcon,
+    showAsAction: true,
     title: 'Custom inspector',
-  },
+  }),
   component: lazy(() => import('./inspector')),
-  showAsAction: true,
 })

--- a/packages/sanity/src/core/config/document/inspector.ts
+++ b/packages/sanity/src/core/config/document/inspector.ts
@@ -1,10 +1,11 @@
-import {ValidationMarker} from '@sanity/types'
 import {ButtonTone} from '@sanity/ui'
 import {ComponentType} from 'react'
 
 /** @beta */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface DocumentInspectorProps {
+  documentId: string
+  documentType: string
   onClose: () => void
 }
 
@@ -12,15 +13,18 @@ export interface DocumentInspectorProps {
 export type DocumentInspectorComponent = ComponentType<DocumentInspectorProps>
 
 /** @beta */
-export interface DocumentInspectorCallbackContext {
-  validation: ValidationMarker[]
+export interface DocumentInspectorMenuItemContext {
+  documentId: string
+  documentType: string
 }
 
 /** @beta */
 export interface DocumentInspectorMenuItem {
-  hidden?: boolean | ((props: DocumentInspectorCallbackContext) => boolean)
+  hidden?: boolean
   hotkeys?: string[]
   icon?: ComponentType
+  showAsAction?: boolean
+  status?: ButtonTone
   title: string
   tone?: ButtonTone
 }
@@ -29,10 +33,10 @@ export interface DocumentInspectorMenuItem {
 export interface DocumentInspector {
   name: string
   component: DocumentInspectorComponent
-  showAsAction?: boolean
-  menuItem?:
-    | DocumentInspectorMenuItem
-    | ((props: DocumentInspectorCallbackContext) => DocumentInspectorMenuItem)
+  /**
+   * Hook for defining a menu item for the inspector.
+   */
+  useMenuItem: (props: DocumentInspectorMenuItemContext) => DocumentInspectorMenuItem
 
   /**
    * Callback for when the inspector is closed, which can be used to clean up custom document pane
@@ -64,12 +68,12 @@ export interface DocumentInspector {
  *
  * const customInspector = defineDocumentInspector({
  *   name: 'custom',
- *   menuItem: {
+ *   useMenuItem: () => ({
  *     icon: RocketIcon,
- *     title: 'Custom',
- *   },
+ *     showAsAction: true,
+ *     title: 'Custom'
+ *   }),
  *   component: lazy(() => import('./inspectors/custom')),
- *   showAsAction: true,
  * })
  *
  * export default defineConfig({

--- a/packages/sanity/src/desk/panes/document/DocumentInspectorMenuItemsResolver.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentInspectorMenuItemsResolver.tsx
@@ -1,0 +1,76 @@
+import React, {memo, useCallback, useEffect, useState} from 'react'
+import {DocumentInspector, DocumentInspectorMenuItem, useUnique} from 'sanity'
+
+interface InspectorMenuItemProps {
+  inspector: DocumentInspector
+  documentId: string
+  documentType: string
+  index: number
+  setMenuItem: (node: DocumentInspectorMenuItem, index: number) => void
+}
+
+const InspectorMenuItem = memo(function InspectorMenuItem(props: InspectorMenuItemProps) {
+  const {inspector, documentId, documentType, index, setMenuItem} = props
+
+  const node = useUnique(
+    inspector.useMenuItem({
+      documentId,
+      documentType,
+    })
+  )
+
+  useEffect(() => {
+    setMenuItem(node, index)
+  }, [index, node, setMenuItem])
+
+  return <></>
+})
+
+interface DocumentInspectorMenuItemsResolverProps {
+  documentId: string
+  documentType: string
+  inspectors: DocumentInspector[]
+  onResolvedItems: (items: DocumentInspectorMenuItem[]) => void
+}
+
+// The menu item in a document inspector are resolved in a React hook (`useMenuItem`).
+// This means that the menu item needs to be resolved in a React component (in accordance with the rules of hooks).
+// In this component, we map over the configured inspectors and render a `InspectorMenuItem` for each.
+// The `InspectorMenuItem` will resolve the menu item in a React hook and call the `setMenuItem` callback
+// with the resolved menu item and the index of the inspector.
+// Finally, we call the `onResolvedItems` callback with the resolved menu items.
+export function DocumentInspectorMenuItemsResolver(props: DocumentInspectorMenuItemsResolverProps) {
+  const {documentId, documentType, inspectors, onResolvedItems} = props
+
+  const [inspectorMenuItems, setInspectorMenuItems] = useState<DocumentInspectorMenuItem[]>([])
+
+  const handleSetInspectorMenuItem = useCallback(
+    (item: DocumentInspectorMenuItem, itemIndex: number) => {
+      setInspectorMenuItems((prev) => {
+        const next = [...prev]
+        next[itemIndex] = item
+        return next
+      })
+    },
+    []
+  )
+
+  useEffect(() => {
+    onResolvedItems(inspectorMenuItems)
+  }, [inspectorMenuItems, onResolvedItems])
+
+  return (
+    <>
+      {inspectors.map((inspector, inspectorIndex) => (
+        <InspectorMenuItem
+          documentId={documentId}
+          documentType={documentType}
+          index={inspectorIndex}
+          inspector={inspector}
+          key={inspector.name}
+          setMenuItem={handleSetInspectorMenuItem}
+        />
+      ))}
+    </>
+  )
+}

--- a/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
@@ -16,6 +16,7 @@ import {usePreviewUrl} from './usePreviewUrl'
 import {getInitialValueTemplateOpts} from './getInitialValueTemplateOpts'
 import {DEFAULT_MENU_ITEM_GROUPS, EMPTY_PARAMS, INSPECT_ACTION_PREFIX} from './constants'
 import {validationInspector} from './inspectors/validation'
+import {DocumentInspectorMenuItemsResolver} from './DocumentInspectorMenuItemsResolver'
 import {
   DocumentInspector,
   DocumentPresence,
@@ -40,6 +41,7 @@ import {
   useDocumentValuePermissions,
   useTimelineStore,
   useTimelineSelector,
+  DocumentInspectorMenuItem,
 } from 'sanity'
 
 /**
@@ -97,6 +99,8 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   const connectionState = useConnectionState(documentId, documentType)
   const schemaType = schema.get(documentType) as ObjectSchemaType | undefined
   const value: SanityDocumentLike = editState?.draft || editState?.published || initialValue.value
+
+  const [inspectorMenuItems, setInspectorMenuItems] = useState<DocumentInspectorMenuItem[]>([])
 
   // Resolve document actions
   const actions = useMemo(
@@ -188,11 +192,11 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
         currentInspector,
         features,
         hasValue,
+        inspectorMenuItems,
         inspectors,
         previewUrl,
-        validation,
       }),
-    [currentInspector, features, hasValue, inspectors, previewUrl, validation]
+    [currentInspector, features, hasValue, inspectorMenuItems, inspectors, previewUrl]
   )
   const inspectOpen = params.inspect === 'on'
   const compareValue: Partial<SanityDocument> | null = changesOpen
@@ -595,7 +599,18 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   }, [params, documentId, setOpenPath, ready, paneRouter])
 
   return (
-    <DocumentPaneContext.Provider value={documentPane}>{children}</DocumentPaneContext.Provider>
+    <DocumentPaneContext.Provider value={documentPane}>
+      {inspectors.length > 0 && (
+        <DocumentInspectorMenuItemsResolver
+          documentId={documentId}
+          documentType={documentType}
+          inspectors={inspectors}
+          onResolvedItems={setInspectorMenuItems}
+        />
+      )}
+
+      {children}
+    </DocumentPaneContext.Provider>
   )
 })
 

--- a/packages/sanity/src/desk/panes/document/documentInspector/DocumentInspectorPanel.tsx
+++ b/packages/sanity/src/desk/panes/document/documentInspector/DocumentInspectorPanel.tsx
@@ -6,8 +6,14 @@ import {DOCUMENT_INSPECTOR_MAX_WIDTH, DOCUMENT_INSPECTOR_MIN_WIDTH} from '../con
 import {useDocumentPane} from '../useDocumentPane'
 import {Resizable} from './Resizable'
 
-export function DocumentInspectorPanel(props: {flex?: number}): ReactElement | null {
-  const {flex} = props
+interface DocumentInspectorPanelProps {
+  documentId: string
+  documentType: string
+  flex?: number | number[]
+}
+
+export function DocumentInspectorPanel(props: DocumentInspectorPanelProps): ReactElement | null {
+  const {documentId, documentType, flex} = props
   const {collapsed} = usePane()
   const {closeInspector, inspector} = useDocumentPane()
   const {features} = useDeskTool()
@@ -18,6 +24,12 @@ export function DocumentInspectorPanel(props: {flex?: number}): ReactElement | n
 
   if (collapsed || !inspector) return null
 
+  const element = createElement(inspector.component, {
+    onClose: handleClose,
+    documentId,
+    documentType,
+  })
+
   if (features.resizablePanes) {
     return (
       <Resizable
@@ -27,14 +39,14 @@ export function DocumentInspectorPanel(props: {flex?: number}): ReactElement | n
         maxWidth={DOCUMENT_INSPECTOR_MAX_WIDTH}
         minWidth={DOCUMENT_INSPECTOR_MIN_WIDTH}
       >
-        {createElement(inspector.component, {onClose: handleClose})}
+        {element}
       </Resizable>
     )
   }
 
   return (
     <Box as="aside" data-ui="DocumentInspectorPanel" flex={flex}>
-      {createElement(inspector.component, {onClose: handleClose})}
+      {element}
     </Box>
   )
 }

--- a/packages/sanity/src/desk/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/DocumentPanel.tsx
@@ -176,7 +176,11 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
 
           {showInspector && (
             <BoundaryElementProvider element={rootElement}>
-              <DocumentInspectorPanel flex={1} />
+              <DocumentInspectorPanel
+                documentId={documentId}
+                documentType={schemaType.name}
+                flex={1}
+              />
             </BoundaryElementProvider>
           )}
         </Flex>

--- a/packages/sanity/src/desk/panes/document/inspectors/changes/index.ts
+++ b/packages/sanity/src/desk/panes/document/inspectors/changes/index.ts
@@ -4,10 +4,10 @@ import {DocumentInspector} from 'sanity'
 
 export const changesInspector: DocumentInspector = {
   name: 'changes',
-  menuItem: {
+  useMenuItem: () => ({
     icon: RestoreIcon,
     title: 'Review changes',
-  },
+  }),
   component: lazy(() => import('./inspector')),
   onClose: ({params}) => {
     return {params: {...params, since: undefined}}

--- a/packages/sanity/src/desk/panes/document/inspectors/validation/index.ts
+++ b/packages/sanity/src/desk/panes/document/inspectors/validation/index.ts
@@ -1,28 +1,51 @@
 import {CheckmarkCircleIcon, ErrorOutlineIcon, WarningOutlineIcon} from '@sanity/icons'
-import {lazy} from 'react'
-import {DocumentInspector, FormNodeValidation, isValidationError, isValidationWarning} from 'sanity'
+import {lazy, useMemo} from 'react'
+import {
+  DocumentInspector,
+  DocumentInspectorMenuItem,
+  DocumentInspectorMenuItemContext,
+  FormNodeValidation,
+  isValidationError,
+  isValidationWarning,
+  useValidationStatus,
+} from 'sanity'
+
+function useMenuItem(props: DocumentInspectorMenuItemContext): DocumentInspectorMenuItem {
+  const {documentId, documentType} = props
+  const {validation} = useValidationStatus(documentId, documentType)
+
+  const formNodeValidation: FormNodeValidation[] = validation.map((item) => ({
+    level: item.level,
+    message: item.item.message,
+    path: item.path,
+  }))
+
+  const hasErrors = formNodeValidation.filter(isValidationError).length > 0
+  const hasWarnings = formNodeValidation.filter(isValidationWarning).length > 0
+
+  const icon = useMemo(() => {
+    if (hasErrors) return ErrorOutlineIcon
+    if (hasWarnings) return WarningOutlineIcon
+    return CheckmarkCircleIcon
+  }, [hasErrors, hasWarnings])
+
+  const tone = useMemo(() => {
+    if (hasErrors) return 'critical'
+    if (hasWarnings) return 'caution'
+    return 'positive'
+  }, [hasErrors, hasWarnings])
+
+  return {
+    // hidden: validation.length === 0,
+    icon,
+    title: 'Validation',
+    tone,
+    showAsAction: true,
+  }
+}
 
 export const validationInspector: DocumentInspector = {
   name: 'validation',
   component: lazy(() => import('./inspector')),
-  showAsAction: true,
-  menuItem: ({validation}) => {
-    const formNodeValidation: FormNodeValidation[] = validation.map((item) => ({
-      level: item.level,
-      path: item.path,
-      message: item.item.message,
-    }))
-
-    const hasErrors = formNodeValidation.filter(isValidationError).length > 0
-    const hasWarnings = formNodeValidation.filter(isValidationWarning).length > 0
-
-    return {
-      // hidden: validation.length === 0,
-      // eslint-disable-next-line no-nested-ternary
-      icon: hasErrors ? ErrorOutlineIcon : hasWarnings ? WarningOutlineIcon : CheckmarkCircleIcon,
-      title: 'Validation',
-      // eslint-disable-next-line no-nested-ternary
-      tone: hasErrors ? 'critical' : hasWarnings ? 'caution' : 'positive',
-    }
-  },
+  useMenuItem,
 }

--- a/packages/sanity/src/desk/panes/document/menuItems.ts
+++ b/packages/sanity/src/desk/panes/document/menuItems.ts
@@ -1,7 +1,7 @@
 import {BinaryDocumentIcon, EarthAmericasIcon} from '@sanity/icons'
 import {DeskToolFeatures, PaneMenuItem} from '../../types'
 import {INSPECT_ACTION_PREFIX} from './constants'
-import {DocumentInspector, DocumentInspectorMenuItem, ValidationMarker, isRecord} from 'sanity'
+import {DocumentInspector, DocumentInspectorMenuItem, ValidationMarker} from 'sanity'
 
 interface GetMenuItemsParams {
   currentInspector?: DocumentInspector
@@ -9,36 +9,30 @@ interface GetMenuItemsParams {
   hasValue: boolean
   inspectors: DocumentInspector[]
   previewUrl?: string | null
-  validation: ValidationMarker[]
+  inspectorMenuItems: DocumentInspectorMenuItem[]
 }
 
 function getInspectorItems({
   currentInspector,
   hasValue,
   inspectors,
-  validation,
+  inspectorMenuItems,
 }: GetMenuItemsParams): PaneMenuItem[] {
   return inspectors
-    .map((inspector) => {
-      let menuItem: DocumentInspectorMenuItem | undefined
-
-      if (typeof inspector.menuItem === 'function') {
-        menuItem = inspector.menuItem({validation})
-      } else if (isRecord(inspector.menuItem)) {
-        menuItem = inspector.menuItem
-      }
+    .map((inspector, index) => {
+      const menuItem = inspectorMenuItems[index]
 
       if (menuItem?.hidden) return null
 
       return {
         action: `${INSPECT_ACTION_PREFIX}${inspector.name}`,
         group: 'inspectors',
-        title: menuItem?.title,
         icon: menuItem?.icon,
         isDisabled: !hasValue,
         selected: currentInspector?.name === inspector.name,
         shortcut: menuItem?.hotkeys?.join('+'),
-        showAsAction: inspector.showAsAction,
+        showAsAction: menuItem?.showAsAction,
+        title: menuItem?.title,
         tone: menuItem?.tone,
       }
     })


### PR DESCRIPTION
### Description

This pull request updates the document inspector API so that the menu item is configured with a React hook (`useMenuItem`). The pull request also moves the `showAsAction` property to be part of the menu item value. This update opens up possibilities to perform custom logic in `useMenuItem` and return a dynamic menu item object (see the validation inspector for example).


Before:
```ts
const inspector = defineDocumentInspector({
  // ...
  
  menuItem: {
    title: 'Inspector',
  },
  showAsAction: true,
})
```

After:
```ts
const inspector = defineDocumentInspector({
  // ...
  
  useMenuItem: () => {
  // ...
  
    return {
      showAsAction: true,
      title: 'Inspector',
    }
  },
})
```

### What to review


### Notes for release

