### PR TITLE
fix(desk): pane item selected ui

### DIFF
--- a/packages/sanity/src/desk/components/paneItem/PaneItem.tsx
+++ b/packages/sanity/src/desk/components/paneItem/PaneItem.tsx
@@ -115,7 +115,14 @@ export function PaneItem(props: PaneItemProps) {
     [ChildLink, id]
   )
 
-  const handleClick = useCallback(() => setClicked(true), [])
+  const handleClick = useCallback((e: React.MouseEvent<HTMLElement>) => {
+    if (e.metaKey) {
+      setClicked(false)
+      return
+    }
+
+    setClicked(true)
+  }, [])
 
   // Reset `clicked` state when `selected` prop changes
   useEffect(() => setClicked(false), [selected])


### PR DESCRIPTION
### Description

This pull request fixes an issue with multiple items receiving selected styles when opening a document in a new tab.

Currently, when opening a document in a new tab using Cmd/Ctrl + click, the selected styles are applied to multiple items in the list panes. While this behavior is technically correct, it does not align with the desired behavior in the context of document list panes.

### What to review

- Make sure that only one item has the selected styling in panes

### Notes for release

n/a
