### PR TITLE
feat(core): convert array input actions strings to use i18n primitives 

### DIFF
--- a/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
@@ -189,6 +189,79 @@ const studioResources: Record<StudioLocaleResourceKeys, string> = {
 
   /** Accessibility label for icon indicating that document does _not_ have any unpublished changes */
   'inputs.reference.preview.has-no-unpublished-changes-aria-label': 'Ingen upubliserte endringer',
+
+  /** --- Array Input --- */
+
+  /** Label for when the array input doesn't have any items */
+  'inputs.array.no-items-label': 'Ingen elementer',
+
+  /** Label for when the array input is resolving the initial value for the item */
+  'inputs.array.resolving-initial-value': 'Finner startverdi…',
+
+  /** Label for read only array fields */
+  'inputs.array.read-only-label': 'Dette feltet er skrivebeskyttet',
+
+  /** Label for removing an array item action  */
+  'inputs.array.action.remove': 'Fjern',
+
+  /** Label for removing action when an array item has an error */
+  'inputs.array.action.remove-invalid-item': 'Fjern',
+
+  /** Label for duplicating an array item */
+  'inputs.array.action.duplicate': 'Dupliser',
+
+  /** Label for viewing the item of a specific type, eg "View Person" */
+  'inputs.array.action.view': 'Se {{itemTypeTitle}}',
+
+  /** Label for editing the item of a specific type, eg "Edit Person" */
+  'inputs.array.action.edit': 'Rediger {{itemTypeTitle}}',
+
+  /** Label for adding array item action when the schema allows for only one schema type */
+  'inputs.array.action.add-item': 'Legg til',
+
+  /**
+   * Label for adding one array item action when the schema allows for multiple schema types,
+   * eg. will prompt the user to select a type once triggered
+   */
+  'inputs.array.action.add-item-select-type': 'Legg til...',
+
+  /** Label for adding item before a specific array item */
+  'inputs.array.action.add-before': 'Legg til før',
+
+  /** Label for adding item after a specific array item */
+  'inputs.array.action.add-after': 'Legg til etter',
+
+  /** Error label for unexpected errors in the Array Input */
+  'inputs.array.error.unexpected-error': `Uventet feil: {{error}}`,
+
+  /** Error title for when an item type within an array input is incompatible, used in the tooltip */
+  'inputs.array.error.type-is-incompatible-title': 'Hvorfor skjer dette?',
+
+  /** Error description for the array item tooltip that explains what the error means with more context */
+  'inputs.array.error.type-is-incompatible-prompt': `Typen <Code>{{typeName}}</Code> er ikke gyldig for denne listen`,
+
+  /** Error description for the array item tooltip that explains that the current type item is not valid for the list  */
+  'inputs.array.error.current-schema-not-declare-description':
+    'Den nåværende skjemaet erklærer ikke typen <Code>{{typeName}}</Code> som gyldig for denne listen. Dette kan bety at typen har blitt fjernet som en gyldig type, eller at noen andre har lagt den til i sitt eget lokale skjema som ennå ikke er distribuert.',
+
+  /** Error description for the array item tooltip that explains that the current item can still be moved or deleted but not edited since the schema definition is not found */
+  'inputs.array.error.can-delete-but-no-edit-description':
+    'Du kan fortsatt flytte eller slette dette elementet, men det kan ikke redigeres siden skjemadefinisjonen for typen ikke finnes.',
+
+  /** Error description to show how the item is being represented in the json format */
+  'inputs.array.error.json-representation-description': 'JSON-representasjon av dette elementet:',
+
+  /** Error label for toast when trying to upload one array item of a type that cannot be converted to array */
+  'inputs.array.error.cannot-upload-unable-to-convert_one':
+    'Følgende element kan ikke lastes opp fordi det ikke finnes noen kjent konvertering fra innholdstypen til element i listen:',
+
+  /** Error label for toast when trying to upload multiple array items of a type that cannot be converted to array */
+  'inputs.array.error.cannot-upload-unable-to-convert_other':
+    'Følgende elementer kan ikke lastes opp fordi det ikke finnes noen kjent konvertering fra innholdstypene til element i listen:',
+
+  /** Error label for toast when array could not resolve the initial value */
+  'inputs.array.error.cannot-resolve-initial-value-title':
+    'Kan ikke finne startverdi for type: {{schemaTypeTitle}}: {{errorMessage}}.',
 }
 
 export default studioResources

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/ArrayOfObjectsFunctions.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/ArrayOfObjectsFunctions.tsx
@@ -13,6 +13,7 @@ import {
   MenuButtonProps,
 } from '@sanity/ui'
 import {ArrayInputFunctionsProps, ObjectItem} from '../../../types'
+import {useTranslation} from '../../../../i18n'
 
 const POPOVER_PROPS: MenuButtonProps['popover'] = {
   constrainSize: true,
@@ -29,6 +30,7 @@ export function ArrayOfObjectsFunctions<
 >(props: ArrayInputFunctionsProps<Item, SchemaType>) {
   const {schemaType, readOnly, children, onValueCreate, onItemAppend} = props
   const menuButtonId = useId()
+  const {t} = useTranslation()
 
   const insertItem = useCallback(
     (itemType: any) => {
@@ -43,23 +45,25 @@ export function ArrayOfObjectsFunctions<
     insertItem(schemaType.of[0])
   }, [schemaType, insertItem])
 
+  // If we have more than a single type candidate, we render a menu, so the button might show
+  // "Add item..." instead of simply "Add item", to indicate that further choices are available.
+  const addItemI18nKey =
+    schemaType.of.length > 1
+      ? 'inputs.array.action.add-item-select-type'
+      : 'inputs.array.action.add-item'
+
   if (readOnly) {
     return (
       <Tooltip
         portal
         content={
           <Box padding={2} sizing="border">
-            <Text size={1}>This field is read-only</Text>
+            <Text size={1}>{t('inputs.array.read-only-label')}</Text>
           </Box>
         }
       >
         <Grid>
-          <Button
-            icon={AddIcon}
-            mode="ghost"
-            disabled
-            text={schemaType.of.length === 1 ? 'Add item' : 'Add item...'}
-          />
+          <Button icon={AddIcon} mode="ghost" disabled text={t(addItemI18nKey)} />
         </Grid>
       </Tooltip>
     )
@@ -68,10 +72,10 @@ export function ArrayOfObjectsFunctions<
   return (
     <Grid gap={1} style={{gridTemplateColumns: 'repeat(auto-fit, minmax(100px, 1fr))'}}>
       {schemaType.of.length === 1 ? (
-        <Button icon={AddIcon} mode="ghost" onClick={handleAddBtnClick} text="Add item" />
+        <Button icon={AddIcon} mode="ghost" onClick={handleAddBtnClick} text={t(addItemI18nKey)} />
       ) : (
         <MenuButton
-          button={<Button icon={AddIcon} mode="ghost" text="Add item…" />}
+          button={<Button icon={AddIcon} mode="ghost" text={t(addItemI18nKey)} />}
           id={menuButtonId || ''}
           menu={
             <Menu>

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/ErrorItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/ErrorItem.tsx
@@ -5,6 +5,7 @@ import {ArrayItemError} from '../../../../store'
 import {useFormCallbacks} from '../../../../studio/contexts/FormCallbacks'
 import {PatchEvent, unset} from '../../../../patch'
 import {CellLayout} from '../../layouts/CellLayout'
+import {useTranslation} from '../../../../../i18n'
 import {IncompatibleItemType} from './IncompatibleItemType'
 
 const MENU_POPOVER_PROPS = {portal: true, tone: 'default'} as const
@@ -13,6 +14,7 @@ export function ErrorItem(props: {member: ArrayItemError; sortable?: boolean}) {
   const {member, sortable} = props
   const id = useId()
   const {onChange} = useFormCallbacks()
+  const {t} = useTranslation()
 
   const handleRemove = useCallback(() => {
     onChange(PatchEvent.from([unset([{_key: member.key}])]))
@@ -29,7 +31,12 @@ export function ErrorItem(props: {member: ArrayItemError; sortable?: boolean}) {
           id={`${id}-menuButton`}
           menu={
             <Menu>
-              <MenuItem text="Remove" tone="critical" icon={TrashIcon} onClick={handleRemove} />
+              <MenuItem
+                text={t('inputs.array.action.remove-invalid-item')}
+                tone="critical"
+                icon={TrashIcon}
+                onClick={handleRemove}
+              />
             </Menu>
           }
           popover={MENU_POPOVER_PROPS}
@@ -39,7 +46,7 @@ export function ErrorItem(props: {member: ArrayItemError; sortable?: boolean}) {
       {member.error.type === 'INVALID_ITEM_TYPE' ? (
         <IncompatibleItemType value={member.error.value} vertical />
       ) : (
-        <div>Unexpected Error: {member.error.type}</div>
+        <div>{t('inputs.array.error.unexpected-error', {error: member.error.type})}</div>
       )}
     </CellLayout>
   )

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridArrayInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridArrayInput.tsx
@@ -7,6 +7,7 @@ import {ArrayOfObjectsItem} from '../../../../members'
 import {createProtoArrayValue} from '../createProtoArrayValue'
 import {UploadTargetCard} from '../../common/UploadTargetCard'
 import {ArrayOfObjectsFunctions} from '../ArrayOfObjectsFunctions'
+import {useTranslation} from '../../../../../i18n'
 import {GridItem} from './GridItem'
 import {ErrorItem} from './ErrorItem'
 
@@ -32,6 +33,7 @@ export function GridArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
     schemaType,
     value = EMPTY,
   } = props
+  const {t} = useTranslation()
 
   const handlePrepend = useCallback(
     (item: Item) => {
@@ -69,7 +71,7 @@ export function GridArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
           {members?.length === 0 && (
             <Card padding={3} border style={{borderStyle: 'dashed'}} radius={2}>
               <Text align="center" muted size={1}>
-                {schemaType.placeholder || <>No items</>}
+                {schemaType.placeholder || <>{t('inputs.array.no-items-label')}</>}
               </Text>
             </Card>
           )}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
@@ -29,6 +29,7 @@ import {createProtoArrayValue} from '../createProtoArrayValue'
 import {InsertMenu} from '../InsertMenu'
 import {FIXME} from '../../../../../FIXME'
 import {EditPortal} from '../../../../components/EditPortal'
+import {useTranslation} from '../../../../../i18n'
 
 type GridItemProps<Item extends ObjectItem> = Omit<ObjectItemProps<Item>, 'renderDefault'>
 
@@ -93,6 +94,7 @@ export function GridItem<Item extends ObjectItem = ObjectItem>(props: GridItemPr
     children,
     inputProps: {renderPreview},
   } = props
+  const {t} = useTranslation()
 
   const sortable = !readOnly && parentSchemaType.options?.sortable !== false
   const insertableTypes = parentSchemaType.of
@@ -155,15 +157,24 @@ export function GridItem<Item extends ObjectItem = ObjectItem>(props: GridItemPr
           id={`${props.inputId}-menuButton`}
           menu={
             <Menu>
-              <MenuItem text="Remove" tone="critical" icon={TrashIcon} onClick={onRemove} />
-              <MenuItem text="Duplicate" icon={DuplicateIcon} onClick={handleDuplicate} />
+              <MenuItem
+                text={t('arrayInput.action.remove')}
+                tone="critical"
+                icon={TrashIcon}
+                onClick={onRemove}
+              />
+              <MenuItem
+                text={t('arrayInput.action.duplicate')}
+                icon={DuplicateIcon}
+                onClick={handleDuplicate}
+              />
               <InsertMenu types={insertableTypes} onInsert={handleInsert} />
             </Menu>
           }
           popover={MENU_POPOVER_PROPS}
         />
       ),
-    [handleDuplicate, handleInsert, onRemove, insertableTypes, props.inputId, readOnly],
+    [handleDuplicate, handleInsert, onRemove, insertableTypes, props.inputId, readOnly, t],
   )
 
   const tone = getTone({readOnly, hasErrors, hasWarnings})
@@ -209,7 +220,7 @@ export function GridItem<Item extends ObjectItem = ObjectItem>(props: GridItemPr
                 <Spinner muted />
               </Box>
               <Text muted size={1}>
-                Resolving initial value…
+                {t('arrayInput.resolving-initial-value')}
               </Text>
             </Flex>
           </Card>
@@ -226,7 +237,11 @@ export function GridItem<Item extends ObjectItem = ObjectItem>(props: GridItemPr
       </ChangeIndicator>
       {open && (
         <EditPortal
-          header={readOnly ? `View ${itemTypeTitle}` : `Edit ${itemTypeTitle}`}
+          header={
+            readOnly
+              ? t('arrayInput.action.view', {itemTypeTitle})
+              : t('arrayInput.action.edit', {itemTypeTitle})
+          }
           type={parentSchemaType?.options?.modal?.type || 'dialog'}
           width={parentSchemaType?.options?.modal?.width ?? 1}
           id={value._key}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
@@ -158,13 +158,13 @@ export function GridItem<Item extends ObjectItem = ObjectItem>(props: GridItemPr
           menu={
             <Menu>
               <MenuItem
-                text={t('arrayInput.action.remove')}
+                text={t('inputs.array.action.remove')}
                 tone="critical"
                 icon={TrashIcon}
                 onClick={onRemove}
               />
               <MenuItem
-                text={t('arrayInput.action.duplicate')}
+                text={t('inputs.array.action.duplicate')}
                 icon={DuplicateIcon}
                 onClick={handleDuplicate}
               />
@@ -220,7 +220,7 @@ export function GridItem<Item extends ObjectItem = ObjectItem>(props: GridItemPr
                 <Spinner muted />
               </Box>
               <Text muted size={1}>
-                {t('arrayInput.resolving-initial-value')}
+                {t('inputs.array.resolving-initial-value')}
               </Text>
             </Flex>
           </Card>
@@ -239,8 +239,8 @@ export function GridItem<Item extends ObjectItem = ObjectItem>(props: GridItemPr
         <EditPortal
           header={
             readOnly
-              ? t('arrayInput.action.view', {itemTypeTitle})
-              : t('arrayInput.action.edit', {itemTypeTitle})
+              ? t('inputs.array.action.view', {itemTypeTitle})
+              : t('inputs.array.action.edit', {itemTypeTitle})
           }
           type={parentSchemaType?.options?.modal?.type || 'dialog'}
           width={parentSchemaType?.options?.modal?.width ?? 1}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/IncompatibleItemType.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/IncompatibleItemType.tsx
@@ -3,6 +3,8 @@ import React, {useCallback} from 'react'
 import {BulbOutlineIcon, UnknownIcon} from '@sanity/icons'
 import {resolveTypeName} from '@sanity/util/content'
 import styled from 'styled-components'
+import {Trans} from 'react-i18next'
+import {useTranslation} from '../../../../../i18n'
 
 const PopoverCard = styled(Card)`
   max-width: ${({theme}: {theme: Theme}) => theme.sanity.container[1]}px;
@@ -18,6 +20,8 @@ export function IncompatibleItemType(props: Props) {
   const {value, onFocus, vertical, ...rest} = props
   const [showDetails, setShowDetails] = React.useState(false)
   const [popoverRef, setPopoverRef] = React.useState<HTMLElement | null>(null)
+
+  const {t} = useTranslation()
 
   useClickOutside(() => setShowDetails(false), [popoverRef])
 
@@ -44,22 +48,24 @@ export function IncompatibleItemType(props: Props) {
         <PopoverCard margin={1} padding={3} onKeyDown={handleKeyDown} tabIndex={0} overflow="auto">
           <Stack space={4}>
             <Box>
-              <Text weight="semibold">Why is this happening?</Text>
+              <Text weight="semibold">{t('inputs.array.error.type-is-incompatible-title')}</Text>
             </Box>
             <Text size={1}>
-              The current schema does not declare items of type <code>{typeName}</code> as valid for
-              this list. This could mean that the type has been removed as a valid item type, or
-              that someone else has added it to their own local schema that is not yet deployed.
+              <Trans
+                t={t}
+                i18nKey="inputs.array.error.current-schema-not-declare-description"
+                components={[<code key={0}>{typeName}</code>]}
+                values={{typeName: typeName}}
+              />
             </Text>
             <Box>
               <Text size={1}>
-                <BulbOutlineIcon /> You can still move or delete this item, but it cannot be edited
-                since the schema definition for its type is nowhere to be found.
+                <BulbOutlineIcon /> {t('inputs.array.error.can-delete-but-no-edit-description')}
               </Text>
             </Box>
             <Stack space={2}>
               <Text size={1} weight="semibold">
-                JSON representation of this item:
+                {t('inputs.array.error.json-representation-description')}
               </Text>
               <Card padding={2} overflow="auto" border>
                 <Code size={1} as="pre" language="json">
@@ -92,7 +98,12 @@ export function IncompatibleItemType(props: Props) {
             </Text>
           </Box>
           <Text align="center" size={1}>
-            Items of type <code>{typeName}</code> is not valid for this list
+            <Trans
+              t={t}
+              i18nKey="inputs.array.error.type-is-incompatible-prompt"
+              components={[<code key={0}>{typeName}</code>]}
+              values={{typeName: typeName}}
+            />
           </Text>
         </Stack>
       </Card>

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/IncompatibleItemType.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/IncompatibleItemType.tsx
@@ -4,7 +4,7 @@ import {BulbOutlineIcon, UnknownIcon} from '@sanity/icons'
 import {resolveTypeName} from '@sanity/util/content'
 import styled from 'styled-components'
 import {Trans} from 'react-i18next'
-import {useTranslation} from '../../../../../i18n'
+import {Translate, useTranslation} from '../../../../../i18n'
 
 const PopoverCard = styled(Card)`
   max-width: ${({theme}: {theme: Theme}) => theme.sanity.container[1]}px;
@@ -51,11 +51,11 @@ export function IncompatibleItemType(props: Props) {
               <Text weight="semibold">{t('inputs.array.error.type-is-incompatible-title')}</Text>
             </Box>
             <Text size={1}>
-              <Trans
+              <Translate
                 t={t}
                 i18nKey="inputs.array.error.current-schema-not-declare-description"
-                components={[<code key={0}>{typeName}</code>]}
-                values={{typeName: typeName}}
+                components={{Code: ({children}) => <code>{children}</code>}}
+                values={{typeName}}
               />
             </Text>
             <Box>
@@ -98,11 +98,11 @@ export function IncompatibleItemType(props: Props) {
             </Text>
           </Box>
           <Text align="center" size={1}>
-            <Trans
+            <Translate
               t={t}
               i18nKey="inputs.array.error.type-is-incompatible-prompt"
-              components={[<code key={0}>{typeName}</code>]}
-              values={{typeName: typeName}}
+              components={{Code: ({children}) => <code>{children}</code>}}
+              values={{typeName}}
             />
           </Text>
         </Stack>

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/IncompatibleItemType.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/IncompatibleItemType.tsx
@@ -3,7 +3,6 @@ import React, {useCallback} from 'react'
 import {BulbOutlineIcon, UnknownIcon} from '@sanity/icons'
 import {resolveTypeName} from '@sanity/util/content'
 import styled from 'styled-components'
-import {Trans} from 'react-i18next'
 import {Translate, useTranslation} from '../../../../../i18n'
 
 const PopoverCard = styled(Card)`

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/InsertMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/InsertMenu.tsx
@@ -3,6 +3,7 @@ import {SchemaType} from '@sanity/types'
 import React, {ComponentProps, memo} from 'react'
 import {MenuGroup, MenuItem, PopoverProps} from '@sanity/ui'
 import {InsertAboveIcon, InsertBelowIcon} from '@sanity/icons'
+import {useTranslation} from '../../../../i18n'
 
 interface Props {
   types?: SchemaType[]
@@ -18,20 +19,21 @@ const MENU_POPOVER_PROPS: PopoverProps = {
 
 export const InsertMenu = memo(function InsertMenu(props: Props) {
   const {types, onInsert} = props
+  const {t} = useTranslation()
   return (
     <>
       <InsertMenuGroup
         pos="before"
         types={types}
         onInsert={onInsert}
-        text="Add item before"
+        text={t('inputs.array.action.add-before')}
         icon={InsertAboveIcon}
       />
       <InsertMenuGroup
         pos="after"
         types={types}
         onInsert={onInsert}
-        text="Add item after"
+        text={t('inputs.array.action.add-after')}
         icon={InsertBelowIcon}
       />
     </>

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ErrorItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ErrorItem.tsx
@@ -3,6 +3,7 @@ import {EllipsisVerticalIcon, TrashIcon} from '@sanity/icons'
 import {Box, Button, Menu, MenuButton, MenuItem} from '@sanity/ui'
 import {ArrayItemError} from '../../../../store'
 import {RowLayout} from '../../layouts/RowLayout'
+import {useTranslation} from '../../../../../i18n'
 import {IncompatibleItemType} from './IncompatibleItemType'
 
 const MENU_POPOVER_PROPS = {portal: true, tone: 'default'} as const
@@ -15,6 +16,8 @@ export function ErrorItem(props: {
   const {member, sortable, onRemove} = props
   const id = useId()
 
+  const {t} = useTranslation()
+
   return (
     <Box paddingX={1}>
       <RowLayout
@@ -26,7 +29,12 @@ export function ErrorItem(props: {
             id={`${id}-menuButton`}
             menu={
               <Menu>
-                <MenuItem text="Remove" tone="critical" icon={TrashIcon} onClick={onRemove} />
+                <MenuItem
+                  text={t('inputs.array.action.remove-invalid-item')}
+                  tone="critical"
+                  icon={TrashIcon}
+                  onClick={onRemove}
+                />
               </Menu>
             }
             popover={MENU_POPOVER_PROPS}
@@ -36,7 +44,7 @@ export function ErrorItem(props: {
         {member.error.type === 'INVALID_ITEM_TYPE' ? (
           <IncompatibleItemType value={member.error.value} />
         ) : (
-          <div>Unexpected Error: {member.error.type}</div>
+          <div>{t('inputs.array.error.unexpected-error', {error: member.error.type})}</div>
         )}
       </RowLayout>
     </Box>

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/IncompatibleItemType.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/IncompatibleItemType.tsx
@@ -3,6 +3,8 @@ import React, {useCallback} from 'react'
 import {BulbOutlineIcon, UnknownIcon} from '@sanity/icons'
 import {resolveTypeName} from '@sanity/util/content'
 import styled from 'styled-components'
+import {Trans} from 'react-i18next'
+import {useTranslation} from '../../../../../i18n'
 
 const PopoverCard = styled(Card)`
   max-width: ${({theme}: {theme: Theme}) => theme.sanity.container[1]}px;
@@ -18,6 +20,8 @@ export function IncompatibleItemType(props: Props) {
   const {value, onFocus, vertical, ...rest} = props
   const [showDetails, setShowDetails] = React.useState(false)
   const [popoverRef, setPopoverRef] = React.useState<HTMLElement | null>(null)
+
+  const {t} = useTranslation()
 
   useClickOutside(() => setShowDetails(false), [popoverRef])
 
@@ -44,22 +48,24 @@ export function IncompatibleItemType(props: Props) {
         <PopoverCard margin={1} padding={3} onKeyDown={handleKeyDown} tabIndex={0} overflow="auto">
           <Stack space={4}>
             <Box>
-              <Text weight="semibold">Why is this happening?</Text>
+              <Text weight="semibold">{t('inputs.array.error.type-is-incompatible-title')}</Text>
             </Box>
             <Text size={1}>
-              The current schema does not declare items of type <code>{typeName}</code> as valid for
-              this list. This could mean that the type has been removed as a valid item type, or
-              that someone else has added it to their own local schema that is not yet deployed.
+              <Trans
+                t={t}
+                i18nKey="inputs.array.error.current-schema-not-declare-description"
+                components={[<code key={0}>{typeName}</code>]}
+                values={{typeName: typeName}}
+              />
             </Text>
             <Box>
               <Text size={1}>
-                <BulbOutlineIcon /> You can still move or delete this item, but it cannot be edited
-                since the schema definition for its type is nowhere to be found.
+                <BulbOutlineIcon /> {t('inputs.array.error.can-delete-but-no-edit-description')}
               </Text>
             </Box>
             <Stack space={2}>
               <Text size={1} weight="semibold">
-                JSON representation of this item:
+                {t('inputs.array.error.json-representation-description')}
               </Text>
               <Card padding={2} overflow="auto" border>
                 <Code size={1} as="pre" language="json">
@@ -94,7 +100,12 @@ export function IncompatibleItemType(props: Props) {
 
           <Box flex={1}>
             <Text size={1} textOverflow="ellipsis">
-              Item of type <code>{typeName}</code> not valid for this list
+              <Trans
+                t={t}
+                i18nKey="inputs.array.error.type-is-incompatible-prompt"
+                components={[<code key={0}>{typeName}</code>]}
+                values={{typeName: typeName}}
+              />
             </Text>
           </Box>
         </Flex>

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/IncompatibleItemType.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/IncompatibleItemType.tsx
@@ -3,8 +3,7 @@ import React, {useCallback} from 'react'
 import {BulbOutlineIcon, UnknownIcon} from '@sanity/icons'
 import {resolveTypeName} from '@sanity/util/content'
 import styled from 'styled-components'
-import {Trans} from 'react-i18next'
-import {useTranslation} from '../../../../../i18n'
+import {Translate, useTranslation} from '../../../../../i18n'
 
 const PopoverCard = styled(Card)`
   max-width: ${({theme}: {theme: Theme}) => theme.sanity.container[1]}px;
@@ -51,11 +50,11 @@ export function IncompatibleItemType(props: Props) {
               <Text weight="semibold">{t('inputs.array.error.type-is-incompatible-title')}</Text>
             </Box>
             <Text size={1}>
-              <Trans
+              <Translate
                 t={t}
                 i18nKey="inputs.array.error.current-schema-not-declare-description"
-                components={[<code key={0}>{typeName}</code>]}
-                values={{typeName: typeName}}
+                components={{Code: ({children}) => <code>{children}</code>}}
+                values={{typeName}}
               />
             </Text>
             <Box>
@@ -100,11 +99,11 @@ export function IncompatibleItemType(props: Props) {
 
           <Box flex={1}>
             <Text size={1} textOverflow="ellipsis">
-              <Trans
+              <Translate
                 t={t}
                 i18nKey="inputs.array.error.type-is-incompatible-prompt"
-                components={[<code key={0}>{typeName}</code>]}
-                values={{typeName: typeName}}
+                components={{Code: ({children}) => <code>{children}</code>}}
+                values={{typeName}}
               />
             </Text>
           </Box>

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.tsx
@@ -17,6 +17,7 @@ import {ArrayOfObjectsItem} from '../../../../members'
 import {createProtoArrayValue} from '../createProtoArrayValue'
 import {UploadTargetCard} from '../../common/UploadTargetCard'
 import {ArrayOfObjectsFunctions} from '../ArrayOfObjectsFunctions'
+import {useTranslation} from '../../../../../i18n'
 import {useVirtualizerScrollInstance} from './useVirtualizerScrollInstance'
 import {ErrorItem} from './ErrorItem'
 import {useMemoCompare} from './useMemoCompare'
@@ -45,6 +46,7 @@ export function ListArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
     schemaType,
     value = EMPTY,
   } = props
+  const {t} = useTranslation()
 
   // Stores the index of the item being dragged
   const [activeDragItemIndex, setActiveDragItemIndex] = useState<number | null>(null)
@@ -197,7 +199,7 @@ export function ListArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
           {members.length === 0 ? (
             <Card padding={3} border style={{borderStyle: 'dashed'}} radius={2}>
               <Text align="center" muted size={1}>
-                {schemaType.placeholder || <>No items</>}
+                {schemaType.placeholder || <>{t('inputs.array.no-items-label')}</>}
               </Text>
             </Card>
           ) : (

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
@@ -27,6 +27,7 @@ import {RowLayout} from '../../layouts/RowLayout'
 import {createProtoArrayValue} from '../createProtoArrayValue'
 import {InsertMenu} from '../InsertMenu'
 import {EditPortal} from '../../../../components/EditPortal'
+import {useTranslation} from '../../../../../i18n'
 
 type PreviewItemProps<Item extends ObjectItem> = Omit<ObjectItemProps<Item>, 'renderDefault'>
 
@@ -77,6 +78,7 @@ export function PreviewItem<Item extends ObjectItem = ObjectItem>(props: Preview
     children,
     inputProps: {renderPreview},
   } = props
+  const {t} = useTranslation()
 
   const sortable = !readOnly && parentSchemaType.options?.sortable !== false
   const insertableTypes = parentSchemaType.of
@@ -139,15 +141,24 @@ export function PreviewItem<Item extends ObjectItem = ObjectItem>(props: Preview
           id={`${props.inputId}-menuButton`}
           menu={
             <Menu>
-              <MenuItem text="Remove" tone="critical" icon={TrashIcon} onClick={onRemove} />
-              <MenuItem text="Duplicate" icon={DuplicateIcon} onClick={handleDuplicate} />
+              <MenuItem
+                text={t('arrayInput.action.remove')}
+                tone="critical"
+                icon={TrashIcon}
+                onClick={onRemove}
+              />
+              <MenuItem
+                text={t('arrayInput.action.duplicate')}
+                icon={DuplicateIcon}
+                onClick={handleDuplicate}
+              />
               <InsertMenu types={insertableTypes} onInsert={handleInsert} />
             </Menu>
           }
           popover={MENU_POPOVER_PROPS}
         />
       ),
-    [handleDuplicate, handleInsert, onRemove, insertableTypes, props.inputId, readOnly],
+    [handleDuplicate, handleInsert, onRemove, insertableTypes, props.inputId, readOnly, t],
   )
 
   const tone = getTone({readOnly, hasErrors, hasWarnings})
@@ -195,7 +206,7 @@ export function PreviewItem<Item extends ObjectItem = ObjectItem>(props: Preview
                 <Spinner muted />
               </Box>
               <Text size={1} muted>
-                Resolving initial value…
+                {t('arrayInput.resolving-initial-value')}
               </Text>
             </Flex>
           </Card>
@@ -212,7 +223,11 @@ export function PreviewItem<Item extends ObjectItem = ObjectItem>(props: Preview
       </ChangeIndicator>
       {open && (
         <EditPortal
-          header={readOnly ? `View ${itemTypeTitle}` : `Edit ${itemTypeTitle}`}
+          header={
+            readOnly
+              ? t('arrayInput.action.view', {itemTypeTitle})
+              : t('arrayInput.action.edit', {itemTypeTitle})
+          }
           type={parentSchemaType?.options?.modal?.type || 'dialog'}
           width={parentSchemaType?.options?.modal?.width ?? 1}
           id={value._key}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
@@ -142,13 +142,13 @@ export function PreviewItem<Item extends ObjectItem = ObjectItem>(props: Preview
           menu={
             <Menu>
               <MenuItem
-                text={t('arrayInput.action.remove')}
+                text={t('inputs.array.action.remove')}
                 tone="critical"
                 icon={TrashIcon}
                 onClick={onRemove}
               />
               <MenuItem
-                text={t('arrayInput.action.duplicate')}
+                text={t('inputs.array.action.duplicate')}
                 icon={DuplicateIcon}
                 onClick={handleDuplicate}
               />
@@ -206,7 +206,7 @@ export function PreviewItem<Item extends ObjectItem = ObjectItem>(props: Preview
                 <Spinner muted />
               </Box>
               <Text size={1} muted>
-                {t('arrayInput.resolving-initial-value')}
+                {t('inputs.array.resolving-initial-value')}
               </Text>
             </Flex>
           </Card>
@@ -225,8 +225,8 @@ export function PreviewItem<Item extends ObjectItem = ObjectItem>(props: Preview
         <EditPortal
           header={
             readOnly
-              ? t('arrayInput.action.view', {itemTypeTitle})
-              : t('arrayInput.action.edit', {itemTypeTitle})
+              ? t('inputs.array.action.view', {itemTypeTitle})
+              : t('inputs.array.action.edit', {itemTypeTitle})
           }
           type={parentSchemaType?.options?.modal?.type || 'dialog'}
           width={parentSchemaType?.options?.modal?.width ?? 1}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesFunctions.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesFunctions.tsx
@@ -4,6 +4,7 @@ import {AddIcon} from '@sanity/icons'
 import React, {useMemo, useId} from 'react'
 import {Box, Button, Grid, Menu, MenuButton, MenuItem, Tooltip, Text} from '@sanity/ui'
 import {ArrayInputFunctionsProps} from '../../../types'
+import {useTranslation} from '../../../../i18n'
 
 /**
  * @hidden
@@ -14,6 +15,7 @@ export function ArrayOfPrimitivesFunctions<
 >(props: ArrayInputFunctionsProps<MemberType, SchemaType>) {
   const {schemaType, readOnly, children, onValueCreate, onItemAppend} = props
   const menuButtonId = useId()
+  const {t} = useTranslation()
 
   const insertItem = React.useCallback(
     (itemType: any) => {
@@ -28,23 +30,25 @@ export function ArrayOfPrimitivesFunctions<
 
   const popoverProps = useMemo(() => ({constrainSize: true, portal: true}), [])
 
+  // If we have more than a single type candidate, we render a menu, so the button might show
+  // "Add item..." instead of simply "Add item", to indicate that further choices are available.
+  const addItemI18nKey =
+    schemaType.of.length > 1
+      ? 'inputs.array.action.add-item-select-type'
+      : 'inputs.array.action.add-item'
+
   if (readOnly) {
     return (
       <Tooltip
         portal
         content={
           <Box padding={2} sizing="border">
-            <Text size={1}>This field is read-only</Text>
+            <Text size={1}>{t('inputs.array.read-only-label')}</Text>
           </Box>
         }
       >
         <Grid>
-          <Button
-            icon={AddIcon}
-            mode="ghost"
-            disabled
-            text={schemaType.of.length === 1 ? 'Add item' : 'Add item...'}
-          />
+          <Button icon={AddIcon} mode="ghost" disabled text={t(addItemI18nKey)} />
         </Grid>
       </Tooltip>
     )
@@ -53,10 +57,10 @@ export function ArrayOfPrimitivesFunctions<
   return (
     <Grid gap={1} style={{gridTemplateColumns: 'repeat(auto-fit, minmax(100px, 1fr))'}}>
       {schemaType.of.length === 1 ? (
-        <Button icon={AddIcon} mode="ghost" onClick={handleAddBtnClick} text="Add item" />
+        <Button icon={AddIcon} mode="ghost" onClick={handleAddBtnClick} text={t(addItemI18nKey)} />
       ) : (
         <MenuButton
-          button={<Button icon={AddIcon} mode="ghost" text="Add item…" />}
+          button={<Button icon={AddIcon} mode="ghost" text={t(addItemI18nKey)} />}
           id={menuButtonId || ''}
           menu={
             <Menu>

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
@@ -8,9 +8,7 @@ import {ArrayOfPrimitivesItem} from '../../../members'
 import {ErrorItem} from '../ArrayOfObjectsInput/List/ErrorItem'
 import {UploadTargetCard} from '../common/UploadTargetCard'
 import {ChangeIndicator} from '../../../../changeIndicators'
-import {ArrayOfPrimitivesItemMember, ArrayOfPrimitivesMember} from '../../../store/types/members'
 import {getEmptyValue} from './getEmptyValue'
-
 import {PrimitiveValue} from './types'
 import {nearestIndexOf} from './utils/nearestIndex'
 import {ItemRow} from './ItemRow'
@@ -155,7 +153,6 @@ export class ArrayOfPrimitivesInput extends React.PureComponent<
       resolveUploader,
       elementProps,
       arrayFunctions: ArrayFunctions = ArrayOfPrimitivesFunctions,
-      path,
       changed,
     } = this.props
 

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
@@ -181,7 +181,7 @@ export class ArrayOfPrimitivesInput extends React.PureComponent<
             {membersWithSortIds.length === 0 ? (
               <Card padding={3} border style={{borderStyle: 'dashed'}} radius={2}>
                 <Text align="center" muted size={1}>
-                  {schemaType.placeholder || <>No items</>}
+                  {schemaType.placeholder || <>No Items</>}
                 </Text>
               </Card>
             ) : (

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ItemRow.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ItemRow.tsx
@@ -4,6 +4,7 @@ import {SchemaType} from '@sanity/types'
 import {CopyIcon as DuplicateIcon, EllipsisVerticalIcon, TrashIcon} from '@sanity/icons'
 import {FormFieldValidationStatus} from '../../../components/formField'
 import {InsertMenu} from '../ArrayOfObjectsInput/InsertMenu'
+import {useTranslation} from '../../../../i18n'
 import {PrimitiveItemProps} from '../../../types/itemProps'
 import {RowLayout} from '../layouts/RowLayout'
 import {FieldPresence} from '../../../../presence'
@@ -59,6 +60,8 @@ export const ItemRow = React.forwardRef(function ItemRow(
     return undefined
   }, [hasError, hasWarning])
 
+  const {t} = useTranslation()
+
   const menu = (
     <MenuButton
       button={<Button padding={2} mode="bleed" icon={EllipsisVerticalIcon} />}
@@ -66,9 +69,17 @@ export const ItemRow = React.forwardRef(function ItemRow(
       popover={MENU_BUTTON_POPOVER_PROPS}
       menu={
         <Menu>
-          <MenuItem text="Remove" tone="critical" icon={TrashIcon} onClick={onRemove} />
-
-          <MenuItem text="Duplicate" icon={DuplicateIcon} onClick={handleDuplicate} />
+          <MenuItem
+            text={t('inputs.array.action.remove')}
+            tone="critical"
+            icon={TrashIcon}
+            onClick={onRemove}
+          />
+          <MenuItem
+            text={t('inputs.array.action.duplicate')}
+            icon={DuplicateIcon}
+            onClick={handleDuplicate}
+          />
           <InsertMenu types={insertableTypes} onInsert={handleInsert} />
         </Menu>
       }

--- a/packages/sanity/src/core/form/inputs/arrays/common/uploadTarget/uploadTarget.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/common/uploadTarget/uploadTarget.tsx
@@ -8,6 +8,7 @@ import {FileInfo, fileTarget} from '../../../common/fileTarget'
 import {DropMessage} from '../../../files/common/DropMessage'
 import {UploadEvent} from '../../../../types'
 import {FIXME} from '../../../../../FIXME'
+import {useTranslation} from '../../../../../i18n'
 import {Overlay} from './styles'
 
 export interface UploadTargetProps {
@@ -48,6 +49,7 @@ export function uploadTarget<Props>(Component: React.ComponentType<Props>) {
   ) {
     const {children, resolveUploader, onUpload, types, ...rest} = props
     const {push: pushToast} = useToast()
+    const {t} = useTranslation()
 
     const uploadFile = React.useCallback(
       (file: File, resolvedUploader: ResolvedUploader) => {
@@ -70,15 +72,12 @@ export function uploadTarget<Props>(Component: React.ComponentType<Props>) {
         const rejected: UploadTask[] = tasks.filter((task) => task.uploaderCandidates.length === 0)
 
         if (rejected.length > 0) {
-          const plural = rejected.length > 1
           pushToast({
             closable: true,
             status: 'warning',
-            title: `The following item${
-              plural ? 's' : ''
-            } can't be uploaded because there's no known conversion from content type${
-              plural ? 's' : ''
-            } to array item:`,
+            title: t('inputs.array.error.cannot-upload-unable-to-convert', {
+              count: rejected.length,
+            }),
             description: rejected.map((task, i) => (
               <Flex key={i} padding={2}>
                 <Box marginLeft={1}>
@@ -104,7 +103,7 @@ export function uploadTarget<Props>(Component: React.ComponentType<Props>) {
           )
         })
       },
-      [pushToast, resolveUploader, types, uploadFile],
+      [pushToast, resolveUploader, types, uploadFile, t],
     )
 
     const [hoveringFiles, setHoveringFiles] = React.useState<FileInfo[]>([])

--- a/packages/sanity/src/core/form/members/array/IncompatibleItemType.tsx
+++ b/packages/sanity/src/core/form/members/array/IncompatibleItemType.tsx
@@ -3,8 +3,7 @@ import React, {useCallback} from 'react'
 import {BulbOutlineIcon, UnknownIcon} from '@sanity/icons'
 import {resolveTypeName} from '@sanity/util/content'
 import styled from 'styled-components'
-import {Trans} from 'react-i18next'
-import {useTranslation} from '../../../i18n'
+import {Translate, useTranslation} from '../../../i18n'
 
 const PopoverCard = styled(Card)`
   max-width: ${({theme}: {theme: Theme}) => theme.sanity.container[1]}px;
@@ -48,22 +47,22 @@ export function IncompatibleItemType(props: Props) {
         <PopoverCard margin={1} padding={3} onKeyDown={handleKeyDown} tabIndex={0} overflow="auto">
           <Stack space={4}>
             <Text weight="semibold">
-              <Trans
+              <Translate
                 t={t}
                 i18nKey="inputs.array.error.type-is-incompatible-prompt"
-                components={[<code key={0}>{typeName}</code>]}
-                values={{typeName: typeName}}
+                components={{Code: ({children}) => <code>{children}</code>}}
+                values={{typeName}}
               />
             </Text>
             <Text size={1} weight="semibold">
               {t('inputs.array.error.type-is-incompatible-title')}
             </Text>
             <Text size={1}>
-              <Trans
+              <Translate
                 t={t}
                 i18nKey="inputs.array.error.current-schema-not-declare-description"
-                components={[<code key={0}>{typeName}</code>]}
-                values={{typeName: typeName}}
+                components={{Code: ({children}) => <code>{children}</code>}}
+                values={{typeName}}
               />
             </Text>
             <Box>
@@ -108,10 +107,10 @@ export function IncompatibleItemType(props: Props) {
 
           <Box flex={1}>
             <Text size={1} textOverflow="ellipsis">
-              <Trans
+              <Translate
                 t={t}
                 i18nKey="inputs.array.error.type-is-incompatible-prompt"
-                components={[<code key={0}>{typeName}</code>]}
+                components={{Code: ({children}) => <code>{children}</code>}}
                 values={{typeName: typeName}}
               />
             </Text>

--- a/packages/sanity/src/core/form/members/array/IncompatibleItemType.tsx
+++ b/packages/sanity/src/core/form/members/array/IncompatibleItemType.tsx
@@ -3,6 +3,8 @@ import React, {useCallback} from 'react'
 import {BulbOutlineIcon, UnknownIcon} from '@sanity/icons'
 import {resolveTypeName} from '@sanity/util/content'
 import styled from 'styled-components'
+import {Trans} from 'react-i18next'
+import {useTranslation} from '../../../i18n'
 
 const PopoverCard = styled(Card)`
   max-width: ${({theme}: {theme: Theme}) => theme.sanity.container[1]}px;
@@ -18,6 +20,8 @@ export function IncompatibleItemType(props: Props) {
   const {value, onFocus, vertical, ...rest} = props
   const [showDetails, setShowDetails] = React.useState(false)
   const [popoverRef, setPopoverRef] = React.useState<HTMLElement | null>(null)
+
+  const {t} = useTranslation()
 
   useClickOutside(() => setShowDetails(false), [popoverRef])
 
@@ -44,25 +48,32 @@ export function IncompatibleItemType(props: Props) {
         <PopoverCard margin={1} padding={3} onKeyDown={handleKeyDown} tabIndex={0} overflow="auto">
           <Stack space={4}>
             <Text weight="semibold">
-              Item of type <code>{typeName}</code> not valid for this list
+              <Trans
+                t={t}
+                i18nKey="inputs.array.error.type-is-incompatible-prompt"
+                components={[<code key={0}>{typeName}</code>]}
+                values={{typeName: typeName}}
+              />
             </Text>
             <Text size={1} weight="semibold">
-              Why is this happening?
+              {t('inputs.array.error.type-is-incompatible-title')}
             </Text>
             <Text size={1}>
-              The current schema does not declare items of type <code>{typeName}</code> as valid for
-              this list. This could mean that the type has been removed as a valid item type, or
-              that someone else has added it to their own local schema that is not yet deployed.
+              <Trans
+                t={t}
+                i18nKey="inputs.array.error.current-schema-not-declare-description"
+                components={[<code key={0}>{typeName}</code>]}
+                values={{typeName: typeName}}
+              />
             </Text>
             <Box>
               <Text size={1}>
-                <BulbOutlineIcon /> You can still move or delete this item, but it cannot be edited
-                since the schema definition for its type is nowhere to be found.
+                <BulbOutlineIcon /> {t('inputs.array.error.can-delete-but-no-edit-description')}
               </Text>
             </Box>
             <Stack space={2}>
               <Text size={1} weight="semibold">
-                JSON representation of this item:
+                {t('inputs.array.error.json-representation-description')}
               </Text>
               <Card padding={2} overflow="auto" border>
                 <Code size={1} as="pre" language="json">
@@ -97,7 +108,12 @@ export function IncompatibleItemType(props: Props) {
 
           <Box flex={1}>
             <Text size={1} textOverflow="ellipsis">
-              Item of type <code>{typeName}</code> not valid for this list
+              <Trans
+                t={t}
+                i18nKey="inputs.array.error.type-is-incompatible-prompt"
+                components={[<code key={0}>{typeName}</code>]}
+                values={{typeName: typeName}}
+              />
             </Text>
           </Box>
         </Flex>

--- a/packages/sanity/src/core/form/members/array/MemberItemError.tsx
+++ b/packages/sanity/src/core/form/members/array/MemberItemError.tsx
@@ -1,14 +1,16 @@
 import React from 'react'
 
 import {ArrayItemError} from '../../store/types/memberErrors'
+import {useTranslation} from '../../../i18n'
 import {IncompatibleItemType} from './IncompatibleItemType'
 
 /** @internal */
 export function MemberItemError(props: {member: ArrayItemError}) {
   const {member} = props
+  const {t} = useTranslation()
 
   if (member.error.type === 'INVALID_ITEM_TYPE') {
     return <IncompatibleItemType value={member.error.value} />
   }
-  return <div>Unexpected Error: {member.error.type}</div>
+  return <div>{t('inputs.array.error.unexpected-error', {error: member.error.type})}</div>
 }

--- a/packages/sanity/src/core/form/members/array/items/ArrayOfObjectsItem.tsx
+++ b/packages/sanity/src/core/form/members/array/items/ArrayOfObjectsItem.tsx
@@ -24,6 +24,7 @@ import {isEmptyItem} from '../../../store/utils/isEmptyItem'
 import {useResolveInitialValueForType} from '../../../../store'
 import {resolveInitialArrayValues} from '../../common/resolveInitialArrayValues'
 import {createDescriptionId} from '../../common/createDescriptionId'
+import {useTranslation} from '../../../../i18n'
 
 /**
  *
@@ -58,6 +59,7 @@ export function ArrayOfObjectsItem(props: MemberItemProps) {
     renderItem,
     renderPreview,
   } = props
+  const {t} = useTranslation()
 
   const {
     onPathBlur,
@@ -119,8 +121,11 @@ export function ArrayOfObjectsItem(props: MemberItemProps) {
                 onChange(PatchEvent.from(result.patches))
               } else {
                 toast.push({
-                  title: `Could not resolve initial value`,
-                  description: `Unable to resolve initial value for type: ${result.schemaType.title}: ${result.error.message}.`,
+                  title: t('inputs.array.error.cannot-resolve-initial-value-title'),
+                  description: t('inputs.array.error.cannot-resolve-initial-value-description', {
+                    schemaTypeTitle: result.schemaType.title,
+                    errorMessage: result.error.message,
+                  }),
                   status: 'error',
                 })
               }
@@ -144,6 +149,7 @@ export function ArrayOfObjectsItem(props: MemberItemProps) {
       onPathFocus,
       resolveInitialValue,
       toast,
+      t,
     ],
   )
 

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -369,6 +369,10 @@ export const studioLocaleStrings = {
   'inputs.array.error.cannot-upload-unable-to-convert_other':
     "The following items can't be uploaded because there's no known conversion from content types to array item:",
 
+  /** Error label for toast when array could not resolve the initial value */
+  'inputs.array.error.cannot-resolve-initial-value-title':
+    'Unable to resolve initial value for type: {{schemaTypeTitle}}: {{errorMessage}}.',
+
   /** --- Workspace menu --- */
 
   /** Title for Workplaces dropdown menu */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -311,6 +311,9 @@ export const studioLocaleStrings = {
   /** Label for read only array fields */
   'inputs.array.read-only-label': 'This field is read-only',
 
+  /** Label for removing an array item action  */
+  'inputs.array.action.remove': 'Remove',
+
   /** Label for removing action when an array item has an error  */
   'inputs.array.action.remove-invalid-item': 'Remove',
 
@@ -332,8 +335,11 @@ export const studioLocaleStrings = {
    */
   'inputs.array.action.add-item-select-type': 'Add item...',
 
-  /** Label for removing an array item action  */
-  'inputs.array.action.remove': 'Remove',
+  /** Label for adding item before a specific array item */
+  'inputs.array.action.add-before': 'Add item before',
+
+  /** Label for adding item after a specific array item */
+  'inputs.array.action.add-after': 'Add item after',
 
   /** Error label for unexpected errors in the Array Input */
   'inputs.array.error.unexpected-error': `Unexpected Error: {{error}}`,

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -300,6 +300,14 @@ export const studioLocaleStrings = {
   /** Accessibility label for icon indicating that document does _not_ have any unpublished changes */
   'inputs.reference.preview.has-no-unpublished-changes-aria-label': 'No unpublished edits',
 
+  /** --- Array Input --- */
+
+  /** Label for removing action when an array item has an error  */
+  'inputs.array.action.remove-invalid-item': 'Remove',
+
+  /** Error label for unexpected errors in the Array Input */
+  'inputs.array.error.unexpected-error': `Unexpected Error: {{error}}`,
+
   /** --- Workspace menu --- */
 
   /** Title for Workplaces dropdown menu */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -361,6 +361,14 @@ export const studioLocaleStrings = {
   /** Error description to show how the item is being represented in the json format */
   'inputs.array.error.json-representation-description': 'JSON representation of this item:',
 
+  /** Error label for toast when trying to upload one array item of a type that cannot be converted to array */
+  'inputs.array.error.cannot-upload-unable-to-convert_one':
+    "The following item can't be uploaded because there's no known conversion from content type to array item:",
+
+  /** Error label for toast when trying to upload multiple array items of a type that cannot be converted to array */
+  'inputs.array.error.cannot-upload-unable-to-convert_other':
+    "The following items can't be uploaded because there's no known conversion from content types to array item:",
+
   /** --- Workspace menu --- */
 
   /** Title for Workplaces dropdown menu */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -348,11 +348,11 @@ export const studioLocaleStrings = {
   'inputs.array.error.type-is-incompatible-title': 'Why is this happening?',
 
   /** Error description for the array item tooltip that explains what the error means with more context */
-  'inputs.array.error.type-is-incompatible-prompt': `Item of type <0>{{typeName}}</0> not valid for this list`,
+  'inputs.array.error.type-is-incompatible-prompt': `Item of type <Code>{{typeName}}</Code> not valid for this list`,
 
   /** Error description for the array item tooltip that explains that the current type item is not valid for the list  */
   'inputs.array.error.current-schema-not-declare-description':
-    'The current schema does not declare items of type <0>{{typeName}}</0> as valid for this list. This could mean that the type has been removed as a valid item type, or that someone else has added it to their own local schema that is not yet deployed.',
+    'The current schema does not declare items of type <Code>{{typeName}}</Code> as valid for this list. This could mean that the type has been removed as a valid item type, or that someone else has added it to their own local schema that is not yet deployed.',
 
   /** Error description for the array item tooltip that explains that the current item can still be moved or deleted but not edited since the schema definition is not found */
   'inputs.array.error.can-delete-but-no-edit-description':
@@ -428,7 +428,7 @@ export const studioLocaleStrings = {
   'new-document.create-new-document-label': 'New document…',
 
   /** Message for when no results are found for a specific search query in the new document menu */
-  'new-document.no-results': 'No results for <0>{{searchQuery}}</0>',
+  'new-document.no-results': 'No results for <QueryString>{{searchQuery}}</QueryString>',
 
   /** Message for when there are no document type options in the new document menu */
   'new-document.no-document-types-found': 'No document types found',
@@ -634,7 +634,7 @@ export const studioLocaleStrings = {
   'search.action.toggle-filters-aria-label': 'Toggle filters',
 
   /** Label for instructions on how to use the search - displayed when no recent searches are available */
-  'search.instructions': 'Use <0></0> to refine your search',
+  'search.instructions': 'Use <ControlsIcon /> to refine your search',
 
   /** --- Help & Resources Menu --- */
 

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -302,6 +302,9 @@ export const studioLocaleStrings = {
 
   /** --- Array Input --- */
 
+  /** Label for when the array input doesn't have any items */
+  'inputs.array.no-items-label': 'No items',
+
   /** Label for removing action when an array item has an error  */
   'inputs.array.action.remove-invalid-item': 'Remove',
 

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -305,8 +305,20 @@ export const studioLocaleStrings = {
   /** Label for when the array input doesn't have any items */
   'inputs.array.no-items-label': 'No items',
 
+  /** Label for when the array input is resolving the initial value for the item */
+  'inputs.array.resolving-initial-value': 'Resolving initial value…',
+
   /** Label for removing action when an array item has an error  */
   'inputs.array.action.remove-invalid-item': 'Remove',
+
+  /** Label for duplicating an array item  */
+  'inputs.array.action.duplicate': 'Duplicate',
+
+  /** Label for viewing the item of a specific type */
+  'inputs.array.action.view': 'View {{itemTypeTitle}}',
+
+  /** Label for editing the item of a specific type */
+  'inputs.array.action.edit': 'Edit {{itemTypeTitle}}',
 
   /** Error label for unexpected errors in the Array Input */
   'inputs.array.error.unexpected-error': `Unexpected Error: {{error}}`,

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -308,17 +308,32 @@ export const studioLocaleStrings = {
   /** Label for when the array input is resolving the initial value for the item */
   'inputs.array.resolving-initial-value': 'Resolving initial value…',
 
+  /** Label for read only array fields */
+  'inputs.array.read-only-label': 'This field is read-only',
+
   /** Label for removing action when an array item has an error  */
   'inputs.array.action.remove-invalid-item': 'Remove',
 
   /** Label for duplicating an array item  */
   'inputs.array.action.duplicate': 'Duplicate',
 
-  /** Label for viewing the item of a specific type */
+  /** Label for viewing the item of a specific type, eg "View Person" */
   'inputs.array.action.view': 'View {{itemTypeTitle}}',
 
-  /** Label for editing the item of a specific type */
+  /** Label for editing the item of a specific type, eg "Edit Person" */
   'inputs.array.action.edit': 'Edit {{itemTypeTitle}}',
+
+  /** Label for adding array item action when the schema allows for only one schema type */
+  'inputs.array.action.add-item': 'Add item',
+
+  /**
+   * Label for adding one array item action when the schema allows for multiple schema types,
+   * eg. will prompt the user to select a type once triggered
+   */
+  'inputs.array.action.add-item-select-type': 'Add item...',
+
+  /** Label for removing an array item action  */
+  'inputs.array.action.remove': 'Remove',
 
   /** Error label for unexpected errors in the Array Input */
   'inputs.array.error.unexpected-error': `Unexpected Error: {{error}}`,

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -311,6 +311,23 @@ export const studioLocaleStrings = {
   /** Error label for unexpected errors in the Array Input */
   'inputs.array.error.unexpected-error': `Unexpected Error: {{error}}`,
 
+  /** Error title for when an item type within an array input is incompatible, used in the tooltip */
+  'inputs.array.error.type-is-incompatible-title': 'Why is this happening?',
+
+  /** Error description for the array item tooltip that explains what the error means with more context */
+  'inputs.array.error.type-is-incompatible-prompt': `Item of type <0>{{typeName}}</0> not valid for this list`,
+
+  /** Error description for the array item tooltip that explains that the current type item is not valid for the list  */
+  'inputs.array.error.current-schema-not-declare-description':
+    'The current schema does not declare items of type <0>{{typeName}}</0> as valid for this list. This could mean that the type has been removed as a valid item type, or that someone else has added it to their own local schema that is not yet deployed.',
+
+  /** Error description for the array item tooltip that explains that the current item can still be moved or deleted but not edited since the schema definition is not found */
+  'inputs.array.error.can-delete-but-no-edit-description':
+    'You can still move or delete this item, but it cannot be edited since the schema definition for its type is nowhere to be found.',
+
+  /** Error description to show how the item is being represented in the json format */
+  'inputs.array.error.json-representation-description': 'JSON representation of this item:',
+
   /** --- Workspace menu --- */
 
   /** Title for Workplaces dropdown menu */

--- a/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentList.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentList.tsx
@@ -2,10 +2,9 @@ import {Flex, Inline, Spinner, Text} from '@sanity/ui'
 import React, {useCallback} from 'react'
 import {CurrentUser} from '@sanity/types'
 import styled from 'styled-components'
-import {Trans} from 'react-i18next'
 import {CommandList} from '../../../../components'
 import {supportsTouch} from '../../../../util'
-import {useTranslation} from '../../../../i18n'
+import {Translate, useTranslation} from '../../../../i18n'
 import {NewDocumentOption, PreviewLayout} from './types'
 import {INLINE_PREVIEW_HEIGHT, NewDocumentListOption} from './NewDocumentListOption'
 
@@ -91,11 +90,11 @@ export function NewDocumentList(props: NewDocumentListProps) {
         sizing="border"
       >
         <Text align="center" muted size={1}>
-          <Trans
+          <Translate
             t={t}
             i18nKey="new-document.no-results"
-            components={[<QueryString key={0}>“{searchQuery}”</QueryString>]}
-            values={{searchQuery: searchQuery}}
+            components={{QueryString: ({children}) => <QueryString>{children}</QueryString>}}
+            values={{searchQuery}}
           />
         </Text>
       </ContentFlex>

--- a/packages/sanity/src/core/studio/components/navbar/search/components/Instructions.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/Instructions.tsx
@@ -1,8 +1,7 @@
 import {ControlsIcon} from '@sanity/icons'
 import {Flex, Inline, Text} from '@sanity/ui'
 import React from 'react'
-import {Trans} from 'react-i18next'
-import {useTranslation} from '../../../../../i18n'
+import {Translate, useTranslation} from '../../../../../i18n'
 
 export function Instructions() {
   const {t} = useTranslation()
@@ -11,10 +10,12 @@ export function Instructions() {
     <Flex align="center" direction="column" gap={4} paddingX={4} paddingY={5}>
       <Inline space={3}>
         <Text muted>
-          <Trans
+          <Translate
             t={t}
             i18nKey="search.instructions"
-            components={[<ControlsIcon key={0} style={{padding: '0 0.25rem'}} />]}
+            components={{
+              ControlsIcon: () => <ControlsIcon key={0} style={{padding: '0 0.25rem'}} />,
+            }}
           />
         </Text>
       </Inline>

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/reference/ReferenceAutocomplete.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/reference/ReferenceAutocomplete.tsx
@@ -2,7 +2,6 @@ import type {ReferenceValue} from '@sanity/types'
 import {Autocomplete, Box, Flex, Popover, Text} from '@sanity/ui'
 import React, {forwardRef, ReactElement, useCallback, useId, useMemo, useRef, useState} from 'react'
 import styled from 'styled-components'
-import {Trans} from 'react-i18next'
 import {useSchema} from '../../../../../../../../../hooks'
 import type {SearchableType, WeightedHit} from '../../../../../../../../../search'
 import {getPublishedId} from '../../../../../../../../../util'
@@ -11,7 +10,7 @@ import {useSearchState} from '../../../../../contexts/search/useSearchState'
 import {useSearch} from '../../../../../hooks/useSearch'
 import {getDocumentTypesTruncated} from '../../../../../utils/documentTypesTruncated'
 import {SearchResultItem} from '../../../../searchResults/item/SearchResultItem'
-import {useTranslation} from '../../../../../../../../../i18n'
+import {Translate, useTranslation} from '../../../../../../../../../i18n'
 
 interface SearchHit {
   hit: WeightedHit
@@ -167,11 +166,13 @@ export const ReferenceAutocomplete = forwardRef(function ReferenceAutocomplete(
                     <Box padding={4}>
                       <Flex align="center" height="fill" justify="center">
                         <StyledText align="center" muted>
-                          <Trans
+                          <Translate
                             t={t}
                             i18nKey="new-document.no-results"
-                            components={[<strong key={0}>“{searchState.terms.query}”</strong>]}
                             values={{searchQuery: searchState.terms.query}}
+                            components={{
+                              QueryString: ({children}) => <strong>{children}</strong>,
+                            }}
                           />
                         </StyledText>
                       </Flex>


### PR DESCRIPTION
### Description

Convert array input strings to use i18n primitives

~~TO DO still in PR:~~

~~ArrayOfPrimitivesInput~~
- ~~ArrayOfPrimitivesInput (class, can’t use the hook, not sure where to send in the prop from)~~
- ~~getEmptyValue (tried sending the t in through params, but used in ArrayOfPrimitives which is a class)~~


