### PR TITLE
test(playwright): fix hotkey activation + helper method

### DIFF
--- a/packages/sanity/playwright-ct/tests/formBuilder/ArrayInput.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/ArrayInput.spec.tsx
@@ -6,8 +6,8 @@ import ArrayInputStory from './ArrayInputStory'
 test.use({viewport: {width: 1200, height: 1000}})
 
 test.describe('Tag layout', () => {
-  test('Pressing enter should create inline tags', async ({mount, page}, testInfo) => {
-    const {typeWithDelay} = testHelpers({page, testInfo})
+  test('Pressing enter should create inline tags', async ({mount, page}) => {
+    const {typeWithDelay} = testHelpers({page})
     const component = await mount(<ArrayInputStory />)
     const $field = component.getByTestId('field-tags')
     const tags = $field.locator('[data-ui="Tag"]')

--- a/packages/sanity/playwright-ct/tests/formBuilder/PortableTextInput.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/PortableTextInput.spec.tsx
@@ -82,13 +82,13 @@ test.describe('Annotations', () => {
       testInfo,
     })
     await mount(<PortableTextInputStory />)
-    const $pteTextbox = await getFocusedPortableTextEditor('field-body')
+    const $pte = await getFocusedPortableTextEditor('field-body')
 
-    await insertPortableText('Now we should insert a link.', $pteTextbox)
+    await insertPortableText('Now we should insert a link.', $pte)
 
     // Assertion: Wait for the text to be rendered
     await expect(
-      $pteTextbox.locator('[data-slate-string="true"]', {
+      $pte.locator('[data-slate-string="true"]', {
         hasText: 'Now we should insert a link.',
       }),
     ).toBeVisible()
@@ -102,7 +102,7 @@ test.describe('Annotations', () => {
       .click()
 
     // Assertion: Wait for link to be re-rendered / PTE internal state to be done
-    await expect($pteTextbox.locator('[data-slate-node="text"] span[data-link]')).toBeVisible()
+    await expect($pte.locator('span[data-link]')).toBeVisible()
 
     // Now we check if the edit popover shows automatically
     await expect(page.getByLabel('Link').first()).toBeAttached({timeout: 10000})
@@ -114,10 +114,13 @@ test.describe('Annotations', () => {
     await expect(page.getByLabel('Link').first()).toBeFocused()
 
     // Type in the URL
-    await typeWithDelay('https://www.sanity.io')
+    await page.keyboard.type('https://www.sanity.io')
 
     // Close the popover
     await page.keyboard.press('Escape')
+
+    // Expect the editor to have focus after closing the popover
+    await expect($pte).toBeFocused()
   })
 })
 
@@ -129,7 +132,7 @@ test.describe('Blocks', () => {
     const {getFocusedPortableTextInput} = testHelpers({page, testInfo})
     await mount(<PortableTextInputStory />)
 
-    const $portableTextField = await getFocusedPortableTextInput('field-body')
+    const $portableTextInput = await getFocusedPortableTextInput('field-body')
 
     await page
       .getByRole('button')
@@ -140,13 +143,13 @@ test.describe('Blocks', () => {
       .click()
 
     // Assertion: Object preview should be visible
-    await expect($portableTextField.locator('.pt-block.pt-object-block')).toBeVisible()
+    await expect($portableTextInput.locator('.pt-block.pt-object-block')).toBeVisible()
   })
 
   test('Custom block preview components renders correctly', async ({mount, page}, testInfo) => {
     const {getFocusedPortableTextEditor} = testHelpers({page, testInfo})
     await mount(<PortableTextInputStory />)
-    const $pteTextbox = await getFocusedPortableTextEditor('field-body')
+    const $pte = await getFocusedPortableTextEditor('field-body')
 
     await page
       .getByRole('button')
@@ -157,17 +160,17 @@ test.describe('Blocks', () => {
       .click()
 
     // Assertion: Object preview should be visible
-    await expect($pteTextbox.getByTestId('inline-preview')).toBeVisible()
+    await expect($pte.getByTestId('inline-preview')).toBeVisible()
 
     // Assertion: Text in custom preview component should show
-    await expect($pteTextbox.getByText('Custom preview block:')).toBeVisible()
+    await expect($pte.getByText('Custom preview block:')).toBeVisible()
   })
 
   test('Double-clicking opens a block', async ({mount, page}, testInfo) => {
     const {getFocusedPortableTextEditor} = testHelpers({page, testInfo})
     await mount(<PortableTextInputStory />)
 
-    const $pteTextbox = await getFocusedPortableTextEditor('field-body')
+    const $pte = await getFocusedPortableTextEditor('field-body')
 
     await page
       .getByRole('button')
@@ -175,7 +178,7 @@ test.describe('Blocks', () => {
       .click()
 
     // Assertion: Object preview should be visible
-    await expect($pteTextbox.locator('.pt-block.pt-object-block')).toBeVisible()
+    await expect($pte.locator('.pt-block.pt-object-block')).toBeVisible()
 
     const $locatorDialog = page.getByTestId('default-edit-object-dialog')
 
@@ -189,7 +192,7 @@ test.describe('Blocks', () => {
     await expect($locatorDialog).toBeHidden()
 
     // Test that we can open dialog by double clicking
-    await $pteTextbox.getByTestId('pte-block-object').dblclick()
+    await $pte.getByTestId('pte-block-object').dblclick()
 
     // Assertion: Object edit dialog should be visible
     await expect($locatorDialog).toBeVisible()
@@ -256,7 +259,7 @@ test.describe('Blocks', () => {
     const {getFocusedPortableTextEditor} = testHelpers({page, testInfo})
     await mount(<PortableTextInputStory />)
 
-    const $pteTextbox = await getFocusedPortableTextEditor('field-body')
+    const $pte = await getFocusedPortableTextEditor('field-body')
 
     await page
       .getByRole('button')
@@ -264,7 +267,7 @@ test.describe('Blocks', () => {
       .click()
 
     // Assertion: Object preview should be visible
-    await expect($pteTextbox.locator('.pt-block.pt-object-block')).toBeVisible()
+    await expect($pte.locator('.pt-block.pt-object-block')).toBeVisible()
 
     // Assertion: Object edit dialog should be visible
     const $dialog = page.getByTestId('default-edit-object-dialog')
@@ -296,18 +299,18 @@ test.describe('Menu bar', () => {
   test('Should display all default styles', async ({mount, page}, testInfo) => {
     const {getFocusedPortableTextInput} = testHelpers({page, testInfo})
     await mount(<PortableTextInputStory />)
-    const $portableTextField = await getFocusedPortableTextInput('field-bodyStyles')
+    const $portableTextInput = await getFocusedPortableTextInput('field-bodyStyles')
 
     // Assertion: All icons in the menu bar should be visible
     const ICONS = ['bold', 'code', 'italic', 'link', 'olist', 'ulist', 'underline']
     for (const icon of ICONS) {
       await expect(
-        $portableTextField.getByRole('button').locator(`[data-sanity-icon="${icon}"]`),
+        $portableTextInput.getByRole('button').locator(`[data-sanity-icon="${icon}"]`),
       ).toBeVisible()
     }
 
     // Assertion: ???
-    await expect($portableTextField.locator('button#block-style-select')).not.toBeVisible()
+    await expect($portableTextInput.locator('button#block-style-select')).not.toBeVisible()
   })
 
   test('Overflow links should appear in the "Add" context menu', async ({
@@ -316,12 +319,12 @@ test.describe('Menu bar', () => {
   }, testInfo) => {
     const {getFocusedPortableTextInput} = testHelpers({page, testInfo})
     await mount(<PortableTextInputStory />)
-    const $portableTextField = await getFocusedPortableTextInput('field-body')
+    const $portableTextInput = await getFocusedPortableTextInput('field-body')
 
     // Adjust the viewport size to make the Inline Object button hidden
     await page.setViewportSize({width: 800, height: 1000})
 
-    const $contextMenuButton = $portableTextField
+    const $contextMenuButton = $portableTextInput
       .getByRole('button')
       .locator('[data-sanity-icon="add"]')
 
@@ -330,7 +333,7 @@ test.describe('Menu bar', () => {
 
     // Assertion: Check if the Inline Object button is now hidden
     await expect(
-      $portableTextField.getByRole('button').filter({hasText: 'Inline Object'}),
+      $portableTextInput.getByRole('button').filter({hasText: 'Inline Object'}),
     ).toBeHidden()
 
     await $contextMenuButton.click()
@@ -348,10 +351,9 @@ test.describe('Menu bar', () => {
     const {getFocusedPortableTextInput} = testHelpers({page, testInfo})
     await mount(<PortableTextInputStory />)
 
-    const $portableTextField = await getFocusedPortableTextInput('field-body')
-
-    await $portableTextField.getByRole('textbox')
-
-    await expect(page.getByRole('button').filter({hasText: 'Object Without Title'})).toBeVisible()
+    const $portableTextInput = await getFocusedPortableTextInput('field-body')
+    await expect(
+      $portableTextInput.getByRole('button').filter({hasText: 'Object Without Title'}),
+    ).toBeVisible()
   })
 })

--- a/packages/sanity/playwright-ct/tests/formBuilder/PortableTextInput.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/PortableTextInput.spec.tsx
@@ -77,7 +77,7 @@ test.describe('Decorators', () => {
 
 test.describe('Annotations', () => {
   test('Create a new link with keyboard only', async ({mount, page}, testInfo) => {
-    const {getFocusedPortableTextEditor, typeWithDelay, insertPortableText} = testHelpers({
+    const {getFocusedPortableTextEditor, insertPortableText} = testHelpers({
       page,
       testInfo,
     })
@@ -85,13 +85,6 @@ test.describe('Annotations', () => {
     const $pte = await getFocusedPortableTextEditor('field-body')
 
     await insertPortableText('Now we should insert a link.', $pte)
-
-    // Assertion: Wait for the text to be rendered
-    await expect(
-      $pte.locator('[data-slate-string="true"]', {
-        hasText: 'Now we should insert a link.',
-      }),
-    ).toBeVisible()
 
     // Backtrack and click link icon in menu bar
     await page.keyboard.press('ArrowLeft')

--- a/packages/sanity/playwright-ct/tests/formBuilder/PortableTextInput.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/PortableTextInput.spec.tsx
@@ -36,33 +36,32 @@ test.describe('Activation', () => {
 
 test.describe('Decorators', () => {
   test('Render default styles with keyboard shortcuts', async ({mount, page}, testInfo) => {
-    const {getModifierKey, focusPTE, typeInPTEWithDelay} = testHelpers({
+    const {getModifierKey, focusPTE, typeInPTEWithDelay, toggleHotKey} = testHelpers({
       page,
       testInfo,
     })
     await mount(<PortableTextInputStory />)
     const $pteField = await focusPTE('field-body')
     const $pteTextbox = $pteField.getByRole('textbox')
+    const modifierKey = getModifierKey()
+    await $pteTextbox.focus()
 
     // Bold
-    await page.keyboard.press(`${getModifierKey()}+b`)
+    await toggleHotkey('b', modifierKey)
     await typeInPTEWithDelay('bold text 123', $pteTextbox)
-
-    await page.keyboard.press(`${getModifierKey()}+b`, {delay: DEFAULT_TYPE_DELAY})
-
+    await toggleHotkey('b', modifierKey)
     await expect($pteTextbox.locator('[data-mark="strong"]', {hasText: 'bold text'})).toBeVisible()
 
     // Italic
-    await page.keyboard.press(`${getModifierKey()}+i`, {delay: DEFAULT_TYPE_DELAY})
+    await toggleHotkey('i', modifierKey)
     await typeInPTEWithDelay('italic text', $pteTextbox)
-
-    await page.keyboard.press(`${getModifierKey()}+i`)
+    await toggleHotkey('i', modifierKey)
     await expect($pteTextbox.locator('[data-mark="em"]', {hasText: 'italic text'})).toBeVisible()
 
     // Underline
-    await page.keyboard.press(`${getModifierKey()}+u`)
+    await toggleHotkey('u', modifierKey)
     await typeInPTEWithDelay('underlined text', $pteTextbox)
-    await page.keyboard.press(`${getModifierKey()}+u`)
+    await toggleHotkey('u', modifierKey)
     await expect(
       $pteTextbox.locator('[data-mark="underline"]', {
         hasText: 'underlined text',
@@ -70,10 +69,10 @@ test.describe('Decorators', () => {
     ).toBeVisible()
 
     // Code
-    await page.keyboard.press(`${getModifierKey()}+'`)
+    await toggleHotkey("'", modifierKey)
     await typeInPTEWithDelay('code text', $pteTextbox)
     await expect($pteTextbox.locator('[data-mark="code"]', {hasText: 'code text'})).toBeVisible()
-    await page.keyboard.press(`${getModifierKey()}+'`)
+    await toggleHotkey("'", modifierKey)
   })
 })
 

--- a/packages/sanity/playwright-ct/tests/formBuilder/PortableTextInput.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/PortableTextInput.spec.tsx
@@ -5,13 +5,6 @@ import {PortableTextInputStory} from './PortableTextInputStory'
 
 test.use({viewport: {width: 1200, height: 1000}})
 
-test.beforeEach(({browserName}, testInfo) => {
-  test.skip(
-    browserName === 'webkit' || testInfo.project.name.toLowerCase().includes('webkit'),
-    'Currently failing on Webkit/Safari due to different focus behaviour on activation of the PTE',
-  )
-})
-
 test.describe('Activation', () => {
   test(`Show call to action on focus`, async ({mount}) => {
     const component = await mount(<PortableTextInputStory />)

--- a/packages/sanity/playwright-ct/tests/formBuilder/PortableTextInput.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/PortableTextInput.spec.tsx
@@ -65,6 +65,18 @@ test.describe('Decorators', () => {
     await expect($pte.locator('[data-mark="code"]', {hasText: 'code text'})).toBeVisible()
     await toggleHotkey("'", modifierKey)
   })
+
+  test('Should not display block style button when no block styles are present', async ({
+    mount,
+    page,
+  }) => {
+    const {getFocusedPortableTextInput} = testHelpers({page})
+    await mount(<PortableTextInputStory />)
+    const $portableTextInput = await getFocusedPortableTextInput('field-bodyStyles')
+
+    // Assertion: Block style button should be hidden
+    await expect($portableTextInput.locator('button#block-style-select')).not.toBeVisible()
+  })
 })
 
 test.describe('Annotations', () => {

--- a/packages/sanity/playwright-ct/tests/formBuilder/PortableTextInput.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/PortableTextInput.spec.tsx
@@ -1,9 +1,17 @@
+import Os from 'os'
 import {expect, test} from '@playwright/experimental-ct-react'
 import React from 'react'
 import {testHelpers} from '../utils/testHelpers'
 import {PortableTextInputStory} from './PortableTextInputStory'
 
 test.use({viewport: {width: 1200, height: 1000}})
+
+test.beforeEach(({browserName}) => {
+  test.skip(
+    browserName === 'webkit' && Os.platform() === 'linux',
+    "Skipping Webkit for Linux which currently isn't supported.",
+  )
+})
 
 test.describe('Activation', () => {
   test(`Show call to action on focus`, async ({mount}) => {

--- a/packages/sanity/playwright-ct/tests/formBuilder/PortableTextInput.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/PortableTextInput.spec.tsx
@@ -28,11 +28,10 @@ test.describe('Activation', () => {
 })
 
 test.describe('Decorators', () => {
-  test('Render default styles with keyboard shortcuts', async ({mount, page}, testInfo) => {
+  test('Render default styles with keyboard shortcuts', async ({mount, page}) => {
     const {getModifierKey, getFocusedPortableTextEditor, insertPortableText, toggleHotkey} =
       testHelpers({
         page,
-        testInfo,
       })
     await mount(<PortableTextInputStory />)
     const $pte = await getFocusedPortableTextEditor('field-body')
@@ -69,10 +68,9 @@ test.describe('Decorators', () => {
 })
 
 test.describe('Annotations', () => {
-  test('Create a new link with keyboard only', async ({mount, page}, testInfo) => {
+  test('Create a new link with keyboard only', async ({mount, page}) => {
     const {getFocusedPortableTextEditor, insertPortableText} = testHelpers({
       page,
-      testInfo,
     })
     await mount(<PortableTextInputStory />)
     const $pte = await getFocusedPortableTextEditor('field-body')
@@ -111,11 +109,8 @@ test.describe('Annotations', () => {
 })
 
 test.describe('Blocks', () => {
-  test('Clicking a block link in the menu create a new block element', async ({
-    mount,
-    page,
-  }, testInfo) => {
-    const {getFocusedPortableTextInput} = testHelpers({page, testInfo})
+  test('Clicking a block link in the menu create a new block element', async ({mount, page}) => {
+    const {getFocusedPortableTextInput} = testHelpers({page})
     await mount(<PortableTextInputStory />)
 
     const $portableTextInput = await getFocusedPortableTextInput('field-body')
@@ -132,8 +127,8 @@ test.describe('Blocks', () => {
     await expect($portableTextInput.locator('.pt-block.pt-object-block')).toBeVisible()
   })
 
-  test('Custom block preview components renders correctly', async ({mount, page}, testInfo) => {
-    const {getFocusedPortableTextEditor} = testHelpers({page, testInfo})
+  test('Custom block preview components renders correctly', async ({mount, page}) => {
+    const {getFocusedPortableTextEditor} = testHelpers({page})
     await mount(<PortableTextInputStory />)
     const $pte = await getFocusedPortableTextEditor('field-body')
 
@@ -152,8 +147,8 @@ test.describe('Blocks', () => {
     await expect($pte.getByText('Custom preview block:')).toBeVisible()
   })
 
-  test('Double-clicking opens a block', async ({mount, page}, testInfo) => {
-    const {getFocusedPortableTextEditor} = testHelpers({page, testInfo})
+  test('Double-clicking opens a block', async ({mount, page}) => {
+    const {getFocusedPortableTextEditor} = testHelpers({page})
     await mount(<PortableTextInputStory />)
 
     const $pte = await getFocusedPortableTextEditor('field-body')
@@ -184,8 +179,8 @@ test.describe('Blocks', () => {
     await expect($locatorDialog).toBeVisible()
   })
 
-  test('Blocks should be accessible via block context menu', async ({mount, page}, testInfo) => {
-    const {getFocusedPortableTextInput} = testHelpers({page, testInfo})
+  test('Blocks should be accessible via block context menu', async ({mount, page}) => {
+    const {getFocusedPortableTextInput} = testHelpers({page})
     await mount(<PortableTextInputStory />)
 
     const $portableTextField = await getFocusedPortableTextInput('field-body')
@@ -241,8 +236,8 @@ test.describe('Blocks', () => {
     await expect($portableTextField.getByTestId('pte-block-object')).not.toBeVisible()
   })
 
-  test('Handle focus correctly in block edit dialog', async ({page, mount}, testInfo) => {
-    const {getFocusedPortableTextEditor} = testHelpers({page, testInfo})
+  test('Handle focus correctly in block edit dialog', async ({page, mount}) => {
+    const {getFocusedPortableTextEditor} = testHelpers({page})
     await mount(<PortableTextInputStory />)
 
     const $pte = await getFocusedPortableTextEditor('field-body')
@@ -282,8 +277,8 @@ test.describe('Blocks', () => {
 })
 
 test.describe('Menu bar', () => {
-  test('Should display all default styles', async ({mount, page}, testInfo) => {
-    const {getFocusedPortableTextInput} = testHelpers({page, testInfo})
+  test('Should display all default styles', async ({mount, page}) => {
+    const {getFocusedPortableTextInput} = testHelpers({page})
     await mount(<PortableTextInputStory />)
     const $portableTextInput = await getFocusedPortableTextInput('field-bodyStyles')
 
@@ -299,11 +294,8 @@ test.describe('Menu bar', () => {
     await expect($portableTextInput.locator('button#block-style-select')).not.toBeVisible()
   })
 
-  test('Overflow links should appear in the "Add" context menu', async ({
-    mount,
-    page,
-  }, testInfo) => {
-    const {getFocusedPortableTextInput} = testHelpers({page, testInfo})
+  test('Overflow links should appear in the "Add" context menu', async ({mount, page}) => {
+    const {getFocusedPortableTextInput} = testHelpers({page})
     await mount(<PortableTextInputStory />)
     const $portableTextInput = await getFocusedPortableTextInput('field-body')
 
@@ -333,8 +325,8 @@ test.describe('Menu bar', () => {
   test('Blocks that appear in the menu bar should always display a title', async ({
     page,
     mount,
-  }, testInfo) => {
-    const {getFocusedPortableTextInput} = testHelpers({page, testInfo})
+  }) => {
+    const {getFocusedPortableTextInput} = testHelpers({page})
     await mount(<PortableTextInputStory />)
 
     const $portableTextInput = await getFocusedPortableTextInput('field-body')

--- a/packages/sanity/playwright-ct/tests/formBuilder/PortableTextInput.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/PortableTextInput.spec.tsx
@@ -1,6 +1,6 @@
 import {expect, test} from '@playwright/experimental-ct-react'
 import React from 'react'
-import {DEFAULT_TYPE_DELAY, testHelpers} from '../utils/testHelpers'
+import {testHelpers} from '../utils/testHelpers'
 import {PortableTextInputStory} from './PortableTextInputStory'
 
 test.use({viewport: {width: 1200, height: 1000}})
@@ -36,54 +36,55 @@ test.describe('Activation', () => {
 
 test.describe('Decorators', () => {
   test('Render default styles with keyboard shortcuts', async ({mount, page}, testInfo) => {
-    const {getModifierKey, focusPTE, typeInPTEWithDelay, toggleHotKey} = testHelpers({
-      page,
-      testInfo,
-    })
+    const {getModifierKey, getFocusedPortableTextEditor, insertPortableText, toggleHotkey} =
+      testHelpers({
+        page,
+        testInfo,
+      })
     await mount(<PortableTextInputStory />)
-    const $pteField = await focusPTE('field-body')
-    const $pteTextbox = $pteField.getByRole('textbox')
+    const $pte = await getFocusedPortableTextEditor('field-body')
     const modifierKey = getModifierKey()
-    await $pteTextbox.focus()
 
     // Bold
     await toggleHotkey('b', modifierKey)
-    await typeInPTEWithDelay('bold text 123', $pteTextbox)
+    await insertPortableText('bold text 123', $pte)
     await toggleHotkey('b', modifierKey)
-    await expect($pteTextbox.locator('[data-mark="strong"]', {hasText: 'bold text'})).toBeVisible()
+    await expect($pte.locator('[data-mark="strong"]', {hasText: 'bold text'})).toBeVisible()
 
     // Italic
     await toggleHotkey('i', modifierKey)
-    await typeInPTEWithDelay('italic text', $pteTextbox)
+    await insertPortableText('italic text', $pte)
     await toggleHotkey('i', modifierKey)
-    await expect($pteTextbox.locator('[data-mark="em"]', {hasText: 'italic text'})).toBeVisible()
+    await expect($pte.locator('[data-mark="em"]', {hasText: 'italic text'})).toBeVisible()
 
     // Underline
     await toggleHotkey('u', modifierKey)
-    await typeInPTEWithDelay('underlined text', $pteTextbox)
+    await insertPortableText('underlined text', $pte)
     await toggleHotkey('u', modifierKey)
     await expect(
-      $pteTextbox.locator('[data-mark="underline"]', {
+      $pte.locator('[data-mark="underline"]', {
         hasText: 'underlined text',
       }),
     ).toBeVisible()
 
     // Code
     await toggleHotkey("'", modifierKey)
-    await typeInPTEWithDelay('code text', $pteTextbox)
-    await expect($pteTextbox.locator('[data-mark="code"]', {hasText: 'code text'})).toBeVisible()
+    await insertPortableText('code text', $pte)
+    await expect($pte.locator('[data-mark="code"]', {hasText: 'code text'})).toBeVisible()
     await toggleHotkey("'", modifierKey)
   })
 })
 
 test.describe('Annotations', () => {
   test('Create a new link with keyboard only', async ({mount, page}, testInfo) => {
-    const {focusPTE, typeWithDelay, typeInPTEWithDelay} = testHelpers({page, testInfo})
+    const {getFocusedPortableTextEditor, typeWithDelay, insertPortableText} = testHelpers({
+      page,
+      testInfo,
+    })
     await mount(<PortableTextInputStory />)
-    const $pteField = await focusPTE('field-body')
-    const $pteTextbox = await $pteField.getByRole('textbox')
+    const $pteTextbox = await getFocusedPortableTextEditor('field-body')
 
-    await typeInPTEWithDelay('Now we should insert a link.', $pteTextbox)
+    await insertPortableText('Now we should insert a link.', $pteTextbox)
 
     // Assertion: Wait for the text to be rendered
     await expect(
@@ -125,11 +126,10 @@ test.describe('Blocks', () => {
     mount,
     page,
   }, testInfo) => {
-    const {focusPTE} = testHelpers({page, testInfo})
+    const {getFocusedPortableTextInput} = testHelpers({page, testInfo})
     await mount(<PortableTextInputStory />)
 
-    const $pteField = await focusPTE('field-body')
-    const $pteTextbox = await $pteField.getByRole('textbox')
+    const $portableTextField = await getFocusedPortableTextInput('field-body')
 
     await page
       .getByRole('button')
@@ -140,15 +140,13 @@ test.describe('Blocks', () => {
       .click()
 
     // Assertion: Object preview should be visible
-    await expect($pteTextbox.locator('.pt-block.pt-object-block')).toBeVisible()
+    await expect($portableTextField.locator('.pt-block.pt-object-block')).toBeVisible()
   })
 
   test('Custom block preview components renders correctly', async ({mount, page}, testInfo) => {
-    const {focusPTE} = testHelpers({page, testInfo})
+    const {getFocusedPortableTextEditor} = testHelpers({page, testInfo})
     await mount(<PortableTextInputStory />)
-
-    const $pteField = await focusPTE('field-body')
-    const $pteTextbox = await $pteField.getByRole('textbox')
+    const $pteTextbox = await getFocusedPortableTextEditor('field-body')
 
     await page
       .getByRole('button')
@@ -166,11 +164,10 @@ test.describe('Blocks', () => {
   })
 
   test('Double-clicking opens a block', async ({mount, page}, testInfo) => {
-    const {focusPTE} = testHelpers({page, testInfo})
+    const {getFocusedPortableTextEditor} = testHelpers({page, testInfo})
     await mount(<PortableTextInputStory />)
 
-    const $pteField = await focusPTE('field-body')
-    const $pteTextbox = await $pteField.getByRole('textbox')
+    const $pteTextbox = await getFocusedPortableTextEditor('field-body')
 
     await page
       .getByRole('button')
@@ -199,11 +196,10 @@ test.describe('Blocks', () => {
   })
 
   test('Blocks should be accessible via block context menu', async ({mount, page}, testInfo) => {
-    const {focusPTE} = testHelpers({page, testInfo})
+    const {getFocusedPortableTextInput} = testHelpers({page, testInfo})
     await mount(<PortableTextInputStory />)
 
-    const $pteField = await focusPTE('field-body')
-    const $pteTextbox = await $pteField.getByRole('textbox')
+    const $portableTextField = await getFocusedPortableTextInput('field-body')
 
     await page
       .getByRole('button')
@@ -211,7 +207,7 @@ test.describe('Blocks', () => {
       .click()
 
     // Assertion: Object preview should be visible
-    await expect($pteTextbox.locator('.pt-block.pt-object-block')).toBeVisible()
+    await expect($portableTextField.locator('.pt-block.pt-object-block')).toBeVisible()
 
     // Assertion: Object edit dialog should be visible
     await expect(page.getByTestId('default-edit-object-dialog')).toBeVisible()
@@ -253,15 +249,14 @@ test.describe('Blocks', () => {
     await page.keyboard.press('Enter')
 
     // Assertion: Block should now be deleted
-    await expect($pteTextbox.getByTestId('pte-block-object')).not.toBeVisible()
+    await expect($portableTextField.getByTestId('pte-block-object')).not.toBeVisible()
   })
 
   test('Handle focus correctly in block edit dialog', async ({page, mount}, testInfo) => {
-    const {focusPTE} = testHelpers({page, testInfo})
+    const {getFocusedPortableTextEditor} = testHelpers({page, testInfo})
     await mount(<PortableTextInputStory />)
 
-    const $pteField = await focusPTE('field-body')
-    const $pteTextbox = await $pteField.getByRole('textbox')
+    const $pteTextbox = await getFocusedPortableTextEditor('field-body')
 
     await page
       .getByRole('button')
@@ -299,40 +294,44 @@ test.describe('Blocks', () => {
 
 test.describe('Menu bar', () => {
   test('Should display all default styles', async ({mount, page}, testInfo) => {
-    const {focusPTE} = testHelpers({page, testInfo})
+    const {getFocusedPortableTextInput} = testHelpers({page, testInfo})
     await mount(<PortableTextInputStory />)
-    const $pteField = await focusPTE('field-bodyStyles')
+    const $portableTextField = await getFocusedPortableTextInput('field-bodyStyles')
 
     // Assertion: All icons in the menu bar should be visible
     const ICONS = ['bold', 'code', 'italic', 'link', 'olist', 'ulist', 'underline']
     for (const icon of ICONS) {
       await expect(
-        $pteField.getByRole('button').locator(`[data-sanity-icon="${icon}"]`),
+        $portableTextField.getByRole('button').locator(`[data-sanity-icon="${icon}"]`),
       ).toBeVisible()
     }
 
     // Assertion: ???
-    await expect($pteField.locator('button#block-style-select')).not.toBeVisible()
+    await expect($portableTextField.locator('button#block-style-select')).not.toBeVisible()
   })
 
   test('Overflow links should appear in the "Add" context menu', async ({
     mount,
     page,
   }, testInfo) => {
-    const {focusPTE} = testHelpers({page, testInfo})
-    const $pteField = await mount(<PortableTextInputStory />)
-    await focusPTE('field-body')
+    const {getFocusedPortableTextInput} = testHelpers({page, testInfo})
+    await mount(<PortableTextInputStory />)
+    const $portableTextField = await getFocusedPortableTextInput('field-body')
 
     // Adjust the viewport size to make the Inline Object button hidden
     await page.setViewportSize({width: 800, height: 1000})
 
-    const $contextMenuButton = $pteField.getByRole('button').locator('[data-sanity-icon="add"]')
+    const $contextMenuButton = $portableTextField
+      .getByRole('button')
+      .locator('[data-sanity-icon="add"]')
 
     // Assertion: Check if the Add + button is showing
     await expect($contextMenuButton).toBeVisible()
 
     // Assertion: Check if the Inline Object button is now hidden
-    await expect($pteField.getByRole('button').filter({hasText: 'Inline Object'})).toBeHidden()
+    await expect(
+      $portableTextField.getByRole('button').filter({hasText: 'Inline Object'}),
+    ).toBeHidden()
 
     await $contextMenuButton.click()
 
@@ -346,12 +345,12 @@ test.describe('Menu bar', () => {
     page,
     mount,
   }, testInfo) => {
-    const {focusPTE} = testHelpers({page, testInfo})
+    const {getFocusedPortableTextInput} = testHelpers({page, testInfo})
     await mount(<PortableTextInputStory />)
 
-    const $pteField = await focusPTE('field-body')
+    const $portableTextField = await getFocusedPortableTextInput('field-body')
 
-    await $pteField.getByRole('textbox')
+    await $portableTextField.getByRole('textbox')
 
     await expect(page.getByRole('button').filter({hasText: 'Object Without Title'})).toBeVisible()
   })

--- a/packages/sanity/playwright-ct/tests/utils/testHelpers.tsx
+++ b/packages/sanity/playwright-ct/tests/utils/testHelpers.tsx
@@ -94,6 +94,7 @@ export function testHelpers({
      * @param locator - editable element of a Portable Text Editor (as returned by getFocusedPortableTextEditorElement)
      */
     insertPortableText: async (text: string, locator: Locator) => {
+      await locator.focus()
       await locator.evaluate((el, value) => {
         el.dispatchEvent(
           new window.InputEvent('beforeinput', {

--- a/packages/sanity/playwright-ct/tests/utils/testHelpers.tsx
+++ b/packages/sanity/playwright-ct/tests/utils/testHelpers.tsx
@@ -1,5 +1,5 @@
 import {type ComponentFixtures} from '@playwright/experimental-ct-react'
-import type {PlaywrightTestArgs, Locator, TestInfo} from '@playwright/test'
+import type {PlaywrightTestArgs, Locator} from '@playwright/test'
 
 export const DEFAULT_TYPE_DELAY = 20
 
@@ -11,30 +11,7 @@ export const TYPE_DELAY_HIGH = 150
 
 export type MountResult = Awaited<ReturnType<ComponentFixtures['mount']>>
 
-/**
- * Get the platform name based on the project name.
- * @param projectName - The name of the project.
- * @returns The platform name or `null`.
- */
-function getPlatformName(projectName: string): string | null {
-  if (projectName.toLowerCase().includes('osx')) {
-    return 'darwin'
-  }
-
-  if (projectName.toLowerCase().includes('windows')) {
-    return 'win32'
-  }
-
-  return null
-}
-
-export function testHelpers({
-  page,
-  testInfo,
-}: {
-  page: PlaywrightTestArgs['page']
-  testInfo: TestInfo
-}) {
+export function testHelpers({page}: {page: PlaywrightTestArgs['page']}) {
   return {
     /**
      * Returns the DOM element of a focused Portable Text Input ready to typed into

--- a/packages/sanity/playwright-ct/tests/utils/testHelpers.tsx
+++ b/packages/sanity/playwright-ct/tests/utils/testHelpers.tsx
@@ -35,7 +35,6 @@ export function testHelpers({
   page: PlaywrightTestArgs['page']
   testInfo: TestInfo
 }) {
-  const platformName = getPlatformName(testInfo.project.name) || process.platform
   return {
     /**
      * Focuses on the PTE and activates it with the space key.
@@ -57,7 +56,7 @@ export function testHelpers({
      * @returns The modifier key name ('Meta' for macOS, 'Control' for other platforms).
      */
     getModifierKey: () => {
-      if ((platformName || process.platform) === 'darwin') {
+      if (process.platform === 'darwin') {
         return 'Meta'
       }
       return 'Control'
@@ -90,6 +89,16 @@ export function testHelpers({
       }, input)
 
       await new Promise((resolve) => setTimeout(resolve, delay || DEFAULT_TYPE_DELAY))
+    },
+    /**
+     * Will create a keyboard event of a given hotkey combination that can be activated with a modifier key
+     * @param hotkey - the hotkey
+     * @param modifierKey - the modifier key (if any) that can activate the hotkey
+     */
+    toggleHotkey: async (hotkey: string, modifierKey?: string) => {
+      if (modifierKey) await page.keyboard.down(modifierKey)
+      await page.keyboard.press(hotkey)
+      if (modifierKey) await page.keyboard.up(modifierKey)
     },
   }
 }

--- a/packages/sanity/playwright-ct/tests/utils/testHelpers.tsx
+++ b/packages/sanity/playwright-ct/tests/utils/testHelpers.tsx
@@ -37,19 +37,38 @@ export function testHelpers({
 }) {
   return {
     /**
-     * Focuses on the PTE and activates it with the space key.
-     * @param testId - The data-testid attribute of the PTE.
-     * @returns The located PTE element.
+     * Returns the DOM element of a focused Portable Text Input ready to typed into
+     *
+     * @param testId The data-testid attribute of the Portable Text Input
+     * @returns The Portable Text Input element
      */
-    focusPTE: async (testId: string) => {
+    getFocusedPortableTextInput: async (testId: string) => {
       const $pteField: Locator = page.getByTestId(testId)
-      // Focus PTE and activate with space key
+      // Activate the input
       await $pteField.getByTestId('activate-overlay').focus()
       await page.keyboard.press('Space')
-
-      // Focus PTE by clicking manually
-      // await $pteLocator.getByTestId('activate-overlay').click({force: true})
+      // Ensure focus on the contentEditable element of the Portable Text Editor
+      const $pteTextbox = $pteField.getByRole('textbox')
+      await $pteTextbox.focus()
       return $pteField
+    },
+    /**
+     * Returns the editable element of a focused Portable Text Input
+     * This can receive events to simulate user action, or be tested for
+     * having the right content.
+     *
+     * @param testId - The data-testid attribute of the Portable Text Input.
+     * @returns The PT-editor's contentEditable element
+     */
+    getFocusedPortableTextEditor: async (testId: string) => {
+      const $pteField: Locator = page.getByTestId(testId)
+      // Activate the input
+      await $pteField.getByTestId('activate-overlay').focus()
+      await page.keyboard.press('Space')
+      // Ensure focus on the contentEditable element of the Portable Text Editor
+      const $pteTextbox = $pteField.getByRole('textbox')
+      await $pteTextbox.focus()
+      return $pteTextbox
     },
     /**
      * Gets the appropriate modifier key for the current platform.
@@ -70,13 +89,11 @@ export function testHelpers({
       await page.keyboard.type(input, {delay: delay || DEFAULT_TYPE_DELAY})
     },
     /**
-     * Types text in the PTE by firing a `beforeinput` event with the input, with a delay after.
-     * The built-in `page.keyboard.type()` function fires each character async. This could lead to
-     * characters being lost, or ending up in the wrong order.
-     * @param input - The text to be typed.
-     * @param delay - (Optional) The delay between key presses in milliseconds.
+     * Write text into a Portable Text Editor's editable element
+     * @param text - The text to be typed.
+     * @param locator - editable element of a Portable Text Editor (as returned by getFocusedPortableTextEditorElement)
      */
-    typeInPTEWithDelay: async (input: string, locator: Locator, delay?: number) => {
+    insertPortableText: async (text: string, locator: Locator) => {
       await locator.evaluate((el, value) => {
         el.dispatchEvent(
           new window.InputEvent('beforeinput', {
@@ -86,9 +103,7 @@ export function testHelpers({
             data: value,
           }),
         )
-      }, input)
-
-      await new Promise((resolve) => setTimeout(resolve, delay || DEFAULT_TYPE_DELAY))
+      }, text)
     },
     /**
      * Will create a keyboard event of a given hotkey combination that can be activated with a modifier key


### PR DESCRIPTION
### Description

This will fix the Playwright form tests to work on Linux (and CI). There were two issues:

* Platform name was returned incorrectly sometimes (confirmed on local Linux)
* To trigger hotkeys (at least on the PT-input), you have to do that on Linux with a combination of metaDown + hotkeyPress + metaUp (`playwright.page.press('Meta+b')` will not work on Linux). I suspect it's either the way the hotkey event listeners are implemented in the PTE, or it could be a Linux-specific behavior in how keyboard events are handled in the browser.

I have moved the 'focusPTE' method into two separate functions that can target either the PortableTextInput element as a whole (`getFocusedPortableTextInput`), and another that targets the Portable Text Editor within the input (`getFocusedPortableTextEditor`).

With the latter, we can create simpler tests code as most tests before had some lines in each test to do this in order to get to the actual text input.

I have also renamed the `typeInPTEWithDelay` function to `writePortableText` and removed the delay function. The delay can be written more in particular for tests that need to simulate human typing or similar, but it should not be needed in general (I know this helper function has changed a bit through time). Webkit tests are passing now as well, so I have enabled them.

I have disabled the Webkit tests only when platform is `linux` at this time as we don't fully support it.
They are passing on Apple Webkit, so I have enabled them there.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
