### PR TITLE
feat(core): convert slug input to use i18n primitives 

### DIFF
--- a/packages/sanity/src/core/form/inputs/Slug/SlugInput.tsx
+++ b/packages/sanity/src/core/form/inputs/Slug/SlugInput.tsx
@@ -78,7 +78,7 @@ export function SlugInput(props: SlugInputProps) {
   const [generateState, handleGenerateSlug] = useAsync(() => {
     if (!sourceField) {
       return Promise.reject(
-        new Error(t('slugInput.error.missing-source', {schemaType: schemaType.name}))
+        new Error(t('inputs.slug.error.missing-source', {schemaType: schemaType.name}))
       )
     }
 
@@ -124,8 +124,8 @@ export function SlugInput(props: SlugInputProps) {
               onClick={handleGenerateSlug}
               text={
                 generateState?.status === 'pending'
-                  ? t('slugInput.action.generating')
-                  : t('slugInput.action.generate')
+                  ? t('inputs.slug.action.generating')
+                  : t('inputs.slug.action.generate')
               }
             />
           </Box>

--- a/packages/sanity/src/core/form/inputs/Slug/SlugInput.tsx
+++ b/packages/sanity/src/core/form/inputs/Slug/SlugInput.tsx
@@ -13,6 +13,7 @@ import {Box, Button, Card, Flex, Stack, TextInput} from '@sanity/ui'
 import {PatchEvent, set, setIfMissing, unset} from '../../patch'
 import {ObjectInputProps} from '../../types'
 import {useFormBuilder} from '../../useFormBuilder'
+import {useTranslation} from '../../../i18n'
 import {slugify} from './utils/slugify'
 import {useAsync} from './utils/useAsync'
 import {SlugContext, useSlugContext} from './utils/useSlugContext'
@@ -58,6 +59,8 @@ export function SlugInput(props: SlugInputProps) {
 
   const slugContext = useSlugContext()
 
+  const {t} = useTranslation()
+
   const updateSlug = useCallback(
     (nextSlug: any) => {
       if (!nextSlug) {
@@ -75,7 +78,7 @@ export function SlugInput(props: SlugInputProps) {
   const [generateState, handleGenerateSlug] = useAsync(() => {
     if (!sourceField) {
       return Promise.reject(
-        new Error(`Source is missing. Check source on type "${schemaType.name}" in schema`)
+        new Error(t('slugInput.error.missing-source', {schemaType: schemaType.name}))
       )
     }
 
@@ -84,7 +87,7 @@ export function SlugInput(props: SlugInputProps) {
     return getNewFromSource(sourceField, doc, sourceContext)
       .then((newFromSource) => slugify(newFromSource || '', schemaType, sourceContext))
       .then((newSlug) => updateSlug(newSlug))
-  }, [sourceField, getDocument, schemaType, path, slugContext, updateSlug])
+  }, [sourceField, getDocument, schemaType, path, slugContext, updateSlug, t])
 
   const isUpdating = generateState?.status === 'pending'
 
@@ -119,7 +122,11 @@ export function SlugInput(props: SlugInputProps) {
               type="button"
               disabled={readOnly || isUpdating}
               onClick={handleGenerateSlug}
-              text={generateState?.status === 'pending' ? 'Generating…' : 'Generate'}
+              text={
+                generateState?.status === 'pending'
+                  ? t('slugInput.action.generating')
+                  : t('slugInput.action.generate')
+              }
             />
           </Box>
         )}

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -164,6 +164,16 @@ export const studioLocaleStrings = {
   'timeline.editLive': 'Live edited',
   'timeline.publish': 'Published',
   'timeline.unpublish': 'Unpublished',
+  /** --- Slug Input --- */
+
+  /** Error message for when the source to generate a slug from is missing */
+  'slugInput.error.missing-source': `Source is missing. Check source on type {{schemaType}} in schema`,
+
+  /** Loading message for when the input is actively generating a slug */
+  'slugInput.action.generating': `Generating…`,
+
+  /** Action message for generating the slug */
+  'slugInput.action.generate': `Generate`,
 }
 
 /**

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -164,16 +164,17 @@ export const studioLocaleStrings = {
   'timeline.editLive': 'Live edited',
   'timeline.publish': 'Published',
   'timeline.unpublish': 'Unpublished',
+
   /** --- Slug Input --- */
 
   /** Error message for when the source to generate a slug from is missing */
-  'slugInput.error.missing-source': `Source is missing. Check source on type {{schemaType}} in schema`,
+  'inputs.slug.error.missing-source': `Source is missing. Check source on type {{schemaType}} in schema`,
 
   /** Loading message for when the input is actively generating a slug */
-  'slugInput.action.generating': `Generating…`,
+  'inputs.slug.action.generating': `Generating…`,
 
   /** Action message for generating the slug */
-  'slugInput.action.generate': `Generate`,
+  'inputs.slug.action.generate': `Generate`,
 }
 
 /**


### PR DESCRIPTION
### Description

Convert slug input strings to use i18n primitives 

### What to review

That all items/strings within the vision are not broken and work as expected.

### Notes for release

N/A 

