### PR TITLE
fix(core): add check for cdr schematype and use PrimitiveField

### DIFF
--- a/packages/sanity/src/core/form/studio/inputResolver/fieldResolver.tsx
+++ b/packages/sanity/src/core/form/studio/inputResolver/fieldResolver.tsx
@@ -1,5 +1,10 @@
 /* eslint-disable react/jsx-handler-names */
-import {isBooleanSchemaType, isReferenceSchemaType, SchemaType} from '@sanity/types'
+import {
+  isBooleanSchemaType,
+  isCrossDatasetReferenceSchemaType,
+  isReferenceSchemaType,
+  SchemaType,
+} from '@sanity/types'
 import React, {useState} from 'react'
 import {ArrayFieldProps, FieldProps, ObjectFieldProps} from '../../types'
 import {ReferenceField} from '../../inputs/ReferenceInput/ReferenceField'
@@ -168,6 +173,10 @@ export function defaultResolveFieldComponent(
 
   if (typeChain.some((t) => t.name === 'image' || t.name === 'file')) {
     return ImageOrFileField as React.ComponentType<Omit<FieldProps, 'renderDefault'>>
+  }
+
+  if (typeChain.some((t) => isCrossDatasetReferenceSchemaType(t))) {
+    return PrimitiveField as React.ComponentType<Omit<FieldProps, 'renderDefault'>>
   }
 
   if (typeChain.some((t) => isReferenceSchemaType(t))) {


### PR DESCRIPTION
### Description
Cross dataset references had the wrong level/depth. There was no check for cdr schematype in the `fieldResolver.tsx`, which resulted in the field type for cdr to be `ObjectOrArrayField`. This PR adds a check for `isCrossDatasetReferenceSchemaType` and rendering a `PrimitiveField` in that case, removing the indent for a cdr.  

![Screenshot 2023-08-22 at 15 13 37](https://github.com/sanity-io/sanity/assets/44635000/ddbcb05d-9bbf-43d6-8f02-1bafafbe3ce9)

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Make sure that the `PrimitiveField` works as intended for a cross dataset reference. 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fixes indent bug for cross dataset references
<!--
A description of the change(s) that should be used in the release notes.
-->
