### PR TITLE
test(e2e): retry once on failures, record video on retry

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,6 +37,8 @@ export default defineConfig({
   /* Maximum time one test can run for. */
   timeout: 30 * 1000,
 
+  retries: 1,
+
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -61,6 +61,7 @@ export default defineConfig({
     storageState: getStorageStateForProjectId(PROJECT_ID),
     viewport: {width: 1728, height: 1000},
     contextOptions: {reducedMotion: 'reduce'},
+    video: {mode: 'on-first-retry'},
   },
 
   /* Configure projects for major browsers */


### PR DESCRIPTION
### Description

When the end to end tests fail, it can be hard to debug what is actually causing it to fail - especially when it fails only on CI but not locally. This PR adds retrying on failures, and when that happens - also enables tracing and video recording.

### What to review

- Config looks correct

### Notes for release

None
