### PR TITLE
fix(core): fixes issue with restoring document in nested panes

### DIFF
--- a/packages/sanity/src/desk/documentActions/HistoryRestoreAction.tsx
+++ b/packages/sanity/src/desk/documentActions/HistoryRestoreAction.tsx
@@ -30,6 +30,8 @@ export const HistoryRestoreAction: DocumentActionComponent = ({id, type, revisio
     if (event.type === 'success' && event.op === 'restore') {
       navigateIntent('edit', {id, type})
     }
+
+    prevEvent.current = event
   }, [event, id, navigateIntent, type])
 
   const handle = useCallback(() => {


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR fixes the hacky workaround in https://github.com/sanity-io/sanity/pull/4668 in a more predictable way where it only navigates to the intent when the operation is successfully completed.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

The solution makes sense and there would be no side effects of this change. 

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
- Fixes issue with restoring document history in nested panes