### PR TITLE
feat(auth): allow using explicit `token` mode for authentication

### DIFF
--- a/packages/sanity/src/core/store/_legacy/authStore/createLoginComponent.tsx
+++ b/packages/sanity/src/core/store/_legacy/authStore/createLoginComponent.tsx
@@ -61,7 +61,7 @@ async function getProviders({client, mode, providers: customProviders = []}: Get
 
 interface CreateLoginComponentOptions {
   getClient: () => Observable<SanityClient>
-  loginMethod: 'dual' | 'cookie'
+  loginMethod: 'dual' | 'cookie' | 'token'
   mode?: 'append' | 'replace'
   redirectOnSingle?: boolean
   providers?: Array<{
@@ -74,7 +74,7 @@ interface CreateLoginComponentOptions {
 
 interface CreateHrefForProviderOptions {
   projectId: string
-  loginMethod: 'dual' | 'cookie'
+  loginMethod: 'dual' | 'cookie' | 'token'
   url: string
   basePath: string
 }
@@ -88,7 +88,17 @@ function createHrefForProvider({
   const params = new URLSearchParams()
   params.set('origin', `${window.location.origin}${basePath}`)
   params.set('projectId', projectId)
-  params.set('type', loginMethod)
+
+  // Setting `type=token` will return the sid as part of the _query_, which may end up in
+  // server access logs and similar. Instead, use `withSid=true` to return the sid as part
+  // of the _hash_ instead, which is only accessible to the client. Other auth types will
+  // use the `type` parameter - `dual` will automatically use the hash, so do not need the
+  // additional parameter.
+  if (loginMethod === 'token') {
+    params.set('withSid', 'true')
+  } else {
+    params.set('type', loginMethod)
+  }
   return `${url}?${params}`
 }
 

--- a/packages/sanity/src/core/store/_legacy/authStore/sessionId.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/sessionId.ts
@@ -1,4 +1,5 @@
-const sidPattern = /sid=[^&]{20,}/
+// Trailing '&' included so we can replace `#sid=foo&bar=baz` with `#bar=baz`
+const sidPattern = /sid=([^&]{20,})&?/
 
 function consumeSessionId(): string | null {
   // Are we in a browser-like environment?
@@ -8,13 +9,13 @@ function consumeSessionId(): string | null {
 
   // Does the hash contain a valid session ID?
   const hash = window.location.hash
-  const [sidParam] = hash.match(sidPattern) || []
+
+  // The first element will be the entire match, including `sid=` - we only care about
+  // the first _group_, being the actual _value_ of the parameter, thus the leading comma
+  const [, sidParam] = hash.match(sidPattern) || []
   if (!sidParam) {
     return null
   }
-
-  // Extract just the sid from the hash
-  const sid = sidParam.slice(sidParam.indexOf('=') + 1)
 
   // Remove the parameter from the URL
   const newHash = hash.replace(sidPattern, '')
@@ -22,7 +23,7 @@ function consumeSessionId(): string | null {
   newUrl.hash = newHash.length > 1 ? newHash : ''
   history.replaceState(null, '', newUrl)
 
-  return sid
+  return sidParam
 }
 
 // this module consumes the session ID as a side-effect as soon as its loaded


### PR DESCRIPTION
### Description

In certain rare cases, such as browsers inconsistently serving cookies, it may be helpful to explicitly turn off cookie-based authentication. This PR adds a new `token` option to the `loginMethod` property, which enables this.

I had to rewrite the flow in the auth store a bit to allow reuse between the `dual` and `token` options, but I think it reads slightly better now anyway. 

### What to review

- Authentication works as before in Chrome/Firefox/Safari
- Setting the `loginMethod` to `token` and `cookie` works (`cookie` _may_ not work in some browsers, but you should be seeing the same behavior as _before this change_)

  You can do so by using `createAuthStore()` - `sanity.config.ts`:
  
  ```ts
  import {defineConfig, createAuthStore} from 'sanity'

  export default defineConfig({
    // ...
    auth: createAuthStore({
      projectId: '...',
      dataset: '...',
      loginMethod: 'token'
    })
  })
  ```


### Notes for release

- Added new `token` login method for rare cases when the more secure cookie approach is not viable/wanted
