### PR TITLE
chore(test): fixes cache key so it can be re-ran successfully without error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           path: './*'
           # Unique key for a workflow run. Should be invalidated in the next run
-          key: ${{ runner.os }}-build-${{ matrix.node }}-${{ env.cache-name }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: ${{ runner.os }}-build-${{ matrix.node }}-${{ env.cache-name }}-${{ github.run_id }}
 
       - name: Install project dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -120,7 +120,7 @@ jobs:
           cache-name: cache-build
         with:
           path: ./*
-          key: ${{ runner.os }}-build-${{ matrix.node }}-${{ env.cache-name }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: ${{ runner.os }}-build-${{ matrix.node }}-${{ env.cache-name }}-${{ github.run_id }}
 
       - name: Install project dependencies
         if: steps.restore-node-modules.outputs.cache-hit != 'true'
@@ -162,7 +162,7 @@ jobs:
 
       # Delete the cache so it is only used once
       - name: Delete Cache
-        run: gh cache delete ${{ runner.os }}-build-${{ matrix.node }}-${{ env.cache-name }}-${{ github.run_id }}-${{ github.run_attempt }}
+        run: gh cache delete ${{ runner.os }}-build-${{ matrix.node }}-${{ env.cache-name }}-${{ github.run_id }}
         env:
           cache-name: cache-build
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,6 +121,8 @@ jobs:
         with:
           path: ./*
           key: ${{ runner.os }}-build-${{ matrix.node }}-${{ env.cache-name }}-${{ github.run_id }}
+          # If the cached build from the pervious step is not available. Fail the build
+          fail-on-cache-miss: true
 
       - name: Install project dependencies
         if: steps.restore-node-modules.outputs.cache-hit != 'true'


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Noticed that when running the action second time incase of a flaky test failure the cache key is missed since it only runs failed builds, like [here](https://github.com/sanity-io/sanity/actions/runs/6709153887/job/18232817737) this removes the `run_attempt` from the key so that the key is same for workflow run and since we are deleting the cache after the workflow successfully runs it should be okay to use just the workflow_id across multiple runs and commits

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

- Changes makes sense.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
- N/A 