### PR TITLE
fix(navbar): reset url state when navigating to other tools

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/tools/ToolLink.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/tools/ToolLink.tsx
@@ -18,7 +18,14 @@ export const ToolLink = forwardRef(function ToolLink(
 ) {
   const {name, ...rest} = props
   const state = useRouterState(
-    useCallback((routerState) => ({...routerState, tool: name, [name]: undefined}), [name]),
+    useCallback(
+      () => ({
+        tool: name,
+        // make sure to clear tool state when navigating to another tool
+        [name]: undefined,
+      }),
+      [name],
+    ),
   )
 
   return <StateLink state={state} {...rest} ref={ref} />


### PR DESCRIPTION
### Description
With the introduction of search params in #5148, we discovered that search params could sometimes carry over from one tool to another. This makes sure any existing state is cleared when generating links to tools in the nav bar.

### What to review
Does it make sense?


### Notes for release

N/A unlikely to be a known issue