### PR TITLE
fix(core): fix auto scrolling issue on collapsed fieldset w/ array

### DIFF
--- a/dev/test-studio/schema/debug/virtualizationInObject.ts
+++ b/dev/test-studio/schema/debug/virtualizationInObject.ts
@@ -1,0 +1,96 @@
+import {defineType} from 'sanity'
+
+const faqItem = {
+  name: 'faqItem',
+  title: 'FAQ Item',
+  type: 'object',
+  fields: [
+    {
+      name: 'question',
+      title: 'Question',
+      type: 'string',
+    },
+    {
+      name: 'answer',
+      title: 'Answer',
+      type: 'array',
+      of: [{type: 'block'}],
+    },
+  ],
+}
+
+export const virtualizationInObject = defineType({
+  name: 'virtualizationInObject',
+  title: 'Virtualization in Object',
+  type: 'document',
+  fieldsets: [
+    {
+      name: 'faq',
+      title: 'FAQ',
+      options: {
+        collapsible: true,
+        collapsed: true,
+      },
+    },
+  ],
+  fields: [
+    {
+      name: 'internalTitle',
+      title: 'Internal title',
+      description:
+        "Descriptive title used to identify different versions of the pricing copy internally - doesn't get exposed to users.",
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      description: 'Title for /pricing',
+      name: 'pageTitle',
+      title: 'Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      name: 'internalTitle1',
+      title: 'Internal title',
+      description:
+        "Descriptive title used to identify different versions of the pricing copy internally - doesn't get exposed to users.",
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      description: 'Title for /pricing',
+      name: 'pageTitle1',
+      title: 'Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      name: 'internalTitle2',
+      title: 'Internal title',
+      description:
+        "Descriptive title used to identify different versions of the pricing copy internally - doesn't get exposed to users.",
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      description: 'Title for /pricing',
+      name: 'pageTitle2',
+      title: 'Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      name: 'faqTitle',
+      fieldset: 'faq',
+      title: 'Pricing FAQ Title',
+      type: 'string',
+    },
+    {
+      name: 'faqs',
+      fieldset: 'faq',
+      title: 'Pricing FAQs',
+      type: 'array',
+      of: [faqItem],
+    },
+  ],
+})

--- a/dev/test-studio/schema/index.ts
+++ b/dev/test-studio/schema/index.ts
@@ -84,6 +84,7 @@ import fieldGroupsDefault from './debug/fieldGroupsDefault'
 import fieldGroupsMany from './debug/fieldGroupsMany'
 import fieldGroupsWithValidation from './debug/fieldGroupsWithValidation'
 import fieldGroupsWithFieldsetsAndValidation from './debug/fieldGroupsWithFieldsetsAndValidation'
+import {virtualizationInObject} from './debug/virtualizationInObject'
 
 // Test documents with official plugin inputs
 import code from './plugins/code'
@@ -258,4 +259,5 @@ export const schemaTypes = [
   allNativeInputComponents,
   ...v3docs.types,
   ...demos3d.types,
+  virtualizationInObject,
 ]

--- a/dev/test-studio/structure/constants.ts
+++ b/dev/test-studio/structure/constants.ts
@@ -76,6 +76,7 @@ export const DEBUG_INPUT_TYPES = [
   'allNativeInputComponents',
   'scrollBug',
   'ptReference',
+  'virtualizationInObject',
 ]
 
 export const CI_INPUT_TYPES = ['conditionalFieldset', 'validationCI']

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.tsx
@@ -7,6 +7,7 @@ import {
   useVirtualizer,
   VirtualizerOptions,
   type Range,
+  elementScroll,
 } from '@tanstack/react-virtual'
 import type {DragStartEvent} from '@dnd-kit/core'
 import {Item, List} from '../../common/list'
@@ -146,6 +147,15 @@ export function ListArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
     observeElementOffset,
     rangeExtractor,
     getItemKey: useCallback((index: number) => memberKeys[index], [memberKeys]),
+    scrollToFn: (offset, options, instance) => {
+      // If the offset is the same as the current scroll offset, don't scroll
+      // Offset gets set to 0 here https://github.com/TanStack/virtual/blob/beta/packages/virtual-core/src/index.ts#L211
+      // which causes the scroll to top
+      if (offset === instance.scrollOffset) {
+        return
+      }
+      elementScroll(offset, options, instance)
+    },
   })
 
   const items = virtualizer.getVirtualItems()


### PR DESCRIPTION
### Description
This PR intends to fix issue where the pane would autoscroll to the top when a collapsed fieldset with an array list is opened.

- chore: add debug schema for array in fieldset

closes #4591 
closes #4406 

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

Added a [debug schema](http://localhost:3333/test/content/input-debug;virtualizationInObject;f9b1dc7a-9dd6-4949-8292-9738bf9e2969)

I would also appreciate a through testing of other array items, I have tested array list by themselves and in PTE also tested focus on validation but would love to know if this breaks anything else.  

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

- Fixes issue with auto scrolling on collapsed fieldset