### PR TITLE
fix(comments): truncate long field names in placeholder

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -44,6 +44,8 @@ const PLACEHOLDER_STYLE: React.CSSProperties = {
   position: 'absolute',
   userSelect: 'none',
   pointerEvents: 'none',
+  left: 0,
+  right: 0,
 }
 
 const EMPTY_DECORATORS: BaseRange[] = []

--- a/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditor.test.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditor.test.tsx
@@ -63,7 +63,7 @@ describe('initialization', () => {
           >
             <span
               contenteditable="false"
-              style="opacity: 0.5; position: absolute; user-select: none; pointer-events: none;"
+              style="opacity: 0.5; position: absolute; user-select: none; pointer-events: none; left: 0px; right: 0px;"
             >
               Jot something down here
             </span>

--- a/packages/sanity/src/desk/comments/src/components/pte/comment-input/Editable.tsx
+++ b/packages/sanity/src/desk/comments/src/components/pte/comment-input/Editable.tsx
@@ -25,6 +25,15 @@ const EditableWrapStack = styled(Stack)(() => {
   `
 })
 
+const PlaceholderWrapper = styled.span(() => {
+  return css`
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-wrap: nowrap;
+    display: block;
+  `
+})
+
 export const StyledPopover = styled(Popover)(({theme}) => {
   const {space, radius} = theme.sanity
 
@@ -88,7 +97,10 @@ export function Editable(props: EditableProps) {
     value,
   } = useCommentInput()
 
-  const renderPlaceholder = useCallback(() => <span>{placeholder}</span>, [placeholder])
+  const renderPlaceholder = useCallback(
+    () => <PlaceholderWrapper>{placeholder}</PlaceholderWrapper>,
+    [placeholder],
+  )
 
   useClickOutside(
     useCallback(() => {


### PR DESCRIPTION
### Description

Fixes instances where long field names will cause the comment input placeholder to be wrapped over multiple lines, causing a overflow.

<img width="969" alt="CleanShot 2023-11-08 at 14 51 24@2x" src="https://github.com/sanity-io/sanity/assets/10508/f463d8d9-d9ef-498c-b9a9-4212b61cbee5">

### What to review

- That long names is truncated and looks good in different scenarios
- That placeholders in normal PTE inputs outside of comments is properly position as before

### Notes for release

- Fixes instances where long field names in placeholders would cause overflow in comments input