### PR TITLE
feat(auth): allow specifying options without createAuthStore()

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -158,6 +158,9 @@ export default defineConfig([
     plugins: [sharedSettings()],
     basePath: '/staging',
     apiHost: 'https://api.sanity.work',
+    auth: {
+      loginMethod: 'token',
+    },
   },
   {
     name: 'custom-components',

--- a/packages/sanity/src/core/config/auth/types.ts
+++ b/packages/sanity/src/core/config/auth/types.ts
@@ -1,0 +1,74 @@
+/**
+ * Authentication options
+ *
+ * @public
+ */
+export interface AuthConfig {
+  /**
+   * Login method to use for the studio the studio. Can be one of:
+   * - `dual` (default) - attempt to use cookies where possible, falling back to
+   *   storing authentication token in `localStorage` otherwise
+   * - `cookie` - explicitly disable `localStorage` method, relying only on cookies. May fail due
+   *   to cookies being treated as third-party cookies in some browsers, thus the default is `dual`.
+   * - `token` - explicitly disable cookies, relying only on `localStorage` method
+   */
+  loginMethod?: 'dual' | 'cookie' | 'token'
+
+  /**
+   * Whether to append the providers specified in `providers` with the default providers from the
+   * API, or replace the default providers with the ones specified.
+   */
+  mode?: 'append' | 'replace'
+
+  /**
+   * If true, the "Choose login provider" (eg "Google, "GitHub", "E-mail/password") screen
+   * will be skipped if only a single provider is configured in the `providers` array -
+   * instead it will redirect unauthenticated users straight to the authenticatino URL.
+   */
+  redirectOnSingle?: boolean
+
+  /**
+   * Array of authentication providers to allow.
+   * If not set, the default providers will be used.
+   */
+  providers?: AuthProvider[]
+
+  /**
+   * The API hostname for requests. Should usually be left undefined,
+   * but can be set if using custom cname for API domain.
+   */
+  apiHost?: string
+}
+
+/**
+ * A provider of authentication.
+ *
+ * By default, a list of providers for a project will be fetched from the
+ * {@link https://api.sanity.io/v1/auth/providers | Sanity API}, but you may choose to limit this
+ * list by explicitly defining the providers you want to allow, or add additional custom providers
+ * that conforms to the authentication provider specification outlined in
+ * {@link https://www.sanity.io/docs/third-party-login | the documentation}.
+ *
+ * @public
+ */
+export interface AuthProvider {
+  /**
+   * URL-friendly identifier/name for the provider, eg `github`
+   */
+  name: string
+
+  /**
+   * Human friendly title for the provider, eg `GitHub`
+   */
+  title: string
+
+  /**
+   * URL for the authentication endpoint that will trigger the authentication flow
+   */
+  url: string
+
+  /**
+   * URL for a logo to display next to the provider in the login screen
+   */
+  logo?: string
+}

--- a/packages/sanity/src/core/config/auth/types.ts
+++ b/packages/sanity/src/core/config/auth/types.ts
@@ -17,6 +17,8 @@ export interface AuthConfig {
   /**
    * Whether to append the providers specified in `providers` with the default providers from the
    * API, or replace the default providers with the ones specified.
+   *
+   * @deprecated Use the function form of `providers` instead for more control
    */
   mode?: 'append' | 'replace'
 
@@ -28,10 +30,18 @@ export interface AuthConfig {
   redirectOnSingle?: boolean
 
   /**
-   * Array of authentication providers to allow.
+   * Array of authentication providers to use, or a function that takes an array of default
+   * authentication providers (fetched from the Sanity API) and should return a new list of
+   * providers. This can be used to selectively replace, add or remove providers from the
+   * list of choices.
+   *
+   * @remarks If a static array of providers is provided, the `mode` property is taken into account
+   *   when determining what to do with it - `append` will append the providers to the default set
+   *   of providers, while `replace` will replace the default providers with the ones specified.
+   *
    * If not set, the default providers will be used.
    */
-  providers?: AuthProvider[]
+  providers?: AuthProvider[] | ((prev: AuthProvider[]) => AuthProvider[] | Promise<AuthProvider[]>)
 
   /**
    * The API hostname for requests. Should usually be left undefined,

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -412,7 +412,9 @@ export interface SourceOptions extends PluginOptions {
    */
   apiHost?: string
 
-  /** @internal */
+  /**
+   * Authentication options for this source.
+   */
   auth?: AuthConfig | AuthStore
 
   /**

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -27,6 +27,7 @@ import type {StudioTheme} from '../theme'
 import type {SearchFilterDefinition} from '../studio/components/navbar/search/definitions/filters'
 import type {SearchOperatorDefinition} from '../studio/components/navbar/search/definitions/operators'
 import type {StudioComponents, StudioComponentsPluginOptions} from './studio'
+import type {AuthConfig} from './auth/types'
 import type {
   DocumentActionComponent,
   DocumentBadgeComponent,
@@ -38,24 +39,9 @@ import type {
 import type {Router, RouterState} from 'sanity/router'
 
 /**
- *
  * @hidden
  * @beta
  */
-export interface SanityAuthConfig {
-  mode?: 'append' | 'replace'
-  redirectOnSingle?: boolean
-  providers?: {
-    name: string
-    title: string
-    url: string
-    logo?: string
-  }[]
-}
-
-/**
- * @hidden
- * @beta */
 export type AssetSourceResolver = ComposableOption<AssetSource[], ConfigContext>
 
 /**
@@ -75,7 +61,8 @@ export interface SanityFormConfig {
   }
   /**
    * @hidden
-   * @beta */
+   * @beta
+   */
   components?: {
     input?: ComponentType<InputProps>
     field?: ComponentType<FieldProps>
@@ -96,7 +83,8 @@ export interface SanityFormConfig {
   }
   /**
    * @hidden
-   * @beta */
+   * @beta
+   */
   image?: {
     assetSources?: AssetSource[] | AssetSourceResolver
     // TODO: this option needs more thought on composition and availability
@@ -185,7 +173,8 @@ export type ComposableOption<TValue, TContext> = (prev: TValue, context: TContex
 
 /**
  * @hidden
- * @beta */
+ * @beta
+ */
 export type AsyncComposableOption<TValue, TContext> = (
   prev: TValue,
   context: TContext
@@ -220,7 +209,8 @@ export type TemplateResolver = ComposableOption<Template[], ConfigContext>
 
 /**
  * @hidden
- * @beta */
+ * @beta
+ */
 export interface SchemaPluginOptions {
   name?: string
   types?:
@@ -234,19 +224,22 @@ export interface SchemaPluginOptions {
 
 /**
  * @hidden
- * @beta */
+ * @beta
+ */
 export type NewDocumentOptionsResolver = ComposableOption<TemplateItem[], NewDocumentOptionsContext>
 
 /**
  * @hidden
- * @beta */
+ * @beta
+ */
 export interface NewDocumentOptionsContext extends ConfigContext {
   creationContext: NewDocumentCreationContext
 }
 
 /**
  * @hidden
- * @beta */
+ * @beta
+ */
 export type NewDocumentCreationContext =
   | {type: 'global'; documentId?: undefined; schemaType?: undefined}
   | {type: 'document'; documentId: string; schemaType: string}
@@ -254,7 +247,8 @@ export type NewDocumentCreationContext =
 
 /**
  * @hidden
- * @beta */
+ * @beta
+ */
 export interface DocumentPluginOptions {
   badges?: DocumentBadgeComponent[] | DocumentBadgesResolver
   actions?: DocumentActionComponent[] | DocumentActionsResolver
@@ -264,15 +258,18 @@ export interface DocumentPluginOptions {
   inspectors?: DocumentInspector[] | DocumentInspectorsResolver
   /**
    * @hidden
-   * @beta */
+   * @beta
+   */
   productionUrl?: AsyncComposableOption<string | undefined, ResolveProductionUrlContext>
   /**
    * @hidden
-   * @beta */
+   * @beta
+   */
   unstable_languageFilter?: DocumentLanguageFilterResolver
   /**
    * @hidden
-   * @beta */
+   * @beta
+   */
   newDocumentOptions?: NewDocumentOptionsResolver
 }
 
@@ -305,7 +302,8 @@ export type DocumentLanguageFilterResolver = ComposableOption<
 
 /**
  * @hidden
- * @beta */
+ * @beta
+ */
 export type DocumentActionsResolver = ComposableOption<
   DocumentActionComponent[],
   DocumentActionsContext
@@ -313,7 +311,8 @@ export type DocumentActionsResolver = ComposableOption<
 
 /**
  * @hidden
- * @beta */
+ * @beta
+ */
 export type DocumentBadgesResolver = ComposableOption<
   DocumentBadgeComponent[],
   DocumentBadgesContext
@@ -327,7 +326,8 @@ export type DocumentInspectorsResolver = ComposableOption<
 
 /**
  * @hidden
- * @beta */
+ * @beta
+ */
 export interface PluginOptions {
   name: string
   plugins?: PluginOptions[]
@@ -358,12 +358,14 @@ export type AsyncConfigPropertyReducer<TValue, TContext> = (
 
 /**
  * @hidden
- * @beta */
+ * @beta
+ */
 export type Plugin<TOptions = void> = (options: TOptions) => PluginOptions
 
 /**
  * @hidden
- * @beta */
+ * @beta
+ */
 export interface WorkspaceOptions extends SourceOptions {
   basePath: string
   subtitle?: string
@@ -372,18 +374,21 @@ export interface WorkspaceOptions extends SourceOptions {
 
   /**
    * @hidden
-   * @beta */
+   * @beta
+   */
   theme?: StudioTheme
 
   /**
    * @hidden
-   * @beta */
+   * @beta
+   */
   unstable_sources?: SourceOptions[]
 }
 
 /**
  * @hidden
- * @beta */
+ * @beta
+ */
 export interface SourceOptions extends PluginOptions {
   title?: string
 
@@ -408,24 +413,27 @@ export interface SourceOptions extends PluginOptions {
   apiHost?: string
 
   /** @internal */
-  auth?: AuthStore
+  auth?: AuthConfig | AuthStore
 
   /**
    * @hidden
-   * @beta */
+   * @beta
+   */
   unstable_clientFactory?: (options: SanityClientConfig) => SanityClient
 }
 
 /**
  * @hidden
- * @beta */
+ * @beta
+ */
 export interface ResolveProductionUrlContext extends ConfigContext {
   document: SanityDocumentLike
 }
 
 /**
  * @hidden
- * @beta */
+ * @beta
+ */
 export interface DocumentActionsContext extends ConfigContext {
   documentId?: string
   schemaType: string
@@ -433,7 +441,8 @@ export interface DocumentActionsContext extends ConfigContext {
 
 /**
  * @hidden
- * @beta */
+ * @beta
+ */
 export interface DocumentBadgesContext extends ConfigContext {
   documentId?: string
   schemaType: string
@@ -447,7 +456,8 @@ export interface DocumentInspectorContext extends ConfigContext {
 
 /**
  * @hidden
- * @beta */
+ * @beta
+ */
 export type PartialContext<TContext extends ConfigContext> = Pick<
   TContext,
   Exclude<keyof TContext, keyof ConfigContext>
@@ -700,12 +710,14 @@ export type SingleWorkspace = Omit<WorkspaceOptions, 'name' | 'basePath'> & {
 
 /**
  * @hidden
- * @beta */
+ * @beta
+ */
 export type Config = SingleWorkspace | WorkspaceOptions[]
 
 /**
  * @hidden
- * @beta */
+ * @beta
+ */
 export interface MissingConfigFile {
   missingConfigFile: true
 }
@@ -715,3 +727,5 @@ export interface PreparedConfig {
   type: 'prepared-config'
   workspaces: WorkspaceSummary[]
 }
+
+export type {AuthConfig, AuthProvider} from './auth/types'

--- a/packages/sanity/src/core/store/_legacy/authStore/providerLogos.tsx
+++ b/packages/sanity/src/core/store/_legacy/authStore/providerLogos.tsx
@@ -1,7 +1,7 @@
-import {Theme} from '@sanity/ui'
+import type {Theme} from '@sanity/ui'
 import React from 'react'
 import styled, {css} from 'styled-components'
-import {AuthProvider} from './createAuthStore'
+import type {AuthProvider} from '../../../config'
 
 const GithubRoot = styled.svg(({theme}: {theme: Theme}) => {
   const {fg} = theme.sanity.color.base

--- a/packages/sanity/src/core/store/_legacy/authStore/types.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/types.ts
@@ -10,7 +10,8 @@ import {WorkspaceSummary} from '../../../config'
  * NOTE: This interface is primarily for internal use. Refer to
  * `createAuthStore` instead.
  *
- * @internal
+ * @beta
+ * @hidden
  */
 export interface AuthStore {
   /**
@@ -50,7 +51,8 @@ export interface AuthStore {
 /**
  * The unit an `AuthStore` emits to determine the user's authentication state.
  *
- * @internal
+ * @beta
+ * @hidden
  */
 export interface AuthState {
   /**
@@ -72,5 +74,11 @@ export interface AuthState {
   client: SanityClient
 }
 
-/** @internal */
-export type LoginComponentProps = Omit<WorkspaceSummary, 'type' | '__internal'>
+/**
+ * @beta
+ * @hidden
+ */
+export interface LoginComponentProps {
+  projectId: string
+  basePath: string
+}


### PR DESCRIPTION
### Description

~**Note**: builds on #4772 - please only review [this commit](https://github.com/sanity-io/sanity/commit/d0fab5cf4ebf4659f7c594eaaf00d52d91c9c448).~

When configuring the authentication aspects, you currently have to give it an `AuthStore`. This is not very ergonomic/developer friendly, and made worse by the fact that it requires you to duplicate project ID and dataset, as well as `createAuthStore` actually being marked as `@internal`.

With this change, I propose that we instead take a partial object of configuration parameters, such as `loginMethod`, `providers` etc, and merge these into the default options and internally call `createAuthStore()`. I left the `AuthStore` as an option because it can be useful for mocking and backwards compatibility, but we should discourage people from using it generally.

### What to review

- Code looks okay
- Regular authentication (without specifying a config) works as expected
- Authentication using an object works (staging workspace in test studio configured to use it, check for `withSid` parameter in login URL to see that it works)
- Providing an auth store still works (tests should take care of this, as they use it for mocking)

### Notes for release

- Allow specifying authentication options using an object instead of `createAuthStore()`
