### PR TITLE
fix(portable-text-editor): allow user event handlers on Editable component

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -12,7 +12,6 @@ import {PortableTextBlock} from '@sanity/types'
 import {
   EditorChange,
   EditorSelection,
-  OnBeforeInputFn,
   OnCopyFn,
   OnPasteFn,
   OnPasteResult,
@@ -54,10 +53,10 @@ const EMPTY_DECORATORS: BaseRange[] = []
  */
 export type PortableTextEditableProps = Omit<
   React.TextareaHTMLAttributes<HTMLDivElement>,
-  'onPaste' | 'onCopy'
+  'onPaste' | 'onCopy' | 'onBeforeInput'
 > & {
   hotkeys?: HotkeyOptions
-  onBeforeInput?: OnBeforeInputFn
+  onBeforeInput?: (event: InputEvent) => void
   onPaste?: OnPasteFn
   onCopy?: OnCopyFn
   renderAnnotation?: RenderAnnotationFunction
@@ -76,7 +75,8 @@ export type PortableTextEditableProps = Omit<
  * @public
  */
 export const PortableTextEditable = forwardRef(function PortableTextEditable(
-  props: PortableTextEditableProps & Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'onPaste'>,
+  props: PortableTextEditableProps &
+    Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'onPaste' | 'onBeforeInput'>,
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
   const {
@@ -328,7 +328,7 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
   )
 
   const handleOnBeforeInput = useCallback(
-    (event: Event) => {
+    (event: InputEvent) => {
       if (onBeforeInput) {
         onBeforeInput(event)
       }

--- a/packages/@sanity/portable-text-editor/src/types/editor.ts
+++ b/packages/@sanity/portable-text-editor/src/types/editor.ts
@@ -362,7 +362,7 @@ export interface PasteData {
 export type OnPasteFn = (data: PasteData) => OnPasteResultOrPromise
 
 /** @beta */
-export type OnBeforeInputFn = (event: Event) => void
+export type OnBeforeInputFn = (event: InputEvent) => void
 
 /** @beta */
 export type OnCopyFn = (


### PR DESCRIPTION
### Description

This will allow the consumer to specify their own `onKeyDown`, `onFocus`, and `onBlur` event handlers on the `Editable` component of the PTE in addition to the internal ones.

Also fixed a prop typing (`onBeforeInput`) that was problematic to use.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

That the code looks alright.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
N/A

<!--
A description of the change(s) that should be used in the release notes.
-->
