### PR TITLE
chore: correct toast text for copied URL

### DIFF
--- a/packages/sanity/src/core/form/inputs/files/common/ActionsMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/ActionsMenu.tsx
@@ -22,7 +22,7 @@ export function ActionsMenu(props: Props) {
 
   const handleCopyURL = useCallback(() => {
     navigator.clipboard.writeText(copyUrl || '')
-    pushToast({closable: true, status: 'success', title: 'The url is copied to the clipboard'})
+    pushToast({closable: true, status: 'success', title: 'The URL is copied to the clipboard'})
   }, [pushToast, copyUrl])
 
   return (


### PR DESCRIPTION
### Description

Fixes casing for "URL" on toast popup when copying an asset's URL to the clipboard

### What to review

That you agree URL should be uppercase?

### Notes for release

Fixes casing for "URL" on toast popup when copying an asset's URL to the clipboard