### PR TITLE
fix(desk): comment mention list issue when using the '@' button

### DIFF
--- a/packages/sanity/playwright-ct/tests/comments/CommentInput.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/comments/CommentInput.spec.tsx
@@ -28,6 +28,19 @@ test.describe('Comments', () => {
       await expect(page.getByTestId('comments-mentions-menu')).toBeVisible()
     })
 
+    test('Should bring up mentions menu when pressing the @ button, whilst retaining focus on PTE', async ({
+      mount,
+      page,
+    }) => {
+      await mount(<CommentsInputStory />)
+      const $editable = page.getByTestId('comment-input-editable')
+      await $editable.waitFor({state: 'visible'})
+      const $mentionButton = page.getByTestId('comment-mention-button')
+      await $mentionButton.click()
+      await expect(page.getByTestId('comments-mentions-menu')).toBeVisible()
+      await expect($editable).toBeFocused()
+    })
+
     test('Should be able to submit', async ({mount, page}) => {
       const {insertPortableText} = testHelpers({page})
       let submitted = false

--- a/packages/sanity/src/desk/comments/src/components/pte/comment-input/CommentInputInner.tsx
+++ b/packages/sanity/src/desk/comments/src/components/pte/comment-input/CommentInputInner.tsx
@@ -130,6 +130,7 @@ export function CommentInputInner(props: CommentInputInnerProps) {
           <Flex align="center" data-ui="CommentInputActions" gap={1} justify="flex-end" padding={1}>
             <ActionButton
               aria-label="Mention user"
+              data-testid="comment-mention-button"
               disabled={readOnly}
               icon={MentionIcon}
               mode="bleed"

--- a/packages/sanity/src/desk/comments/src/components/pte/comment-input/CommentInputProvider.tsx
+++ b/packages/sanity/src/desk/comments/src/components/pte/comment-input/CommentInputProvider.tsx
@@ -142,6 +142,7 @@ export function CommentInputProvider(props: CommentInputProviderProps) {
 
   const insertAtChar = useCallback(() => {
     setMentionsMenuOpen(true)
+    PortableTextEditor.focus(editor)
     PortableTextEditor.insertChild(editor, editor.schemaTypes.span, {text: '@'})
     setSelectionAtMentionInsert(PortableTextEditor.getSelection(editor))
   }, [editor])


### PR DESCRIPTION
### Description

This pull request fixes an issue when opening the mentions menu when inserting an '@' character in the comments input with the button. 

### What to review

 Insert a '@' character with the mention button and make sure that you can navigate the menu.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
