### PR TITLE
fix(core): unset changes in reverse order in patch operation

### DIFF
--- a/packages/sanity/src/core/field/diff/changes/undoChange.ts
+++ b/packages/sanity/src/core/field/diff/changes/undoChange.ts
@@ -1,3 +1,4 @@
+import {toArray} from 'rxjs/operators'
 import {
   isIndexSegment,
   isKeyedObject,
@@ -56,10 +57,7 @@ export function undoChange(
       .forEach((child) => undoChange(child, rootDiff, documentOperations))
 
     patches.push(
-      ...buildUnsetPatches(
-        rootDiff,
-        unsetChanges.reverse().map((unsetChange) => unsetChange.path),
-      ),
+      ...buildUnsetPatches(rootDiff, unsetChanges.map((unsetChange) => unsetChange.path).reverse()),
     )
   } else if (change.diff.action === 'added') {
     // The reverse of an add operation is an unset -

--- a/packages/sanity/src/core/field/diff/changes/undoChange.ts
+++ b/packages/sanity/src/core/field/diff/changes/undoChange.ts
@@ -58,7 +58,7 @@ export function undoChange(
     patches.push(
       ...buildUnsetPatches(
         rootDiff,
-        unsetChanges.map((unsetChange) => unsetChange.path),
+        unsetChanges.reverse().map((unsetChange) => unsetChange.path),
       ),
     )
   } else if (change.diff.action === 'added') {


### PR DESCRIPTION
### Description
There was an issue with reverting changes in arrays of primitives. The list would not be cleared when trying to revert all changes. 
This had to do with shifting indices of the items, but not on the patch operations, so that triggering this operation 
```
{
  unset: ['arrayOfStrings[0]', 'arrayOfStrings[1]', 'arrayOfStrings[2]']
}
```
will remove the first and last item, but the `arrayOfStrings[1]` will be left out of the patch operation. 


By reversing the order of the items in the `unset` operations, the issue with shifted indices will not cause problems. 

`{ unset: ['arrayOfStrings[2]', 'arrayOfStrings[1]', 'arrayOfStrings[0]'] }`

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Reverting changes, especially for arrays, are working as expected. 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fixed issue where reverting all changes did not clear the list
<!--
A description of the change(s) that should be used in the release notes.
-->
