### PR TITLE
feat(desk): export `DocumentPane` and `DocumentListPane`

### DIFF
--- a/packages/sanity/src/desk/components/paneRouter/index.ts
+++ b/packages/sanity/src/desk/components/paneRouter/index.ts
@@ -1,4 +1,5 @@
 export * from './BackLink'
+export * from './PaneRouterContext'
 export * from './PaneRouterProvider'
 export * from './types'
 export * from './usePaneRouter'

--- a/packages/sanity/src/desk/index.ts
+++ b/packages/sanity/src/desk/index.ts
@@ -4,7 +4,6 @@ export {DocumentInspectorHeader} from './panes/document/documentInspector'
 
 // Export `DocumentPaneProvider`
 export {type DocumentPaneProviderProps} from './panes/document/types'
-export * from './panes/document/DocumentPaneProvider'
 
 export * from './panes/document/useDocumentPane'
 
@@ -12,13 +11,12 @@ export * from './types'
 
 export * from './DeskToolProvider'
 
-export {ConfirmDeleteDialog, usePaneRouter} from './components'
-
-export type {ConfirmDeleteDialogProps} from './components'
+export {ConfirmDeleteDialog, PaneLayout, PaneRouterContext, usePaneRouter} from './components'
 
 export type {
   BackLinkProps,
   ChildLinkProps,
+  ConfirmDeleteDialogProps,
   EditReferenceOptions,
   PaneRouterContextValue,
   ParameterizedLinkProps,
@@ -28,3 +26,7 @@ export type {
 export * from './structureBuilder'
 
 export * from './useDeskTool'
+
+export * from './panes/document'
+
+export * from './panes/documentList'

--- a/packages/sanity/src/desk/panes/DeskToolPane.tsx
+++ b/packages/sanity/src/desk/panes/DeskToolPane.tsx
@@ -23,8 +23,8 @@ interface DeskToolPaneProps {
 // TODO: audit this creates separate chunks
 const paneMap = {
   component: lazy(() => import('./userComponent')),
-  document: lazy(() => import('./document')),
-  documentList: lazy(() => import('./documentList')),
+  document: lazy(() => import('./document/pane')),
+  documentList: lazy(() => import('./documentList/pane')),
   list: lazy(() => import('./list')),
 }
 

--- a/packages/sanity/src/desk/panes/document/DocumentPane.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentPane.tsx
@@ -60,7 +60,9 @@ const StyledChangeConnectorRoot = styled(ChangeConnectorRoot)`
   min-height: 0;
   min-width: 0;
 `
-
+/**
+ * @internal
+ */
 export const DocumentPane = memo(function DocumentPane(props: DocumentPaneProviderProps) {
   const {name: parentSourceName} = useSource()
 

--- a/packages/sanity/src/desk/panes/document/index.ts
+++ b/packages/sanity/src/desk/panes/document/index.ts
@@ -1,2 +1,2 @@
-export {DocumentPane as default} from './DocumentPane'
+export * from './DocumentPane'
 export * from './DocumentPaneProvider'

--- a/packages/sanity/src/desk/panes/document/pane.ts
+++ b/packages/sanity/src/desk/panes/document/pane.ts
@@ -1,0 +1,1 @@
+export {DocumentPane as default} from './DocumentPane'

--- a/packages/sanity/src/desk/panes/documentList/DocumentListPane.tsx
+++ b/packages/sanity/src/desk/panes/documentList/DocumentListPane.tsx
@@ -23,7 +23,10 @@ import {LoadingVariant, SortOrder} from './types'
 import {useDocumentList} from './useDocumentList'
 import {GeneralPreviewLayoutKey, SourceProvider, useSchema, useSource, useUnique} from 'sanity'
 
-type DocumentListPaneProps = BaseDeskToolPaneProps<'documentList'>
+/**
+ * @internal
+ */
+export type DocumentListPaneProps = BaseDeskToolPaneProps<'documentList'>
 
 const EMPTY_ARRAY: never[] = []
 

--- a/packages/sanity/src/desk/panes/documentList/index.ts
+++ b/packages/sanity/src/desk/panes/documentList/index.ts
@@ -1,1 +1,1 @@
-export {DocumentListPane as default} from './DocumentListPane'
+export * from './DocumentListPane'

--- a/packages/sanity/src/desk/panes/documentList/pane.ts
+++ b/packages/sanity/src/desk/panes/documentList/pane.ts
@@ -1,0 +1,1 @@
+export {DocumentListPane as default} from './DocumentListPane'


### PR DESCRIPTION
### Description

This is to support the work on visual editing, so that some Desk components can be reused in the Presentation tool. The changes result in some extra components and supporting types being exported from `sanity/desk`.

The Presentation tool needs to import the following from `sanity/desk`:

`BackLinkProps`
`deskTool`
`DeskToolProvider`
`DocumentListPane`
`DocumentPane`
`DocumentPaneNode`
`PaneLayout`
`PaneNode`
`PaneRouterContext`
`PaneRouterContextValue`
`ReferenceChildLinkProps`
`useDeskTool`

To resolve SDX-721, as part of ECO-66.

### What to review

These changes should result in no functional difference. The changes only alter some exports and imports, and add tags.

### Notes for release

N/A
