### PR TITLE
feat(core): add mobile styles for breadcrumbs

### DIFF
--- a/packages/sanity/src/desk/components/breadcrumbs/BreadcrumbItem.tsx
+++ b/packages/sanity/src/desk/components/breadcrumbs/BreadcrumbItem.tsx
@@ -1,4 +1,4 @@
-import {Text, Tooltip, Box, type ButtonProps} from '@sanity/ui'
+import {Text, Tooltip, type ButtonProps} from '@sanity/ui'
 import React, {forwardRef, type HTMLProps, type ReactNode, type ForwardedRef, useRef} from 'react'
 import {BreadcrumbButtonRoot, BreadcrumbItemSpan, TooltipRoot} from './breadcrumbs.styles'
 

--- a/packages/sanity/src/desk/components/breadcrumbs/Breadcrumbs.tsx
+++ b/packages/sanity/src/desk/components/breadcrumbs/Breadcrumbs.tsx
@@ -8,8 +8,8 @@ import React, {
   useMemo,
   useState,
 } from 'react'
-import {ChevronRightIcon, EllipsisHorizontalIcon} from '@sanity/icons'
-import {BreadcrumbItemRoot, ExpandButton, Root} from './breadcrumbs.styles'
+import {ChevronRightIcon} from '@sanity/icons'
+import {BreadcrumbItemRoot, ExpandButton, MobileTitleText, Root} from './breadcrumbs.styles'
 
 /**
  * @internal
@@ -83,20 +83,23 @@ export const Breadcrumbs = forwardRef(function Breadcrumbs(
   }, [collapse, expand, maxLength, open, rawItems])
 
   return (
-    <Root data-ui="Breadcrumbs" {...restProps} ref={ref}>
-      {items.map((item, itemIndex) => (
-        // eslint-disable-next-line react/no-array-index-key
-        <Fragment key={itemIndex}>
-          {itemIndex > 0 && (
-            <Box aria-hidden as="li" paddingX={1}>
-              <Text data-ui="TextChevronRight" muted>
-                <ChevronRightIcon />
-              </Text>
-            </Box>
-          )}
-          <BreadcrumbItemRoot as="li">{item}</BreadcrumbItemRoot>
-        </Fragment>
-      ))}
-    </Root>
+    <>
+      <Root data-ui="Breadcrumbs" {...restProps} ref={ref}>
+        {items.map((item, itemIndex) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <Fragment key={itemIndex}>
+            {itemIndex > 0 && (
+              <Box aria-hidden as="li" paddingX={1}>
+                <Text data-ui="TextChevronRight" muted>
+                  <ChevronRightIcon />
+                </Text>
+              </Box>
+            )}
+            <BreadcrumbItemRoot as="li">{item}</BreadcrumbItemRoot>
+          </Fragment>
+        ))}
+      </Root>
+      <MobileTitleText>{items[items.length - 1]}</MobileTitleText>
+    </>
   )
 })

--- a/packages/sanity/src/desk/components/breadcrumbs/breadcrumbs.styles.ts
+++ b/packages/sanity/src/desk/components/breadcrumbs/breadcrumbs.styles.ts
@@ -1,5 +1,6 @@
 import styled, {css} from 'styled-components'
 import {Box, Button, Theme} from '@sanity/ui'
+import {TitleText} from '../pane/PaneHeader.styles'
 import {BreadcrumbItemProps} from './BreadcrumbItem'
 
 export const BREADCRUMB_ITEM_TITLE_MIN_WIDTH = 220
@@ -14,6 +15,16 @@ export const Root = styled.ol`
   width: 100%;
   overflow: hidden;
   white-space: nowrap;
+
+  @media (max-width: 512px) {
+    display: none;
+  }
+`
+
+export const MobileTitleText = styled(TitleText)`
+  @media (min-width: 512px) {
+    display: none !important;
+  }
 `
 
 export const ExpandButton = styled(Button)`

--- a/packages/sanity/src/desk/components/breadcrumbs/breadcrumbs.styles.ts
+++ b/packages/sanity/src/desk/components/breadcrumbs/breadcrumbs.styles.ts
@@ -7,14 +7,14 @@ export const BREADCRUMB_ITEM_TITLE_MIN_WIDTH = 220
 export const BREADCRUMB_ITEM_MAX_WIDTH = 130
 
 export const Root = styled.ol`
-  margin: 0;
-  padding: 0;
+  align-items: center;
   display: flex;
   list-style: none;
-  align-items: center;
-  width: 100%;
+  margin: 0;
   overflow: hidden;
+  padding: 0;
   white-space: nowrap;
+  width: 100%;
 
   @media (max-width: 512px) {
     display: none;


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Hides the breadcrumbs on mobile screen and shows only the title

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

Code makes sense

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
N/A