### PR TITLE
fix(login): fix issue where logo is not shown on custom auth providers

### DIFF
--- a/packages/sanity/src/core/form/inputs/index.ts
+++ b/packages/sanity/src/core/form/inputs/index.ts
@@ -1,4 +1,5 @@
 export type {PortableTextEditorElement} from './PortableText/Compositor'
+export type {RenderBlockActionsCallback, RenderBlockActionsProps} from '../types/_transitional'
 export * from './files/types'
 export * from './PortableText/PortableTextInput'
 export {PortableTextInput as BlockEditor} from './PortableText/PortableTextInput'

--- a/packages/sanity/src/core/form/inputs/index.ts
+++ b/packages/sanity/src/core/form/inputs/index.ts
@@ -1,5 +1,4 @@
 export type {PortableTextEditorElement} from './PortableText/Compositor'
-export type {RenderBlockActionsCallback, RenderBlockActionsProps} from '../types/_transitional'
 export * from './files/types'
 export * from './PortableText/PortableTextInput'
 export {PortableTextInput as BlockEditor} from './PortableText/PortableTextInput'

--- a/packages/sanity/src/core/store/_legacy/authStore/createLoginComponent.tsx
+++ b/packages/sanity/src/core/store/_legacy/authStore/createLoginComponent.tsx
@@ -4,7 +4,7 @@ import React, {useEffect, useState} from 'react'
 import type {Observable} from 'rxjs'
 import type {AuthConfig} from '../../../config'
 import {createHookFromObservableFactory} from '../../../util'
-import {providerLogos} from './providerLogos'
+import {CustomLogo, providerLogos} from './providerLogos'
 import type {LoginComponentProps} from './types'
 
 interface GetProvidersOptions extends AuthConfig {
@@ -156,7 +156,7 @@ export function createLoginComponent({
               // eslint-disable-next-line react/no-array-index-key
               key={`${provider.url}_${index}`}
               as="a"
-              icon={providerLogos[provider.name]}
+              icon={providerLogos[provider.name] || <CustomLogo provider={provider} />}
               href={createHrefForProvider({
                 loginMethod,
                 projectId,

--- a/packages/sanity/src/core/store/_legacy/authStore/providerLogos.tsx
+++ b/packages/sanity/src/core/store/_legacy/authStore/providerLogos.tsx
@@ -11,6 +11,12 @@ const GithubRoot = styled.svg(({theme}: {theme: Theme}) => {
   `
 })
 
+const CustomImage = styled.img`
+  height: 19px;
+  width: 19px;
+  object-fit: contain;
+`
+
 const GithubLogo = () => (
   <GithubRoot
     // data-sanity-icon="google-logo"
@@ -50,17 +56,16 @@ const GoogleLogo = () => (
   </svg>
 )
 
-function CustomLogo(props: {provider: AuthProvider}) {
+export function CustomLogo(props: {provider: AuthProvider}) {
   const {provider} = props
 
-  return (
-    provider.logo ? <img src={provider.logo} alt={`Logo for ${provider.name}`} /> : undefined
-  ) as any
+  return provider.logo ? (
+    <CustomImage src={provider.logo} alt={`Logo for ${provider.name}`} />
+  ) : undefined
 }
 
 export const providerLogos: Record<string, React.ComponentType<{provider: AuthProvider}>> = {
   google: GoogleLogo,
   github: GithubLogo,
-  custom: CustomLogo,
   // sanity: () => <SanityMonogram data-sanity-icon="" />,
 }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Fixes an issue where custom logo would not show up on custom auth providers unless the name of the provider was `custom` and even in that case it would throw an error since the provider prop was not passed to the component.

![Screenshot 2023-10-17 at 11 35 56 AM](https://github.com/sanity-io/sanity/assets/6476108/f4414773-80ba-4555-9bce-ac2656a47099)


### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

Change makes sense

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

- Fixes an issue where logo is not shown on custom auth providers