### PR TITLE
chore(i18n): add no-literal-string lint exceptions for __workshop__ dirs

### DIFF
--- a/packages/sanity/src/core/changeIndicators/__workshop__/.eslintrc
+++ b/packages/sanity/src/core/changeIndicators/__workshop__/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
+}

--- a/packages/sanity/src/core/components/collapseMenu/__workshop__/.eslintrc
+++ b/packages/sanity/src/core/components/collapseMenu/__workshop__/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
+}

--- a/packages/sanity/src/core/components/commandList/__tests__/.eslintrc
+++ b/packages/sanity/src/core/components/commandList/__tests__/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
+}

--- a/packages/sanity/src/core/components/commandList/__workshop__/.eslintrc
+++ b/packages/sanity/src/core/components/commandList/__workshop__/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
+}

--- a/packages/sanity/src/core/components/image/__workshop__/.eslintrc
+++ b/packages/sanity/src/core/components/image/__workshop__/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
+}

--- a/packages/sanity/src/core/components/previewCard/__workshop__/.eslintrc
+++ b/packages/sanity/src/core/components/previewCard/__workshop__/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
+}

--- a/packages/sanity/src/core/components/previews/__workshop__/.eslintrc
+++ b/packages/sanity/src/core/components/previews/__workshop__/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
+}

--- a/packages/sanity/src/core/components/rovingFocus/__workshop__/.eslintrc
+++ b/packages/sanity/src/core/components/rovingFocus/__workshop__/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
+}

--- a/packages/sanity/src/core/components/textWithTone/__workshop__/.eslintrc
+++ b/packages/sanity/src/core/components/textWithTone/__workshop__/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
+}

--- a/packages/sanity/src/core/components/userAvatar/__workshop__/.eslintrc
+++ b/packages/sanity/src/core/components/userAvatar/__workshop__/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
+}

--- a/packages/sanity/src/core/field/__workshop__/.eslintrc
+++ b/packages/sanity/src/core/field/__workshop__/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
+}

--- a/packages/sanity/src/core/form/__workshop__/.eslintrc
+++ b/packages/sanity/src/core/form/__workshop__/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
+}

--- a/packages/sanity/src/core/form/components/formField/__workshop__/.eslintrc
+++ b/packages/sanity/src/core/form/components/formField/__workshop__/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
+}

--- a/packages/sanity/src/core/form/inputs/PortableText/__workshop__/.eslintrc
+++ b/packages/sanity/src/core/form/inputs/PortableText/__workshop__/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
+}

--- a/packages/sanity/src/core/form/inputs/PortableText/_legacyDefaultParts/__tests__/.eslintrc
+++ b/packages/sanity/src/core/form/inputs/PortableText/_legacyDefaultParts/__tests__/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
+}

--- a/packages/sanity/src/core/form/inputs/__workshop__/.eslintrc
+++ b/packages/sanity/src/core/form/inputs/__workshop__/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
+}

--- a/packages/sanity/src/core/form/inputs/files/__workshop__/.eslintrc
+++ b/packages/sanity/src/core/form/inputs/files/__workshop__/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
+}

--- a/packages/sanity/src/core/preview/__workshop__/.eslintrc
+++ b/packages/sanity/src/core/preview/__workshop__/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
+}

--- a/packages/sanity/src/core/schema/__workshop__/.eslintrc
+++ b/packages/sanity/src/core/schema/__workshop__/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
+}

--- a/packages/sanity/src/core/store/_legacy/__workshop__/.eslintrc
+++ b/packages/sanity/src/core/store/_legacy/__workshop__/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
+}

--- a/packages/sanity/src/core/studio/components/navbar/__workshop__/.eslintrc
+++ b/packages/sanity/src/core/studio/components/navbar/__workshop__/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
+}

--- a/packages/sanity/src/core/studio/components/navbar/search/__workshop__/.eslintrc
+++ b/packages/sanity/src/core/studio/components/navbar/search/__workshop__/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
+}

--- a/packages/sanity/src/desk/__workshop__/.eslintrc
+++ b/packages/sanity/src/desk/__workshop__/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
+}

--- a/packages/sanity/src/desk/components/pane/__workshop__/.eslintrc
+++ b/packages/sanity/src/desk/components/pane/__workshop__/.eslintrc
@@ -1,5 +1,6 @@
 {
   "rules": {
-    "no-nested-ternary": "off"
+    "no-nested-ternary": "off",
+    "i18next/no-literal-string": "off"
   }
 }

--- a/packages/sanity/src/desk/panes/document/statusBar/__workshop__/.eslintrc
+++ b/packages/sanity/src/desk/panes/document/statusBar/__workshop__/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
+}

--- a/packages/sanity/src/desk/panes/document/timeline/__workshop__/.eslintrc
+++ b/packages/sanity/src/desk/panes/document/timeline/__workshop__/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+      "i18next/no-literal-string": "off"
+    }
+}


### PR DESCRIPTION

### Description

Since we are not translating files in `__workshop__` directories, this PR disables the `no-literal-string` rule for these directories.

