### PR TITLE
fix(portable-text-editor): fix issues for .delete fn and add tests

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/plugins/__tests__/withEditableAPIDelete.test.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/__tests__/withEditableAPIDelete.test.tsx
@@ -82,6 +82,60 @@ describe('plugin:withEditableAPI: .delete()', () => {
       }
     })
   })
+
+  it('deletes all the blocks, but leaves a placeholder block', async () => {
+    const editorRef: React.RefObject<PortableTextEditor> = React.createRef()
+    const onChange = jest.fn()
+    render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        schemaType={schemaType}
+        value={initialValue}
+      />,
+    )
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({type: 'value', value: initialValue})
+      expect(onChange).toHaveBeenCalledWith({type: 'ready'})
+    })
+
+    await waitFor(() => {
+      if (editorRef.current) {
+        PortableTextEditor.delete(
+          editorRef.current,
+          {
+            focus: {path: [{_key: 'b'}, 'children', {_key: 'b1'}], offset: 7},
+            anchor: {path: [{_key: 'a'}, 'children', {_key: 'a1'}], offset: 0},
+          },
+          {mode: 'blocks'},
+        )
+      }
+    })
+    await waitFor(() => {
+      if (editorRef.current) {
+        // New keys here confirms that a placeholder block has been created
+        expect(PortableTextEditor.getValue(editorRef.current)).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "_key": "1",
+              "_type": "myTestBlockType",
+              "children": Array [
+                Object {
+                  "_key": "2",
+                  "_type": "span",
+                  "marks": Array [],
+                  "text": "",
+                },
+              ],
+              "markDefs": Array [],
+              "style": "normal",
+            },
+          ]
+        `)
+      }
+    })
+  })
+
   it('deletes children', async () => {
     const editorRef: React.RefObject<PortableTextEditor> = React.createRef()
     const onChange = jest.fn()
@@ -96,7 +150,10 @@ describe('plugin:withEditableAPI: .delete()', () => {
 
     await waitFor(() => {
       if (editorRef.current) {
-        PortableTextEditor.select(editorRef.current, initialSelection)
+        PortableTextEditor.select(editorRef.current, {
+          focus: {path: [{_key: 'b'}, 'children', {_key: 'b1'}], offset: 5},
+          anchor: {path: [{_key: 'b'}, 'children', {_key: 'b1'}], offset: 7},
+        })
         PortableTextEditor.focus(editorRef.current)
         PortableTextEditor.delete(
           editorRef.current,
@@ -128,6 +185,51 @@ describe('plugin:withEditableAPI: .delete()', () => {
                           "_type": "span",
                           "marks": Array [],
                           "text": "",
+                        },
+                      ],
+                      "markDefs": Array [],
+                      "style": "normal",
+                    },
+                  ]
+              `)
+      }
+    })
+  })
+  it('deletes selected', async () => {
+    const editorRef: React.RefObject<PortableTextEditor> = React.createRef()
+    const onChange = jest.fn()
+    render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        schemaType={schemaType}
+        value={initialValue}
+      />,
+    )
+
+    await waitFor(() => {
+      if (editorRef.current) {
+        PortableTextEditor.select(editorRef.current, {
+          focus: {path: [{_key: 'b'}, 'children', {_key: 'b1'}], offset: 5},
+          anchor: {path: [{_key: 'a'}, 'children', {_key: 'a1'}], offset: 0},
+        })
+        PortableTextEditor.focus(editorRef.current)
+        PortableTextEditor.delete(
+          editorRef.current,
+          PortableTextEditor.getSelection(editorRef.current),
+          {mode: 'selected'},
+        )
+        expect(PortableTextEditor.getValue(editorRef.current)).toMatchInlineSnapshot(`
+                  Array [
+                    Object {
+                      "_key": "b",
+                      "_type": "myTestBlockType",
+                      "children": Array [
+                        Object {
+                          "_key": "b1",
+                          "_type": "span",
+                          "marks": Array [],
+                          "text": " B",
                         },
                       ],
                       "markDefs": Array [],

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithEditableAPI.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithEditableAPI.ts
@@ -349,6 +349,10 @@ export function createWithEditableAPI(
       delete: (selection: EditorSelection, options?: EditableAPIDeleteOptions): void => {
         if (selection) {
           const range = toSlateRange(selection, editor)
+          const hasRange = range && range.anchor.path.length > 0 && range.focus.path.length > 0
+          if (!hasRange) {
+            throw new Error('Invalid range')
+          }
           if (range) {
             if (!options?.mode || options?.mode === 'selected') {
               debug(`Deleting content in selection`)

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithEditableAPI.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithEditableAPI.ts
@@ -392,6 +392,14 @@ export function createWithEditableAPI(
                 hanging: true,
               })
             })
+            // If the editor was emptied, insert a placeholder block
+            // directly into the editor's children. We don't want to do this
+            // through a Transform (because that would trigger a change event
+            // that would insert the placeholder into the actual value
+            // which should remain empty)
+            if (editor.children.length === 0) {
+              editor.children = [editor.createPlaceholderBlock()]
+            }
             editor.onChange()
           }
         }


### PR DESCRIPTION
### Description

This will fix bugs related to deleting content in the PTE through the `PortableTextEditor.delete` function.

* Test that the range produced from the `PortableTextEditor.delete` method is valid before deleting anything. There was an issue where if you gave it an invalid path, the resulting path for the produced range would be `[]` which would then delete content not targeted for deletion.
* If you deleted block by block with this method until there were no blocks left, it would not properly produce a new placeholder block causing issues with inserting new content.
* While writing tests for this I discovered some additional bugs with the `block` mode when providing a selection containing multiple blocks.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Code looks good

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* N/A

<!--
A description of the change(s) that should be used in the release notes.
-->
