### PR TITLE
fix(core): change cdr tooltip text

### DIFF
--- a/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/CrossDatasetReferencePreview.tsx
+++ b/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/CrossDatasetReferencePreview.tsx
@@ -143,7 +143,7 @@ export function CrossDatasetReferencePreview(props: {
                 content={
                   <TooltipContent padding={2}>
                     {hasStudioUrl ? (
-                      <Text size={1}>This document opens in another Studio</Text>
+                      <Text size={1}>This document opens in a new tab</Text>
                     ) : (
                       <Text size={1}>
                         This document cannot be opened <br /> (unable to resolve URL to Studio)


### PR DESCRIPTION
### Description
The cross dataset reference tooltip text was changed to avoid any confusion and to be consistent with the icon and text that is used in other places, for example in arrays (see screenshot)
![Screenshot 2023-07-28 at 10 45 14](https://github.com/sanity-io/sanity/assets/44635000/9ed410b8-194d-443e-bfa7-83facf3b5420)

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
The tooltip text for CDR 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Tooltip text for CDR was changed
<!--
A description of the change(s) that should be used in the release notes.
-->
