### PR TITLE
fix(docs): fixed broken getting started link in clean readme

### DIFF
--- a/examples/clean-studio/README.md
+++ b/examples/clean-studio/README.md
@@ -4,6 +4,6 @@ Congratulations, you have now installed the Sanity Content Studio, an open sourc
 
 Now you can do the following things:
 
-- [Read “getting started” in the docs](https://www.sanity.io/docs/introduction/getting-started?utm_source=readme)
+- [Read “getting started” in the docs](https://www.sanity.io/docs/getting-started-with-sanity?utm_source=readme)
 - [Join the community Slack](https://slack.sanity.io/?utm_source=readme)
 - [Extend and build plugins](https://www.sanity.io/docs/content-studio/extending?utm_source=readme)


### PR DESCRIPTION
### Description

* Fixed link to "Getting started" in clean readme (which is used when creating a new project).

### What to review

* Validate if the new link is correct.

### Notes for release

fix(docs): fixed broken getting started link in clean readme
