### PR TITLE
fix(router): memoize `navigate` callback

### DIFF
--- a/packages/sanity/src/router/RouteScope.tsx
+++ b/packages/sanity/src/router/RouteScope.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 
-import React, {useCallback, useMemo} from 'react'
+import React, {useCallback, useMemo, useRef} from 'react'
 import {isEmpty} from './utils/isEmpty'
 import {RouterContext} from './RouterContext'
 import {NavigateOptions, RouterContextValue} from './types'
@@ -61,23 +61,27 @@ export function RouteScope(props: RouteScopeProps): React.ReactElement {
   const parent = useRouter()
   const {resolvePathFromState: parent_resolvePathFromState, navigate: parent_navigate} = parent
 
+  const parentStateRef = useRef(parent.state)
+
+  parentStateRef.current = parent.state
+
   const resolvePathFromState = useCallback(
     (nextState: Record<string, any>): string => {
       const nextStateScoped: Record<string, any> = isEmpty(nextState)
         ? {}
-        : addScope(parent.state, scope, nextState)
+        : addScope(parentStateRef.current, scope, nextState)
 
       return parent_resolvePathFromState(nextStateScoped)
     },
-    [parent_resolvePathFromState, parent.state, scope],
+    [parent_resolvePathFromState, scope],
   )
 
   const navigate = useCallback(
     (nextState: Record<string, any>, options?: NavigateOptions): void => {
-      const nextScopedState = addScope(parent.state, scope, nextState)
+      const nextScopedState = addScope(parentStateRef.current, scope, nextState)
       parent_navigate(nextScopedState, options)
     },
-    [parent_navigate, parent.state, scope],
+    [parent_navigate, scope],
   )
 
   const scopedRouter: RouterContextValue = useMemo(


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This change memoizes the `navigate` callback from the state router when using scoped routes.

Without this fix, depending on `navigate` in hooks could lead to infinite loops (e.g. in Presentation):

```ts
const {navigate} = useRouter()

const [viewParam, setViewParam] = useState(null)

useEffect(() => {
  // navigate because some param was changed
  navigate({
    // ...
  })
}, [navigate, viewParam])
```

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

The changes to the code.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

- fix(router): memoize `navigate` callback