### PR TITLE
fix(cli): use .env.local file for new sanity projects

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -155,7 +155,7 @@ export default async function initSanity(
     frameworkList: frameworks as readonly Framework[],
   })
 
-  const envFilename = typeof env === 'string' ? env : '.env'
+  const envFilename = typeof env === 'string' ? env : '.env.local'
   if (!envFilename.startsWith('.env')) {
     throw new Error(`Env filename must start with .env`)
   }
@@ -1031,7 +1031,7 @@ export default async function initSanity(
       })
     } catch (err) {
       print(err)
-      throw new Error('An error occurred while creating .env', {cause: err})
+      throw new Error('An error occurred while creating .env.local', {cause: err})
     }
   }
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

When creating a new sanity project with `--env` flag, it creates `.env.local` file instead of `.env` file

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

Testing the change

1. Run `yarn build:cli` 
2. Create a new nextjs project `pnpm create next app embeded-studio`
3. Run the command `./packages/@sanity/cli/bin/sanity init --dataset=test --project=<projectId> --output-path=./embeded-studio --env` 

Ensure the env file is named `.env.local` 

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

Uses `.env.local` file when creating a new sanity studio