### PR TITLE
chore(i18n): fixes missing react import for some files

### DIFF
--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceFinalizeAlertStrip.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceFinalizeAlertStrip.tsx
@@ -2,6 +2,7 @@ import type {ReferenceSchemaType} from '@sanity/types'
 import {Button, Stack, Text} from '@sanity/ui'
 import {AlertStrip} from '../../components/AlertStrip'
 import {Translate, useTranslation} from '../../../i18n'
+import React from 'react'
 
 /**
  * Alert strip that shows an explanation and action prompting the user to finalize a reference,

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceMetadataLoadFailure.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceMetadataLoadFailure.tsx
@@ -1,6 +1,7 @@
 import {Button, Stack, Text} from '@sanity/ui'
 import {useTranslation} from '../../../i18n'
 import {AlertStrip} from '../../components/AlertStrip'
+import React from 'react'
 
 /**
  * Alert strip that shows error encountered while fetching reference metadata, and allowing user

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceStrengthMismatchAlertStrip.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceStrengthMismatchAlertStrip.tsx
@@ -1,6 +1,7 @@
 import {Button, Stack, Text} from '@sanity/ui'
 import {AlertStrip} from '../../components/AlertStrip'
 import {Translate, useTranslation} from '../../../i18n'
+import React from 'react'
 
 /**
  * Alert strip that shows an explanation and action prompting the user to fix a mismatch in

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/NoItemsPlaceholder.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/NoItemsPlaceholder.tsx
@@ -1,6 +1,7 @@
 import type {ArraySchemaType} from '@sanity/types'
 import {Card, Text} from '@sanity/ui'
 import {useTranslation} from '../../../../i18n'
+import React from 'react'
 
 const CARD_STYLE = {borderStyle: 'dashed'} as const
 


### PR DESCRIPTION
### Description

Found some non-i18n related lint violations and fixed them. 

The lint error was:
```
'React' must be in scope when using JSX
```