### PR TITLE
fix(schema/types): fix block schema internal structure

### DIFF
--- a/packages/@sanity/block-tools/test/tests/util/__snapshots__/blockContentTypeFeatures.test.ts.snap
+++ b/packages/@sanity/block-tools/test/tests/util/__snapshots__/blockContentTypeFeatures.test.ts.snap
@@ -391,7 +391,7 @@ Object {
               },
             },
             Object {
-              "name": "list",
+              "name": "listItem",
               "type": Object {
                 "jsonType": "string",
                 "name": "string",
@@ -504,6 +504,23 @@ Object {
                   "jsonType": "array",
                   "name": "array",
                   "of": Array [],
+                  "type": null,
+                },
+              },
+            },
+            Object {
+              "name": "level",
+              "type": Object {
+                "jsonType": "number",
+                "name": "number",
+                "preview": Object {
+                  "prepare": [Function],
+                },
+                "title": "Indentation",
+                "type": Object {
+                  "jsonType": "number",
+                  "name": "number",
+                  "title": "Number",
                   "type": null,
                 },
               },
@@ -1863,7 +1880,7 @@ Object {
               },
             },
             Object {
-              "name": "list",
+              "name": "listItem",
               "type": Object {
                 "jsonType": "string",
                 "name": "string",
@@ -2194,6 +2211,23 @@ Object {
                   "jsonType": "array",
                   "name": "array",
                   "of": Array [],
+                  "type": null,
+                },
+              },
+            },
+            Object {
+              "name": "level",
+              "type": Object {
+                "jsonType": "number",
+                "name": "number",
+                "preview": Object {
+                  "prepare": [Function],
+                },
+                "title": "Indentation",
+                "type": Object {
+                  "jsonType": "number",
+                  "name": "number",
+                  "title": "Number",
                   "type": null,
                 },
               },
@@ -2647,7 +2681,7 @@ Object {
                 },
               },
               Object {
-                "name": "list",
+                "name": "listItem",
                 "type": Object {
                   "jsonType": "string",
                   "name": "string",
@@ -2978,6 +3012,23 @@ Object {
                     "jsonType": "array",
                     "name": "array",
                     "of": Array [],
+                    "type": null,
+                  },
+                },
+              },
+              Object {
+                "name": "level",
+                "type": Object {
+                  "jsonType": "number",
+                  "name": "number",
+                  "preview": Object {
+                    "prepare": [Function],
+                  },
+                  "title": "Indentation",
+                  "type": Object {
+                    "jsonType": "number",
+                    "name": "number",
+                    "title": "Number",
                     "type": null,
                   },
                 },

--- a/packages/@sanity/portable-text-editor/src/utils/getPortableTextMemberSchemaTypes.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/getPortableTextMemberSchemaTypes.ts
@@ -73,9 +73,9 @@ function resolveEnabledDecorators(spanType: ObjectSchemaType) {
 }
 
 function resolveEnabledListItems(blockType: ObjectSchemaType) {
-  const listField = blockType.fields?.find((btField) => btField.name === 'list')
+  const listField = blockType.fields?.find((btField) => btField.name === 'listItem')
   if (!listField) {
-    throw new Error("A field with name 'list' is not defined in the block type (required).")
+    throw new Error("A field with name 'listItem' is not defined in the block type (required).")
   }
   const listItems =
     listField.type.options?.list &&

--- a/packages/@sanity/schema/src/legacy/types/blocks/block.ts
+++ b/packages/@sanity/schema/src/legacy/types/blocks/block.ts
@@ -60,14 +60,9 @@ export const BlockType = {
 
     // NOTE: if you update this (EVEN THE ORDER OF FIELDS) you _NEED TO_ also
     // update `BlockSchemaType`, `isBlockSchemaType` and similar in `@sanity/types`
-    const fields = [
-      childrenField,
-      levelField,
-      listItemField,
-      markDefsField,
-      styleField,
-      levelField,
-    ].concat(subTypeDef.fields || [])
+    const fields = [childrenField, styleField, listItemField, markDefsField, levelField].concat(
+      subTypeDef.fields || [],
+    )
 
     const parsed = Object.assign(pick(BLOCK_CORE, INHERITED_FIELDS), rest, {
       type: BLOCK_CORE,

--- a/packages/@sanity/schema/src/legacy/types/blocks/block.ts
+++ b/packages/@sanity/schema/src/legacy/types/blocks/block.ts
@@ -43,7 +43,7 @@ export const BlockType = {
 
     const childrenField = createChildrenField(marks, of)
     const styleField = createStyleField(styles)
-    const listField = createListField(lists)
+    const listItemField = createListItemField(lists)
 
     const markDefsField = {
       name: 'markDefs',
@@ -52,11 +52,22 @@ export const BlockType = {
       of: marks?.annotations || DEFAULT_ANNOTATIONS,
     }
 
+    const levelField = {
+      name: 'level',
+      title: 'Indentation',
+      type: 'number',
+    }
+
     // NOTE: if you update this (EVEN THE ORDER OF FIELDS) you _NEED TO_ also
     // update `BlockSchemaType`, `isBlockSchemaType` and similar in `@sanity/types`
-    const fields = [childrenField, styleField, listField, markDefsField].concat(
-      subTypeDef.fields || [],
-    )
+    const fields = [
+      childrenField,
+      levelField,
+      listItemField,
+      markDefsField,
+      styleField,
+      levelField,
+    ].concat(subTypeDef.fields || [])
 
     const parsed = Object.assign(pick(BLOCK_CORE, INHERITED_FIELDS), rest, {
       type: BLOCK_CORE,
@@ -113,9 +124,9 @@ function createStyleField(styles) {
   }
 }
 
-function createListField(lists) {
+function createListItemField(lists) {
   return {
-    name: 'list',
+    name: 'listItem',
     title: 'List type',
     type: 'string',
     options: {

--- a/packages/@sanity/types/src/schema/asserters.ts
+++ b/packages/@sanity/types/src/schema/asserters.ts
@@ -151,7 +151,7 @@ export function isBlockStyleObjectField(field: unknown): field is BlockStyleObje
 /** @internal */
 export function isBlockListObjectField(field: unknown): field is BlockListObjectField {
   if (!isRecord(field)) return false
-  if (field.name !== 'list') return false
+  if (field.name !== 'listItem') return false
   return isRecord(field.type) && field.type.jsonType === 'string'
 }
 

--- a/packages/@sanity/types/src/schema/asserters.ts
+++ b/packages/@sanity/types/src/schema/asserters.ts
@@ -132,8 +132,9 @@ export function isSpanSchemaType(type: unknown): type is SpanSchemaType {
 export function isBlockSchemaType(type: unknown): type is BlockSchemaType {
   if (!isRecord(type)) return false
   if (!Array.isArray(type.fields)) return false
-
-  const [maybeSpanChildren, maybeStyle, maybeList] = type.fields
+  const maybeSpanChildren = type.fields.find(isBlockChildrenObjectField)
+  const maybeStyle = type.fields.find(isBlockStyleObjectField)
+  const maybeList = type.fields.find(isBlockListObjectField)
   return (
     isBlockChildrenObjectField(maybeSpanChildren) &&
     isBlockStyleObjectField(maybeStyle) &&

--- a/packages/sanity/test/cli/graphql/__snapshots__/extract.test.ts.snap
+++ b/packages/sanity/test/cli/graphql/__snapshots__/extract.test.ts.snap
@@ -151,7 +151,12 @@ Object {
         },
         Object {
           "description": undefined,
-          "fieldName": "list",
+          "fieldName": "level",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "listItem",
           "type": "String",
         },
         Object {

--- a/packages/sanity/test/cli/graphql/__snapshots__/gen2.test.ts.snap
+++ b/packages/sanity/test/cli/graphql/__snapshots__/gen2.test.ts.snap
@@ -663,7 +663,12 @@ Object {
         },
         Object {
           "description": undefined,
-          "fieldName": "list",
+          "fieldName": "level",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "listItem",
           "type": "String",
         },
         Object {

--- a/packages/sanity/test/cli/graphql/__snapshots__/gen3.test.ts.snap
+++ b/packages/sanity/test/cli/graphql/__snapshots__/gen3.test.ts.snap
@@ -705,7 +705,12 @@ Object {
         },
         Object {
           "description": undefined,
-          "fieldName": "list",
+          "fieldName": "level",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "listItem",
           "type": "String",
         },
         Object {


### PR DESCRIPTION
### Description

This follows up https://github.com/sanity-io/sanity/pull/5079. 

This will update some test snapshots that I don't quite understand why didn't fail in the original PR but failed when rebasing on current `next`.

This also fixes an issue with an invalid list of fields array for the block type. Not sure what happened to this during merge either, as tests were passing in the original PR.

I have also strengthened the code in `block-tools` to not rely on array order to find schema fields for the block type but rather to find them exclusively.

I have removed https://github.com/sanity-io/sanity/pull/5079 from `next` and included the merge commit in this new PR.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
* Are the changes to the Graphql schema OK? It is now correct, but maybe there's some logic attached to this inconsistency in the current Graphql code?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
