### PR TITLE
fix(router): omit undefined from search params

### DIFF
--- a/packages/sanity/src/router/__test__/urlSearchParams.test.ts
+++ b/packages/sanity/src/router/__test__/urlSearchParams.test.ts
@@ -42,6 +42,20 @@ describe('encode w/UrlSearchParams', () => {
       }),
     ).toEqual('/tools/desk?page=/main')
   })
+  test('Undefined in values are omitted', () => {
+    expect(
+      router.encode({
+        tool: 'desk',
+        _searchParams: [
+          ['include', 'yes'],
+          // @ts-expect-error - typescript should yell
+          ['invalid', undefined],
+          // @ts-expect-error - typescript should yell
+          ['also', undefined],
+        ],
+      }),
+    ).toEqual('/tools/desk?include=yes')
+  })
 })
 
 describe('scoped url params', () => {

--- a/packages/sanity/src/router/_resolvePathFromState.ts
+++ b/packages/sanity/src/router/_resolvePathFromState.ts
@@ -38,7 +38,10 @@ function bracketify(value: string): string {
 
 function encodeParams(params: InternalSearchParam[]): string {
   return params
-    .map(([key, value]) => {
+    .flatMap(([key, value]) => {
+      if (value === undefined) {
+        return []
+      }
       return [encodeSearchParamKey(serializeScopedPath(key)), encodeSearchParamValue(value)].join(
         '=',
       )


### PR DESCRIPTION
### Description
Note: this stacks on top of changes in #5173 

This omits undefined from being encoded as search params

### Notes for release
N/A