### PR TITLE
chore(cli): use latest API version for GraphQL API calls

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/graphql/deleteApiAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/deleteApiAction.ts
@@ -66,7 +66,7 @@ export default async function deleteGraphQLApi(
     client = apiClient({
       requireUser: true,
       requireProject: true,
-    }).config({apiVersion: '1'})
+    }).config({apiVersion: '2023-08-01'})
 
     projectId = projectId || client.config().projectId
     dataset = dataset || client.config().dataset

--- a/packages/sanity/src/_internal/cli/actions/graphql/deployApiAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/deployApiAction.ts
@@ -66,7 +66,7 @@ export default async function deployGraphQLApiAction(
     // Don't throw if we do not have a project ID defined, as we will infer it from the
     // source/ workspace of each configured API later
     requireProject: false,
-  })
+  }).config({apiVersion: '2023-08-01'})
 
   const apiDefs = await getGraphQLAPIs(context)
   const hasMultipleApis = apiDefs.length > 1 || (flags.api && flags.api.length > 1)

--- a/packages/sanity/src/_internal/cli/actions/graphql/listApisAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/listApisAction.ts
@@ -18,7 +18,7 @@ export default async function listGraphQLApis(
   const client = apiClient({
     requireUser: true,
     requireProject: true,
-  }).config({apiVersion: '1'})
+  }).config({apiVersion: '2023-08-01'})
 
   let endpoints: ListApisResponse | undefined
   try {


### PR DESCRIPTION
### Description

New version of GraphQL is being released, this defaults to using the new version for all GraphQL commands.
This does affect the output as it will now display the new version.
