### PR TITLE
fix(core): fix issue causing history menu list to load indefinitely

### DIFF
--- a/packages/sanity/src/core/store/_legacy/history/history/TimelineController.ts
+++ b/packages/sanity/src/core/store/_legacy/history/history/TimelineController.ts
@@ -322,7 +322,7 @@ export class TimelineController {
       return
     }
 
-    if (count < limit) {
+    if (count <= limit) {
       this._aligner.didReachEarliestEntry()
     }
 


### PR DESCRIPTION
### Description
When fetching revisions from the history api, we have a check to see if we whether we reached the end of the revision history by checking if the number entries received _is less_ than the number of history entries we asked for. This causes the UI to appear as loading indefinitely if the api returns _exactly_ the number of entries we asked for, and it will also not show the earliest entry.

### What to review
Note: Please don't edit the linked document, as it will potentially remove the repro case :)
- Open the revision history menu of this document: https://test-studio.sanity.build/test/content/untitledRepro;documentStore;drafts.15029460-cc14-4532-afab-5d5d1fb6183e
- See that it loads forever, and doesn't show the earliest entry
- Got to the same document with this fix applied: https://test-studio-git-sdx-815.sanity.build/test/content/untitledRepro;documentStore;drafts.15029460-cc14-4532-afab-5d5d1fb6183e
- Verify that it completes and show the earliest entry

### Notes for release
- fix issue causing the history menu list to appear to load indefinitely in certain cases