### PR TITLE
fix(desk): use configured api version when fetching document lists

### DIFF
--- a/dev/test-studio/structure/resolveStructure.ts
+++ b/dev/test-studio/structure/resolveStructure.ts
@@ -196,7 +196,7 @@ export const structure: StructureResolver = (S, {schema, documentStore}) => {
                     options: {
                       filter: '_id in path("drafts.**")',
                     },
-                  }),
+                  }).apiVersion('2023-07-28'),
                 ),
 
               S.listItem()
@@ -317,6 +317,7 @@ export const structure: StructureResolver = (S, {schema, documentStore}) => {
                 child: () =>
                   S.documentTypeList('author')
                     .title('Developers')
+                    .apiVersion('2023-07-27')
                     .filter('_type == $type && role == $role')
                     .params({type: 'author', role: 'developer'})
                     .initialValueTemplates(S.initialValueTemplateItem('author-developer')),

--- a/packages/sanity/src/desk/panes/documentList/useDocumentList.ts
+++ b/packages/sanity/src/desk/panes/documentList/useDocumentList.ts
@@ -43,8 +43,11 @@ const INITIAL_QUERY_RESULTS: QueryResult = {
  * @internal
  */
 export function useDocumentList(opts: UseDocumentListOpts): DocumentListState {
-  const {filter, params: paramsProp, sortOrder, searchQuery} = opts
-  const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
+  const {filter, params: paramsProp, sortOrder, searchQuery, apiVersion} = opts
+  const client = useClient({
+    ...DEFAULT_STUDIO_CLIENT_OPTIONS,
+    apiVersion: apiVersion || DEFAULT_STUDIO_CLIENT_OPTIONS.apiVersion,
+  })
   const schema = useSchema()
 
   const [resultState, setResult] = useState<QueryResult>(INITIAL_STATE)

--- a/packages/sanity/src/desk/structureBuilder/SerializeError.ts
+++ b/packages/sanity/src/desk/structureBuilder/SerializeError.ts
@@ -38,4 +38,5 @@ export enum HELP_URL {
   ACTION_OR_INTENT_REQUIRED = 'structure-action-or-intent-required',
   LIST_ITEM_IDS_MUST_BE_UNIQUE = 'structure-list-item-ids-must-be-unique',
   ACTION_AND_INTENT_MUTUALLY_EXCLUSIVE = 'structure-action-and-intent-mutually-exclusive',
+  API_VERSION_REQUIRED_FOR_CUSTOM_FILTER = 'structure-api-version-required-for-custom-filter',
 }


### PR DESCRIPTION
### Description
Currently, specifying `apiVersion` on either `documentList()` or `documentTypeList()` has no effect. This PR fixes it by forwarding the option to the `useClient()`-call in `useDocumentList()`

### What to review
Make sure specifying `apiVersion(<version>)` on documentList and documentTypeList results in `<version>` actually being used when fetching documents

### Notes for release
- Fixed a bug that made specifying `apiVersion` on `documentList()` and `documentTypeList()` not work
