### PR TITLE
chore(docs): fix dataset delete script

### DIFF
--- a/.github/workflows/docReport.yml
+++ b/.github/workflows/docReport.yml
@@ -51,14 +51,14 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         env:
           DOCS_REPORT_TOKEN: ${{ secrets.DOCS_REPORT_DATASET_TOKEN }}
-          DOCS_REPORT_DATASET: ${{ github.event.number }}
+          DOCS_REPORT_DATASET: pr-${{ github.event.number }}
         run: yarn docs:report:create
 
       - name: Compare Docs Coverage on PR
         if: ${{ github.event_name == 'pull_request' }}
         env:
           DOCS_REPORT_TOKEN: ${{ secrets.DOCS_REPORT_DATASET_TOKEN }}
-          DOCS_REPORT_DATASET: ${{ github.event.number }}
+          DOCS_REPORT_DATASET: pr-${{ github.event.number }}
         run: yarn docs:report
 
       - name: PR comment with report

--- a/.github/workflows/docReport.yml
+++ b/.github/workflows/docReport.yml
@@ -51,14 +51,14 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         env:
           DOCS_REPORT_TOKEN: ${{ secrets.DOCS_REPORT_DATASET_TOKEN }}
-          DOCS_REPORT_DATASET: ${{ github.ref_name }}
+          DOCS_REPORT_DATASET: ${{ github.event.number }}
         run: yarn docs:report:create
 
       - name: Compare Docs Coverage on PR
         if: ${{ github.event_name == 'pull_request' }}
         env:
           DOCS_REPORT_TOKEN: ${{ secrets.DOCS_REPORT_DATASET_TOKEN }}
-          DOCS_REPORT_DATASET: ${{ github.ref_name }}
+          DOCS_REPORT_DATASET: ${{ github.event.number }}
         run: yarn docs:report
 
       - name: PR comment with report

--- a/.github/workflows/docReport.yml
+++ b/.github/workflows/docReport.yml
@@ -11,8 +11,8 @@ jobs:
   report:
     runs-on: ubuntu-latest
     env:
-      TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      TURBO_TEAM: sanity-io
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/docReportTeardown.yml
+++ b/.github/workflows/docReportTeardown.yml
@@ -36,5 +36,5 @@ jobs:
       - name: Remove datasets for closed PRs
         env:
           DOCS_REPORT_TOKEN: ${{ secrets.DOCS_REPORT_DATASET_TOKEN }}
-          DOCS_REPORT_DATASET: ${{ github.event.number }}
+          DOCS_REPORT_DATASET: pr-${{ github.event.number }}
         run: yarn docs:report:cleanup

--- a/.github/workflows/docReportTeardown.yml
+++ b/.github/workflows/docReportTeardown.yml
@@ -9,8 +9,8 @@ jobs:
   reportTeardown:
     runs-on: ubuntu-latest
     env:
-      TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      TURBO_TEAM: sanity-io
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/docReportTeardown.yml
+++ b/.github/workflows/docReportTeardown.yml
@@ -36,5 +36,5 @@ jobs:
       - name: Remove datasets for closed PRs
         env:
           DOCS_REPORT_TOKEN: ${{ secrets.DOCS_REPORT_DATASET_TOKEN }}
-          DOCS_REPORT_DATASET: ${{ github.ref_name }}
+          DOCS_REPORT_DATASET: ${{ github.event.number }}
         run: yarn docs:report:cleanup

--- a/scripts/doc-report/docReportCleanup.ts
+++ b/scripts/doc-report/docReportCleanup.ts
@@ -1,9 +1,12 @@
 import {sanityIdify} from '../utils/sanityIdify'
+import {startTimer} from '../utils/startTimer'
 import {createDocClient} from './docClient'
 import {readEnv} from './envVars'
 
 const DATASET = readEnv('DOCS_REPORT_DATASET')
 const studioMetricsClient = createDocClient(DATASET)
+
+const timer = startTimer(`Deleting dataset ${DATASET}`)
 
 studioMetricsClient.datasets
   .delete(sanityIdify(DATASET))
@@ -16,4 +19,7 @@ studioMetricsClient.datasets
   })
   .catch((err) => {
     throw new Error(`Something went wrong! ${err?.response?.body?.message}`)
+  })
+  .finally(() => {
+    timer.end()
   })


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

- add more logging in delete script
- use PR numbers as dataset names instead of github ref
- fixes turbo token in docs actions 

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

Seems like when the PR is closed the ref actually points to the next branch so it ends up deleting the next dataset. It seems like the `github.event.number` should be more consistent. [Reference](https://shipit.dev/posts/trigger-github-actions-on-pr-close.html) 

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
N/A
