### PR TITLE
fix(schema): remove projectId and __experimental_search from CDR type definitions

### DIFF
--- a/packages/@sanity/types/src/schema/definition/type/crossDatasetReference.ts
+++ b/packages/@sanity/types/src/schema/definition/type/crossDatasetReference.ts
@@ -12,12 +12,9 @@ export interface CrossDatasetReferenceDefinition extends BaseSchemaDefinition {
     title?: string
     icon?: ComponentType
     preview?: PreviewConfig
-    // eslint-disable-next-line camelcase
-    __experimental_search?: {path: string | string[]; weight?: number; mapWith?: string}[]
   }[]
 
   dataset: string
-  projectId: string
   studioUrl?: (document: {id: string; type?: string}) => string | null
   tokenId?: string
   options?: ReferenceOptions

--- a/packages/sanity/src/core/form/types/definitionExtensions.test.ts
+++ b/packages/sanity/src/core/form/types/definitionExtensions.test.ts
@@ -554,7 +554,6 @@ describe('definitionExtensions', () => {
       const type = defineType({
         type: 'crossDatasetReference',
         name: 'test',
-        projectId: 'test',
         dataset: 'test',
         to: [{type: 'some-object'}],
         components: {


### PR DESCRIPTION
### Description

#3670 removed the ability to specify `projectId` and `__experimental_search` for cross dataset references (CDRs), but looks like we forgot to remove these from `defineField` schema typings as well. This PR simply removes both as valid type options.

### What to review
- Is it worth keeping them around as deprecated? They have no effect, so I lean towards making the type checker complain if they are provided.

### Notes for release
- Removes `projectId` and `__experimental_search` options for cross dataset reference types
