### PR TITLE
fix(comments): improve scroll behavior

### DIFF
--- a/packages/sanity/src/desk/comments/plugin/inspector/CommentsInspector.tsx
+++ b/packages/sanity/src/desk/comments/plugin/inspector/CommentsInspector.tsx
@@ -209,13 +209,13 @@ export function CommentsInspector(props: DocumentInspectorProps) {
   )
 
   const handleScrollToComment = useCallback(
-    (id: string) => {
+    (id: string, origin?: CommentsSelectedPath['origin']) => {
       const comment = getComment(id)
 
       if (comment) {
         setSelectedPath({
           fieldPath: comment.target.path.field || null,
-          origin: 'inspector',
+          origin: origin || 'inspector',
           threadId: comment.threadId || null,
         })
 
@@ -267,7 +267,13 @@ export function CommentsInspector(props: DocumentInspectorProps) {
       // Make sure we have the correct status set before we scroll to the comment
       setStatus(commentToScrollTo.status || 'open')
 
-      handleScrollToComment(commentToScrollTo._id)
+      // The second argument sets the select path origin to 'url' which will prevent the field in the form
+      // the comment  refers to from being selected and scrolled to. This is because, on mount, we will in
+      // some cases attempt to perform two scrolls: one to the field and one to the comment.
+      // These scroll events seems to interfere with each other and the result is that the comment is not
+      // scrolled to. Therefore, when there's a comment id in the url, we prioritize scrolling to the comment
+      // and not the field.
+      handleScrollToComment(commentToScrollTo._id, 'url')
 
       didScrollToCommentFromParam.current = true
       commentIdParamRef.current = undefined

--- a/packages/sanity/src/desk/comments/src/components/list/CommentsList.tsx
+++ b/packages/sanity/src/desk/comments/src/components/list/CommentsList.tsx
@@ -56,7 +56,7 @@ export interface CommentsListProps {
   onReply: (payload: CommentCreatePayload) => void
   onStatusChange?: (id: string, status: CommentStatus) => void
   readOnly?: boolean
-  selectedPath: CommentsSelectedPath
+  selectedPath: CommentsSelectedPath | null
   status: CommentStatus
 }
 

--- a/packages/sanity/src/desk/comments/src/context/selected-path/CommentsSelectedPathProvider.tsx
+++ b/packages/sanity/src/desk/comments/src/context/selected-path/CommentsSelectedPathProvider.tsx
@@ -10,9 +10,9 @@ export const CommentsSelectedPathProvider = React.memo(function CommentsSelected
   props: CommentsSelectedPathProviderProps,
 ) {
   const {children} = props
-  const [selectedPath, setSelectedPath] = useState<CommentsSelectedPath>(null)
+  const [selectedPath, setSelectedPath] = useState<CommentsSelectedPath | null>(null)
 
-  const handleSelectPath = useCallback((nextPath: CommentsSelectedPath) => {
+  const handleSelectPath = useCallback((nextPath: CommentsSelectedPath | null) => {
     setSelectedPath(nextPath)
   }, [])
 

--- a/packages/sanity/src/desk/comments/src/context/selected-path/types.ts
+++ b/packages/sanity/src/desk/comments/src/context/selected-path/types.ts
@@ -1,12 +1,10 @@
-interface CommentsSelectedPathValue {
-  origin: 'form' | 'inspector'
+export interface CommentsSelectedPath {
+  origin: 'form' | 'inspector' | 'url'
   fieldPath: string | null
   threadId: string | null
 }
 
-export type CommentsSelectedPath = CommentsSelectedPathValue | null
-
 export interface CommentsSelectedPathContextValue {
-  setSelectedPath: (nextSelectedPath: CommentsSelectedPath) => void
-  selectedPath: CommentsSelectedPath
+  setSelectedPath: (nextSelectedPath: CommentsSelectedPath | null) => void
+  selectedPath: CommentsSelectedPath | null
 }


### PR DESCRIPTION
### Description

This pull request aims to stabilize and improve the scroll behavior in comments. The scroll functionality is intended for the following scenarios:

- When clicking on the comment button with existing comments, the corresponding comment thread item should scroll into view in the inspector and be highlighted.
- When clicking on a comment thread item in the inspector, the related comment item should be highlighted, and the corresponding field in the form should scroll into view and be highlighted.
- When utilizing the "Copy link to comment" feature, the comment should be scrolled to in the inspector when navigating to the URL

### What to review

- Ensure that the scroll functionality works correctly in various scenarios.

### Notes for release

N/A
