### PR TITLE
chore(e2e): Run e2e tests in shards

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,10 +15,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project: [chromium, webkit, firefox]
+        project: [chromium, firefox]
         # Add more shards here if needed
-        shardIndex: [1, 2, 3, 4]
-        shardTotal: [4]
+        shardIndex: [1, 2]
+        shardTotal: [2]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,8 +15,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        project: [chromium, webkit, firefox]
         # Add more shards here if needed
-        shard: [1/4, 2/4, 3/4, 4/4]
+        shardIndex: [1, 2, 3, 4]
+        shardTotal: [4]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -63,7 +65,7 @@ jobs:
       - name: Run end-to-end tests
         env:
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN }}
-        run: yarn test:e2e --shard ${{ matrix.shard }}
+        run: yarn test:e2e --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -69,9 +69,7 @@ jobs:
         if: always()
         with:
           name: playwright-report
-          path: |
-            test/e2e/report
-            test/e2e/results
+          path: blob-report
           retention-days: 30
   merge-reports:
     if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,12 +6,17 @@ on:
   push:
     branches: [next]
 jobs:
-  test:
+  playwright-test:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Add more shards here if needed
+        shard: [1/4, 2/4, 3/4, 4/4]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -58,7 +63,7 @@ jobs:
       - name: Run end-to-end tests
         env:
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN }}
-        run: yarn test:e2e
+        run: yarn test:e2e --shard ${{ matrix.shard }}
 
       - uses: actions/upload-artifact@v3
         if: always()
@@ -67,4 +72,46 @@ jobs:
           path: |
             test/e2e/report
             test/e2e/results
+          retention-days: 30
+  merge-reports:
+    if: always()
+    needs: [playwright-test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-modules-${{ env.cache-name }}-
+            ${{ runner.os }}-modules-
+            ${{ runner.os }}-
+
+      - name: Install project dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
+
+      - name: Download blob reports from Github Actions Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: playwright-report
+          path: playwright-report
+
+      - name: Merge into HTML Report
+        run: npx playwright merge-reports --reporter html ./playwright-report
+
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v3
+        with:
+          name: html-report--attempt-${{ github.run_attempt }}
+          path: playwright-report
           retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ etc
 /test/e2e/report
 /test/e2e/results
 /test/e2e/state
+blob-report
 
 # Temporary files made by yarn when running canary releases
 .yarn

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -43,7 +43,7 @@ export default defineConfig({
 
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: CI
-    ? [['github'], ['html', {outputFolder: HTML_REPORT_PATH}]]
+    ? [['github'], ['blob', {outputFolder: HTML_REPORT_PATH}]]
     : [['list'], ['html', {outputFolder: HTML_REPORT_PATH}]],
 
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -33,6 +33,8 @@ export default defineConfig({
 
   retries: 1,
 
+  fullyParallel: true,
+
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -42,9 +42,7 @@ export default defineConfig({
   },
 
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: CI
-    ? [['github'], ['blob', {outputFolder: HTML_REPORT_PATH}]]
-    : [['list'], ['html', {outputFolder: HTML_REPORT_PATH}]],
+  reporter: CI ? [['github'], ['blob']] : [['list'], ['html', {outputFolder: HTML_REPORT_PATH}]],
 
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {


### PR DESCRIPTION

### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR enables e2e tests to run in shards as well as takes the report from each shard and merges into one final html report. See it [here](https://github.com/sanity-io/sanity/actions/runs/6563629567?pr=5006)

### Shard based on browsers so it will run

- chromium (1, 2)
- chromium (2,2)
- firefox (1, 2)
- firefox(2, 2)

This should reduce the CPU constraint per shard 


Fixes SDX-787

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

- N/A
