### PR TITLE
fix(cli): shopify studio intent fixes

### DIFF
--- a/packages/@sanity/cli/templates/shopify/desk/productStructure.ts
+++ b/packages/@sanity/cli/templates/shopify/desk/productStructure.ts
@@ -12,11 +12,16 @@ export default defineStructure<ListItemBuilder>((S) =>
         .child(async (id) =>
           S.list()
             .title('Product')
+            .canHandleIntent(
+              (intentName, params) => intentName === 'edit' && params.type === 'product'
+            )
             .items([
               // Details
               S.listItem()
                 .title('Details')
                 .icon(InfoOutlineIcon)
+                .schemaType('product')
+                .id(id)
                 .child(S.document().schemaType('product').documentId(id)),
               // Product variants
               S.listItem()
@@ -35,6 +40,10 @@ export default defineStructure<ListItemBuilder>((S) =>
                     .params({
                       productId: Number(id.replace('shopifyProduct-', '')),
                     })
+                    .canHandleIntent(
+                      (intentName, params) =>
+                        intentName === 'edit' && params.type === 'productVariant'
+                    )
                 ),
             ])
         )


### PR DESCRIPTION
### Description

This fixes intents in the Shopify Studio which meant product document restore actions failed, and both product and variant restoring jumped out of the desk structure.

### What to review

Intents in the Shopify Studio work as expected, especially in association with document restore actions.

```
yarn && yarn build
./packages/@sanity/cli/bin/sanity init --template shopify
```
