### PR TITLE
fix(schema/types): fix wrong key being used for block schema def.

### DIFF
--- a/packages/@sanity/portable-text-editor/src/utils/getPortableTextMemberSchemaTypes.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/getPortableTextMemberSchemaTypes.ts
@@ -73,9 +73,9 @@ function resolveEnabledDecorators(spanType: ObjectSchemaType) {
 }
 
 function resolveEnabledListItems(blockType: ObjectSchemaType) {
-  const listField = blockType.fields?.find((btField) => btField.name === 'list')
+  const listField = blockType.fields?.find((btField) => btField.name === 'listItem')
   if (!listField) {
-    throw new Error("A field with name 'list' is not defined in the block type (required).")
+    throw new Error("A field with name 'listItem' is not defined in the block type (required).")
   }
   const listItems =
     listField.type.options?.list &&

--- a/packages/@sanity/schema/src/legacy/types/blocks/block.ts
+++ b/packages/@sanity/schema/src/legacy/types/blocks/block.ts
@@ -43,7 +43,7 @@ export const BlockType = {
 
     const childrenField = createChildrenField(marks, of)
     const styleField = createStyleField(styles)
-    const listField = createListField(lists)
+    const listItemField = createListItemField(lists)
 
     const markDefsField = {
       name: 'markDefs',
@@ -52,11 +52,22 @@ export const BlockType = {
       of: marks?.annotations || DEFAULT_ANNOTATIONS,
     }
 
+    const levelField = {
+      name: 'level',
+      title: 'Indentation',
+      type: 'number',
+    }
+
     // NOTE: if you update this (EVEN THE ORDER OF FIELDS) you _NEED TO_ also
     // update `BlockSchemaType`, `isBlockSchemaType` and similar in `@sanity/types`
-    const fields = [childrenField, styleField, listField, markDefsField].concat(
-      subTypeDef.fields || [],
-    )
+    const fields = [
+      childrenField,
+      levelField,
+      listItemField,
+      markDefsField,
+      styleField,
+      levelField,
+    ].concat(subTypeDef.fields || [])
 
     const parsed = Object.assign(pick(BLOCK_CORE, INHERITED_FIELDS), rest, {
       type: BLOCK_CORE,
@@ -113,9 +124,9 @@ function createStyleField(styles) {
   }
 }
 
-function createListField(lists) {
+function createListItemField(lists) {
   return {
-    name: 'list',
+    name: 'listItem',
     title: 'List type',
     type: 'string',
     options: {

--- a/packages/@sanity/types/src/schema/asserters.ts
+++ b/packages/@sanity/types/src/schema/asserters.ts
@@ -151,7 +151,7 @@ export function isBlockStyleObjectField(field: unknown): field is BlockStyleObje
 /** @internal */
 export function isBlockListObjectField(field: unknown): field is BlockListObjectField {
   if (!isRecord(field)) return false
-  if (field.name !== 'list') return false
+  if (field.name !== 'listItem') return false
   return isRecord(field.type) && field.type.jsonType === 'string'
 }
 


### PR DESCRIPTION
### Description

This will fix some issues with the block type schema, where it is missing definition for level, and the list definition is using the wrong key as illustrated by editing a PT-field with the regular array input:

![image](https://github.com/sanity-io/sanity/assets/373403/de89ca17-ddab-4546-a38b-d28913845453)

The correct key here is `listItem`. 

After:

![image](https://github.com/sanity-io/sanity/assets/373403/430a7cd0-2dfc-4f40-98f2-356b523209f3)


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
This change is trivial to do (renaming the schema field). I think it is, as all tests are passing and I can't find any other references to this field other than those I have already changed.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
N/A - not a user-facing problem.

<!--
A description of the change(s) that should be used in the release notes.
-->
