### PR TITLE
fix(core): include request tag prefix for websocket

### DIFF
--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -205,11 +205,12 @@ interface ResolveSourceOptions {
 
 function getBifurClient(client: SanityClient, auth: AuthStore) {
   const bifurVersionedClient = client.withConfig({apiVersion: '2022-06-30'})
-  const {dataset, url: baseUrl} = bifurVersionedClient.config()
+  const {dataset, url: baseUrl, requestTagPrefix = 'sanity.studio'} = bifurVersionedClient.config()
   const url = `${baseUrl.replace(/\/+$/, '')}/socket/${dataset}`.replace(/^http/, 'ws')
+  const urlWithTag = `${url}?tag=${requestTagPrefix}`
 
   const options = auth.token ? {token$: auth.token} : {}
-  return fromUrl(url, options)
+  return fromUrl(urlWithTag, options)
 }
 
 function resolveSource({


### PR DESCRIPTION
### Description

Adds a `tag=sanity.studio` query parameter to the `/socket` request used for presence, to align with other studio requests. Ask me for background on Slack if you need more details on why :)

### What to review

- Socket request work as expected

### Notes for release

None.
