### PR TITLE
feat(i18n): convert date/datetime input strings to use i18n primitives

### DIFF
--- a/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
@@ -62,6 +62,45 @@ const studioResources: Record<StudioLocaleResourceKeys, string> = {
   'timeAgo.seconds.minimal': '{{count}}m',
   /* Relative time, granularity: seconds, using a minimal format, configured to show ago suffix*/
   'timeAgo.seconds.minimal.ago': '{{count}}m ago',
+
+  /** --- DateTime (and Date) Input --- */
+
+  /** Action message for navigating to previous month */
+  'inputs.datetime.calendar.action.previous-month': `Forrige måned`,
+  /** Action message for navigating to next year */
+  'inputs.datetime.calendar.action.next-year': `Neste år`,
+  /** Action message for navigating to previous year */
+  'inputs.datetime.calendar.action.previous-year': `Forrige år`,
+  /** Action message for selecting hour */
+  'inputs.datetime.calendar.action.select-hour': `Velg time`,
+  /** Action message for setting to current time */
+  'inputs.datetime.calendar.action.set-to-current-time': `Sett til nå`,
+
+  /** Month names */
+  'inputs.datetime.calendar.month-names.january': 'Januar',
+  'inputs.datetime.calendar.month-names.february': 'Februar',
+  'inputs.datetime.calendar.month-names.march': 'Mars',
+  'inputs.datetime.calendar.month-names.april': 'April',
+  'inputs.datetime.calendar.month-names.may': 'Mai',
+  'inputs.datetime.calendar.month-names.june': 'Juni',
+  'inputs.datetime.calendar.month-names.july': 'Juli',
+  'inputs.datetime.calendar.month-names.august': 'August',
+  'inputs.datetime.calendar.month-names.september': 'September',
+  'inputs.datetime.calendar.month-names.october': 'Oktober',
+  'inputs.datetime.calendar.month-names.november': 'November',
+  'inputs.datetime.calendar.month-names.december': 'Desember',
+
+  /** Short weekday names */
+  'inputs.datetime.calendar.weekday-names.short.monday': 'Man',
+  'inputs.datetime.calendar.weekday-names.short.tuesday': 'Tir',
+  'inputs.datetime.calendar.weekday-names.short.wednesday': 'Ons',
+  'inputs.datetime.calendar.weekday-names.short.thursday': 'Tor',
+  'inputs.datetime.calendar.weekday-names.short.friday': 'Fre',
+  'inputs.datetime.calendar.weekday-names.short.saturday': 'Lør',
+  'inputs.datetime.calendar.weekday-names.short.sunday': 'Søn',
+
+  /** Label for selecting a hour preset. Receives a `time` param as a string on hh:mm format and a `date` param as a Date instance denoting the preset date */
+  'inputs.datetime.calendar.action.set-to-time-preset': '{{time}} on {{date, datetime}}',
 }
 
 export default studioResources

--- a/packages/sanity/src/core/form/inputs/DateInputs/CommonDateTimeInput.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/CommonDateTimeInput.tsx
@@ -5,6 +5,7 @@ import React, {useEffect} from 'react'
 import {TextInput, useForwardedRef} from '@sanity/ui'
 import {DateTimeInput} from './base/DateTimeInput'
 import {ParseResult} from './types'
+import {CalendarLabels} from './base/calendar/types'
 
 export interface CommonDateTimeInputProps {
   id: string
@@ -18,6 +19,7 @@ export interface CommonDateTimeInputProps {
   serialize: (date: Date) => string
   timeStep?: number
   value: string | undefined
+  calendarLabels: CalendarLabels
 }
 
 const DEFAULT_PLACEHOLDER_TIME = new Date()
@@ -91,6 +93,7 @@ export const CommonDateTimeInput = React.forwardRef(function CommonDateTimeInput
   ) : (
     <DateTimeInput
       {...restProps}
+      calendarLabels={props.calendarLabels}
       id={id}
       selectTime={selectTime}
       timeStep={timeStep}

--- a/packages/sanity/src/core/form/inputs/DateInputs/DateInput.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/DateInput.tsx
@@ -1,18 +1,11 @@
-import React, {useCallback} from 'react'
+import React, {useCallback, useMemo} from 'react'
 import {format, parse} from '@sanity/util/legacyDateFormat'
 import {set, unset} from '../../patch'
 import {StringInputProps} from '../../types'
+import {useTranslation} from '../../../i18n'
 import {CommonDateTimeInput} from './CommonDateTimeInput'
-
-interface ParsedOptions {
-  dateFormat: string
-  calendarTodayLabel: string
-}
-
-interface SchemaOptions {
-  dateFormat?: string
-  calendarTodayLabel?: string
-}
+import {CalendarLabels} from './base/calendar/types'
+import {getCalendarLabels} from './utils'
 
 /**
  * @hidden
@@ -24,13 +17,6 @@ const VALUE_FORMAT = 'YYYY-MM-DD'
 // default to how they are stored
 const DEFAULT_DATE_FORMAT = VALUE_FORMAT
 
-function parseOptions(options: SchemaOptions = {}): ParsedOptions {
-  return {
-    dateFormat: options.dateFormat || DEFAULT_DATE_FORMAT,
-    calendarTodayLabel: options.calendarTodayLabel || 'Today',
-  }
-}
-
 const deserialize = (value: string) => parse(value, VALUE_FORMAT)
 const serialize = (date: Date) => format(date, VALUE_FORMAT)
 
@@ -39,7 +25,8 @@ const serialize = (date: Date) => format(date, VALUE_FORMAT)
  * @beta */
 export function DateInput(props: DateInputProps) {
   const {readOnly, onChange, schemaType, elementProps, value} = props
-  const {dateFormat} = parseOptions(schemaType.options)
+  const dateFormat = schemaType.options?.dateFormat || DEFAULT_DATE_FORMAT
+  const {t} = useTranslation()
 
   const handleChange = useCallback(
     (nextDate: string | null) => {
@@ -55,6 +42,7 @@ export function DateInput(props: DateInputProps) {
     [dateFormat],
   )
 
+  const calendarLabels: CalendarLabels = useMemo(() => getCalendarLabels(t), [t])
   return (
     <CommonDateTimeInput
       {...elementProps}
@@ -63,6 +51,7 @@ export function DateInput(props: DateInputProps) {
       onChange={handleChange}
       parseInputValue={parseInputValue}
       placeholder={schemaType.placeholder}
+      calendarLabels={calendarLabels}
       readOnly={readOnly}
       selectTime={false}
       serialize={serialize}

--- a/packages/sanity/src/core/form/inputs/DateInputs/DateTimeInput.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/DateTimeInput.tsx
@@ -1,24 +1,24 @@
 import {format, parse} from '@sanity/util/legacyDateFormat'
 import {getMinutes, setMinutes, parseISO} from 'date-fns'
-import React, {useCallback} from 'react'
+import React, {useCallback, useMemo} from 'react'
 import {set, unset} from '../../patch'
 import {StringInputProps} from '../../types'
+import {useTranslation} from '../../../i18n'
 import {CommonDateTimeInput} from './CommonDateTimeInput'
 import {ParseResult} from './types'
-import {isValidDate} from './utils'
+import {getCalendarLabels, isValidDate} from './utils'
+import {CalendarLabels} from './base/calendar/types'
 
 interface ParsedOptions {
   dateFormat: string
   timeFormat: string
   timeStep: number
-  calendarTodayLabel: string
 }
 
 interface SchemaOptions {
   dateFormat?: string
   timeFormat?: string
   timeStep?: number
-  calendarTodayLabel?: string
 }
 
 /**
@@ -34,7 +34,6 @@ function parseOptions(options: SchemaOptions = {}): ParsedOptions {
     dateFormat: options.dateFormat || DEFAULT_DATE_FORMAT,
     timeFormat: options.timeFormat || DEFAULT_TIME_FORMAT,
     timeStep: ('timeStep' in options && Number(options.timeStep)) || 1,
-    calendarTodayLabel: options.calendarTodayLabel || 'Today',
   }
 }
 
@@ -73,6 +72,7 @@ export function DateTimeInput(props: DateTimeInputProps) {
   const {onChange, schemaType, value, elementProps} = props
 
   const {dateFormat, timeFormat, timeStep} = parseOptions(schemaType.options)
+  const {t} = useTranslation()
 
   const handleChange = useCallback(
     (nextDate: string | null) => {
@@ -95,10 +95,11 @@ export function DateTimeInput(props: DateTimeInputProps) {
     (inputValue: string) => parse(inputValue, `${dateFormat} ${timeFormat}`),
     [dateFormat, timeFormat],
   )
-
+  const calendarLabels: CalendarLabels = useMemo(() => getCalendarLabels(t), [t])
   return (
     <CommonDateTimeInput
       {...elementProps}
+      calendarLabels={calendarLabels}
       onChange={handleChange}
       deserialize={deserialize}
       formatInputValue={formatInputValue}

--- a/packages/sanity/src/core/form/inputs/DateInputs/__tests__/CommonDateTimeInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/__tests__/CommonDateTimeInput.test.tsx
@@ -7,6 +7,7 @@ import {ParseResult} from '../types'
 import {CommonDateTimeInput} from '../CommonDateTimeInput'
 import {isValidDate} from '../utils'
 import {renderStringInput} from '../../../../../../test/form'
+import {CalendarLabels} from '../base/calendar/types'
 
 function parseInputValue(input: string): ParseResult {
   const candidate = parse(input, 'yyyy-MM-dd HH:mm', 0)
@@ -28,6 +29,30 @@ function serialize(date: Date): string {
   return date.toISOString()
 }
 
+const CALENDAR_LABELS: CalendarLabels = {
+  previousYear: 'Previous year',
+  nextYear: 'Next year',
+  goToPreviousMonth: 'Goto previous mont',
+  selectHour: 'Select hour',
+  setToCurrentTime: 'Set to current time',
+  monthNames: [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ],
+  weekDayNamesShort: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+  setToTimePreset: (time: string, date: Date) => `${time} on ${format(date, 'yyyy-MM-dd')}`,
+}
+
 async function renderInput() {
   const onChange = jest.fn()
 
@@ -42,6 +67,7 @@ async function renderInput() {
       return (
         <CommonDateTimeInput
           deserialize={deserialize}
+          calendarLabels={CALENDAR_LABELS}
           id={id}
           formatInputValue={formatInputValue}
           onChange={onChange}

--- a/packages/sanity/src/core/form/inputs/DateInputs/base/DatePicker.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/base/DatePicker.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import {Calendar} from './calendar/Calendar'
+import {CalendarLabels} from './calendar/types'
 
 export const DatePicker = React.forwardRef(function DatePicker(
   props: Omit<React.ComponentProps<'div'>, 'onChange'> & {
@@ -7,10 +8,11 @@ export const DatePicker = React.forwardRef(function DatePicker(
     onChange: (nextDate: Date) => void
     selectTime?: boolean
     timeStep?: number
+    calendarLabels: CalendarLabels
   },
   ref: React.ForwardedRef<HTMLDivElement>,
 ) {
-  const {value = new Date(), onChange, ...rest} = props
+  const {value = new Date(), onChange, calendarLabels, ...rest} = props
   const [focusedDate, setFocusedDay] = React.useState<Date>()
 
   const handleSelect = React.useCallback(
@@ -24,6 +26,7 @@ export const DatePicker = React.forwardRef(function DatePicker(
   return (
     <Calendar
       {...rest}
+      labels={calendarLabels}
       ref={ref}
       selectedDate={value}
       onSelect={handleSelect}

--- a/packages/sanity/src/core/form/inputs/DateInputs/base/DateTimeInput.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/base/DateTimeInput.tsx
@@ -4,6 +4,7 @@ import {Box, Button, LayerProvider, Popover, useClickOutside, useForwardedRef} f
 import {CalendarIcon} from '@sanity/icons'
 import {DatePicker} from './DatePicker'
 import {LazyTextInput} from './LazyTextInput'
+import {CalendarLabels, MonthNames} from './calendar/types'
 
 export interface DateTimeInputProps {
   customValidity?: string
@@ -16,13 +17,23 @@ export interface DateTimeInputProps {
   selectTime?: boolean
   timeStep?: number
   value?: Date
+  calendarLabels: CalendarLabels
 }
 
 export const DateTimeInput = forwardRef(function DateTimeInput(
   props: DateTimeInputProps,
   ref: React.ForwardedRef<HTMLInputElement>,
 ) {
-  const {value, inputValue, onInputChange, onChange, selectTime, timeStep, ...rest} = props
+  const {
+    value,
+    inputValue,
+    onInputChange,
+    onChange,
+    selectTime,
+    timeStep,
+    calendarLabels,
+    ...rest
+  } = props
   const [popoverRef, setPopoverRef] = useState<HTMLElement | null>(null)
   const forwardedRef = useForwardedRef(ref)
   const buttonRef = useRef(null)
@@ -78,6 +89,7 @@ export const DateTimeInput = forwardRef(function DateTimeInput(
                 <Box overflow="auto">
                   <FocusLock onDeactivation={handleDeactivation}>
                     <DatePicker
+                      calendarLabels={calendarLabels}
                       selectTime={selectTime}
                       timeStep={timeStep}
                       onKeyUp={handleKeyUp}

--- a/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/Calendar.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/Calendar.tsx
@@ -189,7 +189,7 @@ export const Calendar = forwardRef(function Calendar(
               moveFocusedDate={moveFocusedDate}
               onChange={handleFocusedMonthChange}
               labels={{goToPreviousMonth: labels.goToPreviousMonth}}
-              monthNames={labels.montNames}
+              monthNames={labels.monthNames}
               value={focusedDate?.getMonth()}
             />
           </Box>
@@ -212,7 +212,7 @@ export const Calendar = forwardRef(function Calendar(
           tabIndex={0}
         >
           <CalendarMonth
-            weekDayNames={labels.weekDayNames}
+            weekDayNames={labels.weekDayNamesShort}
             date={focusedDate}
             focused={focusedDate}
             onSelect={handleDateChange}

--- a/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/Calendar.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/Calendar.tsx
@@ -4,10 +4,11 @@ import {addDays, addMonths, setDate, setHours, setMinutes, setMonth, setYear} fr
 import {range} from 'lodash'
 import React, {forwardRef, useCallback, useEffect} from 'react'
 import {CalendarMonth} from './CalendarMonth'
-import {ARROW_KEYS, HOURS_24, MONTH_NAMES, DEFAULT_TIME_PRESETS} from './constants'
+import {ARROW_KEYS, DEFAULT_TIME_PRESETS, HOURS_24} from './constants'
 import {features} from './features'
 import {formatTime} from './utils'
 import {YearInput} from './YearInput'
+import {CalendarLabels, MonthNames} from './types'
 
 type CalendarProps = Omit<React.ComponentProps<'div'>, 'onSelect'> & {
   selectTime?: boolean
@@ -16,6 +17,7 @@ type CalendarProps = Omit<React.ComponentProps<'div'>, 'onSelect'> & {
   onSelect: (date: Date) => void
   focusedDate: Date
   onFocusedDateChange: (index: Date) => void
+  labels: CalendarLabels
 }
 
 // This is used to maintain focus on a child element of the calendar-grid between re-renders
@@ -44,6 +46,7 @@ export const Calendar = forwardRef(function Calendar(
     focusedDate = selectedDate,
     timeStep = 1,
     onSelect,
+    labels,
     ...restProps
   } = props
 
@@ -185,12 +188,15 @@ export const Calendar = forwardRef(function Calendar(
             <CalendarMonthSelect
               moveFocusedDate={moveFocusedDate}
               onChange={handleFocusedMonthChange}
+              labels={{goToPreviousMonth: labels.goToPreviousMonth}}
+              monthNames={labels.montNames}
               value={focusedDate?.getMonth()}
             />
           </Box>
           <Box marginLeft={2}>
             <CalendarYearSelect
               moveFocusedDate={moveFocusedDate}
+              labels={{nextYear: labels.nextYear, previousYear: labels.previousYear}}
               onChange={setFocusedDateYear}
               value={focusedDate.getFullYear()}
             />
@@ -206,6 +212,7 @@ export const Calendar = forwardRef(function Calendar(
           tabIndex={0}
         >
           <CalendarMonth
+            weekDayNames={labels.weekDayNames}
             date={focusedDate}
             focused={focusedDate}
             onSelect={handleDateChange}
@@ -222,7 +229,7 @@ export const Calendar = forwardRef(function Calendar(
             <Flex align="center" flex={1}>
               <Box>
                 <Select
-                  aria-label="Select hour"
+                  aria-label={labels.selectHour}
                   value={selectedDate?.getHours()}
                   onChange={handleHoursChange}
                 >
@@ -254,20 +261,22 @@ export const Calendar = forwardRef(function Calendar(
             </Flex>
 
             <Box marginLeft={2}>
-              <Button text="Set to current time" mode="bleed" onClick={handleNowClick} />
+              <Button text={labels.setToCurrentTime} mode="bleed" onClick={handleNowClick} />
             </Box>
           </Flex>
 
           {features.timePresets && (
             <Flex direction="row" justify="center" align="center" style={{marginTop: 5}}>
               {DEFAULT_TIME_PRESETS.map(([hours, minutes]) => {
+                const text = formatTime(hours, minutes)
                 return (
                   <CalendarTimePresetButton
                     key={`${hours}-${minutes}`}
                     hours={hours}
                     minutes={minutes}
                     onTimeChange={handleTimeChange}
-                    selectedDate={selectedDate}
+                    text={text}
+                    aria-label={labels.setToTimePreset(text, selectedDate)}
                   />
                 )
               })}
@@ -283,10 +292,10 @@ function CalendarTimePresetButton(props: {
   hours: number
   minutes: number
   onTimeChange: (hours: number, minutes: number) => void
-  selectedDate: Date
+  'aria-label': string
+  text: string
 }) {
-  const {hours, minutes, onTimeChange, selectedDate} = props
-  const formatted = formatTime(hours, minutes)
+  const {hours, minutes, text, onTimeChange} = props
 
   const handleClick = useCallback(() => {
     onTimeChange(hours, minutes)
@@ -294,8 +303,8 @@ function CalendarTimePresetButton(props: {
 
   return (
     <Button
-      text={formatted}
-      aria-label={`${formatted} on ${selectedDate.toDateString()}`}
+      text={text}
+      aria-label={props['aria-label']}
       mode="bleed"
       fontSize={1}
       onClick={handleClick}
@@ -307,8 +316,12 @@ function CalendarMonthSelect(props: {
   moveFocusedDate: (by: number) => void
   onChange: (e: React.FormEvent<HTMLSelectElement>) => void
   value?: number
+  monthNames: MonthNames
+  labels: {
+    goToPreviousMonth: string
+  }
 }) {
-  const {moveFocusedDate, onChange, value} = props
+  const {moveFocusedDate, onChange, value, labels, monthNames} = props
 
   const handlePrevMonthClick = useCallback(() => moveFocusedDate(-1), [moveFocusedDate])
 
@@ -317,7 +330,7 @@ function CalendarMonthSelect(props: {
   return (
     <Flex flex={1}>
       <Button
-        aria-label="Go to previous month"
+        aria-label={labels.goToPreviousMonth}
         onClick={handlePrevMonthClick}
         mode="bleed"
         icon={ChevronLeftIcon}
@@ -326,7 +339,7 @@ function CalendarMonthSelect(props: {
       />
       <Box flex={1}>
         <Select radius={0} value={value} onChange={onChange}>
-          {MONTH_NAMES.map((m, i) => (
+          {monthNames.map((m, i) => (
             // eslint-disable-next-line react/no-array-index-key
             <option key={i} value={i}>
               {m}
@@ -350,8 +363,9 @@ function CalendarYearSelect(props: {
   moveFocusedDate: (by: number) => void
   onChange: (year: number) => void
   value?: number
+  labels: {nextYear: string; previousYear: string}
 }) {
-  const {moveFocusedDate, onChange, value} = props
+  const {moveFocusedDate, onChange, value, labels} = props
 
   const handlePrevYearClick = useCallback(() => moveFocusedDate(-12), [moveFocusedDate])
 
@@ -360,7 +374,7 @@ function CalendarYearSelect(props: {
   return (
     <Flex>
       <Button
-        aria-label="Previous year"
+        aria-label={labels.previousYear}
         onClick={handlePrevYearClick}
         mode="bleed"
         icon={ChevronLeftIcon}
@@ -369,7 +383,7 @@ function CalendarYearSelect(props: {
       />
       <YearInput value={value} onChange={onChange} radius={0} style={{width: 65}} />
       <Button
-        aria-label="Next year"
+        aria-label={labels.nextYear}
         onClick={handleNextYearClick}
         mode="bleed"
         icon={ChevronRightIcon}

--- a/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/CalendarMonth.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/CalendarMonth.tsx
@@ -2,7 +2,6 @@ import {Box, Grid, Text} from '@sanity/ui'
 import {isSameDay, isSameMonth} from 'date-fns'
 import React from 'react'
 import {CalendarDay} from './CalendarDay'
-import {WEEK_DAY_NAMES} from './constants'
 import {getWeeksOfMonth} from './utils'
 
 interface CalendarMonthProps {
@@ -11,13 +10,22 @@ interface CalendarMonthProps {
   selected?: Date
   onSelect: (date: Date) => void
   hidden?: boolean
+  weekDayNames: [
+    mon: string,
+    tue: string,
+    wed: string,
+    thu: string,
+    fri: string,
+    sat: string,
+    sun: string,
+  ]
 }
 
 export function CalendarMonth(props: CalendarMonthProps) {
   return (
     <Box aria-hidden={props.hidden || false} data-ui="CalendarMonth">
       <Grid gap={1} style={{gridTemplateColumns: 'repeat(7, minmax(44px, 46px))'}}>
-        {WEEK_DAY_NAMES.map((weekday) => (
+        {props.weekDayNames.map((weekday) => (
           <Box key={weekday} paddingY={2}>
             <Text size={1} weight="medium" style={{textAlign: 'center'}}>
               {weekday}

--- a/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/constants.ts
+++ b/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/constants.ts
@@ -1,6 +1,6 @@
 import {range} from 'lodash'
 
-export const MONTH_NAMES = [
+export const DEFAULT_MONTH_NAMES = [
   'January',
   'February',
   'March',
@@ -15,7 +15,7 @@ export const MONTH_NAMES = [
   'December',
 ]
 
-export const WEEK_DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+export const DEFAULT_WEEK_DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 
 export const HOURS_24 = range(0, 24)
 

--- a/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/types.ts
+++ b/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/types.ts
@@ -4,8 +4,8 @@ export interface CalendarLabels {
   goToPreviousMonth: string
   selectHour: string
   setToCurrentTime: string
-  montNames: MonthNames
-  weekDayNames: WeekDayNames
+  monthNames: MonthNames
+  weekDayNamesShort: WeekDayNames
   setToTimePreset: (time: string, date: Date) => string
 }
 
@@ -28,7 +28,7 @@ export type MonthNames = [
   jun: string,
   jul: string,
   aug: string,
-  sept: string,
+  sep: string,
   oct: string,
   nov: string,
   dec: string,

--- a/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/types.ts
+++ b/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/types.ts
@@ -1,0 +1,35 @@
+export interface CalendarLabels {
+  previousYear: string
+  nextYear: string
+  goToPreviousMonth: string
+  selectHour: string
+  setToCurrentTime: string
+  montNames: MonthNames
+  weekDayNames: WeekDayNames
+  setToTimePreset: (time: string, date: Date) => string
+}
+
+export type WeekDayNames = [
+  mon: string,
+  tue: string,
+  wed: string,
+  thu: string,
+  fri: string,
+  sat: string,
+  sun: string,
+]
+
+export type MonthNames = [
+  jan: string,
+  feb: string,
+  mar: string,
+  apr: string,
+  may: string,
+  jun: string,
+  jul: string,
+  aug: string,
+  sept: string,
+  oct: string,
+  nov: string,
+  dec: string,
+]

--- a/packages/sanity/src/core/form/inputs/DateInputs/utils.ts
+++ b/packages/sanity/src/core/form/inputs/DateInputs/utils.ts
@@ -13,7 +13,7 @@ export function getCalendarLabels(
     previousYear: t('inputs.datetime.calendar.action.previous-year'),
     setToCurrentTime: t('inputs.datetime.calendar.action.set-to-current-time'),
     selectHour: t('inputs.datetime.calendar.action.select-hour'),
-    montNames: [
+    monthNames: [
       t('inputs.datetime.calendar.month-names.january'),
       t('inputs.datetime.calendar.month-names.february'),
       t('inputs.datetime.calendar.month-names.march'),
@@ -27,7 +27,7 @@ export function getCalendarLabels(
       t('inputs.datetime.calendar.month-names.november'),
       t('inputs.datetime.calendar.month-names.december'),
     ],
-    weekDayNames: [
+    weekDayNamesShort: [
       t('inputs.datetime.calendar.weekday-names.short.monday'),
       t('inputs.datetime.calendar.weekday-names.short.tuesday'),
       t('inputs.datetime.calendar.weekday-names.short.wednesday'),

--- a/packages/sanity/src/core/form/inputs/DateInputs/utils.ts
+++ b/packages/sanity/src/core/form/inputs/DateInputs/utils.ts
@@ -1,3 +1,42 @@
+import {CalendarLabels} from './base/calendar/types'
+
 export function isValidDate(date: Date) {
   return date instanceof Date && !isNaN(date.valueOf())
+}
+
+export function getCalendarLabels(
+  t: (key: string, values?: Record<string, unknown>) => string,
+): CalendarLabels {
+  return {
+    goToPreviousMonth: t('inputs.datetime.calendar.go-to-previous-month'),
+    nextYear: t('inputs.datetime.calendar.action.next-year'),
+    previousYear: t('inputs.datetime.calendar.action.previous-year'),
+    setToCurrentTime: t('inputs.datetime.calendar.action.set-to-current-time'),
+    selectHour: t('inputs.datetime.calendar.action.select-hour'),
+    montNames: [
+      t('inputs.datetime.calendar.month-names.january'),
+      t('inputs.datetime.calendar.month-names.february'),
+      t('inputs.datetime.calendar.month-names.march'),
+      t('inputs.datetime.calendar.month-names.april'),
+      t('inputs.datetime.calendar.month-names.may'),
+      t('inputs.datetime.calendar.month-names.june'),
+      t('inputs.datetime.calendar.month-names.july'),
+      t('inputs.datetime.calendar.month-names.august'),
+      t('inputs.datetime.calendar.month-names.september'),
+      t('inputs.datetime.calendar.month-names.october'),
+      t('inputs.datetime.calendar.month-names.november'),
+      t('inputs.datetime.calendar.month-names.december'),
+    ],
+    weekDayNames: [
+      t('inputs.datetime.calendar.weekday-names.short.monday'),
+      t('inputs.datetime.calendar.weekday-names.short.tuesday'),
+      t('inputs.datetime.calendar.weekday-names.short.wednesday'),
+      t('inputs.datetime.calendar.weekday-names.short.thursday'),
+      t('inputs.datetime.calendar.weekday-names.short.friday'),
+      t('inputs.datetime.calendar.weekday-names.short.saturday'),
+      t('inputs.datetime.calendar.weekday-names.short.sunday'),
+    ],
+    setToTimePreset: (time, date) =>
+      t('inputs.datetime.calendar.action.set-to-time-preset', {time, date}),
+  }
 }

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -173,6 +173,45 @@ export const studioLocaleStrings = {
   /** Action message for generating the slug */
   'inputs.slug.action.generate': `Generate`,
 
+  /** --- DateTime (and Date) Input --- */
+
+  /** Action message for navigating to previous month */
+  'inputs.datetime.calendar.action.previous-month': `Previous month`,
+  /** Action message for navigating to next year */
+  'inputs.datetime.calendar.action.next-year': `Next year`,
+  /** Action message for navigating to previous year */
+  'inputs.datetime.calendar.action.previous-year': `Previous year`,
+  /** Action message for selecting hour */
+  'inputs.datetime.calendar.action.select-hour': `Select hour`,
+  /** Action message for setting to current time */
+  'inputs.datetime.calendar.action.set-to-current-time': `Set to current time`,
+
+  /** Month names */
+  'inputs.datetime.calendar.month-names.january': 'January',
+  'inputs.datetime.calendar.month-names.february': 'February',
+  'inputs.datetime.calendar.month-names.march': 'March',
+  'inputs.datetime.calendar.month-names.april': 'April',
+  'inputs.datetime.calendar.month-names.may': 'May',
+  'inputs.datetime.calendar.month-names.june': 'June',
+  'inputs.datetime.calendar.month-names.july': 'July',
+  'inputs.datetime.calendar.month-names.august': 'August',
+  'inputs.datetime.calendar.month-names.september': 'September',
+  'inputs.datetime.calendar.month-names.october': 'October',
+  'inputs.datetime.calendar.month-names.november': 'November',
+  'inputs.datetime.calendar.month-names.december': 'December',
+
+  /** Short weekday names */
+  'inputs.datetime.calendar.weekday-names.short.monday': 'Mon',
+  'inputs.datetime.calendar.weekday-names.short.tuesday': 'Tue',
+  'inputs.datetime.calendar.weekday-names.short.wednesday': 'Wed',
+  'inputs.datetime.calendar.weekday-names.short.thursday': 'Thu',
+  'inputs.datetime.calendar.weekday-names.short.friday': 'Fri',
+  'inputs.datetime.calendar.weekday-names.short.saturday': 'Sat',
+  'inputs.datetime.calendar.weekday-names.short.sunday': 'Sun',
+
+  /** Label for selecting a hour preset. Receives a `time` param as a string on hh:mm format and a `date` param as a Date instance denoting the preset date */
+  'inputs.datetime.calendar.action.set-to-time-preset': '{{time}} on {{date, datetime}}',
+
   /** --- Workspace menu --- */
 
   /** Title for Workplaces dropdown menu */


### PR DESCRIPTION
### Description
Adds internationalization capabilities to Date and DateTime inputs. Tried to keep as much as the i18n framework itself apart from the base datetime-picker, so limited the use of `useTranslation()` to the form input components.