### PR TITLE
chore(e2e): fix report merging

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,6 +65,8 @@ jobs:
       - name: Run end-to-end tests
         env:
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN }}
+          # Missing in docs but in use
+          # here https://github.com/microsoft/playwright/blob/main/packages/playwright/src/reporters/blob.ts#L108
           PWTEST_BLOB_REPORT_NAME: ${{ matrix.project }}
         run: yarn test:e2e --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,6 +65,7 @@ jobs:
       - name: Run end-to-end tests
         env:
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN }}
+          PWTEST_BLOB_REPORT_NAME: ${{ matrix.project }}
         run: yarn test:e2e --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR fixes the playwright report to include all versions of the shards based on browsers.

#### The raw report
![Screenshot 2023-10-23 at 2 18 07 PM](https://github.com/sanity-io/sanity/assets/6476108/be47d16b-d224-4809-978d-f86fb372568a)

#### HTML Report
![Screenshot 2023-10-23 at 2 18 17 PM](https://github.com/sanity-io/sanity/assets/6476108/5a368cb7-87ec-46e4-ae59-3dc0ddbccead)

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

- N/A
