### PR TITLE
fix(form): make recently introduced props for ArrayOfObjectInputMembers optional

### DIFF
--- a/packages/sanity/src/core/form/members/array/ArrayOfObjectsInputMembers.tsx
+++ b/packages/sanity/src/core/form/members/array/ArrayOfObjectsInputMembers.tsx
@@ -14,9 +14,9 @@ import {ArrayOfObjectsInputMember} from './ArrayOfObjectsInputMember'
 /** @internal */
 export interface ArrayOfObjectsInputMembersProps {
   members: ArrayOfObjectsMember[]
-  renderAnnotation: RenderAnnotationCallback
-  renderBlock: RenderBlockCallback
-  renderInlineBlock: RenderBlockCallback
+  renderAnnotation?: RenderAnnotationCallback
+  renderBlock?: RenderBlockCallback
+  renderInlineBlock?: RenderBlockCallback
   renderInput: RenderInputCallback
   renderField: RenderFieldCallback
   renderItem: RenderArrayOfObjectsItemCallback


### PR DESCRIPTION
### Description

https://github.com/sanity-io/sanity/pull/4327 introduced new _required_ PTE related render props for ArrayOfObjectInputMembers, but I think we intended to make them optional. Currently, when creating a custom array input that forwards its props to ArrayOfObjectInputMembers, you get a type error because the received props are optional, but ArrayOfObjectInputMembers doesn't accept them as being optional.

### What to review
- Make sure this is the intended behavior.


### Notes for release
N/A