### PR TITLE
fix(import): increase concurrency of patching, document creation

### DIFF
--- a/packages/@sanity/import/src/importBatches.js
+++ b/packages/@sanity/import/src/importBatches.js
@@ -3,7 +3,7 @@ const progressStepper = require('./util/progressStepper')
 const retryOnFailure = require('./util/retryOnFailure')
 const suffixTag = require('./util/suffixTag')
 
-const DOCUMENT_IMPORT_CONCURRENCY = 3
+const DOCUMENT_IMPORT_CONCURRENCY = 6
 
 async function importBatches(batches, options) {
   const progress = progressStepper(options.onProgress, {

--- a/packages/@sanity/import/src/references.js
+++ b/packages/@sanity/import/src/references.js
@@ -7,7 +7,7 @@ const progressStepper = require('./util/progressStepper')
 const retryOnFailure = require('./util/retryOnFailure')
 const suffixTag = require('./util/suffixTag')
 
-const STRENGTHEN_CONCURRENCY = 1
+const STRENGTHEN_CONCURRENCY = 30
 const STRENGTHEN_BATCH_SIZE = 30
 
 function getStrongRefs(doc) {

--- a/packages/@sanity/import/src/uploadAssets.js
+++ b/packages/@sanity/import/src/uploadAssets.js
@@ -10,7 +10,7 @@ const urlExists = require('./util/urlExists')
 const suffixTag = require('./util/suffixTag')
 
 const ASSET_UPLOAD_CONCURRENCY = 8
-const ASSET_PATCH_CONCURRENCY = 1
+const ASSET_PATCH_CONCURRENCY = 30
 const ASSET_PATCH_BATCH_SIZE = 50
 
 async function uploadAssets(assets, options) {


### PR DESCRIPTION
### Description

We had some concurrency issues when strengthening references in parallel, but this hasn't been the case for years now. This improves the performance of the import by doing more strengthening in parallel.

### What to review

- Importing still works as expected

### Notes for release

- Improved performance of dataset imports using the `sanity dataset import` command/`@sanity/import` module
