### PR TITLE
fix(form/inputs): Track focusPath for a span's .text prop + harden test condition

### DIFF
--- a/packages/sanity/playwright-ct/tests/formBuilder/ArrayInputStory.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/ArrayInputStory.tsx
@@ -1,6 +1,7 @@
 import {defineField, defineType} from '@sanity/types'
 import React from 'react'
 import {TestWrapper} from './utils/TestWrapper'
+import {TestForm} from './utils/TestForm'
 
 const SCHEMA_TYPES = [
   defineType({
@@ -20,7 +21,11 @@ const SCHEMA_TYPES = [
 ]
 
 export function ArrayInputStory() {
-  return <TestWrapper schemaTypes={SCHEMA_TYPES} />
+  return (
+    <TestWrapper schemaTypes={SCHEMA_TYPES}>
+      <TestForm />
+    </TestWrapper>
+  )
 }
 
 export default ArrayInputStory

--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/AnnotationsStory.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/AnnotationsStory.tsx
@@ -1,6 +1,7 @@
 import {defineArrayMember, defineField, defineType} from '@sanity/types'
 import React from 'react'
 import {TestWrapper} from '../../utils/TestWrapper'
+import {TestForm} from '../../utils/TestForm'
 
 const SCHEMA_TYPES = [
   defineType({
@@ -22,7 +23,11 @@ const SCHEMA_TYPES = [
 ]
 
 export function AnnotationsStory() {
-  return <TestWrapper schemaTypes={SCHEMA_TYPES} />
+  return (
+    <TestWrapper schemaTypes={SCHEMA_TYPES}>
+      <TestForm />
+    </TestWrapper>
+  )
 }
 
 export default AnnotationsStory

--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/DecoratorsStory.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/DecoratorsStory.tsx
@@ -2,6 +2,7 @@ import {defineArrayMember, defineField, defineType} from '@sanity/types'
 import React from 'react'
 import {BulbOutlineIcon} from '@sanity/icons'
 import {TestWrapper} from '../../utils/TestWrapper'
+import {TestForm} from '../../utils/TestForm'
 
 const SCHEMA_TYPES = [
   defineType({
@@ -35,7 +36,11 @@ const SCHEMA_TYPES = [
 ]
 
 export function DecoratorsStory() {
-  return <TestWrapper schemaTypes={SCHEMA_TYPES} />
+  return (
+    <TestWrapper schemaTypes={SCHEMA_TYPES}>
+      <TestForm />
+    </TestWrapper>
+  )
 }
 
 export default DecoratorsStory

--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/FocusTracking.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/FocusTracking.spec.tsx
@@ -58,12 +58,11 @@ test.describe('Portable Text Input', () => {
   })
   test.describe('Should track focusPath', () => {
     test(`for span .text`, async ({mount, page}) => {
+      const initialPath = ['body', {_key: 'c'}, 'children', {_key: 'd'}, 'text']
       const component = await mount(
-        <FocusTrackingStory
-          document={document}
-          focusPath={['body', {_key: 'c'}, 'children', {_key: 'd'}, 'text']}
-        />,
+        <FocusTrackingStory document={document} focusPath={initialPath} />,
       )
+      await waitForFocusPath(page, initialPath)
       const $portableTextInput = component.getByTestId('field-body')
       const $pteTextbox = $portableTextInput.getByRole('textbox')
       await expect($pteTextbox).toBeFocused()
@@ -72,12 +71,11 @@ test.describe('Portable Text Input', () => {
       expect(await getFocusedNodeText(page)).toEqual('Baz')
     })
     test(`for span child root`, async ({mount, page}) => {
+      const initialPath = ['body', {_key: 'c'}, 'children', {_key: 'd'}]
       const component = await mount(
-        <FocusTrackingStory
-          document={document}
-          focusPath={['body', {_key: 'c'}, 'children', {_key: 'd'}]}
-        />,
+        <FocusTrackingStory document={document} focusPath={initialPath} />,
       )
+      await waitForFocusPath(page, initialPath)
       const $portableTextInput = component.getByTestId('field-body')
       const $pteTextbox = $portableTextInput.getByRole('textbox')
       await expect($pteTextbox).toBeFocused()
@@ -86,12 +84,11 @@ test.describe('Portable Text Input', () => {
       expect(await getFocusedNodeText(page)).toEqual('Baz')
     })
     test(`for inline objects with .text prop`, async ({mount, page}) => {
+      const initialPath = ['body', {_key: 'g'}, 'children', {_key: 'i'}, 'text']
       const component = await mount(
-        <FocusTrackingStory
-          document={document}
-          focusPath={['body', {_key: 'g'}, 'children', {_key: 'i'}, 'text']}
-        />,
+        <FocusTrackingStory document={document} focusPath={initialPath} />,
       )
+      await waitForFocusPath(page, initialPath)
       const $portableTextInput = component.getByTestId('field-body')
       const $pteTextbox = $portableTextInput.getByRole('textbox')
       await expect($pteTextbox).not.toBeFocused()
@@ -101,9 +98,11 @@ test.describe('Portable Text Input', () => {
       await expect($pteTextbox).toBeFocused()
     })
     test(`for object blocks with .text prop`, async ({mount, page}) => {
+      const initialPath = ['body', {_key: 'k'}, 'text']
       const component = await mount(
-        <FocusTrackingStory document={document} focusPath={['body', {_key: 'k'}, 'text']} />,
+        <FocusTrackingStory document={document} focusPath={initialPath} />,
       )
+      await waitForFocusPath(page, initialPath)
       const $portableTextInput = component.getByTestId('field-body')
       const $pteTextbox = $portableTextInput.getByRole('textbox')
       await expect($pteTextbox).not.toBeFocused()
@@ -111,9 +110,11 @@ test.describe('Portable Text Input', () => {
       await expect(blockObjectInput).toBeFocused()
     })
     test(`for block paths`, async ({mount, page}) => {
+      const initialPath = ['body', {_key: 'k'}]
       const component = await mount(
-        <FocusTrackingStory document={document} focusPath={['body', {_key: 'k'}]} />,
+        <FocusTrackingStory document={document} focusPath={initialPath} />,
       )
+      await waitForFocusPath(page, initialPath)
       const $portableTextInput = component.getByTestId('field-body')
       const $pteTextbox = $portableTextInput.getByRole('textbox')
       await expect($pteTextbox).not.toBeFocused()
@@ -133,6 +134,11 @@ async function setFocusPathFromOutside(page: Page, path: Path) {
     },
     {_path: path},
   )
+  await waitForFocusPath(page, path)
+}
+
+// Make sure the focusPath is propagated before we start testing on it
+async function waitForFocusPath(page: Page, path: Path) {
   await page.waitForSelector(`[data-focus-path='${JSON.stringify(path)}']`)
 }
 

--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/FocusTracking.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/FocusTracking.spec.tsx
@@ -1,0 +1,141 @@
+/* eslint-disable max-nested-callbacks */
+import {expect, test} from '@playwright/experimental-ct-react'
+import React from 'react'
+import {Path, SanityDocument} from '@sanity/types'
+import {Page} from '@playwright/test'
+import FocusTrackingStory from './FocusTrackingStory'
+
+export type UpdateFn = () => {focusPath: Path; document: SanityDocument}
+
+const document: SanityDocument = {
+  _id: '123',
+  _type: 'test',
+  _createdAt: new Date().toISOString(),
+  _updatedAt: new Date().toISOString(),
+  _rev: '123',
+  body: [
+    {
+      _type: 'block',
+      _key: 'a',
+      children: [{_type: 'span', _key: 'b', text: 'Foo'}],
+      markDefs: [],
+    },
+    {
+      _type: 'block',
+      _key: 'c',
+      children: [{_type: 'span', _key: 'd', text: 'Bar'}],
+      markDefs: [],
+    },
+    {
+      _type: 'block',
+      _key: 'e',
+      children: [{_type: 'span', _key: 'f', text: 'Baz'}],
+      markDefs: [],
+    },
+    {
+      _type: 'block',
+      _key: 'g',
+      children: [
+        {_type: 'span', _key: 'h', text: 'Hello '},
+        {_type: 'inlineObjectWithTextProperty', _key: 'i', text: 'there'},
+        {_type: 'span', _key: 'j', text: ' playwright'},
+      ],
+      markDefs: [],
+    },
+    {
+      _type: 'testObjectBlock',
+      _key: 'k',
+      text: 'Hello world',
+    },
+  ],
+}
+
+test.describe('Portable Text Input', () => {
+  test.beforeEach(async ({page}) => {
+    await page.evaluate(() => {
+      window.localStorage.debug = 'sanity-pte:*'
+    })
+  })
+  test.describe('Should track focusPath', () => {
+    test(`for span .text`, async ({mount, page}) => {
+      const component = await mount(
+        <FocusTrackingStory
+          document={document}
+          focusPath={['body', {_key: 'c'}, 'children', {_key: 'd'}, 'text']}
+        />,
+      )
+      const $portableTextInput = component.getByTestId('field-body')
+      const $pteTextbox = $portableTextInput.getByRole('textbox')
+      await expect($pteTextbox).toBeFocused()
+      expect(await getFocusedNodeText(page)).toEqual('Bar')
+      await setFocusPathFromOutside(page, ['body', {_key: 'e'}, 'children', {_key: 'f'}, 'text'])
+      expect(await getFocusedNodeText(page)).toEqual('Baz')
+    })
+    test(`for span child root`, async ({mount, page}) => {
+      const component = await mount(
+        <FocusTrackingStory
+          document={document}
+          focusPath={['body', {_key: 'c'}, 'children', {_key: 'd'}]}
+        />,
+      )
+      const $portableTextInput = component.getByTestId('field-body')
+      const $pteTextbox = $portableTextInput.getByRole('textbox')
+      await expect($pteTextbox).toBeFocused()
+      expect(await getFocusedNodeText(page)).toEqual('Bar')
+      await setFocusPathFromOutside(page, ['body', {_key: 'e'}, 'children', {_key: 'f'}])
+      expect(await getFocusedNodeText(page)).toEqual('Baz')
+    })
+    test(`for inline objects with .text prop`, async ({mount, page}) => {
+      const component = await mount(
+        <FocusTrackingStory
+          document={document}
+          focusPath={['body', {_key: 'g'}, 'children', {_key: 'i'}, 'text']}
+        />,
+      )
+      const $portableTextInput = component.getByTestId('field-body')
+      const $pteTextbox = $portableTextInput.getByRole('textbox')
+      await expect($pteTextbox).not.toBeFocused()
+      const inlineObjectTextInput = page.getByTestId('inlineTextInputField').getByRole('textbox')
+      await expect(inlineObjectTextInput).toBeFocused()
+      await setFocusPathFromOutside(page, ['body', {_key: 'e'}, 'children', {_key: 'f'}])
+      await expect($pteTextbox).toBeFocused()
+    })
+    test(`for object blocks with .text prop`, async ({mount, page}) => {
+      const component = await mount(
+        <FocusTrackingStory document={document} focusPath={['body', {_key: 'k'}, 'text']} />,
+      )
+      const $portableTextInput = component.getByTestId('field-body')
+      const $pteTextbox = $portableTextInput.getByRole('textbox')
+      await expect($pteTextbox).not.toBeFocused()
+      const blockObjectInput = page.getByTestId('objectBlockInputField').getByRole('textbox')
+      await expect(blockObjectInput).toBeFocused()
+    })
+    test(`for block paths`, async ({mount, page}) => {
+      const component = await mount(
+        <FocusTrackingStory document={document} focusPath={['body', {_key: 'k'}]} />,
+      )
+      const $portableTextInput = component.getByTestId('field-body')
+      const $pteTextbox = $portableTextInput.getByRole('textbox')
+      await expect($pteTextbox).not.toBeFocused()
+      const blockObjectInput = page.getByTestId('objectBlockInputField').getByRole('textbox')
+      await expect(blockObjectInput).toBeVisible()
+      await setFocusPathFromOutside(page, ['body', {_key: 'g'}])
+      await expect($pteTextbox).toBeFocused()
+      await expect(blockObjectInput).not.toBeVisible()
+    })
+  })
+})
+
+async function setFocusPathFromOutside(page: Page, path: Path) {
+  await page.evaluate(
+    ({_path}) => {
+      ;(window as any).__setFocusPath(_path)
+    },
+    {_path: path},
+  )
+  await page.waitForSelector(`[data-focus-path='${JSON.stringify(path)}']`)
+}
+
+function getFocusedNodeText(page: Page) {
+  return page.evaluate(() => window.getSelection()?.focusNode?.textContent)
+}

--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/FocusTrackingStory.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/FocusTrackingStory.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-no-bind */
 import {Path, defineArrayMember, defineField, defineType} from '@sanity/types'
-import React, {useEffect, useState} from 'react'
+import React from 'react'
 import {SanityDocument} from '@sanity/client'
 import {TestWrapper} from '../../utils/TestWrapper'
 import {TestForm} from '../../utils/TestForm'
@@ -56,27 +56,16 @@ const SCHEMA_TYPES = [
 ]
 
 export function FocusTrackingStory({
-  focusPath: focusPathFromProps,
+  focusPath,
   document,
 }: {
   focusPath?: Path
   document?: SanityDocument
 }) {
-  const [focusPath, setFocusPath] = useState<Path>(focusPathFromProps || [])
-  useEffect(() => {
-    ;(window as any).__setFocusPath = (path: Path) => {
-      setFocusPath(path)
-    }
-    return () => {
-      ;(window as any).__setFocusPath = undefined
-    }
-  }, [])
   return (
-    <div data-focus-path={JSON.stringify(focusPath)}>
-      <TestWrapper schemaTypes={SCHEMA_TYPES}>
-        <TestForm document={document} focusPath={focusPath} />
-      </TestWrapper>
-    </div>
+    <TestWrapper schemaTypes={SCHEMA_TYPES}>
+      <TestForm document={document} focusPath={focusPath} />
+    </TestWrapper>
   )
 }
 

--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/FocusTrackingStory.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/FocusTrackingStory.tsx
@@ -3,6 +3,7 @@ import {Path, defineArrayMember, defineField, defineType} from '@sanity/types'
 import React, {useEffect, useState} from 'react'
 import {SanityDocument} from '@sanity/client'
 import {TestWrapper} from '../../utils/TestWrapper'
+import {TestForm} from '../../utils/TestForm'
 
 const SCHEMA_TYPES = [
   defineType({
@@ -72,7 +73,9 @@ export function FocusTrackingStory({
   }, [])
   return (
     <div data-focus-path={JSON.stringify(focusPath)}>
-      <TestWrapper schemaTypes={SCHEMA_TYPES} focusPath={focusPath} document={document} />
+      <TestWrapper schemaTypes={SCHEMA_TYPES}>
+        <TestForm document={document} focusPath={focusPath} />
+      </TestWrapper>
     </div>
   )
 }

--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/FocusTrackingStory.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/FocusTrackingStory.tsx
@@ -1,0 +1,80 @@
+/* eslint-disable react/jsx-no-bind */
+import {Path, defineArrayMember, defineField, defineType} from '@sanity/types'
+import React, {useEffect, useState} from 'react'
+import {SanityDocument} from '@sanity/client'
+import {TestWrapper} from '../../utils/TestWrapper'
+
+const SCHEMA_TYPES = [
+  defineType({
+    type: 'document',
+    name: 'test',
+    title: 'Test',
+    fields: [
+      defineField({
+        type: 'array',
+        name: 'body',
+        of: [
+          defineArrayMember({
+            type: 'block',
+            of: [
+              defineArrayMember({
+                type: 'object',
+                name: 'inlineObjectWithTextProperty',
+                fields: [
+                  defineField({
+                    type: 'string',
+                    name: 'text',
+                    components: {
+                      input: (inputProps) => (
+                        <div data-testid="inlineTextInputField">
+                          {inputProps.renderDefault(inputProps)}
+                        </div>
+                      ),
+                    },
+                  }),
+                ],
+              }),
+            ],
+          }),
+          defineArrayMember({
+            type: 'object',
+            name: 'testObjectBlock',
+            fields: [{type: 'string', name: 'text'}],
+            components: {
+              input: (inputProps) => (
+                <div data-testid="objectBlockInputField">
+                  {inputProps.renderDefault(inputProps)}
+                </div>
+              ),
+            },
+          }),
+        ],
+      }),
+    ],
+  }),
+]
+
+export function FocusTrackingStory({
+  focusPath: focusPathFromProps,
+  document,
+}: {
+  focusPath?: Path
+  document?: SanityDocument
+}) {
+  const [focusPath, setFocusPath] = useState<Path>(focusPathFromProps || [])
+  useEffect(() => {
+    ;(window as any).__setFocusPath = (path: Path) => {
+      setFocusPath(path)
+    }
+    return () => {
+      ;(window as any).__setFocusPath = undefined
+    }
+  }, [])
+  return (
+    <div data-focus-path={JSON.stringify(focusPath)}>
+      <TestWrapper schemaTypes={SCHEMA_TYPES} focusPath={focusPath} document={document} />
+    </div>
+  )
+}
+
+export default FocusTrackingStory

--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/InputStory.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/InputStory.tsx
@@ -1,6 +1,7 @@
 import {defineArrayMember, defineField, defineType} from '@sanity/types'
 import React from 'react'
 import {TestWrapper} from '../../utils/TestWrapper'
+import {TestForm} from '../../utils/TestForm'
 
 const SCHEMA_TYPES = [
   defineType({
@@ -22,7 +23,11 @@ const SCHEMA_TYPES = [
 ]
 
 export function InputStory() {
-  return <TestWrapper schemaTypes={SCHEMA_TYPES} />
+  return (
+    <TestWrapper schemaTypes={SCHEMA_TYPES}>
+      <TestForm />
+    </TestWrapper>
+  )
 }
 
 export default InputStory

--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/ObjectBlockStory.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/ObjectBlockStory.tsx
@@ -2,6 +2,7 @@ import {defineArrayMember, defineField, defineType} from '@sanity/types'
 import React from 'react'
 import {Box, Text} from '@sanity/ui'
 import {TestWrapper} from '../../utils/TestWrapper'
+import {TestForm} from '../../utils/TestForm'
 import {PreviewProps} from 'sanity'
 
 // This is to emulate preview updates to the object without the preview store
@@ -73,7 +74,11 @@ const SCHEMA_TYPES = [
 ]
 
 export function ObjectBlockStory() {
-  return <TestWrapper schemaTypes={SCHEMA_TYPES} />
+  return (
+    <TestWrapper schemaTypes={SCHEMA_TYPES}>
+      <TestForm />
+    </TestWrapper>
+  )
 }
 
 export default ObjectBlockStory

--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/StylesStory.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/StylesStory.tsx
@@ -1,6 +1,7 @@
 import {defineArrayMember, defineField, defineType} from '@sanity/types'
 import React from 'react'
 import {TestWrapper} from '../../utils/TestWrapper'
+import {TestForm} from '../../utils/TestForm'
 
 const SCHEMA_TYPES = [
   defineType({
@@ -31,7 +32,11 @@ const SCHEMA_TYPES = [
   }),
 ]
 export function StylesStory() {
-  return <TestWrapper schemaTypes={SCHEMA_TYPES} />
+  return (
+    <TestWrapper schemaTypes={SCHEMA_TYPES}>
+      <TestForm />
+    </TestWrapper>
+  )
 }
 
 export default StylesStory

--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/ToolbarStory.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/ToolbarStory.tsx
@@ -1,6 +1,7 @@
 import {defineArrayMember, defineField, defineType} from '@sanity/types'
 import React from 'react'
 import {TestWrapper} from '../../utils/TestWrapper'
+import {TestForm} from '../../utils/TestForm'
 
 const SCHEMA_TYPES = [
   defineType({
@@ -56,7 +57,11 @@ const SCHEMA_TYPES = [
 ]
 
 export function ToolbarStory() {
-  return <TestWrapper schemaTypes={SCHEMA_TYPES} />
+  return (
+    <TestWrapper schemaTypes={SCHEMA_TYPES}>
+      <TestForm />
+    </TestWrapper>
+  )
 }
 
 export default ToolbarStory

--- a/packages/sanity/playwright-ct/tests/formBuilder/utils/TestForm.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/utils/TestForm.tsx
@@ -1,5 +1,5 @@
 import {Path, SanityDocument, ValidationContext, ValidationMarker} from '@sanity/types'
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import React, {useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react'
 import {validateDocument} from '../../../../src/core/validation'
 import {applyAll} from '../../../../src/core/form/patch/applyPatch'
 import {createMockSanityClient} from '../../mocks/createMockSanityClient'
@@ -18,21 +18,42 @@ import {
 
 const NOOP = () => null
 
-export function TestForm() {
+export function TestForm({
+  focusPath: focusPathFromProps,
+  document: documentFromProps,
+}: {
+  focusPath?: Path
+  document?: SanityDocument
+}) {
   const [validation, setValidation] = useState<ValidationMarker[]>([])
   const [openPath, onSetOpenPath] = useState<Path>([])
   const [fieldGroupState, onSetFieldGroupState] = useState<StateTree<string>>()
   const [collapsedPaths, onSetCollapsedPath] = useState<StateTree<boolean>>()
   const [collapsedFieldSets, onSetCollapsedFieldSets] = useState<StateTree<boolean>>()
-  const [document, setDocument] = useState<SanityDocument>({
-    _id: '123',
-    _type: 'test',
-    _createdAt: new Date().toISOString(),
-    _updatedAt: new Date().toISOString(),
-    _rev: '123',
-  })
-  const [focusPath, setFocusPath] = useState<Path>(() => ['title'])
+  const [document, setDocument] = useState<SanityDocument>(
+    documentFromProps || {
+      _id: '123',
+      _type: 'test',
+      _createdAt: new Date().toISOString(),
+      _updatedAt: new Date().toISOString(),
+      _rev: '123',
+    },
+  )
+  const [focusPath, setFocusPath] = useState<Path>(() => focusPathFromProps || [])
   const patchChannel = useMemo(() => createPatchChannel(), [])
+
+  useEffect(() => {
+    if (documentFromProps) {
+      setDocument(documentFromProps)
+    }
+  }, [documentFromProps])
+
+  useEffect(() => {
+    if (focusPathFromProps) {
+      setFocusPath(focusPathFromProps)
+      onSetOpenPath(focusPathFromProps)
+    }
+  }, [focusPathFromProps])
 
   useEffect(() => {
     patchChannel.publish({
@@ -59,11 +80,11 @@ export function TestForm() {
 
   const formState = useFormState(schemaType, {
     focusPath,
-    collapsedPaths: collapsedPaths,
-    collapsedFieldSets: collapsedFieldSets,
+    collapsedPaths,
+    collapsedFieldSets,
     comparisonValue: null,
-    fieldGroupState: fieldGroupState,
-    openPath: openPath,
+    fieldGroupState,
+    openPath,
     presence: EMPTY_ARRAY,
     validation,
     value: document,

--- a/packages/sanity/playwright-ct/tests/formBuilder/utils/TestForm.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/utils/TestForm.tsx
@@ -1,5 +1,5 @@
 import {Path, SanityDocument, ValidationContext, ValidationMarker} from '@sanity/types'
-import React, {useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react'
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {validateDocument} from '../../../../src/core/validation'
 import {applyAll} from '../../../../src/core/form/patch/applyPatch'
 import {createMockSanityClient} from '../../mocks/createMockSanityClient'

--- a/packages/sanity/playwright-ct/tests/formBuilder/utils/TestWrapper.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/utils/TestWrapper.tsx
@@ -6,7 +6,9 @@ import {createMockSanityClient} from '../../../../test/mocks/mockSanityClient'
 import {getMockWorkspace} from '../../../../test/testUtils/getMockWorkspaceFromConfig'
 import {TestForm} from './TestForm'
 import {
+  Path,
   ResourceCacheProvider,
+  SanityDocument,
   SchemaTypeDefinition,
   SourceProvider,
   Workspace,
@@ -17,7 +19,15 @@ import {
  * @description This component is used to wrap all tests in the providers it needs to be able to run successfully.
  * It provides a mock Sanity client and a mock workspace.
  */
-export const TestWrapper = ({schemaTypes}: {schemaTypes: SchemaTypeDefinition[]}) => {
+export const TestWrapper = ({
+  schemaTypes,
+  focusPath,
+  document,
+}: {
+  schemaTypes: SchemaTypeDefinition[]
+  focusPath?: Path
+  document?: SanityDocument
+}) => {
   const [mockWorkspace, setMockWorkspace] = useState<Workspace | null>(null)
 
   useEffect(() => {
@@ -54,7 +64,7 @@ export const TestWrapper = ({schemaTypes}: {schemaTypes: SchemaTypeDefinition[]}
                   <Pane id="test-pane">
                     <PaneContent>
                       <Card padding={3}>
-                        <TestForm />
+                        <TestForm focusPath={focusPath} document={document} />
                       </Card>
                     </PaneContent>
                   </Pane>

--- a/packages/sanity/playwright-ct/tests/formBuilder/utils/TestWrapper.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/utils/TestWrapper.tsx
@@ -4,11 +4,8 @@ import React, {useEffect, useState} from 'react'
 import {Pane, PaneContent, PaneLayout} from '../../../../src/desk/components'
 import {createMockSanityClient} from '../../../../test/mocks/mockSanityClient'
 import {getMockWorkspace} from '../../../../test/testUtils/getMockWorkspaceFromConfig'
-import {TestForm} from './TestForm'
 import {
-  Path,
   ResourceCacheProvider,
-  SanityDocument,
   SchemaTypeDefinition,
   SourceProvider,
   Workspace,
@@ -20,13 +17,11 @@ import {
  * It provides a mock Sanity client and a mock workspace.
  */
 export const TestWrapper = ({
+  children,
   schemaTypes,
-  focusPath,
-  document,
 }: {
+  children?: React.ReactNode
   schemaTypes: SchemaTypeDefinition[]
-  focusPath?: Path
-  document?: SanityDocument
 }) => {
   const [mockWorkspace, setMockWorkspace] = useState<Workspace | null>(null)
 
@@ -63,9 +58,7 @@ export const TestWrapper = ({
                 <PaneLayout height="fill">
                   <Pane id="test-pane">
                     <PaneContent>
-                      <Card padding={3}>
-                        <TestForm focusPath={focusPath} document={document} />
-                      </Card>
+                      <Card padding={3}>{children}</Card>
                     </PaneContent>
                   </Pane>
                 </PaneLayout>

--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -7,6 +7,7 @@ import {
   BlockRenderProps as EditorBlockRenderProps,
   BlockChildRenderProps as EditorChildRenderProps,
   BlockAnnotationRenderProps,
+  EditorSelection,
 } from '@sanity/portable-text-editor'
 import {Path, PortableTextBlock, PortableTextTextBlock} from '@sanity/types'
 import {Box, Portal, PortalProvider, useBoundaryElement, usePortal} from '@sanity/ui'
@@ -352,10 +353,38 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     ],
   )
   const ariaDescribedBy = props.elementProps['aria-describedby']
+
+  // Create an initial editor selection based on the focusPath
+  // at the time that the editor mounts. Any updates to the
+  // focusPath later will be handled by the useTrackFocusPath hook.
+  // The initial selection is handled explicitly as a separate
+  // prop to the Editable PTE component (initialSelection) so that
+  // selections can be set initially even though the editor value
+  // might not be fully propagated or rendered yet.
+  const initialSelection: EditorSelection | undefined = useMemo(() => {
+    // We can be sure that the focusPath is pointing directly to
+    // editor content when hasFocusWithin is true.
+    if (hasFocusWithin) {
+      return {
+        anchor: {
+          path: focusPath,
+          offset: 0,
+        },
+        focus: {
+          path: focusPath,
+          offset: 0,
+        },
+      }
+    }
+    return undefined
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []) // Only at mount time!
+
   const editorNode = useMemo(
     () => (
       <Editor
         ariaDescribedBy={ariaDescribedBy}
+        initialSelection={initialSelection}
         hasFocus={hasFocus}
         hotkeys={editorHotkeys}
         isActive={isActive}
@@ -377,21 +406,22 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
 
     // Keep only stable ones here!
     [
-      scrollElement,
-      editorHotkeys,
-      handleToggleFullscreen,
+      ariaDescribedBy,
+      initialSelection,
       hasFocus,
+      editorHotkeys,
+      isActive,
+      isFullscreen,
+      onItemOpen,
+      onCopy,
+      onPaste,
+      handleToggleFullscreen,
+      path,
+      readOnly,
       editorRenderAnnotation,
       editorRenderBlock,
       editorRenderChild,
-      isActive,
-      isFullscreen,
-      onCopy,
-      onItemOpen,
-      onPaste,
-      path,
-      readOnly,
-      ariaDescribedBy,
+      scrollElement,
     ],
   )
 

--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -26,7 +26,7 @@ import {useHotkeys} from './hooks/useHotKeys'
 import {useTrackFocusPath} from './hooks/useTrackFocusPath'
 
 interface InputProps extends ArrayOfObjectsInputProps<PortableTextBlock> {
-  hasFocus: boolean
+  hasFocusWithin: boolean
   hotkeys?: HotkeyOptions
   isActive: boolean
   isFullscreen: boolean
@@ -48,7 +48,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     changed,
     focused,
     focusPath = EMPTY_ARRAY,
-    hasFocus,
+    hasFocusWithin,
     hotkeys,
     isActive,
     isFullscreen,
@@ -385,7 +385,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       <Editor
         ariaDescribedBy={ariaDescribedBy}
         initialSelection={initialSelection}
-        hasFocus={hasFocus}
+        hasFocus={hasFocusWithin}
         hotkeys={editorHotkeys}
         isActive={isActive}
         isFullscreen={isFullscreen}
@@ -408,7 +408,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     [
       ariaDescribedBy,
       initialSelection,
-      hasFocus,
+      hasFocusWithin,
       editorHotkeys,
       isActive,
       isFullscreen,
@@ -453,7 +453,10 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
           isChanged={changed}
           path={path}
         >
-          <Root data-focused={hasFocus ? '' : undefined} data-read-only={readOnly ? '' : undefined}>
+          <Root
+            data-focused={hasFocusWithin ? '' : undefined}
+            data-read-only={readOnly ? '' : undefined}
+          >
             <Box data-wrapper="" ref={setWrapperElement}>
               <Portal __unstable_name={isFullscreen ? 'expanded' : 'collapsed'}>
                 {isFullscreen ? <ExpandedLayer>{editorNode}</ExpandedLayer> : editorNode}

--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -385,7 +385,6 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       <Editor
         ariaDescribedBy={ariaDescribedBy}
         initialSelection={initialSelection}
-        hasFocus={hasFocusWithin}
         hotkeys={editorHotkeys}
         isActive={isActive}
         isFullscreen={isFullscreen}
@@ -407,20 +406,19 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     // Keep only stable ones here!
     [
       ariaDescribedBy,
-      initialSelection,
-      hasFocusWithin,
       editorHotkeys,
-      isActive,
-      isFullscreen,
-      onItemOpen,
-      onCopy,
-      onPaste,
-      handleToggleFullscreen,
-      path,
-      readOnly,
       editorRenderAnnotation,
       editorRenderBlock,
       editorRenderChild,
+      handleToggleFullscreen,
+      initialSelection,
+      isActive,
+      isFullscreen,
+      onCopy,
+      onItemOpen,
+      onPaste,
+      path,
+      readOnly,
       scrollElement,
     ],
   )
@@ -444,6 +442,11 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     onItemClose,
   })
 
+  // The editor should have a focus ring when the field itself is focused,
+  // or focus is pointing directly to a node inside the editor
+  // (as opposed to focus on fields inside object nodes like annotations, inline blocks etc.)
+  const editorFocused = focused || hasFocusWithin
+
   return (
     <PortalProvider __unstable_elements={portalElements}>
       <ActivateOnFocus onActivate={onActivate} isOverlayActive={!isActive}>
@@ -454,7 +457,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
           path={path}
         >
           <Root
-            data-focused={hasFocusWithin ? '' : undefined}
+            data-focused={editorFocused ? '' : undefined}
             data-read-only={readOnly ? '' : undefined}
           >
             <Box data-wrapper="" ref={setWrapperElement}>

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -8,14 +8,12 @@ import {
   OnPasteFn,
   OnCopyFn,
   EditorSelection,
-  PortableTextEditor,
-  usePortableTextEditor,
   RenderStyleFunction,
   RenderListItemFunction,
 } from '@sanity/portable-text-editor'
 import {Path} from '@sanity/types'
 import {BoundaryElementProvider, useBoundaryElement, useGlobalKeyDown, useLayer} from '@sanity/ui'
-import React, {useCallback, useEffect, useMemo, useRef} from 'react'
+import React, {useCallback, useMemo, useRef} from 'react'
 import {Toolbar} from './toolbar'
 import {Decorator} from './text'
 import {
@@ -34,7 +32,6 @@ import {ListItem} from './text/ListItem'
 const noOutlineStyle = {outline: 'none'} as const
 
 interface EditorProps {
-  hasFocus: boolean
   hotkeys: HotkeyOptions
   initialSelection?: EditorSelection
   isActive: boolean
@@ -65,10 +62,11 @@ const renderStyle: RenderStyleFunction = (props) => {
 const renderListItem: RenderListItemFunction = (props) => {
   return <ListItem {...props} />
 }
-
+/**
+ * @internal
+ */
 export function Editor(props: EditorProps) {
   const {
-    hasFocus,
     hotkeys,
     initialSelection,
     isActive,
@@ -89,7 +87,6 @@ export function Editor(props: EditorProps) {
   } = props
   const {isTopLayer} = useLayer()
   const editableRef = useRef<HTMLDivElement | null>(null)
-  const editor = usePortableTextEditor()
 
   const {element: boundaryElement} = useBoundaryElement()
 
@@ -115,22 +112,6 @@ export function Editor(props: EditorProps) {
   const spellcheck = useSpellcheck()
 
   const scrollSelectionIntoView = useScrollSelectionIntoView(scrollElement)
-
-  // Re-focus/blur the editor when toggling fullscreen.
-  // The hasFocus is kept in ref so focus or blur is called only
-  // when `isFullscreen` changes (and not when `hasFocus` changes)
-  // This is important to avoid focus/blur loops when opening up
-  // object blocks for editing where the form focus and
-  // the editor selection share the same path.
-  const focusRef = useRef(hasFocus)
-  useEffect(() => {
-    focusRef.current = hasFocus
-  }, [hasFocus])
-  useEffect(() => {
-    if (focusRef.current) {
-      PortableTextEditor.focus(editor)
-    }
-  }, [editor, isFullscreen])
 
   const editable = useMemo(
     () => (

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -224,7 +224,10 @@ export function PortableTextInput(props: PortableTextInputProps) {
     return items
   }, [members, props])
 
-  const hasFocus = focused || isEditorFocusablePath(focusPath)
+  const hasFocus =
+    focused ||
+    (focusPath.length > 0 &&
+      portableTextMemberItems.some((m) => m.member.open && m.kind === 'textBlock'))
 
   // Set active if focused
   useEffect(() => {
@@ -354,9 +357,4 @@ export function PortableTextInput(props: PortableTextInputProps) {
 
 function toFormPatches(patches: any) {
   return patches.map((p: Patch) => ({...p, patchType: SANITY_PATCH_TYPE}))
-}
-
-// Return true if the path directly points to something focusable in the editor
-function isEditorFocusablePath(path: Path) {
-  return path.length === 1 || (path.length === 3 && path[1] === 'children')
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -224,17 +224,20 @@ export function PortableTextInput(props: PortableTextInputProps) {
     return items
   }, [members, props])
 
-  const hasFocus =
+  // Is true if something inside the editor itself has focus,
+  // as opposed to focus on a form field inside an
+  // annotation or object block's editing interface.
+  const hasFocusWithin =
     focused ||
     (focusPath.length > 0 &&
       portableTextMemberItems.some((m) => m.member.open && m.kind === 'textBlock'))
 
-  // Set active if focused
+  // Set active if focused within the editor
   useEffect(() => {
-    if (hasFocus) {
+    if (hasFocusWithin) {
       setIsActive(true)
     }
-  }, [hasFocus])
+  }, [hasFocusWithin])
 
   // Handle editor changes
   const handleEditorChange = useCallback(
@@ -334,7 +337,7 @@ export function PortableTextInput(props: PortableTextInputProps) {
             >
               <Compositor
                 {...props}
-                hasFocus={hasFocus}
+                hasFocusWithin={hasFocusWithin}
                 hotkeys={hotkeys}
                 isActive={isActive}
                 isFullscreen={isFullscreen}

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -1,4 +1,4 @@
-import {Path, PortableTextBlock} from '@sanity/types'
+import {PortableTextBlock} from '@sanity/types'
 import {
   EditorChange,
   Patch as EditorPatch,
@@ -59,8 +59,6 @@ export interface PortableTextMemberItem {
 export function PortableTextInput(props: PortableTextInputProps) {
   const {
     elementProps,
-    focused,
-    focusPath,
     hotkeys,
     markers = EMPTY_ARRAY,
     members,
@@ -96,6 +94,7 @@ export function PortableTextInput(props: PortableTextInputProps) {
   const [isFullscreen, setIsFullscreen] = useState(false)
   const [isActive, setIsActive] = useState(false)
   const [isOffline, setIsOffline] = useState(false)
+  const [hasFocusWithin, setHasFocusWithin] = useState(false)
 
   const toast = useToast()
   const portableTextMemberItemsRef: React.MutableRefObject<PortableTextMemberItem[]> = useRef([])
@@ -224,14 +223,6 @@ export function PortableTextInput(props: PortableTextInputProps) {
     return items
   }, [members, props])
 
-  // Is true if something inside the editor itself has focus,
-  // as opposed to focus on a form field inside an
-  // annotation or object block's editing interface.
-  const hasFocusWithin =
-    focused ||
-    (focusPath.length > 0 &&
-      portableTextMemberItems.some((m) => m.member.open && m.kind === 'textBlock'))
-
   // Set active if focused within the editor
   useEffect(() => {
     if (hasFocusWithin) {
@@ -264,9 +255,11 @@ export function PortableTextInput(props: PortableTextInputProps) {
           break
         case 'focus':
           setIsActive(true)
+          setHasFocusWithin(true)
           break
         case 'blur':
           onBlur(change.event)
+          setHasFocusWithin(false)
           break
         case 'undo':
         case 'redo':

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
@@ -3,7 +3,7 @@ import {
   usePortableTextEditor,
   usePortableTextEditorSelection,
 } from '@sanity/portable-text-editor'
-import {Path} from '@sanity/types'
+import {Path, KeyedObject, isKeyedObject} from '@sanity/types'
 import {useEffect} from 'react'
 import scrollIntoView from 'scroll-into-view-if-needed'
 import {isEqual} from '@sanity/util/paths'
@@ -52,41 +52,62 @@ export function useTrackFocusPath(props: Props): void {
           inline: 'start',
         })
       }
-      const isBlockFocusPath = focusPath.length === 1
       const isTextBlock = openItem.kind === 'textBlock'
-      // Handle paths coming from the outside that are ending on `.text`
-      // when pointing to span nodes. 'Click to edit' does this for instance.
-      const isSpanTextFocusPath =
-        isTextBlock &&
-        focusPath.length === 4 &&
-        focusPath[1] === 'children' &&
-        focusPath[3] === 'text'
-      // This is a normal span node path
-      const isSpanFocusPath = isTextBlock && focusPath.length === 3 && focusPath[1] === 'children'
+      const isBlockFocusPath = focusPath.length === 1
 
-      // If the focusPath i targeting a text block (with focusPath on the block itself),
-      // ensure that an editor selection is pointing to it's first child and then focus the editor.
-      if (openItem.kind === 'textBlock') {
-        const editorPath =
-          isSpanFocusPath || isSpanTextFocusPath
-            ? focusPath.slice(0, 3) // focusPath pointing to known span (slice so that the path doesn't include `.text`)
-            : [
-                focusPath[0],
-                'children',
-                (Array.isArray(openItem.node.value?.children) &&
-                  openItem.node.value?.children[0]._key && {
-                    _key: openItem.node.value?.children[0]._key,
-                  }) ||
-                  0,
-              ] // unknown span (just a block key given as focusPath), select the first span
+      // Track focus and selection for focusPaths that are either inside text blocks,
+      // or is pointing to the block itself (text and object blocks)
+      if (isTextBlock || isBlockFocusPath) {
+        const textBlockChildKey =
+          isTextBlock && isKeyedObject(focusPath[2]) ? focusPath[2]._key : undefined
+        const child =
+          textBlockChildKey && Array.isArray(openItem.node.value?.children)
+            ? (openItem.node.value?.children.find((c) => c._key === textBlockChildKey) as
+                | KeyedObject
+                | undefined)
+            : undefined
 
-        // Make an editor selection if we have a child path, and not have focus inside of it
-        if (isBlockFocusPath || isSpanFocusPath || isSpanTextFocusPath) {
+        // Is the focusPath pointing to span's `.text` property?
+        const isSpanTextFocusPath =
+          (child &&
+            child._type === 'span' &&
+            focusPath.length === 4 &&
+            focusPath[1] === 'children' &&
+            focusPath[3] === 'text') ||
+          false
+
+        // Is focus directly on a text block child?
+        const isTextChildFocusPath =
+          isTextBlock &&
+          ((focusPath.length === 3 && focusPath[1] === 'children') || isSpanTextFocusPath)
+
+        let path: Path = []
+        // Known text block child
+        if (isTextChildFocusPath) {
+          path = focusPath.slice(0, 3)
+        } else if (
+          // Known text block, but unknown child. Select first child in that block.
+          isTextBlock &&
+          isBlockFocusPath &&
+          Array.isArray(openItem.node.value?.children)
+        ) {
+          path = [focusPath[0], 'children', {_key: openItem.node.value?.children[0]._key}]
+          // Directly pointing to a non-text block
+        } else if (isBlockFocusPath) {
+          path = [{_key: openItem.key}]
+        }
+
+        // Select and focus the editor if we produced a path
+        if (path.length) {
           PortableTextEditor.select(editor, {
-            anchor: {path: editorPath, offset: 0},
-            focus: {path: editorPath, offset: 0},
+            anchor: {path, offset: 0},
+            focus: {path, offset: 0},
           })
-          PortableTextEditor.focus(editor)
+          // Object blocks will have their interface opened when focused,
+          // so only call focus for regular text blocks
+          if (isTextBlock) {
+            PortableTextEditor.focus(editor)
+          }
         }
       }
     }

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
@@ -4,7 +4,7 @@ import {
   usePortableTextEditorSelection,
 } from '@sanity/portable-text-editor'
 import {Path, KeyedObject, isKeyedObject} from '@sanity/types'
-import {useEffect} from 'react'
+import {useLayoutEffect} from 'react'
 import scrollIntoView from 'scroll-into-view-if-needed'
 import {isEqual} from '@sanity/util/paths'
 import {usePortableTextMemberItems} from './usePortableTextMembers'
@@ -22,7 +22,7 @@ export function useTrackFocusPath(props: Props): void {
   const editor = usePortableTextEditor()
   const selection = usePortableTextEditorSelection()
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     // Don't do anything if no focusPath
     if (focusPath.length === 0) {
       return

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
@@ -28,11 +28,6 @@ export function useTrackFocusPath(props: Props): void {
       return
     }
 
-    // Don't do anything if the selection focus path already is the focusPath
-    if (selection?.focus.path && isEqual(selection.focus.path, focusPath)) {
-      return
-    }
-
     // Find the opened member item
     const openItem = portableTextMemberItems.find((m) => m.member.open)
 
@@ -52,6 +47,12 @@ export function useTrackFocusPath(props: Props): void {
           inline: 'start',
         })
       }
+
+      // Don't do anything if the selection focus path is already equal to the focusPath
+      if (selection?.focus.path && isEqual(selection.focus.path, focusPath)) {
+        return
+      }
+
       const isTextBlock = openItem.kind === 'textBlock'
       const isBlockFocusPath = focusPath.length === 1
 


### PR DESCRIPTION
### Description

* Track editor focus for a focusPath that points to a span's text property.
* Harden test for span text by testing that the _type property is actually a 'span' too.
  I found and issue where inline blocks having a .text property also triggered editor focus here, which they shouldn't.
* Only focus the editor if focusPath is actually pointing to a editor focusable node.
* Improve test for `hasFocus` variable used in the PT-input (also test that the opened member is a editor node).
* Added component test for this

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
* That the Portable Text Input will correctly track focus paths that terminate with a span's `text` property.
* That the Portable Text Input will not take focus if you have an inline object containing a root `.text` property.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Fixed a bug where the Portable Text Input would capture focus trying to edit an inline object's field named `.text`.


<!--
A description of the change(s) that should be used in the release notes.
-->
