### PR TITLE
fix(cli): correct URL for the `sanity manage` command

### DIFF
--- a/packages/@sanity/cli/src/commands/manage/manageCommand.ts
+++ b/packages/@sanity/cli/src/commands/manage/manageCommand.ts
@@ -12,8 +12,8 @@ const manageCommand: CliCommandDefinition = {
     const projectId = cliConfig?.api?.projectId
 
     const url = projectId
-      ? `https://manage.sanity.io/projects/${projectId}`
-      : 'https://manage.sanity.io/'
+      ? `https://www.sanity.io/manage/project/${projectId}`
+      : 'https://www.sanity.io/manage/'
 
     print(`Opening ${url}`)
     await open(url)


### PR DESCRIPTION
### Description

`manage.sanity.io` has not been used for a while - we should use the new URL to prevent redirects.

### What to review

- Code change looks good

### Notes for release

- Fixed the URL generated by the `sanity manage` CLI command

[sc-35955]