### PR TITLE
chore(deps): version bump @sanity/tsdoc

### DIFF
--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -24,7 +24,7 @@
     "@sanity/icons": "^2.4.0",
     "@sanity/image-url": "^1.0.2",
     "@sanity/portable-text-editor": "3.14.0",
-    "@sanity/tsdoc": "1.0.0-alpha.31",
+    "@sanity/tsdoc": "1.0.0-alpha.34",
     "@sanity/types": "3.14.0",
     "@sanity/ui": "^1.6.0",
     "@sanity/ui-workshop": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@playwright/test": "^1.31.2",
     "@sanity/client": "^6.1.5",
     "@sanity/pkg-utils": "^2.3.1",
-    "@sanity/tsdoc": "1.0.0-alpha.31",
+    "@sanity/tsdoc": "1.0.0-alpha.34",
     "@sanity/uuid": "^3.0.1",
     "@types/jest": "^27.0.3",
     "@types/mkdirp": "^1.0.2",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -229,7 +229,7 @@
     "yargs": "^17.3.0"
   },
   "devDependencies": {
-    "@sanity/tsdoc": "1.0.0-alpha.31",
+    "@sanity/tsdoc": "1.0.0-alpha.34",
     "@sanity/ui-workshop": "^1.0.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4209,10 +4209,10 @@
     scroll-into-view-if-needed "^2.2.20"
     tiny-invariant "1.0.6"
 
-"@sanity/tsdoc@1.0.0-alpha.31":
-  version "1.0.0-alpha.31"
-  resolved "https://registry.yarnpkg.com/@sanity/tsdoc/-/tsdoc-1.0.0-alpha.31.tgz#a6b7e837b672141f125643506788ed1841a29aab"
-  integrity sha512-aSEhdi5HTkwS4P+fHXE2KfiIcFEkLMXLVY3I4biwmi/upOu7i3JjF2w4aMsew2i95Vm6aimwqLynkvwRvWzazg==
+"@sanity/tsdoc@1.0.0-alpha.34":
+  version "1.0.0-alpha.34"
+  resolved "https://registry.yarnpkg.com/@sanity/tsdoc/-/tsdoc-1.0.0-alpha.34.tgz#e5f33db7836a3d72442ff85ff48e35fc2ba31802"
+  integrity sha512-k5kuVRFeN/lang85UWBQjgZ/KwOX7tveG4qkvSvy4Dy9lV4ge3+1W2DYKnvHflMTm8LnRqBjQsEpxONJWRNHlA==
   dependencies:
     "@microsoft/api-extractor" "7.35.0"
     "@microsoft/api-extractor-model" "7.27.0"


### PR DESCRIPTION
### Description

Version bumps tsdoc, notable changes include fixing playground to work in the monorepo

### What to review

Fixes `yarn tsdoc:dev` Instructions 

1. `yarn build` at the root
2. `yarn etl sanity` at the root
3. `yarn tsdoc:dev` at the root

Check if the playground shows the docs

### Notes for release

N/A
