### PR TITLE
docs(sanity): structure/desktool items docs

### DIFF
--- a/package.config.ts
+++ b/package.config.ts
@@ -13,6 +13,11 @@ export default defineConfig({
         allowMultiple: true,
         syntaxKind: 'block',
       },
+      {
+        name: 'todo',
+        allowMultiple: true,
+        syntaxKind: 'block',
+      },
     ],
     rules: {
       // Disable rules for now

--- a/packages/sanity/src/core/components/previews/types.ts
+++ b/packages/sanity/src/core/components/previews/types.ts
@@ -1,16 +1,18 @@
-import {ImageUrlFitMode, SchemaType} from '@sanity/types'
-import React, {ComponentType, ReactNode} from 'react'
+import type {ImageUrlFitMode, SchemaType} from '@sanity/types'
+import type {ComponentType, ReactNode, ReactElement} from 'react'
 
 /**
  * Type for portable text preview layout key
  *
- * @public */
+ * @public
+ */
 export type PortableTextPreviewLayoutKey = 'block' | 'blockImage' | 'inline'
 
 /**
  * Type for generic preview layout key
  *
- * @public */
+ * @public
+ */
 export type GeneralPreviewLayoutKey = 'default' | 'media' | 'detail'
 
 /**
@@ -22,8 +24,9 @@ export type PreviewLayoutKey = GeneralPreviewLayoutKey | PortableTextPreviewLayo
 
 /**
  * @hidden
- * @beta */
-export type PreviewMediaDimensions = {
+ * @beta
+ */
+export interface PreviewMediaDimensions {
   aspect?: number
   dpr?: number
   fit?: ImageUrlFitMode
@@ -32,7 +35,6 @@ export type PreviewMediaDimensions = {
 }
 
 /**
- *
  * @hidden
  * @beta
  */
@@ -55,10 +57,11 @@ export interface PreviewProps<TLayoutKey = PreviewLayoutKey> {
   withRadius?: boolean
   withShadow?: boolean
   schemaType?: SchemaType
-  renderDefault: (props: PreviewProps) => React.ReactElement
+  renderDefault: (props: PreviewProps) => ReactElement
 }
 
 /**
  * @hidden
- * @beta */
+ * @beta
+ */
 export type PreviewComponent = ComponentType<PreviewProps>

--- a/packages/sanity/src/core/components/previews/types.ts
+++ b/packages/sanity/src/core/components/previews/types.ts
@@ -2,21 +2,21 @@ import type {ImageUrlFitMode, SchemaType} from '@sanity/types'
 import type {ComponentType, ReactNode, ReactElement} from 'react'
 
 /**
- * Type for portable text preview layout key
+ * Portable text preview layout key
  *
  * @public
  */
 export type PortableTextPreviewLayoutKey = 'block' | 'blockImage' | 'inline'
 
 /**
- * Type for generic preview layout key
+ * General preview layout key
  *
  * @public
  */
 export type GeneralPreviewLayoutKey = 'default' | 'media' | 'detail'
 
 /**
- * Type for preview layout key. See also {@link GeneralPreviewLayoutKey} and {@link PortableTextPreviewLayoutKey}
+ * Preview layout key. See also {@link GeneralPreviewLayoutKey} and {@link PortableTextPreviewLayoutKey}
  *
  * @public
  */

--- a/packages/sanity/src/core/components/previews/types.ts
+++ b/packages/sanity/src/core/components/previews/types.ts
@@ -2,18 +2,22 @@ import {ImageUrlFitMode, SchemaType} from '@sanity/types'
 import React, {ComponentType, ReactNode} from 'react'
 
 /**
- * @hidden
- * @beta */
+ * Type for portable text preview layout key
+ *
+ * @public */
 export type PortableTextPreviewLayoutKey = 'block' | 'blockImage' | 'inline'
 
 /**
- * @hidden
- * @beta */
+ * Type for generic preview layout key
+ *
+ * @public */
 export type GeneralPreviewLayoutKey = 'default' | 'media' | 'detail'
 
 /**
- * @hidden
- * @beta */
+ * Type for preview layout key
+ *
+ * @public
+ */
 export type PreviewLayoutKey = GeneralPreviewLayoutKey | PortableTextPreviewLayoutKey
 
 /**

--- a/packages/sanity/src/core/components/previews/types.ts
+++ b/packages/sanity/src/core/components/previews/types.ts
@@ -14,7 +14,7 @@ export type PortableTextPreviewLayoutKey = 'block' | 'blockImage' | 'inline'
 export type GeneralPreviewLayoutKey = 'default' | 'media' | 'detail'
 
 /**
- * Type for preview layout key
+ * Type for preview layout key. See also {@link GeneralPreviewLayoutKey} and {@link PortableTextPreviewLayoutKey}
  *
  * @public
  */

--- a/packages/sanity/src/core/config/configPropertyReducers.ts
+++ b/packages/sanity/src/core/config/configPropertyReducers.ts
@@ -1,5 +1,5 @@
 import type {AssetSource, SchemaTypeDefinition} from '@sanity/types'
-import type {Template, TemplateResponse} from '../templates'
+import type {Template, TemplateItem} from '../templates'
 import {DocumentActionComponent, DocumentBadgeComponent, DocumentInspector} from './document'
 import type {
   DocumentLanguageFilterComponent,
@@ -135,7 +135,7 @@ export const documentActionsReducer: ConfigPropertyReducer<
 }
 
 export const newDocumentOptionsResolver: ConfigPropertyReducer<
-  TemplateResponse[],
+  TemplateItem[],
   NewDocumentOptionsContext
 > = (prev, {document}, context) => {
   const resolveNewDocumentOptions = document?.newDocumentOptions

--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -9,7 +9,7 @@ import {isValidElementType} from 'react-is'
 import {createSchema} from '../schema'
 import {AuthStore, createAuthStore} from '../store/_legacy'
 import {FileSource, ImageSource} from '../form/studio/assetSource'
-import {InitialValueTemplateItem, Template, TemplateResponse} from '../templates'
+import {InitialValueTemplateItem, Template, TemplateItem} from '../templates'
 import {EMPTY_ARRAY, isNonNullable} from '../util'
 import {validateWorkspaces} from '../studio'
 import {filterDefinitions} from '../studio/components/navbar/search/definitions/defaultFilters'
@@ -333,7 +333,7 @@ function resolveSource({
     // filter out the ones with parameters to fill
     .filter((template) => !template.parameters?.length)
     .map(
-      (template): TemplateResponse => ({
+      (template): TemplateItem => ({
         templateId: template.id,
         description: template.description,
         icon: template.icon,

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -9,7 +9,7 @@ import type {
   SchemaType,
   SchemaTypeDefinition,
 } from '@sanity/types'
-import React, {type ComponentType} from 'react'
+import type {ComponentType, ReactNode} from 'react'
 import type {Observable} from 'rxjs'
 import type {
   BlockAnnotationProps,
@@ -21,13 +21,13 @@ import type {
   ItemProps,
 } from '../form'
 import type {InitialValueTemplateItem, Template, TemplateItem} from '../templates'
-import {PreviewProps} from '../components/previews'
-import {AuthStore} from '../store'
-import {StudioTheme} from '../theme'
-import {SearchFilterDefinition} from '../studio/components/navbar/search/definitions/filters'
-import {SearchOperatorDefinition} from '../studio/components/navbar/search/definitions/operators'
-import {StudioComponents, StudioComponentsPluginOptions} from './studio'
-import {
+import type {PreviewProps} from '../components/previews'
+import type {AuthStore} from '../store'
+import type {StudioTheme} from '../theme'
+import type {SearchFilterDefinition} from '../studio/components/navbar/search/definitions/filters'
+import type {SearchOperatorDefinition} from '../studio/components/navbar/search/definitions/operators'
+import type {StudioComponents, StudioComponentsPluginOptions} from './studio'
+import type {
   DocumentActionComponent,
   DocumentBadgeComponent,
   DocumentFieldAction,
@@ -35,7 +35,7 @@ import {
   DocumentFieldActionsResolver,
   DocumentInspector,
 } from './document'
-import {Router, RouterState} from 'sanity/router'
+import type {Router, RouterState} from 'sanity/router'
 
 /**
  *
@@ -88,7 +88,8 @@ export interface SanityFormConfig {
   file?: {
     /**
      * @hidden
-     * @beta */
+     * @beta
+     */
     assetSources?: AssetSource[] | AssetSourceResolver
     // TODO: this option needs more thought on composition and availability
     directUploads?: boolean
@@ -411,12 +412,14 @@ export interface Source {
   document: {
     /**
      * @hidden
-     * @beta */
+     * @beta
+     */
     actions: (props: PartialContext<DocumentActionsContext>) => DocumentActionComponent[]
 
     /**
      * @hidden
-     * @beta */
+     * @beta
+     */
     badges: (props: PartialContext<DocumentActionsContext>) => DocumentBadgeComponent[]
 
     /** @internal */
@@ -426,14 +429,16 @@ export interface Source {
 
     /**
      * @hidden
-     * @beta */
+     * @beta
+     */
     resolveProductionUrl: (
       context: PartialContext<ResolveProductionUrlContext>
     ) => Promise<string | undefined>
 
     /**
      * @hidden
-     * @beta */
+     * @beta
+     */
     resolveNewDocumentOptions: (context: NewDocumentCreationContext) => InitialValueTemplateItem[]
 
     /** @alpha */
@@ -441,13 +446,17 @@ export interface Source {
       props: PartialContext<DocumentLanguageFilterContext>
     ) => DocumentLanguageFilterComponent[]
 
-    /** @hidden @beta */
+    /**
+     * @hidden
+     * @beta
+     */
     inspectors: (props: PartialContext<DocumentInspectorContext>) => DocumentInspector[]
   }
   form: {
     /**
      * @hidden
-     * @beta */
+     * @beta
+     */
     file: {
       assetSources: AssetSource[]
       directUploads: boolean
@@ -455,7 +464,8 @@ export interface Source {
 
     /**
      * @hidden
-     * @beta */
+     * @beta
+     */
     image: {
       assetSources: AssetSource[]
       directUploads: boolean
@@ -463,7 +473,8 @@ export interface Source {
 
     /**
      * @hidden
-     * @beta */
+     * @beta
+     */
     components?: {
       input?: ComponentType<Omit<InputProps, 'renderDefault'>>
       field?: ComponentType<Omit<FieldProps, 'renderDefault'>>
@@ -487,7 +498,8 @@ export interface Source {
   studio?: {
     /**
      * @hidden
-     * @beta */
+     * @beta
+     */
     components?: StudioComponents
   }
 
@@ -510,7 +522,7 @@ export interface WorkspaceSummary {
   type: 'workspace-summary'
   name: string
   title: string
-  icon: React.ReactNode
+  icon: ReactNode
   subtitle?: string
   basePath: string
   auth: AuthStore
@@ -540,7 +552,7 @@ export interface Workspace extends Omit<Source, 'type'> {
   type: 'workspace'
   basePath: string
   subtitle?: string
-  icon: React.ReactNode
+  icon: ReactNode
   /**
    *
    * @hidden

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -20,7 +20,7 @@ import type {
   InputProps,
   ItemProps,
 } from '../form'
-import type {InitialValueTemplateItem, Template, TemplateResponse} from '../templates'
+import type {InitialValueTemplateItem, Template, TemplateItem} from '../templates'
 import {PreviewProps} from '../components/previews'
 import {AuthStore} from '../store'
 import {StudioTheme} from '../theme'
@@ -167,10 +167,7 @@ export interface SchemaPluginOptions {
 /**
  * @hidden
  * @beta */
-export type NewDocumentOptionsResolver = ComposableOption<
-  TemplateResponse[],
-  NewDocumentOptionsContext
->
+export type NewDocumentOptionsResolver = ComposableOption<TemplateItem[], NewDocumentOptionsContext>
 
 /**
  * @hidden

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObjectActionsMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObjectActionsMenu.tsx
@@ -19,7 +19,7 @@ import React, {
   useEffect,
   PropsWithChildren,
 } from 'react'
-import {PortableTextBlock} from '@sanity/types'
+import {PortableTextBlock, isReference} from '@sanity/types'
 import {IntentLink} from 'sanity/router'
 
 interface BlockObjectActionsMenuProps extends PropsWithChildren {
@@ -46,7 +46,7 @@ export function BlockObjectActionsMenu(props: BlockObjectActionsMenuProps): Reac
 
   const referenceLink = useMemo(
     () =>
-      '_ref' in value && value._ref
+      isReference(value)
         ? forwardRef(function ReferenceLink(
             linkProps,
             ref: React.Ref<HTMLAnchorElement> | undefined

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/validation.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/validation.ts
@@ -133,7 +133,7 @@ export const validation = memoize(
           )
         )
       ),
-      scan((acc: Record<string, boolean>, [id, result]) => {
+      scan((acc: Record<string, boolean>, [id, result]): Record<string, boolean> => {
         if (Boolean(acc[id]) === result) {
           return acc
         }

--- a/packages/sanity/src/core/studio/components/navbar/search/utils/sanitizeField.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/utils/sanitizeField.ts
@@ -9,7 +9,8 @@ export function sanitizeFieldValue(name: string | ReactElement): string {
   if (isValidElement(name)) {
     return stripHtmlTags(renderToString(name))
   }
-  return name
+
+  return typeof name === 'string' ? name : ''
 }
 
 function stripHtmlTags(str: string) {

--- a/packages/sanity/src/core/templates/types.ts
+++ b/packages/sanity/src/core/templates/types.ts
@@ -182,6 +182,7 @@ export interface TemplateItem {
    *
    * @experimental
    * @beta
+   * @hidden
    */
   initialDocumentId?: string
 

--- a/packages/sanity/src/core/templates/types.ts
+++ b/packages/sanity/src/core/templates/types.ts
@@ -57,11 +57,11 @@ export interface InitialValueTemplateItem extends TemplateResponse {
 }
 
 /**
- * Type for template response
+ * Interface for template response
  *
  * @public
  */
-export type TemplateResponse = {
+export interface TemplateResponse {
   /** Template id */
   templateId: string
   /** Template title */

--- a/packages/sanity/src/core/templates/types.ts
+++ b/packages/sanity/src/core/templates/types.ts
@@ -48,9 +48,7 @@ export type TemplateArrayFieldDefinition = TemplateFieldDefinition & {
  *
  * @public
  */
-export interface InitialValueTemplateItem extends TemplateResponse {
-  /** Initial value id */
-  id: string
+export interface InitialValueTemplateItem extends TemplateItem {
   type: 'initialValueTemplateItem'
   /** Initial value schema type */
   schemaType: string
@@ -61,8 +59,10 @@ export interface InitialValueTemplateItem extends TemplateResponse {
  *
  * @public
  */
-export interface TemplateResponse {
-  /** Template id */
+export interface TemplateItem {
+  /**
+   * ID for the template the item references
+   */
   templateId: string
   /** Template title */
   title?: string

--- a/packages/sanity/src/core/templates/types.ts
+++ b/packages/sanity/src/core/templates/types.ts
@@ -1,20 +1,78 @@
-import {InitialValueProperty, SchemaType} from '@sanity/types'
+import type {InitialValueProperty, SchemaType} from '@sanity/types'
+import type {ElementType, ReactElement} from 'react'
 
-/** @public */
+/**
+ * An initial value template is a template that can be used to create a new documents.
+ *
+ * This allows a document type to have multiple different starting values while having the same
+ * shared schema definition. Using parameters allows for dynamic template values.
+ *
+ * As the name implies, these are _initial_ values, not _default_ values. The distinction is that
+ * the initial value is only set when the document is created - it is not "merged" into existing
+ * documents that may lack values for fields.
+ *
+ * All document types will by default (automatically, behind the scenes) have an initial value
+ * template generated for them, which will have the same ID as the schema type name. The value of
+ * this template will be the value of the `initialValue` property on the schema type definition,
+ * or an empty object if none is set.
+ *
+ * @public
+ */
 export interface Template<Params = any, Value = any> {
+  /**
+   * Template ID. Automatically generated templates will have the same ID as the schema type name.
+   */
   id: string
+
+  /**
+   * Template title.
+   */
   title: string
-  description?: string
+
+  /**
+   * Schema type name the template belongs to. For the automatically generated templates,
+   * this will be equal to the `id` property.
+   */
   schemaType: string
+
+  /**
+   * Template icon. Rendered in places such as the "new document" dialog. Optional.
+   * Inferred from the schema type icon if not set.
+   */
   icon?: SchemaType['icon']
+
+  /**
+   * Value to use as initial value. Can either be a static object value, or a function that
+   * resolves _to_ an object value. If using a function, it can be given a set of parameters,
+   * which can then determine the value that is returned.
+   */
   value: InitialValueProperty<Params, Value>
+
+  /**
+   * Array of parameters the template accepts. Currently not used (any parameters are accepted),
+   * but by defining parameters, the templates that require parameters can be identified and
+   * excluded from UIs that do not provide them.
+   */
   parameters?: TemplateParameter[]
+
+  /**
+   * Template description. Rendered in places such as the "new document" dialog. Optional.
+   *
+   * @deprecated No longer used
+   */
+  description?: string
 }
 
-/** @public */
+/**
+ * Parameter for a template. Closely resembles API used to define fields for object schema types.
+ *
+ * @public
+ */
 export type TemplateParameter = TemplateFieldDefinition | TemplateArrayFieldDefinition
 
-/** @public */
+/**
+ * @public
+ */
 export interface TypeTarget {
   type: string
 }
@@ -25,17 +83,40 @@ export interface TemplateReferenceTarget {
   to: TypeTarget | TypeTarget[]
 }
 
-/** @public */
+/**
+ * Field definition for a template parameter.
+ * Closely resembles API used to define fields for object schema types.
+ *
+ * @public
+ */
 export interface TemplateFieldDefinition {
+  /**
+   * Parameter name. Must be unique within the template.
+   */
   name: string
+
+  /**
+   * Parameter type, eg `string`, `number`, `boolean` etc.
+   */
   type: string
+
+  /**
+   * Parameter type. Will be attempted to be automatically set if not given,
+   * by title-casing the `name` property.
+   */
   title?: string
+
+  /**
+   * Description for the parameter. Optional.
+   * May be used in the future to explain the parameter in UIs.
+   */
   description?: string
+
+  /**
+   * Optional bag of options for the parameter. Currently unused.
+   */
   options?: {[key: string]: any}
 }
-
-/** @internal */
-export type ReferenceFieldDefinition = TemplateFieldDefinition & TemplateReferenceTarget
 
 /** @public */
 export type TemplateArrayFieldDefinition = TemplateFieldDefinition & {
@@ -44,39 +125,75 @@ export type TemplateArrayFieldDefinition = TemplateFieldDefinition & {
 }
 
 /**
- * Interface for initial value template item
+ * Representation of an initial value template _item_
+ * Used by the {@link desk.StructureBuilder} class to determine which initial value templates
+ * should be available for a desk structure node, such as a list pane.
  *
  * @public
  */
 export interface InitialValueTemplateItem extends TemplateItem {
   type: 'initialValueTemplateItem'
-  /** Initial value schema type */
+
+  /** ID for this template item */
+  id: string
+
+  /** Initial value template schema type */
   schemaType: string
 }
 
 /**
- * Interface for template response
+ * Represents the items that can appear in different parts of the Sanity studio when creating
+ * new documents - examples being the "New document" button in the navigation bar,
+ * the corresponding button in panes, as well as the "Create new" button on references.
+ *
+ * Differs from an actual _template_ in that a single template can be pointed at by multiple
+ * different items. This is useful when the template can create different values based on
+ * passed parameters.
  *
  * @public
  */
 export interface TemplateItem {
   /**
-   * ID for the template the item references
+   * ID for the template. Must be unique within the set of templates.
    */
   templateId: string
-  /** Template title */
-  title?: string
-  /** template subtitle */
-  subtitle?: string
-  /** template description */
-  description?: string
-  /** template parameters */
-  parameters?: {[key: string]: any}
-  /** template icon */
-  icon?: React.ElementType | React.ReactElement
+
   /**
-   * The id of the document to use as initial value
+   * Title for the item.
+   * Defaults to the title of the associated template.
+   */
+  title?: string
+
+  /**
+   * Parameters for the template - an object of any JSON-serializable values
+   */
+  parameters?: {[key: string]: any}
+
+  /**
+   * React icon for the item, if any.
+   * Defaults to the icon for the associated template.
+   */
+  icon?: ElementType | ReactElement
+
+  /**
+   * Experimental: not fully supported yet
+   * Hints at what the document ID for the new document should be.
+   * Leave undefined to let the system decide.
+   *
    * @experimental
+   * @beta
    */
   initialDocumentId?: string
+
+  /**
+   * @deprecated No longer used anywhere
+   * @hidden
+   */
+  subtitle?: string
+
+  /**
+   * @deprecated No longer used anywhere
+   * @hidden
+   */
+  description?: string
 }

--- a/packages/sanity/src/core/templates/types.ts
+++ b/packages/sanity/src/core/templates/types.ts
@@ -44,25 +44,38 @@ export type TemplateArrayFieldDefinition = TemplateFieldDefinition & {
 }
 
 /**
- * @hidden
- * @beta */
+ * Interface for initial value template item
+ *
+ * @public
+ */
 export interface InitialValueTemplateItem extends TemplateResponse {
+  /** Initial value id */
   id: string
   type: 'initialValueTemplateItem'
+  /** Initial value schema type */
   schemaType: string
 }
 
 /**
- * @hidden
- * @beta */
+ * Type for template response
+ *
+ * @public
+ */
 export type TemplateResponse = {
+  /** Template id */
   templateId: string
+  /** Template title */
   title?: string
+  /** template subtitle */
   subtitle?: string
+  /** template description */
   description?: string
+  /** template parameters */
   parameters?: {[key: string]: any}
+  /** template icon */
   icon?: React.ElementType | React.ReactElement
   /**
+   * The id of the document to use as initial value
    * @experimental
    */
   initialDocumentId?: string

--- a/packages/sanity/src/core/user-color/manager.ts
+++ b/packages/sanity/src/core/user-color/manager.ts
@@ -33,7 +33,7 @@ const getTints = (scheme: ThemeColorSchemeKey): Record<string, ColorTintKey> => 
   }
 }
 
-const getDefaultColors = (scheme: ThemeColorSchemeKey): Record<ColorHueKey, UserColor> => {
+const getDefaultColors = (scheme: ThemeColorSchemeKey): Record<string, UserColor> => {
   const {background, border, text} = getTints(scheme)
 
   return defaultHues.reduce((colors, hue) => {

--- a/packages/sanity/src/desk/deskTool.ts
+++ b/packages/sanity/src/desk/deskTool.ts
@@ -28,7 +28,8 @@ const documentActions = [
 const documentBadges = [LiveEditBadge]
 
 /**
- * A “desk tool” is a top-level view within Sanity Studio in which content editors can drill down to specific documents to edit them.
+ * The deskTool is a studio plugin which adds the “desk tool” – a tool within Sanity Studio in which
+ * content editors can drill down to specific documents to edit them.
  * You can configure your Studio's desk tool(s).
  *
  * @public

--- a/packages/sanity/src/desk/deskTool.ts
+++ b/packages/sanity/src/desk/deskTool.ts
@@ -32,8 +32,7 @@ const documentBadges = [LiveEditBadge]
  * You can configure your Studio's desk tool(s).
  *
  * @public
- * @param options - Options for the desk tool
- * {@link DeskToolOptions}
+ * @param options - Options for the desk tool. See {@link DeskToolOptions}
  * @example Minimal example
  * ```ts
  * // sanity.config.ts

--- a/packages/sanity/src/desk/deskTool.ts
+++ b/packages/sanity/src/desk/deskTool.ts
@@ -41,14 +41,14 @@ const documentBadges = [LiveEditBadge]
  * import { deskTool } from 'sanity/desk'
  *
  * export default defineConfig((
- * // ...
- * plugins: [
- * deskTool() // use defaults
- * ]
+ *  // ...
+ *  plugins: [
+ *    deskTool() // use defaults
+ *  ]
  * })
  * ```
  *
- * * @example To customise your desk tool
+ * @example To customise your desk tool
  * ```ts
  * // sanity.config.ts
  * import { defineConfig } from 'sanity'
@@ -67,9 +67,9 @@ const documentBadges = [LiveEditBadge]
  *        S.document().views([
  *          S.view.form(),
  *          S.view.component(Preview).title('Preview')
- *     ])
- *  })
- * ]
+ *        ])
+ *    })
+ *  ]
  * })
  * ```
  * */

--- a/packages/sanity/src/desk/deskTool.ts
+++ b/packages/sanity/src/desk/deskTool.ts
@@ -28,8 +28,51 @@ const documentActions = [
 const documentBadges = [LiveEditBadge]
 
 /**
- * @hidden
- * @beta */
+ * A “desk tool” is a top-level view within Sanity Studio in which content editors can drill down to specific documents to edit them.
+ * You can configure your Studio's desk tool(s).
+ *
+ * @public
+ * @param options - Options for the desk tool
+ * {@link DeskToolOptions}
+ * @example Minimal example
+ * ```ts
+ * // sanity.config.ts
+ * import { defineConfig } from 'sanity'
+ * import { deskTool } from 'sanity/desk'
+ *
+ * export default defineConfig((
+ * // ...
+ * plugins: [
+ * deskTool() // use defaults
+ * ]
+ * })
+ * ```
+ *
+ * * @example To customise your desk tool
+ * ```ts
+ * // sanity.config.ts
+ * import { defineConfig } from 'sanity'
+ * import { deskTool } from 'sanity/desk'
+ * import { FaCar } from 'react-icons'
+
+ * export default defineConfig((
+ *	 // ...
+ *   plugins: [
+ *    deskTool({
+ *      name: 'cars',
+ *      title: 'Cars',
+ *      icon: FaCar,
+ *      structure: (S) => S.documentTypeList('car'),
+ *      defaultDocumentNode: (S) =>
+ *        S.document().views([
+ *          S.view.form(),
+ *          S.view.component(Preview).title('Preview')
+ *     ])
+ *  })
+ * ]
+ * })
+ * ```
+ * */
 export const deskTool = definePlugin<DeskToolOptions | void>((options) => ({
   name: '@sanity/desk-tool',
   document: {

--- a/packages/sanity/src/desk/structureBuilder/ChildResolver.ts
+++ b/packages/sanity/src/desk/structureBuilder/ChildResolver.ts
@@ -25,7 +25,7 @@ export interface ChildResolverOptions {
 }
 
 /**
- * Type for Item Child. See {@link CollectionBuilder} and {@link Collection}
+ * Item Child. See {@link CollectionBuilder} and {@link Collection}
  *
  * @public
  */

--- a/packages/sanity/src/desk/structureBuilder/ChildResolver.ts
+++ b/packages/sanity/src/desk/structureBuilder/ChildResolver.ts
@@ -25,7 +25,7 @@ export interface ChildResolverOptions {
 }
 
 /**
- * Type for Item Child
+ * Type for Item Child. See {@link CollectionBuilder} and {@link Collection}
  *
  * @public
  */

--- a/packages/sanity/src/desk/structureBuilder/ChildResolver.ts
+++ b/packages/sanity/src/desk/structureBuilder/ChildResolver.ts
@@ -18,7 +18,7 @@ export interface ChildResolverOptions {
   path: string[]
   /** Child parameters */
   params: Record<string, string | undefined>
-  /** Structure context */
+  /** Structure context. See {@link StructureContext} */
   structureContext: StructureContext
   /** Serialize options. See {@link SerializeOptions} */
   serializeOptions?: SerializeOptions

--- a/packages/sanity/src/desk/structureBuilder/ChildResolver.ts
+++ b/packages/sanity/src/desk/structureBuilder/ChildResolver.ts
@@ -20,7 +20,7 @@ export interface ChildResolverOptions {
   params: Record<string, string | undefined>
   /** Structure context */
   structureContext: StructureContext
-  /** Serialize options */
+  /** Serialize options. See {@link SerializeOptions} */
   serializeOptions?: SerializeOptions
 }
 
@@ -37,6 +37,7 @@ export type ItemChild = CollectionBuilder | Collection | undefined
  * @public
  */
 export interface ChildObservable {
+  /** Subscribes to the child observable. See {@link ItemChild} */
   subscribe: (child: ItemChild | Promise<ItemChild>) => Record<string, unknown>
 }
 

--- a/packages/sanity/src/desk/structureBuilder/ChildResolver.ts
+++ b/packages/sanity/src/desk/structureBuilder/ChildResolver.ts
@@ -3,34 +3,47 @@ import {StructureContext} from './types'
 import {Observable} from 'rxjs'
 
 /**
- * @hidden
- * @beta */
+ * Interface for child resolver options
+ *
+ * @public
+ */
 // TODO: unify with the RouterSplitPaneContext
 export interface ChildResolverOptions {
+  /** Child parent */
   parent: unknown
+  /** Child index */
   index: number
   splitIndex: number
+  /** Child path */
   path: string[]
+  /** Child parameters */
   params: Record<string, string | undefined>
+  /** Structure context */
   structureContext: StructureContext
+  /** Serialize options */
   serializeOptions?: SerializeOptions
 }
 
 /**
- * @hidden
- * @beta */
+ * Type for Item Child
+ *
+ * @public
+ */
 export type ItemChild = CollectionBuilder | Collection | undefined
 
 /**
- * @hidden
- * @beta */
+ * Interface for child observable
+ *
+ * @public
+ */
 export interface ChildObservable {
   subscribe: (child: ItemChild | Promise<ItemChild>) => Record<string, unknown>
 }
 
 /**
- * @hidden
- * @beta */
+ * Interface for child resolver
+ *
+ * @public */
 // TODO: unify with PaneNodeResolver in desk-tool
 export interface ChildResolver {
   (itemId: string, options: ChildResolverOptions):

--- a/packages/sanity/src/desk/structureBuilder/Component.ts
+++ b/packages/sanity/src/desk/structureBuilder/Component.ts
@@ -62,6 +62,7 @@ export interface BuildableComponent extends Partial<StructureNode> {
  * @public
  */
 export class ComponentBuilder implements Serializable<Component> {
+  /** component builder option object */
   protected spec: BuildableComponent
 
   constructor(spec?: ComponentInput) {
@@ -69,6 +70,7 @@ export class ComponentBuilder implements Serializable<Component> {
   }
 
   /** Set Component ID
+   * @param id - component ID
    * @returns component builder based on ID provided
    */
   id(id: string): ComponentBuilder {
@@ -83,6 +85,7 @@ export class ComponentBuilder implements Serializable<Component> {
   }
 
   /** Set Component title
+   * @param title - component title
    * @returns component builder based on title provided (and ID)
    */
   title(title: string): ComponentBuilder {
@@ -97,6 +100,7 @@ export class ComponentBuilder implements Serializable<Component> {
   }
 
   /** Set Component child
+   * @param child - child component
    * @returns component builder based on child component provided
    */
   child(child: Child): ComponentBuilder {
@@ -111,6 +115,7 @@ export class ComponentBuilder implements Serializable<Component> {
   }
 
   /** Set component
+   * @param component - user built component
    * @returns component builder based on component provided
    */
   component(component: UserComponent): ComponentBuilder {
@@ -125,6 +130,7 @@ export class ComponentBuilder implements Serializable<Component> {
   }
 
   /** Set Component options
+   * @param options - component options
    * @returns component builder based on options provided
    */
   options(options: {[key: string]: unknown}): ComponentBuilder {
@@ -139,6 +145,7 @@ export class ComponentBuilder implements Serializable<Component> {
   }
 
   /** Set Component menu items
+   * @param menuItems - component menu items
    * @returns component builder based on menuItems provided
    */
   menuItems(menuItems: (MenuItem | MenuItemBuilder)[]): ComponentBuilder {
@@ -153,6 +160,7 @@ export class ComponentBuilder implements Serializable<Component> {
   }
 
   /** Set Component menu item groups
+   * @param menuItemGroups - component menu item groups
    * @returns component builder based on menuItemGroups provided
    */
   menuItemGroups(menuItemGroups: (MenuItemGroup | MenuItemGroupBuilder)[]): ComponentBuilder {
@@ -167,6 +175,7 @@ export class ComponentBuilder implements Serializable<Component> {
   }
 
   /** Serialize component
+   * @param options - serialization options
    * @returns component object based on path provided in options
    *
    */
@@ -205,6 +214,7 @@ export class ComponentBuilder implements Serializable<Component> {
   }
 
   /** Clone component builder (allows for options overriding)
+   * @param withSpec - component builder options
    * @returns cloned builder
    */
   clone(withSpec?: BuildableComponent): ComponentBuilder {

--- a/packages/sanity/src/desk/structureBuilder/Component.ts
+++ b/packages/sanity/src/desk/structureBuilder/Component.ts
@@ -68,62 +68,108 @@ export class ComponentBuilder implements Serializable<Component> {
     this.spec = {options: {}, ...(spec ? spec : {})}
   }
 
+  /** Set Component ID
+   * @returns component builder based on ID provided
+   */
   id(id: string): ComponentBuilder {
     return this.clone({id})
   }
 
+  /** Get ID
+   * @returns ID
+   */
   getId(): BuildableComponent['id'] {
     return this.spec.id
   }
 
+  /** Set Component title
+   * @returns component builder based on title provided (and ID)
+   */
   title(title: string): ComponentBuilder {
     return this.clone({title, id: getStructureNodeId(title, this.spec.id)})
   }
 
+  /** Get Component title
+   * @returns title
+   */
   getTitle(): BuildableComponent['title'] {
     return this.spec.title
   }
 
+  /** Set Component child
+   * @returns component builder based on child component provided
+   */
   child(child: Child): ComponentBuilder {
     return this.clone({child})
   }
 
+  /** Get Component child
+   * @returns child component
+   */
   getChild(): BuildableComponent['child'] {
     return this.spec.child
   }
 
+  /** Set component
+   * @returns component builder based on component provided
+   */
   component(component: UserComponent): ComponentBuilder {
     return this.clone({component})
   }
 
+  /** Get Component
+   * @returns component
+   */
   getComponent(): BuildableComponent['component'] {
     return this.spec.component
   }
 
+  /** Set Component options
+   * @returns component builder based on options provided
+   */
   options(options: {[key: string]: unknown}): ComponentBuilder {
     return this.clone({options})
   }
 
+  /** Get Component options
+   * @returns component options
+   */
   getOptions(): NonNullable<BuildableComponent['options']> {
     return this.spec.options || {}
   }
 
+  /** Set Component menu items
+   * @returns component builder based on menuItems provided
+   */
   menuItems(menuItems: (MenuItem | MenuItemBuilder)[]): ComponentBuilder {
     return this.clone({menuItems})
   }
 
+  /** Get Component menu items
+   * @returns menu items
+   */
   getMenuItems(): BuildableComponent['menuItems'] {
     return this.spec.menuItems
   }
 
+  /** Set Component menu item groups
+   * @returns component builder based on menuItemGroups provided
+   */
   menuItemGroups(menuItemGroups: (MenuItemGroup | MenuItemGroupBuilder)[]): ComponentBuilder {
     return this.clone({menuItemGroups})
   }
 
+  /** Get Component menu item groups
+   * @returns menu item groups
+   */
   getMenuItemGroups(): BuildableComponent['menuItemGroups'] {
     return this.spec.menuItemGroups
   }
 
+  /** Serialize component
+   * @returns component object based on path provided in options
+   *
+   */
   serialize(options: SerializeOptions = {path: []}): Component {
     const {id, title, child, options: componentOptions, component} = this.spec
     if (!id) {
@@ -158,6 +204,9 @@ export class ComponentBuilder implements Serializable<Component> {
     }
   }
 
+  /** Clone component builder (allows for options overriding)
+   * @returns cloned builder
+   */
   clone(withSpec?: BuildableComponent): ComponentBuilder {
     const builder = new ComponentBuilder()
     builder.spec = {...this.spec, ...(withSpec || {})}

--- a/packages/sanity/src/desk/structureBuilder/Component.ts
+++ b/packages/sanity/src/desk/structureBuilder/Component.ts
@@ -7,8 +7,10 @@ import {UserComponent} from './types'
 import {getStructureNodeId} from './util/getStructureNodeId'
 
 /**
- * @hidden
- * @beta */
+ * Interface for component
+ *
+ * @public
+ */
 // TODO: rename to `StructureComponent` since it clashes with React?
 export interface Component extends StructureNode {
   component: UserComponent
@@ -19,30 +21,46 @@ export interface Component extends StructureNode {
 }
 
 /**
- * @hidden
- * @beta */
+ * Interface for component input
+ *
+ * @public
+ */
 export interface ComponentInput extends StructureNode {
+  /** Component */
   component: UserComponent
+  /** Component child */
   child?: Child
+  /** Component options */
   options?: {[key: string]: unknown}
+  /** Component menu items */
   menuItems?: (MenuItem | MenuItemBuilder)[]
+  /** Component menu item groups */
   menuItemGroups?: (MenuItemGroup | MenuItemGroupBuilder)[]
 }
 
 /**
- * @hidden
- * @beta */
+ * Interface for buildable component
+ *
+ * @public
+ */
 export interface BuildableComponent extends Partial<StructureNode> {
+  /** Component */
   component?: UserComponent
+  /** Component child */
   child?: Child
+  /** Component options */
   options?: {[key: string]: unknown}
+  /** Component menu items */
   menuItems?: (MenuItem | MenuItemBuilder)[]
+  /** Component menu item groups */
   menuItemGroups?: (MenuItemGroup | MenuItemGroupBuilder)[]
 }
 
 /**
- * @hidden
- * @beta */
+ * Class for building components
+ *
+ * @public
+ */
 export class ComponentBuilder implements Serializable<Component> {
   protected spec: BuildableComponent
 

--- a/packages/sanity/src/desk/structureBuilder/Component.ts
+++ b/packages/sanity/src/desk/structureBuilder/Component.ts
@@ -13,10 +13,15 @@ import {getStructureNodeId} from './util/getStructureNodeId'
  */
 // TODO: rename to `StructureComponent` since it clashes with React?
 export interface Component extends StructureNode {
+  /** Component of type {@link UserComponent} */
   component: UserComponent
+  /** Component child of type {@link Child} */
   child?: Child
+  /** Component menu items, array of type {@link MenuItem} */
   menuItems: MenuItem[]
+  /** Component menu item group, array of type {@link MenuItemGroup} */
   menuItemGroups: MenuItemGroup[]
+  /** Component options */
   options: {[key: string]: unknown}
 }
 
@@ -26,15 +31,15 @@ export interface Component extends StructureNode {
  * @public
  */
 export interface ComponentInput extends StructureNode {
-  /** Component */
+  /** Component of type {@link UserComponent} */
   component: UserComponent
-  /** Component child */
+  /** Component child of type {@link Child} */
   child?: Child
   /** Component options */
   options?: {[key: string]: unknown}
-  /** Component menu items */
+  /** Component menu items. See {@link MenuItem} and {@link MenuItemBuilder}  */
   menuItems?: (MenuItem | MenuItemBuilder)[]
-  /** Component menu item groups */
+  /** Component menu item groups. See {@link MenuItemGroup} and {@link MenuItemGroupBuilder} */
   menuItemGroups?: (MenuItemGroup | MenuItemGroupBuilder)[]
 }
 
@@ -44,15 +49,15 @@ export interface ComponentInput extends StructureNode {
  * @public
  */
 export interface BuildableComponent extends Partial<StructureNode> {
-  /** Component */
+  /** Component of type {@link UserComponent} */
   component?: UserComponent
-  /** Component child */
+  /** Component child of type {@link Child} */
   child?: Child
   /** Component options */
   options?: {[key: string]: unknown}
-  /** Component menu items */
+  /** Component menu items. See {@link MenuItem} and {@link MenuItemBuilder}  */
   menuItems?: (MenuItem | MenuItemBuilder)[]
-  /** Component menu item groups */
+  /** Component menu item groups. See {@link MenuItemGroup} and {@link MenuItemGroupBuilder} */
   menuItemGroups?: (MenuItemGroup | MenuItemGroupBuilder)[]
 }
 

--- a/packages/sanity/src/desk/structureBuilder/Document.ts
+++ b/packages/sanity/src/desk/structureBuilder/Document.ts
@@ -34,29 +34,47 @@ const createDocumentChildResolver =
   }
 
 /**
- * @hidden
- * @beta */
+ * Interface for options of Partial Documents
+ * {@link PartialDocumentNode}
+ *
+ * @public */
 export interface DocumentOptions {
+  /** Document Id */
   id: string
+  /** Document Type */
   type: string
+  /** Document Template */
   template?: string
+  /** Template parameters */
   templateParameters?: Record<string, unknown>
 }
 
 /**
- * @hidden
- * @beta */
+ * Type for partial document (focused on the document pane)
+ *
+ * @public */
 export type PartialDocumentNode = {
+  /* Document Id */
   id?: string
+  /* Document title */
   title?: string
+  /* Document children */
   child?: Child
+  /**
+   * Views for the document pane
+   */
   views?: (View | ViewBuilder)[]
+  /**
+   * Document options
+   * {@link DocumentOptions}
+   */
   options?: Partial<DocumentOptions>
 }
 
 /**
- * @hidden
- * @beta */
+ * A `DocumentBuilder` is used to build a document node.
+ *
+ * @public */
 export class DocumentBuilder implements Serializable<DocumentNode> {
   protected spec: PartialDocumentNode
 

--- a/packages/sanity/src/desk/structureBuilder/Document.ts
+++ b/packages/sanity/src/desk/structureBuilder/Document.ts
@@ -78,34 +78,61 @@ export type PartialDocumentNode = {
 export class DocumentBuilder implements Serializable<DocumentNode> {
   protected spec: PartialDocumentNode
 
-  constructor(protected _context: StructureContext, spec?: PartialDocumentNode) {
+  constructor(
+    /**
+     * Desk structure context
+     */
+    protected _context: StructureContext,
+    spec?: PartialDocumentNode
+  ) {
     this.spec = spec ? spec : {}
   }
 
+  /** Set Document Builder ID
+   * @returns document builder based on ID provided
+   */
   id(id: string): DocumentBuilder {
     return this.clone({id})
   }
 
+  /** Get Document Builder ID
+   * @returns document ID
+   */
   getId(): PartialDocumentNode['id'] {
     return this.spec.id
   }
 
+  /** Set Document title
+   * @returns document builder based on title provided (and ID)
+   */
   title(title: string): DocumentBuilder {
     return this.clone({title, id: getStructureNodeId(title, this.spec.id)})
   }
 
+  /** Get Document title
+   * @returns document title
+   */
   getTitle(): PartialDocumentNode['title'] {
     return this.spec.title
   }
 
+  /** Set Document child
+   * @returns document builder based on child provided
+   */
   child(child: Child): DocumentBuilder {
     return this.clone({child})
   }
 
+  /** Get Document child
+   * @returns document child
+   */
   getChild(): PartialDocumentNode['child'] {
     return this.spec.child
   }
 
+  /** Set Document ID
+   * @returns document builder with document based on ID provided
+   */
   documentId(documentId: string): DocumentBuilder {
     // Let's try to be a bit helpful and assign an ID from document ID if none is specified
     const paneId = this.spec.id || documentId
@@ -118,10 +145,16 @@ export class DocumentBuilder implements Serializable<DocumentNode> {
     })
   }
 
+  /** Get Document ID
+   * @returns document ID
+   */
   getDocumentId(): Partial<DocumentOptions>['id'] {
     return this.spec.options?.id
   }
 
+  /** Set Document Type
+   * @returns document builder with document based on type provided
+   */
   schemaType(documentType: SchemaType | string): DocumentBuilder {
     return this.clone({
       options: {
@@ -131,10 +164,16 @@ export class DocumentBuilder implements Serializable<DocumentNode> {
     })
   }
 
+  /** Get Document Type
+   * @returns document type
+   */
   getSchemaType(): Partial<DocumentOptions>['type'] {
     return this.spec.options?.type
   }
 
+  /** Set Document Template
+   * @returns document builder with document based on template provided
+   */
   initialValueTemplate(templateId: string, parameters?: Record<string, unknown>): DocumentBuilder {
     return this.clone({
       options: {
@@ -145,22 +184,37 @@ export class DocumentBuilder implements Serializable<DocumentNode> {
     })
   }
 
+  /** Get Document Template
+   * @returns document template
+   */
   getInitialValueTemplate(): Partial<DocumentOptions>['template'] {
     return this.spec.options?.template
   }
 
+  /** Get Document's initial value Template parameters
+   * @returns document template parameters
+   */
   getInitialValueTemplateParameters(): Partial<DocumentOptions>['templateParameters'] {
     return this.spec.options?.templateParameters
   }
 
+  /** Set Document views
+   * @returns document builder with document based on views provided
+   */
   views(views: (View | ViewBuilder)[]): DocumentBuilder {
     return this.clone({views})
   }
 
+  /** Get Document views
+   * @returns document views
+   */
   getViews(): (View | ViewBuilder)[] {
     return this.spec.views || []
   }
 
+  /** Serialize Document builder
+   * @returns document node based on path, index and hint provided in options
+   */
   serialize({path = [], index, hint}: SerializeOptions = {path: []}): DocumentNode {
     const urlId = path[index || path.length - 1]
 
@@ -226,6 +280,9 @@ export class DocumentBuilder implements Serializable<DocumentNode> {
     }
   }
 
+  /** Clone Document builder
+   * @returns document builder based on context and spec provided
+   */
   clone(withSpec: PartialDocumentNode = {}): DocumentBuilder {
     const builder = new DocumentBuilder(this._context)
     const options = {...(this.spec.options || {}), ...(withSpec.options || {})}

--- a/packages/sanity/src/desk/structureBuilder/Document.ts
+++ b/packages/sanity/src/desk/structureBuilder/Document.ts
@@ -34,8 +34,7 @@ const createDocumentChildResolver =
   }
 
 /**
- * Interface for options of Partial Documents
- * {@link PartialDocumentNode}
+ * Interface for options of Partial Documents. See {@link PartialDocumentNode}
  *
  * @public */
 export interface DocumentOptions {
@@ -97,7 +96,7 @@ export class DocumentBuilder implements Serializable<DocumentNode> {
   }
 
   /** Get Document Builder ID
-   * @returns document ID
+   * @returns document ID. See {@link PartialDocumentNode}
    */
   getId(): PartialDocumentNode['id'] {
     return this.spec.id

--- a/packages/sanity/src/desk/structureBuilder/Document.ts
+++ b/packages/sanity/src/desk/structureBuilder/Document.ts
@@ -76,6 +76,7 @@ export type PartialDocumentNode = {
  *
  * @public */
 export class DocumentBuilder implements Serializable<DocumentNode> {
+  /** component builder option object */
   protected spec: PartialDocumentNode
 
   constructor(
@@ -89,6 +90,7 @@ export class DocumentBuilder implements Serializable<DocumentNode> {
   }
 
   /** Set Document Builder ID
+   * @param id - document builder ID
    * @returns document builder based on ID provided
    */
   id(id: string): DocumentBuilder {
@@ -103,6 +105,7 @@ export class DocumentBuilder implements Serializable<DocumentNode> {
   }
 
   /** Set Document title
+   * @param title - document title
    * @returns document builder based on title provided (and ID)
    */
   title(title: string): DocumentBuilder {
@@ -117,6 +120,7 @@ export class DocumentBuilder implements Serializable<DocumentNode> {
   }
 
   /** Set Document child
+   * @param child - document child
    * @returns document builder based on child provided
    */
   child(child: Child): DocumentBuilder {
@@ -131,6 +135,7 @@ export class DocumentBuilder implements Serializable<DocumentNode> {
   }
 
   /** Set Document ID
+   * @param documentId - document ID
    * @returns document builder with document based on ID provided
    */
   documentId(documentId: string): DocumentBuilder {
@@ -153,6 +158,7 @@ export class DocumentBuilder implements Serializable<DocumentNode> {
   }
 
   /** Set Document Type
+   * @param documentType - document type
    * @returns document builder with document based on type provided
    */
   schemaType(documentType: SchemaType | string): DocumentBuilder {
@@ -172,6 +178,8 @@ export class DocumentBuilder implements Serializable<DocumentNode> {
   }
 
   /** Set Document Template
+   * @param templateId - document template ID
+   * @param parameters - document template parameters
    * @returns document builder with document based on template provided
    */
   initialValueTemplate(templateId: string, parameters?: Record<string, unknown>): DocumentBuilder {
@@ -199,6 +207,7 @@ export class DocumentBuilder implements Serializable<DocumentNode> {
   }
 
   /** Set Document views
+   * @param views - document views
    * @returns document builder with document based on views provided
    */
   views(views: (View | ViewBuilder)[]): DocumentBuilder {
@@ -213,6 +222,7 @@ export class DocumentBuilder implements Serializable<DocumentNode> {
   }
 
   /** Serialize Document builder
+   * @param options - serialization options
    * @returns document node based on path, index and hint provided in options
    */
   serialize({path = [], index, hint}: SerializeOptions = {path: []}): DocumentNode {
@@ -281,6 +291,7 @@ export class DocumentBuilder implements Serializable<DocumentNode> {
   }
 
   /** Clone Document builder
+   * @param withSpec - partial document node specification used to extend the cloned builder
    * @returns document builder based on context and spec provided
    */
   clone(withSpec: PartialDocumentNode = {}): DocumentBuilder {

--- a/packages/sanity/src/desk/structureBuilder/Document.ts
+++ b/packages/sanity/src/desk/structureBuilder/Document.ts
@@ -50,23 +50,22 @@ export interface DocumentOptions {
 }
 
 /**
- * Type for partial document (focused on the document pane)
+ * Interface for partial document (focused on the document pane)
  *
  * @public */
-export type PartialDocumentNode = {
-  /* Document Id */
+export interface PartialDocumentNode {
+  /** Document Id */
   id?: string
-  /* Document title */
+  /** Document title */
   title?: string
-  /* Document children */
+  /** Document children of type {@link Child} */
   child?: Child
   /**
-   * Views for the document pane
+   * Views for the document pane. See {@link ViewBuilder} and {@link View}
    */
   views?: (View | ViewBuilder)[]
   /**
-   * Document options
-   * {@link DocumentOptions}
+   * Document options. See {@link DocumentOptions}
    */
   options?: Partial<DocumentOptions>
 }
@@ -76,12 +75,12 @@ export type PartialDocumentNode = {
  *
  * @public */
 export class DocumentBuilder implements Serializable<DocumentNode> {
-  /** component builder option object */
+  /** Component builder option object See {@link PartialDocumentNode} */
   protected spec: PartialDocumentNode
 
   constructor(
     /**
-     * Desk structure context
+     * Desk structure context. See {@link StructureContext}
      */
     protected _context: StructureContext,
     spec?: PartialDocumentNode
@@ -91,7 +90,7 @@ export class DocumentBuilder implements Serializable<DocumentNode> {
 
   /** Set Document Builder ID
    * @param id - document builder ID
-   * @returns document builder based on ID provided
+   * @returns document builder based on ID provided. See {@link DocumentBuilder}
    */
   id(id: string): DocumentBuilder {
     return this.clone({id})
@@ -106,14 +105,14 @@ export class DocumentBuilder implements Serializable<DocumentNode> {
 
   /** Set Document title
    * @param title - document title
-   * @returns document builder based on title provided (and ID)
+   * @returns document builder based on title provided (and ID). See {@link DocumentBuilder}
    */
   title(title: string): DocumentBuilder {
     return this.clone({title, id: getStructureNodeId(title, this.spec.id)})
   }
 
   /** Get Document title
-   * @returns document title
+   * @returns document title. See {@link PartialDocumentNode}
    */
   getTitle(): PartialDocumentNode['title'] {
     return this.spec.title
@@ -121,14 +120,14 @@ export class DocumentBuilder implements Serializable<DocumentNode> {
 
   /** Set Document child
    * @param child - document child
-   * @returns document builder based on child provided
+   * @returns document builder based on child provided. See {@link DocumentBuilder}
    */
   child(child: Child): DocumentBuilder {
     return this.clone({child})
   }
 
   /** Get Document child
-   * @returns document child
+   * @returns document child. See {@link PartialDocumentNode}
    */
   getChild(): PartialDocumentNode['child'] {
     return this.spec.child
@@ -136,7 +135,7 @@ export class DocumentBuilder implements Serializable<DocumentNode> {
 
   /** Set Document ID
    * @param documentId - document ID
-   * @returns document builder with document based on ID provided
+   * @returns document builder with document based on ID provided. See {@link DocumentBuilder}
    */
   documentId(documentId: string): DocumentBuilder {
     // Let's try to be a bit helpful and assign an ID from document ID if none is specified
@@ -151,7 +150,7 @@ export class DocumentBuilder implements Serializable<DocumentNode> {
   }
 
   /** Get Document ID
-   * @returns document ID
+   * @returns document ID. See {@link DocumentOptions}
    */
   getDocumentId(): Partial<DocumentOptions>['id'] {
     return this.spec.options?.id
@@ -159,7 +158,7 @@ export class DocumentBuilder implements Serializable<DocumentNode> {
 
   /** Set Document Type
    * @param documentType - document type
-   * @returns document builder with document based on type provided
+   * @returns document builder with document based on type provided. See {@link DocumentBuilder}
    */
   schemaType(documentType: SchemaType | string): DocumentBuilder {
     return this.clone({
@@ -171,7 +170,7 @@ export class DocumentBuilder implements Serializable<DocumentNode> {
   }
 
   /** Get Document Type
-   * @returns document type
+   * @returns document type. See {@link DocumentOptions}
    */
   getSchemaType(): Partial<DocumentOptions>['type'] {
     return this.spec.options?.type
@@ -180,7 +179,7 @@ export class DocumentBuilder implements Serializable<DocumentNode> {
   /** Set Document Template
    * @param templateId - document template ID
    * @param parameters - document template parameters
-   * @returns document builder with document based on template provided
+   * @returns document builder with document based on template provided. See {@link DocumentBuilder}
    */
   initialValueTemplate(templateId: string, parameters?: Record<string, unknown>): DocumentBuilder {
     return this.clone({
@@ -193,37 +192,37 @@ export class DocumentBuilder implements Serializable<DocumentNode> {
   }
 
   /** Get Document Template
-   * @returns document template
+   * @returns document template. See {@link DocumentOptions}
    */
   getInitialValueTemplate(): Partial<DocumentOptions>['template'] {
     return this.spec.options?.template
   }
 
   /** Get Document's initial value Template parameters
-   * @returns document template parameters
+   * @returns document template parameters. See {@link DocumentOptions}
    */
   getInitialValueTemplateParameters(): Partial<DocumentOptions>['templateParameters'] {
     return this.spec.options?.templateParameters
   }
 
   /** Set Document views
-   * @param views - document views
-   * @returns document builder with document based on views provided
+   * @param views - document views. See {@link ViewBuilder} and {@link View}
+   * @returns document builder with document based on views provided. See {@link DocumentBuilder}
    */
   views(views: (View | ViewBuilder)[]): DocumentBuilder {
     return this.clone({views})
   }
 
   /** Get Document views
-   * @returns document views
+   * @returns document views. See {@link ViewBuilder} and {@link View}
    */
   getViews(): (View | ViewBuilder)[] {
     return this.spec.views || []
   }
 
   /** Serialize Document builder
-   * @param options - serialization options
-   * @returns document node based on path, index and hint provided in options
+   * @param options - serialization options. See {@link SerializeOptions}
+   * @returns document node based on path, index and hint provided in options. See {@link DocumentNode}
    */
   serialize({path = [], index, hint}: SerializeOptions = {path: []}): DocumentNode {
     const urlId = path[index || path.length - 1]
@@ -291,8 +290,8 @@ export class DocumentBuilder implements Serializable<DocumentNode> {
   }
 
   /** Clone Document builder
-   * @param withSpec - partial document node specification used to extend the cloned builder
-   * @returns document builder based on context and spec provided
+   * @param withSpec - partial document node specification used to extend the cloned builder. See {@link PartialDocumentNode}
+   * @returns document builder based on context and spec provided. See {@link DocumentBuilder}
    */
   clone(withSpec: PartialDocumentNode = {}): DocumentBuilder {
     const builder = new DocumentBuilder(this._context)

--- a/packages/sanity/src/desk/structureBuilder/DocumentList.ts
+++ b/packages/sanity/src/desk/structureBuilder/DocumentList.ts
@@ -48,7 +48,7 @@ const createDocumentChildResolverForItem =
   }
 
 /**
- * Type for partial document list
+ * Partial document list
  *
  * @public
  */

--- a/packages/sanity/src/desk/structureBuilder/DocumentList.ts
+++ b/packages/sanity/src/desk/structureBuilder/DocumentList.ts
@@ -76,9 +76,9 @@ export interface DocumentListInput extends GenericListInput {
  */
 export interface DocumentList extends GenericList {
   type: 'documentList'
-  /** Document list options */
+  /** Document list options. See {@link DocumentListOptions} */
   options: DocumentListOptions
-  /** Document list child */
+  /** Document list child. See {@link Child} */
   child: Child
   /** Document schema type name */
   schemaTypeName?: string
@@ -96,7 +96,7 @@ export interface DocumentListOptions {
   params?: Record<string, unknown>
   /** Document list API version */
   apiVersion?: string
-  /** Document list API default ordering */
+  /** Document list API default ordering array. See {@link SortOrderingItem} */
   defaultOrdering?: SortOrderingItem[]
 }
 
@@ -109,12 +109,12 @@ export class DocumentListBuilder extends GenericListBuilder<
   PartialDocumentList,
   DocumentListBuilder
 > {
-  /** Document list options */
+  /** Document list options. See {@link PartialDocumentList} */
   protected spec: PartialDocumentList
 
   constructor(
     /**
-     * Desk structure context
+     * Desk structure context. See {@link StructureContext}
      */
     protected _context: StructureContext,
     spec?: DocumentListInput
@@ -126,7 +126,7 @@ export class DocumentListBuilder extends GenericListBuilder<
 
   /** Set API version
    * @param apiVersion - API version
-   * @returns document list builder based on the options and API version provided
+   * @returns document list builder based on the options and API version provided. See {@link DocumentListBuilder}
    */
   apiVersion(apiVersion: string): DocumentListBuilder {
     return this.clone({options: {...(this.spec.options || {filter: ''}), apiVersion}})
@@ -141,7 +141,7 @@ export class DocumentListBuilder extends GenericListBuilder<
 
   /** Set Document list filter
    * @param filter - filter
-   * @returns document list builder based on the options and filter provided
+   * @returns document list builder based on the options and filter provided. See {@link DocumentListBuilder}
    */
   filter(filter: string): DocumentListBuilder {
     return this.clone({options: {...(this.spec.options || {}), filter}})
@@ -155,8 +155,8 @@ export class DocumentListBuilder extends GenericListBuilder<
   }
 
   /** Set Document list schema type name
-   * @param type - schema type name
-   * @returns document list builder based on the schema type name provided
+   * @param type - schema type name. See {@link SchemaType}
+   * @returns document list builder based on the schema type name provided. See {@link DocumentListBuilder}
    */
   schemaType(type: SchemaType | string): DocumentListBuilder {
     const schemaTypeName = typeof type === 'string' ? type : type.name
@@ -172,7 +172,7 @@ export class DocumentListBuilder extends GenericListBuilder<
 
   /** Set Document list options' parameters
    * @param params - parameters
-   * @returns document list builder based on the options provided
+   * @returns document list builder based on the options provided. See {@link DocumentListBuilder}
    */
   params(params: Record<string, unknown>): DocumentListBuilder {
     return this.clone({
@@ -188,8 +188,8 @@ export class DocumentListBuilder extends GenericListBuilder<
   }
 
   /** Set Document list default ordering
-   * @param ordering - default sort ordering
-   * @returns document list builder based on ordering provided
+   * @param ordering - default sort ordering array. See {@link SortOrderingItem}
+   * @returns document list builder based on ordering provided. See {@link DocumentListBuilder}
    */
   defaultOrdering(ordering: SortOrderingItem[]): DocumentListBuilder {
     if (!Array.isArray(ordering)) {
@@ -202,15 +202,15 @@ export class DocumentListBuilder extends GenericListBuilder<
   }
 
   /** Get Document list default ordering
-   * @returns default ordering
+   * @returns default ordering. See {@link SortOrderingItem}
    */
   getDefaultOrdering(): SortOrderingItem[] | undefined {
     return this.spec.options?.defaultOrdering
   }
 
   /** Serialize Document list
-   * @param options - serialization options
-   * @returns document list object based on path provided in options
+   * @param options - serialization options. See {@link SerializeOptions}
+   * @returns document list object based on path provided in options. See {@link DocumentList}
    */
   serialize(options: SerializeOptions = {path: []}): DocumentList {
     if (typeof this.spec.id !== 'string' || !this.spec.id) {
@@ -248,8 +248,8 @@ export class DocumentListBuilder extends GenericListBuilder<
   }
 
   /** Clone Document list builder (allows for options overriding)
-   * @param withSpec - override document list spec
-   * @returns document list builder
+   * @param withSpec - override document list spec. See {@link PartialDocumentList}
+   * @returns document list builder. See {@link DocumentListBuilder}
    */
   clone(withSpec?: PartialDocumentList): DocumentListBuilder {
     const builder = new DocumentListBuilder(this._context)
@@ -267,7 +267,7 @@ export class DocumentListBuilder extends GenericListBuilder<
   }
 
   /** Get Document list spec
-   * @returns document list spec
+   * @returns document list spec. See {@link PartialDocumentList}
    */
   getSpec(): PartialDocumentList {
     return this.spec

--- a/packages/sanity/src/desk/structureBuilder/DocumentList.ts
+++ b/packages/sanity/src/desk/structureBuilder/DocumentList.ts
@@ -109,49 +109,83 @@ export class DocumentListBuilder extends GenericListBuilder<
   PartialDocumentList,
   DocumentListBuilder
 > {
+  /** Document list options */
   protected spec: PartialDocumentList
 
-  constructor(protected _context: StructureContext, spec?: DocumentListInput) {
+  constructor(
+    /**
+     * Desk structure context
+     */
+    protected _context: StructureContext,
+    spec?: DocumentListInput
+  ) {
     super()
     this.spec = spec || {}
     this.initialValueTemplatesSpecified = Boolean(spec?.initialValueTemplates)
   }
 
+  /** Set API version
+   * @returns document list builder based on the options and API version provided
+   */
   apiVersion(apiVersion: string): DocumentListBuilder {
     return this.clone({options: {...(this.spec.options || {filter: ''}), apiVersion}})
   }
 
+  /** Get API version
+   * @returns API version
+   */
   getApiVersion(): string | undefined {
     return this.spec.options?.apiVersion
   }
 
+  /** Set Document list filter
+   * @returns document list builder based on the options and filter provided
+   */
   filter(filter: string): DocumentListBuilder {
     return this.clone({options: {...(this.spec.options || {}), filter}})
   }
 
+  /** Get Document list filter
+   * @returns filter
+   */
   getFilter(): string | undefined {
     return this.spec.options?.filter
   }
 
+  /** Set Document list schema type name
+   * @returns document list builder based on the schema type name provided
+   */
   schemaType(type: SchemaType | string): DocumentListBuilder {
     const schemaTypeName = typeof type === 'string' ? type : type.name
     return this.clone({schemaTypeName})
   }
 
+  /** Get Document list schema type name
+   * @returns schema type name
+   */
   getSchemaType(): string | undefined {
     return this.spec.schemaTypeName
   }
 
+  /** Set Document list options' parameters
+   * @returns document list builder based on the options provided
+   */
   params(params: Record<string, unknown>): DocumentListBuilder {
     return this.clone({
       options: {...(this.spec.options || {filter: ''}), params},
     })
   }
 
+  /** Get Document list options' parameters
+   * @returns options
+   */
   getParams(): Record<string, unknown> | undefined {
     return this.spec.options?.params
   }
 
+  /** Set Document list default ordering
+   * @returns document list builder based on ordering provided
+   */
   defaultOrdering(ordering: SortOrderingItem[]): DocumentListBuilder {
     if (!Array.isArray(ordering)) {
       throw new Error('`defaultOrdering` must be an array of order clauses')
@@ -162,10 +196,16 @@ export class DocumentListBuilder extends GenericListBuilder<
     })
   }
 
+  /** Get Document list default ordering
+   * @returns default ordering
+   */
   getDefaultOrdering(): SortOrderingItem[] | undefined {
     return this.spec.options?.defaultOrdering
   }
 
+  /** Serialize Document list
+   * @returns document list object based on path provided in options
+   */
   serialize(options: SerializeOptions = {path: []}): DocumentList {
     if (typeof this.spec.id !== 'string' || !this.spec.id) {
       throw new SerializeError(
@@ -201,6 +241,9 @@ export class DocumentListBuilder extends GenericListBuilder<
     }
   }
 
+  /** Clone Document list builder (allows for options overriding)
+   * @returns document list builder
+   */
   clone(withSpec?: PartialDocumentList): DocumentListBuilder {
     const builder = new DocumentListBuilder(this._context)
     builder.spec = {...this.spec, ...(withSpec || {})}
@@ -216,6 +259,9 @@ export class DocumentListBuilder extends GenericListBuilder<
     return builder
   }
 
+  /** Get Document list spec
+   * @returns document list spec
+   */
   getSpec(): PartialDocumentList {
     return this.spec
   }

--- a/packages/sanity/src/desk/structureBuilder/DocumentList.ts
+++ b/packages/sanity/src/desk/structureBuilder/DocumentList.ts
@@ -125,6 +125,7 @@ export class DocumentListBuilder extends GenericListBuilder<
   }
 
   /** Set API version
+   * @param apiVersion - API version
    * @returns document list builder based on the options and API version provided
    */
   apiVersion(apiVersion: string): DocumentListBuilder {
@@ -139,6 +140,7 @@ export class DocumentListBuilder extends GenericListBuilder<
   }
 
   /** Set Document list filter
+   * @param filter - filter
    * @returns document list builder based on the options and filter provided
    */
   filter(filter: string): DocumentListBuilder {
@@ -153,6 +155,7 @@ export class DocumentListBuilder extends GenericListBuilder<
   }
 
   /** Set Document list schema type name
+   * @param type - schema type name
    * @returns document list builder based on the schema type name provided
    */
   schemaType(type: SchemaType | string): DocumentListBuilder {
@@ -168,6 +171,7 @@ export class DocumentListBuilder extends GenericListBuilder<
   }
 
   /** Set Document list options' parameters
+   * @param params - parameters
    * @returns document list builder based on the options provided
    */
   params(params: Record<string, unknown>): DocumentListBuilder {
@@ -184,6 +188,7 @@ export class DocumentListBuilder extends GenericListBuilder<
   }
 
   /** Set Document list default ordering
+   * @param ordering - default sort ordering
    * @returns document list builder based on ordering provided
    */
   defaultOrdering(ordering: SortOrderingItem[]): DocumentListBuilder {
@@ -204,6 +209,7 @@ export class DocumentListBuilder extends GenericListBuilder<
   }
 
   /** Serialize Document list
+   * @param options - serialization options
    * @returns document list object based on path provided in options
    */
   serialize(options: SerializeOptions = {path: []}): DocumentList {
@@ -242,6 +248,7 @@ export class DocumentListBuilder extends GenericListBuilder<
   }
 
   /** Clone Document list builder (allows for options overriding)
+   * @param withSpec - override document list spec
    * @returns document list builder
    */
   clone(withSpec?: PartialDocumentList): DocumentListBuilder {

--- a/packages/sanity/src/desk/structureBuilder/DocumentList.ts
+++ b/packages/sanity/src/desk/structureBuilder/DocumentList.ts
@@ -53,7 +53,7 @@ const createDocumentChildResolverForItem =
  * @public
  */
 export interface PartialDocumentList extends BuildableGenericList {
-  /** Document list options */
+  /** Document list options. See {@link DocumentListOptions} */
   options?: DocumentListOptions
   /** Schema type name */
   schemaTypeName?: string
@@ -65,7 +65,7 @@ export interface PartialDocumentList extends BuildableGenericList {
  * @public
  */
 export interface DocumentListInput extends GenericListInput {
-  /** Document list options */
+  /** Document list options. See {@link DocumentListOptions} */
   options: DocumentListOptions
 }
 

--- a/packages/sanity/src/desk/structureBuilder/DocumentList.ts
+++ b/packages/sanity/src/desk/structureBuilder/DocumentList.ts
@@ -53,9 +53,9 @@ const createDocumentChildResolverForItem =
  * @public
  */
 export interface PartialDocumentList extends BuildableGenericList {
-  /* Document list options */
+  /** Document list options */
   options?: DocumentListOptions
-  /* Schema type name */
+  /** Schema type name */
   schemaTypeName?: string
 }
 
@@ -65,7 +65,7 @@ export interface PartialDocumentList extends BuildableGenericList {
  * @public
  */
 export interface DocumentListInput extends GenericListInput {
-  /* Document list options */
+  /** Document list options */
   options: DocumentListOptions
 }
 
@@ -76,11 +76,11 @@ export interface DocumentListInput extends GenericListInput {
  */
 export interface DocumentList extends GenericList {
   type: 'documentList'
-  /* Document list options */
+  /** Document list options */
   options: DocumentListOptions
-  /* Document list child */
+  /** Document list child */
   child: Child
-  /* Document schema type name */
+  /** Document schema type name */
   schemaTypeName?: string
 }
 
@@ -90,13 +90,13 @@ export interface DocumentList extends GenericList {
  * @public
  */
 export interface DocumentListOptions {
-  /* Document list filter */
+  /** Document list filter */
   filter: string
-  /* Document list parameters */
+  /** Document list parameters */
   params?: Record<string, unknown>
-  /* Document list API version */
+  /** Document list API version */
   apiVersion?: string
-  /* Document list API default ordering */
+  /** Document list API default ordering */
   defaultOrdering?: SortOrderingItem[]
 }
 

--- a/packages/sanity/src/desk/structureBuilder/DocumentList.ts
+++ b/packages/sanity/src/desk/structureBuilder/DocumentList.ts
@@ -48,43 +48,63 @@ const createDocumentChildResolverForItem =
   }
 
 /**
- * @hidden
- * @beta */
+ * Type for partial document list
+ *
+ * @public
+ */
 export interface PartialDocumentList extends BuildableGenericList {
+  /* Document list options */
   options?: DocumentListOptions
+  /* Schema type name */
   schemaTypeName?: string
 }
 
 /**
- * @hidden
- * @beta */
+ * Interface for document list input
+ *
+ * @public
+ */
 export interface DocumentListInput extends GenericListInput {
+  /* Document list options */
   options: DocumentListOptions
 }
 
 /**
- * @hidden
- * @beta */
+ * Interface for document list
+ *
+ * @public
+ */
 export interface DocumentList extends GenericList {
   type: 'documentList'
+  /* Document list options */
   options: DocumentListOptions
+  /* Document list child */
   child: Child
+  /* Document schema type name */
   schemaTypeName?: string
 }
 
 /**
- * @hidden
- * @beta */
+ * Interface for document List options
+ *
+ * @public
+ */
 export interface DocumentListOptions {
+  /* Document list filter */
   filter: string
+  /* Document list parameters */
   params?: Record<string, unknown>
+  /* Document list API version */
   apiVersion?: string
+  /* Document list API default ordering */
   defaultOrdering?: SortOrderingItem[]
 }
 
 /**
- * @hidden
- * @beta */
+ * Class for building document list
+ *
+ * @public
+ */
 export class DocumentListBuilder extends GenericListBuilder<
   PartialDocumentList,
   DocumentListBuilder

--- a/packages/sanity/src/desk/structureBuilder/DocumentListItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/DocumentListItem.ts
@@ -29,7 +29,7 @@ export interface DocumentListItem extends ListItem {
 }
 
 /**
- * Type for partial document list item
+ * Partial document list item
  *
  * @public
  */

--- a/packages/sanity/src/desk/structureBuilder/DocumentListItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/DocumentListItem.ts
@@ -12,6 +12,7 @@ import {isRecord} from 'sanity'
  * @public
  */
 export interface DocumentListItemInput extends ListItemInput {
+  /** Document list item input schema type */
   schemaType: SchemaType | string
 }
 

--- a/packages/sanity/src/desk/structureBuilder/DocumentListItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/DocumentListItem.ts
@@ -12,7 +12,7 @@ import {isRecord} from 'sanity'
  * @public
  */
 export interface DocumentListItemInput extends ListItemInput {
-  /** Document list item input schema type */
+  /** Document list item input schema type. See {@link SchemaType} */
   schemaType: SchemaType | string
 }
 
@@ -22,7 +22,7 @@ export interface DocumentListItemInput extends ListItemInput {
  * @public
  */
 export interface DocumentListItem extends ListItem {
-  /** Document schema type */
+  /** Document schema type. See {@link SchemaType} */
   schemaType: SchemaType
   /** Document ID */
   _id: string
@@ -52,12 +52,12 @@ const createDefaultChildResolver =
  * @public
  */
 export class DocumentListItemBuilder extends ListItemBuilder {
-  /** Document list options */
+  /** Document list options. See {@link PartialDocumentListItem} */
   protected spec: PartialDocumentListItem
 
   constructor(
     /**
-     * Desk structure context
+     * Desk structure context. See {@link StructureContext}
      */
     protected _context: StructureContext,
     spec?: DocumentListItemInput
@@ -68,8 +68,8 @@ export class DocumentListItemBuilder extends ListItemBuilder {
 
   /**
    * Serialize document list item
-   * @param options - serialization options
-   * @returns document list item object based on path provided in options
+   * @param options - serialization options. See {@link SerializeOptions}
+   * @returns document list item object based on path provided in options. See {@link DocumentListItem}
    */
   serialize(options: SerializeOptions = {path: []}): DocumentListItem {
     const spec = super.serialize({...options, titleIsOptional: true})
@@ -87,8 +87,8 @@ export class DocumentListItemBuilder extends ListItemBuilder {
   }
 
   /** Clone Document list item builder (allows for options overriding)
-   * @param withSpec - Document list item builder options
-   * @returns document list item builder
+   * @param withSpec - Document list item builder options. See {@link PartialDocumentListItem}
+   * @returns document list item builder. See {@link DocumentListItemBuilder}
    */
   clone(withSpec?: PartialDocumentListItem): DocumentListItemBuilder {
     const builder = new DocumentListItemBuilder(this._context)

--- a/packages/sanity/src/desk/structureBuilder/DocumentListItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/DocumentListItem.ts
@@ -68,6 +68,7 @@ export class DocumentListItemBuilder extends ListItemBuilder {
 
   /**
    * Serialize document list item
+   * @param options - serialization options
    * @returns document list item object based on path provided in options
    */
   serialize(options: SerializeOptions = {path: []}): DocumentListItem {
@@ -86,6 +87,7 @@ export class DocumentListItemBuilder extends ListItemBuilder {
   }
 
   /** Clone Document list item builder (allows for options overriding)
+   * @param withSpec - Document list item builder options
    * @returns document list item builder
    */
   clone(withSpec?: PartialDocumentListItem): DocumentListItemBuilder {

--- a/packages/sanity/src/desk/structureBuilder/DocumentListItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/DocumentListItem.ts
@@ -52,13 +52,24 @@ const createDefaultChildResolver =
  * @public
  */
 export class DocumentListItemBuilder extends ListItemBuilder {
+  /** Document list options */
   protected spec: PartialDocumentListItem
 
-  constructor(protected _context: StructureContext, spec?: DocumentListItemInput) {
+  constructor(
+    /**
+     * Desk structure context
+     */
+    protected _context: StructureContext,
+    spec?: DocumentListItemInput
+  ) {
     super(_context, spec)
     this.spec = spec ? spec : {}
   }
 
+  /**
+   * Serialize document list item
+   * @returns document list item object based on path provided in options
+   */
   serialize(options: SerializeOptions = {path: []}): DocumentListItem {
     const spec = super.serialize({...options, titleIsOptional: true})
 
@@ -74,6 +85,9 @@ export class DocumentListItemBuilder extends ListItemBuilder {
     return {...spec, child, schemaType: spec.schemaType, _id: spec.id}
   }
 
+  /** Clone Document list item builder (allows for options overriding)
+   * @returns document list item builder
+   */
   clone(withSpec?: PartialDocumentListItem): DocumentListItemBuilder {
     const builder = new DocumentListItemBuilder(this._context)
     builder.spec = {...this.spec, ...(withSpec || {})}

--- a/packages/sanity/src/desk/structureBuilder/DocumentListItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/DocumentListItem.ts
@@ -7,23 +7,31 @@ import {StructureContext} from './types'
 import {isRecord} from 'sanity'
 
 /**
- * @hidden
- * @beta */
+ * Interface for document list item input
+ *
+ * @public
+ */
 export interface DocumentListItemInput extends ListItemInput {
   schemaType: SchemaType | string
 }
 
 /**
- * @hidden
- * @beta */
+ * Interface for document list item
+ *
+ * @public
+ */
 export interface DocumentListItem extends ListItem {
+  /** Document schema type */
   schemaType: SchemaType
+  /** Document ID */
   _id: string
 }
 
 /**
- * @hidden
- * @beta */
+ * Type for partial document list item
+ *
+ * @public
+ */
 export type PartialDocumentListItem = Partial<UnserializedListItem>
 
 const createDefaultChildResolver =
@@ -38,8 +46,10 @@ const createDefaultChildResolver =
   }
 
 /**
- * @hidden
- * @beta */
+ * Class for building a document list item
+ *
+ * @public
+ */
 export class DocumentListItemBuilder extends ListItemBuilder {
   protected spec: PartialDocumentListItem
 

--- a/packages/sanity/src/desk/structureBuilder/DocumentTypeList.ts
+++ b/packages/sanity/src/desk/structureBuilder/DocumentTypeList.ts
@@ -37,6 +37,7 @@ export class DocumentTypeListBuilder extends DocumentListBuilder {
 
   /**
    * Set Document type list child
+   * @param child - Child component
    * @returns document type list builder based on child component provided without default intent handler
    */
   child(child: Child): DocumentTypeListBuilder {
@@ -44,6 +45,7 @@ export class DocumentTypeListBuilder extends DocumentListBuilder {
   }
 
   /** Clone Document type list builder (allows for options overriding)
+   * @param withSpec - Document type list builder options
    * @returns document type list builder
    */
   clone(withSpec?: PartialDocumentList): DocumentTypeListBuilder {
@@ -54,6 +56,7 @@ export class DocumentTypeListBuilder extends DocumentListBuilder {
   }
 
   /** Clone Document type list builder (allows for options overriding) and remove default intent handler
+   * @param withSpec - Document type list builder options
    * @returns document type list builder without default intent handler
    */
   cloneWithoutDefaultIntentHandler(withSpec?: PartialDocumentList): DocumentTypeListBuilder {

--- a/packages/sanity/src/desk/structureBuilder/DocumentTypeList.ts
+++ b/packages/sanity/src/desk/structureBuilder/DocumentTypeList.ts
@@ -11,6 +11,7 @@ import {StructureContext} from './types'
  * @public
  */
 export interface DocumentTypeListInput extends Partial<GenericListInput> {
+  /** Document type list input schema type */
   schemaType: SchemaType | string
 }
 

--- a/packages/sanity/src/desk/structureBuilder/DocumentTypeList.ts
+++ b/packages/sanity/src/desk/structureBuilder/DocumentTypeList.ts
@@ -21,17 +21,31 @@ export interface DocumentTypeListInput extends Partial<GenericListInput> {
  * @public
  */
 export class DocumentTypeListBuilder extends DocumentListBuilder {
+  /** Document list options */
   protected spec: PartialDocumentList
 
-  constructor(protected _context: StructureContext, spec?: DocumentListInput) {
+  constructor(
+    /**
+     * Desk structure context
+     */
+    protected _context: StructureContext,
+    spec?: DocumentListInput
+  ) {
     super(_context)
     this.spec = spec ? spec : {}
   }
 
+  /**
+   * Set Document type list child
+   * @returns document type list builder based on child component provided without default intent handler
+   */
   child(child: Child): DocumentTypeListBuilder {
     return this.cloneWithoutDefaultIntentHandler({child})
   }
 
+  /** Clone Document type list builder (allows for options overriding)
+   * @returns document type list builder
+   */
   clone(withSpec?: PartialDocumentList): DocumentTypeListBuilder {
     const parent = super.clone(withSpec)
     const builder = new DocumentTypeListBuilder(this._context)
@@ -39,6 +53,9 @@ export class DocumentTypeListBuilder extends DocumentListBuilder {
     return builder
   }
 
+  /** Clone Document type list builder (allows for options overriding) and remove default intent handler
+   * @returns document type list builder without default intent handler
+   */
   cloneWithoutDefaultIntentHandler(withSpec?: PartialDocumentList): DocumentTypeListBuilder {
     const parent = super.clone(withSpec)
     const builder = new DocumentTypeListBuilder(this._context)

--- a/packages/sanity/src/desk/structureBuilder/DocumentTypeList.ts
+++ b/packages/sanity/src/desk/structureBuilder/DocumentTypeList.ts
@@ -11,7 +11,7 @@ import {StructureContext} from './types'
  * @public
  */
 export interface DocumentTypeListInput extends Partial<GenericListInput> {
-  /** Document type list input schema type */
+  /** Document type list input schema type. See {@link SchemaType} */
   schemaType: SchemaType | string
 }
 
@@ -21,12 +21,12 @@ export interface DocumentTypeListInput extends Partial<GenericListInput> {
  * @public
  */
 export class DocumentTypeListBuilder extends DocumentListBuilder {
-  /** Document list options */
+  /** Document list options. See {@link PartialDocumentList} */
   protected spec: PartialDocumentList
 
   constructor(
     /**
-     * Desk structure context
+     * Desk structure context. See {@link StructureContext}
      */
     protected _context: StructureContext,
     spec?: DocumentListInput
@@ -37,16 +37,16 @@ export class DocumentTypeListBuilder extends DocumentListBuilder {
 
   /**
    * Set Document type list child
-   * @param child - Child component
-   * @returns document type list builder based on child component provided without default intent handler
+   * @param child - Child component. See {@link Child}
+   * @returns document type list builder based on child component provided without default intent handler. See {@link DocumentTypeListBuilder}
    */
   child(child: Child): DocumentTypeListBuilder {
     return this.cloneWithoutDefaultIntentHandler({child})
   }
 
   /** Clone Document type list builder (allows for options overriding)
-   * @param withSpec - Document type list builder options
-   * @returns document type list builder
+   * @param withSpec - Document type list builder options. See {@link PartialDocumentList}
+   * @returns document type list builder. See {@link DocumentTypeListBuilder}
    */
   clone(withSpec?: PartialDocumentList): DocumentTypeListBuilder {
     const parent = super.clone(withSpec)
@@ -56,8 +56,8 @@ export class DocumentTypeListBuilder extends DocumentListBuilder {
   }
 
   /** Clone Document type list builder (allows for options overriding) and remove default intent handler
-   * @param withSpec - Document type list builder options
-   * @returns document type list builder without default intent handler
+   * @param withSpec - Document type list builder options. See {@link PartialDocumentList}
+   * @returns document type list builder without default intent handler. See {@link DocumentTypeListBuilder}
    */
   cloneWithoutDefaultIntentHandler(withSpec?: PartialDocumentList): DocumentTypeListBuilder {
     const parent = super.clone(withSpec)

--- a/packages/sanity/src/desk/structureBuilder/DocumentTypeList.ts
+++ b/packages/sanity/src/desk/structureBuilder/DocumentTypeList.ts
@@ -6,15 +6,19 @@ import {GenericListInput} from './GenericList'
 import {StructureContext} from './types'
 
 /**
- * @hidden
- * @beta */
+ * Interface for document type list input
+ *
+ * @public
+ */
 export interface DocumentTypeListInput extends Partial<GenericListInput> {
   schemaType: SchemaType | string
 }
 
 /**
- * @hidden
- * @beta */
+ * Class for building a document type list
+ *
+ * @public
+ */
 export class DocumentTypeListBuilder extends DocumentListBuilder {
   protected spec: PartialDocumentList
 

--- a/packages/sanity/src/desk/structureBuilder/GenericList.ts
+++ b/packages/sanity/src/desk/structureBuilder/GenericList.ts
@@ -22,60 +22,89 @@ export const shallowIntentChecker: IntentChecker = (intentName, params, {pane, i
 }
 
 /**
- * @hidden
- * @beta */
+ * Interface for list display options
+ *
+ * @public */
 export interface ListDisplayOptions {
   showIcons?: boolean
 }
 
 /**
- * @hidden
- * @beta */
+ * Interface for base generic list
+ *
+ * @public
+ */
 export interface BaseGenericList extends StructureNode {
+  /** List layout key */
   defaultLayout?: PreviewLayoutKey
+  /** Can handle intent */
   canHandleIntent?: IntentChecker
+  /** List display options */
   displayOptions?: ListDisplayOptions
+  /** List child */
   child: Child
+  /** List initial values */
   initialValueTemplates?: (InitialValueTemplateItem | InitialValueTemplateItemBuilder)[]
 }
 
 /**
- * @hidden
- * @beta */
+ * Interface for generic list
+ *
+ * @public
+ */
 // "POJO"/verbatim-version - end result
 export interface GenericList extends BaseGenericList {
+  /** List type */
   type: string
+  /** List menu items */
   menuItems: MenuItem[]
+  /** List menu item groups */
   menuItemGroups: MenuItemGroup[]
 }
 
 /**
- * @hidden
- * @beta */
+ * Interface for buildable generic list
+ *
+ * @public
+ */
 // Used internally in builder classes to make everything optional
 export interface BuildableGenericList extends Partial<BaseGenericList> {
+  /** List menu items */
   menuItems?: (MenuItem | MenuItemBuilder)[]
+  /** List menu items groups */
   menuItemGroups?: (MenuItemGroup | MenuItemGroupBuilder)[]
 }
 
 /**
- * @hidden
- * @beta */
+ * Interface for generic list input
+ * Allows builders and only requires things not inferrable
+ *
+ * @public */
 // Input version, allows builders and only requires things not inferrable
 export interface GenericListInput extends StructureNode {
+  /* Input id */
   id: string
+  /* Input title */
   title: string
+  /* Input menu items */
   menuItems?: (MenuItem | MenuItemBuilder)[]
+  /* Input menu items groups */
   menuItemGroups?: (MenuItemGroup | MenuItemGroupBuilder)[]
+  /* Input initial value */
   initialValueTemplates?: (InitialValueTemplateItem | InitialValueTemplateItemBuilder)[]
+  /* Input default layout */
   defaultLayout?: PreviewLayoutKey
+  /* If input can handle intent */
   canHandleIntent?: IntentChecker
+  /* Input child */
   child?: Child
 }
 
 /**
- * @hidden
- * @beta */
+ * Class for building generic lists
+ *
+ * @public
+ */
 export abstract class GenericListBuilder<TList extends BuildableGenericList, ConcreteImpl>
   implements Serializable<GenericList>
 {

--- a/packages/sanity/src/desk/structureBuilder/GenericList.ts
+++ b/packages/sanity/src/desk/structureBuilder/GenericList.ts
@@ -36,15 +36,15 @@ export interface ListDisplayOptions {
  * @public
  */
 export interface BaseGenericList extends StructureNode {
-  /** List layout key */
+  /** List layout key. See {@link PreviewLayoutKey} */
   defaultLayout?: PreviewLayoutKey
-  /** Can handle intent */
+  /** Can handle intent. See {@link IntentChecker} */
   canHandleIntent?: IntentChecker
-  /** List display options */
+  /** List display options. See {@link ListDisplayOptions} */
   displayOptions?: ListDisplayOptions
-  /** List child */
+  /** List child. See {@link Child} */
   child: Child
-  /** List initial values */
+  /** List initial values array. See {@link InitialValueTemplateItem} and {@link InitialValueTemplateItemBuilder} */
   initialValueTemplates?: (InitialValueTemplateItem | InitialValueTemplateItemBuilder)[]
 }
 
@@ -87,17 +87,17 @@ export interface GenericListInput extends StructureNode {
   id: string
   /** Input title */
   title: string
-  /** Input menu items */
+  /** Input menu items groups. See {@link MenuItem} and {@link MenuItemBuilder} */
   menuItems?: (MenuItem | MenuItemBuilder)[]
-  /** Input menu items groups */
+  /** Input menu items groups. See {@link MenuItemGroup} and {@link MenuItemGroupBuilder} */
   menuItemGroups?: (MenuItemGroup | MenuItemGroupBuilder)[]
-  /** Input initial value */
+  /** Input initial value array. See {@link InitialValueTemplateItem} and {@link InitialValueTemplateItemBuilder} */
   initialValueTemplates?: (InitialValueTemplateItem | InitialValueTemplateItemBuilder)[]
-  /** Input default layout */
+  /** Input default layout. See {@link PreviewLayoutKey} */
   defaultLayout?: PreviewLayoutKey
-  /** If input can handle intent */
+  /** If input can handle intent. See {@link IntentChecker} */
   canHandleIntent?: IntentChecker
-  /** Input child */
+  /** Input child of type {@link Child} */
   child?: Child
 }
 

--- a/packages/sanity/src/desk/structureBuilder/GenericList.ts
+++ b/packages/sanity/src/desk/structureBuilder/GenericList.ts
@@ -57,9 +57,9 @@ export interface BaseGenericList extends StructureNode {
 export interface GenericList extends BaseGenericList {
   /** List type */
   type: string
-  /** List menu items */
+  /** List menu items array. See {@link MenuItem} */
   menuItems: MenuItem[]
-  /** List menu item groups */
+  /** List menu item groups array. See {@link MenuItemGroup} */
   menuItemGroups: MenuItemGroup[]
 }
 
@@ -70,9 +70,9 @@ export interface GenericList extends BaseGenericList {
  */
 // Used internally in builder classes to make everything optional
 export interface BuildableGenericList extends Partial<BaseGenericList> {
-  /** List menu items */
+  /** List menu items array. See {@link MenuItem} and {@link MenuItemBuilder} */
   menuItems?: (MenuItem | MenuItemBuilder)[]
-  /** List menu items groups */
+  /** List menu items groups array. See {@link MenuItemGroup} and {@link MenuItemGroupBuilder} */
   menuItemGroups?: (MenuItemGroup | MenuItemGroupBuilder)[]
 }
 
@@ -116,7 +116,7 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
 
   /** Set generic list ID
    * @param id - generic list ID
-   * @returns generic list builder based on ID provided
+   * @returns generic list builder based on ID provided. See {@link ConcreteImpl}
    */
   id(id: string): ConcreteImpl {
     return this.clone({id})
@@ -131,7 +131,7 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
 
   /** Set generic list title
    * @param title - generic list title
-   * @returns generic list builder based on title and ID provided
+   * @returns generic list builder based on title and ID provided. See {@link ConcreteImpl}
    */
   title(title: string): ConcreteImpl {
     return this.clone({title, id: getStructureNodeId(title, this.spec.id)})
@@ -145,8 +145,8 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
   }
 
   /** Set generic list layout
-   * @param defaultLayout - generic list layout key
-   * @returns generic list builder based on layout provided
+   * @param defaultLayout - generic list layout key. See {@link PreviewLayoutKey}
+   * @returns generic list builder based on layout provided. See {@link ConcreteImpl}
    */
   defaultLayout(defaultLayout: PreviewLayoutKey): ConcreteImpl {
     return this.clone({defaultLayout})
@@ -160,8 +160,8 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
   }
 
   /** Set generic list menu items
-   * @param menuItems - generic list menu items
-   * @returns generic list builder based on menu items provided
+   * @param menuItems - generic list menu items. See {@link MenuItem} and {@link MenuItemBuilder}
+   * @returns generic list builder based on menu items provided. See {@link ConcreteImpl}
    */
   menuItems(menuItems: (MenuItem | MenuItemBuilder)[] | undefined): ConcreteImpl {
     return this.clone({menuItems})
@@ -175,8 +175,8 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
   }
 
   /** Set generic list menu item groups
-   * @param menuItemGroups - generic list menu item groups
-   * @returns generic list builder based on menu item groups provided
+   * @param menuItemGroups - generic list menu item groups. See {@link MenuItemGroup} and {@link MenuItemGroupBuilder}
+   * @returns generic list builder based on menu item groups provided. See {@link ConcreteImpl}
    */
   menuItemGroups(menuItemGroups: (MenuItemGroup | MenuItemGroupBuilder)[]): ConcreteImpl {
     return this.clone({menuItemGroups})
@@ -190,8 +190,8 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
   }
 
   /** Set generic list child
-   * @param child - generic list child
-   * @returns generic list builder based on child provided (clone)
+   * @param child - generic list child. See {@link Child}
+   * @returns generic list builder based on child provided (clone). See {@link ConcreteImpl}
    */
   child(child: Child): ConcreteImpl {
     return this.clone({child})
@@ -205,8 +205,8 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
   }
 
   /** Set generic list can handle intent
-   * @param canHandleIntent - generic list intent checker
-   * @returns generic list builder based on can handle intent provided
+   * @param canHandleIntent - generic list intent checker. See {@link IntentChecker}
+   * @returns generic list builder based on can handle intent provided. See {@link ConcreteImpl}
    */
   canHandleIntent(canHandleIntent: IntentChecker): ConcreteImpl {
     return this.clone({canHandleIntent})
@@ -221,7 +221,7 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
 
   /** Set generic list display options
    * @param enabled - allow / disallow for showing icons
-   * @returns generic list builder based on display options (showIcons) provided
+   * @returns generic list builder based on display options (showIcons) provided. See {@link ConcreteImpl}
    */
   showIcons(enabled = true): ConcreteImpl {
     return this.clone({
@@ -237,8 +237,8 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
   }
 
   /** Set generic list initial value templates
-   * @param templates - generic list initial value templates
-   * @returns generic list builder based on templates provided
+   * @param templates - generic list initial value templates. See {@link InitialValueTemplateItem} and {@link InitialValueTemplateItemBuilder}
+   * @returns generic list builder based on templates provided. See {@link ConcreteImpl}
    */
   initialValueTemplates(
     templates:
@@ -258,8 +258,8 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
   }
 
   /** Serialize generic list
-   * @param options - serialization options
-   * @returns generic list object based on path provided in options
+   * @param options - serialization options. See {@link SerializeOptions}
+   * @returns generic list object based on path provided in options. See {@link GenericList}
    */
   serialize(options: SerializeOptions = {path: []}): GenericList {
     const id = this.spec.id || ''
@@ -298,8 +298,8 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
   }
 
   /** Clone generic list builder (allows for options overriding)
-   * @param _withSpec - generic list options
-   * @returns generic list builder
+   * @param _withSpec - generic list options.
+   * @returns generic list builder. See {@link ConcreteImpl}
    */
   abstract clone(_withSpec?: object): ConcreteImpl
 }

--- a/packages/sanity/src/desk/structureBuilder/GenericList.ts
+++ b/packages/sanity/src/desk/structureBuilder/GenericList.ts
@@ -26,6 +26,7 @@ export const shallowIntentChecker: IntentChecker = (intentName, params, {pane, i
  *
  * @public */
 export interface ListDisplayOptions {
+  /** Check if list display should show icons */
   showIcons?: boolean
 }
 
@@ -82,21 +83,21 @@ export interface BuildableGenericList extends Partial<BaseGenericList> {
  * @public */
 // Input version, allows builders and only requires things not inferrable
 export interface GenericListInput extends StructureNode {
-  /* Input id */
+  /** Input id */
   id: string
-  /* Input title */
+  /** Input title */
   title: string
-  /* Input menu items */
+  /** Input menu items */
   menuItems?: (MenuItem | MenuItemBuilder)[]
-  /* Input menu items groups */
+  /** Input menu items groups */
   menuItemGroups?: (MenuItemGroup | MenuItemGroupBuilder)[]
-  /* Input initial value */
+  /** Input initial value */
   initialValueTemplates?: (InitialValueTemplateItem | InitialValueTemplateItemBuilder)[]
-  /* Input default layout */
+  /** Input default layout */
   defaultLayout?: PreviewLayoutKey
-  /* If input can handle intent */
+  /** If input can handle intent */
   canHandleIntent?: IntentChecker
-  /* Input child */
+  /** Input child */
   child?: Child
 }
 

--- a/packages/sanity/src/desk/structureBuilder/GenericList.ts
+++ b/packages/sanity/src/desk/structureBuilder/GenericList.ts
@@ -115,6 +115,7 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
   protected spec: TList = {} as TList
 
   /** Set generic list ID
+   * @param id - generic list ID
    * @returns generic list builder based on ID provided
    */
   id(id: string): ConcreteImpl {
@@ -129,6 +130,7 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
   }
 
   /** Set generic list title
+   * @param title - generic list title
    * @returns generic list builder based on title and ID provided
    */
   title(title: string): ConcreteImpl {
@@ -143,6 +145,7 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
   }
 
   /** Set generic list layout
+   * @param defaultLayout - generic list layout key
    * @returns generic list builder based on layout provided
    */
   defaultLayout(defaultLayout: PreviewLayoutKey): ConcreteImpl {
@@ -157,6 +160,7 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
   }
 
   /** Set generic list menu items
+   * @param menuItems - generic list menu items
    * @returns generic list builder based on menu items provided
    */
   menuItems(menuItems: (MenuItem | MenuItemBuilder)[] | undefined): ConcreteImpl {
@@ -171,6 +175,7 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
   }
 
   /** Set generic list menu item groups
+   * @param menuItemGroups - generic list menu item groups
    * @returns generic list builder based on menu item groups provided
    */
   menuItemGroups(menuItemGroups: (MenuItemGroup | MenuItemGroupBuilder)[]): ConcreteImpl {
@@ -185,6 +190,7 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
   }
 
   /** Set generic list child
+   * @param child - generic list child
    * @returns generic list builder based on child provided (clone)
    */
   child(child: Child): ConcreteImpl {
@@ -199,6 +205,7 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
   }
 
   /** Set generic list can handle intent
+   * @param canHandleIntent - generic list intent checker
    * @returns generic list builder based on can handle intent provided
    */
   canHandleIntent(canHandleIntent: IntentChecker): ConcreteImpl {
@@ -213,6 +220,7 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
   }
 
   /** Set generic list display options
+   * @param enabled - allow / disallow for showing icons
    * @returns generic list builder based on display options (showIcons) provided
    */
   showIcons(enabled = true): ConcreteImpl {
@@ -229,6 +237,7 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
   }
 
   /** Set generic list initial value templates
+   * @param templates - generic list initial value templates
    * @returns generic list builder based on templates provided
    */
   initialValueTemplates(
@@ -249,6 +258,7 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
   }
 
   /** Serialize generic list
+   * @param options - serialization options
    * @returns generic list object based on path provided in options
    */
   serialize(options: SerializeOptions = {path: []}): GenericList {
@@ -288,6 +298,7 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
   }
 
   /** Clone generic list builder (allows for options overriding)
+   * @param _withSpec - generic list options
    * @returns generic list builder
    */
   abstract clone(_withSpec?: object): ConcreteImpl

--- a/packages/sanity/src/desk/structureBuilder/GenericList.ts
+++ b/packages/sanity/src/desk/structureBuilder/GenericList.ts
@@ -109,75 +109,128 @@ export interface GenericListInput extends StructureNode {
 export abstract class GenericListBuilder<TList extends BuildableGenericList, ConcreteImpl>
   implements Serializable<GenericList>
 {
+  /** Check if initial value templates are set */
   protected initialValueTemplatesSpecified = false
+  /** Generic list option object */
   protected spec: TList = {} as TList
 
+  /** Set generic list ID
+   * @returns generic list builder based on ID provided
+   */
   id(id: string): ConcreteImpl {
     return this.clone({id})
   }
 
+  /** Get generic list ID
+   * @returns generic list ID
+   */
   getId(): TList['id'] {
     return this.spec.id
   }
 
+  /** Set generic list title
+   * @returns generic list builder based on title and ID provided
+   */
   title(title: string): ConcreteImpl {
     return this.clone({title, id: getStructureNodeId(title, this.spec.id)})
   }
 
+  /** Get generic list title
+   * @returns generic list title
+   */
   getTitle(): TList['title'] {
     return this.spec.title
   }
 
+  /** Set generic list layout
+   * @returns generic list builder based on layout provided
+   */
   defaultLayout(defaultLayout: PreviewLayoutKey): ConcreteImpl {
     return this.clone({defaultLayout})
   }
 
+  /** Get generic list layout
+   * @returns generic list layout
+   */
   getDefaultLayout(): TList['defaultLayout'] {
     return this.spec.defaultLayout
   }
 
+  /** Set generic list menu items
+   * @returns generic list builder based on menu items provided
+   */
   menuItems(menuItems: (MenuItem | MenuItemBuilder)[] | undefined): ConcreteImpl {
     return this.clone({menuItems})
   }
 
+  /** Get generic list menu items
+   * @returns generic list menu items
+   */
   getMenuItems(): TList['menuItems'] {
     return this.spec.menuItems
   }
 
+  /** Set generic list menu item groups
+   * @returns generic list builder based on menu item groups provided
+   */
   menuItemGroups(menuItemGroups: (MenuItemGroup | MenuItemGroupBuilder)[]): ConcreteImpl {
     return this.clone({menuItemGroups})
   }
 
+  /** Get generic list menu item groups
+   * @returns generic list menu item groups
+   */
   getMenuItemGroups(): TList['menuItemGroups'] {
     return this.spec.menuItemGroups
   }
 
+  /** Set generic list child
+   * @returns generic list builder based on child provided (clone)
+   */
   child(child: Child): ConcreteImpl {
     return this.clone({child})
   }
 
+  /** Get generic list child
+   * @returns generic list child
+   */
   getChild(): TList['child'] {
     return this.spec.child
   }
 
+  /** Set generic list can handle intent
+   * @returns generic list builder based on can handle intent provided
+   */
   canHandleIntent(canHandleIntent: IntentChecker): ConcreteImpl {
     return this.clone({canHandleIntent})
   }
 
+  /** Get generic list can handle intent
+   * @returns generic list can handle intent
+   */
   getCanHandleIntent(): TList['canHandleIntent'] {
     return this.spec.canHandleIntent
   }
 
+  /** Set generic list display options
+   * @returns generic list builder based on display options (showIcons) provided
+   */
   showIcons(enabled = true): ConcreteImpl {
     return this.clone({
       displayOptions: {...(this.spec.displayOptions || {}), showIcons: enabled},
     })
   }
 
+  /** Get generic list display options
+   * @returns generic list display options (specifically showIcons)
+   */
   getShowIcons(): boolean | undefined {
     return this.spec.displayOptions ? this.spec.displayOptions.showIcons : undefined
   }
 
+  /** Set generic list initial value templates
+   * @returns generic list builder based on templates provided
+   */
   initialValueTemplates(
     templates:
       | InitialValueTemplateItem
@@ -188,10 +241,16 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
     return this.clone({initialValueTemplates: Array.isArray(templates) ? templates : [templates]})
   }
 
+  /** Get generic list initial value templates
+   * @returns generic list initial value templates
+   */
   getInitialValueTemplates(): TList['initialValueTemplates'] {
     return this.spec.initialValueTemplates
   }
 
+  /** Serialize generic list
+   * @returns generic list object based on path provided in options
+   */
   serialize(options: SerializeOptions = {path: []}): GenericList {
     const id = this.spec.id || ''
     const path = options.path
@@ -228,5 +287,8 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
     }
   }
 
+  /** Clone generic list builder (allows for options overriding)
+   * @returns generic list builder
+   */
   abstract clone(_withSpec?: object): ConcreteImpl
 }

--- a/packages/sanity/src/desk/structureBuilder/InitialValueTemplateItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/InitialValueTemplateItem.ts
@@ -13,36 +13,64 @@ import {InitialValueTemplateItem} from 'sanity'
  * @public
  */
 export class InitialValueTemplateItemBuilder implements Serializable<InitialValueTemplateItem> {
+  /** Initial Value template item option object */
   protected spec: Partial<InitialValueTemplateItem>
 
-  constructor(protected _context: StructureContext, spec?: Partial<InitialValueTemplateItem>) {
+  constructor(
+    /**
+     * Desk structure context
+     */
+    protected _context: StructureContext,
+    spec?: Partial<InitialValueTemplateItem>
+  ) {
     this.spec = spec ? spec : {}
   }
 
+  /** Set initial value template item builder ID
+   * @returns initial value template item based on ID provided
+   */
   id(id: string): InitialValueTemplateItemBuilder {
     return this.clone({id})
   }
 
+  /** Get initial value template item builder ID
+   * @returns initial value template item ID
+   */
   getId(): Partial<InitialValueTemplateItem>['id'] {
     return this.spec.id
   }
 
+  /** Set initial value template item title
+   * @returns initial value template item based on title provided
+   */
   title(title: string): InitialValueTemplateItemBuilder {
     return this.clone({title})
   }
 
+  /** Get initial value template item title
+   * @returns initial value template item title
+   */
   getTitle(): Partial<InitialValueTemplateItem>['title'] {
     return this.spec.title
   }
 
+  /** Set initial value template item description
+   * @returns initial value template item builder based on description provided
+   */
   description(description: string): InitialValueTemplateItemBuilder {
     return this.clone({description})
   }
 
+  /** Get initial value template item description
+   * @returns initial value template item description
+   */
   getDescription(): Partial<InitialValueTemplateItem>['description'] {
     return this.spec.description
   }
 
+  /** Set initial value template ID
+   * @returns initial value template item based builder on template ID provided
+   */
   templateId(templateId: string): InitialValueTemplateItemBuilder {
     // Let's try to be a bit helpful and assign an ID from template ID if none is specified
     const paneId = this.spec.id || templateId
@@ -52,18 +80,30 @@ export class InitialValueTemplateItemBuilder implements Serializable<InitialValu
     })
   }
 
+  /** Get initial value template item template ID
+   * @returns initial value template item ID
+   */
   getTemplateId(): Partial<InitialValueTemplateItem>['templateId'] {
     return this.spec.templateId
   }
 
+  /** Get initial value template item template parameters
+   * @returns initial value template item builder based on parameters provided
+   */
   parameters(parameters: {[key: string]: any}): InitialValueTemplateItemBuilder {
     return this.clone({parameters})
   }
 
+  /** Get initial value template item template parameters
+   * @returns initial value template item parameters
+   */
   getParameters(): Partial<InitialValueTemplateItem>['parameters'] {
     return this.spec.parameters
   }
 
+  /** Serialize initial value template item
+   * @returns initial value template item object based on the path, index and hint provided in options
+   */
   serialize({path = [], index, hint}: SerializeOptions = {path: []}): InitialValueTemplateItem {
     const {spec, _context} = this
     const {templates} = _context
@@ -111,6 +151,9 @@ export class InitialValueTemplateItemBuilder implements Serializable<InitialValu
     }
   }
 
+  /** Clone generic view builder (allows for options overriding)
+   * @returns initial value template item builder based on the context and options provided
+   */
   clone(withSpec: Partial<InitialValueTemplateItem> = {}): InitialValueTemplateItemBuilder {
     const builder = new InitialValueTemplateItemBuilder(this._context)
     builder.spec = {...this.spec, ...withSpec}

--- a/packages/sanity/src/desk/structureBuilder/InitialValueTemplateItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/InitialValueTemplateItem.ts
@@ -8,8 +8,10 @@ import {StructureContext} from './types'
 import {InitialValueTemplateItem} from 'sanity'
 
 /**
- * @hidden
- * @beta */
+ * A `InitialValueTemplateItemBuilder` is used to build a document node with an initial value set.
+ *
+ * @public
+ */
 export class InitialValueTemplateItemBuilder implements Serializable<InitialValueTemplateItem> {
   protected spec: Partial<InitialValueTemplateItem>
 

--- a/packages/sanity/src/desk/structureBuilder/InitialValueTemplateItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/InitialValueTemplateItem.ts
@@ -13,12 +13,12 @@ import {InitialValueTemplateItem} from 'sanity'
  * @public
  */
 export class InitialValueTemplateItemBuilder implements Serializable<InitialValueTemplateItem> {
-  /** Initial Value template item option object */
+  /** Initial Value template item option object. See {@link InitialValueTemplateItem} */
   protected spec: Partial<InitialValueTemplateItem>
 
   constructor(
     /**
-     * Desk structure context
+     * Desk structure context. See {@link StructureContext}
      */
     protected _context: StructureContext,
     spec?: Partial<InitialValueTemplateItem>
@@ -28,14 +28,14 @@ export class InitialValueTemplateItemBuilder implements Serializable<InitialValu
 
   /** Set initial value template item builder ID
    * @param id - initial value template item ID
-   * @returns initial value template item based on ID provided
+   * @returns initial value template item based on ID provided. See {@link InitialValueTemplateItemBuilder}
    */
   id(id: string): InitialValueTemplateItemBuilder {
     return this.clone({id})
   }
 
   /** Get initial value template item builder ID
-   * @returns initial value template item ID
+   * @returns initial value template item ID. See {@link InitialValueTemplateItem}
    */
   getId(): Partial<InitialValueTemplateItem>['id'] {
     return this.spec.id
@@ -43,14 +43,14 @@ export class InitialValueTemplateItemBuilder implements Serializable<InitialValu
 
   /** Set initial value template item title
    * @param title - initial value template item title
-   * @returns initial value template item based on title provided
+   * @returns initial value template item based on title provided. See {@link InitialValueTemplateItemBuilder}
    */
   title(title: string): InitialValueTemplateItemBuilder {
     return this.clone({title})
   }
 
   /** Get initial value template item title
-   * @returns initial value template item title
+   * @returns initial value template item title. See {@link InitialValueTemplateItem}
    */
   getTitle(): Partial<InitialValueTemplateItem>['title'] {
     return this.spec.title
@@ -58,14 +58,14 @@ export class InitialValueTemplateItemBuilder implements Serializable<InitialValu
 
   /** Set initial value template item description
    * @param description - initial value template item description
-   * @returns initial value template item builder based on description provided
+   * @returns initial value template item builder based on description provided. See {@link InitialValueTemplateItemBuilder}
    */
   description(description: string): InitialValueTemplateItemBuilder {
     return this.clone({description})
   }
 
   /** Get initial value template item description
-   * @returns initial value template item description
+   * @returns initial value template item description. See {@link InitialValueTemplateItem}
    */
   getDescription(): Partial<InitialValueTemplateItem>['description'] {
     return this.spec.description
@@ -73,7 +73,7 @@ export class InitialValueTemplateItemBuilder implements Serializable<InitialValu
 
   /** Set initial value template ID
    * @param templateId - initial value template item template ID
-   * @returns initial value template item based builder on template ID provided
+   * @returns initial value template item based builder on template ID provided. See {@link InitialValueTemplateItemBuilder}
    */
   templateId(templateId: string): InitialValueTemplateItemBuilder {
     // Let's try to be a bit helpful and assign an ID from template ID if none is specified
@@ -85,7 +85,7 @@ export class InitialValueTemplateItemBuilder implements Serializable<InitialValu
   }
 
   /** Get initial value template item template ID
-   * @returns initial value template item ID
+   * @returns initial value template item ID. See {@link InitialValueTemplateItem}
    */
   getTemplateId(): Partial<InitialValueTemplateItem>['templateId'] {
     return this.spec.templateId
@@ -93,22 +93,22 @@ export class InitialValueTemplateItemBuilder implements Serializable<InitialValu
 
   /** Get initial value template item template parameters
    * @param parameters - initial value template item parameters
-   * @returns initial value template item builder based on parameters provided
+   * @returns initial value template item builder based on parameters provided. See {@link InitialValueTemplateItemBuilder}
    */
   parameters(parameters: {[key: string]: any}): InitialValueTemplateItemBuilder {
     return this.clone({parameters})
   }
 
   /** Get initial value template item template parameters
-   * @returns initial value template item parameters
+   * @returns initial value template item parameters. See {@link InitialValueTemplateItem}
    */
   getParameters(): Partial<InitialValueTemplateItem>['parameters'] {
     return this.spec.parameters
   }
 
   /** Serialize initial value template item
-   * @param options - serialization options
-   * @returns initial value template item object based on the path, index and hint provided in options
+   * @param options - serialization options. See {@link SerializeOptions}
+   * @returns initial value template item object based on the path, index and hint provided in options. See {@link InitialValueTemplateItem}
    */
   serialize({path = [], index, hint}: SerializeOptions = {path: []}): InitialValueTemplateItem {
     const {spec, _context} = this
@@ -158,8 +158,8 @@ export class InitialValueTemplateItemBuilder implements Serializable<InitialValu
   }
 
   /** Clone generic view builder (allows for options overriding)
-   * @param withSpec - initial value template item builder options
-   * @returns initial value template item builder based on the context and options provided
+   * @param withSpec - initial value template item builder options. See {@link InitialValueTemplateItemBuilder}
+   * @returns initial value template item builder based on the context and options provided. See {@link InitialValueTemplateItemBuilder}
    */
   clone(withSpec: Partial<InitialValueTemplateItem> = {}): InitialValueTemplateItemBuilder {
     const builder = new InitialValueTemplateItemBuilder(this._context)

--- a/packages/sanity/src/desk/structureBuilder/InitialValueTemplateItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/InitialValueTemplateItem.ts
@@ -27,6 +27,7 @@ export class InitialValueTemplateItemBuilder implements Serializable<InitialValu
   }
 
   /** Set initial value template item builder ID
+   * @param id - initial value template item ID
    * @returns initial value template item based on ID provided
    */
   id(id: string): InitialValueTemplateItemBuilder {
@@ -41,6 +42,7 @@ export class InitialValueTemplateItemBuilder implements Serializable<InitialValu
   }
 
   /** Set initial value template item title
+   * @param title - initial value template item title
    * @returns initial value template item based on title provided
    */
   title(title: string): InitialValueTemplateItemBuilder {
@@ -55,6 +57,7 @@ export class InitialValueTemplateItemBuilder implements Serializable<InitialValu
   }
 
   /** Set initial value template item description
+   * @param description - initial value template item description
    * @returns initial value template item builder based on description provided
    */
   description(description: string): InitialValueTemplateItemBuilder {
@@ -69,6 +72,7 @@ export class InitialValueTemplateItemBuilder implements Serializable<InitialValu
   }
 
   /** Set initial value template ID
+   * @param templateId - initial value template item template ID
    * @returns initial value template item based builder on template ID provided
    */
   templateId(templateId: string): InitialValueTemplateItemBuilder {
@@ -88,6 +92,7 @@ export class InitialValueTemplateItemBuilder implements Serializable<InitialValu
   }
 
   /** Get initial value template item template parameters
+   * @param parameters - initial value template item parameters
    * @returns initial value template item builder based on parameters provided
    */
   parameters(parameters: {[key: string]: any}): InitialValueTemplateItemBuilder {
@@ -102,6 +107,7 @@ export class InitialValueTemplateItemBuilder implements Serializable<InitialValu
   }
 
   /** Serialize initial value template item
+   * @param options - serialization options
    * @returns initial value template item object based on the path, index and hint provided in options
    */
   serialize({path = [], index, hint}: SerializeOptions = {path: []}): InitialValueTemplateItem {
@@ -152,6 +158,7 @@ export class InitialValueTemplateItemBuilder implements Serializable<InitialValu
   }
 
   /** Clone generic view builder (allows for options overriding)
+   * @param withSpec - initial value template item builder options
    * @returns initial value template item builder based on the context and options provided
    */
   clone(withSpec: Partial<InitialValueTemplateItem> = {}): InitialValueTemplateItemBuilder {

--- a/packages/sanity/src/desk/structureBuilder/Intent.ts
+++ b/packages/sanity/src/desk/structureBuilder/Intent.ts
@@ -23,6 +23,7 @@ export interface BaseIntentParams {
    * Experimental field path
    * @beta
    * @experimental
+   * @hidden
    */
   path?: string
 }

--- a/packages/sanity/src/desk/structureBuilder/Intent.ts
+++ b/packages/sanity/src/desk/structureBuilder/Intent.ts
@@ -2,7 +2,7 @@ import {PartialDocumentList, getTypeNamesFromFilter} from './DocumentList'
 import {StructureNode} from './StructureNodes'
 
 /**
- * Type for intent parameters (json)
+ * Intent parameters (json)
  *
  * @public
  */

--- a/packages/sanity/src/desk/structureBuilder/Intent.ts
+++ b/packages/sanity/src/desk/structureBuilder/Intent.ts
@@ -19,6 +19,12 @@ export interface BaseIntentParams {
   id?: string
   /* Intent template */
   template?: string
+  /**
+   * Experimental field path
+   * @beta
+   * @experimental
+   */
+  path?: string
 }
 
 /** @internal */

--- a/packages/sanity/src/desk/structureBuilder/Intent.ts
+++ b/packages/sanity/src/desk/structureBuilder/Intent.ts
@@ -2,16 +2,22 @@ import {PartialDocumentList, getTypeNamesFromFilter} from './DocumentList'
 import {StructureNode} from './StructureNodes'
 
 /**
- * @hidden
- * @beta */
+ * Type for intent parameters (json)
+ *
+ * @public
+ */
 export type IntentJsonParams = {[key: string]: any}
 
 /**
- * @hidden
- * @beta */
+ * Type for base intent parameters
+ *
+ * @public */
 export type BaseIntentParams = {
+  /* Intent type */
   type?: string
+  /* Intent Id */
   id?: string
+  /* Intent template */
   template?: string
 }
 
@@ -19,28 +25,38 @@ export type BaseIntentParams = {
 export const DEFAULT_INTENT_HANDLER = Symbol('Document type list canHandleIntent')
 
 /**
- * @hidden
- * @beta */
+ * Intent parameters
+ *
+ * @public
+ */
 export type IntentParams = BaseIntentParams | [BaseIntentParams, IntentJsonParams]
 
 /**
- * @hidden
- * @beta */
+ * Interface for intents
+ * @public */
 // TODO: intents should be unified somewhere
 export interface Intent {
+  /* Intent type */
   type: string
+  /* Intent parameters */
   params?: IntentParams
 }
 
 /**
- * @hidden
- * @beta */
+ * Interface for intent checker
+ *
+ * @public
+ */
 export interface IntentChecker {
   (
+    /** Intent name */
     intentName: string,
+    /** Intent checker parameter */
     params: {[key: string]: any},
+    /** Structure context */
     context: {pane: StructureNode; index: number}
   ): boolean
+  /** intent checker identify */
   identity?: symbol
 }
 

--- a/packages/sanity/src/desk/structureBuilder/Intent.ts
+++ b/packages/sanity/src/desk/structureBuilder/Intent.ts
@@ -9,10 +9,10 @@ import {StructureNode} from './StructureNodes'
 export type IntentJsonParams = {[key: string]: any}
 
 /**
- * Type for base intent parameters
+ * Interface for base intent parameters
  *
  * @public */
-export type BaseIntentParams = {
+export interface BaseIntentParams {
   /* Intent type */
   type?: string
   /* Intent Id */
@@ -26,6 +26,7 @@ export const DEFAULT_INTENT_HANDLER = Symbol('Document type list canHandleIntent
 
 /**
  * Intent parameters
+ * See {@link BaseIntentParams} and {@link IntentJsonParams}
  *
  * @public
  */
@@ -38,7 +39,8 @@ export type IntentParams = BaseIntentParams | [BaseIntentParams, IntentJsonParam
 export interface Intent {
   /** Intent type */
   type: string
-  /** Intent parameters */
+  /** Intent parameters. See {@link IntentParams}
+   */
   params?: IntentParams
 }
 

--- a/packages/sanity/src/desk/structureBuilder/Intent.ts
+++ b/packages/sanity/src/desk/structureBuilder/Intent.ts
@@ -36,9 +36,9 @@ export type IntentParams = BaseIntentParams | [BaseIntentParams, IntentJsonParam
  * @public */
 // TODO: intents should be unified somewhere
 export interface Intent {
-  /* Intent type */
+  /** Intent type */
   type: string
-  /* Intent parameters */
+  /** Intent parameters */
   params?: IntentParams
 }
 

--- a/packages/sanity/src/desk/structureBuilder/Intent.ts
+++ b/packages/sanity/src/desk/structureBuilder/Intent.ts
@@ -55,7 +55,7 @@ export interface IntentChecker {
     intentName: string,
     /** Intent checker parameter */
     params: {[key: string]: any},
-    /** Structure context */
+    /** Structure context. See {@link StructureNode} */
     context: {pane: StructureNode; index: number}
   ): boolean
   /** intent checker identify */

--- a/packages/sanity/src/desk/structureBuilder/List.ts
+++ b/packages/sanity/src/desk/structureBuilder/List.ts
@@ -86,30 +86,39 @@ function isPromise<T>(thing: unknown): thing is PromiseLike<T> {
 }
 
 /**
- * @hidden
- * @beta */
+ * Interface for List
+ *
+ * @public
+ */
 export interface List extends GenericList {
   type: 'list'
+  /* List items */
   items: (ListItem | Divider)[]
 }
 
 /**
- * @hidden
- * @beta */
+ * Interface for list input
+ *
+ * @public
+ */
 export interface ListInput extends GenericListInput {
   items?: (ListItem | ListItemBuilder | Divider)[]
 }
 
 /**
- * @hidden
- * @beta */
+ * Interface for buildable list
+ *
+ * @public
+ */
 export interface BuildableList extends BuildableGenericList {
+  /** List items */
   items?: (ListItem | ListItemBuilder | Divider)[]
 }
 
 /**
- * @hidden
- * @beta */
+ * A `ListBuilder` is used to build a list of items in the desk tool.
+ *
+ * @public */
 export class ListBuilder extends GenericListBuilder<BuildableList, ListBuilder> {
   protected spec: BuildableList
 

--- a/packages/sanity/src/desk/structureBuilder/List.ts
+++ b/packages/sanity/src/desk/structureBuilder/List.ts
@@ -138,6 +138,7 @@ export class ListBuilder extends GenericListBuilder<BuildableList, ListBuilder> 
 
   /**
    * Set list builder based on items provided
+   * @param items - list items
    * @returns list builder based on items provided
    */
   items(items: (ListItemBuilder | ListItem | Divider)[]): ListBuilder {
@@ -152,6 +153,7 @@ export class ListBuilder extends GenericListBuilder<BuildableList, ListBuilder> 
   }
 
   /** Serialize list builder
+   * @param options - serialization options
    * @returns list based on path in options
    */
   serialize(options: SerializeOptions = {path: []}): List {
@@ -198,6 +200,7 @@ export class ListBuilder extends GenericListBuilder<BuildableList, ListBuilder> 
 
   /**
    * Clone list builder and return new list builder based on context and spec provided
+   * @param withSpec - list options
    * @returns new list builder based on context and spec provided
    */
   clone(withSpec?: BuildableList): ListBuilder {

--- a/packages/sanity/src/desk/structureBuilder/List.ts
+++ b/packages/sanity/src/desk/structureBuilder/List.ts
@@ -121,22 +121,39 @@ export interface BuildableList extends BuildableGenericList {
  *
  * @public */
 export class ListBuilder extends GenericListBuilder<BuildableList, ListBuilder> {
+  /** buildable list option object */
   protected spec: BuildableList
 
-  constructor(protected _context: StructureContext, spec?: ListInput) {
+  constructor(
+    /**
+     * Desk structure context
+     */
+    protected _context: StructureContext,
+    spec?: ListInput
+  ) {
     super()
     this.spec = spec ? spec : {}
     this.initialValueTemplatesSpecified = Boolean(spec && spec.initialValueTemplates)
   }
 
+  /**
+   * Set list builder based on items provided
+   * @returns list builder based on items provided
+   */
   items(items: (ListItemBuilder | ListItem | Divider)[]): ListBuilder {
     return this.clone({items})
   }
 
+  /** Get list builder items
+   * @returns list items
+   */
   getItems(): BuildableList['items'] {
     return this.spec.items
   }
 
+  /** Serialize list builder
+   * @returns list based on path in options
+   */
   serialize(options: SerializeOptions = {path: []}): List {
     const id = this.spec.id
     if (typeof id !== 'string' || !id) {
@@ -179,6 +196,10 @@ export class ListBuilder extends GenericListBuilder<BuildableList, ListBuilder> 
     }
   }
 
+  /**
+   * Clone list builder and return new list builder based on context and spec provided
+   * @returns new list builder based on context and spec provided
+   */
   clone(withSpec?: BuildableList): ListBuilder {
     const builder = new ListBuilder(this._context)
     builder.spec = {...this.spec, ...(withSpec || {})}

--- a/packages/sanity/src/desk/structureBuilder/List.ts
+++ b/packages/sanity/src/desk/structureBuilder/List.ts
@@ -92,7 +92,7 @@ function isPromise<T>(thing: unknown): thing is PromiseLike<T> {
  */
 export interface List extends GenericList {
   type: 'list'
-  /* List items */
+  /** List items */
   items: (ListItem | Divider)[]
 }
 
@@ -102,6 +102,7 @@ export interface List extends GenericList {
  * @public
  */
 export interface ListInput extends GenericListInput {
+  /** List input items array */
   items?: (ListItem | ListItemBuilder | Divider)[]
 }
 

--- a/packages/sanity/src/desk/structureBuilder/List.ts
+++ b/packages/sanity/src/desk/structureBuilder/List.ts
@@ -92,7 +92,7 @@ function isPromise<T>(thing: unknown): thing is PromiseLike<T> {
  */
 export interface List extends GenericList {
   type: 'list'
-  /** List items */
+  /** List items. See {@link ListItem} and {@link Divider} */
   items: (ListItem | Divider)[]
 }
 
@@ -102,7 +102,7 @@ export interface List extends GenericList {
  * @public
  */
 export interface ListInput extends GenericListInput {
-  /** List input items array */
+  /** List input items array. See {@link ListItem}, {@link ListItemBuilder} and {@link Divider} */
   items?: (ListItem | ListItemBuilder | Divider)[]
 }
 
@@ -112,7 +112,7 @@ export interface ListInput extends GenericListInput {
  * @public
  */
 export interface BuildableList extends BuildableGenericList {
-  /** List items */
+  /** List items. See {@link ListItem}, {@link ListItemBuilder} and {@link Divider} */
   items?: (ListItem | ListItemBuilder | Divider)[]
 }
 
@@ -121,12 +121,12 @@ export interface BuildableList extends BuildableGenericList {
  *
  * @public */
 export class ListBuilder extends GenericListBuilder<BuildableList, ListBuilder> {
-  /** buildable list option object */
+  /** buildable list option object. See {@link BuildableList} */
   protected spec: BuildableList
 
   constructor(
     /**
-     * Desk structure context
+     * Desk structure context. See {@link StructureContext}
      */
     protected _context: StructureContext,
     spec?: ListInput
@@ -138,23 +138,23 @@ export class ListBuilder extends GenericListBuilder<BuildableList, ListBuilder> 
 
   /**
    * Set list builder based on items provided
-   * @param items - list items
-   * @returns list builder based on items provided
+   * @param items - list items. See {@link ListItemBuilder}, {@link ListItem} and {@link Divider}
+   * @returns list builder based on items provided. See {@link ListBuilder}
    */
   items(items: (ListItemBuilder | ListItem | Divider)[]): ListBuilder {
     return this.clone({items})
   }
 
   /** Get list builder items
-   * @returns list items
+   * @returns list items. See {@link BuildableList}
    */
   getItems(): BuildableList['items'] {
     return this.spec.items
   }
 
   /** Serialize list builder
-   * @param options - serialization options
-   * @returns list based on path in options
+   * @param options - serialization options. See {@link SerializeOptions}
+   * @returns list based on path in options. See {@link List}
    */
   serialize(options: SerializeOptions = {path: []}): List {
     const id = this.spec.id
@@ -200,8 +200,8 @@ export class ListBuilder extends GenericListBuilder<BuildableList, ListBuilder> 
 
   /**
    * Clone list builder and return new list builder based on context and spec provided
-   * @param withSpec - list options
-   * @returns new list builder based on context and spec provided
+   * @param withSpec - list options. See {@link BuildableList}
+   * @returns new list builder based on context and spec provided. See {@link ListBuilder}
    */
   clone(withSpec?: BuildableList): ListBuilder {
     const builder = new ListBuilder(this._context)

--- a/packages/sanity/src/desk/structureBuilder/ListItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/ListItem.ts
@@ -12,7 +12,7 @@ import {StructureContext} from './types'
 import {getStructureNodeId} from './util/getStructureNodeId'
 
 /**
- * Type for unserialize list item child.
+ * Unserialized list item child.
  * See {@link Collection}, {@link CollectionBuilder}, {@link ChildResolver} and {@link ItemChild}
  *
  * @public
@@ -24,7 +24,7 @@ export type UnserializedListItemChild =
   | Observable<ItemChild>
 
 /**
- * Type for child of List Item
+ * Child of List Item
  * See {@link Collection}, {@link ChildResolver}, {@link ItemChild}
  * @public
  */
@@ -110,7 +110,7 @@ export interface UnserializedListItem {
 }
 
 /**
- * Type for a partial list item. See {@link UnserializedListItem}
+ * Partial list item. See {@link UnserializedListItem}
  *
  * @public */
 export type PartialListItem = Partial<UnserializedListItem>

--- a/packages/sanity/src/desk/structureBuilder/ListItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/ListItem.ts
@@ -119,7 +119,7 @@ export type PartialListItem = Partial<UnserializedListItem>
  *
  * @public */
 export class ListItemBuilder implements Serializable<ListItem> {
-  /** list item option object */
+  /** List item option object */
   protected spec: PartialListItem
 
   constructor(

--- a/packages/sanity/src/desk/structureBuilder/ListItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/ListItem.ts
@@ -12,8 +12,10 @@ import {StructureContext} from './types'
 import {getStructureNodeId} from './util/getStructureNodeId'
 
 /**
- * @hidden
- * @beta */
+ * Type for unserialize list item child
+ *
+ * @public
+ */
 export type UnserializedListItemChild =
   | Collection
   | CollectionBuilder
@@ -21,69 +23,100 @@ export type UnserializedListItemChild =
   | Observable<ItemChild>
 
 /**
- * @hidden
- * @beta */
+ * Type for child of List Item
+ *
+ * @public
+ */
 export type ListItemChild = Collection | ChildResolver | Observable<ItemChild> | undefined
 
 /**
- * @hidden
- * @beta */
+ * Interface for serialize list item options
+ *
+ * @public
+ */
 export interface ListItemSerializeOptions extends SerializeOptions {
+  /** Check if list item title is optional */
   titleIsOptional?: boolean
 }
 
 /**
- * @hidden
- * @beta */
+ * Interface for ist item display options
+ *
+ * @public */
 export interface ListItemDisplayOptions {
   showIcon?: boolean
 }
 
 /**
- * @hidden
- * @beta */
+ * interface for list item input
+ *
+ * @public */
 export interface ListItemInput {
+  /** List item id */
   id: string
+  /** List item title */
   title?: string
+  /** List item icon */
   icon?: React.ComponentType | React.ReactNode
+  /** List item child */
   child?: ListItemChild
+  /** List item display options */
   displayOptions?: ListItemDisplayOptions
+  /** List item schema type */
   schemaType?: SchemaType | string
 }
 
 /**
- * @hidden
- * @beta */
+ * Interface for List Item
+ *
+ * @public */
 export interface ListItem {
+  /* List item id */
   id: string
+  /* List item type */
   type: string
+  /* List item title */
   title?: string
+  /* List item icon */
   icon?: React.ComponentType | React.ReactNode
+  /* List item child */
   child?: ListItemChild
+  /* List item display options */
   displayOptions?: ListItemDisplayOptions
+  /* List item schema type */
   schemaType?: SchemaType
 }
 
 /**
- * @hidden
- * @beta */
+ * Interface for unserialized list items.
+ *
+ * @public
+ */
 export interface UnserializedListItem {
+  /** List item id */
   id: string
+  /** List item title */
   title: string
+  /** List item icon */
   icon?: React.ComponentType | React.ReactNode
+  /** List item child */
   child?: UnserializedListItemChild
+  /** List item display options */
   displayOptions?: ListItemDisplayOptions
+  /** List item schema */
   schemaType?: SchemaType | string
 }
 
 /**
- * @hidden
- * @beta */
+ * Type for a partial list item
+ *
+ * @public */
 export type PartialListItem = Partial<UnserializedListItem>
 
 /**
- * @hidden
- * @beta */
+ * Class for building list items.
+ *
+ * @public */
 export class ListItemBuilder implements Serializable<ListItem> {
   protected spec: PartialListItem
 

--- a/packages/sanity/src/desk/structureBuilder/ListItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/ListItem.ts
@@ -12,7 +12,8 @@ import {StructureContext} from './types'
 import {getStructureNodeId} from './util/getStructureNodeId'
 
 /**
- * Type for unserialize list item child
+ * Type for unserialize list item child.
+ * See {@link Collection}, {@link CollectionBuilder}, {@link ChildResolver} and {@link ItemChild}
  *
  * @public
  */
@@ -24,7 +25,7 @@ export type UnserializedListItemChild =
 
 /**
  * Type for child of List Item
- *
+ * See {@link Collection}, {@link ChildResolver}, {@link ItemChild}
  * @public
  */
 export type ListItemChild = Collection | ChildResolver | Observable<ItemChild> | undefined
@@ -59,11 +60,11 @@ export interface ListItemInput {
   title?: string
   /** List item icon */
   icon?: React.ComponentType | React.ReactNode
-  /** List item child */
+  /** List item child. See {@link ListItemChild} */
   child?: ListItemChild
-  /** List item display options */
+  /** List item display options. See {@link ListItemDisplayOptions} */
   displayOptions?: ListItemDisplayOptions
-  /** List item schema type */
+  /** List item schema type. See {@link SchemaType} */
   schemaType?: SchemaType | string
 }
 
@@ -80,11 +81,11 @@ export interface ListItem {
   title?: string
   /** List item icon */
   icon?: React.ComponentType | React.ReactNode
-  /** List item child */
+  /** List item child. See {@link ListItemChild} */
   child?: ListItemChild
-  /** List item display options */
+  /** List item display options. See {@link ListItemDisplayOptions} */
   displayOptions?: ListItemDisplayOptions
-  /** List item schema type */
+  /** List item schema type. See {@link SchemaType} */
   schemaType?: SchemaType
 }
 
@@ -100,31 +101,31 @@ export interface UnserializedListItem {
   title: string
   /** List item icon */
   icon?: React.ComponentType | React.ReactNode
-  /** List item child */
+  /** List item child. See {@link UnserializedListItemChild} */
   child?: UnserializedListItemChild
-  /** List item display options */
+  /** List item display options. See {@link ListItemDisplayOptions} */
   displayOptions?: ListItemDisplayOptions
-  /** List item schema */
+  /** List item schema. See {@link SchemaType} */
   schemaType?: SchemaType | string
 }
 
 /**
- * Type for a partial list item
+ * Type for a partial list item. See {@link UnserializedListItem}
  *
  * @public */
 export type PartialListItem = Partial<UnserializedListItem>
 
 /**
- * Class for building list items.
+ * Class for building list items
  *
  * @public */
 export class ListItemBuilder implements Serializable<ListItem> {
-  /** List item option object */
+  /** List item option object. See {@link PartialListItem} */
   protected spec: PartialListItem
 
   constructor(
     /**
-     * Desk structure context
+     * Desk structure context. See {@link StructureContext}
      */
     protected _context: StructureContext,
     spec?: ListItemInput
@@ -134,7 +135,7 @@ export class ListItemBuilder implements Serializable<ListItem> {
 
   /**
    * Set list item ID
-   * @returns list item builder based on ID provided
+   * @returns list item builder based on ID provided. See {@link ListItemBuilder}
    */
   id(id: string): ListItemBuilder {
     return this.clone({id})
@@ -142,7 +143,7 @@ export class ListItemBuilder implements Serializable<ListItem> {
 
   /**
    * Get list item ID
-   * @returns list item ID
+   * @returns list item ID. See {@link PartialListItem}
    */
   getId(): PartialListItem['id'] {
     return this.spec.id
@@ -150,7 +151,7 @@ export class ListItemBuilder implements Serializable<ListItem> {
 
   /**
    * Set list item title
-   * @returns list item builder based on title provided
+   * @returns list item builder based on title provided. See {@link ListItemBuilder}
    */
   title(title: string): ListItemBuilder {
     return this.clone({title, id: getStructureNodeId(title, this.spec.id)})
@@ -158,7 +159,7 @@ export class ListItemBuilder implements Serializable<ListItem> {
 
   /**
    * Get list item title
-   * @returns list item title
+   * @returns list item title. See {@link PartialListItem}
    */
   getTitle(): PartialListItem['title'] {
     return this.spec.title
@@ -166,7 +167,7 @@ export class ListItemBuilder implements Serializable<ListItem> {
 
   /**
    * Set list item icon
-   * @returns list item builder based on icon provided
+   * @returns list item builder based on icon provided. See {@link ListItemBuilder}
    */
   icon(icon: React.ComponentType | React.ReactNode): ListItemBuilder {
     return this.clone({icon})
@@ -174,7 +175,7 @@ export class ListItemBuilder implements Serializable<ListItem> {
 
   /**
    * Set if list item should show icon
-   * @returns list item builder based on showIcon provided
+   * @returns list item builder based on showIcon provided. See {@link ListItemBuilder}
    */
   showIcon(enabled = true): ListItemBuilder {
     return this.clone({
@@ -192,7 +193,7 @@ export class ListItemBuilder implements Serializable<ListItem> {
 
   /**
    *Get list item icon
-   * @returns list item icon
+   * @returns list item icon. See {@link PartialListItem}
    */
   getIcon(): PartialListItem['icon'] {
     return this.spec.icon
@@ -200,7 +201,8 @@ export class ListItemBuilder implements Serializable<ListItem> {
 
   /**
    * Set list item child
-   * @returns list item builder based on child provided
+   * @param child - list item child. See {@link UnserializedListItemChild}
+   * @returns list item builder based on child provided. See {@link ListItemBuilder}
    */
   child(child: UnserializedListItemChild): ListItemBuilder {
     return this.clone({child})
@@ -208,7 +210,7 @@ export class ListItemBuilder implements Serializable<ListItem> {
 
   /**
    * Get list item child
-   * @returns list item child
+   * @returns list item child. See {@link PartialListItem}
    */
   getChild(): PartialListItem['child'] {
     return this.spec.child
@@ -216,7 +218,8 @@ export class ListItemBuilder implements Serializable<ListItem> {
 
   /**
    * Set list item schema type
-   * @returns list item builder based on schema type provided
+   * @param schemaType - list item schema type. See {@link SchemaType}
+   * @returns list item builder based on schema type provided. See {@link ListItemBuilder}
    */
   schemaType(schemaType: SchemaType | string): ListItemBuilder {
     return this.clone({schemaType})
@@ -224,7 +227,7 @@ export class ListItemBuilder implements Serializable<ListItem> {
 
   /**
    * Get list item schema type
-   * @returns list item schema type
+   * @returns list item schema type. See {@link PartialListItem}
    */
   getSchemaType(): PartialListItem['schemaType'] {
     const schemaType = this.spec.schemaType
@@ -237,7 +240,8 @@ export class ListItemBuilder implements Serializable<ListItem> {
   }
 
   /** Serialize list item builder
-   * @returns list item node based on path provided in options
+   * @param options - serialization options. See {@link ListItemSerializeOptions}
+   * @returns list item node based on path provided in options. See {@link ListItem}
    */
   serialize(options: ListItemSerializeOptions = {path: []}): ListItem {
     const {id, title, child} = this.spec
@@ -298,7 +302,8 @@ export class ListItemBuilder implements Serializable<ListItem> {
   }
 
   /** Clone list item builder
-   * @returns list item builder based on context and spec provided
+   * @param withSpec - partial list item options. See {@link PartialListItem}
+   * @returns list item builder based on context and spec provided. See {@link ListItemBuilder}
    */
   clone(withSpec?: PartialListItem): ListItemBuilder {
     const builder = new ListItemBuilder(this._context)

--- a/packages/sanity/src/desk/structureBuilder/ListItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/ListItem.ts
@@ -119,58 +119,113 @@ export type PartialListItem = Partial<UnserializedListItem>
  *
  * @public */
 export class ListItemBuilder implements Serializable<ListItem> {
+  /** list item option object */
   protected spec: PartialListItem
 
-  constructor(protected _context: StructureContext, spec?: ListItemInput) {
+  constructor(
+    /**
+     * Desk structure context
+     */
+    protected _context: StructureContext,
+    spec?: ListItemInput
+  ) {
     this.spec = spec ? spec : {}
   }
 
+  /**
+   * Set list item ID
+   * @returns list item builder based on ID provided
+   */
   id(id: string): ListItemBuilder {
     return this.clone({id})
   }
 
+  /**
+   * Get list item ID
+   * @returns list item ID
+   */
   getId(): PartialListItem['id'] {
     return this.spec.id
   }
 
+  /**
+   * Set list item title
+   * @returns list item builder based on title provided
+   */
   title(title: string): ListItemBuilder {
     return this.clone({title, id: getStructureNodeId(title, this.spec.id)})
   }
 
+  /**
+   * Get list item title
+   * @returns list item title
+   */
   getTitle(): PartialListItem['title'] {
     return this.spec.title
   }
 
+  /**
+   * Set list item icon
+   * @returns list item builder based on icon provided
+   */
   icon(icon: React.ComponentType | React.ReactNode): ListItemBuilder {
     return this.clone({icon})
   }
 
+  /**
+   * Set if list item should show icon
+   * @returns list item builder based on showIcon provided
+   */
   showIcon(enabled = true): ListItemBuilder {
     return this.clone({
       displayOptions: {...(this.spec.displayOptions || {}), showIcon: enabled},
     })
   }
 
+  /**
+   * Check if list item should show icon
+   * @returns true if it should show the icon, false if not, undefined if not set
+   */
   getShowIcon(): boolean | undefined {
     return this.spec.displayOptions ? this.spec.displayOptions.showIcon : undefined
   }
 
+  /**
+   *Get list item icon
+   * @returns list item icon
+   */
   getIcon(): PartialListItem['icon'] {
     return this.spec.icon
   }
 
+  /**
+   * Set list item child
+   * @returns list item builder based on child provided
+   */
   child(child: UnserializedListItemChild): ListItemBuilder {
     return this.clone({child})
   }
 
+  /**
+   * Get list item child
+   * @returns list item child
+   */
   getChild(): PartialListItem['child'] {
     return this.spec.child
   }
 
+  /**
+   * Set list item schema type
+   * @returns list item builder based on schema type provided
+   */
   schemaType(schemaType: SchemaType | string): ListItemBuilder {
     return this.clone({schemaType})
   }
 
+  /**
+   * Get list item schema type
+   * @returns list item schema type
+   */
   getSchemaType(): PartialListItem['schemaType'] {
     const schemaType = this.spec.schemaType
 
@@ -181,6 +236,9 @@ export class ListItemBuilder implements Serializable<ListItem> {
     return this.spec.schemaType
   }
 
+  /** Serialize list item builder
+   * @returns list item node based on path provided in options
+   */
   serialize(options: ListItemSerializeOptions = {path: []}): ListItem {
     const {id, title, child} = this.spec
     if (typeof id !== 'string' || !id) {
@@ -239,6 +297,9 @@ export class ListItemBuilder implements Serializable<ListItem> {
     }
   }
 
+  /** Clone list item builder
+   * @returns list item builder based on context and spec provided
+   */
   clone(withSpec?: PartialListItem): ListItemBuilder {
     const builder = new ListItemBuilder(this._context)
     builder.spec = {...this.spec, ...(withSpec || {})}

--- a/packages/sanity/src/desk/structureBuilder/ListItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/ListItem.ts
@@ -44,6 +44,7 @@ export interface ListItemSerializeOptions extends SerializeOptions {
  *
  * @public */
 export interface ListItemDisplayOptions {
+  /** Check if list item display should show icon */
   showIcon?: boolean
 }
 
@@ -71,19 +72,19 @@ export interface ListItemInput {
  *
  * @public */
 export interface ListItem {
-  /* List item id */
+  /** List item id */
   id: string
-  /* List item type */
+  /** List item type */
   type: string
-  /* List item title */
+  /** List item title */
   title?: string
-  /* List item icon */
+  /** List item icon */
   icon?: React.ComponentType | React.ReactNode
-  /* List item child */
+  /** List item child */
   child?: ListItemChild
-  /* List item display options */
+  /** List item display options */
   displayOptions?: ListItemDisplayOptions
-  /* List item schema type */
+  /** List item schema type */
   schemaType?: SchemaType
 }
 
@@ -93,7 +94,7 @@ export interface ListItem {
  * @public
  */
 export interface UnserializedListItem {
-  /** List item id */
+  /** List item ID */
   id: string
   /** List item title */
   title: string

--- a/packages/sanity/src/desk/structureBuilder/MenuItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/MenuItem.ts
@@ -52,7 +52,7 @@ export interface MenuItem {
 }
 
 /**
- * Type for partial menu items
+ * Partial menu items
  * @public
  */
 export type PartialMenuItem = Partial<MenuItem>

--- a/packages/sanity/src/desk/structureBuilder/MenuItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/MenuItem.ts
@@ -17,39 +17,50 @@ export function maybeSerializeMenuItem(
 }
 
 /**
- * @hidden
- * @beta */
+ * Menu item action type
+ * @public */
 export type MenuItemActionType =
   | string
   | ((params: Record<string, string> | undefined, scope?: any) => void)
 
 /**
- * @hidden
- * @beta */
+ * Menu items parameters
+ *
+ * @public */
 export type MenuItemParamsType = Record<string, string | unknown | undefined>
 
 /**
- * @hidden
- * @beta */
+ * Interface for menu items
+ *
+ * @public */
 export interface MenuItem {
+  /** Menu Item title */
   title: string
+  /** Menu Item action */
   action?: MenuItemActionType
+  /** Menu Item intent */
   intent?: Intent
+  /** Menu Item group */
   group?: string
   // TODO: align these with TemplateResponse['icon']
+  /** Menu Item icon */
   icon?: React.ComponentType | React.ReactNode
+  /** Menu Item parameters */
   params?: MenuItemParamsType
+  /** Determine if it will show the MenuItem as action */
   showAsAction?: boolean
 }
 
 /**
- * @hidden
- * @beta */
+ * Type for partial menu items
+ * @public
+ */
 export type PartialMenuItem = Partial<MenuItem>
 
 /**
- * @hidden
- * @beta */
+ * Class for building menu items.
+ *
+ * @public */
 export class MenuItemBuilder implements Serializable<MenuItem> {
   protected spec: PartialMenuItem
 

--- a/packages/sanity/src/desk/structureBuilder/MenuItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/MenuItem.ts
@@ -42,7 +42,7 @@ export interface MenuItem {
   intent?: Intent
   /** Menu Item group */
   group?: string
-  // TODO: align these with TemplateResponse['icon']
+  // TODO: align these with TemplateItem['icon']
   /** Menu Item icon */
   icon?: React.ComponentType | React.ReactNode
   /** Menu Item parameters. See {@link MenuItemParamsType} */

--- a/packages/sanity/src/desk/structureBuilder/MenuItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/MenuItem.ts
@@ -62,68 +62,134 @@ export type PartialMenuItem = Partial<MenuItem>
  *
  * @public */
 export class MenuItemBuilder implements Serializable<MenuItem> {
+  /** menu item option object */
   protected spec: PartialMenuItem
 
-  constructor(protected _context: StructureContext, spec?: MenuItem) {
+  constructor(
+    /**
+     * Desk structure context
+     */
+    protected _context: StructureContext,
+    spec?: MenuItem
+  ) {
     this.spec = spec ? spec : {}
   }
 
+  /**
+   * Set menu item action
+   * @returns menu item builder based on action provided
+   */
   action(action: MenuItemActionType): MenuItemBuilder {
     return this.clone({action})
   }
 
+  /**
+   * Get menu item action
+   * @returns menu item builder action
+   */
   getAction(): PartialMenuItem['action'] {
     return this.spec.action
   }
 
+  /**
+   * Set menu item intent
+   * @returns menu item builder based on intent provided
+   */
   intent(intent: Intent): MenuItemBuilder {
     return this.clone({intent})
   }
 
+  /**
+   * Get menu item intent
+   * @returns menu item intent
+   */
   getIntent(): PartialMenuItem['intent'] {
     return this.spec.intent
   }
 
+  /**
+   * Set menu item title
+   * @returns menu item builder based on title provided
+   */
   title(title: string): MenuItemBuilder {
     return this.clone({title})
   }
 
+  /**
+   * Get menu item title
+   * @returns menu item title
+   */
   getTitle(): string | undefined {
     return this.spec.title
   }
 
+  /**
+   * Set menu item group
+   * @returns menu item builder based on group provided
+   */
   group(group: string): MenuItemBuilder {
     return this.clone({group})
   }
 
+  /**
+   * Get menu item group
+   * @returns menu item group
+   */
   getGroup(): PartialMenuItem['group'] {
     return this.spec.group
   }
 
+  /**
+   * Set menu item icon
+   * @returns menu item builder based on icon provided
+   */
   icon(icon: React.ComponentType | React.ReactNode): MenuItemBuilder {
     return this.clone({icon})
   }
 
+  /**
+   * Get menu item icon
+   * @returns menu item icon
+   */
   getIcon(): PartialMenuItem['icon'] {
     return this.spec.icon
   }
 
+  /**
+   * Set menu item parameters
+   * @returns menu item builder based on parameters provided
+   */
   params(params: MenuItemParamsType): MenuItemBuilder {
     return this.clone({params})
   }
 
+  /**
+   * Get meny item parameters
+   * @returns menu item parameters
+   */
   getParams(): PartialMenuItem['params'] {
     return this.spec.params
   }
 
+  /**
+   * Set menu item to show as action
+   * @returns menu item builder based on if it should show as action
+   */
   showAsAction(showAsAction = true): MenuItemBuilder {
     return this.clone({showAsAction: Boolean(showAsAction)})
   }
 
+  /**
+   * Check if menu item should show as action
+   * @returns true if menu item should show as action, false if not
+   */
   getShowAsAction(): PartialMenuItem['showAsAction'] {
     return this.spec.showAsAction
   }
 
+  /** Serialize menu item builder
+   * @returns menu item node based on path provided in options
+   */
   serialize(options: SerializeOptions = {path: []}): MenuItem {
     const {title, action, intent} = this.spec
     if (!title) {
@@ -157,6 +223,9 @@ export class MenuItemBuilder implements Serializable<MenuItem> {
     return {...this.spec, title}
   }
 
+  /** Clone menu item builder
+   * @returns menu item builder based on context and spec provided
+   */
   clone(withSpec?: PartialMenuItem): MenuItemBuilder {
     const builder = new MenuItemBuilder(this._context)
     builder.spec = {...this.spec, ...(withSpec || {})}

--- a/packages/sanity/src/desk/structureBuilder/MenuItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/MenuItem.ts
@@ -77,6 +77,7 @@ export class MenuItemBuilder implements Serializable<MenuItem> {
 
   /**
    * Set menu item action
+   * @param action - menu item action
    * @returns menu item builder based on action provided
    */
   action(action: MenuItemActionType): MenuItemBuilder {
@@ -93,6 +94,7 @@ export class MenuItemBuilder implements Serializable<MenuItem> {
 
   /**
    * Set menu item intent
+   * @param intent - menu item intent
    * @returns menu item builder based on intent provided
    */
   intent(intent: Intent): MenuItemBuilder {
@@ -109,6 +111,7 @@ export class MenuItemBuilder implements Serializable<MenuItem> {
 
   /**
    * Set menu item title
+   * @param title - menu item title
    * @returns menu item builder based on title provided
    */
   title(title: string): MenuItemBuilder {
@@ -125,6 +128,7 @@ export class MenuItemBuilder implements Serializable<MenuItem> {
 
   /**
    * Set menu item group
+   * @param group - menu item group
    * @returns menu item builder based on group provided
    */
   group(group: string): MenuItemBuilder {
@@ -141,6 +145,7 @@ export class MenuItemBuilder implements Serializable<MenuItem> {
 
   /**
    * Set menu item icon
+   * @param icon - menu item icon
    * @returns menu item builder based on icon provided
    */
   icon(icon: React.ComponentType | React.ReactNode): MenuItemBuilder {
@@ -157,6 +162,7 @@ export class MenuItemBuilder implements Serializable<MenuItem> {
 
   /**
    * Set menu item parameters
+   * @param params - menu item parameters
    * @returns menu item builder based on parameters provided
    */
   params(params: MenuItemParamsType): MenuItemBuilder {
@@ -173,6 +179,7 @@ export class MenuItemBuilder implements Serializable<MenuItem> {
 
   /**
    * Set menu item to show as action
+   * @param showAsAction - determine if menu item should show as action
    * @returns menu item builder based on if it should show as action
    */
   showAsAction(showAsAction = true): MenuItemBuilder {
@@ -188,6 +195,7 @@ export class MenuItemBuilder implements Serializable<MenuItem> {
   }
 
   /** Serialize menu item builder
+   * @param options - serialization options
    * @returns menu item node based on path provided in options
    */
   serialize(options: SerializeOptions = {path: []}): MenuItem {
@@ -224,6 +232,7 @@ export class MenuItemBuilder implements Serializable<MenuItem> {
   }
 
   /** Clone menu item builder
+   * @param withSpec - menu item options
    * @returns menu item builder based on context and spec provided
    */
   clone(withSpec?: PartialMenuItem): MenuItemBuilder {

--- a/packages/sanity/src/desk/structureBuilder/MenuItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/MenuItem.ts
@@ -45,7 +45,7 @@ export interface MenuItem {
   // TODO: align these with TemplateResponse['icon']
   /** Menu Item icon */
   icon?: React.ComponentType | React.ReactNode
-  /** Menu Item parameters */
+  /** Menu Item parameters. See {@link MenuItemParamsType} */
   params?: MenuItemParamsType
   /** Determine if it will show the MenuItem as action */
   showAsAction?: boolean
@@ -62,12 +62,12 @@ export type PartialMenuItem = Partial<MenuItem>
  *
  * @public */
 export class MenuItemBuilder implements Serializable<MenuItem> {
-  /** menu item option object */
+  /** menu item option object. See {@link PartialMenuItem} */
   protected spec: PartialMenuItem
 
   constructor(
     /**
-     * Desk structure context
+     * Desk structure context. See {@link StructureContext}
      */
     protected _context: StructureContext,
     spec?: MenuItem
@@ -77,8 +77,8 @@ export class MenuItemBuilder implements Serializable<MenuItem> {
 
   /**
    * Set menu item action
-   * @param action - menu item action
-   * @returns menu item builder based on action provided
+   * @param action - menu item action. See {@link MenuItemActionType}
+   * @returns menu item builder based on action provided. See {@link MenuItemBuilder}
    */
   action(action: MenuItemActionType): MenuItemBuilder {
     return this.clone({action})
@@ -86,7 +86,7 @@ export class MenuItemBuilder implements Serializable<MenuItem> {
 
   /**
    * Get menu item action
-   * @returns menu item builder action
+   * @returns menu item builder action. See {@link PartialMenuItem}
    */
   getAction(): PartialMenuItem['action'] {
     return this.spec.action
@@ -94,8 +94,8 @@ export class MenuItemBuilder implements Serializable<MenuItem> {
 
   /**
    * Set menu item intent
-   * @param intent - menu item intent
-   * @returns menu item builder based on intent provided
+   * @param intent - menu item intent. See {@link Intent}
+   * @returns menu item builder based on intent provided. See {@link MenuItemBuilder}
    */
   intent(intent: Intent): MenuItemBuilder {
     return this.clone({intent})
@@ -103,7 +103,7 @@ export class MenuItemBuilder implements Serializable<MenuItem> {
 
   /**
    * Get menu item intent
-   * @returns menu item intent
+   * @returns menu item intent. See {@link PartialMenuItem}
    */
   getIntent(): PartialMenuItem['intent'] {
     return this.spec.intent
@@ -112,7 +112,7 @@ export class MenuItemBuilder implements Serializable<MenuItem> {
   /**
    * Set menu item title
    * @param title - menu item title
-   * @returns menu item builder based on title provided
+   * @returns menu item builder based on title provided. See {@link MenuItemBuilder}
    */
   title(title: string): MenuItemBuilder {
     return this.clone({title})
@@ -129,7 +129,7 @@ export class MenuItemBuilder implements Serializable<MenuItem> {
   /**
    * Set menu item group
    * @param group - menu item group
-   * @returns menu item builder based on group provided
+   * @returns menu item builder based on group provided. See {@link MenuItemBuilder}
    */
   group(group: string): MenuItemBuilder {
     return this.clone({group})
@@ -137,7 +137,7 @@ export class MenuItemBuilder implements Serializable<MenuItem> {
 
   /**
    * Get menu item group
-   * @returns menu item group
+   * @returns menu item group. See {@link PartialMenuItem}
    */
   getGroup(): PartialMenuItem['group'] {
     return this.spec.group
@@ -146,7 +146,7 @@ export class MenuItemBuilder implements Serializable<MenuItem> {
   /**
    * Set menu item icon
    * @param icon - menu item icon
-   * @returns menu item builder based on icon provided
+   * @returns menu item builder based on icon provided. See {@link MenuItemBuilder}
    */
   icon(icon: React.ComponentType | React.ReactNode): MenuItemBuilder {
     return this.clone({icon})
@@ -154,7 +154,7 @@ export class MenuItemBuilder implements Serializable<MenuItem> {
 
   /**
    * Get menu item icon
-   * @returns menu item icon
+   * @returns menu item icon. See {@link PartialMenuItem}
    */
   getIcon(): PartialMenuItem['icon'] {
     return this.spec.icon
@@ -162,8 +162,8 @@ export class MenuItemBuilder implements Serializable<MenuItem> {
 
   /**
    * Set menu item parameters
-   * @param params - menu item parameters
-   * @returns menu item builder based on parameters provided
+   * @param params - menu item parameters. See {@link MenuItemParamsType}
+   * @returns menu item builder based on parameters provided. See {@link MenuItemBuilder}
    */
   params(params: MenuItemParamsType): MenuItemBuilder {
     return this.clone({params})
@@ -171,7 +171,7 @@ export class MenuItemBuilder implements Serializable<MenuItem> {
 
   /**
    * Get meny item parameters
-   * @returns menu item parameters
+   * @returns menu item parameters. See {@link PartialMenuItem}
    */
   getParams(): PartialMenuItem['params'] {
     return this.spec.params
@@ -180,7 +180,7 @@ export class MenuItemBuilder implements Serializable<MenuItem> {
   /**
    * Set menu item to show as action
    * @param showAsAction - determine if menu item should show as action
-   * @returns menu item builder based on if it should show as action
+   * @returns menu item builder based on if it should show as action. See {@link MenuItemBuilder}
    */
   showAsAction(showAsAction = true): MenuItemBuilder {
     return this.clone({showAsAction: Boolean(showAsAction)})
@@ -188,15 +188,15 @@ export class MenuItemBuilder implements Serializable<MenuItem> {
 
   /**
    * Check if menu item should show as action
-   * @returns true if menu item should show as action, false if not
+   * @returns true if menu item should show as action, false if not. See {@link PartialMenuItem}
    */
   getShowAsAction(): PartialMenuItem['showAsAction'] {
     return this.spec.showAsAction
   }
 
   /** Serialize menu item builder
-   * @param options - serialization options
-   * @returns menu item node based on path provided in options
+   * @param options - serialization options. See {@link SerializeOptions}
+   * @returns menu item node based on path provided in options. See {@link MenuItem}
    */
   serialize(options: SerializeOptions = {path: []}): MenuItem {
     const {title, action, intent} = this.spec
@@ -232,8 +232,8 @@ export class MenuItemBuilder implements Serializable<MenuItem> {
   }
 
   /** Clone menu item builder
-   * @param withSpec - menu item options
-   * @returns menu item builder based on context and spec provided
+   * @param withSpec - menu item options. See {@link PartialMenuItem}
+   * @returns menu item builder based on context and spec provided. See {@link MenuItemBuilder}
    */
   clone(withSpec?: PartialMenuItem): MenuItemBuilder {
     const builder = new MenuItemBuilder(this._context)

--- a/packages/sanity/src/desk/structureBuilder/MenuItemGroup.ts
+++ b/packages/sanity/src/desk/structureBuilder/MenuItemGroup.ts
@@ -16,9 +16,9 @@ export function maybeSerializeMenuItemGroup(
  * @public
  */
 export interface MenuItemGroup {
-  /* Menu group Id */
+  /** Menu group Id */
   id: string
-  /* Menu group title */
+  /** Menu group title */
   title: string
 }
 

--- a/packages/sanity/src/desk/structureBuilder/MenuItemGroup.ts
+++ b/packages/sanity/src/desk/structureBuilder/MenuItemGroup.ts
@@ -28,30 +28,61 @@ export interface MenuItemGroup {
  * @public
  */
 export class MenuItemGroupBuilder implements Serializable<MenuItemGroup> {
+  /** Menu item group ID */
   protected _id: string
+  /** Menu item group title */
   protected _title: string
 
-  constructor(protected _context: StructureContext, spec?: MenuItemGroup) {
+  constructor(
+    /**
+     * Desk structure context
+     */
+    protected _context: StructureContext,
+    spec?: MenuItemGroup
+  ) {
     this._id = spec ? spec.id : ''
     this._title = spec ? spec.title : ''
   }
 
+  /**
+   * Set menu item group ID
+   * @param id - menu item group ID
+   * @returns menu item group builder based on ID provided
+   */
   id(id: string): MenuItemGroupBuilder {
     return new MenuItemGroupBuilder(this._context, {id, title: this._title})
   }
 
+  /**
+   * Get menu item group ID
+   * @returns menu item group ID
+   */
   getId(): string {
     return this._id
   }
 
+  /**
+   * Set menu item group title
+   * @param title - menu item group title
+   * @returns menu item group builder based on title provided
+   */
   title(title: string): MenuItemGroupBuilder {
     return new MenuItemGroupBuilder(this._context, {id: this._id, title})
   }
 
+  /**
+   * Get menu item group title
+   * @returns menu item group title
+   */
   getTitle(): string {
     return this._title
   }
 
+  /**
+   * Serialize menu item group builder
+   * @param options - serialization options (path)
+   * @returns menu item group based on path provided in options
+   */
   serialize(options: SerializeOptions = {path: []}): MenuItemGroup {
     const {_id, _title} = this
     if (!_id) {

--- a/packages/sanity/src/desk/structureBuilder/MenuItemGroup.ts
+++ b/packages/sanity/src/desk/structureBuilder/MenuItemGroup.ts
@@ -35,7 +35,7 @@ export class MenuItemGroupBuilder implements Serializable<MenuItemGroup> {
 
   constructor(
     /**
-     * Desk structure context
+     * Desk structure context. See {@link StructureContext}
      */
     protected _context: StructureContext,
     spec?: MenuItemGroup
@@ -47,7 +47,7 @@ export class MenuItemGroupBuilder implements Serializable<MenuItemGroup> {
   /**
    * Set menu item group ID
    * @param id - menu item group ID
-   * @returns menu item group builder based on ID provided
+   * @returns menu item group builder based on ID provided. See {@link MenuItemGroupBuilder}
    */
   id(id: string): MenuItemGroupBuilder {
     return new MenuItemGroupBuilder(this._context, {id, title: this._title})
@@ -64,7 +64,7 @@ export class MenuItemGroupBuilder implements Serializable<MenuItemGroup> {
   /**
    * Set menu item group title
    * @param title - menu item group title
-   * @returns menu item group builder based on title provided
+   * @returns menu item group builder based on title provided. See {@link MenuItemGroupBuilder}
    */
   title(title: string): MenuItemGroupBuilder {
     return new MenuItemGroupBuilder(this._context, {id: this._id, title})
@@ -80,8 +80,8 @@ export class MenuItemGroupBuilder implements Serializable<MenuItemGroup> {
 
   /**
    * Serialize menu item group builder
-   * @param options - serialization options (path)
-   * @returns menu item group based on path provided in options
+   * @param options - serialization options (path). See {@link SerializeOptions}
+   * @returns menu item group based on path provided in options. See {@link MenuItemGroup}
    */
   serialize(options: SerializeOptions = {path: []}): MenuItemGroup {
     const {_id, _title} = this

--- a/packages/sanity/src/desk/structureBuilder/MenuItemGroup.ts
+++ b/packages/sanity/src/desk/structureBuilder/MenuItemGroup.ts
@@ -12,16 +12,21 @@ export function maybeSerializeMenuItemGroup(
 }
 
 /**
- * @hidden
- * @beta */
+ * Interface for menu item groups
+ * @public
+ */
 export interface MenuItemGroup {
+  /* Menu group Id */
   id: string
+  /* Menu group title */
   title: string
 }
 
 /**
- * @hidden
- * @beta */
+ * Class for building menu item groups.
+ *
+ * @public
+ */
 export class MenuItemGroupBuilder implements Serializable<MenuItemGroup> {
   protected _id: string
   protected _title: string

--- a/packages/sanity/src/desk/structureBuilder/StructureNodes.ts
+++ b/packages/sanity/src/desk/structureBuilder/StructureNodes.ts
@@ -87,7 +87,7 @@ export interface Divider {
 }
 
 /**
- * Type for the path of a serialized structure node
+ * Path of a serialized structure node
  *
  * @public
  */
@@ -115,7 +115,7 @@ export interface Serializable<T> {
 }
 
 /**
- * Type for a collection.
+ * Collection
  * See {@link List}, {@link DocumentList}, {@link EditorNode}, {@link DocumentNode} and {@link Component}
  *
  * @public
@@ -123,7 +123,7 @@ export interface Serializable<T> {
 export type Collection = List | DocumentList | EditorNode | DocumentNode | Component
 
 /**
- * Type for a collection builder
+ * Collection builder
  * See {@link ListBuilder}, {@link DocumentListBuilder}, {@link DocumentTypeListBuilder}, {@link DocumentBuilder} and {@link ComponentBuilder}
  *
  * @public
@@ -136,7 +136,7 @@ export type CollectionBuilder =
   | ComponentBuilder
 
 /**
- * Type for Child of a structure node
+ * Child of a structure node
  * See {@link Collection}, {@link CollectionBuilder} and {@link ChildResolver}
  *
  * @public

--- a/packages/sanity/src/desk/structureBuilder/StructureNodes.ts
+++ b/packages/sanity/src/desk/structureBuilder/StructureNodes.ts
@@ -12,78 +12,120 @@ import type {DocumentBuilder} from './Document'
 import type {View} from './types'
 
 /**
- * @hidden
- * @beta */
+ * Interface for the structure builder node.
+ *
+ * @public
+ */
 export interface StructureNode {
+  /** Node ID */
   id: string
+  /** Node ID */
   title?: string
+  /** Node type */
   type?: string
 }
 
 /**
- * @hidden
- * @beta */
+ * Interface for the document list builder (focused on the document pane)
+ *
+ * @public */
 export interface DocumentNode extends StructureNode {
+  /**
+   * Document children
+   */
   child?: Child
+  /**
+   * Options for the document pane
+   */
   options: {
+    /** Document Id */
     id: string
+    /** Document Type */
     type?: string
+    /** Document Template */
     template?: string
+    /** Template parameters */
     templateParameters?: {[key: string]: any}
   }
+  /**
+   * Views for the document pane
+   */
   views: View[]
 }
 
 /**
- * @hidden
- * @beta */
+ * Interface for Editor node
+ *
+ * @public */
 export interface EditorNode extends StructureNode {
+  /* Editor Id */
   child?: Child
+  /* Editor options */
   options: {
+    /* Editor ID */
     id: string
+    /* Editor type */
     type?: string
+    /* Editor template */
     template?: string
+    /* Template parameters */
     templateParameters?: {[key: string]: any}
   }
 }
 
 /**
- * @hidden
- * @beta */
+ * A `Divider` is a visual separator in the structure tree.
+ *
+ * @public
+ */
 export interface Divider {
+  /**
+   * The divider's ID
+   */
   id: string
   type: 'divider'
 }
 
 /**
- * @hidden
- * @beta */
+ * Type for the path of a serialized structure node
+ *
+ * @public
+ */
 export type SerializePath = (string | number)[]
 
 /**
- * @hidden
- * @beta */
+ * Interface for seraializing a structure node
+ * @public */
 export interface SerializeOptions {
+  /* path */
   path: SerializePath
+  /* index */
   index?: number
+  /* hint */
   hint?: string
 }
 
 /**
- * @hidden
- * @beta */
+ *  A interface for serializing a structure node to a plain JavaScript object.
+ *
+ * @public
+ */
 export interface Serializable<T> {
   serialize(options: SerializeOptions): T
 }
 
 /**
- * @hidden
- * @beta */
+ * Type for a collection
+ *
+ * @public
+ */
 export type Collection = List | DocumentList | EditorNode | DocumentNode | Component
 
 /**
- * @hidden
- * @beta */
+ * Type for a collection builder
+ *
+ * @public
+ */
 export type CollectionBuilder =
   | ListBuilder
   | DocumentListBuilder
@@ -92,8 +134,10 @@ export type CollectionBuilder =
   | ComponentBuilder
 
 /**
- * @hidden
- * @beta */
+ * Type for Child of a structure node
+ *
+ * @public
+ */
 export type Child = Collection | CollectionBuilder | ChildResolver
 
 /** @internal */

--- a/packages/sanity/src/desk/structureBuilder/StructureNodes.ts
+++ b/packages/sanity/src/desk/structureBuilder/StructureNodes.ts
@@ -58,17 +58,17 @@ export interface DocumentNode extends StructureNode {
  *
  * @public */
 export interface EditorNode extends StructureNode {
-  /* Editor Id */
+  /** Editor Id */
   child?: Child
-  /* Editor options */
+  /** Editor options */
   options: {
-    /* Editor ID */
+    /** Editor ID */
     id: string
-    /* Editor type */
+    /** Editor type */
     type?: string
-    /* Editor template */
+    /** Editor template */
     template?: string
-    /* Template parameters */
+    /** Template parameters */
     templateParameters?: {[key: string]: any}
   }
 }
@@ -97,11 +97,11 @@ export type SerializePath = (string | number)[]
  * Interface for seraializing a structure node
  * @public */
 export interface SerializeOptions {
-  /* path */
+  /** path */
   path: SerializePath
-  /* index */
+  /** index */
   index?: number
-  /* hint */
+  /** hint */
   hint?: string
 }
 

--- a/packages/sanity/src/desk/structureBuilder/StructureNodes.ts
+++ b/packages/sanity/src/desk/structureBuilder/StructureNodes.ts
@@ -31,7 +31,7 @@ export interface StructureNode {
  * @public */
 export interface DocumentNode extends StructureNode {
   /**
-   * Document children
+   * Document children. See {@link Child}
    */
   child?: Child
   /**
@@ -48,7 +48,7 @@ export interface DocumentNode extends StructureNode {
     templateParameters?: {[key: string]: any}
   }
   /**
-   * Views for the document pane
+   * View array for the document pane. See {@link View}
    */
   views: View[]
 }
@@ -58,7 +58,7 @@ export interface DocumentNode extends StructureNode {
  *
  * @public */
 export interface EditorNode extends StructureNode {
-  /** Editor Id */
+  /** Editor child. See {@link Child} */
   child?: Child
   /** Editor options */
   options: {
@@ -97,7 +97,7 @@ export type SerializePath = (string | number)[]
  * Interface for seraializing a structure node
  * @public */
 export interface SerializeOptions {
-  /** path */
+  /** path. See {@link SerializePath} */
   path: SerializePath
   /** index */
   index?: number
@@ -115,7 +115,8 @@ export interface Serializable<T> {
 }
 
 /**
- * Type for a collection
+ * Type for a collection.
+ * See {@link List}, {@link DocumentList}, {@link EditorNode}, {@link DocumentNode} and {@link Component}
  *
  * @public
  */
@@ -123,6 +124,7 @@ export type Collection = List | DocumentList | EditorNode | DocumentNode | Compo
 
 /**
  * Type for a collection builder
+ * See {@link ListBuilder}, {@link DocumentListBuilder}, {@link DocumentTypeListBuilder}, {@link DocumentBuilder} and {@link ComponentBuilder}
  *
  * @public
  */
@@ -135,6 +137,7 @@ export type CollectionBuilder =
 
 /**
  * Type for Child of a structure node
+ * See {@link Collection}, {@link CollectionBuilder} and {@link ChildResolver}
  *
  * @public
  */

--- a/packages/sanity/src/desk/structureBuilder/types.ts
+++ b/packages/sanity/src/desk/structureBuilder/types.ts
@@ -15,14 +15,14 @@ import type {FormView, FormViewBuilder} from './views/FormView'
 import type {ConfigContext, Source, InitialValueTemplateItem} from 'sanity'
 
 /**
- * Type for view. See {@link FormView} and {@link ComponentView}
+ * View. See {@link FormView} and {@link ComponentView}
  *
  * @public
  */
 export type View = FormView | ComponentView
 
 /**
- * Type for a user view component
+ * User view component
  *
  * @public */
 export type UserViewComponent<TOptions = Record<string, any>> = React.ComponentType<{
@@ -38,7 +38,7 @@ export type UserViewComponent<TOptions = Record<string, any>> = React.ComponentT
 }>
 
 /**
- * Type for User defined component
+ * User defined component
  *
  * @public
  */

--- a/packages/sanity/src/desk/structureBuilder/types.ts
+++ b/packages/sanity/src/desk/structureBuilder/types.ts
@@ -15,7 +15,7 @@ import type {FormView, FormViewBuilder} from './views/FormView'
 import type {ConfigContext, Source, InitialValueTemplateItem} from 'sanity'
 
 /**
- * Type for view
+ * Type for view. See {@link FormView} and {@link ComponentView}
  *
  * @public
  */
@@ -43,7 +43,7 @@ export type UserViewComponent<TOptions = Record<string, any>> = React.ComponentT
  * @public
  */
 export type UserComponent = React.ComponentType<{
-  /** Component child */
+  /** Component child. See {@link ComponentBuilder} */
   child?: ComponentBuilder
   /** Component child item ID */
   childItemId?: string
@@ -71,13 +71,14 @@ export type UserComponent = React.ComponentType<{
 export interface StructureContext extends Source {
   /** Resolve document method
    * @returns a document node builder, or null/undefined if no document node should be returned.
+   * See {@link DocumentBuilder}
    */
   resolveDocumentNode: (
     /** an object holding the documentId and schemaType for the document node being resolved. */
     options: {documentId?: string; schemaType: string}
   ) => DocumentBuilder
   /** Get structure builder
-   * @returns a structure builder
+   * @returns a structure builder. See {@link StructureBuilder}
    */
   getStructureBuilder: () => StructureBuilder
 }
@@ -114,11 +115,12 @@ export type DefaultDocumentNodeResolver = (
    * ```ts
    * (S) => S.defaults()
    * ```
+   * See {@link StructureBuilder}
    */
   S: StructureBuilder,
   /**
    * An object holding the documentId and schemaType for the document node being resolved.
-   * {@link DefaultDocumentNodeContext}
+   * See {@link DefaultDocumentNodeContext}
    */
   options: DefaultDocumentNodeContext
 ) => DocumentBuilder | null | undefined
@@ -133,61 +135,125 @@ export interface StructureBuilder {
    * @internal
    */
   component: (spec?: ComponentInput | UserComponent) => ComponentBuilder
-  /** By giving an object of options with documentID and its schema type receive the the respective Document builder */
+  /** By giving an object of options with documentID and its schema type receive the the respective Document builder
+   * @param options - an object holding the documentId and schemaType for the document node being resolved.
+   * @returns a Document builder. See {@link DocumentBuilder}
+   */
   defaultDocument: (options: {documentId?: string; schemaType: string}) => DocumentBuilder
-  /** Get an array of Item builders that take Initial Value template into consideration */
+  /** Get an array of Item builders that take Initial Value template into consideration
+   * @returns an array of initial value template item builders. See {@link ListItemBuilder}
+   */
   defaultInitialValueTemplateItems: () => InitialValueTemplateItemBuilder[]
-  /** Get the default List builder */
+  /** Get the default List builder
+   * @returns a List builder. See {@link ListBuilder}
+   */
   defaults: () => ListBuilder
-  /** Get a structure Divider */
+  /** Get a structure Divider
+   * @returns a Divider. See {@link Divider}
+   */
   divider: () => Divider
-  /** By giving a partial Document Node receive the respective Document Builder */
+  /** By giving a partial Document Node receive the respective Document Builder
+   * @param spec - a partial document node. See {@link PartialDocumentNode}
+   * @returns a Document builder. See {@link DocumentBuilder}
+   */
   document: (spec?: PartialDocumentNode) => DocumentBuilder
-  /** By giving a Document List Input receive the respective Document List Builder */
+  /** By giving a Document List Input receive the respective Document List Builder
+   * @param spec - a document list input. See {@link DocumentListInput}
+   * @returns a Document List builder. See {@link DocumentListBuilder}
+   */
   documentList: (spec?: DocumentListInput) => DocumentListBuilder
-  /** By giving a Document List Item Input receive the respective Document List Item builder */
+  /** By giving a Document List Item Input receive the respective Document List Item builder
+   * @param spec - a document list item input. See {@link DocumentListItemInput}
+   * @returns a Document List Item builder. See {@link DocumentListItemBuilder}
+   */
   documentListItem: (spec?: DocumentListItemInput) => DocumentListItemBuilder
-  /** By giving a type name or Document Type List Input receive the respective Document List Builder */
+  /** By giving a type name or Document Type List Input receive the respective Document List Builder
+   * @param typeNameOrSpec - a type name or a document type list input. See {@link DocumentTypeListInput}
+   * @returns a Document List builder. See {@link DocumentListBuilder}
+   */
   documentTypeList: (typeNameOrSpec: string | DocumentTypeListInput) => DocumentListBuilder
-  /** By providing a type name receive a List Item builder */
+  /** By providing a type name receive a List Item builder
+   * @param typeName - a type name
+   * @returns a List Item builder. See {@link ListItemBuilder}
+   */
   documentTypeListItem: (typeName: string) => ListItemBuilder
-  /** Get an array of List Item builders */
+  /** Get an array of List Item builders
+   * @returns an array of list item builders. See {@link ListItemBuilder}
+   */
   documentTypeListItems: () => ListItemBuilder[]
-  /** By giving a templateID and a set of parameters receive a Document builder that takes InitialValueTemplate into account */
+  /** By giving a templateID and a set of parameters receive a Document builder that takes InitialValueTemplate into account
+   * @param templateId - a template ID
+   * @param parameters - an object of parameters
+   * @returns a Document builder. See {@link DocumentBuilder}
+   */
   documentWithInitialValueTemplate: (
     templateId: string,
     parameters?: Record<string, unknown>
   ) => DocumentBuilder
-  /** By giving a Editor Node receive the respective Document Builder */
+  /** By giving a Editor Node receive the respective Document Builder
+   * @param spec - an editor node. See {@link EditorNode}
+   * @returns a Document builder. See {@link DocumentBuilder}
+   */
   editor: (spec?: EditorNode) => DocumentBuilder
-  /** By giving a templateID and a set of parameters receive an Item Builder that takes InitialValueTemplate into account */
+  /** By giving a templateID and a set of parameters receive an Item Builder that takes InitialValueTemplate into account
+   * @param templateId - a template ID
+   * @param parameters - an object of parameters
+   * @returns an Item builder. See {@link ListItemBuilder}
+   */
   initialValueTemplateItem: (
     templateId: string,
     parameters?: Record<string, any>
   ) => InitialValueTemplateItemBuilder
-  /** By giving a List Input receive the respective Builder, otherwise return default ListBuilder builder */
+  /** By giving a List Input receive the respective Builder, otherwise return default ListBuilder builder
+   * @param spec - a list input. See {@link ListInput}
+   * @returns a List builder. See {@link ListBuilder}
+   */
   list: (spec?: ListInput) => ListBuilder
-  /** By giving a List Item Input receive the respective Builder, otherwise return default ListItem builder */
+  /** By giving a List Item Input receive the respective Builder, otherwise return default ListItem builder
+   * @param spec - a list item input. See {@link ListItemInput}
+   * @returns a List Item builder. See {@link ListItemBuilder}
+   */
   listItem: (spec?: ListItemInput) => ListItemBuilder
-  /** By giving a Menu Item receive the respective Builder, otherwise return default MenuItem builder */
+  /** By giving a Menu Item receive the respective Builder, otherwise return default MenuItem builder
+   * @param spec - a menu item. See {@link MenuItem}
+   * @returns a Menu Item builder. See {@link MenuItemBuilder}
+   */
   menuItem: (spec?: MenuItem) => MenuItemBuilder
-  /** By giving a Menu Item Group receive the respective Builder */
+  /** By giving a Menu Item Group receive the respective Builder
+   * @param spec - a menu item group. See {@link MenuItemGroup}
+   * @returns a Menu Item Group builder. See {@link MenuItemGroupBuilder}
+   */
   menuItemGroup: (spec?: MenuItemGroup) => MenuItemGroupBuilder
-  /** By giving an array of initial value template receive an array of Menu Items, otherwise return default MenuItem builder */
+  /** By giving an array of initial value template receive an array of Menu Items, otherwise return default MenuItem builder
+   * @param templateItems - an array of initial value template items. See {@link InitialValueTemplateItem}
+   * @returns an array of Menu Items. See {@link MenuItem}
+   */
   menuItemsFromInitialValueTemplateItems: (templateItems: InitialValueTemplateItem[]) => MenuItem[]
-  /** By giving a sort ordering object receive a Menu Item Builder */
+  /** By giving a sort ordering object receive a Menu Item Builder
+   * @param ordering - a sort ordering object. See {@link SortOrdering}
+   * @returns a Menu Item builder. See {@link MenuItemBuilder}
+   */
   orderingMenuItem: (ordering: SortOrdering) => MenuItemBuilder
-  /** By giving a type receive a list of Menu Items ordered by it */
+  /** By giving a type receive a list of Menu Items ordered by it
+   * @param type - a type
+   * @returns an array of Menu Items. See {@link MenuItem}
+   */
   orderingMenuItemsForType: (type: string) => MenuItemBuilder[]
   /** View for structure */
   view: {
+    /** form for view
+     * @param spec - a partial form view. See {@link FormView}
+     * @returns a Form View builder. See {@link FormViewBuilder}
+     */
     form: (spec?: Partial<FormView>) => FormViewBuilder
+    /** component for view
+     * @param componentOrSpec - a partial component view or a React component. See {@link ComponentView}
+     * @returns a Component View builder. See {@link ComponentViewBuilder}
+     */
     component: (
       componentOrSpec?: Partial<ComponentView> | React.ComponentType<any>
     ) => ComponentViewBuilder
   }
-  /** Context for the structure builder
-   * {@link StructureContext}
-   */
+  /** Context for the structure builder. See {@link StructureContext} */
   context: StructureContext
 }

--- a/packages/sanity/src/desk/structureBuilder/types.ts
+++ b/packages/sanity/src/desk/structureBuilder/types.ts
@@ -69,7 +69,16 @@ export type UserComponent = React.ComponentType<{
  * @public
  */
 export interface StructureContext extends Source {
-  resolveDocumentNode: (options: {documentId?: string; schemaType: string}) => DocumentBuilder
+  /** Resolve document method
+   * @returns a document node builder, or null/undefined if no document node should be returned.
+   */
+  resolveDocumentNode: (
+    /** an object holding the documentId and schemaType for the document node being resolved. */
+    options: {documentId?: string; schemaType: string}
+  ) => DocumentBuilder
+  /** Get structure builder
+   * @returns a structure builder
+   */
   getStructureBuilder: () => StructureBuilder
 }
 

--- a/packages/sanity/src/desk/structureBuilder/types.ts
+++ b/packages/sanity/src/desk/structureBuilder/types.ts
@@ -133,37 +133,61 @@ export interface StructureBuilder {
    * @internal
    */
   component: (spec?: ComponentInput | UserComponent) => ComponentBuilder
+  /** By giving an object of options with documentID and its schema type receive the the respective Document builder */
   defaultDocument: (options: {documentId?: string; schemaType: string}) => DocumentBuilder
+  /** Get an array of Item builders that take Initial Value template into consideration */
   defaultInitialValueTemplateItems: () => InitialValueTemplateItemBuilder[]
+  /** Get the default List builder */
   defaults: () => ListBuilder
+  /** Get a structure Divider */
   divider: () => Divider
+  /** By giving a partial Document Node receive the respective Document Builder */
   document: (spec?: PartialDocumentNode) => DocumentBuilder
+  /** By giving a Document List Input receive the respective Document List Builder */
   documentList: (spec?: DocumentListInput) => DocumentListBuilder
+  /** By giving a Document List Item Input receive the respective Document List Item builder */
   documentListItem: (spec?: DocumentListItemInput) => DocumentListItemBuilder
+  /** By giving a type name or Document Type List Input receive the respective Document List Builder */
   documentTypeList: (typeNameOrSpec: string | DocumentTypeListInput) => DocumentListBuilder
+  /** By providing a type name receive a List Item builder */
   documentTypeListItem: (typeName: string) => ListItemBuilder
+  /** Get an array of List Item builders */
   documentTypeListItems: () => ListItemBuilder[]
+  /** By giving a templateID and a set of parameters receive a Document builder that takes InitialValueTemplate into account */
   documentWithInitialValueTemplate: (
     templateId: string,
     parameters?: Record<string, unknown>
   ) => DocumentBuilder
+  /** By giving a Editor Node receive the respective Document Builder */
   editor: (spec?: EditorNode) => DocumentBuilder
+  /** By giving a templateID and a set of parameters receive an Item Builder that takes InitialValueTemplate into account */
   initialValueTemplateItem: (
     templateId: string,
     parameters?: Record<string, any>
   ) => InitialValueTemplateItemBuilder
+  /** By giving a List Input receive the respective Builder, otherwise return default ListBuilder builder */
   list: (spec?: ListInput) => ListBuilder
+  /** By giving a List Item Input receive the respective Builder, otherwise return default ListItem builder */
   listItem: (spec?: ListItemInput) => ListItemBuilder
+  /** By giving a Menu Item receive the respective Builder, otherwise return default MenuItem builder */
   menuItem: (spec?: MenuItem) => MenuItemBuilder
+  /** By giving a Menu Item Group receive the respective Builder */
   menuItemGroup: (spec?: MenuItemGroup) => MenuItemGroupBuilder
+  /** By giving an array of initial value template receive an array of Menu Items, otherwise return default MenuItem builder */
   menuItemsFromInitialValueTemplateItems: (templateItems: InitialValueTemplateItem[]) => MenuItem[]
+  /** By giving a sort ordering object receive a Menu Item Builder */
   orderingMenuItem: (ordering: SortOrdering) => MenuItemBuilder
+  /** By giving a type receive a list of Menu Items ordered by it */
   orderingMenuItemsForType: (type: string) => MenuItemBuilder[]
+  /** View for structure */
   view: {
     form: (spec?: Partial<FormView>) => FormViewBuilder
     component: (
       componentOrSpec?: Partial<ComponentView> | React.ComponentType<any>
     ) => ComponentViewBuilder
   }
+  /** Context for the structure builder
+   * {@link StructureContext}
+   */
   context: StructureContext
 }

--- a/packages/sanity/src/desk/structureBuilder/types.ts
+++ b/packages/sanity/src/desk/structureBuilder/types.ts
@@ -15,13 +15,16 @@ import type {FormView, FormViewBuilder} from './views/FormView'
 import type {ConfigContext, Source, InitialValueTemplateItem} from 'sanity'
 
 /**
- * @hidden
- * @beta */
+ * Type for view
+ *
+ * @public
+ */
 export type View = FormView | ComponentView
 
 /**
- * @hidden
- * @beta */
+ * Type for a user view component
+ *
+ * @public */
 export type UserViewComponent<TOptions = Record<string, any>> = React.ComponentType<{
   document: {
     draft: SanityDocument | null
@@ -35,24 +38,35 @@ export type UserViewComponent<TOptions = Record<string, any>> = React.ComponentT
 }>
 
 /**
- * @hidden
- * @beta */
+ * Type for User defined component
+ *
+ * @public
+ */
 export type UserComponent = React.ComponentType<{
+  /** Component child */
   child?: ComponentBuilder
+  /** Component child item ID */
   childItemId?: string
+  /** Component ID */
   id: string
+  /** Is component active */
   isActive?: boolean
+  /** Is component selected */
   isSelected?: boolean
+  /** item ID */
   itemId: string
+  /** Component options */
   options?: Record<string, unknown>
+  /** Pane key */
   paneKey: string
+  /** URL parameters */
   urlParams: Record<string, string | undefined> | undefined
 }>
 
 /**
+ * Interface for the structure builder context.
  *
- * @hidden
- * @beta
+ * @public
  */
 export interface StructureContext extends Source {
   resolveDocumentNode: (options: {documentId?: string; schemaType: string}) => DocumentBuilder
@@ -60,24 +74,51 @@ export interface StructureContext extends Source {
 }
 
 /**
- * @hidden
- * @beta */
+ * An object holding the documentId and schemaType for the document node being resolved.
+ *
+ * @public
+ */
 export interface DefaultDocumentNodeContext extends ConfigContext {
+  /**
+   * The id of the sanity document
+   */
   documentId?: string
+  /**
+   * the schema of the sanity document
+   */
   schemaType: string
 }
 
 /**
- * @hidden
- * @beta */
+ * A resolver function used to return the default document node used when editing documents.
+ *
+ * @public
+ *
+ * @returns a document node builder, or null/undefined if no document node should be returned.
+ *
+ */
 export type DefaultDocumentNodeResolver = (
+  /**
+   * S - an instance of the structure builder, that can be used to build the lists/items/panes for the desk tool
+   * context - an object holding various context that may be used to customize the structure, for instance the current user.
+   *  Defaults to
+   * ```ts
+   * (S) => S.defaults()
+   * ```
+   */
   S: StructureBuilder,
+  /**
+   * An object holding the documentId and schemaType for the document node being resolved.
+   * {@link DefaultDocumentNodeContext}
+   */
   options: DefaultDocumentNodeContext
 ) => DocumentBuilder | null | undefined
 
 /**
- * @hidden
- * @beta */
+ * Interface for the structure builder.
+ *
+ * @public
+ */
 export interface StructureBuilder {
   /**
    * @internal

--- a/packages/sanity/src/desk/structureBuilder/views/ComponentView.ts
+++ b/packages/sanity/src/desk/structureBuilder/views/ComponentView.ts
@@ -10,7 +10,9 @@ import {isRecord} from 'sanity'
  * @public */
 export interface ComponentView<TOptions = Record<string, any>> extends BaseView {
   type: 'component'
+  /** Component view components */
   component: UserViewComponent
+  /** Component view options */
   options: TOptions
 }
 

--- a/packages/sanity/src/desk/structureBuilder/views/ComponentView.ts
+++ b/packages/sanity/src/desk/structureBuilder/views/ComponentView.ts
@@ -5,8 +5,9 @@ import {BaseView, GenericViewBuilder} from './View'
 import {isRecord} from 'sanity'
 
 /**
- * @hidden
- * @beta */
+ * Interface for component views.
+ *
+ * @public */
 export interface ComponentView<TOptions = Record<string, any>> extends BaseView {
   type: 'component'
   component: UserViewComponent
@@ -17,8 +18,9 @@ const isComponentSpec = (spec: unknown): spec is ComponentView =>
   isRecord(spec) && spec.type === 'component'
 
 /**
- * @hidden
- * @beta */
+ * Class for building a component view.
+ *
+ * @public */
 export class ComponentViewBuilder extends GenericViewBuilder<
   Partial<ComponentView>,
   ComponentViewBuilder

--- a/packages/sanity/src/desk/structureBuilder/views/ComponentView.ts
+++ b/packages/sanity/src/desk/structureBuilder/views/ComponentView.ts
@@ -27,6 +27,7 @@ export class ComponentViewBuilder extends GenericViewBuilder<
   Partial<ComponentView>,
   ComponentViewBuilder
 > {
+  /** component view option object */
   protected spec: Partial<ComponentView>
 
   constructor(componentOrSpec?: UserViewComponent | Partial<ComponentView>) {
@@ -45,6 +46,7 @@ export class ComponentViewBuilder extends GenericViewBuilder<
   }
 
   /** Set view Component
+   * @param component - component view component
    * @returns component view builder based on component view provided
    */
   component(component: UserViewComponent): ComponentViewBuilder {
@@ -59,6 +61,7 @@ export class ComponentViewBuilder extends GenericViewBuilder<
   }
 
   /** Set view Component options
+   * @param options - component view options
    * @returns component view builder based on options provided
    */
   options(options: {[key: string]: any}): ComponentViewBuilder {
@@ -73,6 +76,7 @@ export class ComponentViewBuilder extends GenericViewBuilder<
   }
 
   /** Serialize view Component
+   * @param options - serialization options
    * @returns component view based on path provided in options
    *
    */
@@ -97,6 +101,7 @@ export class ComponentViewBuilder extends GenericViewBuilder<
   }
 
   /** Clone Component view builder (allows for options overriding)
+   * @param withSpec - new component view options
    * @returns component view builder
    */
   clone(withSpec?: Partial<ComponentView>): ComponentViewBuilder {

--- a/packages/sanity/src/desk/structureBuilder/views/ComponentView.ts
+++ b/packages/sanity/src/desk/structureBuilder/views/ComponentView.ts
@@ -44,22 +44,38 @@ export class ComponentViewBuilder extends GenericViewBuilder<
     }
   }
 
+  /** Set view Component
+   * @returns component view builder based on component view provided
+   */
   component(component: UserViewComponent): ComponentViewBuilder {
     return this.clone({component})
   }
 
+  /** Get view Component
+   * @returns component view component
+   */
   getComponent(): Partial<ComponentView>['component'] {
     return this.spec.component
   }
 
+  /** Set view Component options
+   * @returns component view builder based on options provided
+   */
   options(options: {[key: string]: any}): ComponentViewBuilder {
     return this.clone({options})
   }
 
+  /** Get view Component options
+   * @returns component view options
+   */
   getOptions(): ComponentView['options'] {
     return this.spec.options || {}
   }
 
+  /** Serialize view Component
+   * @returns component view based on path provided in options
+   *
+   */
   serialize(options: SerializeOptions = {path: []}): ComponentView {
     const base = super.serialize(options)
 
@@ -80,6 +96,9 @@ export class ComponentViewBuilder extends GenericViewBuilder<
     }
   }
 
+  /** Clone Component view builder (allows for options overriding)
+   * @returns component view builder
+   */
   clone(withSpec?: Partial<ComponentView>): ComponentViewBuilder {
     const builder = new ComponentViewBuilder()
     builder.spec = {...this.spec, ...(withSpec || {})}

--- a/packages/sanity/src/desk/structureBuilder/views/ComponentView.ts
+++ b/packages/sanity/src/desk/structureBuilder/views/ComponentView.ts
@@ -10,7 +10,7 @@ import {isRecord} from 'sanity'
  * @public */
 export interface ComponentView<TOptions = Record<string, any>> extends BaseView {
   type: 'component'
-  /** Component view components */
+  /** Component view components. See {@link UserViewComponent} */
   component: UserViewComponent
   /** Component view options */
   options: TOptions
@@ -27,10 +27,16 @@ export class ComponentViewBuilder extends GenericViewBuilder<
   Partial<ComponentView>,
   ComponentViewBuilder
 > {
-  /** component view option object */
+  /** Partial Component view option object. See {@link ComponentView} */
   protected spec: Partial<ComponentView>
 
-  constructor(componentOrSpec?: UserViewComponent | Partial<ComponentView>) {
+  constructor(
+    /**
+     * Component view component or spec
+     * @param componentOrSpec - user view component or partial component view. See {@link UserViewComponent} and {@link ComponentView}
+     */
+    componentOrSpec?: UserViewComponent | Partial<ComponentView>
+  ) {
     const spec = isComponentSpec(componentOrSpec) ? {...componentOrSpec} : {options: {}}
 
     super()
@@ -46,15 +52,15 @@ export class ComponentViewBuilder extends GenericViewBuilder<
   }
 
   /** Set view Component
-   * @param component - component view component
-   * @returns component view builder based on component view provided
+   * @param component - component view component. See {@link UserViewComponent}
+   * @returns component view builder based on component view provided. See {@link ComponentViewBuilder}
    */
   component(component: UserViewComponent): ComponentViewBuilder {
     return this.clone({component})
   }
 
   /** Get view Component
-   * @returns component view component
+   * @returns Partial component view. See {@link ComponentView}
    */
   getComponent(): Partial<ComponentView>['component'] {
     return this.spec.component
@@ -62,22 +68,22 @@ export class ComponentViewBuilder extends GenericViewBuilder<
 
   /** Set view Component options
    * @param options - component view options
-   * @returns component view builder based on options provided
+   * @returns component view builder based on options provided. See {@link ComponentViewBuilder}
    */
   options(options: {[key: string]: any}): ComponentViewBuilder {
     return this.clone({options})
   }
 
   /** Get view Component options
-   * @returns component view options
+   * @returns component view options. See {@link ComponentView}
    */
   getOptions(): ComponentView['options'] {
     return this.spec.options || {}
   }
 
   /** Serialize view Component
-   * @param options - serialization options
-   * @returns component view based on path provided in options
+   * @param options - serialization options. See {@link SerializeOptions}
+   * @returns component view based on path provided in options. See {@link ComponentView}
    *
    */
   serialize(options: SerializeOptions = {path: []}): ComponentView {
@@ -101,8 +107,8 @@ export class ComponentViewBuilder extends GenericViewBuilder<
   }
 
   /** Clone Component view builder (allows for options overriding)
-   * @param withSpec - new component view options
-   * @returns component view builder
+   * @param withSpec - partial for component view option. See {@link ComponentView}
+   * @returns component view builder. See {@link ComponentViewBuilder}
    */
   clone(withSpec?: Partial<ComponentView>): ComponentViewBuilder {
     const builder = new ComponentViewBuilder()

--- a/packages/sanity/src/desk/structureBuilder/views/FormView.ts
+++ b/packages/sanity/src/desk/structureBuilder/views/FormView.ts
@@ -24,6 +24,7 @@ export class FormViewBuilder extends GenericViewBuilder<Partial<BaseView>, FormV
 
   /**
    * Serialize Form view builder
+   * @param options - Serialize options
    * @returns form view builder based on path provided in options
    */
   serialize(options: SerializeOptions = {path: []}): FormView {
@@ -35,6 +36,7 @@ export class FormViewBuilder extends GenericViewBuilder<Partial<BaseView>, FormV
 
   /**
    * Clone Form view builder (allows for options overriding)
+   * @param withSpec - Form view builder options
    * @returns form view builder
    */
   clone(withSpec?: Partial<FormView>): FormViewBuilder {

--- a/packages/sanity/src/desk/structureBuilder/views/FormView.ts
+++ b/packages/sanity/src/desk/structureBuilder/views/FormView.ts
@@ -2,15 +2,17 @@ import {SerializeOptions} from '../StructureNodes'
 import {BaseView, GenericViewBuilder} from './View'
 
 /**
- * @hidden
- * @beta */
+ * Interface for form views.
+ *
+ * @public */
 export interface FormView extends BaseView {
   type: 'form'
 }
 
 /**
- * @hidden
- * @beta */
+ * Class for building a form view.
+ *
+ * @public */
 export class FormViewBuilder extends GenericViewBuilder<Partial<BaseView>, FormViewBuilder> {
   protected spec: Partial<FormView>
 

--- a/packages/sanity/src/desk/structureBuilder/views/FormView.ts
+++ b/packages/sanity/src/desk/structureBuilder/views/FormView.ts
@@ -14,7 +14,7 @@ export interface FormView extends BaseView {
  *
  * @public */
 export class FormViewBuilder extends GenericViewBuilder<Partial<BaseView>, FormViewBuilder> {
-  /** Document list options */
+  /** Document list options. See {@link FormView} */
   protected spec: Partial<FormView>
 
   constructor(spec?: Partial<FormView>) {
@@ -24,8 +24,8 @@ export class FormViewBuilder extends GenericViewBuilder<Partial<BaseView>, FormV
 
   /**
    * Serialize Form view builder
-   * @param options - Serialize options
-   * @returns form view builder based on path provided in options
+   * @param options - Serialize options. See {@link SerializeOptions}
+   * @returns form view builder based on path provided in options. See {@link FormView}
    */
   serialize(options: SerializeOptions = {path: []}): FormView {
     return {
@@ -36,8 +36,8 @@ export class FormViewBuilder extends GenericViewBuilder<Partial<BaseView>, FormV
 
   /**
    * Clone Form view builder (allows for options overriding)
-   * @param withSpec - Form view builder options
-   * @returns form view builder
+   * @param withSpec - Partial form view builder options. See {@link FormView}
+   * @returns form view builder. See {@link FormViewBuilder}
    */
   clone(withSpec?: Partial<FormView>): FormViewBuilder {
     const builder = new FormViewBuilder()

--- a/packages/sanity/src/desk/structureBuilder/views/FormView.ts
+++ b/packages/sanity/src/desk/structureBuilder/views/FormView.ts
@@ -14,6 +14,7 @@ export interface FormView extends BaseView {
  *
  * @public */
 export class FormViewBuilder extends GenericViewBuilder<Partial<BaseView>, FormViewBuilder> {
+  /** Document list options */
   protected spec: Partial<FormView>
 
   constructor(spec?: Partial<FormView>) {
@@ -21,6 +22,10 @@ export class FormViewBuilder extends GenericViewBuilder<Partial<BaseView>, FormV
     this.spec = {id: 'editor', title: 'Editor', ...(spec ? spec : {})}
   }
 
+  /**
+   * Serialize Form view builder
+   * @returns form view builder based on path provided in options
+   */
   serialize(options: SerializeOptions = {path: []}): FormView {
     return {
       ...super.serialize(options),
@@ -28,6 +33,10 @@ export class FormViewBuilder extends GenericViewBuilder<Partial<BaseView>, FormV
     }
   }
 
+  /**
+   * Clone Form view builder (allows for options overriding)
+   * @returns form view builder
+   */
   clone(withSpec?: Partial<FormView>): FormViewBuilder {
     const builder = new FormViewBuilder()
     builder.spec = {...this.spec, ...(withSpec || {})}

--- a/packages/sanity/src/desk/structureBuilder/views/View.ts
+++ b/packages/sanity/src/desk/structureBuilder/views/View.ts
@@ -124,7 +124,7 @@ export function maybeSerializeView(
 }
 
 /**
- * Type for view builder. See {@link ComponentViewBuilder} and {@link FormViewBuilder}
+ * View builder. See {@link ComponentViewBuilder} and {@link FormViewBuilder}
  *
  * @public
  */

--- a/packages/sanity/src/desk/structureBuilder/views/View.ts
+++ b/packages/sanity/src/desk/structureBuilder/views/View.ts
@@ -27,32 +27,53 @@ export interface BaseView {
 export abstract class GenericViewBuilder<TView extends Partial<BaseView>, ConcreteImpl>
   implements Serializable<BaseView>
 {
+  /** Generic view option object */
   protected spec: TView = {} as TView
 
+  /** Set generic view ID
+   * @returns generic view builder based on ID provided
+   */
   id(id: string): ConcreteImpl {
     return this.clone({id})
   }
-
+  /** Get generic view ID
+   * @returns generic view ID
+   */
   getId(): TView['id'] {
     return this.spec.id
   }
 
+  /** Set generic view title
+   * @returns generic view builder based on title provided and (if provided) its ID
+   */
   title(title: string): ConcreteImpl {
     return this.clone({title, id: this.spec.id || kebabCase(title)})
   }
 
+  /** Get generic view title
+   * @returns generic view title
+   */
   getTitle(): TView['title'] {
     return this.spec.title
   }
 
+  /** Set generic view icon
+   * @returns generic view builder based on icon provided
+   */
   icon(icon: React.ComponentType | React.ReactNode): ConcreteImpl {
     return this.clone({icon})
   }
 
+  /** Get generic view icon
+   * @returns generic view icon
+   */
   getIcon(): TView['icon'] {
     return this.spec.icon
   }
 
+  /** Serialize generic view
+   * @returns generic view object based on path provided in options
+   */
   serialize(options: SerializeOptions = {path: []}): BaseView {
     const {id, title, icon} = this.spec
     if (!id) {
@@ -78,6 +99,9 @@ export abstract class GenericViewBuilder<TView extends Partial<BaseView>, Concre
     }
   }
 
+  /** Clone generic view builder (allows for options overriding)
+   * @returns generic view builder
+   */
   abstract clone(withSpec?: Partial<BaseView>): ConcreteImpl
 }
 

--- a/packages/sanity/src/desk/structureBuilder/views/View.ts
+++ b/packages/sanity/src/desk/structureBuilder/views/View.ts
@@ -31,6 +31,7 @@ export abstract class GenericViewBuilder<TView extends Partial<BaseView>, Concre
   protected spec: TView = {} as TView
 
   /** Set generic view ID
+   * @param id - generic view ID
    * @returns generic view builder based on ID provided
    */
   id(id: string): ConcreteImpl {
@@ -44,6 +45,7 @@ export abstract class GenericViewBuilder<TView extends Partial<BaseView>, Concre
   }
 
   /** Set generic view title
+   * @param title - generic view title
    * @returns generic view builder based on title provided and (if provided) its ID
    */
   title(title: string): ConcreteImpl {
@@ -58,6 +60,7 @@ export abstract class GenericViewBuilder<TView extends Partial<BaseView>, Concre
   }
 
   /** Set generic view icon
+   * @param icon - generic view icon
    * @returns generic view builder based on icon provided
    */
   icon(icon: React.ComponentType | React.ReactNode): ConcreteImpl {
@@ -72,6 +75,7 @@ export abstract class GenericViewBuilder<TView extends Partial<BaseView>, Concre
   }
 
   /** Serialize generic view
+   * @param options - serialization options
    * @returns generic view object based on path provided in options
    */
   serialize(options: SerializeOptions = {path: []}): BaseView {
@@ -100,6 +104,7 @@ export abstract class GenericViewBuilder<TView extends Partial<BaseView>, Concre
   }
 
   /** Clone generic view builder (allows for options overriding)
+   * @param withSpec - generic view builder options
    * @returns generic view builder
    */
   abstract clone(withSpec?: Partial<BaseView>): ConcreteImpl

--- a/packages/sanity/src/desk/structureBuilder/views/View.ts
+++ b/packages/sanity/src/desk/structureBuilder/views/View.ts
@@ -32,7 +32,7 @@ export abstract class GenericViewBuilder<TView extends Partial<BaseView>, Concre
 
   /** Set generic view ID
    * @param id - generic view ID
-   * @returns generic view builder based on ID provided
+   * @returns generic view builder based on ID provided. See {@link ConcreteImpl}
    */
   id(id: string): ConcreteImpl {
     return this.clone({id})
@@ -46,7 +46,7 @@ export abstract class GenericViewBuilder<TView extends Partial<BaseView>, Concre
 
   /** Set generic view title
    * @param title - generic view title
-   * @returns generic view builder based on title provided and (if provided) its ID
+   * @returns generic view builder based on title provided and (if provided) its ID. See {@link ConcreteImpl}
    */
   title(title: string): ConcreteImpl {
     return this.clone({title, id: this.spec.id || kebabCase(title)})
@@ -61,7 +61,7 @@ export abstract class GenericViewBuilder<TView extends Partial<BaseView>, Concre
 
   /** Set generic view icon
    * @param icon - generic view icon
-   * @returns generic view builder based on icon provided
+   * @returns generic view builder based on icon provided. See {@link ConcreteImpl}
    */
   icon(icon: React.ComponentType | React.ReactNode): ConcreteImpl {
     return this.clone({icon})
@@ -75,8 +75,8 @@ export abstract class GenericViewBuilder<TView extends Partial<BaseView>, Concre
   }
 
   /** Serialize generic view
-   * @param options - serialization options
-   * @returns generic view object based on path provided in options
+   * @param options - serialization options. See {@link SerializeOptions}
+   * @returns generic view object based on path provided in options. See {@link BaseView}
    */
   serialize(options: SerializeOptions = {path: []}): BaseView {
     const {id, title, icon} = this.spec
@@ -104,8 +104,8 @@ export abstract class GenericViewBuilder<TView extends Partial<BaseView>, Concre
   }
 
   /** Clone generic view builder (allows for options overriding)
-   * @param withSpec - generic view builder options
-   * @returns generic view builder
+   * @param withSpec - Partial generic view builder options. See {@link BaseView}
+   * @returns Generic view builder. See {@link ConcreteImpl}
    */
   abstract clone(withSpec?: Partial<BaseView>): ConcreteImpl
 }
@@ -124,7 +124,7 @@ export function maybeSerializeView(
 }
 
 /**
- * Type for view builder
+ * Type for view builder. See {@link ComponentViewBuilder} and {@link FormViewBuilder}
  *
  * @public
  */

--- a/packages/sanity/src/desk/structureBuilder/views/View.ts
+++ b/packages/sanity/src/desk/structureBuilder/views/View.ts
@@ -7,17 +7,23 @@ import {ComponentViewBuilder} from './ComponentView'
 import {FormViewBuilder} from './FormView'
 
 /**
- * @hidden
- * @beta */
+ * Interface for base view
+ *
+ * @public */
 export interface BaseView {
+  /* View id */
   id: string
+  /* View Title */
   title: string
+  /* View Icon */
   icon?: React.ComponentType | React.ReactNode
 }
 
 /**
- * @hidden
- * @beta */
+ * Class for building generic views.
+ *
+ * @public
+ */
 export abstract class GenericViewBuilder<TView extends Partial<BaseView>, ConcreteImpl>
   implements Serializable<BaseView>
 {
@@ -89,6 +95,8 @@ export function maybeSerializeView(
 }
 
 /**
- * @hidden
- * @beta */
+ * Type for view builder
+ *
+ * @public
+ */
 export type ViewBuilder = ComponentViewBuilder | FormViewBuilder

--- a/packages/sanity/src/desk/structureBuilder/views/View.ts
+++ b/packages/sanity/src/desk/structureBuilder/views/View.ts
@@ -11,11 +11,11 @@ import {FormViewBuilder} from './FormView'
  *
  * @public */
 export interface BaseView {
-  /* View id */
+  /** View id */
   id: string
-  /* View Title */
+  /** View Title */
   title: string
-  /* View Icon */
+  /** View Icon */
   icon?: React.ComponentType | React.ReactNode
 }
 

--- a/packages/sanity/src/desk/types.ts
+++ b/packages/sanity/src/desk/types.ts
@@ -41,7 +41,7 @@ export interface DeskToolContextValue {
 }
 
 /**
- * Type for a desk tool context. Extends from ConfigContext.
+ *  Desk tool context. Extends from {@link ConfigContext}.
  *  @hidden
  *  @public
  */

--- a/packages/sanity/src/desk/types.ts
+++ b/packages/sanity/src/desk/types.ts
@@ -42,6 +42,7 @@ export interface DeskToolContextValue {
 
 /**
  * Type for a desk tool context. Extends from ConfigContext.
+ *  @hidden
  *  @public
  */
 export interface StructureResolverContext extends ConfigContext {
@@ -96,8 +97,7 @@ export type StructureResolver = (
    */
   S: StructureBuilder,
   /**
-   * An object containing pane and index
-   * {@link StructureResolverContext}
+   * An object containing pane and index information for the current desk tool.
    */
   context: StructureResolverContext
 ) => unknown

--- a/packages/sanity/src/desk/types.ts
+++ b/packages/sanity/src/desk/types.ts
@@ -68,24 +68,23 @@ export interface StructureResolverContext extends ConfigContext {
  * import {schemaTypes} from './schema'
  *
  * export default defineConfig({
- * name: 'default',
- * title: 'My Cool Project',
- * projectId: 'my-project-id',
- * dataset: 'production',
- * plugins: [
- *   deskTool({
- *     structure: (S, context) => {
- *       console.log(context) // returns { currentUser, dataset, projectId, schema, getClient, documentStore }
- *       return S.documentTypeList('post')
- *     },
- *   })
- * ],
- * schema: schemaTypes
+ *  name: 'default',
+ *  title: 'My Cool Project',
+ *  projectId: 'my-project-id',
+ *  dataset: 'production',
+ *  plugins: [
+ *    deskTool({
+ *      structure: (S, context) => {
+ *        console.log(context) // returns { currentUser, dataset, projectId, schema, getClient, documentStore }
+ *        return S.documentTypeList('post')
+ *      },
+ *    })
+ *  ],
+ *  schema: schemaTypes
  * })
  * ```
  *
  */
-// TODO: this should be updated to enforce the correct return type
 export type StructureResolver = (
   /**
    * S - An instance of the structure builder, that can be used to build the lists/items/panes for the desk tool

--- a/packages/sanity/src/desk/types.ts
+++ b/packages/sanity/src/desk/types.ts
@@ -40,7 +40,10 @@ export interface DeskToolContextValue {
   structureContext: StructureContext
 }
 
-/** @public */
+/**
+ * Type for a desk tool context. Extends from ConfigContext.
+ *  @public
+ */
 export interface StructureResolverContext extends ConfigContext {
   /**
    * This can be replaced by a different API in the future.
@@ -51,23 +54,94 @@ export interface StructureResolverContext extends ConfigContext {
 }
 
 /**
- * @hidden
- * @beta */
+ * Lets you configure how lists, documents, views, menus, and initial value templates are organized in the Sanity Studio’s desk-tool.
+ *
+ *  @public
+ *
+ * @returns A structure builder, or null/undefined if no structure should be returned.
+ * @example Configuring structure
+ * ```ts
+ * // sanity.config.js
+ *
+ * import {defineConfig} from 'sanity'
+ * import {deskTool} from 'sanity/desk'
+ * import {schemaTypes} from './schema'
+ *
+ * export default defineConfig({
+ * name: 'default',
+ * title: 'My Cool Project',
+ * projectId: 'my-project-id',
+ * dataset: 'production',
+ * plugins: [
+ *   deskTool({
+ *     structure: (S, context) => {
+ *       console.log(context) // returns { currentUser, dataset, projectId, schema, getClient, documentStore }
+ *       return S.documentTypeList('post')
+ *     },
+ *   })
+ * ],
+ * schema: schemaTypes
+ * })
+ * ```
+ *
+ */
 // TODO: this should be updated to enforce the correct return type
-export type StructureResolver = (S: StructureBuilder, context: StructureResolverContext) => unknown
+export type StructureResolver = (
+  /**
+   * S - An instance of the structure builder, that can be used to build the lists/items/panes for the desk tool
+   * context - an object holding various context that may be used to customize the structure, for instance the current user.
+   *  Defaults to
+   * ```ts
+   * (S) => S.defaults()
+   * ```
+   */
+  S: StructureBuilder,
+  /**
+   * An object containing pane and index
+   * {@link StructureResolverContext}
+   */
+  context: StructureResolverContext
+) => unknown
 
 /** @internal */
 export type DeskToolPaneActionHandler = (params: any, scope?: unknown) => void
 
 /**
- * @hidden
- * @beta */
+ * The params for the `deskTool` api
+ * {@link deskTool}
+ *
+ * @public */
 export interface DeskToolOptions {
+  /*
+   * React icon component for the tool, used in navigation bar. Defaults to MasterDetailIcon from @sanity/icons
+   */
   icon?: React.ComponentType
+  /*
+   * The name you want this desk to have (among other places, this name is used in routing,
+   * if name is set to “desk”, it is shown on /desk). Usually lowercase or camelcase by convention. Defaults to desk.
+   */
   name?: string
+  /**
+   * A workspace can have different "sources". These sources were meant to allow using multiple datasets within the same workspace, for instance. 
+   * This is not supported yet, but the API is still here.
+   * 
+    @hidden
+    @alpha
+  */
   source?: string
+  /**
+   * A structure resolver function.
+   * {@link StructureResolver}
+   */
   structure?: StructureResolver
+  /**
+   * A resolver function used to return the default document node used when editing documents.
+   * {@link DefaultDocumentNodeResolver}
+   */
   defaultDocumentNode?: DefaultDocumentNodeResolver
+  /**
+   * The title that will be displayed for the tool. Defaults to Desk
+   */
   title?: string
 }
 

--- a/packages/sanity/src/desk/types.ts
+++ b/packages/sanity/src/desk/types.ts
@@ -57,9 +57,9 @@ export interface StructureResolverContext extends ConfigContext {
 /**
  * Lets you configure how lists, documents, views, menus, and initial value templates are organized in the Sanity Studio’s desk-tool.
  *
- *  @public
+ * @public
  *
- * @returns A structure builder, or null/undefined if no structure should be returned.
+ * @returns A structure builder, or null/undefined if no structure should be returned. See {@link StructureBuilder}
  * @example Configuring structure
  * ```ts
  * // sanity.config.js
@@ -94,10 +94,12 @@ export type StructureResolver = (
    * ```ts
    * (S) => S.defaults()
    * ```
+   * See {@link StructureBuilder}
    */
   S: StructureBuilder,
   /**
    * An object containing pane and index information for the current desk tool.
+   * See {@link StructureResolverContext}
    */
   context: StructureResolverContext
 ) => unknown
@@ -106,8 +108,7 @@ export type StructureResolver = (
 export type DeskToolPaneActionHandler = (params: any, scope?: unknown) => void
 
 /**
- * The params for the `deskTool` api
- * {@link deskTool}
+ * The params for the `deskTool` api. See {@link deskTool}
  *
  * @public */
 export interface DeskToolOptions {
@@ -129,13 +130,11 @@ export interface DeskToolOptions {
   */
   source?: string
   /**
-   * A structure resolver function.
-   * {@link StructureResolver}
+   * A structure resolver function. See {@link StructureResolver}
    */
   structure?: StructureResolver
   /**
-   * A resolver function used to return the default document node used when editing documents.
-   * {@link DefaultDocumentNodeResolver}
+   * A resolver function used to return the default document node used when editing documents. See {@link DefaultDocumentNodeResolver}
    */
   defaultDocumentNode?: DefaultDocumentNodeResolver
   /**

--- a/packages/sanity/src/router/types.ts
+++ b/packages/sanity/src/router/types.ts
@@ -86,6 +86,7 @@ export interface BaseIntentParams {
    * Experimental field path
    * @beta
    * @experimental
+   * @hidden
    */
   path?: string
 }

--- a/packages/sanity/src/router/types.ts
+++ b/packages/sanity/src/router/types.ts
@@ -73,10 +73,35 @@ export type NavigateOptions = {
 
 /**
  * @public
+ * @todo dedupe with intent types in core
  */
-export type IntentParameters =
-  | Record<string, unknown>
-  | [Record<string, unknown>, Record<string, unknown>]
+export interface BaseIntentParams {
+  /* Intent type */
+  type?: string
+  /* Intent Id */
+  id?: string
+  /* Intent template */
+  template?: string
+  /**
+   * Experimental field path
+   * @beta
+   * @experimental
+   */
+  path?: string
+}
+
+/**
+ * Type for intent parameters (json)
+ *
+ * @public
+ */
+export type IntentJsonParams = {[key: string]: any}
+
+/**
+ * @public
+ * @todo dedupe with intent types in core
+ */
+export type IntentParameters = BaseIntentParams | [BaseIntentParams, IntentJsonParams]
 
 /**
  * @public

--- a/packages/sanity/src/router/types.ts
+++ b/packages/sanity/src/router/types.ts
@@ -92,7 +92,7 @@ export interface BaseIntentParams {
 }
 
 /**
- * Type for intent parameters (json)
+ * Intent parameters (json)
  *
  * @public
  */

--- a/packages/sanity/tsdoc.json
+++ b/packages/sanity/tsdoc.json
@@ -5,6 +5,11 @@
       "tagName": "@hidden",
       "syntaxKind": "block",
       "allowMultiple": true
+    },
+    {
+      "tagName": "@todo",
+      "syntaxKind": "block",
+      "allowMultiple": true
     }
   ],
   "supportForTags": {
@@ -22,6 +27,7 @@
     "@returns": true,
     "@remarks": true,
     "@throws": true,
-    "@defaultValue": true
+    "@defaultValue": true,
+    "@todo": true
   }
 }

--- a/packages/sanity/tsdoc.json
+++ b/packages/sanity/tsdoc.json
@@ -5,11 +5,6 @@
       "tagName": "@hidden",
       "syntaxKind": "block",
       "allowMultiple": true
-    },
-    {
-      "tagName": "@todo",
-      "syntaxKind": "block",
-      "allowMultiple": true
     }
   ],
   "supportForTags": {

--- a/packages/sanity/tsdoc.json
+++ b/packages/sanity/tsdoc.json
@@ -5,6 +5,11 @@
       "tagName": "@hidden",
       "syntaxKind": "block",
       "allowMultiple": true
+    },
+    {
+      "tagName": "@todo",
+      "syntaxKind": "block",
+      "allowMultiple": true
     }
   ],
   "supportForTags": {


### PR DESCRIPTION
### Description
 
<img src="https://github.com/sanity-io/sanity/assets/6951139/3a5ec1bc-280a-4e04-a5b6-d0e7728c8ce0" alt="it ain't much but it's honest work" width="300"/>


- [x] Write docs for desktool.
All apis moved from `@beta` to `@public` were done so because otherwise the five items that we had initially set as public wouldn't have made sense to exist and be exposed. 

### What to review

- These were meant to be 5 items which turned into 80ish when moving the needed stuff from `@beta` to `@public` :eye: 
- What does this mean? It means that a lot of items were moved because of tsdoc requesting the tags to match. Please review because some items might not make sense to be exposed in the docs website itself (so, while remaining `@public` should be `@hidden`)

### Notes for release

N/A