### PR TITLE
fix: ensure created comments create URLs with inspect and comment params

### DIFF
--- a/packages/sanity/src/desk/comments/src/types.ts
+++ b/packages/sanity/src/desk/comments/src/types.ts
@@ -69,7 +69,11 @@ export interface CommentPath {
   field: string
 }
 
-interface CommentContext {
+/**
+ * @beta
+ * @hidden
+ */
+export interface CommentContext {
   tool: string
   payload?: Record<string, unknown>
   notification?: {

--- a/packages/sanity/src/desk/components/paneRouter/types.ts
+++ b/packages/sanity/src/desk/components/paneRouter/types.ts
@@ -157,7 +157,7 @@ export interface PaneRouterContextValue {
    * A function that creates a path with the given parameters without navigating to it.
    * Useful for creating links that can be e.g. copied to clipboard and shared.
    */
-  createPathWithParams: (params: Record<string, string | undefined>) => void
+  createPathWithParams: (params: Record<string, string | undefined>) => string
 
   /**
    * Proxied navigation to a given intent. Consider just exposing `router` instead?


### PR DESCRIPTION
### Description

This PR ensures created comments store URLs based on current `window.location.origin` plus the current path based off current pane params.

This is similar to how the current 'copy link to comment' works - the only difference is that we force `inspect` and `comment` params when comments are created directly on fields.

There is a minor point to note which is when links are created on _active panes that are not the most-RHS desk pane_. It's outlined in comments but worth mentioning. E.g. if you have 5 panes open and the second one is active and you create a comment on it, it'll create a link containing the _full_ pane layout. 

We can probably improve on this in future and look to filter out non-active panes (beyond the current active one). The same logic could potentially be applied to 'copy link to comment' too – but the current implementation may be good enough for now.

### What to review

Create a comment (mention / reply) and wait for the notification email. Clicking the "View in Studio" link should take you directly to the comment with the inspector open.
