### PR TITLE
fix(mutator): restore greater than/less than in jsonmatch constraints

### DIFF
--- a/packages/@sanity/mutator/src/jsonpath/tokenize.ts
+++ b/packages/@sanity/mutator/src/jsonpath/tokenize.ts
@@ -14,8 +14,10 @@ const attributeCharMatcher = /^[a-zA-Z0-9_]$/
 const attributeFirstCharMatcher = /^[a-zA-Z_]$/
 
 const symbols: Record<SymbolClass, string[]> = {
+  // NOTE: These are compared against in order of definition,
+  // thus '==' must come before '=', '>=' before '>', etc.
   operator: ['..', '.', ',', ':', '?'],
-  comparator: ['>', '>=', '<', '<=', '==', '!='],
+  comparator: ['>=', '<=', '<', '>', '==', '!='],
   keyword: ['$', '@'],
   boolean: ['true', 'false'],
   paren: ['[', ']'],

--- a/packages/@sanity/mutator/test/parse.test.ts
+++ b/packages/@sanity/mutator/test/parse.test.ts
@@ -151,6 +151,36 @@ const cases = {
     ],
     type: 'union',
   },
+  'variants[stock >= 20].stock': {
+    type: 'path',
+    nodes: [
+      {
+        type: 'attribute',
+        name: 'variants',
+      },
+      {
+        type: 'union',
+        nodes: [
+          {
+            type: 'constraint',
+            operator: '>=',
+            lhs: {
+              type: 'attribute',
+              name: 'stock',
+            },
+            rhs: {
+              type: 'number',
+              value: 20,
+            },
+          },
+        ],
+      },
+      {
+        type: 'attribute',
+        name: 'stock',
+      },
+    ],
+  },
 }
 
 Object.keys(cases).forEach((path) => {

--- a/packages/@sanity/mutator/test/patchExamples/set.ts
+++ b/packages/@sanity/mutator/test/patchExamples/set.ts
@@ -113,6 +113,52 @@ const examples: PatchExample[] = [
     },
   },
   {
+    name: 'Attribute greater than or equal filter',
+    before: {
+      variants: [
+        {name: 'a', stock: 20},
+        {name: 'b', stock: 30},
+        {name: 'c', stock: 10},
+      ],
+    },
+    patch: {
+      id: 'a',
+      set: {
+        'variants[stock >= 20].stock': 5,
+      },
+    },
+    after: {
+      variants: [
+        {name: 'a', stock: 5},
+        {name: 'b', stock: 5},
+        {name: 'c', stock: 10},
+      ],
+    },
+  },
+  {
+    name: 'Attribute less than or equal filter',
+    before: {
+      variants: [
+        {name: 'x', stock: 99},
+        {name: 'y', stock: 50},
+        {name: 'z', stock: 10},
+      ],
+    },
+    patch: {
+      id: 'a',
+      set: {
+        'variants[stock <= 50].stock': 5,
+      },
+    },
+    after: {
+      variants: [
+        {name: 'x', stock: 99},
+        {name: 'y', stock: 5},
+        {name: 'z', stock: 5},
+      ],
+    },
+  },
+  {
     name: 'Set new key',
     before: {},
     patch: {


### PR DESCRIPTION
### Description

Using the `>=` or `<=` attributes in JSONMatch filters would crash the mutator. The tokenizer found a `>` or `<` and consumed it as a token, yielding a lone `=`, which is not a valid token. Fixed by altering the order that the JSONMatch symbols are consumed in, so that longer ones are consumed first.

Fixes #2474

### What to review

- JSONMatch patches gets correctly applied

### Notes for release

- Fixed an issue where using `>=` or `<=` in JSONMatch filters for patch operations would cause the studio to give error messages and not apply patch correctly