### PR TITLE
fix(core): reference links not opening correct pane

### DIFF
--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceLinkCard.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceLinkCard.tsx
@@ -29,14 +29,7 @@ export const ReferenceLinkCard = forwardRef(function ReferenceLinkCard(
   props: ReferenceLinkCardProps & React.HTMLProps<HTMLElement>,
   ref: React.ForwardedRef<HTMLElement>,
 ) {
-  const {
-    as: asProp,
-    // We exclude `documentId` from spread props to avoid passing it to the Card component
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    documentId,
-    documentType,
-    ...cardProps
-  } = props
+  const {as: asProp, documentId, documentType, ...cardProps} = props
   const dataAs = documentType ? 'a' : undefined
 
   // If the child link is clicked without a document type, an error will be thrown.
@@ -48,6 +41,7 @@ export const ReferenceLinkCard = forwardRef(function ReferenceLinkCard(
     <StyledCard
       {...cardProps}
       data-as={dataAs}
+      documentId={documentId}
       documentType={documentType}
       forwardedAs={as}
       ref={ref as unknown as React.ForwardedRef<HTMLDivElement>}


### PR DESCRIPTION
### Description

Fixes #5105

#5093 introduced a regression where references can no longer be opened in-place.
This is caused by removing the `documentId` from [being passed to the state link](https://github.com/sanity-io/sanity/pull/5093/files#diff-f08509f8474b2f3f1c0301d9ca9693b77fa019a86d6ece6c45013ba55f5f7a77).

This revert _this_ change, but reintroduces warnings about passing it to DOM elements, so it is not a perfect solution. I struggled to figure out what is actually being passed to what here - a lot of `as`/`data-as`/Card/StyledCard magic and layers of abstraction, so I would appreciate if either of you had time to fix this properly and push to this branch.

This warrants a hotfix release once addressed.

### What to review

- That it fixes the problem
- What the proper solution is

### Notes for release

- Fixed an issue where references would not open in-place, instead yielding an error about being changed after opening
