### PR TITLE
fix(desk): comments on anonymous objects 

### DIFF
--- a/dev/test-studio/schema/debug/comments.ts
+++ b/dev/test-studio/schema/debug/comments.ts
@@ -37,6 +37,42 @@ export const commentsDebug = defineType({
       ],
     },
     {
+      name: 'arrayWithAnonymousObject',
+      type: 'array',
+      title: 'Array with anonymous object',
+      of: [
+        {
+          type: 'object',
+          title: 'Anonymous object',
+          fields: [
+            {
+              name: 'anonymousString',
+              type: 'string',
+              title: 'Anonymous string',
+            },
+            {
+              type: 'array',
+              name: 'nestedArrayWithAnonymousObject',
+              title: 'Nested array with anonymous object',
+              of: [
+                {
+                  type: 'object',
+                  title: 'Nested anonymous object',
+                  fields: [
+                    {
+                      name: 'nestedAnonymousString',
+                      type: 'string',
+                      title: 'Nested anonymous string',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
       type: 'array',
       name: 'arrayOfObjects',
       title: 'Array 1',

--- a/packages/sanity/src/desk/comments/src/__tests__/buildCommentBreadcrumbs.test.ts
+++ b/packages/sanity/src/desk/comments/src/__tests__/buildCommentBreadcrumbs.test.ts
@@ -73,7 +73,7 @@ const arrayWithAnonymousObjectField = defineField({
 
 const arrayWithAnonymousObjectFieldWithHiddenCallback = defineField({
   name: 'myArrayWithAnonymousObjectFieldWithHiddenCallback',
-  title: 'My array with anonymous object title with hidden callback title',
+  title: 'My array with anonymous object field with hidden callback title',
   type: 'array',
   of: [
     {
@@ -306,12 +306,10 @@ describe('comments: buildCommentBreadcrumbs', () => {
         myArrayWithAnonymousObject: [
           {
             _key: 'key1',
-            _type: 'object',
             anonymousString: 'Hello world',
           },
           {
             _key: 'key2',
-            _type: 'object',
             anonymousString: 'Hello world',
           },
         ],
@@ -334,12 +332,10 @@ describe('comments: buildCommentBreadcrumbs', () => {
         myArrayWithAnonymousObject: [
           {
             _key: 'key1',
-            _type: 'object',
             anonymousString: 'Hello world',
           },
           {
             _key: 'key2',
-            _type: 'object',
             anonymousString: 'Hello world',
           },
         ],
@@ -362,12 +358,10 @@ describe('comments: buildCommentBreadcrumbs', () => {
         myArrayWithAnonymousObjectFieldWithHiddenCallback: [
           {
             _key: 'key1',
-            _type: 'object',
             anonymousStringWithHiddenCallback: 'Hello world',
           },
           {
             _key: 'key2',
-            _type: 'object',
             anonymousStringWithHiddenCallback: 'Hello world',
           },
         ],
@@ -381,7 +375,7 @@ describe('comments: buildCommentBreadcrumbs', () => {
       {
         invalid: false,
         isArrayItem: false,
-        title: 'My array with anonymous object title with hidden callback title',
+        title: 'My array with anonymous object field with hidden callback title',
       },
       {invalid: false, isArrayItem: true, title: '#2'},
       {invalid: true, isArrayItem: false, title: 'Anonymous string with hidden callback title'},

--- a/packages/sanity/src/desk/comments/src/__tests__/buildCommentBreadcrumbs.test.ts
+++ b/packages/sanity/src/desk/comments/src/__tests__/buildCommentBreadcrumbs.test.ts
@@ -53,6 +53,43 @@ const nestedArrayOfObjectsField = defineField({
   ],
 })
 
+const arrayWithAnonymousObjectField = defineField({
+  name: 'myArrayWithAnonymousObject',
+  title: 'My array with anonymous object title',
+  type: 'array',
+  of: [
+    {
+      type: 'object',
+      fields: [
+        {
+          name: 'anonymousString',
+          type: 'string',
+          title: 'Anonymous string title',
+        },
+      ],
+    },
+  ],
+})
+
+const arrayWithAnonymousObjectFieldWithHiddenCallback = defineField({
+  name: 'myArrayWithAnonymousObjectFieldWithHiddenCallback',
+  title: 'My array with anonymous object title with hidden callback title',
+  type: 'array',
+  of: [
+    {
+      type: 'object',
+      fields: [
+        {
+          name: 'anonymousStringWithHiddenCallback',
+          type: 'string',
+          title: 'Anonymous string with hidden callback title',
+          hidden: () => true,
+        },
+      ],
+    },
+  ],
+})
+
 const schema = Schema.compile({
   name: 'default',
   types: [
@@ -67,6 +104,8 @@ const schema = Schema.compile({
         stringWithHiddenCallback,
         arrayOfObjectsField,
         nestedArrayOfObjectsField,
+        arrayWithAnonymousObjectField,
+        arrayWithAnonymousObjectFieldWithHiddenCallback,
       ],
     },
   ],
@@ -257,6 +296,95 @@ describe('comments: buildCommentBreadcrumbs', () => {
       {invalid: false, isArrayItem: false, title: 'My array title'},
       {invalid: false, isArrayItem: true, title: '#2'},
       {invalid: true, isArrayItem: false, title: 'String With Hidden Callback'},
+    ])
+  })
+
+  it('should build breadcrumbs for array of anonymous objects', () => {
+    const crumbs = buildCommentBreadcrumbs({
+      currentUser: CURRENT_USER,
+      documentValue: {
+        myArrayWithAnonymousObject: [
+          {
+            _key: 'key1',
+            _type: 'object',
+            anonymousString: 'Hello world',
+          },
+          {
+            _key: 'key2',
+            _type: 'object',
+            anonymousString: 'Hello world',
+          },
+        ],
+      },
+      fieldPath: 'myArrayWithAnonymousObject[_key=="key2"].anonymousString',
+      schemaType: schema.get('testDocument'),
+    })
+
+    expect(crumbs).toEqual([
+      {invalid: false, isArrayItem: false, title: 'My array with anonymous object title'},
+      {invalid: false, isArrayItem: true, title: '#2'},
+      {invalid: false, isArrayItem: false, title: 'Anonymous string title'},
+    ])
+  })
+
+  it('should invalidate the breadcrumb if the array item is not found in an array of anonymous objects', () => {
+    const crumbs = buildCommentBreadcrumbs({
+      currentUser: CURRENT_USER,
+      documentValue: {
+        myArrayWithAnonymousObject: [
+          {
+            _key: 'key1',
+            _type: 'object',
+            anonymousString: 'Hello world',
+          },
+          {
+            _key: 'key2',
+            _type: 'object',
+            anonymousString: 'Hello world',
+          },
+        ],
+      },
+      fieldPath: 'myArrayWithAnonymousObject[_key=="key3"].anonymousString',
+      schemaType: schema.get('testDocument'),
+    })
+
+    expect(crumbs).toEqual([
+      {invalid: false, isArrayItem: false, title: 'My array with anonymous object title'},
+      {invalid: true, isArrayItem: true, title: 'Unknown array item'},
+      {invalid: true, isArrayItem: false, title: 'Unknown field'},
+    ])
+  })
+
+  it('should invalidate the breadcrumb if the array item is hidden in an array of anonymous objects', () => {
+    const crumbs = buildCommentBreadcrumbs({
+      currentUser: CURRENT_USER,
+      documentValue: {
+        myArrayWithAnonymousObjectFieldWithHiddenCallback: [
+          {
+            _key: 'key1',
+            _type: 'object',
+            anonymousStringWithHiddenCallback: 'Hello world',
+          },
+          {
+            _key: 'key2',
+            _type: 'object',
+            anonymousStringWithHiddenCallback: 'Hello world',
+          },
+        ],
+      },
+      fieldPath:
+        'myArrayWithAnonymousObjectFieldWithHiddenCallback[_key=="key2"].anonymousStringWithHiddenCallback',
+      schemaType: schema.get('testDocument'),
+    })
+
+    expect(crumbs).toEqual([
+      {
+        invalid: false,
+        isArrayItem: false,
+        title: 'My array with anonymous object title with hidden callback title',
+      },
+      {invalid: false, isArrayItem: true, title: '#2'},
+      {invalid: true, isArrayItem: false, title: 'Anonymous string with hidden callback title'},
     ])
   })
 })

--- a/packages/sanity/src/desk/comments/src/components/list/CommentThreadLayout.tsx
+++ b/packages/sanity/src/desk/comments/src/components/list/CommentThreadLayout.tsx
@@ -22,6 +22,10 @@ const BreadcrumbsButton = styled(Button)(({theme}) => {
   const fg = theme.sanity.color.base.fg
   return css`
     --card-fg-color: ${fg};
+
+    // The width is needed to make the text ellipsis work
+    // in the breadcrumbs component
+    max-width: 100%;
   `
 })
 


### PR DESCRIPTION
### Description

This pull request fixes:
- Issue with adding comments to anonymous objects
- Issue with the breadcrumbs in comments where text overflow ellipsis wasn't handled correctly.

### What to review

- Make sure that you can add comments to anonymous objects
- Make sure that the breadcrumbs handles text overflow ellipsis correctly

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
