### PR TITLE
fix(desk/comments): insert space after mention insert

### DIFF
--- a/packages/sanity/playwright-ct/tests/comments/CommentInput.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/comments/CommentInput.spec.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-nested-callbacks */
 import {expect, test} from '@playwright/experimental-ct-react'
 import React from 'react'
 import {testHelpers} from '../utils/testHelpers'
@@ -26,6 +27,10 @@ test.describe('Comments', () => {
       await $editable.waitFor({state: 'visible'})
       await page.keyboard.type('@')
       await expect(page.getByTestId('comments-mentions-menu')).toBeVisible()
+      await page.keyboard.press('Enter')
+      await expect(page.getByTestId('comments-mentions-menu')).not.toBeVisible()
+      // TODO: find a way to mock `useUser`!
+      await expect($editable).toHaveText('@Loading')
     })
 
     test('Should bring up mentions menu when pressing the @ button, whilst retaining focus on PTE', async ({

--- a/packages/sanity/playwright-ct/tests/comments/CommentInputStory.tsx
+++ b/packages/sanity/playwright-ct/tests/comments/CommentInputStory.tsx
@@ -3,6 +3,7 @@ import {CurrentUser, PortableTextBlock} from '@sanity/types'
 import {noop} from 'lodash'
 import {CommentInput} from '../../../src/desk/comments/src/components/pte/comment-input/CommentInput'
 import {TestWrapper} from '../formBuilder/utils/TestWrapper'
+import {MentionOptionsHookValue} from '../../../src/desk/comments'
 
 const currentUser: CurrentUser = {
   email: '',
@@ -15,6 +16,19 @@ const currentUser: CurrentUser = {
 }
 
 const SCHEMA_TYPES: [] = []
+
+const MENTION_DATA: MentionOptionsHookValue = {
+  data: [
+    {
+      id: 'l33t',
+      displayName: 'Test Person',
+      email: 'test@test.com',
+      canBeMentioned: true,
+    },
+  ],
+  loading: false,
+  error: null,
+}
 
 export function CommentsInputStory({
   onDiscardCancel = noop,
@@ -37,7 +51,7 @@ export function CommentsInputStory({
         currentUser={currentUser}
         onChange={setValueState}
         value={valueState}
-        mentionOptions={{data: [], error: null, loading: false}}
+        mentionOptions={MENTION_DATA}
         onDiscardConfirm={onDiscardConfirm}
         onDiscardCancel={onDiscardCancel}
         onSubmit={onSubmit}

--- a/packages/sanity/src/desk/comments/src/components/pte/comment-input/CommentInputProvider.tsx
+++ b/packages/sanity/src/desk/comments/src/components/pte/comment-input/CommentInputProvider.tsx
@@ -4,7 +4,7 @@ import {
   usePortableTextEditor,
 } from '@sanity/portable-text-editor'
 import React, {useCallback, useMemo, useState} from 'react'
-import {Path, isKeySegment, isPortableTextSpan, isPortableTextTextBlock} from '@sanity/types'
+import {Path, isPortableTextSpan} from '@sanity/types'
 import {CommentMessage, MentionOptionsHookValue} from '../../../types'
 import {hasCommentMessageValue, useCommentHasChanged} from '../../../helpers'
 import {useDidUpdate} from 'sanity'

--- a/packages/sanity/src/desk/comments/src/components/pte/comment-input/CommentInputProvider.tsx
+++ b/packages/sanity/src/desk/comments/src/components/pte/comment-input/CommentInputProvider.tsx
@@ -170,33 +170,10 @@ export function CommentInputProvider(props: CommentInputProviderProps) {
             },
             {mode: 'selected'},
           )
-          mentionPath = PortableTextEditor.insertChild(editor, mentionSchemaType, {
-            _type: 'mention',
+          PortableTextEditor.insertChild(editor, mentionSchemaType, {
             userId: userId,
           })
-        }
-
-        const focusBlock = PortableTextEditor.focusBlock(editor)
-
-        // Set the focus on the next text node after the mention object
-        if (focusBlock && isPortableTextTextBlock(focusBlock) && mentionPath) {
-          const mentionKeyPathSegment = mentionPath?.slice(-1)[0]
-          const nextChildKey =
-            focusBlock.children[
-              focusBlock.children.findIndex(
-                (c) => isKeySegment(mentionKeyPathSegment) && c._key === mentionKeyPathSegment._key,
-              ) + 1
-            ]?._key
-
-          if (nextChildKey) {
-            const path: Path = [{_key: focusBlock._key}, 'children', {_key: nextChildKey}]
-            const sel: EditorSelection = {
-              anchor: {path, offset: 0},
-              focus: {path, offset: 0},
-            }
-            PortableTextEditor.select(editor, sel)
-            PortableTextEditor.focus(editor)
-          }
+          PortableTextEditor.insertChild(editor, editor.schemaTypes.span, {text: ' '})
         }
       }
     },


### PR DESCRIPTION
### Description

This will conveniently insert a space after a mention is inserted into the comment input.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
