### PR TITLE
fix: ensure `@sanity/client` pulls in the right `get-it` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@babel/preset-typescript": "^7.18.6",
     "@optimize-lodash/rollup-plugin": "^4.0.1",
     "@playwright/test": "^1.31.2",
-    "@sanity/client": "^6.4.0",
+    "@sanity/client": "^6.4.5",
     "@sanity/pkg-utils": "^2.3.10",
     "@sanity/tsdoc": "1.0.0-alpha.38",
     "@sanity/uuid": "^3.0.2",

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -67,14 +67,14 @@
     "chalk": "^4.1.2",
     "esbuild": "^0.18.0",
     "esbuild-register": "^3.4.1",
-    "get-it": "^8.0.9",
+    "get-it": "^8.4.2",
     "golden-fleece": "^1.0.9",
     "pkg-dir": "^5.0.0"
   },
   "devDependencies": {
     "@rexxars/gitconfiglocal": "^3.0.1",
     "@rollup/plugin-node-resolve": "^15.0.0",
-    "@sanity/client": "^6.4.0",
+    "@sanity/client": "^6.4.5",
     "@sanity/eslint-config-studio": "^2.0.0",
     "@sanity/generate-help-url": "^3.0.0",
     "@sanity/types": "3.15.0",

--- a/packages/@sanity/export/package.json
+++ b/packages/@sanity/export/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "archiver": "^5.0.0",
     "debug": "^3.2.7",
-    "get-it": "^8.0.9",
+    "get-it": "^8.4.2",
     "lodash": "^4.17.21",
     "mississippi": "^4.0.0",
     "p-queue": "^2.3.0",

--- a/packages/@sanity/import-cli/package.json
+++ b/packages/@sanity/import-cli/package.json
@@ -31,9 +31,9 @@
     "src"
   ],
   "dependencies": {
-    "@sanity/client": "^6.3.0",
+    "@sanity/client": "^6.4.5",
     "@sanity/import": "3.15.0",
-    "get-it": "^8.0.9",
+    "get-it": "^8.4.2",
     "meow": "^9.0.0",
     "ora": "^5.4.1",
     "pretty-ms": "^7.0.1"

--- a/packages/@sanity/import/package.json
+++ b/packages/@sanity/import/package.json
@@ -37,7 +37,7 @@
     "@sanity/uuid": "^3.0.1",
     "debug": "^3.2.7",
     "file-url": "^2.0.2",
-    "get-it": "^8.0.9",
+    "get-it": "^8.4.2",
     "get-uri": "^2.0.2",
     "globby": "^10.0.0",
     "gunzip-maybe": "^1.4.1",
@@ -51,7 +51,7 @@
     "tar-fs": "^2.1.1"
   },
   "devDependencies": {
-    "@sanity/client": "^6.4.0",
+    "@sanity/client": "^6.4.5",
     "nock": "^13.2.9"
   },
   "engines": {

--- a/packages/@sanity/types/package.json
+++ b/packages/@sanity/types/package.json
@@ -56,7 +56,7 @@
     "watch": "pkg-utils watch --tsconfig tsconfig.lib.json"
   },
   "dependencies": {
-    "@sanity/client": "^6.3.0",
+    "@sanity/client": "^6.4.5",
     "@types/react": "^18.0.25"
   },
   "devDependencies": {

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -75,7 +75,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@sanity/client": "^6.4.0",
+    "@sanity/client": "^6.4.5",
     "react": "^18.2.0",
     "sanity": "3.15.0",
     "styled-components": "^5.3.11"

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -176,7 +176,7 @@
     "execa": "^2.0.0",
     "exif-component": "^1.0.1",
     "framer-motion": "^10.0.0",
-    "get-it": "^8.0.9",
+    "get-it": "^8.4.2",
     "get-random-values-esm": "^1.0.0",
     "groq-js": "^1.0.0",
     "hashlru": "^2.3.0",

--- a/perf/package.json
+++ b/perf/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@playwright/test": "^1.31.2",
-    "@sanity/client": "^6.3.0",
+    "@sanity/client": "^6.4.5",
     "@sanity/uuid": "^3.0.1",
     "@types/lodash": "^4.14.191",
     "@types/node": "^18.15.3",

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,12 @@
       "matchFileNames": ["package.json", "dev/**/package.json", "examples/**/package.json"],
       "extends": [":semanticCommitTypeAll(chore)"],
       "groupSlug": "dev"
+    },
+    {
+      "matchDepTypes": ["dependencies"],
+      "matchPackageNames": ["get-it", "@sanity/client"],
+      "rangeStrategy": "bump",
+      "semanticCommitType": "fix"
     }
   ],
   "ignorePaths": ["packages/@sanity/cli/test/__fixtures__/v2/package.json"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3775,13 +3775,13 @@
     nanoid "^3.1.12"
     rxjs "^7.0.0"
 
-"@sanity/client@^6.1.2", "@sanity/client@^6.3.0", "@sanity/client@^6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@sanity/client/-/client-6.4.0.tgz#35a7c9324f01454cd2c909a4a1a9cbea0289cba0"
-  integrity sha512-nmu9/gtKPruR6CROvKAqvK/vYfEMMi/La8k/w/leQpRtKySivOIsWX+BT7S5xvK+9wBn0Q8dj9L64no3SEa5vg==
+"@sanity/client@^6.1.2", "@sanity/client@^6.3.0", "@sanity/client@^6.4.5":
+  version "6.4.5"
+  resolved "https://registry.yarnpkg.com/@sanity/client/-/client-6.4.5.tgz#3d21041a9b950b9a9d8b8f036fe96ca3001ad282"
+  integrity sha512-IL+fzoZ2ZJKke07fFzq8Y6/NbWHvcQqSc4FLSO2O4xyCdZl6H/hyvOODvWRP01NFS63IJS2GHLjufD9II8pLYQ==
   dependencies:
     "@sanity/eventsource" "^5.0.0"
-    get-it "^8.3.0"
+    get-it "^8.4.2"
     rxjs "^7.0.0"
 
 "@sanity/color@^2.1.20", "@sanity/color@^2.2.5":
@@ -9793,10 +9793,10 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@
     has-proto "^1.0.1"
     has-symbols "^1.0.3"
 
-get-it@^8.0.9, get-it@^8.3.0:
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/get-it/-/get-it-8.4.1.tgz#59def03274cd2ba3317ad4c8cab8a0ecea197505"
-  integrity sha512-B81/lof6jHW2/YyvH4gzKclBMdHNl2B4hRpuIiwVYtZjUiV5mBAQa2GTX6EPTuNhPxw8K5c14cJAFUa78b4A/g==
+get-it@^8.0.9, get-it@^8.4.2:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/get-it/-/get-it-8.4.2.tgz#dd247bd855aa7f8583a586fe0b81bc324995e943"
+  integrity sha512-xseDj1loKLcPYKhdlP2k7ZYDE03jTrHgRNt0AURtALOu+8pREmBn+UxZ4JbsxpQ8AvupgmpYuuTa3cS1mtuy2w==
   dependencies:
     debug "^4.3.4"
     decompress-response "^7.0.0"


### PR DESCRIPTION
### Description

Fixes #4808, which is caused by package managers (npm, yarn, pnpm) very lazily bumping dependencies over time. More information in #4808. 
Also tunes renovatebot to create PRs that bump `@sanity/client` and `get-it` to reduce the risk for this to happen to our users in the future.

### What to review

If it builds it works.

### Notes for release

fix: ensure package managers pulls in the `get-it` version that `@sanity/client` needs
