### PR TITLE
fix(cli): improve performance of projects list

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@babel/preset-typescript": "^7.18.6",
     "@optimize-lodash/rollup-plugin": "^4.0.1",
     "@playwright/test": "^1.31.2",
-    "@sanity/client": "^6.1.5",
+    "@sanity/client": "^6.3.0",
     "@sanity/pkg-utils": "^2.3.1",
     "@sanity/tsdoc": "1.0.0-alpha.38",
     "@sanity/uuid": "^3.0.1",

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -74,7 +74,7 @@
   "devDependencies": {
     "@rexxars/gitconfiglocal": "^3.0.1",
     "@rollup/plugin-node-resolve": "^15.0.0",
-    "@sanity/client": "^6.1.5",
+    "@sanity/client": "^6.3.0",
     "@sanity/eslint-config-studio": "^2.0.0",
     "@sanity/generate-help-url": "^3.0.0",
     "@sanity/types": "3.14.5",

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -568,7 +568,7 @@ export default async function initSanity(
     try {
       const client = apiClient({requireUser: true, requireProject: false})
       const [allProjects, allOrgs] = await Promise.all([
-        client.projects.list(),
+        client.projects.list({includeMembers: false}),
         client.request({uri: '/organizations'}),
       ])
       projects = allProjects.sort((a, b) => b.createdAt.localeCompare(a.createdAt))

--- a/packages/@sanity/cli/src/actions/init-project/reconfigureV2Project.ts
+++ b/packages/@sanity/cli/src/actions/init-project/reconfigureV2Project.ts
@@ -173,7 +173,7 @@ export async function reconfigureV2Project(
   }> {
     let projects
     try {
-      projects = await apiClient({requireProject: false}).projects.list()
+      projects = await apiClient({requireProject: false}).projects.list({includeMembers: false})
     } catch (err) {
       if (unattended && flags.project) {
         return {projectId: flags.project, displayName: 'Unknown project', isFirstProject: false}

--- a/packages/@sanity/import-cli/package.json
+++ b/packages/@sanity/import-cli/package.json
@@ -31,7 +31,7 @@
     "src"
   ],
   "dependencies": {
-    "@sanity/client": "^6.1.5",
+    "@sanity/client": "^6.3.0",
     "@sanity/import": "3.14.5",
     "get-it": "^8.0.9",
     "meow": "^9.0.0",

--- a/packages/@sanity/import/package.json
+++ b/packages/@sanity/import/package.json
@@ -51,7 +51,7 @@
     "tar-fs": "^2.1.1"
   },
   "devDependencies": {
-    "@sanity/client": "^6.1.5",
+    "@sanity/client": "^6.3.0",
     "nock": "^13.2.9"
   },
   "engines": {

--- a/packages/@sanity/types/package.json
+++ b/packages/@sanity/types/package.json
@@ -56,7 +56,7 @@
     "watch": "pkg-utils watch --tsconfig tsconfig.lib.json"
   },
   "dependencies": {
-    "@sanity/client": "^6.1.5",
+    "@sanity/client": "^6.3.0",
     "@types/react": "^18.0.25"
   },
   "devDependencies": {

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -75,7 +75,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@sanity/client": "^6.1.5",
+    "@sanity/client": "^6.3.0",
     "react": "^18.2.0",
     "sanity": "3.14.5",
     "styled-components": "^5.2.0"

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -135,7 +135,7 @@
     "@sanity/bifur-client": "^0.3.1",
     "@sanity/block-tools": "3.14.5",
     "@sanity/cli": "3.14.5",
-    "@sanity/client": "^6.1.5",
+    "@sanity/client": "^6.3.0",
     "@sanity/color": "^2.1.20",
     "@sanity/diff": "3.14.5",
     "@sanity/eventsource": "^5.0.0",

--- a/perf/package.json
+++ b/perf/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@playwright/test": "^1.31.2",
-    "@sanity/client": "^6.1.5",
+    "@sanity/client": "^6.3.0",
     "@sanity/uuid": "^3.0.1",
     "@types/lodash": "^4.14.191",
     "@types/node": "^18.15.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3825,13 +3825,22 @@
     nanoid "^3.1.12"
     rxjs "^7.0.0"
 
-"@sanity/client@^6.1.2", "@sanity/client@^6.1.5":
+"@sanity/client@^6.1.2":
   version "6.1.7"
   resolved "https://registry.yarnpkg.com/@sanity/client/-/client-6.1.7.tgz#15e6e61ddfbf3fabb4b9f8e60c03092839317ee4"
   integrity sha512-crleZDBic3VpmBhIuiVZNkJMxAWE/fj5v+hHBXt+2psW1CJrvBdTLX14f4cqC40W1YDDE4ZGrDkYuph6Y6/YzQ==
   dependencies:
     "@sanity/eventsource" "^5.0.0"
     get-it "^8.1.0"
+    rxjs "^7.0.0"
+
+"@sanity/client@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@sanity/client/-/client-6.3.0.tgz#61db96aa484e0db1d34c0a5676763f2579e5cf96"
+  integrity sha512-SFw53wHejjBUVitSRWufMAJJKIjSIAEs2CA52KAcAUK4TxF8IpHrQTkkWKHzxbfEZWKNwxlhVMm5sQUKso1atg==
+  dependencies:
+    "@sanity/eventsource" "^5.0.0"
+    get-it "^8.2.0"
     rxjs "^7.0.0"
 
 "@sanity/color@^2.1.20", "@sanity/color@^2.2.5":
@@ -9842,6 +9851,22 @@ get-it@^8.0.9, get-it@^8.1.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/get-it/-/get-it-8.3.0.tgz#376ab5f13a75923f737491b6665ee43674627e1f"
   integrity sha512-R8rM45CWEI1shdTegGCs/9yy/z6DgwS5XMVIVZtSVpu0XABxPp3PA3TCl6mzVQOcHecbqD+VUFg1poAtBtO19A==
+  dependencies:
+    debug "^4.3.4"
+    decompress-response "^7.0.0"
+    follow-redirects "^1.15.2"
+    into-stream "^6.0.0"
+    is-plain-object "^5.0.0"
+    is-retry-allowed "^2.2.0"
+    is-stream "^2.0.1"
+    parse-headers "^2.0.5"
+    progress-stream "^2.0.0"
+    tunnel-agent "^0.6.0"
+
+get-it@^8.2.0:
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/get-it/-/get-it-8.3.1.tgz#bb92c6740a1260275ad13b31a543755b38a8b5c9"
+  integrity sha512-fi5wQakZVHWRy3zP0env52PHXP9Zl/p8Q2Ow8z9SmwpYgfCaA90hCSW2twC5/cpV5M1wB6tSmLqldVMP1tS1qw==
   dependencies:
     debug "^4.3.4"
     decompress-response "^7.0.0"


### PR DESCRIPTION
### Description

When a user has a large number of projects, and/or those projects have a large number of members, the API request might take a second to respond. Because we in many cases do not need the member list, we can speed up this request by omitting it. This PR does this for the request performed when initializing a new project, making for a slightly snappier experience for some users.

### What to review

- `sanity init` works as before

### Notes for release

- Improved performance when fetching projects list as part of the `sanity init` CLI command
