### PR TITLE
Feat/range decorations

### DIFF
--- a/dev/test-studio/schema/index.ts
+++ b/dev/test-studio/schema/index.ts
@@ -13,6 +13,7 @@ import blocks from './standard/portableText/blocks'
 import {ptCustomMarkersTestType} from './standard/portableText/customMarkers'
 import richTextObject from './standard/portableText/richTextObject'
 import simpleBlock from './standard/portableText/simpleBlock'
+import customBlockType from './standard/portableText/customBlockType'
 import manyEditors from './standard/portableText/manyEditors'
 import simpleBlockNote from './standard/portableText/simpleBlockNote'
 import simpleBlockNoteBody from './standard/portableText/simpleBlockNoteBody'
@@ -229,6 +230,7 @@ export const schemaTypes = [
   richTextObject,
   ...Object.values(scrollBugTypes),
   select,
+  customBlockType,
   simpleBlock,
   simpleBlockNote,
   simpleBlockNoteBody,

--- a/dev/test-studio/schema/standard/portableText/PortableTextInputWithSpecialChars.tsx
+++ b/dev/test-studio/schema/standard/portableText/PortableTextInputWithSpecialChars.tsx
@@ -1,0 +1,213 @@
+/* eslint-disable max-nested-callbacks */
+import React, {
+  MouseEvent,
+  PropsWithChildren,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import {Button, Card, Grid, Popover, useClickOutside, useGlobalKeyDown, useTheme} from '@sanity/ui'
+import {InputProps, Path, PortableTextInput, PortableTextInputProps, PortableTextSpan} from 'sanity'
+import {
+  EditorChange,
+  HotkeyOptions,
+  PortableTextEditor,
+  RangeDecoration,
+} from '@sanity/portable-text-editor'
+import {isEqual} from 'lodash'
+
+export interface BlackListLocation {
+  matchText: string
+  message: string
+  offset: number
+  path: Path
+  span: PortableTextSpan
+  level: 'error' | 'info' | 'warning'
+}
+
+const BlackListHighlighter = (props: PropsWithChildren & {level: BlackListLocation['level']}) => {
+  const theme = useTheme()
+  const level = 'level' in props && typeof props.level === 'string' ? props.level : undefined
+  let color
+  switch (level) {
+    case 'info':
+      color = theme.sanity.color.solid.positive.enabled.bg
+      break
+    case 'warning':
+      color = theme.sanity.color.solid.caution.enabled.bg
+      break
+    default:
+      color = theme.sanity.color.solid.critical.enabled.bg
+  }
+  return (
+    <span style={{backgroundColor: color, backgroundBlendMode: 'multiply'}}>{props.children}</span>
+  )
+}
+
+export const PortableTextInputWithSpecialCharacters = (props: InputProps) => {
+  const portableTextInputProps = props as PortableTextInputProps
+  const [showInsertCharacterMenu, setShowInsertCharacterMenu] = useState(false)
+  const [cursorRect, setCursorRect] = useState<DOMRect | null>(null)
+  const [popoverElement, setPopoverElement] = useState<HTMLDivElement | null>(null)
+  const [rangeDecorations, setRangeDecorations] = useState<RangeDecoration[]>([])
+
+  const editorRef = useRef<PortableTextEditor | null>(null)
+
+  const handleSelectionChange = useCallback(() => {
+    const selection = window.getSelection()
+    const range = selection?.getRangeAt(0)
+    const rect = range?.getBoundingClientRect()
+    setCursorRect(rect || null)
+  }, [])
+
+  const cursorElement = useMemo(() => {
+    if (!cursorRect) {
+      return null
+    }
+    return {
+      getBoundingClientRect: () => {
+        return cursorRect
+      },
+    }
+  }, [cursorRect]) as HTMLElement
+
+  const hotkeys: HotkeyOptions = useMemo(
+    () => ({
+      custom: {
+        'ctrl+shift+-': () => {
+          setShowInsertCharacterMenu(true)
+        },
+      },
+    }),
+    []
+  )
+
+  const closeMenu = useCallback(() => {
+    setShowInsertCharacterMenu(false)
+    if (editorRef.current) {
+      PortableTextEditor.focus(editorRef.current)
+    }
+  }, [])
+
+  useClickOutside(closeMenu, [popoverElement])
+
+  useGlobalKeyDown((event) => {
+    if (event.key === 'Escape') {
+      closeMenu()
+    }
+  })
+
+  useEffect(() => {
+    document.addEventListener('selectionchange', handleSelectionChange, {
+      passive: true,
+    })
+
+    return () => {
+      document.removeEventListener('selectionchange', handleSelectionChange)
+    }
+  }, [handleSelectionChange])
+
+  const handleInsertCharacterButtonClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      closeMenu()
+      if (editorRef.current && event.currentTarget.textContent) {
+        const spanSchemaType = editorRef.current.schemaTypes.span
+        PortableTextEditor.insertChild(editorRef.current, spanSchemaType, {
+          text: event.currentTarget.textContent,
+        })
+        PortableTextEditor.focus(editorRef.current)
+      }
+    },
+    [editorRef, closeMenu]
+  )
+
+  const setRangeDecorators = useCallback(() => {
+    const decorations: RangeDecoration[] = []
+    portableTextInputProps.members.forEach((member) => {
+      if (member.kind !== 'item') {
+        return
+      }
+      const validation = (member.kind === 'item' && member.item.validation) || []
+      validation.forEach((item) => {
+        const {metaData} = item
+        if (metaData && typeof metaData === 'object' && 'blacklistMatchLocations' in metaData) {
+          const locations = metaData.blacklistMatchLocations as BlackListLocation[]
+          locations.forEach((location) => {
+            const {offset, path, matchText} = location
+            const relativePath = path.slice(props.path.length, path.length)
+            const memberBlockValue = member.kind === 'item' ? member.item.value : undefined
+            if (memberBlockValue) {
+              const isRangeInvalid = (editor: PortableTextEditor) => {
+                const [currentBlockValue] = PortableTextEditor.findByPath(
+                  editor,
+                  relativePath.slice(0, 1)
+                )
+                if (!isEqual(memberBlockValue, currentBlockValue)) {
+                  return true
+                }
+                return false
+              }
+              decorations.push({
+                isRangeInvalid,
+                component: (componentProps: PropsWithChildren) => (
+                  <BlackListHighlighter {...location}>
+                    {componentProps.children}
+                  </BlackListHighlighter>
+                ),
+                selection: {
+                  anchor: {path: relativePath, offset},
+                  focus: {path: relativePath, offset: offset + matchText.length},
+                },
+              })
+            }
+          })
+        }
+      })
+    })
+    setRangeDecorations(decorations)
+    return decorations
+  }, [portableTextInputProps.members, props.path.length])
+
+  useEffect(() => {
+    setRangeDecorators()
+  }, [props.validation, setRangeDecorators])
+
+  const handleEditorChange = useCallback((change: EditorChange, editor: PortableTextEditor) => {
+    if (change.type === 'ready') {
+      editorRef.current = editor
+    }
+  }, [])
+
+  return (
+    <>
+      <Popover
+        open={showInsertCharacterMenu}
+        portal
+        ref={setPopoverElement}
+        referenceElement={cursorElement}
+        content={
+          <Card>
+            <Grid gapX={1} rows={1} columns={3}>
+              <Button onClick={handleInsertCharacterButtonClick} autoFocus>
+                –
+              </Button>
+              <Button onClick={handleInsertCharacterButtonClick}>«</Button>
+              <Button onClick={handleInsertCharacterButtonClick}>»</Button>
+            </Grid>
+          </Card>
+        }
+        padding={2}
+        radius={2}
+        shadow={1}
+      />
+      <PortableTextInput
+        {...portableTextInputProps}
+        onEditorChange={handleEditorChange}
+        hotkeys={hotkeys}
+        rangeDecorations={rangeDecorations}
+      />
+    </>
+  )
+}

--- a/dev/test-studio/schema/standard/portableText/PortableTextInputWithSpecialChars.tsx
+++ b/dev/test-studio/schema/standard/portableText/PortableTextInputWithSpecialChars.tsx
@@ -81,7 +81,7 @@ export const PortableTextInputWithSpecialCharacters = (props: InputProps) => {
         },
       },
     }),
-    []
+    [],
   )
 
   const closeMenu = useCallback(() => {
@@ -120,7 +120,7 @@ export const PortableTextInputWithSpecialCharacters = (props: InputProps) => {
         PortableTextEditor.focus(editorRef.current)
       }
     },
-    [editorRef, closeMenu]
+    [editorRef, closeMenu],
   )
 
   const setRangeDecorators = useCallback(() => {
@@ -142,7 +142,7 @@ export const PortableTextInputWithSpecialCharacters = (props: InputProps) => {
               const isRangeInvalid = (editor: PortableTextEditor) => {
                 const [currentBlockValue] = PortableTextEditor.findByPath(
                   editor,
-                  relativePath.slice(0, 1)
+                  relativePath.slice(0, 1),
                 )
                 if (!isEqual(memberBlockValue, currentBlockValue)) {
                   return true

--- a/dev/test-studio/schema/standard/portableText/customBlockType.tsx
+++ b/dev/test-studio/schema/standard/portableText/customBlockType.tsx
@@ -1,0 +1,138 @@
+/* eslint-disable max-nested-callbacks */
+import React from 'react'
+import {BoldIcon, PlugIcon} from '@sanity/icons'
+import {
+  BlockAnnotationProps,
+  BlockProps,
+  defineArrayMember,
+  defineField,
+  defineType,
+  isPortableTextSpan,
+  isPortableTextTextBlock,
+} from 'sanity'
+import {Text} from '@sanity/ui'
+import {
+  BlackListLocation,
+  PortableTextInputWithSpecialCharacters,
+} from './PortableTextInputWithSpecialChars'
+
+const renderAnnotation = (props: BlockAnnotationProps) => {
+  return props.renderDefault(props)
+}
+
+const renderInlineBlock = (props: BlockProps) => {
+  return props.renderDefault(props)
+}
+
+const renderBlock = (props: BlockProps) => {
+  return props.renderDefault(props)
+}
+
+const customObject = defineArrayMember({
+  type: 'object',
+  name: 'customObject',
+  title: 'Custom Object',
+  fields: [{type: 'string', name: 'someString', validation: (Rule) => Rule.required()}],
+  components: {
+    annotation: renderAnnotation,
+    block: renderBlock,
+    inlineBlock: renderInlineBlock,
+  },
+  icon: PlugIcon,
+})
+
+const customBlock = defineArrayMember({
+  type: 'block',
+  marks: {
+    annotations: [customObject],
+    decorators: [
+      {
+        title: 'Strong',
+        value: 'strong',
+        icon: BoldIcon,
+      },
+    ],
+  },
+  styles: [
+    {
+      title: 'Lead',
+      value: 'lead',
+      component(props) {
+        return (
+          <Text weight="bold" size={3}>
+            {props.children}
+          </Text>
+        )
+      },
+    },
+  ],
+  of: [defineArrayMember({...customObject, title: `${customObject.title} (inline)`})],
+  options: {
+    spellCheck: true,
+  },
+  validation: (Rule) => [
+    Rule.error().custom((value, context) => {
+      const blacklist: {regExp: RegExp; message: string}[] = [
+        {
+          message: 'Use n-dash (–) instead',
+          regExp: new RegExp(/^- /g),
+        },
+        {
+          message: 'Use a bulleted list instead',
+          regExp: new RegExp(/^\* /g),
+        },
+        {
+          message: 'Never write foo',
+          regExp: new RegExp(/\bfoo\b/g),
+        },
+      ]
+      const {path} = context
+      const locations: BlackListLocation[] = []
+      if (path && isPortableTextTextBlock(value)) {
+        value.children.forEach((child) => {
+          if (isPortableTextSpan(child)) {
+            blacklist.forEach((entry) => {
+              const matches = isPortableTextSpan(child) && child.text.matchAll(entry.regExp)
+              if (matches) {
+                Array.from(matches).forEach((match) => {
+                  locations.push({
+                    span: child,
+                    matchText: match[0],
+                    path: path.concat(['children', {_key: child._key}]),
+                    offset: match.index || 0,
+                    message: entry.message,
+                    level: 'error',
+                  })
+                })
+              }
+            })
+          }
+        })
+      }
+      if (locations.length) {
+        return {
+          message: `${locations.map((item) => item.message).join('. ')}.`,
+          metaData: {id: 'blacklistMatchLocations', blacklistMatchLocations: locations},
+        }
+      }
+      return true
+    }),
+  ],
+})
+
+const blockArray = defineField({
+  name: 'body',
+  title: 'Body',
+  type: 'array',
+  of: [customBlock, customObject],
+  components: {
+    input: PortableTextInputWithSpecialCharacters,
+  },
+})
+
+export default defineType({
+  name: 'customBlockTypeDocument',
+  title: 'Custom block type',
+  type: 'document',
+  fields: [blockArray],
+})

--- a/dev/test-studio/structure/constants.ts
+++ b/dev/test-studio/structure/constants.ts
@@ -21,6 +21,7 @@ export const STANDARD_PORTABLE_TEXT_INPUT_TYPES = [
   'blocksTest',
   // 'richTextObject',
   'simpleBlock',
+  'customBlockTypeDocument',
   'manyEditors',
   'documentWithHoistedPt',
 ]

--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -1,12 +1,5 @@
 import {BaseRange, Transforms, Text, NodeEntry, Range as SlateRange} from 'slate'
-import React, {
-  forwardRef,
-  KeyboardEvent,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react'
+import React, {forwardRef, KeyboardEvent, useCallback, useEffect, useMemo, useState} from 'react'
 import {
   Editable as SlateEditable,
   ReactEditor,

--- a/packages/@sanity/portable-text-editor/src/types/editor.ts
+++ b/packages/@sanity/portable-text-editor/src/types/editor.ts
@@ -37,7 +37,7 @@ export interface EditableAPI {
   blur: () => void
   delete: (selection: EditorSelection, options?: EditableAPIDeleteOptions) => void
   findByPath: (path: Path) => [PortableTextBlock | PortableTextChild | undefined, Path | undefined]
-  findDOMNode: (element: PortableTextBlock | PortableTextChild) => Node | undefined
+  findDOMNode: (element: PortableTextBlock | PortableTextChild) => DOMNode | undefined
   focus: () => void
   focusBlock: () => PortableTextBlock | undefined
   focusChild: () => PortableTextChild | undefined
@@ -96,6 +96,7 @@ export interface PortableTextSlateEditor extends ReactEditor {
   isTextSpan: (value: unknown) => value is PortableTextSpan
   isListBlock: (value: unknown) => value is PortableTextListBlock
   subscriptions: (() => () => void)[]
+  nodeToRangeDecorations?: Map<Node, Range[]>
 
   /**
    * Increments selected list items levels, or decrements them if `reverse` is true.
@@ -480,6 +481,38 @@ export type ScrollSelectionIntoViewFunction = (
   editor: PortableTextEditor,
   domRange: globalThis.Range,
 ) => void
+
+/**
+ * A range decoration is a UI affordance that wraps a given selection range in the editor
+ * with a custom component. This can be used to highlight search results,
+ * mark validation errors on specific words, draw user presence and similar.
+ * @alpha */
+export interface RangeDecoration {
+  /**
+   * A component for rendering the range decoration.
+   * This component takes only children, and you could render
+   * your own component with own props by wrapping those children.
+   *
+   * @example
+   * ```ts
+   * (rangeComponentProps: PropsWithChildren) => (
+   *    <BlackListHighlighter {...location}>
+   *      {rangeComponentProps.children}
+   *    </BlackListHighlighter>
+   *  )
+   * ```
+   */
+  component: (props: PropsWithChildren) => ReactElement
+  /**
+   * A function that will can tell if the range has become invalid.
+   * The range will not be rendered when you return `true` from this function.
+   */
+  isRangeInvalid: (editor: PortableTextEditor) => boolean
+  /**
+   * The editor content selection range
+   */
+  selection: EditorSelection
+}
 
 /** @internal */
 export type PortableTextMemberSchemaTypes = {

--- a/packages/@sanity/portable-text-editor/src/types/editor.ts
+++ b/packages/@sanity/portable-text-editor/src/types/editor.ts
@@ -18,7 +18,8 @@ import {
 import {Subject, Observable} from 'rxjs'
 import {Descendant, Node as SlateNode, Operation as SlateOperation} from 'slate'
 import {ReactEditor} from 'slate-react'
-import {FocusEvent} from 'react'
+import {FocusEvent, PropsWithChildren, ReactElement} from 'react'
+import {DOMNode} from 'slate-react/dist/utils/dom'
 import type {Patch} from '../types/patch'
 import {PortableTextEditor} from '../editor/PortableTextEditor'
 

--- a/packages/@sanity/schema/src/legacy/types/blocks/block.ts
+++ b/packages/@sanity/schema/src/legacy/types/blocks/block.ts
@@ -127,17 +127,27 @@ function createListField(lists) {
 const DEFAULT_ANNOTATIONS = [DEFAULT_LINK_ANNOTATION]
 
 function createChildrenField(marks, of = []) {
+  const userSpanType = of.find((t) => t.type === 'span')
+  const defaultSpanType = {
+    type: 'span',
+    title: 'Span',
+    fields: [DEFAULT_TEXT_FIELD, DEFAULT_MARKS_FIELD],
+    annotations: marks && marks.annotations ? marks.annotations : DEFAULT_ANNOTATIONS,
+    decorators: marks && marks.decorators ? marks.decorators : DEFAULT_DECORATORS,
+  }
   return {
     name: 'children',
     title: 'Content',
     type: 'array',
     of: [
-      {
-        type: 'span',
-        fields: [DEFAULT_TEXT_FIELD, DEFAULT_MARKS_FIELD],
-        annotations: marks && marks.annotations ? marks.annotations : DEFAULT_ANNOTATIONS,
-        decorators: marks && marks.decorators ? marks.decorators : DEFAULT_DECORATORS,
-      },
+      userSpanType
+        ? {
+            ...userSpanType,
+            fields: [DEFAULT_TEXT_FIELD, DEFAULT_MARKS_FIELD],
+            annotations: marks && marks.annotations ? marks.annotations : DEFAULT_ANNOTATIONS,
+            decorators: marks && marks.decorators ? marks.decorators : DEFAULT_DECORATORS,
+          }
+        : defaultSpanType,
       ...of.filter((memberType) => memberType.type !== 'span'),
     ],
   }

--- a/packages/@sanity/types/src/validation/types.ts
+++ b/packages/@sanity/types/src/validation/types.ts
@@ -293,6 +293,7 @@ export interface ValidationErrorOptions {
   paths?: Path[]
   children?: ValidationMarker[]
   operation?: 'AND' | 'OR'
+  metaData?: unknown
 }
 
 /**
@@ -309,6 +310,7 @@ export interface ValidationErrorClass {
 /** @public */
 export interface ValidationError {
   message: string
+  metaData?: unknown
   children?: ValidationMarker[]
   operation?: 'AND' | 'OR'
   /**
@@ -351,4 +353,5 @@ export interface FormNodeValidation {
   level: 'error' | 'warning' | 'info'
   message: string
   path: Path
+  metaData?: unknown
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -8,6 +8,7 @@ import {
   BlockChildRenderProps as EditorChildRenderProps,
   BlockAnnotationRenderProps,
   EditorSelection,
+  RangeDecoration,
 } from '@sanity/portable-text-editor'
 import {Path, PortableTextBlock, PortableTextTextBlock} from '@sanity/types'
 import {Box, Portal, PortalProvider, useBoundaryElement, usePortal} from '@sanity/ui'
@@ -35,6 +36,7 @@ interface InputProps extends ArrayOfObjectsInputProps<PortableTextBlock> {
   onPaste?: OnPasteFn
   onToggleFullscreen: () => void
   path: Path
+  rangeDecorations?: RangeDecoration[]
   renderBlockActions?: RenderBlockActionsCallback
   renderCustomMarkers?: RenderCustomMarkers
 }
@@ -62,6 +64,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     onToggleFullscreen,
     path,
     readOnly,
+    rangeDecorations,
     renderAnnotation,
     renderBlock,
     renderBlockActions,
@@ -145,13 +148,12 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     [
       _renderBlockActions,
       _renderCustomMarkers,
-      scrollElement,
+      boundaryElement,
       isFullscreen,
       onItemClose,
       onItemOpen,
       onItemRemove,
       onPathFocus,
-      boundaryElement,
       path,
       readOnly,
       renderAnnotation,
@@ -277,14 +279,14 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       )
     },
     [
-      boundaryElement,
-      scrollElement,
       editor.schemaTypes.span.name,
+      boundaryElement,
       onItemClose,
       onItemOpen,
       onPathFocus,
       path,
       readOnly,
+      scrollElement,
       renderAnnotation,
       renderBlock,
       renderCustomMarkers,
@@ -393,6 +395,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
         onPaste={onPaste}
         onToggleFullscreen={handleToggleFullscreen}
         path={path}
+        rangeDecorations={rangeDecorations}
         readOnly={readOnly}
         renderAnnotation={editorRenderAnnotation}
         renderBlock={editorRenderBlock}
@@ -407,6 +410,16 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     [
       ariaDescribedBy,
       editorHotkeys,
+      editorHotkeys,
+      isActive,
+      isFullscreen,
+      onItemOpen,
+      onCopy,
+      onPaste,
+      handleToggleFullscreen,
+      path,
+      rangeDecorations,
+      readOnly,
       editorRenderAnnotation,
       editorRenderBlock,
       editorRenderChild,

--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -163,6 +163,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       renderInput,
       renderItem,
       renderPreview,
+      scrollElement,
     ],
   )
 
@@ -410,16 +411,6 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     [
       ariaDescribedBy,
       editorHotkeys,
-      editorHotkeys,
-      isActive,
-      isFullscreen,
-      onItemOpen,
-      onCopy,
-      onPaste,
-      handleToggleFullscreen,
-      path,
-      rangeDecorations,
-      readOnly,
       editorRenderAnnotation,
       editorRenderBlock,
       editorRenderChild,
@@ -431,6 +422,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       onItemOpen,
       onPaste,
       path,
+      rangeDecorations,
       readOnly,
       scrollElement,
     ],

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -10,6 +10,7 @@ import {
   EditorSelection,
   RenderStyleFunction,
   RenderListItemFunction,
+  RangeDecoration,
 } from '@sanity/portable-text-editor'
 import {Path} from '@sanity/types'
 import {BoundaryElementProvider, useBoundaryElement, useGlobalKeyDown, useLayer} from '@sanity/ui'
@@ -42,6 +43,7 @@ interface EditorProps {
   onToggleFullscreen: () => void
   path: Path
   readOnly?: boolean
+  rangeDecorations?: RangeDecoration[]
   renderAnnotation: RenderAnnotationFunction
   renderBlock: RenderBlockFunction
   renderChild: RenderChildFunction
@@ -77,6 +79,7 @@ export function Editor(props: EditorProps) {
     onToggleFullscreen,
     path,
     readOnly,
+    rangeDecorations,
     renderAnnotation,
     renderBlock,
     renderChild,
@@ -120,6 +123,7 @@ export function Editor(props: EditorProps) {
         onCopy={onCopy}
         onPaste={onPaste}
         ref={editableRef}
+        rangeDecorations={rangeDecorations}
         renderAnnotation={renderAnnotation}
         renderBlock={renderBlock}
         renderChild={renderChild}
@@ -139,6 +143,7 @@ export function Editor(props: EditorProps) {
       initialSelection,
       onCopy,
       onPaste,
+      rangeDecorations,
       renderAnnotation,
       renderBlock,
       renderChild,

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -64,12 +64,14 @@ export function PortableTextInput(props: PortableTextInputProps) {
     members,
     onChange,
     onCopy,
+    onEditorChange,
     onItemRemove,
     onInsert,
     onPaste,
     onPathFocus,
     path,
     readOnly,
+    rangeDecorations,
     renderBlockActions,
     renderCustomMarkers,
     schemaType,
@@ -340,6 +342,7 @@ export function PortableTextInput(props: PortableTextInputProps) {
                 onInsert={onInsert}
                 onPaste={onPaste}
                 onToggleFullscreen={handleToggleFullscreen}
+                rangeDecorations={rangeDecorations}
                 renderBlockActions={renderBlockActions}
                 renderCustomMarkers={renderCustomMarkers}
               />

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -235,6 +235,9 @@ export function PortableTextInput(props: PortableTextInputProps) {
   // Handle editor changes
   const handleEditorChange = useCallback(
     (change: EditorChange): void => {
+      if (editorRef.current && onEditorChange) {
+        onEditorChange(change, editorRef.current)
+      }
       switch (change.type) {
         case 'mutation':
           onChange(toFormPatches(change.patches))

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -282,7 +282,7 @@ export function PortableTextInput(props: PortableTextInputProps) {
         default:
       }
     },
-    [onBlur, onChange, onPathFocus, toast],
+    [onBlur, onChange, onEditorChange, onPathFocus, toast],
   )
 
   useEffect(() => {

--- a/packages/sanity/src/core/form/store/formState.ts
+++ b/packages/sanity/src/core/form/store/formState.ts
@@ -677,7 +677,12 @@ function prepareObjectInputState<T>(
 
   const validation = props.validation
     .filter((item) => isEqual(item.path, props.path))
-    .map((v) => ({level: v.level, message: v.item.message, path: v.path}))
+    .map((v) => ({
+      level: v.level,
+      message: v.item.message,
+      path: v.path,
+      metaData: v.item.metaData,
+    }))
 
   const visibleMembers = members.filter(
     (member): member is ObjectMember => member.kind !== 'hidden',
@@ -1031,7 +1036,12 @@ function preparePrimitiveInputState<SchemaType extends PrimitiveSchemaType>(
 
   const validation = props.validation
     .filter((item) => isEqual(item.path, props.path))
-    .map((v) => ({level: v.level, message: v.item.message, path: v.path}))
+    .map((v) => ({
+      level: v.level,
+      message: v.item.message,
+      path: v.path,
+      metaData: v.item.metaData,
+    }))
   return {
     schemaType: props.schemaType,
     changed: isChangedValue(props.value, props.comparisonValue),

--- a/packages/sanity/src/core/form/studio/contexts/Validation.tsx
+++ b/packages/sanity/src/core/form/studio/contexts/Validation.tsx
@@ -41,6 +41,7 @@ export function useChildValidation(path: Path, inclusive = false): FormNodeValid
           message: marker.item.message,
           level: marker.level,
           path: marker.path,
+          metaData: marker.item.metaData,
         })) as FormNodeValidation[],
     [inclusive, path, validation],
   )

--- a/packages/sanity/src/core/form/types/inputProps.ts
+++ b/packages/sanity/src/core/form/types/inputProps.ts
@@ -20,6 +20,7 @@ import {
   HotkeyOptions,
   OnCopyFn,
   OnPasteFn,
+  PortableTextEditor,
   RangeDecoration,
 } from '@sanity/portable-text-editor'
 import {FormPatch, PatchEvent} from '../patch'
@@ -497,7 +498,7 @@ export interface PortableTextInputProps
   /**
    * Returns changes from the underlying editor
    */
-  onEditorChange?: (change: EditorChange) => void
+  onEditorChange?: (change: EditorChange, editor: PortableTextEditor) => void
   /**
    * Custom copy function
    */
@@ -506,6 +507,10 @@ export interface PortableTextInputProps
    * Custom paste function
    */
   onPaste?: OnPasteFn
+  /**
+   * Range decorations
+   */
+  rangeDecorations?: RangeDecoration[]
   /**
    * Function to render custom block actions
    * @deprecated will be removed in the next major version of Sanity Studio.
@@ -518,7 +523,6 @@ export interface PortableTextInputProps
    * Use the `renderBlock` interface instead.
    */
   renderCustomMarkers?: RenderCustomMarkers
-  rangeDecorations?: RangeDecoration[]
 }
 
 /**

--- a/packages/sanity/src/core/form/types/inputProps.ts
+++ b/packages/sanity/src/core/form/types/inputProps.ts
@@ -15,7 +15,13 @@ import {
   StringSchemaType,
 } from '@sanity/types'
 import React, {ComponentType, FocusEventHandler, FormEventHandler} from 'react'
-import {HotkeyOptions, OnCopyFn, OnPasteFn} from '@sanity/portable-text-editor'
+import {
+  EditorChange,
+  HotkeyOptions,
+  OnCopyFn,
+  OnPasteFn,
+  RangeDecoration,
+} from '@sanity/portable-text-editor'
 import {FormPatch, PatchEvent} from '../patch'
 import {
   ArrayOfObjectsFormNode,
@@ -489,6 +495,10 @@ export interface PortableTextInputProps
    */
   markers?: PortableTextMarker[]
   /**
+   * Returns changes from the underlying editor
+   */
+  onEditorChange?: (change: EditorChange) => void
+  /**
    * Custom copy function
    */
   onCopy?: OnCopyFn
@@ -508,6 +518,7 @@ export interface PortableTextInputProps
    * Use the `renderBlock` interface instead.
    */
   renderCustomMarkers?: RenderCustomMarkers
+  rangeDecorations?: RangeDecoration[]
 }
 
 /**

--- a/packages/sanity/src/core/validation/ValidationError.ts
+++ b/packages/sanity/src/core/validation/ValidationError.ts
@@ -14,12 +14,14 @@ export const ValidationError: ValidationErrorClass = class ValidationError
   paths: Path[]
   children: ValidationMarker[] | undefined
   operation: 'AND' | 'OR' | undefined
+  metaData: unknown
 
   constructor(message: string, options: ValidationErrorOptions = {}) {
     this.message = message
     this.paths = options.paths || []
     this.children = options.children
     this.operation = options.operation
+    this.metaData = options.metaData
   }
 
   cloneWithMessage(msg: string): ValidationError {
@@ -27,6 +29,7 @@ export const ValidationError: ValidationErrorClass = class ValidationError
       paths: this.paths,
       children: this.children,
       operation: this.operation,
+      metaData: this.metaData,
     })
   }
 }

--- a/packages/sanity/src/desk/panes/document/inspectors/validation/index.ts
+++ b/packages/sanity/src/desk/panes/document/inspectors/validation/index.ts
@@ -22,6 +22,7 @@ function useMenuItem(props: DocumentInspectorUseMenuItemProps): DocumentInspecto
         level: item.level,
         message: item.item.message,
         path: item.path,
+        metaData: item.item.metaData,
       })),
     [validationMarkers],
   )


### PR DESCRIPTION
### Description

This will add support for wrapping a selection inside the PT-input with a custom wrapper component, which comes in handy for search highlighting, presence, validation and other things that are not part of the actual editable content.

![image](https://github.com/sanity-io/sanity/assets/373403/6b79d362-07d4-45de-a361-2c7cbede8f94)


This PR also brings support to put custom meta data on the validation items, which can be used in combination with this feature, and for any other input that want to reference custom things like selections or regex-match data or whatever.

I have also made the `span` type a core type, and made it extendable with it's own validation etc. Not needed here, so I'll probably pull that out into a separate PR when this is out of draft.


Can be tested in the test studio by navigating to here:
![image](https://github.com/sanity-io/sanity/assets/373403/d9caf223-083e-484e-ac9a-b7c47b0b7e10)


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
