### PR TITLE
fix: upgrade `next-sanity` in `init` to `v5`

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -373,11 +373,11 @@ export default async function initSanity(
     }
 
     if (chosen === 'npm') {
-      await execa('npm', ['install', 'next-sanity@4'], execOptions)
+      await execa('npm', ['install', 'next-sanity@5'], execOptions)
     } else if (chosen === 'yarn') {
-      await execa('npx', ['install-peerdeps', '--yarn', 'next-sanity@4'], execOptions)
+      await execa('npx', ['install-peerdeps', '--yarn', 'next-sanity@5'], execOptions)
     } else if (chosen === 'pnpm') {
-      await execa('pnpm', ['install', 'next-sanity@4'], execOptions)
+      await execa('pnpm', ['install', 'next-sanity@5'], execOptions)
     }
 
     print(


### PR DESCRIPTION
### Description

Fixes a problem where new validation in the latest version of `@sanity/client` throws an error if you're not using the latest version of `next-sanity`

### What to review

Test `sanity init` on a Next.js project that queries data from Content Lake, and chose 'yes' to embedding Studio. It should no longer throw an error.

### Notes for release

- fix: upgrade `next-sanity` to `v5` when using `sanity init` in a Next.js project
