### PR TITLE
feat(i18n): fix confirm delete dialog

### DIFF
--- a/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
+++ b/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
@@ -75,8 +75,8 @@ export function ConfirmDeleteDialogBody({
         <Translate
           t={t}
           i18nKey="confirm-delete-dialog.confirmation.text"
+          context={action}
           components={{DocumentTitle: () => <strong>{documentTitle}</strong>}}
-          values={{context: action}}
         />
       </Text>
     )
@@ -122,8 +122,8 @@ export function ConfirmDeleteDialogBody({
           <Translate
             i18nKey="confirm-delete-dialog.referring-documents-descriptor.text"
             t={t}
+            context={action}
             components={{DocumentTitle: () => documentTitle}}
-            values={{context: action}}
           />
         </Text>
       </Box>
@@ -275,8 +275,8 @@ export function ConfirmDeleteDialogBody({
           <Translate
             i18nKey="confirm-delete-dialog.referential-integrity-disclaimer.text"
             t={t}
+            context={action}
             components={{DocumentTitle: () => documentTitle}}
-            values={{context: action}}
           />
         </Text>
       </Box>

--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -280,14 +280,14 @@ const deskLocaleStrings = {
   /** The text when a generic operation failed  */
   'panes.document-operation-results.operation-error': 'An error occurred during {{context}}',
 
-  /** The text when a publish operation succeded  */
+  /** The text when a publish operation succeeded  */
   'panes.document-operation-results.operation-success_publish': 'The document was published',
 
-  /** The text when an unpublish operation succeded  */
+  /** The text when an unpublish operation succeeded  */
   'panes.document-operation-results.operation-success_unpublish':
     'The document was unpublished. A draft has been created from the latest published version.',
 
-  /** The text when a discard changes operation succeded  */
+  /** The text when a discard changes operation succeeded  */
   'panes.document-operation-results.operation-success_discardChanges':
     'All changes since last publish has now been discarded. The discarded draft can still be recovered from history',
 


### PR DESCRIPTION
### Description

A follow up from #5114 so that these components use the `context` prop instead of passing it through `values`
