### PR TITLE
fix(validation): reset regex state between validation checks

### DIFF
--- a/packages/sanity/src/core/validation/validators/stringValidator.ts
+++ b/packages/sanity/src/core/validation/validators/stringValidator.ts
@@ -95,6 +95,9 @@ export const stringValidators: Validators = {
     const {pattern, name, invert} = options
     const regName = name || `"${pattern.toString()}"`
     const strValue = value || ''
+    // Regexes with global or sticky flags are stateful (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex).
+    // This resets the state stored from the previous check
+    pattern.lastIndex = 0
     const matches = pattern.test(strValue)
     if ((!invert && !matches) || (invert && matches)) {
       const defaultMessage = invert


### PR DESCRIPTION
### Description

A regex validation rule using the global flag currently give intermittent validation errors, even for completely valid values:

https://github.com/sanity-io/sanity/assets/876086/4beccc45-1f4b-4a12-bc4b-01281e731687

This PR fixes the issue by resetting the regex state before testing input against it.

### What to review

- Make sure validation works as intended with regexes with global (and sticky flags - which doesn't really make much sense to use for validation?). Here's an example of a field definition that currently give intermittent validation errors for valid values:
```ts
defineField({
    type: 'string',
    name: 'fielda',
    title: 'Field A',
    description: 'Only letters, numbers and -_',
    validation: (Rule) => Rule.required().regex(/^[A-Za-z0-9_-]*$/g),
}),
```

Props to @pauloborges for pointing straight at the core issue <3

### Notes for release
- Fixes an issue that would give intermittent validation errors for valid string values when using a regex with global flag