### PR TITLE
fix(core): optimize wheel event on CommandList virtual element

### DIFF
--- a/packages/sanity/src/core/components/commandList/CommandList.tsx
+++ b/packages/sanity/src/core/components/commandList/CommandList.tsx
@@ -496,7 +496,7 @@ export const CommandList = forwardRef<CommandListHandle, CommandListProps>(funct
       enableChildContainerPointerEvents(true)
     }
     virtualListElement?.addEventListener('mousemove', handleMouseEvent)
-    virtualListElement?.addEventListener('wheel', handleMouseEvent)
+    virtualListElement?.addEventListener('wheel', handleMouseEvent, {passive: true})
     return () => {
       virtualListElement?.removeEventListener('mousemove', handleMouseEvent)
       virtualListElement?.removeEventListener('wheel', handleMouseEvent)


### PR DESCRIPTION
### Description

Small change: sets the mouse wheel listener on the virtual list element to be passive ([background](https://chromestatus.com/feature/5745543795965952)). This potentially speeds up the scrolling, and should be safe since we never call `preventDefault()` in the attached listener.

### What to review

- Lists work as before

### Notes for release

None.
