### PR TITLE
fix(comments): handle text overflow in editable surfaces, optically align field titles

### DIFF
--- a/packages/sanity/src/desk/comments/src/components/list/CommentThreadLayout.tsx
+++ b/packages/sanity/src/desk/comments/src/components/list/CommentThreadLayout.tsx
@@ -76,7 +76,7 @@ export function CommentThreadLayout(props: CommentThreadLayoutProps) {
 
   return (
     <Stack space={2}>
-      <HeaderFlex align="center" gap={2} paddingX={1} sizing="border">
+      <HeaderFlex align="center" gap={2} paddingLeft={2} paddingRight={1} sizing="border">
         <Stack flex={1}>
           <Breadcrumbs
             maxLength={3}

--- a/packages/sanity/src/desk/comments/src/components/pte/comment-input/CommentInputInner.tsx
+++ b/packages/sanity/src/desk/comments/src/components/pte/comment-input/CommentInputInner.tsx
@@ -10,7 +10,7 @@ import {Editable} from './Editable'
 import {useUser} from 'sanity'
 
 const EditableWrap = styled(Box)`
-  max-height: 30vh;
+  max-height: 20vh;
   overflow-y: auto;
 `
 

--- a/packages/sanity/src/desk/comments/src/components/pte/comment-input/CommentInputInner.tsx
+++ b/packages/sanity/src/desk/comments/src/components/pte/comment-input/CommentInputInner.tsx
@@ -9,9 +9,10 @@ import {useCommentInput} from './useCommentInput'
 import {Editable} from './Editable'
 import {useUser} from 'sanity'
 
-const EditableWrap = styled(Box)({
-  // ...
-})
+const EditableWrap = styled(Box)`
+  max-height: 30vh;
+  overflow-y: auto;
+`
 
 const ButtonDivider = styled(MenuDivider)({
   height: 20,
@@ -118,19 +119,16 @@ export function CommentInputInner(props: CommentInputInnerProps) {
         data-expand-on-focus={expandOnFocus && !canSubmit ? 'true' : 'false'}
         data-focused={focused ? 'true' : 'false'}
         flex={1}
-        paddingX={1}
-        paddingY={2}
-        paddingBottom={1}
         sizing="border"
         tone="default"
         shadow={1}
       >
-        <Stack space={2}>
-          <EditableWrap sizing="border">
+        <Stack>
+          <EditableWrap paddingX={1} paddingY={2} sizing="border">
             <Editable placeholder={placeholder} focusLock={focusLock} />
           </EditableWrap>
 
-          <Flex align="center" gap={1} justify="flex-end" data-ui="CommentInputActions">
+          <Flex align="center" data-ui="CommentInputActions" gap={1} justify="flex-end" padding={1}>
             <ActionButton
               aria-label="Mention user"
               icon={MentionIcon}


### PR DESCRIPTION
### Description

This PR adds a max-height (20% of current viewport height) to comment inputs to better handle long text / overflow scenarios. 

It also optically aligns thread titles with the document inspector title.

### What to review

Try create comments with massive amounts of text – comment footer actions should still be accessible in these scenarios and/or when on smaller viewports (at both the field and inspector level). 