### PR TITLE
fix(core): preserve earlier document availability status

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/validation.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/validation.ts
@@ -134,10 +134,10 @@ export const validation = memoize(
         ),
       ),
       scan((acc: Record<string, boolean>, [id, result]): Record<string, boolean> => {
-        if (Boolean(acc[id]) === result) {
+        if (acc[id] === result) {
           return acc
         }
-        return result ? {...acc, [id]: result} : omit(acc, id)
+        return {...acc, [id]: result}
       }, {}),
       distinctUntilChanged(shallowEquals),
       shareReplay({refCount: true, bufferSize: 1}),


### PR DESCRIPTION
### Description

This fixes a regression in #4860 that would sometimes prevent document existence check from being run at page load.

### What to review

- Make sure validation of unpublished references works as intended both when creating and after reload (the referenced document needs to be published)
- Make sure the "initial flash of validation error" fixed by #4860 is still fixed

### Notes for release
- Fixes a regression in v3.16.0 that prevented reference validation errors from appearing in certain cases
