### PR TITLE
fix(desk): multiple desk support

### DIFF
--- a/packages/sanity/src/desk/DeskToolProvider.tsx
+++ b/packages/sanity/src/desk/DeskToolProvider.tsx
@@ -8,12 +8,14 @@ import {useConfigContextFromSource, useDocumentStore, useSource} from 'sanity'
 export interface DeskToolProviderProps {
   structure?: StructureResolver
   defaultDocumentNode?: DefaultDocumentNodeResolver
+  deskConfigName?: string
   children: React.ReactNode
 }
 
 /** @internal */
 export function DeskToolProvider({
   defaultDocumentNode,
+  deskConfigName,
   structure: resolveStructure,
   children,
 }: DeskToolProviderProps): React.ReactElement {
@@ -52,13 +54,14 @@ export function DeskToolProvider({
 
   const deskTool: DeskToolContextValue = useMemo(() => {
     return {
+      deskConfigName,
       features,
       layoutCollapsed,
       setLayoutCollapsed,
       rootPaneNode,
       structureContext: S.context,
     }
-  }, [features, layoutCollapsed, rootPaneNode, S.context])
+  }, [deskConfigName, features, layoutCollapsed, rootPaneNode, S.context])
 
   return <DeskToolContext.Provider value={deskTool}>{children}</DeskToolContext.Provider>
 }

--- a/packages/sanity/src/desk/components/deskTool/DeskToolBoundary.tsx
+++ b/packages/sanity/src/desk/components/deskTool/DeskToolBoundary.tsx
@@ -15,7 +15,7 @@ interface DeskToolBoundaryProps {
 export function DeskToolBoundary({tool: {options}}: DeskToolBoundaryProps) {
   const {unstable_sources: sources} = useWorkspace()
   const [firstSource] = sources
-  const {source, defaultDocumentNode, structure} = options || {}
+  const {source, defaultDocumentNode, structure, name: deskConfigName} = options || {}
 
   // Set active panes to blank on mount and unmount
   useEffect(() => {
@@ -30,7 +30,11 @@ export function DeskToolBoundary({tool: {options}}: DeskToolBoundaryProps) {
   return (
     <ErrorBoundary onCatch={setError}>
       <SourceProvider name={source || firstSource.name}>
-        <DeskToolProvider defaultDocumentNode={defaultDocumentNode} structure={structure}>
+        <DeskToolProvider
+          deskConfigName={deskConfigName}
+          defaultDocumentNode={defaultDocumentNode}
+          structure={structure}
+        >
           <DeskTool onPaneChange={setActivePanes} />
           <IntentResolver />
         </DeskToolProvider>

--- a/packages/sanity/src/desk/deskTool.ts
+++ b/packages/sanity/src/desk/deskTool.ts
@@ -94,7 +94,7 @@ export const deskTool = definePlugin<DeskToolOptions | void>((options) => ({
       }
       return badges
     },
-    inspectors: [validationInspector, changesInspector],
+    inspectors: [validationInspector(options?.name), changesInspector(options?.name)],
   },
   tools: [
     {

--- a/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
@@ -9,16 +9,12 @@ import {usePaneRouter} from '../../components'
 import {PaneMenuItem} from '../../types'
 import {useDeskTool} from '../../useDeskTool'
 import {DocumentPaneContext, DocumentPaneContextValue} from './DocumentPaneContext'
+import {getHistoryInspectorName} from './getHistoryInspectorName'
 import {getMenuItems} from './menuItems'
 import {DocumentPaneProviderProps} from './types'
 import {usePreviewUrl} from './usePreviewUrl'
 import {getInitialValueTemplateOpts} from './getInitialValueTemplateOpts'
-import {
-  DEFAULT_MENU_ITEM_GROUPS,
-  EMPTY_PARAMS,
-  HISTORY_INSPECTOR_NAME,
-  INSPECT_ACTION_PREFIX,
-} from './constants'
+import {DEFAULT_MENU_ITEM_GROUPS, EMPTY_PARAMS, INSPECT_ACTION_PREFIX} from './constants'
 import {DocumentInspectorMenuItemsResolver} from './DocumentInspectorMenuItemsResolver'
 import {
   DocumentInspector,
@@ -70,7 +66,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   const presenceStore = usePresenceStore()
   const paneRouter = usePaneRouter()
   const setPaneParams = paneRouter.setParams
-  const {features} = useDeskTool()
+  const {deskConfigName, features} = useDeskTool()
   const {push: pushToast} = useToast()
   const {
     options,
@@ -189,6 +185,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     }
   }, [params.inspect])
 
+  const HISTORY_INSPECTOR_NAME = getHistoryInspectorName(deskConfigName)
   const currentInspector = inspectors?.find((i) => i.name === inspectorName)
   const resolvedChangesInspector = inspectors.find((i) => i.name === HISTORY_INSPECTOR_NAME)
 

--- a/packages/sanity/src/desk/panes/document/constants.ts
+++ b/packages/sanity/src/desk/panes/document/constants.ts
@@ -12,7 +12,3 @@ export const EMPTY_PARAMS: NonNullable<PaneRouterContextValue['params']> = {}
 export const INSPECT_ACTION_PREFIX = 'inspect:'
 
 export const DEFAULT_MENU_ITEM_GROUPS: PaneMenuItemGroup[] = [{id: 'inspectors'}, {id: 'links'}]
-
-// inspectors
-export const HISTORY_INSPECTOR_NAME = 'sanity/desk/history'
-export const VALIDATION_INSPECTOR_NAME = 'sanity/desk/validation'

--- a/packages/sanity/src/desk/panes/document/getHistoryInspectorName.ts
+++ b/packages/sanity/src/desk/panes/document/getHistoryInspectorName.ts
@@ -1,0 +1,4 @@
+export function getHistoryInspectorName(deskConfigName = 'desk'): string {
+  const configName = deskConfigName === 'desk' ? '' : `/${deskConfigName}`
+  return `sanity/desk${configName}/history`
+}

--- a/packages/sanity/src/desk/panes/document/getValidationInspectorName.ts
+++ b/packages/sanity/src/desk/panes/document/getValidationInspectorName.ts
@@ -1,0 +1,4 @@
+export function getValidationInspectorName(deskConfigName = 'desk'): string {
+  const configName = deskConfigName === 'desk' ? '' : `/${deskConfigName}`
+  return `sanity/desk${configName}/validation`
+}

--- a/packages/sanity/src/desk/panes/document/inspectors/changes/index.ts
+++ b/packages/sanity/src/desk/panes/document/inspectors/changes/index.ts
@@ -1,21 +1,23 @@
 import {RestoreIcon} from '@sanity/icons'
-import {HISTORY_INSPECTOR_NAME} from '../../constants'
+import {getHistoryInspectorName} from '../../getHistoryInspectorName'
 import {useDeskTool} from '../../../../useDeskTool'
 import {ChangesInspector} from './ChangesInspector'
 import {DocumentInspector} from 'sanity'
 
-export const changesInspector: DocumentInspector = {
-  name: HISTORY_INSPECTOR_NAME,
-  useMenuItem: () => {
-    const {features} = useDeskTool()
+export function changesInspector(deskConfigName?: string): DocumentInspector {
+  return {
+    name: getHistoryInspectorName(deskConfigName),
+    useMenuItem: () => {
+      const {features} = useDeskTool()
 
-    return {
-      hidden: !features.reviewChanges,
-      icon: RestoreIcon,
-      title: 'Review changes',
-    }
-  },
-  component: ChangesInspector,
-  onClose: ({params}) => ({params: {...params, since: undefined}}),
-  onOpen: ({params}) => ({params: {...params, since: '@lastPublished'}}),
+      return {
+        hidden: !features.reviewChanges,
+        icon: RestoreIcon,
+        title: 'Review changes',
+      }
+    },
+    component: ChangesInspector,
+    onClose: ({params}) => ({params: {...params, since: undefined}}),
+    onOpen: ({params}) => ({params: {...params, since: '@lastPublished'}}),
+  }
 }

--- a/packages/sanity/src/desk/panes/document/inspectors/validation/index.ts
+++ b/packages/sanity/src/desk/panes/document/inspectors/validation/index.ts
@@ -1,6 +1,6 @@
 import {CheckmarkCircleIcon, ErrorOutlineIcon, WarningOutlineIcon} from '@sanity/icons'
 import {useMemo} from 'react'
-import {VALIDATION_INSPECTOR_NAME} from '../../constants'
+import {getValidationInspectorName} from '../../getValidationInspectorName'
 import {ValidationInspector} from './ValidationInspector'
 import {
   DocumentInspector,
@@ -50,8 +50,10 @@ function useMenuItem(props: DocumentInspectorUseMenuItemProps): DocumentInspecto
   }
 }
 
-export const validationInspector: DocumentInspector = {
-  name: VALIDATION_INSPECTOR_NAME,
-  component: ValidationInspector,
-  useMenuItem,
+export function validationInspector(deskConfigName?: string): DocumentInspector {
+  return {
+    name: getValidationInspectorName(deskConfigName),
+    component: ValidationInspector,
+    useMenuItem,
+  }
 }

--- a/packages/sanity/src/desk/types.ts
+++ b/packages/sanity/src/desk/types.ts
@@ -32,6 +32,7 @@ export interface DeskToolFeatures {
 
 /** @internal */
 export interface DeskToolContextValue {
+  deskConfigName?: string
   features: DeskToolFeatures
   layoutCollapsed: boolean
   setLayoutCollapsed: (layoutCollapsed: boolean) => void
@@ -122,9 +123,9 @@ export interface DeskToolOptions {
    */
   name?: string
   /**
-   * A workspace can have different "sources". These sources were meant to allow using multiple datasets within the same workspace, for instance. 
+   * A workspace can have different "sources". These sources were meant to allow using multiple datasets within the same workspace, for instance.
    * This is not supported yet, but the API is still here.
-   * 
+   *
     @hidden
     @alpha
   */


### PR DESCRIPTION
### Description

With the work done in #4742, two constants (HISTORY_INSPECTOR_NAME & VALIDATION_INSPECTOR_NAME) were introduced that cause a conflict when trying to use more than one desk in a workspace.

This change introduces replacement functions that use the name defined in the config of the desk tool which is used as the url segment, ensuring uniqueness.

### What to review

This has a minimal surface area to test, and intoduces no new functionality.
The intent is if no desk name is defined in the config, there is no change from the original default.

### Notes for release

To support multiple desks, tool name now used in validator names
