### PR TITLE
feat(titles): Update titles inside desk tool

### DIFF
--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -142,6 +142,11 @@ export interface Tool<Options = any> {
   title: string
 
   /**
+   * Determines whether the tool will control the `document.title`.
+   */
+  controlsDocumentTitle?: boolean
+
+  /**
    * Gets the state for the given intent.
    *
    * @param intent - The intent to get the state for.

--- a/packages/sanity/src/core/studio/StudioLayout.tsx
+++ b/packages/sanity/src/core/studio/StudioLayout.tsx
@@ -89,14 +89,14 @@ export function StudioLayout() {
 
     return mainTitle
   }, [activeToolName, name, title])
+  const toolControlsDocumentTitle = !!activeTool?.controlsDocumentTitle
 
   useEffect(() => {
-    if (activeToolName === 'content') {
-      // Will be handled by sanity/src/desk/components/deskTool/DeskTitle.tsx
+    if (toolControlsDocumentTitle) {
       return
     }
     document.title = documentTitle
-  }, [documentTitle, activeToolName])
+  }, [documentTitle, toolControlsDocumentTitle])
 
   const handleSearchFullscreenOpenChange = useCallback((open: boolean) => {
     setSearchFullscreenOpen(open)

--- a/packages/sanity/src/core/studio/StudioLayout.tsx
+++ b/packages/sanity/src/core/studio/StudioLayout.tsx
@@ -84,15 +84,19 @@ export function StudioLayout() {
     const mainTitle = title || startCase(name)
 
     if (activeToolName) {
-      return `${mainTitle} – ${startCase(activeToolName)}`
+      return `${startCase(activeToolName)} | ${mainTitle}`
     }
 
     return mainTitle
   }, [activeToolName, name, title])
 
   useEffect(() => {
+    if (activeToolName === 'content') {
+      // Will be handled by sanity/src/desk/components/deskTool/DeskTitle.tsx
+      return
+    }
     document.title = documentTitle
-  }, [documentTitle])
+  }, [documentTitle, activeToolName])
 
   const handleSearchFullscreenOpenChange = useCallback((open: boolean) => {
     setSearchFullscreenOpen(open)

--- a/packages/sanity/src/desk/components/deskTool/DeskTitle.test.tsx
+++ b/packages/sanity/src/desk/components/deskTool/DeskTitle.test.tsx
@@ -1,0 +1,170 @@
+import React from 'react'
+import {render} from '@testing-library/react'
+import {Panes} from '../../structureResolvers'
+import * as USE_DESK_TOOL from '../../useDeskTool'
+import {DeskTitle} from './DeskTitle'
+import * as SANITY from 'sanity'
+
+jest.mock('sanity')
+
+describe('DeskTitle', () => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore  it's a minimal mock implementation of useDeskTool
+  jest.spyOn(USE_DESK_TOOL, 'useDeskTool').mockImplementation(() => ({
+    structureContext: {title: 'My Desk Tool'},
+  }))
+  describe('Non document panes', () => {
+    const mockPanes: Panes['resolvedPanes'] = [
+      {
+        id: 'content',
+        type: 'list',
+        title: 'Content',
+      },
+      {
+        id: 'author',
+        type: 'documentList',
+        title: 'Author',
+        schemaTypeName: 'author',
+        options: {
+          filter: '_type == $type',
+        },
+      },
+      {
+        id: 'documentEditor',
+        type: 'document',
+        title: 'Authors created',
+        options: {
+          id: 'fake-document',
+          type: 'author',
+        },
+      },
+    ]
+    beforeEach(() => {
+      document.title = 'Sanity Studio'
+    })
+    it('renders the correct title when the content pane is open', () => {
+      render(<DeskTitle resolvedPanes={mockPanes.slice(0, 1)} />)
+      expect(document.title).toBe('Content | My Desk Tool')
+    })
+    it('renders the correct title when an inner pane is open', () => {
+      render(<DeskTitle resolvedPanes={mockPanes.slice(0, 2)} />)
+      expect(document.title).toBe('Author | My Desk Tool')
+    })
+    it('renders the correct title when the document pane has a title', () => {
+      render(<DeskTitle resolvedPanes={mockPanes} />)
+      expect(document.title).toBe('Authors created | My Desk Tool')
+    })
+    it('should not update the title if no panes are available', () => {
+      render(<DeskTitle resolvedPanes={[]} />)
+      expect(document.title).toBe('Sanity Studio')
+    })
+  })
+  describe('With document panes', () => {
+    const mockPanes: Panes['resolvedPanes'] = [
+      {
+        id: 'content',
+        type: 'list',
+        title: 'Content',
+      },
+      {
+        id: 'author',
+        type: 'documentList',
+        title: 'Author',
+        schemaTypeName: 'author',
+        options: {
+          filter: '_type == $type',
+        },
+      },
+      {
+        id: 'documentEditor',
+        type: 'document',
+        title: '',
+        options: {
+          id: 'fake-document',
+          type: 'author',
+        },
+      },
+    ]
+
+    const doc = {
+      name: 'Foo',
+      _id: 'drafts.fake-document',
+      _type: 'author',
+      _updatedAt: '',
+      _createdAt: '',
+      _rev: '',
+    }
+    const editState = {
+      ready: true,
+      type: 'author',
+      draft: doc,
+      published: null,
+      id: 'fake-document',
+      transactionSyncLock: {enabled: false},
+      liveEdit: false,
+    }
+    const valuePreview = {
+      isLoading: false,
+      value: {
+        title: doc.name,
+      },
+    }
+    const useSchemaMock = () =>
+      ({
+        get: () => ({
+          title: 'Author',
+          name: 'author',
+          type: 'document',
+        }),
+      }) as unknown as SANITY.Schema
+
+    it('should not update the when the document is still loading', () => {
+      const useEditStateMock = () => ({...editState, ready: false})
+      const useValuePreviewMock = () => valuePreview
+      jest.spyOn(SANITY, 'useSchema').mockImplementationOnce(useSchemaMock)
+      jest.spyOn(SANITY, 'useEditState').mockImplementationOnce(useEditStateMock)
+      jest.spyOn(SANITY, 'unstable_useValuePreview').mockImplementationOnce(useValuePreviewMock)
+
+      document.title = 'Sanity Studio'
+      render(<DeskTitle resolvedPanes={mockPanes} />)
+      expect(document.title).toBe('Sanity Studio')
+    })
+
+    it('renders the correct title when the document pane has a title', () => {
+      const useEditStateMock = () => editState
+      const useValuePreviewMock = () => valuePreview
+      jest.spyOn(SANITY, 'useSchema').mockImplementationOnce(useSchemaMock)
+      jest.spyOn(SANITY, 'useEditState').mockImplementationOnce(useEditStateMock)
+      jest.spyOn(SANITY, 'unstable_useValuePreview').mockImplementationOnce(useValuePreviewMock)
+
+      document.title = 'Sanity Studio'
+      render(<DeskTitle resolvedPanes={mockPanes} />)
+      expect(document.title).toBe('Foo | My Desk Tool')
+    })
+    it('renders the correct title when the document is new', () => {
+      const useEditStateMock = () => ({...editState, draft: null})
+      const useValuePreviewMock = () => valuePreview
+      jest.spyOn(SANITY, 'useSchema').mockImplementationOnce(useSchemaMock)
+      jest.spyOn(SANITY, 'useEditState').mockImplementationOnce(useEditStateMock)
+      jest.spyOn(SANITY, 'unstable_useValuePreview').mockImplementationOnce(useValuePreviewMock)
+
+      document.title = 'Sanity Studio'
+      render(<DeskTitle resolvedPanes={mockPanes} />)
+      expect(document.title).toBe('New Author | My Desk Tool')
+    })
+    it('renders the correct title when the document is untitled', () => {
+      const useEditStateMock = () => editState
+      const useValuePreviewMock = () => ({
+        isLoading: false,
+        value: {title: ''},
+      })
+      jest.spyOn(SANITY, 'useSchema').mockImplementationOnce(useSchemaMock)
+      jest.spyOn(SANITY, 'useEditState').mockImplementationOnce(useEditStateMock)
+      jest.spyOn(SANITY, 'unstable_useValuePreview').mockImplementationOnce(useValuePreviewMock)
+
+      document.title = 'Sanity Studio'
+      render(<DeskTitle resolvedPanes={mockPanes} />)
+      expect(document.title).toBe('Untitled | My Desk Tool')
+    })
+  })
+})

--- a/packages/sanity/src/desk/components/deskTool/DeskTitle.tsx
+++ b/packages/sanity/src/desk/components/deskTool/DeskTitle.tsx
@@ -29,7 +29,6 @@ const DocumentTitle = (props: {title: string; documentId: string; documentType: 
     : value?.title || 'Untitled'
 
   const settled = editState.ready && !previewValueIsLoading
-
   useEffect(() => {
     if (!settled) return
     // Set the title as the document title
@@ -50,6 +49,7 @@ const NoDocumentTitle = (props: {title: string}) => {
 
 export const DeskTitle = (props: DeskTitleProps) => {
   const {resolvedPanes} = props
+
   const deskToolTitle = useDeskTool().structureContext.title
   // Will show up to the first pane of type document.
   const paneWithTypeDocumentIndex = resolvedPanes.findIndex((pane) => {

--- a/packages/sanity/src/desk/components/deskTool/DeskTitle.tsx
+++ b/packages/sanity/src/desk/components/deskTool/DeskTitle.tsx
@@ -1,0 +1,80 @@
+import React, {useEffect} from 'react'
+import {ObjectSchemaType} from '@sanity/types'
+import {Panes} from '../../structureResolvers'
+import {useDeskTool} from '../../useDeskTool'
+import {LOADING_PANE} from '../../constants'
+import {DocumentPaneNode} from '../../types'
+import {useEditState, useSchema, unstable_useValuePreview as useValuePreview} from 'sanity'
+
+interface DeskTitleProps {
+  resolvedPanes: Panes['resolvedPanes']
+}
+
+const DocumentTitle = (props: {title: string; documentId: string; documentType: string}) => {
+  const {title, documentId, documentType} = props
+  const editState = useEditState(documentId, documentType)
+  const schema = useSchema()
+  const isNewDocument = !editState?.published && !editState?.draft
+  const documentValue = editState?.draft || editState?.published
+  const schemaType = schema.get(documentType) as ObjectSchemaType | undefined
+
+  const {value, isLoading: previewValueIsLoading} = useValuePreview({
+    enabled: true,
+    schemaType,
+    value: documentValue,
+  })
+
+  const documentTitle = isNewDocument
+    ? `New ${schemaType?.title || schemaType?.name}`
+    : value?.title || 'Untitled'
+
+  const settled = editState.ready && !previewValueIsLoading
+
+  useEffect(() => {
+    if (!settled) return
+    // Set the title as the document title
+    document.title = `${documentTitle} ${title}`
+  }, [documentTitle, title, settled])
+
+  return null
+}
+
+const NoDocumentTitle = (props: {title: string}) => {
+  const {title} = props
+  useEffect(() => {
+    // Set the title as the document title
+    document.title = title
+  }, [title])
+  return null
+}
+
+export const DeskTitle = (props: DeskTitleProps) => {
+  const {resolvedPanes} = props
+  const deskToolTitle = useDeskTool().structureContext.title
+  // Will show up to the first pane of type document.
+  const paneWithTypeDocumentIndex = resolvedPanes.findIndex((pane) => {
+    return pane !== LOADING_PANE && pane.type === 'document'
+  })
+  const paneToShow =
+    paneWithTypeDocumentIndex > -1
+      ? resolvedPanes[paneWithTypeDocumentIndex]
+      : resolvedPanes[resolvedPanes.length - 1]
+
+  const paneTitle = `${
+    paneToShow === LOADING_PANE ? '' : paneToShow?.title ?? ''
+  } |  ${deskToolTitle}`
+
+  if (!resolvedPanes?.length) return null
+  if (paneWithTypeDocumentIndex === -1) return <NoDocumentTitle title={paneTitle} />
+
+  const documentPane = resolvedPanes[paneWithTypeDocumentIndex] as DocumentPaneNode
+  if (documentPane.title) return <NoDocumentTitle title={paneTitle} />
+
+  return (
+    <DocumentTitle
+      title={paneTitle}
+      documentId={documentPane.options.id}
+      documentType={documentPane.options.type}
+    />
+  )
+}

--- a/packages/sanity/src/desk/components/deskTool/DeskTool.tsx
+++ b/packages/sanity/src/desk/components/deskTool/DeskTool.tsx
@@ -9,6 +9,7 @@ import {PaneNode} from '../../types'
 import {PaneLayout} from '../pane'
 import {useDeskTool} from '../../useDeskTool'
 import {NoDocumentTypesScreen} from './NoDocumentTypesScreen'
+import {DeskTitle} from './DeskTitle'
 import {useSchema, _isCustomDocumentTypeDefinition} from 'sanity'
 import {useRouterState} from 'sanity/router'
 
@@ -130,6 +131,7 @@ export const DeskTool = memo(function DeskTool({onPaneChange}: DeskToolProps) {
           <LoadingPane paneKey="intent-resolver" />
         )}
       </StyledPaneLayout>
+      <DeskTitle resolvedPanes={resolvedPanes} />
       <div data-portal="" ref={setPortalElement} />
     </PortalProvider>
   )

--- a/packages/sanity/src/desk/deskTool.ts
+++ b/packages/sanity/src/desk/deskTool.ts
@@ -107,6 +107,8 @@ export const deskTool = definePlugin<DeskToolOptions | void>((options) => ({
             (intent === 'create' && params.template),
         )
       },
+      // Controlled by sanity/src/desk/components/deskTool/DeskTitle.tsx
+      controlsDocumentTitle: true,
       getIntentState,
       options,
       router,

--- a/packages/sanity/src/desk/structureResolvers/useResolvedPanes.ts
+++ b/packages/sanity/src/desk/structureResolvers/useResolvedPanes.ts
@@ -22,7 +22,7 @@ interface PaneData {
   siblingIndex: number
 }
 
-interface Panes {
+export interface Panes {
   paneDataItems: PaneData[]
   routerPanes: RouterPanes
   resolvedPanes: (PaneNode | typeof LOADING_PANE)[]


### PR DESCRIPTION
When the user is moving through documents and panes, update the title property to be  more specific to the current route

### Description

Update the `<title>` element to be more specific to the current route every time a user follows a link in the studio.
Changes titles to use pipes as divider, in the title structure, mention first the most unique thing.

- Previously: `Test Studio - Content`
- Updated:  `Content | Test Studio`

Uses the following pattern:
- Desk root: `{{tool}} | {{desktoolTitle}}`
- Document list: `{{paneTitle}} | {{desktoolTitle}}`
- Document: `{{documentTitle}} | {{desktoolTitle}}`
- Document (new): `New {{schemaTitle}} | {{desktoolTitle}}`


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Titles inside the studio, navigating through documents in the desk and also navigating between tools.
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->
### Notes for release

Update the <title> element to be more specific to the current route every time a user follows a link in the studio.
<!--
A description of the change(s) that should be used in the release notes.
-->


https://github.com/sanity-io/sanity/assets/46196328/5fd43734-5f2c-4533-ac36-c083c780701a


