### PR TITLE
chore(CI): update renovate to use the new preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>sanity-io/renovate-presets//ecosystem/auto", ":dependencyDashboardApproval"],
-  "ignorePresets": ["github>sanity-io/renovate-presets//ecosystem/group-after-types"],
+  "extends": ["github>sanity-io/renovate-config", ":dependencyDashboardApproval"],
+  "ignorePresets": ["github>sanity-io/renovate-config:group-non-major"],
   "packageRules": [
     {
       "description": "Dependency updates to examples and the root should always use the chore scope as they aren't published to npm",


### PR DESCRIPTION
### Description

Nothing user facing, it just improves the way Renovatebot handle updates, group them, and it now ensures updates dedupe lockfiles when needed so it's no longer necessary to run `chore(deps): regenerate lockfile` PRs that effectively just delete `yarn.lock`

### What to review

Not before really before merging. After merging the [Dependency Dashboard](https://github.com/sanity-io/sanity/issues/4030) will edit itself and show a warning if there's any problem in the new configuration preset.
It should update existing PRs as needed: https://github.com/sanity-io/sanity/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc+author%3Aapp%2Frenovate

But we may have to close https://github.com/sanity-io/sanity/pull/4549 manually, on some repos we've tested the new preset it seems like turning off lockfile maintenance it also turns off the checks Renovabot performs when it sees if those PRs should be closed and the branches deleted 🤔 


### Notes for release

N/A
