### PR TITLE
feat: make splitpanes responsive for minimal breakpoint

### DIFF
--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -77,9 +77,13 @@ interface PaneSizeOptions {
   maxSize: number
 }
 
+function narrowBreakpoint(): boolean {
+  return typeof window !== 'undefined' && window.innerWidth > 600
+}
+
 function calculatePaneSizeOptions(rootHeight: number): PaneSizeOptions {
   return {
-    defaultSize: rootHeight / 2,
+    defaultSize: rootHeight / (narrowBreakpoint() ? 2 : 1),
     size: rootHeight > 550 ? undefined : rootHeight * 0.4,
     allowResize: rootHeight > 550,
     minSize: Math.min(170, Math.max(170, rootHeight / 2)),
@@ -773,9 +777,14 @@ export class VisionGui extends React.PureComponent<VisionGuiProps, VisionGuiStat
             )}
           </Grid>
         </Header>
-        <SplitpaneContainer flex={1}>
+        <SplitpaneContainer flex={'auto'}>
           {/* @ts-expect-error: https://github.com/tomkp/react-split-pane/pull/819 */}
-          <SplitPane split="vertical" minSize={280} defaultSize={400} maxSize={-400}>
+          <SplitPane
+            split={narrowBreakpoint() ? 'vertical' : 'horizontal'}
+            minSize={280}
+            defaultSize={400}
+            maxSize={-400}
+          >
             <Box height="stretch" flex={1}>
               {/*
                   The way react-split-pane handles the sizes is kind of finicky and not clear. What the props above does is:
@@ -790,11 +799,13 @@ export class VisionGui extends React.PureComponent<VisionGuiProps, VisionGuiStat
               {/* @ts-expect-error: https://github.com/tomkp/react-split-pane/pull/819 */}
               <SplitPane
                 className="sidebarPanes"
-                split="horizontal"
-                defaultSize={paneSizeOptions.defaultSize}
+                split={'horizontal'}
+                defaultSize={
+                  narrowBreakpoint() ? paneSizeOptions.defaultSize : paneSizeOptions.minSize
+                }
                 size={paneSizeOptions.size}
                 allowResize={paneSizeOptions.allowResize}
-                minSize={paneSizeOptions.minSize}
+                minSize={narrowBreakpoint() ? paneSizeOptions.minSize : 100}
                 maxSize={paneSizeOptions.maxSize}
                 primary="first"
               >

--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -659,7 +659,7 @@ export class VisionGui extends React.PureComponent<VisionGuiProps, VisionGuiStat
         overflow="hidden"
       >
         <Header paddingX={3} paddingY={2}>
-          <Grid columns={[6, 6, 12]}>
+          <Grid columns={[1, 4, 8, 12]}>
             {/* Dataset selector */}
             <Box padding={1} column={2}>
               <Stack>

--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -777,7 +777,7 @@ export class VisionGui extends React.PureComponent<VisionGuiProps, VisionGuiStat
             )}
           </Grid>
         </Header>
-        <SplitpaneContainer flex={'auto'}>
+        <SplitpaneContainer flex="auto">
           {/* @ts-expect-error: https://github.com/tomkp/react-split-pane/pull/819 */}
           <SplitPane
             split={narrowBreakpoint() ? 'vertical' : 'horizontal'}


### PR DESCRIPTION
### Description

This PR makes the Vision plugin somewhat more responsive for narrow(er) screens by:
- Tuning the responsive grid column values so the 3-4 option boxes collapse more neatly
- Adjust the vertical/horizontal props and sizing to the split panes so they change direction beneath the narrowest breakpoint (600px).

This is useful when you want to test a query on mobile or with a narrow studio in a browser‘s split pane. The balance between the query/param/results panes could probably be tuned a tiny bit more, but it's at least functional.

![localhost_3333_test_vision(iPhone 12 Pro)](https://github.com/sanity-io/sanity/assets/1131579/491e490c-1e3b-4b7f-8af9-610e4d693185)


### What to review

I did try to see if there was a way to reuse the Sanity UI logic to get the breakpoints but ended up doing a simple `window.innerWidth < 600` wrapped in the `narrowBreakpoint()` function. 

### Notes for release

Responsive improvements to the Vision plugin to accommodate narrower screens.