### PR TITLE
chore(i18n): add the i18next/no-literal-string eslint rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -13,7 +13,7 @@ const baseConfig = {
     'prettier',
   ],
   parser: '@typescript-eslint/parser',
-  plugins: ['import', '@typescript-eslint', 'prettier', 'react', 'tsdoc','i18next'],
+  plugins: ['import', '@typescript-eslint', 'prettier', 'react', 'tsdoc', 'i18next'],
   rules: {
     '@typescript-eslint/no-var-requires': 'off', // prefer import/no-dynamic-require
     'import/extensions': ['error', {pattern: {cjs: 'always', json: 'always'}}],

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -13,7 +13,7 @@ const baseConfig = {
     'prettier',
   ],
   parser: '@typescript-eslint/parser',
-  plugins: ['import', '@typescript-eslint', 'prettier', 'react', 'tsdoc'],
+  plugins: ['import', '@typescript-eslint', 'prettier', 'react', 'tsdoc','i18next'],
   rules: {
     '@typescript-eslint/no-var-requires': 'off', // prefer import/no-dynamic-require
     'import/extensions': ['error', {pattern: {cjs: 'always', json: 'always'}}],
@@ -32,6 +32,7 @@ const baseConfig = {
         additionalHooks: '(useMemoObservable|useObservableCallback|useAsync)',
       },
     ],
+    'i18next/no-literal-string': 2,
   },
   settings: {
     'import/extensions': ['.cjs', '.mjs', '.js', '.jsx', '.ts', '.tsx'],

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "eslint-config-sanity": "^6.0.0",
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-boundaries": "^3.4.0",
+    "eslint-plugin-i18next": "^6.0.3",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react": "^7.33.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8912,6 +8912,14 @@ eslint-plugin-flowtype@^8.0.3:
     lodash "^4.17.21"
     string-natural-compare "^3.0.1"
 
+eslint-plugin-i18next@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-i18next/-/eslint-plugin-i18next-6.0.3.tgz#a388f9982deb040102c1c4498e4dc38d9bd6ffd9"
+  integrity sha512-RtQXYfg6PZCjejIQ/YG+dUj/x15jPhufJ9hUDGH0kCpJ6CkVMAWOQ9exU1CrbPmzeykxLjrXkjAaOZF/V7+DOA==
+  dependencies:
+    lodash "^4.17.21"
+    requireindex "~1.1.0"
+
 eslint-plugin-import@^2.25.3, eslint-plugin-import@^2.28.1:
   version "2.28.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.28.1.tgz#63b8b5b3c409bfc75ebaf8fb206b07ab435482c4"
@@ -16532,6 +16540,11 @@ require-package-name@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/require-package-name/-/require-package-name-2.0.1.tgz#c11e97276b65b8e2923f75dabf5fb2ef0c3841b9"
   integrity sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q==
+
+requireindex@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
+  integrity sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==
 
 requires-port@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### Description

This PR adds an [eslint rule](https://github.com/edvardchen/eslint-plugin-i18next) for preventing string literals in javascript file