### PR TITLE
fix: delay refetching for listener events arriving with visibility != query

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/types.ts
+++ b/packages/sanity/src/core/store/_legacy/document/types.ts
@@ -15,6 +15,7 @@ export interface MutationEvent {
 
   transactionTotalEvents: number
   transactionCurrentEvent: number
+  visibility: 'transaction' | 'query'
 
   transition: 'update' | 'appear' | 'disappear'
 }

--- a/packages/sanity/src/desk/panes/documentList/listenSearchQuery.ts
+++ b/packages/sanity/src/desk/panes/documentList/listenSearchQuery.ts
@@ -11,6 +11,7 @@ import {
   take,
   throttleTime,
   throwError,
+  timer,
 } from 'rxjs'
 import {exhaustMapWithTrailing} from 'rxjs-exhaustmap-with-trailing'
 import {SortOrder} from './types'
@@ -74,7 +75,7 @@ export function listenSearchQuery(options: ListenQueryOptions): Observable<Sanit
     welcome$.pipe(take(1)),
     mutationAndReconnect$.pipe(throttleTime(1000, asyncScheduler, {leading: true, trailing: true}))
   ).pipe(
-    exhaustMapWithTrailing(() => {
+    exhaustMapWithTrailing((event) => {
       // Get the types names to use for searching.
       // If we have a static list of types, we can skip fetching the types and use the static list.
       const typeNames$ = staticTypeNames
@@ -104,8 +105,15 @@ export function listenSearchQuery(options: ListenQueryOptions): Observable<Sanit
             searchTerms,
             searchOptions
           )
+          const doFetch = () => client.observable.fetch(createdQuery, createdParams)
 
-          return client.observable.fetch(createdQuery, createdParams)
+          if (event.type === 'mutation' && event.visibility !== 'query') {
+            // Even though the listener request specifies visibility=query, the events are not guaranteed to be delivered with visibility=query
+            // If the event we are responding to arrives with visibility != query, we add a little delay to allow for the updated document to be available for queries
+            // See https://www.sanity.io/docs/listening#visibility-c4786e55c3ff
+            return timer(1200).pipe(mergeMap(doFetch))
+          }
+          return doFetch()
         })
       )
     })


### PR DESCRIPTION
### Description
The listener requests we use for document lists are set up with visibility=query, however, this does not guarantee that the listener events arrive after their mutations have been made visible to queries.

From our docs about [listener visibility](https://www.sanity.io/docs/listening#visibility-c4786e55c3ff):
> (...) listeners with `query` may in certain cases (notably with deferred transactions) receive events that are not yet visible to queries. The visibility event field will indicate the actual visibility.

This will often enough lead to document lists in the Studio not reflecting the actual reality of the data store. One fairly consistent way of reproducing the issue is to create a new document, make a single change (e.g. type a single character in a text field) and watch the newly created document *not* appearing in the document list before another change is made.

### What to review
- Make sure the document lists updates more reliably when documents are added/removed

### Notes for release

- Fixed an issue that would sometimes cause document lists to not refresh properly after adding or removing a document