### PR TITLE
feat(desk): add `onFocusPath` callback property

### DIFF
--- a/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
@@ -294,6 +294,10 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
 
   const handleBlur = useCallback(
     (blurredPath: Path) => {
+      if (disableBlurRef.current) {
+        return
+      }
+
       setFocusPath(EMPTY_ARRAY)
 
       if (focusPathRef.current !== EMPTY_ARRAY) {
@@ -658,11 +662,16 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
     }
   }, [connectionState, pushToast])
 
+  const disableBlurRef = useRef(false)
+
   // Reset `focusPath` when `documentId` or `params.path` changes
   useEffect(() => {
     if (ready && params.path) {
       const {path, ...restParams} = params
       const pathFromUrl = resolveKeyedPath(formStateRef.current?.value, pathFromString(path))
+
+      disableBlurRef.current = true
+
       // Reset focus path when url params path changes
       setFocusPath(pathFromUrl)
       setOpenPath(pathFromUrl)
@@ -671,6 +680,10 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
         focusPathRef.current = pathFromUrl
         onFocusPath?.(pathFromUrl)
       }
+
+      setTimeout(() => {
+        disableBlurRef.current = false
+      }, 0)
 
       // remove the `path`-param from url after we have consumed it as the initial focus path
       paneRouter.setParams(restParams)

--- a/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
@@ -681,13 +681,17 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
         onFocusPath?.(pathFromUrl)
       }
 
-      setTimeout(() => {
+      const timeout = setTimeout(() => {
         disableBlurRef.current = false
       }, 0)
 
       // remove the `path`-param from url after we have consumed it as the initial focus path
       paneRouter.setParams(restParams)
+
+      return () => clearTimeout(timeout)
     }
+
+    return undefined
   }, [params, documentId, onFocusPath, setOpenPath, ready, paneRouter])
 
   const [rootFieldActionNodes, setRootFieldActionNodes] = useState<DocumentFieldActionNode[]>([])

--- a/packages/sanity/src/desk/panes/document/types.ts
+++ b/packages/sanity/src/desk/panes/document/types.ts
@@ -1,3 +1,4 @@
+import {Path} from '@sanity/types'
 import {BaseDeskToolPaneProps} from '../types'
 
 /** @internal */
@@ -6,4 +7,5 @@ export type TimelineMode = 'since' | 'rev' | 'closed'
 /** @internal */
 export type DocumentPaneProviderProps = {
   children?: React.ReactNode
+  onFocusPath?: (path: Path) => void
 } & BaseDeskToolPaneProps<'document'>


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This introduces a `onFocusPath` callback property on `DocumentPane`. This is needed by the new Presentation tool in order to subscribe to currently focused path within a document pane.

It also introduces an optimization to prevent unecessary `blur` events from triggering when the `path` is changed from the outside of `DocumentPane`.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

- Read the code changes.
- Consider what sorts of unit tests we might add for this.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

n/a