### PR TITLE
fix(core): add aria-label to resources button

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/resources/ResourcesButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/ResourcesButton.tsx
@@ -30,7 +30,14 @@ export function ResourcesButton() {
       >
         <div>
           <MenuButton
-            button={<Button icon={HelpCircleIcon} mode="bleed" fontSize={2} />}
+            button={
+              <Button
+                aria-label="Help and resources"
+                icon={HelpCircleIcon}
+                mode="bleed"
+                fontSize={2}
+              />
+            }
             id="menu-button-resources"
             menu={
               <StyledMenu>


### PR DESCRIPTION
### Description
The `Help and resources` button was missing an `aria-label` for accessibility. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
