### PR TITLE
feat(desk): improve comments mention list filtering

### DIFF
--- a/packages/sanity/src/desk/comments/src/components/mentions/MentionsMenu.tsx
+++ b/packages/sanity/src/desk/comments/src/components/mentions/MentionsMenu.tsx
@@ -66,9 +66,20 @@ export const MentionsMenu = React.forwardRef(function MentionsMenu(
   const filteredOptions = useMemo(() => {
     if (!searchTerm) return options || EMPTY_ARRAY
 
-    const filtered = options?.filter((option) => {
-      return option?.displayName?.toLowerCase().includes(searchTerm.toLowerCase())
-    })
+    const filtered = options
+      ?.filter((option) => {
+        return option?.displayName?.toLowerCase().includes(searchTerm.toLowerCase())
+      })
+      // Sort by whether the displayName starts with the search term to get more relevant results first
+      ?.sort((a, b) => {
+        const matchA = a.displayName?.toLowerCase().startsWith(searchTerm.toLowerCase())
+        const matchB = b.displayName?.toLowerCase().startsWith(searchTerm.toLowerCase())
+
+        if (matchA && !matchB) return -1
+        if (!matchA && matchB) return 1
+
+        return 0
+      })
 
     return filtered || EMPTY_ARRAY
   }, [options, searchTerm])

--- a/packages/sanity/src/desk/comments/src/components/mentions/MentionsMenu.tsx
+++ b/packages/sanity/src/desk/comments/src/components/mentions/MentionsMenu.tsx
@@ -1,6 +1,7 @@
 import {Box, Flex, Spinner, Stack, Text} from '@sanity/ui'
 import styled from 'styled-components'
 import React, {useCallback, useImperativeHandle, useMemo, useRef, useState} from 'react'
+import {deburr} from 'lodash'
 import {MentionOptionUser} from '../../types'
 import {MentionsMenuItem} from './MentionsMenuItem'
 import {CommandList, CommandListHandle} from 'sanity'
@@ -66,14 +67,23 @@ export const MentionsMenu = React.forwardRef(function MentionsMenu(
   const filteredOptions = useMemo(() => {
     if (!searchTerm) return options || EMPTY_ARRAY
 
-    const filtered = options
+    // We deburr the search term and the display names so that when searching
+    // for e.g "bjorge" we also get results for "bjørge"
+    const deburredSearchTerm = deburr(searchTerm).toLocaleLowerCase()
+
+    const deburredOptions = options?.map((option) => ({
+      ...option,
+      displayName: deburr(option.displayName || '').toLocaleLowerCase(),
+    }))
+
+    const filtered = deburredOptions
       ?.filter((option) => {
-        return option?.displayName?.toLowerCase().includes(searchTerm.toLowerCase())
+        return option?.displayName?.includes(deburredSearchTerm)
       })
       // Sort by whether the displayName starts with the search term to get more relevant results first
       ?.sort((a, b) => {
-        const matchA = a.displayName?.toLowerCase().startsWith(searchTerm.toLowerCase())
-        const matchB = b.displayName?.toLowerCase().startsWith(searchTerm.toLowerCase())
+        const matchA = a.displayName?.startsWith(deburredSearchTerm)
+        const matchB = b.displayName?.startsWith(deburredSearchTerm)
 
         if (matchA && !matchB) return -1
         if (!matchA && matchB) return 1


### PR DESCRIPTION
### Description

This pull request improves the filtering logic in the comments mention list by sorting the results with what the user has searched for first

### What to review

- Make sure that you get most relevant results first in the list when you search for a user

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
