### PR TITLE
feat(cli): add `is_defined` filter to GraphQL APIs

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/graphql/gen1/generateTypeFilters.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/gen1/generateTypeFilters.ts
@@ -80,6 +80,18 @@ function getDocumentFilters(): InputFilterField[] {
   ]
 }
 
+function createIsDefinedFilter(field: ConvertedFieldDefinition): InputFilterField {
+  return {
+    fieldName: getFieldName(field, 'is_defined'),
+    type: 'Boolean',
+    description: 'All documents that have a value for this field',
+    constraint: {
+      field: field.fieldName,
+      comparator: 'IS_DEFINED',
+    },
+  }
+}
+
 function createEqualityFilter(field: ConvertedFieldDefinition): InputFilterField {
   return {
     fieldName: getFieldName(field),
@@ -105,7 +117,7 @@ function createInequalityFilter(field: ConvertedFieldDefinition): InputFilterFie
 }
 
 function createDefaultFilters(field: ConvertedFieldDefinition): InputFilterField[] {
-  return [createEqualityFilter(field), createInequalityFilter(field)]
+  return [createEqualityFilter(field), createInequalityFilter(field), createIsDefinedFilter(field)]
 }
 
 function createGtLtFilters(field: ConvertedFieldDefinition): InputFilterField[] {

--- a/packages/sanity/src/_internal/cli/actions/graphql/gen2/filters/booleanFilters.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/gen2/filters/booleanFilters.ts
@@ -16,6 +16,11 @@ export function createBooleanFilters(): InputObjectType {
         type: 'Boolean',
         description: 'Checks if the value is not equal to the given input.',
       },
+      {
+        fieldName: 'is_defined',
+        type: 'Boolean',
+        description: 'Checks if the value is defined.',
+      },
     ],
   }
 }

--- a/packages/sanity/src/_internal/cli/actions/graphql/gen2/filters/dateFilters.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/gen2/filters/dateFilters.ts
@@ -36,6 +36,11 @@ export function createDateFilters(): InputObjectType {
         type: 'Date',
         description: 'Checks if the value is lesser than or equal to the given input.',
       },
+      {
+        fieldName: 'is_defined',
+        type: 'Boolean',
+        description: 'Checks if the value is defined.',
+      },
     ],
   }
 }

--- a/packages/sanity/src/_internal/cli/actions/graphql/gen2/filters/dateTimeFilters.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/gen2/filters/dateTimeFilters.ts
@@ -36,6 +36,11 @@ export function createDateTimeFilters(): InputObjectType {
         type: 'Datetime',
         description: 'Checks if the value is lesser than or equal to the given input.',
       },
+      {
+        fieldName: 'is_defined',
+        type: 'Boolean',
+        description: 'Checks if the value is defined.',
+      },
     ],
   }
 }

--- a/packages/sanity/src/_internal/cli/actions/graphql/gen2/filters/floatFilters.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/gen2/filters/floatFilters.ts
@@ -36,6 +36,11 @@ export function createFloatFilters(): InputObjectType {
         type: 'Float',
         description: 'Checks if the value is lesser than or equal to the given input.',
       },
+      {
+        fieldName: 'is_defined',
+        type: 'Boolean',
+        description: 'Checks if the value is defined.',
+      },
     ],
   }
 }

--- a/packages/sanity/src/_internal/cli/actions/graphql/gen2/filters/integerFilters.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/gen2/filters/integerFilters.ts
@@ -36,6 +36,11 @@ export function createIntegerFilters(): InputObjectType {
         type: 'Int',
         description: 'Checks if the value is lesser than or equal to the given input.',
       },
+      {
+        fieldName: 'is_defined',
+        type: 'Boolean',
+        description: 'Checks if the value is defined.',
+      },
     ],
   }
 }

--- a/packages/sanity/src/_internal/cli/actions/graphql/gen2/filters/stringFilters.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/gen2/filters/stringFilters.ts
@@ -39,6 +39,11 @@ export function createStringFilters(): InputObjectType {
         },
         description: 'Checks if the value is not equal to one of the given values.',
       },
+      {
+        fieldName: 'is_defined',
+        type: 'Boolean',
+        description: 'Checks if the value is defined.',
+      },
     ],
   }
 }

--- a/packages/sanity/test/cli/graphql/__snapshots__/gen2.test.ts.snap
+++ b/packages/sanity/test/cli/graphql/__snapshots__/gen2.test.ts.snap
@@ -621,6 +621,11 @@ Object {
           "type": "Boolean",
         },
         Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
           "description": "Checks if the value is not equal to the given input.",
           "fieldName": "neq",
           "type": "Boolean",
@@ -968,6 +973,11 @@ Object {
           "type": "Date",
         },
         Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
           "description": "Checks if the value is lesser than the given input.",
           "fieldName": "lt",
           "type": "Date",
@@ -1003,6 +1013,11 @@ Object {
           "description": "Checks if the value is greater than or equal to the given input.",
           "fieldName": "gte",
           "type": "Datetime",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
         },
         Object {
           "description": "Checks if the value is lesser than the given input.",
@@ -1249,6 +1264,11 @@ Object {
           "description": "Checks if the value is greater than or equal to the given input.",
           "fieldName": "gte",
           "type": "Float",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
         },
         Object {
           "description": "Checks if the value is lesser than the given input.",
@@ -1713,6 +1733,11 @@ Object {
           "description": "Checks if the value is greater than or equal to the given input.",
           "fieldName": "gte",
           "type": "Int",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
         },
         Object {
           "description": "Checks if the value is lesser than the given input.",
@@ -4065,6 +4090,11 @@ Object {
           "description": "Checks if the value is equal to one of the given values.",
           "fieldName": "in",
           "kind": "List",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
         },
         Object {
           "description": "Checks if the value matches the given word/words.",

--- a/packages/sanity/test/cli/graphql/__snapshots__/gen3.test.ts.snap
+++ b/packages/sanity/test/cli/graphql/__snapshots__/gen3.test.ts.snap
@@ -663,6 +663,11 @@ Object {
           "type": "Boolean",
         },
         Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
           "description": "Checks if the value is not equal to the given input.",
           "fieldName": "neq",
           "type": "Boolean",
@@ -1010,6 +1015,11 @@ Object {
           "type": "Date",
         },
         Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
           "description": "Checks if the value is lesser than the given input.",
           "fieldName": "lt",
           "type": "Date",
@@ -1045,6 +1055,11 @@ Object {
           "description": "Checks if the value is greater than or equal to the given input.",
           "fieldName": "gte",
           "type": "Datetime",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
         },
         Object {
           "description": "Checks if the value is lesser than the given input.",
@@ -1336,6 +1351,11 @@ Object {
           "description": "Checks if the value is greater than or equal to the given input.",
           "fieldName": "gte",
           "type": "Float",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
         },
         Object {
           "description": "Checks if the value is lesser than the given input.",
@@ -1800,6 +1820,11 @@ Object {
           "description": "Checks if the value is greater than or equal to the given input.",
           "fieldName": "gte",
           "type": "Int",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
         },
         Object {
           "description": "Checks if the value is lesser than the given input.",
@@ -4169,6 +4194,11 @@ Object {
           "description": "Checks if the value is equal to one of the given values.",
           "fieldName": "in",
           "kind": "List",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
         },
         Object {
           "description": "Checks if the value matches the given word/words.",


### PR DESCRIPTION
### Description

Adds a `is_defined` field filter for all generations, which can be used to remove null values from responses.

### What to review

Are we happy for this to be backported to all schema generations?

### Notes for release

- GraphQL APIs now have a new `is_defined` filter, mirroring the `defined()` function in GROQ. GraphQL APIs will have to be re-deployed to enable the new filter.