### PR TITLE
fix(desk): center align pane header action icons

### DIFF
--- a/packages/sanity/src/desk/components/pane/PaneHeader.tsx
+++ b/packages/sanity/src/desk/components/pane/PaneHeader.tsx
@@ -81,9 +81,9 @@ export const PaneHeader = forwardRef(function PaneHeader(
               </TitleCard>
 
               {actions && (
-                <Box flex="none" hidden={collapsed}>
+                <Flex align="center" hidden={collapsed}>
                   <LegacyLayerProvider zOffset="paneHeader">{actions}</LegacyLayerProvider>
-                </Box>
+                </Flex>
               )}
             </Layout>
 


### PR DESCRIPTION
### Description
The action icons (the icons to the right) in the pane header were not centered and did not match the back button and the header. 

![Screenshot 2023-08-21 at 14 00 21](https://github.com/sanity-io/sanity/assets/44635000/55fe2481-2686-42a1-821b-3c95570edd1a)

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
The pane header for mobile and desktop. Make sure alignment is not off for any elements. 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fixes alignment of action items in pane header. 
<!--
A description of the change(s) that should be used in the release notes.
-->
