### PR TITLE
fix(comments): prevent pasted links from being rendered as DefaultAnnotations at author time

### DIFF
--- a/packages/sanity/src/desk/comments/src/components/pte/config.ts
+++ b/packages/sanity/src/desk/comments/src/components/pte/config.ts
@@ -16,6 +16,9 @@ const blockType = defineField({
   type: 'block',
   name: 'block',
   of: [mentionObject],
+  marks: {
+    annotations: [],
+  },
   styles: [{title: 'Normal', value: 'normal'}],
   lists: [],
 })


### PR DESCRIPTION
### Description

This PR updates the block schema to explicitly provide an empty annotations array. Pasting HTML with links will no longer render unsightly `DefaultAnnotations` at author time (before submission). Please refer to the issue for more context!

### What to review

Pasting HTML with links should always render as 'plain' text.

### Notes for release

N/A