### PR TITLE
fix(desk): minor style change of references in delete/unpublish dialog

### DIFF
--- a/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialog.tsx
+++ b/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialog.tsx
@@ -6,10 +6,8 @@ import {useReferringDocuments} from './useReferringDocuments'
 import {ConfirmDeleteDialogBody} from './ConfirmDeleteDialogBody'
 
 /** @internal */
-export const DialogBody = styled(Flex).attrs({
+export const DialogBody = styled(Box).attrs({
   padding: 4,
-  direction: 'column',
-  height: 'fill',
 })`
   box-sizing: border-box;
 `

--- a/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.styles.tsx
+++ b/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.styles.tsx
@@ -9,8 +9,6 @@ export const ChevronWrapper = styled(Box)`
 
 export const CrossDatasetReferencesDetails = styled.details`
   flex: none;
-  padding-left: 11px;
-  padding-right: 3px;
 
   &[open] ${ChevronWrapper} {
     transform: rotate(180deg);
@@ -26,7 +24,6 @@ export const CrossDatasetReferencesSummary = styled.summary`
 `
 
 export const TableContainer = styled(Box).attrs({paddingX: 2, paddingBottom: 2})`
-  overflow: auto;
   max-height: 150px;
 `
 
@@ -38,6 +35,7 @@ export const Table = styled.table`
 
   th {
     padding: ${({theme}) => rem(theme.sanity.space[1])};
+    padding-bottom: 15px;
   }
 
   thead > tr {
@@ -58,16 +56,6 @@ export const Table = styled.table`
 
 export const DocumentIdFlex = styled(Flex)`
   min-height: 35px;
-`
-
-export const ReferencesCard = styled(Card).attrs({
-  radius: 2,
-  shadow: 1,
-  marginBottom: 4,
-  flex: 'auto',
-})`
-  overflow: hidden;
-  overflow: clip;
 `
 
 export const OtherReferenceCount = (props: {totalCount: number; references: unknown[]}) => {

--- a/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.styles.tsx
+++ b/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.styles.tsx
@@ -23,10 +23,6 @@ export const CrossDatasetReferencesSummary = styled.summary`
   }
 `
 
-export const TableContainer = styled(Box).attrs({paddingX: 2, paddingBottom: 2})`
-  overflow-x: auto;
-`
-
 export const Table = styled.table`
   width: 100%;
   text-align: left;
@@ -34,10 +30,7 @@ export const Table = styled.table`
   border-collapse: collapse;
 
   th {
-    padding-left: ${({theme}) => rem(theme.sanity.space[1])};
-    padding-right: ${({theme}) => rem(theme.sanity.space[1])};
-    padding-bottom: ${({theme}) => rem(theme.sanity.space[3])};
-    padding-top: ${({theme}) => rem(theme.sanity.space[3])};
+    padding: ${({theme}) => `${rem(theme.sanity.space[3])} ${rem(theme.sanity.space[1])}`};
   }
 
   thead > tr {

--- a/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.styles.tsx
+++ b/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.styles.tsx
@@ -30,14 +30,7 @@ export const Table = styled.table`
   border-collapse: collapse;
 
   th {
-    padding: ${({theme}) => `${rem(theme.sanity.space[3])} ${rem(theme.sanity.space[1])}`};
-  }
-
-  thead > tr {
-    position: sticky;
-    top: 0;
-    background: var(--card-bg-color);
-    z-index: 1;
+    padding: ${({theme}) => rem(theme.sanity.space[1])};
   }
 
   td {

--- a/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.styles.tsx
+++ b/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.styles.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import {rem, Flex, Text, Card, Box, Tooltip, Container, Inline} from '@sanity/ui'
+import {rem, Flex, Text, Box, Tooltip, Container, Inline} from '@sanity/ui'
 import {InfoOutlineIcon} from '@sanity/icons'
 
 export const ChevronWrapper = styled(Box)`
@@ -24,7 +24,7 @@ export const CrossDatasetReferencesSummary = styled.summary`
 `
 
 export const TableContainer = styled(Box).attrs({paddingX: 2, paddingBottom: 2})`
-  max-height: 150px;
+  overflow-x: auto;
 `
 
 export const Table = styled.table`
@@ -34,8 +34,10 @@ export const Table = styled.table`
   border-collapse: collapse;
 
   th {
-    padding: ${({theme}) => rem(theme.sanity.space[1])};
-    padding-bottom: 15px;
+    padding-left: ${({theme}) => rem(theme.sanity.space[1])};
+    padding-right: ${({theme}) => rem(theme.sanity.space[1])};
+    padding-bottom: ${({theme}) => rem(theme.sanity.space[3])};
+    padding-top: ${({theme}) => rem(theme.sanity.space[3])};
   }
 
   thead > tr {

--- a/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.styles.tsx
+++ b/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.styles.tsx
@@ -9,6 +9,8 @@ export const ChevronWrapper = styled(Box)`
 
 export const CrossDatasetReferencesDetails = styled.details`
   flex: none;
+  padding-left: 11px;
+  padding-right: 3px;
 
   &[open] ${ChevronWrapper} {
     transform: rotate(180deg);
@@ -66,7 +68,6 @@ export const ReferencesCard = styled(Card).attrs({
 })`
   overflow: hidden;
   overflow: clip;
-  min-height: 150px;
 `
 
 export const OtherReferenceCount = (props: {totalCount: number; references: unknown[]}) => {

--- a/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
+++ b/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
@@ -186,12 +186,12 @@ export function ConfirmDeleteDialogBody({
                 </Card>
               </CrossDatasetReferencesSummary>
 
-              <Box paddingBottom={2} paddingX={2}>
+              <Box overflow="auto" paddingBottom={2} paddingX={2}>
                 <Table>
                   <thead>
                     <tr>
                       <th>
-                        <Label muted size={0}>
+                        <Label muted size={0} style={{minWidth: '5rem'}}>
                           Project ID
                         </Label>
                       </th>

--- a/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
+++ b/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
@@ -102,7 +102,7 @@ export function ConfirmDeleteDialogBody({
   }
 
   return (
-    <>
+    <Card>
       <Card padding={3} radius={2} tone="caution" marginBottom={4} flex="none">
         <Flex>
           <Text aria-hidden="true" size={1}>
@@ -129,7 +129,7 @@ export function ConfirmDeleteDialogBody({
         </Text>
       </Box>
 
-      <Card radius={2} shadow={1} marginBottom={4} flex="auto" overflow="auto">
+      <Card radius={2} shadow={1} marginBottom={4} flex="auto">
         <Flex direction="column">
           {internalReferences.totalCount > 0 && (
             <Stack as="ul" padding={2} space={3} data-testid="internal-references">
@@ -159,9 +159,9 @@ export function ConfirmDeleteDialogBody({
               }}
             >
               <CrossDatasetReferencesSummary>
-                <Card as="a" paddingY={1} margin={2}>
-                  <Flex align="center" margin={3}>
-                    <Box marginLeft={2} marginRight={4}>
+                <Card as="a" margin={2} radius={2} shadow={1} paddingY={1}>
+                  <Flex align="center" margin={2}>
+                    <Box marginLeft={3} marginRight={4}>
                       <Text size={3}>
                         <DocumentsIcon />
                       </Text>
@@ -269,6 +269,6 @@ export function ConfirmDeleteDialogBody({
           it.
         </Text>
       </Box>
-    </>
+    </Card>
   )
 }

--- a/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
+++ b/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
@@ -14,7 +14,6 @@ import {
   OtherReferenceCount,
   CrossDatasetReferencesDetails,
   CrossDatasetReferencesSummary,
-  TableContainer,
   Table,
   ChevronWrapper,
   DocumentIdFlex,
@@ -187,7 +186,7 @@ export function ConfirmDeleteDialogBody({
                 </Card>
               </CrossDatasetReferencesSummary>
 
-              <TableContainer>
+              <Box paddingBottom={2} paddingX={2}>
                 <Table>
                   <thead>
                     <tr>
@@ -257,7 +256,7 @@ export function ConfirmDeleteDialogBody({
                 <Box padding={2}>
                   <OtherReferenceCount {...crossDatasetReferences} />
                 </Box>
-              </TableContainer>
+              </Box>
             </CrossDatasetReferencesDetails>
           )}
         </Flex>

--- a/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
+++ b/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
@@ -11,7 +11,6 @@ import CopyToClipboard from 'react-copy-to-clipboard'
 import {ReferencePreviewLink} from './ReferencePreviewLink'
 import {ReferringDocuments} from './useReferringDocuments'
 import {
-  ReferencesCard,
   OtherReferenceCount,
   CrossDatasetReferencesDetails,
   CrossDatasetReferencesSummary,
@@ -130,10 +129,10 @@ export function ConfirmDeleteDialogBody({
         </Text>
       </Box>
 
-      <ReferencesCard>
-        <Flex direction="column" height="fill">
+      <Card radius={2} shadow={1} marginBottom={4} flex="auto" overflow="auto">
+        <Flex direction="column">
           {internalReferences.totalCount > 0 && (
-            <Stack as="ul" padding={3} space={3} overflow="auto" data-testid="internal-references">
+            <Stack as="ul" padding={2} space={3} data-testid="internal-references">
               {internalReferences?.references.map((item) => (
                 <Box as="li" key={item._id}>
                   {renderPreviewItem(item)}
@@ -160,30 +159,32 @@ export function ConfirmDeleteDialogBody({
               }}
             >
               <CrossDatasetReferencesSummary>
-                <Flex padding={4} align="center">
-                  <Box marginRight={4}>
-                    <Text size={3}>
-                      <DocumentsIcon />
-                    </Text>
-                  </Box>
-                  <Flex marginRight={4} direction="column">
-                    <Box marginBottom={2}>
-                      <Text>
-                        {documentCount} in {datasetsCount}
+                <Card as="a" paddingY={1} margin={2}>
+                  <Flex align="center" margin={3}>
+                    <Box marginLeft={2} marginRight={4}>
+                      <Text size={3}>
+                        <DocumentsIcon />
                       </Text>
                     </Box>
-                    <Box>
-                      <Text title={datasetNameList} textOverflow="ellipsis" size={1} muted>
-                        {datasetNameList}
+                    <Flex marginRight={4} direction="column">
+                      <Box marginBottom={2}>
+                        <Text>
+                          {documentCount} in {datasetsCount}
+                        </Text>
+                      </Box>
+                      <Box>
+                        <Text title={datasetNameList} textOverflow="ellipsis" size={1} muted>
+                          {datasetNameList}
+                        </Text>
+                      </Box>
+                    </Flex>
+                    <ChevronWrapper>
+                      <Text muted>
+                        <ChevronDownIcon />
                       </Text>
-                    </Box>
+                    </ChevronWrapper>
                   </Flex>
-                  <ChevronWrapper>
-                    <Text muted>
-                      <ChevronDownIcon />
-                    </Text>
-                  </ChevronWrapper>
-                </Flex>
+                </Card>
               </CrossDatasetReferencesSummary>
 
               <TableContainer>
@@ -252,6 +253,7 @@ export function ConfirmDeleteDialogBody({
                       ))}
                   </tbody>
                 </Table>
+
                 <Box padding={2}>
                   <OtherReferenceCount {...crossDatasetReferences} />
                 </Box>
@@ -259,7 +261,7 @@ export function ConfirmDeleteDialogBody({
             </CrossDatasetReferencesDetails>
           )}
         </Flex>
-      </ReferencesCard>
+      </Card>
 
       <Box flex="none">
         <Text>


### PR DESCRIPTION
### Description
Alignment was off in the unpublish/delete dialog when listing cross-references and internal reference referring to the document. 
<img width="585" alt="Clipboard 2022-16-10 at 8 52 01 PM" src="https://github.com/sanity-io/sanity/assets/44635000/2e2a19b6-abee-405d-be07-6b9a841e7948">

The list of references has also had some smaller fixes: the external references is now also a link and there is now one scrollbar for all references. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
The delete/unpublish dialog of document with referring documents. 
Test scrolling 

![Screenshot 2023-07-17 at 13 25 35](https://github.com/sanity-io/sanity/assets/44635000/ac1f1f7e-016b-4c89-93e2-1e5bcb65aff1)
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fixes alignment/scrolling issues of references in delete/unpublish dialog 
<!--
A description of the change(s) that should be used in the release notes.
-->
