### PR TITLE
fix(core/inputs): fix issue with toolbar popover visibility toggling

### DIFF
--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/Annotations.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/Annotations.spec.tsx
@@ -21,6 +21,9 @@ test.describe('Portable Text Input', () => {
       // Assertion: Wait for link to be re-rendered / PTE internal state to be done
       await expect($pte.locator('span[data-link]')).toBeVisible()
 
+      // Assertion: the annotation toolbar popover should not be visible
+      await expect(page.getByTestId('annotation-toolbar-popover')).not.toBeVisible()
+
       // Now we check if the edit popover shows automatically
       await expect(page.getByLabel('Link').first()).toBeAttached({timeout: 10000})
 
@@ -38,6 +41,9 @@ test.describe('Portable Text Input', () => {
 
       // Expect the editor to have focus after closing the popover
       await expect($pte).toBeFocused()
+
+      // Assertion: the annotation toolbar popover should be visible
+      await expect(page.getByTestId('annotation-toolbar-popover')).toBeVisible()
     })
   })
 })

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
@@ -254,6 +254,7 @@ export const DefaultAnnotationComponent = (props: BlockAnnotationProps) => {
     onRemove,
     open,
     readOnly,
+    selected,
     schemaType,
     textElement,
     validation,
@@ -289,11 +290,13 @@ export const DefaultAnnotationComponent = (props: BlockAnnotationProps) => {
     >
       {textElement}
       <AnnotationToolbarPopover
+        annotationOpen={open}
         floatingBoundary={floatingBoundary}
-        referenceBoundary={referenceBoundary}
-        referenceElement={referenceElement}
         onOpen={onOpen}
         onRemove={onRemove}
+        referenceBoundary={referenceBoundary}
+        referenceElement={referenceElement}
+        selected={selected}
         title={schemaType.title || schemaType.name}
       />
       {open && (

--- a/packages/sanity/src/core/form/inputs/PortableText/object/AnnotationToolbarPopover.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/AnnotationToolbarPopover.tsx
@@ -131,23 +131,23 @@ export function AnnotationToolbarPopover(props: AnnotationToolbarPopoverProps) {
     onRemove()
   }, [onRemove])
 
+  const handleScroll = useCallback(() => {
+    if (rangeRef.current) {
+      setCursorRect(rangeRef.current.getBoundingClientRect())
+    }
+  }, [])
+
   useEffect(() => {
     if (!popoverOpen) {
       return undefined
     }
 
-    const handleScroll = () => {
-      if (rangeRef.current) {
-        setCursorRect(rangeRef.current.getBoundingClientRect())
-      }
-    }
-
-    floatingBoundary?.addEventListener('scroll', handleScroll, {passive: true})
+    referenceBoundary?.addEventListener('scroll', handleScroll)
 
     return () => {
-      floatingBoundary?.removeEventListener('scroll', handleScroll)
+      referenceBoundary?.removeEventListener('scroll', handleScroll)
     }
-  }, [popoverOpen, floatingBoundary])
+  }, [popoverOpen, referenceBoundary, handleScroll])
 
   if (!popoverOpen) {
     return null


### PR DESCRIPTION
### Description

This will fix an issue with the annotation toolbar popover's visibility in the PT-input.

* It should never show when the annotation object is open (this was not the case when an annotation was created)
* It should show again when closing the annotation object editing popover

Added tests for this.

Also fixed an issue where the toolbar would not scroll with the content when visible.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

The annotation toolbar is showing and hiding correctly when creating and editing annotations in the PT-input.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Fixed minor issues with annotation toolbar popover not displaying correctly in some situations.


<!--
A description of the change(s) that should be used in the release notes.
-->
