### PR TITLE
fix(core): improve PTE popover behavior

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -9,7 +9,7 @@ import {
   BlockAnnotationRenderProps,
 } from '@sanity/portable-text-editor'
 import {Path, PortableTextBlock, PortableTextTextBlock} from '@sanity/types'
-import {Box, Portal, PortalProvider, usePortal} from '@sanity/ui'
+import {Box, Portal, PortalProvider, useBoundaryElement, usePortal} from '@sanity/ui'
 import {ArrayOfObjectsInputProps, RenderCustomMarkers} from '../../types'
 import {ActivateOnFocus} from '../../components/ActivateOnFocus/ActivateOnFocus'
 import {EMPTY_ARRAY} from '../../../util'
@@ -39,7 +39,7 @@ interface InputProps extends ArrayOfObjectsInputProps<PortableTextBlock> {
 }
 
 /** @internal */
-export type PortableTextEditorElement = HTMLDivElement | HTMLSpanElement | null
+export type PortableTextEditorElement = HTMLDivElement | HTMLSpanElement
 
 /** @internal */
 export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunctions'>) {
@@ -75,8 +75,9 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
 
   const editor = usePortableTextEditor()
 
+  const boundaryElement = useBoundaryElement().element
   const [wrapperElement, setWrapperElement] = useState<HTMLDivElement | null>(null)
-  const [boundaryElement, setBoundaryElement] = useState<HTMLElement | null>(null)
+  const [scrollElement, setScrollElement] = useState<HTMLElement | null>(null)
 
   const handleToggleFullscreen = useCallback(() => {
     onToggleFullscreen()
@@ -113,7 +114,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       } = blockProps
       return (
         <TextBlock
-          boundaryElement={boundaryElement || undefined}
+          floatingBoundary={boundaryElement}
           focused={blockFocused}
           isFullscreen={isFullscreen}
           onItemClose={onItemClose}
@@ -122,6 +123,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
           onPathFocus={onPathFocus}
           path={path.concat(blockPath)}
           readOnly={readOnly}
+          referenceBoundary={scrollElement}
           renderAnnotation={renderAnnotation}
           renderField={renderField}
           renderInlineBlock={renderInlineBlock}
@@ -142,12 +144,13 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     [
       _renderBlockActions,
       _renderCustomMarkers,
-      boundaryElement,
+      scrollElement,
       isFullscreen,
       onItemClose,
       onItemOpen,
       onItemRemove,
       onPathFocus,
+      boundaryElement,
       path,
       readOnly,
       renderAnnotation,
@@ -171,7 +174,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       } = blockProps
       return (
         <BlockObject
-          boundaryElement={boundaryElement || undefined}
+          floatingBoundary={boundaryElement}
           focused={blockFocused}
           isFullscreen={isFullscreen}
           onItemClose={onItemClose}
@@ -180,6 +183,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
           onPathFocus={onPathFocus}
           path={path.concat(blockPath)}
           readOnly={readOnly}
+          referenceBoundary={scrollElement}
           relativePath={blockPath}
           renderAnnotation={renderAnnotation}
           renderBlock={renderBlock}
@@ -198,6 +202,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     },
     [
       boundaryElement,
+      scrollElement,
       isFullscreen,
       onItemClose,
       onItemOpen,
@@ -247,13 +252,14 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       }
       return (
         <InlineObject
-          boundaryElement={boundaryElement || undefined}
+          floatingBoundary={boundaryElement}
           focused={childFocused}
           onItemClose={onItemClose}
           onItemOpen={onItemOpen}
           onPathFocus={onPathFocus}
           path={path.concat(childPath)}
           readOnly={readOnly}
+          referenceBoundary={scrollElement}
           relativePath={childPath}
           renderAnnotation={renderAnnotation}
           renderBlock={renderBlock}
@@ -270,8 +276,9 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       )
     },
     [
-      editor.schemaTypes.span.name,
       boundaryElement,
+      scrollElement,
+      editor.schemaTypes.span.name,
       onItemClose,
       onItemOpen,
       onPathFocus,
@@ -300,14 +307,15 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       } = annotationProps
       return (
         <Annotation
-          boundaryElement={boundaryElement}
-          focused={Boolean(focused)}
           editorNodeFocused={editorNodeFocused}
+          floatingBoundary={boundaryElement}
+          focused={Boolean(focused)}
           onItemClose={onItemClose}
           onItemOpen={onItemOpen}
           onPathFocus={onPathFocus}
           path={path.concat(aPath)}
           readOnly={readOnly}
+          referenceBoundary={scrollElement}
           renderAnnotation={renderAnnotation}
           renderBlock={renderBlock}
           renderCustomMarkers={renderCustomMarkers}
@@ -326,15 +334,16 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     },
     [
       boundaryElement,
+      scrollElement,
       focused,
       onItemClose,
       onItemOpen,
       onPathFocus,
       path,
       readOnly,
-      renderCustomMarkers,
       renderAnnotation,
       renderBlock,
+      renderCustomMarkers,
       renderField,
       renderInlineBlock,
       renderInput,
@@ -360,14 +369,14 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
         renderBlock={editorRenderBlock}
         renderChild={editorRenderChild}
         setPortalElement={setPortalElement}
-        scrollElement={boundaryElement}
-        setScrollElement={setBoundaryElement}
+        scrollElement={scrollElement}
+        setScrollElement={setScrollElement}
       />
     ),
 
     // Keep only stable ones here!
     [
-      boundaryElement,
+      scrollElement,
       editorHotkeys,
       handleToggleFullscreen,
       hasFocus,
@@ -399,7 +408,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
   // Scroll to the DOM element of the "opened" portable text member when relevant.
   useTrackFocusPath({
     focusPath,
-    boundaryElement: boundaryElement || undefined,
+    boundaryElement: scrollElement,
     onItemClose,
   })
 

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -40,7 +40,7 @@ export interface PortableTextMemberItem {
   key: string
   member: ArrayOfObjectsItemMember
   node: ObjectFormNode
-  elementRef?: React.MutableRefObject<PortableTextEditorElement> | undefined
+  elementRef?: React.MutableRefObject<PortableTextEditorElement | null>
   input?: ReactNode
 }
 
@@ -206,7 +206,7 @@ export function PortableTextInput(props: PortableTextInputProps) {
         key,
         member: item.member,
         node: item.node,
-        elementRef: createRef<PortableTextEditorElement>(),
+        elementRef: createRef<PortableTextEditorElement | null>(),
         input,
       }
     })

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
@@ -11,7 +11,7 @@ import {usePortableTextMemberItems} from './usePortableTextMembers'
 
 interface Props {
   focusPath: Path
-  boundaryElement?: HTMLElement
+  boundaryElement: HTMLElement | null
   onItemClose: () => void
 }
 

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
@@ -27,15 +27,16 @@ import {Root, TooltipBox} from './Annotation.styles'
 import {ObjectEditModal} from './modals/ObjectEditModal'
 
 interface AnnotationProps {
-  boundaryElement: HTMLElement | null
   children: React.ReactElement
   editorNodeFocused: boolean
+  floatingBoundary: HTMLElement | null
   focused: boolean
   onItemClose: () => void
   onItemOpen: (path: Path) => void
   onPathFocus: (path: Path) => void
   path: Path
   readOnly?: boolean
+  referenceBoundary: HTMLElement | null
   renderAnnotation?: RenderAnnotationCallback
   renderBlock?: RenderBlockCallback
   renderCustomMarkers?: RenderCustomMarkers
@@ -51,15 +52,16 @@ interface AnnotationProps {
 
 export function Annotation(props: AnnotationProps) {
   const {
-    boundaryElement,
     children,
     editorNodeFocused,
+    floatingBoundary,
     focused,
     onItemClose,
     onItemOpen,
     onPathFocus,
     path,
     readOnly,
+    referenceBoundary,
     renderAnnotation,
     renderBlock,
     renderCustomMarkers,
@@ -148,9 +150,10 @@ export function Annotation(props: AnnotationProps) {
 
   const componentProps = useMemo(
     (): BlockAnnotationProps => ({
+      __unstable_floatingBoundary: floatingBoundary,
+      __unstable_referenceBoundary: referenceBoundary,
+      __unstable_referenceElement: referenceElement,
       __unstable_textElementFocus: editorNodeFocused, // Is there focus on the related text element for this object?
-      __unstable_boundaryElement: boundaryElement || undefined,
-      __unstable_referenceElement: referenceElement || undefined,
       children: input,
       focused,
       markers,
@@ -178,9 +181,9 @@ export function Annotation(props: AnnotationProps) {
       value,
     }),
     [
-      boundaryElement,
       editor.schemaTypes.block,
       editorNodeFocused,
+      floatingBoundary,
       focused,
       input,
       isOpen,
@@ -192,6 +195,7 @@ export function Annotation(props: AnnotationProps) {
       onPathFocus,
       onRemove,
       readOnly,
+      referenceBoundary,
       referenceElement,
       renderAnnotation,
       renderBlock,
@@ -239,8 +243,9 @@ export function Annotation(props: AnnotationProps) {
 
 export const DefaultAnnotationComponent = (props: BlockAnnotationProps) => {
   const {
-    __unstable_boundaryElement,
-    __unstable_referenceElement,
+    __unstable_floatingBoundary: floatingBoundary,
+    __unstable_referenceBoundary: referenceBoundary,
+    __unstable_referenceElement: referenceElement,
     children,
     focused,
     markers,
@@ -284,19 +289,21 @@ export const DefaultAnnotationComponent = (props: BlockAnnotationProps) => {
     >
       {textElement}
       <AnnotationToolbarPopover
-        referenceElement={__unstable_referenceElement}
-        boundaryElement={__unstable_boundaryElement}
+        floatingBoundary={floatingBoundary}
+        referenceBoundary={referenceBoundary}
+        referenceElement={referenceElement}
         onOpen={onOpen}
         onRemove={onRemove}
         title={schemaType.title || schemaType.name}
       />
       {open && (
         <ObjectEditModal
-          boundaryElement={__unstable_boundaryElement}
           defaultType="popover"
+          floatingBoundary={floatingBoundary}
           onClose={onClose}
           autoFocus={focused}
-          referenceElement={__unstable_referenceElement}
+          referenceBoundary={referenceBoundary}
+          referenceElement={referenceElement}
           schemaType={schemaType}
         >
           {children}

--- a/packages/sanity/src/core/form/inputs/PortableText/object/AnnotationToolbarPopover.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/AnnotationToolbarPopover.tsx
@@ -21,15 +21,16 @@ const ToolbarPopover = styled(Popover)`
 const POPOVER_FALLBACK_PLACEMENTS: PopoverProps['fallbackPlacements'] = ['top', 'bottom']
 
 interface AnnotationToolbarPopoverProps {
-  boundaryElement?: HTMLElement
+  floatingBoundary: HTMLElement | null
   onOpen: () => void
   onRemove: () => void
-  referenceElement?: HTMLElement
+  referenceBoundary: HTMLElement | null
+  referenceElement: HTMLElement | null
   title: string
 }
 
 export function AnnotationToolbarPopover(props: AnnotationToolbarPopoverProps) {
-  const {boundaryElement, onOpen, onRemove, referenceElement, title} = props
+  const {floatingBoundary, onOpen, onRemove, referenceBoundary, referenceElement, title} = props
   const [popoverOpen, setPopoverOpen] = useState<boolean>(false)
   const [cursorRect, setCursorRect] = useState<DOMRect | null>(null)
   const [selection, setSelection] = useState<{
@@ -138,12 +139,12 @@ export function AnnotationToolbarPopover(props: AnnotationToolbarPopoverProps) {
       }
     }
 
-    boundaryElement?.addEventListener('scroll', handleScroll, {passive: true})
+    floatingBoundary?.addEventListener('scroll', handleScroll, {passive: true})
 
     return () => {
-      boundaryElement?.removeEventListener('scroll', handleScroll)
+      floatingBoundary?.removeEventListener('scroll', handleScroll)
     }
-  }, [popoverOpen, boundaryElement])
+  }, [popoverOpen, floatingBoundary])
 
   if (!popoverOpen) {
     return null
@@ -151,9 +152,8 @@ export function AnnotationToolbarPopover(props: AnnotationToolbarPopoverProps) {
 
   return (
     <ToolbarPopover
-      boundaryElement={boundaryElement}
+      floatingBoundary={floatingBoundary}
       constrainSize
-      ref={popoverRef}
       content={
         <Box padding={1}>
           <Inline space={1}>
@@ -185,7 +185,10 @@ export function AnnotationToolbarPopover(props: AnnotationToolbarPopoverProps) {
       fallbackPlacements={POPOVER_FALLBACK_PLACEMENTS}
       open
       placement="top"
-      portal="editor"
+      portal
+      preventOverflow
+      ref={popoverRef}
+      referenceBoundary={referenceBoundary}
       referenceElement={cursorElement}
       scheme={popoverScheme}
     />

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
@@ -43,7 +43,7 @@ import {BlockObjectActionsMenu} from './BlockObjectActionsMenu'
 import {ObjectEditModal} from './modals/ObjectEditModal'
 
 interface BlockObjectProps extends PropsWithChildren {
-  boundaryElement?: HTMLElement
+  floatingBoundary: HTMLElement | null
   focused: boolean
   isActive?: boolean
   isFullscreen?: boolean
@@ -53,6 +53,7 @@ interface BlockObjectProps extends PropsWithChildren {
   onPathFocus: (path: Path) => void
   path: Path
   readOnly?: boolean
+  referenceBoundary: HTMLElement | null
   relativePath: Path
   renderAnnotation?: RenderAnnotationCallback
   renderBlock?: RenderBlockCallback
@@ -70,7 +71,7 @@ interface BlockObjectProps extends PropsWithChildren {
 
 export function BlockObject(props: BlockObjectProps) {
   const {
-    boundaryElement,
+    floatingBoundary,
     focused,
     isFullscreen,
     onItemClose,
@@ -78,6 +79,7 @@ export function BlockObject(props: BlockObjectProps) {
     onPathFocus,
     path,
     readOnly,
+    referenceBoundary,
     relativePath,
     renderAnnotation,
     renderBlock,
@@ -204,8 +206,9 @@ export function BlockObject(props: BlockObjectProps) {
 
   const componentProps: BlockProps = useMemo(
     () => ({
-      __unstable_boundaryElement: boundaryElement || undefined,
-      __unstable_referenceElement: referenceElement || undefined,
+      __unstable_floatingBoundary: floatingBoundary,
+      __unstable_referenceBoundary: referenceBoundary,
+      __unstable_referenceElement: (referenceElement || null) as HTMLElement | null,
       children: input,
       focused,
       markers,
@@ -232,7 +235,7 @@ export function BlockObject(props: BlockObjectProps) {
       value,
     }),
     [
-      boundaryElement,
+      floatingBoundary,
       referenceElement,
       input,
       focused,
@@ -246,6 +249,7 @@ export function BlockObject(props: BlockObjectProps) {
       nodePath,
       rootPresence,
       readOnly,
+      referenceBoundary,
       renderAnnotation,
       renderBlock,
       renderField,
@@ -332,7 +336,8 @@ export function BlockObject(props: BlockObjectProps) {
 
 export const DefaultBlockObjectComponent = (props: BlockProps) => {
   const {
-    __unstable_boundaryElement,
+    __unstable_floatingBoundary,
+    __unstable_referenceBoundary,
     __unstable_referenceElement,
     children,
     focused,
@@ -399,11 +404,12 @@ export const DefaultBlockObjectComponent = (props: BlockProps) => {
       </Root>
       {open && (
         <ObjectEditModal
-          boundaryElement={__unstable_boundaryElement}
+          floatingBoundary={__unstable_floatingBoundary}
           defaultType="dialog"
           onClose={onClose}
           autoFocus={focused}
           schemaType={schemaType}
+          referenceBoundary={__unstable_referenceBoundary}
           referenceElement={__unstable_referenceElement}
         >
           {children}

--- a/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
@@ -29,13 +29,14 @@ import {ObjectEditModal} from './modals/ObjectEditModal'
 import {PreviewSpan, Root, TooltipBox} from './InlineObject.styles'
 
 interface InlineObjectProps {
-  boundaryElement?: HTMLElement
+  floatingBoundary: HTMLElement | null
   focused: boolean
   onItemClose: () => void
   onItemOpen: (path: Path) => void
   onPathFocus: (path: Path) => void
   path: Path
   readOnly?: boolean
+  referenceBoundary: HTMLElement | null
   relativePath: Path
   renderAnnotation?: RenderAnnotationCallback
   renderBlock?: RenderBlockCallback
@@ -52,13 +53,14 @@ interface InlineObjectProps {
 
 export const InlineObject = (props: InlineObjectProps) => {
   const {
-    boundaryElement,
+    floatingBoundary,
     focused,
     onItemClose,
     onItemOpen,
     onPathFocus,
     path,
     readOnly,
+    referenceBoundary,
     relativePath,
     renderAnnotation,
     renderBlock,
@@ -119,8 +121,9 @@ export const InlineObject = (props: InlineObjectProps) => {
 
   const componentProps: BlockProps = useMemo(
     () => ({
-      __unstable_boundaryElement: boundaryElement || undefined,
-      __unstable_referenceElement: referenceElement || undefined,
+      __unstable_floatingBoundary: floatingBoundary,
+      __unstable_referenceBoundary: referenceBoundary,
+      __unstable_referenceElement: referenceElement as HTMLElement | null,
       children: input,
       focused,
       onClose,
@@ -148,7 +151,7 @@ export const InlineObject = (props: InlineObjectProps) => {
       validation,
     }),
     [
-      boundaryElement,
+      floatingBoundary,
       focused,
       input,
       isOpen,
@@ -161,6 +164,7 @@ export const InlineObject = (props: InlineObjectProps) => {
       onRemove,
       parentSchemaType,
       readOnly,
+      referenceBoundary,
       referenceElement,
       renderAnnotation,
       renderBlock,
@@ -216,8 +220,9 @@ export const InlineObject = (props: InlineObjectProps) => {
 
 export const DefaultInlineObjectComponent = (props: BlockProps) => {
   const {
-    __unstable_boundaryElement,
-    __unstable_referenceElement,
+    __unstable_floatingBoundary: floatingBoundary,
+    __unstable_referenceBoundary: referenceBoundary,
+    __unstable_referenceElement: referenceElement,
     children,
     focused,
     markers,
@@ -296,24 +301,26 @@ export const DefaultInlineObjectComponent = (props: BlockProps) => {
           })}
         </PreviewSpan>
       </Root>
-      {__unstable_referenceElement && (
+      {referenceElement && (
         <InlineObjectToolbarPopover
-          boundaryElement={__unstable_boundaryElement}
+          floatingBoundary={floatingBoundary}
           onClosePopover={onClosePopover}
           onDelete={onRemove}
           onEdit={openItem}
           open={popoverOpen}
-          referenceElement={__unstable_referenceElement}
+          referenceBoundary={referenceBoundary}
+          referenceElement={referenceElement}
           title={popoverTitle}
         />
       )}
       {open && (
         <ObjectEditModal
-          boundaryElement={__unstable_boundaryElement}
           defaultType="popover"
           onClose={onClose}
           autoFocus={focused}
-          referenceElement={__unstable_referenceElement}
+          floatingBoundary={floatingBoundary}
+          referenceBoundary={referenceBoundary}
+          referenceElement={referenceElement}
           schemaType={schemaType}
         >
           {children}

--- a/packages/sanity/src/core/form/inputs/PortableText/object/InlineObjectToolbarPopover.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/InlineObjectToolbarPopover.tsx
@@ -1,4 +1,4 @@
-import React, {useRef, useCallback, useMemo, MouseEvent} from 'react'
+import React, {useRef, useCallback, useMemo} from 'react'
 import {
   Box,
   Button,
@@ -21,17 +21,27 @@ const ToolbarPopover = styled(Popover)`
 const POPOVER_FALLBACK_PLACEMENTS: PopoverProps['fallbackPlacements'] = ['top', 'bottom']
 
 interface InlineObjectToolbarPopoverProps {
+  floatingBoundary: HTMLElement | null
   open: boolean
   onClosePopover: () => void
   onDelete: (event: React.MouseEvent<HTMLButtonElement>) => void
   onEdit: (event: React.MouseEvent<HTMLButtonElement>) => void
-  referenceElement?: HTMLElement
-  boundaryElement?: HTMLElement
+  referenceBoundary: HTMLElement | null
+  referenceElement: HTMLElement | null
   title: string
 }
 
 export function InlineObjectToolbarPopover(props: InlineObjectToolbarPopoverProps) {
-  const {onClosePopover, onEdit, onDelete, referenceElement, boundaryElement, title, open} = props
+  const {
+    floatingBoundary,
+    onClosePopover,
+    onEdit,
+    onDelete,
+    referenceBoundary,
+    referenceElement,
+    title,
+    open,
+  } = props
   const {sanity} = useTheme()
   const editButtonRef = useRef<HTMLButtonElement | null>(null)
   const deleteButtonRef = useRef<HTMLButtonElement | null>(null)
@@ -106,13 +116,14 @@ export function InlineObjectToolbarPopover(props: InlineObjectToolbarPopoverProp
 
   return (
     <ToolbarPopover
-      boundaryElement={boundaryElement}
       constrainSize
       content={popoverContent}
       fallbackPlacements={POPOVER_FALLBACK_PLACEMENTS}
+      floatingBoundary={floatingBoundary}
       open={open}
       placement="top"
-      portal="editor"
+      portal
+      referenceBoundary={referenceBoundary}
       referenceElement={referenceElement}
       scheme={popoverScheme}
     />

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx
@@ -6,14 +6,23 @@ import {PopoverEditDialog} from './PopoverModal'
 
 export function ObjectEditModal(props: {
   autoFocus?: boolean
-  boundaryElement: HTMLElement | undefined
   children: React.ReactNode
   defaultType: 'dialog' | 'popover'
+  floatingBoundary: HTMLElement | null
   onClose: () => void
-  referenceElement: HTMLElement | undefined
+  referenceBoundary: HTMLElement | null
+  referenceElement: HTMLElement | null
   schemaType: ObjectSchemaType
 }) {
-  const {onClose, defaultType, referenceElement, boundaryElement, schemaType, autoFocus} = props
+  const {
+    autoFocus,
+    defaultType,
+    floatingBoundary,
+    onClose,
+    referenceBoundary,
+    referenceElement,
+    schemaType,
+  } = props
 
   const schemaModalOption = useMemo(() => _getModalOption(schemaType), [schemaType])
   const modalType = schemaModalOption?.type || defaultType
@@ -30,8 +39,9 @@ export function ObjectEditModal(props: {
     return (
       <PopoverEditDialog
         autoFocus={autoFocus}
-        boundaryElement={boundaryElement}
+        floatingBoundary={floatingBoundary}
         onClose={handleClose}
+        referenceBoundary={referenceBoundary}
         referenceElement={referenceElement}
         title={modalTitle}
         width={modalWidth}

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.styles.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.styles.ts
@@ -1,4 +1,4 @@
-import {Box, Container, Flex, Popover} from '@sanity/ui'
+import {Box, Popover} from '@sanity/ui'
 import styled from 'styled-components'
 
 export const RootPopover = styled(Popover)`
@@ -11,21 +11,6 @@ export const RootPopover = styled(Popover)`
     overflow: hidden;
     overflow: clip;
   }
-`
-
-export const ContentContainer = styled(Container)`
-  &:not([hidden]) {
-    display: flex;
-  }
-  direction: column;
-`
-/*
-Setting a static max-height here to avoid scrolling issue.
-Calculating a dynamic height to make the popover more responsive is complex, as the popover can switch top/bottom placement,
-with different height requirements.
-*/
-export const ModalWrapper = styled(Flex)`
-  max-height: 300px;
 `
 
 export const ContentScrollerBox = styled(Box)`

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
@@ -7,20 +7,15 @@ import {PresenceOverlay} from '../../../../../presence'
 import {PortableTextEditorElement} from '../../Compositor'
 import {VirtualizerScrollInstanceProvider} from '../../../arrays/ArrayOfObjectsInput/List/VirtualizerScrollInstanceProvider'
 import {ModalWidth} from './types'
-import {
-  ContentContainer,
-  ContentHeaderBox,
-  ContentScrollerBox,
-  ModalWrapper,
-  RootPopover,
-} from './PopoverModal.styles'
+import {ContentHeaderBox, ContentScrollerBox, RootPopover} from './PopoverModal.styles'
 
 interface PopoverEditDialogProps {
   autoFocus?: boolean
-  boundaryElement?: PortableTextEditorElement
   children: React.ReactNode
+  floatingBoundary: HTMLElement | null
   onClose: () => void
-  referenceElement?: PortableTextEditorElement
+  referenceBoundary: HTMLElement | null
+  referenceElement: PortableTextEditorElement | null
   title: string | React.ReactNode
   width?: ModalWidth
 }
@@ -28,7 +23,7 @@ interface PopoverEditDialogProps {
 const POPOVER_FALLBACK_PLACEMENTS: PopoverProps['fallbackPlacements'] = ['top', 'bottom']
 
 export function PopoverEditDialog(props: PopoverEditDialogProps) {
-  const {referenceElement, boundaryElement} = props
+  const {floatingBoundary, referenceBoundary, referenceElement, width = 0} = props
   const [open, setOpen] = useState(false)
 
   // This hook is here to set open after the initial render.
@@ -41,19 +36,25 @@ export function PopoverEditDialog(props: PopoverEditDialogProps) {
 
   return (
     <RootPopover
-      boundaryElement={boundaryElement}
       content={<Content {...props} />}
+      constrainSize
+      data-ui="PopoverEditDialog"
       fallbackPlacements={POPOVER_FALLBACK_PLACEMENTS}
+      floatingBoundary={floatingBoundary}
       open={open}
+      overflow="auto"
       placement="bottom"
       portal="default"
+      preventOverflow
+      referenceBoundary={referenceBoundary}
       referenceElement={referenceElement}
+      width={width}
     />
   )
 }
 
 function Content(props: PopoverEditDialogProps) {
-  const {onClose, referenceElement, width = 0, title, boundaryElement, autoFocus} = props
+  const {onClose, referenceBoundary, referenceElement, title, autoFocus} = props
 
   useGlobalKeyDown(
     useCallback(
@@ -66,39 +67,37 @@ function Content(props: PopoverEditDialogProps) {
     )
   )
 
-  useClickOutside(onClose, referenceElement ? [referenceElement] : [], boundaryElement)
+  useClickOutside(onClose, referenceElement ? [referenceElement] : [], referenceBoundary)
 
   // This seems to work with regular refs as well, but it might be safer to use state.
   const [contentElement, setContentElement] = useState<HTMLDivElement | null>(null)
 
   return (
     <VirtualizerScrollInstanceProvider scrollElement={contentElement}>
-      <ContentContainer width={width}>
-        <ModalWrapper direction="column" flex={1}>
-          <ContentHeaderBox padding={1}>
-            <Flex align="center">
-              <Box flex={1} padding={2}>
-                <Text weight="semibold">{title}</Text>
-              </Box>
+      <Flex direction="column" height="fill">
+        <ContentHeaderBox flex="none" padding={1}>
+          <Flex align="center">
+            <Box flex={1} padding={2}>
+              <Text weight="semibold">{title}</Text>
+            </Box>
 
-              <Button
-                autoFocus={Boolean(autoFocus)}
-                icon={CloseIcon}
-                mode="bleed"
-                onClick={onClose}
-                padding={2}
-              />
-            </Flex>
-          </ContentHeaderBox>
-          <ContentScrollerBox flex={1}>
-            <PresenceOverlay margins={[0, 0, 1, 0]}>
-              <Box padding={3} ref={setContentElement}>
-                {props.children}
-              </Box>
-            </PresenceOverlay>
-          </ContentScrollerBox>
-        </ModalWrapper>
-      </ContentContainer>
+            <Button
+              autoFocus={Boolean(autoFocus)}
+              icon={CloseIcon}
+              mode="bleed"
+              onClick={onClose}
+              padding={2}
+            />
+          </Flex>
+        </ContentHeaderBox>
+        <ContentScrollerBox flex={1}>
+          <PresenceOverlay margins={[0, 0, 1, 0]}>
+            <Box padding={3} ref={setContentElement}>
+              {props.children}
+            </Box>
+          </PresenceOverlay>
+        </ContentScrollerBox>
+      </Flex>
     </VirtualizerScrollInstanceProvider>
   )
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/types.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/types.ts
@@ -1,1 +1,1 @@
-export type ModalWidth = (number | 'auto')[]
+export type ModalWidth = number | 'auto' | (number | 'auto')[]

--- a/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.tsx
@@ -44,8 +44,8 @@ import {
 import {TextContainer} from './textStyles'
 
 export interface TextBlockProps {
-  boundaryElement?: HTMLElement
   children: React.ReactNode
+  floatingBoundary: HTMLElement | null
   focused: boolean
   isFullscreen?: boolean
   onItemClose: () => void
@@ -54,6 +54,7 @@ export interface TextBlockProps {
   onPathFocus: (path: Path) => void
   path: Path
   readOnly?: boolean
+  referenceBoundary: HTMLElement | null
   renderAnnotation?: RenderAnnotationCallback
   renderBlock?: RenderBlockCallback
   renderBlockActions?: RenderBlockActionsCallback
@@ -71,8 +72,8 @@ export interface TextBlockProps {
 
 export function TextBlock(props: TextBlockProps) {
   const {
-    boundaryElement,
     children,
+    floatingBoundary,
     focused,
     isFullscreen,
     onItemClose,
@@ -80,6 +81,7 @@ export function TextBlock(props: TextBlockProps) {
     onPathFocus,
     path,
     readOnly,
+    referenceBoundary,
     renderBlock,
     renderAnnotation,
     renderBlockActions,
@@ -183,8 +185,9 @@ export function TextBlock(props: TextBlockProps) {
 
   const componentProps: BlockProps = useMemo(
     () => ({
-      __unstable_boundaryElement: boundaryElement || undefined,
-      __unstable_referenceElement: memberItem?.elementRef?.current || undefined,
+      __unstable_floatingBoundary: floatingBoundary,
+      __unstable_referenceBoundary: referenceBoundary,
+      __unstable_referenceElement: (memberItem?.elementRef?.current || null) as HTMLElement | null,
       children: text,
       focused,
       markers,
@@ -211,7 +214,7 @@ export function TextBlock(props: TextBlockProps) {
       value,
     }),
     [
-      boundaryElement,
+      floatingBoundary,
       focused,
       isOpen,
       markers,
@@ -223,6 +226,7 @@ export function TextBlock(props: TextBlockProps) {
       onRemove,
       parentSchemaType,
       readOnly,
+      referenceBoundary,
       renderAnnotation,
       renderBlock,
       renderField,

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/CreateButton.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/CreateButton.tsx
@@ -1,9 +1,6 @@
-/* eslint-disable complexity */
-/* eslint-disable max-nested-callbacks,no-nested-ternary */
-
 import React, {ComponentProps} from 'react'
 import {AddIcon} from '@sanity/icons'
-import {Box, Button, Menu, MenuButton, MenuItem, Tooltip} from '@sanity/ui'
+import {Box, Button, Menu, MenuButton, MenuButtonProps, MenuItem, Tooltip} from '@sanity/ui'
 import {InsufficientPermissionsMessage} from '../../../components'
 import {CreateReferenceOption} from './types'
 
@@ -15,15 +12,17 @@ interface Props extends ComponentProps<typeof Button> {
   readOnly?: boolean
 }
 
-function ConditionalTooltip(
-  props: ComponentProps<typeof Tooltip> & {enabled: boolean}
-): React.ReactElement {
-  const {enabled, ...rest} = props
-  return enabled ? <Tooltip {...rest} /> : <>{props.children}</>
-}
-
 const INLINE_BLOCK_STYLE = {display: 'inline-flex'}
 const FULL_WIDTH = {width: '100%'}
+
+const POPOVER_PROPS: MenuButtonProps['popover'] = {
+  portal: true,
+  tone: 'default',
+  constrainSize: true,
+  fallbackPlacements: ['bottom', 'left', 'top'],
+  placement: 'right',
+  preventOverflow: true,
+}
 
 export function CreateButton(props: Props) {
   const {createOptions, onCreate, id, ...rest} = props
@@ -61,8 +60,8 @@ export function CreateButton(props: Props) {
       menu={
         <Menu ref={props.menuRef}>
           {createOptions.map((createOption) => (
-            <ConditionalTooltip
-              enabled={!createOption.permission.granted}
+            <Tooltip
+              disabled={createOption.permission.granted}
               key={createOption.id}
               content={
                 <Box padding={2}>
@@ -80,12 +79,11 @@ export function CreateButton(props: Props) {
                   onClick={() => onCreate(createOption)}
                 />
               </div>
-            </ConditionalTooltip>
+            </Tooltip>
           ))}
         </Menu>
       }
-      placement="right"
-      popover={{portal: true, tone: 'default', constrainSize: true}}
+      popover={POPOVER_PROPS}
     />
   ) : (
     <Button

--- a/packages/sanity/src/core/form/types/blockProps.ts
+++ b/packages/sanity/src/core/form/types/blockProps.ts
@@ -61,8 +61,9 @@ export interface BlockListItemProps {
 
 /** @beta */
 export interface BlockAnnotationProps {
-  __unstable_boundaryElement?: HTMLElement // Boundary element for the annotation, typically a scroll container
-  __unstable_referenceElement?: HTMLElement // Reference element representing the annotation in the DOM
+  __unstable_floatingBoundary: HTMLElement | null
+  __unstable_referenceBoundary: HTMLElement | null
+  __unstable_referenceElement: HTMLElement | null // Reference element representing the annotation in the DOM
   __unstable_textElementFocus?: boolean // Wether the related text element (in the editor) has selection focus. Differs from form state focus.
   children: ReactNode
   focused: boolean // Whether the annotation data object has form focus
@@ -93,8 +94,9 @@ export interface BlockAnnotationProps {
 
 /** @beta */
 export interface BlockProps {
-  __unstable_boundaryElement?: HTMLElement // Boundary element for the block, typically a scroll container
-  __unstable_referenceElement?: HTMLElement // Reference element representing the block in the DOM
+  __unstable_floatingBoundary: HTMLElement | null
+  __unstable_referenceBoundary: HTMLElement | null
+  __unstable_referenceElement: HTMLElement | null // Reference element representing the block in the DOM
   children: ReactNode
   focused: boolean // Whether the object has form focus
   markers: PortableTextMarker[]


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR updates how popovers are rendered and behave, making use of the new props in`@sanity/ui`'s `Popover`: `floatingBoundary` and `referenceBoundary`.

- `referenceBoundary` is the HTML element that is used as boundary for the element which the popover points to. The annotation or inline object in the case of PTE. Specifying this boundary will make the popover disappear when an annotation or inline object is scrolled out of view (i.e. out the scrollable editable area).
- `floatingBoundary` is the HTML element that is used as boundary for the popover itself. When this is set to the document pane's scrollable area, the popover will grow outside of the PTE when needed (which is good!).

Before:
<img width="657" alt="image" src="https://github.com/sanity-io/sanity/assets/406933/e47754ea-eb10-472f-ab33-40ee041c48b8">

After:
<img width="653" alt="image" src="https://github.com/sanity-io/sanity/assets/406933/381848db-bee2-4bbc-8f72-c59d03bc1181">


### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

- That PTE popovers are accessible.
- That PTE popovers respect the `options.width` property from the schema definition.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

- Improves behavior of popover in the Portable Text editor.
