### PR TITLE
chore: change clipboard icon to copy icon

### DIFF
--- a/packages/sanity/src/core/form/inputs/files/common/ActionsMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/ActionsMenu.tsx
@@ -1,6 +1,6 @@
 import React, {MouseEventHandler, useCallback} from 'react'
 
-import {UploadIcon, ClipboardIcon, ResetIcon, DownloadIcon} from '@sanity/icons'
+import {UploadIcon, CopyIcon, ResetIcon, DownloadIcon} from '@sanity/icons'
 import {Box, MenuItem, MenuDivider, Label, useToast} from '@sanity/ui'
 import {FileInputMenuItem} from './FileInputMenuItem/FileInputMenuItem'
 
@@ -46,7 +46,7 @@ export function ActionsMenu(props: Props) {
 
       {(downloadUrl || copyUrl) && <MenuDivider />}
       {downloadUrl && <MenuItem as="a" icon={DownloadIcon} text="Download" href={downloadUrl} />}
-      {copyUrl && <MenuItem icon={ClipboardIcon} text="Copy URL" onClick={handleCopyURL} />}
+      {copyUrl && <MenuItem icon={CopyIcon} text="Copy URL" onClick={handleCopyURL} />}
 
       <MenuDivider />
       <MenuItem

--- a/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
+++ b/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
@@ -2,7 +2,7 @@ import React, {useCallback} from 'react'
 import {
   WarningOutlineIcon,
   DocumentsIcon,
-  ClipboardIcon,
+  CopyIcon,
   UnknownIcon,
   ChevronDownIcon,
 } from '@sanity/icons'
@@ -62,7 +62,7 @@ export function ConfirmDeleteDialogBody({
         </Box>
       )
     },
-    [schema, onReferenceLinkClick],
+    [schema, onReferenceLinkClick]
   )
 
   if (internalReferences?.totalCount === 0 && crossDatasetReferences?.totalCount === 0) {
@@ -241,7 +241,7 @@ export function ConfirmDeleteDialogBody({
                                   <Button
                                     title="Copy ID to clipboard"
                                     mode="bleed"
-                                    icon={ClipboardIcon}
+                                    icon={CopyIcon}
                                     fontSize={0}
                                   />
                                 </CopyToClipboard>

--- a/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
+++ b/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
@@ -62,7 +62,7 @@ export function ConfirmDeleteDialogBody({
         </Box>
       )
     },
-    [schema, onReferenceLinkClick]
+    [schema, onReferenceLinkClick],
   )
 
   if (internalReferences?.totalCount === 0 && crossDatasetReferences?.totalCount === 0) {


### PR DESCRIPTION
### Description

Replaces the `ClipboardIcon` for "copy" events to the `CopyIcon`

### What to review

That this icon makes sense?

### Notes for release

Updated icon for copy buttons