### PR TITLE
chore(cli): move vercel dependencies to dev dependencies

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -62,8 +62,6 @@
   },
   "dependencies": {
     "@babel/traverse": "^7.19.0",
-    "@vercel/frameworks": "1.6.0",
-    "@vercel/fs-detectors": "4.1.3",
     "chalk": "^4.1.2",
     "esbuild": "^0.19.0",
     "esbuild-register": "^3.4.1",
@@ -89,6 +87,8 @@
     "@types/tar": "^6.1.3",
     "@types/validate-npm-package-name": "^3.0.3",
     "@types/which": "^2.0.1",
+    "@vercel/frameworks": "1.6.0",
+    "@vercel/fs-detectors": "4.1.3",
     "babylon": "^6.18.0",
     "boxen": "^4.1.0",
     "clean-stack": "^3.0.0",

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -9,7 +9,7 @@ import resolveFrom from 'resolve-from'
 import which from 'which'
 
 import type {DatasetAclMode} from '@sanity/client'
-import {Framework, frameworks} from '@vercel/frameworks'
+import {type Framework, frameworks} from '@vercel/frameworks'
 import execa, {CommonOptions} from 'execa'
 import {evaluate, patch} from 'golden-fleece'
 import {LocalFileSystemDetector, detectFrameworkRecord} from '@vercel/fs-detectors'

--- a/packages/@sanity/cli/src/commands/init/initCommand.ts
+++ b/packages/@sanity/cli/src/commands/init/initCommand.ts
@@ -1,8 +1,8 @@
+import {type Framework, frameworks} from '@vercel/frameworks'
+import {LocalFileSystemDetector, detectFrameworkRecord} from '@vercel/fs-detectors'
 import initProject from '../../actions/init-project/initProject'
 import initPlugin from '../../actions/init-plugin/initPlugin'
 import {CliCommandDefinition} from '../../types'
-import {Framework, frameworks} from '@vercel/frameworks'
-import {LocalFileSystemDetector, detectFrameworkRecord} from '@vercel/fs-detectors'
 
 const helpText = `
 Options


### PR DESCRIPTION
### Description

The CLI is currently built to a compiled bundle for a speedier installation. This means the `@vercel/fs-detectors` and `@vercel/frameworks` modules both become part of the bundle, and do not need to be runtime dependencies. By moving them to dev dependencies, we both reduce installation time and (as a side effect) reduce noise about [a vulnerability](https://security.snyk.io/vuln/SNYK-JS-SEMVER-3247795) that does not impact the CLI.

### What to review

- Building the CLI and running the `sanity init` command works, even without the `@vercel` dependencies in your node modules resolution tree

### Notes for release

None.
