### PR TITLE
feat(schema): do not warn on missing title for schema type

### DIFF
--- a/dev/test-studio/schema/debug/fieldGroupsWithValidation.js
+++ b/dev/test-studio/schema/debug/fieldGroupsWithValidation.js
@@ -1,13 +1,13 @@
 import {CogIcon} from '@sanity/icons'
+import {defineType} from 'sanity'
 
-export default {
+export default defineType({
   name: 'fieldGroupsWithValidation',
   title: 'With validation',
   type: 'document',
   groups: [
     {
       name: 'group1',
-      title: 'Group 1',
       icon: CogIcon,
     },
     {
@@ -39,4 +39,4 @@ export default {
       ],
     },
   ],
-}
+})

--- a/packages/@sanity/schema/src/legacy/types/object.ts
+++ b/packages/@sanity/schema/src/legacy/types/object.ts
@@ -1,5 +1,5 @@
 import {castArray, flatMap, keyBy, pick, startCase} from 'lodash'
-import type {FieldGroupDefinition, ObjectDefinition, ObjectField} from '@sanity/types'
+import type {FieldGroupDefinition, ObjectDefinition, FieldGroup, ObjectField} from '@sanity/types'
 import createPreviewGetter from '../preview/createPreviewGetter'
 import guessOrderingConfig from '../ordering/guessOrderingConfig'
 import {normalizeSearchConfigs} from '../searchConfig/normalize'
@@ -144,7 +144,7 @@ export function createFieldsets(typeDef, fields) {
     .filter(Boolean)
 }
 
-function createFieldsGroups(typeDef: ObjectDefinition, fields: ObjectField[]) {
+function createFieldsGroups(typeDef: ObjectDefinition, fields: ObjectField[]): FieldGroup[] {
   const groupsByName: Record<string, FieldGroupDefinition & {fields: ObjectField[]}> = {}
 
   let numDefaultGroups = 0

--- a/packages/@sanity/schema/src/sanity/validation/types/rootType.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/rootType.ts
@@ -42,14 +42,7 @@ export default (typeDef, visitorContext) => {
 
   problems.push(...validateComponent(typeDef))
 
-  if (!('title' in typeDef)) {
-    problems.push(
-      warning(
-        "Type is missing title. It's recommended to always set a descriptive title.",
-        HELP_IDS.TYPE_TITLE_RECOMMENDED
-      )
-    )
-  } else if (typeof typeDef.title !== 'string') {
+  if ('title' in typeDef && typeof typeDef.title !== 'string') {
     problems.push(warning('Type title is not a string.', HELP_IDS.TYPE_TITLE_INVALID))
   }
   return {

--- a/packages/@sanity/types/src/schema/definition/type/common.ts
+++ b/packages/@sanity/types/src/schema/definition/type/common.ts
@@ -7,6 +7,7 @@ export type FieldsetDefinition = {
   name: string
   title?: string
   description?: string
+  group?: string
   hidden?: ConditionalProperty
   readOnly?: ConditionalProperty
   options?: ObjectOptions

--- a/packages/@sanity/types/src/schema/definition/type/common.ts
+++ b/packages/@sanity/types/src/schema/definition/type/common.ts
@@ -18,7 +18,7 @@ export type FieldGroupDefinition = {
   name: string
   title?: string
   hidden?: ConditionalProperty
-  icon?: ComponentType | ReactNode
+  icon?: ComponentType
   default?: boolean
 }
 


### PR DESCRIPTION
### Description

We've discussed this internally quite a while ago, and agreed that since we automatically generate a title for schema types that are missing it, it doesn't make sense to also warn about it (in the case you're happy with the automatic title, you have to explicitly define the same title as it generated to avoid the warning).

This PR drops this warning, and also introduces automatic titles for field groups and fieldsets, which was missing this functionality. Going forward, we want to always apply titles where we can instead of warning.

While adding types to the fieldset/group functionality, I noticed a few incorrect/missing properties, so also went ahead and fixed those - apologies for the slight scope creep.

### What to review

- Changes make sense, and function as expected
  - You should see a reduction in warnings on the test studio as compared to previous versions
  - If you navigate to the [field groups with validation type](https://test-studio-git-fix-drop-schema-title-warning.sanity.build/test/content/input-debug;field-groups;fieldGroupsWithValidation;24f43b51-d0eb-45d1-8d40-ae02a5f0b3c5) you should see "Group 1" and "Group 2" instead of "group1" and "Group 2".

### Notes for release

- Dropped warning about missing titles for schema types (titles are automatically created based on schema type name - a title is only necessary if the automatic name is incorrect/inaccurate)
- Titled are now automatically applied to field groups and fieldsets, in the same way as with schema types.
