### PR TITLE
chore(ci): drop Node v16 from test matrix, add Node v20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [16, 18]
+        node: [18, 20]
         experimental: [false]
         # include:
         #   - os: windows-latest


### PR DESCRIPTION
### Description

Node 16 goes out of maintenance [LTS](https://nodejs.dev/en/about/releases/) today, so let's drop it form our test matrix. Also, probably a good idea to add v20 now.

### What to review
- Tests are passing

### Notes for release
- Drop Node 16.x from CI test matrix
