### PR TITLE
feat(core): adds title to document panel

### DIFF
--- a/packages/sanity/src/desk/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/documentViews/FormView.tsx
@@ -18,6 +18,7 @@ import {
   useDocumentPresence,
   useDocumentStore,
 } from 'sanity'
+import {Title} from './styles'
 
 interface FormViewProps {
   hidden: boolean
@@ -152,9 +153,9 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
       <PresenceOverlay margins={margins}>
         <Box as="form" onSubmit={preventDefault} ref={setRef}>
           <Box marginBottom={4}>
-            <Heading muted={!title} size={5}>
+            <Title forwardedAs="h6" muted={!title} size={5}>
               {title ?? 'Untitled'}
-            </Heading>
+            </Title>
           </Box>
           {ready ? (
             formState === null ? (

--- a/packages/sanity/src/desk/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/documentViews/FormView.tsx
@@ -1,10 +1,11 @@
 /* eslint-disable no-nested-ternary */
 
-import {Box, Container, Flex, Spinner, Text, focusFirstDescendant} from '@sanity/ui'
-import React, {forwardRef, useEffect, useMemo, useRef, type Ref, useCallback, useState} from 'react'
+import {Box, Container, Flex, Heading, Spinner, Text, focusFirstDescendant} from '@sanity/ui'
+import React, {forwardRef, useEffect, useMemo, useCallback, useState} from 'react'
 import {tap} from 'rxjs/operators'
 import {useDocumentPane} from '../../useDocumentPane'
 import {Delay} from '../../../../components/Delay'
+import {useDocumentTitle} from '../../useDocumentTitle'
 import {useConditionalToast} from './useConditionalToast'
 import {
   DocumentMutationEvent,
@@ -49,6 +50,7 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
   } = useDocumentPane()
   const documentStore = useDocumentStore()
   const presence = useDocumentPresence(documentId)
+  const {title} = useDocumentTitle()
 
   // The `patchChannel` is an INTERNAL publish/subscribe channel that we use to notify form-builder
   // nodes about both remote and local patches.
@@ -149,6 +151,11 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
     >
       <PresenceOverlay margins={margins}>
         <Box as="form" onSubmit={preventDefault} ref={setRef}>
+          <Box marginBottom={4}>
+            <Heading muted={!title} size={5}>
+              {title ?? 'Untitled'}
+            </Heading>
+          </Box>
           {ready ? (
             formState === null ? (
               <Box padding={2}>

--- a/packages/sanity/src/desk/panes/document/documentPanel/documentViews/styles.ts
+++ b/packages/sanity/src/desk/panes/document/documentPanel/documentViews/styles.ts
@@ -1,0 +1,6 @@
+import {Heading} from '@sanity/ui'
+import styled from 'styled-components'
+
+export const Title = styled(Heading)`
+  word-break: break-word;
+`

--- a/packages/sanity/src/desk/panes/document/documentPanel/header/DocumentHeaderTitle.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/header/DocumentHeaderTitle.tsx
@@ -1,32 +1,12 @@
 import React, {ReactElement} from 'react'
-import {useDocumentPane} from '../../useDocumentPane'
-import {unstable_useValuePreview as useValuePreview} from 'sanity'
+import {useDocumentTitle} from '../../useDocumentTitle'
 
 export function DocumentHeaderTitle(): ReactElement {
-  const {connectionState, schemaType, title, value: documentValue} = useDocumentPane()
-  const subscribed = Boolean(documentValue) && connectionState === 'connected'
-
-  const {error, value} = useValuePreview({
-    enabled: subscribed,
-    schemaType,
-    value: documentValue,
-  })
-
-  if (connectionState !== 'connected') {
-    return <></>
-  }
-
-  if (title) {
-    return <>{title}</>
-  }
-
-  if (!documentValue) {
-    return <>New {schemaType?.title || schemaType?.name}</>
-  }
+  const {error, title} = useDocumentTitle()
 
   if (error) {
-    return <>Error: {error.message}</>
+    return <>{error}</>
   }
 
-  return <>{value?.title || <span style={{color: 'var(--card-muted-fg-color)'}}>Untitled</span>}</>
+  return <>{title || <span style={{color: 'var(--card-muted-fg-color)'}}>Untitled</span>}</>
 }

--- a/packages/sanity/src/desk/panes/document/documentPanel/header/DocumentHeaderTitle.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/header/DocumentHeaderTitle.tsx
@@ -1,8 +1,14 @@
 import React, {ReactElement} from 'react'
 import {useDocumentTitle} from '../../useDocumentTitle'
+import {useDocumentPane} from '../../useDocumentPane'
 
 export function DocumentHeaderTitle(): ReactElement {
+  const {connectionState} = useDocumentPane()
   const {error, title} = useDocumentTitle()
+
+  if (connectionState !== 'connected') {
+    return <></>
+  }
 
   if (error) {
     return <>{error}</>

--- a/packages/sanity/src/desk/panes/document/index.ts
+++ b/packages/sanity/src/desk/panes/document/index.ts
@@ -1,2 +1,3 @@
 export {DocumentPane as default} from './DocumentPane'
 export * from './DocumentPaneProvider'
+export * from './useDocumentTitle'

--- a/packages/sanity/src/desk/panes/document/useDocumentTitle.ts
+++ b/packages/sanity/src/desk/panes/document/useDocumentTitle.ts
@@ -18,7 +18,7 @@ interface UseDocumentTitle {
  * @beta
  * @hidden
  *
- * @returns The document title
+ * @returns The document title or error. See {@link UseDocumentTitle}
  */
 export function useDocumentTitle(): UseDocumentTitle {
   const {connectionState, schemaType, title, value: documentValue} = useDocumentPane()

--- a/packages/sanity/src/desk/panes/document/useDocumentTitle.ts
+++ b/packages/sanity/src/desk/panes/document/useDocumentTitle.ts
@@ -1,0 +1,50 @@
+import {useDocumentPane} from './useDocumentPane'
+import {unstable_useValuePreview as useValuePreview} from 'sanity'
+
+/**
+ * useDocumentTitle hook return type.
+ *
+ * @beta
+ * @hidden
+ */
+interface UseDocumentTitle {
+  error?: string
+  title?: string
+}
+
+/**
+ * React hook that returns the document title for the current document in the document pane.
+ *
+ * @beta
+ * @hidden
+ *
+ * @returns The document title
+ */
+export function useDocumentTitle(): UseDocumentTitle {
+  const {connectionState, schemaType, title, value: documentValue} = useDocumentPane()
+  const subscribed = Boolean(documentValue) && connectionState === 'connected'
+
+  const {error, value} = useValuePreview({
+    enabled: subscribed,
+    schemaType,
+    value: documentValue,
+  })
+
+  if (connectionState !== 'connected') {
+    return {error: undefined, title: undefined}
+  }
+
+  if (title) {
+    return {error: undefined, title}
+  }
+
+  if (!documentValue) {
+    return {error: undefined, title: `New ${schemaType?.title || schemaType?.name}`}
+  }
+
+  if (error) {
+    return {error: `Error: ${error.message}`, title: undefined}
+  }
+
+  return {error: undefined, title: value?.title}
+}


### PR DESCRIPTION
### Description

Adds a document title to the document panel. Note this does not include the title treatment when editing just shows the title. 

#### Long Title
<img width="691" alt="Screenshot 2023-08-03 at 11 24 59 AM" src="https://github.com/sanity-io/sanity/assets/6476108/5aaa0fcb-2d68-47d4-a774-3cb856643e0c">

#### Short Title
<img width="679" alt="Screenshot 2023-08-03 at 11 25 09 AM" src="https://github.com/sanity-io/sanity/assets/6476108/3499ed28-d14a-4b68-a4d8-d09aa15fc940">


### What to review

1. Does the hook makes sense
2. Does the location of the hook make sense

### Notes for release

N/A (Part of bigger release announcement) 
