### PR TITLE
docs(desk): fix 404 links

### DIFF
--- a/packages/sanity/src/desk/structureBuilder/DocumentList.ts
+++ b/packages/sanity/src/desk/structureBuilder/DocumentList.ts
@@ -96,7 +96,7 @@ export interface DocumentListOptions {
   params?: Record<string, unknown>
   /** Document list API version */
   apiVersion?: string
-  /** Document list API default ordering array. See {@link SortOrderingItem} */
+  /** Document list API default ordering array. */
   defaultOrdering?: SortOrderingItem[]
 }
 
@@ -155,7 +155,7 @@ export class DocumentListBuilder extends GenericListBuilder<
   }
 
   /** Set Document list schema type name
-   * @param type - schema type name. See {@link SchemaType}
+   * @param type - schema type name.
    * @returns document list builder based on the schema type name provided. See {@link DocumentListBuilder}
    */
   schemaType(type: SchemaType | string): DocumentListBuilder {

--- a/packages/sanity/src/desk/structureBuilder/GenericList.ts
+++ b/packages/sanity/src/desk/structureBuilder/GenericList.ts
@@ -237,7 +237,7 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
   }
 
   /** Set generic list initial value templates
-   * @param templates - generic list initial value templates. See {@link InitialValueTemplateItem} and {@link InitialValueTemplateItemBuilder}
+   * @param templates - generic list initial value templates. See {@link InitialValueTemplateItemBuilder}
    * @returns generic list builder based on templates provided.
    */
   initialValueTemplates(

--- a/packages/sanity/src/desk/structureBuilder/Intent.ts
+++ b/packages/sanity/src/desk/structureBuilder/Intent.ts
@@ -33,7 +33,7 @@ export const DEFAULT_INTENT_HANDLER = Symbol('Document type list canHandleIntent
 
 /**
  * Intent parameters
- * See {@link BaseIntentParams} and {@link IntentJsonParams}
+ * See {@link router.BaseIntentParams} and {@link router.IntentJsonParams}
  *
  * @public
  */


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Fixes 404 links for docs. Here are the the fixes and some current caveats

- `SchemaType` and `SortOrderingItem` are imported from `@sanity/types` whose docs are not exported yet
- `InitialValueTemplateItem` is in the core package, currently we don't have the ability to link from sub package to root package. i.e `desk` -> `core` linking is not currently possible
- `IntentJsonParams` and `BaseIntentParams` are duplicated in `desk` and `router` package but on docs we dedupe them and only one is shown, as a stopgap  we are linking to the `router` package which shows those interfaces but we will follow up with deduping the interfaces and fixing the links properly in the future

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

Everything still works

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

N/A
