### PR TITLE
feat(tab): add StudioUI Tab component

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -228,6 +228,7 @@ module.exports = {
                   'DialogProps',
                   'MenuItem',
                   'MenuItemProps',
+                  'Tab',
                   'Tooltip',
                   'TooltipProps',
                 ],

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -229,6 +229,7 @@ module.exports = {
                   'MenuItem',
                   'MenuItemProps',
                   'Tab',
+                  'TabProps',
                   'Tooltip',
                   'TooltipProps',
                 ],

--- a/packages/sanity/src/core/form/inputs/ObjectInput/fieldGroups/FieldGroupTabs.tsx
+++ b/packages/sanity/src/core/form/inputs/ObjectInput/fieldGroups/FieldGroupTabs.tsx
@@ -44,7 +44,6 @@ const GroupTabs = ({
           aria-controls={`${inputId}-field-group-fields`}
           autoFocus={shouldAutoFocus && group.selected}
           disabled={disabled || group.disabled}
-          icon={group?.icon}
           key={`${inputId}-${group.name}-tab`}
           name={group.name}
           onClick={onClick}

--- a/packages/sanity/src/core/form/inputs/ObjectInput/fieldGroups/FieldGroupTabs.tsx
+++ b/packages/sanity/src/core/form/inputs/ObjectInput/fieldGroups/FieldGroupTabs.tsx
@@ -44,6 +44,7 @@ const GroupTabs = ({
           aria-controls={`${inputId}-field-group-fields`}
           autoFocus={shouldAutoFocus && group.selected}
           disabled={disabled || group.disabled}
+          icon={group?.icon}
           key={`${inputId}-${group.name}-tab`}
           name={group.name}
           onClick={onClick}

--- a/packages/sanity/src/core/form/inputs/ObjectInput/fieldGroups/GroupTab.tsx
+++ b/packages/sanity/src/core/form/inputs/ObjectInput/fieldGroups/GroupTab.tsx
@@ -5,6 +5,7 @@ interface GroupType {
   'aria-controls': string
   autoFocus?: boolean
   disabled?: boolean
+  icon?: React.ComponentType
   name: string
   onClick?: (value: string) => void
   selected: boolean
@@ -29,6 +30,7 @@ export const GroupTab = forwardRef(function GroupTab(
       id={`${props.name}-tab`}
       label={props.title}
       ref={ref}
+      size="small"
       {...props}
       onClick={handleClick}
     />

--- a/packages/sanity/src/core/form/inputs/ObjectInput/fieldGroups/GroupTab.tsx
+++ b/packages/sanity/src/core/form/inputs/ObjectInput/fieldGroups/GroupTab.tsx
@@ -1,11 +1,11 @@
 import React, {forwardRef} from 'react'
-import {Tab} from '@sanity/ui'
+import {Tab} from '../../../../../ui'
+//import {Tab} from '@sanity/ui'
 
 interface GroupType {
   'aria-controls': string
   autoFocus?: boolean
   disabled?: boolean
-  icon?: React.ComponentType
   name: string
   onClick?: (value: string) => void
   selected: boolean
@@ -27,7 +27,6 @@ export const GroupTab = forwardRef(function GroupTab(
   return (
     <Tab
       data-testid={`group-tab-${name}`}
-      size={1}
       id={`${props.name}-tab`}
       label={props.title}
       ref={ref}

--- a/packages/sanity/src/core/form/inputs/ObjectInput/fieldGroups/GroupTab.tsx
+++ b/packages/sanity/src/core/form/inputs/ObjectInput/fieldGroups/GroupTab.tsx
@@ -1,6 +1,5 @@
 import React, {forwardRef} from 'react'
 import {Tab} from '../../../../../ui'
-//import {Tab} from '@sanity/ui'
 
 interface GroupType {
   'aria-controls': string

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferencePreview.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferencePreview.tsx
@@ -5,8 +5,9 @@ import {RenderPreviewCallback} from '../../types'
 import {PreviewLayoutKey} from '../../../components'
 import {useDocumentPresence} from '../../../store'
 import {DocumentPreviewPresence} from '../../../presence'
-import {DraftStatus, PublishedStatus} from '../../../../ui'
 import {ReferenceInfo} from './types'
+import {DraftStatus} from '../../../../ui/draftStatus'
+import {PublishedStatus} from '../../../../ui/publishedStatus'
 
 /**
  * Used to preview a referenced type

--- a/packages/sanity/src/core/studio/Studio.test.tsx
+++ b/packages/sanity/src/core/studio/Studio.test.tsx
@@ -45,7 +45,7 @@ describe('Studio', () => {
       const html = renderToStaticMarkup(sheet.collectStyles(<Studio config={config} />))
 
       expect(html).toMatchInlineSnapshot(
-        `"<div data-as=\\"div\\" data-ui=\\"Flex\\" data-scheme=\\"light\\" data-tone=\\"default\\" class=\\"sc-pNWRh kHzIXK sc-bqGGcD qnyZO sc-pNWRh bjOKiY sc-kEqXeH eHpRnW\\"><div data-ui=\\"Text\\" class=\\"sc-bdnyFh jYLJCW\\"><span>Loading…</span></div><div data-ui=\\"Spinner\\" class=\\"sc-bdnyFh jYLJCW sc-iqAbyq fizVKG\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
+        `"<div data-as=\\"div\\" data-ui=\\"Flex\\" data-scheme=\\"light\\" data-tone=\\"default\\" class=\\"sc-pNWRh kHzIXK sc-bqGGcD lfCnLK sc-pNWRh bjOKiY sc-kEqXeH eHpRnW\\"><div data-ui=\\"Text\\" class=\\"sc-bdnyFh jYLJCW\\"><span>Loading…</span></div><div data-ui=\\"Spinner\\" class=\\"sc-bdnyFh jYLJCW sc-iqAbyq fizVKG\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
       )
     } finally {
       sheet.seal()
@@ -62,7 +62,7 @@ describe('Studio', () => {
     try {
       const html = renderToString(sheet.collectStyles(<Studio config={config} />))
       expect(html).toMatchInlineSnapshot(
-        `"<div data-as=\\"div\\" data-ui=\\"Flex\\" data-scheme=\\"light\\" data-tone=\\"default\\" class=\\"sc-pNWRh kHzIXK sc-bqGGcD qnyZO sc-pNWRh bjOKiY sc-kEqXeH eHpRnW\\"><div data-ui=\\"Text\\" class=\\"sc-bdnyFh jYLJCW\\"><span>Loading…</span></div><div data-ui=\\"Spinner\\" class=\\"sc-bdnyFh jYLJCW sc-iqAbyq fizVKG\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
+        `"<div data-as=\\"div\\" data-ui=\\"Flex\\" data-scheme=\\"light\\" data-tone=\\"default\\" class=\\"sc-pNWRh kHzIXK sc-bqGGcD lfCnLK sc-pNWRh bjOKiY sc-kEqXeH eHpRnW\\"><div data-ui=\\"Text\\" class=\\"sc-bdnyFh jYLJCW\\"><span>Loading…</span></div><div data-ui=\\"Spinner\\" class=\\"sc-bdnyFh jYLJCW sc-iqAbyq fizVKG\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
       )
     } finally {
       sheet.seal()
@@ -82,7 +82,7 @@ describe('Studio', () => {
       const html = renderToString(sheet.collectStyles(<Studio config={config} />))
       node.innerHTML = html
       expect(html).toMatchInlineSnapshot(
-        `"<div data-as=\\"div\\" data-ui=\\"Flex\\" data-scheme=\\"light\\" data-tone=\\"default\\" class=\\"sc-pNWRh kHzIXK sc-bqGGcD qnyZO sc-pNWRh bjOKiY sc-kEqXeH eHpRnW\\"><div data-ui=\\"Text\\" class=\\"sc-bdnyFh jYLJCW\\"><span>Loading…</span></div><div data-ui=\\"Spinner\\" class=\\"sc-bdnyFh jYLJCW sc-iqAbyq fizVKG\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
+        `"<div data-as=\\"div\\" data-ui=\\"Flex\\" data-scheme=\\"light\\" data-tone=\\"default\\" class=\\"sc-pNWRh kHzIXK sc-bqGGcD lfCnLK sc-pNWRh bjOKiY sc-kEqXeH eHpRnW\\"><div data-ui=\\"Text\\" class=\\"sc-bdnyFh jYLJCW\\"><span>Loading…</span></div><div data-ui=\\"Spinner\\" class=\\"sc-bdnyFh jYLJCW sc-iqAbyq fizVKG\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
       )
       document.head.innerHTML += sheet.getStyleTags()
 

--- a/packages/sanity/src/desk/components/pane/__workshop__/ExampleStory.tsx
+++ b/packages/sanity/src/desk/components/pane/__workshop__/ExampleStory.tsx
@@ -1,9 +1,9 @@
 import {EllipsisHorizontalIcon, SelectIcon} from '@sanity/icons'
-import {Container, Stack, Tab, TabList, Text} from '@sanity/ui'
+import {Container, Stack, TabList, Text} from '@sanity/ui'
 import {useBoolean, useSelect} from '@sanity/ui-workshop'
 import React, {useMemo} from 'react'
+import {Button, Tab} from '../../../../ui'
 import {Pane} from '../Pane'
-import {Button} from '../../../../ui'
 import {PaneContent} from '../PaneContent'
 import {PaneFooter} from '../PaneFooter'
 import {PaneHeader} from '../PaneHeader'
@@ -27,33 +27,21 @@ export default function ExampleStory() {
     () =>
       manyTabs ? (
         <TabList space={1}>
-          <Tab
-            aria-controls="content-panel"
-            fontSize={1}
-            id="content-tab"
-            label="Content"
-            selected
-          />
-          <Tab aria-controls="preview-panel" fontSize={1} id="preview-tab" label="Preview" />
-          <Tab aria-controls="preview-panel" fontSize={1} id="preview-tab" label="Preview" />
-          <Tab aria-controls="preview-panel" fontSize={1} id="preview-tab" label="Preview" />
-          <Tab aria-controls="preview-panel" fontSize={1} id="preview-tab" label="Preview" />
-          <Tab aria-controls="preview-panel" fontSize={1} id="preview-tab" label="Preview" />
-          <Tab aria-controls="preview-panel" fontSize={1} id="preview-tab" label="Preview" />
-          <Tab aria-controls="preview-panel" fontSize={1} id="preview-tab" label="Preview" />
-          <Tab aria-controls="preview-panel" fontSize={1} id="preview-tab" label="Preview" />
-          <Tab aria-controls="preview-panel" fontSize={1} id="preview-tab" label="Preview" />
+          <Tab aria-controls="content-panel" id="content-tab" label="Content" selected />
+          <Tab aria-controls="preview-panel" id="preview-tab" label="Preview" />
+          <Tab aria-controls="preview-panel" id="preview-tab" label="Preview" />
+          <Tab aria-controls="preview-panel" id="preview-tab" label="Preview" />
+          <Tab aria-controls="preview-panel" id="preview-tab" label="Preview" />
+          <Tab aria-controls="preview-panel" id="preview-tab" label="Preview" />
+          <Tab aria-controls="preview-panel" id="preview-tab" label="Preview" />
+          <Tab aria-controls="preview-panel" id="preview-tab" label="Preview" />
+          <Tab aria-controls="preview-panel" id="preview-tab" label="Preview" />
+          <Tab aria-controls="preview-panel" id="preview-tab" label="Preview" />
         </TabList>
       ) : (
         <TabList space={1}>
-          <Tab
-            aria-controls="content-panel"
-            fontSize={1}
-            id="content-tab"
-            label="Content"
-            selected
-          />
-          <Tab aria-controls="preview-panel" fontSize={1} id="preview-tab" label="Preview" />
+          <Tab aria-controls="content-panel" id="content-tab" label="Content" selected />
+          <Tab aria-controls="preview-panel" id="preview-tab" label="Preview" />
         </TabList>
       ),
     [manyTabs],

--- a/packages/sanity/src/desk/components/paneItem/PaneItemPreview.tsx
+++ b/packages/sanity/src/desk/components/paneItem/PaneItemPreview.tsx
@@ -3,7 +3,8 @@ import React, {isValidElement} from 'react'
 import {isNumber, isString} from 'lodash'
 import {Inline} from '@sanity/ui'
 import {useMemoObservable} from 'react-rx'
-import {DraftStatus, PublishedStatus} from '../../../ui'
+import {DraftStatus} from '../../../ui/draftStatus'
+import {PublishedStatus} from '../../../ui/publishedStatus'
 import type {PaneItemPreviewState} from './types'
 import {
   DocumentPresence,

--- a/packages/sanity/src/desk/panes/document/documentPanel/header/DocumentHeaderTabs.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/header/DocumentHeaderTabs.tsx
@@ -1,7 +1,8 @@
 import React, {useCallback} from 'react'
-import {Tab, TabList} from '@sanity/ui'
+import {TabList} from '@sanity/ui'
 import {useDocumentPane} from '../../useDocumentPane'
 import {usePaneRouter} from '../../../../components'
+import {Tab} from '../../../../../ui'
 
 export function DocumentHeaderTabs() {
   const {activeViewId, paneKey, views} = useDocumentPane()
@@ -15,7 +16,7 @@ export function DocumentHeaderTabs() {
           id={`${paneKey}tab-${view.id}`}
           isActive={activeViewId === view.id}
           key={view.id}
-          label={<>{view.title}</>}
+          label={view.title}
           tabPanelId={tabPanelId}
           viewId={index === 0 ? null : view.id ?? null}
         />
@@ -28,23 +29,25 @@ function DocumentHeaderTab(props: {
   icon?: React.ComponentType | React.ReactNode
   id: string
   isActive: boolean
-  label: React.ReactNode
+  label: string
   tabPanelId: string
   viewId: string | null
 }) {
-  const {isActive, tabPanelId, viewId, ...rest} = props
+  const {icon, id, isActive, label, tabPanelId, viewId} = props
   const {ready} = useDocumentPane()
   const {setView} = usePaneRouter()
   const handleClick = useCallback(() => setView(viewId), [setView, viewId])
 
   return (
     <Tab
-      {...rest} // required to enable <TabList> keyboard navigation
       aria-controls={tabPanelId}
       disabled={!ready}
-      fontSize={1}
-      selected={isActive}
+      icon={icon}
+      id={id}
+      label={label}
       onClick={handleClick}
+      selected={isActive}
+      size="small"
     />
   )
 }

--- a/packages/sanity/src/desk/panes/document/inspectDialog/InspectDialog.tsx
+++ b/packages/sanity/src/desk/panes/document/inspectDialog/InspectDialog.tsx
@@ -1,8 +1,8 @@
 import {SanityDocument} from '@sanity/types'
-import {Card, Code, Flex, Tab, TabList, TabPanel} from '@sanity/ui'
+import {Card, Code, Flex, TabList, TabPanel} from '@sanity/ui'
 import React, {useCallback} from 'react'
 import JSONInspector from '@rexxars/react-json-inspector'
-import {Dialog} from '../../../../ui'
+import {Dialog, Tab} from '../../../../ui'
 import {DocTitle} from '../../../components'
 import {useDeskToolSetting} from '../../../useDeskToolSetting'
 import {useDocumentPane} from '../useDocumentPane'
@@ -63,7 +63,6 @@ export function InspectDialog(props: InspectDialogProps) {
           <TabList space={1}>
             <Tab
               aria-controls={`${dialogIdPrefix}tabpanel`}
-              fontSize={1}
               id={`${dialogIdPrefix}tab-${VIEW_MODE_PARSED.id}`}
               label={VIEW_MODE_PARSED.title}
               onClick={setParsedViewMode}
@@ -71,7 +70,6 @@ export function InspectDialog(props: InspectDialogProps) {
             />
             <Tab
               aria-controls={`${dialogIdPrefix}tabpanel`}
-              fontSize={1}
               id={`${dialogIdPrefix}tab-${VIEW_MODE_RAW.id}`}
               label={VIEW_MODE_RAW.title}
               onClick={setRawViewMode}

--- a/packages/sanity/src/ui/index.ts
+++ b/packages/sanity/src/ui/index.ts
@@ -1,6 +1,7 @@
 export * from './button'
 export * from './dialog'
 export * from './menuItem'
+export * from './tab'
 export * from './tooltip'
 
 // @todo: consider an alternative pattern for non studio ui components, avoiding circular dependencies

--- a/packages/sanity/src/ui/index.ts
+++ b/packages/sanity/src/ui/index.ts
@@ -1,6 +1,6 @@
 export * from './button'
 export * from './dialog'
-export * from './draftStatus'
 export * from './menuItem'
-export * from './publishedStatus'
 export * from './tooltip'
+
+// @todo: consider an alternative pattern for non studio ui components, avoiding circular dependencies

--- a/packages/sanity/src/ui/tab/Tab.tsx
+++ b/packages/sanity/src/ui/tab/Tab.tsx
@@ -1,10 +1,26 @@
-import {Tab as UITab, TabProps as UITabProps} from '@sanity/ui'
-import React from 'react'
+import {ButtonTone, Tab as UITab, TabProps as UITabProps} from '@sanity/ui'
+import React, {forwardRef} from 'react'
 
-/** @internal */
-export interface TabProps extends Omit<UITabProps, 'icon' | 'padding' | 'fontSize'> {
-  size?: 'small'
-  ref: React.Ref<HTMLButtonElement>
+/**
+ * @internal
+ */
+export type TabProps = Pick<
+  UITabProps,
+  'id' | 'label' | 'aria-controls' | 'tone' | 'selected' | 'focused'
+> & {
+  size?: 'default' | 'small'
+}
+
+const smallTabProps = {
+  padding: 2,
+  muted: true,
+  tone: 'positive' as ButtonTone,
+}
+
+const defaultTabProps = {
+  padding: 3,
+  muted: true,
+  tone: 'positive' as ButtonTone,
 }
 
 /**
@@ -15,10 +31,9 @@ export interface TabProps extends Omit<UITabProps, 'icon' | 'padding' | 'fontSiz
  *
  * @internal
  */
-export const Tab = ({size, ...rest}: TabProps) => {
-  if (size === 'small') {
-    return <UITab padding={2} {...rest} />
-  }
-
-  return <UITab {...rest} padding={4} />
-}
+export const Tab = forwardRef(function Tab(
+  {size = 'default', ...props}: TabProps & Omit<React.HTMLProps<HTMLButtonElement>, 'as' | 'size'>,
+  ref: React.ForwardedRef<HTMLButtonElement>,
+) {
+  return <UITab {...props} {...(size === 'default' ? defaultTabProps : smallTabProps)} ref={ref} />
+})

--- a/packages/sanity/src/ui/tab/Tab.tsx
+++ b/packages/sanity/src/ui/tab/Tab.tsx
@@ -1,0 +1,24 @@
+import {Tab as UITab, TabProps as UITabProps} from '@sanity/ui'
+import React from 'react'
+
+/** @internal */
+export interface TabProps extends Omit<UITabProps, 'icon' | 'padding' | 'fontSize'> {
+  size?: 'small'
+  ref: React.Ref<HTMLButtonElement>
+}
+
+/**
+ * Studio UI <Tab>.
+ *
+ * Studio UI components are opinionated `@sanity/ui` components meant for internal use only.
+ * Props and options are intentionally limited to ensure consistency and ease of use.
+ *
+ * @internal
+ */
+export const Tab = ({size, ...rest}: TabProps) => {
+  if (size === 'small') {
+    return <UITab padding={2} {...rest} />
+  }
+
+  return <UITab {...rest} padding={4} />
+}

--- a/packages/sanity/src/ui/tab/Tab.tsx
+++ b/packages/sanity/src/ui/tab/Tab.tsx
@@ -1,28 +1,25 @@
+/* eslint-disable no-restricted-imports */
 import {Tab as UITab, TabProps as UITabProps} from '@sanity/ui'
 import React, {forwardRef} from 'react'
 
 /**
  * @internal
  *
- * Icons are not supported in the Studio UI <Tab> component.
- * Padding and font size are fixed.
- *
+ * Padding and font sizes are fixed in Studio UI <Tab> components.
  */
 export type TabProps = Pick<
   UITabProps,
-  'id' | 'label' | 'aria-controls' | 'tone' | 'selected' | 'focused'
+  'aria-controls' | 'focused' | 'icon' | 'id' | 'label' | 'selected' | 'tone'
 > & {
   size?: 'default' | 'small'
 }
 
-const smallTabProps = {
+const SMALL_TAB_PROPS = {
   padding: 2,
-  muted: true,
 }
 
-const defaultTabProps = {
+const DEFAULT_TAB_PROPS = {
   padding: 3,
-  muted: true,
 }
 
 /**
@@ -36,7 +33,7 @@ const defaultTabProps = {
 export const Tab = forwardRef(function Tab(
   {
     size = 'default',
-    tone = 'primary',
+    tone = 'default',
     ...props
   }: TabProps & Omit<React.HTMLProps<HTMLButtonElement>, 'as' | 'size'>,
   ref: React.ForwardedRef<HTMLButtonElement>,
@@ -44,9 +41,10 @@ export const Tab = forwardRef(function Tab(
   return (
     <UITab
       {...props}
-      {...(size === 'default' ? defaultTabProps : smallTabProps)}
-      tone={tone}
+      {...(size === 'default' ? DEFAULT_TAB_PROPS : SMALL_TAB_PROPS)}
+      muted
       ref={ref}
+      tone={tone}
     />
   )
 })

--- a/packages/sanity/src/ui/tab/Tab.tsx
+++ b/packages/sanity/src/ui/tab/Tab.tsx
@@ -1,4 +1,4 @@
-import {ButtonTone, Tab as UITab, TabProps as UITabProps} from '@sanity/ui'
+import {Tab as UITab, TabProps as UITabProps} from '@sanity/ui'
 import React, {forwardRef} from 'react'
 
 /**
@@ -18,13 +18,11 @@ export type TabProps = Pick<
 const smallTabProps = {
   padding: 2,
   muted: true,
-  tone: 'positive' as ButtonTone,
 }
 
 const defaultTabProps = {
   padding: 3,
   muted: true,
-  tone: 'positive' as ButtonTone,
 }
 
 /**
@@ -36,8 +34,19 @@ const defaultTabProps = {
  * @internal
  */
 export const Tab = forwardRef(function Tab(
-  {size = 'default', ...props}: TabProps & Omit<React.HTMLProps<HTMLButtonElement>, 'as' | 'size'>,
+  {
+    size = 'default',
+    tone = 'primary',
+    ...props
+  }: TabProps & Omit<React.HTMLProps<HTMLButtonElement>, 'as' | 'size'>,
   ref: React.ForwardedRef<HTMLButtonElement>,
 ) {
-  return <UITab {...props} {...(size === 'default' ? defaultTabProps : smallTabProps)} ref={ref} />
+  return (
+    <UITab
+      {...props}
+      {...(size === 'default' ? defaultTabProps : smallTabProps)}
+      tone={tone}
+      ref={ref}
+    />
+  )
 })

--- a/packages/sanity/src/ui/tab/Tab.tsx
+++ b/packages/sanity/src/ui/tab/Tab.tsx
@@ -3,6 +3,10 @@ import React, {forwardRef} from 'react'
 
 /**
  * @internal
+ *
+ * Icons are not supported in the Studio UI <Tab> component.
+ * Padding and font size are fixed.
+ *
  */
 export type TabProps = Pick<
   UITabProps,

--- a/packages/sanity/src/ui/tab/index.ts
+++ b/packages/sanity/src/ui/tab/index.ts
@@ -1,0 +1,1 @@
+export * from './Tab'


### PR DESCRIPTION
### Description

Introduces `StudioUI Tab`, adding defaults to create the tabs. Introduces a `small` and `default` size. 
Removes the possibility of adding `icons`, custom `padding` and `fontSize`. 
Updates all the uses of tabs to use the ones.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Tab uses (can be tested in field groups)

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Introduces `StudioUI Tab` components, adding defaults to create them. 
<!--
A description of the change(s) that should be used in the release notes.
-->
