### PR TITLE
fix(core): set default placements for certain studio popovers

### DIFF
--- a/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/ReferenceAutocomplete.tsx
+++ b/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/ReferenceAutocomplete.tsx
@@ -1,5 +1,5 @@
 import React, {forwardRef, useCallback} from 'react'
-import {Autocomplete, Box, Flex, Popover, Text} from '@sanity/ui'
+import {Autocomplete, Box, Flex, Placement, Popover, Text} from '@sanity/ui'
 import styled from 'styled-components'
 
 const StyledPopover = styled(Popover)`
@@ -12,6 +12,8 @@ const StyledPopover = styled(Popover)`
 const StyledText = styled(Text)`
   word-break: break-word;
 `
+
+const FALLBACK_PLACEMENTS: Placement[] = ['top-start', 'bottom-start']
 
 export const ReferenceAutocomplete = forwardRef(function ReferenceAutocomplete(
   props: React.ComponentProps<typeof Autocomplete> & {
@@ -42,6 +44,7 @@ export const ReferenceAutocomplete = forwardRef(function ReferenceAutocomplete(
       <StyledPopover
         data-testid="autocomplete-popover"
         placement="bottom-start"
+        fallbackPlacements={FALLBACK_PLACEMENTS}
         arrow={false}
         constrainSize
         onMouseEnter={onMouseEnter}

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceAutocomplete.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceAutocomplete.tsx
@@ -1,5 +1,5 @@
 import React, {forwardRef, useCallback} from 'react'
-import {Autocomplete, Box, Flex, Popover, Text} from '@sanity/ui'
+import {Autocomplete, Box, Flex, Placement, Popover, Text} from '@sanity/ui'
 import styled from 'styled-components'
 
 const StyledPopover = styled(Popover)`
@@ -12,6 +12,8 @@ const StyledPopover = styled(Popover)`
 const StyledText = styled(Text)`
   word-break: break-word;
 `
+
+const FALLBACK_PLACEMENTS: Placement[] = ['top-start', 'bottom-start']
 
 export const ReferenceAutocomplete = forwardRef(function ReferenceAutocomplete(
   props: React.ComponentProps<typeof Autocomplete> & {
@@ -41,6 +43,7 @@ export const ReferenceAutocomplete = forwardRef(function ReferenceAutocomplete(
     ) => (
       <StyledPopover
         placement="bottom-start"
+        fallbackPlacements={FALLBACK_PLACEMENTS}
         arrow={false}
         constrainSize
         onMouseEnter={onMouseEnter}

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/documentTypes/DocumentTypesButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/documentTypes/DocumentTypesButton.tsx
@@ -1,5 +1,5 @@
 import {SelectIcon} from '@sanity/icons'
-import {Button, Popover, Theme, useClickOutside} from '@sanity/ui'
+import {Button, Placement, Popover, Theme, useClickOutside} from '@sanity/ui'
 import React, {useCallback, useMemo, useState} from 'react'
 import styled, {css} from 'styled-components'
 import {POPOVER_RADIUS, POPOVER_VERTICAL_MARGIN} from '../../../constants'
@@ -17,6 +17,8 @@ const StyledButton = styled(Button)(({theme}: {theme: Theme}) => {
     }
   `
 })
+
+const FALLBACK_PLACEMENTS: Placement[] = ['top-start', 'bottom-start']
 
 export function DocumentTypesButton() {
   const [open, setOpen] = useState(false)
@@ -47,6 +49,7 @@ export function DocumentTypesButton() {
       }
       open={open}
       placement="bottom-start"
+      fallbackPlacements={FALLBACK_PLACEMENTS}
       portal
       radius={POPOVER_RADIUS}
       ref={setPopoverElement}


### PR DESCRIPTION
### Description

The new default fallback  placements for popovers released in Sanity UI v1.8.2 are good for most use cases, but in the Studio it has been causing issues for popovers used by the reference input, cross dataset reference input and the document type selector used by the array input.

This PR fixes these issues by explicitly choosing better fallback placements.

## Before
![image](https://github.com/sanity-io/sanity/assets/876086/7a06410f-5f6d-45a5-9d0c-89b7f38d8c61)


### What to review

Make popovers used by the following components places themselves where they should and renders nicely:
- reference input,
- cross dataset reference input
- the document type selector used by the array input.

### Notes for release

- Fixed rendering issues with certain popovers being caused by wrong placement
