### PR TITLE
fix: syntax issues in next.js JS blog template

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/templates/nextjs/schemas/blog.ts
+++ b/packages/@sanity/cli/src/actions/init-project/templates/nextjs/schemas/blog.ts
@@ -451,7 +451,7 @@ const postJS = `export const post = {
       return {...selection, subtitle: author && \`by \${author}\`}
     },
   },
-})
+}
 `
 
 // Schema definition

--- a/packages/@sanity/cli/src/actions/init-project/templates/nextjs/schemas/blog.ts
+++ b/packages/@sanity/cli/src/actions/init-project/templates/nextjs/schemas/blog.ts
@@ -59,7 +59,7 @@ export default defineType({
 })
 `
 
-const authorJS = `export default author = {
+const authorJS = `export const author = {
   name: 'author',
   title: 'Author',
   type: 'document',
@@ -128,7 +128,7 @@ const blockContentTS = `import {defineType, defineArrayMember} from 'sanity'
  *    type: 'blockContent'
  *  }
  */
- 
+
 export default defineType({
   title: 'Block Content',
   name: 'blockContent',
@@ -204,7 +204,7 @@ const blockContentJS = `/**
  *  }
  */
 
-export default blockContent = {
+export const blockContent = {
   title: 'Block Content',
   name: 'blockContent',
   type: 'array',
@@ -289,7 +289,7 @@ export default defineType({
 })
 `
 
-const categoryJS = `export default category = {
+const categoryJS = `export const category = {
   name: 'category',
   title: 'Category',
   type: 'document',
@@ -382,7 +382,7 @@ export default defineType({
 })
 `
 
-const postJS = `export default post = {
+const postJS = `export const post = {
   name: 'post',
   title: 'Post',
   type: 'document',
@@ -468,10 +468,10 @@ export const schema: { types: SchemaTypeDefinition[] } = {
 }
 `
 
-export const blogSchemaJS = `import blockContent from './schemas/blockContent'
-import category from './schemas/category'
-import post from './schemas/post'
-import author from './schemas/author'
+export const blogSchemaJS = `import {blockContent} from './schemas/blockContent'
+import {category} from './schemas/category'
+import {post} from './schemas/post'
+import {author} from './schemas/author'
 
 export const schema = {
   types: [post, author, category, blockContent],


### PR DESCRIPTION
### Description
This PR corrects schema errors that were previously present when initializing a new project inside of a Next app using the default blog template without Typescript.

### What to review
In [packages/@sanity/cli/src/actions/init-project/templates/nextjs/schemas/blog.ts](https://github.com/sanity-io/sanity/compare/feat/fix-no-ts-nextjs-blog-template?expand=1#diff-b9fdd7bd4e02ade67fa60e59aa6aa13457fe000faa58f91fc352923ad1c10ccf), the following changes have been made:
1. All schemas ending in JS have been changed from `export default <name>` to `export const <name>`
2. `blogSchemaJS` has been changed to use named imports where they previously use default imports.
3. Removes errant `)` in postJS

### Notes for release
 Fixes syntax errors in schema files when initializing a blog template without Typescript in a Next.js app.
