### PR TITLE
refactor: split Studio UI MenuItem into separate components

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -221,7 +221,7 @@ module.exports = {
             paths: [
               {
                 name: '@sanity/ui',
-                importNames: ['Tooltip', 'TooltipProps', 'MenuItem', 'MenuItemProps'],
+                importNames: ['MenuItem', 'MenuItemProps', 'Tooltip', 'TooltipProps'],
                 message:
                   'Please use the (more opinionated) exported components in sanity/src/ui instead.',
               },

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/BlockStyleSelect.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/BlockStyleSelect.tsx
@@ -1,6 +1,13 @@
 import React, {memo, useCallback, useMemo} from 'react'
 import {PortableTextEditor, usePortableTextEditor} from '@sanity/portable-text-editor'
-import {Button, Menu, MenuButton, MenuButtonProps, MenuItem, Text} from '@sanity/ui'
+import {
+  Button,
+  Menu,
+  MenuButton,
+  MenuButtonProps,
+  MenuItem, // eslint-disable-line no-restricted-imports
+  Text,
+} from '@sanity/ui'
 import {SelectIcon} from '@sanity/icons'
 import styled from 'styled-components'
 import {

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/BlockStyleSelect.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/BlockStyleSelect.tsx
@@ -1,6 +1,6 @@
 import React, {memo, useCallback, useMemo} from 'react'
 import {PortableTextEditor, usePortableTextEditor} from '@sanity/portable-text-editor'
-import {Button, Menu, MenuButton, MenuButtonProps, Text} from '@sanity/ui'
+import {Button, Menu, MenuButton, MenuButtonProps, MenuItem, Text} from '@sanity/ui'
 import {SelectIcon} from '@sanity/icons'
 import styled from 'styled-components'
 import {
@@ -13,7 +13,6 @@ import {
   BlockQuote,
   Normal,
 } from '../text/textStyles'
-import {MenuItem} from '../../../../../ui'
 import {useActiveStyleKeys, useFocusBlock} from './hooks'
 import {BlockStyleItem} from './types'
 

--- a/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenuItem.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenuItem.tsx
@@ -5,6 +5,7 @@ import {GlobalPresence} from '../../../../store'
 import {UserAvatar} from '../../../../components'
 import {MenuItem} from '../../../../../ui'
 import {IntentLink} from 'sanity/router'
+import {PreviewMenuItem} from '../../../../../ui/previewMenuItem'
 
 interface PresenceListRowProps {
   focused: boolean
@@ -62,15 +63,11 @@ export const PresenceMenuItem = memo(function PresenceMenuItem(props: PresenceLi
   )
 
   return (
-    <MenuItem
-      size="large"
+    <PreviewMenuItem
       as={lastActiveLocation ? LinkComponent : 'div'}
       data-as={lastActiveLocation ? 'a' : 'div'}
       onFocus={handleFocus}
-      ref={setMenuItemElement}
-      text={presence.user.displayName}
-      subText={hasLink ? undefined : 'Not in a document'}
-      avatar={
+      preview={
         <UserAvatar
           size={1}
           key={presence.user.id}
@@ -78,6 +75,9 @@ export const PresenceMenuItem = memo(function PresenceMenuItem(props: PresenceLi
           status={hasLink ? 'editing' : 'inactive'}
         />
       }
+      ref={setMenuItemElement}
+      subtitle={hasLink ? undefined : 'Not in a document'}
+      text={presence.user.displayName}
     />
   )
 })

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/string/StringList.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/string/StringList.tsx
@@ -29,12 +29,11 @@ function CustomMenuItem({
 
   return (
     <MenuItem
-      size="large"
       onClick={handleClick}
       pressed={selected}
-      tone="default"
+      subtitle={value ? `${value}` : undefined}
       text={title}
-      subText={value ? `${value}` : undefined}
+      tone="default"
     />
   )
 }

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/WorkspaceAuth.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/WorkspaceAuth.tsx
@@ -1,4 +1,4 @@
-import {Box, Button, Card, Flex, Stack} from '@sanity/ui'
+import {Button, Card, Flex, Stack} from '@sanity/ui'
 import React, {useCallback, useState} from 'react'
 import {omit} from 'lodash'
 import {AddIcon, ArrowLeftIcon, ChevronRightIcon} from '@sanity/icons'
@@ -45,13 +45,11 @@ export function WorkspaceAuth() {
 
         <Layout
           header={
-            <Box padding={3}>
-              <WorkspacePreview
-                icon={selectedWorkspace.icon}
-                title={selectedWorkspace.title}
-                subtitle={selectedWorkspace?.subtitle}
-              />
-            </Box>
+            <WorkspacePreview
+              icon={selectedWorkspace.icon}
+              title={selectedWorkspace.title}
+              subtitle={selectedWorkspace?.subtitle}
+            />
           }
         >
           <Stack padding={2} paddingBottom={3} paddingTop={4}>
@@ -83,7 +81,7 @@ export function WorkspaceAuth() {
         </Stack>
       }
     >
-      <Stack space={1} paddingX={1} paddingY={2}>
+      <Stack space={1} paddingY={1}>
         {workspaces.map((workspace) => {
           const authState = authStates[workspace.name]
           // eslint-disable-next-line no-nested-ternary
@@ -108,7 +106,6 @@ export function WorkspaceAuth() {
               as="button"
               radius={2}
               key={workspace.name}
-              padding={2}
               // eslint-disable-next-line react/jsx-no-bind
               onClick={handleSelectWorkspace}
             >

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
@@ -1,11 +1,18 @@
 import {SelectIcon} from '@sanity/icons'
-import {Button, MenuButton, Menu, MenuButtonProps, Box, Label, Stack} from '@sanity/ui'
+import {
+  Button,
+  Menu,
+  MenuButton,
+  MenuButtonProps,
+  MenuItem, // eslint-disable-line no-restricted-imports
+  Stack,
+} from '@sanity/ui'
 import React, {useCallback, useMemo, useState} from 'react'
 import styled from 'styled-components'
 import {useActiveWorkspace} from '../../../activeWorkspaceMatcher'
 import {useColorScheme} from '../../../colorScheme'
 import {useWorkspaces} from '../../../workspaces'
-import {Tooltip, MenuItem} from '../../../../../ui'
+import {Tooltip} from '../../../../../ui'
 import {useWorkspaceAuthStates} from './hooks'
 import {WorkspacePreview} from './WorkspacePreview'
 import {useRouter} from 'sanity/router'
@@ -65,12 +72,6 @@ export function WorkspaceMenuButton(props: WorkspaceMenuButtonProps) {
           id="workspace-menu"
           menu={
             <StyledMenu>
-              <Box paddingX={3} paddingY={3}>
-                <Label size={1} muted>
-                  Workspaces
-                </Label>
-              </Box>
-
               {authStates &&
                 workspaces.map((workspace) => {
                   const authState = authStates[workspace.name]
@@ -98,10 +99,9 @@ export function WorkspaceMenuButton(props: WorkspaceMenuButtonProps) {
                       key={workspace.name}
                       // eslint-disable-next-line react/jsx-no-bind
                       onClick={handleSelectWorkspace}
+                      padding={0}
                       pressed={workspace.name === activeWorkspace.name}
                     >
-                      {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
-                      {/* @ts-ignore - Workspace preview hasn't been redesigned for facelift */}
                       <WorkspacePreview
                         icon={workspace?.icon}
                         selected={workspace.name === activeWorkspace.name}

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspacePreview.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspacePreview.tsx
@@ -1,5 +1,5 @@
 import {CheckmarkIcon} from '@sanity/icons'
-import {Flex, Stack, Box, Text, Card} from '@sanity/ui'
+import {Flex, Stack, Box, Text, Card, Badge} from '@sanity/ui'
 import React, {createElement, isValidElement, useMemo} from 'react'
 import {isValidElementType} from 'react-is'
 import styled from 'styled-components'
@@ -35,6 +35,11 @@ export interface WorkspacePreviewProps {
   title: string
 }
 
+/**
+ * This Workspace preview component is used in multiple places:
+ * 1. As separate buttons in the workspace selector (pre-auth)
+ * 2. Within <MenuItems> in the navbar workspace <Menu> (once logged in)
+ */
 export function WorkspacePreview(props: WorkspacePreviewProps) {
   const {state, subtitle, selected, title, icon, iconRight} = props
 
@@ -42,13 +47,13 @@ export function WorkspacePreview(props: WorkspacePreviewProps) {
   const iconRightComponent = useMemo(() => createIcon(iconRight), [iconRight])
 
   return (
-    <Flex align="center" flex="none" gap={3}>
+    <Flex align="center" flex="none" gap={3} padding={3}>
       <MediaCard radius={2} tone="transparent">
         {iconComponent}
       </MediaCard>
 
       <Stack flex={1} space={2}>
-        <Text textOverflow="ellipsis" weight="medium">
+        <Text size={1} textOverflow="ellipsis" weight="medium">
           {title}
         </Text>
 
@@ -59,13 +64,7 @@ export function WorkspacePreview(props: WorkspacePreviewProps) {
         )}
       </Stack>
 
-      {state && STATE_TITLES[state] && (
-        <Box paddingLeft={1}>
-          <Text size={1} muted textOverflow="ellipsis">
-            {STATE_TITLES[state]}
-          </Text>
-        </Box>
-      )}
+      {state && STATE_TITLES[state] && <Badge marginLeft={1}>{STATE_TITLES[state]}</Badge>}
 
       {(selected || iconRightComponent) && (
         <Flex align="center" gap={4} paddingLeft={3} paddingRight={2}>

--- a/packages/sanity/src/ui/__workshop__/MenuItemStory.tsx
+++ b/packages/sanity/src/ui/__workshop__/MenuItemStory.tsx
@@ -1,0 +1,56 @@
+import {CheckmarkIcon, WarningOutlineIcon} from '@sanity/icons'
+import {Box, Card, Menu, MenuDivider} from '@sanity/ui'
+import {useString} from '@sanity/ui-workshop'
+import React from 'react'
+import {MenuItem} from '../menuItem'
+
+const HOTKEYS = ['Ctrl', 'Alt', 'P']
+
+export default function MenuItemStory() {
+  const subtitle = useString('Subtitle', 'Subtitle', 'Props') || ''
+  const text = useString('Text', 'Text', 'Props') || ''
+
+  return (
+    <Box padding={4}>
+      <Card border>
+        <Menu>
+          <MenuItem text={text} />
+          <MenuItem iconRight={CheckmarkIcon} text={text} />
+          <MenuItem hotkeys={HOTKEYS} text={text} />
+          <MenuItem hotkeys={HOTKEYS} iconRight={CheckmarkIcon} text={text} />
+          <MenuDivider />
+          <MenuItem icon={WarningOutlineIcon} text={text} />
+          <MenuItem icon={WarningOutlineIcon} iconRight={CheckmarkIcon} text={text} />
+          <MenuItem hotkeys={HOTKEYS} icon={WarningOutlineIcon} text={text} />
+          <MenuItem
+            hotkeys={HOTKEYS}
+            icon={WarningOutlineIcon}
+            iconRight={CheckmarkIcon}
+            text={text}
+          />
+          <MenuDivider />
+          <MenuItem subtitle={subtitle} text={text} />
+          <MenuItem iconRight={CheckmarkIcon} subtitle={subtitle} text={text} />
+          <MenuItem hotkeys={HOTKEYS} subtitle={subtitle} text={text} />
+          <MenuItem hotkeys={HOTKEYS} iconRight={CheckmarkIcon} subtitle={subtitle} text={text} />
+          <MenuDivider />
+          <MenuItem icon={WarningOutlineIcon} subtitle={subtitle} text={text} />
+          <MenuItem
+            icon={WarningOutlineIcon}
+            iconRight={CheckmarkIcon}
+            subtitle={subtitle}
+            text={text}
+          />
+          <MenuItem hotkeys={HOTKEYS} icon={WarningOutlineIcon} subtitle={subtitle} text={text} />
+          <MenuItem
+            hotkeys={HOTKEYS}
+            icon={WarningOutlineIcon}
+            iconRight={CheckmarkIcon}
+            subtitle={subtitle}
+            text={text}
+          />
+        </Menu>
+      </Card>
+    </Box>
+  )
+}

--- a/packages/sanity/src/ui/__workshop__/PreviewMenuItemStory.tsx
+++ b/packages/sanity/src/ui/__workshop__/PreviewMenuItemStory.tsx
@@ -1,0 +1,150 @@
+import {CheckmarkIcon} from '@sanity/icons'
+import {Avatar, Box, Card, Menu, MenuDivider} from '@sanity/ui'
+import {useString} from '@sanity/ui-workshop'
+import React from 'react'
+import {PreviewMenuItem} from '../previewMenuItem'
+
+const AVATAR_INITIALS = 'A.W.'
+
+export default function PreviewMenuItemStory() {
+  const badge = useString('Badge', 'Badge', 'Props') || ''
+  const subtitle = useString('Subtitle', 'Subtitle', 'Props') || ''
+  const text = useString('Text', 'Text', 'Props') || ''
+
+  return (
+    <Box padding={4}>
+      <Card border>
+        <Menu>
+          <PreviewMenuItem preview={<Avatar initials={AVATAR_INITIALS} size={0} />} text="Text" />
+          <PreviewMenuItem
+            iconRight={CheckmarkIcon}
+            preview={<Avatar initials={AVATAR_INITIALS} size={0} />}
+            text={text}
+          />
+          <PreviewMenuItem
+            badge={badge}
+            preview={<Avatar initials={AVATAR_INITIALS} size={0} />}
+            text={text}
+          />
+          <PreviewMenuItem
+            badge={badge}
+            iconRight={CheckmarkIcon}
+            preview={<Avatar initials={AVATAR_INITIALS} size={0} />}
+            text={text}
+          />
+          <MenuDivider />
+          <PreviewMenuItem
+            preview={<Avatar initials={AVATAR_INITIALS} size={0} />}
+            subtitle={subtitle}
+            text={text}
+          />
+          <PreviewMenuItem
+            iconRight={CheckmarkIcon}
+            preview={<Avatar initials={AVATAR_INITIALS} size={0} />}
+            subtitle={subtitle}
+            text={text}
+          />
+          <PreviewMenuItem
+            badge={badge}
+            preview={<Avatar initials={AVATAR_INITIALS} size={0} />}
+            subtitle={subtitle}
+            text={text}
+          />
+          <PreviewMenuItem
+            badge={badge}
+            iconRight={CheckmarkIcon}
+            preview={<Avatar initials={AVATAR_INITIALS} size={0} />}
+            subtitle={subtitle}
+            text={text}
+          />
+          <MenuDivider />
+          <PreviewMenuItem preview={<Avatar initials={AVATAR_INITIALS} size={1} />} text={text} />
+          <PreviewMenuItem
+            iconRight={CheckmarkIcon}
+            preview={<Avatar initials={AVATAR_INITIALS} size={1} />}
+            text={text}
+          />
+          <PreviewMenuItem
+            badge={badge}
+            preview={<Avatar initials={AVATAR_INITIALS} size={1} />}
+            text={text}
+          />
+          <PreviewMenuItem
+            badge={badge}
+            iconRight={CheckmarkIcon}
+            preview={<Avatar initials={AVATAR_INITIALS} size={1} />}
+            text={text}
+          />
+          <MenuDivider />
+          <PreviewMenuItem
+            preview={<Avatar initials={AVATAR_INITIALS} size={1} />}
+            subtitle={subtitle}
+            text={text}
+          />
+          <PreviewMenuItem
+            iconRight={CheckmarkIcon}
+            preview={<Avatar initials={AVATAR_INITIALS} size={1} />}
+            subtitle={subtitle}
+            text={text}
+          />
+          <PreviewMenuItem
+            badge={badge}
+            preview={<Avatar initials={AVATAR_INITIALS} size={1} />}
+            subtitle={subtitle}
+            text={text}
+          />
+          <PreviewMenuItem
+            badge={badge}
+            iconRight={CheckmarkIcon}
+            preview={<Avatar initials={AVATAR_INITIALS} size={1} />}
+            subtitle={subtitle}
+            text={text}
+          />
+          <MenuDivider />
+          <PreviewMenuItem preview={<Avatar initials={AVATAR_INITIALS} size={2} />} text={text} />
+          <PreviewMenuItem
+            iconRight={CheckmarkIcon}
+            preview={<Avatar initials={AVATAR_INITIALS} size={2} />}
+            text={text}
+          />
+          <PreviewMenuItem
+            badge={badge}
+            preview={<Avatar initials={AVATAR_INITIALS} size={2} />}
+            text={text}
+          />
+          <PreviewMenuItem
+            badge={badge}
+            iconRight={CheckmarkIcon}
+            preview={<Avatar initials={AVATAR_INITIALS} size={2} />}
+            text={text}
+          />
+          <MenuDivider />
+          <PreviewMenuItem
+            preview={<Avatar initials={AVATAR_INITIALS} size={2} />}
+            subtitle={subtitle}
+            text={text}
+          />
+          <PreviewMenuItem
+            iconRight={CheckmarkIcon}
+            preview={<Avatar initials={AVATAR_INITIALS} size={2} />}
+            subtitle={subtitle}
+            text={text}
+          />
+          <PreviewMenuItem
+            badge={badge}
+            preview={<Avatar initials={AVATAR_INITIALS} size={2} />}
+            subtitle={subtitle}
+            text={text}
+          />
+          <PreviewMenuItem
+            badge={badge}
+            iconRight={CheckmarkIcon}
+            preview={<Avatar initials={AVATAR_INITIALS} size={2} />}
+            subtitle={subtitle}
+            text={text}
+          />
+        </Menu>
+      </Card>
+    </Box>
+  )
+}

--- a/packages/sanity/src/ui/__workshop__/index.ts
+++ b/packages/sanity/src/ui/__workshop__/index.ts
@@ -1,0 +1,19 @@
+import {defineScope} from '@sanity/ui-workshop'
+import {lazy} from 'react'
+
+export default defineScope({
+  name: 'studio-ui',
+  title: 'Studio UI',
+  stories: [
+    {
+      name: 'menu-item',
+      title: 'MenuItem',
+      component: lazy(() => import('./MenuItemStory')),
+    },
+    {
+      name: 'preview-menu-item',
+      title: 'PreviewMenuItem',
+      component: lazy(() => import('./PreviewMenuItemStory')),
+    },
+  ],
+})

--- a/packages/sanity/src/ui/previewMenuItem/PreviewMenuItem.tsx
+++ b/packages/sanity/src/ui/previewMenuItem/PreviewMenuItem.tsx
@@ -1,27 +1,28 @@
 import {
   Flex,
-  Hotkeys,
-  Stack,
-  Text,
   MenuItem as UIMenuItem,
   MenuItemProps as UIMenuItemProps,
+  Stack,
+  Text,
+  Badge,
 } from '@sanity/ui'
 import React, {createElement, forwardRef, isValidElement, useMemo} from 'react'
 import {isValidElementType} from 'react-is'
 
-const FONT_SIZE = 1
-
 /** @internal */
-export type MenuItemProps = Pick<
+export type PreviewMenuItemProps = Pick<
   UIMenuItemProps,
-  'as' | 'icon' | 'iconRight' | 'pressed' | 'selected' | 'text' | 'tone'
+  'as' | 'iconRight' | 'pressed' | 'selected' | 'text' | 'tone'
 > &
   Omit<React.HTMLProps<HTMLDivElement>, 'as' | 'children' | 'ref' | 'selected'> & {
-    hotkeys?: UIMenuItemProps['hotkeys']
+    badge?: string
+    preview: React.ReactNode
+    subtitle?: string
     /** Add wrappers to the menu item, e.g. `Tooltip`. */
     renderMenuItem?: (menuItem: React.JSX.Element) => React.ReactNode
-    subtitle?: string
   }
+
+const FONT_SIZE = 1
 
 /**
  * Studio UI <MenuItem>.
@@ -31,19 +32,14 @@ export type MenuItemProps = Pick<
  *
  * @internal
  */
-export const MenuItem = forwardRef(function MenuItem(
-  {hotkeys, icon, iconRight, subtitle, text, ...props}: MenuItemProps,
+export const PreviewMenuItem = forwardRef(function MenuItem(
+  {preview: avatar, badge, iconRight, subtitle, text, ...props}: PreviewMenuItemProps,
   ref: React.Ref<HTMLDivElement>,
 ) {
   const menuItemContent = useMemo(() => {
     return (
       <Flex as="span" gap={3} align="center">
-        {icon && (
-          <Text align="center" size={FONT_SIZE}>
-            {isValidElement(icon) && icon}
-            {isValidElementType(icon) && createElement(icon)}
-          </Text>
-        )}
+        {avatar && avatar}
 
         <Stack flex={1} space={2}>
           <Text size={FONT_SIZE} textOverflow="ellipsis" weight="medium">
@@ -56,9 +52,7 @@ export const MenuItem = forwardRef(function MenuItem(
           )}
         </Stack>
 
-        {hotkeys && (
-          <Hotkeys fontSize={FONT_SIZE} keys={hotkeys} style={{marginTop: -4, marginBottom: -4}} />
-        )}
+        {badge && <Badge>{badge}</Badge>}
 
         {iconRight && (
           <Text size={FONT_SIZE}>
@@ -68,7 +62,7 @@ export const MenuItem = forwardRef(function MenuItem(
         )}
       </Flex>
     )
-  }, [hotkeys, icon, iconRight, subtitle, text])
+  }, [avatar, text, subtitle, badge, iconRight])
 
   return (
     <UIMenuItem ref={ref} {...props}>

--- a/packages/sanity/src/ui/previewMenuItem/index.ts
+++ b/packages/sanity/src/ui/previewMenuItem/index.ts
@@ -1,0 +1,1 @@
+export * from './PreviewMenuItem'


### PR DESCRIPTION
### Description

- Rather than varying on `size`, this PR splits `<MenuItem>` into two separate components – `<MenuItem>` and `<PreviewMenuItem>`
- Workshop stories have been created for the above, indicating optionality
- Workspace preview component has been updated to match updated layout
- Support for `children` has been removed from Studio UI `<MenuItem>` variants – in these (rare) instances, users can just use regular Sanity UI components. Known cases:
   - [WorkspaceMenuButton](https://github.com/sanity-io/sanity/blob/EDX-635-menu-items-split-components/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx) – this uses WorkspacePreview (which is reappropriated in other non-menu contexts, such as the workspace auth screen)
   - [BlockStyleSelect](https://github.com/sanity-io/sanity/blob/EDX-635-menu-items-split-components/packages/sanity/src/core/form/inputs/PortableText/toolbar/BlockStyleSelect.tsx) - this needs to render custom PT styles
- Renamed some props – opting against hungarian notation (e.g. `subText => subtitle`) and making some other values more agnostic (`avatar => preview`)