### PR TITLE
Add blockEditor definition to BlockDecoratorDefinition

### DIFF
--- a/packages/@sanity/types/src/schema/definition/type/block.ts
+++ b/packages/@sanity/types/src/schema/definition/type/block.ts
@@ -15,10 +15,17 @@ export interface BlockOptions {
 export interface BlockRule extends RuleDef<BlockRule, any[]> {}
 
 /** @public */
+export interface BlockEditorDefinition {
+  icon: ReactNode | ComponentType
+  render: ReactNode | ComponentType
+}
+
+/** @public */
 export interface BlockDecoratorDefinition {
   title: string
   value: string
   icon?: ReactNode | ComponentType
+  blockEditor?: BlockEditorDefinition
 }
 
 /** @public */


### PR DESCRIPTION
### Description
Adds a new interface definition `BlockEditorDefinition` to `packages/@sanity/types/src/schema/definition/type/block.ts` to define the blockEditor property. This will allow TypeScript users to simply use the blockEditor property without having to have `as BlockDecoratorDefinition` appended to the declaration.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Defining a block field in TypeScript with the blockEditor property. Overall, this is no more than a hotfix with really nothing being affected, as the only changes are to the block type interfaces and the blockEditor property is added as an optional property on the `BlockDecoratorDefinition`.
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Added the optional blockEditor property to the BlockDecoratorDefinition interface.
<!--
A description of the change(s) that should be used in the release notes.
-->
