### PR TITLE
fix(portable-text-editor): fix empty placeholder placement for webkit

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -158,9 +158,9 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
       if (renderPlaceholder && lProps.leaf.placeholder && lProps.text.text === '') {
         return (
           <>
-            <div style={PLACEHOLDER_STYLE} contentEditable={false}>
+            <span style={PLACEHOLDER_STYLE} contentEditable={false}>
               {renderPlaceholder()}
-            </div>
+            </span>
             {rendered}
           </>
         )

--- a/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditor.test.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditor.test.tsx
@@ -65,12 +65,12 @@ describe('initialization', () => {
                     <span
                       data-slate-node="text"
                     >
-                      <div
+                      <span
                         contenteditable="false"
                         style="opacity: 0.5; position: absolute; user-select: none; pointer-events: none;"
                       >
                         Jot something down here
-                      </div>
+                      </span>
                       <span
                         data-slate-leaf="true"
                       >


### PR DESCRIPTION
### Description
On WebKit the 'Empty' placeholder for the Portable Text Editor is oddly placed. Changing the container from a `div` to a `span` will fix that.

Before:
![image](https://github.com/sanity-io/sanity/assets/373403/22f602f9-3b2b-41c5-b2c7-004552d00c9b)

Now:
![image](https://github.com/sanity-io/sanity/assets/373403/77e8021e-ea97-417c-9a8b-0b974df54612)


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
That it looks the same on the supported browsers.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Fixed odd placement of "Empty" placeholder in the Portable Text Editor on WebKit browsers.
<!--
A description of the change(s) that should be used in the release notes.
-->
