### PR TITLE
fix(core): svg preview issue in safari

### DIFF
--- a/packages/sanity/src/core/components/previews/_common/Media.styled.ts
+++ b/packages/sanity/src/core/components/previews/_common/Media.styled.ts
@@ -38,6 +38,7 @@ export const MediaWrapper = styled.span<{
 
     & svg {
       display: block;
+      flex: 1;
       font-size: calc(21 / 16 * 1em);
     }
 


### PR DESCRIPTION
### Description

This pull request addresses an issue where media for list previews wouldn't always be visible in Safari when a custom SVG element is configured (as reported in [#4074](https://github.com/sanity-io/sanity/issues/4074)). Currently, the media is visible only if the SVG element has both width and height attributes. This pull request ensures that the SVG is visible even when these attributes are absent.

```ts
const myDocument = defineType({
  name: 'myDocument',
  type: 'document',
  title: 'My document',
  icon: () => <svg>...</svg>,
})
```

<img width="1002" alt="Untitled" src="https://github.com/sanity-io/sanity/assets/15094168/e69916d9-fe8b-4a9d-95c9-33d4dda0d7a2">


### What to review

- Make sure that media is rendered as expected

### Notes for release

Fixes media visibility issue in Safari for list previews with custom SVG element