### PR TITLE
fix(core): allow `null` and `role`-less user in `userHasRole` fn

### DIFF
--- a/packages/sanity/src/core/util/userHasRole.test.ts
+++ b/packages/sanity/src/core/util/userHasRole.test.ts
@@ -1,4 +1,4 @@
-import type {CurrentUser} from '@sanity/types'
+import type {ConditionalPropertyCallbackContext, CurrentUser} from '@sanity/types'
 import {userHasRole} from './userHasRole'
 
 const roleLessUser: CurrentUser = {
@@ -7,6 +7,13 @@ const roleLessUser: CurrentUser = {
   name: 'Some User',
   role: '',
   roles: [],
+}
+
+const conditionalContextUser: ConditionalPropertyCallbackContext['currentUser'] = {
+  id: 'pabc123',
+  email: 'some@user.com',
+  name: 'Some User',
+  roles: [{name: 'administrator', title: 'Administrator'}],
 }
 
 const adminUser: CurrentUser = {
@@ -42,4 +49,9 @@ test('userHasRole(): match (multiple roles)', () => {
 
 test('userHasRole(): no match (multiple roles)', () => {
   expect(userHasRole(multiRoleUser, 'administrator')).toBe(false)
+})
+
+test('userHasRole(): conditional property callback context (no `role` prop)', () => {
+  expect(userHasRole(conditionalContextUser, 'administrator')).toBe(true)
+  expect(userHasRole(conditionalContextUser, 'dogwalker')).toBe(false)
 })

--- a/packages/sanity/src/core/util/userHasRole.ts
+++ b/packages/sanity/src/core/util/userHasRole.ts
@@ -4,13 +4,14 @@ import type {CurrentUser} from '@sanity/types'
  * Checks whether or not the given user has the role with the given ID
  *
  * @param user - The user to check (currently only the current user is supported)
+ *   If `null` is passed, this function always returns `false`.
  * @param roleId - The ID of the role to check for
  *
  * @returns true if the user has the role, false otherwise
  *
  * @example
  * Fetch the current user and check if they have the role "administrator":
- * ```
+ * ```ts
  * import {userHasRole, useCurrentUser} from 'sanity'
  *
  * export function MyComponent() {
@@ -21,6 +22,9 @@ import type {CurrentUser} from '@sanity/types'
  * ```
  * @public
  */
-export function userHasRole(user: CurrentUser, roleId: string): boolean {
-  return user.roles.some((role) => role.name === roleId)
+export function userHasRole(
+  user: (Omit<CurrentUser, 'role'> & {role?: string}) | null,
+  roleId: string
+): boolean {
+  return user !== null && user.roles.some((role) => role.name === roleId)
 }


### PR DESCRIPTION
### Description

This allows it to be used directly from a conditional property callback, where `null` is valid since a studio may not require authenticated users. In addition, the conditional property callback context have dropped the legacy `user` property, which meant the signature did not match.

### Notes for release

- Made the `userHasRole` function more relaxed on user value, allowing easier use in places such as conditional callbacks

