### PR TITLE
fix(form/inputs): fix invalid path used with onRemove for TextBlock

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.tsx
@@ -130,11 +130,14 @@ export function TextBlock(props: TextBlockProps) {
   }, [onItemOpen, memberItem])
 
   const onRemove = useCallback(() => {
-    const sel: EditorSelection = {focus: {path, offset: 0}, anchor: {path, offset: 0}}
+    const point = {path: path.slice(-1), offset: 0}
+    const sel: EditorSelection = {
+      focus: point,
+      anchor: point,
+    }
     PortableTextEditor.delete(editor, sel, {mode: 'blocks'})
-    // Focus will not stick unless this is done through a timeout when deleted through clicking the menu button.
-    setTimeout(() => PortableTextEditor.focus(editor))
-  }, [editor, path])
+    PortableTextEditor.focus(editor)
+  }, [path, editor])
 
   const text = useMemo(() => {
     return (


### PR DESCRIPTION
### Description

This will fix an issue with the wrong path being sent to the PTE inside the block component's `onRemove` function. It should be the relative path, not the form builder path.

Also,  `.focus` can now be called without a `setTimeout` here.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
I have already tested this with a custom component, but if you want to test it yourself, you can use this schema:

```
    {
      name: 'foo',
      title: 'Foo',
      type: 'array',
      of: [
        defineArrayMember({
          type: 'block',
          components: {
            block: (blockProps) => {
              return (
                <Flex>
                  <Box flex={1}>{blockProps.renderDefault(blockProps)}</Box>
                  <Box contentEditable={false} style={{userSelect: 'none'}}>
                    <Button
                      icon={TrashIcon}
                      onClick={(event) => {
                        event.preventDefault()
                        blockProps.onRemove()
                      }}
                    />
                  </Box>
                </Flex>
              )
            },
          },
        }),
      ],
    },
```
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
N/A

<!--
A description of the change(s) that should be used in the release notes.
-->
