### PR TITLE
fix(core): fixes crash when custom array input is hidden

### DIFF
--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.tsx
@@ -164,6 +164,13 @@ export function ListArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
   const listGridGap = 1
   const paddingY = 1
 
+  // If the item is visible. Custom component could be using a hidden display
+  const isItemVisible = !!(
+    elementProps.ref?.current?.offsetWidth ||
+    elementProps.ref?.current?.offsetHeight ||
+    elementProps.ref?.current?.getClientRects().length
+  )
+
   return (
     <Stack space={3} ref={parentRef}>
       <UploadTargetCard
@@ -212,38 +219,40 @@ export function ListArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
                   transform: `translateY(${items[0].start}px)`,
                 }}
               >
-                {items.map((virtualRow) => {
-                  const member = members[virtualRow.index]
-                  return (
-                    <Item
-                      ref={virtualizer.measureElement}
-                      key={virtualRow.key}
-                      sortable={sortable}
-                      data-index={virtualRow.index}
-                      id={member.key}
-                    >
-                      {member.kind === 'item' && (
-                        <ArrayOfObjectsItem
-                          member={member}
-                          renderAnnotation={renderAnnotation}
-                          renderBlock={renderBlock}
-                          renderField={renderField}
-                          renderInlineBlock={renderInlineBlock}
-                          renderInput={renderInput}
-                          renderItem={renderItem}
-                          renderPreview={renderPreview}
-                        />
-                      )}
-                      {member.kind === 'error' && (
-                        <ErrorItem
+                {isItemVisible === true
+                  ? items.map((virtualRow) => {
+                      const member = members[virtualRow.index]
+                      return (
+                        <Item
+                          ref={virtualizer.measureElement}
+                          key={virtualRow.key}
                           sortable={sortable}
-                          member={member}
-                          onRemove={() => props.onItemRemove(member.key)}
-                        />
-                      )}
-                    </Item>
-                  )
-                })}
+                          data-index={virtualRow.index}
+                          id={member.key}
+                        >
+                          {member.kind === 'item' && (
+                            <ArrayOfObjectsItem
+                              member={member}
+                              renderAnnotation={renderAnnotation}
+                              renderBlock={renderBlock}
+                              renderField={renderField}
+                              renderInlineBlock={renderInlineBlock}
+                              renderInput={renderInput}
+                              renderItem={renderItem}
+                              renderPreview={renderPreview}
+                            />
+                          )}
+                          {member.kind === 'error' && (
+                            <ErrorItem
+                              sortable={sortable}
+                              member={member}
+                              onRemove={() => props.onItemRemove(member.key)}
+                            />
+                          )}
+                        </Item>
+                      )
+                    })
+                  : null}
               </List>
             </Card>
           )}


### PR DESCRIPTION
### Description

If a custom component is using display hidden then it fixes the crash by not rendering the arrays.

```tsx
export const CustomArray = (props: any) => {
  return (
    <div style={{display: "none"}}>
      {props.renderDefault(props)}
    </div>
  )
}

export const deepArray = {
  type: 'document',
  name: 'deepArray',
  fields: [
    {
      name: 'deep',
      type: 'array',
      of: [{type: 'deepArray'}],
      components: {
        input: CustomArray,
      },
    },
  ],
}
```

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->


### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
