### PR TITLE
fix(core): restore not working on nested panes

### DIFF
--- a/packages/sanity/src/desk/documentActions/HistoryRestoreAction.tsx
+++ b/packages/sanity/src/desk/documentActions/HistoryRestoreAction.tsx
@@ -11,8 +11,8 @@ export const HistoryRestoreAction: DocumentActionComponent = ({id, type, revisio
 
   const handleConfirm = useCallback(() => {
     restore.execute(revision!)
-    navigateIntent('edit', {id, type})
     onComplete()
+    navigateIntent('edit', {id, type})
   }, [restore, revision, navigateIntent, id, type, onComplete])
 
   const handle = useCallback(() => {

--- a/packages/sanity/src/desk/documentActions/HistoryRestoreAction.tsx
+++ b/packages/sanity/src/desk/documentActions/HistoryRestoreAction.tsx
@@ -12,7 +12,8 @@ export const HistoryRestoreAction: DocumentActionComponent = ({id, type, revisio
   const handleConfirm = useCallback(() => {
     restore.execute(revision!)
     onComplete()
-    navigateIntent('edit', {id, type})
+    // wrapping in setTimeout gives the onComplete time to finish before navigating
+    setTimeout(() => navigateIntent('edit', {id, type}), 0)
   }, [restore, revision, navigateIntent, id, type, onComplete])
 
   const handle = useCallback(() => {


### PR DESCRIPTION
### Description

When an item is restored in a nested pane or in a filtered view it does not actually restore after the confirmation and reverts back to the original state. 

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

I am not sure if this is the correct fix honestly but from my testing this seems to fix the issue where we run the complete actions first before navigating to an intent. Please let me know if this makes sense or if there is some better way to solve this

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

- Fixes an issue where restore document does not work in nested pane view