### PR TITLE
feat(core): support weighted `template`, `mode` intent parameters

### DIFF
--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -165,12 +165,22 @@ export interface Tool<Options = any> {
   /**
    * Determines whether the tool can handle the given intent.
    *
+   * Can either return a boolean, or an object where the keys represent the parameters that
+   * can/can not be handled. This will be used to determine whether or not a tool is the best
+   * suited to handle an intent. Note that an object of only `false` values (or an empty object)
+   * is treated as `true`, so you want to explicitly return `false` if you know the intent cannot
+   * fulfill the intent request.
+   *
    * @param intent - The intent to check.
    * @param params - The parameters for the intent.
    * @param payload - The payload for the intent.
-   * @returns `true` if the tool can handle the intent, `false` otherwise.
+   * @returns Boolean: whether it can handle the intent. Object: Values representing what specific parameters can be handled.
    */
-  canHandleIntent?: (intent: string, params: Record<string, unknown>, payload: unknown) => boolean
+  canHandleIntent?: (
+    intent: string,
+    params: Record<string, unknown>,
+    payload: unknown,
+  ) => boolean | {[key: string]: boolean}
 }
 
 /** @public */

--- a/packages/sanity/src/desk/deskTool.ts
+++ b/packages/sanity/src/desk/deskTool.ts
@@ -135,8 +135,8 @@ function canHandleEditIntent(params: Record<string, unknown>) {
     return false
   }
 
-  // We can handle any edit intent with a document ID, but we're best at `structured` mode
-  // This ensures that other tools that can handle modes such as `visual` or `batch` can
-  // take precedence over the desk tool
-  return 'mode' in params ? {mode: params.mode === 'structured'} : true
+  // We can handle any edit intent with a document ID, but we're best at `structure` mode
+  // This ensures that other tools that can handle modes such as `presentation` or `batch`
+  // can take precedence over the desk tool
+  return 'mode' in params ? {mode: params.mode === 'structure'} : true
 }

--- a/packages/sanity/src/desk/structureBuilder/InitialValueTemplateItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/InitialValueTemplateItem.ts
@@ -1,11 +1,10 @@
-import {pickBy} from 'lodash'
 import {ComposeIcon} from '@sanity/icons'
 import {HELP_URL, SerializeError} from './SerializeError'
-import {Serializable, SerializeOptions, SerializePath} from './StructureNodes'
-import {MenuItemBuilder, MenuItem} from './MenuItem'
-import {IntentParams} from './Intent'
-import {StructureContext} from './types'
-import {InitialValueTemplateItem} from 'sanity'
+import type {Serializable, SerializeOptions, SerializePath} from './StructureNodes'
+import type {BaseIntentParams, IntentParams} from './Intent'
+import type {StructureContext} from './types'
+import {MenuItemBuilder, type MenuItem} from './MenuItem'
+import type {InitialValueTemplateItem} from 'sanity'
 
 /**
  * A `InitialValueTemplateItemBuilder` is used to build a document node with an initial value set.
@@ -204,10 +203,16 @@ export function menuItemsFromInitialValueTemplateItems(
   return templateItems.map((item) => {
     const template = templates.find((t) => t.id === item.templateId)
     const title = item.title || template?.title || 'Create new'
-    const params = pickBy(
-      {type: template && template.schemaType, template: item.templateId},
-      Boolean,
-    )
+
+    const params: BaseIntentParams = {}
+    if (template && template.schemaType) {
+      params.type = template.schemaType
+    }
+
+    if (item.templateId) {
+      params.template = item.templateId
+    }
+
     const intentParams: IntentParams = item.parameters ? [params, item.parameters] : params
     const schemaType = template && schema.get(template.schemaType)
 

--- a/packages/sanity/src/desk/structureBuilder/Intent.ts
+++ b/packages/sanity/src/desk/structureBuilder/Intent.ts
@@ -43,9 +43,16 @@ export interface BaseIntentParams {
 
   /**
    * Optional "mode" to use for edit intent.
-   * Known modes are `structured` and `visual`.
+   * Known modes are `structure` and `presentation`.
    */
   mode?: string
+
+  /**
+   * Arbitrary/custom parameters should be prefixed with an underscore (`_`), to signal that they
+   * do not have any defined semantics to the intent itself, but to some implementer. Implementers
+   * are free to ignore these if they want to.
+   */
+  [key: `_${string}`]: string
 }
 
 /** @internal */

--- a/packages/sanity/src/desk/structureBuilder/Intent.ts
+++ b/packages/sanity/src/desk/structureBuilder/Intent.ts
@@ -48,11 +48,10 @@ export interface BaseIntentParams {
   mode?: string
 
   /**
-   * Arbitrary/custom parameters should be prefixed with an underscore (`_`), to signal that they
-   * do not have any defined semantics to the intent itself, but to some implementer. Implementers
-   * are free to ignore these if they want to.
+   * Arbitrary/custom parameters are generally discouraged - try to keep them to a minimum,
+   * or use `payload` (arbitrary JSON-serializable object) instead.
    */
-  [key: `_${string}`]: string
+  [key: string]: string | undefined
 }
 
 /** @internal */

--- a/packages/sanity/src/desk/structureBuilder/Intent.ts
+++ b/packages/sanity/src/desk/structureBuilder/Intent.ts
@@ -9,23 +9,43 @@ import {StructureNode} from './StructureNodes'
 export type IntentJsonParams = {[key: string]: any}
 
 /**
- * Interface for base intent parameters
+ * Base intent parameters
  *
- * @public */
+ * @public
+ * @todo dedupe with core
+ */
 export interface BaseIntentParams {
-  /* Intent type */
+  /**
+   * Document schema type name to create/edit.
+   * Required for `create` intents, optional for `edit` (but encouraged, safer and faster)
+   */
   type?: string
-  /* Intent Id */
+
+  /**
+   * ID of the document to create/edit.
+   * Required for `edit` intents, optional for `create`.
+   */
   id?: string
-  /* Intent template */
+
+  /**
+   * Name (ID) of initial value template to use for `create` intent. Optional.
+   */
   template?: string
+
   /**
    * Experimental field path
+   *
    * @beta
    * @experimental
    * @hidden
    */
   path?: string
+
+  /**
+   * Optional "mode" to use for edit intent.
+   * Known modes are `structured` and `visual`.
+   */
+  mode?: string
 }
 
 /** @internal */

--- a/packages/sanity/src/router/types.ts
+++ b/packages/sanity/src/router/types.ts
@@ -173,23 +173,41 @@ export interface NavigateOptions {
 }
 
 /**
+ * Base intent parameters
+ *
  * @public
- * @todo dedupe with intent types in core
+ * @todo dedupe with core/desk
  */
 export interface BaseIntentParams {
-  /* Intent type */
+  /**
+   * Document schema type name to create/edit.
+   * Required for `create` intents, optional for `edit` (but encouraged, safer and faster)
+   */
   type?: string
-  /* Intent Id */
+
+  /**
+   * ID of the document to create/edit.
+   * Required for `edit` intents, optional for `create`.
+   */
   id?: string
-  /* Intent template */
+
+  /* Name (ID) of initial value template to use for `create` intent. Optional.  */
   template?: string
+
   /**
    * Experimental field path
+   *
    * @beta
    * @experimental
    * @hidden
    */
   path?: string
+
+  /**
+   * Optional "mode" to use for edit intent.
+   * Known modes are `structured` and `visual`.
+   */
+  mode?: string
 }
 
 /**

--- a/packages/sanity/src/router/types.ts
+++ b/packages/sanity/src/router/types.ts
@@ -205,9 +205,16 @@ export interface BaseIntentParams {
 
   /**
    * Optional "mode" to use for edit intent.
-   * Known modes are `structured` and `visual`.
+   * Known modes are `structure` and `presentation`.
    */
   mode?: string
+
+  /**
+   * Arbitrary/custom parameters should be prefixed with an underscore (`_`), to signal that they
+   * do not have any defined semantics to the intent itself, but to some implementer. Implementers
+   * are free to ignore these if they want to.
+   */
+  [key: `_${string}`]: string
 }
 
 /**

--- a/packages/sanity/src/router/types.ts
+++ b/packages/sanity/src/router/types.ts
@@ -210,11 +210,10 @@ export interface BaseIntentParams {
   mode?: string
 
   /**
-   * Arbitrary/custom parameters should be prefixed with an underscore (`_`), to signal that they
-   * do not have any defined semantics to the intent itself, but to some implementer. Implementers
-   * are free to ignore these if they want to.
+   * Arbitrary/custom parameters are generally discouraged - try to keep them to a minimum,
+   * or use `payload` (arbitrary JSON-serializable object) instead.
    */
-  [key: `_${string}`]: string
+  [key: string]: string | undefined
 }
 
 /**


### PR DESCRIPTION
### Description

Attempts to solve the problem where you have multiple tools that can handle the same intent, and you want to weight them differently based on a parameter.

#### Requirements:
- One should be able to link from inside and outside of a studio to an edit intent, and give it a `mode` that is _better_ handled by one tool than another, but still be able to fall back if that "better" tool is not installed
- The currently active tool should be given priority if multiple tools are _equally_ good at handling the intent
- If the current active tool _can_ handle the intent, but a _better_ one is found, we should navigate to it

#### Example:
You have a "visual editing" tool and a "structured content" tool. They can both modify (edit) documents, but one is better at the schematic modification ("structured") and the other is better at the visual modifications ("visual").
- The structured content tool should be able to generate an intent link to a "visual edit" tool, and wise versa.
- If the structured content tool is open and you use the global search to find a document and open a result, the structured tool should open it, since it is the active tool. The same would be true for the visual editing tool.
  - If the global search included a preference for a "visual" editing mode, the visual editing tool should answer the intent, even if the structured content tool is open


#### Additional thoughts

I intentionally scoped down the parameters supported to the `template` param for the `create` intent and the `mode` param for the `edit` intent, since these are the ones I could see the most use for in the current landscape. 

In the future, it would be nice if the same (or a similar) approach could be used to score the intent based on other parameters. For instance:

- Two desk tools could argue about which one is best to handle an intent based on the structure definition (eg which one has the deepest/most specific point to edit it in)
- Two tools ("Desk" and "DealCreator") could argue about which one is the best to handle a create intent for a "deal" schema type.

I left this out of scope since it needs some more thinking on how these rankings would work - arbitrary score numbers? Still returned by `canHandleIntent` (seems oddly named if so)?
 
### What to review

- Does the approach solve the explained scenarios?
- Is this a forward-compatible approach?

### Notes for release

(Not sure if we need to feature this, as it is quite deep in tool/intent territory, but in case we do)

- Added the ability for tools to indicate that they can handle the `mode` and `template` parameters for intents, to give higher/lower priority to tools in certain scenarios

