### PR TITLE
fix: add missing styled components dependency

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -356,7 +356,7 @@ export default async function initSanity(
     await installNewPackages(
       {
         packageManager: chosen,
-        packages: ['@sanity/vision@3', 'sanity@3', '@sanity/image-url@1'],
+        packages: ['@sanity/vision@3', 'sanity@3', '@sanity/image-url@1', 'styled-components@5.2'],
       },
       {
         output: context.output,


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Add missing dependency (`styled-components@5.2`) to dependency array when initializing a Sanity project. This fixes a missing dependency issue when running `npm create sanity@latest` in a Next.js project folder.

With the current build, the following error is thrown when opening the embedded Studio:
![image](https://github.com/sanity-io/sanity/assets/15170904/f76ff1ce-9128-44b3-8312-cc2990e3e0db)

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

1. Create a new Next.js project with `npx create-next-app@latest`
2. From within the project folder, run `npm create sanity@latest`
3. Run `npm install` to install the new Sanity dependencies
4. Run `npm run dev`
5. Navigate to `localhost:3000/studio` and ensure that the Studio loads correctly

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

Add missing dependency (`styled-components@5.2`) to dependency array when initializing a Sanity project.
