### PR TITLE
chore(deps): update dependency @babel/traverse to ^7.23.2

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -61,7 +61,7 @@
     "watch": "pkg-utils watch --tsconfig tsconfig.lib.json"
   },
   "dependencies": {
-    "@babel/traverse": "^7.19.0",
+    "@babel/traverse": "^7.23.2",
     "chalk": "^4.1.2",
     "esbuild": "^0.19.0",
     "esbuild-register": "^3.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1153,7 +1153,7 @@
     "@babel/parser" "^7.22.15"
     "@babel/types" "^7.22.15"
 
-"@babel/traverse@^7.12.5", "@babel/traverse@^7.19.0", "@babel/traverse@^7.23.2", "@babel/traverse@^7.7.2":
+"@babel/traverse@^7.12.5", "@babel/traverse@^7.23.2", "@babel/traverse@^7.7.2":
   version "7.23.2"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.2.tgz#329c7a06735e144a506bdb2cad0268b7f46f4ad8"
   integrity sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->
Updates the @babel/traverse dependency in @sanity/cli to at least 7.23.2, due to [CVE-2023-45133](https://github.com/advisories/GHSA-67hx-6x53-jw92).

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->
Ensure the [createCliConfig](https://github.com/sanity-io/sanity/blob/2f3e76354537b54c9481b14c59996c8a21dec928/packages/%40sanity/cli/src/actions/init-project/createCliConfig.ts) and [createStudioConfig](https://github.com/sanity-io/sanity/blob/2f3e76354537b54c9481b14c59996c8a21dec928/packages/%40sanity/cli/src/actions/init-project/createStudioConfig.ts) functions work as expected.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
