### PR TITLE
feat(i18n): allow simple HTML tags when using Translate component

### DIFF
--- a/dev/test-studio/components/TranslateExample.tsx
+++ b/dev/test-studio/components/TranslateExample.tsx
@@ -1,27 +1,35 @@
 import {Translate, useTranslation} from 'sanity'
 import React from 'react'
-import {Card, Text} from '@sanity/ui'
+import {Card, Stack, Text} from '@sanity/ui'
 import {InfoFilledIcon} from '@sanity/icons'
 
 export function TranslateExample() {
   const {t} = useTranslation('testStudio')
   return (
     <Card padding={4}>
-      <Text>
-        <Translate
-          t={t}
-          i18nKey="translate.example"
-          components={{
-            Icon: () => <InfoFilledIcon />,
-            Red: ({children}) => <span style={{color: 'red'}}>{children}</span>,
-            Bold: ({children}) => <b>{children}</b>,
-          }}
-          values={{
-            keyword: 'something',
-            duration: '30',
-          }}
-        />
-      </Text>
+      <Stack space={4}>
+        <Text>{t('use-translation.with-html')}</Text>
+
+        <Text>
+          <Translate t={t} i18nKey="use-translation.with-html" />
+        </Text>
+
+        <Text>
+          <Translate
+            t={t}
+            i18nKey="translate.example"
+            components={{
+              Icon: () => <InfoFilledIcon />,
+              Red: ({children}) => <span style={{color: 'red'}}>{children}</span>,
+              Bold: ({children}) => <b>{children}</b>,
+            }}
+            values={{
+              keyword: 'something',
+              duration: '30',
+            }}
+          />
+        </Text>
+      </Stack>
     </Card>
   )
 }

--- a/dev/test-studio/locales/index.ts
+++ b/dev/test-studio/locales/index.ts
@@ -7,6 +7,7 @@ const enUSStrings = {
   'structure.root.title': 'Content 🇺🇸',
   'translate.example':
     '<Icon/> Your search for "<Red>{{keyword}}</Red>" took <Bold>{{duration}}ms</Bold>',
+  'use-translation.with-html': 'Apparently, <code>code</code> is an HTML element?',
 }
 
 const enUS = defineLocaleResourceBundle({
@@ -23,6 +24,7 @@ const noNB = defineLocaleResourceBundle({
     'structure.root.title': 'Innhold 🇳🇴',
     'translate.example':
       '<Icon/> Ditt søk på "<Red>{{keyword}}</Red>" tok <Bold>{{duration}}</Bold> millisekunder',
+    'use-translation.with-html': 'Faktisk er <code>code</code> et HTML-element?',
   },
 })
 

--- a/packages/sanity/src/core/i18n/__tests__/simpleParser.test.ts
+++ b/packages/sanity/src/core/i18n/__tests__/simpleParser.test.ts
@@ -90,14 +90,14 @@ describe('simpleParser - errors', () => {
       'Expected closing tag for <Red>, but found closing tag </Blue> instead. Make sure each opening tag has a matching closing tag.',
     )
   })
-  test('tags must be title cased', () => {
-    expect(() => simpleParser('foo <red> bar</Blue>')).toThrow(
-      'Invalid tag "<red>". Tag names must start with an uppercase letter and can only include letters and numbers.',
+  test('does not allow camelCased tag names', () => {
+    expect(() => simpleParser('foo <camelCased>bar</camelCased>')).toThrow(
+      'Invalid tag "<camelCased>". Tag names must be lowercase HTML tags or start with an uppercase letter and can only include letters and numbers.',
     )
   })
   test('tags cant contain whitespace or special characters', () => {
     expect(() => simpleParser('foo <Em@ail> bar</Em@ail>')).toThrow(
-      'Invalid tag "<Em@ail>". Tag names must start with an uppercase letter and can only include letters and numbers.',
+      'Invalid tag "<Em@ail>". Tag names must be lowercase HTML tags or start with an uppercase letter and can only include letters and numbers.',
     )
     expect(() => simpleParser('foo <Bold >bar</Bold>')).toThrow(
       'Invalid tag "<Bold >". No whitespace allowed in tags.',
@@ -112,5 +112,47 @@ describe('simpleParser - errors', () => {
     expect(() => simpleParser('<foo < or > bar>')).not.toThrow()
     expect(() => simpleParser('a < 1 < or > bar>')).not.toThrow()
     expect(() => simpleParser('0 <2 > 1')).not.toThrow()
+  })
+  test('regular, lowercase html tag names', () => {
+    expect(
+      simpleParser('the type <code>author</code> is not <em>explicitly</em> allowed'),
+    ).toMatchObject([
+      {
+        text: 'the type ',
+        type: 'text',
+      },
+      {
+        name: 'code',
+        type: 'tagOpen',
+      },
+      {
+        text: 'author',
+        type: 'text',
+      },
+      {
+        name: 'code',
+        type: 'tagClose',
+      },
+      {
+        text: ' is not ',
+        type: 'text',
+      },
+      {
+        name: 'em',
+        type: 'tagOpen',
+      },
+      {
+        text: 'explicitly',
+        type: 'text',
+      },
+      {
+        name: 'em',
+        type: 'tagClose',
+      },
+      {
+        text: ' allowed',
+        type: 'text',
+      },
+    ])
   })
 })

--- a/packages/sanity/src/core/i18n/simpleParser.ts
+++ b/packages/sanity/src/core/i18n/simpleParser.ts
@@ -16,7 +16,8 @@ export type Token = OpenTagToken | CloseTagToken | TextToken
 const OPEN_TAG_RE = /<(?<tag>[^\s\d][^/?><]+)\/?>/
 const CLOSE_TAG_RE = /<\/(?<tag>[^>]+)>/
 const SELF_CLOSING_RE = /<[^>]+\/>/
-const VALID_TAG_NAME = /^[A-Z][A-Za-z0-9]+$/
+const VALID_COMPONENT_NAME_RE = /^[A-Z][A-Za-z0-9]+$/
+const VALID_HTML_TAG_NAME_RE = /^[a-z]+$/
 
 function isSelfClosing(tag: string) {
   return SELF_CLOSING_RE.test(tag)
@@ -26,6 +27,24 @@ function matchOpenTag(input: string) {
 }
 function matchCloseTag(input: string) {
   return input.match(CLOSE_TAG_RE)
+}
+
+function validateTagName(tagName: string) {
+  const isValidComponentName = VALID_COMPONENT_NAME_RE.test(tagName)
+  if (isValidComponentName) {
+    return
+  }
+
+  const isValidHtmlTagName = VALID_HTML_TAG_NAME_RE.test(tagName)
+  if (isValidHtmlTagName) {
+    return
+  }
+
+  throw new Error(
+    tagName.trim() === tagName
+      ? `Invalid tag "<${tagName}>". Tag names must be lowercase HTML tags or start with an uppercase letter and can only include letters and numbers.`
+      : `Invalid tag "<${tagName}>". No whitespace allowed in tags.`,
+  )
 }
 
 /**
@@ -42,13 +61,7 @@ export function simpleParser(input: string): Token[] {
       const match = matchOpenTag(remainder)
       if (match) {
         const tagName = match.groups!.tag
-        if (!VALID_TAG_NAME.test(tagName)) {
-          throw new Error(
-            tagName.trim() === tagName
-              ? `Invalid tag "<${tagName}>". Tag names must start with an uppercase letter and can only include letters and numbers."`
-              : `Invalid tag "<${tagName}>". No whitespace allowed in tags."`,
-          )
-        }
+        validateTagName(tagName)
         if (text) {
           tokens.push({type: 'text', text})
           text = ''


### PR DESCRIPTION
### Description

It's a bit tedious to pass in components like `<Code>` that just maps to `<code>`. This PR allows using this predefined list of tags without specifying it directly: `<abbr>`, `<address>`, `<cite>`, `<code>`, `<del>`, `<em>`, `<ins>`, `<kbd>`, `<q>`, `<samp>`, `<strong>`, `<sub>`, `<sup>`.

The reason for these specifically is that they are inline elements that do not require any attributes for use, and is not deprecated by the HTML5 spec.

I'm not sure if my solution in the parser was the best, but I didn't want to spend more time finding a more elegant way to approach it - open to suggestions.

### What to review

- Using simple tags with the `<Translate/>` component works as it should

### Notes for release

None.
