### PR TITLE
feat(core): avoid layout shift when editing title

### DIFF
--- a/packages/sanity/src/desk/panes/document/documentPanel/documentViews/FormTitle.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/documentViews/FormTitle.tsx
@@ -1,51 +1,36 @@
-import React, {useEffect, useRef} from 'react'
-import {useTheme} from '@sanity/ui'
-import {HiddenTitle, Root, Title} from './styles'
+import React, {useLayoutEffect, useRef} from 'react'
+import {Root, Title} from './styles'
 
 /**
  * @internal
  */
 export interface FormTitleProps {
   title?: string
-  isEditingForm?: boolean
+  ready?: boolean
 }
 
 /**
  *
  * @internal
  */
-export function FormTitle({title, isEditingForm}: FormTitleProps) {
+export function FormTitle({title, ready}: FormTitleProps) {
   const titleRef = useRef<HTMLDivElement | null>(null)
-  const [titleHeight, setTitleHeight] = React.useState<number | undefined>(
-    titleRef?.current?.clientHeight
-  )
-  const {lineHeight} = useTheme().sanity.fonts.heading.sizes[5]
+  const [titleHeight, setTitleHeight] = React.useState<number | undefined>()
 
-  useEffect(() => {
-    setTitleHeight(titleRef?.current?.clientHeight)
-  }, [])
-
-  useEffect(() => {
-    // If the form is focused then calculate the height of the title using the hidden title
-    if (isEditingForm && titleRef.current) {
-      const {scrollWidth, clientWidth} = titleRef.current
-      const height = Math.ceil(scrollWidth / clientWidth)
-
-      setTitleHeight(height * lineHeight)
-    } else {
-      // Otherwise reset the height to undefined so it automatically fills the correct position
-      setTitleHeight(undefined)
+  useLayoutEffect(() => {
+    // if it's not ready and titleHeight is already set return
+    if (!ready || titleHeight) {
+      return
     }
-  }, [isEditingForm, lineHeight])
+
+    setTitleHeight(titleRef?.current?.clientHeight)
+  }, [ready, titleHeight])
 
   return (
     <Root marginBottom={4}>
-      <Title $muted={!title} $titleHeight={titleHeight} $isEditingForm={isEditingForm}>
+      <Title ref={titleRef} $muted={!title} $titleHeight={titleHeight}>
         {title ?? 'Untitled'}
       </Title>
-      <HiddenTitle ref={titleRef} $isEditingForm={isEditingForm}>
-        {title ?? 'Untitled'}
-      </HiddenTitle>
     </Root>
   )
 }

--- a/packages/sanity/src/desk/panes/document/documentPanel/documentViews/FormTitle.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/documentViews/FormTitle.tsx
@@ -1,0 +1,51 @@
+import React, {useEffect, useRef} from 'react'
+import {useTheme} from '@sanity/ui'
+import {HiddenTitle, Root, Title} from './styles'
+
+/**
+ * @internal
+ */
+export interface FormTitleProps {
+  title?: string
+  isEditingForm?: boolean
+}
+
+/**
+ *
+ * @internal
+ */
+export function FormTitle({title, isEditingForm}: FormTitleProps) {
+  const titleRef = useRef<HTMLDivElement | null>(null)
+  const [titleHeight, setTitleHeight] = React.useState<number | undefined>(
+    titleRef?.current?.clientHeight
+  )
+  const {lineHeight} = useTheme().sanity.fonts.heading.sizes[5]
+
+  useEffect(() => {
+    setTitleHeight(titleRef?.current?.clientHeight)
+  }, [])
+
+  useEffect(() => {
+    // If the form is focused then calculate the height of the title using the hidden title
+    if (isEditingForm && titleRef.current) {
+      const {scrollWidth, clientWidth} = titleRef.current
+      const height = Math.ceil(scrollWidth / clientWidth)
+
+      setTitleHeight(height * lineHeight)
+    } else {
+      // Otherwise reset the height to undefined so it automatically fills the correct position
+      setTitleHeight(undefined)
+    }
+  }, [isEditingForm, lineHeight])
+
+  return (
+    <Root marginBottom={4}>
+      <Title $muted={!title} $titleHeight={titleHeight} $isEditingForm={isEditingForm}>
+        {title ?? 'Untitled'}
+      </Title>
+      <HiddenTitle ref={titleRef} $isEditingForm={isEditingForm}>
+        {title ?? 'Untitled'}
+      </HiddenTitle>
+    </Root>
+  )
+}

--- a/packages/sanity/src/desk/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/documentViews/FormView.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable no-nested-ternary */
 
-import {Box, Container, Flex, Heading, Spinner, Text, focusFirstDescendant} from '@sanity/ui'
+import {Box, Container, Flex, Spinner, Text, focusFirstDescendant} from '@sanity/ui'
 import React, {forwardRef, useEffect, useMemo, useCallback, useState} from 'react'
 import {tap} from 'rxjs/operators'
 import {useDocumentPane} from '../../useDocumentPane'
 import {Delay} from '../../../../components/Delay'
 import {useDocumentTitle} from '../../useDocumentTitle'
 import {useConditionalToast} from './useConditionalToast'
+import {FormTitle} from './FormTitle'
 import {
   DocumentMutationEvent,
   DocumentRebaseEvent,
@@ -18,7 +19,6 @@ import {
   useDocumentPresence,
   useDocumentStore,
 } from 'sanity'
-import {Title} from './styles'
 
 interface FormViewProps {
   hidden: boolean
@@ -131,6 +131,8 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
     [ref],
   )
 
+  const isEditingForm = !!formState?.focusPath?.length
+
   // const after = useMemo(
   //   () =>
   //     Array.isArray(afterEditorComponents) &&
@@ -152,11 +154,7 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
     >
       <PresenceOverlay margins={margins}>
         <Box as="form" onSubmit={preventDefault} ref={setRef}>
-          <Box marginBottom={4}>
-            <Title forwardedAs="h6" muted={!title} size={5}>
-              {title ?? 'Untitled'}
-            </Title>
-          </Box>
+          <FormTitle title={title} isEditingForm={isEditingForm} />
           {ready ? (
             formState === null ? (
               <Box padding={2}>

--- a/packages/sanity/src/desk/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/documentViews/FormView.tsx
@@ -131,8 +131,6 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
     [ref],
   )
 
-  const isEditingForm = !!formState?.focusPath?.length
-
   // const after = useMemo(
   //   () =>
   //     Array.isArray(afterEditorComponents) &&
@@ -154,7 +152,7 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
     >
       <PresenceOverlay margins={margins}>
         <Box as="form" onSubmit={preventDefault} ref={setRef}>
-          <FormTitle title={title} isEditingForm={isEditingForm} />
+          <FormTitle title={title} ready={ready} />
           {ready ? (
             formState === null ? (
               <Box padding={2}>

--- a/packages/sanity/src/desk/panes/document/documentPanel/documentViews/styles.ts
+++ b/packages/sanity/src/desk/panes/document/documentPanel/documentViews/styles.ts
@@ -1,6 +1,65 @@
-import {Heading} from '@sanity/ui'
-import styled from 'styled-components'
+import {Box, Theme} from '@sanity/ui'
+import styled, {css} from 'styled-components'
 
-export const Title = styled(Heading)`
-  word-break: break-word;
+export const Root = styled(Box)`
+  position: relative;
 `
+
+export const Title = styled.h6(({theme}: {theme: Theme}) => {
+  const {fontSize, lineHeight} = theme.sanity.fonts.heading.sizes[5]
+
+  return css`
+    font-size: ${fontSize}px;
+    margin: 0;
+    line-height: ${lineHeight}px;
+    ${({
+      $titleHeight,
+      $isEditingForm,
+      $muted,
+    }: {
+      $titleHeight?: number
+      $isEditingForm?: boolean
+      $muted: boolean
+    }) => {
+      return css`
+        ${$titleHeight ? `height: ${$titleHeight}px` : ''};
+        ${$isEditingForm
+          ? css`
+              overflow: hidden;
+              text-overflow: ellipsis;
+            `
+          : ''}
+        ${$muted ? `color: ${theme.sanity.color.card.disabled.fg};` : ''}
+      `
+    }}
+  `
+})
+
+/**
+ * This component is a hidden component that is laid on top of the title to calculate the height of the title
+ */
+export const HiddenTitle = styled.h6(({theme}: {theme: Theme}) => {
+  const {fontSize, lineHeight} = theme.sanity.fonts.heading.sizes[5]
+  return css`
+    font-size: ${fontSize}px;
+    margin: 0;
+    line-height: ${lineHeight}px;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    visibility: hidden;
+    display: block;
+
+    ${({$isEditingForm}: {$isEditingForm?: boolean}) => {
+      return css`
+        ${$isEditingForm
+          ? css`
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            `
+          : ''}
+      `
+    }}
+  `
+})

--- a/packages/sanity/src/desk/panes/document/documentPanel/documentViews/styles.ts
+++ b/packages/sanity/src/desk/panes/document/documentPanel/documentViews/styles.ts
@@ -5,61 +5,20 @@ export const Root = styled(Box)`
   position: relative;
 `
 
-export const Title = styled.h6(({theme}: {theme: Theme}) => {
-  const {fontSize, lineHeight} = theme.sanity.fonts.heading.sizes[5]
+export const Title = styled.h6(
+  ({theme, $titleHeight, $muted}: {theme: Theme; $titleHeight?: number; $muted?: boolean}) => {
+    const {fontSize, lineHeight} = theme.sanity.fonts.heading.sizes[5]
 
-  return css`
-    font-size: ${fontSize}px;
-    margin: 0;
-    line-height: ${lineHeight}px;
-    ${({
-      $titleHeight,
-      $isEditingForm,
-      $muted,
-    }: {
-      $titleHeight?: number
-      $isEditingForm?: boolean
-      $muted: boolean
-    }) => {
-      return css`
-        ${$titleHeight ? `height: ${$titleHeight}px` : ''};
-        ${$isEditingForm
-          ? css`
-              overflow: hidden;
-              text-overflow: ellipsis;
-            `
-          : ''}
-        ${$muted ? `color: ${theme.sanity.color.card.disabled.fg};` : ''}
-      `
-    }}
-  `
-})
-
-/**
- * This component is a hidden component that is laid on top of the title to calculate the height of the title
- */
-export const HiddenTitle = styled.h6(({theme}: {theme: Theme}) => {
-  const {fontSize, lineHeight} = theme.sanity.fonts.heading.sizes[5]
-  return css`
-    font-size: ${fontSize}px;
-    margin: 0;
-    line-height: ${lineHeight}px;
-    position: absolute;
-    top: 0;
-    width: 100%;
-    visibility: hidden;
-    display: block;
-
-    ${({$isEditingForm}: {$isEditingForm?: boolean}) => {
-      return css`
-        ${$isEditingForm
-          ? css`
-              overflow: hidden;
-              text-overflow: ellipsis;
-              white-space: nowrap;
-            `
-          : ''}
-      `
-    }}
-  `
-})
+    return css`
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: ${$titleHeight ? Math.ceil($titleHeight / lineHeight) : 'auto'};
+      overflow: hidden;
+      font-size: ${fontSize}px;
+      margin: 0;
+      line-height: ${lineHeight}px;
+      height: ${$titleHeight ? `${$titleHeight}px` : 'auto'};
+      ${$muted ? `color: ${theme.sanity.color.card.disabled.fg};` : ''}
+    `
+  },
+)


### PR DESCRIPTION
### Description

This PR enables so that when you are editing the form the title does not do a layout shift. It only changes it's height when any of the form fields are not focused.

FIXES SDX-672

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

~This was a little complicated to implement, the way this works if there are two elements created. One is the actual display and the other one is a `visibility:hidden` element, the reason to keep visibility is so it still occupies the height so we can calculate it. When you focus on the form it changes hidden title's style to text overflow and then uses it's `scrollWidth` and `clientWidth` to calculate the height. This height is then set to the title that is displayed and it has an overflow of hidden so it does not cause a layout shift when the content is greater then the height.~

~I would love to know if there is a different and/or better way to implement this.~

The above has changed to use `line-clamp` instead. When you land on the document, the height of the title is calculated and it does not change unless you visit another document or do a reload, this would avoid a layout shift if the title is using a field that is at the bottom of the page.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

N/A