### PR TITLE
fix(core): add logic to focusFirst in customised popover

### DIFF
--- a/packages/sanity/src/core/form/inputs/files/FileInput/FileActionsMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/FileActionsMenu.tsx
@@ -1,5 +1,5 @@
 import {BinaryDocumentIcon, EllipsisVerticalIcon} from '@sanity/icons'
-import React, {ReactNode, useCallback, useState} from 'react'
+import React, {ReactNode, useCallback, useEffect, useState} from 'react'
 import {
   Box,
   Button,
@@ -40,6 +40,7 @@ export function FileActionsMenu(props: Props) {
   } = props
   const [menuElement, setMenuElement] = useState<HTMLDivElement | null>(null)
   const [buttonElement, setButtonElement] = useState<HTMLButtonElement | null>(null)
+  const [shouldFocus, setShouldFocus] = useState<'first' | undefined>('first')
 
   const handleClick = useCallback(() => onMenuOpen(true), [onMenuOpen])
 
@@ -53,6 +54,17 @@ export function FileActionsMenu(props: Props) {
     },
     [setMenuButtonElement]
   )
+
+  //Necessary to prevent focus to be on first element when hovering over MenuDivider
+  useEffect(() => {
+    if (isMenuOpen) {
+      setTimeout(() => setShouldFocus(undefined), 1)
+    }
+
+    if (!isMenuOpen) {
+      setShouldFocus('first')
+    }
+  }, [isMenuOpen])
 
   useGlobalKeyDown(
     useCallback(
@@ -101,7 +113,15 @@ export function FileActionsMenu(props: Props) {
 
       <Box padding={2}>
         <Flex justify="center">
-          <Popover content={<Menu ref={setMenuElement}>{children}</Menu>} portal open={isMenuOpen}>
+          <Popover
+            content={
+              <Menu ref={setMenuElement} shouldFocus={shouldFocus}>
+                {children}
+              </Menu>
+            }
+            portal
+            open={isMenuOpen}
+          >
             <Button
               data-testid="options-menu-button"
               icon={EllipsisVerticalIcon}

--- a/packages/sanity/src/core/form/inputs/files/FileInput/FileActionsMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/FileActionsMenu.tsx
@@ -113,6 +113,8 @@ export function FileActionsMenu(props: Props) {
 
       <Box padding={2}>
         <Flex justify="center">
+          {/* Using a customized Popover instead of MenuButton because a MenuButton will close on click
+     and break replacing an uploaded file. */}
           <Popover
             content={
               <Menu ref={setMenuElement} shouldFocus={shouldFocus}>

--- a/packages/sanity/src/core/form/inputs/files/FileInput/FileActionsMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/FileActionsMenu.tsx
@@ -101,15 +101,7 @@ export function FileActionsMenu(props: Props) {
 
       <Box padding={2}>
         <Flex justify="center">
-          <Popover
-            content={
-              <Menu ref={setMenuElement} shouldFocus="first">
-                {children}
-              </Menu>
-            }
-            portal
-            open={isMenuOpen}
-          >
+          <Popover content={<Menu ref={setMenuElement}>{children}</Menu>} portal open={isMenuOpen}>
             <Button
               data-testid="options-menu-button"
               icon={EllipsisVerticalIcon}

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageActionsMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageActionsMenu.tsx
@@ -32,7 +32,6 @@ export function ImageActionsMenu(props: ImageActionsMenuProps) {
 
   const [menuElement, setMenuElement] = useState<HTMLDivElement | null>(null)
   const [buttonElement, setButtonElement] = useState<HTMLButtonElement | null>(null)
-  const [shouldFocus, setShouldFocus] = useState<'first' | undefined>('first')
 
   const handleClick = useCallback(() => onMenuOpen(!isMenuOpen), [onMenuOpen, isMenuOpen])
 
@@ -47,17 +46,6 @@ export function ImageActionsMenu(props: ImageActionsMenuProps) {
       [isMenuOpen, onMenuOpen, buttonElement]
     )
   )
-
-  //Necessary to prevent focus to be on first element when hovering over MenuDivider
-  useEffect(() => {
-    if (isMenuOpen) {
-      setTimeout(() => setShouldFocus(undefined), 1)
-    }
-
-    if (!isMenuOpen) {
-      setShouldFocus('first')
-    }
-  }, [isMenuOpen])
 
   // Close menu when clicking outside of it
   // Not when clicking on the button
@@ -84,6 +72,13 @@ export function ImageActionsMenu(props: ImageActionsMenuProps) {
     [setMenuButtonElement]
   )
 
+  // When the popover is open, focus the menu to enable keyboard navigation
+  useEffect(() => {
+    if (isMenuOpen) {
+      menuElement?.focus()
+    }
+  }, [isMenuOpen, menuElement])
+
   return (
     <MenuActionsWrapper data-buttons space={1} padding={2}>
       {showEdit && (
@@ -100,11 +95,7 @@ export function ImageActionsMenu(props: ImageActionsMenuProps) {
      and break replacing an uploaded file. */}
       <Popover
         id="image-actions-menu"
-        content={
-          <Menu ref={setMenuElement} shouldFocus={shouldFocus}>
-            {children}
-          </Menu>
-        }
+        content={<Menu ref={setMenuElement}>{children}</Menu>}
         portal
         open={isMenuOpen}
         constrainSize

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageActionsMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageActionsMenu.tsx
@@ -96,7 +96,8 @@ export function ImageActionsMenu(props: ImageActionsMenuProps) {
           ref={setHotspotButtonElement}
         />
       )}
-
+      {/* Using a customized Popover instead of MenuButton because a MenuButton will close on click
+     and break replacing an uploaded file. */}
       <Popover
         id="image-actions-menu"
         content={

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageActionsMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageActionsMenu.tsx
@@ -87,11 +87,7 @@ export function ImageActionsMenu(props: ImageActionsMenuProps) {
 
       <Popover
         id="image-actions-menu"
-        content={
-          <Menu ref={setMenuElement} shouldFocus="first">
-            {children}
-          </Menu>
-        }
+        content={<Menu ref={setMenuElement}>{children}</Menu>}
         portal
         open={isMenuOpen}
         constrainSize

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageActionsMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageActionsMenu.tsx
@@ -1,4 +1,4 @@
-import React, {MouseEventHandler, ReactNode, useCallback, useState} from 'react'
+import React, {MouseEventHandler, ReactNode, useCallback, useEffect, useState} from 'react'
 import {EllipsisVerticalIcon, CropIcon} from '@sanity/icons'
 import {Button, Inline, Menu, Popover, useClickOutside, useGlobalKeyDown} from '@sanity/ui'
 import styled from 'styled-components'
@@ -32,6 +32,7 @@ export function ImageActionsMenu(props: ImageActionsMenuProps) {
 
   const [menuElement, setMenuElement] = useState<HTMLDivElement | null>(null)
   const [buttonElement, setButtonElement] = useState<HTMLButtonElement | null>(null)
+  const [shouldFocus, setShouldFocus] = useState<'first' | undefined>('first')
 
   const handleClick = useCallback(() => onMenuOpen(!isMenuOpen), [onMenuOpen, isMenuOpen])
 
@@ -46,6 +47,17 @@ export function ImageActionsMenu(props: ImageActionsMenuProps) {
       [isMenuOpen, onMenuOpen, buttonElement]
     )
   )
+
+  //Necessary to prevent focus to be on first element when hovering over MenuDivider
+  useEffect(() => {
+    if (isMenuOpen) {
+      setTimeout(() => setShouldFocus(undefined), 1)
+    }
+
+    if (!isMenuOpen) {
+      setShouldFocus('first')
+    }
+  }, [isMenuOpen])
 
   // Close menu when clicking outside of it
   // Not when clicking on the button
@@ -87,7 +99,11 @@ export function ImageActionsMenu(props: ImageActionsMenuProps) {
 
       <Popover
         id="image-actions-menu"
-        content={<Menu ref={setMenuElement}>{children}</Menu>}
+        content={
+          <Menu ref={setMenuElement} shouldFocus={shouldFocus}>
+            {children}
+          </Menu>
+        }
         portal
         open={isMenuOpen}
         constrainSize

--- a/packages/sanity/src/core/form/inputs/files/common/FileInputMenuItem/FileInputMenuItem.styled.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/FileInputMenuItem/FileInputMenuItem.styled.tsx
@@ -2,7 +2,7 @@ import {Theme, MenuItem} from '@sanity/ui'
 import styled, {css} from 'styled-components'
 import {focusRingStyle} from '../../../../components/withFocusRing/helpers'
 
-export const FileButton = styled(MenuItem)(({theme}: {theme: Theme}) => {
+export const FileButton = styled(MenuItem)(({theme}: {theme: Theme; showFocusRing: boolean}) => {
   const {focusRing} = theme.sanity
   const base = theme.sanity.color.base
   const border = {width: 1, color: 'var(--card-border-color)'}
@@ -10,9 +10,11 @@ export const FileButton = styled(MenuItem)(({theme}: {theme: Theme}) => {
   return css`
     position: relative;
 
-    &:not([data-disabled='true']) {
-      &:focus-within {
-        box-shadow: ${focusRingStyle({base, border, focusRing})};
+    showFocusRing && {
+      &:not([data-disabled='true']) {
+        &:focus-within {
+          box-shadow: ${focusRingStyle({base, border, focusRing})};
+        }
       }
     }
 

--- a/packages/sanity/src/core/form/inputs/files/common/FileInputMenuItem/FileInputMenuItem.styled.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/FileInputMenuItem/FileInputMenuItem.styled.tsx
@@ -1,38 +1,23 @@
-import {Theme, MenuItem} from '@sanity/ui'
-import styled, {css} from 'styled-components'
-import {focusRingStyle} from '../../../../components/withFocusRing/helpers'
+import {MenuItem} from '@sanity/ui'
+import styled from 'styled-components'
 
-export const FileButton = styled(MenuItem)(({theme}: {theme: Theme; showFocusRing: boolean}) => {
-  const {focusRing} = theme.sanity
-  const base = theme.sanity.color.base
-  const border = {width: 1, color: 'var(--card-border-color)'}
+export const FileMenuItem = styled(MenuItem)`
+  position: relative;
 
-  return css`
-    position: relative;
-
-    showFocusRing && {
-      &:not([data-disabled='true']) {
-        &:focus-within {
-          box-shadow: ${focusRingStyle({base, border, focusRing})};
-        }
-      }
-    }
-
-    & input {
-      overflow: hidden;
-      overflow: clip;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      position: absolute;
-      min-width: 0;
-      display: block;
-      appearance: none;
-      padding: 0;
-      margin: 0;
-      border: 0;
-      opacity: 0;
-    }
-  `
-})
+  & input {
+    overflow: hidden;
+    overflow: clip;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    min-width: 0;
+    display: block;
+    appearance: none;
+    padding: 0;
+    margin: 0;
+    border: 0;
+    opacity: 0;
+  }
+`

--- a/packages/sanity/src/core/form/inputs/files/common/FileInputMenuItem/FileInputMenuItem.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/FileInputMenuItem/FileInputMenuItem.tsx
@@ -71,6 +71,7 @@ export const FileInputMenuItem = React.forwardRef(function FileInputMenuItem(
       fontSize={2}
       disabled={disabled}
       ref={forwardedRef}
+      showFocusRing={false}
     >
       {content}
 

--- a/packages/sanity/src/core/form/inputs/files/common/FileInputMenuItem/FileInputMenuItem.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/FileInputMenuItem/FileInputMenuItem.tsx
@@ -1,7 +1,7 @@
 import React, {createElement, isValidElement, useId} from 'react'
 import {isValidElementType} from 'react-is'
 import {Box, ButtonProps, Flex, Text} from '@sanity/ui'
-import {FileButton} from './FileInputMenuItem.styled'
+import {FileMenuItem} from './FileInputMenuItem.styled'
 
 export interface FileInputMenuItemProps extends ButtonProps {
   accept?: string
@@ -64,20 +64,19 @@ export const FileInputMenuItem = React.forwardRef(function FileInputMenuItem(
   )
 
   return (
-    <FileButton
+    <FileMenuItem
       {...rest}
       htmlFor={id}
       padding={0}
       fontSize={2}
       disabled={disabled}
       ref={forwardedRef}
-      showFocusRing={false}
     >
       {content}
 
       {/* Visibly hidden input */}
       <input
-        data-testid="file-button-input"
+        data-testid="file-menuitem-input"
         accept={accept}
         capture={capture}
         id={id}
@@ -87,6 +86,6 @@ export const FileInputMenuItem = React.forwardRef(function FileInputMenuItem(
         value=""
         disabled={disabled}
       />
-    </FileButton>
+    </FileMenuItem>
   )
 })


### PR DESCRIPTION
### Description
There was a bug with the focus in the dropdown menu. Focus on hover would jump back to the first item when hovering over the dividers for dropdown menu for file/image. 

https://github.com/sanity-io/sanity/assets/44635000/43709138-4573-4912-b507-9f1830167d09

This pr adds logic to focus on first element only when the menu is closed, preventing the focus to be on the first element when hovering over the dividers. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
The dropdown menu for the file and image. 
<img width="645" alt="Screenshot 2023-07-05 at 14 34 31" src="https://github.com/sanity-io/sanity/assets/44635000/8d99d769-239e-4fec-8138-0e6b3472fa41">

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fixes issue where focus would jump to first element when hovering divider in menu
<!--
A description of the change(s) that should be used in the release notes.
-->
