### PR TITLE
feat(i18n): convert document actions strings to use i18n primitives

### DIFF
--- a/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
@@ -15,10 +15,10 @@ const deskResources: Record<DeskLocaleResourceKeys, string> = {
   'action.publish.published.label': 'Publisert',
 
   /** Label for the "Publish" document action when the document has live edit enabled.*/
-  'action.publish.liveEdit.label': 'Publiser',
+  'action.publish.live-edit.label': 'Publiser',
 
   /** Tooltip for the "Publish" document action when the document has live edit enabled.*/
-  'action.publish.liveEdit.tooltip':
+  'action.publish.live-edit.tooltip':
     '"Live Edit" er skrudd på for denne dokumenttypen og publisering skjer automatisk når du gjør endringer',
 
   /** Fallback tooltip for the "Publish" document action when publish is invoked for a document with live edit enabled.*/
@@ -26,17 +26,17 @@ const deskResources: Record<DeskLocaleResourceKeys, string> = {
     'Kan ikke publisere fordi "Live Edit" er skrudd på for denne dokumenttypen.',
 
   /** Tooltip when the "Publish" document action is disabled due to validation issues */
-  'action.publish.validationIssues.tooltip':
+  'action.publish.validation-issues.tooltip':
     'Valideringsfeil som må rettes før dokumentet kan publiseres',
 
   /** Tooltip when publish button is disabled because the document is already published.*/
-  'action.publish.alreadyPublished.tooltip': 'Publisert for {{timeSincePublished}} siden',
+  'action.publish.already-published.tooltip': 'Publisert for {{timeSincePublished}} siden',
 
   /** Tooltip when publish button is disabled because the document is already published, and published time is unavailable.*/
   'action.publish.already-published.no-time-ago.tooltip': 'Allerede publisert',
 
   /** Tooltip when publish button is disabled because there are no changes.*/
-  'action.publish.tooltip.noChanges': 'Ingen upubliserte endringer',
+  'action.publish.tooltip.no-changes': 'Ingen upubliserte endringer',
 
   /** Tooltip when publish button is waiting for validation and async tasks to complete.*/
   'action.publish.waiting': 'Venter på at andre oppgaver skal fullføre',

--- a/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
@@ -74,10 +74,11 @@ const deskResources: Record<DeskLocaleResourceKeys, string> = {
 
   /** --- DUPLICATE ACTION --- */
   /** Tooltip when action is disabled because the operation is not ready   */
-  'action.duplicate.disabled.notReady': 'Operasjonen er ikke klar',
+  'action.duplicate.disabled.not-ready': 'Operasjonen er ikke klar',
 
   /** Tooltip when action is disabled because the document doesn't exist */
-  'action.duplicate.disabled.nothingToDuplicate': 'Dette dokumentet er tomt og kan ikke dupliseres',
+  'action.duplicate.disabled.nothing-to-duplicate':
+    'Dette dokumentet er tomt og kan ikke dupliseres',
 
   /** Label for the "Duplicate" document action */
   'action.duplicate.label': 'Duplisèr',

--- a/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
@@ -69,7 +69,7 @@ const deskResources: Record<DeskLocaleResourceKeys, string> = {
   'action.discardChanges.disabled.notPublished': 'Dette dokumentet er ikke publisert',
 
   /** Message prompting the user to confirm discarding changes */
-  'action.discardChanges.confirmDialog.confirmDiscardChanges':
+  'action.discardChanges.confirmDialog.confirm-discard-changes':
     'Er du sikker på at du vil forkaste alle endringer siden forrige gang dette dokumentet ble publisert?',
 
   /** --- DUPLICATE ACTION --- */
@@ -110,7 +110,7 @@ const deskResources: Record<DeskLocaleResourceKeys, string> = {
   'action.restore.tooltip': 'Gjenopprett til denne versjonen',
 
   /** Message prompting the user to confirm that they want to restore to an earlier version*/
-  'action.restore.confirmDialog.confirmDiscardChanges':
+  'action.restore.confirmDialog.confirm-discard-changes':
     'Er du sikker på at du vil gjenopprette til valgte versjon?',
 }
 

--- a/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
@@ -1,7 +1,11 @@
 import type {DeskLocaleResourceKeys} from 'sanity/desk'
 
 const deskResources: Record<DeskLocaleResourceKeys, string> = {
-  /** Label for the "Publish" document action when there are pending changes.*/
+  /** --- PUBLISH ACTION --- */
+  /** Tooltip when action is disabled because the studio is not ready.*/
+  'action.publish.disabled.notReady': 'Operasjonen er ikke klar',
+
+  /** Label for action when there are pending changes.*/
   'action.publish.draft.label': 'Publiser',
 
   /** Label for the "Publish" document action while publish is being executed.*/
@@ -19,7 +23,7 @@ const deskResources: Record<DeskLocaleResourceKeys, string> = {
 
   /** Fallback tooltip for the "Publish" document action when publish is invoked for a document with live edit enabled.*/
   'action.publish.liveEdit.publishDisabled':
-    'Kan ikke publsere fordi liveEdit er skrudd på for denne dokumenttypen.',
+    'Kan ikke publisere fordi "Live Edit" er skrudd på for denne dokumenttypen.',
 
   /** Tooltip when the "Publish" document action is disabled due to validation issues */
   'action.publish.validationIssues.tooltip':
@@ -33,9 +37,6 @@ const deskResources: Record<DeskLocaleResourceKeys, string> = {
 
   /** Tooltip when publish button is disabled because there are no changes.*/
   'action.publish.tooltip.noChanges': 'Ingen upubliserte endringer',
-
-  /** Tooltip when publish button is disabled because the studio is not ready.*/
-  'action.publish.disabled.notReady': 'Operasjonen er ikke klar',
 
   /** Tooltip when publish button is waiting for validation and async tasks to complete.*/
   'action.publish.waiting': 'Venter på at andre oppgaver skal fullføre',

--- a/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
@@ -71,6 +71,19 @@ const deskResources: Record<DeskLocaleResourceKeys, string> = {
   /** Message prompting the user to confirm discarding changes */
   'action.discardChanges.confirmDialog.confirmDiscardChanges':
     'Er du sikker på at du vil forkaste alle endringer siden forrige gang dette dokumentet ble publisert?',
+
+  /** --- DUPLICATE ACTION --- */
+  /** Tooltip when action is disabled because the operation is not ready   */
+  'action.duplicate.disabled.notReady': 'Operasjonen er ikke klar',
+
+  /** Tooltip when action is disabled because the document doesn't exist */
+  'action.duplicate.disabled.nothingToDuplicate': 'Dette dokumentet er tomt og kan ikke dupliseres',
+
+  /** Label for the "Duplicate" document action */
+  'action.duplicate.label': 'Duplisèr',
+
+  /** Label for the "Duplicate" document action while the document is being duplicated */
+  'action.duplicate.running.label': 'Duplisèrer…',
 }
 
 export default deskResources

--- a/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
@@ -54,6 +54,23 @@ const deskResources: Record<DeskLocaleResourceKeys, string> = {
 
   /** Label for the "Delete" document action while the document is being deleted */
   'action.delete.running.label': 'Sletter…',
+
+  /** --- DISCARD CHANGES ACTION --- **/
+  /** Tooltip when action button is disabled because the operation is not ready   */
+  'action.discardChanges.disabled.notReady': 'Operasjonen er ikke klar',
+
+  /** Label for the "Discard changes" document action */
+  'action.discardChanges.label': 'Forkast endringer',
+
+  /** Tooltip when action is disabled because the document has no unpublished changes */
+  'action.discardChanges.disabled.noChange': 'Dette dokumentet har ingen endringer',
+
+  /** Tooltip when action is disabled because the document is not published */
+  'action.discardChanges.disabled.notPublished': 'Dette dokumentet er ikke publisert',
+
+  /** Message prompting the user to confirm discarding changes */
+  'action.discardChanges.confirmDialog.confirmDiscardChanges':
+    'Er du sikker på at du vil forkaste alle endringer siden forrige gang dette dokumentet ble publisert?',
 }
 
 export default deskResources

--- a/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
@@ -98,6 +98,20 @@ const deskResources: Record<DeskLocaleResourceKeys, string> = {
   /** Fallback tooltip for the Unpublish document action when publish is invoked for a document with live edit enabled.*/
   'action.unpublish.liveEdit.disabled':
     'Dette dokumentet har "Live Edit" skrudd på og kan ikke avpubliseres',
+
+  /** --- RESTORE ACTION --- */
+  /** Label for the "Restore" document action */
+  'action.restore.label': 'Gjenopprett',
+
+  /** Fallback tooltip for when user is looking at the initial version */
+  'action.restore.disabled.cantRestoreInitial': 'Kan ikke gjenopprette til første version',
+
+  /** Default tooltip for the action */
+  'action.restore.tooltip': 'Gjenopprett til denne versjonen',
+
+  /** Message prompting the user to confirm that they want to restore to an earlier version*/
+  'action.restore.confirmDialog.confirmDiscardChanges':
+    'Er du sikker på at du vil gjenopprette til valgte versjon?',
 }
 
 export default deskResources

--- a/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
@@ -88,16 +88,16 @@ const deskResources: Record<DeskLocaleResourceKeys, string> = {
 
   /** --- UNPUBLISH ACTION --- */
   /** Tooltip when action is disabled because the operation is not ready   */
-  'action.unpublish.disabled.notReady': 'Operasjonen er ikke klar',
+  'action.unpublish.disabled.not-ready': 'Operasjonen er ikke klar',
 
   /** Label for the "Unpublish" document action */
   'action.unpublish.label': 'Avpubliser',
 
   /** Tooltip when action is disabled because the document is not already published */
-  'action.unpublish.disabled.notPublished': 'Dette dokumentet er ikke publisert',
+  'action.unpublish.disabled.not-published': 'Dette dokumentet er ikke publisert',
 
   /** Fallback tooltip for the Unpublish document action when publish is invoked for a document with live edit enabled.*/
-  'action.unpublish.liveEdit.disabled':
+  'action.unpublish.live-edit.disabled':
     'Dette dokumentet har "Live Edit" skrudd på og kan ikke avpubliseres',
 
   /** --- RESTORE ACTION --- */

--- a/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
@@ -104,7 +104,7 @@ const deskResources: Record<DeskLocaleResourceKeys, string> = {
   'action.restore.label': 'Gjenopprett',
 
   /** Fallback tooltip for when user is looking at the initial version */
-  'action.restore.disabled.cantRestoreInitial': 'Kan ikke gjenopprette til første version',
+  'action.restore.disabled.cannot-restore-initial': 'Kan ikke gjenopprette til første version',
 
   /** Default tooltip for the action */
   'action.restore.tooltip': 'Gjenopprett til denne versjonen',

--- a/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
@@ -40,6 +40,20 @@ const deskResources: Record<DeskLocaleResourceKeys, string> = {
 
   /** Tooltip when publish button is waiting for validation and async tasks to complete.*/
   'action.publish.waiting': 'Venter på at andre oppgaver skal fullføre',
+
+  /** --- DELETE ACTION --- **/
+  /** Tooltip when action button is disabled because the operation is not ready   */
+  'action.delete.disabled.notReady': 'Operasjonen er ikke klar',
+
+  /** Tooltip when action button is disabled because the document does not exist */
+  'action.delete.disabled.nothingToDelete':
+    'Dette dokumentet eksisterer ikke eller har allerede blitt slettet',
+
+  /** Label for the "Delete" document action button */
+  'action.delete.label': 'Slett',
+
+  /** Label for the "Delete" document action while the document is being deleted */
+  'action.delete.running.label': 'Sletter…',
 }
 
 export default deskResources

--- a/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
@@ -57,19 +57,19 @@ const deskResources: Record<DeskLocaleResourceKeys, string> = {
 
   /** --- DISCARD CHANGES ACTION --- **/
   /** Tooltip when action button is disabled because the operation is not ready   */
-  'action.discardChanges.disabled.notReady': 'Operasjonen er ikke klar',
+  'action.discard-changes.disabled.not-ready': 'Operasjonen er ikke klar',
 
   /** Label for the "Discard changes" document action */
-  'action.discardChanges.label': 'Forkast endringer',
+  'action.discard-changes.label': 'Forkast endringer',
 
   /** Tooltip when action is disabled because the document has no unpublished changes */
-  'action.discardChanges.disabled.noChange': 'Dette dokumentet har ingen endringer',
+  'action.discard-changes.disabled.no-change': 'Dette dokumentet har ingen endringer',
 
   /** Tooltip when action is disabled because the document is not published */
-  'action.discardChanges.disabled.notPublished': 'Dette dokumentet er ikke publisert',
+  'action.discard-changes.disabled.not-published': 'Dette dokumentet er ikke publisert',
 
   /** Message prompting the user to confirm discarding changes */
-  'action.discardChanges.confirmDialog.confirm-discard-changes':
+  'action.discard-changes.confirm-dialog.confirm-discard-changes':
     'Er du sikker på at du vil forkaste alle endringer siden forrige gang dette dokumentet ble publisert?',
 
   /** --- DUPLICATE ACTION --- */
@@ -110,7 +110,7 @@ const deskResources: Record<DeskLocaleResourceKeys, string> = {
   'action.restore.tooltip': 'Gjenopprett til denne versjonen',
 
   /** Message prompting the user to confirm that they want to restore to an earlier version*/
-  'action.restore.confirmDialog.confirm-discard-changes':
+  'action.restore.confirm-dialog.confirm-discard-changes':
     'Er du sikker på at du vil gjenopprette til valgte versjon?',
 }
 

--- a/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
@@ -3,7 +3,7 @@ import type {DeskLocaleResourceKeys} from 'sanity/desk'
 const deskResources: Record<DeskLocaleResourceKeys, string> = {
   /** --- PUBLISH ACTION --- */
   /** Tooltip when action is disabled because the studio is not ready.*/
-  'action.publish.disabled.notReady': 'Operasjonen er ikke klar',
+  'action.publish.disabled.not-ready': 'Operasjonen er ikke klar',
 
   /** Label for action when there are pending changes.*/
   'action.publish.draft.label': 'Publiser',
@@ -22,7 +22,7 @@ const deskResources: Record<DeskLocaleResourceKeys, string> = {
     '"Live Edit" er skrudd på for denne dokumenttypen og publisering skjer automatisk når du gjør endringer',
 
   /** Fallback tooltip for the "Publish" document action when publish is invoked for a document with live edit enabled.*/
-  'action.publish.liveEdit.publishDisabled':
+  'action.publish.live-edit.publish-disabled':
     'Kan ikke publisere fordi "Live Edit" er skrudd på for denne dokumenttypen.',
 
   /** Tooltip when the "Publish" document action is disabled due to validation issues */
@@ -33,7 +33,7 @@ const deskResources: Record<DeskLocaleResourceKeys, string> = {
   'action.publish.alreadyPublished.tooltip': 'Publisert for {{timeSincePublished}} siden',
 
   /** Tooltip when publish button is disabled because the document is already published, and published time is unavailable.*/
-  'action.publish.alreadyPublished.noTimeAgo.tooltip': 'Allerede publisert',
+  'action.publish.already-published.no-time-ago.tooltip': 'Allerede publisert',
 
   /** Tooltip when publish button is disabled because there are no changes.*/
   'action.publish.tooltip.noChanges': 'Ingen upubliserte endringer',

--- a/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
@@ -43,10 +43,10 @@ const deskResources: Record<DeskLocaleResourceKeys, string> = {
 
   /** --- DELETE ACTION --- **/
   /** Tooltip when action button is disabled because the operation is not ready   */
-  'action.delete.disabled.notReady': 'Operasjonen er ikke klar',
+  'action.delete.disabled.not-ready': 'Operasjonen er ikke klar',
 
   /** Tooltip when action button is disabled because the document does not exist */
-  'action.delete.disabled.nothingToDelete':
+  'action.delete.disabled.nothing-to-delete':
     'Dette dokumentet eksisterer ikke eller har allerede blitt slettet',
 
   /** Label for the "Delete" document action button */

--- a/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
@@ -84,6 +84,20 @@ const deskResources: Record<DeskLocaleResourceKeys, string> = {
 
   /** Label for the "Duplicate" document action while the document is being duplicated */
   'action.duplicate.running.label': 'Duplisèrer…',
+
+  /** --- UNPUBLISH ACTION --- */
+  /** Tooltip when action is disabled because the operation is not ready   */
+  'action.unpublish.disabled.notReady': 'Operasjonen er ikke klar',
+
+  /** Label for the "Unpublish" document action */
+  'action.unpublish.label': 'Avpubliser',
+
+  /** Tooltip when action is disabled because the document is not already published */
+  'action.unpublish.disabled.notPublished': 'Dette dokumentet er ikke publisert',
+
+  /** Fallback tooltip for the Unpublish document action when publish is invoked for a document with live edit enabled.*/
+  'action.unpublish.liveEdit.disabled':
+    'Dette dokumentet har "Live Edit" skrudd på og kan ikke avpubliseres',
 }
 
 export default deskResources

--- a/packages/sanity/src/desk/documentActions/DeleteAction.tsx
+++ b/packages/sanity/src/desk/documentActions/DeleteAction.tsx
@@ -3,17 +3,20 @@
 import {TrashIcon} from '@sanity/icons'
 import React, {useCallback, useState} from 'react'
 import {ConfirmDeleteDialog} from '../components'
+import {useDocumentPane} from '../panes/document/useDocumentPane'
+import {deskLocaleNamespace} from '../i18n'
 import {
   DocumentActionComponent,
   InsufficientPermissionsMessage,
   useCurrentUser,
   useDocumentOperation,
   useDocumentPairPermissions,
+  useTranslation,
 } from 'sanity'
-import {useDocumentPane} from '../panes/document/useDocumentPane'
 
-const DISABLED_REASON_TITLE = {
-  NOTHING_TO_DELETE: 'This document doesn’t yet exist or is already deleted',
+const DISABLED_REASON_TITLE_KEY = {
+  NOTHING_TO_DELETE: 'action.delete.disabled.nothingToDelete',
+  NOT_READY: 'action.delete.disabled.notReady',
 }
 
 /** @internal */
@@ -22,6 +25,8 @@ export const DeleteAction: DocumentActionComponent = ({id, type, draft, onComple
   const {delete: deleteOp} = useDocumentOperation(id, type)
   const [isDeleting, setIsDeleting] = useState(false)
   const [isConfirmDialogOpen, setConfirmDialogOpen] = useState(false)
+
+  const {t} = useTranslation(deskLocaleNamespace)
 
   const handleCancel = useCallback(() => {
     setConfirmDialogOpen(false)
@@ -53,7 +58,7 @@ export const DeleteAction: DocumentActionComponent = ({id, type, draft, onComple
       tone: 'critical',
       icon: TrashIcon,
       disabled: true,
-      label: 'Delete',
+      label: t('action.delete.label'),
       title: (
         <InsufficientPermissionsMessage
           operationLabel="delete this document"
@@ -67,11 +72,8 @@ export const DeleteAction: DocumentActionComponent = ({id, type, draft, onComple
     tone: 'critical',
     icon: TrashIcon,
     disabled: isDeleting || Boolean(deleteOp.disabled) || isPermissionsLoading,
-    title:
-      (deleteOp.disabled &&
-        DISABLED_REASON_TITLE[deleteOp.disabled as keyof typeof DISABLED_REASON_TITLE]) ||
-      '',
-    label: isDeleting ? 'Deleting…' : 'Delete',
+    title: (deleteOp.disabled && t(DISABLED_REASON_TITLE_KEY[deleteOp.disabled])) || '',
+    label: isDeleting ? t('action.delete.running.label') : t('action.delete.label'),
     shortcut: 'Ctrl+Alt+D',
     onHandle: handle,
     dialog: isConfirmDialogOpen && {

--- a/packages/sanity/src/desk/documentActions/DiscardChangesAction.tsx
+++ b/packages/sanity/src/desk/documentActions/DiscardChangesAction.tsx
@@ -2,6 +2,7 @@
 
 import {ResetIcon} from '@sanity/icons'
 import React, {useCallback, useMemo, useState} from 'react'
+import {deskLocaleNamespace} from '../i18n'
 import {
   DocumentActionComponent,
   DocumentActionDialogProps,
@@ -9,12 +10,14 @@ import {
   useCurrentUser,
   useDocumentOperation,
   useDocumentPairPermissions,
+  useTranslation,
 } from 'sanity'
 
-const DISABLED_REASON_TITLE = {
-  NO_CHANGES: 'This document has no unpublished changes',
-  NOT_PUBLISHED: 'This document is not published',
-}
+const DISABLED_REASON_KEY = {
+  NO_CHANGES: 'action.discardChanges.disabled.noChanges',
+  NOT_PUBLISHED: 'action.discardChanges.disabled.notPublished',
+  NOT_READY: 'action.discardChanges.disabled.notReady',
+} as const
 
 /** @internal */
 export const DiscardChangesAction: DocumentActionComponent = ({
@@ -33,6 +36,8 @@ export const DiscardChangesAction: DocumentActionComponent = ({
   })
   const currentUser = useCurrentUser()
 
+  const {t} = useTranslation(deskLocaleNamespace)
+
   const handleConfirm = useCallback(() => {
     discardChanges.execute()
     onComplete()
@@ -49,9 +54,9 @@ export const DiscardChangesAction: DocumentActionComponent = ({
         tone: 'critical',
         onCancel: onComplete,
         onConfirm: handleConfirm,
-        message: <>Are you sure you want to discard all changes since last published?</>,
+        message: t('action.discardChanges.confirmDialog.confirmDiscardChanges'),
       },
-    [handleConfirm, isConfirmDialogOpen, onComplete],
+    [handleConfirm, isConfirmDialogOpen, onComplete, t],
   )
 
   if (!published || liveEdit) {
@@ -63,7 +68,7 @@ export const DiscardChangesAction: DocumentActionComponent = ({
       tone: 'critical',
       icon: ResetIcon,
       disabled: true,
-      label: 'Discard changes',
+      label: t('action.discardChanges.label'),
       title: (
         <InsufficientPermissionsMessage
           operationLabel="discard changes in this document"
@@ -77,11 +82,8 @@ export const DiscardChangesAction: DocumentActionComponent = ({
     tone: 'critical',
     icon: ResetIcon,
     disabled: Boolean(discardChanges.disabled) || isPermissionsLoading,
-    title:
-      (discardChanges.disabled &&
-        DISABLED_REASON_TITLE[discardChanges.disabled as keyof typeof DISABLED_REASON_TITLE]) ||
-      '',
-    label: 'Discard changes',
+    title: (discardChanges.disabled && DISABLED_REASON_KEY[discardChanges.disabled]) || '',
+    label: t('action.discardChanges.label'),
     onHandle: handle,
     dialog,
   }

--- a/packages/sanity/src/desk/documentActions/DiscardChangesAction.tsx
+++ b/packages/sanity/src/desk/documentActions/DiscardChangesAction.tsx
@@ -54,7 +54,7 @@ export const DiscardChangesAction: DocumentActionComponent = ({
         tone: 'critical',
         onCancel: onComplete,
         onConfirm: handleConfirm,
-        message: t('action.discardChanges.confirmDialog.confirmDiscardChanges'),
+        message: t('action.discardChanges.confirmDialog.confirm-discard-changes'),
       },
     [handleConfirm, isConfirmDialogOpen, onComplete, t],
   )

--- a/packages/sanity/src/desk/documentActions/DuplicateAction.tsx
+++ b/packages/sanity/src/desk/documentActions/DuplicateAction.tsx
@@ -1,6 +1,7 @@
 import {CopyIcon} from '@sanity/icons'
 import {uuid} from '@sanity/uuid'
 import React, {useCallback, useState} from 'react'
+import {deskLocaleNamespace} from '../i18n'
 import {useRouter} from 'sanity/router'
 import {
   DocumentActionComponent,
@@ -8,10 +9,12 @@ import {
   useDocumentPairPermissions,
   useDocumentOperation,
   useCurrentUser,
+  useTranslation,
 } from 'sanity'
 
-const DISABLED_REASON_TITLE = {
-  NOTHING_TO_DUPLICATE: 'This document doesn’t yet exist so there‘s nothing to duplicate',
+const DISABLED_REASON_KEY = {
+  NOTHING_TO_DUPLICATE: 'action.duplicate.disabled.nothingToDuplicate',
+  NOT_READY: 'action.duplicate.disabled.notReady',
 }
 
 /** @internal */
@@ -24,6 +27,8 @@ export const DuplicateAction: DocumentActionComponent = ({id, type, onComplete})
     type,
     permission: 'duplicate',
   })
+
+  const {t} = useTranslation(deskLocaleNamespace)
 
   const currentUser = useCurrentUser()
 
@@ -40,7 +45,7 @@ export const DuplicateAction: DocumentActionComponent = ({id, type, onComplete})
     return {
       icon: CopyIcon,
       disabled: true,
-      label: 'Duplicate',
+      label: t('action.duplicate.label'),
       title: (
         <InsufficientPermissionsMessage
           operationLabel="duplicate this document"
@@ -53,11 +58,8 @@ export const DuplicateAction: DocumentActionComponent = ({id, type, onComplete})
   return {
     icon: CopyIcon,
     disabled: isDuplicating || Boolean(duplicate.disabled) || isPermissionsLoading,
-    label: isDuplicating ? 'Duplicating…' : 'Duplicate',
-    title:
-      (duplicate.disabled &&
-        DISABLED_REASON_TITLE[duplicate.disabled as keyof typeof DISABLED_REASON_TITLE]) ||
-      '',
+    label: isDuplicating ? t('action.duplicate.running.label') : t('action.duplicate.label'),
+    title: duplicate.disabled ? t(DISABLED_REASON_KEY[duplicate.disabled]) : '',
     onHandle: handle,
   }
 }

--- a/packages/sanity/src/desk/documentActions/HistoryRestoreAction.tsx
+++ b/packages/sanity/src/desk/documentActions/HistoryRestoreAction.tsx
@@ -1,10 +1,12 @@
 import {RestoreIcon} from '@sanity/icons'
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {deskLocaleNamespace} from '../i18n'
 import {
   DocumentActionComponent,
   DocumentActionDialogProps,
   useDocumentOperation,
   useDocumentOperationEvent,
+  useTranslation,
 } from 'sanity'
 import {useRouter} from 'sanity/router'
 
@@ -15,6 +17,7 @@ export const HistoryRestoreAction: DocumentActionComponent = ({id, type, revisio
   const {navigateIntent} = useRouter()
   const prevEvent = useRef(event)
   const [isConfirmDialogOpen, setConfirmDialogOpen] = useState(false)
+  const {t} = useTranslation(deskLocaleNamespace)
 
   const handleConfirm = useCallback(() => {
     restore.execute(revision!)
@@ -45,12 +48,12 @@ export const HistoryRestoreAction: DocumentActionComponent = ({id, type, revisio
         tone: 'critical',
         onCancel: onComplete,
         onConfirm: handleConfirm,
-        message: <>Are you sure you want to restore this document?</>,
+        message: t('action.restore.confirm.message'),
       }
     }
 
     return null
-  }, [handleConfirm, isConfirmDialogOpen, onComplete])
+  }, [handleConfirm, isConfirmDialogOpen, onComplete, t])
 
   const isRevisionInitialVersion = revision === '@initial'
   const isRevisionLatestVersion = revision === undefined // undefined means latest version
@@ -60,12 +63,14 @@ export const HistoryRestoreAction: DocumentActionComponent = ({id, type, revisio
   }
 
   return {
-    label: 'Restore',
+    label: t('action.restore.label'),
     color: 'primary',
     onHandle: handle,
-    title: isRevisionInitialVersion
-      ? "You can't restore to the initial version"
-      : 'Restore to this version',
+    title: t(
+      isRevisionInitialVersion
+        ? 'action.restore.disabled.cantRestoreInitial'
+        : 'action.restore.tooltip',
+    ),
     icon: RestoreIcon,
     dialog,
     disabled: isRevisionInitialVersion,

--- a/packages/sanity/src/desk/documentActions/HistoryRestoreAction.tsx
+++ b/packages/sanity/src/desk/documentActions/HistoryRestoreAction.tsx
@@ -68,7 +68,7 @@ export const HistoryRestoreAction: DocumentActionComponent = ({id, type, revisio
     onHandle: handle,
     title: t(
       isRevisionInitialVersion
-        ? 'action.restore.disabled.cantRestoreInitial'
+        ? 'action.restore.disabled.cannot-restore-initial'
         : 'action.restore.tooltip',
     ),
     icon: RestoreIcon,

--- a/packages/sanity/src/desk/documentActions/PublishAction.tsx
+++ b/packages/sanity/src/desk/documentActions/PublishAction.tsx
@@ -18,10 +18,10 @@ import {
 } from 'sanity'
 
 const DISABLED_REASON_TITLE_KEY: Record<string, DeskLocaleResourceKeys> = {
-  LIVE_EDIT_ENABLED: 'action.publish.liveEdit.publishDisabled',
-  ALREADY_PUBLISHED: 'action.publish.alreadyPublished.noTimeAgo.tooltip',
-  NO_CHANGES: 'action.publish.tooltip.noChanges',
-  NOT_READY: 'action.publish.disabled.notReady',
+  LIVE_EDIT_ENABLED: 'action.publish.live-edit.publish-disabled',
+  ALREADY_PUBLISHED: 'action.publish.already-published.no-time-ago.tooltip',
+  NO_CHANGES: 'action.publish.tooltip.no-changes',
+  NOT_READY: 'action.publish.disabled.not-ready',
 } as const
 
 function getDisabledReason(
@@ -143,8 +143,8 @@ export const PublishAction: DocumentActionComponent = (props) => {
   if (liveEdit) {
     return {
       tone: 'positive',
-      label: t('action.publish.liveEdit.label'),
-      title: t('action.publish.liveEdit.tooltip'),
+      label: t('action.publish.live-edit.label'),
+      title: t('action.publish.live-edit.tooltip'),
       disabled: true,
     }
   }

--- a/packages/sanity/src/desk/documentActions/UnpublishAction.tsx
+++ b/packages/sanity/src/desk/documentActions/UnpublishAction.tsx
@@ -1,6 +1,7 @@
 import {UnpublishIcon} from '@sanity/icons'
 import React, {useCallback, useMemo, useState} from 'react'
 import {ConfirmDeleteDialog} from '../components'
+import {deskLocaleNamespace} from '../i18n'
 import {
   DocumentActionComponent,
   InsufficientPermissionsMessage,
@@ -8,10 +9,13 @@ import {
   useCurrentUser,
   useDocumentOperation,
   DocumentActionModalDialogProps,
+  useTranslation,
 } from 'sanity'
 
-const DISABLED_REASON_TITLE = {
-  NOT_PUBLISHED: 'This document is not published',
+const DISABLED_REASON_KEY = {
+  NOT_PUBLISHED: 'action.unpublish.disabled.notPublished',
+  NOT_READY: 'action.unpublish.disabled.notReady',
+  LIVE_EDIT_ENABLED: 'action.unpublish.disabled.liveEditEnabled',
 }
 
 /** @internal */
@@ -30,6 +34,7 @@ export const UnpublishAction: DocumentActionComponent = ({
     permission: 'unpublish',
   })
   const currentUser = useCurrentUser()
+  const {t} = useTranslation(deskLocaleNamespace)
 
   const handleCancel = useCallback(() => {
     setConfirmDialogOpen(false)
@@ -85,10 +90,8 @@ export const UnpublishAction: DocumentActionComponent = ({
     tone: 'critical',
     icon: UnpublishIcon,
     disabled: Boolean(unpublish.disabled) || isPermissionsLoading,
-    label: 'Unpublish',
-    title: unpublish.disabled
-      ? DISABLED_REASON_TITLE[unpublish.disabled as keyof typeof DISABLED_REASON_TITLE]
-      : '',
+    label: t('action.unpublish.label'),
+    title: unpublish.disabled ? t(DISABLED_REASON_KEY[unpublish.disabled]) : '',
     onHandle: () => setConfirmDialogOpen(true),
     dialog,
   }

--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -77,10 +77,10 @@ const deskLocaleStrings = {
 
   /** --- DUPLICATE ACTION --- */
   /** Tooltip when action is disabled because the operation is not ready   */
-  'action.duplicate.disabled.notReady': 'Operation not ready',
+  'action.duplicate.disabled.not-ready': 'Operation not ready',
 
   /** Tooltip when action is disabled because the document doesn't exist */
-  'action.duplicate.disabled.nothingToDuplicate':
+  'action.duplicate.disabled.nothing-to-duplicate':
     "This document doesn't yet exist so there‘s nothing to duplicate",
 
   /** Label for the "Duplicate" document action */

--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -4,7 +4,11 @@
  * @internal
  */
 const deskLocaleStrings = {
-  /** Label for the "Publish" document action when there are pending changes.*/
+  /** --- PUBLISH ACTION --- */
+  /** Tooltip when action is disabled because the studio is not ready.*/
+  'action.publish.disabled.notReady': 'Operation not ready',
+
+  /** Label for action when there are pending changes.*/
   'action.publish.draft.label': 'Publish',
 
   /** Label for the "Publish" document action while publish is being executed.*/
@@ -36,9 +40,6 @@ const deskLocaleStrings = {
 
   /** Tooltip when publish button is disabled because there are no changes.*/
   'action.publish.tooltip.noChanges': 'No unpublished changes',
-
-  /** Tooltip when publish button is disabled because the studio is not ready.*/
-  'action.publish.disabled.notReady': 'Operation not ready',
 
   /** Tooltip when publish button is waiting for validation and async tasks to complete.*/
   'action.publish.waiting': 'Waiting for tasks to finish before publishing',

--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -101,6 +101,20 @@ const deskLocaleStrings = {
   /** Fallback tooltip for the Unpublish document action when publish is invoked for a document with live edit enabled.*/
   'action.unpublish.liveEdit.disabled':
     'This document has live edit enabled and cannot be unpublished',
+
+  /** --- RESTORE ACTION --- */
+  /** Label for the "Restore" document action */
+  'action.restore.label': 'Restore',
+
+  /** Fallback tooltip for when user is looking at the initial version */
+  'action.restore.disabled.cantRestoreInitial': "You can't restore to the initial version",
+
+  /** Default tooltip for the action */
+  'action.restore.tooltip': 'Restore to this version',
+
+  /** Message prompting the user to confirm that they want to restore to an earlier version*/
+  'action.restore.confirmDialog.confirmDiscardChanges':
+    'Are you sure you want to restore this document?',
 }
 
 /**

--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -91,16 +91,16 @@ const deskLocaleStrings = {
 
   /** --- UNPUBLISH ACTION --- */
   /** Tooltip when action is disabled because the operation is not ready   */
-  'action.unpublish.disabled.notReady': 'Operation not ready',
+  'action.unpublish.disabled.not-ready': 'Operation not ready',
 
   /** Label for the "Unpublish" document action */
   'action.unpublish.label': 'Unpublish',
 
   /** Tooltip when action is disabled because the document is not already published */
-  'action.unpublish.disabled.notPublished': 'This document is not published',
+  'action.unpublish.disabled.not-published': 'This document is not published',
 
   /** Fallback tooltip for the Unpublish document action when publish is invoked for a document with live edit enabled.*/
-  'action.unpublish.liveEdit.disabled':
+  'action.unpublish.live-edit.disabled':
     'This document has live edit enabled and cannot be unpublished',
 
   /** --- RESTORE ACTION --- */

--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -87,6 +87,20 @@ const deskLocaleStrings = {
 
   /** Label for the "Duplicate" document action while the document is being duplicated */
   'action.duplicate.running.label': 'Duplicating…',
+
+  /** --- UNPUBLISH ACTION --- */
+  /** Tooltip when action is disabled because the operation is not ready   */
+  'action.unpublish.disabled.notReady': 'Operation not ready',
+
+  /** Label for the "Unpublish" document action */
+  'action.unpublish.label': 'Unpublish',
+
+  /** Tooltip when action is disabled because the document is not already published */
+  'action.unpublish.disabled.notPublished': 'This document is not published',
+
+  /** Fallback tooltip for the Unpublish document action when publish is invoked for a document with live edit enabled.*/
+  'action.unpublish.liveEdit.disabled':
+    'This document has live edit enabled and cannot be unpublished',
 }
 
 /**

--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -71,7 +71,7 @@ const deskLocaleStrings = {
   'action.discardChanges.disabled.notPublished': 'This document is not published',
 
   /** Message prompting the user to confirm discarding changes */
-  'action.discardChanges.confirmDialog.confirmDiscardChanges':
+  'action.discardChanges.confirmDialog.confirm-discardchanges':
     'Are you sure you want to discard all changes since last published?',
 
   /** --- DUPLICATE ACTION --- */
@@ -113,7 +113,7 @@ const deskLocaleStrings = {
   'action.restore.tooltip': 'Restore to this version',
 
   /** Message prompting the user to confirm that they want to restore to an earlier version*/
-  'action.restore.confirmDialog.confirmDiscardChanges':
+  'action.restore.confirmDialog.confirm-discard-changes':
     'Are you sure you want to restore this document?',
 }
 

--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -18,28 +18,28 @@ const deskLocaleStrings = {
   'action.publish.published.label': 'Published',
 
   /** Label for the "Publish" document action when the document has live edit enabled.*/
-  'action.publish.liveEdit.label': 'Publish',
+  'action.publish.live-edit.label': 'Publish',
 
   /** Tooltip for the "Publish" document action when the document has live edit enabled.*/
-  'action.publish.liveEdit.tooltip':
+  'action.publish.live-edit.tooltip':
     'Live Edit is enabled for this content type and publishing happens automatically as you make changes',
 
   /** Fallback tooltip for the "Publish" document action when publish is invoked for a document with live edit enabled.*/
-  'action.publish.liveEdit.publishDisabled':
+  'action.publish.live-edit.publish-disabled':
     'Cannot publish since liveEdit is enabled for this document type',
 
   /** Tooltip when the "Publish" document action is disabled due to validation issues */
-  'action.publish.validationIssues.tooltip':
+  'action.publish.validation-issues.tooltip':
     'There are validation errors that need to be fixed before this document can be published',
 
   /** Tooltip when publish button is disabled because the document is already published.*/
-  'action.publish.alreadyPublished.tooltip': 'Published {{timeSincePublished}} ago',
+  'action.publish.already-published.tooltip': 'Published {{timeSincePublished}} ago',
 
   /** Tooltip when publish button is disabled because the document is already published, and published time is unavailable.*/
   'action.publish.already-published.no-time-ago.tooltip': 'Already published',
 
   /** Tooltip when publish button is disabled because there are no changes.*/
-  'action.publish.tooltip.noChanges': 'No unpublished changes',
+  'action.publish.tooltip.no-changes': 'No unpublished changes',
 
   /** Tooltip when publish button is waiting for validation and async tasks to complete.*/
   'action.publish.waiting': 'Waiting for tasks to finish before publishing',

--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -107,7 +107,7 @@ const deskLocaleStrings = {
   'action.restore.label': 'Restore',
 
   /** Fallback tooltip for when user is looking at the initial version */
-  'action.restore.disabled.cantRestoreInitial': "You can't restore to the initial version",
+  'action.restore.disabled.cannot-restore-initial': "You can't restore to the initial version",
 
   /** Default tooltip for the action */
   'action.restore.tooltip': 'Restore to this version',

--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -6,7 +6,7 @@
 const deskLocaleStrings = {
   /** --- PUBLISH ACTION --- */
   /** Tooltip when action is disabled because the studio is not ready.*/
-  'action.publish.disabled.notReady': 'Operation not ready',
+  'action.publish.disabled.not-ready': 'Operation not ready',
 
   /** Label for action when there are pending changes.*/
   'action.publish.draft.label': 'Publish',
@@ -36,7 +36,7 @@ const deskLocaleStrings = {
   'action.publish.alreadyPublished.tooltip': 'Published {{timeSincePublished}} ago',
 
   /** Tooltip when publish button is disabled because the document is already published, and published time is unavailable.*/
-  'action.publish.alreadyPublished.noTimeAgo.tooltip': 'Already published',
+  'action.publish.already-published.no-time-ago.tooltip': 'Already published',
 
   /** Tooltip when publish button is disabled because there are no changes.*/
   'action.publish.tooltip.noChanges': 'No unpublished changes',

--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -73,6 +73,20 @@ const deskLocaleStrings = {
   /** Message prompting the user to confirm discarding changes */
   'action.discardChanges.confirmDialog.confirmDiscardChanges':
     'Are you sure you want to discard all changes since last published?',
+
+  /** --- DUPLICATE ACTION --- */
+  /** Tooltip when action is disabled because the operation is not ready   */
+  'action.duplicate.disabled.notReady': 'Operation not ready',
+
+  /** Tooltip when action is disabled because the document doesn't exist */
+  'action.duplicate.disabled.nothingToDuplicate':
+    "This document doesn't yet exist so there‘s nothing to duplicate",
+
+  /** Label for the "Duplicate" document action */
+  'action.duplicate.label': 'Duplicate',
+
+  /** Label for the "Duplicate" document action while the document is being duplicated */
+  'action.duplicate.running.label': 'Duplicating…',
 }
 
 /**

--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -56,6 +56,23 @@ const deskLocaleStrings = {
 
   /** Label for the "Delete" document action while the document is being deleted */
   'action.delete.running.label': 'Deleting…',
+
+  /** --- DISCARD CHANGES ACTION --- **/
+  /** Tooltip when action button is disabled because the operation is not ready   */
+  'action.discardChanges.disabled.notReady': 'Operation not ready',
+
+  /** Label for the "Discard changes" document action */
+  'action.discardChanges.label': 'Discard changes',
+
+  /** Tooltip when action is disabled because the document has no unpublished changes */
+  'action.discardChanges.disabled.noChange': 'This document has no unpublished changes',
+
+  /** Tooltip when action is disabled because the document is not published */
+  'action.discardChanges.disabled.notPublished': 'This document is not published',
+
+  /** Message prompting the user to confirm discarding changes */
+  'action.discardChanges.confirmDialog.confirmDiscardChanges':
+    'Are you sure you want to discard all changes since last published?',
 }
 
 /**

--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -46,10 +46,11 @@ const deskLocaleStrings = {
 
   /** --- DELETE ACTION --- **/
   /** Tooltip when action button is disabled because the operation is not ready   */
-  'action.delete.disabled.notReady': 'Operation not ready',
+  'action.delete.disabled.not-ready': 'Operation not ready',
 
   /** Tooltip when action button is disabled because the document does not exist */
-  'action.delete.disabled.nothingToDelete': 'This document doesn’t yet exist or is already deleted',
+  'action.delete.disabled.nothing-to-delete':
+    'This document doesn’t yet exist or is already deleted',
 
   /** Label for the "Delete" document action button */
   'action.delete.label': 'Delete',

--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -43,6 +43,19 @@ const deskLocaleStrings = {
 
   /** Tooltip when publish button is waiting for validation and async tasks to complete.*/
   'action.publish.waiting': 'Waiting for tasks to finish before publishing',
+
+  /** --- DELETE ACTION --- **/
+  /** Tooltip when action button is disabled because the operation is not ready   */
+  'action.delete.disabled.notReady': 'Operation not ready',
+
+  /** Tooltip when action button is disabled because the document does not exist */
+  'action.delete.disabled.nothingToDelete': 'This document doesn’t yet exist or is already deleted',
+
+  /** Label for the "Delete" document action button */
+  'action.delete.label': 'Delete',
+
+  /** Label for the "Delete" document action while the document is being deleted */
+  'action.delete.running.label': 'Deleting…',
 }
 
 /**

--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -60,19 +60,19 @@ const deskLocaleStrings = {
 
   /** --- DISCARD CHANGES ACTION --- **/
   /** Tooltip when action button is disabled because the operation is not ready   */
-  'action.discardChanges.disabled.notReady': 'Operation not ready',
+  'action.discard-changes.disabled.not-ready': 'Operation not ready',
 
   /** Label for the "Discard changes" document action */
-  'action.discardChanges.label': 'Discard changes',
+  'action.discard-changes.label': 'Discard changes',
 
   /** Tooltip when action is disabled because the document has no unpublished changes */
-  'action.discardChanges.disabled.noChange': 'This document has no unpublished changes',
+  'action.discard-changes.disabled.no-change': 'This document has no unpublished changes',
 
   /** Tooltip when action is disabled because the document is not published */
-  'action.discardChanges.disabled.notPublished': 'This document is not published',
+  'action.discard-changes.disabled.not-published': 'This document is not published',
 
   /** Message prompting the user to confirm discarding changes */
-  'action.discardChanges.confirmDialog.confirm-discardchanges':
+  'action.discard-changes.confirm-dialog.confirm-discard-changes':
     'Are you sure you want to discard all changes since last published?',
 
   /** --- DUPLICATE ACTION --- */
@@ -114,7 +114,7 @@ const deskLocaleStrings = {
   'action.restore.tooltip': 'Restore to this version',
 
   /** Message prompting the user to confirm that they want to restore to an earlier version*/
-  'action.restore.confirmDialog.confirm-discard-changes':
+  'action.restore.confirm-dialog.confirm-discard-changes':
     'Are you sure you want to restore this document?',
 }
 


### PR DESCRIPTION
### Description
This converts various document action strings into 18n-keys

Also includes some minor cleanup. Commits can be reviewed one-by-one.