### PR TITLE
fix(desk): fix readOnly document state while document is syncing

### DIFF
--- a/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
@@ -331,6 +331,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     const updateActionDisabled = !isActionEnabled(schemaType!, 'update')
     const createActionDisabled = isNonExistent && !isActionEnabled(schemaType!, 'create')
     const reconnecting = connectionState === 'reconnecting'
+    const isLocked = editState.transactionSyncLock?.enabled
 
     return (
       !ready ||
@@ -338,7 +339,8 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
       hasNoPermission ||
       updateActionDisabled ||
       createActionDisabled ||
-      reconnecting
+      reconnecting ||
+      isLocked
     )
   }, [
     connectionState,
@@ -348,6 +350,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     ready,
     revTime,
     schemaType,
+    editState.transactionSyncLock,
   ])
 
   const formState = useFormState(schemaType!, {


### PR DESCRIPTION
### Description

This fixes a regression in [this commit](https://github.com/sanity-io/sanity/commit/ef9e762ec14df3ff0ff86aff20ed96cf2c46ec08) that broke documents being set to readOnly while there is transactions pending.

This can lead to pending patches being discarded if a user makes a change while the document is being synced

### What to review

- To simulate pending patches, go into `getPairListener.ts`, find line 114 and change it to `if (false && allPendingTransactionEventsReceived(nextBuffer)) {`
- Make any changes to a document
- Click publish
- The syncing toast should show, and the document should be read only

### Notes for release

- Fixes a issue where documents wasn't locked while a document was being synced
