### PR TITLE
feat(portable-text-editor): add value snapshot to mutation change

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/components/Synchronizer.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/components/Synchronizer.tsx
@@ -61,9 +61,10 @@ export function Synchronizer(props: SynchronizerProps) {
         finalPatches.length,
         pendingPatches.current.length
       )
-      onChange({type: 'mutation', patches: finalPatches})
+      const editorValue = PortableTextEditor.getValue(portableTextEditor)
+      onChange({type: 'mutation', patches: finalPatches, snapshot: editorValue})
     }
-  }, [onChange])
+  }, [portableTextEditor, onChange])
 
   // Debounced version of flush pending patches
   const onFlushPendingPatchesDebounced = useMemo(

--- a/packages/@sanity/portable-text-editor/src/types/editor.ts
+++ b/packages/@sanity/portable-text-editor/src/types/editor.ts
@@ -196,6 +196,7 @@ export interface PortableTextSlateEditor extends ReactEditor {
 export type MutationChange = {
   type: 'mutation'
   patches: Patch[]
+  snapshot: PortableTextBlock[] | undefined
 }
 
 /** @beta */


### PR DESCRIPTION
### Description

This will add a snapshot of the current editor value with the mutation change that is emitted when the user edits something.

The PortableTextEditor only emits a value change when the props.value is changed, so this snapshot can be used to set the outside value without needing to perform any patching.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

* That the snapshot is provided in the mutation event is enabling what is needed to simply set the value on the outside and sending it in through `props.value` again.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Added  `snapshot` of the editor value to the mutation changes the Portable Text Editor is emitting.

<!--
A description of the change(s) that should be used in the release notes.
-->
