### PR TITLE
fix: attach workspace title to comments notification context

### DIFF
--- a/packages/sanity/src/desk/comments/src/hooks/useCommentOperations.ts
+++ b/packages/sanity/src/desk/comments/src/hooks/useCommentOperations.ts
@@ -52,7 +52,7 @@ export function useCommentOperations(
 
   const authorId = currentUser?.id
 
-  const {title, url, toolName} = useNotificationTarget({
+  const {documentTitle, toolName, url, workspaceTitle} = useNotificationTarget({
     documentId,
     documentType,
   })
@@ -76,7 +76,11 @@ export function useCommentOperations(
           payload: {
             workspace,
           },
-          notification: {title, url},
+          notification: {
+            documentTitle,
+            url,
+            workspaceTitle,
+          },
           tool: toolName,
         },
         target: {
@@ -114,14 +118,15 @@ export function useCommentOperations(
       client,
       dataset,
       documentId,
+      documentTitle,
       documentType,
       onCreate,
       onCreateError,
       projectId,
-      title,
       toolName,
       url,
       workspace,
+      workspaceTitle,
     ],
   )
 

--- a/packages/sanity/src/desk/comments/src/hooks/useNotificationTarget.ts
+++ b/packages/sanity/src/desk/comments/src/hooks/useNotificationTarget.ts
@@ -10,9 +10,10 @@ interface NotificationTargetHookOptions {
 }
 
 interface NotificationTargetHookValue {
-  url: string
-  title: string
+  documentTitle: string
   toolName: string
+  url: string
+  workspaceTitle: string
 }
 
 /** @internal */
@@ -21,7 +22,7 @@ export function useNotificationTarget(
 ): NotificationTargetHookValue {
   const {documentId, documentType} = opts || {}
   const schemaType = useSchema().get(documentType)
-  const {basePath, tools} = useWorkspace()
+  const {basePath, title: workspaceTitle, tools} = useWorkspace()
 
   const activeToolName = useRouterState(
     useCallback(
@@ -42,7 +43,7 @@ export function useNotificationTarget(
   }, [documentId, documentPreviewStore, schemaType])
 
   const {published, draft} = previewState || {}
-  const notificationTitle = (draft?.title || published?.title || 'Sanity document') as string
+  const documentTitle = (draft?.title || published?.title || 'Sanity document') as string
 
   const currentUrl = new URL(window.location.href)
   const deskToolSegment = currentUrl.pathname.split('/').slice(2, 3).join('')
@@ -50,8 +51,9 @@ export function useNotificationTarget(
   const notificationUrl = currentUrl.toString()
 
   return {
-    url: notificationUrl,
-    title: notificationTitle,
+    documentTitle,
     toolName: activeTool?.name || '',
+    url: notificationUrl,
+    workspaceTitle,
   }
 }

--- a/packages/sanity/src/desk/comments/src/types.ts
+++ b/packages/sanity/src/desk/comments/src/types.ts
@@ -72,9 +72,10 @@ export interface CommentPath {
 interface CommentContext {
   tool: string
   payload?: Record<string, unknown>
-  notification: {
-    title: string
+  notification?: {
+    documentTitle: string
     url: string
+    workspaceTitle: string
   }
 }
 


### PR DESCRIPTION
### Description

This PR ensures that workspace titles are saved to comments (in `context.notification`). This workspace title is needed since email notifications display this title to highlight which Studio the comment may have originated from.

`notification.title` has also been renamed to `notification.documentTitle`

(If approved, please don't merge until upstream changes have been made to handle this new payload)