### PR TITLE
fix(mutator): apply `setIfMissing` prior to `set`

### DIFF
--- a/packages/@sanity/mutator/src/patch/parse.ts
+++ b/packages/@sanity/mutator/src/patch/parse.ts
@@ -14,15 +14,15 @@ export function parsePatch(patch: SingleDocumentPatch | SingleDocumentPatch[]): 
   }
 
   const {set, setIfMissing, unset, diffMatchPatch, inc, dec, insert} = patch
-  if (set) {
-    Object.keys(set).forEach((path) => {
-      result.push(new SetPatch(patch.id, path, set[path]))
-    })
-  }
-
   if (setIfMissing) {
     Object.keys(setIfMissing).forEach((path) => {
       result.push(new SetIfMissingPatch(patch.id, path, setIfMissing[path]))
+    })
+  }
+
+  if (set) {
+    Object.keys(set).forEach((path) => {
+      result.push(new SetPatch(patch.id, path, set[path]))
     })
   }
 

--- a/packages/@sanity/mutator/test/patch.test.ts
+++ b/packages/@sanity/mutator/test/patch.test.ts
@@ -9,8 +9,17 @@ import unset from './patchExamples/unset'
 import diffMatchPatch from './patchExamples/diffMatchPatch'
 import insert from './patchExamples/insert'
 import incDec from './patchExamples/incDec'
+import mixed from './patchExamples/mixed'
 
-const examples = [...set, ...setIfMissing, ...unset, ...diffMatchPatch, ...insert, ...incDec]
+const examples = [
+  ...set,
+  ...setIfMissing,
+  ...unset,
+  ...diffMatchPatch,
+  ...insert,
+  ...incDec,
+  ...mixed,
+]
 
 examples.forEach((example) => {
   test(example.name, () => {

--- a/packages/@sanity/mutator/test/patchExamples/mixed.ts
+++ b/packages/@sanity/mutator/test/patchExamples/mixed.ts
@@ -1,0 +1,51 @@
+import type {PatchExample} from './types'
+
+const examples: PatchExample[] = [
+  {
+    name: 'Mix `setIfMissing` and `set`',
+    before: {
+      a: {},
+    },
+    patch: {
+      id: 'a',
+      setIfMissing: {
+        'a.b': 10,
+      },
+      set: {
+        'a.b': 20,
+      },
+    },
+    after: {
+      a: {
+        b: 20,
+      },
+    },
+  },
+  {
+    name: 'Mix `setIfMissing` and `set` (different attributes)',
+    before: {
+      a: {},
+    },
+    patch: {
+      id: 'a',
+      setIfMissing: {
+        'a._type': 'object',
+        'a.b': {_type: 'object'},
+      },
+      set: {
+        'a.b.c': 'hello',
+      },
+    },
+    after: {
+      a: {
+        _type: 'object',
+        b: {
+          _type: 'object',
+          c: 'hello',
+        },
+      },
+    },
+  },
+]
+
+export default examples


### PR DESCRIPTION
### Description

Fixes an issue where the order of operations of set/setIfMissing is reversed from what Content Lake does. By applying `setIfMissing` first, it ensures we can "prepare" structures that a deep `set` operation might use, for instance.

### What to review

- Mutations still work and apply as before

### Notes for release

- Fixes an issue where certain patches would apply differently in the studio and in Content Lake, leading to the studio UI not reflecting new values for certain fields 
