### PR TITLE
feat(WCAG): Associate field descriptions to inputs

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -67,6 +67,7 @@ export type PortableTextEditableProps = {
   scrollSelectionIntoView?: ScrollSelectionIntoViewFunction
   selection?: EditorSelection
   spellCheck?: boolean
+  describedBy?: string
 }
 
 /**
@@ -91,6 +92,7 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
     selection: propsSelection,
     scrollSelectionIntoView,
     spellCheck,
+    describedBy,
     ...restProps
   } = props
 
@@ -405,6 +407,7 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
         renderLeaf={renderLeaf}
         style={props.style}
         scrollSelectionIntoView={scrollSelectionIntoViewToSlate}
+        aria-describedby={describedBy}
       />
     ),
     [
@@ -420,6 +423,7 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
       renderElement,
       renderLeaf,
       scrollSelectionIntoViewToSlate,
+      describedBy,
     ],
   )
 

--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -67,7 +67,7 @@ export type PortableTextEditableProps = {
   scrollSelectionIntoView?: ScrollSelectionIntoViewFunction
   selection?: EditorSelection
   spellCheck?: boolean
-  describedBy?: string
+  'aria-describedby'?: string
 }
 
 /**
@@ -92,7 +92,7 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
     selection: propsSelection,
     scrollSelectionIntoView,
     spellCheck,
-    describedBy,
+    'aria-describedby': ariaDescribedBy,
     ...restProps
   } = props
 
@@ -407,7 +407,7 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
         renderLeaf={renderLeaf}
         style={props.style}
         scrollSelectionIntoView={scrollSelectionIntoViewToSlate}
-        aria-describedby={describedBy}
+        aria-describedby={ariaDescribedBy}
       />
     ),
     [
@@ -423,7 +423,7 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
       renderElement,
       renderLeaf,
       scrollSelectionIntoViewToSlate,
-      describedBy,
+      ariaDescribedBy,
     ],
   )
 

--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -395,46 +395,28 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
     ref.current = ReactEditor.toDOMNode(slateEditor, slateEditor) as HTMLDivElement | null
   }, [slateEditor, ref])
 
-  // The editor
-  const slateEditable = useMemo(
-    () => (
-      <SlateEditable
-        {...restProps}
-        autoFocus={false}
-        className="pt-editable"
-        decorate={decorate}
-        onBlur={handleOnBlur}
-        onCopy={handleCopy}
-        onDOMBeforeInput={handleOnBeforeInput}
-        onFocus={handleOnFocus}
-        onKeyDown={handleKeyDown}
-        onPaste={handlePaste}
-        readOnly={readOnly}
-        // We have implemented our own placeholder logic with decorations. This 'renderPlaceholder' should not be used.
-        renderPlaceholder={undefined}
-        renderElement={renderElement}
-        renderLeaf={renderLeaf}
-        scrollSelectionIntoView={scrollSelectionIntoViewToSlate}
-      />
-    ),
-    [
-      decorate,
-      handleCopy,
-      handleKeyDown,
-      handleOnBeforeInput,
-      handleOnBlur,
-      handleOnFocus,
-      handlePaste,
-      readOnly,
-      renderElement,
-      renderLeaf,
-      restProps,
-      scrollSelectionIntoViewToSlate,
-    ],
-  )
-
   if (!portableTextEditor) {
     return null
   }
-  return hasInvalidValue ? null : slateEditable
+  return hasInvalidValue ? null : (
+    <SlateEditable
+      {...restProps}
+      autoFocus={false}
+      className={restProps.className || 'pt-editable'}
+      decorate={decorate}
+      onBlur={handleOnBlur}
+      onCopy={handleCopy}
+      onDOMBeforeInput={handleOnBeforeInput}
+      onFocus={handleOnFocus}
+      onKeyDown={handleKeyDown}
+      onPaste={handlePaste}
+      readOnly={readOnly}
+      // We have implemented our own placeholder logic with decorations.
+      // This 'renderPlaceholder' should not be used.
+      renderPlaceholder={undefined}
+      renderElement={renderElement}
+      renderLeaf={renderLeaf}
+      scrollSelectionIntoView={scrollSelectionIntoViewToSlate}
+    />
+  )
 })

--- a/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditor.test.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditor.test.tsx
@@ -38,6 +38,7 @@ describe('initialization', () => {
         <div>
           <div>
             <div
+              aria-describedby="desc_foo"
               aria-multiline="true"
               autocapitalize="false"
               autocorrect="false"

--- a/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditor.test.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditor.test.tsx
@@ -35,58 +35,56 @@ describe('initialization', () => {
       expect(onChange).toHaveBeenCalledWith({type: 'ready'})
       expect(onChange).toHaveBeenCalledWith({type: 'value', value: undefined})
       expect(container).toMatchInlineSnapshot(`
+<div>
+  <div
+    aria-describedby="desc_foo"
+    aria-multiline="true"
+    autocapitalize="false"
+    autocorrect="false"
+    class="pt-editable"
+    contenteditable="true"
+    data-slate-editor="true"
+    data-slate-node="value"
+    role="textbox"
+    spellcheck="false"
+    style="position: relative; white-space: pre-wrap; word-wrap: break-word;"
+    zindex="-1"
+  >
+    <div
+      class="pt-block pt-text-block pt-text-block-style-normal"
+      data-slate-node="element"
+    >
+      <div
+        draggable="false"
+      >
         <div>
-          <div>
-            <div
-              aria-describedby="desc_foo"
-              aria-multiline="true"
-              autocapitalize="false"
-              autocorrect="false"
-              class="pt-editable"
-              contenteditable="true"
-              data-slate-editor="true"
-              data-slate-node="value"
-              role="textbox"
-              spellcheck="false"
-              style="position: relative; white-space: pre-wrap; word-wrap: break-word;"
-              zindex="-1"
+          <span
+            data-slate-node="text"
+          >
+            <span
+              contenteditable="false"
+              style="opacity: 0.5; position: absolute; user-select: none; pointer-events: none;"
             >
-              <div
-                class="pt-block pt-text-block pt-text-block-style-normal"
-                data-slate-node="element"
+              Jot something down here
+            </span>
+            <span
+              data-slate-leaf="true"
+            >
+              <span
+                data-slate-length="0"
+                data-slate-zero-width="n"
               >
-                <div
-                  draggable="false"
-                >
-                  <div>
-                    <span
-                      data-slate-node="text"
-                    >
-                      <span
-                        contenteditable="false"
-                        style="opacity: 0.5; position: absolute; user-select: none; pointer-events: none;"
-                      >
-                        Jot something down here
-                      </span>
-                      <span
-                        data-slate-leaf="true"
-                      >
-                        <span
-                          data-slate-length="0"
-                          data-slate-zero-width="n"
-                        >
-                          ﻿
-                          <br />
-                        </span>
-                      </span>
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+                ﻿
+                <br />
+              </span>
+            </span>
+          </span>
         </div>
-      `)
+      </div>
+    </div>
+  </div>
+</div>
+`)
     })
   })
   it('takes value from props', async () => {

--- a/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditorTester.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditorTester.tsx
@@ -73,6 +73,7 @@ export const PortableTextEditorTester = forwardRef(function PortableTextEditorTe
       <PortableTextEditable
         selection={props.selection || undefined}
         renderPlaceholder={props.renderPlaceholder}
+        describedBy="desc_foo"
       />
     </PortableTextEditor>
   )

--- a/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditorTester.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditorTester.tsx
@@ -73,7 +73,7 @@ export const PortableTextEditorTester = forwardRef(function PortableTextEditorTe
       <PortableTextEditable
         selection={props.selection || undefined}
         renderPlaceholder={props.renderPlaceholder}
-        describedBy="desc_foo"
+        aria-describedby="desc_foo"
       />
     </PortableTextEditor>
   )

--- a/packages/sanity/src/core/form/components/formField/FormFieldHeaderText.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldHeaderText.tsx
@@ -3,6 +3,7 @@
 import {FormNodeValidation} from '@sanity/types'
 import {Box, Flex, Stack, Text} from '@sanity/ui'
 import React, {memo} from 'react'
+import {constructDescriptionId} from '../../members/common/constructDescriptionId'
 import {FormFieldValidationStatus} from './FormFieldValidationStatus'
 
 /** @internal */
@@ -45,7 +46,7 @@ export const FormFieldHeaderText = memo(function FormFieldHeaderText(
       </Flex>
 
       {description && (
-        <Text muted size={1}>
+        <Text muted size={1} id={constructDescriptionId(inputId, description)}>
           {description}
         </Text>
       )}

--- a/packages/sanity/src/core/form/components/formField/FormFieldHeaderText.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldHeaderText.tsx
@@ -3,7 +3,7 @@
 import {FormNodeValidation} from '@sanity/types'
 import {Box, Flex, Stack, Text} from '@sanity/ui'
 import React, {memo} from 'react'
-import {constructDescriptionId} from '../../members/common/constructDescriptionId'
+import {createDescriptionId} from '../../members/common/createDescriptionId'
 import {FormFieldValidationStatus} from './FormFieldValidationStatus'
 
 /** @internal */
@@ -46,7 +46,7 @@ export const FormFieldHeaderText = memo(function FormFieldHeaderText(
       </Flex>
 
       {description && (
-        <Text muted size={1} id={constructDescriptionId(inputId, description)}>
+        <Text muted size={1} id={createDescriptionId(inputId, description)}>
           {description}
         </Text>
       )}

--- a/packages/sanity/src/core/form/components/formField/FormFieldSet.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldSet.tsx
@@ -6,7 +6,7 @@ import {FormNodeValidation} from '@sanity/types'
 import {FormNodePresence} from '../../../presence'
 import {DocumentFieldActionNode} from '../../../config'
 import {useFieldActions} from '../../field'
-import {constructDescriptionId} from '../../members/common/constructDescriptionId'
+import {createDescriptionId} from '../../members/common/createDescriptionId'
 import {FormFieldValidationStatus} from './FormFieldValidationStatus'
 import {FormFieldSetLegend} from './FormFieldSetLegend'
 import {focusRingStyle} from './styles'
@@ -173,7 +173,7 @@ export const FormFieldSet = forwardRef(function FormFieldSet(
             </Flex>
 
             {description && (
-              <Text muted size={1} id={constructDescriptionId(inputId, description)}>
+              <Text muted size={1} id={createDescriptionId(inputId, description)}>
                 {description}
               </Text>
             )}

--- a/packages/sanity/src/core/form/components/formField/FormFieldSet.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldSet.tsx
@@ -6,6 +6,7 @@ import {FormNodeValidation} from '@sanity/types'
 import {FormNodePresence} from '../../../presence'
 import {DocumentFieldActionNode} from '../../../config'
 import {useFieldActions} from '../../field'
+import {constructDescriptionId} from '../../members/common/constructDescriptionId'
 import {FormFieldValidationStatus} from './FormFieldValidationStatus'
 import {FormFieldSetLegend} from './FormFieldSetLegend'
 import {focusRingStyle} from './styles'
@@ -43,6 +44,7 @@ export interface FormFieldSetProps {
    * @beta
    */
   validation?: FormNodeValidation[]
+  inputId: string
 }
 
 function getChildren(children: React.ReactNode | (() => React.ReactNode)): React.ReactNode {
@@ -109,6 +111,7 @@ export const FormFieldSet = forwardRef(function FormFieldSet(
     tabIndex,
     title,
     validation = EMPTY_ARRAY,
+    inputId,
     ...restProps
   } = props
 
@@ -170,7 +173,7 @@ export const FormFieldSet = forwardRef(function FormFieldSet(
             </Flex>
 
             {description && (
-              <Text muted size={1}>
+              <Text muted size={1} id={constructDescriptionId(inputId, description)}>
                 {description}
               </Text>
             )}

--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -351,11 +351,11 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       renderPreview,
     ],
   )
-  const describedBy = props.elementProps['aria-describedby']
+  const ariaDescribedBy = props.elementProps['aria-describedby']
   const editorNode = useMemo(
     () => (
       <Editor
-        describedBy={describedBy}
+        ariaDescribedBy={ariaDescribedBy}
         hasFocus={hasFocus}
         hotkeys={editorHotkeys}
         isActive={isActive}
@@ -391,7 +391,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       onPaste,
       path,
       readOnly,
-      describedBy,
+      ariaDescribedBy,
     ],
   )
 

--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -351,10 +351,11 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       renderPreview,
     ],
   )
-
+  const describedBy = props.elementProps['aria-describedby']
   const editorNode = useMemo(
     () => (
       <Editor
+        describedBy={describedBy}
         hasFocus={hasFocus}
         hotkeys={editorHotkeys}
         isActive={isActive}
@@ -390,6 +391,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       onPaste,
       path,
       readOnly,
+      describedBy,
     ],
   )
 

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -51,7 +51,7 @@ interface EditorProps {
   scrollElement: HTMLElement | null
   setPortalElement?: (portalElement: HTMLDivElement | null) => void
   setScrollElement: (scrollElement: HTMLElement | null) => void
-  describedBy: string | undefined
+  ariaDescribedBy: string | undefined
 }
 
 const renderDecorator: RenderDecoratorFunction = (props) => {
@@ -85,7 +85,7 @@ export function Editor(props: EditorProps) {
     scrollElement,
     setPortalElement,
     setScrollElement,
-    describedBy,
+    ariaDescribedBy,
   } = props
   const {isTopLayer} = useLayer()
   const editableRef = useRef<HTMLDivElement | null>(null)
@@ -150,7 +150,7 @@ export function Editor(props: EditorProps) {
         selection={initialSelection}
         style={noOutlineStyle}
         spellCheck={spellcheck}
-        describedBy={describedBy}
+        aria-describedby={ariaDescribedBy}
       />
     ),
     [
@@ -164,7 +164,7 @@ export function Editor(props: EditorProps) {
       renderPlaceholder,
       scrollSelectionIntoView,
       spellcheck,
-      describedBy,
+      ariaDescribedBy,
     ],
   )
 

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -51,6 +51,7 @@ interface EditorProps {
   scrollElement: HTMLElement | null
   setPortalElement?: (portalElement: HTMLDivElement | null) => void
   setScrollElement: (scrollElement: HTMLElement | null) => void
+  describedBy: string | undefined
 }
 
 const renderDecorator: RenderDecoratorFunction = (props) => {
@@ -84,6 +85,7 @@ export function Editor(props: EditorProps) {
     scrollElement,
     setPortalElement,
     setScrollElement,
+    describedBy,
   } = props
   const {isTopLayer} = useLayer()
   const editableRef = useRef<HTMLDivElement | null>(null)
@@ -148,6 +150,7 @@ export function Editor(props: EditorProps) {
         selection={initialSelection}
         style={noOutlineStyle}
         spellCheck={spellcheck}
+        aria-describedby={describedBy}
       />
     ),
     [
@@ -161,6 +164,7 @@ export function Editor(props: EditorProps) {
       renderPlaceholder,
       scrollSelectionIntoView,
       spellcheck,
+      describedBy,
     ],
   )
 

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -150,7 +150,7 @@ export function Editor(props: EditorProps) {
         selection={initialSelection}
         style={noOutlineStyle}
         spellCheck={spellcheck}
-        aria-describedby={describedBy}
+        describedBy={describedBy}
       />
     ),
     [

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceField.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceField.tsx
@@ -300,6 +300,7 @@ export function ReferenceField(props: ReferenceFieldProps) {
         level={props.level}
         title={props.title}
         validation={props.validation}
+        inputId={props.inputId}
       >
         {isEditing ? (
           <Box>{children}</Box>

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
@@ -369,6 +369,7 @@ export function ReferenceItem<Item extends ReferenceItemValue = ReferenceItemVal
               description={schemaType.description}
               __unstable_presence={presence}
               validation={validation}
+              inputId={inputId}
             >
               {children}
             </FormFieldSet>

--- a/packages/sanity/src/core/form/members/array/items/ArrayOfObjectsItem.tsx
+++ b/packages/sanity/src/core/form/members/array/items/ArrayOfObjectsItem.tsx
@@ -23,6 +23,7 @@ import {createProtoValue} from '../../../utils/createProtoValue'
 import {isEmptyItem} from '../../../store/utils/isEmptyItem'
 import {useResolveInitialValueForType} from '../../../../store'
 import {resolveInitialArrayValues} from '../../common/resolveInitialArrayValues'
+import {constructDescriptionId} from '../../common/constructDescriptionId'
 
 /**
  *
@@ -242,8 +243,12 @@ export function ArrayOfObjectsItem(props: MemberItemProps) {
       onFocus: handleFocus,
       id: member.item.id,
       ref: focusRef,
+      'aria-describedby': constructDescriptionId(
+        member.item.id,
+        member.item.schemaType.description,
+      ),
     }),
-    [handleBlur, handleFocus, member.item.id],
+    [handleBlur, handleFocus, member.item.id, member.item.schemaType.description],
   )
 
   const inputProps = useMemo((): Omit<ObjectInputProps, 'renderDefault'> => {

--- a/packages/sanity/src/core/form/members/array/items/ArrayOfObjectsItem.tsx
+++ b/packages/sanity/src/core/form/members/array/items/ArrayOfObjectsItem.tsx
@@ -23,7 +23,7 @@ import {createProtoValue} from '../../../utils/createProtoValue'
 import {isEmptyItem} from '../../../store/utils/isEmptyItem'
 import {useResolveInitialValueForType} from '../../../../store'
 import {resolveInitialArrayValues} from '../../common/resolveInitialArrayValues'
-import {constructDescriptionId} from '../../common/constructDescriptionId'
+import {createDescriptionId} from '../../common/createDescriptionId'
 
 /**
  *
@@ -243,10 +243,7 @@ export function ArrayOfObjectsItem(props: MemberItemProps) {
       onFocus: handleFocus,
       id: member.item.id,
       ref: focusRef,
-      'aria-describedby': constructDescriptionId(
-        member.item.id,
-        member.item.schemaType.description,
-      ),
+      'aria-describedby': createDescriptionId(member.item.id, member.item.schemaType.description),
     }),
     [handleBlur, handleFocus, member.item.id, member.item.schemaType.description],
   )

--- a/packages/sanity/src/core/form/members/array/items/ArrayOfPrimitivesItem.tsx
+++ b/packages/sanity/src/core/form/members/array/items/ArrayOfPrimitivesItem.tsx
@@ -13,7 +13,7 @@ import {
 import {insert, PatchArg, PatchEvent, set, unset} from '../../../patch'
 import {useFormCallbacks} from '../../../studio/contexts/FormCallbacks'
 import {resolveNativeNumberInputValue} from '../../common/resolveNativeNumberInputValue'
-import {constructDescriptionId} from '../../common/constructDescriptionId'
+import {createDescriptionId} from '../../common/createDescriptionId'
 
 /**
  *
@@ -112,10 +112,7 @@ export function ArrayOfPrimitivesItem(props: PrimitiveMemberItemProps) {
       value: resolveNativeInputValue(member.item.schemaType, member.item.value, localValue),
       readOnly: Boolean(member.item.readOnly),
       placeholder: member.item.schemaType.placeholder,
-      'aria-describedby': constructDescriptionId(
-        member.item.id,
-        member.item.schemaType.description,
-      ),
+      'aria-describedby': createDescriptionId(member.item.id, member.item.schemaType.description),
     }),
     [
       handleBlur,

--- a/packages/sanity/src/core/form/members/array/items/ArrayOfPrimitivesItem.tsx
+++ b/packages/sanity/src/core/form/members/array/items/ArrayOfPrimitivesItem.tsx
@@ -13,6 +13,7 @@ import {
 import {insert, PatchArg, PatchEvent, set, unset} from '../../../patch'
 import {useFormCallbacks} from '../../../studio/contexts/FormCallbacks'
 import {resolveNativeNumberInputValue} from '../../common/resolveNativeNumberInputValue'
+import {constructDescriptionId} from '../../common/constructDescriptionId'
 
 /**
  *
@@ -111,6 +112,10 @@ export function ArrayOfPrimitivesItem(props: PrimitiveMemberItemProps) {
       value: resolveNativeInputValue(member.item.schemaType, member.item.value, localValue),
       readOnly: Boolean(member.item.readOnly),
       placeholder: member.item.schemaType.placeholder,
+      'aria-describedby': constructDescriptionId(
+        member.item.id,
+        member.item.schemaType.description,
+      ),
     }),
     [
       handleBlur,

--- a/packages/sanity/src/core/form/members/common/constructDescriptionId.ts
+++ b/packages/sanity/src/core/form/members/common/constructDescriptionId.ts
@@ -1,0 +1,14 @@
+import React from 'react'
+
+/**
+ * Creates a description id from a field id, for use with aria-describedby in the field,
+ * and added to the descriptive element id.
+ * @internal
+ */
+export function constructDescriptionId(
+  id: string | undefined,
+  description: React.ReactNode | undefined,
+): string | undefined {
+  if (!description || !id) return undefined
+  return `desc_${id}`
+}

--- a/packages/sanity/src/core/form/members/common/createDescriptionId.ts
+++ b/packages/sanity/src/core/form/members/common/createDescriptionId.ts
@@ -5,7 +5,7 @@ import React from 'react'
  * and added to the descriptive element id.
  * @internal
  */
-export function constructDescriptionId(
+export function createDescriptionId(
   id: string | undefined,
   description: React.ReactNode | undefined,
 ): string | undefined {

--- a/packages/sanity/src/core/form/members/object/MemberFieldset.tsx
+++ b/packages/sanity/src/core/form/members/object/MemberFieldset.tsx
@@ -57,6 +57,7 @@ export const MemberFieldSet = memo(function MemberFieldSet(props: {
       onExpand={handleExpand}
       columns={member?.fieldSet?.columns}
       data-testid={`fieldset-${member.fieldSet.name}`}
+      inputId={member.fieldSet.name}
     >
       {member.fieldSet.members.map((fieldsetMember) => {
         if (fieldsetMember.kind === 'error') {

--- a/packages/sanity/src/core/form/members/object/fields/ArrayOfObjectsField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/ArrayOfObjectsField.tsx
@@ -34,7 +34,7 @@ import {resolveInitialArrayValues} from '../../common/resolveInitialArrayValues'
 import {applyAll} from '../../../patch/applyPatch'
 import {useFormPublishedId} from '../../../useFormPublishedId'
 import {DocumentFieldActionNode} from '../../../../config'
-import {constructDescriptionId} from '../../common/constructDescriptionId'
+import {createDescriptionId} from '../../common/createDescriptionId'
 
 /**
  * Responsible for creating inputProps and fieldProps to pass to ´renderInput´ and ´renderField´ for an array input
@@ -299,10 +299,7 @@ export function ArrayOfObjectsField(props: {
       onFocus: handleFocus,
       id: member.field.id,
       ref: focusRef,
-      'aria-describedby': constructDescriptionId(
-        member.field.id,
-        member.field.schemaType.description,
-      ),
+      'aria-describedby': createDescriptionId(member.field.id, member.field.schemaType.description),
     }),
     [handleBlur, handleFocus, member.field.id, member.field.schemaType.description],
   )

--- a/packages/sanity/src/core/form/members/object/fields/ArrayOfObjectsField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/ArrayOfObjectsField.tsx
@@ -34,6 +34,7 @@ import {resolveInitialArrayValues} from '../../common/resolveInitialArrayValues'
 import {applyAll} from '../../../patch/applyPatch'
 import {useFormPublishedId} from '../../../useFormPublishedId'
 import {DocumentFieldActionNode} from '../../../../config'
+import {constructDescriptionId} from '../../common/constructDescriptionId'
 
 /**
  * Responsible for creating inputProps and fieldProps to pass to ´renderInput´ and ´renderField´ for an array input
@@ -298,8 +299,12 @@ export function ArrayOfObjectsField(props: {
       onFocus: handleFocus,
       id: member.field.id,
       ref: focusRef,
+      'aria-describedby': constructDescriptionId(
+        member.field.id,
+        member.field.schemaType.description,
+      ),
     }),
-    [handleBlur, handleFocus, member.field.id],
+    [handleBlur, handleFocus, member.field.id, member.field.schemaType.description],
   )
 
   const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)

--- a/packages/sanity/src/core/form/members/object/fields/ArrayOfPrimitivesField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/ArrayOfPrimitivesField.tsx
@@ -36,6 +36,7 @@ import {readAsText} from '../../../studio/uploads/file/readAsText'
 import {accepts} from '../../../studio/uploads/accepts'
 import {applyAll} from '../../../patch/applyPatch'
 import {useFormBuilder} from '../../../useFormBuilder'
+import {constructDescriptionId} from '../../common/constructDescriptionId'
 
 function move<T>(arr: T[], from: number, to: number): T[] {
   const copy = arr.slice()
@@ -301,8 +302,12 @@ export function ArrayOfPrimitivesField(props: {
       onFocus: handleFocus,
       id: member.field.id,
       ref: focusRef,
+      'aria-describedby': constructDescriptionId(
+        member.field.id,
+        member.field.schemaType.description,
+      ),
     }),
-    [handleBlur, handleFocus, member.field.id],
+    [handleBlur, handleFocus, member.field.id, member.field.schemaType.description],
   )
 
   const plainTextUploader = useMemo(

--- a/packages/sanity/src/core/form/members/object/fields/ArrayOfPrimitivesField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/ArrayOfPrimitivesField.tsx
@@ -36,7 +36,7 @@ import {readAsText} from '../../../studio/uploads/file/readAsText'
 import {accepts} from '../../../studio/uploads/accepts'
 import {applyAll} from '../../../patch/applyPatch'
 import {useFormBuilder} from '../../../useFormBuilder'
-import {constructDescriptionId} from '../../common/constructDescriptionId'
+import {createDescriptionId} from '../../common/createDescriptionId'
 
 function move<T>(arr: T[], from: number, to: number): T[] {
   const copy = arr.slice()
@@ -302,10 +302,7 @@ export function ArrayOfPrimitivesField(props: {
       onFocus: handleFocus,
       id: member.field.id,
       ref: focusRef,
-      'aria-describedby': constructDescriptionId(
-        member.field.id,
-        member.field.schemaType.description,
-      ),
+      'aria-describedby': createDescriptionId(member.field.id, member.field.schemaType.description),
     }),
     [handleBlur, handleFocus, member.field.id, member.field.schemaType.description],
   )

--- a/packages/sanity/src/core/form/members/object/fields/ObjectField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/ObjectField.tsx
@@ -19,6 +19,7 @@ import {FormCallbacksProvider, useFormCallbacks} from '../../../studio/contexts/
 import {createProtoValue} from '../../../utils/createProtoValue'
 import {applyAll} from '../../../patch/applyPatch'
 import {useFormBuilder} from '../../../useFormBuilder'
+import {constructDescriptionId} from '../../common/constructDescriptionId'
 
 /**
  * Responsible for creating inputProps and fieldProps to pass to ´renderInput´ and ´renderField´ for an object input
@@ -183,8 +184,12 @@ export const ObjectField = function ObjectField(props: {
       onFocus: handleFocus,
       id: member.field.id,
       ref: focusRef,
+      'aria-describedby': constructDescriptionId(
+        member.field.id,
+        member.field.schemaType.description,
+      ),
     }),
-    [handleBlur, handleFocus, member.field.id],
+    [handleBlur, handleFocus, member.field.id, member.field.schemaType.description],
   )
 
   const inputProps = useMemo((): Omit<ObjectInputProps, 'renderDefault'> => {

--- a/packages/sanity/src/core/form/members/object/fields/ObjectField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/ObjectField.tsx
@@ -19,7 +19,7 @@ import {FormCallbacksProvider, useFormCallbacks} from '../../../studio/contexts/
 import {createProtoValue} from '../../../utils/createProtoValue'
 import {applyAll} from '../../../patch/applyPatch'
 import {useFormBuilder} from '../../../useFormBuilder'
-import {constructDescriptionId} from '../../common/constructDescriptionId'
+import {createDescriptionId} from '../../common/createDescriptionId'
 
 /**
  * Responsible for creating inputProps and fieldProps to pass to ´renderInput´ and ´renderField´ for an object input
@@ -184,10 +184,7 @@ export const ObjectField = function ObjectField(props: {
       onFocus: handleFocus,
       id: member.field.id,
       ref: focusRef,
-      'aria-describedby': constructDescriptionId(
-        member.field.id,
-        member.field.schemaType.description,
-      ),
+      'aria-describedby': createDescriptionId(member.field.id, member.field.schemaType.description),
     }),
     [handleBlur, handleFocus, member.field.id, member.field.schemaType.description],
   )

--- a/packages/sanity/src/core/form/members/object/fields/PrimitiveField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/PrimitiveField.tsx
@@ -11,7 +11,7 @@ import {FormPatch, PatchEvent, set, unset} from '../../../patch'
 import {useFormCallbacks} from '../../../studio/contexts/FormCallbacks'
 import {resolveNativeNumberInputValue} from '../../common/resolveNativeNumberInputValue'
 import {useFormBuilder} from '../../../useFormBuilder'
-import {constructDescriptionId} from '../../common/constructDescriptionId'
+import {createDescriptionId} from '../../common/createDescriptionId'
 
 /**
  * Responsible for creating inputProps and fieldProps to pass to ´renderInput´ and ´renderField´ for a primitive field/input
@@ -106,10 +106,7 @@ export function PrimitiveField(props: {
       value: resolveNativeNumberInputValue(member.field.schemaType, member.field.value, localValue),
       readOnly: Boolean(member.field.readOnly),
       placeholder: member.field.schemaType.placeholder,
-      'aria-describedby': constructDescriptionId(
-        member.field.id,
-        member.field.schemaType.description,
-      ),
+      'aria-describedby': createDescriptionId(member.field.id, member.field.schemaType.description),
     }),
     [
       handleBlur,

--- a/packages/sanity/src/core/form/members/object/fields/PrimitiveField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/PrimitiveField.tsx
@@ -11,6 +11,7 @@ import {FormPatch, PatchEvent, set, unset} from '../../../patch'
 import {useFormCallbacks} from '../../../studio/contexts/FormCallbacks'
 import {resolveNativeNumberInputValue} from '../../common/resolveNativeNumberInputValue'
 import {useFormBuilder} from '../../../useFormBuilder'
+import {constructDescriptionId} from '../../common/constructDescriptionId'
 
 /**
  * Responsible for creating inputProps and fieldProps to pass to ´renderInput´ and ´renderField´ for a primitive field/input
@@ -105,6 +106,10 @@ export function PrimitiveField(props: {
       value: resolveNativeNumberInputValue(member.field.schemaType, member.field.value, localValue),
       readOnly: Boolean(member.field.readOnly),
       placeholder: member.field.schemaType.placeholder,
+      'aria-describedby': constructDescriptionId(
+        member.field.id,
+        member.field.schemaType.description,
+      ),
     }),
     [
       handleBlur,

--- a/packages/sanity/src/core/form/studio/FormBuilder.tsx
+++ b/packages/sanity/src/core/form/studio/FormBuilder.tsx
@@ -177,7 +177,13 @@ function RootInput() {
 
   const rootInputProps: Omit<ObjectInputProps, 'renderDefault'> = {
     focusPath,
-    elementProps: {ref: focusRef, id, onBlur: handleBlur, onFocus: handleFocus},
+    elementProps: {
+      ref: focusRef,
+      id,
+      onBlur: handleBlur,
+      onFocus: handleFocus,
+      'aria-describedby': undefined, // Root input should not have any aria-describedby
+    },
     changed: members.some((m) => m.kind === 'field' && m.field.changed),
     focused,
     groups,

--- a/packages/sanity/src/core/form/studio/inputResolver/fieldResolver.tsx
+++ b/packages/sanity/src/core/form/studio/inputResolver/fieldResolver.tsx
@@ -105,6 +105,7 @@ function ObjectOrArrayField(field: ObjectFieldProps | ArrayFieldProps) {
           onExpand={field.onExpand}
           title={field.title}
           validation={field.validation}
+          inputId={field.inputId}
         >
           {field.children}
         </FormFieldSet>
@@ -152,6 +153,7 @@ function ImageOrFileField(field: ObjectFieldProps) {
           onExpand={field.onExpand}
           title={field.title}
           validation={field.validation}
+          inputId={field.inputId}
         >
           {field.children}
         </FormFieldSet>

--- a/packages/sanity/src/core/form/types/inputProps.ts
+++ b/packages/sanity/src/core/form/types/inputProps.ts
@@ -392,6 +392,7 @@ export interface PrimitiveInputElementProps {
   onFocus: FocusEventHandler
   onBlur: FocusEventHandler
   ref: React.MutableRefObject<any>
+  'aria-describedby': string | undefined
 }
 
 /**
@@ -402,6 +403,7 @@ export interface ComplexElementProps {
   onFocus: FocusEventHandler
   onBlur: FocusEventHandler
   ref: React.MutableRefObject<any>
+  'aria-describedby': string | undefined
 }
 
 /**


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->
In the editor, some fields have a description in addition to just a label. This description is not associated with the field in code. This makes it harder to discover for some users, including screenreader users.

With this changes, when fields have a description, this description will be associated to the input by using `aria-describedby`. This is discoverable by screen readers.

**Note**: Couldn't make it work in portable text editor correctly, as the focused element in PTE is not the same one that receives the aria-describedby value when passing the prop , a follow up ticket will be created for this.


### What to review

Is there any missing field type to consider?
To trigger the descriptions using voice over functionality you have to:
1) Focus on the field, voiceover will let you know it has more information available.
2) Click `cmd+shift+option+/` to show the information. 

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
WCAG : When fields have a description, associate them to the input by using `aria-describedby`.

https://github.com/sanity-io/sanity/assets/46196328/d072b1f9-1761-49c0-b84b-686c59e13193




