### PR TITLE
feature(schema): improve validation of block members

### DIFF
--- a/packages/@sanity/schema/src/sanity/coreTypes.ts
+++ b/packages/@sanity/schema/src/sanity/coreTypes.ts
@@ -14,6 +14,7 @@ const coreTypes = [
   {name: 'reference', jsonType: 'object', type: 'type'},
   {name: 'crossDatasetReference', jsonType: 'object', type: 'type'},
   {name: 'slug', jsonType: 'object', type: 'type'},
+  {name: 'span', jsonType: 'object', type: 'type'},
   {name: 'string', jsonType: 'string', type: 'type'},
   {name: 'telephone', jsonType: 'string', type: 'type'},
   {name: 'text', jsonType: 'string', type: 'type'},

--- a/packages/@sanity/schema/test/validation/validation.test.ts
+++ b/packages/@sanity/schema/test/validation/validation.test.ts
@@ -1,12 +1,5 @@
 import {flatten} from 'lodash'
-import {traverseSchema} from '../../src/core/traverseSchema'
 import {validateSchema} from '../../src/sanity/validateSchema'
-import array from '../../src/sanity/validation/types/array'
-import block from '../../src/sanity/validation/types/block'
-import file from '../../src/sanity/validation/types/file'
-import image from '../../src/sanity/validation/types/image'
-import object from '../../src/sanity/validation/types/object'
-import reference from '../../src/sanity/validation/types/reference'
 
 describe('Validation test', () => {
   test('assigns/populates `_problems` property', () => {
@@ -27,21 +20,7 @@ describe('Validation test', () => {
       },
     ]
 
-    const coreTypes = [
-      {name: 'array', type: 'type'},
-      {name: 'string', type: 'type'},
-      {name: 'object', type: 'type'},
-    ]
-
-    const visitors = {
-      array: {visit: array},
-      object: {visit: object},
-    }
-
-    const validation = traverseSchema(schemaDef, coreTypes, (typeDef, visitorContext) => {
-      const visitor = visitors[typeDef.type]
-      return visitor ? visitor.visit(typeDef, visitorContext) : typeDef
-    })
+    const validation = validateSchema(schemaDef)
 
     const myArray = validation.get('myArray')
     expect(myArray._problems.length).toBeGreaterThan(0)
@@ -150,28 +129,8 @@ describe('Validation test', () => {
         ],
       },
     ]
-    const coreTypes = [
-      {name: 'array', type: 'type'},
-      {name: 'object', type: 'type'},
-      {name: 'block', type: 'type'},
-      {name: 'reference', type: 'type'},
-      {name: 'image', type: 'type'},
-      {name: 'file', type: 'type'},
-    ]
 
-    const visitors = {
-      array: {visit: array},
-      object: {visit: object},
-      block: {visit: block},
-      reference: {visit: reference},
-      image: {visit: image},
-      file: {visit: file},
-    }
-
-    const validation = traverseSchema(schemaDef, coreTypes, (typeDef, visitorContext) => {
-      const visitor = visitors[typeDef.type]
-      return visitor ? visitor.visit(typeDef, visitorContext) : typeDef
-    })
+    const validation = validateSchema(schemaDef)
 
     const validObjectResult = validation.get('validObject')
     expect(validObjectResult._problems).toHaveLength(0)
@@ -180,7 +139,7 @@ describe('Validation test', () => {
     const problems = flatten(
       invalidObjectResult.fields[0].of[0].of.map((item) => item._problems),
     ).filter(Boolean)
-    expect(problems).toHaveLength(6)
+    expect(problems).toHaveLength(7)
     expect(problems[0]).toMatchObject({
       severity: 'error',
       helpId: 'schema-array-of-type-builtin-type-conflict',
@@ -202,6 +161,10 @@ describe('Validation test', () => {
       helpId: 'schema-array-of-type-global-type-conflict',
     })
     expect(problems[5]).toMatchObject({
+      severity: 'warning',
+      helpId: 'schema-array-of-type-global-type-conflict',
+    })
+    expect(problems[6]).toMatchObject({
       severity: 'error',
       helpId: 'schema-array-of-type-builtin-type-conflict',
     })

--- a/packages/@sanity/schema/test/validation/validation.test.ts
+++ b/packages/@sanity/schema/test/validation/validation.test.ts
@@ -1,7 +1,12 @@
+import {flatten} from 'lodash'
 import {traverseSchema} from '../../src/core/traverseSchema'
 import {validateSchema} from '../../src/sanity/validateSchema'
-import object from '../../src/sanity/validation/types/object'
 import array from '../../src/sanity/validation/types/array'
+import block from '../../src/sanity/validation/types/block'
+import file from '../../src/sanity/validation/types/file'
+import image from '../../src/sanity/validation/types/image'
+import object from '../../src/sanity/validation/types/object'
+import reference from '../../src/sanity/validation/types/reference'
 
 describe('Validation test', () => {
   test('assigns/populates `_problems` property', () => {
@@ -87,6 +92,118 @@ describe('Validation test', () => {
     expect(invalidObjectResult._problems[0]).toMatchObject({
       severity: 'error',
       helpId: 'schema-standalone-block-type',
+    })
+  })
+
+  test('validate block members as object like', () => {
+    const schemaDef = [
+      {
+        title: 'Valid object',
+        name: 'validObject',
+        type: 'object',
+        fields: [
+          {
+            title: 'Blocks',
+            name: 'blocks',
+            type: 'array',
+            of: [{type: 'block', of: [{type: 'image', name: 'myImage'}]}],
+          },
+        ],
+      },
+      {
+        title: 'Invalid object',
+        name: 'invalidObject',
+        type: 'object',
+        fields: [
+          {
+            title: 'Blocks',
+            name: 'blocks',
+            type: 'array',
+            of: [
+              {
+                type: 'block',
+                of: [
+                  // Should produce error
+                  {type: 'string', name: 'foo'},
+                  // Should produce warning
+                  {type: 'object', name: 'validObject', fields: [{type: 'string', name: 'foo'}]},
+                  // Should be allowed
+                  {type: 'image', name: 'image'},
+                  // Should be allowed
+                  {type: 'reference', name: 'reference', to: {type: 'author'}},
+                  // Should produce warning
+                  {type: 'object', name: 'reference', fields: [{type: 'string', name: 'foo'}]},
+                  // Should produce warning
+                  {type: 'object', name: 'image', fields: [{type: 'string', name: 'foo'}]},
+                  // Should produce warning
+                  {type: 'object', name: 'file', fields: [{type: 'string', name: 'foo'}]},
+                  // Should produce warning
+                  {type: 'object', name: 'span', fields: [{type: 'string', name: 'foo'}]},
+                  // Should not be allowed
+                  {type: 'span', name: 'something', fields: [{type: 'string', name: 'foo'}]},
+                  // Should be allowed
+                  {type: 'reference', name: 'reference', to: {type: 'author'}},
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ]
+    const coreTypes = [
+      {name: 'array', type: 'type'},
+      {name: 'object', type: 'type'},
+      {name: 'block', type: 'type'},
+      {name: 'reference', type: 'type'},
+      {name: 'image', type: 'type'},
+      {name: 'file', type: 'type'},
+    ]
+
+    const visitors = {
+      array: {visit: array},
+      object: {visit: object},
+      block: {visit: block},
+      reference: {visit: reference},
+      image: {visit: image},
+      file: {visit: file},
+    }
+
+    const validation = traverseSchema(schemaDef, coreTypes, (typeDef, visitorContext) => {
+      const visitor = visitors[typeDef.type]
+      return visitor ? visitor.visit(typeDef, visitorContext) : typeDef
+    })
+
+    const validObjectResult = validation.get('validObject')
+    expect(validObjectResult._problems).toHaveLength(0)
+
+    const invalidObjectResult = validation.get('invalidObject')
+    const problems = flatten(
+      invalidObjectResult.fields[0].of[0].of.map((item) => item._problems),
+    ).filter(Boolean)
+    expect(problems).toHaveLength(6)
+    expect(problems[0]).toMatchObject({
+      severity: 'error',
+      helpId: 'schema-array-of-type-builtin-type-conflict',
+    })
+    expect(problems[1]).toMatchObject({
+      severity: 'warning',
+      helpId: 'schema-array-of-type-global-type-conflict',
+    })
+    expect(problems[2]).toMatchObject({
+      severity: 'warning',
+      helpId: 'schema-array-of-type-global-type-conflict',
+    })
+    expect(problems[3]).toMatchObject({
+      severity: 'warning',
+      helpId: 'schema-array-of-type-global-type-conflict',
+    })
+    expect(problems[4]).toMatchObject({
+      severity: 'warning',
+      helpId: 'schema-array-of-type-global-type-conflict',
+    })
+    expect(problems[5]).toMatchObject({
+      severity: 'error',
+      helpId: 'schema-array-of-type-builtin-type-conflict',
     })
   })
 })


### PR DESCRIPTION
### Description

Block members can not be given a type that is not an object-like type, but nothing is stopping you today and can lead to strange errors.

For instance, a type like `{type: 'string'}` doesn't make sense inside block children, as they have to be wrapped in an object. We do however have core types that are object-like, like image, file, and reference that should be
supported.

We also have the core type 'span', which I have included in the core types in this PR (I think it was an oversight). This should however not be supported here (as it's injected automatically into the schema). Thus we also need
an allow list for those core object types that actually are supported.

I have identified the following supported core types for the block schema type `of`:
```
['file', 'image', 'object', 'reference']
```

Also, previously defined object types can be used here with a shorthand, like:  `{type: 'author'}` like before.

Everything else will lead to a validation error like this:

![image](https://github.com/sanity-io/sanity/assets/373403/e4bea0e1-1a94-4709-8f3f-cae74783ea97)

I have also added a rule that will check that the name of an object definition here is not the same as any previously defined types (like we do with arrays). This is only a warning though.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Is the error message ok? Do we need a special help article?

Check that we have allowed all the supported object-like types and report problems on the unsupported ones.

I have written some tests for this in the `@sanity/schema` package, but it should be tested e2e also because
the code path is quite different.

We can write e2e tests for this as well with playwright-ct for the PortableText Input.

You can test it out in the studio by making schemas like this:

```ts
defineField({
  title: 'Blocks',
  name: 'blocks',
  type: 'array',
  of: [
    {
      type: 'block',
      of: [
        // Should produce error
        {type: 'string', name: 'foo'},
        // Should produce warning
        {type: 'object', name: 'validObject', fields: [{type: 'string', name: 'foo'}]},
        // Should be allowed
        {type: 'image', name: 'image'},
        // Should be allowed
        {type: 'reference', name: 'reference', to: {type: 'author'}},
        // Should produce warning
        {type: 'object', name: 'reference', fields: [{type: 'string', name: 'foo'}]},
        // Should produce warning
        {type: 'object', name: 'image', fields: [{type: 'string', name: 'foo'}]},
        // Should produce warning
        {type: 'object', name: 'file', fields: [{type: 'string', name: 'foo'}]},
        // Should produce warning
        {type: 'object', name: 'span', fields: [{type: 'string', name: 'foo'}]},
        // Should not be allowed
        {type: 'span', name: 'something', fields: [{type: 'string', name: 'foo'}]},
        // Should be allowed
        {type: 'reference', name: 'reference', to: {type: 'author'}},
      ],
    },
  ],
}),
```
This should now fail because the type `string` is a core type that is not object-like.

Even though the `span` type is a core object-like type, it is not supported because it
isn't in the allow-list of core object types that are supported.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling are affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Improve validation of block schema members

<!--
A description of the change(s) that should be used in the release notes.
-->
