### PR TITLE
docs(desk): fix links in tsdoc comment

### DIFF
--- a/packages/sanity/src/desk/structureBuilder/GenericList.ts
+++ b/packages/sanity/src/desk/structureBuilder/GenericList.ts
@@ -36,7 +36,7 @@ export interface ListDisplayOptions {
  * @public
  */
 export interface BaseGenericList extends StructureNode {
-  /** List layout key. See {@link PreviewLayoutKey} */
+  /** List layout key. */
   defaultLayout?: PreviewLayoutKey
   /** Can handle intent. See {@link IntentChecker} */
   canHandleIntent?: IntentChecker
@@ -93,7 +93,7 @@ export interface GenericListInput extends StructureNode {
   menuItemGroups?: (MenuItemGroup | MenuItemGroupBuilder)[]
   /** Input initial value array. See {@link InitialValueTemplateItem} and {@link InitialValueTemplateItemBuilder} */
   initialValueTemplates?: (InitialValueTemplateItem | InitialValueTemplateItemBuilder)[]
-  /** Input default layout. See {@link PreviewLayoutKey} */
+  /** Input default layout. */
   defaultLayout?: PreviewLayoutKey
   /** If input can handle intent. See {@link IntentChecker} */
   canHandleIntent?: IntentChecker
@@ -116,7 +116,7 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
 
   /** Set generic list ID
    * @param id - generic list ID
-   * @returns generic list builder based on ID provided. See {@link ConcreteImpl}
+   * @returns generic list builder based on ID provided.
    */
   id(id: string): ConcreteImpl {
     return this.clone({id})
@@ -131,7 +131,7 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
 
   /** Set generic list title
    * @param title - generic list title
-   * @returns generic list builder based on title and ID provided. See {@link ConcreteImpl}
+   * @returns generic list builder based on title and ID provided.
    */
   title(title: string): ConcreteImpl {
     return this.clone({title, id: getStructureNodeId(title, this.spec.id)})
@@ -145,8 +145,8 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
   }
 
   /** Set generic list layout
-   * @param defaultLayout - generic list layout key. See {@link PreviewLayoutKey}
-   * @returns generic list builder based on layout provided. See {@link ConcreteImpl}
+   * @param defaultLayout - generic list layout key.
+   * @returns generic list builder based on layout provided.
    */
   defaultLayout(defaultLayout: PreviewLayoutKey): ConcreteImpl {
     return this.clone({defaultLayout})
@@ -161,7 +161,7 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
 
   /** Set generic list menu items
    * @param menuItems - generic list menu items. See {@link MenuItem} and {@link MenuItemBuilder}
-   * @returns generic list builder based on menu items provided. See {@link ConcreteImpl}
+   * @returns generic list builder based on menu items provided.
    */
   menuItems(menuItems: (MenuItem | MenuItemBuilder)[] | undefined): ConcreteImpl {
     return this.clone({menuItems})
@@ -176,7 +176,7 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
 
   /** Set generic list menu item groups
    * @param menuItemGroups - generic list menu item groups. See {@link MenuItemGroup} and {@link MenuItemGroupBuilder}
-   * @returns generic list builder based on menu item groups provided. See {@link ConcreteImpl}
+   * @returns generic list builder based on menu item groups provided.
    */
   menuItemGroups(menuItemGroups: (MenuItemGroup | MenuItemGroupBuilder)[]): ConcreteImpl {
     return this.clone({menuItemGroups})
@@ -191,7 +191,7 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
 
   /** Set generic list child
    * @param child - generic list child. See {@link Child}
-   * @returns generic list builder based on child provided (clone). See {@link ConcreteImpl}
+   * @returns generic list builder based on child provided (clone).
    */
   child(child: Child): ConcreteImpl {
     return this.clone({child})
@@ -206,7 +206,7 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
 
   /** Set generic list can handle intent
    * @param canHandleIntent - generic list intent checker. See {@link IntentChecker}
-   * @returns generic list builder based on can handle intent provided. See {@link ConcreteImpl}
+   * @returns generic list builder based on can handle intent provided.
    */
   canHandleIntent(canHandleIntent: IntentChecker): ConcreteImpl {
     return this.clone({canHandleIntent})
@@ -221,7 +221,7 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
 
   /** Set generic list display options
    * @param enabled - allow / disallow for showing icons
-   * @returns generic list builder based on display options (showIcons) provided. See {@link ConcreteImpl}
+   * @returns generic list builder based on display options (showIcons) provided.
    */
   showIcons(enabled = true): ConcreteImpl {
     return this.clone({
@@ -238,7 +238,7 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
 
   /** Set generic list initial value templates
    * @param templates - generic list initial value templates. See {@link InitialValueTemplateItem} and {@link InitialValueTemplateItemBuilder}
-   * @returns generic list builder based on templates provided. See {@link ConcreteImpl}
+   * @returns generic list builder based on templates provided.
    */
   initialValueTemplates(
     templates:
@@ -299,7 +299,7 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
 
   /** Clone generic list builder (allows for options overriding)
    * @param _withSpec - generic list options.
-   * @returns generic list builder. See {@link ConcreteImpl}
+   * @returns generic list builder.
    */
   abstract clone(_withSpec?: object): ConcreteImpl
 }

--- a/packages/sanity/src/desk/structureBuilder/views/View.ts
+++ b/packages/sanity/src/desk/structureBuilder/views/View.ts
@@ -32,7 +32,7 @@ export abstract class GenericViewBuilder<TView extends Partial<BaseView>, Concre
 
   /** Set generic view ID
    * @param id - generic view ID
-   * @returns generic view builder based on ID provided. See {@link ConcreteImpl}
+   * @returns generic view builder based on ID provided.
    */
   id(id: string): ConcreteImpl {
     return this.clone({id})
@@ -46,7 +46,7 @@ export abstract class GenericViewBuilder<TView extends Partial<BaseView>, Concre
 
   /** Set generic view title
    * @param title - generic view title
-   * @returns generic view builder based on title provided and (if provided) its ID. See {@link ConcreteImpl}
+   * @returns generic view builder based on title provided and (if provided) its ID.
    */
   title(title: string): ConcreteImpl {
     return this.clone({title, id: this.spec.id || kebabCase(title)})
@@ -61,7 +61,7 @@ export abstract class GenericViewBuilder<TView extends Partial<BaseView>, Concre
 
   /** Set generic view icon
    * @param icon - generic view icon
-   * @returns generic view builder based on icon provided. See {@link ConcreteImpl}
+   * @returns generic view builder based on icon provided.
    */
   icon(icon: React.ComponentType | React.ReactNode): ConcreteImpl {
     return this.clone({icon})
@@ -105,7 +105,7 @@ export abstract class GenericViewBuilder<TView extends Partial<BaseView>, Concre
 
   /** Clone generic view builder (allows for options overriding)
    * @param withSpec - Partial generic view builder options. See {@link BaseView}
-   * @returns Generic view builder. See {@link ConcreteImpl}
+   * @returns Generic view builder.
    */
   abstract clone(withSpec?: Partial<BaseView>): ConcreteImpl
 }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

`ConcreteImpl` - is not actually a type that is defined so it cannot be linked to
`PreviewLayoutKey` - Currently it is not possible to link from other packages to sanity package. So the link will result in a 404. Removing the link for now

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

N/A
