### PR TITLE
fix(core): various fixes and improvements to studio search [v2]

### DIFF
--- a/packages/@sanity/base/src/_exports/_internal.ts
+++ b/packages/@sanity/base/src/_exports/_internal.ts
@@ -15,7 +15,7 @@ export type {DocumentAvailability} from '../preview/types'
 export {AvailabilityReason} from '../preview/types'
 
 export {getSearchableTypes} from '../search/common/utils'
-export {createWeightedSearch} from '../search/weighted/createWeightedSearch'
+export {createSearchQuery, createWeightedSearch} from '../search/weighted'
 export type {WeightedHit} from '../search/weighted/types'
 
 export {createHookFromObservableFactory} from '../util/createHookFromObservableFactory'

--- a/packages/@sanity/base/src/search/index.ts
+++ b/packages/@sanity/base/src/search/index.ts
@@ -6,14 +6,6 @@ import {versionedClient} from '../client/versionedClient'
 import {getSearchableTypes} from './common/utils'
 import {createWeightedSearch} from './weighted/createWeightedSearch'
 
-export type {
-  SearchOptions,
-  SearchSort,
-  SearchTerms,
-  SearchableType,
-  WeightedHit,
-} from './weighted/types'
-
 // Use >= 2021-03-25 for pt::text() support
 const searchClient = versionedClient.withConfig({
   apiVersion: '2021-03-25',
@@ -23,3 +15,5 @@ export default createWeightedSearch(getSearchableTypes(schema), searchClient, {
   unique: true,
   tag: 'search.global',
 })
+
+export * from './weighted'

--- a/packages/@sanity/base/src/search/weighted/applyWeights.test.ts
+++ b/packages/@sanity/base/src/search/weighted/applyWeights.test.ts
@@ -1,6 +1,6 @@
 import {
   calculatePhraseScore,
-  calculateMatchingWordScore,
+  calculateWordScore,
   partitionAndSanitizeSearchTerms,
   calculateCharacterScore,
 } from './applyWeights'
@@ -21,30 +21,18 @@ describe('calculatePhraseScore', () => {
   })
 })
 
-describe('calculateMatchingWordScore', () => {
+describe('calculateWordScore', () => {
   it('should handle exact matches', () => {
-    expect(calculateMatchingWordScore(['foo'], 'foo')).toEqual([1, '[Word] Exact match'])
-    expect(calculateMatchingWordScore(['foo', 'foo'], 'foo foo')).toEqual([1, '[Word] Exact match'])
-    expect(calculateMatchingWordScore(['bar', 'foo'], 'foo bar')).toEqual([1, '[Word] Exact match'])
-    expect(calculateMatchingWordScore(['foo', 'bar'], 'bar, foo')).toEqual([
-      1,
-      '[Word] Exact match',
-    ])
-    expect(calculateMatchingWordScore(['foo', 'bar'], 'bar & foo')).toEqual([
-      1,
-      '[Word] Exact match',
-    ])
+    expect(calculateWordScore(['foo'], 'foo')).toEqual([1, '[Word] Exact match'])
+    expect(calculateWordScore(['foo', 'foo'], 'foo foo')).toEqual([1, '[Word] Exact match'])
+    expect(calculateWordScore(['bar', 'foo'], 'foo bar')).toEqual([1, '[Word] Exact match'])
+    expect(calculateWordScore(['foo', 'bar'], 'bar, foo')).toEqual([1, '[Word] Exact match'])
+    expect(calculateWordScore(['foo', 'bar'], 'bar & foo')).toEqual([1, '[Word] Exact match'])
   })
   it('should handle partial matches', () => {
-    expect(calculateMatchingWordScore(['foo'], 'bar foo')).toEqual([
-      0.25,
-      '[Word] 1/2 terms: [foo]',
-    ])
-    expect(calculateMatchingWordScore(['foo', 'bar'], 'foo')).toEqual([
-      0.25,
-      `[Word] 1/2 terms: [foo]`,
-    ])
-    expect(calculateMatchingWordScore(['foo', 'bar', 'baz'], 'foo foo bar')).toEqual([
+    expect(calculateWordScore(['foo'], 'bar foo')).toEqual([0.25, '[Word] 1/2 terms: [foo]'])
+    expect(calculateWordScore(['foo', 'bar'], 'foo')).toEqual([0.25, `[Word] 1/2 terms: [foo]`])
+    expect(calculateWordScore(['foo', 'bar', 'baz'], 'foo foo bar')).toEqual([
       1 / 3,
       `[Word] 2/3 terms: [foo, bar]`,
     ])

--- a/packages/@sanity/base/src/search/weighted/applyWeights.test.ts
+++ b/packages/@sanity/base/src/search/weighted/applyWeights.test.ts
@@ -1,37 +1,9 @@
 import {
-  applyWeights,
   calculatePhraseScore,
   calculateMatchingWordScore,
   partitionAndSanitizeSearchTerms,
   calculateCharacterScore,
 } from './applyWeights'
-import {SearchSpec} from './types'
-
-describe('applyWeights', () => {
-  it('should not apply word score weighting to internal fields', () => {
-    const mockSearchSpec: SearchSpec[] = [
-      {
-        typeName: 'author',
-        paths: [{path: '_id', weight: 1}],
-      },
-    ]
-    const hits = [
-      {
-        _type: 'author',
-        _id: 'ca3b55a5-51ee-4b20-8e22-4bbd822814b4',
-        w0: 'ca3b55a5-51ee-4b20-8e22-4bbd822814b4',
-      },
-    ]
-    const searchTerms = ['ca3b55a5-51ee-4b20-8e22-4bbd822814b4']
-    const weights = applyWeights(mockSearchSpec, hits, searchTerms)
-
-    expect(weights[0].stories[0]).toEqual({
-      path: '_id',
-      score: 1,
-      why: '[Char] Contains all, [Phrase] 0/36 chars (*1)',
-    })
-  })
-})
 
 describe('calculatePhraseScore', () => {
   it('should handle exact matches', () => {

--- a/packages/@sanity/base/src/search/weighted/applyWeights.ts
+++ b/packages/@sanity/base/src/search/weighted/applyWeights.ts
@@ -20,7 +20,7 @@ export const calculateScore = (searchTerms: string[], value: string): SearchScor
   // Calculate an aggregated score of words (partial + whole) and phrase matches.
   const [charScore, charWhy] = calculateCharacterScore(uniqueSearchWords, value)
   const [phraseScore, phraseWhy] = calculatePhraseScore(uniqueSearchPhrases, value)
-  const [wordScore, wordWhy] = calculateMatchingWordScore(uniqueSearchWords, value)
+  const [wordScore, wordWhy] = calculateWordScore(uniqueSearchWords, value)
   return [charScore + wordScore + phraseScore, [charWhy, wordWhy, phraseWhy].flat().join(', ')]
 }
 
@@ -156,10 +156,7 @@ export function calculateCharacterScore(uniqueSearchTerms: string[], value: stri
  * @param value - The string to match against
  * @returns SearchScore containing the search score as well as a human readable explanation
  */
-export function calculateMatchingWordScore(
-  uniqueSearchTerms: string[],
-  value: string
-): SearchScore {
+export function calculateWordScore(uniqueSearchTerms: string[], value: string): SearchScore {
   const uniqueValueTerms = uniq(compact(words(toLower(value))))
 
   const matches = intersection(uniqueSearchTerms, uniqueValueTerms)

--- a/packages/@sanity/base/src/search/weighted/applyWeights.ts
+++ b/packages/@sanity/base/src/search/weighted/applyWeights.ts
@@ -84,7 +84,7 @@ export function applyWeights(
 }
 
 /**
- * Generate a sccore on the total number of matching characters.
+ * For phrases: score on the total number of matching characters.
  * E.g. given the phrases ["the fox", "of london"] for the target value "the wily fox of london"
  *
  * - "the fox" isn't included in the target value (score: 0)
@@ -114,7 +114,7 @@ export function calculatePhraseScore(uniqueSearchPhrases: string[], value: strin
 }
 
 /**
- * Generate a score on the total number of matching characters.
+ * For words: score on the total number of matching words.
  * E.g. given the terms ["bar", "fo"] for the target value "food bar".
  *
  * - "fo" is included in the target value, and 2 out of 7 non-whitespace characters match (score: 2/7)

--- a/packages/@sanity/base/src/search/weighted/applyWeights.ts
+++ b/packages/@sanity/base/src/search/weighted/applyWeights.ts
@@ -7,10 +7,10 @@ type SearchScore = [number, string]
  * Calculates a score (between 0 and 1) indicating general search relevance of an array of
  * search tokens within a specific string.
  *
- * @internal
  * @param searchTerms - All search terms
  * @param value - The string to match against
  * @returns A [score, story] pair containing the search score as well as a human readable explanation
+ * @internal
  */
 export const calculateScore = (searchTerms: string[], value: string): SearchScore => {
   // Separate search terms by phrases (wrapped with quotes) and words.
@@ -31,11 +31,11 @@ const stringify = (value: unknown): string =>
  * Applies path weights from a supplied SearchSpec to existing search hits to create _weighted_ hits
  * augmented with search ranking and human readable explanations.
  *
- * @internal
  * @param searchSpec - SearchSpec containing path weighting
  * @param hits - SearchHit objects to augment
  * @param terms - All search terms
  * @returns WeightedHit array containing search scores and ranking explanations
+ * @internal
  */
 export function applyWeights(
   searchSpec: SearchSpec[],
@@ -91,10 +91,10 @@ export function applyWeights(
  * - "of london" is included in the target value, and 9 out of 22 characters match (score: 9/22 = ~0.408)
  * - non-exact matches have their score divided in half (final score: ~0.204)
  *
- * @internal
  * @param uniqueSearchPhrases - All search phrases
  * @param value - The string to match against
  * @returns SearchScore containing the search score as well as a human readable explanation
+ * @internal
  */
 export function calculatePhraseScore(uniqueSearchPhrases: string[], value: string): SearchScore {
   const sanitizedValue = value.toLowerCase().trim()
@@ -121,10 +121,10 @@ export function calculatePhraseScore(uniqueSearchPhrases: string[], value: strin
  * - "bar" is included in the target value, and 3 out of 7 non-whitespace characters match (score: 3/7)
  * - all values are accumulated and have their score devidied by half (final score: ~0.357)
  *
- * @internal
  * @param uniqueSearchTerms - A string array of search terms
  * @param value - The string to match against
  * @returns SearchScore containing the search score as well as a human readable explanation
+ * @internal
  */
 export function calculateCharacterScore(uniqueSearchTerms: string[], value: string): SearchScore {
   const sanitizedValue = value.toLowerCase().trim()
@@ -151,10 +151,10 @@ export function calculateCharacterScore(uniqueSearchTerms: string[], value: stri
  * - 4 out of 5 words match (score: 4/5 = 0.8)
  * - non-exact matches have their score divided in half (final score: 0.4)
  *
- * @internal
  * @param uniqueSearchTerms - All search terms
  * @param value - The string to match against
  * @returns SearchScore containing the search score as well as a human readable explanation
+ * @internal
  */
 export function calculateWordScore(uniqueSearchTerms: string[], value: string): SearchScore {
   const uniqueValueTerms = uniq(compact(words(toLower(value))))
@@ -170,9 +170,9 @@ export function calculateWordScore(uniqueSearchTerms: string[], value: string): 
 /**
  * Partition search terms by phrases (wrapped with quotes) and words.
  *
- * @internal
  * @param searchTerms - All search terms
  * @returns Partitioned phrases and words
+ * @internal
  */
 export function partitionAndSanitizeSearchTerms(
   searchTerms: string[]
@@ -193,10 +193,10 @@ export function partitionAndSanitizeSearchTerms(
  * Returns matching array indices of `values` containing _any_ member of `uniqueSearchTerms`.
  * When comparing for matches, members of `values` are stringified, trimmed and lowercased.
  *
- * @internal
  * @param uniqueSearchTerms - All search terms
  * @param values - Values to match against (members are stringified)
  * @returns All matching indices in `values`
+ * @internal
  */
 export function findMatchingIndices(uniqueSearchTerms: string[], values: unknown[]): number[] {
   const {phrases: uniqueSearchPhrases, words: uniqueSearchWords} = partitionAndSanitizeSearchTerms(

--- a/packages/@sanity/base/src/search/weighted/applyWeights.ts
+++ b/packages/@sanity/base/src/search/weighted/applyWeights.ts
@@ -28,7 +28,7 @@ export function applyWeights(
   return hits.reduce((allHits, hit, index) => {
     const typeSpec = specByType[hit._type]
     const stories = typeSpec.paths.map((pathSpec, idx) => {
-      const pathHit = hit[`w${idx}`]
+      const pathHit = hit[idx]
       const indices = Array.isArray(pathHit) ? findMatchingIndices(terms, pathHit) : null
       // Only stringify non-falsy values so null values don't pollute search
       const value = pathHit ? stringify(pathHit) : null

--- a/packages/@sanity/base/src/search/weighted/applyWeights.ts
+++ b/packages/@sanity/base/src/search/weighted/applyWeights.ts
@@ -25,10 +25,11 @@ export function applyWeights(
   terms: string[] = []
 ): WeightedHit[] {
   const specByType = keyBy(searchSpec, (spec) => spec.typeName)
+
   return hits.reduce((allHits, hit, index) => {
     const typeSpec = specByType[hit._type]
     const stories = typeSpec.paths.map((pathSpec, idx) => {
-      const pathHit = hit[idx]
+      const pathHit = ['_id', '_type'].includes(pathSpec.path) ? hit[pathSpec.path] : hit[idx]
       const indices = Array.isArray(pathHit) ? findMatchingIndices(terms, pathHit) : null
       // Only stringify non-falsy values so null values don't pollute search
       const value = pathHit ? stringify(pathHit) : null

--- a/packages/@sanity/base/src/search/weighted/applyWeights.ts
+++ b/packages/@sanity/base/src/search/weighted/applyWeights.ts
@@ -3,7 +3,15 @@ import {SearchHit, WeightedHit, SearchSpec} from './types'
 
 type SearchScore = [number, string]
 
-// takes a set of terms and a value and returns a [score, story] pair where score is a value between 0, 1 and story is the explanation
+/**
+ * Calculates a score (between 0 and 1) indicating general search relevance of an array of
+ * search tokens within a specific string.
+ *
+ * @internal
+ * @param searchTerms - All search terms
+ * @param value - The string to match against
+ * @returns A [score, story] pair containing the search score as well as a human readable explanation
+ */
 export const calculateScore = (searchTerms: string[], value: string): SearchScore => {
   // Separate search terms by phrases (wrapped with quotes) and words.
   const {phrases: uniqueSearchPhrases, words: uniqueSearchWords} = partitionAndSanitizeSearchTerms(
@@ -19,6 +27,16 @@ export const calculateScore = (searchTerms: string[], value: string): SearchScor
 const stringify = (value: unknown): string =>
   typeof value === 'string' ? value : JSON.stringify(value)
 
+/**
+ * Applies path weights from a supplied SearchSpec to existing search hits to create _weighted_ hits
+ * augmented with search ranking and human readable explanations.
+ *
+ * @internal
+ * @param searchSpec - SearchSpec containing path weighting
+ * @param hits - SearchHit objects to augment
+ * @param terms - All search terms
+ * @returns WeightedHit array containing search scores and ranking explanations
+ */
 export function applyWeights(
   searchSpec: SearchSpec[],
   hits: SearchHit[],
@@ -46,7 +64,7 @@ export function applyWeights(
     })
 
     const totalScore = stories.reduce((acc, rank) => acc + rank.score, 0)
-    /**
+    /*
      * Filter out hits with no score.
      * (only if search terms are present, otherwise we always show results)
      *
@@ -66,12 +84,17 @@ export function applyWeights(
 }
 
 /**
- * Score on the total number of matching characters.
+ * Generate a sccore on the total number of matching characters.
  * E.g. given the phrases ["the fox", "of london"] for the target value "the wily fox of london"
  *
  * - "the fox" isn't included in the target value (score: 0)
  * - "of london" is included in the target value, and 9 out of 22 characters match (score: 9/22 = ~0.408)
  * - non-exact matches have their score divided in half (final score: ~0.204)
+ *
+ * @internal
+ * @param uniqueSearchPhrases - All search phrases
+ * @param value - The string to match against
+ * @returns SearchScore containing the search score as well as a human readable explanation
  */
 export function calculatePhraseScore(uniqueSearchPhrases: string[], value: string): SearchScore {
   const sanitizedValue = value.toLowerCase().trim()
@@ -91,12 +114,17 @@ export function calculatePhraseScore(uniqueSearchPhrases: string[], value: strin
 }
 
 /**
- * Score on the total number of matching characters.
+ * Generate a score on the total number of matching characters.
  * E.g. given the terms ["bar", "fo"] for the target value "food bar".
  *
  * - "fo" is included in the target value, and 2 out of 7 non-whitespace characters match (score: 2/7)
  * - "bar" is included in the target value, and 3 out of 7 non-whitespace characters match (score: 3/7)
  * - all values are accumulated and have their score devidied by half (final score: ~0.357)
+ *
+ * @internal
+ * @param uniqueSearchTerms - A string array of search terms
+ * @param value - The string to match against
+ * @returns SearchScore containing the search score as well as a human readable explanation
  */
 export function calculateCharacterScore(uniqueSearchTerms: string[], value: string): SearchScore {
   const sanitizedValue = value.toLowerCase().trim()
@@ -117,11 +145,16 @@ export function calculateCharacterScore(uniqueSearchTerms: string[], value: stri
 }
 
 /**
- * Score on the total number of matching _whole_ words.
+ * Generate a score on the total number of matching _whole_ words.
  * E.g. given the words ["the", "fox", "of", "london"] for the target value "the wily fox of london"
  *
  * - 4 out of 5 words match (score: 4/5 = 0.8)
  * - non-exact matches have their score divided in half (final score: 0.4)
+ *
+ * @internal
+ * @param uniqueSearchTerms - All search terms
+ * @param value - The string to match against
+ * @returns SearchScore containing the search score as well as a human readable explanation
  */
 export function calculateMatchingWordScore(
   uniqueSearchTerms: string[],
@@ -137,6 +170,13 @@ export function calculateMatchingWordScore(
     : [fieldScore / 2, `[Word] ${matches.length}/${all.length} terms: [${matches.join(', ')}]`]
 }
 
+/**
+ * Partition search terms by phrases (wrapped with quotes) and words.
+ *
+ * @internal
+ * @param searchTerms - All search terms
+ * @returns Partitioned phrases and words
+ */
 export function partitionAndSanitizeSearchTerms(
   searchTerms: string[]
 ): {
@@ -152,8 +192,16 @@ export function partitionAndSanitizeSearchTerms(
   }
 }
 
+/**
+ * Returns matching array indices of `values` containing _any_ member of `uniqueSearchTerms`.
+ * When comparing for matches, members of `values` are stringified, trimmed and lowercased.
+ *
+ * @internal
+ * @param uniqueSearchTerms - All search terms
+ * @param values - Values to match against (members are stringified)
+ * @returns All matching indices in `values`
+ */
 export function findMatchingIndices(uniqueSearchTerms: string[], values: unknown[]): number[] {
-  // Separate search terms by phrases (wrapped with quotes) and words.
   const {phrases: uniqueSearchPhrases, words: uniqueSearchWords} = partitionAndSanitizeSearchTerms(
     uniqueSearchTerms
   )

--- a/packages/@sanity/base/src/search/weighted/applyWeights.ts
+++ b/packages/@sanity/base/src/search/weighted/applyWeights.ts
@@ -4,16 +4,29 @@ import {SearchHit, WeightedHit, SearchSpec} from './types'
 type SearchScore = [number, string]
 
 // takes a set of terms and a value and returns a [score, story] pair where score is a value between 0, 1 and story is the explanation
-export const calculateScore = (searchTerms: string[], value: string): SearchScore => {
+export const calculateScore = (
+  searchTerms: string[],
+  value: string,
+  options?: {
+    skipPhraseScore?: boolean
+    skipWordScore?: boolean
+  }
+): SearchScore => {
+  const {skipPhraseScore, skipWordScore} = options
+
   // Separate search terms by phrases (wrapped with quotes) and words.
   const {phrases: uniqueSearchPhrases, words: uniqueSearchWords} = partitionAndSanitizeSearchTerms(
     searchTerms
   )
-
-  // Calculate an aggregated score of both phrase and word matches.
-  const [phraseScore, phraseWhy] = calculatePhraseScore(uniqueSearchPhrases, value)
-  const [wordScore, wordWhy] = calculateWordScore(uniqueSearchWords, value)
-  return [phraseScore + wordScore, [wordWhy, phraseWhy].join(', ')]
+  // Calculate an aggregated score of words (partial + whole) and phrase matches.
+  const [baseScore, baseWhy] = calculateCharacterScore(uniqueSearchWords, value)
+  const [phraseScore, phraseWhy] = skipPhraseScore
+    ? [0, []]
+    : calculatePhraseScore(uniqueSearchPhrases, value)
+  const [wordScore, wordWhy] = skipWordScore
+    ? [0, []]
+    : calculateMatchingWordScore(uniqueSearchWords, value)
+  return [baseScore + wordScore + phraseScore, [baseWhy, wordWhy, phraseWhy].flat().join(', ')]
 }
 
 const stringify = (value: unknown): string =>
@@ -28,11 +41,18 @@ export function applyWeights(
   return hits.map((hit, index) => {
     const typeSpec = specByType[hit._type]
     const stories = typeSpec.paths.map((pathSpec, idx) => {
-      const value = stringify(hit[`w${idx}`])
+      const pathHit = hit[`w${idx}`]
+      // Only stringify non-falsy values so null values don't pollute search
+      const value = pathHit ? stringify(pathHit) : null
       if (!value) {
         return {path: pathSpec.path, score: 0, why: 'No match'}
       }
-      const [score, why] = calculateScore(terms, value)
+      // Don't calculate word score for internal fields (_id, _type) etc.
+      // This is to ensure that document IDs don't errorenously get broken up into
+      // multiple tokens, which creates false positives.
+      const [score, why] = calculateScore(terms, value, {
+        skipWordScore: pathSpec.path.startsWith('_'),
+      })
       return {
         path: pathSpec.path,
         score: score * pathSpec.weight,
@@ -45,8 +65,9 @@ export function applyWeights(
     return {hit, resultIndex: hits.length - index, score: totalScore, stories: stories}
   })
 }
+
 /**
- * For phrases: score on the total number of matching characters.
+ * Score on the total number of matching characters.
  * E.g. given the phrases ["the fox", "of london"] for the target value "the wily fox of london"
  *
  * - "the fox" isn't included in the target value (score: 0)
@@ -67,17 +88,46 @@ export function calculatePhraseScore(uniqueSearchPhrases: string[], value: strin
 
   return fieldScore === 1
     ? [1, '[Phrase] Exact match']
-    : [fieldScore / 2, `[Phrase] Matched ${matchCount} of ${sanitizedValue.length} characters`]
+    : [fieldScore / 2, `[Phrase] ${matchCount}/${sanitizedValue.length} chars`]
 }
 
 /**
- * For words: score on the total number of matching words.
+ * Score on the total number of matching characters.
+ * E.g. given the terms ["bar", "fo"] for the target value "food bar".
+ *
+ * - "fo" is included in the target value, and 2 out of 7 non-whitespace characters match (score: 2/7)
+ * - "bar" is included in the target value, and 3 out of 7 non-whitespace characters match (score: 3/7)
+ * - all values are accumulated and have their score devidied by half (final score: ~0.357)
+ */
+export function calculateCharacterScore(uniqueSearchTerms: string[], value: string): SearchScore {
+  const sanitizedValue = value.toLowerCase().trim()
+  const sanitizedValueCompact = sanitizedValue.replace(/ /g, '')
+
+  let fieldScore = 0
+  let matchCount = 0
+  uniqueSearchTerms.forEach((term) => {
+    if (sanitizedValue.includes(term)) {
+      fieldScore += term.length / sanitizedValueCompact.length
+      matchCount += term.length
+    }
+  })
+
+  return fieldScore === 1
+    ? [fieldScore, `[Char] Contains all`]
+    : [fieldScore / 2, `[Char] ${matchCount}/${sanitizedValueCompact.length} chars`]
+}
+
+/**
+ * Score on the total number of matching _whole_ words.
  * E.g. given the words ["the", "fox", "of", "london"] for the target value "the wily fox of london"
  *
  * - 4 out of 5 words match (score: 4/5 = 0.8)
  * - non-exact matches have their score divided in half (final score: 0.4)
  */
-export function calculateWordScore(uniqueSearchTerms: string[], value: string): SearchScore {
+export function calculateMatchingWordScore(
+  uniqueSearchTerms: string[],
+  value: string
+): SearchScore {
   const uniqueValueTerms = uniq(compact(words(toLower(value))))
 
   const matches = intersection(uniqueSearchTerms, uniqueValueTerms)
@@ -85,10 +135,7 @@ export function calculateWordScore(uniqueSearchTerms: string[], value: string): 
   const fieldScore = matches.length / all.length
   return fieldScore === 1
     ? [1, '[Word] Exact match']
-    : [
-        fieldScore / 2,
-        `[Word] Matched ${matches.length} of ${all.length} terms: [${matches.join(', ')}]`,
-      ]
+    : [fieldScore / 2, `[Word] ${matches.length}/${all.length} terms: [${matches.join(', ')}]`]
 }
 
 export function partitionAndSanitizeSearchTerms(

--- a/packages/@sanity/base/src/search/weighted/createSearchQuery.test.ts
+++ b/packages/@sanity/base/src/search/weighted/createSearchQuery.test.ts
@@ -322,13 +322,12 @@ describe('createSearchSpecs', () => {
       {path: ['name'], weight: 1},
     ],
   }
-  const playlist: SearchableType = {
-    name: 'playlist',
-    __experimental_search: [{path: ['name'], weight: 1}],
-  }
-  const species: SearchableType = {
-    name: 'species',
-    __experimental_search: [{path: ['name'], weight: 1}],
+  const poem: SearchableType = {
+    name: 'poem',
+    __experimental_search: [
+      {path: ['author'], weight: 1},
+      {path: ['title'], weight: 1},
+    ],
   }
 
   it('should order paths by length', () => {
@@ -338,7 +337,7 @@ describe('createSearchSpecs', () => {
   })
 
   it('should not include duplicate paths when factoring maxAttributes', () => {
-    const {specs} = createSearchSpecs([playlist, species], true, 1)
+    const {specs} = createSearchSpecs([book, poem], true, 1)
     const {paths} = flattenSpecs(specs)
     expect(paths).toHaveLength(2)
   })

--- a/packages/@sanity/base/src/search/weighted/createSearchQuery.test.ts
+++ b/packages/@sanity/base/src/search/weighted/createSearchQuery.test.ts
@@ -21,10 +21,10 @@ describe('createSearchQuery', () => {
       })
 
       expect(query).toEqual(
-        '*[_type in $__types && (title match $t0)]' +
+        '*[_type in $__types&&(title match $t0)]' +
           '| order(_id asc)' +
           '[$__offset...$__limit]' +
-          '{_type, _id, ...select(_type == "basic-schema-test" => { "w0": title })}'
+          '{_type,_id,...select(_type=="basic-schema-test"=>{"0":title})}'
       )
 
       expect(params).toEqual({
@@ -55,7 +55,7 @@ describe('createSearchQuery', () => {
         ],
       })
 
-      expect(query).toContain('*[_type in $__types && (title match $t0 || object.field match $t0)]')
+      expect(query).toContain('*[_type in $__types&&(title match $t0||object.field match $t0)]')
     })
 
     it('should have one match filter per term', () => {
@@ -64,7 +64,7 @@ describe('createSearchQuery', () => {
         types: [testType],
       })
 
-      expect(query).toContain('*[_type in $__types && (title match $t0) && (title match $t1)]')
+      expect(query).toContain('*[_type in $__types&&(title match $t0)&&(title match $t1)]')
       expect(params.t0).toEqual('term0*')
       expect(params.t1).toEqual('term1*')
     })
@@ -120,7 +120,7 @@ describe('createSearchQuery', () => {
       )
 
       expect(query).toContain(
-        '*[_type in $__types && (title match $t0) && (randomCondition == $customParam)]'
+        '*[_type in $__types&&(title match $t0)&&(randomCondition == $customParam)]'
       )
       expect(params.customParam).toEqual('custom')
     })
@@ -165,10 +165,10 @@ describe('createSearchQuery', () => {
       )
 
       expect(query).toEqual(
-        '*[_type in $__types && (title match $t0)]' +
+        '*[_type in $__types&&(title match $t0)]' +
           '| order(exampleField desc)' +
           '[$__offset...$__limit]' +
-          '{_type, _id, ...select(_type == "basic-schema-test" => { "w0": title })}'
+          '{_type,_id,...select(_type=="basic-schema-test"=>{"0":title})}'
       )
     })
 
@@ -179,10 +179,10 @@ describe('createSearchQuery', () => {
       })
 
       expect(query).toEqual(
-        '*[_type in $__types && (title match $t0)]' +
+        '*[_type in $__types&&(title match $t0)]' +
           '| order(_id asc)' +
           '[$__offset...$__limit]' +
-          '{_type, _id, ...select(_type == "basic-schema-test" => { "w0": title })}'
+          '{_type,_id,...select(_type=="basic-schema-test"=>{"0":title})}'
       )
     })
 
@@ -261,13 +261,12 @@ describe('createSearchQuery', () => {
          * As a workaround, we replace numbers with [] array syntax, so we at least get hits when the path matches anywhere in the array.
          * This is an improvement over before, where an illegal term was used (number-as-string, ala ["0"]),
          * which lead to no hits at all. */
-
-        '*[_type in $__types && (cover[].cards[].title match $t0) && (cover[].cards[].title match $t1)]' +
+        '*[_type in $__types&&(cover[].cards[].title match $t0)&&(cover[].cards[].title match $t1)]' +
           '| order(_id asc)' +
           '[$__offset...$__limit]' +
           // at this point we could refilter using cover[0].cards[0].title.
           // This solution was discarded at it would increase the size of the query payload by up to 50%
-          '{_type, _id, ...select(_type == "numbers-in-path" => { "w0": cover[].cards[].title })}'
+          '{_type,_id,...select(_type=="numbers-in-path"=>{"0":cover[].cards[].title})}'
       )
     })
 
@@ -288,8 +287,8 @@ describe('createSearchQuery', () => {
         ],
       })
 
-      expect(query).toContain('*[_type in $__types && (pt::text(pteField) match $t0)')
-      expect(query).toContain('...select(_type == "type1" => { "w0": pt::text(pteField) })')
+      expect(query).toContain('*[_type in $__types&&(pt::text(pteField) match $t0)')
+      expect(query).toContain('...select(_type=="type1"=>{"0":pt::text(pteField)})')
     })
   })
 })

--- a/packages/@sanity/base/src/search/weighted/createSearchQuery.test.ts
+++ b/packages/@sanity/base/src/search/weighted/createSearchQuery.test.ts
@@ -267,9 +267,7 @@ describe('createSearchQuery', () => {
           '[$__offset...$__limit]' +
           // at this point we could refilter using cover[0].cards[0].title.
           // This solution was discarded at it would increase the size of the query payload by up to 50%
-
-          // we still map out the path with number
-          '{_type, _id, ...select(_type == "numbers-in-path" => { "w0": cover[0].cards[0].title })}'
+          '{_type, _id, ...select(_type == "numbers-in-path" => { "w0": cover[].cards[].title })}'
       )
     })
 

--- a/packages/@sanity/base/src/search/weighted/createSearchQuery.ts
+++ b/packages/@sanity/base/src/search/weighted/createSearchQuery.ts
@@ -132,7 +132,7 @@ function createConstraints(terms: string[], specs: SearchSpec[]) {
     .map((_term, i) => combinedSearchPaths.map((joinedPath) => `${joinedPath} match $t${i}`))
     .filter((constraint) => constraint.length > 0)
 
-  return constraints.map((constraint) => `(${constraint.join(' || ')})`)
+  return constraints.map((constraint) => `(${constraint.join('||')})`)
 }
 
 /**
@@ -194,24 +194,24 @@ export function createSearchQuery(
   ].filter(Boolean)
 
   const selections = optimizedSpecs.map((spec) => {
-    const constraint = `_type == "${spec.typeName}" => `
-    const selection = `{ ${spec.paths.map((cfg, i) => `"w${i}": ${pathWithMapper(cfg)}`)} }`
+    const constraint = `_type=="${spec.typeName}"=>`
+    const selection = `{${spec.paths.map((cfg, i) => `"${i}":${pathWithMapper(cfg)}`)}}`
     return `${constraint}${selection}`
   })
 
-  const selection = selections.length > 0 ? `...select(${selections.join(',\n')})` : ''
+  const selection = selections.length > 0 ? `...select(${selections.join(',')})` : ''
 
   // Default to `_id asc` (GROQ default) if no search sort is provided
   const sortDirection = searchOpts?.sort?.direction || ('asc' as SortDirection)
   const sortField = searchOpts?.sort?.field || '_id'
 
   const query =
-    `*[${filters.join(' && ')}]` +
+    `*[${filters.join('&&')}]` +
     `| order(${sortField} ${sortDirection})` +
     `[$__offset...$__limit]` +
     // the following would improve search quality for paths-with-numbers, but increases the size of the query by up to 50%
     // `${hasIndexedPaths ? `[${createConstraints(terms, exactSearchSpec).join(' && ')}]` : ''}` +
-    `{_type, _id, ${selection}}`
+    `{_type,_id,${selection}}`
 
   // Prepend optional GROQ comments to query
   const groqComments = (searchOpts?.comments || []).map((s) => `// ${s}`).join('\n')

--- a/packages/@sanity/base/src/search/weighted/createSearchQuery.ts
+++ b/packages/@sanity/base/src/search/weighted/createSearchQuery.ts
@@ -1,4 +1,4 @@
-import {ExperimentalSearchPath} from '@sanity/types/src'
+import {ExperimentalSearchPath} from '@sanity/types'
 import {compact, flatten, flow, toLower, trim, union, uniq, words} from 'lodash'
 import {joinPath} from '../../util/searchUtils'
 import {tokenize} from '../common/tokenize'
@@ -193,12 +193,15 @@ export function createSearchQuery(
     filter ? `(${filter})` : '',
   ].filter(Boolean)
 
+  // Construct individual type selections based on __experimental_search paths,
+  // but ignore _id and _type keys (as these are included in all types)
   const selections = optimizedSpecs.map((spec) => {
     const constraint = `_type=="${spec.typeName}"=>`
-    const selection = `{${spec.paths.map((cfg, i) => `"${i}":${pathWithMapper(cfg)}`)}}`
+    const selection = `{${spec.paths
+      .filter((cfg) => !['_id', '_type'].includes(cfg.path))
+      .map((cfg, i) => `"${i}":${pathWithMapper(cfg)}`)}}`
     return `${constraint}${selection}`
   })
-
   const selection = selections.length > 0 ? `...select(${selections.join(',')})` : ''
 
   // Default to `_id asc` (GROQ default) if no search sort is provided

--- a/packages/@sanity/base/src/search/weighted/createSearchQuery.ts
+++ b/packages/@sanity/base/src/search/weighted/createSearchQuery.ts
@@ -47,7 +47,6 @@ const combinePaths = flow([flatten, union, compact])
  * Create search specs from supplied searchable types.
  * Search specs contain weighted paths which are used to construct GROQ queries for search.
  *
- * @internal
  * @param types - Searchable document types to create specs from.
  * @param optimizedIndexPaths - If true, will will convert all `__experimental_search` paths containing numbers into array syntax.
  *  E.g. ['cover', 0, 'cards', 0, 'title'] => "cover[].cards[].title"
@@ -57,6 +56,7 @@ const combinePaths = flow([flatten, union, compact])
  * @param maxAttributes - Maximum number of _unique_ searchable attributes to include across all types.
  *  User-provided paths (e.g. with __experimental_search) do not count towards this limit.
  * @returns All matching search specs and `hasIndexedPaths`, a boolean indicating whether any paths contain indices.
+ * @internal
  */
 export function createSearchSpecs(
   types: SearchableType[],
@@ -162,9 +162,9 @@ function createConstraints(terms: string[], specs: SearchSpec[]) {
  *
  * Phrases wrapped in quotes are assigned relevance scoring differently from regular words.
  *
- * @internal
  * @param query - A string to convert into individual tokens
  * @returns All extracted tokens
+ * @internal
  */
 export function extractTermsFromQuery(query: string): string[] {
   const quotedQueries = [] as string[]
@@ -192,10 +192,10 @@ export function extractTermsFromQuery(query: string): string[] {
 /**
  * Generate search query data based off provided search terms and options.
  *
- * @internal
  * @param searchTerms - SearchTerms containing a string query and any number of searchable document types.
  * @param searchOpts - Optional search configuration.
  * @returns GROQ query, params and options to be used to fetch search results.
+ * @internal
  */
 export function createSearchQuery(
   searchTerms: SearchTerms,

--- a/packages/@sanity/base/src/search/weighted/createSearchQuery.ts
+++ b/packages/@sanity/base/src/search/weighted/createSearchQuery.ts
@@ -44,17 +44,16 @@ const combinePaths = flow([flatten, union, compact])
  * Create search specs from supplied searchable types.
  * Search specs contain weighted paths which are used to construct GROQ queries for search.
  *
- * @param types - The searchable document types to create specs from.
+ * @internal
+ * @param types - Searchable document types to create specs from.
  * @param optimizedIndexPaths - If true, will will convert all `__experimental_search` paths containing numbers into array syntax.
  *  E.g. ['cover', 0, 'cards', 0, 'title'] => "cover[].cards[].title"
  *
  *  This optimization will yield more search results than may be intended, but offers better performance over arrays with indices.
  *  (which are currently unoptimizable by Content Lake)
- * @param maxAttributes - The maximum number of _unique_ searchable attributes to include across all types.
+ * @param maxAttributes - Maximum number of _unique_ searchable attributes to include across all types.
  *  User-provided paths (e.g. with __experimental_search) do not count towards this limit.
- * @returns An object containing all matching search specs and `hasIndexedPaths`, a boolean indicating whether any paths contain indices.
- *   E.g. `['cover', 0, 'cards', 0, 'title']`
- * @internal
+ * @returns All matching search specs and `hasIndexedPaths`, a boolean indicating whether any paths contain indices.
  */
 export function createSearchSpecs(
   types: SearchableType[],
@@ -159,9 +158,9 @@ function createConstraints(terms: string[], specs: SearchSpec[]) {
  *
  * Phrases wrapped in quotes are assigned relevance scoring differently from regular words.
  *
- * @param query - A string to convert into tokens.
- * @returns An array of string tokens.
  * @internal
+ * @param query - A string to convert into individual tokens
+ * @returns All extracted tokens
  */
 export function extractTermsFromQuery(query: string): string[] {
   const quotedQueries = [] as string[]
@@ -176,7 +175,7 @@ export function extractTermsFromQuery(query: string): string[] {
   // Lowercase and trim quoted queries
   const quotedTerms = quotedQueries.map((str) => trim(toLower(str)))
 
-  /**
+  /*
    * Convert (remaining) search query into an array of deduped, sanitized tokens.
    * All white space and special characters are removed.
    * e.g. "The saint of Saint-Germain-des-Prés" => ['the', 'saint', 'of', 'germain', 'des', 'pres']
@@ -189,10 +188,10 @@ export function extractTermsFromQuery(query: string): string[] {
 /**
  * Generate search query data based off provided search terms and options.
  *
- * @param searchTerms - An object containing a string query and any number of searchable document types.
- * @param searchOpts - Optional search configuration.
- * @returns A object containing a GROQ query, params and options to be used to fetch search results.
  * @internal
+ * @param searchTerms - SearchTerms containing a string query and any number of searchable document types.
+ * @param searchOpts - Optional search configuration.
+ * @returns GROQ query, params and options to be used to fetch search results.
  */
 export function createSearchQuery(
   searchTerms: SearchTerms,
@@ -203,7 +202,7 @@ export function createSearchQuery(
   // Extract search terms from string query, factoring in phrases wrapped in quotes
   const terms = extractTermsFromQuery(searchTerms.query)
 
-  /**
+  /*
    * Create an optimized search spec which removes array indices from __experimental_search paths.
    * e.g. ["authors", 0, "title"] => "authors[].title"
    *

--- a/packages/@sanity/base/src/search/weighted/createSearchQuery.ts
+++ b/packages/@sanity/base/src/search/weighted/createSearchQuery.ts
@@ -1,5 +1,5 @@
-import {ExperimentalSearchPath} from '@sanity/types'
 import {compact, flatten, flow, toLower, trim, union, uniq, words} from 'lodash'
+import {ExperimentalSearchPath} from '../../../../types'
 import {joinPath} from '../../util/searchUtils'
 import {tokenize} from '../common/tokenize'
 import type {

--- a/packages/@sanity/base/src/search/weighted/createSearchQuery.ts
+++ b/packages/@sanity/base/src/search/weighted/createSearchQuery.ts
@@ -37,7 +37,7 @@ interface IntermediateSearchType extends Omit<ExperimentalSearchPath, 'path'> {
 export const DEFAULT_LIMIT = 1000
 
 // Maximum number of unique searchable attributes to include in a single search query (across all document types)
-const MAX_UNIQUE_ATTRIBUTES =
+const SEARCH_ATTR_LIMIT =
   // eslint-disable-next-line no-process-env
   Number(process.env.SANITY_STUDIO_UNSTABLE_SEARCH_ATTR_LIMIT) || 1000
 
@@ -213,7 +213,7 @@ export function createSearchQuery(
    * These optimized specs are used when building constraints in this search query and assigning
    * weight to search hits.
    */
-  const optimizedSpecs = createSearchSpecs(searchTerms.types, true, MAX_UNIQUE_ATTRIBUTES).specs
+  const optimizedSpecs = createSearchSpecs(searchTerms.types, true, SEARCH_ATTR_LIMIT).specs
 
   // Construct search filters used in this GROQ query
   const filters = [

--- a/packages/@sanity/base/src/search/weighted/createWeightedSearch.test.ts
+++ b/packages/@sanity/base/src/search/weighted/createWeightedSearch.test.ts
@@ -20,8 +20,8 @@ const mockSchema = Schema.compile({
 
 const searchHits = defer(() =>
   of([
-    {_id: 'id0', _type: 'book', w0: 'id0', w1: 'book', w2: 'Harry Potter'},
-    {_id: 'id1', _type: 'book', w0: 'id1', w1: 'book', w2: 'Harry'},
+    {_id: 'id0', _type: 'book', 0: 'id0', 1: 'book', 2: 'Harry Potter'},
+    {_id: 'id1', _type: 'book', 0: 'id1', 1: 'book', 2: 'Harry'},
   ])
 )
 

--- a/packages/@sanity/base/src/search/weighted/createWeightedSearch.test.ts
+++ b/packages/@sanity/base/src/search/weighted/createWeightedSearch.test.ts
@@ -37,8 +37,8 @@ describe('createWeightedSearch', () => {
     // @todo: replace `toPromise` with `firstValueFrom` in rxjs 7+
     const result = await search({query: 'harry', types: []} as SearchTerms).toPromise()
 
-    expect(result[0].score).toEqual(10)
-    expect(result[1].score).toEqual(2.5)
+    expect(result[0].score).toEqual(20)
+    expect(result[1].score).toEqual(4.772727272727273)
   })
 
   it('should not order hits by score if skipSortByScore is enabled', async () => {
@@ -47,7 +47,7 @@ describe('createWeightedSearch', () => {
       skipSortByScore: true,
     }).toPromise()
 
-    expect(result[0].score).toEqual(2.5)
-    expect(result[1].score).toEqual(10)
+    expect(result[0].score).toEqual(4.772727272727273)
+    expect(result[1].score).toEqual(20)
   })
 })

--- a/packages/@sanity/base/src/search/weighted/index.ts
+++ b/packages/@sanity/base/src/search/weighted/index.ts
@@ -1,1 +1,3 @@
 export {createWeightedSearch} from './createWeightedSearch'
+export {createSearchQuery} from './createSearchQuery'
+export * from './types'

--- a/packages/@sanity/base/src/search/weighted/types.ts
+++ b/packages/@sanity/base/src/search/weighted/types.ts
@@ -42,7 +42,7 @@ export interface SearchSpec {
 export interface SearchHit {
   _type: string
   _id: string
-  [key: string]: unknown
+  [key: string]: string
 }
 
 /**

--- a/packages/@sanity/base/src/search/weighted/types.ts
+++ b/packages/@sanity/base/src/search/weighted/types.ts
@@ -48,6 +48,7 @@ export interface SearchHit {
  * @internal
  */
 export interface SearchStory {
+  indices?: number[]
   path: string
   score: number
   why: string

--- a/packages/@sanity/base/src/search/weighted/types.ts
+++ b/packages/@sanity/base/src/search/weighted/types.ts
@@ -33,6 +33,7 @@ export interface SearchPath {
 export interface SearchSpec {
   typeName: string
   paths: SearchPath[]
+  skippedPaths: SearchPath[]
 }
 
 /**

--- a/packages/@sanity/default-layout/src/navbar/search/components/searchResultItem/DebugOverlay.tsx
+++ b/packages/@sanity/default-layout/src/navbar/search/components/searchResultItem/DebugOverlay.tsx
@@ -39,6 +39,9 @@ export function DebugOverlay({data}: DebugScoreProps) {
                       <Code size={0} weight="semibold">
                         {story.path}
                       </Code>
+                      {!!story.indices?.length && (
+                        <Code size={0}>{JSON.stringify(story.indices)}</Code>
+                      )}
                       <Code size={0}>{story.why}</Code>
                     </Inline>
                   ))}

--- a/packages/@sanity/schema/package.json
+++ b/packages/@sanity/schema/package.json
@@ -31,6 +31,7 @@
   "license": "MIT",
   "dependencies": {
     "@sanity/generate-help-url": "^3.0.0",
+    "@sanity/types": "2.35.0",
     "arrify": "^1.0.1",
     "humanize-list": "^1.0.1",
     "leven": "^3.1.0",

--- a/packages/@sanity/schema/src/legacy/searchConfig/normalize.test.ts
+++ b/packages/@sanity/schema/src/legacy/searchConfig/normalize.test.ts
@@ -1,9 +1,9 @@
-import {normalizeSearchConfigs} from './normalize'
+import {normalizeUserSearchConfigs} from './normalize'
 
 describe('searchConfig.normalize', () => {
   describe('normalizeSearchConfigs', () => {
     it('should keep numbers as numbers in path segments', () => {
-      const normalized = normalizeSearchConfigs([
+      const normalized = normalizeUserSearchConfigs([
         {weight: 10, path: ['retain', 0, 'numbers']},
         {weight: 1, path: 'with.0.number'},
         {path: 'missing.weight'},
@@ -11,10 +11,10 @@ describe('searchConfig.normalize', () => {
       ])
 
       expect(normalized).toEqual([
-        {weight: 10, path: ['retain', 0, 'numbers'], mapWith: undefined},
-        {weight: 1, path: ['with', 0, 'number'], mapWith: undefined},
-        {weight: 1, path: ['missing', 'weight'], mapWith: undefined},
-        {weight: 2, path: ['map', 'with'], mapWith: 'datetime'},
+        {weight: 10, path: ['retain', 0, 'numbers'], mapWith: undefined, userProvided: true},
+        {weight: 1, path: ['with', 0, 'number'], mapWith: undefined, userProvided: true},
+        {weight: 1, path: ['missing', 'weight'], mapWith: undefined, userProvided: true},
+        {weight: 2, path: ['map', 'with'], mapWith: 'datetime', userProvided: true},
       ])
     })
   })

--- a/packages/@sanity/schema/src/legacy/searchConfig/normalize.ts
+++ b/packages/@sanity/schema/src/legacy/searchConfig/normalize.ts
@@ -1,6 +1,6 @@
 import {isPlainObject, toPath} from 'lodash'
 
-export function normalizeSearchConfigs(configs) {
+export function normalizeUserSearchConfigs(configs) {
   if (!Array.isArray(configs)) {
     throw new Error(
       'The search config of a document type must be an array of search config objects'
@@ -17,6 +17,7 @@ export function normalizeSearchConfigs(configs) {
       weight: 'weight' in conf ? conf.weight : 1,
       path: toPath(conf.path).map(stringsToNumbers),
       mapWith: typeof conf.mapWith === 'string' ? conf.mapWith : undefined,
+      userProvided: true,
     }
   })
 }

--- a/packages/@sanity/schema/src/legacy/searchConfig/resolve.test.ts
+++ b/packages/@sanity/schema/src/legacy/searchConfig/resolve.test.ts
@@ -143,6 +143,7 @@ describe('searchConfig.resolve', () => {
             title: 'cover.0.card.0.title',
             subtitle: 'singleField',
             description: 'nested.field',
+            // @ts-expect-error test-specific: ignored isn't a valid key
             ignored: 'anyField',
           },
         },

--- a/packages/@sanity/schema/src/legacy/searchConfig/resolve.test.ts
+++ b/packages/@sanity/schema/src/legacy/searchConfig/resolve.test.ts
@@ -1,6 +1,140 @@
-import {deriveFromPreview} from './resolve'
+import Schema from '../Schema'
+import {
+  deriveFromPreview,
+  getCachedStringFieldPaths,
+  pathCountSymbol,
+  stringFieldsSymbol,
+} from './resolve'
 
 describe('searchConfig.resolve', () => {
+  describe('getCachedStringFieldPaths', () => {
+    const mockSchema = Schema.compile({
+      name: 'default',
+      types: [
+        {
+          name: 'objA',
+          title: 'Circular Document A',
+          type: 'document',
+          fields: [
+            {name: 'description', type: 'text'},
+            {
+              name: 'nested',
+              type: 'object',
+              fields: [
+                {name: 'objA', type: 'objA'},
+                {name: 'nestedTitle', type: 'string'},
+              ],
+            },
+            {name: 'authors', type: 'array', of: [{type: 'string'}]},
+            {name: 'objB', type: 'objB'},
+            {name: 'objATitle', type: 'string'},
+            {name: 'title', type: 'string'},
+          ],
+        },
+        {
+          name: 'objB',
+          title: 'Circular Document B',
+          type: 'document',
+          fields: [
+            {
+              name: 'nested',
+              type: 'object',
+              fields: [
+                {name: 'objB', type: 'objB'},
+                {name: 'nestedTitle', type: 'string'},
+              ],
+            },
+            {name: 'objA', type: 'objA'},
+            {name: 'authors', type: 'array', of: [{type: 'string'}]},
+            {name: 'title', type: 'string'},
+            {name: 'description', type: 'text'},
+            {name: 'objBTitle', type: 'string'},
+          ],
+        },
+      ],
+    })
+
+    const objA = mockSchema.get('objA')
+    // Clear cached values
+    beforeEach(() => {
+      delete objA[stringFieldsSymbol]
+      delete objA[pathCountSymbol]
+    })
+
+    it('should always include _id and _type fields', () => {
+      expect(getCachedStringFieldPaths(objA, 0, 10)).toEqual(
+        expect.arrayContaining([
+          {path: ['_id'], weight: 1},
+          {path: ['_type'], weight: 1},
+        ])
+      )
+    })
+
+    it('should sort all other fields ahead of objects and arrays', () => {
+      expect(getCachedStringFieldPaths(objA, 2, 100)).toEqual([
+        {path: ['_id'], weight: 1},
+        {path: ['_type'], weight: 1},
+        {path: ['title'], weight: 10},
+        {path: ['description'], weight: 1},
+        {path: ['objATitle'], weight: 1},
+        //
+        {path: ['authors', []], weight: 1},
+        {path: ['nested', 'nestedTitle'], weight: 1},
+        {path: ['objB', 'description'], weight: 1},
+        {path: ['objB', 'objBTitle'], weight: 1},
+        {path: ['objB', 'title'], weight: 1},
+      ])
+    })
+
+    it('should limit on depth (1 level)', () => {
+      expect(getCachedStringFieldPaths(objA, 1, 250)).toEqual([
+        {path: ['_id'], weight: 1},
+        {path: ['_type'], weight: 1},
+        {path: ['title'], weight: 10},
+        {path: ['description'], weight: 1},
+        {path: ['objATitle'], weight: 1},
+      ])
+    })
+
+    it('should limit on depth (10 levels)', () => {
+      const paths = getCachedStringFieldPaths(objA, 10, 5000)
+      expect(paths).toEqual(
+        expect.arrayContaining([
+          // prettier-ignore
+          { path: ['objB', 'objA', 'objB', 'objA', 'objB', 'objA', 'objB', 'objA', 'objB', 'title'], weight: 1 },
+        ])
+      )
+      expect(paths).toEqual(
+        expect.arrayContaining([
+          // prettier-ignore
+          { path: ['nested', 'objA', 'nested', 'objA', 'nested', 'objA', 'nested', 'objA', 'objB', 'title'], weight: 1 },
+        ])
+      )
+    })
+
+    it('should include all root-level non-object/array fields even when dealing with recursive structures', () => {
+      expect(getCachedStringFieldPaths(objA, 500, 10)).toEqual(
+        expect.arrayContaining([
+          {path: ['_id'], weight: 1},
+          {path: ['_type'], weight: 1},
+          {path: ['description'], weight: 1},
+          {path: ['objATitle'], weight: 1},
+          {path: ['title'], weight: 10},
+        ])
+      )
+    })
+
+    it('should limit on the total number of search paths', () => {
+      expect(getCachedStringFieldPaths(objA, 100, 250)).toHaveLength(250)
+    })
+
+    it('should cache field paths by type', () => {
+      getCachedStringFieldPaths(objA, 100, 500)
+      const paths = getCachedStringFieldPaths(objA, 1, 1)
+      expect(paths).toHaveLength(500)
+    })
+  })
+
   describe('deriveFromPreview', () => {
     it('should split selected fields, and add default weights, keeping numbers as numbers', () => {
       const weightedPaths = deriveFromPreview({

--- a/packages/@sanity/schema/src/legacy/searchConfig/resolve.ts
+++ b/packages/@sanity/schema/src/legacy/searchConfig/resolve.ts
@@ -21,11 +21,11 @@ export const pathCountSymbol = Symbol('__cachedPathCount')
 
 // Max number of levels to traverse per root-level object
 // eslint-disable-next-line no-process-env
-const MAX_TRAVERSAL_DEPTH = Number(process.env.SANITY_STUDIO_UNSTABLE_SEARCH_DEPTH) || 15
+const SEARCH_DEPTH_LIMIT = Number(process.env.SANITY_STUDIO_UNSTABLE_SEARCH_DEPTH_LIMIT) || 15
 
 // Max number of search paths to extract per root-level object
 // eslint-disable-next-line no-process-env
-const MAX_OBJECT_SEARCH_PATHS = Number(process.env.SANITY_STUDIO_UNSTABLE_SEARCH_PATH_LIMIT) || 500
+const SEARCH_PATH_LIMIT = Number(process.env.SANITY_STUDIO_UNSTABLE_SEARCH_PATH_LIMIT) || 500
 
 const BASE_WEIGHTS = [
   {weight: 1, path: ['_id']},
@@ -187,5 +187,5 @@ export function resolveSearchConfigForBaseFieldPaths(type: ObjectSchemaType): Se
 }
 
 export default function resolveSearchConfig(type: ObjectSchemaType): SearchPath[] {
-  return getCachedStringFieldPaths(type, MAX_TRAVERSAL_DEPTH, MAX_OBJECT_SEARCH_PATHS)
+  return getCachedStringFieldPaths(type, SEARCH_DEPTH_LIMIT, SEARCH_PATH_LIMIT)
 }

--- a/packages/@sanity/schema/src/legacy/searchConfig/resolve.ts
+++ b/packages/@sanity/schema/src/legacy/searchConfig/resolve.ts
@@ -24,6 +24,7 @@ export const pathCountSymbol = Symbol('__cachedPathCount')
 const MAX_TRAVERSAL_DEPTH = Number(process.env.SANITY_STUDIO_UNSTABLE_SEARCH_DEPTH) || 15
 
 // Max number of search paths to extract per root-level object
+// eslint-disable-next-line no-process-env
 const MAX_OBJECT_SEARCH_PATHS = Number(process.env.SANITY_STUDIO_UNSTABLE_SEARCH_PATH_LIMIT) || 500
 
 const BASE_WEIGHTS = [

--- a/packages/@sanity/schema/src/legacy/searchConfig/resolve.ts
+++ b/packages/@sanity/schema/src/legacy/searchConfig/resolve.ts
@@ -6,7 +6,7 @@ const stringFieldsSymbol = Symbol('__cachedStringFields')
 const isReference = (type) => type.type && type.type.name === 'reference'
 
 // eslint-disable-next-line no-process-env
-const maxTraversalDepth = process.env.SANITY_STUDIO_UNSTABLE_SEARCH_DEPTH || 4
+const maxTraversalDepth = Number(process.env.SANITY_STUDIO_UNSTABLE_SEARCH_DEPTH) || 4
 
 const portableTextFields = ['style', 'list']
 const isPortableTextBlock = (type) =>

--- a/packages/@sanity/schema/src/legacy/searchConfig/resolve.ts
+++ b/packages/@sanity/schema/src/legacy/searchConfig/resolve.ts
@@ -5,6 +5,9 @@ const stringFieldsSymbol = Symbol('__cachedStringFields')
 
 const isReference = (type) => type.type && type.type.name === 'reference'
 
+// eslint-disable-next-line no-process-env
+const maxTraversalDepth = process.env.SANITY_STUDIO_UNSTABLE_SEARCH_DEPTH || 4
+
 const portableTextFields = ['style', 'list']
 const isPortableTextBlock = (type) =>
   type.name === 'block' || (type.type && isPortableTextBlock(type.type))
@@ -98,7 +101,7 @@ function getCachedStringFieldPaths(type, maxDepth) {
   return type[stringFieldsSymbol]
 }
 
-function getCachedBaseFieldPaths(type, maxDepth) {
+function getCachedBaseFieldPaths(type) {
   if (!type[stringFieldsSymbol]) {
     type[stringFieldsSymbol] = uniqBy([...BASE_WEIGHTS, ...deriveFromPreview(type)], (spec) =>
       spec.path.join('.')
@@ -122,9 +125,9 @@ function getPortableTextFieldPaths(type, maxDepth) {
 }
 
 export function resolveSearchConfigForBaseFieldPaths(type) {
-  return getCachedBaseFieldPaths(type, 4)
+  return getCachedBaseFieldPaths(type)
 }
 
 export default function resolveSearchConfig(type) {
-  return getCachedStringFieldPaths(type, 4)
+  return getCachedStringFieldPaths(type, maxTraversalDepth)
 }

--- a/packages/@sanity/schema/src/legacy/searchConfig/resolve.ts
+++ b/packages/@sanity/schema/src/legacy/searchConfig/resolve.ts
@@ -1,55 +1,30 @@
 import {uniqBy} from 'lodash'
+import {
+  ArraySchemaType,
+  isArraySchemaType,
+  isObjectSchemaType,
+  isBlockSchemaType,
+  isReferenceSchemaType,
+  ObjectSchemaType,
+  SchemaType,
+} from '../../../../types'
 import {stringsToNumbers} from './normalize'
 
-const stringFieldsSymbol = Symbol('__cachedStringFields')
+interface SearchPath {
+  path: (string | number | [])[]
+  weight: number
+  mapWith?: string
+}
 
-const isReference = (type) => type.type && type.type.name === 'reference'
+export const stringFieldsSymbol = Symbol('__cachedStringFields')
+export const pathCountSymbol = Symbol('__cachedPathCount')
 
+// Max number of levels to traverse per root-level object
 // eslint-disable-next-line no-process-env
-const maxTraversalDepth = Number(process.env.SANITY_STUDIO_UNSTABLE_SEARCH_DEPTH) || 4
+const MAX_TRAVERSAL_DEPTH = Number(process.env.SANITY_STUDIO_UNSTABLE_SEARCH_DEPTH) || 15
 
-const portableTextFields = ['style', 'list']
-const isPortableTextBlock = (type) =>
-  type.name === 'block' || (type.type && isPortableTextBlock(type.type))
-const isPortableTextArray = (type) =>
-  type.jsonType === 'array' && Array.isArray(type.of) && type.of.some(isPortableTextBlock)
-
-function reduceType(type, reducer, acc, path = [], maxDepth) {
-  if (maxDepth < 0) {
-    return acc
-  }
-
-  const accumulator = reducer(acc, type, path)
-  if (type.jsonType === 'array' && Array.isArray(type.of)) {
-    return reduceArray(type, reducer, accumulator, path, maxDepth)
-  }
-
-  if (type.jsonType === 'object' && Array.isArray(type.fields) && !isReference(type)) {
-    return reduceObject(type, reducer, accumulator, path, maxDepth)
-  }
-
-  return accumulator
-}
-
-function reduceArray(arrayType, reducer, accumulator, path, maxDepth) {
-  return arrayType.of.reduce(
-    (acc, ofType) => reduceType(ofType, reducer, acc, path, maxDepth - 1),
-    accumulator
-  )
-}
-
-function reduceObject(objectType, reducer, accumulator, path, maxDepth) {
-  const isPtBlock = isPortableTextBlock(objectType)
-  return objectType.fields.reduce((acc, field) => {
-    // Don't include styles and list types as searchable paths for portable text blocks
-    if (isPtBlock && portableTextFields.includes(field.name)) {
-      return acc
-    }
-
-    const segment = [field.name].concat(field.type.jsonType === 'array' ? [[]] : [])
-    return reduceType(field.type, reducer, acc, path.concat(segment), maxDepth - 1)
-  }, accumulator)
-}
+// Max number of search paths to extract per root-level object
+const MAX_OBJECT_SEARCH_PATHS = Number(process.env.SANITY_STUDIO_UNSTABLE_SEARCH_PATH_LIMIT) || 500
 
 const BASE_WEIGHTS = [
   {weight: 1, path: ['_id']},
@@ -62,12 +37,97 @@ const PREVIEW_FIELD_WEIGHT_MAP = {
   description: 1.5,
 }
 
+const PORTABLE_TEXT_FIELDS = ['style', 'list']
+
+const isPortableTextArray = (type) =>
+  isArraySchemaType(type) && Array.isArray(type.of) && type.of.some(isBlockSchemaType)
+
+type SchemaTypeReducer = (
+  acc: SearchPath[],
+  type: SchemaType,
+  path: SearchPath['path']
+) => SearchPath[]
+
+// eslint-disable-next-line max-params
+function reduceType(
+  parentType: ObjectSchemaType,
+  type: SchemaType,
+  reducer: SchemaTypeReducer,
+  acc: SearchPath[],
+  path = [],
+  maxDepth: number
+) {
+  if (maxDepth < 0 || parentType[pathCountSymbol] < 0) {
+    return acc
+  }
+
+  const accumulator = reducer(acc, type, path)
+  if (isArraySchemaType(type) && Array.isArray(type.of)) {
+    return reduceArray(parentType, type, reducer, accumulator, path, maxDepth)
+  }
+
+  if (isObjectSchemaType(type) && Array.isArray(type.fields) && !isReferenceSchemaType(type)) {
+    return reduceObject(parentType, type, reducer, accumulator, path, maxDepth)
+  }
+
+  parentType[pathCountSymbol] -= 1
+  return accumulator
+}
+
+// eslint-disable-next-line max-params
+function reduceArray(
+  parentType: ObjectSchemaType,
+  arrayType: ArraySchemaType,
+  reducer: SchemaTypeReducer,
+  accumulator: SearchPath[],
+  path: SearchPath['path'],
+  maxDepth: number
+) {
+  return arrayType.of.reduce(
+    (acc, ofType) => reduceType(parentType, ofType, reducer, acc, path, maxDepth - 1),
+    accumulator
+  )
+}
+
+// eslint-disable-next-line max-params
+function reduceObject(
+  parentType: ObjectSchemaType,
+  objectType: ObjectSchemaType,
+  reducer: SchemaTypeReducer,
+  accumulator: SearchPath[],
+  path: SearchPath['path'],
+  maxDepth: number
+) {
+  return Array.from(objectType.fields)
+    .sort((a, b) => {
+      // Object fields with these types will be pushed to the end
+      const sortTypes = ['array', 'object']
+
+      const aIsObjectOrArray = sortTypes.includes(a.type.jsonType)
+      const bIsObjectOrArray = sortTypes.includes(b.type.jsonType)
+
+      // Sort by name when either both (or neither) comparators are objects and/or arrays
+      if (aIsObjectOrArray) {
+        return bIsObjectOrArray ? a.name.localeCompare(b.name) : 1
+      }
+      return bIsObjectOrArray ? -1 : a.name.localeCompare(b.name)
+    })
+    .reduce((acc, field) => {
+      // Don't include styles and list types as searchable paths for portable text blocks
+      if (isBlockSchemaType(objectType) && PORTABLE_TEXT_FIELDS.includes(field.name)) {
+        return acc
+      }
+      const segment = ([field.name] as SearchPath['path']).concat(
+        isArraySchemaType(field.type) ? [[]] : []
+      )
+      return reduceType(parentType, field.type, reducer, acc, path.concat(segment), maxDepth - 1)
+    }, accumulator)
+}
+
 /**
  * @internal
  */
-export function deriveFromPreview(type: {
-  preview: {select: Record<string, string>}
-}): {weight?: number; path: (string | number)[]}[] {
+export function deriveFromPreview(type: ObjectSchemaType): SearchPath[] {
   const select = type?.preview?.select
 
   if (!select) {
@@ -82,26 +142,23 @@ export function deriveFromPreview(type: {
     }))
 }
 
-function getCachedStringFieldPaths(type, maxDepth) {
+export function getCachedStringFieldPaths(
+  type: ObjectSchemaType,
+  maxDepth: number,
+  maxSearchPaths: number
+): SearchPath[] {
+  type[pathCountSymbol] = maxSearchPaths
+
   if (!type[stringFieldsSymbol]) {
     type[stringFieldsSymbol] = uniqBy(
-      [
-        ...BASE_WEIGHTS,
-        ...deriveFromPreview(type),
-        ...getStringFieldPaths(type, maxDepth).map((path) => ({weight: 1, path})),
-        ...getPortableTextFieldPaths(type, maxDepth).map((path) => ({
-          weight: 1,
-          path,
-          mapWith: 'pt::text',
-        })),
-      ],
+      [...BASE_WEIGHTS, ...deriveFromPreview(type), ...getFieldSearchPaths(type, maxDepth)],
       (spec) => spec.path.join('.')
-    )
+    ).slice(0, maxSearchPaths)
   }
   return type[stringFieldsSymbol]
 }
 
-function getCachedBaseFieldPaths(type) {
+function getCachedBaseFieldPaths(type: ObjectSchemaType) {
   if (!type[stringFieldsSymbol]) {
     type[stringFieldsSymbol] = uniqBy([...BASE_WEIGHTS, ...deriveFromPreview(type)], (spec) =>
       spec.path.join('.')
@@ -110,24 +167,24 @@ function getCachedBaseFieldPaths(type) {
   return type[stringFieldsSymbol]
 }
 
-function getStringFieldPaths(type, maxDepth) {
-  const reducer = (accumulator, childType, path) =>
-    childType.jsonType === 'string' ? [...accumulator, path] : accumulator
+function getFieldSearchPaths(type: ObjectSchemaType, maxDepth: number) {
+  const reducer: SchemaTypeReducer = (acc, childType, path) => {
+    if (childType.jsonType === 'string') {
+      return [...acc, {path, weight: 1}]
+    }
+    if (isPortableTextArray(childType)) {
+      return [...acc, {mapWith: 'pt::text', path, weight: 1}]
+    }
+    return acc
+  }
 
-  return reduceType(type, reducer, [], [], maxDepth)
+  return reduceType(type, type, reducer, [], [], maxDepth)
 }
 
-function getPortableTextFieldPaths(type, maxDepth) {
-  const reducer = (accumulator, childType, path) =>
-    isPortableTextArray(childType) ? [...accumulator, path] : accumulator
-
-  return reduceType(type, reducer, [], [], maxDepth)
-}
-
-export function resolveSearchConfigForBaseFieldPaths(type) {
+export function resolveSearchConfigForBaseFieldPaths(type: ObjectSchemaType): SearchPath[] {
   return getCachedBaseFieldPaths(type)
 }
 
-export default function resolveSearchConfig(type) {
-  return getCachedStringFieldPaths(type, maxTraversalDepth)
+export default function resolveSearchConfig(type: ObjectSchemaType): SearchPath[] {
+  return getCachedStringFieldPaths(type, MAX_TRAVERSAL_DEPTH, MAX_OBJECT_SEARCH_PATHS)
 }

--- a/packages/@sanity/schema/src/legacy/searchConfig/resolve.ts
+++ b/packages/@sanity/schema/src/legacy/searchConfig/resolve.ts
@@ -7,7 +7,7 @@ import {
   isReferenceSchemaType,
   ObjectSchemaType,
   SchemaType,
-} from '../../../../types'
+} from '@sanity/types'
 import {stringsToNumbers} from './normalize'
 
 interface SearchPath {

--- a/packages/@sanity/schema/src/legacy/types/object.ts
+++ b/packages/@sanity/schema/src/legacy/types/object.ts
@@ -1,7 +1,7 @@
 import {castArray, flatMap, keyBy, pick, startCase} from 'lodash'
 import createPreviewGetter from '../preview/createPreviewGetter'
 import guessOrderingConfig from '../ordering/guessOrderingConfig'
-import {normalizeSearchConfigs} from '../searchConfig/normalize'
+import {normalizeUserSearchConfigs} from '../searchConfig/normalize'
 import resolveSearchConfig from '../searchConfig/resolve'
 import {lazyGetter} from './utils'
 
@@ -65,12 +65,12 @@ export const ObjectType = {
       '__experimental_search',
       () => {
         const userProvidedSearchConfig = subTypeDef.__experimental_search
-          ? normalizeSearchConfigs(subTypeDef.__experimental_search)
+          ? normalizeUserSearchConfigs(subTypeDef.__experimental_search)
           : null
 
         if (userProvidedSearchConfig) {
           return userProvidedSearchConfig.map((entry) =>
-            entry === 'defaults' ? normalizeSearchConfigs(subTypeDef) : entry
+            entry === 'defaults' ? normalizeUserSearchConfigs(subTypeDef) : entry
           )
         }
         return resolveSearchConfig(parsed)

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -256,6 +256,7 @@ export interface ExperimentalSearchPath {
   path: (string | number)[]
   weight: number
   mapWith?: string
+  userProvided?: boolean
 }
 
 export interface ObjectSchemaTypeWithOptions extends ObjectSchemaType {


### PR DESCRIPTION
### Description

This PR brings a number of fixes and minor improvements to studio search in v2. Please refer to the internal slack thread for more context.

#### Search path generation:
- The maximum traversal depth (`SEARCH_DEPTH_LIMIT`) has increased significantly (now 15, up from 4)
- To compensate for this, we've introduced a maximum cap on search paths (`SEARCH_PATH_LIMIT`) generated _per root-level object_ (defaults to 500)
- When sorting paths for truncation, we sort by path length (shortest to longest) and then by name (alphabetically), meaning longer paths will be removed first.

These changes help ensure that deeper fields are more easily searchable, whilst the path limit per object ensures a reasonable cap when dealing with recursive structures, preventing the client from hanging when generating these on studio initialisation.

#### Search query generation:
- We set a maximum cap on _unique_ attributes (`SEARCH_ATTR_LIMIT`) included in search queries (defaults to 1000). 
- This provides some limited protection from ensuring we don't generate search queries that are too large and are likely to timeout
- User created `__experimental_search` paths are always included, regardless of the limit defined above
- Unnecessary whitespace has been reduced to slightly reduce request payload size
- We no longer unnecessarily include `_id` and `_type` fields twice in object projections, also reducing response sizes slightly
- We now export the _internal_ `createSearchQuery` function (in addition to the existing `createWeightedSearch`)

Combined with the changes to search path generation, this should mean that type-constrained searches (e.g. filtering by document types) should be able to access much more deeply nested fields. In most 'regular' cases (i.e. studio schema without recursive / circular structures), users should be able to search beyond the original 4 level limit we had before, even when searching across all document types.

#### Search weighting / scoring:
- Search `stories` included in each `WeightedHit` now also includes `indices` – a value which indicates any matching array indices, where applicable. Custom search implementations can use this to visually surface additional context.
- We now correctly assign search scores to _partial_ word matches
- Fixed an issue where array items beyond the first index weren't being assigned the correct score included when using array paths in `__experimental_search`

#### New unstable environment variables (which override the above):
- `SANITY_STUDIO_UNSTABLE_SEARCH_ATTR_LIMIT`
- `SANITY_STUDIO_UNSTABLE_SEARCH_DEPTH_LIMIT`
- `SANITY_STUDIO_UNSTABLE_SEARCH_PATH_LIMIT`

### What to review

- Partial word searches (e.g. `fo`, `tes` on the test studio) – these should now be ordered much more intuitively
- Search payloads should have whitespace reduced and should generally be smaller, due to changes in path generation
- It should be possible to search for deeply nested fields when constraining search (in the test studio, try search for "can you see me" with the "Recursive Objects Test" type selected.)

### Notes for release

- Minor fixes and improvements to studio search