### PR TITLE
fix(desk): handle edge cases when documents are deleted on a specific revision

### DIFF
--- a/packages/sanity/src/core/store/_legacy/history/useTimelineStore.ts
+++ b/packages/sanity/src/core/store/_legacy/history/useTimelineStore.ts
@@ -21,6 +21,7 @@ export interface TimelineState {
   diff: ObjectDiff<Annotation, Record<string, any>> | null
   hasMoreChunks: boolean | null
   isLoading: boolean
+  lastNonDeletedRevId: string | null
   onOlderRevision: boolean
   realRevChunk: Chunk | null
   revTime: Chunk | null
@@ -36,6 +37,7 @@ const INITIAL_TIMELINE_STATE: TimelineState = {
   diff: null,
   hasMoreChunks: null,
   isLoading: false,
+  lastNonDeletedRevId: null,
   onOlderRevision: false,
   realRevChunk: null,
   revTime: null,
@@ -169,20 +171,27 @@ export function useTimelineStore({
             // Manually stop loading transactions in TimelineController, otherwise transaction history
             // will continue to be fetched – even if unwanted.
             tap((innerController) => innerController.setLoadMore(false)),
-            map((innerController) => ({
-              chunks: innerController.timeline.mapChunks((c) => c),
-              diff: innerController.sinceTime ? innerController.currentObjectDiff() : null,
-              isLoading: false,
-              hasMoreChunks: !innerController.timeline.reachedEarliestEntry,
-              onOlderRevision: innerController.onOlderRevision(),
-              realRevChunk: innerController.realRevChunk,
-              revTime: innerController.revTime,
-              selectionState: innerController.selectionState,
-              sinceAttributes: innerController.sinceAttributes(),
-              sinceTime: innerController.sinceTime,
-              timelineDisplayed: innerController.displayed(),
-              timelineReady: !['invalid', 'loading'].includes(innerController.selectionState),
-            })),
+            map((innerController) => {
+              const chunks = innerController.timeline.mapChunks((c) => c)
+              const lastNonDeletedChunk = chunks.filter(
+                (chunk) => !['delete', 'initial'].includes(chunk.type)
+              )
+              return {
+                chunks,
+                diff: innerController.sinceTime ? innerController.currentObjectDiff() : null,
+                isLoading: false,
+                hasMoreChunks: !innerController.timeline.reachedEarliestEntry,
+                lastNonDeletedRevId: lastNonDeletedChunk?.[0]?.id,
+                onOlderRevision: innerController.onOlderRevision(),
+                realRevChunk: innerController.realRevChunk,
+                revTime: innerController.revTime,
+                selectionState: innerController.selectionState,
+                sinceAttributes: innerController.sinceAttributes(),
+                sinceTime: innerController.sinceTime,
+                timelineDisplayed: innerController.displayed(),
+                timelineReady: !['invalid', 'loading'].includes(innerController.selectionState),
+              }
+            }),
             // Only emit (and in turn, re-render) when values have changed
             distinctUntilChanged(deepEquals),
             // Emit initial timeline state whenever we encounter an error in TimelineController's `handler` callback.

--- a/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
@@ -176,18 +176,6 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     [editState?.draft, editState?.published, isPristine]
   )
 
-  /**
-   * This covers the edge case when a person have the document open and is viewing
-   * another revision while it was being deleted remotely. Without removing the
-   * rev param, the timeline and document action will be in the wrong state
-   */
-  useEffect(() => {
-    if (!isDeleting && isDeleted && params?.rev) {
-      navigateIntent('edit', {id: documentId, type: documentType}, {replace: true})
-      setTimelineError(null)
-    }
-  }, [documentId, documentType, isDeleted, isDeleting, navigateIntent, params?.rev])
-
   // TODO: this may cause a lot of churn. May be a good idea to prevent these
   // requests unless the menu is open somehow
   const previewUrl = usePreviewUrl(value)

--- a/packages/sanity/src/desk/panes/document/documentPanel/DeletedDocumentBanner.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/DeletedDocumentBanner.tsx
@@ -1,46 +1,49 @@
-import React, {useCallback, useMemo} from 'react'
+import React, {useCallback} from 'react'
 import {Button, Card, Container, Flex, Text} from '@sanity/ui'
 import {ReadOnlyIcon} from '@sanity/icons'
 import styled from 'styled-components'
 import {useDocumentPane} from '../useDocumentPane'
-import {useDocumentOperation, useTimelineSelector} from 'sanity'
+import {useDocumentOperation} from 'sanity'
+import {useRouter} from 'sanity/router'
 
 const Root = styled(Card)`
   position: relative;
   z-index: 50;
 `
-export function DeletedDocumentBanner() {
-  const {documentId, documentType, timelineStore} = useDocumentPane()
-  const chunks = useTimelineSelector(timelineStore, (state) => state.chunks)
-  const lastRevisionId = useMemo(() => {
-    const lastRevision = chunks.filter((chunk) => !['delete', 'initial'].includes(chunk.type))
 
-    return lastRevision?.[0]?.id
-  }, [chunks])
+interface DeletedDocumentBannerProps {
+  revisionId?: string | null
+}
+
+export function DeletedDocumentBanner({revisionId}: DeletedDocumentBannerProps) {
+  const {documentId, documentType} = useDocumentPane()
   const {restore} = useDocumentOperation(documentId, documentType)
+  const {navigateIntent} = useRouter()
   const handleRestore = useCallback(() => {
-    restore.execute(lastRevisionId)
-  }, [restore, lastRevisionId])
+    if (revisionId) {
+      restore.execute(revisionId)
+      navigateIntent('edit', {id: documentId, type: documentType})
+    }
+  }, [documentId, documentType, navigateIntent, restore, revisionId])
 
   return (
     <Root data-testid="deleted-document-banner" shadow={1} tone="transparent">
-      <Container paddingX={4} paddingY={lastRevisionId ? 2 : 3} sizing="border" width={1}>
+      <Container paddingX={4} paddingY={revisionId ? 2 : 3} sizing="border" width={1}>
         <Flex align="center">
           <Text size={1}>
             <ReadOnlyIcon />
           </Text>
 
           <Flex align="center" gap={2} flex={1} marginLeft={3}>
-            <Text size={1}>This document is deleted and can’t be edited.</Text>
-            {lastRevisionId && (
+            <Text size={1}>This document has been deleted.</Text>
+            {revisionId && (
               <Button
-                radius={0}
                 fontSize={1}
                 padding={2}
                 mode="bleed"
                 tone="primary"
                 onClick={handleRestore}
-                text={'Restore most recent vision'}
+                text="Restore most recent version"
               />
             )}
           </Flex>

--- a/packages/sanity/src/desk/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/DocumentPanel.tsx
@@ -17,7 +17,7 @@ import {ReferenceChangedBanner} from './ReferenceChangedBanner'
 import {PermissionCheckBanner} from './PermissionCheckBanner'
 import {FormView} from './documentViews'
 import {DocumentPanelHeader} from './header'
-import {ScrollContainer, VirtualizerScrollInstanceProvider} from 'sanity'
+import {ScrollContainer, useTimelineSelector, VirtualizerScrollInstanceProvider} from 'sanity'
 import {DeletedDocumentBanner} from './DeletedDocumentBanner'
 
 interface DocumentPanelProps {
@@ -61,6 +61,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     isPermissionsLoading,
     isDeleting,
     isDeleted,
+    timelineStore,
   } = useDocumentPane()
   const {collapsed: layoutCollapsed} = usePaneLayout()
   const {collapsed} = usePane()
@@ -113,6 +114,11 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     [activeView, displayed, documentId, editState?.draft, editState?.published, schemaType, value]
   )
 
+  const lastNonDeletedRevId = useTimelineSelector(
+    timelineStore,
+    (state) => state.lastNonDeletedRevId
+  )
+
   // Scroll to top as `documentId` changes
   useEffect(() => {
     if (!documentScrollElement?.scrollTo) return
@@ -155,7 +161,9 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
                           granted={Boolean(permissions?.granted)}
                           requiredPermission={requiredPermission}
                         />
-                        {!isDeleting && isDeleted && <DeletedDocumentBanner />}
+                        {!isDeleting && isDeleted && (
+                          <DeletedDocumentBanner revisionId={lastNonDeletedRevId} />
+                        )}
                         <ReferenceChangedBanner />
                       </>
                     )}

--- a/packages/sanity/src/desk/panes/document/timeline/timelineItem.tsx
+++ b/packages/sanity/src/desk/panes/document/timeline/timelineItem.tsx
@@ -29,8 +29,6 @@ interface TimelineItemProps {
   type: ChunkType
 }
 
-const NOT_SELECTABLE_TYPES = ['delete', 'discardDraft']
-
 export function TimelineItem({
   chunk,
   isFirst,
@@ -43,9 +41,7 @@ export function TimelineItem({
 }: TimelineItemProps) {
   const iconComponent = getTimelineEventIconComponent(type)
   const authorUserIds = Array.from(chunk.authors)
-  const isSelectable = useMemo(() => {
-    return !NOT_SELECTABLE_TYPES.includes(type)
-  }, [type])
+  const isSelectable = type !== 'delete'
   const formattedTimestamp = useMemo(() => {
     const parsedDate = new Date(timestamp)
     const formattedDate = format(parsedDate, 'MMM d, yyyy, hh:mm a')

--- a/packages/sanity/src/desk/panes/document/timeline/timelineMenu.tsx
+++ b/packages/sanity/src/desk/panes/document/timeline/timelineMenu.tsx
@@ -2,7 +2,7 @@ import {SelectIcon} from '@sanity/icons'
 import {Button, Placement, Popover, useClickOutside, useGlobalKeyDown, useToast} from '@sanity/ui'
 import {format} from 'date-fns'
 import {upperFirst} from 'lodash'
-import React, {useCallback, useEffect, useMemo, useState} from 'react'
+import React, {useCallback, useMemo, useState} from 'react'
 import styled from 'styled-components'
 import {useDocumentPane} from '../useDocumentPane'
 import {TimelineError} from './TimelineError'
@@ -44,12 +44,6 @@ export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {
     setTimelineMode('closed')
     setOpen(false)
   }, [setTimelineMode])
-
-  useEffect(() => {
-    if (open && isDeleted) {
-      handleClose()
-    }
-  }, [open, isDeleted, handleClose])
 
   const handleClickOutside = useCallback(() => {
     if (open) {
@@ -161,7 +155,7 @@ export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {
       ref={setPopover}
     >
       <Button
-        disabled={!ready || isDeleted}
+        disabled={!ready}
         mode="bleed"
         fontSize={1}
         padding={2}


### PR DESCRIPTION
### Description

This PR handles primarily addresses two issues:

1. An edge case where the timeline menu wouldn't be accessible:
    - User 1 selects an older document revision
    - User 2 deletes the document
    - User 1 is able to restore the document (to the most recent version), but is then unable to access the timeline menu
2. Review changes' dropdowns not working (due to the timeline menu being disabled) in deleted documents 

Other changes have been outlined as comments!

Finally, a video demonstrating some of the paths that were tested:

https://github.com/sanity-io/sanity/assets/209129/f028ead1-3203-46bf-b6a6-63c5fc1682a2

