### PR TITLE
chore(perf): add support for --excludeTestIds and fail hard on unknown test-id

### DIFF
--- a/perf/cli.ts
+++ b/perf/cli.ts
@@ -20,6 +20,7 @@ async function main(args: {
   pattern?: string
   local?: boolean
   testIds?: string
+  excludeTestIds?: string
   count?: string
   label?: string
 }) {
@@ -98,6 +99,7 @@ async function main(args: {
     testFiles,
     deployments,
     testIds: args.testIds ? args.testIds.split(',') : undefined,
+    excludeTestIds: args.excludeTestIds ? args.excludeTestIds.split(',') : undefined,
     perfStudioClient,
     studioMetricsClient,
     registerHelpersFile: require.resolve(`${__dirname}/tests/helpers/register.ts`),
@@ -139,6 +141,10 @@ const {values: args} = parseArgs({
     testIds: {
       type: 'string',
       short: 'i',
+    },
+    excludeTestIds: {
+      type: 'string',
+      short: 'e',
     },
     count: {
       type: 'string',


### PR DESCRIPTION
### Description

Adds support for excluding one or more tests, and fails the test runner if an unknown test-id is given for either `--testIds` or 
`--excludeTestIds`

### Notes for release

N/A internal tooling