### PR TITLE
feat(i18n): implement a very simple tags/components parser to use in a Translate component

### DIFF
--- a/dev/test-studio/components/TranslateExample.tsx
+++ b/dev/test-studio/components/TranslateExample.tsx
@@ -1,0 +1,27 @@
+import {Translate, useTranslation} from 'sanity'
+import React from 'react'
+import {Card, Text} from '@sanity/ui'
+import {InfoFilledIcon} from '@sanity/icons'
+
+export function TranslateExample() {
+  const {t} = useTranslation('testStudio')
+  return (
+    <Card padding={4}>
+      <Text>
+        <Translate
+          t={t}
+          i18nKey="translate.example"
+          components={{
+            Icon: () => <InfoFilledIcon />,
+            Red: ({children}) => <span style={{color: 'red'}}>{children}</span>,
+            Bold: ({children}) => <b>{children}</b>,
+          }}
+          values={{
+            keyword: 'something',
+            duration: '30',
+          }}
+        />
+      </Text>
+    </Card>
+  )
+}

--- a/dev/test-studio/locales/index.ts
+++ b/dev/test-studio/locales/index.ts
@@ -5,6 +5,8 @@ export const testStudioLocaleNamespace = 'testStudio' as const
 const enUSStrings = {
   'studio.logo.title': 'English logo',
   'structure.root.title': 'Content 🇺🇸',
+  'translate.example':
+    '<Icon/> Your search for "<Red>{{keyword}}</Red>" took <Bold>{{duration}}ms</Bold>',
 }
 
 const enUS = defineLocaleResourceBundle({
@@ -19,6 +21,8 @@ const noNB = defineLocaleResourceBundle({
   resources: {
     'studio.logo.title': 'Norsk logo',
     'structure.root.title': 'Innhold 🇳🇴',
+    'translate.example':
+      '<Icon/> Ditt søk på "<Red>{{keyword}}</Red>" tok <Bold>{{duration}}</Bold> millisekunder',
   },
 })
 

--- a/dev/test-studio/structure/resolveStructure.ts
+++ b/dev/test-studio/structure/resolveStructure.ts
@@ -10,12 +10,14 @@ import {
   CodeIcon,
 } from '@sanity/icons'
 import {uuid} from '@sanity/uuid'
-import {DocumentStore, SanityDocument, Schema} from 'sanity'
+import {DocumentStore, SanityDocument, Schema, Translate} from 'sanity'
 import {ItemChild, StructureBuilder, StructureResolver} from 'sanity/desk'
 import {map} from 'rxjs/operators'
 import {Observable, timer} from 'rxjs'
+import React from 'react'
 import {DebugPane} from '../components/panes/debug'
 import {JsonDocumentDump} from '../components/panes/JsonDocumentDump'
+import {TranslateExample} from '../components/TranslateExample'
 import {_buildTypeGroup} from './_buildTypeGroup'
 import {
   CI_INPUT_TYPES,
@@ -37,6 +39,10 @@ export const structure: StructureResolver = (S, {schema, documentStore, i18n}) =
     .items([
       S.documentListItem().id('validation').schemaType('allTypes'),
 
+      S.listItem()
+        .id('translate')
+        .title('Translate Test')
+        .child(S.component(TranslateExample).id('example')),
       S.listItem()
         .title('Untitled repro')
         .child(

--- a/packages/sanity/src/core/i18n/LocaleContext.ts
+++ b/packages/sanity/src/core/i18n/LocaleContext.ts
@@ -1,4 +1,5 @@
 import {createContext} from 'react'
+import {i18n} from 'i18next'
 
 /**
  * @internal
@@ -11,5 +12,6 @@ export const LocaleContext = createContext<LocaleContextValue | undefined>(undef
 export interface LocaleContextValue {
   locales: {id: string; title: string}[]
   currentLocale: string
+  __internal: {i18next: i18n}
   changeLocale: (newLocale: string) => Promise<void>
 }

--- a/packages/sanity/src/core/i18n/Translate.tsx
+++ b/packages/sanity/src/core/i18n/Translate.tsx
@@ -10,8 +10,8 @@ type ComponentMap = Record<string, ComponentType<{children?: ReactNode}>>
 export interface TranslationProps {
   t: TFunction
   i18nKey: string
-  components: ComponentMap
-  values: Record<string, string>
+  components?: ComponentMap
+  values?: Record<string, string>
 }
 
 function render(tokens: Token[], componentMap: ComponentMap): ReactNode {
@@ -72,5 +72,5 @@ export function Translate(props: TranslationProps) {
 
   const tokens = useMemo(() => simpleParser(translated), [translated])
 
-  return <>{render(tokens, props.components)}</>
+  return <>{render(tokens, props.components || {})}</>
 }

--- a/packages/sanity/src/core/i18n/Translate.tsx
+++ b/packages/sanity/src/core/i18n/Translate.tsx
@@ -1,0 +1,76 @@
+import React, {ComponentType, ReactNode, useMemo} from 'react'
+import type {TFunction} from 'i18next'
+import {CloseTagToken, simpleParser, TextToken, Token} from './simpleParser'
+
+type ComponentMap = Record<string, ComponentType<{children?: ReactNode}>>
+
+/**
+ * @beta
+ */
+export interface TranslationProps {
+  t: TFunction
+  i18nKey: string
+  components: ComponentMap
+  values: Record<string, string>
+}
+
+function render(tokens: Token[], componentMap: ComponentMap): ReactNode {
+  const [head, ...tail] = tokens
+  if (!head) {
+    return null
+  }
+  if (head.type === 'text') {
+    return (
+      <>
+        {head.text}
+        {render(tail, componentMap)}
+      </>
+    )
+  }
+  if (head.type === 'tagOpen' && head.selfClosing) {
+    const Component = componentMap[head.name]
+
+    if (!Component) {
+      throw new Error(`Component not found: ${head.name}`)
+    }
+    return (
+      <>
+        <Component />
+        {render(tail, componentMap)}
+      </>
+    )
+  }
+  if (head.type === 'tagOpen' && !head.selfClosing) {
+    const nextCloseIdx = tail.findIndex((token) => token.type === 'tagClose')
+    const nextClose = tail[nextCloseIdx]
+    if (nextClose) {
+      if (head.name !== (nextClose as CloseTagToken).name) {
+        throw new Error('Nested tags is not allowed')
+      }
+    }
+    const Component = componentMap[head.name]
+    if (!Component) {
+      throw new Error(`Component not found: ${head.name}`)
+    }
+    const children = tail.slice(0, nextCloseIdx) as TextToken[]
+    const remaining = tail.slice(nextCloseIdx + 1)
+    return (
+      <>
+        <Component>{render(children, componentMap)}</Component>
+        {render(remaining, componentMap)}
+      </>
+    )
+  }
+  return null
+}
+
+/**
+ * @beta
+ */
+export function Translate(props: TranslationProps) {
+  const translated = props.t(props.i18nKey, props.values)
+
+  const tokens = useMemo(() => simpleParser(translated), [translated])
+
+  return <>{render(tokens, props.components)}</>
+}

--- a/packages/sanity/src/core/i18n/__tests__/Translate.test.tsx
+++ b/packages/sanity/src/core/i18n/__tests__/Translate.test.tsx
@@ -1,0 +1,98 @@
+// eslint-disable-next-line import/no-unassigned-import
+import '@testing-library/jest-dom/extend-expect'
+import {render} from '@testing-library/react'
+import React, {ComponentProps} from 'react'
+import {studioTheme, ThemeProvider} from '@sanity/ui'
+import {Translate} from '../Translate'
+import {LocaleProviderBase} from '../components/LocaleProvider'
+import {useTranslation} from '../hooks/useTranslation'
+import {prepareI18n} from '../i18nConfig'
+import {LocaleResourceBundle, LocaleResourceRecord} from '../types'
+import {defineLocaleResourceBundle} from '../helpers'
+
+type TestComponentProps = Omit<ComponentProps<typeof Translate>, 't'>
+
+function createBundle(resources: LocaleResourceRecord) {
+  return defineLocaleResourceBundle({
+    locale: 'en-US',
+    namespace: 'testNs',
+    resources,
+  })
+}
+
+function TestProviders(props: {children: React.ReactNode; bundles: LocaleResourceBundle[]}) {
+  const {i18next} = prepareI18n({
+    projectId: 'test',
+    dataset: 'test',
+    name: 'test',
+    i18n: {bundles: props.bundles},
+  })
+  return (
+    <ThemeProvider theme={studioTheme}>
+      <LocaleProviderBase
+        locales={[{id: 'en-US', title: 'English'}]}
+        i18next={i18next}
+        projectId="test"
+        sourceId="test"
+      >
+        {props.children}
+      </LocaleProviderBase>
+    </ThemeProvider>
+  )
+}
+
+function TestComponent(props: TestComponentProps) {
+  const {t} = useTranslation('testNs')
+  return (
+    <div data-testid="output">
+      <Translate
+        t={t}
+        i18nKey={props.i18nKey}
+        components={props.components}
+        values={props.values}
+      />
+    </div>
+  )
+}
+
+describe('Translate component', () => {
+  it('it translates a key', async () => {
+    const {findByTestId} = render(
+      <TestProviders bundles={[createBundle({title: 'English title'})]}>
+        <TestComponent i18nKey="title" />
+      </TestProviders>,
+    )
+    expect((await findByTestId('output')).innerHTML).toEqual('English title')
+  })
+  it('it renders the key as-is if translation is missing', async () => {
+    const {findByTestId} = render(
+      <TestProviders bundles={[createBundle({title: 'English title'})]}>
+        <TestComponent i18nKey="does-not-exist" />
+      </TestProviders>,
+    )
+    expect((await findByTestId('output')).innerHTML).toEqual('does-not-exist')
+  })
+  it('it supports providing a component map to use for customizing message rendering', async () => {
+    const {findByTestId} = render(
+      <TestProviders
+        bundles={[
+          createBundle({
+            message: 'Your search for "<Red>{{keyword}}</Red>" took <Bold>{{duration}}ms</Bold>',
+          }),
+        ]}
+      >
+        <TestComponent
+          i18nKey="message"
+          components={{
+            Red: ({children}) => <span style={{color: 'red'}}>{children}</span>,
+            Bold: ({children}) => <b>{children}</b>,
+          }}
+          values={{keyword: 'something', duration: '123'}}
+        />
+      </TestProviders>,
+    )
+    expect((await findByTestId('output')).innerHTML).toEqual(
+      `Your search for "<span style="color: red;">something</span>" took <b>123ms</b>`,
+    )
+  })
+})

--- a/packages/sanity/src/core/i18n/__tests__/simpleParser.test.ts
+++ b/packages/sanity/src/core/i18n/__tests__/simpleParser.test.ts
@@ -1,0 +1,54 @@
+import {simpleParser} from '../simpleParser'
+
+describe('simpleParser', () => {
+  test('simple string', () => {
+    expect(simpleParser('foo')).toMatchObject([{text: 'foo', type: 'text'}])
+    expect(simpleParser('foo bar baz')).toMatchObject([{text: 'foo bar baz', type: 'text'}])
+    expect(simpleParser('foo. This is a bar, baz')).toMatchObject([
+      {type: 'text', text: 'foo. This is a bar, baz'},
+    ])
+  })
+  test('tag characters among text', () => {
+    expect(simpleParser('foo is greater than (>) bar')).toMatchObject([
+      {type: 'text', text: 'foo is greater than (>) bar'},
+    ])
+  })
+  test('self closing tags', () => {
+    expect(simpleParser('foo <is/> greater than (>) bar')).toMatchObject([
+      {type: 'text', text: 'foo '},
+      {type: 'tagOpen', name: 'is', selfClosing: true},
+      {type: 'text', text: ' greater than (>) bar'},
+    ])
+    expect(simpleParser('foo <is/> greater <than/> (>) bar')).toMatchObject([
+      {type: 'text', text: 'foo '},
+      {type: 'tagOpen', name: 'is', selfClosing: true},
+      {type: 'text', text: ' greater '},
+      {type: 'tagOpen', name: 'than', selfClosing: true},
+      {type: 'text', text: ' (>) bar'},
+    ])
+  })
+  test('tags with children', () => {
+    expect(simpleParser('foo <em>is</em> greater than (>) bar')).toMatchObject([
+      {type: 'text', text: 'foo '},
+      {type: 'tagOpen', name: 'em'},
+      {type: 'text', text: 'is'},
+      {type: 'tagClose', name: 'em'},
+      {type: 'text', text: ' greater than (>) bar'},
+    ])
+  })
+  test('mixed', () => {
+    expect(
+      simpleParser('<Icon/> Your search for "<Red>{{keyword}}</Red>" took <Bold>{{time}}ms</Bold>'),
+    ).toMatchObject([
+      {type: 'tagOpen', name: 'Icon', selfClosing: true},
+      {type: 'text', text: ' Your search for "'},
+      {type: 'tagOpen', name: 'Red'},
+      {type: 'text', text: '{{keyword}}'},
+      {type: 'tagClose', name: 'Red'},
+      {type: 'text', text: '" took '},
+      {type: 'tagOpen', name: 'Bold'},
+      {type: 'text', text: '{{time}}ms'},
+      {type: 'tagClose', name: 'Bold'},
+    ])
+  })
+})

--- a/packages/sanity/src/core/i18n/__tests__/simpleParser.test.ts
+++ b/packages/sanity/src/core/i18n/__tests__/simpleParser.test.ts
@@ -14,26 +14,46 @@ describe('simpleParser', () => {
     ])
   })
   test('self closing tags', () => {
-    expect(simpleParser('foo <is/> greater than (>) bar')).toMatchObject([
+    expect(simpleParser('foo <Is/> greater than (>) bar')).toMatchObject([
       {type: 'text', text: 'foo '},
-      {type: 'tagOpen', name: 'is', selfClosing: true},
+      {type: 'tagOpen', name: 'Is', selfClosing: true},
       {type: 'text', text: ' greater than (>) bar'},
     ])
-    expect(simpleParser('foo <is/> greater <than/> (>) bar')).toMatchObject([
+    expect(simpleParser('foo <Is/> greater <Than/> (>) bar')).toMatchObject([
       {type: 'text', text: 'foo '},
-      {type: 'tagOpen', name: 'is', selfClosing: true},
+      {type: 'tagOpen', name: 'Is', selfClosing: true},
       {type: 'text', text: ' greater '},
-      {type: 'tagOpen', name: 'than', selfClosing: true},
+      {type: 'tagOpen', name: 'Than', selfClosing: true},
       {type: 'text', text: ' (>) bar'},
     ])
   })
   test('tags with children', () => {
-    expect(simpleParser('foo <em>is</em> greater than (>) bar')).toMatchObject([
+    expect(simpleParser('foo <Em>is</Em> greater than (>) bar')).toMatchObject([
       {type: 'text', text: 'foo '},
-      {type: 'tagOpen', name: 'em'},
+      {type: 'tagOpen', name: 'Em'},
       {type: 'text', text: 'is'},
-      {type: 'tagClose', name: 'em'},
+      {type: 'tagClose', name: 'Em'},
       {type: 'text', text: ' greater than (>) bar'},
+    ])
+  })
+
+  test('valid tag names', () => {
+    // tags cannot start with a number
+    expect(
+      simpleParser('<H2>heading</H2> <FooBar>foo bar</FooBar> <H3/> <FooBar123/> '),
+    ).toMatchObject([
+      {type: 'tagOpen', name: 'H2'},
+      {type: 'text', text: 'heading'},
+      {type: 'tagClose', name: 'H2'},
+      {type: 'text', text: ' '},
+      {type: 'tagOpen', name: 'FooBar'},
+      {type: 'text', text: 'foo bar'},
+      {type: 'tagClose', name: 'FooBar'},
+      {type: 'text', text: ' '},
+      {type: 'tagOpen', name: 'H3', selfClosing: true},
+      {type: 'text', text: ' '},
+      {type: 'tagOpen', name: 'FooBar123', selfClosing: true},
+      {type: 'text', text: ' '},
     ])
   })
   test('mixed', () => {
@@ -50,5 +70,44 @@ describe('simpleParser', () => {
       {type: 'text', text: '{{time}}ms'},
       {type: 'tagClose', name: 'Bold'},
     ])
+  })
+})
+describe('simpleParser - errors', () => {
+  test('unpaired tags', () => {
+    expect(() =>
+      simpleParser('<Icon/> Your search for "<Red>{{keyword}}" took <Bold>{{time}}ms</Bold>'),
+    ).toThrow(
+      'Expected closing tag for <Red>, but found new opening tag <Bold>. Nested tags is not supported.',
+    )
+  })
+  test('unclosed tags', () => {
+    expect(() => simpleParser('foo <Icon> bar')).toThrow(
+      'No matching closing tag for <Icon> found. Either make it self closing (e.g. "<Icon/>") or close it (e.g "<Icon>...</Icon>")',
+    )
+  })
+  test('unclosed tags before another close tag', () => {
+    expect(() => simpleParser('foo <Red> bar</Blue>')).toThrow(
+      'Expected closing tag for <Red>, but found closing tag </Blue> instead. Make sure each opening tag has a matching closing tag.',
+    )
+  })
+  test('tags must be title cased', () => {
+    expect(() => simpleParser('foo <red> bar</Blue>')).toThrow(
+      'Invalid tag "<red>". Tag names must start with an uppercase letter and can only include letters and numbers"',
+    )
+  })
+  test('tags cant contain whitespace or special characters', () => {
+    expect(() => simpleParser('foo <Em@ail> bar</Em@ail>')).toThrow(
+      'Invalid tag "<Em@ail>". Tag names must start with an uppercase letter and can only include letters and numbers"',
+    )
+    expect(() => simpleParser('foo <Bold >bar</Bold>')).toThrow(
+      'Invalid tag "<Bold >". Tag names must start with an uppercase letter and can only include letters and numbers"',
+    )
+  })
+  test('handles tag chars at random positions', () => {
+    expect(() => simpleParser('foo <> bar')).not.toThrow()
+    expect(() => simpleParser('foo < or > bar')).not.toThrow()
+    expect(() => simpleParser('<foo < or > bar>')).not.toThrow()
+    expect(() => simpleParser('a < 1 < or > bar>')).not.toThrow()
+    expect(() => simpleParser('0 <2 > 1')).not.toThrow()
   })
 })

--- a/packages/sanity/src/core/i18n/components/LocaleProvider.tsx
+++ b/packages/sanity/src/core/i18n/components/LocaleProvider.tsx
@@ -1,10 +1,10 @@
 import {I18nextProvider} from 'react-i18next'
-import React, {PropsWithChildren, Suspense, useMemo} from 'react'
+import React, {PropsWithChildren, Suspense, useCallback, useMemo, useSyncExternalStore} from 'react'
+import type {i18n} from 'i18next'
 import {useSource} from '../../studio'
 import {LoadingScreen} from '../../studio/screens'
 import {storePreferredLocale} from '../localeStore'
 import {LocaleContext, LocaleContextValue} from '../LocaleContext'
-import {useCurrentLocale} from '../hooks/useLocale'
 
 /**
  * @internal
@@ -14,15 +14,52 @@ export function LocaleProvider(props: PropsWithChildren<{}>) {
   const {
     projectId,
     name: sourceId,
+
     i18n: {locales},
     __internal: {i18next},
   } = useSource()
 
-  const currentLocale = useCurrentLocale()
+  return (
+    <LocaleProviderBase
+      {...props}
+      projectId={projectId}
+      sourceId={sourceId}
+      locales={locales}
+      i18next={i18next}
+    />
+  )
+}
+
+/**
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/ban-types
+export function LocaleProviderBase({
+  projectId,
+  sourceId,
+  locales,
+  i18next,
+  children,
+}: PropsWithChildren<{
+  projectId: string
+  sourceId: string
+  locales: {id: string; title: string}[]
+  i18next: i18n
+}>) {
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      i18next.on('languageChanged', callback)
+      return () => i18next.off('languageChanged', callback)
+    },
+    [i18next],
+  )
+  const currentLocale = useSyncExternalStore(subscribe, () => i18next.language)
+
   const context = useMemo<LocaleContextValue>(
     () => ({
       locales,
       currentLocale,
+      __internal: {i18next},
       changeLocale: async (newLocale: string) => {
         storePreferredLocale(projectId, sourceId, newLocale)
         await i18next.changeLanguage(newLocale)
@@ -36,7 +73,7 @@ export function LocaleProvider(props: PropsWithChildren<{}>) {
       <I18nextProvider i18n={i18next}>
         {/* Use locale as key to force re-render, updating non-reactive parts */}
         <LocaleContext.Provider value={context} key={currentLocale}>
-          {props.children}
+          {children}
         </LocaleContext.Provider>
       </I18nextProvider>
     </Suspense>

--- a/packages/sanity/src/core/i18n/components/LocaleProvider.tsx
+++ b/packages/sanity/src/core/i18n/components/LocaleProvider.tsx
@@ -32,7 +32,6 @@ export function LocaleProvider(props: PropsWithChildren) {
 /**
  * @internal
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
 export function LocaleProviderBase({
   projectId,
   sourceId,

--- a/packages/sanity/src/core/i18n/components/LocaleProvider.tsx
+++ b/packages/sanity/src/core/i18n/components/LocaleProvider.tsx
@@ -9,8 +9,7 @@ import {LocaleContext, LocaleContextValue} from '../LocaleContext'
 /**
  * @internal
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
-export function LocaleProvider(props: PropsWithChildren<{}>) {
+export function LocaleProvider(props: PropsWithChildren) {
   const {
     projectId,
     name: sourceId,

--- a/packages/sanity/src/core/i18n/hooks/useLocale.ts
+++ b/packages/sanity/src/core/i18n/hooks/useLocale.ts
@@ -6,17 +6,7 @@ import {useSource} from '../../studio'
  * @internal
  */
 export function useCurrentLocale(): string {
-  const i18next = useSource().__internal.i18next
-
-  const subscribe = useCallback(
-    (callback: () => void) => {
-      i18next.on('languageChanged', callback)
-      return () => i18next.off('languageChanged', callback)
-    },
-    [i18next],
-  )
-
-  return useSyncExternalStore(subscribe, () => i18next.language)
+  return useLocale().currentLocale
 }
 
 /**

--- a/packages/sanity/src/core/i18n/index.ts
+++ b/packages/sanity/src/core/i18n/index.ts
@@ -2,6 +2,7 @@ export * from './hooks/useTranslation'
 export * from './hooks/useLocale'
 export * from './components/LocaleProvider'
 export * from './locales'
+export * from './Translate'
 export type {
   ImplicitLocaleResourceBundle,
   LocaleConfigContext,

--- a/packages/sanity/src/core/i18n/simpleParser.ts
+++ b/packages/sanity/src/core/i18n/simpleParser.ts
@@ -1,0 +1,92 @@
+export type OpenTagToken = {
+  type: 'tagOpen'
+  name: string
+  selfClosing?: boolean
+}
+export type CloseTagToken = {
+  type: 'tagClose'
+  name: string
+}
+export type TextToken = {
+  type: 'text'
+  text: string
+}
+export type Token = OpenTagToken | CloseTagToken | TextToken
+
+const OPEN_TAG_RE = /<(?<tag>\w+)\/?>/
+const CLOSE_TAG_RE = /<\/(?<tag>\w+)>/
+const SELF_CLOSING_RE = /<\w+\/>/
+
+function isSelfClosing(tag: string) {
+  return SELF_CLOSING_RE.test(tag)
+}
+function matchOpenTag(input: string) {
+  return input.match(OPEN_TAG_RE)
+}
+function matchCloseTag(input: string) {
+  return input.match(CLOSE_TAG_RE)
+}
+
+/**
+ * Parses a string for simple tags
+ * @param input - input string to parse
+ */
+export function simpleParser(input: string): Token[] {
+  const tokens: Token[] = []
+  let text = ''
+  let openTag = ''
+  let remainder = input
+  while (remainder.length > 0) {
+    if (!openTag && remainder[0] === '<') {
+      const match = matchOpenTag(remainder)
+      if (match) {
+        const tagName = match.groups!.tag
+        if (text) {
+          tokens.push({type: 'text', text})
+          text = ''
+        }
+        if (isSelfClosing(match[0])) {
+          tokens.push({type: 'tagOpen', selfClosing: true, name: tagName})
+        } else {
+          tokens.push({type: 'tagOpen', name: tagName})
+          openTag = tagName
+        }
+        remainder = remainder.substring(match[0].length)
+      } else {
+        // move on to next char
+        text += remainder[0]
+        remainder = remainder.substring(1)
+      }
+    } else if (openTag && remainder[0] === '<') {
+      const match = matchCloseTag(remainder)
+      if (match) {
+        if (remainder[1] !== '/') {
+          throw new Error('Expected closing tag')
+        }
+        const tagName = match.groups!.tag
+        if (tagName !== openTag) {
+          throw new Error(`Unbalanced tag: expected a closing tag for ${openTag}`)
+        }
+        if (text) {
+          tokens.push({type: 'text', text})
+          text = ''
+        }
+        tokens.push({type: 'tagClose', name: tagName})
+        openTag = ''
+        remainder = remainder.substring(match[0].length)
+      } else {
+        // move on to next char
+        text += remainder[0]
+        remainder = remainder.substring(1)
+      }
+    } else {
+      // move on to next char
+      text += remainder[0]
+      remainder = remainder.substring(1)
+    }
+  }
+  if (text) {
+    tokens.push({type: 'text', text})
+  }
+  return tokens
+}

--- a/packages/sanity/src/core/studio/screens/schemaErrors/SchemaProblemGroups.tsx
+++ b/packages/sanity/src/core/studio/screens/schemaErrors/SchemaProblemGroups.tsx
@@ -5,8 +5,8 @@ import {SchemaValidationProblemGroup} from '@sanity/types'
 import React, {useMemo} from 'react'
 import styled from 'styled-components'
 import {capitalize} from 'lodash'
-import {Trans} from 'react-i18next'
 import {useTranslation} from '../../../i18n'
+import {Translate} from '../../../i18n/Translate'
 
 const TONES: Record<'error' | 'warning', ThemeColorToneKey> = {
   error: 'critical',


### PR DESCRIPTION
Implements a simple tags/components (not html!) parser for use with i18n, plus a <Translate component that takes a translation key and a component map, looks up the a translation string associated with the key, and replaces any `<Component>` parts of the translation string with the matching component provided through the `componentMap`.


- See unit tests for the [parser](https://github.com/sanity-io/sanity/blob/13dcc260cf483f194e5b53c22ae2c08d5c07540e/packages/sanity/src/core/i18n/__tests__/simpleParser.test.ts) or the [Translate](https://github.com/sanity-io/sanity/blob/13dcc260cf483f194e5b53c22ae2c08d5c07540e/packages/sanity/src/core/i18n/__tests__/Translate.test.tsx) component for more details
- Example usage [here](https://github.com/sanity-io/sanity/blob/de9a406d58a7314b11c640011c7cda93206ccd17/dev/test-studio/components/TranslateExample.tsx) with live [example here](https://test-studio-git-feature-sdx-598simple-translate-component.sanity.build/test/content/translate)