### PR TITLE
chore(cli): remove '--reconfigure' command from help for sanity init command

### DIFF
--- a/packages/@sanity/cli/src/commands/init/initCommand.ts
+++ b/packages/@sanity/cli/src/commands/init/initCommand.ts
@@ -20,7 +20,6 @@ Options
   --create-project <name> Create a new project with the given name
   --project-plan <name> Optionally select a plan for a new project
   --coupon <name> Optionally select a coupon for a new project (cannot be used with --project-plan)
-  --reconfigure Reconfigure Sanity studio in current folder with new project/dataset
   --no-typescript Do not use TypeScript for template files
 
 Examples
@@ -64,6 +63,9 @@ export interface InitFlags {
   'dataset-default'?: boolean
 
   coupon?: string
+  /**
+   * @deprecated `--reconfigure` is deprecated - manual configuration is now required
+   */
   reconfigure?: boolean
 
   organization?: string


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Removes `--reconfigure` from sanity init help

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

Change makes sense

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
(Maybe not needed) - Removes deprecated `--reconfigure` from `sanity init --help` 