### PR TITLE
test(import): fix test failure caused by error message update in node v20

### DIFF
--- a/packages/@sanity/import/test/import.test.js
+++ b/packages/@sanity/import/test/import.test.js
@@ -39,10 +39,9 @@ test('rejects on invalid input type (non-array)', async () => {
 
 test('rejects on invalid JSON', async () => {
   expect.assertions(1)
-  await expect(importer(getFixtureStream('invalid-json'), importOptions)).rejects.toHaveProperty(
-    'message',
-    'Failed to parse line #3: Unexpected token _ in JSON at position 1',
-  )
+  await expect(importer(getFixtureStream('invalid-json'), importOptions)).rejects.toMatchObject({
+    message: /Failed to parse line #3:.+/,
+  })
 })
 
 test('rejects on invalid `_id` property', async () => {


### PR DESCRIPTION
### Description

One of the tests in the `@sanity/import` package cufrently fails in node v20 due to JSON parse errors having a slightly different error message. This fixes it by using a regex that verifies the first part of the error message, which is unchanged between node v18 and v20.

### What to review
Change looks ok, tests are passing

### Notes for release

N/A