### PR TITLE
fix(portable-text-editor): fix various

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/hooks/useSyncValue.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/hooks/useSyncValue.ts
@@ -7,7 +7,7 @@ import {useSlate} from 'slate-react'
 import {PortableTextEditor} from '../PortableTextEditor'
 import {EditorChange, PortableTextSlateEditor} from '../../types/editor'
 import {debugWithName} from '../../utils/debug'
-import {toSlateValue} from '../../utils/values'
+import {VOID_CHILD_KEY, toSlateValue} from '../../utils/values'
 import {withoutSaving} from '../plugins/createWithUndoRedo'
 import {withPreserveKeys} from '../../utils/withPreserveKeys'
 import {withoutPatching} from '../../utils/withoutPatching'
@@ -320,7 +320,7 @@ function _updateBlock(
             debug('Updating changed inline object child', currentBlockChild)
             Transforms.setNodes(
               slateEditor,
-              {_key: `${currentBlock._key}-void-child`},
+              {_key: VOID_CHILD_KEY},
               {
                 at: [...path, 0],
                 voids: true,

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/__tests__/withEditableAPIInsert.test.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/__tests__/withEditableAPIInsert.test.tsx
@@ -1,0 +1,139 @@
+import {render, waitFor} from '@testing-library/react'
+
+import React from 'react'
+import {PortableTextEditor} from '../../PortableTextEditor'
+import {PortableTextEditorTester, schemaType} from '../../__tests__/PortableTextEditorTester'
+
+const initialValue = [
+  {
+    _key: 'a',
+    _type: 'myTestBlockType',
+    children: [
+      {
+        _key: 'a1',
+        _type: 'span',
+        marks: [],
+        text: 'Block A',
+      },
+    ],
+    markDefs: [],
+    style: 'normal',
+  },
+]
+
+const initialSelection = {
+  focus: {path: [{_key: 'a'}, 'children', {_key: 'a1'}], offset: 7},
+  anchor: {path: [{_key: 'a'}, 'children', {_key: 'a1'}], offset: 7},
+}
+
+describe('plugin:withEditableAPI: .insertChild()', () => {
+  it('inserts child nodes correctly', async () => {
+    const editorRef: React.RefObject<PortableTextEditor> = React.createRef()
+    const onChange = jest.fn()
+    render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        schemaType={schemaType}
+        value={initialValue}
+      />,
+    )
+    const editor = editorRef.current
+    const inlineType = editor?.schemaTypes.inlineObjects.find((t) => t.name === 'someObject')
+    await waitFor(() => {
+      if (editor && inlineType) {
+        PortableTextEditor.focus(editor)
+        PortableTextEditor.select(editor, initialSelection)
+        PortableTextEditor.insertChild(editorRef.current, inlineType, {color: 'red'})
+        expect(PortableTextEditor.getValue(editorRef.current)).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "_key": "a",
+              "_type": "myTestBlockType",
+              "children": Array [
+                Object {
+                  "_key": "a1",
+                  "_type": "span",
+                  "marks": Array [],
+                  "text": "Block A",
+                },
+                Object {
+                  "_key": "3",
+                  "_type": "someObject",
+                  "color": "red",
+                },
+                Object {
+                  "_key": "4",
+                  "_type": "span",
+                  "marks": Array [],
+                  "text": "",
+                },
+              ],
+              "markDefs": Array [],
+              "style": "normal",
+            },
+          ]
+        `)
+        PortableTextEditor.insertChild(editor, editor.schemaTypes.span, {text: ' '})
+        expect(PortableTextEditor.getValue(editor)).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "_key": "a",
+              "_type": "myTestBlockType",
+              "children": Array [
+                Object {
+                  "_key": "a1",
+                  "_type": "span",
+                  "marks": Array [],
+                  "text": "Block A",
+                },
+                Object {
+                  "_key": "3",
+                  "_type": "someObject",
+                  "color": "red",
+                },
+                Object {
+                  "_key": "7",
+                  "_type": "span",
+                  "marks": Array [],
+                  "text": " ",
+                },
+              ],
+              "markDefs": Array [],
+              "style": "normal",
+            },
+          ]
+        `)
+        const sel = PortableTextEditor.getSelection(editor)
+        expect(sel).toMatchInlineSnapshot(`
+          Object {
+            "anchor": Object {
+              "offset": 1,
+              "path": Array [
+                Object {
+                  "_key": "a",
+                },
+                "children",
+                Object {
+                  "_key": "7",
+                },
+              ],
+            },
+            "focus": Object {
+              "offset": 1,
+              "path": Array [
+                Object {
+                  "_key": "a",
+                },
+                "children",
+                Object {
+                  "_key": "7",
+                },
+              ],
+            },
+          }
+        `)
+      }
+    })
+  })
+})

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPortableTextMarkModel.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPortableTextMarkModel.ts
@@ -223,6 +223,7 @@ export function createWithPortableTextMarkModel(
               {marks: marksWithoutAnnotationMarks},
               {at: Path.next(selection.focus.path)},
             )
+            debug('Inserting text at end of annotation')
             return
           }
         }

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/index.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/index.ts
@@ -59,7 +59,7 @@ export const withPlugins = <T extends Editor>(
   }
   const operationToPatches = createOperationToPatches(schemaTypes)
   const withObjectKeys = createWithObjectKeys(schemaTypes, keyGenerator)
-  const withSchemaTypes = createWithSchemaTypes(schemaTypes)
+  const withSchemaTypes = createWithSchemaTypes({schemaTypes, keyGenerator})
   const withEditableAPI = createWithEditableAPI(portableTextEditor, schemaTypes, keyGenerator)
   const withPatches = createWithPatches({
     change$,

--- a/packages/@sanity/portable-text-editor/src/utils/__tests__/patchToOperations.test.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/__tests__/patchToOperations.test.ts
@@ -5,6 +5,7 @@ import {createApplyPatch} from '../applyPatch'
 import {withPlugins} from '../../editor/plugins'
 import {keyGenerator, Patch, PortableTextEditor} from '../..'
 import {getPortableTextMemberSchemaTypes} from '../getPortableTextMemberSchemaTypes'
+import {VOID_CHILD_KEY} from '../values'
 
 const schemaTypes = getPortableTextMemberSchemaTypes(schemaType)
 
@@ -23,7 +24,7 @@ const createDefaultValue = (): Descendant[] => [
     _key: 'c01739b0d03b',
     children: [
       {
-        _key: 'c01739b0d03b-void-child',
+        _key: VOID_CHILD_KEY,
         _type: 'span',
         text: '',
         marks: [],
@@ -70,7 +71,7 @@ describe('operationToPatches', () => {
           "_type": "image",
           "children": Array [
             Object {
-              "_key": "c01739b0d03b-void-child",
+              "_key": "${VOID_CHILD_KEY}",
               "_type": "span",
               "marks": Array [],
               "text": "",
@@ -93,7 +94,7 @@ describe('operationToPatches', () => {
         _key: 'c01739b0d03b',
         children: [
           {
-            _key: 'c01739b0d03b-void-child',
+            _key: VOID_CHILD_KEY,
             _type: 'span',
             text: '',
             marks: [],
@@ -123,7 +124,7 @@ describe('operationToPatches', () => {
           "_type": "someType",
           "children": Array [
             Object {
-              "_key": "c01739b0d03b-void-child",
+              "_key": "${VOID_CHILD_KEY}",
               "_type": "span",
               "marks": Array [],
               "text": "",
@@ -147,7 +148,7 @@ describe('operationToPatches', () => {
         _key: 'c01739b0d03b',
         children: [
           {
-            _key: 'c01739b0d03b-void-child',
+            _key: VOID_CHILD_KEY,
             _type: 'span',
             text: '',
             marks: [],
@@ -182,7 +183,7 @@ describe('operationToPatches', () => {
           "_type": "someType",
           "children": Array [
             Object {
-              "_key": "c01739b0d03b-void-child",
+              "_key": "${VOID_CHILD_KEY}",
               "_type": "span",
               "marks": Array [],
               "text": "",

--- a/packages/@sanity/portable-text-editor/src/utils/__tests__/values.test.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/__tests__/values.test.ts
@@ -1,4 +1,4 @@
-import {fromSlateValue, toSlateValue} from '../values'
+import {VOID_CHILD_KEY, fromSlateValue, toSlateValue} from '../values'
 import {schemaType} from '../../editor/__tests__/PortableTextEditorTester'
 import {getPortableTextMemberSchemaTypes} from '../getPortableTextMemberSchemaTypes'
 
@@ -117,7 +117,7 @@ describe('toSlateValue', () => {
               "_type": "image",
               "children": Array [
                 Object {
-                  "_key": "123-void-child",
+                  "_key": "${VOID_CHILD_KEY}",
                   "_type": "span",
                   "marks": Array [],
                   "text": "",

--- a/packages/@sanity/portable-text-editor/src/utils/values.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/values.ts
@@ -11,6 +11,8 @@ import {PortableTextMemberSchemaTypes} from '../types/editor'
 
 const EMPTY_MARKDEFS: PortableTextObject[] = []
 
+export const VOID_CHILD_KEY = 'void-child'
+
 type Partial<T> = {
   [P in keyof T]?: T[P]
 }
@@ -35,7 +37,7 @@ export function toSlateValue(
   if (value && Array.isArray(value)) {
     return value.map((block) => {
       const {_type, _key, ...rest} = block
-      const voidChildren = [{_key: `${_key}-void-child`, _type: 'span', text: '', marks: []}]
+      const voidChildren = [{_key: VOID_CHILD_KEY, _type: 'span', text: '', marks: []}]
       const isPortableText = block && block._type === schemaTypes.block.name
       if (isPortableText) {
         const textBlock = block as PortableTextTextBlock


### PR DESCRIPTION
### Description

This will improve and fix a couple of things with the PTE:

* Simplify the key name used for the "virtual" text node of inline objects and object blocks in the state for easier tests and value comparisons. This key doesn't need to be unique and can be put in a constant. This will fix an issue where the external value would need to be synced after inserting inline objects when it really isn't needed.

* When normalizing a Slate node that haven't been assigned the span type, generate a key and spread the existing node data (possibly .marks) in the normalization step. This will save us other normalization steps (`._key` normalization, and `.marks` normalization) down the line.
* Fix an issue with the `PortableTextEditor.insertChild`  function, where if you inserted a new span child when having focus on a inline object, it would try to insert it into the inline-object's "virtual" text node instead as a child of the block itself.

* Added and updated tests for these things.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
That the changes look good. The tests should cover most of the changes I think.
 

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
N/A - mostly internal and non-user-facing improvements.

<!--
A description of the change(s) that should be used in the release notes.
-->
