### PR TITLE
fix(comments): default placement of comment popover

### DIFF
--- a/packages/sanity/src/desk/comments/plugin/field/CommentFieldButton.tsx
+++ b/packages/sanity/src/desk/comments/plugin/field/CommentFieldButton.tsx
@@ -147,9 +147,9 @@ export function CommentFieldButton(props: CommentFieldButtonProps) {
       <Popover
         constrainSize
         content={content}
-        fallbackPlacements={['left-start']}
+        fallbackPlacements={['bottom-end']}
         open={open}
-        placement="bottom-end"
+        placement="right-start"
         portal
         ref={setPopoverElement}
       >


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This pull request changes the default placement of the comment input popover. Ideally, when there's available space, the popover will now be positioned to the right. In cases where space is limited, the fallback position will be at the bottom.

<img width="781" alt="Screenshot 2023-11-09 at 15 28 46" src="https://github.com/sanity-io/sanity/assets/15094168/5e93cdfb-8a34-434d-9cf9-9b1dcb8bb6eb">

### What to review

- Make sure that the position of the tooltip works correctly

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

n/a