### PR TITLE
fix(block-tools): fix Google Docs preprocessing issue on Windows

### DIFF
--- a/packages/@sanity/block-tools/src/HtmlDeserializer/preprocessors/gdocs.ts
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/preprocessors/gdocs.ts
@@ -1,15 +1,17 @@
 import {_XPathResult} from './xpathResult'
 
-function isGoogleDocsDocument(el: Element) {
-  if (el.nodeType !== 1) {
-    return false
-  }
-  const id = el.getAttribute('id')
-  return id && id.match(/^docs-internal-guid-/) && el.tagName === 'B'
-}
-
 export default (html: string, doc: Document): Document => {
-  if (doc.body.firstElementChild && isGoogleDocsDocument(doc.body.firstElementChild)) {
+  const gDocsRootNode = doc
+    .evaluate(
+      '//b[contains(@id, "docs-internal-guid")]',
+      doc,
+      null,
+      _XPathResult.ORDERED_NODE_ITERATOR_TYPE,
+      null,
+    )
+    .iterateNext()
+
+  if (gDocsRootNode) {
     // Tag every child with attribute 'is-google-docs' so that the GDocs rule-set can
     // work exclusivly on these children
     const childNodes = doc.evaluate(
@@ -24,7 +26,7 @@ export default (html: string, doc: Document): Document => {
       elm?.setAttribute('data-is-google-docs', 'true')
     }
     // Remove that 'b' which Google Docs wraps the HTML content in
-    doc.body.firstElementChild.replaceWith(...Array.from(doc.body.firstElementChild.childNodes))
+    doc.body.firstElementChild?.replaceWith(...Array.from(gDocsRootNode.childNodes))
     return doc
   }
   return doc

--- a/packages/@sanity/block-tools/src/HtmlDeserializer/rules/gdocs.ts
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/rules/gdocs.ts
@@ -82,7 +82,7 @@ export default function createGDocsRules(
           const span = {
             ...DEFAULT_SPAN,
             marks: [] as string[],
-            text: (el as HTMLElement).innerText,
+            text: el.textContent,
           }
           if (isStrong(el)) {
             span.marks.push('strong')

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/gdocs/index.ts
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/gdocs/index.ts
@@ -1,0 +1,12 @@
+import {BlockTestFn} from '../types'
+import defaultSchema from '../../../fixtures/defaultSchema'
+
+const blockContentType = defaultSchema
+  .get('blogPost')
+  .fields.find((field: any) => field.name === 'body').type
+
+const testFn: BlockTestFn = (html, blockTools, commonOptions) => {
+  return blockTools.htmlToBlocks(html, blockContentType, commonOptions)
+}
+
+export default testFn

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/gdocs/input.html
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/gdocs/input.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<!--StartFragment--><meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-21a47c78-7fff-15da-47f1-302ae3839dbc"><h1 dir="ltr" style="line-height:1.2;margin-right: -1.5pt;margin-top:16pt;margin-bottom:0pt;"><span style="font-size:13.999999999999998pt;font-family:'Playfair Display',serif;color:#f75d5d;background-color:transparent;font-weight:700;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Skills</span></h1><p dir="ltr" style="line-height:1.56;margin-top:10pt;margin-bottom:0pt;"><span style="font-size:10pt;font-family:Lato,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean ac interdum nisi. Sed in consequat mi. Sed pulvinar lacinia felis eu finibus.</span></p></b><br class="Apple-interchange-newline"><!--EndFragment-->
+</body>
+</html>

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/gdocs/output.json
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/gdocs/output.json
@@ -1,0 +1,30 @@
+[
+  {
+    "_key": "randomKey0",
+    "_type": "block",
+    "children": [{"_key": "randomKey00", "_type": "span", "marks": ["strong"], "text": "Skills"}],
+    "markDefs": [],
+    "style": "h1"
+  },
+  {
+    "_key": "randomKey1",
+    "_type": "block",
+    "children": [
+      {
+        "_key": "randomKey10",
+        "_type": "span",
+        "marks": [],
+        "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean ac interdum nisi. Sed in consequat mi. Sed pulvinar lacinia felis eu finibus."
+      }
+    ],
+    "markDefs": [],
+    "style": "normal"
+  },
+  {
+    "_key": "randomKey2",
+    "_type": "block",
+    "children": [{"_key": "randomKey20", "_type": "span", "marks": [], "text": "\n"}],
+    "markDefs": [],
+    "style": "normal"
+  }
+]


### PR DESCRIPTION
### Description

This will fix an issue on Windows when serializing a Google Docs HTML fragment into blocks.

The clipboard HTML was slightly different on Windows and our code didn't take that into account.

I have made some xpath matchers more specific and resilient now so they work both places. 

I have also added tests for this.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

That pasting from Google Docs into the PTE on Windows and MacOS will work correctly, without adding everything as bold.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Fix an issue where pasting from Google Docs into the Portable Text editor would make everything 'bold' on Windows computers.

<!--
A description of the change(s) that should be used in the release notes.
-->
