### PR TITLE
feat(desk): delay comments onboarding popover visibility

### DIFF
--- a/packages/sanity/src/desk/comments/src/components/onboarding/CommentsOnboardingPopover.tsx
+++ b/packages/sanity/src/desk/comments/src/components/onboarding/CommentsOnboardingPopover.tsx
@@ -1,9 +1,24 @@
 import {Box, Button, Flex, Popover, PopoverProps, Stack, Text} from '@sanity/ui'
 import React from 'react'
-import styled from 'styled-components'
+import styled, {keyframes} from 'styled-components'
 
 const Root = styled(Box)`
   max-width: 280px;
+`
+
+const fadeInKeyFrame = keyframes`
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+`
+
+const StyledPopover = styled(Popover)`
+  opacity: 0;
+  // Fade in the popover after 500ms
+  animation: ${fadeInKeyFrame} 200ms 500ms forwards;
 `
 
 interface CommentsOnboardingPopoverProps extends Omit<PopoverProps, 'content'> {
@@ -15,7 +30,7 @@ export function CommentsOnboardingPopover(props: CommentsOnboardingPopoverProps)
   const {onDismiss} = props
 
   return (
-    <Popover
+    <StyledPopover
       content={
         <Root padding={4}>
           <Stack space={3}>


### PR DESCRIPTION
### Description

This pull request adds a delay to the comments onboarding popover.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

The onboarding popover should fade in after 500ms when opening the comments inspector.

### Notes for release

n/a
