### PR TITLE
chore(sanity): :zap: add sideEffects: false to package.json for smaller bundles

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -20,6 +20,7 @@
   },
   "license": "MIT",
   "author": "Sanity.io <hello@sanity.io>",
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./lib/exports/index.d.ts",


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Adding `"sideEffects": false` helps bundlers shake out more dead code resulting in smaller bundles of anything library consuming the base `sanity` package. 

Fixes #4711 

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

Confirm no dependent packages were depending on `sideEffect` code.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

Add sideEffects: false to package.json for smaller bundles
