### PR TITLE
chore: dedupe `@sanity/icons` and update snapshot

### DIFF
--- a/packages/sanity/src/core/studio/Studio.test.tsx
+++ b/packages/sanity/src/core/studio/Studio.test.tsx
@@ -44,7 +44,7 @@ describe('Studio', () => {
     try {
       const html = renderToStaticMarkup(sheet.collectStyles(<Studio config={config} />))
       expect(html).toMatchInlineSnapshot(
-        `"<div data-ui=\\"Flex\\" data-scheme=\\"light\\" data-tone=\\"default\\" class=\\"sc-kcuKUB kEVEyA sc-jeCNp fjPKEK sc-kcuKUB ccGxHm sc-jrrXlR hqyqRw\\"><div data-ui=\\"Text\\" class=\\"sc-bgqQcB owQdh\\"><span>Loading…</span></div><div data-ui=\\"Spinner\\" class=\\"sc-bgqQcB owQdh sc-crozmw gfwpRZ\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\"></path></svg></span></div></div>"`
+        `"<div data-ui=\\"Flex\\" data-scheme=\\"light\\" data-tone=\\"default\\" class=\\"sc-kcuKUB kEVEyA sc-jeCNp fjPKEK sc-kcuKUB ccGxHm sc-jrrXlR hqyqRw\\"><div data-ui=\\"Text\\" class=\\"sc-bgqQcB owQdh\\"><span>Loading…</span></div><div data-ui=\\"Spinner\\" class=\\"sc-bgqQcB owQdh sc-crozmw gfwpRZ\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`
       )
     } finally {
       sheet.seal()
@@ -61,7 +61,7 @@ describe('Studio', () => {
     try {
       const html = renderToString(sheet.collectStyles(<Studio config={config} />))
       expect(html).toMatchInlineSnapshot(
-        `"<div data-ui=\\"Flex\\" data-scheme=\\"light\\" data-tone=\\"default\\" class=\\"sc-kcuKUB kEVEyA sc-jeCNp fjPKEK sc-kcuKUB ccGxHm sc-jrrXlR hqyqRw\\"><div data-ui=\\"Text\\" class=\\"sc-bgqQcB owQdh\\"><span>Loading…</span></div><div data-ui=\\"Spinner\\" class=\\"sc-bgqQcB owQdh sc-crozmw gfwpRZ\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\"></path></svg></span></div></div>"`
+        `"<div data-ui=\\"Flex\\" data-scheme=\\"light\\" data-tone=\\"default\\" class=\\"sc-kcuKUB kEVEyA sc-jeCNp fjPKEK sc-kcuKUB ccGxHm sc-jrrXlR hqyqRw\\"><div data-ui=\\"Text\\" class=\\"sc-bgqQcB owQdh\\"><span>Loading…</span></div><div data-ui=\\"Spinner\\" class=\\"sc-bgqQcB owQdh sc-crozmw gfwpRZ\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`
       )
     } finally {
       sheet.seal()
@@ -81,7 +81,7 @@ describe('Studio', () => {
       const html = renderToString(sheet.collectStyles(<Studio config={config} />))
       node.innerHTML = html
       expect(html).toMatchInlineSnapshot(
-        `"<div data-ui=\\"Flex\\" data-scheme=\\"light\\" data-tone=\\"default\\" class=\\"sc-kcuKUB kEVEyA sc-jeCNp fjPKEK sc-kcuKUB ccGxHm sc-jrrXlR hqyqRw\\"><div data-ui=\\"Text\\" class=\\"sc-bgqQcB owQdh\\"><span>Loading…</span></div><div data-ui=\\"Spinner\\" class=\\"sc-bgqQcB owQdh sc-crozmw gfwpRZ\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\"></path></svg></span></div></div>"`
+        `"<div data-ui=\\"Flex\\" data-scheme=\\"light\\" data-tone=\\"default\\" class=\\"sc-kcuKUB kEVEyA sc-jeCNp fjPKEK sc-kcuKUB ccGxHm sc-jrrXlR hqyqRw\\"><div data-ui=\\"Text\\" class=\\"sc-bgqQcB owQdh\\"><span>Loading…</span></div><div data-ui=\\"Spinner\\" class=\\"sc-bgqQcB owQdh sc-crozmw gfwpRZ\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`
       )
       document.head.innerHTML += sheet.getStyleTags()
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4616,12 +4616,7 @@
   resolved "https://registry.yarnpkg.com/@sanity/icons/-/icons-1.3.10.tgz#df934a94ae6669fe6b15515d800afb221cba0498"
   integrity sha512-5wVG/vIiGuGrSmq+Bl3PY7XDgQrGv0fyHdJI64FSulnr2wH3NMqZ6C59UFxnrZ93sr7kOt0zQFoNv2lkPBi0Cg==
 
-"@sanity/icons@^2", "@sanity/icons@^2.0.0", "@sanity/icons@^2.2.2", "@sanity/icons@^2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@sanity/icons/-/icons-2.3.1.tgz#38e0e85095a2ae41c7e9836aa4e4dbf1905ac68f"
-  integrity sha512-DyUdjjWFIokrMewnK24Vvxpv2lKx5LrzUM3eEk0ZVwhS8+hWkFFN1Z7jhcwQnQ5NweejhzsZkT4JHUdffCAQaw==
-
-"@sanity/icons@^2.4.0":
+"@sanity/icons@^2", "@sanity/icons@^2.0.0", "@sanity/icons@^2.2.2", "@sanity/icons@^2.3.1", "@sanity/icons@^2.4.0":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@sanity/icons/-/icons-2.4.1.tgz#34ce2c5b58f53c7369ff926b651ea57c4e3c0a8c"
   integrity sha512-/yxcIT0k1RxStI/pP/oHM44fHI6Oxiygf0jPcdV06Ce0xfFo+51UEqJSfE8hQ3fh+uFkat8ZZObZjq5v1ceJzw==


### PR DESCRIPTION
Follows up on @binoy14 [from](https://github.com/sanity-io/sanity/pull/4599#issuecomment-1607597138):
> the tests are failing. From looking at it, it seems like it's due to @sanity/icons version change. stroke-linejoin="round" is added to the svgs

This PR fixes that. Looks like it's a result from when @mariuslundgard updated `@sanity/icons` but it appears it the lockfile introduced a duplicate of `@sanity/icons`, which is why it didn't break the snapshot test at the time https://github.com/sanity-io/sanity/commit/0b2c40e9697f2712d541ab4f05c99e25b4094940