### PR TITLE
refactor(i18n): couple of tweaks

### DIFF
--- a/packages/sanity/src/core/i18n/Translate.tsx
+++ b/packages/sanity/src/core/i18n/Translate.tsx
@@ -11,7 +11,7 @@ export interface TranslationProps {
   t: TFunction
   i18nKey: string
   components?: ComponentMap
-  values?: Record<string, string>
+  values?: Record<string, string | string[]>
 }
 
 function render(tokens: Token[], componentMap: ComponentMap): ReactNode {

--- a/packages/sanity/src/core/i18n/Translate.tsx
+++ b/packages/sanity/src/core/i18n/Translate.tsx
@@ -10,7 +10,7 @@ type ComponentMap = Record<string, ComponentType<{children?: ReactNode}>>
 export interface TranslationProps {
   t: TFunction
   i18nKey: string
-  components?: ComponentMap
+  components: ComponentMap
   values?: Record<string, string | string[]>
 }
 

--- a/packages/sanity/src/core/i18n/__tests__/Translate.test.tsx
+++ b/packages/sanity/src/core/i18n/__tests__/Translate.test.tsx
@@ -59,7 +59,7 @@ describe('Translate component', () => {
   it('it translates a key', async () => {
     const {findByTestId} = render(
       <TestProviders bundles={[createBundle({title: 'English title'})]}>
-        <TestComponent i18nKey="title" />
+        <TestComponent i18nKey="title" components={{}} />
       </TestProviders>,
     )
     expect((await findByTestId('output')).innerHTML).toEqual('English title')
@@ -67,7 +67,7 @@ describe('Translate component', () => {
   it('it renders the key as-is if translation is missing', async () => {
     const {findByTestId} = render(
       <TestProviders bundles={[createBundle({title: 'English title'})]}>
-        <TestComponent i18nKey="does-not-exist" />
+        <TestComponent i18nKey="does-not-exist" components={{}} />
       </TestProviders>,
     )
     expect((await findByTestId('output')).innerHTML).toEqual('does-not-exist')

--- a/packages/sanity/src/core/i18n/hooks/useLocale.ts
+++ b/packages/sanity/src/core/i18n/hooks/useLocale.ts
@@ -1,6 +1,5 @@
-import {useCallback, useContext, useSyncExternalStore} from 'react'
+import {useContext} from 'react'
 import {LocaleContext, LocaleContextValue} from '../LocaleContext'
-import {useSource} from '../../studio'
 
 /**
  * @internal


### PR DESCRIPTION
### Description

Three minor changes:

- Drop some unused imports from `useLocale` hook
- Make `components` prop required for `<Translate />` component in order to discourage using it when not needed (can always bypass with `components={{}}` if necessary)
- Allow string arrays as values to `<Translate />`. This allows us to use the [list formatting function](https://www.i18next.com/translation-function/formatting#list).
