### PR TITLE
fix(core/form/inputs): fix issue with tabbing to popover toolbar buttons in PT-input

### DIFF
--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/Annotations.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/Annotations.spec.tsx
@@ -48,8 +48,25 @@ test.describe('Portable Text Input', () => {
       // Expect the editor to have focus after closing the popover
       await expect($pte).toBeFocused()
 
+      const $toolbarPopover = page.getByTestId('annotation-toolbar-popover')
+
       // Assertion: the annotation toolbar popover should be visible
       await expect(page.getByTestId('annotation-toolbar-popover')).toBeVisible()
+      await expect($toolbarPopover).toBeVisible()
+
+      // Assertion: tab works to get to the toolbar popover buttons
+      await page.keyboard.press('Tab')
+      await expect(page.getByTestId('edit-annotation-button')).toBeFocused()
+      await page.keyboard.press('Tab')
+      await expect(page.getByTestId('remove-annotation-button')).toBeFocused()
+      await page.keyboard.press('Escape')
+      await expect($pte).toBeFocused()
+      await expect($toolbarPopover).toBeVisible()
+      await page.waitForTimeout(100)
+      await page.keyboard.press('Escape')
+      await page.waitForTimeout(100)
+      // Assertion: escape closes the toolbar popover
+      await expect($toolbarPopover).not.toBeVisible()
     })
 
     test('Can create, and then open the existing annotation again for editing', async ({

--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/FocusTracking.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/FocusTracking.spec.tsx
@@ -117,6 +117,7 @@ test.describe('Portable Text Input', () => {
       const $portableTextInput = component.getByTestId('field-body')
       const $pteTextbox = $portableTextInput.getByRole('textbox')
       await expect($pteTextbox).not.toBeFocused()
+      await page.keyboard.press('Tab+Tab')
       const blockObjectInput = page.getByTestId('objectBlockInputField').getByRole('textbox')
       await expect(blockObjectInput).toBeFocused()
     })

--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/ObjectBlock.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/ObjectBlock.spec.tsx
@@ -30,6 +30,32 @@ test.describe('Portable Text Input', () => {
       await expect($pte.getByText('Custom preview block:')).toBeVisible()
     })
 
+    test('Inline object toolbars works as expected', async ({mount, page}) => {
+      const {getFocusedPortableTextEditor} = testHelpers({page})
+      await mount(<ObjectBlockStory />)
+      const $pte = await getFocusedPortableTextEditor('field-body')
+      await page.getByRole('button', {name: 'Insert Inline Object (inline)'}).click()
+      // Assertion: the annotation toolbar popover should not be visible
+      await expect(page.getByTestId('inline-object-toolbar-popover')).not.toBeVisible()
+      const $locatorDialog = page.getByTestId('popover-edit-dialog')
+      // Assertion: Object edit dialog should be visible
+      await expect($locatorDialog).toBeVisible()
+      await page.keyboard.press('Escape')
+      // Assertion: the annotation toolbar popover should be visible
+      await expect(page.getByTestId('inline-object-toolbar-popover')).toBeVisible()
+      // Assertion: tab works to get to the toolbar popover buttons
+      await page.keyboard.press('Tab')
+      await expect(page.getByTestId('edit-inline-object-button')).toBeFocused()
+      await page.keyboard.press('Tab')
+      await expect(page.getByTestId('remove-inline-object-button')).toBeFocused()
+      await page.keyboard.press('Escape')
+      await expect(page.getByTestId('edit-inline-object-button')).toBeVisible()
+      await expect($pte).toBeFocused()
+      await page.keyboard.press('Escape')
+      // Assertion: escape closes the toolbar popover
+      await expect(page.getByTestId('inline-object-toolbar-popover')).not.toBeVisible()
+    })
+
     test('Double-clicking opens a block', async ({mount, page}) => {
       const {getFocusedPortableTextEditor} = testHelpers({page})
       await mount(<ObjectBlockStory />)

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
@@ -1,7 +1,7 @@
 import {PortableTextEditor, usePortableTextEditor} from '@portabletext/editor'
 import {type ObjectSchemaType, type Path, type PortableTextObject} from '@sanity/types'
 import {isEqual} from '@sanity/util/paths'
-import {type ComponentType, type ReactNode, useCallback, useMemo, useState} from 'react'
+import {type ComponentType, useCallback, useMemo, useState} from 'react'
 
 import {Tooltip} from '../../../../../ui-components'
 import {pathToString} from '../../../../field'
@@ -54,7 +54,7 @@ interface AnnotationProps {
   value: PortableTextObject
 }
 
-export function Annotation(props: AnnotationProps): ReactNode {
+export function Annotation(props: AnnotationProps): React.JSX.Element {
   const {
     children,
     editorNodeFocused,
@@ -241,7 +241,7 @@ export function Annotation(props: AnnotationProps): ReactNode {
   )
 }
 
-export const DefaultAnnotationComponent = (props: BlockAnnotationProps) => {
+export const DefaultAnnotationComponent = (props: BlockAnnotationProps): React.JSX.Element => {
   const {
     __unstable_floatingBoundary: floatingBoundary,
     __unstable_referenceBoundary: referenceBoundary,
@@ -252,8 +252,8 @@ export const DefaultAnnotationComponent = (props: BlockAnnotationProps) => {
     onRemove,
     open,
     readOnly,
-    selected,
     schemaType,
+    selected,
     textElement,
     validation,
   } = props
@@ -264,6 +264,7 @@ export const DefaultAnnotationComponent = (props: BlockAnnotationProps) => {
   const isReady = Boolean(children)
 
   const {t} = useTranslation()
+
   const toneKey = useMemo(() => {
     if (hasError) {
       return 'critical'
@@ -294,11 +295,11 @@ export const DefaultAnnotationComponent = (props: BlockAnnotationProps) => {
         <AnnotationToolbarPopover
           annotationOpen={open}
           floatingBoundary={floatingBoundary}
-          onOpen={onOpen}
-          onRemove={onRemove}
+          onOpenAnnotation={onOpen}
+          onRemoveAnnotation={onRemove}
           referenceBoundary={referenceBoundary}
           referenceElement={referenceElement}
-          selected={selected}
+          annotationTextSelected={selected}
           title={
             schemaType.i18nTitleKey
               ? t(schemaType.i18nTitleKey)

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
@@ -435,7 +435,7 @@ export const DefaultBlockObjectComponent = (props: BlockProps) => {
           floatingBoundary={__unstable_floatingBoundary}
           defaultType="dialog"
           onClose={onClose}
-          autoFocus={focused}
+          autoFocus
           schemaType={schemaType}
           referenceBoundary={__unstable_referenceBoundary}
           referenceElement={__unstable_referenceElement}

--- a/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
@@ -6,7 +6,7 @@ import {
   type PortableTextChild,
 } from '@sanity/types'
 import {isEqual} from '@sanity/util/paths'
-import {useCallback, useEffect, useMemo, useState} from 'react'
+import {useCallback, useMemo, useState} from 'react'
 
 import {Tooltip} from '../../../../../ui-components'
 import {pathToString} from '../../../../field/paths'
@@ -56,7 +56,7 @@ interface InlineObjectProps {
   value: PortableTextChild
 }
 
-export const InlineObject = (props: InlineObjectProps) => {
+export const InlineObject = (props: InlineObjectProps): React.JSX.Element => {
   const {
     floatingBoundary,
     focused,
@@ -107,7 +107,7 @@ export const InlineObject = (props: InlineObjectProps) => {
       PortableTextEditor.blur(editor)
       onItemOpen(memberItem.node.path)
     }
-  }, [editor, onItemOpen, memberItem])
+  }, [onItemOpen, editor, memberItem])
 
   const onClose = useCallback(() => {
     onItemClose()
@@ -236,7 +236,7 @@ export const InlineObject = (props: InlineObjectProps) => {
   )
 }
 
-export const DefaultInlineObjectComponent = (props: BlockProps) => {
+export const DefaultInlineObjectComponent = (props: BlockProps): React.JSX.Element => {
   const {
     __unstable_floatingBoundary: floatingBoundary,
     __unstable_referenceBoundary: referenceBoundary,
@@ -257,25 +257,9 @@ export const DefaultInlineObjectComponent = (props: BlockProps) => {
   } = props
   const {t} = useTranslation()
   const hasMarkers = markers.length > 0
-  const [popoverOpen, setPopoverOpen] = useState<boolean>(false)
   const popoverTitle = schemaType?.title || schemaType.name
   const hasError = validation.filter((v) => v.level === 'error').length > 0
   const hasWarning = validation.filter((v) => v.level === 'warning').length > 0
-
-  const openItem = useCallback((): void => {
-    setPopoverOpen(false)
-    onOpen()
-  }, [onOpen])
-
-  useEffect(() => {
-    if (open) {
-      setPopoverOpen(false)
-    } else if (focused) {
-      setPopoverOpen(true)
-    } else {
-      setPopoverOpen(false)
-    }
-  }, [focused, open])
 
   const tone = useMemo(() => {
     if (hasError) {
@@ -292,10 +276,6 @@ export const DefaultInlineObjectComponent = (props: BlockProps) => {
     return undefined
   }, [focused, hasError, hasWarning, selected])
 
-  const onClosePopover = useCallback(() => {
-    setPopoverOpen(false)
-  }, [])
-
   return (
     <>
       <Root
@@ -307,8 +287,8 @@ export const DefaultInlineObjectComponent = (props: BlockProps) => {
         data-selected={selected || undefined}
         data-warning={hasWarning || undefined}
         forwardedAs="span"
-        onClick={readOnly ? openItem : undefined}
-        onDoubleClick={openItem}
+        onClick={readOnly ? onOpen : undefined}
+        onDoubleClick={onOpen}
         tone={tone}
       >
         <PreviewSpan>
@@ -324,10 +304,10 @@ export const DefaultInlineObjectComponent = (props: BlockProps) => {
       {referenceElement && (
         <InlineObjectToolbarPopover
           floatingBoundary={floatingBoundary}
-          onClosePopover={onClosePopover}
-          onDelete={onRemove}
-          onEdit={openItem}
-          open={popoverOpen}
+          inlineObjectFocused={focused}
+          inlineObjectOpen={open}
+          onOpenInlineObject={onOpen}
+          onRemoveInlineObject={onRemove}
           referenceBoundary={referenceBoundary}
           referenceElement={referenceElement}
           title={popoverTitle}
@@ -335,10 +315,10 @@ export const DefaultInlineObjectComponent = (props: BlockProps) => {
       )}
       {open && (
         <ObjectEditModal
+          autoFocus
           defaultType="popover"
-          onClose={onClose}
-          autoFocus={focused}
           floatingBoundary={floatingBoundary}
+          onClose={onClose}
           referenceBoundary={referenceBoundary}
           referenceElement={referenceElement}
           schemaType={schemaType}

--- a/packages/sanity/src/core/form/inputs/PortableText/object/InlineObjectToolbarPopover.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/InlineObjectToolbarPopover.tsx
@@ -1,6 +1,7 @@
+import {PortableTextEditor, usePortableTextEditor} from '@portabletext/editor'
 import {EditIcon, TrashIcon} from '@sanity/icons'
-import {Box, Inline, Text, useGlobalKeyDown, useTheme} from '@sanity/ui'
-import {type MouseEvent, useCallback, useMemo, useRef} from 'react'
+import {Box, Flex, Text, useGlobalKeyDown, useTheme} from '@sanity/ui'
+import {type ReactNode, useCallback, useEffect, useRef, useState} from 'react'
 
 import {Button, Popover, type PopoverProps} from '../../../../../ui-components'
 import {useTranslation} from '../../../../i18n'
@@ -9,108 +10,142 @@ const POPOVER_FALLBACK_PLACEMENTS: PopoverProps['fallbackPlacements'] = ['top', 
 
 interface InlineObjectToolbarPopoverProps {
   floatingBoundary: HTMLElement | null
-  open: boolean
-  onClosePopover: () => void
-  onDelete: (event: MouseEvent<HTMLButtonElement>) => void
-  onEdit: (event: MouseEvent<HTMLButtonElement>) => void
+  inlineObjectFocused: boolean
+  inlineObjectOpen: boolean
+  onOpenInlineObject: () => void
+  onRemoveInlineObject: () => void
   referenceBoundary: HTMLElement | null
   referenceElement: HTMLElement | null
   title: string
 }
 
-export function InlineObjectToolbarPopover(props: InlineObjectToolbarPopoverProps) {
+export function InlineObjectToolbarPopover(props: InlineObjectToolbarPopoverProps): ReactNode {
   const {
     floatingBoundary,
-    onClosePopover,
-    onEdit,
-    onDelete,
+    inlineObjectFocused,
+    inlineObjectOpen,
+    onOpenInlineObject,
+    onRemoveInlineObject,
     referenceBoundary,
     referenceElement,
     title,
-    open,
   } = props
+  const [popoverOpen, setPopoverOpen] = useState<boolean>(false)
   const {sanity} = useTheme()
   const {t} = useTranslation()
   const editButtonRef = useRef<HTMLButtonElement | null>(null)
   const deleteButtonRef = useRef<HTMLButtonElement | null>(null)
+  const focusTrappedRef = useRef<HTMLButtonElement | null>(null)
   const popoverScheme = sanity.color.dark ? 'light' : 'dark'
+  const editor = usePortableTextEditor()
+  const contentRef = useRef<HTMLDivElement | null>(null)
 
+  const handleClosePopover = useCallback(() => {
+    setPopoverOpen(false)
+    PortableTextEditor.focus(editor)
+    focusTrappedRef.current = null
+  }, [editor])
+
+  // Tab to edit button on tab
   // Close floating toolbar on Escape
-  // Focus to edit button on Tab
   useGlobalKeyDown(
     useCallback(
       (event) => {
+        if (!popoverOpen) {
+          return
+        }
+        if (event.key === 'Tab') {
+          if (
+            inlineObjectFocused &&
+            event.target instanceof HTMLElement &&
+            event.target.contentEditable &&
+            focusTrappedRef.current === null
+          ) {
+            event.preventDefault()
+            editButtonRef.current?.focus()
+            focusTrappedRef.current = editButtonRef.current
+            return
+          }
+          if (event.target === deleteButtonRef.current) {
+            event.preventDefault()
+            event.stopPropagation()
+            focusTrappedRef.current = null
+            PortableTextEditor.focus(editor)
+            return
+          }
+        }
         if (event.key === 'Escape') {
-          event.preventDefault()
-          event.stopPropagation()
-          onClosePopover()
+          handleClosePopover()
         }
       },
-      [onClosePopover],
+      [editor, inlineObjectFocused, handleClosePopover, popoverOpen],
     ),
   )
 
-  const handleDelete = useCallback(
-    (event: MouseEvent<HTMLButtonElement>) => {
-      if (deleteButtonRef.current?.disabled) {
-        return
-      }
-      event.preventDefault()
-      event.stopPropagation()
-      try {
-        onDelete(event)
-      } catch (err) {
-        console.error(err)
-      } finally {
-        if (deleteButtonRef.current) {
-          deleteButtonRef.current.disabled = true
-        }
-      }
-    },
-    [onDelete],
-  )
+  useEffect(() => {
+    focusTrappedRef.current = null
+    if (inlineObjectOpen) {
+      setPopoverOpen(false)
+      return
+    }
+    if (inlineObjectFocused) {
+      setPopoverOpen(true)
+      return
+    }
+    setPopoverOpen(false)
+  }, [inlineObjectFocused, inlineObjectOpen])
 
-  const popoverContent = useMemo(
-    () => (
-      <Box padding={1}>
-        <Inline space={1}>
-          <Box padding={2}>
-            <Text weight="medium" size={1}>
-              {title}
-            </Text>
-          </Box>
-          <Button
-            aria-label={t('inputs.portable-text.inline-object.edit-aria-label')}
-            icon={EditIcon}
-            mode="bleed"
-            onClick={onEdit}
-            ref={editButtonRef}
-            tooltipProps={{content: t('inputs.portable-text.inline-object.edit')}}
-          />
-          <Button
-            aria-label={t('inputs.portable-text.inline-object.remove-aria-label')}
-            ref={deleteButtonRef}
-            icon={TrashIcon}
-            mode="bleed"
-            onClick={handleDelete}
-            tone="critical"
-            tooltipProps={{content: t('inputs.portable-text.inline-object.remove')}}
-          />
-        </Inline>
-      </Box>
-    ),
-    [handleDelete, onEdit, title, t],
-  )
+  const handleEditButtonClicked = useCallback(() => {
+    setPopoverOpen(false)
+    onOpenInlineObject()
+  }, [onOpenInlineObject])
+
+  const handleRemoveButtonClicked = useCallback(() => {
+    setPopoverOpen(false)
+    onRemoveInlineObject()
+  }, [onRemoveInlineObject])
 
   return (
     <Popover
-      constrainSize
-      content={popoverContent}
-      fallbackPlacements={POPOVER_FALLBACK_PLACEMENTS}
+      open={!inlineObjectOpen && popoverOpen}
       floatingBoundary={floatingBoundary}
-      open={open}
+      constrainSize
+      content={
+        <Box padding={1} data-testid="inline-object-toolbar-popover" ref={contentRef}>
+          <Flex gap={1}>
+            <Box padding={2}>
+              <Text weight="medium" size={1}>
+                {title}
+              </Text>
+            </Box>
+            <Button
+              aria-label={t('inputs.portable-text.inline-object.edit-aria-label')}
+              data-testid="edit-inline-object-button"
+              icon={EditIcon}
+              mode="bleed"
+              onClick={handleEditButtonClicked}
+              ref={editButtonRef}
+              tabIndex={0}
+              tooltipProps={{content: t('inputs.portable-text.inline-object.edit')}}
+            />
+            <Button
+              aria-label={t('inputs.portable-text.inline-object.remove-aria-label')}
+              data-testid="remove-inline-object-button"
+              icon={TrashIcon}
+              mode="bleed"
+              onClick={handleRemoveButtonClicked}
+              ref={deleteButtonRef}
+              tabIndex={0}
+              tone="critical"
+              tooltipProps={{content: t('inputs.portable-text.inline-object.remove')}}
+            />
+          </Flex>
+        </Box>
+      }
+      fallbackPlacements={POPOVER_FALLBACK_PLACEMENTS}
       placement="top"
       portal
+      preventOverflow
       referenceBoundary={referenceBoundary}
       referenceElement={referenceElement}
       scheme={popoverScheme}


### PR DESCRIPTION
### Description

There is currently an issue with reaching the annotation and inline object edit toolbar buttons with the keyboard leaving annotation editing impossible with the keyboard.

This will make sure that when these toolbars shows, it will be possible to press `Tab` in order to get to the buttons with the keyboard.


https://github.com/user-attachments/assets/6a928a83-980b-47ba-83b3-ad1e49cb7d74



Also added component tests for this.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

That you are able to tab into the buttons when the toolbar is showing.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Fixed an issue with keyboard navigation to edit buttons for annotation and inline objects in the Portable Text Input.
<!--
A description of the change(s) that should be used in the release notes.
-->
