### PR TITLE
feat(core): implement fade-in and improved focus behavior for field actions

### DIFF
--- a/packages/sanity/src/desk/comments/src/components/pte/comment-input/CommentInput.tsx
+++ b/packages/sanity/src/desk/comments/src/components/pte/comment-input/CommentInput.tsx
@@ -196,7 +196,7 @@ export const CommentInput = forwardRef<CommentInputHandle, CommentInputProps>(
               <FocusLock
                 as={Stack}
                 disabled={!focusLock || showDiscardDialog}
-                // returnFocus // This causes issues with focusing the dialog
+                returnFocus={focusLock}
               >
                 <CommentInputInner
                   currentUser={currentUser}


### PR DESCRIPTION
### Description

This pull request enables keyboard navigation for previously non-accessible field actions and adds a fade-in effect of field actions when hovering over the field.

### What to review

- Verify that field actions can now be navigated using keyboard input.
- Check the implementation of the fade-in effect to ensure it functions as expected when hovering over field actions.

### Notes for release

n/a