### PR TITLE
Fixed: case where empty references where passed for union generation

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/graphql/extractFromSanitySchema.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/extractFromSanitySchema.ts
@@ -444,9 +444,11 @@ export function extractFromSanitySchema(
         .map((type) => type.name || '')
 
       // Here we remove duplicates, as they might appear twice due to in-line usage of types as well as references
-      const allTypeNames: string[] = flattened.map((type: any) => {
-        return type.isReference ? type.type : type.name
-      })
+      const allTypeNames: string[] = flattened
+        .filter((type: any) => type.name || type.type)
+        .map((type: any) => {
+          return type.isReference ? type.type : type.name
+        })
 
       const possibleTypes = [...new Set(allTypeNames)].sort()
 


### PR DESCRIPTION
### Description

When creating a GraphQL union that combines multiple references in an array field type, the union name was not being created correctly.

The `flattened` array could end up containing an item that matched the follow signature: 

```
{
  kind: 'Type',
  name: 'Carousel',
  type: 'Object',
  description: undefined,
  fields: [Array],
  originalName: 'carousel'
},
  // problem object
  {
    description: undefined,
    isReference: true,
    originalName: 'reference'
  },
{
  kind: 'Type',
  name: 'Gallery',
  type: 'Object',
  description: undefined,
  fields: [Array],
  originalName: 'gallery'
},
```

This means that when the `allTypeNames` is created, it could contain the value `undefined` because neither `type` nor `name` exists on that object. The next step tries to create a union name using that array that contains an `undefined` which causes the union to be named something like `CarouselOrGalleryOr` since the `undefined` value cannot be converted to a valid Schema name. 

### What to review

Create a schema that includes both custom types and an array of *more than one* references. This error does not seem to occur when there is only 1 reference. I think there is a bug further up the stack that causes this reference to be malformed before it gets to generating the union name.
