### PR TITLE
feat(vision): add v2022-03-07 to list of API versions

### DIFF
--- a/packages/@sanity/vision/src/apiVersions.ts
+++ b/packages/@sanity/vision/src/apiVersions.ts
@@ -1,2 +1,2 @@
-export const API_VERSIONS = ['v1', 'vX', 'v2021-03-25', 'v2021-10-21']
+export const API_VERSIONS = ['v1', 'vX', 'v2021-03-25', 'v2021-10-21', 'v2022-03-07']
 export const [DEFAULT_API_VERSION] = API_VERSIONS.slice(-1)


### PR DESCRIPTION
### Description

Adds `v2022-03-07` to the list of known API versions. It is the lowest version required to use cross-dataset references, and is explicitly called out in documentation.

### What to review

- API version appears, is choosable, and can be used to query cross-dataset references

### Notes for release

- Adds `v2022-03-07` to predefined list of API versions in the Vision tool
