### PR TITLE
feat(i18n): add translation for deskTool components

### DIFF
--- a/packages/sanity/src/desk/components/deskTool/NoDocumentTypesScreen.tsx
+++ b/packages/sanity/src/desk/components/deskTool/NoDocumentTypesScreen.tsx
@@ -1,8 +1,11 @@
 import {WarningOutlineIcon} from '@sanity/icons'
 import {Box, Card, Container, Flex, Stack, Text} from '@sanity/ui'
 import React from 'react'
+import {deskLocaleNamespace} from '../../i18n'
+import {useTranslation} from 'sanity'
 
 export function NoDocumentTypesScreen() {
+  const {t} = useTranslation(deskLocaleNamespace)
   return (
     <Card height="fill">
       <Flex align="center" height="fill" justify="center" padding={4} sizing="border">
@@ -16,10 +19,10 @@ export function NoDocumentTypesScreen() {
               </Box>
               <Stack flex={1} marginLeft={3} space={3}>
                 <Text as="h1" size={1} weight="bold">
-                  No document types
+                  {t('desk-tool.no-document-types-screen.title')}
                 </Text>
                 <Text as="p" muted size={1}>
-                  Please define at least one document type in your schema.
+                  {t('desk-tool.no-document-types-screen.body')}
                 </Text>
                 <Text as="p" muted size={1}>
                   <a
@@ -27,7 +30,7 @@ export function NoDocumentTypesScreen() {
                     target="_blank"
                     rel="noreferrer"
                   >
-                    Learn how to add a document type &rarr;
+                    {t('desk-tool.no-document-types-screen.learn-more')} &rarr;
                   </a>
                 </Text>
               </Stack>

--- a/packages/sanity/src/desk/components/deskTool/StructureError.tsx
+++ b/packages/sanity/src/desk/components/deskTool/StructureError.tsx
@@ -5,6 +5,8 @@ import styled from 'styled-components'
 import {SyncIcon} from '@sanity/icons'
 import {SerializeError} from '../../structureBuilder'
 import {PaneResolutionError} from '../../structureResolvers'
+import {deskLocaleNamespace} from '../../i18n'
+import {useTranslation} from 'sanity'
 
 const PathSegment = styled.span`
   &:not(:last-child)::after {
@@ -51,15 +53,17 @@ export function StructureError({error}: StructureErrorProps) {
     window.location.reload()
   }, [])
 
+  const {t} = useTranslation(deskLocaleNamespace)
+
   return (
     <Card height="fill" overflow="auto" padding={4} sizing="border" tone="critical">
       <Container>
-        <Heading as="h2">Encountered an error while reading structure</Heading>
+        <Heading as="h2">{t('desk-tool.structured-error.title')}</Heading>
 
         <Card marginTop={4} padding={4} radius={2} overflow="auto" shadow={1} tone="inherit">
           {path.length > 0 && (
             <Stack space={2}>
-              <Label>Structure path</Label>
+              <Label>{t('desk-tool.structured-error.structure-label')}</Label>
               <Code>
                 {/* TODO: it seems like the path is off by one and includes */}
                 {/* `root` twice  */}
@@ -72,7 +76,7 @@ export function StructureError({error}: StructureErrorProps) {
           )}
 
           <Stack marginTop={4} space={2}>
-            <Label>Error</Label>
+            <Label>{t('desk-tool.structured-error.error-label')}</Label>
             <Code>{showStack ? formatStack(stack) : error.message}</Code>
           </Stack>
 
@@ -80,7 +84,7 @@ export function StructureError({error}: StructureErrorProps) {
             <Box marginTop={4}>
               <Text>
                 <a href={generateHelpUrl(helpId)} rel="noopener noreferrer" target="_blank">
-                  View documentation
+                  {t('desk-tool.structured-error.view-doc')}
                 </a>
               </Text>
             </Box>

--- a/packages/sanity/src/desk/components/paneHeaderActions/InsufficientPermissionsMessageTooltip.tsx
+++ b/packages/sanity/src/desk/components/paneHeaderActions/InsufficientPermissionsMessageTooltip.tsx
@@ -1,6 +1,7 @@
 import {Tooltip, Text, Box} from '@sanity/ui'
 import React from 'react'
-import {useCurrentUser, InsufficientPermissionsMessage} from 'sanity'
+import {deskLocaleNamespace} from '../../i18n'
+import {useCurrentUser, useTranslation, InsufficientPermissionsMessage} from 'sanity'
 
 interface InsufficientPermissionsMessageTooltipProps {
   reveal: boolean
@@ -14,6 +15,7 @@ export function InsufficientPermissionsMessageTooltip({
   children,
 }: InsufficientPermissionsMessageTooltipProps) {
   const currentUser = useCurrentUser()
+  const {t} = useTranslation(deskLocaleNamespace)
 
   if (!reveal) {
     return <>{children}</>
@@ -24,7 +26,7 @@ export function InsufficientPermissionsMessageTooltip({
       content={
         loading ? (
           <Box padding={2}>
-            <Text>Loading…</Text>
+            <Text>{t('desk-tool.insufficient-permissions-message-tooltip.loading')}</Text>
           </Box>
         ) : (
           <InsufficientPermissionsMessage currentUser={currentUser} />

--- a/packages/sanity/src/desk/components/paneHeaderActions/PaneHeaderCreateButton.tsx
+++ b/packages/sanity/src/desk/components/paneHeaderActions/PaneHeaderCreateButton.tsx
@@ -5,6 +5,8 @@ import {Schema} from '@sanity/types'
 import {IntentButton} from '../IntentButton'
 import {InsufficientPermissionsMessageTooltip} from './InsufficientPermissionsMessageTooltip'
 import {IntentLink} from 'sanity/router'
+import {deskLocaleNamespace} from '../../i18n'
+
 import {
   useTemplatePermissions,
   TemplatePermissionsResult,
@@ -12,6 +14,7 @@ import {
   InitialValueTemplateItem,
   useSchema,
   useTemplates,
+  useTranslation,
 } from 'sanity'
 
 export type PaneHeaderIntentProps = React.ComponentProps<typeof IntentButton>['intent']
@@ -72,6 +75,8 @@ export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonPr
     )
   }, [templatePermissions])
 
+  const {t} = useTranslation(deskLocaleNamespace)
+
   if (nothingGranted) {
     return (
       <InsufficientPermissionsMessageTooltip reveal loading={isTemplatePermissionsLoading}>
@@ -117,14 +122,14 @@ export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonPr
       menu={
         <Menu>
           <Box paddingX={3} paddingTop={3} paddingBottom={2}>
-            <Label muted>Create</Label>
+            <Label muted>{t('desk-tool.pane-header-create-button.label')}</Label>
           </Box>
 
           {templateItems.map((item, itemIndex) => {
             const permissions = permissionsById[item.id]
             const disabled = !permissions?.granted
             const intent = getIntent(schema, templates, item)
-            const template = templates.find((t) => t.id === item.templateId)
+            const template = templates.find((temp) => temp.id === item.templateId)
             if (!template || !intent) return null
 
             const Link = forwardRef((linkProps, linkRef: React.ForwardedRef<never>) =>

--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -165,6 +165,29 @@ const deskLocaleStrings = {
 
   /** --- "PRODUCTION PREVIEW", eg link to content --- */
   'production-preview.menu-item.title': 'Open preview',
+
+  /** -- DESK TOOL -- */
+  /** The title for the no document types screen */
+  'desk-tool.no-document-types-screen.title': 'No document types',
+
+  /** The body for the no document types screen */
+  'desk-tool.no-document-types-screen.body':
+    'Please define at least one document type in your schema.',
+
+  /** The text for the learn more link for the no document types screen */
+  'desk-tool.no-document-types-screen.learn-more': 'Learn how to add a document type',
+
+  /** The title for the structured error card */
+  'desk-tool.structured-error.title': 'Encountered an error while reading structure',
+
+  /** The label for the structure field for the structured error card */
+  'desk-tool.structured-error.structure-label': 'Structure path',
+
+  /** The label for the error field for the structured error card */
+  'desk-tool.structured-error.error-label': 'Error',
+
+  /** The text for the view documentation link for the structured error card */
+  'desk-tool.structured-error.view-doc': 'View documentation',
 }
 
 /**

--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -188,6 +188,12 @@ const deskLocaleStrings = {
 
   /** The text for the view documentation link for the structured error card */
   'desk-tool.structured-error.view-doc': 'View documentation',
+
+  /** The text for the insufficient permissions message tooltip when it is loading data */
+  'desk-tool.insufficient-permissions-message-tooltip.loading': 'Loading…',
+
+  /** The label for the pane header create button */
+  'desk-tool.pane-header-create-button.label': 'Create',
 }
 
 /**


### PR DESCRIPTION
### Description

Adds translation for the the components in `packages/sanity/src/desk/components/deskTool`