### PR TITLE
fix(portable-text-editor): fix issue with sequencing mark toggles

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPortableTextMarkModel.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPortableTextMarkModel.ts
@@ -276,6 +276,7 @@ export function createWithPortableTextMarkModel(
                       marks: (Array.isArray(node.marks) ? node.marks : []).filter(
                         (eMark: string) => eMark !== mark,
                       ),
+                      _type: 'span',
                     },
                     {at: path},
                   )
@@ -293,7 +294,7 @@ export function createWithPortableTextMarkModel(
             ...(Editor.marks(editor) || {}),
             marks: existingMarks.filter((eMark) => eMark !== mark),
           } as Text
-          editor.marks = {marks: marks.marks} as Text
+          editor.marks = {marks: marks.marks, _type: 'span'} as Text
           return editor
         }
         editor.onChange()

--- a/packages/@sanity/portable-text-editor/test/__tests__/selectionAdjustment.collaborative.test.ts
+++ b/packages/@sanity/portable-text-editor/test/__tests__/selectionAdjustment.collaborative.test.ts
@@ -453,7 +453,7 @@ describe('selection adjustment', () => {
     }
     await editorB.setSelection(expectedSelectionB)
     expect(await editorB.getSelection()).toEqual(expectedSelectionB)
-    await editorB.toggleMark()
+    await editorB.toggleMark('b')
     const valueB = await editorB.getValue()
     expect(valueB).toMatchInlineSnapshot(`
       Array [
@@ -511,7 +511,7 @@ describe('selection adjustment', () => {
     await editorB.setSelection(expectedSelectionB)
     expect(await editorA.getSelection()).toEqual(expectedSelectionA)
     expect(await editorB.getSelection()).toEqual(expectedSelectionB)
-    await editorA.toggleMark()
+    await editorA.toggleMark('b')
     const valueB = await editorB.getValue()
     expect(valueB).toMatchInlineSnapshot(`
       Array [

--- a/packages/@sanity/portable-text-editor/test/__tests__/writingTogether.collaborative.test.ts
+++ b/packages/@sanity/portable-text-editor/test/__tests__/writingTogether.collaborative.test.ts
@@ -725,4 +725,44 @@ describe('collaborate editing', () => {
     const valB = await editorB.getValue()
     expect(newValA).toEqual(valB)
   })
+  it('sends the correct patches when toggling marks in a sequence', async () => {
+    const [editorA, editorB] = await getEditors()
+    await editorA.toggleMark('b')
+    await editorA.insertText('Bold')
+    await editorA.toggleMark('b')
+    await editorA.toggleMark('i')
+    await editorA.insertText('Italic')
+    await editorA.toggleMark('i')
+    const valueA = await editorA.getValue()
+    const valueB = await editorB.getValue()
+    expect(valueB).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "_key": "A-4",
+          "_type": "block",
+          "children": Array [
+            Object {
+              "_key": "A-5",
+              "_type": "span",
+              "marks": Array [
+                "strong",
+              ],
+              "text": "Bold",
+            },
+            Object {
+              "_key": "A-6",
+              "_type": "span",
+              "marks": Array [
+                "em",
+              ],
+              "text": "Italic",
+            },
+          ],
+          "markDefs": Array [],
+          "style": "normal",
+        },
+      ]
+    `)
+    expect(valueA).toEqual(valueB)
+  })
 })

--- a/packages/@sanity/portable-text-editor/test/__tests__/writingTogether.collaborative.test.ts
+++ b/packages/@sanity/portable-text-editor/test/__tests__/writingTogether.collaborative.test.ts
@@ -686,7 +686,7 @@ describe('collaborate editing', () => {
   it('will not result in duplicate keys when overwriting some partial bold text line, as the only content in the editor', async () => {
     const [editorA, editorB] = await getEditors()
     await editorA.insertText('Hey')
-    await editorA.toggleMark()
+    await editorA.toggleMark('b')
     await editorA.insertText('there')
     const valA = await editorA.getValue()
     if (!valA || !Array.isArray(valA[0].children)) {

--- a/packages/@sanity/portable-text-editor/test/setup/collaborative.jest.env.ts
+++ b/packages/@sanity/portable-text-editor/test/setup/collaborative.jest.env.ts
@@ -268,11 +268,11 @@ export default class CollaborationEnvironment extends NodeEnvironment {
                 }
               }
             },
-            toggleMark: async () => {
+            toggleMark: async (hotkey: string) => {
               await page.keyboard.down(metaKey)
-              await page.keyboard.down('b')
+              await page.keyboard.down(hotkey)
 
-              await page.keyboard.up('b')
+              await page.keyboard.up(hotkey)
               await page.keyboard.up(metaKey)
               const selection = await selectionHandle.evaluate((node) =>
                 node instanceof HTMLElement && node.innerText ? JSON.parse(node.innerText) : null,

--- a/packages/@sanity/portable-text-editor/test/setup/globals.jest.ts
+++ b/packages/@sanity/portable-text-editor/test/setup/globals.jest.ts
@@ -16,7 +16,7 @@ type Editor = {
   redo: () => Promise<void>
   setSelection: (selection: EditorSelection | null) => Promise<void>
   testId: string
-  toggleMark: () => Promise<void>
+  toggleMark: (hotkey: string) => Promise<void>
   undo: () => Promise<void>
 }
 


### PR DESCRIPTION
### Description

Found a bug where if you toggle different decorators in sequence while
typing along, it can sometimes reset your applied decorator when reconciling with
the server value.

This was happening because we didn't specify the `_type` when splitting text
nodes with a new mark, and the new node would miss the span type.

The normalizer function would then assign the 'span' type to it however,
but it is not setting the marks (it's not the responsibility of that normalization).

This will make sure we don't need to normalize in this situation in the first place,
and that the type is correctly set in the split operation when toggling the mark.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
That you can perform the following sequence and keep the marks intact:

* Empty editor
* Press hotkey `cmd+b`
* Write a word
* Press hotkey `cmd+b`
* Press hotkey `cmd+i`
* Write a word
* Confirm that it is still italic when the new server value is returned

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Fix a problem with toggling text decorators in succession while typing in the Portable Text Input.

<!--
A description of the change(s) that should be used in the release notes.
-->
