### PR TITLE
chore(CI): remove double PRs on prettier fixes

### DIFF
--- a/.github/workflows/lint-fix-if-needed.yml
+++ b/.github/workflows/lint-fix-if-needed.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           path: .eslintcache
           key: eslint-v1-${{ hashFiles('.eslintrc.cjs') }}
-      - run: yarn lint:fix
+      - run: "yarn lint:fix --rule 'prettier/prettier: [off]'"
       - uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1
         # Run even if `yarn lint:fix` fails
         if: always()
@@ -57,9 +57,9 @@ jobs:
         if: always()
         with:
           author: github-actions <41898282+github-actions[bot]@users.noreply.github.com>
-          body: I ran `yarn lint:fix` 🧑‍💻
+          body: "I ran `yarn lint:fix --rule 'prettier/prettier: [off]'` 🧑‍💻"
           branch: actions/lint-fix-if-needed
           commit-message: 'chore(lint): fix linter issues 🤖 ✨'
           labels: 🤖 bot
-          title: 'chore(prettier): fix linter issues 🤖 ✨'
+          title: 'chore(lint): fix linter issues 🤖 ✨'
           token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
### Description

When I added the `lint-fix-if-needed.yml` GitHub action I forgot to take into account that ESLint is also setup to run Prettier.
And so if code lands on `next` that needs prettier you get two identical PRs:
- https://github.com/sanity-io/sanity/pull/4840
- https://github.com/sanity-io/sanity/pull/4839

We already have a `prettier-if-needed.yml`, which runs Prettier also on files that ESLint usually ignores. Like `.yml`, `.html`, `.md` and `.json` files and more.

This PR changes the linter GitHub action to ignore the prettier rule and instead let the prettier action handle that. So we don't get doubly noise.

### What to review

If it builds it works, and the actual test won't happen until this PR is merged.

### Notes for release

N/A
