### PR TITLE
fix(core): use context in FormFieldValidationStatus to add portal prop to pte popover

### DIFF
--- a/packages/sanity/src/core/form/components/formField/FormFieldValidationStatus.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldValidationStatus.tsx
@@ -156,4 +156,5 @@ function FormFieldValidationSummary({validation}: {validation: FormNodeValidatio
   )
 }
 
+/** @internal */
 export const PortalEnabledContext = React.createContext(false)

--- a/packages/sanity/src/core/form/components/formField/FormFieldValidationStatus.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldValidationStatus.tsx
@@ -4,7 +4,7 @@ import {hues} from '@sanity/color'
 import {ErrorOutlineIcon, InfoOutlineIcon, WarningOutlineIcon} from '@sanity/icons'
 import {FormNodeValidation} from '@sanity/types'
 import {Box, Flex, Placement, Stack, Text, Tooltip} from '@sanity/ui'
-import React, {useMemo} from 'react'
+import React, {useContext, useMemo} from 'react'
 
 /** @internal */
 export interface FormFieldValidationStatusProps {
@@ -42,8 +42,11 @@ export function FormFieldValidationStatus(props: FormFieldValidationStatusProps)
     __unstable_showSummary: showSummary,
     fontSize,
     placement = 'top',
-    portal,
+    portal: portalProp,
   } = props
+
+  const portalEnabledContextValue = useContext(PortalEnabledContext)
+  const portal = portalProp ?? portalEnabledContextValue
 
   const errors = validation.filter((v) => v.level === 'error')
   const warnings = validation.filter((v) => v.level === 'warning')
@@ -152,3 +155,5 @@ function FormFieldValidationSummary({validation}: {validation: FormNodeValidatio
     </Text>
   )
 }
+
+export const PortalEnabledContext = React.createContext(false)

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
@@ -6,6 +6,7 @@ import React, {useCallback, useEffect, useState} from 'react'
 import {PresenceOverlay} from '../../../../../presence'
 import {PortableTextEditorElement} from '../../Compositor'
 import {VirtualizerScrollInstanceProvider} from '../../../arrays/ArrayOfObjectsInput/List/VirtualizerScrollInstanceProvider'
+import {PortalEnabledContext} from '../../../../components'
 import {ModalWidth} from './types'
 import {
   ContentContainer,
@@ -92,9 +93,11 @@ function Content(props: PopoverEditDialogProps) {
           </ContentHeaderBox>
           <ContentScrollerBox flex={1}>
             <PresenceOverlay margins={[0, 0, 1, 0]}>
-              <Box padding={3} ref={setContentElement}>
-                {props.children}
-              </Box>
+              <PortalEnabledContext.Provider value>
+                <Box padding={3} ref={setContentElement}>
+                  {props.children}
+                </Box>
+              </PortalEnabledContext.Provider>
             </PresenceOverlay>
           </ContentScrollerBox>
         </ModalWrapper>


### PR DESCRIPTION
### Description
The popover for links in pte cropped the validation warnings. 

![Clipboard 2022-17-02 at 7 39 24 AM](https://github.com/sanity-io/sanity/assets/44635000/17b88e8f-b97f-41ec-939c-46900737c12d)

The `portal` prop should be `true` in the case for the pte popover. This PR adds a context to the `FormFieldValidationStatus` that is used in the `PopoverModal` for pte to allow for this and to not disturb the other use cases of the `FormFieldValidationStatus`. 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Make sure that the validation warnings in the pte is as expected and not clipped. 
![Screenshot 2023-06-13 at 12 17 58](https://github.com/sanity-io/sanity/assets/44635000/baa4cd62-8c54-446f-b73b-090b160fda77)

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fixes issue where PTE popovers were clipped 
<!--
A description of the change(s) that should be used in the release notes.
-->
