### PR TITLE
fix(core/desk): remove muted prop in tooltip content

### DIFF
--- a/packages/sanity/src/core/field/diff/components/DiffTooltip.tsx
+++ b/packages/sanity/src/core/field/diff/components/DiffTooltip.tsx
@@ -43,7 +43,7 @@ function DiffTooltipWithAnnotation(props: DiffTooltipWithAnnotationsProps) {
 
   const content = (
     <Stack padding={3} space={2}>
-      <Label size={1} style={{textTransform: 'uppercase'}} muted>
+      <Label size={1} style={{textTransform: 'uppercase'}}>
         {description}
       </Label>
       <Stack space={2}>

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/ArrayOfObjectsFunctions.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/ArrayOfObjectsFunctions.tsx
@@ -45,9 +45,7 @@ export function ArrayOfObjectsFunctions<
         portal
         content={
           <Box padding={2} sizing="border">
-            <Text size={1} muted>
-              This field is read-only
-            </Text>
+            <Text size={1}>This field is read-only</Text>
           </Box>
         }
       >

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesFunctions.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesFunctions.tsx
@@ -34,9 +34,7 @@ export function ArrayOfPrimitivesFunctions<
         portal
         content={
           <Box padding={2} sizing="border">
-            <Text size={1} muted>
-              This field is read-only
-            </Text>
+            <Text size={1}>This field is read-only</Text>
           </Box>
         }
       >

--- a/packages/sanity/src/desk/panes/document/statusBar/sparkline/PublishStatus.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/sparkline/PublishStatus.tsx
@@ -32,7 +32,7 @@ export function PublishStatus(props: PublishStatusProps) {
         portal
         content={
           <Stack padding={3} space={3}>
-            <Text size={1} muted>
+            <Text size={1}>
               {liveEdit ? (
                 <>Last updated {lastUpdated ? lastUpdatedTimeAgo : lastPublishedTimeAgo}</>
               ) : (


### PR DESCRIPTION
### Description
Some tooltip content had a `muted` prop, leading to potential accessibility issues. It should be darker. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
That all the tooltips in the studio does not have a muted prop. 

Note: there are a lot of muted props in the tooltips in the search component. I have not changed this component, as this seems to be intentional. 

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fixes accessibility issues in tooltip text color contrast
<!--
A description of the change(s) that should be used in the release notes.
-->
