### PR TITLE
fix(desk): prevent fallback editor node from getting 'Editor' as title

### DIFF
--- a/packages/sanity/src/desk/structureResolvers/createResolvedPaneNodeStream.ts
+++ b/packages/sanity/src/desk/structureResolvers/createResolvedPaneNodeStream.ts
@@ -36,9 +36,7 @@ const fallbackEditorChild: PaneNodeResolver = (nodeId, context): DocumentPaneNod
     )
   }
 
-  let defaultDocumentBuilder = resolveDocumentNode({schemaType: type, documentId: id})
-
-  defaultDocumentBuilder = defaultDocumentBuilder.id('editor').title('Editor')
+  let defaultDocumentBuilder = resolveDocumentNode({schemaType: type, documentId: id}).id('editor')
 
   if (template) {
     defaultDocumentBuilder = defaultDocumentBuilder.initialValueTemplate(


### PR DESCRIPTION
### Description

Currently, if you navigate to an intent that does not resolve to a fully qualified structure node, it renders a fallback editor. This editor had an override for the document title, which resulted in the title always being simply "Editor", which is less than ideal.

This PR fixes that issue by simply removing the override for the title. I believe it was required previously because we did not  use the document title, so it was shown "empty". 

### What to review

To reproduce, you need a structure that does not fully resolve - the easiest way to do this is to create an empty structure:

```ts
deskTool({
  // ...
  structure: S => S.list().title('Content')
})
```

Then head to an edit intent (with a document ID you know exists):
http://localhost:3333/test/intent/edit/id=grrm;type=author/

Verify that the title of the editor shows the name of the document, not "Editor".

### Notes for release

- Fixed an issue where the fallback editor had the title "Editor", instead of the name of the document being edited