### PR TITLE
refactor(i18n): hoist locale from source to workspace

### DIFF
--- a/packages/sanity/src/core/config/resolveConfig.ts
+++ b/packages/sanity/src/core/config/resolveConfig.ts
@@ -26,6 +26,10 @@ export function resolveConfig(config: Config): Observable<Workspace[]> {
             ...sources[0],
             unstable_sources: sources,
             type: 'workspace',
+            __internal: {
+              ...sources[0].__internal,
+              i18next: workspaceSummary.__internal.i18next,
+            },
           }),
         ),
       ),

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -646,9 +646,6 @@ export interface Source {
   }
 
   /** @internal */
-  i18n: LocaleSource
-
-  /** @internal */
   __internal: {
     /** @internal */
     bifur: BifurClient
@@ -656,11 +653,6 @@ export interface Source {
     staticInitialValueTemplateItems: InitialValueTemplateItem[]
     /** @internal */
     options: SourceOptions
-    /**
-     * _VERY_ internal, likely to change at any point.
-     * @internal
-     */
-    i18next: i18n
   }
 }
 
@@ -690,9 +682,14 @@ export interface WorkspaceSummary {
       title: string
       auth: AuthStore
       schema: Schema
-      i18n: LocaleSource
       source: Observable<Source>
     }>
+
+    /**
+     * _VERY_ internal, likely to change at any point.
+     * @internal
+     */
+    i18next: i18n
   }
 }
 
@@ -701,7 +698,7 @@ export interface WorkspaceSummary {
  *
  * @public
  */
-export interface Workspace extends Omit<Source, 'type'> {
+export interface Workspace extends Omit<Source, 'type' | '__internal'> {
   type: 'workspace'
   /**
    * URL base path to use, for instance `/myWorkspace`
@@ -714,12 +711,17 @@ export interface Workspace extends Omit<Source, 'type'> {
   subtitle?: string
   /** React component to use as icon for this workspace */
   icon: ReactNode
+  /** Localization resources */
+  i18n: LocaleSource
   /**
    *
    * @hidden
    * @beta
    */
   unstable_sources: Source[]
+  __internal: Source['__internal'] & {
+    i18next: i18n
+  }
 }
 
 /**

--- a/packages/sanity/src/core/config/useConfigContextFromSource.ts
+++ b/packages/sanity/src/core/config/useConfigContextFromSource.ts
@@ -1,15 +1,20 @@
 import {useMemo} from 'react'
-import type {Source, ConfigContext} from './types'
+import type {Source, ConfigContext, WorkspaceSummary} from './types'
 
 /**
  * Reduce a {@link Source} down to a {@link ConfigContext}, memoizing using `React.useMemo`
  *
  * @param source - Source to convert
+ * @param workspace - Workspace to grab i18n source from
  * @returns A config context containing only the defined properties of that interface
  * @internal
  */
-export function useConfigContextFromSource(source: Source): ConfigContext {
-  const {projectId, dataset, schema, currentUser, getClient, i18n} = source
+export function useConfigContextFromSource(
+  source: Source,
+  workspace: {i18n: WorkspaceSummary['i18n']},
+): ConfigContext {
+  const {i18n} = workspace
+  const {projectId, dataset, schema, currentUser, getClient} = source
   return useMemo(() => {
     return {projectId, dataset, schema, currentUser, getClient, i18n}
   }, [projectId, dataset, schema, currentUser, getClient, i18n])
@@ -19,10 +24,15 @@ export function useConfigContextFromSource(source: Source): ConfigContext {
  * Reduce a {@link Source} down to a {@link ConfigContext}, without memoization - use for non-react contexts
  *
  * @param source - Source to convert
+ * @param workspace - Workspace to grab i18n source from
  * @returns A config context containing only the defined properties of that interface
  * @internal
  */
-export function getConfigContextFromSource(source: Source): ConfigContext {
-  const {projectId, dataset, schema, currentUser, getClient, i18n} = source
+export function getConfigContextFromSource(
+  source: Source,
+  workspace: {i18n: WorkspaceSummary['i18n']},
+): ConfigContext {
+  const {i18n} = workspace
+  const {projectId, dataset, schema, currentUser, getClient} = source
   return {projectId, dataset, schema, currentUser, getClient, i18n}
 }

--- a/packages/sanity/src/core/i18n/__tests__/Translate.test.tsx
+++ b/packages/sanity/src/core/i18n/__tests__/Translate.test.tsx
@@ -22,8 +22,6 @@ function createBundle(resources: LocaleResourceRecord) {
 
 function TestProviders(props: {children: React.ReactNode; bundles: LocaleResourceBundle[]}) {
   const {i18next} = prepareI18n({
-    projectId: 'test',
-    dataset: 'test',
     name: 'test',
     i18n: {bundles: props.bundles},
   })
@@ -32,8 +30,7 @@ function TestProviders(props: {children: React.ReactNode; bundles: LocaleResourc
       <LocaleProviderBase
         locales={[{id: 'en-US', title: 'English'}]}
         i18next={i18next}
-        projectId="test"
-        sourceId="test"
+        workspaceName="test"
       >
         {props.children}
       </LocaleProviderBase>

--- a/packages/sanity/src/core/i18n/components/LocaleProvider.tsx
+++ b/packages/sanity/src/core/i18n/components/LocaleProvider.tsx
@@ -1,7 +1,7 @@
 import {I18nextProvider} from 'react-i18next'
 import React, {PropsWithChildren, Suspense, useCallback, useMemo, useSyncExternalStore} from 'react'
 import type {i18n} from 'i18next'
-import {useSource} from '../../studio'
+import {useWorkspace} from '../../studio'
 import {LoadingScreen} from '../../studio/screens'
 import {storePreferredLocale} from '../localeStore'
 import {LocaleContext, LocaleContextValue} from '../LocaleContext'
@@ -11,18 +11,15 @@ import {LocaleContext, LocaleContextValue} from '../LocaleContext'
  */
 export function LocaleProvider(props: PropsWithChildren) {
   const {
-    projectId,
-    name: sourceId,
-
+    name: workspaceName,
     i18n: {locales},
     __internal: {i18next},
-  } = useSource()
+  } = useWorkspace()
 
   return (
     <LocaleProviderBase
       {...props}
-      projectId={projectId}
-      sourceId={sourceId}
+      workspaceName={workspaceName}
       locales={locales}
       i18next={i18next}
     />
@@ -33,14 +30,12 @@ export function LocaleProvider(props: PropsWithChildren) {
  * @internal
  */
 export function LocaleProviderBase({
-  projectId,
-  sourceId,
+  workspaceName,
   locales,
   i18next,
   children,
 }: PropsWithChildren<{
-  projectId: string
-  sourceId: string
+  workspaceName: string
   locales: {id: string; title: string}[]
   i18next: i18n
 }>) {
@@ -51,7 +46,11 @@ export function LocaleProviderBase({
     },
     [i18next],
   )
-  const currentLocale = useSyncExternalStore(subscribe, () => i18next.language)
+  const currentLocale = useSyncExternalStore(
+    subscribe,
+    () => i18next.language,
+    () => i18next.language,
+  )
 
   const context = useMemo<LocaleContextValue>(
     () => ({
@@ -59,11 +58,11 @@ export function LocaleProviderBase({
       currentLocale,
       __internal: {i18next},
       changeLocale: async (newLocale: string) => {
-        storePreferredLocale(projectId, sourceId, newLocale)
+        storePreferredLocale(workspaceName, newLocale)
         await i18next.changeLanguage(newLocale)
       },
     }),
-    [currentLocale, i18next, locales, projectId, sourceId],
+    [currentLocale, i18next, locales, workspaceName],
   )
 
   return (

--- a/packages/sanity/src/core/i18n/localeStore.ts
+++ b/packages/sanity/src/core/i18n/localeStore.ts
@@ -9,16 +9,15 @@ const LOCAL_STORAGE_PREFIX = 'sanity-locale'
 /**
  * Get the users' preferred locale, if any
  *
- * @param projectId - Project ID to segment on
- * @param sourceId - Source ID to segment on
+ * @param workspaceName - Workspace name to segment on
  * @returns Locale identifier, or `undefined`
  * @internal
  */
-export function getPreferredLocale(projectId: string, sourceId: string): string | undefined {
+export function getPreferredLocale(workspaceName: string): string | undefined {
   if (!supportsLocalStorage) {
     return undefined
   }
-  const locale = localStorage.getItem(getItemKey(projectId, sourceId))
+  const locale = localStorage.getItem(getItemKey(workspaceName))
   return locale ?? undefined
 }
 
@@ -31,11 +30,11 @@ export function getPreferredLocale(projectId: string, sourceId: string): string 
  * @returns
  * @internal
  */
-export function storePreferredLocale(projectId: string, sourceId: string, locale: string): void {
+export function storePreferredLocale(workspaceName: string, locale: string): void {
   if (!supportsLocalStorage) {
     return
   }
-  localStorage.setItem(getItemKey(projectId, sourceId), locale)
+  localStorage.setItem(getItemKey(workspaceName), locale)
 }
 
 /**
@@ -46,6 +45,6 @@ export function storePreferredLocale(projectId: string, sourceId: string, locale
  * @returns Storage key
  * @internal
  */
-function getItemKey(projectId: string, sourceId: string) {
-  return [LOCAL_STORAGE_PREFIX, projectId, sourceId].join(':')
+function getItemKey(workspaceName: string) {
+  return [LOCAL_STORAGE_PREFIX, workspaceName].join(':')
 }

--- a/packages/sanity/src/core/i18n/types.ts
+++ b/packages/sanity/src/core/i18n/types.ts
@@ -28,8 +28,7 @@ export interface LocaleResourceRecord {
  * @beta
  */
 export interface LocaleConfigContext {
-  projectId: string
-  dataset: string
+  workspaceName: string
 }
 
 /** @beta @hidden */

--- a/packages/sanity/src/core/store/_legacy/datastores.ts
+++ b/packages/sanity/src/core/store/_legacy/datastores.ts
@@ -122,12 +122,13 @@ export function useDocumentPreviewStore(): DocumentPreviewStore {
  * @hidden
  * @beta */
 export function useDocumentStore(): DocumentStore {
-  const {getClient, i18n} = useSource()
+  const {getClient} = useSource()
   const schema = useSchema()
   const templates = useTemplates()
   const resourceCache = useResourceCache()
   const historyStore = useHistoryStore()
   const documentPreviewStore = useDocumentPreviewStore()
+  const {i18n} = useWorkspace()
 
   return useMemo(() => {
     const documentStore =

--- a/packages/sanity/src/core/store/_legacy/document/document-store.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-store.ts
@@ -7,6 +7,7 @@ import {DocumentPreviewStore} from '../../../preview'
 import {getDraftId, isDraftId} from '../../../util'
 import {Template} from '../../../templates'
 import {SourceClientOptions} from '../../../config'
+import type {LocaleSource} from '../../../i18n'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../studioClient'
 import {checkoutPair, DocumentVersionEvent, Pair} from './document-pair/checkoutPair'
 import {consistencyStatus} from './document-pair/consistencyStatus'
@@ -20,7 +21,6 @@ import {listenQuery, ListenQueryOptions} from './listenQuery'
 import {resolveTypeForDocument} from './resolveTypeForDocument'
 import type {IdPair} from './types'
 import {getInitialValueStream, InitialValueMsg, InitialValueOptions} from './initialValue'
-import {LocaleSource} from '../../../i18n'
 
 /**
  * @hidden

--- a/packages/sanity/src/core/studio/workspaceLoader/WorkspaceLoader.tsx
+++ b/packages/sanity/src/core/studio/workspaceLoader/WorkspaceLoader.tsx
@@ -57,6 +57,10 @@ function WorkspaceLoader({
             ...rootSource,
             unstable_sources: [rootSource, ...restOfSources],
             type: 'workspace',
+            __internal: {
+              ...rootSource.__internal,
+              i18next: activeWorkspace.__internal.i18next,
+            },
           }),
         ),
       )

--- a/packages/sanity/src/desk/DeskToolProvider.tsx
+++ b/packages/sanity/src/desk/DeskToolProvider.tsx
@@ -2,7 +2,7 @@ import React, {useMemo, useState} from 'react'
 import {DeskToolContext} from './DeskToolContext'
 import {createStructureBuilder, DefaultDocumentNodeResolver} from './structureBuilder'
 import {DeskToolContextValue, StructureResolver, UnresolvedPaneNode} from './types'
-import {useConfigContextFromSource, useDocumentStore, useSource} from 'sanity'
+import {useActiveWorkspace, useConfigContextFromSource, useDocumentStore, useSource} from 'sanity'
 
 /** @internal */
 export interface DeskToolProviderProps {
@@ -19,15 +19,17 @@ export function DeskToolProvider({
 }: DeskToolProviderProps): React.ReactElement {
   const [layoutCollapsed, setLayoutCollapsed] = useState(false)
   const source = useSource()
-  const configContext = useConfigContextFromSource(source)
+  const {activeWorkspace: workspace} = useActiveWorkspace()
+  const configContext = useConfigContextFromSource(source, workspace)
   const documentStore = useDocumentStore()
 
   const S = useMemo(() => {
     return createStructureBuilder({
       defaultDocumentNode,
       source,
+      workspace,
     })
-  }, [defaultDocumentNode, source])
+  }, [defaultDocumentNode, source, workspace])
 
   const rootPaneNode = useMemo(() => {
     // TODO: unify types and remove cast

--- a/packages/sanity/src/desk/structureBuilder/createStructureBuilder.ts
+++ b/packages/sanity/src/desk/structureBuilder/createStructureBuilder.ts
@@ -27,11 +27,17 @@ import type {
   StructureContext,
   DefaultDocumentNodeResolver,
 } from './types'
-import {Source, getConfigContextFromSource, getPublishedId} from 'sanity'
+import {
+  type Source,
+  type WorkspaceSummary,
+  getConfigContextFromSource,
+  getPublishedId,
+} from 'sanity'
 
 /** @internal */
 export interface StructureBuilderOptions {
   source: Source
+  workspace: Pick<WorkspaceSummary, 'i18n'>
   defaultDocumentNode?: DefaultDocumentNodeResolver
 }
 
@@ -56,8 +62,9 @@ function getDefaultStructure(context: StructureContext): ListBuilder {
 export function createStructureBuilder({
   defaultDocumentNode,
   source,
+  workspace,
 }: StructureBuilderOptions): StructureBuilder {
-  const configContext = getConfigContextFromSource(source)
+  const configContext = getConfigContextFromSource(source, workspace)
   const context: StructureContext = {
     ...source,
     getStructureBuilder: () => structureBuilder,

--- a/packages/sanity/src/desk/structureResolvers/__tests__/resolveIntent.test.ts
+++ b/packages/sanity/src/desk/structureResolvers/__tests__/resolveIntent.test.ts
@@ -2,7 +2,10 @@ import {PaneNode, UnresolvedPaneNode} from '../../types'
 import {createStructureBuilder, SerializeError} from '../../structureBuilder'
 import {resolveIntent} from '../resolveIntent'
 import {PaneResolutionError} from '../PaneResolutionError'
-import {getMockSource} from '../../../../test/testUtils/getMockWorkspaceFromConfig'
+import {
+  getMockSource,
+  getMockWorkspace,
+} from '../../../../test/testUtils/getMockWorkspaceFromConfig'
 import {SchemaPluginOptions} from 'sanity'
 
 const mockSchema: SchemaPluginOptions = {
@@ -38,7 +41,8 @@ const mockSchema: SchemaPluginOptions = {
 describe('resolveIntent', () => {
   it('takes in an intent request and returns `RouterPanes` that match the request', async () => {
     const source = await getMockSource({config: {schema: mockSchema}})
-    const S = createStructureBuilder({source})
+    const workspace = await getMockWorkspace({config: {schema: mockSchema}})
+    const S = createStructureBuilder({source, workspace})
 
     const rootPaneNode = S.list()
       .title('Content')
@@ -65,7 +69,8 @@ describe('resolveIntent', () => {
 
   it('resolves singletons', async () => {
     const source = await getMockSource({config: {schema: mockSchema}})
-    const S = createStructureBuilder({source})
+    const workspace = await getMockWorkspace({config: {schema: mockSchema}})
+    const S = createStructureBuilder({source, workspace})
 
     const rootPaneNode = S.list()
       .title('Content')
@@ -92,7 +97,8 @@ describe('resolveIntent', () => {
 
   it('resolves nested singletons', async () => {
     const source = await getMockSource({config: {schema: mockSchema}})
-    const S = createStructureBuilder({source})
+    const workspace = await getMockWorkspace({config: {schema: mockSchema}})
+    const S = createStructureBuilder({source, workspace})
 
     const rootPaneNode = S.list()
       .title('Content')
@@ -139,7 +145,8 @@ describe('resolveIntent', () => {
 
   it('returns the shallowest match', async () => {
     const source = await getMockSource({config: {schema: mockSchema}})
-    const S = createStructureBuilder({source})
+    const workspace = await getMockWorkspace({config: {schema: mockSchema}})
+    const S = createStructureBuilder({source, workspace})
 
     const rootPaneNode = S.list()
       .title('Content')
@@ -194,7 +201,8 @@ describe('resolveIntent', () => {
 
   it('resolves to the fallback editor if no match is found', async () => {
     const source = await getMockSource({config: {schema: mockSchema}})
-    const S = createStructureBuilder({source})
+    const workspace = await getMockWorkspace({config: {schema: mockSchema}})
+    const S = createStructureBuilder({source, workspace})
 
     const rootPaneNode = S.list()
       .title('Content')
@@ -218,7 +226,8 @@ describe('resolveIntent', () => {
 
   it('matches document nodes that have the same ID as the target ID', async () => {
     const source = await getMockSource({config: {schema: mockSchema}})
-    const S = createStructureBuilder({source})
+    const workspace = await getMockWorkspace({config: {schema: mockSchema}})
+    const S = createStructureBuilder({source, workspace})
 
     const rootPaneNode = S.list()
       .title('Content')
@@ -248,7 +257,8 @@ describe('resolveIntent', () => {
 
   it('resolves pane nodes that implement `canHandleIntent`', async () => {
     const source = await getMockSource({config: {schema: mockSchema}})
-    const S = createStructureBuilder({source})
+    const workspace = await getMockWorkspace({config: {schema: mockSchema}})
+    const S = createStructureBuilder({source, workspace})
 
     const list = S.list()
       .canHandleIntent(() => true)
@@ -290,7 +300,8 @@ describe('resolveIntent', () => {
 
   it('bubbles (re-throws) structure errors wrapped in a PaneResolutionError', async () => {
     const source = await getMockSource({config: {schema: mockSchema}})
-    const S = createStructureBuilder({source})
+    const workspace = await getMockWorkspace({config: {schema: mockSchema}})
+    const S = createStructureBuilder({source, workspace})
 
     const rootPaneNode = S.list().title('Content').items([
       // will give a missing ID error

--- a/packages/sanity/test/testUtils/TestProvider.tsx
+++ b/packages/sanity/test/testUtils/TestProvider.tsx
@@ -23,8 +23,6 @@ export async function createTestProvider({client, config}: TestProviderOptions =
 
   const locales = [usEnglishLocale]
   const {i18next} = prepareI18n({
-    projectId: 'test',
-    dataset: 'test',
     name: 'test',
     i18n: {bundles: [studioDefaultLocaleResources]},
   })
@@ -34,17 +32,17 @@ export async function createTestProvider({client, config}: TestProviderOptions =
   function TestProvider({children}: {children: React.ReactNode}) {
     return (
       <ThemeProvider theme={studioTheme}>
-        <LocaleProviderBase locales={locales} i18next={i18next} projectId="test" sourceId="test">
-          <ToastProvider>
-            <LayerProvider>
-              <WorkspaceProvider workspace={workspace}>
+        <WorkspaceProvider workspace={workspace}>
+          <LocaleProviderBase locales={locales} i18next={i18next} workspaceName="test">
+            <ToastProvider>
+              <LayerProvider>
                 <SourceProvider source={workspace.unstable_sources[0]}>
                   <ResourceCacheProvider>{children}</ResourceCacheProvider>
                 </SourceProvider>
-              </WorkspaceProvider>
-            </LayerProvider>
-          </ToastProvider>
-        </LocaleProviderBase>
+              </LayerProvider>
+            </ToastProvider>
+          </LocaleProviderBase>
+        </WorkspaceProvider>
       </ThemeProvider>
     )
   }

--- a/packages/sanity/test/testUtils/getMockWorkspaceFromConfig.ts
+++ b/packages/sanity/test/testUtils/getMockWorkspaceFromConfig.ts
@@ -6,8 +6,10 @@ import {
   SingleWorkspace,
   Source,
   Workspace,
+  WorkspaceSummary,
 } from '../../src/core/config'
 import {createMockSanityClient} from '../mocks/mockSanityClient'
+import {studioTheme} from '@sanity/ui'
 
 const defaultMockUser: CurrentUser = {
   id: 'doug',


### PR DESCRIPTION
### Description

Previously, the i18n source was attached to each _source_. That doesn't actually make much sense, as the sources were meant to function as a source of _data_. Instead, I think it makes more sense for the _workspace_ to have the localization attached to it, since that is what you are switching between. Theoretically, one could even argue it belongs a level above that - but since the configuration is done on a per-workspace level, I figured this was better.

### What to review

Localization should still work as expected.
