### PR TITLE
fix(desk): use index as key instead of path

### DIFF
--- a/packages/sanity/src/desk/panes/document/inspectors/validation/ValidationInspector.tsx
+++ b/packages/sanity/src/desk/panes/document/inspectors/validation/ValidationInspector.tsx
@@ -52,9 +52,9 @@ export function ValidationInspector(props: DocumentInspectorProps) {
 
         {validation.length > 0 && (
           <Stack space={2}>
-            {validation.map((marker) => (
+            {validation.map((marker, i) => (
               <ValidationCard
-                key={pathToString(marker.path)}
+                key={i}
                 marker={marker}
                 onOpen={handleOpen}
                 schemaType={schemaType}


### PR DESCRIPTION
### Description

The validation document inspector currently uses the path as react key, assuming only one validation marker per path, which is not always the case. Couldn't find any unique value on the validation markers, so this fixes it by using index as key instead.

### What to review

- Make sure validation inspector can handle multiple validation errors for the same field/node

### Notes for release
- Fixes a react key error when having multiple validation errors for the same document node