### PR TITLE
fix(block-tools): enforce list support in schema

### DIFF
--- a/packages/@sanity/block-tools/src/HtmlDeserializer/helpers.ts
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/helpers.ts
@@ -26,10 +26,12 @@ export function createRuleOptions(blockContentType: ArraySchemaType): BlockEnabl
   const enabledBlockStyles = features.styles.map((item) => item.value || item.title)
   const enabledSpanDecorators = features.decorators.map((item) => item.value || item.title)
   const enabledBlockAnnotations = features.annotations.map((item) => item.value || item.title || '')
+  const enabledListTypes = features.lists.map((item) => item.value || item.title || '')
   return {
     enabledBlockStyles,
     enabledSpanDecorators,
     enabledBlockAnnotations,
+    enabledListTypes,
   }
 }
 

--- a/packages/@sanity/block-tools/src/types.ts
+++ b/packages/@sanity/block-tools/src/types.ts
@@ -118,5 +118,6 @@ export interface DeserializerRule {
 export interface BlockEnabledFeatures {
   enabledBlockStyles: string[]
   enabledSpanDecorators: string[]
+  enabledListTypes: string[]
   enabledBlockAnnotations: string[]
 }


### PR DESCRIPTION
### Description

This will make sure that HTML is not deserialized to list blocks where there is no such support in the given schema.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
That pasting HTML lists into Portable Text will not produce any list blocks with the current schema:
```
{
  type: 'block',
  lists: [],
}
```

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Fixed a bug where pasting HTML lists into the Portable Text Input would disregard schema configuration for list blocks.

<!--
A description of the change(s) that should be used in the release notes.
-->
