### PR TITLE
feat(i18n): more translated surfaces

### DIFF
--- a/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
@@ -26,8 +26,7 @@ const deskResources: Record<DeskLocaleResourceKeys, string> = {
     'Kan ikke publisere fordi "Live Edit" er skrudd på for denne dokumenttypen.',
 
   /** Tooltip when the "Publish" document action is disabled due to validation issues */
-  'action.publish.validation-issues.tooltip':
-    'Valideringsfeil som må rettes før dokumentet kan publiseres',
+  'action.publish.validation-issues.tooltip': 'Valideringsfeil må rettes før det kan publiseres',
 
   /** Tooltip when publish button is disabled because the document is already published.*/
   'action.publish.already-published.tooltip': 'Publisert for {{timeSincePublished}} siden',
@@ -36,7 +35,7 @@ const deskResources: Record<DeskLocaleResourceKeys, string> = {
   'action.publish.already-published.no-time-ago.tooltip': 'Allerede publisert',
 
   /** Tooltip when publish button is disabled because there are no changes.*/
-  'action.publish.tooltip.no-changes': 'Ingen upubliserte endringer',
+  'action.publish.no-changes.tooltip': 'Ingen upubliserte endringer',
 
   /** Tooltip when publish button is waiting for validation and async tasks to complete.*/
   'action.publish.waiting': 'Venter på at andre oppgaver skal fullføre',
@@ -81,10 +80,10 @@ const deskResources: Record<DeskLocaleResourceKeys, string> = {
     'Dette dokumentet er tomt og kan ikke dupliseres',
 
   /** Label for the "Duplicate" document action */
-  'action.duplicate.label': 'Duplisèr',
+  'action.duplicate.label': 'Dupliser',
 
   /** Label for the "Duplicate" document action while the document is being duplicated */
-  'action.duplicate.running.label': 'Duplisèrer…',
+  'action.duplicate.running.label': 'Dupliserer…',
 
   /** --- UNPUBLISH ACTION --- */
   /** Tooltip when action is disabled because the operation is not ready   */
@@ -113,6 +112,37 @@ const deskResources: Record<DeskLocaleResourceKeys, string> = {
   /** Message prompting the user to confirm that they want to restore to an earlier version*/
   'action.restore.confirm-dialog.confirm-discard-changes':
     'Er du sikker på at du vil gjenopprette til valgte versjon?',
+
+  /** --- PUBLISH STATUS BUTTON --- */
+  /** Accessibility label indicating when the document was last updated, in relative time, eg "2 hours ago" */
+  'status-bar.publish-status-button.last-updated-time.aria-label':
+    'Sist oppdatert {{relativeTime}}',
+
+  /** Accessibility label indicating when the document was last published, in relative time, eg "3 weeks ago" */
+  'status-bar.publish-status-button.last-published-time.aria-label':
+    'Sist publisert {{relativeTime}}',
+
+  /** Text for tooltip showing explanation of timestamp/relative time, eg "Last updated <RelativeTime/>" */
+  'status-bar.publish-status-button.last-updated-time.tooltip': 'Sist oppdatert <RelativeTime/>',
+
+  /** Text for tooltip showing explanation of timestamp/relative time, eg "Last published <RelativeTime/>" */
+  'status-bar.publish-status-button.last-published-time.tooltip': 'Sist publisert <RelativeTime/>',
+
+  /** --- REVIEW CHANGES BUTTON --- */
+  /** Label for button when status is syncing */
+  'status-bar.review-changes-button.status.syncing.text': 'Lagrer...',
+
+  /** Label for button when status is saved */
+  'status-bar.review-changes-button.status.saved.text': 'Lagret!',
+
+  /** Primary text for tooltip for the button */
+  'status-bar.review-changes-button.tooltip.text': 'Se endringer',
+
+  /** Text for the secondary text for tooltip for the button */
+  'status-bar.review-changes-button.tooltip.changes-saved': 'Endringer lagret',
+
+  /** Aria label for the button */
+  'status-bar.review-changes-button.aria-label': 'Se endringer',
 }
 
 export default deskResources

--- a/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/desk.ts
@@ -143,6 +143,25 @@ const deskResources: Record<DeskLocaleResourceKeys, string> = {
 
   /** Aria label for the button */
   'status-bar.review-changes-button.aria-label': 'Se endringer',
+
+  /** --- DOCUMENT JSON INSPECTOR --- */
+  /** Title shown for menu item that opens the "Inspect" dialog */
+  'document-inspector.menu-item.title': 'Inspiser',
+
+  /** The title shown in the dialog header, when inspecting a valid document */
+  'document-inspector.dialog.title': 'Inspiserer <DocumentTitle/>',
+
+  /** The title shown in the dialog header, when the document being inspected is not created yet/has no value */
+  'document-inspector.dialog.title-no-value': 'Ingen verdi',
+
+  /** The "parsed" view mode, meaning the JSON is searchable, collapsible etc */
+  'document-inspector.view-mode.parsed': 'Behandlet',
+
+  /** The "raw" view mode, meaning the JSON is presented syntax-highlighted, but with no other features - optimal for copying */
+  'document-inspector.view-mode.raw-json': 'Rå JSON',
+
+  /** --- "PRODUCTION PREVIEW", eg link to content --- */
+  'production-preview.menu-item.title': 'Åpne forhåndsvisning',
 }
 
 export default deskResources

--- a/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
@@ -1,11 +1,116 @@
 import type {StudioLocaleResourceKeys} from 'sanity'
 
 const studioResources: Record<StudioLocaleResourceKeys, string> = {
-  /** Placeholder text for the omnisearch input field */
-  'search.placeholder': 'Søk',
-
   /* Relative time, just now */
   'relative-time.just-now': 'akkurat nå',
+
+  /** --- Review Changes --- */
+
+  /** Title for the Review Changes pane */
+  'changes.title': 'Se endringer',
+
+  /** Label for the close button label in Review Changes pane */
+  'changes.action.close-label': 'Lukk gjennomgang av endringer',
+
+  /** Label and text for tooltip that indicates the authors of the changes */
+  'changes.changes-by-author': 'Endringer av',
+
+  /** Loading changes in Review Changes Pane */
+  'changes.loading-changes': 'Laster endringer',
+
+  /** No Changes title in the Review Changes pane */
+  'changes.no-changes-title': 'Det er ingen endringer',
+
+  /** No Changes description in the Review Changes pane */
+  'changes.no-changes-description':
+    'Rediger dokumentet eller velg en eldre versjon i tidslinjen for å se en liste over endringer i dette panelet.',
+
+  /** Prompt for reverting all changes in document in Review Changes pane. Includes a count of changes. */
+  'changes.action.revert-all-description': `Er du sikker på at du vil angre alle {{count}} endringer?`,
+
+  /** Cancel label for revert button prompt action */
+  'changes.action.revert-all-cancel': `Avbryt`,
+
+  /** Revert all confirm label for revert button action - used on prompt button + review changes pane */
+  'changes.action.revert-all-confirm': `Angre alle`,
+
+  /** Loading author of change in the differences tooltip in the review changes pane */
+  'changes.loading-author': 'Laster…',
+
+  /** --- Review Changes: Field + Group --- */
+
+  /** Prompt for reverting changes for a field change */
+  'changes.action.revert-changes-description': `Er du sikker på at du vil angre endringene?`,
+
+  /** Prompt for reverting changes for a group change, eg multiple changes */
+  'changes.action.revert-changes-description_one': `Er du sikker på at du vil angre endringen?`,
+
+  /** Prompt for confirming revert change (singular) label for field change action */
+  'changes.action.revert-changes-confirm-change_one': `Angre endring`,
+
+  /** Revert for confirming revert (plural) label for field change action */
+  'changes.action.revert-changes-confirm-change_other': `Angre endringer`,
+
+  /** --- Document timeline, for navigating different revisions of a document --- */
+
+  /** Error prompt when revision cannot be loaded */
+  'timeline.error.unable-to-load-revision': 'Kan ikke laste revisjon',
+
+  /** Label for latest version for timeline menu dropdown */
+  'timeline.latest-version': 'Siste versjon',
+
+  /** Label for loading history */
+  'timeline.loading-history': 'Laster historikk',
+
+  /**
+   * Label for determining since which version the changes for timeline menu dropdown are showing.
+   * Receives the time label as a parameter.
+   */
+  'timeline.since': 'Siden: {{timestamp, datetime}}',
+
+  /** Label for missing change version for timeline menu dropdown are showing */
+  'timeline.since-version-missing': 'Siden: ukjent versjon',
+
+  /** Title for error when the timeline for the given document can't be loaded */
+  'timeline.error.load-document-changes-title':
+    'En feil oppstod under henting av dokumentendringer.',
+
+  /** Description for error when the timeline for the given document can't be loaded */
+  'timeline.error.load-document-changes-description': 'Historikk har ikke blitt påvirket.',
+
+  /** Error title for when the document doesn't have history */
+  'timeline.error.no-document-history-title': 'Ingen historikk',
+
+  /** Error description for when the document doesn't have history */
+  'timeline.error.no-document-history-description':
+    'Når du endrer innholdet i dokumentet, vil dokumentversjonene vises i denne menyen.',
+
+  /** --- Timeline constants --- */
+
+  /** Label for when the timeline item is the latest in the history */
+  'timeline.latest': 'Siste',
+
+  /** Consts used in the timeline item component (dropdown menu) - helpers */
+  'timeline.create': 'Opprettet',
+  'timeline.delete': 'Slettet',
+  'timeline.discardDraft': 'Utkast forkastet',
+  'timeline.initial': 'Opprettet',
+  'timeline.editDraft': 'Redigert',
+  'timeline.editLive': 'Live redigert',
+  'timeline.publish': 'Publisert',
+  'timeline.unpublish': 'Avpublisert',
+
+  /** --- Slug Input --- */
+
+  /** Error message for when the source to generate a slug from is missing */
+  'inputs.slug.error.missing-source':
+    'Kilde mangler. Sjekk `source` på skjematypen «{{schemaType}}»',
+
+  /** Loading message for when the input is actively generating a slug */
+  'inputs.slug.action.generating': `Genererer…`,
+
+  /** Action message for generating the slug */
+  'inputs.slug.action.generate': `Generer`,
 
   /** --- DateTime (and Date) Input --- */
 
@@ -45,6 +150,115 @@ const studioResources: Record<StudioLocaleResourceKeys, string> = {
 
   /** Label for selecting a hour preset. Receives a `time` param as a string on hh:mm format and a `date` param as a Date instance denoting the preset date */
   'inputs.datetime.calendar.action.set-to-time-preset': '{{time}} on {{date, datetime}}',
+
+  /** --- File (Image, File and ImageTool) Inputs --- */
+
+  /** Open image edit dialog */
+  'inputs.files.image.actions-menu.edit-details.label': 'Åpne bilderedigeringsdialog',
+
+  /** Open image options menu */
+  'inputs.files.image.actions-menu.options.label': 'Åpne bildeinnstillingsmeny',
+
+  /** The upload could not be completed at this time. */
+  'inputs.files.image.upload-error.description':
+    'Opplastingen kunne ikke fullføres på dette tidspunktet.',
+
+  /** Upload failed */
+  'inputs.files.image.upload-error.title': 'Opplasting mislyktes',
+
+  /** Edit hotspot and crop */
+  'inputs.files.image.hotspot-dialog.title': 'Rediger fokuspunkt og beskjær',
+
+  /** Preview of uploaded image */
+  'inputs.files.image.preview-uploaded-image': 'Forhåndsvisning av opplastet bilde',
+
+  /** Cannot upload this file here */
+  'inputs.files.image.drag-overlay.cannot-upload-here': 'Kan ikke laste opp denne filen her',
+
+  /** This field is read only */
+  'inputs.files.image.drag-overlay.this-field-is-read-only': 'Dette feltet er skrivebeskyttet',
+
+  /** Drop image to upload */
+  'inputs.files.image.drag-overlay.drop-to-upload-image': 'Slipp bilde for å laste opp',
+
+  /** Invalid image value */
+  'inputs.files.image.invalid-image-warning.title': 'Ugyldig bildeverdi',
+
+  /** The value of this field is not a valid image. Resetting this field will let you choose a new image. */
+  'inputs.files.image.invalid-image-warning.description':
+    'Verdien i dette feltet er ikke et gyldig bilde. Ved å tilbakestille dette feltet kan du velge et nytt bilde.',
+
+  /** The URL is copied to the clipboard */
+  'inputs.files.common.actions-menu.notification.url-copied':
+    'URL-en er kopiert til utklippstavlen',
+
+  /** Replace */
+  'inputs.files.common.actions-menu.replace.label': 'Erstatt',
+
+  /** Upload */
+  'inputs.files.common.actions-menu.upload.label': 'Last opp',
+
+  /** Download */
+  'inputs.files.common.actions-menu.download.label': 'Last ned',
+
+  /** Copy URL */
+  'inputs.files.common.actions-menu.copy-url.label': 'Kopier URL',
+
+  /** Clear field */
+  'inputs.files.common.actions-menu.clear-field.label': 'Tøm felt',
+
+  /** Can't upload files here */
+  'inputs.files.common.placeholder.upload-not-supported': 'Kan ikke laste opp filer her',
+
+  /** Read only */
+  'inputs.files.common.placeholder.read-only': 'Skrivebeskyttet',
+
+  /** Drop to upload file */
+  'inputs.files.common.placeholder.drop-to-upload_file': 'Slipp for å laste opp fil',
+
+  /** Drop to upload image */
+  'inputs.files.common.placeholder.drop-to-upload_image': 'Slipp for å laste opp bilde',
+
+  /** Cannot upload `{{count}}` files */
+  'inputs.files.common.placeholder.cannot-upload-some-files_one': 'Kan ikke laste opp fil',
+  'inputs.files.common.placeholder.cannot-upload-some-files_other':
+    'Kan ikke laste opp {{count}} filer',
+
+  /** Drag or paste file here */
+  'inputs.files.common.placeholder.drag-or-paste-to-upload_file': 'Dra eller lim inn fil her',
+  /** Drag or paste image here */
+  'inputs.files.common.placeholder.drag-or-paste-to-upload_image': 'Dra eller lim inn bilde her',
+
+  /** Drop to upload */
+  'inputs.files.common.drop-message.drop-to-upload': 'Slipp for å laste opp',
+
+  /** Drop to upload `{{count}}` file */
+  'inputs.files.common.drop-message.drop-to-upload-multi_one':
+    'Slipp for å laste opp {{count}} fil',
+
+  /** Drop to upload `{{count}}` files */
+  'inputs.files.common.drop-message.drop-to-upload-multi_other':
+    'Slipp for å laste opp {{count}} filer',
+
+  /** Uploading <FileName/> */
+  'input.files.common.upload-progress': 'Laster opp <FileName/>',
+
+  /** Incomplete upload */
+  'inputs.files.common.stale-upload-warning.title': 'Ufullstendig opplasting',
+
+  /** An upload has made no progress for at least `{{staleThresholdMinutes}}` minutes and likely got interrupted. You can safely clear the incomplete upload and try uploading again. */
+  'inputs.files.common.stale-upload-warning.description':
+    'En opplasting har ikke gjort fremskritt på minst {{staleThresholdMinutes}} minutter og ble sannsynligvis avbrutt. Du kan trygt fjerne den ufullstendige opplastingen og prøve å laste opp på nytt.',
+
+  /** Clear upload */
+  'inputs.files.common.stale-upload-warning.clear': 'Fjern opplasting',
+
+  /** Hotspot & Crop */
+  'inputs.files.imagetool.field.title': 'Fokuspunkt & beskjæring',
+
+  /** Adjust the rectangle to crop image. Adjust the circle to specify the area that should always be visible. */
+  'inputs.files.imagetool.field.description':
+    'Juster rektangelet for å beskjære bildet. Juster sirkelen for å spesifisere området som alltid skal være synlig.',
 
   /** --- Reference (and Cross-Dataset Reference) Input --- */
 
@@ -207,114 +421,330 @@ const studioResources: Record<StudioLocaleResourceKeys, string> = {
   'inputs.array.error.cannot-resolve-initial-value-title':
     'Kan ikke finne startverdi for type: {{schemaTypeTitle}}: {{errorMessage}}.',
 
-  /** --- File (Image, File and ImageTool) Inputs --- */
+  /** --- Workspace menu --- */
 
-  /** Open image edit dialog */
-  'inputs.files.image.actions-menu.edit-details.label': 'Åpne bilderedigeringsdialog',
+  /** Title for Workplaces dropdown menu */
+  'workspaces.title': 'Arbeidsområder',
 
-  /** Open image options menu */
-  'inputs.files.image.actions-menu.options.label': 'Åpne bildeinnstillingsmeny',
+  /** Label for the workspace menu */
+  'workspaces.select-workspace-aria-label': 'Velg arbeidsområde',
 
-  /** The upload could not be completed at this time. */
-  'inputs.files.image.upload-error.description':
-    'Opplastingen kunne ikke fullføres på dette tidspunktet.',
+  /** Button label for opening the workspace switcher */
+  'workspaces.select-workspace-label': 'Velg arbeidsområde',
 
-  /** Upload failed */
-  'inputs.files.image.upload-error.title': 'Opplasting mislyktes',
+  /** Label for heading that indicates that you can choose your workspace */
+  'workspaces.choose-your-workspace-label': 'Velg ditt arbeidsområde',
 
-  /** Edit hotspot and crop */
-  'inputs.files.image.hotspot-dialog.title': 'Rediger fokuspunkt og beskjær',
+  /**
+   * Label for action to choose a different workspace, in the case where you are not logged in,
+   * have selected a workspace, and are faced with the authentication options for the selected
+   * workspace. In other words, label for the action shown when you have reconsidered which
+   * workspace to authenticate in.
+   */
+  'workspaces.action.choose-another-workspace': 'Velg et annet arbeidsområde',
 
-  /** Preview of uploaded image */
-  'inputs.files.image.preview-uploaded-image': 'Forhåndsvisning av opplastet bilde',
+  /**
+   * Label for action to add a workspace (currently a developer-oriented action, as this will
+   * lead to the documentation on workspace configuration)
+   */
+  'workspaces.action.add-workspace': 'Legg til arbeidsområde',
 
-  /** Cannot upload this file here */
-  'inputs.files.image.drag-overlay.cannot-upload-here': 'Kan ikke laste opp denne filen her',
+  /** --- New Document --- */
 
-  /** This field is read only */
-  'inputs.files.image.drag-overlay.this-field-is-read-only': 'Dette feltet er skrivebeskyttet',
+  /** Placeholder for the "filter" input within the new document menu */
+  'new-document.filter-placeholder': 'Filtrér',
 
-  /** Drop image to upload */
-  'inputs.files.image.drag-overlay.drop-to-upload-image': 'Slipp bilde for å laste opp',
+  /** Loading indicator text within the new document menu */
+  'new-document.loading': 'Laster…',
 
-  /** Invalid image value */
-  'inputs.files.image.invalid-image-warning.title': 'Ugyldig bildeverdi',
+  /** Title for "Create new document" dialog */
+  'new-document.title': 'Opprett nytt dokument',
 
-  /** The value of this field is not a valid image. Resetting this field will let you choose a new image. */
-  'inputs.files.image.invalid-image-warning.description':
-    'Verdien i dette feltet er ikke et gyldig bilde. Ved å tilbakestille dette feltet kan du velge et nytt bilde.',
+  /** Aria label for the button that opens the "Create new document" popover/dialog */
+  'new-document.open-dialog-aria-label': 'Opprett nytt dokument',
 
-  /** The URL is copied to the clipboard */
-  'inputs.files.common.actions-menu.notification.url-copied':
-    'URL-en er kopiert til utklippstavlen',
+  /**
+   * Tooltip message displayed when hovering/activating the "Create new document" action,
+   * when there are no templates/types to create from
+   */
+  'new-document.no-document-types-label': 'Ingen dokumenttyper',
 
-  /** Replace */
-  'inputs.files.common.actions-menu.replace.label': 'Erstatt',
+  /**
+   * Tooltip message displayed when hovering/activating the "Create new document" action,
+   * when there are templates/types available for creation
+   */
+  'new-document.create-new-document-label': 'Nytt dokument…',
 
-  /** Upload */
-  'inputs.files.common.actions-menu.upload.label': 'Last opp',
+  /** Message for when no results are found for a specific search query in the new document menu */
+  'new-document.no-results': 'Ingen resultater for <QueryString>«{{searchQuery}}»</QueryString>',
 
-  /** Download */
-  'inputs.files.common.actions-menu.download.label': 'Last ned',
+  /** Message for when there are no document type options in the new document menu */
+  'new-document.no-document-types-found': 'Ingen dokumenttyper funnet',
 
-  /** Copy URL */
-  'inputs.files.common.actions-menu.copy-url.label': 'Kopier URL',
+  /** Accessibility label for the list displaying options in the new document menu */
+  'new-document.new-document-aria-label': 'Nytt dokument',
 
-  /** Clear field */
-  'inputs.files.common.actions-menu.clear-field.label': 'Tøm felt',
+  /** Error label for when a user is unable to create a document */
+  'new-document.error.unable-to-create-document': 'opprette dette dokumentet',
 
-  /** Can't upload files here */
-  'inputs.files.common.placeholder.upload-not-supported': 'Kan ikke laste opp filer her',
+  /** --- Search --- */
 
-  /** Read only */
-  'inputs.files.common.placeholder.read-only': 'Skrivebeskyttet',
+  /** Placeholder text for the omnisearch input field */
+  'search.placeholder': 'Søk',
 
-  /** Drop to upload file */
-  'inputs.files.common.placeholder.drop-to-upload_file': 'Slipp for å laste opp fil',
+  /** Accessibility label to open search action when the search would go fullscreen (eg on narrower screens) */
+  'search.action-open-aria-label': 'Åpne søk',
 
-  /** Drop to upload image */
-  'inputs.files.common.placeholder.drop-to-upload_image': 'Slipp for å laste opp bilde',
+  /** Accessibility label for the search results section, shown when the user has typed valid terms */
+  'search.search-results-aria-label': 'Søkeresultater',
 
-  /** Cannot upload `{{count}}` files */
-  'inputs.files.common.placeholder.cannot-upload-some-files_one': 'Kan ikke laste opp fil',
-  'inputs.files.common.placeholder.cannot-upload-some-files_other':
-    'Kan ikke laste opp {{count}} filer',
+  /** Accessibility label for the recent searches section, shown when no valid search terms has been given */
+  'search.recent-searches-aria-label': 'Nylige søk',
 
-  /** Drag or paste file here */
-  'inputs.files.common.placeholder.drag-or-paste-to-upload_file': 'Dra eller lim inn fil her',
-  /** Drag or paste image here */
-  'inputs.files.common.placeholder.drag-or-paste-to-upload_image': 'Dra eller lim inn bilde her',
+  /** Label/heading shown for the recent searches section */
+  'search.recent-searches-label': 'Nylige søk',
 
-  /** Drop to upload */
-  'inputs.files.common.drop-message.drop-to-upload': 'Slipp for å laste opp',
+  /** Action label for clearing search filters */
+  'search.action.clear-filters': 'Fjern filtre',
 
-  /** Drop to upload `{{count}}` file */
-  'inputs.files.common.drop-message.drop-to-upload-multi_one':
-    'Slipp for å laste opp {{count}} fil',
+  /** Accessibility label for filtering by document type */
+  'search.action.filter-by-document-type-aria-label': 'Filtrer etter dokumenttype',
 
-  /** Drop to upload `{{count}}` files */
-  'inputs.files.common.drop-message.drop-to-upload-multi_other':
-    'Slipp for å laste opp {{count}} filer',
+  /** Accessibility label for the "Filters" list, that is shown when using "Add filter" in search (singular) */
+  'search.filters-aria-label_one': 'Filter',
 
-  /** Uploading <FileName/> */
-  'input.files.common.upload-progress': 'Laster opp <FileName/>',
+  /** Accessibility label for the "Filters" list, that is shown when using "Add filter" in search (plural) */
+  'search.filters-aria-label_other': 'Filtre',
 
-  /** Incomplete upload */
-  'inputs.files.common.stale-upload-warning.title': 'Ufullstendig opplasting',
+  /** Placeholder for the "Filter" input, when narrowing possible fields/filters */
+  'search.filter-placeholder': 'Filtrer',
 
-  /** An upload has made no progress for at least `{{staleThresholdMinutes}}` minutes and likely got interrupted. You can safely clear the incomplete upload and try uploading again. */
-  'inputs.files.common.stale-upload-warning.description':
-    'En opplasting har ikke gjort fremskritt på minst {{staleThresholdMinutes}} minutter og ble sannsynligvis avbrutt. Du kan trygt fjerne den ufullstendige opplastingen og prøve å laste opp på nytt.',
+  /** Label for when no fields/filters are found for the given term */
+  'search.filter-no-matches-found': `Ingen treff for «{{filter}}»`,
 
-  /** Clear upload */
-  'inputs.files.common.stale-upload-warning.clear': 'Fjern opplasting',
+  /** Accessibility label for list displaying the available document types */
+  'search.document-types-aria-label': 'Dokumenttyper',
 
-  /** Hotspot & Crop */
-  'inputs.files.imagetool.field.title': 'Fokuspunkt & beskjæring',
+  /** Label for when no document types matching the filter are found */
+  'search.document-types-no-matches-found': 'Ingen dokumenttyper funnet',
 
-  /** Adjust the rectangle to crop image. Adjust the circle to specify the area that should always be visible. */
-  'inputs.files.imagetool.field.description':
-    'Juster rektangelet for å beskjære bildet. Juster sirkelen for å spesifisere området som alltid skal være synlig.',
+  /** Accessibility label for action to clear all currently applied document type filters */
+  'search.action.clear-type-filters-aria-label': 'Fjern valgte filtre',
+
+  /** Label for action to clear all currently applied document type filters */
+  'search.action.clear-type-filters-label': 'Fjern',
+
+  /** Accessibility action label for removing an already applied search filter */
+  'search.action.remove-filter-aria-label': 'Fjern filter',
+
+  /** Action label for adding a search filter */
+  'search.action.add-filter': 'Legg til filter',
+
+  /** Accessibility label for list that lets you filter fields by title, when adding a new filter in search */
+  'search.filter-by-title-aria-label': 'Filtrer etter tittel',
+
+  /** Label for "field name" shown in tooltip when navigating list of possible fields to filter */
+  'search.filter-field-tooltip-name': 'Feltnavn',
+
+  /** Label for "field description" shown in tooltip when navigating list of possible fields to filter */
+  'search.filter-field-tooltip-description': 'Feltopplysninger',
+
+  /** Label for "Used in document types", a list of the document types a field appears in. Shown in tooltip when navigating list of possible fields to filter */
+  'search.filter-field-tooltip-used-in-document-types': 'Brukt i dokumenttyper',
+
+  /** Label for "All fields", a label that appears above the list of available fields when filtering. */
+  'search.filter-all-fields-header': 'Alle felter',
+
+  /** Label for "shared fields", a label that appears above a list of fields that all filtered types have in common, when adding a new filter. */
+  'search.filter-shared-fields-header': 'Delte felter',
+
+  /** Label for boolean filter - true */
+  'search.filter-boolean-true': 'Sant',
+
+  /** Label for boolean filter - false */
+  'search.filter-boolean-false': 'Usant',
+
+  /** Placeholder value for the string filter */
+  'search.filter-string-value-placeholder': 'Verdi',
+
+  /** Placeholder value for the number filter */
+  'search.filter-number-value-placeholder': 'Verdi',
+
+  /** Placeholder value for minimum numeric value filter */
+  'search.filter-number-min-value-placeholder': 'Min verdi',
+
+  /** Placeholder value for maximum numeric value filter */
+  'search.filter-number-max-value-placeholder': 'Maks verdi',
+
+  /** Label/placeholder prompting user to select one of the predefined, allowed values for a string field */
+  'search.filter-string-value-select-predefined-value': 'Velg…',
+
+  /** Label for the action of clearing the currently selected asset in an image/file filter */
+  'search.filter-asset-clear': 'Fjern',
+
+  /** Label for the action of clearing the currently selected document in a reference filter */
+  'search.filter-reference-clear': 'Fjern',
+
+  /** Label for search value in a range of numbers */
+  // @todo Part of `arrayOperators` - needs `<Translate />` refactoring
+  'search.filter-number-items-range': `{{min}} → {{max}} elementer`,
+
+  /** Title label for when no search results are found */
+  'search.no-results-title': 'Ingen resultater funnet',
+
+  /** Helpful description for when no search results are found */
+  'search.no-results-help-description': 'Prøv et annet nøkkelord eller juster filtrene dine',
+
+  /** Title label for when search returned an error that we are not able to describe in detail */
+  'search.error.unspecified-error-title': 'Noe gikk galt under søket',
+
+  /** Helpful description for when search returned an error that we are not able to describe in detail */
+  'search.error.unspecified-error-help-description':
+    'Vennligst prøv igjen eller sjekk tilkoblingen din',
+
+  /** Title for error when no valid asset sources found */
+  'search.error.no-valid-asset-source-title': 'Ingen gyldige kilder funnet.',
+
+  /** Description for error when no valid asset source is found, describes that only the default asset is supported */
+  'search.error.no-valid-asset-source-only-default-description':
+    'For øyeblikket støttes bare standardkilden for bilder/filer.',
+
+  /** Description for error when no valid asset source is found, describes that you should check the the current studio config */
+  'search.error.no-valid-asset-source-check-config-description': `Vennligst forsikre deg om at den er aktivert i studioets konfigurasjonsfil.`,
+
+  /** Title for error when a filter cannot be displayed (mainly a developer-oriented error) */
+  'search.error.display-filter-title': 'En feil oppstod under visning av dette filteret.',
+
+  /** Description for error when a filter cannot be displayed, describes that you should check the schema */
+  'search.error.display-filter-description':
+    'Dette kan indikere ugyldige alternativer definert i skjemaet ditt.',
+
+  /** Label for action to clear recent searches */
+  'search.action.clear-recent-searches': 'Fjern nylige søk',
+
+  /** Dialog title for action to select an asset of unknown type */
+  'search.action.select-asset': 'Velg element',
+
+  /** Dialog title for action to select an image asset */
+  'search.action.select-asset_image': 'Velg bilde',
+
+  /** Dialog title for action to select a file asset */
+  'search.action.select-asset_file': 'Velg fil',
+
+  /** Text displayed when either no document type(s) have been selected, or we need a fallback, */
+  'search.action.search-all-types': 'Søk i alle dokumenter',
+
+  /** Text displayed when we are able to determine one or more document types that will be used for searching */
+  'search.action.search-specific-types': `Søk etter {{types, list}}`,
+
+  /** Text displayed when we are able to determine one or more document types that will be used for searching, but cannot list them all within the space assigned by the design */
+  'search.action.search-specific-types-truncated': `Søk etter {{types, list}} +{{count}} flere`,
+
+  /** In the context of a list of document types - no filtering selection has been done, thus the default is "all types". */
+  'search.document-type-list-all-types': 'Alle typer',
+
+  /** A list of provided types, formatted with the locales list formatter. */
+  'search.document-type-list': `{{types, list}}`,
+
+  /** A list of provided types that has been truncated - more types are included but not displayed, thus we need to indicate that there are more. */
+  'search.document-type-list-truncated': `{{types, list}} +{{count}} flere`,
+
+  /** Accessibility label for when the search is full screen (on narrow screens) and you want to close the search */
+  'search.action.close-search-aria-label': 'Lukk søk',
+
+  /** Accessibility label for when the search is full screen (on narrow screens) and you want to toggle filters */
+  'search.action.toggle-filters-aria-label_hide': 'Skjul filtre',
+  'search.action.toggle-filters-aria-label_show': 'Vis filtre',
+
+  /** Label for instructions on how to use the search - displayed when no recent searches are available */
+  'search.instructions': 'Bruk <ControlsIcon/> for å rafinere søket.',
+
+  /** --- Help & Resources Menu --- */
+
+  /** Title for help and resources menus */
+  'helpResources.title': 'Hjelp og ressurser',
+
+  /** Information for what studio version the current studio is running */
+  'helpResources.studio-version': `Sanity Studio versjon {{studioVersion}}`,
+
+  /** Information for what the latest sanity version is */
+  'helpResources.latest-sanity-version': `Siste versjon er {{latestVersion}}`,
+
+  /**
+   * Label for "join our community" call to action
+   * These are titles for fallback links in the event the help & resources endpoint isn't able to be fetched
+   */
+  'helpResources.action.join-our-community': `Bli med i vårt community`,
+
+  /**
+   * Label for "help and support" call to action
+   * These are titles for fallback links in the event the help & resources endpoint isn't able to be fetched
+   */
+  'helpResources.action.help-and-support': `Hjelp og støtte`,
+
+  /**
+   * Label for "contact sales" call to action
+   * These are titles for fallback links in the event the help & resources endpoint isn't able to be fetched
+   */
+  'helpResources.action.contact-sales': `Kontakt salg`,
+
+  /** --- User Menu --- */
+
+  /** Label for tooltip to show which provider the currently logged in user is using */
+  'user-menu.login-provider': `Logget inn med {{providerTitle}}`,
+
+  /** Label for action to manage the current sanity project */
+  'user-menu.action.manage-project': 'Administrer prosjekt',
+
+  /** Accessibility label for the action to manage the current project */
+  'user-menu.action.manage-project-aria-label': 'Administrer prosjekt',
+
+  /** Label for action to invite members to the current sanity project */
+  'user-menu.action.invite-members': 'Inviter medlemmer',
+
+  /** Accessibility label for action to invite members to the current sanity project */
+  'user-menu.action.invite-members-aria-label': 'Inviter medlemmer',
+
+  /** Label for action to sign out of the current sanity project */
+  'user-menu.action.sign-out': 'Logg ut',
+
+  /** Title for appearance section for the current studio (dark / light / system scheme) */
+  'user-menu.appearance-title': 'Utseende',
+
+  /** Title for using system apparence in the appearance user menu */
+  'user-menu.color-scheme.system-title': 'System',
+
+  /** Description for using "system apparence" in the appearance user menu */
+  'user-menu.color-scheme.system-description': 'Bruk systemutseende',
+
+  /** Title for using the "dark theme" in the appearance user menu */
+  'user-menu.color-scheme.dark-title': 'Mørk',
+
+  /** Description for using the "dark theme" in the appearance user menu */
+  'user-menu.color-scheme.dark-description': 'Bruk mørkt utseende',
+
+  /** Title for using the "light theme" in the appearance user menu */
+  'user-menu.color-scheme.light-title': 'Lys',
+
+  /** Description for using the "light theme" in the appearance user menu */
+  'user-menu.color-scheme.light-description': 'Bruk lyst utseende',
+
+  /** Title for locale section for the current studio */
+  'user-menu.locale-title': 'Språk',
+
+  /** --- Presence --- */
+
+  /** Message title for when no one else is currently present */
+  'presence.no-one-else-title': 'Ingen andre er her',
+
+  /** Message description for when no one else is currently present */
+  'presence.no-one-else-description': 'Inviter folk til prosjektet for å se deres onlinestatus.',
+
+  /** Label for action to manage members of the current studio project */
+  'presence.action.manage-members': 'Administrer medlemmer',
+
+  /** Message for when a user is not in a document (displayed in the global presence menu) */
+  'presence.not-in-a-document': 'Ikke i et dokument',
 }
 
 export default studioResources

--- a/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
@@ -662,31 +662,31 @@ const studioResources: Record<StudioLocaleResourceKeys, string> = {
   /** --- Help & Resources Menu --- */
 
   /** Title for help and resources menus */
-  'helpResources.title': 'Hjelp og ressurser',
+  'help-resources.title': 'Hjelp og ressurser',
 
   /** Information for what studio version the current studio is running */
-  'helpResources.studio-version': `Sanity Studio versjon {{studioVersion}}`,
+  'help-resources.studio-version': `Sanity Studio versjon {{studioVersion}}`,
 
   /** Information for what the latest sanity version is */
-  'helpResources.latest-sanity-version': `Siste versjon er {{latestVersion}}`,
+  'help-resources.latest-sanity-version': `Siste versjon er {{latestVersion}}`,
 
   /**
    * Label for "join our community" call to action
    * These are titles for fallback links in the event the help & resources endpoint isn't able to be fetched
    */
-  'helpResources.action.join-our-community': `Bli med i vårt community`,
+  'help-resources.action.join-our-community': `Bli med i vårt community`,
 
   /**
    * Label for "help and support" call to action
    * These are titles for fallback links in the event the help & resources endpoint isn't able to be fetched
    */
-  'helpResources.action.help-and-support': `Hjelp og støtte`,
+  'help-resources.action.help-and-support': `Hjelp og støtte`,
 
   /**
    * Label for "contact sales" call to action
    * These are titles for fallback links in the event the help & resources endpoint isn't able to be fetched
    */
-  'helpResources.action.contact-sales': `Kontakt salg`,
+  'help-resources.action.contact-sales': `Kontakt salg`,
 
   /** --- User Menu --- */
 

--- a/dev/test-studio/plugins/locale-no-nb/bundles/validation.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/validation.ts
@@ -1,4 +1,13 @@
 const validationResources = {
+  /** Title for the actual "Validation" panel/feature */
+  'panel.title': 'Validering',
+
+  /** Accessibility label for closing the validation panel */
+  'panel.close-button-aria-label': 'Lukk validering',
+
+  /** Message shown when the validation panel is opened but there are no errors/warnings */
+  'panel.no-errors-message': 'Ingen valideringsfeil',
+
   /** A value of incorrect type is found, eg found `number` instead of `string` */
   'generic.incorrect-type': 'Forventet type "{{expectedType}}", fikk "{{actualType}}"',
 

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -691,31 +691,31 @@ export const studioLocaleStrings = {
   /** --- Help & Resources Menu --- */
 
   /** Title for help and resources menus */
-  'helpResources.title': 'Help and resources',
+  'help-resources.title': 'Help and resources',
 
   /** Information for what studio version the current studio is running */
-  'helpResources.studio-version': `Sanity Studio version {{studioVersion}}`,
+  'help-resources.studio-version': `Sanity Studio version {{studioVersion}}`,
 
   /** Information for what the latest sanity version is */
-  'helpResources.latest-sanity-version': `Latest version is {{latestVersion}}`,
+  'help-resources.latest-sanity-version': `Latest version is {{latestVersion}}`,
 
   /**
    * Label for "join our community" call to action
    * These are titles for fallback links in the event the help & resources endpoint isn't able to be fetched
    */
-  'helpResources.action.join-our-community': `Join our community`,
+  'help-resources.action.join-our-community': `Join our community`,
 
   /**
    * Label for "help and support" call to action
    * These are titles for fallback links in the event the help & resources endpoint isn't able to be fetched
    */
-  'helpResources.action.help-and-support': `Help and support`,
+  'help-resources.action.help-and-support': `Help and support`,
 
   /**
    * Label for "contact sales" call to action
    * These are titles for fallback links in the event the help & resources endpoint isn't able to be fetched
    */
-  'helpResources.action.contact-sales': `Contact sales`,
+  'help-resources.action.contact-sales': `Contact sales`,
 
   /** --- User Menu --- */
 

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -18,7 +18,7 @@ export const studioLocaleStrings = {
   /** Label for the close button label in Review Changes pane */
   'changes.action.close-label': 'Close review changes',
 
-  /** Label and text for differences tooltip that indicates the authors of the changes */
+  /** Label and text for tooltip that indicates the authors of the changes */
   'changes.changes-by-author': 'Changes by',
 
   /** Loading changes in Review Changes Pane */
@@ -68,7 +68,8 @@ export const studioLocaleStrings = {
   /** Label for loading history */
   'timeline.loading-history': 'Loading history',
 
-  /** Label for determining since which version the changes for timeline menu dropdown are showing.
+  /**
+   * Label for determining since which version the changes for timeline menu dropdown are showing.
    * Receives the time label as a parameter.
    */
   'timeline.since': 'Since: {{timestamp, datetime}}',
@@ -152,6 +153,9 @@ export const studioLocaleStrings = {
   'inputs.datetime.calendar.weekday-names.short.friday': 'Fri',
   'inputs.datetime.calendar.weekday-names.short.saturday': 'Sat',
   'inputs.datetime.calendar.weekday-names.short.sunday': 'Sun',
+
+  /** Label for selecting a hour preset. Receives a `time` param as a string on hh:mm format and a `date` param as a Date instance denoting the preset date */
+  'inputs.datetime.calendar.action.set-to-time-preset': '{{time}} on {{date, datetime}}',
 
   /** --- File (Image, File and ImageTool) Inputs --- */
 
@@ -257,9 +261,6 @@ export const studioLocaleStrings = {
   /** Adjust the rectangle to crop image. Adjust the circle to specify the area that should always be visible. */
   'inputs.files.imagetool.field.description':
     'Adjust the rectangle to crop image. Adjust the circle to specify the area that should always be visible.',
-
-  /** Label for selecting a hour preset. Receives a `time` param as a string on hh:mm format and a `date` param as a Date instance denoting the preset date */
-  'inputs.datetime.calendar.action.set-to-time-preset': '{{time}} on {{date, datetime}}',
 
   /** --- Reference (and Cross-Dataset Reference) Input --- */
 
@@ -486,6 +487,7 @@ export const studioLocaleStrings = {
   'new-document.new-document-aria-label': 'New document',
 
   /** Error label for when a user is unable to create a document */
+  // @todo refactor InsufficientPermissionsMessage
   'new-document.error.unable-to-create-document': 'create this document',
 
   /** --- Search --- */
@@ -680,10 +682,11 @@ export const studioLocaleStrings = {
   'search.action.close-search-aria-label': 'Close search',
 
   /** Accessibility label for when the search is full screen (on narrow screens) and you want to toggle filters */
-  'search.action.toggle-filters-aria-label': 'Toggle filters',
+  'search.action.toggle-filters-aria-label_hide': 'Hide filters',
+  'search.action.toggle-filters-aria-label_show': 'Show filters',
 
   /** Label for instructions on how to use the search - displayed when no recent searches are available */
-  'search.instructions': 'Use <ControlsIcon /> to refine your search',
+  'search.instructions': 'Use <ControlsIcon/> to refine your search',
 
   /** --- Help & Resources Menu --- */
 
@@ -729,7 +732,7 @@ export const studioLocaleStrings = {
   'user-menu.action.invite-members': 'Invite members',
 
   /** Accessibility label for action to invite members to the current sanity project */
-  'user-menu.action.invite-members-aria-lable': 'Invite members',
+  'user-menu.action.invite-members-aria-label': 'Invite members',
 
   /** Label for action to sign out of the current sanity project */
   'user-menu.action.sign-out': 'Sign out',

--- a/packages/sanity/src/core/i18n/bundles/validation.ts
+++ b/packages/sanity/src/core/i18n/bundles/validation.ts
@@ -7,6 +7,15 @@ import {validationLocaleNamespace} from '../localeNamespaces'
  * @internal
  */
 const validationLocaleStrings = {
+  /** Title for the actual "Validation" panel/feature */
+  'panel.title': 'Validation',
+
+  /** Accessibility label for closing the validation panel */
+  'panel.close-button-aria-label': 'Close validation',
+
+  /** Message shown when the validation panel is opened but there are no errors/warnings */
+  'panel.no-errors-message': 'No validation errors',
+
   /** A value of incorrect type is found, eg found `number` instead of `string` */
   'generic.incorrect-type': 'Expected type "{{expectedType}}", got "{{actualType}}"',
 

--- a/packages/sanity/src/core/studio/components/navbar/resources/ResourcesButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/ResourcesButton.tsx
@@ -27,7 +27,7 @@ export function ResourcesButton() {
       <Tooltip
         content={
           <Box padding={2}>
-            <Text size={1}>{t('helpResources.title')}</Text>
+            <Text size={1}>{t('help-resources.title')}</Text>
           </Box>
         }
         scheme={scheme}
@@ -39,7 +39,7 @@ export function ResourcesButton() {
           <MenuButton
             button={
               <Button
-                aria-label={t('helpResources.title')}
+                aria-label={t('help-resources.title')}
                 icon={HelpCircleIcon}
                 mode="bleed"
                 fontSize={2}

--- a/packages/sanity/src/core/studio/components/navbar/resources/ResourcesMenuItems.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/ResourcesMenuItems.tsx
@@ -27,7 +27,7 @@ export function ResourcesMenuItems({error, isLoading, value}: ResourcesMenuItemP
     <>
       <MenuItem
         as="a"
-        text={t('helpResources.action.join-our-community')}
+        text={t('help-resources.action.join-our-community')}
         size={0}
         href="https://www.sanity.io/exchange/community"
         target="_blank"
@@ -35,7 +35,7 @@ export function ResourcesMenuItems({error, isLoading, value}: ResourcesMenuItemP
       />
       <MenuItem
         as="a"
-        text={t('helpResources.action.help-and-support')}
+        text={t('help-resources.action.help-and-support')}
         size={0}
         href="https://www.sanity.io/contact/support"
         target="_blank"
@@ -43,7 +43,7 @@ export function ResourcesMenuItems({error, isLoading, value}: ResourcesMenuItemP
       />
       <MenuItem
         as="a"
-        text={t('helpResources.action.contact-sales')}
+        text={t('help-resources.action.contact-sales')}
         size={0}
         href="https://www.sanity.io/contact/sales?ref=studio"
         target="_blank"
@@ -67,12 +67,12 @@ export function ResourcesMenuItems({error, isLoading, value}: ResourcesMenuItemP
       {/* Studio version information */}
       <Box padding={3}>
         <Text size={1} muted weight="medium" textOverflow="ellipsis">
-          {t('helpResources.studio-version', {studioVersion: SANITY_VERSION})}
+          {t('help-resources.studio-version', {studioVersion: SANITY_VERSION})}
         </Text>
         {!error && latestStudioVersion && (
           <Box paddingTop={2}>
             <Text size={1} muted textOverflow="ellipsis">
-              {t('helpResources.latest-sanity-version', {
+              {t('help-resources.latest-sanity-version', {
                 latestVersion: latestStudioVersion,
               })}
             </Text>

--- a/packages/sanity/src/core/studio/components/navbar/search/components/SearchHeader.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/SearchHeader.tsx
@@ -125,7 +125,9 @@ export const SearchHeader = forwardRef<HTMLInputElement, SearchHeaderProps>(func
           <FilterBox>
             <Button
               aria-expanded={filtersVisible}
-              aria-label={t('search.action.toggle-filters-aria-label')}
+              aria-label={t('search.action.toggle-filters-aria-label', {
+                context: filtersVisible ? 'hide' : 'show',
+              })}
               height="fill"
               icon={ControlsIcon}
               mode="bleed"

--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -117,6 +117,20 @@ const deskLocaleStrings = {
   'action.restore.confirm-dialog.confirm-discard-changes':
     'Are you sure you want to restore this document?',
 
+  /** --- PUBLISH STATUS BUTTON --- */
+  /** Accessibility label indicating when the document was last updated, in relative time, eg "2 hours ago" */
+  'status-bar.publish-status-button.last-updated-time.aria-label': 'Last updated {{relativeTime}}',
+
+  /** Accessibility label indicating when the document was last published, in relative time, eg "3 weeks ago" */
+  'status-bar.publish-status-button.last-published-time.aria-label':
+    'Last published {{relativeTime}}',
+
+  /** Text for tooltip showing explanation of timestamp/relative time, eg "Last updated <RelativeTime/>" */
+  'status-bar.publish-status-button.last-updated-time.tooltip': 'Last updated <RelativeTime/>',
+
+  /** Text for tooltip showing explanation of timestamp/relative time, eg "Last published <RelativeTime/>" */
+  'status-bar.publish-status-button.last-published-time.tooltip': 'Last published <RelativeTime/>',
+
   /** --- REVIEW CHANGES BUTTON --- */
   /** Label for button when status is syncing */
   'status-bar.review-changes-button.status.syncing.text': 'Saving...',

--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -146,6 +146,25 @@ const deskLocaleStrings = {
 
   /** Aria label for the button */
   'status-bar.review-changes-button.aria-label': 'Review changes',
+
+  /** --- DOCUMENT JSON INSPECTOR --- */
+  /** Title shown for menu item that opens the "Inspect" dialog */
+  'document-inspector.menu-item.title': 'Inspect',
+
+  /** The title shown in the dialog header, when inspecting a valid document */
+  'document-inspector.dialog.title': 'Inspecting <DocumentTitle/>',
+
+  /** The title shown in the dialog header, when the document being inspected is not created yet/has no value */
+  'document-inspector.dialog.title-no-value': 'No value',
+
+  /** The "parsed" view mode, meaning the JSON is searchable, collapsible etc */
+  'document-inspector.view-mode.parsed': 'Parsed',
+
+  /** The "raw" view mode, meaning the JSON is presented syntax-highlighted, but with no other features - optimal for copying */
+  'document-inspector.view-mode.raw-json': 'Raw JSON',
+
+  /** --- "PRODUCTION PREVIEW", eg link to content --- */
+  'production-preview.menu-item.title': 'Open preview',
 }
 
 /**

--- a/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
@@ -1,16 +1,17 @@
 import React, {memo, useCallback, useEffect, useMemo, useRef, useState} from 'react'
-import {ObjectSchemaType, Path, SanityDocument, SanityDocumentLike} from '@sanity/types'
-import {omit, set} from 'lodash'
+import type {ObjectSchemaType, Path, SanityDocument, SanityDocumentLike} from '@sanity/types'
+import {omit} from 'lodash'
 import {useToast} from '@sanity/ui'
 import {fromString as pathFromString, resolveKeyedPath} from '@sanity/util/paths'
 import isHotkey from 'is-hotkey'
 import {isActionEnabled} from '@sanity/schema/_internal'
 import {usePaneRouter} from '../../components'
-import {PaneMenuItem} from '../../types'
+import type {PaneMenuItem} from '../../types'
 import {useDeskTool} from '../../useDeskTool'
-import {DocumentPaneContext, DocumentPaneContextValue} from './DocumentPaneContext'
+import {deskLocaleNamespace} from '../../i18n'
+import {DocumentPaneContext, type DocumentPaneContextValue} from './DocumentPaneContext'
 import {getMenuItems} from './menuItems'
-import {DocumentPaneProviderProps} from './types'
+import type {DocumentPaneProviderProps} from './types'
 import {usePreviewUrl} from './usePreviewUrl'
 import {getInitialValueTemplateOpts} from './getInitialValueTemplateOpts'
 import {
@@ -21,16 +22,24 @@ import {
 } from './constants'
 import {DocumentInspectorMenuItemsResolver} from './DocumentInspectorMenuItemsResolver'
 import {
-  DocumentInspector,
-  DocumentPresence,
-  PatchEvent,
-  StateTree,
-  toMutationPatches,
+  type DocumentFieldAction,
+  type DocumentFieldActionNode,
+  type DocumentInspector,
+  type DocumentInspectorMenuItem,
+  type DocumentPresence,
+  type PatchEvent,
+  type StateTree,
+  EMPTY_ARRAY,
+  FieldActionsProvider,
+  FieldActionsResolver,
+  getDraftId,
   getExpandOperations,
   getPublishedId,
   setAtPath,
+  toMutationPatches,
   useConnectionState,
   useDocumentOperation,
+  useDocumentValuePermissions,
   useEditState,
   useFormState,
   useInitialValue,
@@ -38,18 +47,11 @@ import {
   useSchema,
   useSource,
   useTemplates,
+  useTimelineSelector,
+  useTimelineStore,
+  useTranslation,
   useUnique,
   useValidationStatus,
-  getDraftId,
-  useDocumentValuePermissions,
-  useTimelineStore,
-  useTimelineSelector,
-  DocumentFieldAction,
-  DocumentInspectorMenuItem,
-  FieldActionsResolver,
-  EMPTY_ARRAY,
-  DocumentFieldActionNode,
-  FieldActionsProvider,
 } from 'sanity'
 
 /**
@@ -216,6 +218,7 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
   const changesOpen = currentInspector?.name === HISTORY_INSPECTOR_NAME
 
   const hasValue = Boolean(value)
+  const {t} = useTranslation(deskLocaleNamespace)
   const menuItems = useMemo(
     () =>
       getMenuItems({
@@ -225,8 +228,9 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
         inspectorMenuItems,
         inspectors,
         previewUrl,
+        t,
       }),
-    [currentInspector, features, hasValue, inspectorMenuItems, inspectors, previewUrl],
+    [currentInspector, features, hasValue, inspectorMenuItems, inspectors, previewUrl, t],
   )
   const inspectOpen = params.inspect === 'on'
   const compareValue: Partial<SanityDocument> | null = changesOpen

--- a/packages/sanity/src/desk/panes/document/inspectDialog/InspectDialog.tsx
+++ b/packages/sanity/src/desk/panes/document/inspectDialog/InspectDialog.tsx
@@ -4,11 +4,13 @@ import React, {useCallback} from 'react'
 import JSONInspector from '@rexxars/react-json-inspector'
 import {DocTitle} from '../../../components'
 import {useDeskToolSetting} from '../../../useDeskToolSetting'
+import {deskLocaleNamespace} from '../../../i18n'
 import {useDocumentPane} from '../useDocumentPane'
 import {VIEW_MODE_PARSED, VIEW_MODE_RAW, VIEW_MODES} from './constants'
 import {isDocumentLike, isExpanded, maybeSelectAll, select, toggleExpanded} from './helpers'
 import {JSONInspectorWrapper} from './InspectDialog.styles'
 import {Search} from './Search'
+import {Translate, useTranslation} from 'sanity'
 
 interface InspectDialogProps {
   value: Partial<SanityDocument> | null
@@ -39,19 +41,26 @@ export function InspectDialog(props: InspectDialogProps) {
     onViewModeChange(VIEW_MODE_RAW.id)
   }, [onViewModeChange])
 
+  const {t} = useTranslation(deskLocaleNamespace)
+
   return (
     <Dialog
       id={`${dialogIdPrefix}dialog`}
       header={
         isDocumentLike(value) ? (
-          <>
-            Inspecting{' '}
-            <em>
-              <DocTitle document={value} />
-            </em>
-          </>
+          <Translate
+            t={t}
+            i18nKey="document-inspector.dialog.title"
+            components={{
+              DocumentTitle: () => (
+                <em>
+                  <DocTitle document={value} />
+                </em>
+              ),
+            }}
+          />
         ) : (
-          <em>No value</em>
+          <em>{t('document-inspector.dialog.title-no-value')}</em>
         )
       }
       onClose={onInspectClose}
@@ -65,7 +74,7 @@ export function InspectDialog(props: InspectDialogProps) {
               aria-controls={`${dialogIdPrefix}tabpanel`}
               fontSize={1}
               id={`${dialogIdPrefix}tab-${VIEW_MODE_PARSED.id}`}
-              label={VIEW_MODE_PARSED.title}
+              label={t(VIEW_MODE_PARSED.title)}
               onClick={setParsedViewMode}
               selected={viewMode === VIEW_MODE_PARSED}
             />
@@ -73,7 +82,7 @@ export function InspectDialog(props: InspectDialogProps) {
               aria-controls={`${dialogIdPrefix}tabpanel`}
               fontSize={1}
               id={`${dialogIdPrefix}tab-${VIEW_MODE_RAW.id}`}
-              label={VIEW_MODE_RAW.title}
+              label={t(VIEW_MODE_RAW.title)}
               onClick={setRawViewMode}
               selected={viewMode === VIEW_MODE_RAW}
             />

--- a/packages/sanity/src/desk/panes/document/inspectDialog/constants.ts
+++ b/packages/sanity/src/desk/panes/document/inspectDialog/constants.ts
@@ -1,3 +1,3 @@
-export const VIEW_MODE_PARSED = {id: 'parsed', title: 'Parsed'}
-export const VIEW_MODE_RAW = {id: 'raw', title: 'Raw JSON'}
+export const VIEW_MODE_PARSED = {id: 'parsed', title: 'document-inspector.view-mode.parsed'}
+export const VIEW_MODE_RAW = {id: 'raw', title: 'document-inspector.view-mode.raw-json'}
 export const VIEW_MODES = [VIEW_MODE_PARSED, VIEW_MODE_RAW]

--- a/packages/sanity/src/desk/panes/document/inspectors/changes/index.ts
+++ b/packages/sanity/src/desk/panes/document/inspectors/changes/index.ts
@@ -2,17 +2,18 @@ import {RestoreIcon} from '@sanity/icons'
 import {HISTORY_INSPECTOR_NAME} from '../../constants'
 import {useDeskTool} from '../../../../useDeskTool'
 import {ChangesInspector} from './ChangesInspector'
-import {DocumentInspector} from 'sanity'
+import {DocumentInspector, useTranslation} from 'sanity'
 
 export const changesInspector: DocumentInspector = {
   name: HISTORY_INSPECTOR_NAME,
   useMenuItem: () => {
     const {features} = useDeskTool()
+    const {t} = useTranslation()
 
     return {
       hidden: !features.reviewChanges,
       icon: RestoreIcon,
-      title: 'Review changes',
+      title: t('changes.title'),
     }
   },
   component: ChangesInspector,

--- a/packages/sanity/src/desk/panes/document/inspectors/validation/ValidationInspector.tsx
+++ b/packages/sanity/src/desk/panes/document/inspectors/validation/ValidationInspector.tsx
@@ -5,7 +5,7 @@ import React, {ErrorInfo, Fragment, createElement, useCallback, useMemo, useStat
 import {useDocumentPane} from '../../useDocumentPane'
 import {DocumentInspectorHeader} from '../../documentInspector'
 import {getPathTypes} from './getPathTypes'
-import {DocumentInspectorProps} from 'sanity'
+import {DocumentInspectorProps, useTranslation} from 'sanity'
 
 const MARKER_ICON: Record<'error' | 'warning' | 'info', IconComponent> = {
   error: ErrorOutlineIcon,
@@ -22,6 +22,7 @@ const MARKER_TONE: Record<'error' | 'warning' | 'info', CardTone> = {
 export function ValidationInspector(props: DocumentInspectorProps) {
   const {onClose} = props
   const {onFocus, onPathOpen, schemaType, validation, value} = useDocumentPane()
+  const {t} = useTranslation('validation')
 
   const handleOpen = useCallback(
     (path: Path) => {
@@ -35,17 +36,17 @@ export function ValidationInspector(props: DocumentInspectorProps) {
     <Flex direction="column" height="fill" overflow="hidden">
       <DocumentInspectorHeader
         as="header"
-        closeButtonLabel="Close validation"
+        closeButtonLabel={t('panel.close-button-aria-label')}
         flex="none"
         onClose={onClose}
-        title="Validation"
+        title={t('panel.title')}
       />
 
       <Card flex={1} overflow="auto" padding={3}>
         {validation.length === 0 && (
           <Box padding={2}>
             <Text muted size={1}>
-              No validation errors
+              {t('panel.no-errors-message')}
             </Text>
           </Box>
         )}

--- a/packages/sanity/src/desk/panes/document/inspectors/validation/index.ts
+++ b/packages/sanity/src/desk/panes/document/inspectors/validation/index.ts
@@ -3,17 +3,19 @@ import {useMemo} from 'react'
 import {VALIDATION_INSPECTOR_NAME} from '../../constants'
 import {ValidationInspector} from './ValidationInspector'
 import {
-  DocumentInspector,
-  DocumentInspectorMenuItem,
-  DocumentInspectorUseMenuItemProps,
-  FormNodeValidation,
+  type DocumentInspector,
+  type DocumentInspectorMenuItem,
+  type DocumentInspectorUseMenuItemProps,
+  type FormNodeValidation,
   isValidationError,
   isValidationWarning,
+  useTranslation,
   useValidationStatus,
 } from 'sanity'
 
 function useMenuItem(props: DocumentInspectorUseMenuItemProps): DocumentInspectorMenuItem {
   const {documentId, documentType} = props
+  const {t} = useTranslation('validation')
   const {validation: validationMarkers} = useValidationStatus(documentId, documentType)
 
   const validation: FormNodeValidation[] = useMemo(
@@ -44,7 +46,7 @@ function useMenuItem(props: DocumentInspectorUseMenuItemProps): DocumentInspecto
   return {
     hidden: validation.length === 0,
     icon,
-    title: 'Validation',
+    title: t('panel.title'),
     tone,
     showAsAction: true,
   }

--- a/packages/sanity/src/desk/panes/document/menuItems.ts
+++ b/packages/sanity/src/desk/panes/document/menuItems.ts
@@ -1,7 +1,7 @@
 import {BinaryDocumentIcon, EarthAmericasIcon} from '@sanity/icons'
-import {DeskToolFeatures, PaneMenuItem} from '../../types'
+import type {DeskToolFeatures, PaneMenuItem} from '../../types'
 import {INSPECT_ACTION_PREFIX} from './constants'
-import {DocumentInspector, DocumentInspectorMenuItem, ValidationMarker} from 'sanity'
+import type {DocumentInspector, DocumentInspectorMenuItem, TFunction} from 'sanity'
 
 interface GetMenuItemsParams {
   currentInspector?: DocumentInspector
@@ -10,6 +10,7 @@ interface GetMenuItemsParams {
   inspectors: DocumentInspector[]
   previewUrl?: string | null
   inspectorMenuItems: DocumentInspectorMenuItem[]
+  t: TFunction
 }
 
 function getInspectorItems({
@@ -39,24 +40,24 @@ function getInspectorItems({
     .filter(Boolean) as PaneMenuItem[]
 }
 
-function getInspectItem({hasValue}: GetMenuItemsParams): PaneMenuItem {
+function getInspectItem({hasValue, t}: GetMenuItemsParams): PaneMenuItem {
   return {
     action: 'inspect',
     group: 'inspectors',
-    title: 'Inspect',
+    title: t('document-inspector.menu-item.title'),
     icon: BinaryDocumentIcon,
     isDisabled: !hasValue,
     shortcut: 'Ctrl+Alt+I',
   }
 }
 
-export function getProductionPreviewItem({previewUrl}: GetMenuItemsParams): PaneMenuItem | null {
+export function getProductionPreviewItem({previewUrl, t}: GetMenuItemsParams): PaneMenuItem | null {
   if (!previewUrl) return null
 
   return {
     action: 'production-preview',
     group: 'links',
-    title: 'Open preview',
+    title: t('production-preview.menu-item.title'),
     icon: EarthAmericasIcon,
     shortcut: 'Ctrl+Alt+O',
   }

--- a/packages/sanity/src/desk/panes/document/statusBar/sparkline/PublishStatus.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/sparkline/PublishStatus.tsx
@@ -2,7 +2,8 @@ import {Box, Button, Flex, Stack, Text, Tooltip} from '@sanity/ui'
 import {PlayIcon, PublishIcon} from '@sanity/icons'
 import React from 'react'
 import styled from 'styled-components'
-import {useRelativeTime} from 'sanity'
+import {deskLocaleNamespace} from '../../../../i18n'
+import {Translate, useRelativeTime, useTranslation} from 'sanity'
 
 interface PublishStatusProps {
   collapsed?: boolean
@@ -18,6 +19,7 @@ const Root = styled(Flex)`
 
 export function PublishStatus(props: PublishStatusProps) {
   const {collapsed, disabled, lastPublished, lastUpdated, liveEdit} = props
+  const {t} = useTranslation(deskLocaleNamespace)
 
   // Label with abbreviations and suffix
   const lastPublishedTimeAgo = useRelativeTime(lastPublished || '', {
@@ -45,11 +47,15 @@ export function PublishStatus(props: PublishStatusProps) {
     useTemporalPhrase: true,
   })
   const a11yLabel = liveEdit
-    ? `Last updated ${a11yUpdatedAgo}`
-    : `Last published ${a11yPublishedAgo}`
+    ? t('status-bar.publish-status-button.last-updated-time.aria-label', {
+        relativeTime: a11yUpdatedAgo,
+      })
+    : t('status-bar.publish-status-button.last-published-time.aria-label', {
+        relativeTime: a11yPublishedAgo,
+      })
 
   return (
-    <Root align="center" data-ui="SessionLayout" sizing="border">
+    <Root align="center" data-ui="PublishStatus" sizing="border">
       <Tooltip
         placement="top"
         portal
@@ -57,16 +63,32 @@ export function PublishStatus(props: PublishStatusProps) {
           <Stack padding={3} space={3}>
             <Text size={1}>
               {liveEdit ? (
-                <>
-                  Last updated{' '}
-                  <abbr aria-label={lastUpdated ? a11yUpdatedAgo : a11yPublishedAgo}>
-                    {lastUpdated ? lastUpdatedTimeAgo : lastPublishedTimeAgo}
-                  </abbr>
-                </>
+                <Translate
+                  t={t}
+                  i18nKey="status-bar.publish-status-button.last-updated-time.tooltip"
+                  components={{
+                    RelativeTime: () => (
+                      <time
+                        dateTime={lastUpdated}
+                        aria-label={lastUpdated ? a11yUpdatedAgo : a11yPublishedAgo}
+                      >
+                        {lastUpdated ? lastUpdatedTimeAgo : lastPublishedTimeAgo}
+                      </time>
+                    ),
+                  }}
+                />
               ) : (
-                <>
-                  Last published <abbr aria-label={a11yPublishedAgo}>{lastPublishedTimeAgo}</abbr>
-                </>
+                <Translate
+                  t={t}
+                  i18nKey="status-bar.publish-status-button.last-published-time.tooltip"
+                  components={{
+                    RelativeTime: () => (
+                      <time dateTime={lastPublished} aria-label={a11yPublishedAgo}>
+                        {lastPublishedTimeAgo}
+                      </time>
+                    ),
+                  }}
+                />
               )}
             </Text>
           </Stack>
@@ -88,11 +110,13 @@ export function PublishStatus(props: PublishStatusProps) {
             {!collapsed && (
               <Text size={1} weight="medium">
                 {liveEdit ? (
-                  <abbr aria-label={a11yLabel}>
+                  <time dateTime={lastUpdated || lastPublished} aria-label={a11yLabel}>
                     {lastUpdated ? lastUpdatedTime : lastPublishedTime}
-                  </abbr>
+                  </time>
                 ) : (
-                  <abbr aria-label={a11yLabel}>{lastPublishedTime}</abbr>
+                  <time dateTime={lastPublished} aria-label={a11yLabel}>
+                    {lastPublishedTime}
+                  </time>
                 )}
               </Text>
             )}

--- a/packages/sanity/src/desk/panes/document/timeline/timelineItem.styled.tsx
+++ b/packages/sanity/src/desk/panes/document/timeline/timelineItem.styled.tsx
@@ -1,4 +1,4 @@
-import {Text, Box, Button, Theme, Flex, rem} from '@sanity/ui'
+import {Box, Button, Theme, Flex, rem} from '@sanity/ui'
 import styled, {css} from 'styled-components'
 
 export interface IconWrapperProps {
@@ -69,10 +69,6 @@ export const IconBox = styled(Box)`
   border-radius: 50px;
   position: relative;
   z-index: 2;
-`
-
-export const EventLabel = styled(Text)`
-  text-transform: capitalize;
 `
 
 export const TimestampBox = styled(Box)`

--- a/packages/sanity/src/desk/panes/document/timeline/timelineItem.tsx
+++ b/packages/sanity/src/desk/panes/document/timeline/timelineItem.tsx
@@ -1,10 +1,9 @@
 import React, {useCallback, createElement, useMemo} from 'react'
 import {Box, ButtonTone, Card, Flex, Label, Stack, Text} from '@sanity/ui'
 import {format} from 'date-fns'
-import {deskLocaleNamespace} from '../../../i18n'
 import {getTimelineEventIconComponent} from './helpers'
 import {UserAvatarStack} from './userAvatarStack'
-import {EventLabel, IconBox, IconWrapper, Root, TimestampBox} from './timelineItem.styled'
+import {IconBox, IconWrapper, Root, TimestampBox} from './timelineItem.styled'
 import {ChunkType, Chunk, useTranslation} from 'sanity'
 
 const TIMELINE_ITEM_EVENT_TONE: Record<ChunkType | 'withinSelection', ButtonTone> = {
@@ -102,9 +101,9 @@ export function TimelineItem({
               </Flex>
             )}
             <Box>
-              <EventLabel size={1} weight="medium">
+              <Text size={1} weight="medium">
                 {t(`timeline.${type}`) || <code>{type}</code>}
-              </EventLabel>
+              </Text>
             </Box>
             <TimestampBox paddingX={1}>
               <Text size={0} muted>


### PR DESCRIPTION
Bit of a mixed bag here, apologies for not splitting up into separate PRs, but seems a bit excessive. Bit of a whack-a-mole at this point ;) 

1. Adds a large number of missing Norwegian translations to easier get overview of missing surfaces (also sorted in same order as english resource file)
2. Added i18n primitives for:
    - Publish status button
    - Review changes (panel title etc)
    - Validation panel
    - Inspect dialog
    - Document pane menu items (Inspect, Open preview)
