### PR TITLE
feat(router): add support for search params

### DIFF
--- a/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.tsx
+++ b/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.tsx
@@ -57,7 +57,7 @@ function useRouterFromWorkspaceHistory(
       routerBasePath === '/' ? true : routerBasePathRegex.test(pathname)
     return {
       subscribe: (onStoreChange: () => void) => history.listen(onStoreChange),
-      getSnapshot: () => history.location.pathname,
+      getSnapshot: () => history.location.pathname + history.location.search ?? '',
       // Always return null for the server snapshot, as we can't know how to resolve intents until after authentication is done, which is browser-only
       getServerSnapshot: () => null,
       selector: (pathname: string | null) =>

--- a/packages/sanity/src/router/README.md
+++ b/packages/sanity/src/router/README.md
@@ -1,0 +1,331 @@
+# `sanity/router`
+
+## Features
+
+Based on a routing schema:
+
+- A state object can be derived from the current pathname
+- A state object can be used to generate a path name
+
+## API Usage
+
+Define the routes for your application and how they should map to application state
+
+```js
+import {route} from '@sanity/state-router'
+
+const router = route.create('/', [route.create('/products/:productId'), route.create('/users/:userId'), route('/:page')])
+
+router.encode({})
+// => '/'
+router.decode('/')
+// => {}
+
+router.encode({productId: 54})
+// => '/products/54'
+
+router.decode('/products/54')
+// => {productId: 54}
+
+router.encode({userId: 22})
+// => '/users/22'
+
+router.decode('/users/54')
+// => {userId: 54}
+
+router.encode({page: 'about'})
+// => '/about'
+
+router.decode('/about')
+// => {page: about}
+```
+
+## React usage
+
+### Setup routes and provider
+
+```jsx
+import {route} from '@sanity/state-router'
+import {RouterProvider, withRouter} from '@sanity/state-router/components'
+
+const router = route('/', [route('/bikes/:bikeId')])
+
+const history = createHistory()
+
+function handleNavigate(nextUrl, {replace} = {}) {
+  if (replace) {
+    history.replace(nextUrl)
+  } else {
+    history.push(nextUrl)
+  }
+}
+
+const App = withRouter(function App({router}) {
+  if (router.state.bikeId) {
+    return <BikePage id={router.state.bikeId} />
+  }
+  return (
+    <div>
+      <h1>Welcome</h1>
+      <StateLink state={{bikeId: 22}}>Go to bike 22</StateLink>
+    </div>
+  )
+})
+
+function render(location) {
+  ReactDOM.render(
+    <RouterProvider
+      router={router}
+      onNavigate={handleNavigate}
+      state={router.decode(location.pathname)}
+    >
+      <App />
+    </RouterProvider>,
+    document.getElementById('container')
+  )
+}
+history.listen(() => render(document.location))
+```
+
+## API
+
+- `route(path : string, ?options : Options, ?children : ) : Router`
+- `route.scope(name : string, path : string, ?options : Options, ?children : ) : Router`
+- `Router`:
+
+  - `encode(state : object) : string`
+  - `decode(path : string) : object`
+  - `isRoot(path : string) : boolean`
+  - `getBasePath() : string`,
+  - `isNotFound(pathname: string): boolean`
+  - `getRedirectBase(pathname : string) : ?string`
+
+- `RouteChildren`:
+  ```
+  Router | [Router] | ((state) => Router | [Router])
+  ```
+- `Options`:
+
+  ```
+  {
+    path?: string,
+    children?: RouteChildren,
+    transform?: {[key: string] : Transform<*>},
+    scope?: string
+  }
+  ```
+
+  - `children` can be either another router returned from another `route()-call`, an array of routers or a function that gets passed the matched parameters, and conditionally returns child routes
+
+## Limitations
+
+- Parameterized paths _only_. Each route must have at least one unique parameter. If not, there's no way of unambiguously resolve a path from an empty state.
+
+Consider the following routes:
+
+```js
+const router = route('/', [route('/about'), route('/contact')])
+```
+
+What route should be resolved from an empty state? Since both `/about` and `/contact` above resolves to an empty state object, there's no way to encode an empty state unambiguously back to either of them. The solution to this would be to introduce the page name as a parameter instead:
+
+```js
+const router = route('/', route('/:page'))
+```
+
+Now, `/about` would resolve to the state `{page: 'about'}` which unambiguously can map back to `/page`, and an empty state can map to `/`. To figure out if you are on the index page, you can check for `state.page == null`, (and set the state.page to null to navigate back to the index)
+
+### No query params
+
+Query parameters doesn't work too well with router scopes as they operate in a global namespace. A possible workaround is to "fake" query params in a path segment using transforms:
+
+```js
+function decodeParams(pathsegment) {
+  return pathsegment.split(';').reduce((params, pair) => {
+    const [key, value] = pair.split('=')
+    params[key] = value
+    return params
+  }, {})
+}
+function encodeParams(params) {
+  return Object.keys(params)
+    .map((key) => `${key}=${params[key]}`)
+    .join(';')
+}
+
+const router = route(
+  '/some/:section/:settings',
+  {
+    transform: {
+      settings: {
+        toState: decodeParams,
+        toPath: encodeParams,
+      },
+    },
+  },
+  route('/other/:page')
+)
+```
+
+This call...
+
+```js
+router.decode('/some/bar/width=full;view=details')
+```
+
+...will return the following state
+
+```js
+{
+  section: 'bar',
+  settings: {
+    width: 'full',
+    view: 'details',
+  }
+}
+```
+
+Conversely calling
+
+```js
+router.encode({
+  section: 'bar',
+  settings: {
+    width: 'full',
+    view: 'details',
+  },
+})
+```
+
+will return
+
+```
+/some/bar/width=full;view=details
+```
+
+## Scopes
+
+A scope is a separate router state space, allowing different parts of an application to be completely agnostic about the overall routing schema is like. Let's illustrate:
+
+```js
+import {route} from './src'
+function findAppByName(name) {
+  return (
+    name === 'pokemon' && {
+      name: 'pokemon',
+      router: route('/:section', route('/:pokemonName')),
+    }
+  )
+}
+
+const router = route('/', [
+  route('/users/:username'),
+  route('/apps/:appName', (params) => {
+    const app = findAppByName(params.appName)
+    return app && route.scope(app.name, '/', app.router)
+  }),
+])
+```
+
+Decoding the following path...
+
+```js
+router.decode('/apps/pokemon/stats/bulbasaur')
+```
+
+...will give us the state:
+
+```js
+{
+  appName: 'pokemon',
+  pokemon: {
+    section: 'stats',
+    pokemonName: 'bulbasaur'
+  }
+}
+```
+
+## Intents
+
+An _intent_ is a kind of global route that can be used for dispatching user actions. The intent route can be mounted with
+
+```js
+route.intents(<basePath>)
+```
+
+Intent links bypasses scoping, and will always be mapped to the configured `basePath`.
+
+An intent consists of a name, e.g. `open` and a set of parameters, e.g. `{id: 'abc33'}` and the easiest way to make a link to an intent is using the `IntentLink` React component:
+
+```jsx
+<IntentLink intent="open" params={{id: abc33}}>
+  Open document
+</IntentLink>
+```
+
+This will generate an `<a` tag with a href like `/<base path>/open/id=abc33` depending on where the intent handler is mounted
+
+State router comes with a built in intent-route parser that decodes an intent route to route state.
+
+Full example:
+
+```
+const router = route('/', [
+  route('/users/:username'),
+  route.intents('/intents') // <-- sets up intent routes at the /intents base path
+])
+```
+
+Decoding the url `/intents/open/id=abc33` will produce the following state:
+
+```js
+{
+  intent: 'open',
+  params: {id: 'abc33'}
+}
+```
+
+It is now up to your application logic to translate this intent into an action, and redirect accordingly.
+
+## 404s
+
+To check whether a path name matches, you can use the isNotFound method on the returned router instance:
+
+```js
+const router = route('/pages/:page')
+
+router.isNotFound('/some/invalid/path')
+// => true
+```
+
+## Base paths
+
+Using a base path is as simple as adding a toplevel route with no params:
+
+```js
+const router = route('/some/basepath', [route('/:foo'), route('/:bar')])
+```
+
+Any empty router state will resolve to `/some/basepath`. To check if you should redirect to the base path on app init, you can use the `router.isRoot(path)` and `router.getBasePath()` method:
+
+```js
+if (router.isRoot(location.pathname)) {
+  const basePath = router.getBasePath()
+  if (basePath !== location.pathname) {
+    history.replaceState(null, null, basePath)
+  }
+}
+```
+
+For convenience, this check is combined in the method `router.getRedirectBase()`, that if a redirect is needed, will return the base path, otherwise `null`
+
+```js
+const redirectTo = router.getRedirectBase(location.pathname)
+if (redirectTo) {
+  history.replaceState(null, null, redirectTo)
+}
+```
+
+## License
+
+MIT-licensed

--- a/packages/sanity/src/router/__test__/api.test.ts
+++ b/packages/sanity/src/router/__test__/api.test.ts
@@ -1,0 +1,107 @@
+import {route} from '../route'
+
+test('route.create(options)', () => {
+  const router = route.create({
+    path: '/root/:param',
+    transform: {
+      param: {
+        toState: (param) => param.toUpperCase(),
+        toPath: (param) => param.toLowerCase(),
+      },
+    },
+    children: [route.create({path: '/sub/:subparam'})],
+  })
+
+  expect(router.decode('/root/banana')).toEqual({param: 'BANANA'})
+  expect(router.encode({param: 'BANANA'})).toEqual('/root/banana')
+
+  expect(router.decode('/root/banana/sub/lemon')).toEqual({
+    param: 'BANANA',
+    subparam: 'lemon',
+  })
+  expect(router.encode({param: 'BANANA', subparam: 'lemon'})).toEqual('/root/banana/sub/lemon')
+})
+
+test('route.create(path, options)', () => {
+  const router = route.create('/root/:param', {
+    transform: {
+      param: {
+        toState: (param) => param.toUpperCase(),
+        toPath: (param) => param.toLowerCase(),
+      },
+    },
+    children: [route.create('/sub/:subparam')],
+  })
+
+  expect(router.decode('/root/banana')).toEqual({param: 'BANANA'})
+  expect(router.encode({param: 'BANANA'})).toEqual('/root/banana')
+
+  expect(router.decode('/root/banana/sub/lemon')).toEqual({
+    param: 'BANANA',
+    subparam: 'lemon',
+  })
+  expect(router.encode({param: 'BANANA', subparam: 'lemon'})).toEqual('/root/banana/sub/lemon')
+})
+
+test('route.create(path, options, children)', () => {
+  const router = route.create(
+    '/root/:param',
+    {
+      transform: {
+        param: {
+          toState: (param) => param.toUpperCase(),
+          toPath: (param) => param.toLowerCase(),
+        },
+      },
+    },
+    [route.create('/sub/:subparam')],
+  )
+
+  expect(router.decode('/root/banana')).toEqual({param: 'BANANA'})
+  expect(router.encode({param: 'BANANA'})).toEqual('/root/banana')
+
+  expect(router.decode('/root/banana/sub/lemon')).toEqual({
+    param: 'BANANA',
+    subparam: 'lemon',
+  })
+  expect(router.encode({param: 'BANANA', subparam: 'lemon'})).toEqual('/root/banana/sub/lemon')
+})
+
+test('route.create(path, children)', () => {
+  const router = route.create('/root/:param', [route.create('/sub/:subparam')])
+
+  expect(router.decode('/root/banana')).toEqual({param: 'banana'})
+  expect(router.encode({param: 'banana'})).toEqual('/root/banana')
+
+  expect(router.decode('/root/banana/sub/lemon')).toEqual({
+    param: 'banana',
+    subparam: 'lemon',
+  })
+  expect(router.encode({param: 'banana', subparam: 'lemon'})).toEqual('/root/banana/sub/lemon')
+})
+
+test('overrides conflicting params', () => {
+  const router = route.create(
+    '/this/will/be/ignored',
+    {
+      path: '/root/:param',
+      transform: {
+        param: {
+          toState: (param) => param.toUpperCase(),
+          toPath: (param) => param.toLowerCase(),
+        },
+      },
+      children: [route.create('/sub/:thiswillbeignored')],
+    },
+    [route.create('/sub/:subparam')],
+  )
+
+  expect(router.decode('/root/banana')).toEqual({param: 'BANANA'})
+  expect(router.encode({param: 'BANANA'})).toEqual('/root/banana')
+
+  expect(router.decode('/root/banana/sub/lemon')).toEqual({
+    param: 'BANANA',
+    subparam: 'lemon',
+  })
+  expect(router.encode({param: 'BANANA', subparam: 'lemon'})).toEqual('/root/banana/sub/lemon')
+})

--- a/packages/sanity/src/router/__test__/basepath.test.ts
+++ b/packages/sanity/src/router/__test__/basepath.test.ts
@@ -1,0 +1,9 @@
+import {route} from '../route'
+
+test('route(options)', () => {
+  const router = route.create('/some/basepath', [route.create('/:param')])
+
+  expect(router.decode('/some/basepath')).toEqual({})
+  expect(router.encode({})).toEqual('/some/basepath')
+  expect(router.encode({param: 'foo'})).toEqual('/some/basepath/foo')
+})

--- a/packages/sanity/src/router/__test__/errors.test.ts
+++ b/packages/sanity/src/router/__test__/errors.test.ts
@@ -1,0 +1,27 @@
+import {route} from '../route'
+
+function mock<T, K extends keyof T>(obj: T, methodName: K, mockFn: T[K]) {
+  const original = obj[methodName]
+  obj[methodName] = mockFn
+  return function restore() {
+    obj[methodName] = original
+  }
+}
+
+test('warn on invalid characters', () => {
+  const restore = mock(console, 'error', (error) => {
+    expect(error.message).toEqual('Warning: Param segments ":pa`ram" includes invalid characters.')
+    restore()
+  })
+  route.create('/root/:pa`ram')
+})
+
+test('warn on splats', () => {
+  const restore = mock(console, 'error', (error) => {
+    expect(error.message).toEqual(
+      'Warning: Param segments ":pa*ram" includes invalid characters. Splats are not supported. Consider using child routes instead',
+    )
+    restore()
+  })
+  route.create('/root/:pa*ram')
+})

--- a/packages/sanity/src/router/__test__/examples.ts
+++ b/packages/sanity/src/router/__test__/examples.ts
@@ -1,0 +1,65 @@
+/* eslint-disable quote-props */
+
+import {route} from '../route'
+
+export const router = route.create('/:dataset', [
+  route.create('/settings/:setting'),
+  route.create('/tools/:tool', (params: any): any => {
+    if (params.tool === 'desk') {
+      return [route.scope('desk', '/collections/:collection')]
+    }
+    if (params.tool === 'another-tool') {
+      return [route.scope('another-tool', '/omg/:nope')]
+    }
+    return null
+  }),
+])
+
+export const examples: Array<[string, Record<string, string | Record<string, string>>]> = [
+  ['/some-dataset', {dataset: 'some-dataset'}],
+  ['/some-dataset/tools/desk', {dataset: 'some-dataset', tool: 'desk'}],
+  [
+    '/some-dataset/settings/desk',
+    {
+      dataset: 'some-dataset',
+      setting: 'desk',
+    },
+  ],
+  [
+    '/some-dataset/tools/desk',
+    {
+      dataset: 'some-dataset',
+      tool: 'desk',
+    },
+  ],
+  [
+    '/some-dataset/tools/desk/collections/articles',
+    {
+      dataset: 'some-dataset',
+      tool: 'desk',
+      desk: {
+        collection: 'articles',
+      },
+    },
+  ],
+  [
+    '/some-dataset/tools/another-tool/omg/foo',
+    {
+      dataset: 'some-dataset',
+      tool: 'another-tool',
+      'another-tool': {
+        nope: 'foo',
+      },
+    },
+  ],
+  [
+    '/some-dataset/tools/another-tool/omg/foo',
+    {
+      dataset: 'some-dataset',
+      tool: 'another-tool',
+      'another-tool': {
+        nope: 'foo',
+      },
+    },
+  ],
+]

--- a/packages/sanity/src/router/__test__/factory.test.ts
+++ b/packages/sanity/src/router/__test__/factory.test.ts
@@ -1,0 +1,26 @@
+import {route} from '../route'
+
+test('only route', () => {
+  const router = route.create('/foo/:bar')
+  expect(router.decode('/foo/bar')).toEqual({bar: 'bar'})
+})
+
+test('null options', () => {
+  const router = route.create('/foo/:bar', null)
+  expect(router.decode('/foo/bar')).toEqual({bar: 'bar'})
+})
+
+test('empty children', () => {
+  const router = route.create('/foo/:bar', [])
+  expect(router.decode('/foo/bar')).toEqual({bar: 'bar'})
+})
+
+test('nonempty children', () => {
+  const router = route.create('/foo/:bar', [route.create('/:baz')])
+  expect(router.decode('/foo/bar/baz')).toEqual({bar: 'bar', baz: 'baz'})
+})
+
+test('children and options', () => {
+  const router = route.scope('foobar', '/foo/:bar', [route.create('/:baz')])
+  expect(router.decode('/foo/bar/baz')).toEqual({foobar: {bar: 'bar', baz: 'baz'}})
+})

--- a/packages/sanity/src/router/__test__/findMatchingNodes.test.ts
+++ b/packages/sanity/src/router/__test__/findMatchingNodes.test.ts
@@ -1,0 +1,105 @@
+import {MatchResult, RouterNode} from '../types'
+import {_findMatchingRoutes} from '../_findMatchingRoutes'
+
+const node: RouterNode = {
+  route: {
+    raw: '/foo/:bar',
+    segments: [
+      {type: 'dir', name: 'foo'},
+      {type: 'param', name: 'bar'},
+    ],
+  },
+  children: [
+    {
+      route: {
+        raw: '/nix/:animal',
+        segments: [
+          {type: 'dir', name: 'nix'},
+          {type: 'param', name: 'animal'},
+        ],
+      },
+      children: [],
+    },
+    {
+      route: {
+        raw: '/qux/:animal',
+        segments: [
+          {type: 'dir', name: 'qux'},
+          {type: 'param', name: 'animal'},
+        ],
+        transform: {
+          animal: {
+            toState: (value) => ({name: value.toUpperCase()}),
+            toPath: (animal) => (animal.name as string).toLowerCase(),
+          },
+        },
+      },
+      children: [
+        {
+          route: {
+            raw: 'flargh/:snargh',
+            segments: [
+              {type: 'dir', name: 'flargh'},
+              {type: 'param', name: 'snargh'},
+            ],
+            transform: {},
+          },
+          children: [],
+        },
+      ],
+    },
+  ],
+}
+
+const examples: [Record<string, unknown>, MatchResult][] = [
+  [
+    {},
+    {
+      nodes: [],
+      missing: ['bar'],
+      remaining: [],
+    },
+  ],
+  [
+    {bar: 'bar'},
+    {
+      nodes: [node],
+      missing: [],
+      remaining: [],
+    },
+  ],
+  [
+    {bar: 'bar', animal: 'cat'},
+    {
+      nodes: [node, (node.children as RouterNode[])[0]],
+      remaining: [],
+      missing: [],
+    },
+  ],
+  [
+    {bar: 'bar', animal: 'cat', snargh: 'gnargh'},
+    {
+      nodes: [
+        node,
+        (node.children as RouterNode[])[1],
+        ((node.children as RouterNode[])[1].children as RouterNode[])[0],
+      ],
+      remaining: [],
+      missing: [],
+    },
+  ],
+  [
+    {bar: 'bar', creature: 'cat'},
+    {
+      nodes: [],
+      remaining: ['creature'],
+      missing: [],
+    },
+  ],
+]
+
+examples.forEach(([state, result]) => {
+  test(`state ${JSON.stringify(state)} matches`, () => {
+    expect(_findMatchingRoutes(node, state)).toEqual(result)
+  })
+})

--- a/packages/sanity/src/router/__test__/findMatchingNodes.test.ts
+++ b/packages/sanity/src/router/__test__/findMatchingNodes.test.ts
@@ -55,45 +55,69 @@ const examples: [Record<string, unknown>, MatchResult][] = [
   [
     {},
     {
-      nodes: [],
-      missing: ['bar'],
-      remaining: [],
+      type: 'error',
+      node,
+      missingKeys: ['bar'],
+      unmappableStateKeys: [],
     },
   ],
   [
     {bar: 'bar'},
     {
-      nodes: [node],
-      missing: [],
-      remaining: [],
+      type: 'ok',
+      node: node,
+      matchedState: {bar: 'bar'},
+      child: undefined,
+      searchParams: [],
     },
   ],
   [
     {bar: 'bar', animal: 'cat'},
     {
-      nodes: [node, (node.children as RouterNode[])[0]],
-      remaining: [],
-      missing: [],
+      node,
+      type: 'ok',
+      child: {
+        type: 'ok',
+        child: undefined,
+        matchedState: {
+          animal: 'cat',
+        },
+        node: expect.objectContaining({children: expect.any(Object), route: expect.any(Object)}),
+        searchParams: [],
+      },
+      matchedState: {
+        bar: 'bar',
+      },
+      searchParams: [],
     },
   ],
   [
     {bar: 'bar', animal: 'cat', snargh: 'gnargh'},
     {
-      nodes: [
-        node,
-        (node.children as RouterNode[])[1],
-        ((node.children as RouterNode[])[1].children as RouterNode[])[0],
-      ],
-      remaining: [],
-      missing: [],
+      type: 'ok',
+      node,
+      child: {
+        type: 'ok',
+        child: expect.any(Object),
+        matchedState: {
+          animal: 'cat',
+        },
+        node: expect.objectContaining({children: expect.any(Object), route: expect.any(Object)}),
+        searchParams: [],
+      },
+      matchedState: {
+        bar: 'bar',
+      },
+      searchParams: [],
     },
   ],
   [
     {bar: 'bar', creature: 'cat'},
     {
-      nodes: [],
-      remaining: ['creature'],
-      missing: [],
+      type: 'error',
+      node,
+      unmappableStateKeys: ['creature'],
+      missingKeys: [],
     },
   ],
 ]

--- a/packages/sanity/src/router/__test__/resolvePathFromState.test.ts
+++ b/packages/sanity/src/router/__test__/resolvePathFromState.test.ts
@@ -1,0 +1,65 @@
+import {route} from '../route'
+import {Router} from '../types'
+import {_resolvePathFromState} from '../_resolvePathFromState'
+
+test('resolves empty state to fixed base path', () => {
+  const rootRoute: Router = route.create('/root', [
+    route.create('/:page', [route.create('/:productId')]),
+  ])
+  expect(_resolvePathFromState(rootRoute, {})).toEqual('/root')
+})
+
+test('throws on unresolvable state', () => {
+  const rootRoute = route.create('/root', [route.create('/:page', [route.create('/:productId')])])
+  expect(() => _resolvePathFromState(rootRoute, {foo: 'bar'})).toThrow(
+    'Unable to find matching route for state. Could not map the following state key to a valid url: foo',
+  )
+})
+
+test('points to unmapped keys', () => {
+  const routesDef = route.create('/:dataset', [
+    route.create('/settings/:setting'),
+    route.create('/tools/:tool', (params: any): any => {
+      if (params.tool === 'desk') {
+        return [route.scope('desk', '/collections/:collection')]
+      }
+      if (params.tool === 'another-tool') {
+        return [route.scope('foo', '/omg/:nope')]
+      }
+      return undefined
+    }),
+  ])
+  const state = {
+    dataset: 'some-dataset',
+    tool: 'another-tool',
+    foo: {
+      nop: 'bar',
+    },
+  }
+  expect(() => _resolvePathFromState(routesDef, state)).toThrow(
+    'Unable to find matching route for state. Could not map the following state keys to a valid url: tool, foo',
+  )
+})
+
+test('Resolves this', () => {
+  const routesDef = route.create('/:dataset', [
+    route.create('/settings/:setting'),
+    route.create('/tools/:tool', (params: any): any => {
+      if (params.tool === 'desk') {
+        return [route.scope('desk', '/collections/:collection')]
+      }
+      if (params.tool === 'another-tool') {
+        return [route.scope('foo', '/omg/:nope')]
+      }
+      return undefined
+    }),
+  ])
+  const state = {
+    dataset: 'some-dataset',
+    tool: 'another-tool',
+    foo: {
+      nope: 'foo',
+    },
+  }
+  expect(_resolvePathFromState(routesDef, state)).toBe('/some-dataset/tools/another-tool/omg/foo')
+})

--- a/packages/sanity/src/router/__test__/resolvePathFromState.test.ts
+++ b/packages/sanity/src/router/__test__/resolvePathFromState.test.ts
@@ -9,10 +9,17 @@ test('resolves empty state to fixed base path', () => {
   expect(_resolvePathFromState(rootRoute, {})).toEqual('/root')
 })
 
-test('throws on unresolvable state', () => {
+test('throws if state is missing required params', () => {
+  const rootRoute = route.create('/base/:one/:another')
+  expect(() => _resolvePathFromState(rootRoute, {})).toThrow(
+    'Unable to find matching route for state. State object is missing the following keys defined in route: "one", "another"',
+  )
+})
+
+test('throws on state values that dont map to url params', () => {
   const rootRoute = route.create('/root', [route.create('/:page', [route.create('/:productId')])])
   expect(() => _resolvePathFromState(rootRoute, {foo: 'bar'})).toThrow(
-    'Unable to find matching route for state. Could not map the following state key to a valid url: foo',
+    'Unable to find matching route for state. Could not map the following state key to a valid url: "foo"',
   )
 })
 
@@ -37,7 +44,7 @@ test('points to unmapped keys', () => {
     },
   }
   expect(() => _resolvePathFromState(routesDef, state)).toThrow(
-    'Unable to find matching route for state. Could not map the following state keys to a valid url: tool, foo',
+    'Unable to find matching route for state. Could not map the following state keys to a valid url: "tool", "foo"',
   )
 })
 

--- a/packages/sanity/src/router/__test__/resolveStateFromPath.test.ts
+++ b/packages/sanity/src/router/__test__/resolveStateFromPath.test.ts
@@ -1,0 +1,121 @@
+import {RouterNode} from '../types'
+import {_resolveStateFromPath} from '../_resolveStateFromPath'
+
+const node: RouterNode = {
+  route: {
+    raw: '/foo/:bar',
+    segments: [
+      {type: 'dir', name: 'foo'},
+      {type: 'param', name: 'bar'},
+    ],
+  },
+  children: [
+    {
+      route: {
+        raw: '/dynamic/:foo',
+        segments: [
+          {type: 'dir', name: 'dynamic'},
+          {type: 'param', name: 'foo'},
+        ],
+      },
+      children(state: any) {
+        if (state.foo === 'foo') {
+          return [
+            {
+              route: {
+                raw: '/:whenfoo',
+                segments: [{type: 'param', name: 'whenfoo'}],
+              },
+              transform: {},
+              children: [],
+            },
+          ]
+        }
+        return [
+          {
+            route: {
+              raw: '/:notfoo',
+              segments: [{type: 'param', name: 'notfoo'}],
+            },
+            transform: {},
+            children: [],
+          },
+        ]
+      },
+    },
+    {
+      route: {
+        raw: '/nix/:animal',
+        segments: [
+          {type: 'dir', name: 'nix'},
+          {type: 'param', name: 'animal'},
+        ],
+      },
+      children: [],
+    },
+    {
+      route: {
+        raw: '/qux/:animal',
+        segments: [
+          {type: 'dir', name: 'qux'},
+          {type: 'param', name: 'animal'},
+        ],
+      },
+      transform: {
+        animal: {
+          toState: (value) => ({name: value.toUpperCase()}),
+          toPath: (animal) => (animal.name as string).toLowerCase(),
+        },
+      },
+      children: [],
+    },
+  ],
+}
+
+const examples: any[] = [
+  ['/foo/bar', {bar: 'bar'}],
+  ['foo/bar', {bar: 'bar'}],
+  ['foo/bar/baz', null],
+  [
+    '/foo/bar/qux/cat',
+    {
+      animal: {name: 'CAT'},
+      bar: 'bar',
+    },
+  ],
+  [
+    '/foo/bar/nix/cat',
+    {
+      animal: 'cat',
+      bar: 'bar',
+    },
+  ],
+  [
+    '/foo/bar/nix/cat',
+    {
+      animal: 'cat',
+      bar: 'bar',
+    },
+  ],
+  ['/nope/bar', null],
+  [
+    '/foo/bar/dynamic/foo/thisisfoo',
+    {
+      bar: 'bar',
+      foo: 'foo',
+      whenfoo: 'thisisfoo',
+    },
+  ],
+  ['/foo', null],
+].filter(Boolean)
+
+examples.forEach(([path, state]) => {
+  test(`path ${path} => ${JSON.stringify(state)}`, () => {
+    expect(_resolveStateFromPath(node, path)).toEqual(state)
+  })
+})
+
+// IDEA! Can/should not map from a global param space to state because conflicts
+// assert.deepEqual(resolveStateFromPath(node, '/foo/bar;flabla=flarb/nix/cat;family=mammal'), {
+//
+// })

--- a/packages/sanity/src/router/__test__/scope.test.ts
+++ b/packages/sanity/src/router/__test__/scope.test.ts
@@ -6,12 +6,22 @@ test('toplevel', () => {
   expect(router.encode({omg: {bar: 'bar'}})).toBe('/foo/bar')
 })
 
+test('toplevel, with params', () => {
+  const router = route.scope('omg', '/foo/:bar')
+  expect(router.decode('/foo/bar?omg%5Bsomething%5D=xyz')).toEqual({
+    omg: {bar: 'bar', _searchParams: [['something', 'xyz']]},
+  })
+  expect(router.encode({omg: {bar: 'bar', _searchParams: [['something', 'xyz']]}})).toBe(
+    '/foo/bar?omg%5Bsomething%5D=xyz',
+  )
+})
+
 test('scopes all the way down', () => {
   const router = route.scope('first', '/foo/:bar', [
     route.scope('second', '/baz/:qux', [route.scope('third', '/omg/:lol')]),
   ])
 
-  expect({first: {bar: 'bar'}}).toEqual(router.decode('/foo/bar'))
+  expect(router.decode('/foo/bar')).toEqual({first: {bar: 'bar'}})
   expect('/foo/bar').toBe(router.encode({first: {bar: 'bar'}}))
 
   expect({first: {bar: 'bar', second: {qux: 'qux'}}}).toEqual(router.decode('/foo/bar/baz/qux'))
@@ -40,5 +50,85 @@ test('scopes all the way down', () => {
         },
       },
     }),
+  )
+})
+
+test('scopes all the way down, with params', () => {
+  const router = route.scope('first', '/foo/:bar', [
+    route.scope('second', '/baz/:qux', [route.scope('third', '/omg/:lol')]),
+  ])
+
+  expect(router.decode('/foo/bar?first%5Ba%5D=b')).toEqual({
+    first: {bar: 'bar', _searchParams: [['a', 'b']]},
+  })
+
+  expect(router.encode({first: {bar: 'bar', _searchParams: [['a', 'b']]}})).toBe(
+    '/foo/bar?first%5Ba%5D=b',
+  )
+
+  expect(router.decode('/foo/bar/baz/qux?first%5Ba%5D=b&first%5Bsecond%5D%5Bc%5D=d')).toEqual({
+    first: {
+      bar: 'bar',
+      _searchParams: [['a', 'b']],
+      second: {qux: 'qux', _searchParams: [['c', 'd']]},
+    },
+  })
+  expect(
+    router.encode({
+      first: {
+        bar: 'bar',
+        _searchParams: [['a', 'b']],
+        second: {qux: 'qux', _searchParams: [['c', 'd']]},
+      },
+    }),
+  ).toBe('/foo/bar/baz/qux?first%5Ba%5D=b&first%5Bsecond%5D%5Bc%5D=d')
+
+  expect(
+    router.decode(
+      '/foo/bar/baz/qux/omg/lol?first%5Bx%5D=1&first%5By%5D=2&first%5Bsecond%5D%5Ba%5D=0&first%5Bsecond%5D%5Bb%5D=1&first%5Bsecond%5D%5Bthird%5D%5Bfoo%5D=bar',
+    ),
+  ).toEqual({
+    first: {
+      bar: 'bar',
+      _searchParams: [
+        ['x', '1'],
+        ['y', '2'],
+      ],
+      second: {
+        _searchParams: [
+          ['a', '0'],
+          ['b', '1'],
+        ],
+        qux: 'qux',
+        third: {
+          _searchParams: [['foo', 'bar']],
+          lol: 'lol',
+        },
+      },
+    },
+  })
+  expect(
+    router.encode({
+      first: {
+        bar: 'bar',
+        _searchParams: [
+          ['x', '1'],
+          ['y', '2'],
+        ],
+        second: {
+          _searchParams: [
+            ['a', '0'],
+            ['b', '1'],
+          ],
+          qux: 'qux',
+          third: {
+            _searchParams: [['foo', 'bar']],
+            lol: 'lol',
+          },
+        },
+      },
+    }),
+  ).toEqual(
+    '/foo/bar/baz/qux/omg/lol?first%5Bx%5D=1&first%5By%5D=2&first%5Bsecond%5D%5Ba%5D=0&first%5Bsecond%5D%5Bb%5D=1&first%5Bsecond%5D%5Bthird%5D%5Bfoo%5D=bar',
   )
 })

--- a/packages/sanity/src/router/__test__/scope.test.ts
+++ b/packages/sanity/src/router/__test__/scope.test.ts
@@ -1,0 +1,44 @@
+import {route} from '../route'
+
+test('toplevel', () => {
+  const router = route.scope('omg', '/foo/:bar')
+  expect(router.decode('/foo/bar')).toEqual({omg: {bar: 'bar'}})
+  expect(router.encode({omg: {bar: 'bar'}})).toBe('/foo/bar')
+})
+
+test('scopes all the way down', () => {
+  const router = route.scope('first', '/foo/:bar', [
+    route.scope('second', '/baz/:qux', [route.scope('third', '/omg/:lol')]),
+  ])
+
+  expect({first: {bar: 'bar'}}).toEqual(router.decode('/foo/bar'))
+  expect('/foo/bar').toBe(router.encode({first: {bar: 'bar'}}))
+
+  expect({first: {bar: 'bar', second: {qux: 'qux'}}}).toEqual(router.decode('/foo/bar/baz/qux'))
+  expect('/foo/bar/baz/qux').toBe(router.encode({first: {bar: 'bar', second: {qux: 'qux'}}}))
+
+  expect({
+    first: {
+      bar: 'bar',
+      second: {
+        qux: 'qux',
+        third: {
+          lol: 'lol',
+        },
+      },
+    },
+  }).toEqual(router.decode('/foo/bar/baz/qux/omg/lol'))
+  expect('/foo/bar/baz/qux/omg/lol').toEqual(
+    router.encode({
+      first: {
+        bar: 'bar',
+        second: {
+          qux: 'qux',
+          third: {
+            lol: 'lol',
+          },
+        },
+      },
+    }),
+  )
+})

--- a/packages/sanity/src/router/__test__/scope.test.ts
+++ b/packages/sanity/src/router/__test__/scope.test.ts
@@ -25,7 +25,7 @@ test('scopes all the way down', () => {
   expect('/foo/bar').toBe(router.encode({first: {bar: 'bar'}}))
 
   expect({first: {bar: 'bar', second: {qux: 'qux'}}}).toEqual(router.decode('/foo/bar/baz/qux'))
-  expect('/foo/bar/baz/qux').toBe(router.encode({first: {bar: 'bar', second: {qux: 'qux'}}}))
+  expect(router.encode({first: {bar: 'bar', second: {qux: 'qux'}}})).toBe('/foo/bar/baz/qux')
 
   expect({
     first: {

--- a/packages/sanity/src/router/__test__/transform.test.ts
+++ b/packages/sanity/src/router/__test__/transform.test.ts
@@ -1,0 +1,89 @@
+import {route} from '../route'
+import {decodeParams, encodeParams} from '../utils/paramsEncoding'
+
+test('transform config on regular routes', () => {
+  const router = route.create(
+    '/some/:section/:settings',
+    {
+      transform: {
+        settings: {
+          toState: decodeParams,
+          toPath: encodeParams,
+        },
+      },
+    },
+    route.create('/other/:page'),
+  )
+
+  expect(router.decode('/some/bar/width=full;view=details')).toEqual({
+    section: 'bar',
+    settings: {
+      width: 'full',
+      view: 'details',
+    },
+  })
+  expect(
+    router.encode({
+      section: 'bar',
+      settings: {
+        width: 'full',
+        view: 'details',
+      },
+    }),
+  ).toBe('/some/bar/width=full;view=details')
+
+  expect(
+    router.encode({
+      section: 'bar',
+      settings: {
+        width: 'full',
+      },
+    }),
+  ).toBe('/some/bar/width=full')
+
+  expect(
+    router.encode({
+      section: 'bar',
+      page: 'stuff',
+      settings: {
+        foo: 'bar',
+      },
+    }),
+  ).toBe('/some/bar/foo=bar/other/stuff')
+})
+
+test('transform config on scoped routes', () => {
+  const router = route.create('/some/:section', [
+    route.create('/other/:params', {
+      scope: 'myscope',
+      transform: {
+        params: {
+          toState: decodeParams,
+          toPath: encodeParams,
+        },
+      },
+    }),
+  ])
+
+  expect(router.decode('/some/foo/other/width=full;view=details')).toEqual({
+    section: 'foo',
+    myscope: {
+      params: {
+        width: 'full',
+        view: 'details',
+      },
+    },
+  })
+
+  expect(
+    router.encode({
+      section: 'foo',
+      myscope: {
+        params: {
+          width: 'full',
+          view: 'details',
+        },
+      },
+    }),
+  ).toBe('/some/foo/other/width=full;view=details')
+})

--- a/packages/sanity/src/router/__test__/urlSearchParams.test.ts
+++ b/packages/sanity/src/router/__test__/urlSearchParams.test.ts
@@ -1,0 +1,120 @@
+import {route} from '../route'
+
+describe('decode w/UrlSearchParams', () => {
+  const router = route.create('/tools/:tool', route.create('/edit/:documentId'))
+  test('UrlSearchParams params with a simple route', () => {
+    expect(router.decode('/tools/desk?a=b')).toEqual({
+      tool: 'desk',
+      _searchParams: [['a', 'b']],
+    })
+  })
+  test('UrlSearchParams params with a nested route', () => {
+    expect(router.decode('/tools/desk?view=zen')).toEqual({
+      tool: 'desk',
+      _searchParams: [['view', 'zen']],
+    })
+  })
+})
+
+describe('encode w/UrlSearchParams', () => {
+  const router = route.create('/tools/:tool', route.create('/edit/:documentId'))
+  test('UrlSearchParams params with a simple route', () => {
+    expect(
+      router.encode({
+        tool: 'desk',
+        _searchParams: [['a', 'b']],
+      }),
+    ).toEqual('/tools/desk?a=b')
+  })
+  test('UrlSearchParams params with a nested route', () => {
+    expect(
+      router.encode({
+        tool: 'desk',
+        _searchParams: [['view', 'zen']],
+      }),
+    ).toEqual('/tools/desk?view=zen')
+  })
+})
+
+describe('scoped url params', () => {
+  const router = route.scope('pluginA', '/pluginA/:id', [
+    route.scope('pluginAB', '/pluginAB/:qux', [route.scope('pluginABC', '/pluginABC/space/:arg')]),
+  ])
+
+  test('UrlSearchParams params with a simple route', () => {
+    expect(
+      router.encode({
+        pluginA: {
+          id: 'foo',
+          pluginAB: {
+            qux: 'something',
+            pluginABC: {
+              arg: 'hello',
+              _searchParams: [
+                ['a', 'b'],
+                ['c', 'd'],
+              ],
+            },
+          },
+        },
+      }),
+    ).toEqual(
+      `/pluginA/foo/pluginAB/something/pluginABC/space/hello?${new URLSearchParams(
+        'pluginA[pluginAB][pluginABC][a]=b&pluginA[pluginAB][pluginABC][c]=d',
+      )}`,
+    )
+  })
+
+  test('UrlSearchParams params with a simple route', () => {
+    expect(
+      router.decode(
+        `/pluginA/foo/pluginAB/something/pluginABC/space/hello?${new URLSearchParams(
+          'pluginA[pluginAB][pluginABC][a]=b&pluginA[pluginAB][pluginABC][c]=d',
+        )}`,
+      ),
+    ).toEqual({
+      pluginA: {
+        id: 'foo',
+        pluginAB: {
+          qux: 'something',
+          pluginABC: {
+            arg: 'hello',
+            _searchParams: [
+              ['a', 'b'],
+              ['c', 'd'],
+            ],
+          },
+        },
+      },
+    })
+  })
+})
+
+describe('encode with dynamically scoped url params', () => {
+  const router = route.create('/tools/:tool', (state) =>
+    route.scope(state.tool as string, '/edit/:documentId'),
+  )
+
+  test('UrlSearchParams params with a simple route', () => {
+    expect(
+      router.encode({
+        tool: 'desk',
+        desk: {documentId: '12', _searchParams: [['a', 'b']]},
+      }),
+    ).toEqual(`/tools/desk/edit/12?desk%5Ba%5D=b`)
+  })
+})
+
+describe('decode with dynamically scoped url params', () => {
+  const router = route.create('/tools/:tool', (state) =>
+    route.scope(state.tool as string, '/edit/:documentId'),
+  )
+
+  test('UrlSearchParams params with a simple route', () => {
+    expect(router.decode(`/tools/desk/edit/12?desk%5Ba%5D=b&foo=bar`)).toEqual({
+      tool: 'desk',
+      _searchParams: [['foo', 'bar']],
+      desk: {documentId: '12', _searchParams: [['a', 'b']]},
+    })
+  })
+})

--- a/packages/sanity/src/router/__test__/usage.test.ts
+++ b/packages/sanity/src/router/__test__/usage.test.ts
@@ -1,0 +1,56 @@
+import {route} from '../route'
+
+const router = route.create('/', [
+  route.create('/animals/:animal'),
+  route.create('/countries', [
+    route.create('/:country', [route.create('/:county', [route.create('/:municipality')])]),
+    route.create('/:country/:county'),
+    route.create('/:country/:county/:municipality/neighbors/:neighbor'),
+  ]),
+])
+
+test('root', () => {
+  expect('/').toBe(router.encode({}))
+  expect({}).toEqual(router.decode('/'))
+})
+
+test('cow', () => {
+  expect(router.encode({animal: 'cow'})).toBe('/animals/cow')
+  expect(router.decode('/animals/cow')).toEqual({animal: 'cow'})
+})
+
+test('sweden', () => {
+  expect(router.encode({country: 'sweden'})).toBe('/countries/sweden')
+  expect(router.decode('/countries/sweden')).toEqual({country: 'sweden'})
+})
+
+test('finnmark', () => {
+  expect(router.encode({country: 'norway', county: 'finnmark'})).toBe('/countries/norway/finnmark')
+  expect(router.decode('/countries/norway/finnmark')).toEqual({
+    country: 'norway',
+    county: 'finnmark',
+  })
+})
+
+test('kautokeino', () => {
+  const path = '/countries/norway/finnmark/kautokeino'
+  const state = {
+    municipality: 'kautokeino',
+    country: 'norway',
+    county: 'finnmark',
+  }
+  expect(router.encode(state)).toBe(path)
+  expect(router.decode(path)).toEqual(state)
+})
+
+test('murmansk', () => {
+  const path = '/countries/norway/finnmark/kautokeino/neighbors/murmansk'
+  const state = {
+    neighbor: 'murmansk',
+    municipality: 'kautokeino',
+    country: 'norway',
+    county: 'finnmark',
+  }
+  expect(router.encode(state)).toBe(path)
+  expect(router.decode(path)).toEqual(state)
+})

--- a/packages/sanity/src/router/_resolvePathFromState.ts
+++ b/packages/sanity/src/router/_resolvePathFromState.ts
@@ -1,50 +1,90 @@
-import {flatten} from 'lodash'
 import {_findMatchingRoutes} from './_findMatchingRoutes'
-import {RouterNode, MatchResult} from './types'
+import {InternalSearchParam, MatchOk, RouterNode, RouterState, SearchParam} from './types'
 import {debug} from './utils/debug'
 
 /** @internal */
-export function _resolvePathFromState(node: RouterNode, state: Record<string, unknown>): string {
-  debug('Resolving path from state %o', state)
+export function _resolvePathFromState(node: RouterNode, _state: RouterState): string {
+  debug('Resolving path from state %o', _state)
 
-  const match: MatchResult = _findMatchingRoutes(node, state)
-
-  if (match.remaining.length > 0) {
-    const remaining = match.remaining
+  const match = _findMatchingRoutes(node, _state)
+  if (match.type === 'error') {
+    const unmappable = match.unmappableStateKeys
+    if (unmappable.length > 0) {
+      throw new Error(
+        `Unable to find matching route for state. Could not map the following state key${
+          unmappable.length == 1 ? '' : 's'
+        } to a valid url: ${unmappable.map(quote).join(', ')}`,
+      )
+    }
+    const missingKeys = match.missingKeys
     throw new Error(
-      `Unable to find matching route for state. Could not map the following state key${
-        remaining.length == 1 ? '' : 's'
-      } to a valid url: ${remaining.join(', ')}`,
+      `Unable to find matching route for state. State object is missing the following key${
+        missingKeys.length == 1 ? '' : 's'
+      } defined in route: ${missingKeys.map(quote).join(', ')}`,
     )
   }
 
-  if (match.nodes.length === 0) {
-    throw new Error(`Unable to resolve path from given state: ${JSON.stringify(state)}`)
+  const {path, searchParams} = pathFromMatchResult(match)
+
+  const search =
+    searchParams.length > 0 ? new URLSearchParams(encodeParams(searchParams)).toString() : ''
+
+  return `/${path.join('/')}${search ? `?${search}` : ''}`
+}
+
+function bracketify(value: string): string {
+  return `[${value}]`
+}
+
+function encodeParamPath(paramPath: string[]): string {
+  const [head, ...tail] = paramPath
+
+  return tail.length > 0 ? [head, ...tail.map(bracketify)].join('') : head
+}
+function encodeParams(params: InternalSearchParam[]): SearchParam[] {
+  return params.map(([key, value]): SearchParam => [encodeParamPath(key), value])
+}
+
+function pathFromMatchResult(match: MatchOk): {
+  path: string[]
+  searchParams: InternalSearchParam[]
+} {
+  const matchedState = match.matchedState
+
+  const base = match.node.route.segments.map((segment) => {
+    if (segment.type === 'dir') {
+      return segment.name
+    }
+
+    const transform = match.node.transform && match.node.transform[segment.name]
+
+    return transform
+      ? transform.toPath(matchedState[segment.name] as any)
+      : matchedState[segment.name]
+  })
+
+  const childMatch = match.child ? pathFromMatchResult(match.child) : undefined
+
+  const searchParams = childMatch?.searchParams
+    ? [...match.searchParams, ...childMatch.searchParams]
+    : match.searchParams
+
+  return {
+    searchParams: addNodeScope(match.node, searchParams),
+    path: [...(base || []), ...(childMatch?.path || [])],
   }
+}
 
-  let scopedState: Record<string, unknown> = state
+function addNodeScope(
+  node: RouterNode,
+  searchParams: InternalSearchParam[],
+): InternalSearchParam[] {
+  const scope = node.scope
+  return scope
+    ? searchParams.map(([namespaces, value]) => [[scope, ...namespaces], value])
+    : searchParams
+}
 
-  const relative = flatten(
-    match.nodes.map((matchNode) => {
-      if (matchNode.scope && matchNode.scope in scopedState) {
-        scopedState = scopedState[matchNode.scope] as Record<string, unknown>
-      }
-
-      return matchNode.route.segments.map((segment) => {
-        if (segment.type === 'dir') {
-          return segment.name
-        }
-
-        const transform = matchNode.transform && matchNode.transform[segment.name]
-
-        return transform
-          ? transform.toPath(scopedState[segment.name] as any)
-          : scopedState[segment.name]
-      })
-    }),
-  ).join('/')
-
-  debug('Resolved to /%s', relative)
-
-  return `/${relative}`
+function quote(value: string): string {
+  return `"${value}"`
 }

--- a/packages/sanity/src/router/_resolveStateFromPath.ts
+++ b/packages/sanity/src/router/_resolveStateFromPath.ts
@@ -1,8 +1,14 @@
-import {RouterNode} from './types'
+import {partition} from 'lodash'
+import {InternalSearchParam, RouterNode, RouterState, SearchParam} from './types'
 import {debug} from './utils/debug'
 import {arrayify} from './utils/arrayify'
+import {parseScopedParams} from './utils/parseScopedParams'
 
-function matchPath(node: RouterNode, path: string): Record<string, string> | null {
+function matchPath(
+  node: RouterNode,
+  path: string,
+  searchParams: InternalSearchParam[],
+): RouterState | null {
   const parts = path.split('/').filter(Boolean)
   const segmentsLength = node.route.segments.length
 
@@ -10,7 +16,7 @@ function matchPath(node: RouterNode, path: string): Record<string, string> | nul
     return null
   }
 
-  const state: Record<string, unknown> = {}
+  const state: RouterState = {}
   const isMatching = node.route.segments.every((segment, i) => {
     if (segment.type === 'dir') {
       return segment.name === parts[i]
@@ -29,24 +35,22 @@ function matchPath(node: RouterNode, path: string): Record<string, string> | nul
 
   const rest = parts.slice(segmentsLength)
 
-  let childState: {
-    [key: string]: string
-  } | null = null
+  let childState: RouterState | null = null
 
   const children =
     typeof node.children === 'function' ? arrayify(node.children(state)) : node.children
 
+  const unscopedParams = removeScope(node.scope, searchParams)
+
   children.some((childNode) => {
-    // console.log('----childNode')
-    // console.log(childNode)
-    // console.log('----childNode')
-
     if (childNode) {
-      childState = matchPath(childNode, rest.join('/'))
+      const childParams = childNode.scope
+        ? unscopedParams.filter(([namespaces]) => childNode.scope === namespaces[0])
+        : unscopedParams
 
+      childState = matchPath(childNode, rest.join('/'), childParams)
       return childState
     }
-
     return undefined
   })
 
@@ -54,7 +58,15 @@ function matchPath(node: RouterNode, path: string): Record<string, string> | nul
     return null
   }
 
-  const mergedState = {...state, ...(childState || {})}
+  const selfParams = unscopedParams.flatMap(([namespace, value]): SearchParam[] => {
+    return namespace.length === 1 ? [[namespace[0], value]] : []
+  })
+
+  const mergedState: RouterState = {
+    ...state,
+    ...(childState || {}),
+    ...(selfParams.length > 0 ? {_searchParams: selfParams} : {}),
+  }
 
   return node.scope ? {[node.scope]: mergedState} : mergedState
 }
@@ -65,9 +77,24 @@ function matchPath(node: RouterNode, path: string): Record<string, string> | nul
 export function _resolveStateFromPath(node: RouterNode, path: string): Record<string, any> | null {
   debug('resolving state from path %s', path)
 
-  const pathMatch = matchPath(node, path.split('?')[0])
+  const [pathname, search] = path.split('?')
+  const urlSearchParams = Array.from(new URLSearchParams(search).entries())
+
+  const pathMatch = matchPath(node, pathname, parseScopedParams(urlSearchParams))
 
   debug('resolved: %o', pathMatch || null)
 
   return pathMatch || null
+}
+
+function removeScope(
+  scope: string | undefined,
+  searchParams: InternalSearchParam[],
+): InternalSearchParam[] {
+  return scope
+    ? searchParams.map(([namespaces, value]) => [
+        namespaces[0] === scope ? namespaces.slice(1) : namespaces,
+        value,
+      ])
+    : searchParams
 }

--- a/packages/sanity/src/router/route.ts
+++ b/packages/sanity/src/router/route.ts
@@ -90,7 +90,7 @@ export interface RouteObject {
  */
 export const route: RouteObject = {
   create: (routeOrOpts, childrenOrOpts, children) =>
-    createNode(normalizeArgs(routeOrOpts, childrenOrOpts, children)),
+    _createNode(normalizeArgs(routeOrOpts, childrenOrOpts, children)),
   intents: (base: string) => {
     const basePath = normalize(base).join('/')
 
@@ -121,7 +121,7 @@ export const route: RouteObject = {
   scope: (scopeName, ...rest) => {
     const options = normalizeArgs(...rest)
 
-    return createNode({
+    return _createNode({
       ...options,
       scope: scopeName,
     })
@@ -175,7 +175,11 @@ function isRoot(pathname: string): boolean {
   return pathname.split('/').every((segment) => !segment)
 }
 
-function createNode(options: RouteNodeOptions): Router {
+/**
+ * @internal
+ * @param options - Route node options
+ */
+export function _createNode(options: RouteNodeOptions): Router {
   const {path, scope, transform, children} = options
 
   if (!path) {

--- a/packages/sanity/src/router/types.ts
+++ b/packages/sanity/src/router/types.ts
@@ -126,11 +126,32 @@ export interface Router extends RouterNode {
 }
 
 /** @internal */
-export interface MatchResult {
-  nodes: RouterNode[]
-  missing: string[]
-  remaining: string[]
+export type InternalSearchParam = [scopedPath: string[], value: string]
+
+/** @internal */
+export interface MatchOk {
+  type: 'ok'
+  node: RouterNode
+  matchedState: Record<string, string>
+  searchParams: InternalSearchParam[]
+  child: MatchOk | undefined
 }
+
+/** @internal */
+export interface MatchError {
+  type: 'error'
+  node: RouterNode
+  /**
+   * Parameters found in the route string but not provided as a key in the state object
+   */
+  missingKeys: string[]
+  /**
+   * These are keys found in the state object but not in the route definition (and can't be mapped to a child route)
+   */
+  unmappableStateKeys: string[]
+}
+/** @internal */
+export type MatchResult = MatchError | MatchOk
 
 /**
  * @public
@@ -178,7 +199,12 @@ export type IntentParameters = BaseIntentParams | [BaseIntentParams, IntentJsonP
 /**
  * @public
  */
-export type RouterState = Record<string, unknown>
+export type SearchParam = [key: string, value: string]
+
+/**
+ * @public
+ */
+export type RouterState = Record<string, unknown> & {_searchParams?: SearchParam[]}
 
 /**
  * @public

--- a/packages/sanity/src/router/utils/parseScopedParams.ts
+++ b/packages/sanity/src/router/utils/parseScopedParams.ts
@@ -1,0 +1,41 @@
+import {InternalSearchParam} from '../types'
+
+export function parseScopedParams(params: [key: string, value: string][]): InternalSearchParam[] {
+  return params.map(([key, value]) => [parse(key), value])
+}
+
+const OPEN = 1
+const CLOSED = 0
+
+function parse(str: string) {
+  const result = []
+  let i = 0
+  let state = CLOSED
+  while (i < str.length) {
+    const nextBracketIdx = str.indexOf('[', i)
+    if (nextBracketIdx === -1) {
+      result.push(str.slice(i, str.length))
+      break
+    }
+    if (state === OPEN) {
+      throw new Error('Nested brackets not supported')
+    }
+    state = OPEN
+    if (nextBracketIdx > i) {
+      result.push(str.slice(i, nextBracketIdx))
+      i = nextBracketIdx
+    }
+
+    const nextClosing = str.indexOf(']', nextBracketIdx)
+    if (nextClosing === -1) {
+      if (state === OPEN) {
+        throw new Error('Unclosed bracket')
+      }
+      break
+    }
+    state = CLOSED
+    result.push(str.slice(i + 1, nextClosing))
+    i = nextClosing + 1
+  }
+  return result
+}


### PR DESCRIPTION
### Description
This PR adds support for a special key on the url state: `_searchParams` , which is an array of `[key: string, value: string]` tuples (similar to what you'd get from `URLSearchParams.entries()`).



It uses the scope (aka namespace) feature of the router, so when you're within a scope you don't need to worry about how your own search params fits in with the global environment. In the url, they will be namespaced with `/some/route?scope[param]=value`. Params in nested scopes will be `scopeA[scopeB][param]=value` (see added unit tests for details).

### Usage example

Given the route `/path/to/:someParam`

#### Read search params

Given the url: `/path/to/something?foo=bar&bar=baz`

```ts
const router = useRouter()

console.log(router.state)
```
Will log
```ts
{
  someParam: 'something',
  _searchParams: [['foo', 'bar'], ['bar', 'baz']]
//^ see note about prefix below 
}
```

#### Navigate w/search params

```ts
const router = useRouter()

router.navigate({
  someParam: 'something',
  _searchParams: [['foo', 'bar'], ['bar', 'baz']]
})
```
Will navigate to:
```
/path/to/something?foo=bar&bar=baz
```
### What to review
- Does the API make sense?
- I chose the `_`-prefix, which isn't *strictly* speaking safe as someone could potentially (although quite unlikely) have an existing route with `_searchParams` as a param (e.g. `/path/to/:_searchParams`), which will then be in conflict. If we want to play it extra safe, we can consider changing to `$searchParams`. We currently don't allow using `$` in url params (i.e. defining a route as `/path/to/:$param` throws an error).

Note: this PR also recovers the test suite and readme that somehow didn't make it when we moved this from `@sanity/state-router` over to the `sanity`-package

### Notes for release
- Adds support for search params in `sanity/router`