### PR TITLE
feat(facelift): create CollapseTabList for redesigned navbar

### DIFF
--- a/packages/sanity/src/core/components/collapseTabList/CollapseTabList.tsx
+++ b/packages/sanity/src/core/components/collapseTabList/CollapseTabList.tsx
@@ -1,0 +1,149 @@
+import React, {cloneElement, forwardRef, useCallback, useMemo, useState} from 'react'
+import {Flex, MenuButtonProps} from '@sanity/ui'
+import {EllipsisHorizontalIcon} from '@sanity/icons'
+import styled from 'styled-components'
+import {Button} from '../../../ui'
+import {CollapseOverflowMenu} from '../collapseMenu/CollapseOverflowMenu'
+import {ObserveElement} from '../collapseMenu/ObserveElement'
+
+function _isReactElement(node: unknown): node is React.ReactElement {
+  return Boolean(node)
+}
+
+const OptionObserveElement = styled(ObserveElement)`
+  list-style: none;
+  white-space: nowrap;
+  flex-shrink: 0;
+  opacity: 0;
+  visibility: hidden;
+`
+
+const HiddenRow = styled(Flex)`
+  opacity: 0;
+  height: 0.1px;
+  overflow: hidden;
+`
+
+interface CollapseTabListProps {
+  children: React.ReactNode
+  gap?: number | number[]
+  menuButtonProps?: Omit<MenuButtonProps, 'id' | 'menu' | 'button'> & {
+    id?: string
+    button?: React.ReactElement
+  }
+  onMenuClose?: () => void
+  collapsed?: boolean
+  disableRestoreFocusOnClose?: boolean
+}
+
+/**
+ * Similar to `<CollapseMenu />` but instead of collapsing the inner items by removing the text
+ * it shows the items that fit, and the rest are rendered in a menu.
+ * @internal */
+export const CollapseTabList = forwardRef(function CollapseTabList(
+  props: CollapseTabListProps,
+  ref: React.ForwardedRef<HTMLDivElement>,
+) {
+  const {
+    children: childrenProp,
+    gap,
+    menuButtonProps,
+    disableRestoreFocusOnClose,
+    onMenuClose,
+    collapsed,
+  } = props
+  const [rootEl, setRootEl] = useState<HTMLDivElement | null>(null)
+  const [hiddenElements, setHiddenElements] = useState<React.ReactElement[]>([])
+  const [showChildren, setShowChildren] = useState(false)
+
+  const children = useMemo(
+    () => React.Children.toArray(childrenProp).filter(_isReactElement),
+    [childrenProp],
+  )
+
+  /**
+   * Keeps track of the children that will be shown in place and not in the menu.
+   */
+  const displayChildren = useMemo(() => {
+    if (collapsed) return null // If collapsed, we don't want to show any children
+    if (!showChildren) return null // If we haven't run the intersection observer yet, we don't want to show any children
+    // eslint-disable-next-line max-nested-callbacks
+    return children.filter((c) => !hiddenElements.some((h) => h.key === c.key))
+  }, [children, collapsed, hiddenElements, showChildren])
+
+  const intersectionOptions = useMemo(
+    () => ({
+      root: rootEl,
+      threshold: 1,
+      rootMargin: '1px',
+    }),
+    [rootEl],
+  )
+
+  const menuButton = useMemo(
+    () => menuButtonProps?.button || <Button icon={EllipsisHorizontalIcon} mode="bleed" />,
+    [menuButtonProps],
+  )
+
+  const menuOptionsArray = useMemo(
+    () =>
+      collapsed
+        ? children
+        : // eslint-disable-next-line max-nested-callbacks
+          children.filter(({key}) => hiddenElements.find((o: React.ReactElement) => o.key === key)),
+    [children, hiddenElements, collapsed],
+  )
+
+  const handleIntersection = useCallback(
+    (e: IntersectionObserverEntry, child: React.ReactElement) => {
+      const isHidden = hiddenElements.some((el) => el.key === child.key)
+
+      if (!showChildren) setShowChildren(true)
+      const isIntersecting = e.isIntersecting
+      if (!isHidden && !isIntersecting) setHiddenElements((prev) => [...prev, child])
+      if (isHidden && isIntersecting)
+        // eslint-disable-next-line max-nested-callbacks
+        setHiddenElements((prev) => prev.filter((el) => el.key !== child.key))
+    },
+    [hiddenElements, showChildren, setShowChildren, setHiddenElements],
+  )
+
+  return (
+    <Flex direction="column" ref={ref} sizing="border" style={{position: 'relative'}}>
+      <Flex justify="center" gap={gap} flex={1}>
+        {displayChildren}
+        {(hiddenElements.length > 0 || collapsed) && (
+          <CollapseOverflowMenu
+            disableRestoreFocusOnClose={disableRestoreFocusOnClose}
+            menuButton={menuButton}
+            menuButtonProps={menuButtonProps}
+            menuOptionsArray={menuOptionsArray}
+            onMenuClose={onMenuClose}
+          />
+        )}
+      </Flex>
+
+      {/* Element that always render all the children to keep track of their position and if the available space to render them */}
+      <HiddenRow justify="flex-start" gap={gap} ref={setRootEl} data-hidden aria-hidden="true">
+        {cloneElement(menuButton, {
+          disabled: true,
+          'aria-hidden': true,
+        })}
+        {children?.map((child) => (
+          <OptionObserveElement
+            key={`${child.key}_observer`}
+            options={intersectionOptions}
+            // eslint-disable-next-line react/jsx-no-bind
+            callback={(e) => handleIntersection(e[0], child)}
+          >
+            {cloneElement(child, {
+              disabled: true,
+              'aria-hidden': true,
+              tabIndex: -1,
+            })}
+          </OptionObserveElement>
+        ))}
+      </HiddenRow>
+    </Flex>
+  )
+})

--- a/packages/sanity/src/core/components/collapseTabList/__workshop__/CollapseTabListStory.tsx
+++ b/packages/sanity/src/core/components/collapseTabList/__workshop__/CollapseTabListStory.tsx
@@ -1,0 +1,42 @@
+import {useState} from 'react'
+import {IceCreamIcon} from '@sanity/icons'
+import {Card, Flex} from '@sanity/ui'
+import {useBoolean, useSelect} from '@sanity/ui-workshop'
+import {Button} from '../../../../ui'
+import {CollapseTabList} from '..'
+
+const GAP_OPTIONS = {'0': 0, '1': 1, '2': 2, '3': 3, '4': 4}
+
+export default function CollapseMenuStory() {
+  const collapsed = useBoolean('Collapsed', false)
+  const gap = useSelect('Gap', GAP_OPTIONS, 1)
+  const [selected, setSelected] = useState(0)
+
+  return (
+    <Flex align="center" height="fill" justify="center" padding={2}>
+      <Card
+        shadow={1}
+        radius={3}
+        padding={1}
+        style={{
+          overflow: 'hidden',
+          resize: 'horizontal',
+        }}
+      >
+        <CollapseTabList gap={gap} collapsed={collapsed}>
+          {[...Array(5).keys()].map((num) => (
+            <Button
+              key={num}
+              text={`Button ${num + 1}`}
+              icon={IceCreamIcon}
+              mode="bleed"
+              selected={selected === num}
+              // eslint-disable-next-line react/jsx-no-bind
+              onClick={() => setSelected(num)}
+            />
+          ))}
+        </CollapseTabList>
+      </Card>
+    </Flex>
+  )
+}

--- a/packages/sanity/src/core/components/collapseTabList/__workshop__/index.ts
+++ b/packages/sanity/src/core/components/collapseTabList/__workshop__/index.ts
@@ -1,0 +1,14 @@
+import {defineScope} from '@sanity/ui-workshop'
+import {lazy} from 'react'
+
+export default defineScope({
+  name: 'core/components/collapseTabList',
+  title: 'CollapseTabList',
+  stories: [
+    {
+      name: 'collapse-tab-list',
+      title: 'Default',
+      component: lazy(() => import('./CollapseTabListStory')),
+    },
+  ],
+})

--- a/packages/sanity/src/core/components/collapseTabList/index.ts
+++ b/packages/sanity/src/core/components/collapseTabList/index.ts
@@ -1,0 +1,1 @@
+export * from './CollapseTabList'

--- a/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
@@ -160,7 +160,7 @@ export function StudioNavbar() {
       <RootCard borderBottom data-testid="navbar" data-ui="Navbar" padding={2} sizing="border">
         {/** Left flex */}
         <Flex align="center" justify="space-between">
-          <Flex align="center" gap={2}>
+          <Flex align="center" gap={2} style={{flexShrink: 0}}>
             <Flex align="center" gap={1}>
               {/* Menu button */}
               {!shouldRender.tools && (

--- a/packages/sanity/src/core/studio/components/navbar/tools/ToolCollapseMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/tools/ToolCollapseMenu.tsx
@@ -1,16 +1,22 @@
-import {UnknownIcon} from '@sanity/icons'
 import React, {forwardRef, useMemo, useState} from 'react'
 import {startCase} from 'lodash'
-import {CollapseMenu, CollapseMenuButton} from '../../../../components/collapseMenu'
+import {Flex} from '@sanity/ui'
+import styled from 'styled-components'
+import {CollapseTabList} from '../../../../components/collapseTabList/CollapseTabList'
 import {useRovingFocus} from '../../../../components'
 import {useColorScheme} from '../../../colorScheme'
 import {Tool} from '../../../../config'
+import {Button} from '../../../../../ui'
 import {ToolLink, ToolLinkProps} from './ToolLink'
 
 interface ToolCollapseMenuProps {
   activeToolName?: string
   tools: Tool[]
 }
+
+const CollapseTabListWrapper = styled(Flex)`
+  margin: 0 80px;
+`
 
 export function ToolCollapseMenu(props: ToolCollapseMenuProps) {
   const {activeToolName, tools} = props
@@ -32,7 +38,6 @@ export function ToolCollapseMenu(props: ToolCollapseMenuProps) {
     }),
     [scheme],
   )
-
   const children = useMemo(
     () =>
       tools.map((tool, index) => {
@@ -46,30 +51,30 @@ export function ToolCollapseMenu(props: ToolCollapseMenuProps) {
         })
 
         return (
-          <CollapseMenuButton
+          <Button
             as={Link}
             data-as="a"
-            collapsedProps={{tooltipText: tool.title}}
             // eslint-disable-next-line react/no-array-index-key
             key={`${tool.name}-${index}`}
             mode="bleed"
             selected={activeToolName === tool.name}
             text={title}
-            tooltipProps={{scheme: scheme}}
           />
         )
       }),
-    [activeToolName, scheme, tools],
+    [activeToolName, tools],
   )
 
   return (
-    <CollapseMenu
-      data-testid="tool-collapse-menu"
-      gap={1}
-      menuButtonProps={menuButtonProps}
-      ref={setCollapseMenuEl}
-    >
-      {children}
-    </CollapseMenu>
+    <CollapseTabListWrapper justify="center">
+      <CollapseTabList
+        data-testid="tool-collapse-menu"
+        gap={1}
+        menuButtonProps={menuButtonProps}
+        ref={setCollapseMenuEl}
+      >
+        {children}
+      </CollapseTabList>
+    </CollapseTabListWrapper>
   )
 }


### PR DESCRIPTION
### Description

Adds `<CollapseTabList />` component, which works similar to ColapseMenu but instead of removing the text it hides the elements that don't fit and renders them into a `<Menu />`

https://test-studio-git-edx-742.sanity.build/test/workshop/core;components;collapseTabList;collapse-tab-list?scheme=light

<img width="1153" alt="Screenshot 2023-11-14 at 08 54 39" src="https://github.com/sanity-io/sanity/assets/46196328/361ab21d-fac9-4741-9568-378e54b7ea01">
<img width="1070" alt="Screenshot 2023-11-14 at 08 53 59" src="https://github.com/sanity-io/sanity/assets/46196328/99b79e7b-d38a-44ec-bb5f-d5fb8b2b25a6">


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
