### PR TITLE
feat(core): implement document creation context in `document.newDocumentOptions`

### DIFF
--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -412,6 +412,9 @@ function resolveSource({
           // then keep everything
           if (!schemaTypeName) return true
 
+          // If we are in a 'document' creationContext then keep everything
+          if (creationContext.type === 'document') return true
+
           // else only keep the `schemaType`s that match the creationContext
           return schemaTypeName === templateMap.get(item.templateId)?.schemaType
         })

--- a/packages/sanity/src/desk/panes/document/DocumentPane.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentPane.tsx
@@ -77,11 +77,15 @@ function DocumentPaneInner(props: DocumentPaneProviderProps) {
   const options = usePaneOptions(pane.options, paneRouter.params)
   const {documentType, isLoaded: isDocumentLoaded} = useDocumentType(options.id, options.type)
 
+  // The templates that should be creatable from inside this document pane.
+  // For example, from the "Create new" menu in reference inputs.
   const templateItems = useMemo(() => {
     return resolveNewDocumentOptions({
-      type: 'global',
+      type: 'document',
+      documentId: options.id,
+      schemaType: options.type,
     })
-  }, [resolveNewDocumentOptions])
+  }, [options.id, options.type, resolveNewDocumentOptions])
 
   const [templatePermissions, isTemplatePermissionsLoading] = useTemplatePermissions({
     templateItems,


### PR DESCRIPTION
### Description

This pull request implements the 'document' creation context to the `document.newDocumentOptions` API. The 'document' creation context has been available in the Typescript definition, but it has not been fully implemented.

Currently, there are two different creation contexts:

1. Global creation context: The template options available in the global create menu.
2. Structure creation context: The template options in the desk structure (in the list pane headers).

The addition of the new 'document' creation context allows for filtering of document types that can be created from within another document (currently, it is only possible to create a new document with the "create new" button in reference inputs).

Example usage scenarios:

1. Removing the ability to create an "author" document from within another document:
```ts
export default defineConfig({
  // ...

  document: {
    newDocumentOptions: (options, {creationContext}) => {
      if (creationContext.type === 'document') {
        return options.filter((o) => o.templateId !== 'author')
      }

      return options
    },
  },
})
```

2. Removing the ability to create an "author" document from within a "book" document:
```ts
export default defineConfig({
  // ...

  document: {
    newDocumentOptions: (options, {creationContext}) => {
      const {type, schemaType} = creationContext

      if (type === 'document' && schemaType === 'book') {
        return options.filter((o) => o.templateId !== 'author')
      }

      return options
    },
  },
})
```

3. Removing the ability to create an "author" document from a document with the ID "xyz123":
```ts
export default defineConfig({
  // ...

  document: {
    newDocumentOptions: (options, context) => {
      const {creationContext} = context
      const {type, documentId} = creationContext

      if (type === 'document' && documentId === 'xyz123') {
        return options.filter((o) => o.templateId !== 'author')
      }

      return options
    },
  },
})
```

**Image illustrating the various creation contexts**

![Creation Contexts](https://github.com/sanity-io/sanity/assets/15094168/4b63812a-5f52-4f5f-8bac-4a330ea13893)


**Breaking change**
Currently, the "global" creation context controls the "create new" button in reference inputs. This pull request changes this so that the new "document" creation context is used instead. This means a breaking change.


### What to review
- The code
- That the API makes sense

### Notes for release

Implement the 'document' creation context in the `document.newDocumentOptions` API.