### PR TITLE
chore(deps): bump @sanity/ui to latest

### DIFF
--- a/dev/design-studio/package.json
+++ b/dev/design-studio/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@sanity/icons": "^2.6.0",
-    "@sanity/ui": "^1.8.3",
+    "@sanity/ui": "^1.9.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "sanity": "3.19.2",

--- a/dev/studio-e2e-testing/package.json
+++ b/dev/studio-e2e-testing/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@sanity/google-maps-input": "^3.0.1",
     "@sanity/icons": "^2.4.0",
-    "@sanity/ui": "^1.7.2",
+    "@sanity/ui": "^1.9.3",
     "@sanity/vision": "3.19.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -29,7 +29,7 @@
     "@sanity/portable-text-editor": "3.19.2",
     "@sanity/tsdoc": "1.0.0-alpha.38",
     "@sanity/types": "3.19.2",
-    "@sanity/ui": "^1.8.3",
+    "@sanity/ui": "^1.9.3",
     "@sanity/ui-workshop": "^1.0.0",
     "@sanity/util": "3.19.2",
     "@sanity/uuid": "^3.0.1",

--- a/examples/ecommerce-studio/package.json
+++ b/examples/ecommerce-studio/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@sanity/cli": "3.19.2",
-    "@sanity/ui": "^1.8.3",
+    "@sanity/ui": "^1.9.3",
     "react": "^18.2.0",
     "react-barcode": "^1.4.1",
     "react-dom": "^18.2.0",

--- a/packages/@sanity/portable-text-editor/package.json
+++ b/packages/@sanity/portable-text-editor/package.json
@@ -77,7 +77,7 @@
     "@playwright/test": "^1.39.0",
     "@portabletext/toolkit": "^2.0.10",
     "@sanity/diff-match-patch": "^3.1.1",
-    "@sanity/ui": "^1.8.3",
+    "@sanity/ui": "^1.9.3",
     "@testing-library/react": "^13.4.0",
     "@types/debug": "^4.1.5",
     "@types/express": "^4.16.1",

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -66,7 +66,7 @@
     "@rexxars/react-split-pane": "^0.1.93",
     "@sanity/color": "^2.1.20",
     "@sanity/icons": "^2.6.0",
-    "@sanity/ui": "^1.8.3",
+    "@sanity/ui": "^1.9.3",
     "@uiw/react-codemirror": "^4.11.4",
     "hashlru": "^2.3.0",
     "is-hotkey": "^0.1.6",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -150,7 +150,7 @@
     "@sanity/portable-text-editor": "3.19.2",
     "@sanity/schema": "3.19.2",
     "@sanity/types": "3.19.2",
-    "@sanity/ui": "^1.8.3",
+    "@sanity/ui": "^1.9.3",
     "@sanity/util": "3.19.2",
     "@sanity/uuid": "^3.0.1",
     "@tanstack/react-virtual": "3.0.0-beta.54",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3739,10 +3739,22 @@
     segmented-property "^3.0.3"
     vite "^4.4.9"
 
-"@sanity/ui@^1", "@sanity/ui@^1.0.0", "@sanity/ui@^1.6.0", "@sanity/ui@^1.7.2", "@sanity/ui@^1.8.3":
+"@sanity/ui@^1", "@sanity/ui@^1.0.0", "@sanity/ui@^1.6.0", "@sanity/ui@^1.7.2":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sanity/ui/-/ui-1.8.3.tgz#e527c2e9df0951f546c05cf015770be2b7e1927f"
   integrity sha512-LOYVLkpnGrWlCRTjluFn2wf7y4BzYhFBzdnBmNT0uRWH3pXN24xXH49e0HfbJ3tzRLOKwLo35IexvBKQwPgYZg==
+  dependencies:
+    "@floating-ui/react-dom" "2.0.0"
+    "@sanity/color" "^2.2.5"
+    "@sanity/icons" "^2.4.1"
+    csstype "^3.1.2"
+    framer-motion "^10.16.2"
+    react-refractor "^2.1.7"
+
+"@sanity/ui@^1.9.3":
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/@sanity/ui/-/ui-1.9.3.tgz#4af45902ac95801aa5ea57f377beaf3e3cb36339"
+  integrity sha512-AdWEVFaK0Snk6xxP0lGPVP3QQYKwzkfGFpFZnL9d6UtWt8yeuS8BMLVAzmXzg14hrqH50ex9nvNl3eq6a0MWiw==
   dependencies:
     "@floating-ui/react-dom" "2.0.0"
     "@sanity/color" "^2.2.5"


### PR DESCRIPTION
### Description

This PR updates `@sanity/ui` to latest (`1.9.3`)

### What to review

Tooltips should render correctly and not appear 'squashed', especially at the periphery of boundary elements.

For comparison, try hover over field actions in the first field (`name`) in this document: [before](https://test-studio.sanity.build/ai-assist/content/untitledRepro;grrm) and [after](https://test-studio-git-chore-bump-sanity-ui.sanity.build/ai-assist/content/untitledRepro;grrm)

### Notes for release

N/A