### PR TITLE
fix(form): set fallback placement for type-select popover in array input

### DIFF
--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/ArrayOfObjectsFunctions.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/ArrayOfObjectsFunctions.tsx
@@ -14,7 +14,11 @@ import {
 } from '@sanity/ui'
 import {ArrayInputFunctionsProps, ObjectItem} from '../../../types'
 
-const POPOVER_PROPS: MenuButtonProps['popover'] = {constrainSize: true, portal: true}
+const POPOVER_PROPS: MenuButtonProps['popover'] = {
+  constrainSize: true,
+  portal: true,
+  fallbackPlacements: ['top', 'bottom'],
+}
 
 /**
  * @hidden


### PR DESCRIPTION
### Description
Follow-up from #4963, which missed a fix for the popover that appears when adding an item to an array input that can hold several diferent types.

**Before**:
![image](https://github.com/sanity-io/sanity/assets/876086/45401564-9157-4e7d-8ee7-70a44c0d3128)
**After**:
![image](https://github.com/sanity-io/sanity/assets/876086/922fa93d-108d-44a5-a57c-29239f05f0ba)


### What to review
- Make sure long lists of possible types are placed either above or below the "Add item…" button in array inputs

### Notes for release

- Fixed placement of "Add item…" popover in array inputs