### PR TITLE
feat(core): make field actions keyboard accessible

### DIFF
--- a/packages/sanity/src/core/form/components/formField/FormFieldBaseHeader.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldBaseHeader.tsx
@@ -66,7 +66,6 @@ const FieldActionsFloatingCard = styled(Card)(({theme}: {theme: Theme}) => {
     position: absolute;
     right: 0;
     width: 0;
-    will-change: opacity, width;
 
     @media (hover: hover) {
       // If hover is supported, we hide the floating card by default
@@ -122,7 +121,6 @@ const FieldActionsFloatingCard = styled(Card)(({theme}: {theme: Theme}) => {
 
 const FieldActionsFlex = styled(Flex)`
   gap: inherit;
-  will-change: opacity, width;
 `
 
 const MAX_AVATARS = 4


### PR DESCRIPTION
### Description

This pull request makes field actions keyboard accessible + fixes a few issues in comments.

`core` changes:
- Make field actions keyboard accessible

`desk` changes:
- Replaces `react-focus-lock` with custom focus lock behavior to resolve issues related to return focus.
- Adjusts click outside functionality to trigger only when the comment input popover is open.
- Enables discarding a comment using the "Escape" key, not just when the comment input is focused.

### What to review

- Make sure that you can use the keyboard to access field actions
- Make sure that everything still works as before

### Notes for release

Make field actions keyboard accessible
