### PR TITLE
fix(desk): use correct dialog positioning at smaller breakpoints

### DIFF
--- a/packages/sanity/src/desk/components/deskTool/DeskTool.tsx
+++ b/packages/sanity/src/desk/components/deskTool/DeskTool.tsx
@@ -1,4 +1,4 @@
-import {PortalProvider, useToast} from '@sanity/ui'
+import {PortalProvider, useTheme, useToast} from '@sanity/ui'
 import React, {memo, Fragment, useState, useEffect, useCallback} from 'react'
 import styled from 'styled-components'
 import isHotkey from 'is-hotkey'
@@ -38,6 +38,9 @@ export const DeskTool = memo(function DeskTool({onPaneChange}: DeskToolProps) {
   const isResolvingIntent = useRouterState(
     useCallback((routerState) => typeof routerState.intent === 'string', []),
   )
+  const {
+    sanity: {media},
+  } = useTheme()
 
   const [portalElement, setPortalElement] = useState<HTMLDivElement | null>(null)
 
@@ -84,7 +87,7 @@ export const DeskTool = memo(function DeskTool({onPaneChange}: DeskToolProps) {
       <StyledPaneLayout
         flex={1}
         height={layoutCollapsed ? undefined : 'fill'}
-        minWidth={512}
+        minWidth={media[1]}
         onCollapse={handleRootCollapse}
         onExpand={handleRootExpand}
       >

--- a/packages/sanity/src/desk/components/pane/__workshop__/ChangeConnectorsStory.tsx
+++ b/packages/sanity/src/desk/components/pane/__workshop__/ChangeConnectorsStory.tsx
@@ -14,6 +14,7 @@ import {
   Stack,
   Text,
   TextInput,
+  useTheme,
 } from '@sanity/ui'
 import {useAction} from '@sanity/ui-workshop'
 import React, {useCallback, useState} from 'react'
@@ -60,6 +61,10 @@ export default function ChangeConnectorsStory() {
   const handleLayoutCollapse = useAction('PaneLayout.onCollapse')
   const handleLayoutExpand = useAction('PaneLayout.onExpand')
 
+  const {
+    sanity: {media},
+  } = useTheme()
+
   return (
     <LayerProvider>
       <Card height="fill" tone="transparent">
@@ -72,7 +77,7 @@ export default function ChangeConnectorsStory() {
             >
               <PaneLayout
                 height="fill"
-                minWidth={512}
+                minWidth={media[1]}
                 onCollapse={handleLayoutCollapse}
                 onExpand={handleLayoutExpand}
               >

--- a/packages/sanity/src/desk/components/pane/__workshop__/SplitPanesStory/SplitPanesStory.tsx
+++ b/packages/sanity/src/desk/components/pane/__workshop__/SplitPanesStory/SplitPanesStory.tsx
@@ -1,4 +1,4 @@
-import {Flex, ToastProvider, PortalProvider} from '@sanity/ui'
+import {Flex, ToastProvider, PortalProvider, useTheme} from '@sanity/ui'
 import React, {useState, useCallback} from 'react'
 import {useBoolean} from '@sanity/ui-workshop'
 import {PaneLayout} from '../../PaneLayout'
@@ -50,11 +50,15 @@ function DeskTool(props: {
 }) {
   const {collapsed, onCollapse, onExpand, path, setPath} = props
 
+  const {
+    sanity: {media},
+  } = useTheme()
+
   return (
     <PaneLayout
       flex={1}
       height={collapsed ? undefined : 'fill'}
-      minWidth={512}
+      minWidth={media[1]}
       onCollapse={onCollapse}
       onExpand={onExpand}
     >

--- a/packages/sanity/src/desk/panes/document/DocumentPane.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentPane.tsx
@@ -46,7 +46,8 @@ import {
 type DocumentPaneOptions = DocumentPaneNode['options']
 
 const DIALOG_PROVIDER_POSITION: DialogProviderProps['position'] = [
-  // We use the `position: fixed` for dialogs on narrow screens (< 512px).
+  // We use the `position: fixed` for dialogs on narrower screens (first two media breakpoints).
+  'fixed',
   'fixed',
   // And we use the `position: absolute` strategy (within panes) on wide screens.
   'absolute',


### PR DESCRIPTION
### Description

This PR ensures that object dialogs are correctly positioned at smaller breakpoints (when the desk collapses into a single pane layout).

There was previously a mismatch between theme breakpoints (used by `<DialogProvider>`) and the `minWidth` value in `<StyledPaneLayout>`. Desk would collapse into a single pane at `512px` whilst dialogs would only use `fixed` positioning at `< 360px`. 

This PR ensures the desk tool will collapse at a theme media breakpoint instead of a hardcoded value, so it should be in lock-step with `<DialogProvider>` moving forward.

### What to review

Collapse your viewport enough so that the studio desk collapses into a single column layout.

In the following examples, scroll to the bottom of the page and click either the 'Sydney' or 'Melbourne' events

- [Before](https://test-studio.sanity.build/test/content/input-standard;objectsTest;0759e8b3-04a8-4e40-872f-e447856e8bda)
- [After](https://test-studio-git-feature-edx-197-studio-dialogs-are-incor-5862fd.sanity.build/test/content/input-standard;objectsTest;0759e8b3-04a8-4e40-872f-e447856e8bda)

In the after case, object dialogs should appear correctly when scrolled down the page.

One byproduct of this change is that the studio collapses to a single column breakpoint a little earlier than previously (600px vs 512px). I believe this is an acceptable trade-off, but please chime if you think otherwise @kaylasanity 

### Notes for release

Fixes an issue where dialogs wouldn't correctly appear at smaller breakpoints