### PR TITLE
fix(import): rewrite cross-dataset references, add option to skip

### DIFF
--- a/dev/test-studio/schema/debug/allNativeInputComponents.ts
+++ b/dev/test-studio/schema/debug/allNativeInputComponents.ts
@@ -129,7 +129,6 @@ export const allNativeInputComponents = defineType({
     defineField({
       type: 'crossDatasetReference',
       name: 'crossDatasetReference',
-      projectId: 'ppsg7ml5',
       dataset: 'test',
       to: [
         {

--- a/dev/test-studio/schema/debug/circularCrossDatasetReference.js
+++ b/dev/test-studio/schema/debug/circularCrossDatasetReference.js
@@ -13,10 +13,9 @@ export const circularCrossDatasetReferenceTest = {
       title: 'Reference to a circularCrossDatasetReference test document in the playground dataset',
       type: 'crossDatasetReference',
       dataset: 'playground',
-      projectId: 'ppsg7ml5',
       studioUrl: ({id, type}) => {
         return type
-          ? `${document.location.protocol}//${document.location.host}/playground/desk/${type};${id}`
+          ? `${document.location.protocol}//${document.location.host}/playground/content/${type};${id}`
           : null
       },
       to: [
@@ -36,10 +35,9 @@ export const circularCrossDatasetReferenceTest = {
       title: 'Reference to a circularCrossDatasetReference test document in the playground dataset',
       type: 'crossDatasetReference',
       dataset: 'test',
-      projectId: 'ppsg7ml5',
       studioUrl: ({id, type}) => {
         return type
-          ? `${document.location.protocol}//${document.location.host}/playground/desk/${type};${id}`
+          ? `${document.location.protocol}//${document.location.host}/playground/content/${type};${id}`
           : null
       },
       to: [
@@ -59,7 +57,6 @@ export const circularCrossDatasetReferenceTest = {
       name: 'docsArticle',
       type: 'crossDatasetReference',
       dataset: 'next',
-      projectId: '3do82whm',
       studioUrl: ({id, type}) => {
         return type ? `https://admin.sanity.io/desk/docs;${type};${id}` : null
       },

--- a/dev/test-studio/schema/standard/crossDatasetReference.ts
+++ b/dev/test-studio/schema/standard/crossDatasetReference.ts
@@ -36,12 +36,12 @@ export default defineType({
     {name: 'title', type: 'string'},
     {
       name: 'bookInPlayground',
-      title: 'Reference to book in the "playground" dataset in project "ppsg7ml5"',
+      title: 'Reference to book in the "playground" dataset',
       type: 'crossDatasetReference',
       dataset: 'playground',
       studioUrl: ({id, type}) => {
         return type
-          ? `${document.location.protocol}//${document.location.host}/playground/desk/${type};${id}`
+          ? `${document.location.protocol}//${document.location.host}/playground/content/${type};${id}`
           : null
       },
       to: [
@@ -66,13 +66,13 @@ export default defineType({
       ],
     },
     {
-      title: 'Reference to book or author in the "playground" dataset in project "ppsg7ml5"',
+      title: 'Reference to book or author in the "playground" dataset',
       name: 'bookOrAuthorInPlayground',
       type: 'crossDatasetReference',
       dataset: 'playground',
       studioUrl: ({id, type}) => {
         return type
-          ? `${document.location.protocol}//${document.location.host}/playground/desk/${type};${id}`
+          ? `${document.location.protocol}//${document.location.host}/playground/content/${type};${id}`
           : null
       },
       to: [

--- a/packages/@sanity/import-cli/README.md
+++ b/packages/@sanity/import-cli/README.md
@@ -23,6 +23,9 @@ npm install -g @sanity/import-cli
     --asset-concurrency <concurrency> Number of parallel asset imports
     --replace Replace documents with the same IDs
     --missing Skip documents that already exist
+    --allow-failing-assets Skip assets that cannot be fetched/uploaded
+    --replace-assets Skip reuse of existing assets
+    --skip-cross-dataset-references Skips references to other datasets
     --help Show this help
 
   Examples

--- a/packages/@sanity/import-cli/src/sanity-import.js
+++ b/packages/@sanity/import-cli/src/sanity-import.js
@@ -29,6 +29,7 @@ const cli = meow(
     --missing Skip documents that already exist
     --allow-failing-assets Skip assets that cannot be fetched/uploaded
     --replace-assets Skip reuse of existing assets
+    --skip-cross-dataset-references Skips references to other datasets
     --help Show this help
 
   Rarely used options (should generally not be used)
@@ -88,6 +89,11 @@ const cli = meow(
         default: false,
       },
 
+      skipCrossDatasetReferences: {
+        type: 'boolean',
+        default: false,
+      },
+
       assetConcurrency: {
         type: 'number',
         alias: 'c',
@@ -97,7 +103,13 @@ const cli = meow(
 )
 
 const {flags, input, showHelp} = cli
-const {dataset, allowFailingAssets, replaceAssets, allowAssetsInDifferentDataset} = flags
+const {
+  dataset,
+  allowFailingAssets,
+  replaceAssets,
+  allowAssetsInDifferentDataset,
+  skipCrossDatasetReferences,
+} = flags
 const token = flags.token || process.env.SANITY_IMPORT_TOKEN
 const projectId = flags.project
 const assetConcurrency = flags.assetConcurrency
@@ -154,6 +166,7 @@ getStream()
       onProgress,
       allowFailingAssets,
       allowAssetsInDifferentDataset,
+      skipCrossDatasetReferences,
       assetConcurrency,
       replaceAssets,
       assetsBase: getAssetsBase(),

--- a/packages/@sanity/import/README.md
+++ b/packages/@sanity/import/README.md
@@ -24,10 +24,63 @@ const client = sanityClient({
 
 // Input can either be a readable stream (for a `.tar.gz` or `.ndjson` file), a folder location (string), or an array of documents
 const input = fs.createReadStream('my-documents.ndjson')
-sanityImport(input, {
+
+const options = {
+  /**
+   * A Sanity client instance, preconfigured with the project ID and dataset
+   * you want to import data to, and with a token that has write access.
+   */
   client: client,
-  operation: 'create', // `create`, `createOrReplace` or `createIfNotExists`
-})
+
+  /**
+   * Which mutation type to use for creating documents:
+   * `create` (default)  - throws error if document IDs already exists
+   * `createOrReplace`   - replaces documents with same IDs
+   * `createIfNotExists` - skips document with IDs that already exists
+   *
+   * Optional.
+   */
+  operation: 'create',
+
+  /**
+   * Function called when making progress. Gets called with an object of
+   * the following shape:
+   * `step` (string) - the current step name of the import process
+   * `current` (number) - the current progress of the step, only present on some steps
+   * `total` (number) - total items before complete, only present on some steps
+   */
+  onProgress: (progress) => {
+    /* report progress */
+  },
+
+  /**
+   * Whether or not to allow assets in different datasets. This is usually
+   * an error in the export, where asset documents are part of the export.
+   *
+   * Optional, defaults to `false`.
+   */
+  allowAssetsInDifferentDataset: false,
+
+  /**
+   * Whether or not to replace any existing assets with the same hash.
+   * Setting this to `true` will regenerate image metadata on the server,
+   * but slows down the import.
+   *
+   * Optional, defaults to `false`.
+   */
+  replaceAssets: false,
+
+  /**
+   * Whether or not to skip cross-dataset references. This may be required
+   * when importing a dataset with cross-dataset references to a different
+   * project, unless a dataset with the referenced name exists.
+   *
+   * Optional, defaults to `false`.
+   */
+  skipCrossDatasetReferences: false,
+}
+
+sanityImport(input, options)
   .then(({numDocs, warnings}) => {
     console.log('Imported %d documents', numDocs)
     // Note: There might be warnings! Check `warnings`

--- a/packages/@sanity/import/src/importFromArray.js
+++ b/packages/@sanity/import/src/importFromArray.js
@@ -3,6 +3,7 @@ const flatten = require('lodash/flatten')
 const ensureUniqueIds = require('./util/ensureUniqueIds')
 const {getAssetRefs, unsetAssetRefs, absolutifyPaths} = require('./assetRefs')
 const validateAssetDocuments = require('./validateAssetDocuments')
+const validateCdrDatasets = require('./validateCdrDatasets')
 const assignArrayKeys = require('./assignArrayKeys')
 const assignDocumentId = require('./assignDocumentId')
 const uploadAssets = require('./uploadAssets')
@@ -23,6 +24,11 @@ async function importDocuments(documents, options) {
 
   // Validate that there are no duplicate IDs in the documents
   ensureUniqueIds(documents)
+
+  // Ensure that any cross-dataset references has datasets to point to
+  if (!options.skipCrossDatasetReferences) {
+    validateCdrDatasets(documents, options)
+  }
 
   // Replace relative asset paths if one is defined
   // (file://./images/foo-bar.png -> file:///abs/olute/images/foo-bar.png)

--- a/packages/@sanity/import/src/importFromArray.js
+++ b/packages/@sanity/import/src/importFromArray.js
@@ -13,7 +13,7 @@ const importBatches = require('./importBatches')
 const {
   getStrongRefs,
   weakenStrongRefs,
-  setTypeOnReferences,
+  cleanupReferences,
   strengthenReferences,
 } = require('./references')
 
@@ -37,8 +37,8 @@ async function importDocuments(documents, options) {
   const keyed = ided.map((doc) => assignArrayKeys(doc))
 
   // Sanity prefers to have a `_type` on every object. Make sure references
-  // has `_type` set to `reference`.
-  const docs = keyed.map((doc) => setTypeOnReferences(doc))
+  // has `_type` set to `reference`, and that there are no `_projectId` keys
+  const docs = keyed.map((doc) => cleanupReferences(doc, options))
 
   // Find references that will need strengthening when import is done
   const strongRefs = docs.map(getStrongRefs).filter(Boolean)

--- a/packages/@sanity/import/src/validateAssetDocuments.js
+++ b/packages/@sanity/import/src/validateAssetDocuments.js
@@ -17,8 +17,7 @@ const REQUIRED_PROPERTIES = {
 }
 
 module.exports = async function validateAssetDocuments(docs, options) {
-  const config = options.client.config()
-  const {projectId: targetProjectId, dataset: targetDataset} = config
+  const {targetProjectId, targetDataset} = options
   const concurrency = options.assetVerificationConcurrency || DEFAULT_VERIFY_CONCURRENCY
 
   const assetDocs = docs.filter((doc) => /^sanity\.[a-zA-Z]+Asset$/.test(doc._type || ''))

--- a/packages/@sanity/import/src/validateCdrDatasets.js
+++ b/packages/@sanity/import/src/validateCdrDatasets.js
@@ -3,9 +3,13 @@ const {extractWithPath} = require('@sanity/mutator')
 
 module.exports = async function validateCdrDatasets(docs, options) {
   const datasets = getDatasetsFromCrossDatasetReferences(docs)
+  if (datasets.length === 0) {
+    return
+  }
+
   const {client} = options
   const existing = (await client.datasets.list()).map((dataset) => dataset.name)
-  const missing = datasets.filter((dataset) => !existing.includes(dataset.name))
+  const missing = datasets.filter((dataset) => !existing.includes(dataset))
 
   if (missing.length > 1) {
     throw new Error(

--- a/packages/@sanity/import/src/validateCdrDatasets.js
+++ b/packages/@sanity/import/src/validateCdrDatasets.js
@@ -1,0 +1,45 @@
+const {get} = require('lodash')
+const {extractWithPath} = require('@sanity/mutator')
+
+module.exports = async function validateCdrDatasets(docs, options) {
+  const datasets = getDatasetsFromCrossDatasetReferences(docs)
+  const {client} = options
+  const existing = (await client.datasets.list()).map((dataset) => dataset.name)
+  const missing = datasets.filter((dataset) => !existing.includes(dataset.name))
+
+  if (missing.length > 1) {
+    throw new Error(
+      [
+        `The data to be imported contains one or more cross-dataset references, which refers to datasets that do not exist in the target project.`,
+        `Missing datasets: ${missing.map((ds) => `"${ds}"`).join(', ')}`,
+        'Either create these datasets in the given project, or use the `skipCrossDatasetReferences` option to skip these references.',
+      ].join('\n')
+    )
+  }
+
+  if (missing.length === 1) {
+    throw new Error(
+      [
+        `The data to be imported contains one or more cross-dataset references, which refers to a dataset that do not exist in the target project.`,
+        `Missing dataset: "${missing[0]}"`,
+        'Either create this dataset in the given project, or use the `skipCrossDatasetReferences` option to skip these references.',
+      ].join('\n')
+    )
+  }
+}
+
+function getDatasetsFromCrossDatasetReferences(docs) {
+  const datasets = new Set()
+  for (const doc of docs) {
+    findCrossCdr(doc, datasets)
+  }
+
+  return Array.from(datasets)
+}
+
+function findCrossCdr(doc, set) {
+  return extractWithPath('..[_ref]', doc)
+    .map((match) => get(doc, match.path.slice(0, -1)))
+    .filter((ref) => typeof ref._dataset === 'string')
+    .reduce((datasets, ref) => datasets.add(ref._dataset), set)
+}

--- a/packages/@sanity/import/src/validateOptions.js
+++ b/packages/@sanity/import/src/validateOptions.js
@@ -13,6 +13,7 @@ function validateOptions(input, opts) {
     onProgress: noop,
     allowAssetsInDifferentDataset: false,
     replaceAssets: false,
+    skipCrossDatasetReferences: false,
   })
 
   if (!isValidInput(input)) {
@@ -56,6 +57,9 @@ function validateOptions(input, opts) {
       `Tag can only contain alphanumeric characters, underscores, dashes and dots, and be between one and 75 characters long.`
     )
   }
+
+  options.targetProjectId = clientConfig.projectId
+  options.targetDataset = clientConfig.dataset
 
   return options
 }

--- a/packages/@sanity/import/test/fixtures/references.ndjson
+++ b/packages/@sanity/import/test/fixtures/references.ndjson
@@ -1,0 +1,6 @@
+{"_id": "grrm", "_type": "author", "name": "George R. R. Martin"}
+{"_id": "no-ref", "_type": "mock", "title": "No references"}
+{"_id": "normal-ref", "_type": "mock", "title": "Normal reference", "author": {"_type": "reference", "_ref": "grrm"}}
+{"_id": "missing-type-ref", "_type": "mock", "title": "Reference missing `_type`", "author": {"_ref": "grrm"}}
+{"_id": "cpr", "_type": "mock", "title": "Rewrite project IDs", "author": {"_ref": "grrm", "_projectId":"xyz987", "_dataset": "authors"}}
+{"_id": "cdr", "_type": "mock", "title": "Optionally skip CDRs", "deep": {"author": {"_ref": "grrm", "_projectId":"abc123", "_dataset": "authors"}}}

--- a/packages/@sanity/import/test/import.test.js
+++ b/packages/@sanity/import/test/import.test.js
@@ -177,6 +177,10 @@ function getMockMutationHandler(match = 'employee creation') {
       return {body: {results}}
     }
 
+    if (uri.includes('/datasets')) {
+      return {body: [{name: 'foo'}, {name: 'authors'}]}
+    }
+
     return {statusCode: 400, body: {error: `"${uri}" should not be called`}}
   }
 }

--- a/packages/@sanity/schema/src/legacy/types/crossDatasetReference.ts
+++ b/packages/@sanity/schema/src/legacy/types/crossDatasetReference.ts
@@ -26,6 +26,7 @@ const PROJECT_ID_FIELD = {
   name: '_projectId',
   title: 'Target project ID',
   type: 'string',
+  hidden: true,
 }
 
 const REFERENCE_FIELDS = [REF_FIELD, WEAK_FIELD, DATASET_FIELD, PROJECT_ID_FIELD]

--- a/packages/@sanity/types/src/schema/definition/type/crossDatasetReference.ts
+++ b/packages/@sanity/types/src/schema/definition/type/crossDatasetReference.ts
@@ -17,8 +17,12 @@ export interface CrossDatasetReferenceDefinition extends BaseSchemaDefinition {
   }[]
 
   dataset: string
-  projectId: string
   studioUrl?: (document: {id: string; type?: string}) => string | null
   tokenId?: string
   options?: ReferenceOptions
+
+  /**
+   * @deprecated Cross-project references are no longer supported, only cross-dataset
+   */
+  projectId?: string
 }

--- a/packages/@sanity/types/src/schema/definition/type/crossDatasetReference.ts
+++ b/packages/@sanity/types/src/schema/definition/type/crossDatasetReference.ts
@@ -12,7 +12,10 @@ export interface CrossDatasetReferenceDefinition extends BaseSchemaDefinition {
     title?: string
     icon?: ComponentType
     preview?: PreviewConfig
-    // eslint-disable-next-line camelcase
+
+    /**
+     * @deprecated Configuring search is no longer supported
+     */
     __experimental_search?: {path: string | string[]; weight?: number; mapWith?: string}[]
   }[]
 

--- a/packages/sanity/src/_internal/cli/commands/dataset/importDatasetCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/dataset/importDatasetCommand.ts
@@ -19,6 +19,7 @@ Options
   --replace On duplicate document IDs, replace existing document with imported document
   --allow-failing-assets Skip assets that cannot be fetched/uploaded
   --replace-assets Skip reuse of existing assets
+  --skip-cross-dataset-references Skips references to other datasets
 
 Rarely used options (should generally not be used)
   --allow-assets-in-different-dataset Allow asset documents to reference different project/dataset
@@ -45,6 +46,7 @@ interface ImportFlags {
   'allow-failing-assets'?: boolean
   'asset-concurrency'?: boolean
   'replace-assets'?: boolean
+  'skip-cross-dataset-references'?: boolean
   replace?: boolean
   missing?: boolean
 }
@@ -53,6 +55,7 @@ interface ParsedImportFlags {
   allowAssetsInDifferentDataset?: boolean
   allowFailingAssets?: boolean
   assetConcurrency?: boolean
+  skipCrossDatasetReferences?: boolean
   replaceAssets?: boolean
   replace?: boolean
   missing?: boolean
@@ -78,12 +81,14 @@ function parseFlags(rawFlags: ImportFlags): ParsedImportFlags {
   const allowFailingAssets = toBoolIfSet(rawFlags['allow-failing-assets'])
   const assetConcurrency = toBoolIfSet(rawFlags['asset-concurrency'])
   const replaceAssets = toBoolIfSet(rawFlags['replace-assets'])
+  const skipCrossDatasetReferences = toBoolIfSet(rawFlags['skip-cross-dataset-references'])
   const replace = toBoolIfSet(rawFlags.replace)
   const missing = toBoolIfSet(rawFlags.missing)
   return {
     allowAssetsInDifferentDataset,
     allowFailingAssets,
     assetConcurrency,
+    skipCrossDatasetReferences,
     replaceAssets,
     replace,
     missing,

--- a/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/__tests__/CrossDatasetReferenceInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/__tests__/CrossDatasetReferenceInput.test.tsx
@@ -8,7 +8,7 @@ import {SanityClient} from '@sanity/client'
 import {renderCrossDatasetReferenceInput} from '../../../../../../test/form'
 import {CrossDatasetReferenceInput} from '../CrossDatasetReferenceInput'
 import {CrossDatasetSearchHit} from '../types'
-import {createConfig} from '../../../../config'
+import {defineConfig} from '../../../../config'
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
 import {createMockSanityClient} from '../../../../../../test/mocks/mockSanityClient'
 import {featureDisabledRequest, featureEnabledRequest} from './mocks'
@@ -19,8 +19,8 @@ const AVAILABLE = {
 } as const
 
 function createWrapperComponent(client: SanityClient) {
-  const config = createConfig({
-    projectId: 'abcxyz',
+  const config = defineConfig({
+    projectId: 'mock-project-id',
     dataset: 'test',
   })
 
@@ -51,7 +51,6 @@ describe('render states', () => {
         name: 'productReference',
         type: 'crossDatasetReference',
         dataset: 'products',
-        projectId: 'abcxyz',
         to: [
           {
             type: 'product',
@@ -103,7 +102,6 @@ describe('render states', () => {
         name: 'productReference',
         type: 'crossDatasetReference',
         dataset: 'products',
-        projectId: 'abcxyz',
         to: [
           {
             type: 'product',
@@ -147,7 +145,7 @@ describe('render states', () => {
       _type: 'reference',
       _ref: 'someActor',
       _dataset: 'otherDataset',
-      _projectId: 'otherProject',
+      _projectId: 'mock-project-id',
     }
 
     const {result} = await renderCrossDatasetReferenceInput({
@@ -155,7 +153,6 @@ describe('render states', () => {
         name: 'productReference',
         type: 'crossDatasetReference',
         dataset: 'products',
-        projectId: 'abcxyz',
         weak: true,
         to: [
           {
@@ -209,7 +206,6 @@ describe('render states', () => {
         name: 'productReference',
         type: 'crossDatasetReference',
         dataset: 'products',
-        projectId: 'abcxyz',
         weak: true,
         to: [
           {
@@ -265,7 +261,6 @@ describe('user interaction happy paths', () => {
         name: 'productReference',
         type: 'crossDatasetReference',
         dataset: 'products',
-        projectId: 'abcxyz',
         to: [
           {
             type: 'product',
@@ -362,7 +357,6 @@ describe('user interaction happy paths', () => {
         name: 'productReference',
         type: 'crossDatasetReference',
         dataset: 'products',
-        projectId: 'abcxyz',
         to: [
           {
             type: 'product',
@@ -457,7 +451,7 @@ describe('user interaction happy paths', () => {
       _type: 'productReference',
       _ref: 'some-product',
       _dataset: 'products',
-      _projectId: 'abcxyz',
+      _projectId: 'mock-project-id',
     }
 
     const {onChange, result} = await renderCrossDatasetReferenceInput({
@@ -467,7 +461,6 @@ describe('user interaction happy paths', () => {
         name: 'productReference',
         type: 'crossDatasetReference',
         dataset: 'products',
-        projectId: 'abcxyz',
         to: [
           {
             type: 'product',

--- a/packages/sanity/src/core/form/types/definitionExtensions.test.ts
+++ b/packages/sanity/src/core/form/types/definitionExtensions.test.ts
@@ -554,7 +554,6 @@ describe('definitionExtensions', () => {
       const type = defineType({
         type: 'crossDatasetReference',
         name: 'test',
-        projectId: 'test',
         dataset: 'test',
         to: [{type: 'some-object'}],
         components: {

--- a/packages/sanity/src/core/preview/createPathObserver.ts
+++ b/packages/sanity/src/core/preview/createPathObserver.ts
@@ -1,6 +1,7 @@
 import {uniq} from 'lodash'
 import {Observable, of as observableOf} from 'rxjs'
 import {switchMap} from 'rxjs/operators'
+import {isCrossDatasetReference, isReference} from '@sanity/types'
 import {isRecord} from '../util'
 import {ApiConfig, FieldName, PreviewPath, Previewable} from './types'
 import {props} from './utils/props'
@@ -16,12 +17,8 @@ function resolveMissingHeads(value: Record<string, unknown>, paths: string[][]) 
   return paths.filter((path) => !(path[0] in value))
 }
 
-function isReferenceLike(value: Previewable): value is {_ref: string} {
-  return '_ref' in value
-}
-
 function getDocumentId(value: Previewable) {
-  if (isReferenceLike(value)) {
+  if (isReference(value)) {
     return value._ref
   }
   return '_id' in value ? value._id : undefined
@@ -65,13 +62,9 @@ function observePaths(
 
     const nextHeads: string[] = uniq(pathsWithMissingHeads.map((path: string[]) => path[0]))
 
-    const dataset = isReferenceLike(value) ? value._dataset : undefined
-    const projectId = isReferenceLike(value) ? value._projectId : undefined
-
-    const refApiConfig =
-      // if it's a cross dataset reference we want to use it's `_projectId` + `_dataset`
-      // attributes as api config
-      dataset && projectId ? {projectId: projectId, dataset: dataset} : apiConfig
+    const refApiConfig = isCrossDatasetReference(value)
+      ? {projectId: value._projectId, dataset: value._dataset}
+      : apiConfig
 
     return observeFields(id, nextHeads, refApiConfig).pipe(
       switchMap((snapshot) => {
@@ -82,7 +75,7 @@ function observePaths(
         return observePaths(
           {
             ...createEmpty(nextHeads),
-            ...(isReferenceLike(value) ? {...value, ...refApiConfig} : value),
+            ...(isReference(value) ? {...value, ...refApiConfig} : value),
             ...snapshot,
           } as Previewable,
           paths,


### PR DESCRIPTION
### Description

Cross-dataset references no longer allow referencing other projects, which means when we are importing a previous export to a different project, the import will fail with a mutation error.

There are two possible fixes here:
1. Assume the new project has datasets with the same names. This is the new default behavior - any project IDs found during import and rewritten to the new. We then check if all the referenced datasets actually exist in the project, and throw an error if they do not.
2. Skip the cross-dataset references altogether. New options have been added:
    - `@sanity/import`: `skipCrossDatasetReferences: true`
    - `@sanity/import-cli`: `--skip-cross-dataset-references`
    - `@sanity/cli`: `--skip-cross-dataset-references` (`sanity dataset import …`)

Along with this change, 05aeed4 also adds `@deprecated` to the `projectId` property of the CDR definitions, as well as removing this property from our fixtures and tests.

Note that content lake still (currently) requires both a `_projectId` and a `_dataset` to be specified - otherwise I would remove the property from being stored altogether.

### What to review

- Cross-dataset references still work as expected in studio
- Import commands look and work correctly

### Notes for release

- Fixed an issue where exported datasets with cross-dataset references could not be imported to different projects. Note that referenced datasets must exist within same project - otherwise use `--skip-cross-dataset-references`.