### PR TITLE
fix(core): fix array items not showing in field groups

### DIFF
--- a/dev/test-studio/schema/debug/virtualizationDebug.tsx
+++ b/dev/test-studio/schema/debug/virtualizationDebug.tsx
@@ -19,8 +19,8 @@ export function MyField(props: FieldProps) {
   )
 }
 
-const getAuthors = (client: SanityClient) => {
-  const query = `*[_type == "author"][0...20]{_id}`
+const getAuthors = (client: SanityClient, limit = 20) => {
+  const query = `*[_type == "author"][0...${limit}]{_id}`
 
   return client.fetch(query)
 }
@@ -37,6 +37,10 @@ export const virtualizationDebug = defineType({
     {
       name: 'objects',
       title: 'Objects',
+    },
+    {
+      name: 'singleItem',
+      title: 'Single Item test',
     },
   ],
 
@@ -244,6 +248,28 @@ export const virtualizationDebug = defineType({
           },
         }),
       ],
+    }),
+    defineField({
+      name: 'arrayListSingleGroup',
+      title: 'Array List single item in group',
+      type: 'array',
+      group: 'singleItem',
+      of: [
+        {
+          type: 'reference',
+          to: [{type: 'author'}],
+        },
+      ],
+      initialValue: async (_, context) => {
+        const {getClient} = context
+        const client = getClient({apiVersion: '2022-12-07'})
+        const authors = await getAuthors(client, 8)
+
+        return authors.map((author: any) => ({
+          _type: 'reference',
+          _ref: author._id,
+        }))
+      },
     }),
   ],
 })

--- a/dev/test-studio/schema/debug/virtualizationDebug.tsx
+++ b/dev/test-studio/schema/debug/virtualizationDebug.tsx
@@ -42,6 +42,10 @@ export const virtualizationDebug = defineType({
       name: 'singleItem',
       title: 'Single Item test',
     },
+    {
+      name: 'singleItemNested',
+      title: 'Single Item Nested Group',
+    },
   ],
 
   fields: [
@@ -270,6 +274,63 @@ export const virtualizationDebug = defineType({
           _ref: author._id,
         }))
       },
+    }),
+
+    defineField({
+      name: 'arrayInObjectNestedGroup',
+      title: 'Array in Object Arrays',
+      type: 'object',
+      group: 'singleItemNested',
+      options: {
+        collapsible: true,
+      },
+      groups: [
+        {
+          name: 'nestedGroup',
+          title: 'Nested Group',
+        },
+      ],
+      fields: [
+        defineField({
+          name: 'arrayListNestedGroup',
+          title: 'Array List with no customization',
+          type: 'array',
+          of: [
+            {
+              type: 'playlist',
+            },
+          ],
+          initialValue: () => {
+            const arr = new Array(10).fill(null)
+            return arr.map((_, i) => ({
+              _type: 'playlist',
+              name: `Playlist ${i}`,
+            }))
+          },
+        }),
+        defineField({
+          name: 'arrayListNestedSingleGroup',
+          title: 'Array List single item in nested group',
+          type: 'array',
+          group: 'nestedGroup',
+          of: [
+            {
+              type: 'reference',
+              to: [{type: 'author'}],
+            },
+          ],
+          initialValue: async (_, context) => {
+            const {getClient} = context
+            const client = getClient({apiVersion: '2022-12-07'})
+            const authors = await getAuthors(client, 8)
+
+            return authors.map((author: any) => ({
+              _type: 'reference',
+              _ref: author._id,
+            }))
+          },
+        }),
+      ],
     }),
   ],
 })

--- a/packages/sanity/src/desk/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/DocumentPanel.tsx
@@ -62,6 +62,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     isDeleting,
     isDeleted,
     timelineStore,
+    formState,
   } = useDocumentPane()
   const {collapsed: layoutCollapsed} = usePaneLayout()
   const {collapsed} = usePane()
@@ -74,6 +75,12 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
   const formContainerElement = useRef<HTMLDivElement | null>(null)
 
   const requiredPermission = value._createdAt ? 'update' : 'create'
+
+  const selectedGroup = useMemo(() => {
+    if (!formState) return undefined
+
+    return formState.groups.find((group) => group.selected)
+  }, [formState])
 
   const activeView = useMemo(
     () => views.find((view) => view.id === activeViewId) || views[0] || {type: 'form'},
@@ -172,6 +179,10 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
                       $disabled={layoutCollapsed || false}
                       data-testid="document-panel-scroller"
                       ref={setDocumentScrollElement}
+                      // Note: this is to make sure the scroll container is changed
+                      // when the selected group changes which causes virtualization
+                      // to re-render and re-measure the scroll container
+                      key={`${selectedGroup?.name}-${documentId}}`}
                     >
                       <FormView
                         hidden={formViewHidden}


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR adds a debug schema, the issue is when you have an array of items in a field group which is smaller then the height of the window which does not provide a scroll bar the virtualizer does not trigger a re-render causing items to not be recalculated and missing items in the array. 

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

The fix adds a key to the scroll element which will cause it to change when the field group changes. This change in the scrollbar should trigger a recalculation in the virtualization library according to this lines of [code](https://github.com/TanStack/virtual/blob/beta/packages/virtual-core/src/index.ts#L376)   

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

Fixes an issues with array items not showing all items inside a field group under specific conditions 