### PR TITLE
fix(core): disable pointer events when field actions are hidden

### DIFF
--- a/packages/sanity/src/core/form/components/formField/FormFieldBaseHeader.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldBaseHeader.tsx
@@ -72,6 +72,7 @@ const FieldActionsFloatingCard = styled(Card)(({theme}: {theme: Theme}) => {
       // and only show it when it has focus within or when the field is hovered or focused.
       opacity: 0;
       width: 0;
+      pointer-events: none;
 
       [data-ui='FieldActionsFlex'] {
         opacity: 0;
@@ -96,10 +97,12 @@ const FieldActionsFloatingCard = styled(Card)(({theme}: {theme: Theme}) => {
       // Show the floating card when it has focus within (ie when field actions are focused).
       &:focus-within {
         opacity: 1;
+        pointer-events: auto;
         width: max-content;
 
         [data-ui='FieldActionsFlex'] {
           opacity: 1;
+          pointer-events: auto;
           width: max-content;
         }
       }
@@ -107,12 +110,14 @@ const FieldActionsFloatingCard = styled(Card)(({theme}: {theme: Theme}) => {
 
     &[data-visible='true'] {
       opacity: 1;
+      pointer-events: auto;
       width: max-content;
     }
 
     &[data-actions-visible='true'] {
       [data-ui='FieldActionsFlex'] {
         opacity: 1;
+        pointer-events: auto;
         width: max-content;
       }
     }


### PR DESCRIPTION
### Description

This pull request makes sure that the field actions don't allow pointer events until they are visible. Currently, it is possible to hover the field actions when they are not visible, causing them to flicker. See video of the current issue:

https://github.com/sanity-io/sanity/assets/15094168/b13dd842-f678-4a67-ab18-4f0e70981100

### What to review

Make sure that field action appears on hovering without flickering### Notes for release


## Notes for release

n/a
