### PR TITLE
fix(core): add missing validation at input level validation (boolean)

### DIFF
--- a/dev/test-studio/schema/docs/v3/async-functions/schemaType.ts
+++ b/dev/test-studio/schema/docs/v3/async-functions/schemaType.ts
@@ -35,6 +35,12 @@ export const validationTest = defineType({
       },
     }),
     {
+      name: 'switchTestValidation',
+      type: 'boolean',
+      title: `I'm a switch with a validation`,
+      validation: (Rule) => Rule.required(),
+    },
+    {
       type: 'array',
       name: 'testArray',
       title: 'Test array',

--- a/packages/sanity/src/core/form/inputs/BooleanInput.tsx
+++ b/packages/sanity/src/core/form/inputs/BooleanInput.tsx
@@ -19,7 +19,7 @@ const ZeroLineHeightBox = styled(Box)`
  * @beta
  */
 export function BooleanInput(props: BooleanInputProps) {
-  const {id, value, schemaType, readOnly, elementProps} = props
+  const {id, value, schemaType, readOnly, elementProps, validation} = props
   const layout = schemaType.options?.layout || 'switch'
 
   const indeterminate = typeof value !== 'boolean'
@@ -46,7 +46,7 @@ export function BooleanInput(props: BooleanInputProps) {
           <FormFieldHeaderText
             description={schemaType.description}
             inputId={id}
-            // validation={validation}
+            validation={validation}
             title={schemaType.title}
           />
         </Box>


### PR DESCRIPTION
### Description

Add input validation for boolean inputs.
Before it wasn't showing in the document that the boolean had missing / breaking validations.

### What to review

**Boolean**
- Go to V3 APIs -> V3 validations
- Pick any document or create a new one
- Check that the validation works for booleans once those are set.

### Notes for release
 
- Boolean inputs will now show validation errors at the input level (in document)