### PR TITLE
feat(i18n) localize insufficient permissions message

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -89,6 +89,7 @@ const config = {
               'autoFocus',
               'axis',
               'className',
+              'context',
               'direction',
               'display',
               'fill',

--- a/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
@@ -752,9 +752,6 @@ const studioResources: Record<StudioLocaleResourceKeys, string> = {
   /** Accessibility label for the list displaying options in the new document menu */
   'new-document.new-document-aria-label': 'Nytt dokument',
 
-  /** Error label for when a user is unable to create a document */
-  'new-document.error.unable-to-create-document': 'opprette dette dokumentet',
-
   /** --- Search --- */
 
   /** Placeholder text for the omnisearch input field */

--- a/packages/sanity/src/core/components/InsufficientPermissionsMessage.tsx
+++ b/packages/sanity/src/core/components/InsufficientPermissionsMessage.tsx
@@ -2,24 +2,26 @@ import {AccessDeniedIcon} from '@sanity/icons'
 import {CurrentUser} from '@sanity/types'
 import {Text, Inline, Box} from '@sanity/ui'
 import React from 'react'
+// note: these are both available from the `../i18n` export but importing through
+// that export fails the build. may be due to a circular reference.
+import {useTranslation} from '../i18n/hooks/useTranslation'
+import {Translate} from '../i18n/Translate'
 
 /** @internal */
 export interface InsufficientPermissionsMessageProps {
-  title?: string
   operationLabel?: string
   currentUser?: CurrentUser | null
 }
 
 /** @internal */
 export function InsufficientPermissionsMessage(props: InsufficientPermissionsMessageProps) {
+  const {t} = useTranslation()
   const {
     currentUser,
-    title = 'Insufficient permissions',
-    operationLabel = 'access this feature',
+    operationLabel = t('insufficient-permissions-message.default-operation-label'),
   } = props
 
   const roles = currentUser?.roles || []
-  const plural = roles.length !== 1
 
   return (
     <Box padding={2}>
@@ -27,21 +29,25 @@ export function InsufficientPermissionsMessage(props: InsufficientPermissionsMes
         <Text size={1}>
           <AccessDeniedIcon />
         </Text>
-        <Text weight="semibold">{title}</Text>
+        <Text weight="semibold">{t('insufficient-permissions-message.title')}</Text>
       </Inline>
       <Inline marginTop={4}>
         <Text size={1}>
           {roles.length === 0 ? (
-            <>You have no role that grants you permission to {operationLabel}</>
+            t('insufficient-permissions-message.no-roles', {operationLabel})
           ) : (
-            <>
-              Your role{plural && 's'}{' '}
-              {join(
-                roles.map((r) => <code key={r.name}>{r.title}</code>),
-                <>, </>,
-              )}{' '}
-              do{plural || 'es'} not have permissions to {operationLabel}
-            </>
+            <Translate
+              i18nKey="insufficient-permissions-message.has-roles"
+              t={t}
+              components={{
+                Roles: () =>
+                  join(
+                    roles.map((r) => <code key={r.name}>{r.title}</code>),
+                    <>, </>,
+                  ),
+              }}
+              values={{operationLabel, count: roles.length}}
+            />
           )}
         </Text>
       </Inline>

--- a/packages/sanity/src/core/components/InsufficientPermissionsMessage.tsx
+++ b/packages/sanity/src/core/components/InsufficientPermissionsMessage.tsx
@@ -12,15 +12,20 @@ import {useIntlListFormat} from '../i18n/hooks/useIntlListFormat'
 /** @internal */
 export interface InsufficientPermissionsMessageProps {
   currentUser?: CurrentUser | null
-  action: string
+  /**
+   * the i18n key that represents the action the user is not allowed to do
+   */
+  i18nKey: string
 }
 
 const EMPTY_ARRAY = [] as never[]
 
 /** @internal */
-export function InsufficientPermissionsMessage(props: InsufficientPermissionsMessageProps) {
+export function InsufficientPermissionsMessage({
+  currentUser,
+  i18nKey: i18nActionKey,
+}: InsufficientPermissionsMessageProps) {
   const {t} = useTranslation()
-  const {currentUser, action} = props
 
   const list = useIntlListFormat({style: 'short', type: 'unit'})
   const roles = currentUser?.roles || EMPTY_ARRAY
@@ -57,7 +62,7 @@ export function InsufficientPermissionsMessage(props: InsufficientPermissionsMes
           <Translate
             i18nKey="insufficient-permissions-message.not-authorized"
             t={t}
-            values={{action}}
+            values={{action: t(i18nActionKey)}}
           />
         </Text>
       </Inline>

--- a/packages/sanity/src/core/components/InsufficientPermissionsMessage.tsx
+++ b/packages/sanity/src/core/components/InsufficientPermissionsMessage.tsx
@@ -33,22 +33,18 @@ export function InsufficientPermissionsMessage(props: InsufficientPermissionsMes
       </Inline>
       <Inline marginTop={4}>
         <Text size={1}>
-          {roles.length === 0 ? (
-            t('insufficient-permissions-message.no-roles', {operationLabel})
-          ) : (
-            <Translate
-              i18nKey="insufficient-permissions-message.has-roles"
-              t={t}
-              components={{
-                Roles: () =>
-                  join(
-                    roles.map((r) => <code key={r.name}>{r.title}</code>),
-                    <>, </>,
-                  ),
-              }}
-              values={{operationLabel, count: roles.length}}
-            />
-          )}
+          <Translate
+            i18nKey="insufficient-permissions-message.roles"
+            t={t}
+            components={{
+              Roles: () =>
+                join(
+                  roles.map((r) => <code key={r.name}>{r.title}</code>),
+                  <>, </>,
+                ),
+            }}
+            values={{operationLabel, count: roles.length}}
+          />
         </Text>
       </Inline>
     </Box>

--- a/packages/sanity/src/core/components/InsufficientPermissionsMessage.tsx
+++ b/packages/sanity/src/core/components/InsufficientPermissionsMessage.tsx
@@ -12,10 +12,16 @@ import {useIntlListFormat} from '../i18n/hooks/useIntlListFormat'
 /** @internal */
 export interface InsufficientPermissionsMessageProps {
   currentUser?: CurrentUser | null
-  /**
-   * the i18n key that represents the action the user is not allowed to do
-   */
-  i18nKey: string
+  context:
+    | 'create-new-reference'
+    | 'create-document-type'
+    | 'create-any-document'
+    | 'create-document'
+    | 'delete-document'
+    | 'discard-changes'
+    | 'duplicate-document'
+    | 'publish-document'
+    | 'unpublish-document'
 }
 
 const EMPTY_ARRAY = [] as never[]
@@ -23,7 +29,7 @@ const EMPTY_ARRAY = [] as never[]
 /** @internal */
 export function InsufficientPermissionsMessage({
   currentUser,
-  i18nKey: i18nActionKey,
+  context,
 }: InsufficientPermissionsMessageProps) {
   const {t} = useTranslation()
 
@@ -60,9 +66,9 @@ export function InsufficientPermissionsMessage({
       <Inline marginTop={4}>
         <Text size={1}>
           <Translate
-            i18nKey="insufficient-permissions-message.not-authorized"
+            i18nKey="insufficient-permissions-message.not-authorized-explanation"
             t={t}
-            values={{action: t(i18nActionKey)}}
+            context={context}
           />
         </Text>
       </Inline>

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/CreateButton.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/CreateButton.tsx
@@ -39,7 +39,7 @@ export function CreateButton(props: Props) {
           <Box padding={2}>
             <InsufficientPermissionsMessage
               currentUser={currentUser}
-              i18nKey="insufficient-permissions-message.action.create-new-reference"
+              context="create-new-reference"
             />
           </Box>
         }
@@ -80,7 +80,7 @@ export function CreateButton(props: Props) {
                 <Box padding={2}>
                   <InsufficientPermissionsMessage
                     currentUser={currentUser}
-                    i18nKey="insufficient-permissions-message.action.create-document-type"
+                    context="create-document-type"
                   />
                 </Box>
               }

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/CreateButton.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/CreateButton.tsx
@@ -36,9 +36,7 @@ export function CreateButton(props: Props) {
         content={
           <Box padding={2}>
             <InsufficientPermissionsMessage
-              operationLabel={t(
-                'insufficient-permissions-message.operation-label.create-new-reference',
-              )}
+              action={t('insufficient-permissions-message.action.create-new-reference')}
             />
           </Box>
         }
@@ -78,9 +76,7 @@ export function CreateButton(props: Props) {
               content={
                 <Box padding={2}>
                   <InsufficientPermissionsMessage
-                    operationLabel={t(
-                      'insufficient-permissions-message.operation-label.create-document-type',
-                    )}
+                    action={t('insufficient-permissions-message.action.create-document-type')}
                   />
                 </Box>
               }

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/CreateButton.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/CreateButton.tsx
@@ -3,6 +3,7 @@ import {AddIcon} from '@sanity/icons'
 import {Box, Button, Menu, MenuButton, MenuButtonProps, MenuItem, Tooltip} from '@sanity/ui'
 import {useTranslation} from '../../../i18n'
 import {InsufficientPermissionsMessage} from '../../../components'
+import {useCurrentUser} from '../../../store'
 import type {CreateReferenceOption} from './types'
 
 interface Props extends ComponentProps<typeof Button> {
@@ -27,6 +28,7 @@ const POPOVER_PROPS: MenuButtonProps['popover'] = {
 
 export function CreateButton(props: Props) {
   const {createOptions, onCreate, id, ...rest} = props
+  const currentUser = useCurrentUser()
 
   const {t} = useTranslation()
   const canCreateAny = createOptions.some((option) => option.permission.granted)
@@ -36,7 +38,8 @@ export function CreateButton(props: Props) {
         content={
           <Box padding={2}>
             <InsufficientPermissionsMessage
-              action={t('insufficient-permissions-message.action.create-new-reference')}
+              currentUser={currentUser}
+              i18nKey="insufficient-permissions-message.action.create-new-reference"
             />
           </Box>
         }
@@ -76,7 +79,8 @@ export function CreateButton(props: Props) {
               content={
                 <Box padding={2}>
                   <InsufficientPermissionsMessage
-                    action={t('insufficient-permissions-message.action.create-document-type')}
+                    currentUser={currentUser}
+                    i18nKey="insufficient-permissions-message.action.create-document-type"
                   />
                 </Box>
               }

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/CreateButton.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/CreateButton.tsx
@@ -35,7 +35,11 @@ export function CreateButton(props: Props) {
       <Tooltip
         content={
           <Box padding={2}>
-            <InsufficientPermissionsMessage operationLabel="create a new reference" />
+            <InsufficientPermissionsMessage
+              operationLabel={t(
+                'insufficient-permissions-message.operation-label.create-new-reference',
+              )}
+            />
           </Box>
         }
       >
@@ -73,7 +77,11 @@ export function CreateButton(props: Props) {
               key={createOption.id}
               content={
                 <Box padding={2}>
-                  <InsufficientPermissionsMessage operationLabel="create this type of document" />
+                  <InsufficientPermissionsMessage
+                    operationLabel={t(
+                      'insufficient-permissions-message.operation-label.create-document-type',
+                    )}
+                  />
                 </Box>
               }
               portal
@@ -84,6 +92,7 @@ export function CreateButton(props: Props) {
                   disabled={!createOption.permission.granted}
                   icon={createOption.icon}
                   text={createOption.title}
+                  // eslint-disable-next-line react/jsx-no-bind
                   onClick={() => onCreate(createOption)}
                 />
               </div>
@@ -99,6 +108,7 @@ export function CreateButton(props: Props) {
       text={t('inputs.reference.action-create-new-document')}
       mode="ghost"
       disabled={!createOptions[0].permission.granted || props.readOnly}
+      // eslint-disable-next-line react/jsx-no-bind
       onClick={() => onCreate(createOptions[0])}
       icon={AddIcon}
     />

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1589,23 +1589,47 @@ export const studioLocaleStrings = {
   /** The title for the insufficient permissions message component */
   'insufficient-permissions-message.title': 'Insufficient permissions',
 
-  /** Informs the users that their current roles do not have the required permissions to do a particular action */
-  'insufficient-permissions-message.not-authorized': 'Not authorized to {{action}}.',
+  /** The fallback explanation if no context is provided */
+  'insufficient-permissions-message.not-authorized-explanation':
+    'Your roles do not have permission to access this feature.',
+
+  'insufficient-permissions-message.not-authorized-explanation_create-new-reference':
+    'Your roles do not have permission to create a new reference.',
+
+  /** The explanation when unable to create a particular type of document */
+  'insufficient-permissions-message.not-authorized-explanation_create-document-type':
+    'Your roles do not have permission to create this kind of document.',
+
+  /** The explanation when unable to create any document at all */
+  'insufficient-permissions-message.not-authorized-explanation_create-any-document':
+    'Your roles do not have permission to create a document.',
+
+  /** The explanation when unable to create a particular document */
+  'insufficient-permissions-message.not-authorized-explanation_create-document':
+    'Your roles do not have permission to create this document.',
+
+  /** The explanation when unable to delete a particular document */
+  'insufficient-permissions-message.not-authorized-explanation_delete-document':
+    'Your roles do not have permission to delete this document.',
+
+  /** The explanation when unable to discard changes in a particular document */
+  'insufficient-permissions-message.not-authorized-explanation_discard-changes':
+    'Your roles do not have permission to discard changes in this document.',
+
+  /** The explanation when unable to duplicate a particular document */
+  'insufficient-permissions-message.not-authorized-explanation_duplicate-document':
+    'Your roles do not have permission to duplicate this document.',
+
+  /** The explanation when unable to publish a particular document */
+  'insufficient-permissions-message.not-authorized-explanation_publish-document':
+    'Your roles do not have permission to publish this document.',
+
+  /** The explanation when unable to unpublish a particular document */
+  'insufficient-permissions-message.not-authorized-explanation_unpublish-document':
+    'Your roles do not have permission to unpublish this document.',
 
   /** Appears after the not-authorized message. Lists the current roles. */
   'insufficient-permissions-message.roles': 'Your roles: <Roles/>',
-
-  /** The action when unable to create a new reference */
-  'insufficient-permissions-message.action.create-new-reference': 'create a new reference',
-
-  /** The action when unable to create a particular type of document */
-  'insufficient-permissions-message.action.create-document-type': 'create this kind of document',
-
-  /** The action when unable to create any document */
-  'insufficient-permissions-message.action.create-any-document': 'create any document',
-
-  /** The action when unable to create a particular document */
-  'insufficient-permissions-message.action.create-document': 'create this document',
 }
 
 /**

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1591,42 +1591,43 @@ export const studioLocaleStrings = {
 
   /** The fallback explanation if no context is provided */
   'insufficient-permissions-message.not-authorized-explanation':
-    'Your roles do not have permission to access this feature.',
+    'You do not have permission to access this feature.',
 
+  /** The explanation when unable to create a new reference in a document */
   'insufficient-permissions-message.not-authorized-explanation_create-new-reference':
-    'Your roles do not have permission to create a new reference.',
+    'You do not have permission to create a new reference.',
 
   /** The explanation when unable to create a particular type of document */
   'insufficient-permissions-message.not-authorized-explanation_create-document-type':
-    'Your roles do not have permission to create this kind of document.',
+    'You do not have permission to create this kind of document.',
 
   /** The explanation when unable to create any document at all */
   'insufficient-permissions-message.not-authorized-explanation_create-any-document':
-    'Your roles do not have permission to create a document.',
+    'You do not have permission to create a document.',
 
   /** The explanation when unable to create a particular document */
   'insufficient-permissions-message.not-authorized-explanation_create-document':
-    'Your roles do not have permission to create this document.',
+    'You do not have permission to create this document.',
 
   /** The explanation when unable to delete a particular document */
   'insufficient-permissions-message.not-authorized-explanation_delete-document':
-    'Your roles do not have permission to delete this document.',
+    'You do not have permission to delete this document.',
 
   /** The explanation when unable to discard changes in a particular document */
   'insufficient-permissions-message.not-authorized-explanation_discard-changes':
-    'Your roles do not have permission to discard changes in this document.',
+    'You do not have permission to discard changes in this document.',
 
   /** The explanation when unable to duplicate a particular document */
   'insufficient-permissions-message.not-authorized-explanation_duplicate-document':
-    'Your roles do not have permission to duplicate this document.',
+    'You do not have permission to duplicate this document.',
 
   /** The explanation when unable to publish a particular document */
   'insufficient-permissions-message.not-authorized-explanation_publish-document':
-    'Your roles do not have permission to publish this document.',
+    'You do not have permission to publish this document.',
 
   /** The explanation when unable to unpublish a particular document */
   'insufficient-permissions-message.not-authorized-explanation_unpublish-document':
-    'Your roles do not have permission to unpublish this document.',
+    'You do not have permission to unpublish this document.',
 
   /** Appears after the not-authorized message. Lists the current roles. */
   'insufficient-permissions-message.roles': 'Your roles: <Roles/>',

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1589,33 +1589,23 @@ export const studioLocaleStrings = {
   /** The title for the insufficient permissions message component */
   'insufficient-permissions-message.title': 'Insufficient permissions',
 
-  /** The insufficient permissions messages when the user has no roles */
-  'insufficient-permissions-message.roles_zero':
-    'You have no role that grants you permission to {{operationLabel}}',
+  /** Informs the users that their current roles do not have the required permissions to do a particular action */
+  'insufficient-permissions-message.not-authorized': 'Not authorized to {{action}}.',
 
-  /** The insufficient permissions messages when the user has one role */
-  'insufficient-permissions-message.roles_one':
-    'Your role <Roles/> does not have permission to {{operationLabel}}',
+  /** Appears after the not-authorized message. Lists the current roles. */
+  'insufficient-permissions-message.roles': 'Your roles: <Roles/>',
 
-  /** The insufficient permissions messages when the user has more than one role */
-  'insufficient-permissions-message.roles_other':
-    'Your roles <Roles/> do not have permission to {{operationLabel}}',
+  /** The action when unable to create a new reference */
+  'insufficient-permissions-message.action.create-new-reference': 'create a new reference',
 
-  /** The default `{{operationLabel}}`. Refer to `insufficient-permissions-message.has-roles`. */
-  'insufficient-permissions-message.default-operation-label': 'access this feature',
+  /** The action when unable to create a particular type of document */
+  'insufficient-permissions-message.action.create-document-type': 'create this kind of document',
 
-  /** The operation label when unable to create a new reference */
-  'insufficient-permissions-message.operation-label.create-new-reference': 'create a new reference',
+  /** The action when unable to create any document */
+  'insufficient-permissions-message.action.create-any-document': 'create any document',
 
-  /** The operation label when unable to create a particular type of document */
-  'insufficient-permissions-message.operation-label.create-document-type':
-    'create this type of document',
-
-  /** The operation label when unable to create any document */
-  'insufficient-permissions-message.operation-label.create-any-document': 'create any document',
-
-  /** The operation label when unable to create a particular document */
-  'insufficient-permissions-message.operation-label.create-document': 'create this document',
+  /** The action when unable to create a particular document */
+  'insufficient-permissions-message.action.create-document': 'create this document',
 }
 
 /**

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -977,10 +977,6 @@ export const studioLocaleStrings = {
   /** Accessibility label for the list displaying options in the new document menu */
   'new-document.new-document-aria-label': 'New document',
 
-  /** Error label for when a user is unable to create a document */
-  // @todo refactor InsufficientPermissionsMessage
-  'new-document.error.unable-to-create-document': 'create this document',
-
   /** --- Search --- */
 
   /** Placeholder text for the omnisearch input field */
@@ -1587,6 +1583,39 @@ export const studioLocaleStrings = {
 
   /** Alternative text for image being shown while image is being uploaded, in previews */
   'preview.image.file-is-being-uploaded.alt-text': 'The image currently being uploaded',
+
+  /** --- Insufficient permissions message --- */
+
+  /** The title for the insufficient permissions message component */
+  'insufficient-permissions-message.title': 'Insufficient permissions',
+
+  /** The insufficient permissions messages when the user has no roles */
+  'insufficient-permissions-message.no-roles':
+    'You have no role that grants you permission to {{operationLabel}}',
+
+  /** The insufficient permissions messages when the user has one role */
+  'insufficient-permissions-message.has-roles_one':
+    'Your role <Roles/> does not have permission to {{operationLabel}}',
+
+  /** The insufficient permissions messages when the user has more than one role */
+  'insufficient-permissions-message.has-roles_other':
+    'Your roles <Roles/> do not have permission to {{operationLabel}}',
+
+  /** The default `{{operationLabel}}`. Refer to `insufficient-permissions-message.has-roles`. */
+  'insufficient-permissions-message.default-operation-label': 'access this feature',
+
+  /** The operation label when unable to create a new reference */
+  'insufficient-permissions-message.operation-label.create-new-reference': 'create a new reference',
+
+  /** The operation label when unable to create a particular type of document */
+  'insufficient-permissions-message.operation-label.create-document-type':
+    'create this type of document',
+
+  /** The operation label when unable to create any document */
+  'insufficient-permissions-message.operation-label.create-any-document': 'create any document',
+
+  /** The operation label when unable to create a particular document */
+  'insufficient-permissions-message.operation-label.create-document': 'create this document',
 }
 
 /**

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1590,15 +1590,15 @@ export const studioLocaleStrings = {
   'insufficient-permissions-message.title': 'Insufficient permissions',
 
   /** The insufficient permissions messages when the user has no roles */
-  'insufficient-permissions-message.no-roles':
+  'insufficient-permissions-message.roles_zero':
     'You have no role that grants you permission to {{operationLabel}}',
 
   /** The insufficient permissions messages when the user has one role */
-  'insufficient-permissions-message.has-roles_one':
+  'insufficient-permissions-message.roles_one':
     'Your role <Roles/> does not have permission to {{operationLabel}}',
 
   /** The insufficient permissions messages when the user has more than one role */
-  'insufficient-permissions-message.has-roles_other':
+  'insufficient-permissions-message.roles_other':
     'Your roles <Roles/> do not have permission to {{operationLabel}}',
 
   /** The default `{{operationLabel}}`. Refer to `insufficient-permissions-message.has-roles`. */

--- a/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.tsx
@@ -170,7 +170,7 @@ export function NewDocumentButton(props: NewDocumentButtonProps) {
     return (
       <InsufficientPermissionsMessage
         currentUser={currentUser}
-        action={t('insufficient-permissions-message.action.create-any-document')}
+        i18nKey="insufficient-permissions-message.action.create-any-document"
       />
     )
   }, [canCreateDocument, currentUser, hasNewDocumentOptions, t])

--- a/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.tsx
@@ -170,7 +170,7 @@ export function NewDocumentButton(props: NewDocumentButtonProps) {
     return (
       <InsufficientPermissionsMessage
         currentUser={currentUser}
-        operationLabel={t('insufficient-permissions-message.operation-label.create-any-document')}
+        action={t('insufficient-permissions-message.action.create-any-document')}
       />
     )
   }, [canCreateDocument, currentUser, hasNewDocumentOptions, t])

--- a/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.tsx
@@ -170,7 +170,7 @@ export function NewDocumentButton(props: NewDocumentButtonProps) {
     return (
       <InsufficientPermissionsMessage
         currentUser={currentUser}
-        operationLabel="create any document"
+        operationLabel={t('insufficient-permissions-message.operation-label.create-any-document')}
       />
     )
   }, [canCreateDocument, currentUser, hasNewDocumentOptions, t])

--- a/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.tsx
@@ -168,10 +168,7 @@ export function NewDocumentButton(props: NewDocumentButtonProps) {
     }
 
     return (
-      <InsufficientPermissionsMessage
-        currentUser={currentUser}
-        i18nKey="insufficient-permissions-message.action.create-any-document"
-      />
+      <InsufficientPermissionsMessage currentUser={currentUser} context="create-any-document" />
     )
   }, [canCreateDocument, currentUser, hasNewDocumentOptions, t])
 

--- a/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentListOption.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentListOption.tsx
@@ -51,10 +51,7 @@ export function NewDocumentListOption(props: NewDocumentListOptionProps) {
       portal
       content={
         <TooltipContentBox padding={2}>
-          <InsufficientPermissionsMessage
-            currentUser={currentUser}
-            i18nKey="insufficient-permissions-message.action.create-document"
-          />
+          <InsufficientPermissionsMessage currentUser={currentUser} context="create-document" />
         </TooltipContentBox>
       }
     >

--- a/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentListOption.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentListOption.tsx
@@ -3,9 +3,9 @@ import {Tooltip, Box, Card, Text} from '@sanity/ui'
 import React, {useCallback, useMemo} from 'react'
 import styled from 'styled-components'
 import {InsufficientPermissionsMessage} from '../../../../components'
+import {useTranslation} from '../../../../i18n'
 import {NewDocumentOption, PreviewLayout} from './types'
 import {useIntentLink} from 'sanity/router'
-import {useTranslation} from '../../../../i18n'
 
 const TooltipContentBox = styled(Box)`
   max-width: 300px;
@@ -53,7 +53,7 @@ export function NewDocumentListOption(props: NewDocumentListOptionProps) {
         <TooltipContentBox padding={2}>
           <InsufficientPermissionsMessage
             currentUser={currentUser}
-            operationLabel={t('insufficient-permissions-message.operation-label.create-document')}
+            action={t('insufficient-permissions-message.action.create-document')}
           />
         </TooltipContentBox>
       }

--- a/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentListOption.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentListOption.tsx
@@ -53,7 +53,7 @@ export function NewDocumentListOption(props: NewDocumentListOptionProps) {
         <TooltipContentBox padding={2}>
           <InsufficientPermissionsMessage
             currentUser={currentUser}
-            action={t('insufficient-permissions-message.action.create-document')}
+            i18nKey="insufficient-permissions-message.action.create-document"
           />
         </TooltipContentBox>
       }

--- a/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentListOption.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentListOption.tsx
@@ -53,7 +53,7 @@ export function NewDocumentListOption(props: NewDocumentListOptionProps) {
         <TooltipContentBox padding={2}>
           <InsufficientPermissionsMessage
             currentUser={currentUser}
-            operationLabel={t('new-document.error.unable-to-create-document')}
+            operationLabel={t('insufficient-permissions-message.operation-label.create-document')}
           />
         </TooltipContentBox>
       }

--- a/packages/sanity/src/desk/components/paneHeaderActions/InsufficientPermissionsMessageTooltip.tsx
+++ b/packages/sanity/src/desk/components/paneHeaderActions/InsufficientPermissionsMessageTooltip.tsx
@@ -5,14 +5,18 @@ import {useCurrentUser, InsufficientPermissionsMessage, useTranslation} from 'sa
 
 interface InsufficientPermissionsMessageTooltipProps {
   reveal: boolean
-  action: string
+  /**
+   * delegates to `InsufficientPermissionsMessage`'s i18n key
+   * @see InsufficientPermissionsMessage
+   */
+  i18nKey: string
   loading: boolean
   children: React.ReactNode
 }
 
 export function InsufficientPermissionsMessageTooltip({
   reveal,
-  action,
+  i18nKey,
   loading,
   children,
 }: InsufficientPermissionsMessageTooltipProps) {
@@ -31,7 +35,7 @@ export function InsufficientPermissionsMessageTooltip({
             <Text>{t('insufficient-permissions-message-tooltip.loading-text')}</Text>
           </Box>
         ) : (
-          <InsufficientPermissionsMessage action={action} currentUser={currentUser} />
+          <InsufficientPermissionsMessage i18nKey={i18nKey} currentUser={currentUser} />
         )
       }
       portal

--- a/packages/sanity/src/desk/components/paneHeaderActions/InsufficientPermissionsMessageTooltip.tsx
+++ b/packages/sanity/src/desk/components/paneHeaderActions/InsufficientPermissionsMessageTooltip.tsx
@@ -6,17 +6,17 @@ import {useCurrentUser, InsufficientPermissionsMessage, useTranslation} from 'sa
 interface InsufficientPermissionsMessageTooltipProps {
   reveal: boolean
   /**
-   * delegates to `InsufficientPermissionsMessage`'s i18n key
+   * delegates to `InsufficientPermissionsMessage`'s `context` prop
    * @see InsufficientPermissionsMessage
    */
-  i18nKey: string
+  context: React.ComponentProps<typeof InsufficientPermissionsMessage>['context']
   loading: boolean
   children: React.ReactNode
 }
 
 export function InsufficientPermissionsMessageTooltip({
   reveal,
-  i18nKey,
+  context,
   loading,
   children,
 }: InsufficientPermissionsMessageTooltipProps) {
@@ -35,7 +35,7 @@ export function InsufficientPermissionsMessageTooltip({
             <Text>{t('insufficient-permissions-message-tooltip.loading-text')}</Text>
           </Box>
         ) : (
-          <InsufficientPermissionsMessage i18nKey={i18nKey} currentUser={currentUser} />
+          <InsufficientPermissionsMessage context={context} currentUser={currentUser} />
         )
       }
       portal

--- a/packages/sanity/src/desk/components/paneHeaderActions/InsufficientPermissionsMessageTooltip.tsx
+++ b/packages/sanity/src/desk/components/paneHeaderActions/InsufficientPermissionsMessageTooltip.tsx
@@ -5,12 +5,14 @@ import {useCurrentUser, InsufficientPermissionsMessage, useTranslation} from 'sa
 
 interface InsufficientPermissionsMessageTooltipProps {
   reveal: boolean
+  action: string
   loading: boolean
   children: React.ReactNode
 }
 
 export function InsufficientPermissionsMessageTooltip({
   reveal,
+  action,
   loading,
   children,
 }: InsufficientPermissionsMessageTooltipProps) {
@@ -29,7 +31,7 @@ export function InsufficientPermissionsMessageTooltip({
             <Text>{t('insufficient-permissions-message-tooltip.loading-text')}</Text>
           </Box>
         ) : (
-          <InsufficientPermissionsMessage currentUser={currentUser} />
+          <InsufficientPermissionsMessage action={action} currentUser={currentUser} />
         )
       }
       portal

--- a/packages/sanity/src/desk/components/paneHeaderActions/InsufficientPermissionsMessageTooltip.tsx
+++ b/packages/sanity/src/desk/components/paneHeaderActions/InsufficientPermissionsMessageTooltip.tsx
@@ -1,6 +1,7 @@
 import {Tooltip, Text, Box} from '@sanity/ui'
 import React from 'react'
-import {useCurrentUser, InsufficientPermissionsMessage} from 'sanity'
+import {deskLocaleNamespace} from '../../i18n'
+import {useCurrentUser, InsufficientPermissionsMessage, useTranslation} from 'sanity'
 
 interface InsufficientPermissionsMessageTooltipProps {
   reveal: boolean
@@ -14,6 +15,7 @@ export function InsufficientPermissionsMessageTooltip({
   children,
 }: InsufficientPermissionsMessageTooltipProps) {
   const currentUser = useCurrentUser()
+  const {t} = useTranslation(deskLocaleNamespace)
 
   if (!reveal) {
     return <>{children}</>
@@ -24,7 +26,7 @@ export function InsufficientPermissionsMessageTooltip({
       content={
         loading ? (
           <Box padding={2}>
-            <Text>Loading…</Text>
+            <Text>{t('insufficient-permissions-message-tooltip.loading-text')}</Text>
           </Box>
         ) : (
           <InsufficientPermissionsMessage currentUser={currentUser} />

--- a/packages/sanity/src/desk/components/paneHeaderActions/PaneHeaderCreateButton.tsx
+++ b/packages/sanity/src/desk/components/paneHeaderActions/PaneHeaderCreateButton.tsx
@@ -78,7 +78,7 @@ export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonPr
   if (nothingGranted) {
     return (
       <InsufficientPermissionsMessageTooltip
-        action={t('insufficient-permissions-message.action.create-document-type')}
+        i18nKey="insufficient-permissions-message.action.create-document-type"
         reveal
         loading={isTemplatePermissionsLoading}
       >
@@ -104,7 +104,7 @@ export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonPr
       <InsufficientPermissionsMessageTooltip
         reveal={disabled}
         loading={isTemplatePermissionsLoading}
-        action={t('insufficient-permissions-message.action.create-document-type')}
+        i18nKey="insufficient-permissions-message.action.create-document-type"
       >
         <IntentButton
           aria-label={firstItem.title}
@@ -152,7 +152,7 @@ export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonPr
 
             return (
               <InsufficientPermissionsMessageTooltip
-                action={t('insufficient-permissions-message.action.create-document-type')}
+                i18nKey="insufficient-permissions-message.action.create-document-type"
                 key={item.id}
                 reveal={disabled}
                 loading={isTemplatePermissionsLoading}

--- a/packages/sanity/src/desk/components/paneHeaderActions/PaneHeaderCreateButton.tsx
+++ b/packages/sanity/src/desk/components/paneHeaderActions/PaneHeaderCreateButton.tsx
@@ -78,7 +78,7 @@ export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonPr
   if (nothingGranted) {
     return (
       <InsufficientPermissionsMessageTooltip
-        i18nKey="insufficient-permissions-message.action.create-document-type"
+        context="create-document-type"
         reveal
         loading={isTemplatePermissionsLoading}
       >
@@ -104,7 +104,7 @@ export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonPr
       <InsufficientPermissionsMessageTooltip
         reveal={disabled}
         loading={isTemplatePermissionsLoading}
-        i18nKey="insufficient-permissions-message.action.create-document-type"
+        context="create-document-type"
       >
         <IntentButton
           aria-label={firstItem.title}
@@ -152,7 +152,7 @@ export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonPr
 
             return (
               <InsufficientPermissionsMessageTooltip
-                i18nKey="insufficient-permissions-message.action.create-document-type"
+                context="create-document-type"
                 key={item.id}
                 reveal={disabled}
                 loading={isTemplatePermissionsLoading}

--- a/packages/sanity/src/desk/components/paneHeaderActions/PaneHeaderCreateButton.tsx
+++ b/packages/sanity/src/desk/components/paneHeaderActions/PaneHeaderCreateButton.tsx
@@ -77,7 +77,11 @@ export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonPr
 
   if (nothingGranted) {
     return (
-      <InsufficientPermissionsMessageTooltip reveal loading={isTemplatePermissionsLoading}>
+      <InsufficientPermissionsMessageTooltip
+        action={t('insufficient-permissions-message.action.create-document-type')}
+        reveal
+        loading={isTemplatePermissionsLoading}
+      >
         <Button
           aria-label={t('pane-header.disabled-created-button.aria-label')}
           icon={ComposeIcon}
@@ -100,6 +104,7 @@ export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonPr
       <InsufficientPermissionsMessageTooltip
         reveal={disabled}
         loading={isTemplatePermissionsLoading}
+        action={t('insufficient-permissions-message.action.create-document-type')}
       >
         <IntentButton
           aria-label={firstItem.title}
@@ -147,6 +152,7 @@ export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonPr
 
             return (
               <InsufficientPermissionsMessageTooltip
+                action={t('insufficient-permissions-message.action.create-document-type')}
                 key={item.id}
                 reveal={disabled}
                 loading={isTemplatePermissionsLoading}

--- a/packages/sanity/src/desk/documentActions/DeleteAction.tsx
+++ b/packages/sanity/src/desk/documentActions/DeleteAction.tsx
@@ -61,7 +61,7 @@ export const DeleteAction: DocumentActionComponent = ({id, type, draft, onComple
       label: t('action.delete.label'),
       title: (
         <InsufficientPermissionsMessage
-          operationLabel={t('insufficient-permissions-message.operation-label.delete-document')}
+          action={t('insufficient-permissions-message.action.delete-document')}
           currentUser={currentUser}
         />
       ),

--- a/packages/sanity/src/desk/documentActions/DeleteAction.tsx
+++ b/packages/sanity/src/desk/documentActions/DeleteAction.tsx
@@ -61,7 +61,7 @@ export const DeleteAction: DocumentActionComponent = ({id, type, draft, onComple
       label: t('action.delete.label'),
       title: (
         <InsufficientPermissionsMessage
-          action={t('insufficient-permissions-message.action.delete-document')}
+          i18nKey="insufficient-permissions-message.action.delete-document"
           currentUser={currentUser}
         />
       ),

--- a/packages/sanity/src/desk/documentActions/DeleteAction.tsx
+++ b/packages/sanity/src/desk/documentActions/DeleteAction.tsx
@@ -59,12 +59,7 @@ export const DeleteAction: DocumentActionComponent = ({id, type, draft, onComple
       icon: TrashIcon,
       disabled: true,
       label: t('action.delete.label'),
-      title: (
-        <InsufficientPermissionsMessage
-          i18nKey="insufficient-permissions-message.action.delete-document"
-          currentUser={currentUser}
-        />
-      ),
+      title: <InsufficientPermissionsMessage context="delete-document" currentUser={currentUser} />,
     }
   }
 

--- a/packages/sanity/src/desk/documentActions/DeleteAction.tsx
+++ b/packages/sanity/src/desk/documentActions/DeleteAction.tsx
@@ -61,7 +61,7 @@ export const DeleteAction: DocumentActionComponent = ({id, type, draft, onComple
       label: t('action.delete.label'),
       title: (
         <InsufficientPermissionsMessage
-          operationLabel="delete this document"
+          operationLabel={t('insufficient-permissions-message.operation-label.delete-document')}
           currentUser={currentUser}
         />
       ),
@@ -80,6 +80,7 @@ export const DeleteAction: DocumentActionComponent = ({id, type, draft, onComple
       type: 'custom',
       component: (
         <ConfirmDeleteDialog
+          // eslint-disable-next-line no-attribute-string-literals/no-attribute-string-literals
           action="delete"
           id={draft?._id || id}
           type={type}

--- a/packages/sanity/src/desk/documentActions/DiscardChangesAction.tsx
+++ b/packages/sanity/src/desk/documentActions/DiscardChangesAction.tsx
@@ -71,7 +71,7 @@ export const DiscardChangesAction: DocumentActionComponent = ({
       label: t('action.discard-changes.label'),
       title: (
         <InsufficientPermissionsMessage
-          operationLabel="discard changes in this document"
+          operationLabel={t('insufficient-permissions-message.operation-label.discard-changes')}
           currentUser={currentUser}
         />
       ),

--- a/packages/sanity/src/desk/documentActions/DiscardChangesAction.tsx
+++ b/packages/sanity/src/desk/documentActions/DiscardChangesAction.tsx
@@ -71,7 +71,7 @@ export const DiscardChangesAction: DocumentActionComponent = ({
       label: t('action.discard-changes.label'),
       title: (
         <InsufficientPermissionsMessage
-          operationLabel={t('insufficient-permissions-message.operation-label.discard-changes')}
+          action={t('insufficient-permissions-message.action.discard-changes')}
           currentUser={currentUser}
         />
       ),

--- a/packages/sanity/src/desk/documentActions/DiscardChangesAction.tsx
+++ b/packages/sanity/src/desk/documentActions/DiscardChangesAction.tsx
@@ -71,7 +71,7 @@ export const DiscardChangesAction: DocumentActionComponent = ({
       label: t('action.discard-changes.label'),
       title: (
         <InsufficientPermissionsMessage
-          action={t('insufficient-permissions-message.action.discard-changes')}
+          i18nKey="insufficient-permissions-message.action.discard-changes"
           currentUser={currentUser}
         />
       ),

--- a/packages/sanity/src/desk/documentActions/DiscardChangesAction.tsx
+++ b/packages/sanity/src/desk/documentActions/DiscardChangesAction.tsx
@@ -69,12 +69,7 @@ export const DiscardChangesAction: DocumentActionComponent = ({
       icon: ResetIcon,
       disabled: true,
       label: t('action.discard-changes.label'),
-      title: (
-        <InsufficientPermissionsMessage
-          i18nKey="insufficient-permissions-message.action.discard-changes"
-          currentUser={currentUser}
-        />
-      ),
+      title: <InsufficientPermissionsMessage context="discard-changes" currentUser={currentUser} />,
     }
   }
 

--- a/packages/sanity/src/desk/documentActions/DuplicateAction.tsx
+++ b/packages/sanity/src/desk/documentActions/DuplicateAction.tsx
@@ -48,7 +48,7 @@ export const DuplicateAction: DocumentActionComponent = ({id, type, onComplete})
       label: t('action.duplicate.label'),
       title: (
         <InsufficientPermissionsMessage
-          operationLabel={t('insufficient-permissions-message.operation-label.duplicate-document')}
+          action={t('insufficient-permissions-message.action.duplicate-document')}
           currentUser={currentUser}
         />
       ),

--- a/packages/sanity/src/desk/documentActions/DuplicateAction.tsx
+++ b/packages/sanity/src/desk/documentActions/DuplicateAction.tsx
@@ -48,7 +48,7 @@ export const DuplicateAction: DocumentActionComponent = ({id, type, onComplete})
       label: t('action.duplicate.label'),
       title: (
         <InsufficientPermissionsMessage
-          action={t('insufficient-permissions-message.action.duplicate-document')}
+          i18nKey="insufficient-permissions-message.action.duplicate-document"
           currentUser={currentUser}
         />
       ),

--- a/packages/sanity/src/desk/documentActions/DuplicateAction.tsx
+++ b/packages/sanity/src/desk/documentActions/DuplicateAction.tsx
@@ -47,10 +47,7 @@ export const DuplicateAction: DocumentActionComponent = ({id, type, onComplete})
       disabled: true,
       label: t('action.duplicate.label'),
       title: (
-        <InsufficientPermissionsMessage
-          i18nKey="insufficient-permissions-message.action.duplicate-document"
-          currentUser={currentUser}
-        />
+        <InsufficientPermissionsMessage context="duplicate-document" currentUser={currentUser} />
       ),
     }
   }

--- a/packages/sanity/src/desk/documentActions/DuplicateAction.tsx
+++ b/packages/sanity/src/desk/documentActions/DuplicateAction.tsx
@@ -48,7 +48,7 @@ export const DuplicateAction: DocumentActionComponent = ({id, type, onComplete})
       label: t('action.duplicate.label'),
       title: (
         <InsufficientPermissionsMessage
-          operationLabel="duplicate this document"
+          operationLabel={t('insufficient-permissions-message.operation-label.duplicate-document')}
           currentUser={currentUser}
         />
       ),

--- a/packages/sanity/src/desk/documentActions/PublishAction.tsx
+++ b/packages/sanity/src/desk/documentActions/PublishAction.tsx
@@ -155,7 +155,7 @@ export const PublishAction: DocumentActionComponent = (props) => {
       label: 'Publish',
       title: (
         <InsufficientPermissionsMessage
-          operationLabel={t('insufficient-permissions-message.operation-label.publish-document')}
+          action={t('insufficient-permissions-message.action.publish-document')}
           currentUser={currentUser}
         />
       ),

--- a/packages/sanity/src/desk/documentActions/PublishAction.tsx
+++ b/packages/sanity/src/desk/documentActions/PublishAction.tsx
@@ -155,7 +155,7 @@ export const PublishAction: DocumentActionComponent = (props) => {
       label: 'Publish',
       title: (
         <InsufficientPermissionsMessage
-          operationLabel="publish this document"
+          operationLabel={t('insufficient-permissions-message.operation-label.publish-document')}
           currentUser={currentUser}
         />
       ),

--- a/packages/sanity/src/desk/documentActions/PublishAction.tsx
+++ b/packages/sanity/src/desk/documentActions/PublishAction.tsx
@@ -154,10 +154,7 @@ export const PublishAction: DocumentActionComponent = (props) => {
       tone: 'positive',
       label: 'Publish',
       title: (
-        <InsufficientPermissionsMessage
-          i18nKey="insufficient-permissions-message.action.publish-document"
-          currentUser={currentUser}
-        />
+        <InsufficientPermissionsMessage context="publish-document" currentUser={currentUser} />
       ),
       disabled: true,
     }

--- a/packages/sanity/src/desk/documentActions/PublishAction.tsx
+++ b/packages/sanity/src/desk/documentActions/PublishAction.tsx
@@ -155,7 +155,7 @@ export const PublishAction: DocumentActionComponent = (props) => {
       label: 'Publish',
       title: (
         <InsufficientPermissionsMessage
-          action={t('insufficient-permissions-message.action.publish-document')}
+          i18nKey="insufficient-permissions-message.action.publish-document"
           currentUser={currentUser}
         />
       ),

--- a/packages/sanity/src/desk/documentActions/UnpublishAction.tsx
+++ b/packages/sanity/src/desk/documentActions/UnpublishAction.tsx
@@ -79,7 +79,7 @@ export const UnpublishAction: DocumentActionComponent = ({
       label: 'Unpublish',
       title: (
         <InsufficientPermissionsMessage
-          operationLabel={t('insufficient-permissions-message.operation-label.unpublish-document')}
+          action={t('insufficient-permissions-message.action.unpublish-document')}
           currentUser={currentUser}
         />
       ),

--- a/packages/sanity/src/desk/documentActions/UnpublishAction.tsx
+++ b/packages/sanity/src/desk/documentActions/UnpublishAction.tsx
@@ -79,7 +79,7 @@ export const UnpublishAction: DocumentActionComponent = ({
       label: 'Unpublish',
       title: (
         <InsufficientPermissionsMessage
-          action={t('insufficient-permissions-message.action.unpublish-document')}
+          i18nKey="insufficient-permissions-message.action.unpublish-document"
           currentUser={currentUser}
         />
       ),

--- a/packages/sanity/src/desk/documentActions/UnpublishAction.tsx
+++ b/packages/sanity/src/desk/documentActions/UnpublishAction.tsx
@@ -78,10 +78,7 @@ export const UnpublishAction: DocumentActionComponent = ({
       icon: UnpublishIcon,
       label: 'Unpublish',
       title: (
-        <InsufficientPermissionsMessage
-          i18nKey="insufficient-permissions-message.action.unpublish-document"
-          currentUser={currentUser}
-        />
+        <InsufficientPermissionsMessage context="unpublish-document" currentUser={currentUser} />
       ),
       disabled: true,
     }

--- a/packages/sanity/src/desk/documentActions/UnpublishAction.tsx
+++ b/packages/sanity/src/desk/documentActions/UnpublishAction.tsx
@@ -56,6 +56,7 @@ export const UnpublishAction: DocumentActionComponent = ({
           <ConfirmDeleteDialog
             id={draft?._id || id}
             type={type}
+            // eslint-disable-next-line no-attribute-string-literals/no-attribute-string-literals
             action="unpublish"
             onCancel={handleCancel}
             onConfirm={handleConfirm}
@@ -78,7 +79,7 @@ export const UnpublishAction: DocumentActionComponent = ({
       label: 'Unpublish',
       title: (
         <InsufficientPermissionsMessage
-          operationLabel="unpublish this document"
+          operationLabel={t('insufficient-permissions-message.operation-label.unpublish-document')}
           currentUser={currentUser}
         />
       ),

--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -503,21 +503,23 @@ const deskLocaleStrings = {
   /** the loading messaging for when the tooltip is still loading permission info */
   'insufficient-permissions-message-tooltip.loading-text': 'Loading…',
 
-  /** The operation label when unable to delete a particular document */
-  'insufficient-permissions-message.operation-label.delete-document': 'delete this document',
+  /** The action when unable to delete a particular document */
+  'insufficient-permissions-message.action.delete-document': 'delete this document',
 
-  /** The operation label when unable to discard changes in a particular document */
-  'insufficient-permissions-message.operation-label.discard-changes':
-    'discard changes in this document',
+  /** The action when unable to discard changes in a particular document */
+  'insufficient-permissions-message.action.discard-changes': 'discard changes in this document',
 
-  /** The operation label when unable to duplicate a particular document */
-  'insufficient-permissions-message.operation-label.duplicate-document': 'duplicate this document',
+  /** The action when unable create a particular kind of document in the document list pane header */
+  'insufficient-permissions-message.action.create-document-type': 'create this kind of document',
 
-  /** The operation label when unable to publish a particular document */
-  'insufficient-permissions-message.operation-label.publish-document': 'publish this document',
+  /** The action when unable to duplicate a particular document */
+  'insufficient-permissions-message.action.duplicate-document': 'duplicate this document',
 
-  /** The operation label when unable to unpublish a particular document */
-  'insufficient-permissions-message.operation-label.unpublish-document': 'unpublish this document',
+  /** The action when unable to publish a particular document */
+  'insufficient-permissions-message.action.publish-document': 'publish this document',
+
+  /** The action when unable to unpublish a particular document */
+  'insufficient-permissions-message.action.unpublish-document': 'unpublish this document',
 }
 
 /**

--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -498,6 +498,26 @@ const deskLocaleStrings = {
 
   /** Appears in a document list pane header if there are more than one option for create. This is the label for that menu */
   'pane-header.create-menu.label': 'Create',
+
+  /** --- Insufficient permissions message --- */
+  /** the loading messaging for when the tooltip is still loading permission info */
+  'insufficient-permissions-message-tooltip.loading-text': 'Loading…',
+
+  /** The operation label when unable to delete a particular document */
+  'insufficient-permissions-message.operation-label.delete-document': 'delete this document',
+
+  /** The operation label when unable to discard changes in a particular document */
+  'insufficient-permissions-message.operation-label.discard-changes':
+    'discard changes in this document',
+
+  /** The operation label when unable to duplicate a particular document */
+  'insufficient-permissions-message.operation-label.duplicate-document': 'duplicate this document',
+
+  /** The operation label when unable to publish a particular document */
+  'insufficient-permissions-message.operation-label.publish-document': 'publish this document',
+
+  /** The operation label when unable to unpublish a particular document */
+  'insufficient-permissions-message.operation-label.unpublish-document': 'unpublish this document',
 }
 
 /**

--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -502,24 +502,6 @@ const deskLocaleStrings = {
   /** --- Insufficient permissions message --- */
   /** the loading messaging for when the tooltip is still loading permission info */
   'insufficient-permissions-message-tooltip.loading-text': 'Loading…',
-
-  /** The action when unable to delete a particular document */
-  'insufficient-permissions-message.action.delete-document': 'delete this document',
-
-  /** The action when unable to discard changes in a particular document */
-  'insufficient-permissions-message.action.discard-changes': 'discard changes in this document',
-
-  /** The action when unable create a particular kind of document in the document list pane header */
-  'insufficient-permissions-message.action.create-document-type': 'create this kind of document',
-
-  /** The action when unable to duplicate a particular document */
-  'insufficient-permissions-message.action.duplicate-document': 'duplicate this document',
-
-  /** The action when unable to publish a particular document */
-  'insufficient-permissions-message.action.publish-document': 'publish this document',
-
-  /** The action when unable to unpublish a particular document */
-  'insufficient-permissions-message.action.unpublish-document': 'unpublish this document',
 }
 
 /**


### PR DESCRIPTION
~~EDIT: Alright second try here. I opted to keep the interpolation value in the roles string but simplify the english phrase so that there is a clearer and stronger "action" clause. Additionally. I removed the roles from the phrase and move it into another that always displays it as a unit list. I think the result should translate better and has some nice consistencies. See new screenshot:~~

Edit edit: talked to @jtpetty who clarified and went with another approach that uses known context keys instead of the interpolation.

<img width="321" alt="CleanShot 2023-11-14 at 16 13 34@2x" src="https://github.com/sanity-io/sanity/assets/10551026/eb1ed221-a9c9-4d48-9621-b80e5be5146f">
