### PR TITLE
fix(core): add scrolling to workspace login screen 

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/Layout.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/Layout.tsx
@@ -60,7 +60,7 @@ export function Layout(props: LayoutProps) {
         </Stack>
       </Card>
 
-      <Flex direction="column" gap={4} justify="center" align="center">
+      <Flex direction="column" gap={4} justify="center" align="center" paddingBottom={4}>
         <Text size={3}>
           <SanityLogo />
         </Text>

--- a/packages/sanity/src/core/studio/screens/AuthenticateScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/AuthenticateScreen.tsx
@@ -4,8 +4,8 @@ import {WorkspaceAuth} from '../components/navbar/workspace'
 
 export function AuthenticateScreen() {
   return (
-    <Card height="fill">
-      <Flex align="center" justify="center" height="fill">
+    <Card height="fill" overflow="auto">
+      <Flex align="center" justify="center" marginTop={4}>
         <Container width={0}>
           <WorkspaceAuth />
         </Container>

--- a/packages/sanity/src/core/studio/screens/AuthenticateScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/AuthenticateScreen.tsx
@@ -5,7 +5,7 @@ import {WorkspaceAuth} from '../components/navbar/workspace'
 export function AuthenticateScreen() {
   return (
     <Card height="fill" overflow="auto">
-      <Flex align="center" justify="center" marginTop={4}>
+      <Flex height="fill" direction="column" align="center" justify="center" paddingTop={4}>
         <Container width={0}>
           <WorkspaceAuth />
         </Container>


### PR DESCRIPTION
### Description
Added scrolling to the list of workspaces on the login screen. 
![image](https://github.com/sanity-io/sanity/assets/44635000/a5bba4fe-6f17-4506-b863-211767ebc32e)

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
That the login screen can be scrolled. 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fixes issue with scrolling of workspaces on login screen

<!--
A description of the change(s) that should be used in the release notes.
-->
