### PR TITLE
fix(desk): close document panes when document is deleted

### DIFF
--- a/packages/sanity/src/core/store/_legacy/history/useTimelineStore.ts
+++ b/packages/sanity/src/core/store/_legacy/history/useTimelineStore.ts
@@ -19,7 +19,8 @@ interface UseTimelineControllerOpts {
 export interface TimelineState {
   chunks: Chunk[]
   diff: ObjectDiff<Annotation, Record<string, any>> | null
-  hasMoreChunks: boolean
+  /** null is used here when the chunks hasn't loaded / is not known */
+  hasMoreChunks: boolean | null
   isLoading: boolean
   onOlderRevision: boolean
   realRevChunk: Chunk | null
@@ -34,7 +35,7 @@ export interface TimelineState {
 const INITIAL_TIMELINE_STATE: TimelineState = {
   chunks: [],
   diff: null,
-  hasMoreChunks: false,
+  hasMoreChunks: null,
   isLoading: false,
   onOlderRevision: false,
   realRevChunk: null,

--- a/packages/sanity/src/desk/components/paneRouter/PaneRouterContext.tsx
+++ b/packages/sanity/src/desk/components/paneRouter/PaneRouterContext.tsx
@@ -25,6 +25,7 @@ export const PaneRouterContext = createContext<PaneRouterContextValue>({
   handleEditReference: () => missingContext(),
   ParameterizedLink: () => missingContext(),
   replaceCurrent: () => missingContext(),
+  closeCurrentAndAfter: () => missingContext(),
   closeCurrent: () => missingContext(),
   duplicateCurrent: () => missingContext(),
   setView: () => missingContext(),

--- a/packages/sanity/src/desk/components/paneRouter/PaneRouterProvider.tsx
+++ b/packages/sanity/src/desk/components/paneRouter/PaneRouterProvider.tsx
@@ -2,6 +2,7 @@ import {omit} from 'lodash'
 import React, {useCallback, useMemo} from 'react'
 import {toString as pathToString} from '@sanity/util/paths'
 import {RouterPaneGroup, RouterPanes, RouterPaneSibling} from '../../types'
+import {usePaneLayout} from '../pane/usePaneLayout'
 import {ChildLink} from './ChildLink'
 import {BackLink} from './BackLink'
 import {ReferenceChildLink} from './ReferenceChildLink'
@@ -26,10 +27,12 @@ export function PaneRouterProvider(props: {
   const {children, flatIndex, index, params, payload, siblingIndex} = props
   const {navigate, navigateIntent} = useRouter()
   const routerState = useRouterState()
+  const {panes, expand} = usePaneLayout()
   const routerPaneGroups: RouterPaneGroup[] = useMemo(
     () => (routerState?.panes || emptyArray) as RouterPanes,
     [routerState?.panes]
   )
+  const lastPane = useMemo(() => panes?.[panes.length - 2], [panes])
 
   const groupIndex = index - 1
 
@@ -151,7 +154,10 @@ export function PaneRouterProvider(props: {
       },
 
       // Removes all panes to the right including current
-      closeCurrentAndAfter: (): void => {
+      closeCurrentAndAfter: (expandLast = true): void => {
+        if (expandLast && lastPane) {
+          expand(lastPane.element)
+        }
         navigate(
           {
             panes: [...routerPaneGroups.slice(0, groupIndex)],
@@ -195,16 +201,18 @@ export function PaneRouterProvider(props: {
     [
       flatIndex,
       groupIndex,
-      handleEditReference,
-      modifyCurrentGroup,
-      navigateIntent,
-      navigate,
-      params,
+      siblingIndex,
       payload,
+      params,
       routerPaneGroups,
+      handleEditReference,
       setParams,
       setPayload,
-      siblingIndex,
+      navigateIntent,
+      modifyCurrentGroup,
+      lastPane,
+      navigate,
+      expand,
     ]
   )
 

--- a/packages/sanity/src/desk/components/paneRouter/PaneRouterProvider.tsx
+++ b/packages/sanity/src/desk/components/paneRouter/PaneRouterProvider.tsx
@@ -150,6 +150,16 @@ export function PaneRouterProvider(props: {
         )
       },
 
+      // Removes all panes to the right including current
+      closeCurrentAndAfter: (): void => {
+        navigate(
+          {
+            panes: [...routerPaneGroups.slice(0, groupIndex)],
+          },
+          {replace: true}
+        )
+      },
+
       // Duplicate the current pane, with optional overrides for payload, parameters
       duplicateCurrent: (options): void => {
         modifyCurrentGroup((siblings, item) => {
@@ -188,6 +198,7 @@ export function PaneRouterProvider(props: {
       handleEditReference,
       modifyCurrentGroup,
       navigateIntent,
+      navigate,
       params,
       payload,
       routerPaneGroups,

--- a/packages/sanity/src/desk/components/paneRouter/types.ts
+++ b/packages/sanity/src/desk/components/paneRouter/types.ts
@@ -129,6 +129,11 @@ export interface PaneRouterContextValue {
   closeCurrent: () => void
 
   /**
+   * Removes all panes to the right including current pane
+   */
+  closeCurrentAndAfter: () => void
+
+  /**
    * Duplicate the current pane, with optional overrides for item ID and parameters
    */
   duplicateCurrent: (pane?: {payload?: unknown; params?: Record<string, string>}) => void

--- a/packages/sanity/src/desk/components/paneRouter/types.ts
+++ b/packages/sanity/src/desk/components/paneRouter/types.ts
@@ -131,7 +131,7 @@ export interface PaneRouterContextValue {
   /**
    * Removes all panes to the right including current pane
    */
-  closeCurrentAndAfter: () => void
+  closeCurrentAndAfter: (expandLast?: boolean) => void
 
   /**
    * Duplicate the current pane, with optional overrides for item ID and parameters

--- a/packages/sanity/src/desk/documentActions/DeleteAction.tsx
+++ b/packages/sanity/src/desk/documentActions/DeleteAction.tsx
@@ -10,6 +10,7 @@ import {
   useDocumentOperation,
   useDocumentPairPermissions,
 } from 'sanity'
+import {useDocumentPane} from '../panes/document/useDocumentPane'
 
 const DISABLED_REASON_TITLE = {
   NOTHING_TO_DELETE: 'This document doesn’t yet exist or is already deleted',
@@ -17,6 +18,7 @@ const DISABLED_REASON_TITLE = {
 
 /** @internal */
 export const DeleteAction: DocumentActionComponent = ({id, type, draft, onComplete}) => {
+  const {setIsDeleting: paneSetIsDeleting} = useDocumentPane()
   const {delete: deleteOp} = useDocumentOperation(id, type)
   const [isDeleting, setIsDeleting] = useState(false)
   const [isConfirmDialogOpen, setConfirmDialogOpen] = useState(false)
@@ -29,9 +31,10 @@ export const DeleteAction: DocumentActionComponent = ({id, type, draft, onComple
   const handleConfirm = useCallback(() => {
     setIsDeleting(true)
     setConfirmDialogOpen(false)
+    paneSetIsDeleting(true)
     deleteOp.execute()
     onComplete()
-  }, [deleteOp, onComplete])
+  }, [deleteOp, onComplete, paneSetIsDeleting])
 
   const handle = useCallback(() => {
     setConfirmDialogOpen(true)

--- a/packages/sanity/src/desk/panes/document/DocumentOperationResults.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentOperationResults.tsx
@@ -2,6 +2,7 @@ import {useToast} from '@sanity/ui'
 import React, {memo, useEffect, useRef} from 'react'
 import {useDocumentPane} from './useDocumentPane'
 import {useDocumentOperationEvent} from 'sanity'
+import {usePaneRouter} from '../../components'
 
 function getOpErrorTitle(op: string): string {
   if (op === 'delete') {
@@ -38,6 +39,7 @@ export const DocumentOperationResults = memo(function DocumentOperationResults()
   const {documentId, documentType} = useDocumentPane()
   const event: any = useDocumentOperationEvent(documentId, documentType)
   const prevEvent = useRef(event)
+  const paneRouter = usePaneRouter()
 
   useEffect(() => {
     if (!event || event === prevEvent.current) return
@@ -65,8 +67,16 @@ export const DocumentOperationResults = memo(function DocumentOperationResults()
       })
     }
 
+    /**
+     * If the document was deleted successfully, close the pane.
+     * This lives here instead of in the DocumentPaneProvider to avoid race conditions.
+     */
+    if (event.type === 'success' && event.op === 'delete') {
+      paneRouter.closeCurrentAndAfter()
+    }
+
     prevEvent.current = event
-  }, [event, pushToast])
+  }, [event, paneRouter, pushToast])
 
   return null
 })

--- a/packages/sanity/src/desk/panes/document/DocumentOperationResults.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentOperationResults.tsx
@@ -44,6 +44,8 @@ export const DocumentOperationResults = memo(function DocumentOperationResults()
   useEffect(() => {
     if (!event || event === prevEvent.current) return
 
+    let cleanupId: number | undefined
+
     if (event.type === 'error') {
       pushToast({
         closable: true,
@@ -69,13 +71,16 @@ export const DocumentOperationResults = memo(function DocumentOperationResults()
 
     /**
      * If the document was deleted successfully, close the pane.
-     * This lives here instead of in the DocumentPaneProvider to avoid race conditions.
      */
     if (event.type === 'success' && event.op === 'delete') {
-      paneRouter.closeCurrentAndAfter()
+      // Wait until next tick to allow deletion toasts to appear first
+      cleanupId = setTimeout(() => paneRouter.closeCurrentAndAfter(), 0) as any as number
     }
 
     prevEvent.current = event
+
+    // eslint-disable-next-line consistent-return
+    return () => clearTimeout(cleanupId)
   }, [event, paneRouter, pushToast])
 
   return null

--- a/packages/sanity/src/desk/panes/document/DocumentPaneContext.ts
+++ b/packages/sanity/src/desk/panes/document/DocumentPaneContext.ts
@@ -69,6 +69,7 @@ export interface DocumentPaneContextValue {
   schemaType: ObjectSchemaType
   setTimelineMode: (mode: TimelineMode) => void
   setTimelineRange(since: string | null, rev: string | null): void
+  setIsDeleting: (state: boolean) => void
   source?: string
   timelineError: Error | null
   timelineMode: TimelineMode
@@ -79,6 +80,7 @@ export interface DocumentPaneContextValue {
   views: View[]
   formState: DocumentFormNode | null
   permissions?: PermissionCheckResult | null
+  isDeleting: boolean
   isPermissionsLoading: boolean
   unstable_languageFilter: DocumentLanguageFilterComponent[]
 }

--- a/packages/sanity/src/desk/panes/document/DocumentPaneContext.ts
+++ b/packages/sanity/src/desk/panes/document/DocumentPaneContext.ts
@@ -81,6 +81,7 @@ export interface DocumentPaneContextValue {
   formState: DocumentFormNode | null
   permissions?: PermissionCheckResult | null
   isDeleting: boolean
+  isDeleted: boolean
   isPermissionsLoading: boolean
   unstable_languageFilter: DocumentLanguageFilterComponent[]
 }

--- a/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
@@ -44,7 +44,6 @@ import {
   useDocumentValuePermissions,
   useTimelineStore,
   useTimelineSelector,
-  useDocumentOperationEvent,
   DocumentFieldAction,
   DocumentInspectorMenuItem,
   FieldActionsResolver,
@@ -52,7 +51,6 @@ import {
   DocumentFieldActionNode,
   FieldActionsProvider,
 } from 'sanity'
-import {useRouter} from 'sanity/router'
 
 /**
  * @internal
@@ -71,7 +69,6 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   } = useSource().document
   const presenceStore = usePresenceStore()
   const paneRouter = usePaneRouter()
-  const {navigateIntent} = useRouter()
   const setPaneParams = paneRouter.setParams
   const {features} = useDeskTool()
   const {push: pushToast} = useToast()
@@ -162,19 +159,26 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   const sinceAttributes = useTimelineSelector(timelineStore, (state) => state.sinceAttributes)
   const timelineDisplayed = useTimelineSelector(timelineStore, (state) => state.timelineDisplayed)
   const timelineReady = useTimelineSelector(timelineStore, (state) => state.timelineReady)
-  const isPristine = useTimelineSelector(
-    timelineStore,
-    (state) => !state.isLoading && state.chunks.length === 0 && state.hasMoreChunks === false
-  )
+  const isPristine = useTimelineSelector(timelineStore, (state) => state.isPristine)
+
   /**
-   * This checks if there is no document pair, but the document still has history
-   * We have to check it this way because the document value will always have atleast
-   * an _id/_type
+   * Determine if the current document is deleted.
+   *
+   * When the timeline is available – we check for the absence of an editable document pair
+   * (both draft + published versions) as well as a non 'pristine' timeline (i.e. a timeline that consists
+   * of at least one chunk).
+   *
+   * In the _very rare_ case where the timeline cannot be loaded – we skip this check and always assume
+   * the document is NOT deleted. Since we can't accurately determine document deleted status without history,
+   * skipping this check means that in these cases, users will at least be able to create new documents
+   * without them being incorrectly marked as deleted.
    */
-  const isDeleted = useMemo(
-    () => Boolean(!editState?.draft && !editState?.published) && !isPristine,
-    [editState?.draft, editState?.published, isPristine]
-  )
+  const isDeleted = useMemo(() => {
+    if (!timelineReady) {
+      return false
+    }
+    return Boolean(!editState?.draft && !editState?.published) && !isPristine
+  }, [editState?.draft, editState?.published, isPristine, timelineReady])
 
   // TODO: this may cause a lot of churn. May be a good idea to prevent these
   // requests unless the menu is open somehow

--- a/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
@@ -44,6 +44,7 @@ import {
   useDocumentValuePermissions,
   useTimelineStore,
   useTimelineSelector,
+  useDocumentOperationEvent,
   DocumentFieldAction,
   DocumentInspectorMenuItem,
   FieldActionsResolver,
@@ -108,6 +109,11 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   const connectionState = useConnectionState(documentId, documentType)
   const schemaType = schema.get(documentType) as ObjectSchemaType | undefined
   const value: SanityDocumentLike = editState?.draft || editState?.published || initialValue.value
+  const [isDeleting, setIsDeleting] = useState(false)
+  const isDeleted = useMemo(
+    () => Boolean(!editState?.draft && !editState?.published),
+    [editState?.draft, editState?.published]
+  )
 
   const [inspectorMenuItems, setInspectorMenuItems] = useState<DocumentInspectorMenuItem[]>([])
 
@@ -500,17 +506,21 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
       updateActionDisabled ||
       createActionDisabled ||
       reconnecting ||
-      isLocked
+      isLocked ||
+      isDeleting ||
+      isDeleted
     )
   }, [
     connectionState,
+    editState.transactionSyncLock,
     isNonExistent,
+    isDeleted,
+    isDeleting,
     isPermissionsLoading,
     permissions?.granted,
     ready,
     revTime,
     schemaType,
-    editState.transactionSyncLock,
   ])
 
   const formState = useFormState(schemaType!, {
@@ -596,6 +606,8 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     permissions,
     setTimelineMode,
     setTimelineRange,
+    setIsDeleting,
+    isDeleting,
     timelineError,
     timelineMode,
     timelineStore,

--- a/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
@@ -176,18 +176,6 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     [editState?.draft, editState?.published, isPristine]
   )
 
-  /**
-   * This covers the edge case when a person have the document open and is viewing
-   * another revision while it was being deleted remotely. Without removing the
-   * rev param, the timeline and document action will be in the wrong state
-   */
-  useEffect(() => {
-    if (!isDeleting && isDeleted && params?.rev) {
-      navigateIntent('edit', {id: documentId, type: documentType}, {replace: true})
-      setTimelineError(null)
-    }
-  }, [documentId, documentType, isDeleted, isDeleting, navigateIntent, params?.rev])
-
   // TODO: this may cause a lot of churn. May be a good idea to prevent these
   // requests unless the menu is open somehow
   const previewUrl = usePreviewUrl(value)

--- a/packages/sanity/src/desk/panes/document/documentPanel/DeletedDocumentBanner.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/DeletedDocumentBanner.tsx
@@ -1,46 +1,49 @@
-import React, {useCallback, useMemo} from 'react'
+import React, {useCallback} from 'react'
 import {Button, Card, Container, Flex, Text} from '@sanity/ui'
 import {ReadOnlyIcon} from '@sanity/icons'
 import styled from 'styled-components'
 import {useDocumentPane} from '../useDocumentPane'
-import {useDocumentOperation, useTimelineSelector} from 'sanity'
+import {useDocumentOperation} from 'sanity'
+import {useRouter} from 'sanity/router'
 
 const Root = styled(Card)`
   position: relative;
   z-index: 50;
 `
-export function DeletedDocumentBanner() {
-  const {documentId, documentType, timelineStore} = useDocumentPane()
-  const chunks = useTimelineSelector(timelineStore, (state) => state.chunks)
-  const lastRevisionId = useMemo(() => {
-    const lastRevision = chunks.filter((chunk) => !['delete', 'initial'].includes(chunk.type))
 
-    return lastRevision?.[0]?.id
-  }, [chunks])
+interface DeletedDocumentBannerProps {
+  revisionId?: string | null
+}
+
+export function DeletedDocumentBanner({revisionId}: DeletedDocumentBannerProps) {
+  const {documentId, documentType} = useDocumentPane()
   const {restore} = useDocumentOperation(documentId, documentType)
+  const {navigateIntent} = useRouter()
   const handleRestore = useCallback(() => {
-    restore.execute(lastRevisionId)
-  }, [restore, lastRevisionId])
+    if (revisionId) {
+      restore.execute(revisionId)
+      navigateIntent('edit', {id: documentId, type: documentType})
+    }
+  }, [documentId, documentType, navigateIntent, restore, revisionId])
 
   return (
     <Root data-testid="deleted-document-banner" shadow={1} tone="transparent">
-      <Container paddingX={4} paddingY={lastRevisionId ? 2 : 3} sizing="border" width={1}>
+      <Container paddingX={4} paddingY={revisionId ? 2 : 3} sizing="border" width={1}>
         <Flex align="center">
           <Text size={1}>
             <ReadOnlyIcon />
           </Text>
 
           <Flex align="center" gap={2} flex={1} marginLeft={3}>
-            <Text size={1}>This document is deleted and can’t be edited.</Text>
-            {lastRevisionId && (
+            <Text size={1}>This document has been deleted.</Text>
+            {revisionId && (
               <Button
-                radius={0}
                 fontSize={1}
                 padding={2}
                 mode="bleed"
                 tone="primary"
                 onClick={handleRestore}
-                text={'Restore most recent vision'}
+                text="Restore most recent version"
               />
             )}
           </Flex>

--- a/packages/sanity/src/desk/panes/document/documentPanel/DeletedDocumentBanner.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/DeletedDocumentBanner.tsx
@@ -1,24 +1,49 @@
-import React from 'react'
-import {Box, Card, Container, Flex, Text} from '@sanity/ui'
+import React, {useCallback, useMemo} from 'react'
+import {Button, Card, Container, Flex, Text} from '@sanity/ui'
 import {ReadOnlyIcon} from '@sanity/icons'
 import styled from 'styled-components'
+import {useDocumentPane} from '../useDocumentPane'
+import {useDocumentOperation, useTimelineSelector} from 'sanity'
 
 const Root = styled(Card)`
   position: relative;
   z-index: 50;
 `
 export function DeletedDocumentBanner() {
+  const {documentId, documentType, timelineStore} = useDocumentPane()
+  const chunks = useTimelineSelector(timelineStore, (state) => state.chunks)
+  const lastRevisionId = useMemo(() => {
+    const lastRevision = chunks.filter((chunk) => !['delete', 'initial'].includes(chunk.type))
+
+    return lastRevision?.[0]?.id
+  }, [chunks])
+  const {restore} = useDocumentOperation(documentId, documentType)
+  const handleRestore = useCallback(() => {
+    restore.execute(lastRevisionId)
+  }, [restore, lastRevisionId])
+
   return (
     <Root data-testid="deleted-document-banner" shadow={1} tone="transparent">
-      <Container paddingX={4} paddingY={3} sizing="border" width={1}>
-        <Flex align="flex-start">
+      <Container paddingX={4} paddingY={lastRevisionId ? 2 : 3} sizing="border" width={1}>
+        <Flex align="center">
           <Text size={1}>
             <ReadOnlyIcon />
           </Text>
 
-          <Box flex={1} marginLeft={3}>
+          <Flex align="center" gap={2} flex={1} marginLeft={3}>
             <Text size={1}>This document is deleted and can’t be edited.</Text>
-          </Box>
+            {lastRevisionId && (
+              <Button
+                radius={0}
+                fontSize={1}
+                padding={2}
+                mode="bleed"
+                tone="primary"
+                onClick={handleRestore}
+                text={'Restore most recent vision'}
+              />
+            )}
+          </Flex>
         </Flex>
       </Container>
     </Root>

--- a/packages/sanity/src/desk/panes/document/documentPanel/DeletedDocumentBanner.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/DeletedDocumentBanner.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import {Box, Card, Container, Flex, Text} from '@sanity/ui'
+import {ReadOnlyIcon} from '@sanity/icons'
+import styled from 'styled-components'
+
+const Root = styled(Card)`
+  position: relative;
+  z-index: 50;
+`
+export function DeletedDocumentBanner() {
+  return (
+    <Root data-testid="deleted-document-banner" shadow={1} tone="transparent">
+      <Container paddingX={4} paddingY={3} sizing="border" width={1}>
+        <Flex align="flex-start">
+          <Text size={1}>
+            <ReadOnlyIcon />
+          </Text>
+
+          <Box flex={1} marginLeft={3}>
+            <Text size={1}>This document is deleted and can’t be edited.</Text>
+          </Box>
+        </Flex>
+      </Container>
+    </Root>
+  )
+}

--- a/packages/sanity/src/desk/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/DocumentPanel.tsx
@@ -13,12 +13,12 @@ import {useDocumentPane} from '../useDocumentPane'
 import {useDeskTool} from '../../../useDeskTool'
 import {DocumentInspectorPanel} from '../documentInspector'
 import {InspectDialog} from '../inspectDialog'
+import {DeletedDocumentBanner} from './DeletedDocumentBanner'
 import {ReferenceChangedBanner} from './ReferenceChangedBanner'
 import {PermissionCheckBanner} from './PermissionCheckBanner'
 import {FormView} from './documentViews'
 import {DocumentPanelHeader} from './header'
 import {ScrollContainer, useTimelineSelector, VirtualizerScrollInstanceProvider} from 'sanity'
-import {DeletedDocumentBanner} from './DeletedDocumentBanner'
 
 interface DocumentPanelProps {
   footerHeight: number | null

--- a/packages/sanity/src/desk/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/DocumentPanel.tsx
@@ -60,6 +60,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     permissions,
     isPermissionsLoading,
     isDeleting,
+    isDeleted,
   } = useDocumentPane()
   const {collapsed: layoutCollapsed} = usePaneLayout()
   const {collapsed} = usePane()
@@ -94,10 +95,6 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
 
   const formViewHidden = activeView.type !== 'form'
 
-  const isDeleted = useMemo(
-    () => Boolean(!editState?.draft && !editState?.published),
-    [editState?.draft, editState?.published]
-  )
   const activeViewNode = useMemo(
     () =>
       activeView.type === 'component' &&

--- a/packages/sanity/src/desk/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/DocumentPanel.tsx
@@ -17,7 +17,7 @@ import {ReferenceChangedBanner} from './ReferenceChangedBanner'
 import {PermissionCheckBanner} from './PermissionCheckBanner'
 import {FormView} from './documentViews'
 import {DocumentPanelHeader} from './header'
-import {ScrollContainer, VirtualizerScrollInstanceProvider} from 'sanity'
+import {ScrollContainer, useTimelineSelector, VirtualizerScrollInstanceProvider} from 'sanity'
 import {DeletedDocumentBanner} from './DeletedDocumentBanner'
 
 interface DocumentPanelProps {
@@ -61,6 +61,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     isPermissionsLoading,
     isDeleting,
     isDeleted,
+    timelineStore,
   } = useDocumentPane()
   const {collapsed: layoutCollapsed} = usePaneLayout()
   const {collapsed} = usePane()
@@ -113,6 +114,11 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     [activeView, displayed, documentId, editState?.draft, editState?.published, schemaType, value]
   )
 
+  const lastNonDeletedRevId = useTimelineSelector(
+    timelineStore,
+    (state) => state.lastNonDeletedRevId
+  )
+
   // Scroll to top as `documentId` changes
   useEffect(() => {
     if (!documentScrollElement?.scrollTo) return
@@ -155,7 +161,9 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
                           granted={Boolean(permissions?.granted)}
                           requiredPermission={requiredPermission}
                         />
-                        {!isDeleting && isDeleted && <DeletedDocumentBanner />}
+                        {!isDeleting && isDeleted && (
+                          <DeletedDocumentBanner revisionId={lastNonDeletedRevId} />
+                        )}
                         <ReferenceChangedBanner />
                       </>
                     )}

--- a/packages/sanity/src/desk/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/DocumentPanel.tsx
@@ -18,6 +18,7 @@ import {PermissionCheckBanner} from './PermissionCheckBanner'
 import {FormView} from './documentViews'
 import {DocumentPanelHeader} from './header'
 import {ScrollContainer, VirtualizerScrollInstanceProvider} from 'sanity'
+import {DeletedDocumentBanner} from './DeletedDocumentBanner'
 
 interface DocumentPanelProps {
   footerHeight: number | null
@@ -58,6 +59,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     schemaType,
     permissions,
     isPermissionsLoading,
+    isDeleting,
   } = useDocumentPane()
   const {collapsed: layoutCollapsed} = usePaneLayout()
   const {collapsed} = usePane()
@@ -92,6 +94,10 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
 
   const formViewHidden = activeView.type !== 'form'
 
+  const isDeleted = useMemo(
+    () => Boolean(!editState?.draft && !editState?.published),
+    [editState?.draft, editState?.published]
+  )
   const activeViewNode = useMemo(
     () =>
       activeView.type === 'component' &&
@@ -152,6 +158,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
                           granted={Boolean(permissions?.granted)}
                           requiredPermission={requiredPermission}
                         />
+                        {!isDeleting && isDeleted && <DeletedDocumentBanner />}
                         <ReferenceChangedBanner />
                       </>
                     )}

--- a/packages/sanity/src/desk/panes/document/timeline/timeline.tsx
+++ b/packages/sanity/src/desk/panes/document/timeline/timeline.tsx
@@ -8,7 +8,7 @@ interface TimelineProps {
   chunks: Chunk[]
   disabledBeforeFirstChunk?: boolean
   firstChunk?: Chunk | null
-  hasMoreChunks: boolean
+  hasMoreChunks: boolean | null
   lastChunk?: Chunk | null
   onLoadMore: () => void
   onSelect: (chunk: Chunk) => void

--- a/packages/sanity/src/desk/panes/document/timeline/timelineItem.styled.tsx
+++ b/packages/sanity/src/desk/panes/document/timeline/timelineItem.styled.tsx
@@ -28,30 +28,37 @@ export const IconWrapper = styled(Flex)(({theme}: IconWrapperProps) => {
   `
 })
 
-export const Root = styled(Button)(({$selected}: {$selected: boolean}) => {
-  return css`
-    position: relative;
-    width: 100%;
+export const Root = styled(Button)(
+  ({$selected, $disabled}: {$selected: boolean; $disabled: boolean}) => {
+    return css`
+      position: relative;
+      width: 100%;
 
-    /* Line styling */
-    &[data-first] ${IconWrapper}::before {
-      height: 50%;
-      top: unset;
-      bottom: 0;
-    }
-
-    &[data-last] ${IconWrapper}::before {
-      height: 50%;
-    }
-
-    ${$selected &&
-    css`
-      ${IconWrapper}::before {
-        background: transparent;
+      /* Line styling */
+      &[data-first] ${IconWrapper}::before {
+        height: 50%;
+        top: unset;
+        bottom: 0;
       }
-    `}
-  `
-})
+
+      &[data-last] ${IconWrapper}::before {
+        height: 50%;
+      }
+
+      ${$selected &&
+      css`
+        ${IconWrapper}::before {
+          background: transparent;
+        }
+      `}
+
+      ${$disabled &&
+      css`
+        cursor: not-allowed;
+      `}
+    `
+  }
+)
 
 export const IconBox = styled(Box)`
   background: var(--card-bg-color);

--- a/packages/sanity/src/desk/panes/document/timeline/timelineItem.tsx
+++ b/packages/sanity/src/desk/panes/document/timeline/timelineItem.tsx
@@ -29,8 +29,6 @@ interface TimelineItemProps {
   type: ChunkType
 }
 
-const NOT_SELECTABLE_TYPES = ['delete', 'discardDraft']
-
 export function TimelineItem({
   chunk,
   isFirst,
@@ -43,9 +41,7 @@ export function TimelineItem({
 }: TimelineItemProps) {
   const iconComponent = getTimelineEventIconComponent(type)
   const authorUserIds = Array.from(chunk.authors)
-  const isSelectable = useMemo(() => {
-    return !NOT_SELECTABLE_TYPES.includes(type)
-  }, [type])
+  const isSelectable = type !== 'delete'
   const formattedTimestamp = useMemo(() => {
     const parsedDate = new Date(timestamp)
     const formattedDate = format(parsedDate, 'MMM d, yyyy, hh:mm a')

--- a/packages/sanity/src/desk/panes/document/timeline/timelineItem.tsx
+++ b/packages/sanity/src/desk/panes/document/timeline/timelineItem.tsx
@@ -29,6 +29,8 @@ interface TimelineItemProps {
   type: ChunkType
 }
 
+const NOT_SELECTABLE_TYPES = ['delete', 'discardDraft']
+
 export function TimelineItem({
   chunk,
   isFirst,
@@ -41,6 +43,9 @@ export function TimelineItem({
 }: TimelineItemProps) {
   const iconComponent = getTimelineEventIconComponent(type)
   const authorUserIds = Array.from(chunk.authors)
+  const isSelectable = useMemo(() => {
+    return !NOT_SELECTABLE_TYPES.includes(type)
+  }, [type])
   const formattedTimestamp = useMemo(() => {
     const parsedDate = new Date(timestamp)
     const formattedDate = format(parsedDate, 'MMM d, yyyy, hh:mm a')
@@ -52,14 +57,18 @@ export function TimelineItem({
     (evt: React.MouseEvent<HTMLButtonElement>) => {
       evt.preventDefault()
       evt.stopPropagation()
-      onSelect(chunk)
+
+      if (isSelectable) {
+        onSelect(chunk)
+      }
     },
-    [onSelect, chunk]
+    [onSelect, chunk, isSelectable]
   )
 
   return (
     <Root
       $selected={isSelected}
+      $disabled={!isSelectable}
       data-chunk-id={chunk.id}
       data-first={isFirst ? true : undefined}
       data-last={isLast ? true : undefined}

--- a/packages/sanity/src/desk/panes/document/timeline/timelineMenu.tsx
+++ b/packages/sanity/src/desk/panes/document/timeline/timelineMenu.tsx
@@ -2,7 +2,7 @@ import {SelectIcon} from '@sanity/icons'
 import {Button, Placement, Popover, useClickOutside, useGlobalKeyDown, useToast} from '@sanity/ui'
 import {format} from 'date-fns'
 import {upperFirst} from 'lodash'
-import React, {useCallback, useMemo, useState} from 'react'
+import React, {useCallback, useEffect, useMemo, useState} from 'react'
 import styled from 'styled-components'
 import {useDocumentPane} from '../useDocumentPane'
 import {TimelineError} from './TimelineError'
@@ -22,7 +22,8 @@ const Root = styled(Popover)`
 `
 
 export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {
-  const {setTimelineRange, setTimelineMode, timelineError, ready, timelineStore} = useDocumentPane()
+  const {setTimelineRange, setTimelineMode, timelineError, ready, timelineStore, isDeleted} =
+    useDocumentPane()
   const [open, setOpen] = useState(false)
   const [button, setButton] = useState<HTMLButtonElement | null>(null)
   const [popover, setPopover] = useState<HTMLElement | null>(null)
@@ -43,6 +44,12 @@ export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {
     setTimelineMode('closed')
     setOpen(false)
   }, [setTimelineMode])
+
+  useEffect(() => {
+    if (open && isDeleted) {
+      handleClose()
+    }
+  }, [open, isDeleted, handleClose])
 
   const handleClickOutside = useCallback(() => {
     if (open) {
@@ -154,7 +161,7 @@ export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {
       ref={setPopover}
     >
       <Button
-        disabled={!ready}
+        disabled={!ready || isDeleted}
         mode="bleed"
         fontSize={1}
         padding={2}

--- a/packages/sanity/src/desk/panes/document/timeline/timelineMenu.tsx
+++ b/packages/sanity/src/desk/panes/document/timeline/timelineMenu.tsx
@@ -2,7 +2,7 @@ import {SelectIcon} from '@sanity/icons'
 import {Button, Placement, Popover, useClickOutside, useGlobalKeyDown, useToast} from '@sanity/ui'
 import {format} from 'date-fns'
 import {upperFirst} from 'lodash'
-import React, {useCallback, useEffect, useMemo, useState} from 'react'
+import React, {useCallback, useMemo, useState} from 'react'
 import styled from 'styled-components'
 import {useDocumentPane} from '../useDocumentPane'
 import {TimelineError} from './TimelineError'
@@ -44,12 +44,6 @@ export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {
     setTimelineMode('closed')
     setOpen(false)
   }, [setTimelineMode])
-
-  useEffect(() => {
-    if (open && isDeleted) {
-      handleClose()
-    }
-  }, [open, isDeleted, handleClose])
 
   const handleClickOutside = useCallback(() => {
     if (open) {
@@ -161,7 +155,7 @@ export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {
       ref={setPopover}
     >
       <Button
-        disabled={!ready || isDeleted}
+        disabled={!ready}
         mode="bleed"
         fontSize={1}
         padding={2}

--- a/packages/sanity/src/desk/types.ts
+++ b/packages/sanity/src/desk/types.ts
@@ -1,6 +1,5 @@
 import {SchemaType} from '@sanity/types'
 import {Observable} from 'rxjs'
-import {ButtonTone} from '@sanity/ui'
 import {
   DefaultDocumentNodeResolver,
   MenuItem as DeskToolMenuItem,
@@ -251,7 +250,7 @@ export interface PaneMenuItem extends DeskToolMenuItem {
   isDisabled?: boolean
   shortcut?: string
   selected?: boolean
-  tone?: ButtonTone
+  tone?: 'primary' | 'positive' | 'caution' | 'critical'
 }
 
 /** @internal */

--- a/packages/sanity/src/desk/types.ts
+++ b/packages/sanity/src/desk/types.ts
@@ -251,7 +251,7 @@ export interface PaneMenuItem extends DeskToolMenuItem {
   isDisabled?: boolean
   shortcut?: string
   selected?: boolean
-  tone?: 'primary' | 'positive' | 'caution' | 'critical'
+  tone?: ButtonTone
 }
 
 /** @internal */


### PR DESCRIPTION
### Description

This fixes an issue where the document pane of the deleted document was left open after the document was deleted, including any open panes to the right.

After this change, all open panes to the right including the deleted one will close.

We will also show a banner similar to the permissions banner that includes a restore button if another user has the document open.

Example video:

https://github.com/sanity-io/sanity/assets/209129/1276151f-dad4-48db-87c9-bcbc6fc52504

### What to review

- That all panes to the right including the deleted document pane closes when you delete the document
- That the delete confirmation toast shows
- Another user has the deleted document open: That the Deleted document banner shows for the user
- Another user has the deleted document open: That the user is able to restore the document from the Restore button in the banner
- Another user has the deleted document open: That it is possible to open the timeline menu without seeing an error when the timeline menu is open

### Questions
- Is checking if the history timeline has entries in combination with no document pair a solid way to detect if a document was deleted while the user was viewing it?
- Is it fine to close the pane in `DocumentOperationResults.tsx`? I tried using the `useDocumentOperationEvent` hook in the document pane to handle closing there, but there was race conditions where the pane would close before the toast  was triggered.

### Notes for release

- Improved UX when deleting a document
