### PR TITLE
fix(desk): fixes type for canHandleIntent in documentList

### DIFF
--- a/packages/sanity/src/desk/structureBuilder/GenericList.ts
+++ b/packages/sanity/src/desk/structureBuilder/GenericList.ts
@@ -208,7 +208,7 @@ export abstract class GenericListBuilder<TList extends BuildableGenericList, Con
    * @param canHandleIntent - generic list intent checker. See {@link IntentChecker}
    * @returns generic list builder based on can handle intent provided.
    */
-  canHandleIntent(canHandleIntent: IntentChecker): ConcreteImpl {
+  canHandleIntent(canHandleIntent?: IntentChecker): ConcreteImpl {
     return this.clone({canHandleIntent})
   }
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

`getCanHandleIntent` can return `undefined`, but `canHandleIntent` cannot received `undefined`.
In all of our examples, we pass the result of `getCanHandleIntent` directly into `canHandleIntent`.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

This fixes the types for `canHandleIntent` to take undefined as everywhere else the params are optional so this changes matches the other interfaces. Adding the below structure still works and does not show TS error

```
S.listItem()
  .title('Custom books list')
  .child(
    S.documentList()
      .title('Unspecified books list')
      .filter('_type == $type')
      .params({type: 'book'})
      .menuItems(S.documentTypeList('book').getMenuItems())
      .canHandleIntent(S.documentTypeList('book').getCanHandleIntent()),
  )
```

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

- Fixes type for `canHandleIntent` to allow passing undefined
