### PR TITLE
chore(i18n): temporarily ignore i18n in Comments files

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -317,6 +317,15 @@ const config = {
         'no-attribute-string-literals/no-attribute-string-literals': 'off',
       },
     },
+
+    // Ignore i18n in Comments files for now. This will need to be removed before Comments feature is GA
+    {
+      files: ['**/*/Comment*.{js,ts,tsx}'],
+      rules: {
+        'i18next/no-literal-string': 'off',
+        'no-attribute-string-literals/no-attribute-string-literals': 'off',
+      },
+    },
   ],
 }
 


### PR DESCRIPTION
### Description

For now, we want to ignore i18n requirements in files related to the newly added Comments feature. The feature squad working on Comments will do the string extraction before the feature goes GA.