### PR TITLE
refactor(comments): remove unused function in comments provider

### DIFF
--- a/packages/sanity/src/desk/comments/plugin/inspector/CommentsInspector.tsx
+++ b/packages/sanity/src/desk/comments/plugin/inspector/CommentsInspector.tsx
@@ -54,7 +54,6 @@ export function CommentsInspector(props: DocumentInspectorProps) {
     create,
     edit,
     getComment,
-    getCommentPath,
     isRunningSetup,
     mentionOptions,
     remove,
@@ -275,7 +274,7 @@ export function CommentsInspector(props: DocumentInspectorProps) {
         comment: undefined,
       })
     }
-  }, [getComment, getCommentPath, handleScrollToComment, loading, params, setParams])
+  }, [getComment, handleScrollToComment, loading, params, setParams])
 
   return (
     <Fragment>

--- a/packages/sanity/src/desk/comments/src/context/comments/CommentsProvider.tsx
+++ b/packages/sanity/src/desk/comments/src/context/comments/CommentsProvider.tsx
@@ -68,7 +68,6 @@ const COMMENTS_DISABLED_CONTEXT: CommentsContextValue = {
   create: noopOperation,
   edit: noopOperation,
   getComment: () => undefined,
-  getCommentPath: () => null,
   isRunningSetup: false,
   mentionOptions: EMPTY_MENTION_OPTIONS,
   remove: noopOperation,
@@ -162,16 +161,6 @@ const CommentsProviderInner = memo(function CommentsProviderInner(
   )
 
   const getComment = useCallback((id: string) => data?.find((c) => c._id === id), [data])
-
-  const getCommentPath = useCallback(
-    (id: string) => {
-      const comment = getComment(id)
-      if (!comment) return null
-
-      return comment.target.path.field
-    },
-    [getComment],
-  )
 
   const handleOnCreate = useCallback(
     async (payload: CommentPostPayload) => {
@@ -290,7 +279,6 @@ const CommentsProviderInner = memo(function CommentsProviderInner(
       setStatus,
 
       getComment,
-      getCommentPath,
 
       comments: {
         data: threadItemsByStatus,
@@ -315,7 +303,6 @@ const CommentsProviderInner = memo(function CommentsProviderInner(
       isRunningSetup,
       status,
       getComment,
-      getCommentPath,
       threadItemsByStatus,
       error,
       loading,

--- a/packages/sanity/src/desk/comments/src/context/comments/types.ts
+++ b/packages/sanity/src/desk/comments/src/context/comments/types.ts
@@ -12,7 +12,6 @@ import {
  */
 export interface CommentsContextValue {
   getComment: (id: string) => CommentDocument | undefined
-  getCommentPath: (id: string) => string | null
 
   isRunningSetup: boolean
 


### PR DESCRIPTION
### Description

This pull request cleans up the `CommentsProvider` by removing the unused `getCommentPath` function.

### What to review

- Everything should work as normal

### Notes for release

n/a
