### PR TITLE
fix(core): use portal prop on validation tooltip, remove muted text

### DIFF
--- a/packages/sanity/src/core/form/components/formField/FormFieldValidationStatus.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldValidationStatus.tsx
@@ -18,7 +18,6 @@ export interface FormFieldValidationStatusProps {
   __unstable_showSummary?: boolean
   fontSize?: number | number
   placement?: Placement
-  portal?: boolean
 }
 
 const EMPTY_ARRAY: never[] = []
@@ -42,7 +41,6 @@ export function FormFieldValidationStatus(props: FormFieldValidationStatusProps)
     __unstable_showSummary: showSummary,
     fontSize,
     placement = 'top',
-    portal,
   } = props
 
   const errors = validation.filter((v) => v.level === 'error')
@@ -83,7 +81,7 @@ export function FormFieldValidationStatus(props: FormFieldValidationStatusProps)
           )}
         </Stack>
       }
-      portal={portal}
+      portal
       placement={placement}
       fallbackPlacements={['bottom', 'right', 'left']}
     >
@@ -121,9 +119,7 @@ function FormFieldValidationStatusItem(props: {validation: FormNodeValidation}) 
         </Text>
       </Box>
       <Box flex={1}>
-        <Text muted size={1}>
-          {validation.message}
-        </Text>
+        <Text size={1}>{validation.message}</Text>
       </Box>
     </Flex>
   )
@@ -145,7 +141,7 @@ function FormFieldValidationSummary({validation}: {validation: FormNodeValidatio
   const hasBoth = hasErrors && hasWarnings
 
   return (
-    <Text muted size={1}>
+    <Text size={1}>
       {errorText || ''}
       {hasBoth && <> and </>}
       {warningText || ''}

--- a/packages/sanity/src/core/form/components/formField/FormFieldValidationStatus.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldValidationStatus.tsx
@@ -5,6 +5,7 @@ import {ErrorOutlineIcon, InfoOutlineIcon, WarningOutlineIcon} from '@sanity/ico
 import {FormNodeValidation} from '@sanity/types'
 import {Box, Flex, Placement, Stack, Text, Tooltip} from '@sanity/ui'
 import React, {useMemo} from 'react'
+import styled from 'styled-components'
 
 /** @internal */
 export interface FormFieldValidationStatusProps {
@@ -33,6 +34,10 @@ const VALIDATION_ICONS: Record<'error' | 'warning' | 'info', React.ReactElement>
   warning: <WarningOutlineIcon data-testid="input-validation-icon-warning" />,
   info: <InfoOutlineIcon data-testid="input-validation-icon-info" />,
 }
+
+const StyledStack = styled(Stack)`
+  max-width: 200px;
+`
 
 /** @internal */
 export function FormFieldValidationStatus(props: FormFieldValidationStatusProps) {
@@ -68,7 +73,7 @@ export function FormFieldValidationStatus(props: FormFieldValidationStatusProps)
   return (
     <Tooltip
       content={
-        <Stack padding={3} space={3}>
+        <StyledStack padding={3} space={3}>
           {showSummary && <FormFieldValidationSummary validation={validation} />}
 
           {!showSummary && (
@@ -79,7 +84,7 @@ export function FormFieldValidationStatus(props: FormFieldValidationStatusProps)
               ))}
             </>
           )}
-        </Stack>
+        </StyledStack>
       }
       portal
       placement={placement}


### PR DESCRIPTION
### Description
The validation popover was cropped inside pte due to a lacking `portal` prop in the `FormFieldValidationStatus`. 

![Clipboard 2022-17-02 at 7 39 24 AM](https://github.com/sanity-io/sanity/assets/44635000/be719ed0-b20b-495d-a0b2-ec13a1f8df4a)

This pr sets the `portal` prop to `true` for all validation tooltips and removes the `muted` prop for the validation text. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
That the validation tooltips behave as expected and is not clipped, e.g. for links in the pte. 

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fixes issue where validation tooltips were clipped
<!--
A description of the change(s) that should be used in the release notes.
-->
