### PR TITLE
fix(router): improve search params encoding

### DIFF
--- a/packages/sanity/src/router/__test__/scope.test.ts
+++ b/packages/sanity/src/router/__test__/scope.test.ts
@@ -8,11 +8,11 @@ test('toplevel', () => {
 
 test('toplevel, with params', () => {
   const router = route.scope('omg', '/foo/:bar')
-  expect(router.decode('/foo/bar?omg%5Bsomething%5D=xyz')).toEqual({
+  expect(router.decode('/foo/bar?omg[something]=xyz')).toEqual({
     omg: {bar: 'bar', _searchParams: [['something', 'xyz']]},
   })
   expect(router.encode({omg: {bar: 'bar', _searchParams: [['something', 'xyz']]}})).toBe(
-    '/foo/bar?omg%5Bsomething%5D=xyz',
+    '/foo/bar?omg[something]=xyz',
   )
 })
 
@@ -58,15 +58,15 @@ test('scopes all the way down, with params', () => {
     route.scope('second', '/baz/:qux', [route.scope('third', '/omg/:lol')]),
   ])
 
-  expect(router.decode('/foo/bar?first%5Ba%5D=b')).toEqual({
+  expect(router.decode('/foo/bar?first[a]=b')).toEqual({
     first: {bar: 'bar', _searchParams: [['a', 'b']]},
   })
 
   expect(router.encode({first: {bar: 'bar', _searchParams: [['a', 'b']]}})).toBe(
-    '/foo/bar?first%5Ba%5D=b',
+    '/foo/bar?first[a]=b',
   )
 
-  expect(router.decode('/foo/bar/baz/qux?first%5Ba%5D=b&first%5Bsecond%5D%5Bc%5D=d')).toEqual({
+  expect(router.decode('/foo/bar/baz/qux?first[a]=b&first[second][c]=d')).toEqual({
     first: {
       bar: 'bar',
       _searchParams: [['a', 'b']],
@@ -81,11 +81,11 @@ test('scopes all the way down, with params', () => {
         second: {qux: 'qux', _searchParams: [['c', 'd']]},
       },
     }),
-  ).toBe('/foo/bar/baz/qux?first%5Ba%5D=b&first%5Bsecond%5D%5Bc%5D=d')
+  ).toBe('/foo/bar/baz/qux?first[a]=b&first[second][c]=d')
 
   expect(
     router.decode(
-      '/foo/bar/baz/qux/omg/lol?first%5Bx%5D=1&first%5By%5D=2&first%5Bsecond%5D%5Ba%5D=0&first%5Bsecond%5D%5Bb%5D=1&first%5Bsecond%5D%5Bthird%5D%5Bfoo%5D=bar',
+      '/foo/bar/baz/qux/omg/lol?first[x]=1&first[y]=2&first[second][a]=0&first[second][b]=1&first[second][third][foo]=bar',
     ),
   ).toEqual({
     first: {
@@ -129,6 +129,6 @@ test('scopes all the way down, with params', () => {
       },
     }),
   ).toEqual(
-    '/foo/bar/baz/qux/omg/lol?first%5Bx%5D=1&first%5By%5D=2&first%5Bsecond%5D%5Ba%5D=0&first%5Bsecond%5D%5Bb%5D=1&first%5Bsecond%5D%5Bthird%5D%5Bfoo%5D=bar',
+    '/foo/bar/baz/qux/omg/lol?first[x]=1&first[y]=2&first[second][a]=0&first[second][b]=1&first[second][third][foo]=bar',
   )
 })

--- a/packages/sanity/src/router/__test__/urlSearchParams.test.ts
+++ b/packages/sanity/src/router/__test__/urlSearchParams.test.ts
@@ -67,18 +67,14 @@ describe('scoped url params', () => {
         },
       }),
     ).toEqual(
-      `/pluginA/foo/pluginAB/something/pluginABC/space/hello?${new URLSearchParams(
-        'pluginA[pluginAB][pluginABC][a]=b&pluginA[pluginAB][pluginABC][c]=d',
-      )}`,
+      '/pluginA/foo/pluginAB/something/pluginABC/space/hello?pluginA[pluginAB][pluginABC][a]=b&pluginA[pluginAB][pluginABC][c]=d',
     )
   })
 
   test('UrlSearchParams params with a simple route', () => {
     expect(
       router.decode(
-        `/pluginA/foo/pluginAB/something/pluginABC/space/hello?${new URLSearchParams(
-          'pluginA[pluginAB][pluginABC][a]=b&pluginA[pluginAB][pluginABC][c]=d',
-        )}`,
+        '/pluginA/foo/pluginAB/something/pluginABC/space/hello?pluginA[pluginAB][pluginABC][a]=b&pluginA[pluginAB][pluginABC][c]=d',
       ),
     ).toEqual({
       pluginA: {
@@ -109,7 +105,7 @@ describe('encode with dynamically scoped url params', () => {
         tool: 'desk',
         desk: {documentId: '12', _searchParams: [['a', 'b']]},
       }),
-    ).toEqual(`/tools/desk/edit/12?desk%5Ba%5D=b`)
+    ).toEqual('/tools/desk/edit/12?desk[a]=b')
   })
 })
 

--- a/packages/sanity/src/router/__test__/urlSearchParams.test.ts
+++ b/packages/sanity/src/router/__test__/urlSearchParams.test.ts
@@ -34,6 +34,14 @@ describe('encode w/UrlSearchParams', () => {
       }),
     ).toEqual('/tools/desk?view=zen')
   })
+  test('Slashes in values are not encoded', () => {
+    expect(
+      router.encode({
+        tool: 'desk',
+        _searchParams: [['page', '/main']],
+      }),
+    ).toEqual('/tools/desk?page=/main')
+  })
 })
 
 describe('scoped url params', () => {

--- a/packages/sanity/src/router/__test__/urlSearchParams.test.ts
+++ b/packages/sanity/src/router/__test__/urlSearchParams.test.ts
@@ -42,6 +42,20 @@ describe('encode w/UrlSearchParams', () => {
       }),
     ).toEqual('/tools/desk?page=/main')
   })
+  test('Undefined in values are omitted', () => {
+    expect(
+      router.encode({
+        tool: 'desk',
+        _searchParams: [
+          ['include', 'yes'],
+          // @ts-expect-error - typescript should yell
+          ['invalid', undefined],
+          // @ts-expect-error - typescript should yell
+          ['also', undefined],
+        ],
+      }),
+    ).toEqual('/tools/desk?include=yes')
+  })
 })
 
 describe('scoped url params', () => {

--- a/packages/sanity/src/router/_resolvePathFromState.ts
+++ b/packages/sanity/src/router/_resolvePathFromState.ts
@@ -38,7 +38,10 @@ function bracketify(value: string): string {
 
 function encodeParams(params: InternalSearchParam[]): string {
   return params
-    .map(([key, value]) => {
+    .flatMap(([key, value]) => {
+      if (value === undefined) {
+        return []
+      }
       return [encodeSearchParamKey(serializeScopedPath(key)), encodeSearchParamValue(value)].join(
         '=',
       )

--- a/packages/sanity/src/router/_resolvePathFromState.ts
+++ b/packages/sanity/src/router/_resolvePathFromState.ts
@@ -53,7 +53,7 @@ function serializeScopedPath(scopedPath: string[]): string {
 }
 
 function encodeSearchParamValue(value: string): string {
-  return encodeURIComponent(value)
+  return encodeURIComponentExcept(value, '/')
 }
 
 function encodeSearchParamKey(value: string): string {

--- a/packages/sanity/src/router/_resolvePathFromState.ts
+++ b/packages/sanity/src/router/_resolvePathFromState.ts
@@ -1,6 +1,7 @@
 import {_findMatchingRoutes} from './_findMatchingRoutes'
-import {InternalSearchParam, MatchOk, RouterNode, RouterState, SearchParam} from './types'
+import {InternalSearchParam, MatchOk, RouterNode, RouterState} from './types'
 import {debug} from './utils/debug'
+import {encodeURIComponentExcept} from './encodeURIComponentExcept'
 
 /** @internal */
 export function _resolvePathFromState(node: RouterNode, _state: RouterState): string {
@@ -26,8 +27,7 @@ export function _resolvePathFromState(node: RouterNode, _state: RouterState): st
 
   const {path, searchParams} = pathFromMatchResult(match)
 
-  const search =
-    searchParams.length > 0 ? new URLSearchParams(encodeParams(searchParams)).toString() : ''
+  const search = searchParams.length > 0 ? encodeParams(searchParams) : ''
 
   return `/${path.join('/')}${search ? `?${search}` : ''}`
 }
@@ -36,13 +36,28 @@ function bracketify(value: string): string {
   return `[${value}]`
 }
 
-function encodeParamPath(paramPath: string[]): string {
-  const [head, ...tail] = paramPath
+function encodeParams(params: InternalSearchParam[]): string {
+  return params
+    .map(([key, value]) => {
+      return [encodeSearchParamKey(serializeScopedPath(key)), encodeSearchParamValue(value)].join(
+        '=',
+      )
+    })
+    .join('&')
+}
+
+function serializeScopedPath(scopedPath: string[]): string {
+  const [head, ...tail] = scopedPath
 
   return tail.length > 0 ? [head, ...tail.map(bracketify)].join('') : head
 }
-function encodeParams(params: InternalSearchParam[]): SearchParam[] {
-  return params.map(([key, value]): SearchParam => [encodeParamPath(key), value])
+
+function encodeSearchParamValue(value: string): string {
+  return encodeURIComponent(value)
+}
+
+function encodeSearchParamKey(value: string): string {
+  return encodeURIComponent(value)
 }
 
 function pathFromMatchResult(match: MatchOk): {

--- a/packages/sanity/src/router/_resolvePathFromState.ts
+++ b/packages/sanity/src/router/_resolvePathFromState.ts
@@ -57,7 +57,7 @@ function encodeSearchParamValue(value: string): string {
 }
 
 function encodeSearchParamKey(value: string): string {
-  return encodeURIComponent(value)
+  return encodeURIComponentExcept(value, '[]')
 }
 
 function pathFromMatchResult(match: MatchOk): {

--- a/packages/sanity/src/router/encodeURIComponentExcept.ts
+++ b/packages/sanity/src/router/encodeURIComponentExcept.ts
@@ -1,0 +1,21 @@
+/**
+ * Like encodeURIComponent, but supports a custom set of unescaped characters.
+ * @param uriComponent - A value representing an unencoded URI component.
+ * @param unescaped - a string containing characters to not escape
+ */
+export function encodeURIComponentExcept(
+  uriComponent: string | number | boolean,
+  unescaped: string,
+): string {
+  const chars = [...String(uriComponent)]
+  let res = ''
+  for (let i = 0; i < chars.length; i++) {
+    const char = chars[i]
+    if (unescaped.includes(char)) {
+      res += char
+    } else {
+      res += encodeURIComponent(char)
+    }
+  }
+  return res
+}


### PR DESCRIPTION
### Description
This adds support for skipping certain characters when encoding urls using sanity/router. This results in more readable urls. For now, only brackets and forward slashes are preserved, so instead of encoding the url like this
```
/section/foobar?tool%5Bpage%5D=%2Fproducts
```
it will be encoded like this
```
/section/foobar?tool[page]=/products
```

### What to review
Does it make sense? Any unintended consequences of this that I'm forgetting?

### Notes for release

N/A