### PR TITLE
fix(core): parenthesis around GROQ-filters crashing ACL checks

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -178,7 +178,7 @@
     "framer-motion": "^10.0.0",
     "get-it": "^8.4.2",
     "get-random-values-esm": "^1.0.0",
-    "groq-js": "^1.0.0",
+    "groq-js": "^1.1.12",
     "hashlru": "^2.3.0",
     "history": "^5.3.0",
     "import-fresh": "^3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10297,10 +10297,10 @@ graphemer@^1.4.0:
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
-groq-js@^1.0.0, groq-js@^1.1.9:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/groq-js/-/groq-js-1.1.11.tgz#14e45099921997646f7bea785793a96dbf7955d8"
-  integrity sha512-LLYg7+nuOOcbQD7FKJjZj442W4ws+j/yggJV474VS6kmeIpBxfNGNMnBsfGSaJ/iDIhknjL4OcDgJ60FL+UJXA==
+groq-js@^1.1.12, groq-js@^1.1.9:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/groq-js/-/groq-js-1.1.12.tgz#247a81e52f12f0fa2eaae1ce4f41812c578148ed"
+  integrity sha512-02KhsoLuTwr/MOf6bBzt+rQOj+QuLoZ5IDDkzXM2NWY73CF1d29KTRBffzCAjsjBvY7kn+oQcwPdQVb3vBkl9w==
 
 growly@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
### Description

Supersedes #4817 which only updates the lockfile. We want to force the new version.

Upgrades `groq-js` to fix an issue where parenthesis around a GROQ-filter (used in access control rules) would crash the studio. Eg:

```
_type == 'article' // Fine
(_type == 'article') // Crash
```

Actual fix is here: https://github.com/sanity-io/groq-js/pull/133/files

### What to review

- ACL checks still works as expected in studio

### Notes for release

- Fixes an issue where certain GROQ-filters used for access control rules would crash the studio
