### PR TITLE
feat(i18n): add environment variable flag for debugging i18n

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "deploy:movies": "yarn build && cd examples/movies-studio && sanity deploy",
     "deploy:test": "yarn build && cd dev/test-studio && sanity deploy",
     "dev": "yarn start",
+    "dev:i18n": "SANITY_STUDIO_DEBUG_I18N=true yarn start",
     "dev:design-studio": "yarn --cwd dev/design-studio dev",
     "dev:starter-studio": "yarn --cwd dev/starter-studio dev",
     "dev:strict-studio": "yarn --cwd dev/strict-studio dev",

--- a/packages/sanity/src/core/i18n/debug.ts
+++ b/packages/sanity/src/core/i18n/debug.ts
@@ -1,0 +1,21 @@
+/* eslint-disable no-process-env */
+import type {TFunction} from 'i18next'
+
+/**
+ * Whether or not the debug mode for i18n should be enabled
+ *
+ * @internal
+ */
+export const DEBUG_I18N = Boolean(process.env.SANITY_STUDIO_DEBUG_I18N)
+
+/**
+ * If in debug mode, wrap the given `t` function in a function that adds a prefix and suffix to the
+ * translated string. If not, return the original `t` function as-is.
+ *
+ * @param t - The `t` function to wrap
+ * @returns The wrapped `t` function, or the original `t` function if not in debug mode
+ * @internal
+ */
+export function maybeWrapT(t: TFunction): TFunction {
+  return DEBUG_I18N ? (((...args: any) => `◤ ${t(...args)} ◢`) as any as TFunction) : t
+}

--- a/packages/sanity/src/core/i18n/hooks/useTranslation.ts
+++ b/packages/sanity/src/core/i18n/hooks/useTranslation.ts
@@ -1,6 +1,7 @@
 import type {FlatNamespace, KeyPrefix, Namespace, TFunction} from 'i18next'
 import type {$Tuple} from 'react-i18next/helpers'
 import {type FallbackNs, useTranslation as useOriginalTranslation} from 'react-i18next'
+import {maybeWrapT} from '../debug'
 
 /**
  * @alpha
@@ -44,5 +45,5 @@ export function useTranslation<
       : translationOptionOverrides,
   )
 
-  return {t}
+  return {t: maybeWrapT(t)}
 }

--- a/packages/sanity/src/core/i18n/i18nConfig.ts
+++ b/packages/sanity/src/core/i18n/i18nConfig.ts
@@ -8,6 +8,7 @@ import {createSanityI18nBackend} from './backend'
 import {LocaleSource, LocaleDefinition, LocaleResourceBundle} from './types'
 import {studioLocaleNamespace} from './localeNamespaces'
 import {getPreferredLocale} from './localeStore'
+import {DEBUG_I18N, maybeWrapT} from './debug'
 
 /**
  * @internal
@@ -73,7 +74,7 @@ function createI18nApi({
         return missing.length === 0 ? Promise.resolve() : i18nInstance.loadNamespaces(namespaces)
       },
       locales: reducedLocales,
-      t: i18nInstance.t,
+      t: maybeWrapT(i18nInstance.t),
     },
 
     /** @internal */
@@ -136,7 +137,7 @@ const defaultOptions: InitOptions = {
 
   // In rare cases we'll want to be able to debug i18next - there is a `debug` option
   // in the studio i18n configuration for that, which will override this value.
-  debug: false,
+  debug: DEBUG_I18N,
 
   // When specifying language 'en-US', do not load 'en-US', 'en', 'dev' - only `en-US`.
   load: 'currentOnly',


### PR DESCRIPTION
### Description

Adds a flag based on the `SANITY_STUDIO_DEBUG_I18N` environment variable, which enables the debug mode in `i18next`, as well as adding "markers" (◤ this is translated ◢) around anything translated by the `t` function. I think this is what you meant, @jtpetty ?

We can (probably) remove this before this goes live, but helpful for spotting parts that are not yet localized.

Example:

![image](https://github.com/sanity-io/sanity/assets/48200/ed37de00-eb16-4316-aaef-311f093b98de)

The user menu options are translated, but the locale names are not (they shouldn't be, I guess).
You can also see the tooltip on the configuration issues button is not localized (this one we said we would wait with, but proves the concept of spotting unlocalized areas)