### PR TITLE
test(cli): symlinkDependencies before running `npm install`

### DIFF
--- a/packages/@sanity/cli/test/shared/globalSetup.ts
+++ b/packages/@sanity/cli/test/shared/globalSetup.ts
@@ -79,6 +79,7 @@ function prepareStudios() {
       const destinationPath = path.join(studiosPath, version)
       const customDocStudioPath = path.join(studiosPath, `${version}-custom-document`)
 
+      await mkdir(destinationPath, {recursive: true})
       await copy(`${sourceStudioPath}/**/{*,.*}`, destinationPath, {dereference: true})
 
       if (version === 'v2') {

--- a/scripts/symlinkDependencies.js
+++ b/scripts/symlinkDependencies.js
@@ -40,6 +40,9 @@ if (!argv.all) {
   targetDeps = Object.keys(targetDeclared)
 }
 
+// make sure node_modules/@sanity directory exists (e.g. in case it's ran in a project without a prior node_modules)
+fs.mkdirSync(path.join(targetDepsPath, '@sanity'), {recursive: true})
+
 const targetRootPackages = fs.readdirSync(targetDepsPath).filter(notSanity)
 const targetSanityPackages = fs.readdirSync(path.join(targetDepsPath, '@sanity')).map(prefix)
 
@@ -59,7 +62,10 @@ const sharedDeclared = argv.all
   ? packages
   : packages.filter((pkgName) => targetDeps.indexOf(pkgName) > -1)
 
-const removeFolders = sharedPackages.map(normalize).map((dir) => path.join(targetDepsPath, dir))
+const removeFolders = sharedPackages
+  .map(normalize)
+  .map((dir) => path.join(targetDepsPath, dir))
+  .filter((dir) => fs.existsSync(dir))
 
 // First, remove all locally installed dependencies that exists as a package in our monorepo
 console.log('Removing dependencies from node_modules:')


### PR DESCRIPTION
### Description

#4917 adds styled-components@6.1 as default to newly created Sanity Studios. The CLI tests are currently installing dependencies first, before symlinking in the local dependencies, but this now fails because the current `@sanity/cli` from npm doesn't have `styled-components@6` in it's accepted peer-dependency range. This addresses the issue (and future similar issues) by symlinking the local dependencies before running npm install.

Note: We might want to consider looking into replacing this with installing from local tarballs of the local packages instead (potentially via something like [yalc](https://github.com/wclr/yalc)), to make sure dependencies are installed in a way that is more like a "real-life" npm install, but this seems to work fine for now.

### Notes for release
N/A – internal