### PR TITLE
fix(portable-text-editor): selection validation and perf. improvement

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -26,7 +26,7 @@ import {
 import {HotkeyOptions} from '../types/options'
 import {fromSlateValue, isEqualToEmptyEditor, toSlateValue} from '../utils/values'
 import {normalizeSelection} from '../utils/selection'
-import {removeAllDocumentSelectionRanges, toPortableTextRange, toSlateRange} from '../utils/ranges'
+import {toPortableTextRange, toSlateRange} from '../utils/ranges'
 import {debugWithName} from '../utils/debug'
 import {usePortableTextEditorReadOnlyStatus} from './hooks/usePortableTextReadOnly'
 import {usePortableTextEditorKeyGenerator} from './hooks/usePortableTextEditorKeyGenerator'
@@ -105,6 +105,7 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
   const readOnly = usePortableTextEditorReadOnlyStatus()
   const keyGenerator = usePortableTextEditorKeyGenerator()
   const ref = useForwardedRef(forwardedRef)
+  const [editableElement, setEditableElement] = useState<HTMLDivElement | null>(null)
   const [hasInvalidValue, setHasInvalidValue] = useState(false)
 
   const {change$, schemaTypes} = portableTextEditor
@@ -338,35 +339,80 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
     [onBeforeInput],
   )
 
-  const handleDOMChange = useCallback(() => {
-    let newDomRange: any = null
-    const currentSelection = slateEditor.selection
-    try {
-      newDomRange =
-        slateEditor.selection && ReactEditor.toDOMRange(slateEditor, slateEditor.selection)
-    } catch (error) {
-      removeAllDocumentSelectionRanges(true)
-      Transforms.deselect(slateEditor)
-      Transforms.select(slateEditor, [0, 0])
-      slateEditor.onChange()
-      debug(`Could not resolve selection (${JSON.stringify(currentSelection)}), unselecting`)
+  // This function will handle unexpected DOM changes inside the Editable rendering,
+  // and make sure that we can maintain a stable slateEditor.selection when that happens.
+  //
+  // For example, if this Editable is rendered inside something that might re-render
+  // this component (hidden contexts) while the user is still actively changing the
+  // contentEditable, this could interfere with the intermediate DOM selection,
+  // which again could be picked up by ReactEditor's event listeners.
+  // If that range is invalid at that point, the slate.editorSelection could be
+  // set either wrong, or invalid, to which slateEditor will throw exceptions
+  // that are impossible to recover properly from or result in a wrong selection.
+  //
+  // Also the other way around, when the ReactEditor will try to create a DOM Range
+  // from the current slateEditor.selection, it may throw unrecoverable errors
+  // if the current editor.selection is invalid according to the DOM.
+  // If this is the case, default to selecting the top of the document, if the
+  // user already had a selection.
+  const validateSelection = useCallback(() => {
+    if (!slateEditor.selection) {
+      return
     }
-  }, [slateEditor])
+    const root = ReactEditor.findDocumentOrShadowRoot(slateEditor)
+    const {activeElement} = root
+    // Return if the editor isn't the active element
+    if (ref.current !== activeElement) {
+      return
+    }
+    const window = ReactEditor.getWindow(slateEditor)
+    const domSelection = window.getSelection()
+    if (!domSelection) {
+      return
+    }
+    const existingDOMRange = domSelection.getRangeAt(0)
+    try {
+      const newDOMRange = ReactEditor.toDOMRange(slateEditor, slateEditor.selection)
+      if (
+        newDOMRange.startOffset !== existingDOMRange.startOffset ||
+        newDOMRange.endOffset !== existingDOMRange.endOffset
+      ) {
+        debug('DOM range out of sync, validating selection')
+        // Remove all ranges temporary
+        domSelection?.removeAllRanges()
+        // Set the correct range
+        domSelection.addRange(newDOMRange)
+      }
+    } catch (error) {
+      debug(`Could not resolve selection, selecting top document`)
+      // Deselect the editor
+      Transforms.deselect(slateEditor)
+      // Select top document if there is a top block to select
+      if (slateEditor.children.length > 0) {
+        Transforms.select(slateEditor, [0, 0])
+      }
+      slateEditor.onChange()
+    }
+  }, [ref, slateEditor])
 
+  // Observe mutations (child list and subtree) to this component's DOM,
+  // and make sure the editor selection is valid when that happens.
   useEffect(() => {
-    const mutationObserver = new MutationObserver(handleDOMChange)
-
-    if (ref.current) {
-      mutationObserver.observe(ref.current, {
+    if (editableElement) {
+      const mutationObserver = new MutationObserver(validateSelection)
+      mutationObserver.observe(editableElement, {
+        attributeOldValue: false,
+        attributes: false,
+        characterData: false,
         childList: true,
         subtree: true,
       })
+      return () => {
+        mutationObserver.disconnect()
+      }
     }
-
-    return () => {
-      mutationObserver.disconnect()
-    }
-  }, [handleDOMChange, ref])
+    return undefined
+  }, [validateSelection, editableElement])
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLDivElement>) => {
@@ -415,8 +461,11 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
   }, [schemaTypes, slateEditor])
 
   // Set the forwarded ref to be the Slate editable DOM element
+  // Also set the editable element in a state so that the MutationObserver
+  // is setup when this element is ready.
   useEffect(() => {
     ref.current = ReactEditor.toDOMNode(slateEditor, slateEditor) as HTMLDivElement | null
+    setEditableElement(ref.current)
   }, [slateEditor, ref])
 
   if (!portableTextEditor) {

--- a/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditor.test.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditor.test.tsx
@@ -128,7 +128,7 @@ describe('initialization', () => {
     await waitFor(() => {
       if (editorRef.current) {
         PortableTextEditor.focus(editorRef.current)
-        expect(PortableTextEditor.getSelection(editorRef.current)).toEqual(initialSelection)
+        expect(PortableTextEditor.getSelection(editorRef.current)).toStrictEqual(initialSelection)
       }
     })
   })

--- a/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditor.test.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditor.test.tsx
@@ -87,15 +87,25 @@ describe('initialization', () => {
 `)
     })
   })
-  it('takes value from props', async () => {
+  it('takes value from props and confirms it by emitting value change event', async () => {
     const initialValue = [helloBlock]
     const onChange = jest.fn()
+    const editorRef = React.createRef<PortableTextEditor>()
     render(
-      <PortableTextEditorTester onChange={onChange} schemaType={schemaType} value={initialValue} />,
+      <PortableTextEditorTester
+        ref={editorRef}
+        onChange={onChange}
+        schemaType={schemaType}
+        value={initialValue}
+      />,
     )
+    const normalizedEditorValue = [{...initialValue[0], style: 'normal'}]
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith({type: 'value', value: initialValue})
     })
+    if (editorRef.current) {
+      expect(PortableTextEditor.getValue(editorRef.current)).toStrictEqual(normalizedEditorValue)
+    }
   })
 
   it('takes initial selection from props', async () => {

--- a/packages/@sanity/portable-text-editor/src/editor/components/Synchronizer.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/components/Synchronizer.tsx
@@ -71,11 +71,11 @@ export function Synchronizer(props: SynchronizerProps) {
         debug(`Patches:\n${JSON.stringify(pendingPatches.current, null, 2)}`)
       }
       const snapshot = PortableTextEditor.getValue(portableTextEditor)
-      onChange({type: 'mutation', patches: pendingPatches.current, snapshot})
+      change$.next({type: 'mutation', patches: pendingPatches.current, snapshot})
       pendingPatches.current = []
     }
     IS_PROCESSING_LOCAL_CHANGES.set(slateEditor, false)
-  }, [slateEditor, portableTextEditor, onChange])
+  }, [slateEditor, portableTextEditor, change$])
 
   const onFlushPendingPatchesThrottled = useMemo(() => {
     return throttle(
@@ -131,14 +131,7 @@ export function Synchronizer(props: SynchronizerProps) {
       debug('Unsubscribing to changes$')
       sub.unsubscribe()
     }
-  }, [
-    change$,
-    onChange,
-    onFlushPendingPatches,
-    onFlushPendingPatchesThrottled,
-    slateEditor,
-    syncValue,
-  ])
+  }, [change$, onChange, onFlushPendingPatchesThrottled, slateEditor])
 
   // Sync the value when going online
   const handleOnline = useCallback(() => {

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithHotKeys.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithHotKeys.ts
@@ -209,6 +209,7 @@ export function createWithHotkeys(
           if (endAtEndOfNode) {
             Editor.insertNode(editor, createEmptyBlock())
             event.preventDefault()
+            editor.onChange()
             return
           }
         }
@@ -216,10 +217,13 @@ export function createWithHotkeys(
         if (focusBlock && Editor.isVoid(editor, focusBlock)) {
           Editor.insertNode(editor, createEmptyBlock())
           event.preventDefault()
+          editor.onChange()
           return
         }
+        // Default enter key behavior
         event.preventDefault()
         editor.insertBreak()
+        editor.onChange()
       }
 
       // Soft line breaks

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -116,6 +116,7 @@ export function Editor(props: EditorProps) {
   const editable = useMemo(
     () => (
       <PortableTextEditable
+        aria-describedby={ariaDescribedBy}
         hotkeys={hotkeys}
         onCopy={onCopy}
         onPaste={onPaste}
@@ -129,12 +130,12 @@ export function Editor(props: EditorProps) {
         renderStyle={renderStyle}
         scrollSelectionIntoView={scrollSelectionIntoView}
         selection={initialSelection}
-        style={noOutlineStyle}
         spellCheck={spellcheck}
-        aria-describedby={ariaDescribedBy}
+        style={noOutlineStyle}
       />
     ),
     [
+      ariaDescribedBy,
       hotkeys,
       initialSelection,
       onCopy,
@@ -145,7 +146,6 @@ export function Editor(props: EditorProps) {
       renderPlaceholder,
       scrollSelectionIntoView,
       spellcheck,
-      ariaDescribedBy,
     ],
   )
 

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -191,18 +191,17 @@ export function PortableTextInput(props: PortableTextInputProps) {
     const items: PortableTextMemberItem[] = result.map((item) => {
       const key = pathToString(item.node.path)
       const existingItem = portableTextMemberItemsRef.current.find((ref) => ref.key === key)
+      const isObject = item.kind !== 'textBlock'
       let input: ReactNode
 
-      if (item.kind !== 'textBlock') {
-        input = <FormInput absolutePath={item.node.path} {...(props as FIXME)} />
+      // Only render the input if the item is open or new
+      if (isObject && (item.member.open || !existingItem)) {
+        const inputProps = {...(props as FIXME), absolutePath: item.node.path}
+        input = <FormInput {...inputProps} />
       }
 
       if (existingItem) {
-        // Only update the input if the node is open or the value has changed
-        // This is a performance optimization.
-        if (item.member.open || existingItem.node.value !== item.node.value) {
-          existingItem.input = input
-        }
+        existingItem.input = input
         existingItem.member = item.member
         existingItem.node = item.node
         return existingItem


### PR DESCRIPTION
### Description

This will improve the selection management of the Portable Text Editor's Editable component when used in unknown contexts where the underlying context might uncontrollably cause re-renders to be made.

For instance when having a PortableText Input inside an object that is inside another Portable Text Input.

In this case, we would have two nested form contexts that each will update themselves as soon as the value from the nested editor is propagated to the root PT-input, and the `component.input`'s for both of them will then be re-rendered.

Though none of the actual editor nodes are re-rendered, this may cause the window selection to change and the editor will try to make an editor selection out of it.

If the user then is in the middle of making changes (like splitting a block into a new one) this may cause the selection to become out of sync and act weird.

To solve this problem I have improved the DOMMutation observer function we already have in the `Editable` component to:

* Actually _work_ in React non-strict mode (the way the observer was set up with a ref dependency, never engaged the MutationObserver in production mode as it was only set once (to null). Use a state var to control this rather.
* Test that the editor is selected and active before actually doing something (perf. optimization)
* Test the current DOM Range against the DOMRange produced from the editor selection. If they differ, set the actual DOM Range to be the one based on the editor selection.

BONUS: while debugging this, I was also able to significantly optimize performance on rendering the form members' inputs which is pretty notable in the editing experience. 🎉 

I have also made some other minor improvements. See the commits.

* Improved accuracy of some tests
* Refactor away a redundant function in the Synchronizer (it's still doing the exact same thing, just less code).
* Call `editor.onChange` on hotkey actions that should produce a change instantly (like splitting a block with enter).


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
That the cursor is stable and correct when editing Portable Text in nested Portable Text Inputs.

You can test with [the recursive inputs here](https://test-studio-git-edx-727.sanity.build/test/content/input-standard;portable-text;blocksTest;).

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Fixed an issue with cursor instability when using the Portable Text Input inside another Portable Text Input's embedded objects.
* Improved performance in the Portable Text Input

<!--
A description of the change(s) that should be used in the release notes.
-->
