### PR TITLE
chore: Changed CLI help prompt to `yarn up`

### DIFF
--- a/packages/@sanity/cli/src/packageManager/getUpgradeCommand.ts
+++ b/packages/@sanity/cli/src/packageManager/getUpgradeCommand.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import isInstalledGlobally from 'is-installed-globally'
-import {debug} from '../debug'
-import {getPackageManagerChoice} from './packageManagerChoice'
+import { debug } from '../debug'
+import { getPackageManagerChoice } from './packageManagerChoice'
 
 const cliPkgName = '@sanity/cli'
 
@@ -11,7 +11,7 @@ interface Options {
 }
 
 export async function getCliUpgradeCommand(options: Options = {}): Promise<string> {
-  let {cwd, workDir} = options
+  let { cwd, workDir } = options
   cwd = path.resolve(cwd || process.cwd())
   workDir = path.resolve(workDir || cwd)
 
@@ -27,10 +27,10 @@ export async function getCliUpgradeCommand(options: Options = {}): Promise<strin
 
   const cmds = cwd === workDir ? [] : [`cd ${path.relative(cwd, workDir)}`]
 
-  const {chosen} = await getPackageManagerChoice(workDir, {interactive: false})
+  const { chosen } = await getPackageManagerChoice(workDir, { interactive: false })
 
   if (chosen === 'yarn') {
-    cmds.push(`yarn upgrade ${cliPkgName}`)
+    cmds.push(`yarn up ${cliPkgName}`)
   } else if (chosen === 'pnpm') {
     cmds.push(`pnpm update ${cliPkgName}`)
   } else {


### PR DESCRIPTION
### Description

**Changes Introduced:**
Previously, this was the CLI prompt when `@sanity/cli` was out of date:
![CleanShot 2023-07-22 at 08 31 25](https://github.com/sanity-io/sanity/assets/212300/de3095c4-4c38-4726-a0ec-b387f7fa6f5b)

I changed the help command from `yarn upgrade` to `yarn up`

**Why are these changes introduced?**
`yarn upgrade` is from yarn version 1 and is no longer supported. If you run the suggested command, you'll get the following error:
![CleanShot 2023-07-22 at 08 33 34](https://github.com/sanity-io/sanity/assets/212300/6cdb45d3-8c9b-43fb-9aff-4b1ff5724f80)

Modern versions of yarn use `yarn up` instead: https://yarnpkg.com/cli/up

**What issue(s) does this solve? (with link, if possible)**
Hopefully, this will help users upgrade their CLI tool without additional errors.

### What to review

**What steps should the reviewer take in order to review?**

- Run `yarn dev` within a project using an outdated version of @sanity/cli
- The new message should say `Run yarn up @sanity/cli to update` 

### Notes for release

- Updated command help prompt when running an outdated version of @sanity/cli
