### PR TITLE
feat(i18n): translate/localize diff components

### DIFF
--- a/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
@@ -122,6 +122,10 @@ const studioResources: Record<StudioLocaleResourceKeys, string> = {
   /** Label for the "to" value in the change inspector */
   'changes.inspector.to-label': 'Til',
 
+  /** Error message shown when the value of a field is not the expected one */
+  'changes.error.incorrect-type-message':
+    'Verdifeil: Vedien har typen «<code>{{actualType}}</code>», forventet «<code>{{expectedType}}</code>»',
+
   /** --- Document timeline, for navigating different revisions of a document --- */
 
   /** Error prompt when revision cannot be loaded */

--- a/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
@@ -113,6 +113,15 @@ const studioResources: Record<StudioLocaleResourceKeys, string> = {
   'changes.error-boundary.developer-info':
     'Sjekk konsollen i utviklerverktøyet for mer informasjon',
 
+  /** Label for the "meta" (field path, action etc) information in the change inspector */
+  'changes.inspector.meta-label': 'Meta',
+
+  /** Label for the "from" value in the change inspector */
+  'changes.inspector.from-label': 'Fra',
+
+  /** Label for the "to" value in the change inspector */
+  'changes.inspector.to-label': 'Til',
+
   /** --- Document timeline, for navigating different revisions of a document --- */
 
   /** Error prompt when revision cannot be loaded */

--- a/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
@@ -80,6 +80,12 @@ const studioResources: Record<StudioLocaleResourceKeys, string> = {
   'changes.no-changes-description':
     'Rediger dokumentet eller velg en eldre versjon i tidslinjen for å se en liste over endringer i dette panelet.',
 
+  /** Label for when a field was cleared, eg the contents was removed - for references, assets and similar */
+  'changes.removed-label': 'Fjernet',
+
+  /** Label for when a field was given a value where it was previously empty - for references, assets and similar */
+  'changes.added-label': 'Lagt til',
+
   /** Prompt for reverting all changes in document in Review Changes pane. Includes a count of changes. */
   'changes.action.revert-all-description': `Er du sikker på at du vil angre alle {{count}} endringer?`,
 

--- a/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
@@ -98,6 +98,29 @@ const studioResources: Record<StudioLocaleResourceKeys, string> = {
   /** Loading author of change in the differences tooltip in the review changes pane */
   'changes.loading-author': 'Laster…',
 
+  /** --- Review Changes: Specific types --- */
+
+  /** Image diff: Text shown in tooltip when hovering hotspot that has changed in diff view */
+  'changes.image.crop-changed': 'Beskjæring endret',
+
+  /** Image diff: Text shown in tooltip when hovering hotspot that has changed in diff view */
+  'changes.image.hotspot-changed': 'Fokuspunkt endret',
+
+  /** Image diff: Text shown if no asset has been set for the field (but has metadata changes) */
+  'changes.image.no-asset-set': 'Bilde ikke satt',
+
+  /** Image diff: Text shown when the from/to state has/had no image */
+  'changes.image.no-image-placeholder': '(ingen bilde)',
+
+  /** Image diff: Fallback title for the meta info section when there is no original filename to use  */
+  'changes.image.meta-info-fallback-title': 'Navnløst bilde',
+
+  /** Image diff: Text shown if the previous image asset was deleted (shouldn't theoretically happen) */
+  'changes.image.deleted': 'Bilde slettet',
+
+  /** Image diff: Text shown if the image failed to be loaded when previewing it */
+  'changes.image.error-loading-image': 'Feil under lasting av bilde',
+
   /** --- Review Changes: Field + Group --- */
 
   /** Prompt for reverting changes for a field change */

--- a/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
@@ -106,6 +106,13 @@ const studioResources: Record<StudioLocaleResourceKeys, string> = {
   /** Revert for confirming revert (plural) label for field change action */
   'changes.action.revert-changes-confirm-change_other': `Angre endringer`,
 
+  /** Text shown when a diff component crashes during rendering, triggering the error boundary */
+  'changes.error-boundary.title': 'En feil oppsto under visning av endringer',
+
+  /** Additional text shown in development mode when a diff component crashes during rendering */
+  'changes.error-boundary.developer-info':
+    'Sjekk konsollen i utviklerverktøyet for mer informasjon',
+
   /** --- Document timeline, for navigating different revisions of a document --- */
 
   /** Error prompt when revision cannot be loaded */

--- a/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
@@ -134,8 +134,48 @@ const studioResources: Record<StudioLocaleResourceKeys, string> = {
   /** Portable Text diff: Removed a chunk of text */
   'change.portable-text.text_removed': 'Fjernet tekst',
 
+  /** Portable Text diff: An annotation was added */
+  'change.portable-text.annotation_added': 'La til berikelse',
+
+  /** Portable Text diff: An annotation was removed */
+  'change.portable-text.annotation_removed': 'Fjernet berikelse',
+
+  /** Portable Text diff: An annotation was changed */
+  'change.portable-text.annotation_changed': 'Endret berikelse',
+
+  /** Portable Text diff: An annotation was left unchanged */
+  'change.portable-text.annotation_unchanged': 'Uendret berikelse',
+
+  /** Portable Text diff: An inline object was added */
+  'change.portable-text.inline-object_added': 'La til inline objekt',
+
+  /** Portable Text diff: An inline object was removed */
+  'change.portable-text.inline-object_removed': 'Fjernet inline objekt',
+
+  /** Portable Text diff: An inline object was changed */
+  'change.portable-text.inline-object_changed': 'Endet inline objekt',
+
+  /** Portable Text diff: An inline object was left unchanged */
+  'change.portable-text.inline-object_unchanged': 'Uendret inline object',
+
   /** Portable Text diff: Change formatting of text (setting/unsetting marks, eg bold/italic etc) */
   'change.portable-text.changed-formatting': 'Endret formattering',
+
+  /** Portable Text diff: A block changed from one style to another (eg `normal` to `h1` or similar) */
+  'change.portable-text.block-style-changed':
+    'Endret blokkstil fra "{{fromStyle}}" til "{{toStyle}}"',
+
+  /** Portable Text diff: Annotation has an unknown schema type */
+  'change.portable-text.unknown-annotation-schema-type': 'Ukjent skjematype',
+
+  /** Portable Text diff: Inline object has an unknown schema type */
+  'change.portable-text.unknown-inline-object-schema-type': 'Ukjent skjematype',
+
+  /** Portable Text diff: An empty object is the result of adding/removing an annotation */
+  'change.portable-text.empty-object-annotation': 'Tom {{annotationType}}',
+
+  /** Portable Text diff: An empty inline object is part of a change */
+  'change.portable-text.empty-inline-object': 'Tom {{inlineObjectType}}',
 
   /** File diff: Fallback title for the meta info section when there is no original filename to use  */
   'changes.file.meta-info-fallback-title': 'Navnløs fil',

--- a/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
@@ -80,11 +80,14 @@ const studioResources: Record<StudioLocaleResourceKeys, string> = {
   'changes.no-changes-description':
     'Rediger dokumentet eller velg en eldre versjon i tidslinjen for å se en liste over endringer i dette panelet.',
 
-  /** Label for when a field was cleared, eg the contents was removed - for references, assets and similar */
+  /** Label for when the action of the change was a removal, eg a field was cleared, an array item was removed, an asset was deselected or similar */
   'changes.removed-label': 'Fjernet',
 
-  /** Label for when a field was given a value where it was previously empty - for references, assets and similar */
+  /** Label for when the action of the change was to set something that was previously empty, eg a field was given a value, an array item was added, an asset was selected or similar */
   'changes.added-label': 'Lagt til',
+
+  /** Label for when the action of the change was _not_ an add/remove, eg a text field changed value, an image was changed from one asset to another or similar */
+  'changes.changed-label': 'Endret',
 
   /** Prompt for reverting all changes in document in Review Changes pane. Includes a count of changes. */
   'changes.action.revert-all-description': `Er du sikker på at du vil angre alle {{count}} endringer?`,
@@ -99,6 +102,43 @@ const studioResources: Record<StudioLocaleResourceKeys, string> = {
   'changes.loading-author': 'Laster…',
 
   /** --- Review Changes: Specific types --- */
+
+  /** Array diff: An item was added in a given position (`{{position}}`) */
+  'changes.array.item-added-in-position': 'Lagt til i posisjon {{position}}',
+
+  /** Array diff: An item was removed from a given position (`{{position}}`) */
+  'changes.array.item-removed-from-position': 'Fjernet fra posisjon {{position}}',
+
+  /**
+   * Array diff: An item was moved within the array.
+   * Receives `{{count}}` representing number of positions it moved.
+   * Context is the direction of the move, either `up` or `down`.
+   */
+  'change.array.item-moved_up_one': 'Flyttet {{count}} posisjon opp',
+  'change.array.item-moved_up_other': 'Flyttet {{count}} posisjoner opp',
+  'change.array.item-moved_down_one': 'Flyttet {{count}} posisjon ned',
+  'change.array.item-moved_down_other': 'Flyttet {{count}} posisjoner ned',
+
+  /** Portable Text diff: Removed a block containing no text (eg empty block) */
+  'change.portable-text.empty-text_removed': 'Fjernet tomt avsnitt',
+
+  /** Portable Text diff: Added a block containing no text (eg empty block) */
+  'change.portable-text.empty-text_added': 'La til tomt avsnitt',
+
+  /** Portable Text diff: Changed a block that contained no text (eg empty block) */
+  'change.portable-text.empty-text_changed': 'Endret tomt avsnitt',
+
+  /** Portable Text diff: Added a chunk of text */
+  'change.portable-text.text_added': 'La til tekst',
+
+  /** Portable Text diff: Removed a chunk of text */
+  'change.portable-text.text_removed': 'Fjernet tekst',
+
+  /** Portable Text diff: Change formatting of text (setting/unsetting marks, eg bold/italic etc) */
+  'change.portable-text.changed-formatting': 'Endret formattering',
+
+  /** File diff: Fallback title for the meta info section when there is no original filename to use  */
+  'changes.file.meta-info-fallback-title': 'Navnløs fil',
 
   /** Image diff: Text shown in tooltip when hovering hotspot that has changed in diff view */
   'changes.image.crop-changed': 'Beskjæring endret',

--- a/packages/sanity/src/core/field/__workshop__/ChangeResolverStory.tsx
+++ b/packages/sanity/src/core/field/__workshop__/ChangeResolverStory.tsx
@@ -39,23 +39,6 @@ export default function ChangeResolverStory() {
     [],
   )
 
-  // export interface FieldChangeNode {
-  //   type: 'field'
-  //   diff: Diff
-  //   itemDiff?: ItemDiff
-  //   parentDiff?: ObjectDiff | ArrayDiff
-  //   key: string
-  //   path: Path
-  //   error?: FieldValueError
-  //   titlePath: ChangeTitlePath
-  //   schemaType: ObjectFieldType
-  //   showHeader: boolean
-  //   showIndex: boolean
-  //   diffComponent?: DiffComponent
-  //   parentSchema?: ArraySchemaType | ObjectSchemaType
-  //   readOnly?: ConditionalProperty
-  //   hidden?: ConditionalProperty
-  // }
   const change: FieldChangeNode = useMemo(
     () => ({
       type: 'field',

--- a/packages/sanity/src/core/field/__workshop__/DiffErrorBoundaryStory.tsx
+++ b/packages/sanity/src/core/field/__workshop__/DiffErrorBoundaryStory.tsx
@@ -1,11 +1,13 @@
 import {Box, Button} from '@sanity/ui'
 import React, {useCallback, useState} from 'react'
 import {DiffErrorBoundary} from '../diff/components/DiffErrorBoundary'
+import {useTranslation} from '../../i18n'
 
 export default function DiffErrorBoundaryStory() {
+  const {t} = useTranslation()
   return (
     <Box padding={4}>
-      <DiffErrorBoundary>
+      <DiffErrorBoundary t={t}>
         <Test />
       </DiffErrorBoundary>
     </Box>

--- a/packages/sanity/src/core/field/__workshop__/ValueErrorStory.tsx
+++ b/packages/sanity/src/core/field/__workshop__/ValueErrorStory.tsx
@@ -1,11 +1,18 @@
 import {Box} from '@sanity/ui'
-import {useText} from '@sanity/ui-workshop'
 import React, {useMemo} from 'react'
 import {ValueError} from '../diff/components/ValueError'
+import type {FieldValueError} from '../validation'
 
 export default function ValueErrorStory() {
-  const message = useText('Message', 'Error message')!
-  const error = useMemo(() => ({message, value: 123}), [message])
+  const error: FieldValueError = useMemo(
+    () => ({
+      value: 123,
+      actualType: 'number',
+      expectedType: 'string',
+      messageKey: 'changes.error.incorrect-type-message',
+    }),
+    [],
+  )
 
   return (
     <Box padding={4}>

--- a/packages/sanity/src/core/field/diff/components/ChangeResolver.tsx
+++ b/packages/sanity/src/core/field/diff/components/ChangeResolver.tsx
@@ -52,6 +52,7 @@ export function ChangeResolver(props: ChangeResolverProps) {
   }
 
   return (
+    // eslint-disable-next-line i18next/no-literal-string
     <Text>
       Unknown change type: <code>{(change as any).type || 'undefined'}</code>
     </Text>

--- a/packages/sanity/src/core/field/diff/components/ChangeTitleSegment.tsx
+++ b/packages/sanity/src/core/field/diff/components/ChangeTitleSegment.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import {Box, rem, Text} from '@sanity/ui'
 import styled from 'styled-components'
-import {FromToIndex, Annotation, FieldChangeNode} from '../../types'
+import {useTranslation} from '../../../i18n'
+import type {FromToIndex, Annotation, FieldChangeNode} from '../../types'
 import {getAnnotationAtPath} from '../annotations'
 import {DiffCard} from './DiffCard'
 
@@ -68,8 +69,9 @@ function CreatedTitleSegment(props: {
   toIndex?: number
 }) {
   const {annotation: annotationProp, change, toIndex = 0} = props
+  const {t} = useTranslation()
   const readableIndex = toIndex + 1
-  const description = `Added in position ${readableIndex}`
+  const description = t('changes.array.item-added-in-position', {position: readableIndex})
   const content = <>#{readableIndex}</>
   const diffAnnotation = change?.diff ? getAnnotationAtPath(change.diff, []) : undefined
   const annotation = diffAnnotation || annotationProp
@@ -98,8 +100,9 @@ function CreatedTitleSegment(props: {
 
 function DeletedTitleSegment(props: {annotation: Annotation | undefined; fromIndex?: number}) {
   const {annotation, fromIndex = 0} = props
+  const {t} = useTranslation()
   const readableIndex = fromIndex + 1
-  const description = `Removed from position ${readableIndex}`
+  const description = t('changes.array.item-removed-from-position', {position: readableIndex})
   return (
     <DiffCard annotation={annotation || null} as={RoundedCard} tooltip={{description}}>
       <AnnotationText size={1} weight="semibold" forwardedAs="del">
@@ -115,12 +118,15 @@ function MovedTitleSegment(props: {
   toIndex: number
 }) {
   const {annotation, fromIndex, toIndex} = props
+  const {t} = useTranslation()
   const indexDiff = toIndex - fromIndex
   const indexSymbol = indexDiff < 0 ? '↑' : '↓'
   const positions = Math.abs(indexDiff)
-  const description = `Moved ${positions} position${positions === 1 ? '' : 's'} ${
-    indexDiff < 0 ? 'up' : 'down'
-  }`
+  const direction = indexDiff < 0 ? 'up' : 'down'
+  const description = t('change.array.item-moved', {
+    count: positions,
+    context: direction,
+  })
 
   return (
     <>

--- a/packages/sanity/src/core/field/diff/components/DiffErrorBoundary.tsx
+++ b/packages/sanity/src/core/field/diff/components/DiffErrorBoundary.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
 import {ErrorOutlineIcon} from '@sanity/icons'
 import {Box, Card, Flex, Text} from '@sanity/ui'
+import type {TFunction} from '../../../i18n'
 import {isDev} from '../../../environment'
 
 /** @internal */
 export interface DiffErrorBoundaryProps {
   children: React.ReactNode
+  t: TFunction
 }
 
 /** @internal */
@@ -31,6 +33,7 @@ export class DiffErrorBoundary extends React.Component<
   }
 
   render() {
+    const {t} = this.props
     const {error} = this.state
 
     if (!error) {
@@ -46,13 +49,13 @@ export class DiffErrorBoundary extends React.Component<
 
           <Box paddingLeft={3}>
             <Text as="h3" size={1} weight="medium">
-              Rendering the changes to this field caused an error
+              {t('changes.error-boundary.title')}
             </Text>
 
             {isDev && (
               <Box marginTop={2}>
                 <Text as="p" size={1}>
-                  Check the developer console for more information
+                  {t('changes.error-boundary.developer-info')}
                 </Text>
               </Box>
             )}

--- a/packages/sanity/src/core/field/diff/components/DiffFromTo.tsx
+++ b/packages/sanity/src/core/field/diff/components/DiffFromTo.tsx
@@ -1,8 +1,8 @@
-import {Path, SchemaType} from '@sanity/types'
+import type {Path, SchemaType} from '@sanity/types'
 import React, {createElement, CSSProperties} from 'react'
-import {FieldPreviewComponent} from '../../preview'
-import {Diff} from '../../types'
-import {getChangeVerb} from '../helpers'
+import type {FieldPreviewComponent} from '../../preview'
+import type {Diff} from '../../types'
+import {useChangeVerb} from '../hooks/useChangeVerb'
 import {DiffCard} from './DiffCard'
 import {DiffTooltip} from './DiffTooltip'
 import {FromTo} from './FromTo'
@@ -29,7 +29,7 @@ const cardStyles: CSSProperties = {
 export function DiffFromTo(props: DiffFromToProps) {
   const {align, cardClassName, diff, layout, path, previewComponent, schemaType} = props
   const {action} = diff
-  const changeVerb = getChangeVerb(diff)
+  const changeVerb = useChangeVerb(diff)
 
   if (action === 'unchanged') {
     return (

--- a/packages/sanity/src/core/field/diff/components/DiffInspectWrapper.tsx
+++ b/packages/sanity/src/core/field/diff/components/DiffInspectWrapper.tsx
@@ -1,8 +1,9 @@
 import {Box, BoxProps, Card, Code, Label, Stack} from '@sanity/ui'
 import React, {useCallback, useEffect, useRef, useState} from 'react'
 import styled, {type ExecutionProps} from 'styled-components'
+import {useTranslation} from '../../../i18n'
 import {pathToString} from '../../paths'
-import {FieldChangeNode} from '../../types'
+import type {FieldChangeNode} from '../../types'
 import {FromToArrow} from './FromToArrow'
 
 /** @internal */
@@ -61,10 +62,11 @@ const MetaLabel = ({title}: {title: string}) => (
 )
 
 function DiffInspector({change}: {change: FieldChangeNode}): React.ReactElement | null {
+  const {t} = useTranslation()
   return (
     <Stack space={3}>
       <Card padding={3} tone="transparent" as={CodeWrapper} radius={1}>
-        <MetaLabel title="meta" />
+        <MetaLabel title={t('changes.inspector.meta-label')} />
         <Code language="json" size={1}>
           {printMeta({
             path: pathToString(change.path),
@@ -77,7 +79,7 @@ function DiffInspector({change}: {change: FieldChangeNode}): React.ReactElement 
         </Code>
       </Card>
       <Card as={CodeWrapper} tone="critical" padding={3} radius={1}>
-        <MetaLabel title="from" />
+        <MetaLabel title={t('changes.inspector.from-label')} />
         <Code language="json" size={1}>
           {jsonify(change.diff.fromValue)}
         </Code>
@@ -86,7 +88,7 @@ function DiffInspector({change}: {change: FieldChangeNode}): React.ReactElement 
         <FromToArrow direction="down" align="center" />
       </Card>
       <Card as={CodeWrapper} tone="positive" padding={3} radius={1}>
-        <MetaLabel title="to" />
+        <MetaLabel title={t('changes.inspector.to-label')} />
         <Code language="json" size={1}>
           {jsonify(change.diff.toValue)}
         </Code>

--- a/packages/sanity/src/core/field/diff/components/DiffString.tsx
+++ b/packages/sanity/src/core/field/diff/components/DiffString.tsx
@@ -1,7 +1,8 @@
 import {Text, Card, rem} from '@sanity/ui'
 import React from 'react'
 import styled from 'styled-components'
-import {StringDiffSegment, StringDiff} from '../../types'
+import {useTranslation} from '../../../i18n'
+import type {StringDiffSegment, StringDiff} from '../../types'
 import {DiffCard} from './DiffCard'
 
 const RoundedCard = styled.span`
@@ -36,13 +37,14 @@ const ChangeSegment = styled(Text)`
 export function DiffStringSegment(props: {segment: StringDiffSegment}): React.ReactElement {
   const {segment} = props
   const {text} = segment
+  const {t} = useTranslation()
 
   if (segment.action === 'added') {
     return (
       <DiffCard
         annotation={segment.annotation}
         disableHoverEffect
-        tooltip={{description: 'Added'}}
+        tooltip={{description: t('change.added-label')}}
         as={RoundedCard}
       >
         <ChangeSegment as="ins" style={{textDecoration: 'none'}}>
@@ -58,7 +60,7 @@ export function DiffStringSegment(props: {segment: StringDiffSegment}): React.Re
         annotation={segment.annotation}
         as={RoundedCard}
         disableHoverEffect
-        tooltip={{description: 'Removed'}}
+        tooltip={{description: t('change.removed-label')}}
       >
         <ChangeSegment as="del">{text}</ChangeSegment>
       </DiffCard>

--- a/packages/sanity/src/core/field/diff/components/DiffTooltip.tsx
+++ b/packages/sanity/src/core/field/diff/components/DiffTooltip.tsx
@@ -1,12 +1,12 @@
-import {Path} from '@sanity/types'
+import type {Path} from '@sanity/types'
 import {Tooltip, TooltipProps, Text, Stack, Flex, Inline, Label} from '@sanity/ui'
 import React from 'react'
 import {LegacyLayerProvider, UserAvatar} from '../../../components'
 import {useRelativeTime} from '../../../hooks'
 import {useUser} from '../../../store'
-import {AnnotationDetails, Diff} from '../../types'
-import {getAnnotationAtPath, useAnnotationColor} from '../annotations'
 import {useTranslation} from '../../../i18n'
+import type {AnnotationDetails, Diff} from '../../types'
+import {getAnnotationAtPath, useAnnotationColor} from '../annotations'
 
 /** @internal */
 export interface DiffTooltipProps extends TooltipProps {
@@ -25,18 +25,19 @@ export interface DiffTooltipWithAnnotationsProps extends TooltipProps {
 
 /** @internal */
 export function DiffTooltip(props: DiffTooltipProps | DiffTooltipWithAnnotationsProps) {
-  if ('diff' in props) {
-    const {diff, path = [], ...restProps} = props
-    const annotation = getAnnotationAtPath(diff, path)
-
-    return <DiffTooltipWithAnnotation {...restProps} annotations={annotation ? [annotation] : []} />
+  if (!('diff' in props)) {
+    return <DiffTooltipWithAnnotation {...props} />
   }
 
-  return <DiffTooltipWithAnnotation {...props} />
+  const {diff, path = [], ...restProps} = props
+  const annotation = getAnnotationAtPath(diff, path)
+
+  return <DiffTooltipWithAnnotation {...restProps} annotations={annotation ? [annotation] : []} />
 }
 
 function DiffTooltipWithAnnotation(props: DiffTooltipWithAnnotationsProps) {
-  const {annotations, children, description = 'Changed', ...restProps} = props
+  const {annotations, children, description, ...restProps} = props
+  const {t} = useTranslation()
 
   if (!annotations) {
     return children
@@ -45,7 +46,7 @@ function DiffTooltipWithAnnotation(props: DiffTooltipWithAnnotationsProps) {
   const content = (
     <Stack padding={3} space={2}>
       <Label size={1} style={{textTransform: 'uppercase'}}>
-        {description}
+        {description || t('changes.changed-label')}
       </Label>
       <Stack space={2}>
         {annotations.map((annotation, idx) => (

--- a/packages/sanity/src/core/field/diff/components/FieldChange.tsx
+++ b/packages/sanity/src/core/field/diff/components/FieldChange.tsx
@@ -95,7 +95,7 @@ export function FieldChange(
               {change.error ? (
                 <ValueError error={change.error} />
               ) : (
-                <DiffErrorBoundary>
+                <DiffErrorBoundary t={t}>
                   <DiffContext.Provider value={{path: change.path}}>
                     <DiffComponent
                       diff={change.diff}

--- a/packages/sanity/src/core/field/diff/components/ValueError.tsx
+++ b/packages/sanity/src/core/field/diff/components/ValueError.tsx
@@ -1,10 +1,12 @@
 import {ErrorOutlineIcon} from '@sanity/icons'
 import {Text, Box, Card, Flex} from '@sanity/ui'
 import React from 'react'
-import {FieldValueError} from '../../validation'
+import type {FieldValueError} from '../../validation'
+import {useTranslation} from '../../../i18n'
 
 /** @internal */
 export function ValueError({error}: {error: FieldValueError}) {
+  const {t} = useTranslation()
   return (
     <Card tone="critical" padding={3}>
       <Flex align="flex-start">
@@ -15,7 +17,10 @@ export function ValueError({error}: {error: FieldValueError}) {
         </Box>
         <Box flex={1} paddingLeft={3}>
           <Text size={1} as="p">
-            Value error: {error.message}
+            {t(error.messageKey, {
+              expectedType: error.expectedType,
+              actualType: error.actualType,
+            })}
           </Text>
         </Box>
       </Flex>

--- a/packages/sanity/src/core/field/diff/helpers.ts
+++ b/packages/sanity/src/core/field/diff/helpers.ts
@@ -1,19 +1,4 @@
-import {ChangeNode, Diff, FieldChangeNode, GroupChangeNode, ItemDiff} from '../types'
-
-/** @internal */
-export function getChangeVerb(diff: Diff): 'Added' | 'Removed' | 'Changed' {
-  const hadPrevValue = hasValue(diff.fromValue)
-  const hasNextValue = hasValue(diff.toValue)
-  if (!hadPrevValue && hasNextValue) {
-    return 'Added'
-  }
-
-  if (!hasNextValue && hadPrevValue) {
-    return 'Removed'
-  }
-
-  return 'Changed'
-}
+import type {ChangeNode, Diff, FieldChangeNode, GroupChangeNode, ItemDiff} from '../types'
 
 /** @internal */
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -46,9 +31,4 @@ export function isRemovedItemDiff(
 /** @internal */
 export function isUnchangedDiff(diff: Diff): diff is Diff & {action: 'unchanged'} {
   return diff.action === 'unchanged'
-}
-
-/** @internal */
-function hasValue(value: unknown) {
-  return value !== null && typeof value !== 'undefined' && value !== ''
 }

--- a/packages/sanity/src/core/field/diff/hooks/useChangeVerb.ts
+++ b/packages/sanity/src/core/field/diff/hooks/useChangeVerb.ts
@@ -1,0 +1,23 @@
+import {useTranslation} from '../../../i18n'
+import type {Diff} from '../../types'
+
+/** @internal */
+export function useChangeVerb(diff: Diff): string {
+  const {t} = useTranslation()
+  const hadPrevValue = hasValue(diff.fromValue)
+  const hasNextValue = hasValue(diff.toValue)
+  if (!hadPrevValue && hasNextValue) {
+    return t('changes.added-label')
+  }
+
+  if (!hasNextValue && hadPrevValue) {
+    return t('changes.removed-label')
+  }
+
+  return t('changes.changed-label')
+}
+
+/** @internal */
+function hasValue(value: unknown) {
+  return value !== null && typeof value !== 'undefined' && value !== ''
+}

--- a/packages/sanity/src/core/field/types.ts
+++ b/packages/sanity/src/core/field/types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Path,
   Reference,
   ArraySchemaType,
@@ -11,8 +11,8 @@ import {
   SchemaType,
   PatchOperations,
 } from '@sanity/types'
-import {ComponentType} from 'react'
-import {
+import type {ComponentType} from 'react'
+import type {
   ArrayDiff as AgnosticArrayDiff,
   BooleanDiff as AgnosticBooleanDiff,
   ItemDiff as AgnosticItemDiff,
@@ -24,8 +24,7 @@ import {
   StringSegmentUnchanged as AgnosticStringSegmentUnchanged,
   TypeChangeDiff as AgnosticTypeChangeDiff,
 } from '@sanity/diff'
-import {FormInsertPatch} from '../form'
-import {FieldValueError} from './validation'
+import type {FieldValueError} from './validation'
 
 /**
  * History timeline / chunking

--- a/packages/sanity/src/core/field/types/array/diff/ArrayOfOptionsFieldDiff.tsx
+++ b/packages/sanity/src/core/field/types/array/diff/ArrayOfOptionsFieldDiff.tsx
@@ -1,9 +1,10 @@
-import {ArraySchemaType, isKeyedObject, SchemaType, TypedObject} from '@sanity/types'
+import {type ArraySchemaType, type SchemaType, type TypedObject, isKeyedObject} from '@sanity/types'
 import {Box, Flex} from '@sanity/ui'
 import React from 'react'
 import {useUserColorManager} from '../../../../user-color'
 import {DiffTooltip, FromToArrow, getAnnotationColor} from '../../../diff'
-import {Annotation, ArrayDiff, Diff, DiffComponent, ItemDiff} from '../../../types'
+import type {Annotation, ArrayDiff, Diff, DiffComponent, ItemDiff} from '../../../types'
+import {useTranslation} from '../../../../i18n'
 import {Checkbox} from '../../boolean/preview'
 import {isEqual} from '../util/arrayUtils'
 import {Preview} from '../../../../preview/components/Preview'
@@ -25,6 +26,7 @@ interface NormalizedListOption {
 export const ArrayOfOptionsFieldDiff: DiffComponent<ArrayDiff> = ({diff, schemaType}) => {
   const options = schemaType.options?.list
   const colorManager = useUserColorManager()
+  const {t} = useTranslation()
   if (!Array.isArray(options)) {
     // Shouldn't happen, because the resolver should only resolve here if it does
     return null
@@ -39,7 +41,7 @@ export const ArrayOfOptionsFieldDiff: DiffComponent<ArrayDiff> = ({diff, schemaT
         .map((item, index) => {
           const {annotation, isPresent, value, memberType, title} = item
           const color = getAnnotationColor(colorManager, annotation)
-          const action = isPresent ? 'Added' : 'Removed'
+          const action = isPresent ? t('changes.added-label') : t('changes.removed-label')
           return (
             <Flex align="center" key={getItemKey(diff, index)}>
               <DiffTooltip annotations={annotation ? [annotation] : []} description={action}>

--- a/packages/sanity/src/core/field/types/file/diff/FileFieldDiff.tsx
+++ b/packages/sanity/src/core/field/types/file/diff/FileFieldDiff.tsx
@@ -3,10 +3,12 @@ import React, {useMemo} from 'react'
 import {Box, Card, Flex, Text} from '@sanity/ui'
 import styled from 'styled-components'
 import {DiffCard, DiffTooltip, FromTo, MetaInfo, ChangeList} from '../../../diff'
-import {DiffComponent, ObjectDiff} from '../../../types'
+import {useTranslation} from '../../../../i18n'
+import type {DiffComponent, ObjectDiff} from '../../../types'
+import {useUnitFormatter} from '../../../../hooks'
 import {useRefValue} from '../../../diff/hooks'
-import {getSizeDiff} from './helpers'
-import {File, FileAsset} from './types'
+import {getHumanFriendlyBytes, getSizeDiff} from './helpers'
+import type {File, FileAsset} from './types'
 
 const SizeDiff = styled.div`
   ${({theme}) => `
@@ -30,8 +32,10 @@ export const FileFieldDiff: DiffComponent<ObjectDiff<File>> = ({diff, schemaType
   const {fromValue, toValue, fields} = diff
   const fromAsset = fromValue?.asset
   const toAsset = toValue?.asset
+  const {t} = useTranslation()
   const prev = useRefValue<FileAsset>(fromAsset?._ref)
   const next = useRefValue<FileAsset>(toAsset?._ref)
+  const formatUnit = useUnitFormatter({unitDisplay: 'short', maximumFractionDigits: 2})
 
   const changedFields = Object.entries(fields)
     .filter(([name, field]) => field.isChanged && name !== '_type')
@@ -43,20 +47,18 @@ export const FileFieldDiff: DiffComponent<ObjectDiff<File>> = ({diff, schemaType
     .filter((field) => field.name !== 'asset' && changedFields.includes(field.name))
     .map((field) => field.name)
 
-  // Sizes in MB TODO: improve. Apple uses 1000^2
-  const prevSize = prev?.size && prev.size / 1000 / 1000
-  const nextSize = next?.size && next.size / 1000 / 1000
-  const pctDiff = getSizeDiff(prevSize, nextSize)
-
-  const roundedPrevSize = prevSize ? prevSize.toFixed(2) : undefined
-  const roundedNextSize = nextSize ? nextSize.toFixed(2) : undefined
+  const pctDiff = getSizeDiff(prev?.size, next?.size)
+  const prevSize = prev?.size && getHumanFriendlyBytes(prev.size, formatUnit)
+  const nextSize = next?.size && getHumanFriendlyBytes(next.size, formatUnit)
 
   const cardStyles = useMemo(() => ({display: 'block', flex: 1}), [])
 
   const from = prev && (
     <DiffCard as="del" diff={diff} path="asset._ref" style={cardStyles}>
       <MetaInfo title={prev.originalFilename || 'Untitled'} icon={DocumentIcon}>
-        <Text size={0} style={{color: 'inherit'}}>{`${roundedPrevSize}MB`}</Text>
+        <Text size={0} style={{color: 'inherit'}}>
+          {prevSize}
+        </Text>
       </MetaInfo>
     </DiffCard>
   )
@@ -65,11 +67,13 @@ export const FileFieldDiff: DiffComponent<ObjectDiff<File>> = ({diff, schemaType
     <DiffCard as="ins" diff={diff} path="asset._ref" style={cardStyles}>
       <MetaInfo title={next.originalFilename || 'Untitled'} icon={DocumentIcon}>
         <Flex align="center">
-          <Text size={0} style={{color: 'inherit'}}>{`${roundedNextSize}MB`}</Text>
+          <Text size={0} style={{color: 'inherit'}}>
+            {nextSize}
+          </Text>
           {pctDiff !== 0 && (
             <Card radius={2} padding={1} as={SizeDiff} marginLeft={2}>
               <Text size={0} data-number={pctDiff > 0 ? 'positive' : 'negative'}>
-                {pctDiff > 0 && '+'}
+                {pctDiff > 0 ? '+' : '-'}
                 {pctDiff}%
               </Text>
             </Card>
@@ -83,7 +87,7 @@ export const FileFieldDiff: DiffComponent<ObjectDiff<File>> = ({diff, schemaType
     <>
       {/* Removed only */}
       {from && !to && (
-        <DiffTooltip diff={diff} path="asset._ref" description="Removed">
+        <DiffTooltip diff={diff} path="asset._ref" description={t('changes.removed-label')}>
           {from}
         </DiffTooltip>
       )}
@@ -97,7 +101,7 @@ export const FileFieldDiff: DiffComponent<ObjectDiff<File>> = ({diff, schemaType
 
       {/* Added only */}
       {!from && to && (
-        <DiffTooltip diff={diff} path="asset._ref" description="Added">
+        <DiffTooltip diff={diff} path="asset._ref" description={t('changes.added-label')}>
           {to}
         </DiffTooltip>
       )}

--- a/packages/sanity/src/core/field/types/file/diff/FileFieldDiff.tsx
+++ b/packages/sanity/src/core/field/types/file/diff/FileFieldDiff.tsx
@@ -55,7 +55,10 @@ export const FileFieldDiff: DiffComponent<ObjectDiff<File>> = ({diff, schemaType
 
   const from = prev && (
     <DiffCard as="del" diff={diff} path="asset._ref" style={cardStyles}>
-      <MetaInfo title={prev.originalFilename || 'Untitled'} icon={DocumentIcon}>
+      <MetaInfo
+        title={prev.originalFilename || t('changes.file.meta-info-fallback-title')}
+        icon={DocumentIcon}
+      >
         <Text size={0} style={{color: 'inherit'}}>
           {prevSize}
         </Text>
@@ -65,7 +68,10 @@ export const FileFieldDiff: DiffComponent<ObjectDiff<File>> = ({diff, schemaType
 
   const to = next && (
     <DiffCard as="ins" diff={diff} path="asset._ref" style={cardStyles}>
-      <MetaInfo title={next.originalFilename || 'Untitled'} icon={DocumentIcon}>
+      <MetaInfo
+        title={next.originalFilename || t('changes.file.meta-info-fallback-title')}
+        icon={DocumentIcon}
+      >
         <Flex align="center">
           <Text size={0} style={{color: 'inherit'}}>
             {nextSize}

--- a/packages/sanity/src/core/field/types/file/diff/helpers.ts
+++ b/packages/sanity/src/core/field/types/file/diff/helpers.ts
@@ -1,3 +1,13 @@
+import type {UnitFormatter} from '../../../../hooks'
+
+/**
+ * Calculates the size difference between two numbers, in percent
+ *
+ * @param prev - Previous size
+ * @param next - Next size
+ * @returns The size difference in percent
+ * @internal
+ */
 export function getSizeDiff(prev: number | undefined, next: number | undefined): number {
   if (!prev || !next) {
     return 0
@@ -7,4 +17,32 @@ export function getSizeDiff(prev: number | undefined, next: number | undefined):
   const pct = Math.round((increase / prev) * 100)
 
   return pct
+}
+
+/**
+ * Get a "human friendly" representation of a number of bytes, using base10 units
+ *
+ * @param bytes - Number of bytes
+ * @param format - The unit formatter to use (from `useUnitFormatter`)
+ * @returns A human friendly representation of the number of bytes
+ * @internal
+ */
+export function getHumanFriendlyBytes(bytes: number, format: UnitFormatter): string {
+  if (bytes < 1000) {
+    return format(bytes, 'byte')
+  }
+
+  if (bytes < 1000 * 1000) {
+    return format(bytes / 1000, 'kilobyte')
+  }
+
+  if (bytes < 1000 * 1000 * 1000) {
+    return format(bytes / (1000 * 1000), 'megabyte')
+  }
+
+  if (bytes < 1000 * 1000 * 1000 * 1000) {
+    return format(bytes / (1000 * 1000 * 1000), 'gigabyte')
+  }
+
+  return format(bytes / (1000 * 1000 * 1000 * 1000), 'terabyte')
 }

--- a/packages/sanity/src/core/field/types/image/diff/HotspotCropSVG.tsx
+++ b/packages/sanity/src/core/field/types/image/diff/HotspotCropSVG.tsx
@@ -1,7 +1,8 @@
-import {Image, ImageCrop, ImageHotspot} from '@sanity/types'
+import type {Image, ImageCrop, ImageHotspot} from '@sanity/types'
 import React from 'react'
 import {DiffTooltip, useDiffAnnotationColor} from '../../../diff'
-import {ObjectDiff} from '../../../types'
+import {useTranslation} from '../../../../i18n'
+import type {ObjectDiff} from '../../../types'
 import {hexToRgba} from './helpers'
 
 interface HotspotCropSVGProps {
@@ -17,6 +18,7 @@ export function HotspotCropSVG(
   props: HotspotCropSVGProps & Omit<React.SVGProps<SVGElement>, 'ref' | 'width' | 'height'>,
 ) {
   const {crop, diff, hash, hotspot, width = 100, height = 100, ...restProps} = props
+  const {t} = useTranslation()
   const cropColor = useDiffAnnotationColor(diff, 'crop')
   const hotspotColor = useDiffAnnotationColor(diff, 'hotspot')
 
@@ -46,7 +48,7 @@ export function HotspotCropSVG(
       </defs>
 
       {crop && (
-        <DiffTooltip diff={diff} path="crop" description="Crop changed">
+        <DiffTooltip diff={diff} path="crop" description={t('changes.image.crop-changed')}>
           <g>
             <CropSVG
               crop={crop}
@@ -62,7 +64,7 @@ export function HotspotCropSVG(
       )}
 
       {hotspot && (
-        <DiffTooltip diff={diff} path="hotspot" description="Hotspot changed">
+        <DiffTooltip diff={diff} path="hotspot" description={t('changes.image.crop-changed')}>
           <g>
             <HotspotSVG
               hotspot={hotspot}

--- a/packages/sanity/src/core/field/types/image/diff/ImageFieldDiff.tsx
+++ b/packages/sanity/src/core/field/types/image/diff/ImageFieldDiff.tsx
@@ -2,7 +2,7 @@ import type {Image} from '@sanity/types'
 import React from 'react'
 import {Box, Card, Text} from '@sanity/ui'
 import {DiffCard, DiffTooltip, ChangeList, getAnnotationAtPath} from '../../../diff'
-import {useTranslation} from '../../../../i18n'
+import {type TFunction, useTranslation} from '../../../../i18n'
 import type {DiffComponent, ObjectDiff} from '../../../types'
 import {FromTo} from '../../../diff/components'
 import {ImagePreview, NoImagePreview} from './ImagePreview'
@@ -104,7 +104,7 @@ export const ImageFieldDiff: DiffComponent<ObjectDiff<Image>> = ({diff, schemaTy
         (didAssetChange ? (
           <DiffTooltip
             annotations={assetAnnotation ? [assetAnnotation] : []}
-            description={`${assetAction[0].toUpperCase()}${assetAction.slice(1)}`}
+            description={getChangeDescription(assetAction, t)}
           >
             {imageDiff}
           </DiffTooltip>
@@ -118,4 +118,18 @@ export const ImageFieldDiff: DiffComponent<ObjectDiff<Image>> = ({diff, schemaTy
       )}
     </>
   )
+}
+
+function getChangeDescription(action: 'changed' | 'added' | 'removed', t: TFunction): string {
+  switch (action) {
+    case 'changed':
+      return t('changes.changed-label')
+    case 'added':
+      return t('changes.added-label')
+    case 'removed':
+      return t('changes.removed-label')
+    default:
+      // Should never happen, but for linters' sake
+      return 'Unknown change'
+  }
 }

--- a/packages/sanity/src/core/field/types/image/diff/ImageFieldDiff.tsx
+++ b/packages/sanity/src/core/field/types/image/diff/ImageFieldDiff.tsx
@@ -1,8 +1,9 @@
-import {Image} from '@sanity/types'
+import type {Image} from '@sanity/types'
 import React from 'react'
 import {Box, Card, Text} from '@sanity/ui'
 import {DiffCard, DiffTooltip, ChangeList, getAnnotationAtPath} from '../../../diff'
-import {DiffComponent, ObjectDiff} from '../../../types'
+import {useTranslation} from '../../../../i18n'
+import type {DiffComponent, ObjectDiff} from '../../../types'
 import {FromTo} from '../../../diff/components'
 import {ImagePreview, NoImagePreview} from './ImagePreview'
 
@@ -14,6 +15,8 @@ const CARD_STYLES = {
 }
 
 export const ImageFieldDiff: DiffComponent<ObjectDiff<Image>> = ({diff, schemaType}) => {
+  const {t} = useTranslation()
+
   const {fromValue, toValue, fields, isChanged} = diff
   const fromRef = fromValue?.asset?._ref
   const toRef = toValue?.asset?._ref
@@ -79,7 +82,7 @@ export const ImageFieldDiff: DiffComponent<ObjectDiff<Image>> = ({diff, schemaTy
     return (
       <Card padding={4} radius={2} tone="transparent">
         <Text muted size={1} align="center">
-          Image not set
+          {t('changes.image.no-asset-set')}
         </Text>
       </Card>
     )

--- a/packages/sanity/src/core/field/types/portableText/diff/PTDiff.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/PTDiff.tsx
@@ -1,6 +1,6 @@
 import React, {useMemo} from 'react'
-import {DiffComponent, ObjectDiff} from '../../../types'
-import PortableText from './components/PortableText'
+import type {DiffComponent, ObjectDiff} from '../../../types'
+import {PortableText} from './components/PortableText'
 import {createPortableTextDiff} from './helpers'
 
 export const PTDiff: DiffComponent<ObjectDiff> = (props) => {

--- a/packages/sanity/src/core/field/types/portableText/diff/components/Annotation.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/Annotation.tsx
@@ -1,11 +1,12 @@
 import {ChevronDownIcon} from '@sanity/icons'
 import {useClickOutside, Label, Popover, Flex} from '@sanity/ui'
 import {toString} from '@sanity/util/paths'
-import {isKeySegment, ObjectSchemaType, Path, PortableTextChild} from '@sanity/types'
-import React, {useCallback, useContext, useEffect, useMemo, useState} from 'react'
+import {isKeySegment, type ObjectSchemaType, type Path, type PortableTextChild} from '@sanity/types'
+import React, {useCallback, useContext, useEffect, useMemo, useState, type ReactNode} from 'react'
 import styled from 'styled-components'
+import {useTranslation} from '../../../../../i18n'
 import {ChangeList, DiffContext, DiffTooltip, useDiffAnnotationColor} from '../../../../diff'
-import {ObjectDiff} from '../../../../types'
+import type {ObjectDiff} from '../../../../types'
 import {isEmptyObject} from '../helpers'
 import {ConnectorContext, useReportedValues} from '../../../../../changeIndicators'
 import {InlineBox, InlineText, PopoverContainer, PreviewContainer} from './styledComponents'
@@ -15,7 +16,7 @@ interface AnnotationProps {
   object: PortableTextChild
   schemaType?: ObjectSchemaType
   path: Path
-  children: React.ReactNode
+  children: ReactNode
 }
 
 const AnnotationWrapper = styled.div`
@@ -51,8 +52,13 @@ export function Annotation({
   path,
   ...restProps
 }: AnnotationProps) {
+  const {t} = useTranslation()
   if (!schemaType) {
-    return <AnnotationWrapper {...restProps}>Unknown schema type</AnnotationWrapper>
+    return (
+      <AnnotationWrapper {...restProps}>
+        {t('change.portable-text.unknown-annotation-schema-type')}
+      </AnnotationWrapper>
+    )
   }
   if (diff && diff.action !== 'unchanged') {
     return (
@@ -75,7 +81,7 @@ interface AnnnotationWithDiffProps {
   object: PortableTextChild
   schemaType: ObjectSchemaType
   path: Path
-  children?: React.ReactNode
+  children?: ReactNode
 }
 
 function AnnnotationWithDiff({
@@ -89,6 +95,7 @@ function AnnnotationWithDiff({
   const {onSetFocus} = useContext(ConnectorContext)
   const {path: fullPath} = useContext(DiffContext)
   const [popoverElement, setPopoverElement] = useState<HTMLDivElement | null>(null)
+  const {t} = useTranslation()
   const color = useDiffAnnotationColor(diff, [])
   const style = useMemo(
     () => (color ? {background: color.background, color: color.text} : {}),
@@ -126,7 +133,7 @@ function AnnnotationWithDiff({
   }, [isEditing, myPath, onSetFocus, open])
 
   const handleOpenPopup = useCallback(
-    (event: any) => {
+    (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
       event.stopPropagation()
       setOpen(true)
       if (!isRemoved) {
@@ -155,7 +162,9 @@ function AnnnotationWithDiff({
         <div>
           {emptyObject && (
             <Label size={1} muted>
-              Empty {schemaType.title}
+              {t('change.portable-text.empty-object-annotation', {
+                annotationType: schemaType.title || schemaType.name,
+              })}
             </Label>
           )}
           {!emptyObject && <ChangeList diff={diff} schemaType={schemaType} />}
@@ -174,7 +183,10 @@ function AnnnotationWithDiff({
     >
       <Popover content={popoverContent} open={open} ref={setPopoverElement} portal>
         <PreviewContainer paddingLeft={1}>
-          <DiffTooltip annotations={annotations} description={`${diff.action} annotation`}>
+          <DiffTooltip
+            annotations={annotations}
+            description={t('change.portable-text.annotation', {context: diff.action})}
+          >
             <InlineBox style={{display: 'inline-flex'}}>
               <span>{children}</span>
               <Flex align="center" paddingX={1}>

--- a/packages/sanity/src/core/field/types/portableText/diff/components/Block.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/Block.tsx
@@ -1,13 +1,14 @@
 import {Box, Card, Stack, Text} from '@sanity/ui'
-import {Path, PortableTextTextBlock} from '@sanity/types'
+import type {Path, PortableTextTextBlock} from '@sanity/types'
 import React, {useCallback, useContext} from 'react'
 import {DiffContext, DiffTooltip, useDiffAnnotationColor} from '../../../../diff'
-import {isHeader} from '../helpers'
-import {PortableTextDiff} from '../types'
 import {ConnectorContext} from '../../../../../changeIndicators'
-import Blockquote from './Blockquote'
-import Header from './Header'
-import Paragraph from './Paragraph'
+import {useTranslation} from '../../../../../i18n'
+import {isHeader} from '../helpers'
+import type {PortableTextDiff} from '../types'
+import {Blockquote} from './Blockquote'
+import {Header} from './Header'
+import {Paragraph} from './Paragraph'
 
 const EMPTY_PATH: Path = []
 
@@ -20,11 +21,12 @@ export function Block(props: {
   const color = useDiffAnnotationColor(diff, EMPTY_PATH)
   const {path: fullPath} = useContext(DiffContext)
   const {onSetFocus} = useContext(ConnectorContext)
+  const {t} = useTranslation()
   const isRemoved = diff.action === 'removed'
   let returned = children
 
   const handleClick = useCallback(
-    (event: any) => {
+    (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
       event.stopPropagation()
 
       if (!isRemoved) {
@@ -69,7 +71,7 @@ export function Block(props: {
             diff={diff.origin.fields.style}
           >
             <Text size={0}>
-              Changed block style from '{fromStyle}' to '{block.style}'
+              {t('change.portable-text.block-style-changed', {fromStyle, toStyle: block.style})}
             </Text>
           </DiffTooltip>
           <Box style={style}>{returned}</Box>

--- a/packages/sanity/src/core/field/types/portableText/diff/components/Block.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/Block.tsx
@@ -11,7 +11,7 @@ import Paragraph from './Paragraph'
 
 const EMPTY_PATH: Path = []
 
-export default function Block(props: {
+export function Block(props: {
   diff: PortableTextDiff
   block: PortableTextTextBlock
   children: JSX.Element

--- a/packages/sanity/src/core/field/types/portableText/diff/components/Blockquote.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/Blockquote.tsx
@@ -5,7 +5,7 @@ const Quote = styled.blockquote`
   margin: 0;
 `
 
-export default function Blockquote({children}: {children: React.ReactNode}): JSX.Element {
+export function Blockquote({children}: {children: React.ReactNode}): JSX.Element {
   return (
     <div>
       <Quote>{children}</Quote>

--- a/packages/sanity/src/core/field/types/portableText/diff/components/Decorator.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/Decorator.tsx
@@ -26,6 +26,6 @@ const DecoratorWrapper = styled.span<{decoration: string}>`
   }}
 `
 
-export default function Decorator({mark, children}: {mark: string; children: JSX.Element}) {
+export function Decorator({mark, children}: {mark: string; children: JSX.Element}) {
   return <DecoratorWrapper decoration={mark}>{children}</DecoratorWrapper>
 }

--- a/packages/sanity/src/core/field/types/portableText/diff/components/Header.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/Header.tsx
@@ -24,12 +24,6 @@ const StyledHeading = styled(Heading)`
   }
 `
 
-export default function Header({
-  style,
-  children,
-}: {
-  style: string
-  children: React.ReactNode
-}): JSX.Element {
+export function Header({style, children}: {style: string; children: React.ReactNode}): JSX.Element {
   return <StyledHeading size={headingSizes[style]}>{children}</StyledHeading>
 }

--- a/packages/sanity/src/core/field/types/portableText/diff/components/InlineObject.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/InlineObject.tsx
@@ -1,17 +1,18 @@
 import {ChevronDownIcon} from '@sanity/icons'
 import {
   isKeySegment,
-  ObjectSchemaType,
-  Path,
-  PortableTextChild,
-  PortableTextObject,
+  type ObjectSchemaType,
+  type Path,
+  type PortableTextChild,
+  type PortableTextObject,
 } from '@sanity/types'
 import {Card, Flex, Label, Popover, useClickOutside} from '@sanity/ui'
 import {FOCUS_TERMINATOR, toString} from '@sanity/util/paths'
 import React, {useCallback, useContext, useState, useEffect, useMemo} from 'react'
 import styled from 'styled-components'
+import {useTranslation} from '../../../../../i18n'
 import {ChangeList, DiffContext, DiffTooltip, useDiffAnnotationColor} from '../../../../diff'
-import {ObjectDiff} from '../../../../types'
+import type {ObjectDiff} from '../../../../types'
 import {isEmptyObject} from '../helpers'
 import {ConnectorContext, useReportedValues} from '../../../../../changeIndicators'
 import {Preview} from '../../../../../preview/components/Preview'
@@ -42,10 +43,11 @@ const InlineObjectWrapper = styled(Card)`
 `
 
 export function InlineObject({diff, object, schemaType, ...restProps}: InlineObjectProps) {
+  const {t} = useTranslation()
   if (!schemaType) {
     return (
       <InlineObjectWrapper {...restProps} border radius={1}>
-        Unknown schema type: {object._type}
+        {t('change.portable-text.unknown-inline-object-schema-type', {schemaType: object._type})}
       </InlineObjectWrapper>
     )
   }
@@ -79,6 +81,7 @@ function InlineObjectWithDiff({
 }: InlineObjectWithDiffProps) {
   const {path: fullPath} = useContext(DiffContext)
   const {onSetFocus} = useContext(ConnectorContext)
+  const {t} = useTranslation()
   const color = useDiffAnnotationColor(diff, [])
   const style = useMemo(
     () => (color ? {background: color.background, color: color.text} : {}),
@@ -106,7 +109,7 @@ function InlineObjectWithDiff({
   }, [focusPath, isEditing, onSetFocus])
 
   const handleOpenPopup = useCallback(
-    (event: any) => {
+    (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
       event.stopPropagation()
       setOpen(true)
       if (!isRemoved) {
@@ -147,7 +150,10 @@ function InlineObjectWithDiff({
     >
       <Popover content={popoverContent} open={open} portal>
         <PreviewContainer>
-          <DiffTooltip annotations={annotations} description={`${diff.action} inline object`}>
+          <DiffTooltip
+            annotations={annotations}
+            description={t('change.portable-text.inline-object', {context: diff.action})}
+          >
             <InlineBox>
               <Preview schemaType={schemaType} value={object} layout="inline" />
               <Flex align="center" paddingX={1}>
@@ -174,22 +180,18 @@ function PopoverContent({
   onClose: () => void
   schemaType: ObjectSchemaType
 }) {
+  const {t} = useTranslation()
   const [popoverElement, setPopoverElement] = useState<HTMLDivElement | null>(null)
-  // const {isTopLayer} = useLayer()
 
-  const handleClickOutside = useCallback(() => {
-    // Popover doesn't close at all when using this condition
-    // if (!isTopLayer) return
-    onClose()
-  }, [onClose])
-
-  useClickOutside(handleClickOutside, [popoverElement])
+  useClickOutside(onClose, [popoverElement])
 
   return (
     <PopoverContainer ref={setPopoverElement} padding={3}>
       {emptyObject && (
         <Label size={1} muted>
-          Empty {schemaType.title}
+          {t('change.portable-text.empty-inline-object', {
+            inlineObjectType: schemaType.title || schemaType.name,
+          })}
         </Label>
       )}
       {!emptyObject && <ChangeList diff={diff} schemaType={schemaType} />}

--- a/packages/sanity/src/core/field/types/portableText/diff/components/Paragraph.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/Paragraph.tsx
@@ -9,6 +9,6 @@ const StyledParagraph = styled.div`
   margin: 0;
 `
 
-export default function Paragraph({children}: {children: React.ReactNode}): JSX.Element {
+export function Paragraph({children}: {children: React.ReactNode}): JSX.Element {
   return <StyledParagraph>{children}</StyledParagraph>
 }

--- a/packages/sanity/src/core/field/types/portableText/diff/components/PortableText.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/PortableText.tsx
@@ -1,15 +1,16 @@
 import {
   isPortableTextSpan,
-  ObjectSchemaType,
-  PortableTextChild,
-  PortableTextTextBlock,
-  SpanSchemaType,
+  type ObjectSchemaType,
+  type PortableTextChild,
+  type PortableTextTextBlock,
+  type SpanSchemaType,
 } from '@sanity/types'
-import {startCase, uniq, xor} from 'lodash'
+import {uniq, xor} from 'lodash'
 import React, {ReactElement, useCallback, useMemo} from 'react'
+import {type TFunction, useTranslation} from '../../../../../i18n'
 import {DiffCard} from '../../../../diff'
-import {ArrayDiff, ObjectDiff, StringDiff, StringDiffSegment} from '../../../../types'
-import {PortableTextDiff} from '../types'
+import type {ArrayDiff, ObjectDiff, StringDiff, StringDiffSegment} from '../../../../types'
+import type {PortableTextDiff} from '../types'
 
 import * as TextSymbols from '../symbols'
 
@@ -25,9 +26,9 @@ import {
   isDecorator,
 } from '../helpers'
 
-import Block from './Block'
+import {Block} from './Block'
 import {Annotation} from './Annotation'
-import Decorator from './Decorator'
+import {Decorator} from './Decorator'
 import {InlineObject} from './InlineObject'
 import {Text} from './Text'
 
@@ -47,9 +48,10 @@ type Props = {
   schemaType: ObjectSchemaType
 }
 
-export default function PortableText(props: Props): JSX.Element {
+export function PortableText(props: Props): JSX.Element {
   const {diff, schemaType} = props
   const block = (diff.origin.toValue || diff.origin.fromValue) as PortableTextTextBlock
+  const {t} = useTranslation()
 
   const inlineObjects = useMemo(
     () => (diff.origin.toValue ? getInlineObjects(diff.origin) : []),
@@ -84,7 +86,7 @@ export default function PortableText(props: Props): JSX.Element {
                 as={textDiff.action === 'removed' ? 'del' : 'ins'}
                 key={`empty-block-${block._key}`}
                 tooltip={{
-                  description: `${startCase(textDiff.action)} empty text`,
+                  description: t('change.portable-text.empty-text', {context: textDiff.action}),
                 }}
               >
                 <span>{TextSymbols.EMPTY_BLOCK_SYMBOL}</span>
@@ -177,6 +179,7 @@ export default function PortableText(props: Props): JSX.Element {
                   seg,
                   segIndex,
                   spanSchemaType,
+                  t,
                 })}
               </Text>
             )
@@ -226,7 +229,7 @@ export default function PortableText(props: Props): JSX.Element {
       }
       throw new Error("'span' schemaType not found")
     },
-    [block, diff, inlineObjects, schemaType],
+    [block, diff, inlineObjects, schemaType, t],
   )
 
   return (
@@ -243,6 +246,7 @@ function renderTextSegment({
   seg,
   segIndex,
   spanSchemaType,
+  t,
 }: {
   diff: PortableTextDiff
   child: PortableTextChild
@@ -250,6 +254,7 @@ function renderTextSegment({
   seg: StringDiffSegment
   segIndex: number
   spanSchemaType: SpanSchemaType
+  t: TFunction
 }): JSX.Element {
   // Newlines
   if (seg.text === '\n') {
@@ -274,6 +279,7 @@ function renderTextSegment({
       segIndex,
       spanDiff,
       spanSchemaType,
+      t,
     })
   }
   // Render the segment with the active marks
@@ -301,6 +307,7 @@ function renderDecorators({
   segIndex,
   spanDiff,
   spanSchemaType,
+  t,
 }: {
   activeMarks: string[]
   decoratorTypes: {title: string; value: string}[]
@@ -310,6 +317,7 @@ function renderDecorators({
   segIndex: number
   spanDiff: ObjectDiff
   spanSchemaType: SpanSchemaType
+  t: TFunction
 }): JSX.Element {
   let returned = <span key={`text-segment-${segIndex}`}>{children}</span>
   const fromPtDiffText: string =
@@ -371,7 +379,7 @@ function renderDecorators({
         key={`diffcard-annotation-${segIndex}-${marksChanged.join('-')}`}
         as={'ins'}
         tooltip={{
-          description: 'Changed formatting',
+          description: t('change.portable-text.changed-formatting'),
         }}
       >
         {returned}

--- a/packages/sanity/src/core/field/types/portableText/diff/components/Text.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/Text.tsx
@@ -1,8 +1,8 @@
-import {isKeySegment, Path} from '@sanity/types'
-import React, {SyntheticEvent, useCallback, useMemo} from 'react'
-import {startCase} from 'lodash'
+import {isKeySegment, type Path} from '@sanity/types'
+import React, {type SyntheticEvent, useCallback, useMemo, useContext} from 'react'
+import {useTranslation} from '../../../../../i18n'
 import {DiffCard, DiffContext} from '../../../../diff'
-import {ObjectDiff, StringDiff, StringDiffSegment} from '../../../../types'
+import type {ObjectDiff, StringDiff, StringDiffSegment} from '../../../../types'
 import {ConnectorContext} from '../../../../../changeIndicators'
 import {InlineBox} from './styledComponents'
 
@@ -36,9 +36,10 @@ export function Text({
 }
 
 export function TextWithDiff({diff, childDiff, children, path, segment, ...restProps}: TextProps) {
-  const {onSetFocus} = React.useContext(ConnectorContext)
-  const {path: fullPath} = React.useContext(DiffContext)
+  const {onSetFocus} = useContext(ConnectorContext)
+  const {path: fullPath} = useContext(DiffContext)
   const spanSegment = useMemo(() => path.slice(-2, 1)[0], [path])
+  const {t} = useTranslation()
   const isRemoved = diff && diff.action === 'removed'
   const prefix = fullPath.slice(
     0,
@@ -58,22 +59,24 @@ export function TextWithDiff({diff, childDiff, children, path, segment, ...restP
     },
     [focusPath, isRemoved, onSetFocus],
   )
-  const realSeg = diff && diff.segments.find((rSeg: any) => rSeg.text === segment.text)
+  const realSeg = diff && diff.segments.find((rSeg) => rSeg.text === segment.text)
 
   const diffWithFallback = realSeg || diff || childDiff
   const annotation =
     (diffWithFallback && diffWithFallback.action !== 'unchanged' && diffWithFallback.annotation) ||
     null
+
   const diffCard =
     annotation && segment.action !== 'unchanged' ? (
       <DiffCard
         annotation={annotation}
         as={segment.action === 'removed' ? 'del' : 'ins'}
-        tooltip={{description: `${startCase(segment.action)} text`}}
+        tooltip={{description: t('change.portable-text.text', {context: segment.action})}}
       >
         {children}
       </DiffCard>
     ) : null
+
   return (
     <InlineBox {...restProps} onClick={handleClick} data-changed="">
       <span>

--- a/packages/sanity/src/core/field/validation/index.ts
+++ b/packages/sanity/src/core/field/validation/index.ts
@@ -1,8 +1,27 @@
 import {SchemaType, ObjectSchemaType} from '@sanity/types'
+import {getPrintableType} from '../../util/getPrintableType'
+import {StudioLocaleResourceKeys} from '../../i18n'
 
 /** @internal */
 export interface FieldValueError {
-  message: string
+  /**
+   * i18n key for the error message
+   */
+  messageKey: StudioLocaleResourceKeys
+
+  /**
+   * The expected type of the value
+   */
+  expectedType: string
+
+  /**
+   * The actual type of the value
+   */
+  actualType: string
+
+  /**
+   * The actual value of the field
+   */
   value: unknown
 }
 
@@ -16,7 +35,12 @@ export function getValueError(value: unknown, schemaType: SchemaType): FieldValu
   }
 
   if (valueType !== jsonType) {
-    return {message: `Value is ${valueType}, expected ${jsonType}`, value}
+    return {
+      messageKey: 'changes.error.incorrect-type-message',
+      value,
+      expectedType: jsonType,
+      actualType: getPrintableType(value),
+    }
   }
 
   if (isObjectType(schemaType) && isObjectValue(value)) {

--- a/packages/sanity/src/core/hooks/useUnitFormatter.ts
+++ b/packages/sanity/src/core/hooks/useUnitFormatter.ts
@@ -6,7 +6,10 @@ import {useCurrentLocale} from '../i18n/hooks/useLocale'
  *
  * @public
  */
-export type UseUnitFormatterOptions = Omit<Intl.NumberFormatOptions, 'unit'>
+export type UseUnitFormatterOptions = Pick<
+  Intl.NumberFormatOptions,
+  'notation' | 'signDisplay' | 'unitDisplay' | 'maximumFractionDigits' | 'minimumFractionDigits'
+>
 
 /**
  * Available measurement units
@@ -59,6 +62,16 @@ export type FormattableMeasurementUnit =
   | 'year'
 
 /**
+ * Formats a number using the specified unit, using the currently active locale.
+ *
+ * @param value - The number to format
+ * @param unit - The unit to format the number as
+ * @returns The formatted number
+ * @public
+ */
+export type UnitFormatter = (value: number, unit: FormattableMeasurementUnit) => string
+
+/**
  * Returns a formatter with the given options. Function takes a number and the unit to format as
  * the second argument. The formatter will yield localized output, based on the users' selected
  * locale.
@@ -82,9 +95,7 @@ export type FormattableMeasurementUnit =
  * @returns Formatter function
  * @public
  */
-export function useUnitFormatter(
-  options: UseUnitFormatterOptions = {},
-): (value: number, unit: FormattableMeasurementUnit) => string {
+export function useUnitFormatter(options: UseUnitFormatterOptions = {}): UnitFormatter {
   const currentLocale = useCurrentLocale()
   const defaultOptions: Intl.NumberFormatOptions = {
     unitDisplay: 'long',

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -104,6 +104,29 @@ export const studioLocaleStrings = {
   /** Loading author of change in the differences tooltip in the review changes pane */
   'changes.loading-author': 'Loading…',
 
+  /** --- Review Changes: Specific types --- */
+
+  /** Image diff: Text shown in tooltip when hovering hotspot that has changed in diff view */
+  'changes.image.crop-changed': 'Crop changed',
+
+  /** Image diff: Text shown in tooltip when hovering hotspot that has changed in diff view */
+  'changes.image.hotspot-changed': 'Hotspot changed',
+
+  /** Image diff: Text shown if no asset has been set for the field (but has metadata changes) */
+  'changes.image.no-asset-set': 'Image not set',
+
+  /** Image diff: Text shown when the from/to state has/had no image */
+  'changes.image.no-image-placeholder': '(no image)',
+
+  /** Image diff: Fallback title for the meta info section when there is no original filename to use  */
+  'changes.image.meta-info-fallback-title': 'Untitled',
+
+  /** Image diff: Text shown if the previous image asset was deleted (shouldn't theoretically happen) */
+  'changes.image.deleted': 'Image deleted',
+
+  /** Image diff: Text shown if the image failed to be loaded when previewing it */
+  'changes.image.error-loading-image': 'Error loading image',
+
   /** --- Review Changes: Field + Group --- */
 
   /** Prompt for reverting changes for a field change */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -112,6 +112,12 @@ export const studioLocaleStrings = {
   /** Revert for confirming revert (plural) label for field change action */
   'changes.action.revert-changes-confirm-change_other': `Revert changes`,
 
+  /** Text shown when a diff component crashes during rendering, triggering the error boundary */
+  'changes.error-boundary.title': 'Rendering the changes to this field caused an error',
+
+  /** Additional text shown in development mode when a diff component crashes during rendering */
+  'changes.error-boundary.developer-info': 'Check the developer console for more information',
+
   /** --- Document timeline, for navigating different revisions of a document --- */
 
   /** Error prompt when revision cannot be loaded */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -86,11 +86,14 @@ export const studioLocaleStrings = {
   'changes.no-changes-description':
     'Edit the document or select an older version in the timeline to see a list of changes appear in this panel.',
 
-  /** Label for when a field was cleared, eg the contents was removed - for references, assets and similar */
+  /** Label for when the action of the change was a removal, eg a field was cleared, an array item was removed, an asset was deselected or similar */
   'changes.removed-label': 'Removed',
 
-  /** Label for when a field was given a value where it was previously empty - for references, assets and similar */
+  /** Label for when the action of the change was to set something that was previously empty, eg a field was given a value, an array item was added, an asset was selected or similar */
   'changes.added-label': 'Added',
+
+  /** Label for when the action of the change was _not_ an add/remove, eg a text field changed value, an image was changed from one asset to another or similar */
+  'changes.changed-label': 'Changed',
 
   /** Prompt for reverting all changes in document in Review Changes pane. Includes a count of changes. */
   'changes.action.revert-all-description': `Are you sure you want to revert all {{count}} changes?`,
@@ -105,6 +108,43 @@ export const studioLocaleStrings = {
   'changes.loading-author': 'Loading…',
 
   /** --- Review Changes: Specific types --- */
+
+  /** Array diff: An item was added in a given position (`{{position}}`) */
+  'changes.array.item-added-in-position': 'Added in position {{position}}',
+
+  /** Array diff: An item was removed from a given position (`{{position}}`) */
+  'changes.array.item-removed-from-position': 'Removed from position {{position}}',
+
+  /**
+   * Array diff: An item was moved within the array.
+   * Receives `{{count}}` representing number of positions it moved.
+   * Context is the direction of the move, either `up` or `down`.
+   */
+  'change.array.item-moved_up_one': 'Moved {{count}} position up',
+  'change.array.item-moved_up_other': 'Moved {{count}} positions up',
+  'change.array.item-moved_down_one': 'Moved {{count}} position down',
+  'change.array.item-moved_down_other': 'Moved {{count}} positions down',
+
+  /** Portable Text diff: Removed a block containing no text (eg empty block) */
+  'change.portable-text.empty-text_removed': 'Removed empty text',
+
+  /** Portable Text diff: Added a block containing no text (eg empty block) */
+  'change.portable-text.empty-text_added': 'Added empty text',
+
+  /** Portable Text diff: Changed a block that contained no text (eg empty block) */
+  'change.portable-text.empty-text_changed': 'Changed empty text',
+
+  /** Portable Text diff: Added a chunk of text */
+  'change.portable-text.text_added': 'Added text',
+
+  /** Portable Text diff: Removed a chunk of text */
+  'change.portable-text.text_removed': 'Removed text',
+
+  /** Portable Text diff: Change formatting of text (setting/unsetting marks, eg bold/italic etc) */
+  'change.portable-text.changed-formatting': 'Changed formatting',
+
+  /** File diff: Fallback title for the meta info section when there is no original filename to use  */
+  'changes.file.meta-info-fallback-title': 'Untitled',
 
   /** Image diff: Text shown in tooltip when hovering hotspot that has changed in diff view */
   'changes.image.crop-changed': 'Crop changed',

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -127,6 +127,10 @@ export const studioLocaleStrings = {
   /** Label for the "to" value in the change inspector */
   'changes.inspector.to-label': 'To',
 
+  /** Error message shown when the value of a field is not the expected one */
+  'changes.error.incorrect-type-message':
+    'Value error: Value is of type "<code>{{actualType}}</code>", expected "<code>{{expectedType}}</code>"',
+
   /** --- Document timeline, for navigating different revisions of a document --- */
 
   /** Error prompt when revision cannot be loaded */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -86,6 +86,12 @@ export const studioLocaleStrings = {
   'changes.no-changes-description':
     'Edit the document or select an older version in the timeline to see a list of changes appear in this panel.',
 
+  /** Label for when a field was cleared, eg the contents was removed - for references, assets and similar */
+  'changes.removed-label': 'Removed',
+
+  /** Label for when a field was given a value where it was previously empty - for references, assets and similar */
+  'changes.added-label': 'Added',
+
   /** Prompt for reverting all changes in document in Review Changes pane. Includes a count of changes. */
   'changes.action.revert-all-description': `Are you sure you want to revert all {{count}} changes?`,
 

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -140,8 +140,48 @@ export const studioLocaleStrings = {
   /** Portable Text diff: Removed a chunk of text */
   'change.portable-text.text_removed': 'Removed text',
 
+  /** Portable Text diff: An annotation was added */
+  'change.portable-text.annotation_added': 'Added annotation',
+
+  /** Portable Text diff: An annotation was removed */
+  'change.portable-text.annotation_removed': 'Removed annotation',
+
+  /** Portable Text diff: An annotation was changed */
+  'change.portable-text.annotation_changed': 'Changed annotation',
+
+  /** Portable Text diff: An annotation was left unchanged */
+  'change.portable-text.annotation_unchanged': 'Unchanged annotation',
+
+  /** Portable Text diff: An inline object was added */
+  'change.portable-text.inline-object_added': 'Added inline object',
+
+  /** Portable Text diff: An inline object was removed */
+  'change.portable-text.inline-object_removed': 'Removed inline object',
+
+  /** Portable Text diff: An inline object was changed */
+  'change.portable-text.inline-object_changed': 'Changed inline object',
+
+  /** Portable Text diff: An inline object was left unchanged */
+  'change.portable-text.inline-object_unchanged': 'Unchanged inline object',
+
   /** Portable Text diff: Change formatting of text (setting/unsetting marks, eg bold/italic etc) */
   'change.portable-text.changed-formatting': 'Changed formatting',
+
+  /** Portable Text diff: A block changed from one style to another (eg `normal` to `h1` or similar) */
+  'change.portable-text.block-style-changed':
+    'Changed block style from "{{fromStyle}}" to "{{toStyle}}"',
+
+  /** Portable Text diff: Annotation has an unknown schema type */
+  'change.portable-text.unknown-annotation-schema-type': 'Unknown schema type',
+
+  /** Portable Text diff: Inline object has an unknown schema type */
+  'change.portable-text.unknown-inline-object-schema-type': 'Unknown schema type',
+
+  /** Portable Text diff: An empty object is the result of adding/removing an annotation */
+  'change.portable-text.empty-object-annotation': 'Empty {{annotationType}}',
+
+  /** Portable Text diff: An empty inline object is part of a change */
+  'change.portable-text.empty-inline-object': 'Empty {{inlineObjectType}}',
 
   /** File diff: Fallback title for the meta info section when there is no original filename to use  */
   'changes.file.meta-info-fallback-title': 'Untitled',

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -118,6 +118,15 @@ export const studioLocaleStrings = {
   /** Additional text shown in development mode when a diff component crashes during rendering */
   'changes.error-boundary.developer-info': 'Check the developer console for more information',
 
+  /** Label for the "meta" (field path, action etc) information in the change inspector */
+  'changes.inspector.meta-label': 'Meta',
+
+  /** Label for the "from" value in the change inspector */
+  'changes.inspector.from-label': 'From',
+
+  /** Label for the "to" value in the change inspector */
+  'changes.inspector.to-label': 'To',
+
   /** --- Document timeline, for navigating different revisions of a document --- */
 
   /** Error prompt when revision cannot be loaded */


### PR DESCRIPTION
### Description

Localizes all built-in diff components and related diff utilities.
Snuck in some changes to how units are displayed in the file diff, since I had to use the unit formatter anyway. It now chooses a more appropriate unit than megabytes if it makes sense.

### What to review

The usual

### Notes for release

None
