### PR TITLE
feat(types): add `isSlug` asserter method

### DIFF
--- a/packages/@sanity/types/src/slug/asserters.ts
+++ b/packages/@sanity/types/src/slug/asserters.ts
@@ -1,0 +1,13 @@
+import {isObject} from '../helpers'
+import type {Slug} from './types'
+
+/**
+ * Checks whether the given `thing` is a slug, eg an object with a `current` string property.
+ *
+ * @param thing - The thing to check
+ * @returns True if slug, false otherwise
+ * @public
+ */
+export function isSlug(thing: unknown): thing is Slug {
+  return isObject(thing) && typeof thing.current === 'string'
+}

--- a/packages/@sanity/types/src/slug/index.ts
+++ b/packages/@sanity/types/src/slug/index.ts
@@ -1,1 +1,2 @@
 export * from './types'
+export * from './asserters'

--- a/packages/@sanity/types/src/slug/types.ts
+++ b/packages/@sanity/types/src/slug/types.ts
@@ -5,7 +5,13 @@ import type {SanityDocument} from '../documents'
 import type {Path} from '../paths'
 import {CurrentUser} from '../user'
 
-/** @internal */
+/**
+ * A slug object, currently holding a `current` property
+ *
+ * In the future, this may be extended with a `history` property
+ *
+ * @public
+ */
 export interface Slug {
   _type: 'slug'
   current: string


### PR DESCRIPTION
### Description

Will be used in the upcoming validation changes, for instance. Figured it was worth a separate PR for easier reviewing.

### What to review

- Assertion looks okay (I don't think we need to go deeper - this matches the overall shape we need) 

### Notes for release

- Added `isSlug()` method to `@sanity/types` for type-safe asserting of a slug object
