### PR TITLE
fix(core): wait for availability status to arrive before passing on document existence status

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/validation.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/validation.ts
@@ -13,6 +13,7 @@ import {
 import {
   distinct,
   distinctUntilChanged,
+  filter,
   first,
   groupBy,
   map,
@@ -148,7 +149,9 @@ export const validation = memoize(
     const getDocumentExists: GetDocumentExists = ({id}) =>
       lastValueFrom(
         referenceExistence$.pipe(
-          first(),
+          // If the id is not present as key in the `referenceExistence` map it means it's existence status
+          // isn't yet loaded, so we want to wait until it is
+          first((referenceExistence) => id in referenceExistence),
           map((referenceExistence) => referenceExistence[id]),
         ),
       )

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/validation.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/validation.ts
@@ -13,7 +13,6 @@ import {
 import {
   distinct,
   distinctUntilChanged,
-  filter,
   first,
   groupBy,
   map,


### PR DESCRIPTION
### Description
When the validation machinery is validating the existence/publish state of referenced documents, we subscribe to existence state and keep a local map of `<documentId, existenceStatus>`. However, if the validation asks for existence status before it's loaded, it will get back `undefined`, which is taken to mean "document doesn't exist". This again, causes the UI to render the reference field as invalid for a brief moment until the reference status actually arrives. This PR fixes the issue by waiting until the `documentId` is present in the `<documentId, existenceStatus>`, which means we have actually received the existence status.

### What to review

- Observe initial flashes of validation errors in the following test document in [next](https://test-studio.sanity.build/test/content/input-standard;arraysTest;bf366789-61e0-419e-96b0-abb53bdf21e5)
- Verify that they are gone in this branch's [preview deployment](https://test-studio-i1qm08aih.sanity.build/test/content/input-standard;arraysTest;bf366789-61e0-419e-96b0-abb53bdf21e5)
with

### Notes for release
- Fixes initial flashes of validation errors for valid content on document load
