### PR TITLE
chore: add @sanity/assist to test-studio workspace

### DIFF
--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -17,7 +17,7 @@
     "@react-three/cannon": "^6.4.0",
     "@react-three/drei": "^9.38.1",
     "@react-three/fiber": "^8.8.10",
-    "@sanity/assist": "^1.0.4",
+    "@sanity/assist": "^1.0.6",
     "@sanity/block-tools": "3.13.0",
     "@sanity/color": "^2.1.20",
     "@sanity/google-maps-input": "^3.0.1",

--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -17,6 +17,7 @@
     "@react-three/cannon": "^6.4.0",
     "@react-three/drei": "^9.38.1",
     "@react-three/fiber": "^8.8.10",
+    "@sanity/assist": "^1.0.4",
     "@sanity/block-tools": "3.13.0",
     "@sanity/color": "^2.1.20",
     "@sanity/google-maps-input": "^3.0.1",

--- a/dev/test-studio/sanity.cli.ts
+++ b/dev/test-studio/sanity.cli.ts
@@ -17,7 +17,7 @@ export default defineCliConfig({
       ...viteConfig,
       optimizeDeps: {
         ...viteConfig.optimizeDeps,
-        exclude: [...(viteConfig.optimizeDeps?.exclude || []), '@sanity/tsdoc'],
+        exclude: [...(viteConfig.optimizeDeps?.exclude || []), '@sanity/tsdoc', '@sanity/assist'],
       },
       // server: {
       //   ...viteConfig.server,

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -3,6 +3,7 @@ import {visionTool} from '@sanity/vision'
 import {defineConfig, definePlugin} from 'sanity'
 import {deskTool} from 'sanity/desk'
 import {muxInput} from 'sanity-plugin-mux-input'
+import {assist} from '@sanity/assist'
 import {theme as tailwindTheme} from 'https://themer.sanity.build/api/hues?preset=tw-cyan&default=64748b&primary=d946ef;lightest:fdf4ff;darkest:701a75&transparent=6b7180;darkest:111826&positive=43d675;400;lightest:f8fafc&caution=f59e09;300;lightest:fffbeb;darkest:783510&critical=f43f5e;lightest:fef1f2;darkest:881337&lightest=ffffff&darkest=0f172a'
 import {googleMapsInput} from '@sanity/google-maps-input'
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -215,5 +216,13 @@ export default defineConfig([
     basePath: '/tailwind',
     theme: tailwindTheme,
     icon: TailwindLogo,
+  },
+  {
+    name: 'ai-assist',
+    title: 'Sanity AI Assist',
+    projectId: 'ppsg7ml5',
+    dataset: 'test',
+    plugins: [sharedSettings(), assist()],
+    basePath: '/ai-assist',
   },
 ])

--- a/yarn.lock
+++ b/yarn.lock
@@ -4037,10 +4037,10 @@
   resolved "https://registry.yarnpkg.com/@sanity/asset-utils/-/asset-utils-1.3.0.tgz#6460cd993a2c24368a6308028f3bc57df91f131e"
   integrity sha512-uyIOtGA4Duf+68I3BSbYHY5P+WGftn3QtNJD2Pn7h9WPGYsSrWViIPebE9yRN8N0NHhYj+hDQXaMpVdjG7r+zA==
 
-"@sanity/assist@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@sanity/assist/-/assist-1.0.4.tgz#fd6faaceac385b3c4c937e81a576c32c56734eaa"
-  integrity sha512-thjKX42OQ+ShUn+d9Qea8nf6Mq+bz8lHZGq2QsNlSSSBbPpHGaf25OFCzIqr5dmQnDoEYmSsua3dqPIxEtG7Rw==
+"@sanity/assist@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@sanity/assist/-/assist-1.0.6.tgz#90c60eee0944f213fd33266cdad8a60b4d7afdfc"
+  integrity sha512-lWYTKL1S4kWqpwihxrMOJj8Un0qGwbQhParjF0FjjxzrzUconKFKoRWp/XY1eHKUrXC5BbAzJoZmvdnhXcQHTg==
   dependencies:
     "@sanity/icons" "^2.4.0"
     "@sanity/incompatible-plugin" "^1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4037,6 +4037,18 @@
   resolved "https://registry.yarnpkg.com/@sanity/asset-utils/-/asset-utils-1.3.0.tgz#6460cd993a2c24368a6308028f3bc57df91f131e"
   integrity sha512-uyIOtGA4Duf+68I3BSbYHY5P+WGftn3QtNJD2Pn7h9WPGYsSrWViIPebE9yRN8N0NHhYj+hDQXaMpVdjG7r+zA==
 
+"@sanity/assist@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@sanity/assist/-/assist-1.0.4.tgz#fd6faaceac385b3c4c937e81a576c32c56734eaa"
+  integrity sha512-thjKX42OQ+ShUn+d9Qea8nf6Mq+bz8lHZGq2QsNlSSSBbPpHGaf25OFCzIqr5dmQnDoEYmSsua3dqPIxEtG7Rw==
+  dependencies:
+    "@sanity/icons" "^2.4.0"
+    "@sanity/incompatible-plugin" "^1.0.4"
+    "@sanity/ui" "^1.6.0"
+    react-fast-compare "^3.2.1"
+    rxjs "^7.8.0"
+    rxjs-exhaustmap-with-trailing "^2.1.1"
+
 "@sanity/bifur-client@^0.3.1":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@sanity/bifur-client/-/bifur-client-0.3.1.tgz#9c80f31b6bfee3dbaf694e9db7d4f85dba3b79e2"
@@ -16250,6 +16262,11 @@ react-fast-compare@^3.2.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.1.tgz#53933d9e14f364281d6cba24bfed7a4afb808b5f"
   integrity sha512-xTYf9zFim2pEif/Fw16dBiXpe0hoy5PxcD8+OwBnTtNLfIm3g6WxhKNurY+6OmdH1u6Ta/W/Vl6vjbYP1MFnDg==
+
+react-fast-compare@^3.2.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"
+  integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
 
 react-focus-lock@^2.8.1:
   version "2.9.4"


### PR DESCRIPTION
### Description

Adds the @sanity/assist plugin to the test-studio. 
Adds a new workspace where it is enabled.

Did _not_ do any schema tailoring, which means assist field actions will be enabled for most types and fields in that workspace.

### What to review

Feel free to take it for a spin. 
Let me know if yet another workspace is too much.
