### PR TITLE
fix(core): use primitiveField for slug schema type

### DIFF
--- a/packages/sanity/src/core/form/studio/inputResolver/fieldResolver.tsx
+++ b/packages/sanity/src/core/form/studio/inputResolver/fieldResolver.tsx
@@ -179,6 +179,10 @@ export function defaultResolveFieldComponent(
     return PrimitiveField as React.ComponentType<Omit<FieldProps, 'renderDefault'>>
   }
 
+  if (typeChain.some((t) => t.name === 'slug')) {
+    return PrimitiveField as React.ComponentType<Omit<FieldProps, 'renderDefault'>>
+  }
+
   if (typeChain.some((t) => isReferenceSchemaType(t))) {
     return ReferenceField as React.ComponentType<Omit<FieldProps, 'renderDefault'>>
   }


### PR DESCRIPTION
### Description
There was no check for the `slug` schematype, resulting in it rendering an `ObjectOrArrayField`. Hence it was lacking a `<label>` for the `title`. This PR adds a check for `slug` schematype and renders a `PrimitiveField` instead. 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
The `slug` schematype - that it works as expected and that the title is wrapped in a `label`
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Change field type of slug from `ObjectOrArrayField` to `PrimitiveField`
<!--
A description of the change(s) that should be used in the release notes.
-->
