### PR TITLE
fix(core): increase button hit area of collapsible fieldset

### DIFF
--- a/packages/sanity/src/core/form/components/formField/FormFieldSetLegend.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldSetLegend.tsx
@@ -31,6 +31,7 @@ const ToggleButton = styled(Flex).attrs({forwardedAs: 'button'})((props: {theme:
     font: inherit;
     outline: none;
     border-radius: ${rem(radius[1])};
+    position: relative;
 
     &:not([hidden]) {
       display: flex;
@@ -42,6 +43,16 @@ const ToggleButton = styled(Flex).attrs({forwardedAs: 'button'})((props: {theme:
 
     &:focus:not(:focus-visible) {
       box-shadow: none;
+    }
+
+    /* Added to increase the hit area of the collapsible fieldset */
+    &::after {
+      content: '';
+      position: absolute;
+      top: -10px;
+      right: -10px;
+      bottom: -10px;
+      left: -10px;
     }
   `
 })


### PR DESCRIPTION
### Description

The hit area for the collapsable field appears tiny with the little arrow (even though you can press the text as well). This PR increases this area. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
<img width="663" alt="Screenshot 2023-06-27 at 14 54 22" src="https://github.com/sanity-io/sanity/assets/44635000/f4415b03-8703-49df-8d12-fbadffa7c604">

Expanding the fieldset has an increased hit area without affecting the design. 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fixes issue with small hit area for collapsible fieldsets. 
<!--
A description of the change(s) that should be used in the release notes.
-->
