### PR TITLE
fix(mutator): match deep set/setIfMissing behavior

### DIFF
--- a/packages/@sanity/mutator/src/patch/SetIfMissingPatch.ts
+++ b/packages/@sanity/mutator/src/patch/SetIfMissingPatch.ts
@@ -16,9 +16,14 @@ export class SetIfMissingPatch {
     let result = accessor
     targets.forEach((target) => {
       if (target.isIndexReference()) {
-        // setIfMissing do not apply to arrays, since Gradient will reject nulls in arrays
+        // setIfMissing do not apply to arrays, since Content Lake will reject nulls in arrays
       } else if (target.isAttributeReference()) {
-        if (!result.hasAttribute(target.name())) {
+        // setting a subproperty on a primitive value overwrites it, eg
+        // `{setIfMissing: {'address.street': 'California St'}}` on `{address: 'Fiction St'}` will
+        // result in `{address: {street: 'California St'}}`
+        if (result.containerType() === 'primitive') {
+          result = result.set({[target.name()]: this.value})
+        } else if (!result.hasAttribute(target.name())) {
           result = accessor.setAttribute(target.name(), this.value)
         }
       } else {

--- a/packages/@sanity/mutator/src/patch/SetPatch.ts
+++ b/packages/@sanity/mutator/src/patch/SetPatch.ts
@@ -22,7 +22,14 @@ export class SetPatch {
           result = result.setIndex(i, this.value)
         })
       } else if (target.isAttributeReference()) {
-        result = result.setAttribute(target.name(), this.value)
+        // setting a subproperty on a primitive value overwrites it, eg
+        // `{set: {'address.street': 'California St'}}` on `{address: 'Fiction St'}` will result in
+        // `{address: {street: 'California St'}}`
+        if (result.containerType() === 'primitive') {
+          result = result.set({[target.name()]: this.value})
+        } else {
+          result = result.setAttribute(target.name(), this.value)
+        }
       } else {
         throw new Error(`Unable to apply to target ${target.toString()}`)
       }

--- a/packages/@sanity/mutator/test/patchExamples/set.ts
+++ b/packages/@sanity/mutator/test/patchExamples/set.ts
@@ -126,6 +126,78 @@ const examples: PatchExample[] = [
     },
   },
   {
+    name: 'Set new deep key',
+    before: {},
+    patch: {
+      id: 'a',
+      set: {
+        'a.b.c': 'hello',
+      },
+    },
+    after: {
+      a: {
+        b: {
+          c: 'hello',
+        },
+      },
+    },
+  },
+  {
+    name: 'Set deep key on previous string value',
+    before: {
+      a: 'stringValue',
+    },
+    patch: {
+      id: 'a',
+      set: {
+        'a.b.c': 'hello',
+      },
+    },
+    after: {
+      a: {
+        b: {
+          c: 'hello',
+        },
+      },
+    },
+  },
+  {
+    name: 'Set deep key on previous number value',
+    before: {
+      a: 123,
+    },
+    patch: {
+      id: 'a',
+      set: {
+        'a.b.c': 'hello',
+      },
+    },
+    after: {
+      a: {
+        b: {
+          c: 'hello',
+        },
+      },
+    },
+  },
+  {
+    name: 'Set key on previous number value',
+    before: {
+      a: 123,
+    },
+    patch: {
+      id: 'a',
+      set: {
+        'a.b': 'hello',
+      },
+    },
+    after: {
+      a: {
+        b: 'hello',
+      },
+    },
+  },
+  {
     name: 'Set range',
     before: {
       a: [0, 1, 2, 3, 4, 5, 6, 7],

--- a/packages/@sanity/mutator/test/patchExamples/setIfMissing.ts
+++ b/packages/@sanity/mutator/test/patchExamples/setIfMissing.ts
@@ -60,7 +60,80 @@ const examples: PatchExample[] = [
         {b: 7, p: 'Thorvald Meyers gt.', zz: {yyy: 55, zzz: 10}},
       ],
     },
-  }, // Potentially redundant, added to exactly match a test case from @sanity/form-builder that was failing.
+  },
+  {
+    name: 'Set new deep key',
+    before: {},
+    patch: {
+      id: 'a',
+      setIfMissing: {
+        'a.b.c': 'hello',
+      },
+    },
+    after: {
+      a: {
+        b: {
+          c: 'hello',
+        },
+      },
+    },
+  },
+  {
+    name: 'Set deep key on previous string value',
+    before: {
+      a: 'stringValue',
+    },
+    patch: {
+      id: 'a',
+      setIfMissing: {
+        'a.b.c': 'hello',
+      },
+    },
+    after: {
+      a: {
+        b: {
+          c: 'hello',
+        },
+      },
+    },
+  },
+  {
+    name: 'Set deep key on previous number value',
+    before: {
+      a: 123,
+    },
+    patch: {
+      id: 'a',
+      setIfMissing: {
+        'a.b.c': 'hello',
+      },
+    },
+    after: {
+      a: {
+        b: {
+          c: 'hello',
+        },
+      },
+    },
+  },
+  {
+    name: 'Set key on previous number value',
+    before: {
+      a: 123,
+    },
+    patch: {
+      id: 'a',
+      setIfMissing: {
+        'a.b': 'hello',
+      },
+    },
+    after: {
+      a: {
+        b: 'hello',
+      },
+    },
+  },
+  // Potentially redundant, added to exactly match a test case from @sanity/form-builder that was failing.
   {
     name: 'Set if missing by key',
     before: {


### PR DESCRIPTION
### Description

There seems to be a few mismatches between `@sanity/mutator` and Content Lake:
 
- In Content Lake, a `set`/`setIfMissing`-patch targeting a deep key with missing parents will recursively create an object structure for it
- In `@sanity/mutator`, it will stop once it encounters a key that is not present in the document.

This PR attempts to align the behavior with what Content Lake does. Please review carefully - my knowledge of the mutator is limited and there may be (edge) cases I have not considered.

Fixes SDX-772.

Edit: I see that arrays also gets overwritten in a similar vein as primitives, but I am not quite sure yet how to resolve it.

### What to review

- Mutations work as expected

### Notes for release

- Fixed an issue where certain remote patches would not cleanly apply in the studio, requiring a reload of the document in order to see the change
