### PR TITLE
fix(desk): various comments UX papercuts

### DIFF
--- a/packages/sanity/src/desk/comments/src/components/CommentDeleteDialog.tsx
+++ b/packages/sanity/src/desk/comments/src/components/CommentDeleteDialog.tsx
@@ -8,7 +8,7 @@ const DIALOG_COPY: Record<
 > = {
   thread: {
     title: 'Delete this comment thread?',
-    body: 'All comments in this thread will be deleted, and once deleted cannot be recovered.',
+    body: 'This comment and its replies will be deleted, and once deleted cannot be recovered.',
     confirmButtonText: 'Delete thread',
   },
   comment: {

--- a/packages/sanity/src/desk/comments/src/components/list/CommentsListItemLayout.tsx
+++ b/packages/sanity/src/desk/comments/src/components/list/CommentsListItemLayout.tsx
@@ -1,3 +1,4 @@
+import {hues} from '@sanity/color'
 import {
   TextSkeleton,
   Flex,
@@ -39,9 +40,16 @@ export function StopPropagation(props: React.PropsWithChildren) {
 
 const SKELETON_INLINE_STYLE: React.CSSProperties = {width: '50%'}
 
-const TimeText = styled(Text)`
-  min-width: max-content;
-`
+const TimeText = styled(Text)(({theme}) => {
+  const isDark = theme.sanity.color.dark
+  const fg = hues.gray[isDark ? 200 : 800].hex
+
+  return css`
+    min-width: max-content;
+    --card-fg-color: ${fg};
+    color: var(--card-fg-color);
+  `
+})
 
 const InnerStack = styled(Stack)`
   transition: opacity 200ms ease;
@@ -64,12 +72,6 @@ const RetryCardButton = styled(Card)`
 `
 
 const StyledCommentsListItemContextMenu = styled(CommentsListItemContextMenu)``
-
-// Container which displays comment dates in gray.
-// Transparent tone cards still contain a background, which we unset to ensure parent colors take precedence.
-const TransparentDateCard = styled(Card).attrs({tone: 'transparent'})`
-  background: unset;
-`
 
 const RootStack = styled(Stack)(({theme}) => {
   const {space} = theme.sanity
@@ -271,19 +273,17 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
               <Box flex={1}>{name}</Box>
 
               {!displayError && (
-                <TransparentDateCard>
-                  <Flex align="center" gap={1}>
-                    <TimeText muted size={0} title={formattedCreatedAt}>
-                      {createdTimeAgo}
-                    </TimeText>
+                <Flex align="center" gap={1}>
+                  <TimeText muted size={0} title={formattedCreatedAt}>
+                    {createdTimeAgo}
+                  </TimeText>
 
-                    {formattedLastEditAt && (
-                      <TimeText muted size={0} title={formattedLastEditAt}>
-                        (edited)
-                      </TimeText>
-                    )}
-                  </Flex>
-                </TransparentDateCard>
+                  {formattedLastEditAt && (
+                    <TimeText muted size={0} title={formattedLastEditAt}>
+                      (edited)
+                    </TimeText>
+                  )}
+                </Flex>
               )}
             </Flex>
           </Flex>

--- a/packages/sanity/src/desk/comments/src/components/list/CommentsListItemLayout.tsx
+++ b/packages/sanity/src/desk/comments/src/components/list/CommentsListItemLayout.tsx
@@ -65,6 +65,12 @@ const RetryCardButton = styled(Card)`
 
 const StyledCommentsListItemContextMenu = styled(CommentsListItemContextMenu)``
 
+// Container which displays comment dates in gray.
+// Transparent tone cards still contain a background, which we unset to ensure parent colors take precedence.
+const TransparentDateCard = styled(Card).attrs({tone: 'transparent'})`
+  background: unset;
+`
+
 const RootStack = styled(Stack)(({theme}) => {
   const {space} = theme.sanity
 
@@ -265,17 +271,19 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
               <Box flex={1}>{name}</Box>
 
               {!displayError && (
-                <Flex align="center" gap={1}>
-                  <TimeText size={0} muted title={formattedCreatedAt}>
-                    {createdTimeAgo}
-                  </TimeText>
-
-                  {formattedLastEditAt && (
-                    <TimeText size={0} muted title={formattedLastEditAt}>
-                      (edited)
+                <TransparentDateCard>
+                  <Flex align="center" gap={1}>
+                    <TimeText muted size={0} title={formattedCreatedAt}>
+                      {createdTimeAgo}
                     </TimeText>
-                  )}
-                </Flex>
+
+                    {formattedLastEditAt && (
+                      <TimeText muted size={0} title={formattedLastEditAt}>
+                        (edited)
+                      </TimeText>
+                    )}
+                  </Flex>
+                </TransparentDateCard>
               )}
             </Flex>
           </Flex>

--- a/packages/sanity/src/desk/comments/src/components/onboarding/CommentsOnboardingPopover.tsx
+++ b/packages/sanity/src/desk/comments/src/components/onboarding/CommentsOnboardingPopover.tsx
@@ -20,11 +20,11 @@ export function CommentsOnboardingPopover(props: CommentsOnboardingPopoverProps)
         <Root padding={4}>
           <Stack space={3}>
             <Text weight="semibold" size={1}>
-              Collaborate in One Place
+              Document fields now have comments
             </Text>
 
             <Text size={1}>
-              Add a comment on any field. All comments for this document will be here, grouped by
+              You can add comments to any field in a document. They'll show up here, grouped by
               field.
             </Text>
 

--- a/packages/sanity/src/desk/comments/src/components/pte/blocks/MentionInlineBlock.tsx
+++ b/packages/sanity/src/desk/comments/src/components/pte/blocks/MentionInlineBlock.tsx
@@ -43,7 +43,7 @@ export function MentionInlineBlock(props: MentionInlineBlockProps) {
       open={selected}
       delay={TOOLTIP_DELAY}
       content={
-        <Flex align="center" padding={2} gap={1}>
+        <Flex align="center" padding={2} gap={2}>
           <Flex>
             <CommentsAvatar user={user} />
           </Flex>


### PR DESCRIPTION
### Description

(These changes only affect comments within desk)

- Forces gray on all comment dates (edx-701)
- Fixes mention tooltip layout (edx-709)
- Updates thread delete copy (edx-711)
- Updates coachmark copy (edx-716)

### What to review

That all of the above looks as it should!

### Notes for release

N/A