### PR TITLE
feat(router): add support for tools to bypass search param scoping

### DIFF
--- a/packages/sanity/src/core/studio/StudioLayout.tsx
+++ b/packages/sanity/src/core/studio/StudioLayout.tsx
@@ -130,7 +130,12 @@ export function StudioLayout() {
       <StudioErrorBoundary key={activeTool?.name} heading={`The ${activeTool?.name} tool crashed`}>
         <Card flex={1} hidden={searchFullscreenOpen}>
           {activeTool && activeToolName && (
-            <RouteScope scope={activeToolName}>
+            <RouteScope
+              scope={activeToolName}
+              __unsafe_disableScopedSearchParams={
+                activeTool.router?.__unsafe_disableScopedSearchParams
+              }
+            >
               <Suspense fallback={<LoadingTool />}>
                 {createElement(activeTool.component, {tool: activeTool})}
               </Suspense>

--- a/packages/sanity/src/core/studio/router/helpers.ts
+++ b/packages/sanity/src/core/studio/router/helpers.ts
@@ -74,21 +74,29 @@ export function resolveIntentState(
   )
 
   if (matchingTool?.getIntentState) {
-    const toolState = matchingTool.getIntentState(
+    const _toolState = matchingTool.getIntentState(
       intent,
       params as any,
       prevState && (prevState[matchingTool.name] as any),
       payload,
-    )
+    ) as Record<string, unknown>
 
+    const {_searchParams, ...toolState} = _toolState
+
+    const nextUrlState: Record<string, unknown> = {
+      ...prevState,
+      tool: matchingTool.name,
+      [matchingTool.name]: toolState,
+    }
+    if (matchingTool.router?.__unsafe_disableScopedSearchParams) {
+      nextUrlState._searchParams = _searchParams
+    } else {
+      toolState._searchParams = _searchParams
+    }
     return {
       type: 'state',
       isNotFound: false,
-      state: {
-        ...prevState,
-        tool: matchingTool.name,
-        [matchingTool.name]: toolState,
-      },
+      state: nextUrlState,
     }
   }
 

--- a/packages/sanity/src/router/__test__/urlSearchParams.test.ts
+++ b/packages/sanity/src/router/__test__/urlSearchParams.test.ts
@@ -90,6 +90,43 @@ describe('scoped url params', () => {
   })
 })
 
+describe('url params without opt-out scoping', () => {
+  const router = route.scope(
+    'pluginA',
+    '/pluginA/:id',
+    // eslint-disable-next-line camelcase
+    {__unsafe_disableScopedSearchParams: true},
+    [
+      route.scope('pluginAB', '/pluginAB/:qux', [
+        route.scope('pluginABC', '/pluginABC/space/:arg'),
+      ]),
+    ],
+  )
+
+  test('UrlSearchParams params with a simple route', () => {
+    expect(
+      router.encode({
+        pluginA: {
+          id: 'foo',
+          pluginAB: {
+            qux: 'something',
+            pluginABC: {
+              arg: 'hello',
+              _searchParams: [
+                ['a', 'b'],
+                ['c', 'd'],
+              ],
+            },
+          },
+        },
+      }),
+    ).toEqual(
+      `/pluginA/foo/pluginAB/something/pluginABC/space/hello?${new URLSearchParams(
+        'pluginAB[pluginABC][a]=b&pluginAB[pluginABC][c]=d',
+      )}`,
+    )
+  })
+})
 describe('encode with dynamically scoped url params', () => {
   const router = route.create('/tools/:tool', (state) =>
     route.scope(state.tool as string, '/edit/:documentId'),

--- a/packages/sanity/src/router/_resolvePathFromState.ts
+++ b/packages/sanity/src/router/_resolvePathFromState.ts
@@ -80,7 +80,7 @@ function addNodeScope(
   searchParams: InternalSearchParam[],
 ): InternalSearchParam[] {
   const scope = node.scope
-  return scope
+  return scope && !node.__unsafe_disableScopedSearchParams
     ? searchParams.map(([namespaces, value]) => [[scope, ...namespaces], value])
     : searchParams
 }

--- a/packages/sanity/src/router/types.ts
+++ b/packages/sanity/src/router/types.ts
@@ -69,6 +69,15 @@ export interface RouterNode {
    * An optional scope for this node.
    */
   scope?: string
+
+  /**
+   * Optionally disable scoping of search params
+   * Scoped search params will be represented as scope[param]=value in the url
+   * Disabling this will still scope search params based on any parent scope unless the parent scope also has disabled search params scoping
+   * Caution: enabling this can cause conflicts with multiple plugins defining search params with the same name
+   */
+  __unsafe_disableScopedSearchParams?: boolean
+
   /**
    * An optional object containing transforms to apply to this node.
    * See {@link RouteTransform} and {@link RouterState}


### PR DESCRIPTION
### Description
This task enables a tool to declare that it fully "owns" and controls the search params, as a way to conditionally opt-out of the search parameter scoping, resulting in cleaner urls (see #5148 for backround info about search params support).

Declaring this on the tool level makes it possible to detect if there are multiple tools that declare they own the search params, and enables us to add safeguards/dev warnings if we want to do this later.

### What to review
Whether the change makes sense. I'm not too satisfied with having to add special handling in so many different places, so ideally we should look into refactoring this behavior into core router utilities.

### Notes for release
N/A