### PR TITLE
fix(desk): prevent duplicate validation/change inspectors

### DIFF
--- a/packages/sanity/src/desk/deskTool.ts
+++ b/packages/sanity/src/desk/deskTool.ts
@@ -27,6 +27,8 @@ const documentActions = [
 
 const documentBadges = [LiveEditBadge]
 
+const inspectors = [validationInspector, changesInspector]
+
 /**
  * The deskTool is a studio plugin which adds the “desk tool” – a tool within Sanity Studio in which
  * content editors can drill down to specific documents to edit them.
@@ -79,22 +81,18 @@ export const deskTool = definePlugin<DeskToolOptions | void>((options) => ({
     actions: (prevActions) => {
       // NOTE: since it's possible to have several desk tools in one Studio,
       // we need to check whether the document actions already exist in the Studio config
-      const actions = prevActions.slice(0)
-      for (const action of documentActions) {
-        if (!actions.includes(action)) actions.push(action)
-      }
-      return actions
+      return Array.from(new Set([...prevActions, ...documentActions]))
     },
     badges: (prevBadges) => {
       // NOTE: since it's possible to have several desk tools in one Studio,
       // we need to check whether the document badges already exist in the Studio config
-      const badges = prevBadges.slice(0)
-      for (const badge of documentBadges) {
-        if (!badges.includes(badge)) badges.push(badge)
-      }
-      return badges
+      return Array.from(new Set([...prevBadges, ...documentBadges]))
     },
-    inspectors: [validationInspector, changesInspector],
+    inspectors: (prevInspectors) => {
+      // NOTE: since it's possible to have several desk tools in one Studio,
+      // we need to check whether the inspectors already exist in the Studio config
+      return Array.from(new Set([...prevInspectors, ...inspectors]))
+    },
   },
   tools: [
     {


### PR DESCRIPTION
### Description

When multiple desks are configured for a studio, you ended up with duplicate change and validation inspectors.
This PR addresses this with the same approach as the badges/actions: it only adds those plugin elements if not already present, as part of the plugin configuration.

Also refactored the duplication checks to use a Set instead, as it is a little less verbose.

Supersedes #4743 if approved (will give credit to author as part of release notes, even though we didn't specifically use their code)

### What to review

- No duplicate document inspectors, badges, or actions exists

### Notes for release

- Fixed an issue where using multiple desk tools in the same studio would cause duplicate "review changes" actions and validation lists to appear. Thanks @andparsons!
