### PR TITLE
fix(core): close navbar tooltips when menubutton is open

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/NavDrawer.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/NavDrawer.tsx
@@ -182,9 +182,7 @@ export const NavDrawer = memo(function NavDrawer(props: NavDrawerProps) {
                     </Box>
                   </Flex>
 
-                  {workspaces.length > 1 && (
-                    <WorkspaceMenuButton text="Select workspace" justify="flex-start" />
-                  )}
+                  {workspaces.length > 1 && <WorkspaceMenuButton />}
                 </Stack>
               </Card>
 

--- a/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
@@ -137,6 +137,8 @@ export function StudioNavbar() {
     setDrawerOpen(true)
   }, [])
 
+  const [isWorkspaceMenuOpen, setIsWorkspaceMenuOpen] = useState(false)
+
   return (
     <RootLayer zOffset={100} data-search-open={searchFullscreenOpen}>
       <RootCard
@@ -179,9 +181,10 @@ export function StudioNavbar() {
                   placement="bottom"
                   portal
                   scheme={scheme}
+                  disabled={isWorkspaceMenuOpen}
                 >
                   <Box>
-                    <WorkspaceMenuButton />
+                    <WorkspaceMenuButton setIsMenuOpen={setIsWorkspaceMenuOpen} />
                   </Box>
                 </Tooltip>
               </Box>

--- a/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
@@ -137,8 +137,6 @@ export function StudioNavbar() {
     setDrawerOpen(true)
   }, [])
 
-  const [isWorkspaceMenuOpen, setIsWorkspaceMenuOpen] = useState(false)
-
   return (
     <RootLayer zOffset={100} data-search-open={searchFullscreenOpen}>
       <RootCard
@@ -172,21 +170,7 @@ export function StudioNavbar() {
 
             {shouldRender.workspaces && (
               <Box marginRight={2}>
-                <Tooltip
-                  content={
-                    <Box padding={2}>
-                      <Text size={1}>Select workspace</Text>
-                    </Box>
-                  }
-                  placement="bottom"
-                  portal
-                  scheme={scheme}
-                  disabled={isWorkspaceMenuOpen}
-                >
-                  <Box>
-                    <WorkspaceMenuButton onMenuOpenChange={setIsWorkspaceMenuOpen} />
-                  </Box>
-                </Tooltip>
+                <WorkspaceMenuButton collapsed />
               </Box>
             )}
 

--- a/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
@@ -184,7 +184,7 @@ export function StudioNavbar() {
                   disabled={isWorkspaceMenuOpen}
                 >
                   <Box>
-                    <WorkspaceMenuButton setIsMenuOpen={setIsWorkspaceMenuOpen} />
+                    <WorkspaceMenuButton onMenuOpenChange={setIsWorkspaceMenuOpen} />
                   </Box>
                 </Tooltip>
               </Box>

--- a/packages/sanity/src/core/studio/components/navbar/resources/ResourcesButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/ResourcesButton.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable react/jsx-no-bind */
 import {HelpCircleIcon} from '@sanity/icons'
 import {Box, Button, Flex, Menu, MenuButton, Text, Tooltip} from '@sanity/ui'
-import React, {useState} from 'react'
+import React, {useCallback, useState} from 'react'
 import styled from 'styled-components'
 import {useColorScheme} from '../../../colorScheme'
 import {useGetHelpResources} from './helper-functions/hooks'
@@ -17,6 +16,9 @@ export function ResourcesButton() {
   const [menuOpen, setMenuOpen] = useState(false)
 
   const {value, error, isLoading} = useGetHelpResources()
+
+  const handleOnOpen = useCallback(() => setMenuOpen(true), [])
+  const handleOnClose = useCallback(() => setMenuOpen(false), [])
 
   return (
     <Flex>
@@ -48,8 +50,8 @@ export function ResourcesButton() {
               </StyledMenu>
             }
             popover={{constrainSize: true, placement: 'bottom', portal: true, scheme}}
-            onClose={() => setMenuOpen(false)}
-            onOpen={() => setMenuOpen(true)}
+            onClose={handleOnClose}
+            onOpen={handleOnOpen}
           />
         </div>
       </Tooltip>

--- a/packages/sanity/src/core/studio/components/navbar/resources/ResourcesButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/ResourcesButton.tsx
@@ -1,6 +1,7 @@
+/* eslint-disable react/jsx-no-bind */
 import {HelpCircleIcon} from '@sanity/icons'
 import {Box, Button, Flex, Menu, MenuButton, Text, Tooltip} from '@sanity/ui'
-import React from 'react'
+import React, {useState} from 'react'
 import styled from 'styled-components'
 import {useColorScheme} from '../../../colorScheme'
 import {useGetHelpResources} from './helper-functions/hooks'
@@ -13,6 +14,7 @@ const StyledMenu = styled(Menu)`
 
 export function ResourcesButton() {
   const {scheme} = useColorScheme()
+  const [menuOpen, setMenuOpen] = useState(false)
 
   const {value, error, isLoading} = useGetHelpResources()
 
@@ -27,6 +29,7 @@ export function ResourcesButton() {
         scheme={scheme}
         placement="bottom"
         portal
+        disabled={menuOpen}
       >
         <div>
           <MenuButton
@@ -45,6 +48,8 @@ export function ResourcesButton() {
               </StyledMenu>
             }
             popover={{constrainSize: true, placement: 'bottom', portal: true, scheme}}
+            onClose={() => setMenuOpen(false)}
+            onOpen={() => setMenuOpen(true)}
           />
         </div>
       </Tooltip>

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
@@ -5,11 +5,13 @@ import {
   MenuItem,
   Menu,
   MenuButtonProps,
-  ButtonProps,
   Box,
   Label,
+  Tooltip,
+  Text,
+  Stack,
 } from '@sanity/ui'
-import React, {useCallback, useMemo} from 'react'
+import React, {useCallback, useMemo, useState} from 'react'
 import styled from 'styled-components'
 import {useActiveWorkspace} from '../../../activeWorkspaceMatcher'
 import {useColorScheme} from '../../../colorScheme'
@@ -22,88 +24,114 @@ const StyledMenu = styled(Menu)`
   max-width: 350px;
   min-width: 250px;
 `
-interface WorkspaceMenuButtonProps extends ButtonProps {
-  onMenuOpenChange?: (open: boolean) => void
+
+const TITLE = 'Select workspace'
+
+interface WorkspaceMenuButtonProps {
+  collapsed?: boolean
 }
 
 export function WorkspaceMenuButton(props: WorkspaceMenuButtonProps) {
+  const {collapsed = false} = props
+  const [menuOpen, setMenuOpen] = useState<boolean>(false)
   const {scheme} = useColorScheme()
   const workspaces = useWorkspaces()
   const {activeWorkspace, setActiveWorkspace} = useActiveWorkspace()
   const [authStates] = useWorkspaceAuthStates(workspaces)
   const {navigateUrl} = useRouter()
-  const {onMenuOpenChange} = props
+
+  const handleOnOpen = useCallback(() => setMenuOpen(true), [])
+  const handleOnClose = useCallback(() => setMenuOpen(false), [])
 
   const popoverProps: MenuButtonProps['popover'] = useMemo(
     () => ({constrainSize: true, scheme, portal: true}),
     [scheme],
   )
-
-  const handleOnOpen = useCallback(() => {
-    onMenuOpenChange?.(true)
-  }, [onMenuOpenChange])
-
-  const handleOnClose = useCallback(() => {
-    onMenuOpenChange?.(false)
-  }, [onMenuOpenChange])
+  //Tooltip should be disabled in the Navdrawer
+  const tooltipDisabled = menuOpen || !collapsed
+  const ariaLabel = collapsed ? TITLE : undefined
+  const buttonText = collapsed ? undefined : TITLE
 
   return (
-    <MenuButton
-      button={<Button icon={SelectIcon} mode="bleed" {...props} disabled={!authStates} />}
-      id="workspace-menu"
-      menu={
-        <StyledMenu>
-          <Box paddingX={3} paddingY={3}>
-            <Label size={1} muted>
-              Workspaces
-            </Label>
-          </Box>
-
-          {authStates &&
-            workspaces.map((workspace) => {
-              const authState = authStates[workspace.name]
-
-              // eslint-disable-next-line no-nested-ternary
-              const state = authState.authenticated
-                ? 'logged-in'
-                : workspace.auth.LoginComponent
-                ? 'logged-out'
-                : 'no-access'
-
-              const handleSelectWorkspace = () => {
-                if (state === 'logged-in' && workspace.name !== activeWorkspace.name) {
-                  setActiveWorkspace(workspace.name)
-                }
-
-                // Navigate to the base path of the workspace to authenticate
-                if (state === 'logged-out') {
-                  navigateUrl({path: workspace.basePath})
-                }
-              }
-
-              return (
-                <MenuItem
-                  key={workspace.name}
-                  // eslint-disable-next-line react/jsx-no-bind
-                  onClick={handleSelectWorkspace}
-                  padding={2}
-                  pressed={workspace.name === activeWorkspace.name}
-                >
-                  <WorkspacePreview
-                    icon={workspace?.icon}
-                    selected={workspace.name === activeWorkspace.name}
-                    state={state}
-                    subtitle={workspace?.subtitle}
-                    title={workspace?.title || workspace.name}
-                  />
-                </MenuItem>
-              )
-            })}
-        </StyledMenu>
+    <Tooltip
+      content={
+        <Box padding={2}>
+          <Text size={1}>Select workspace</Text>
+        </Box>
       }
-      onClose={handleOnClose}
-      onOpen={handleOnOpen}
-      popover={popoverProps}
-    />
+      disabled={tooltipDisabled}
+      placement="bottom"
+      portal
+      scheme={scheme}
+    >
+      <Stack>
+        <MenuButton
+          button={
+            <Button
+              icon={SelectIcon}
+              mode="bleed"
+              text={buttonText}
+              disabled={!authStates}
+              aria-label={ariaLabel}
+              justify={collapsed ? undefined : 'flex-start'}
+            />
+          }
+          id="workspace-menu"
+          menu={
+            <StyledMenu>
+              <Box paddingX={3} paddingY={3}>
+                <Label size={1} muted>
+                  Workspaces
+                </Label>
+              </Box>
+
+              {authStates &&
+                workspaces.map((workspace) => {
+                  const authState = authStates[workspace.name]
+
+                  // eslint-disable-next-line no-nested-ternary
+                  const state = authState.authenticated
+                    ? 'logged-in'
+                    : workspace.auth.LoginComponent
+                    ? 'logged-out'
+                    : 'no-access'
+
+                  const handleSelectWorkspace = () => {
+                    if (state === 'logged-in' && workspace.name !== activeWorkspace.name) {
+                      setActiveWorkspace(workspace.name)
+                    }
+
+                    // Navigate to the base path of the workspace to authenticate
+                    if (state === 'logged-out') {
+                      navigateUrl({path: workspace.basePath})
+                    }
+                  }
+
+                  return (
+                    <MenuItem
+                      key={workspace.name}
+                      // eslint-disable-next-line react/jsx-no-bind
+                      onClick={handleSelectWorkspace}
+                      padding={2}
+                      pressed={workspace.name === activeWorkspace.name}
+                    >
+                      <WorkspacePreview
+                        icon={workspace?.icon}
+                        selected={workspace.name === activeWorkspace.name}
+                        state={state}
+                        subtitle={workspace?.subtitle}
+                        title={workspace?.title || workspace.name}
+                      />
+                    </MenuItem>
+                  )
+                })}
+            </StyledMenu>
+          }
+          onClose={handleOnClose}
+          onOpen={handleOnOpen}
+          popover={popoverProps}
+        />
+      </Stack>
+    </Tooltip>
   )
 }

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
@@ -23,7 +23,11 @@ const StyledMenu = styled(Menu)`
   min-width: 250px;
 `
 
-export function WorkspaceMenuButton(props: ButtonProps) {
+interface Props extends ButtonProps {
+  setIsMenuOpen?: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+export function WorkspaceMenuButton(props: Props) {
   const {scheme} = useColorScheme()
   const workspaces = useWorkspaces()
   const {activeWorkspace, setActiveWorkspace} = useActiveWorkspace()
@@ -89,6 +93,8 @@ export function WorkspaceMenuButton(props: ButtonProps) {
             })}
         </StyledMenu>
       }
+      onClose={() => props.setIsMenuOpen && props.setIsMenuOpen(false)}
+      onOpen={() => props.setIsMenuOpen && props.setIsMenuOpen(true)}
       popover={popoverProps}
     />
   )

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
@@ -9,7 +9,7 @@ import {
   Box,
   Label,
 } from '@sanity/ui'
-import React, {useMemo} from 'react'
+import React, {useCallback, useMemo} from 'react'
 import styled from 'styled-components'
 import {useActiveWorkspace} from '../../../activeWorkspaceMatcher'
 import {useColorScheme} from '../../../colorScheme'
@@ -22,22 +22,30 @@ const StyledMenu = styled(Menu)`
   max-width: 350px;
   min-width: 250px;
 `
-
-interface Props extends ButtonProps {
-  setIsMenuOpen?: React.Dispatch<React.SetStateAction<boolean>>
+interface WorkspaceMenuButtonProps extends ButtonProps {
+  onMenuOpenChange?: (open: boolean) => void
 }
 
-export function WorkspaceMenuButton(props: Props) {
+export function WorkspaceMenuButton(props: WorkspaceMenuButtonProps) {
   const {scheme} = useColorScheme()
   const workspaces = useWorkspaces()
   const {activeWorkspace, setActiveWorkspace} = useActiveWorkspace()
   const [authStates] = useWorkspaceAuthStates(workspaces)
   const {navigateUrl} = useRouter()
+  const {onMenuOpenChange} = props
 
   const popoverProps: MenuButtonProps['popover'] = useMemo(
     () => ({constrainSize: true, scheme, portal: true}),
     [scheme],
   )
+
+  const handleOnOpen = useCallback(() => {
+    onMenuOpenChange?.(true)
+  }, [onMenuOpenChange])
+
+  const handleOnClose = useCallback(() => {
+    onMenuOpenChange?.(false)
+  }, [onMenuOpenChange])
 
   return (
     <MenuButton
@@ -93,8 +101,8 @@ export function WorkspaceMenuButton(props: Props) {
             })}
         </StyledMenu>
       }
-      onClose={() => props.setIsMenuOpen && props.setIsMenuOpen(false)}
-      onOpen={() => props.setIsMenuOpen && props.setIsMenuOpen(true)}
+      onClose={handleOnClose}
+      onOpen={handleOnOpen}
       popover={popoverProps}
     />
   )


### PR DESCRIPTION
### Description
Tooltips remained on screen after opening a `MenuButton`  (most notably on both the Workspaces + Help navbar buttons) in the navbar. 
To prevent the tooltip from showing underneath the `MenuButton` when it is open, the `tooltip` is `disabled` when the `MenuButton` is open. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
The `Workspaces` and the `Help and Resources` dropdowns - make sure that they work as expected. 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fixes annoyance where tooltip was showing under menubutton. 

<!--
A description of the change(s) that should be used in the release notes.
-->
