### PR TITLE
chore: upgrade typescript to 5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "pretty-quick": "^3.1.3",
     "rimraf": "^3.0.2",
     "semver": "^7.3.5",
-    "typescript": "^4.9.4",
+    "typescript": "^5.1.6",
     "yargs": "^17.3.0"
   },
   "optionalDependencies": {

--- a/packages/@sanity/portable-text-editor/package.json
+++ b/packages/@sanity/portable-text-editor/package.json
@@ -81,7 +81,7 @@
     "@types/express": "^4.16.1",
     "@types/express-ws": "^3.0.1",
     "@types/jest": "^27.0.3",
-    "@types/jest-dev-server": "^4.2.1",
+    "@types/jest-dev-server": "^5.0.0",
     "@types/lodash": "^4.14.149",
     "@types/node": "^14.18.9",
     "@types/node-ipc": "^9.0.0",

--- a/packages/@sanity/types/src/schema/test/alias.test.ts
+++ b/packages/@sanity/types/src/schema/test/alias.test.ts
@@ -88,6 +88,7 @@ describe('alias type test', () => {
   })
 
   it('should support alias with preview', () => {
+    //@ts-expect-error {error: any} has no properties in common with PreviewValue
     defineType({
       type: 'custom-object',
       name: 'redefined',
@@ -98,6 +99,7 @@ describe('alias type test', () => {
       },
     })
 
+    //@ts-expect-error {error: any} has no properties in common with PreviewValue
     defineField({
       type: 'custom-object',
       name: 'redefined',
@@ -108,6 +110,7 @@ describe('alias type test', () => {
       },
     })
 
+    //@ts-expect-error {error: any} has no properties in common with PreviewValue
     defineArrayMember({
       type: 'custom-object',
       name: 'redefined',

--- a/packages/@sanity/types/src/schema/test/document.test.ts
+++ b/packages/@sanity/types/src/schema/test/document.test.ts
@@ -183,13 +183,11 @@ describe('document types', () => {
         type: 'document',
         name: 'custom-document',
         fields: [
+          //@ts-expect-error not assignable to FieldDefinition
           {
             type: 'object',
             name: 'error-fields-type',
-            fields: [
-              //@ts-expect-error not assignable to FieldDefinition
-              {},
-            ],
+            fields: [{}],
           },
         ],
       })

--- a/packages/@sanity/types/src/schema/test/file.test.ts
+++ b/packages/@sanity/types/src/schema/test/file.test.ts
@@ -3,8 +3,8 @@
  * Some of these tests have no expect statement;
  * use of ts-expect-error serves the same purpose - TypeScript is the testrunner here
  */
-import {defineField, defineType} from '../types'
 import {FileDefinition, StringDefinition} from '_self_'
+import {defineField, defineType} from '../types'
 
 describe('file types', () => {
   describe('defineType', () => {
@@ -67,6 +67,7 @@ describe('file types', () => {
           hidden: false,
           fieldset: 'test',
           group: 'test',
+          //@ts-expect-error fields is not a known property for string types
           fields: [],
           validation: (Rule) => Rule.max(45),
           initialValue: 'string',

--- a/perf/package.json
+++ b/perf/package.json
@@ -28,6 +28,6 @@
     "rxjs": "^7.8.0",
     "sanity": "3.15.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.1.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4555,10 +4555,10 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest-dev-server@^4.2.1":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@types/jest-dev-server/-/jest-dev-server-4.2.1.tgz#0fd8923c400abfad48144fa5b5b74f17447bf357"
-  integrity sha512-hZYqCfhk9o9zOrTGeaFUaG4WTZsyoEzO4wd0U4/D8uz/gCRQNptHwRRw14hSksn0wFCgC1ZpzCQTagNwqdV5bg==
+"@types/jest-dev-server@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/jest-dev-server/-/jest-dev-server-5.0.0.tgz#1c89fb8b2c6ceae75b73d7bb9bab6207c07ac101"
+  integrity sha512-2o5mY2c/WTXO0j+FrtWMxDt0NBi0o6R6aNx4xaym/OfVP8owAeZa582eFxQEqZ7KzHDqvkEEJ9YZ9O3Zw/MpPw==
   dependencies:
     "@types/node" "*"
     "@types/wait-on" "*"
@@ -18409,10 +18409,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^4.9.4, typescript@^4.9.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@^5.1.6:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
+  integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
 
 typescript@~5.0.4:
   version "5.0.4"


### PR DESCRIPTION
### Description
This upgrades TypeScript to latest 5.x. Very few changes needed to be done to the code base except from adjusting and adding few expect-error directives (kept in a separate commit 909b93fc26367e3cd8671cb8638f789c99f47f58).

### What to review
- Can this have unintended consequences? From what I can tell by reading the [release notes](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#breaking-changes-and-deprecations) there doesn't seem to be any breaking changes with the declaration output, so types generated by 5.x should still work in projects using 4.x

### Notes for release

N/A - transparent to end users/devs