### PR TITLE
fix(portable-text-editor): normalize user insert data

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/hooks/useSyncValue.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/hooks/useSyncValue.ts
@@ -320,7 +320,7 @@ function _updateBlock(
             debug('Updating changed inline object child', currentBlockChild)
             Transforms.setNodes(
               slateEditor,
-              {_key: `${currentBlock._key}-void-child`},
+              {_key: `void-child`},
               {
                 at: [...path, 0],
                 voids: true,

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithSchemaTypes.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithSchemaTypes.ts
@@ -1,4 +1,4 @@
-import {Element, Operation, InsertNodeOperation, Text as SlateText, Transforms} from 'slate'
+import {Element, Text as SlateText, Transforms} from 'slate'
 import {
   isPortableTextTextBlock,
   PortableTextTextBlock,

--- a/packages/@sanity/portable-text-editor/src/utils/__tests__/patchToOperations.test.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/__tests__/patchToOperations.test.ts
@@ -23,7 +23,7 @@ const createDefaultValue = (): Descendant[] => [
     _key: 'c01739b0d03b',
     children: [
       {
-        _key: 'c01739b0d03b-void-child',
+        _key: 'void-child',
         _type: 'span',
         text: '',
         marks: [],
@@ -70,7 +70,7 @@ describe('operationToPatches', () => {
           "_type": "image",
           "children": Array [
             Object {
-              "_key": "c01739b0d03b-void-child",
+              "_key": "void-child",
               "_type": "span",
               "marks": Array [],
               "text": "",
@@ -93,7 +93,7 @@ describe('operationToPatches', () => {
         _key: 'c01739b0d03b',
         children: [
           {
-            _key: 'c01739b0d03b-void-child',
+            _key: 'void-child',
             _type: 'span',
             text: '',
             marks: [],
@@ -123,7 +123,7 @@ describe('operationToPatches', () => {
           "_type": "someType",
           "children": Array [
             Object {
-              "_key": "c01739b0d03b-void-child",
+              "_key": "void-child",
               "_type": "span",
               "marks": Array [],
               "text": "",
@@ -147,7 +147,7 @@ describe('operationToPatches', () => {
         _key: 'c01739b0d03b',
         children: [
           {
-            _key: 'c01739b0d03b-void-child',
+            _key: 'void-child',
             _type: 'span',
             text: '',
             marks: [],
@@ -182,7 +182,7 @@ describe('operationToPatches', () => {
           "_type": "someType",
           "children": Array [
             Object {
-              "_key": "c01739b0d03b-void-child",
+              "_key": "void-child",
               "_type": "span",
               "marks": Array [],
               "text": "",

--- a/packages/@sanity/portable-text-editor/src/utils/__tests__/valueNormalization.test.tsx
+++ b/packages/@sanity/portable-text-editor/src/utils/__tests__/valueNormalization.test.tsx
@@ -19,7 +19,6 @@ describe('values: normalization', () => {
             text: 'Hello',
           },
         ],
-        markDefs: [],
       },
     ]
     const onChange = jest.fn()

--- a/packages/@sanity/portable-text-editor/src/utils/__tests__/values.test.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/__tests__/values.test.ts
@@ -117,7 +117,7 @@ describe('toSlateValue', () => {
               "_type": "image",
               "children": Array [
                 Object {
-                  "_key": "123-void-child",
+                  "_key": "void-child",
                   "_type": "span",
                   "marks": Array [],
                   "text": "",

--- a/packages/@sanity/portable-text-editor/src/utils/operationToPatches.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/operationToPatches.ts
@@ -96,9 +96,13 @@ export function createOperationToPatches(types: PortableTextMemberSchemaTypes): 
           const blockKey = block._key
           const childKey = child._key
           const patches: Patch[] = []
-          Object.keys(operation.newProperties).forEach((keyName) => {
-            const val = get(operation.newProperties, keyName)
-            patches.push(set(val, [{_key: blockKey}, 'children', {_key: childKey}, keyName]))
+          Object.keys(operation.newProperties).forEach((propertyName) => {
+            // Use index over keyed path if _key is undefined,
+            // or we are actually setting the _key with this patch.
+            const keyOrIndex =
+              !childKey || propertyName === '_key' ? operation.path[1] : {_key: childKey}
+            const val = get(operation.newProperties, propertyName)
+            patches.push(set(val, [{_key: blockKey}, 'children', keyOrIndex, propertyName]))
           })
           return patches
         }

--- a/packages/@sanity/portable-text-editor/src/utils/validateValue.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/validateValue.ts
@@ -92,6 +92,15 @@ export function validateValue(
           }
           return true
         }
+        if (!Array.isArray(textBlock.children)) {
+          resolution = {
+            patches: [unset([{_key: textBlock._key}])],
+            description: `Children of text block with _key '${textBlock._key}' is not an array.`,
+            action: 'Remove the block',
+            item: textBlock,
+          }
+          return true
+        }
         // Test that markDefs exists
         if (!blk.markDefs) {
           resolution = {

--- a/packages/@sanity/portable-text-editor/src/utils/validateValue.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/validateValue.ts
@@ -101,21 +101,24 @@ export function validateValue(
           }
           return true
         }
-        // Test that markDefs exists
-        if (!blk.markDefs) {
-          resolution = {
-            patches: [set({...textBlock, markDefs: []}, [{_key: textBlock._key}])],
-            description: `Block is missing required key 'markDefs'.`,
-            action: 'Add empty markDefs array',
-            item: textBlock,
-          }
-          return true
-        }
-        // NOTE: this is commented out as we want to allow the saved data to have optional .marks for spans (as specified by the schema)
+
+        // NOTE: this is commented out as we want to allow the saved data to have
+        // optional .markDefs for block (as specified by the PortableTextTextBlock schema)
+        // if (!blk.markDefs) {
+        //   resolution = {
+        //     patches: [set({...textBlock, markDefs: []}, [{_key: textBlock._key}])],
+        //     description: `Block is missing required key 'markDefs'.`,
+        //     action: 'Add empty markDefs array',
+        //     item: textBlock,
+        //   }
+        //   return true
+        // }
+
+        // NOTE: this is commented out as we want to allow the saved data to have
+        // optional .marks for spans (as specified by the PortableTextTextBlock schema)
         // const spansWithUndefinedMarks = blk.children
         //   .filter(cld => cld._type === types.span.name)
         //   .filter(cld => typeof cld.marks === 'undefined')
-
         // if (spansWithUndefinedMarks.length > 0) {
         //   const first = spansWithUndefinedMarks[0]
         //   resolution = {

--- a/packages/@sanity/portable-text-editor/src/utils/values.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/values.ts
@@ -35,7 +35,7 @@ export function toSlateValue(
   if (value && Array.isArray(value)) {
     return value.map((block) => {
       const {_type, _key, ...rest} = block
-      const voidChildren = [{_key: `${_key}-void-child`, _type: 'span', text: '', marks: []}]
+      const voidChildren = [{_key: `void-child`, _type: 'span', text: '', marks: []}]
       const isPortableText = block && block._type === schemaTypes.block.name
       if (isPortableText) {
         const textBlock = block as PortableTextTextBlock

--- a/packages/@sanity/portable-text-editor/src/utils/values.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/values.ts
@@ -37,7 +37,7 @@ export function toSlateValue(
       const {_type, _key, ...rest} = block
       const voidChildren = [{_key: `void-child`, _type: 'span', text: '', marks: []}]
       const isPortableText = block && block._type === schemaTypes.block.name
-      if (isPortableText) {
+      if (isPortableText && Array.isArray(block.children)) {
         const textBlock = block as PortableTextTextBlock
         let hasInlines = false
         const hasMissingStyle = typeof textBlock.style === 'undefined'

--- a/packages/@sanity/portable-text-editor/test/web-server/components/Editor.tsx
+++ b/packages/@sanity/portable-text-editor/test/web-server/components/Editor.tsx
@@ -73,6 +73,7 @@ export const Editor = ({
   const keyGenFn = useMemo(() => createKeyGenerator(editorId.substring(0, 1)), [editorId])
   const [isOffline, setIsOffline] = useState(!window.navigator.onLine)
   const [readOnly, setReadOnly] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
 
   const renderBlock: RenderBlockFunction = useCallback((props) => {
     const {value: block, schemaType, children} = props
@@ -149,14 +150,17 @@ export const Editor = ({
             setIsOffline(false)
           }
           break
+        case 'invalidValue':
+          console.error(change.resolution?.description)
+          setError(new Error(change.resolution?.description))
+          break
+        case 'value':
         case 'blur':
         case 'focus':
-        case 'invalidValue':
         case 'loading':
         case 'patch':
         case 'ready':
         case 'unset':
-        case 'value':
           break
         default:
           throw new Error(`Unhandled editor change ${JSON.stringify(change)}`)
@@ -233,6 +237,13 @@ export const Editor = ({
           Toggle readonly ({JSON.stringify(readOnly)})
         </button>
       </Box>
+      {error && (
+        <Box marginTop={6}>
+          <Card tone="critical" paddingTop={2} title="Error" padding={[2, 4]}>
+            <Text>{error?.message}</Text>
+          </Card>
+        </Box>
+      )}
     </PortableTextEditor>
   )
 }


### PR DESCRIPTION
### Description

This will fix a couple of problems that I discovered in the Portable Text Editor code.

* Improved normalization of nodes to always assign _key to nodes that are missing keys. I discovered that in some cases children of text blocks (inline blocks) would not get a key assigned like they were supposed to. Also span nodes was assigned keys in a separate patch after they were created. This ensures they get the key assigned at creation time.
* Added value validation rule to test that a text block's children are an actual array.
* Allow a text block's `markDefs` to be undefined. According to the PT-spec and TS-type, this is optional, and we should allow them to be missing from an input value. Added tests for this.
* Don't prefix void child `_key` with block key as it's not necessary and just complicates things. These nodes doesn't exist in the real data, only in the temporary editor state.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
