### PR TITLE
refactor(core): improve navbar collapse menu

### DIFF
--- a/packages/sanity/src/core/components/collapseMenu/CollapseMenu.tsx
+++ b/packages/sanity/src/core/components/collapseMenu/CollapseMenu.tsx
@@ -1,6 +1,14 @@
 import {EllipsisVerticalIcon} from '@sanity/icons'
 import {Box, Button, Flex, MenuButtonProps, Text, Tooltip} from '@sanity/ui'
-import React, {cloneElement, forwardRef, ReactElement, useCallback, useMemo, useState} from 'react'
+import React, {
+  cloneElement,
+  forwardRef,
+  memo,
+  ReactElement,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react'
 import styled, {css} from 'styled-components'
 import {difference} from 'lodash'
 import {CollapseOverflowMenu} from './CollapseOverflowMenu'
@@ -307,54 +315,20 @@ export const AutoCollapseMenu = forwardRef(function AutoCollapseMenu(
               )
             })}
         </RowFlex>
-        {/* Rendered hidden in order to calculate intersections for expanded menu options */}
-        <RowFlex data-hidden aria-hidden="true" gap={gap} overflow="hidden">
-          {menuOptions.map((child, index) => {
-            const {dividerBefore} = child.props
-            return (
-              <React.Fragment key={child.key}>
-                {dividerBefore && index !== 0 && <CollapseMenuDivider hidden />}
-
-                <OptionObserveElement
-                  options={intersectionOptions}
-                  // eslint-disable-next-line react/jsx-no-bind
-                  onIntersectionChange={(e) => handleExpandedIntersection(e[0], child)}
-                >
-                  <Flex>
-                    {cloneElement(child, {
-                      disabled: true,
-                      'aria-hidden': true,
-                    })}
-                  </Flex>
-                </OptionObserveElement>
-              </React.Fragment>
-            )
-          })}
-        </RowFlex>
+        {/* Rendered hidden in order to calculate intersections for original (expanded) menu options */}
+        <RenderHidden
+          gap={gap}
+          elements={menuOptions}
+          intersectionOptions={intersectionOptions}
+          onIntersectionChange={handleExpandedIntersection}
+        />
         {/* Rendered hidden in order to calculate intersections for collapsed menu options */}
-        <RowFlex data-hidden aria-hidden="true" gap={gap} overflow="hidden">
-          {collapsedElements.map((child, index) => {
-            const {dividerBefore} = child.props
-            return (
-              <React.Fragment key={child.key}>
-                {dividerBefore && index !== 0 && <CollapseMenuDivider hidden />}
-
-                <OptionObserveElement
-                  options={intersectionOptions}
-                  // eslint-disable-next-line react/jsx-no-bind
-                  onIntersectionChange={(e) => handleCollapsedIntersection(e[0], child)}
-                >
-                  <Flex>
-                    {cloneElement(child, {
-                      disabled: true,
-                      'aria-hidden': true,
-                    })}
-                  </Flex>
-                </OptionObserveElement>
-              </React.Fragment>
-            )
-          })}
-        </RowFlex>
+        <RenderHidden
+          gap={gap}
+          elements={collapsedElements}
+          intersectionOptions={intersectionOptions}
+          onIntersectionChange={handleCollapsedIntersection}
+        />
       </RootFlex>
 
       {/* Show the collapsed items that doesn't fit in a menu */}
@@ -370,5 +344,39 @@ export const AutoCollapseMenu = forwardRef(function AutoCollapseMenu(
         </Flex>
       )}
     </OuterFlex>
+  )
+})
+
+const RenderHidden = memo(function RenderHidden(props: {
+  elements: ReactElement[]
+  gap?: number | number[]
+  intersectionOptions: IntersectionObserverInit
+  onIntersectionChange: (e: IntersectionObserverEntry, child: React.ReactElement) => void
+}) {
+  const {elements, gap, intersectionOptions, onIntersectionChange} = props
+  return (
+    <RowFlex data-hidden aria-hidden="true" gap={gap} overflow="hidden">
+      {elements.map((element, index) => {
+        const {dividerBefore} = element.props
+        return (
+          <React.Fragment key={element.key}>
+            {dividerBefore && index !== 0 && <CollapseMenuDivider hidden />}
+
+            <OptionObserveElement
+              options={intersectionOptions}
+              // eslint-disable-next-line react/jsx-no-bind
+              onIntersectionChange={(e) => onIntersectionChange(e[0], element)}
+            >
+              <Flex>
+                {cloneElement(element, {
+                  disabled: true,
+                  'aria-hidden': true,
+                })}
+              </Flex>
+            </OptionObserveElement>
+          </React.Fragment>
+        )
+      })}
+    </RowFlex>
   )
 })

--- a/packages/sanity/src/core/components/collapseMenu/CollapseMenu.tsx
+++ b/packages/sanity/src/core/components/collapseMenu/CollapseMenu.tsx
@@ -48,8 +48,9 @@ const RootFlex = styled(Flex)`
 const RowFlex = styled(Flex)`
   width: max-content;
   &[data-hidden='true'] {
-    position: absolute;
     visibility: hidden;
+    position: relative;
+    margin-top: -1px;
     height: 1px;
   }
 `

--- a/packages/sanity/src/core/components/collapseMenu/CollapseOverflowMenu.tsx
+++ b/packages/sanity/src/core/components/collapseMenu/CollapseOverflowMenu.tsx
@@ -1,5 +1,5 @@
 import {Menu, MenuButton, MenuButtonProps, MenuDivider, MenuItem} from '@sanity/ui'
-import React from 'react'
+import React, {ForwardedRef, forwardRef} from 'react'
 import {CollapseMenuProps} from './CollapseMenu'
 
 const MENU_BUTTON_POPOVER_PROPS: MenuButtonProps['popover'] = {
@@ -7,26 +7,27 @@ const MENU_BUTTON_POPOVER_PROPS: MenuButtonProps['popover'] = {
   constrainSize: true,
 }
 
-export function CollapseOverflowMenu(
+export const CollapseOverflowMenu = forwardRef(function CollapseOverflowMenu(
   props: Pick<
     CollapseMenuProps,
     'disableRestoreFocusOnClose' | 'menuButtonProps' | 'onMenuClose'
-  > & {menuOptionsArray: React.ReactElement[]; menuButton: React.ReactElement},
+  > & {menuOptions: React.ReactElement[]; menuButton: React.ReactElement},
+  forwardedRef: ForwardedRef<HTMLButtonElement>,
 ) {
-  const {disableRestoreFocusOnClose, menuButton, menuButtonProps, menuOptionsArray, onMenuClose} =
-    props
+  const {disableRestoreFocusOnClose, menuButton, menuButtonProps, menuOptions, onMenuClose} = props
 
   return (
     <MenuButton
       __unstable_disableRestoreFocusOnClose={disableRestoreFocusOnClose}
       id="menu-button"
+      ref={forwardedRef}
       onClose={onMenuClose}
       popover={MENU_BUTTON_POPOVER_PROPS}
       {...menuButtonProps}
       button={menuButton}
       menu={
         <Menu>
-          {menuOptionsArray.map((c, index) => {
+          {menuOptions.map((c, index) => {
             const {
               // eslint-disable-next-line @typescript-eslint/no-unused-vars
               collapsedProps = {},
@@ -59,4 +60,4 @@ export function CollapseOverflowMenu(
       }
     />
   )
-}
+})

--- a/packages/sanity/src/core/components/collapseMenu/ObserveElement.tsx
+++ b/packages/sanity/src/core/components/collapseMenu/ObserveElement.tsx
@@ -4,24 +4,24 @@ import React, {useEffect, useState} from 'react'
 interface ObserveElementProps {
   children: React.ReactElement
   options?: IntersectionObserverInit
-  callback: IntersectionObserverCallback
+  onIntersectionChange: IntersectionObserverCallback
 }
 
 export function ObserveElement(props: ObserveElementProps) {
-  const {callback, children, options, ...rest} = props
+  const {onIntersectionChange, children, options, ...rest} = props
   const [el, setEl] = useState<HTMLDivElement | null>(null)
 
   useEffect(() => {
     if (!el) return undefined
 
-    const io = new IntersectionObserver(callback, options)
+    const io = new IntersectionObserver(onIntersectionChange, options)
     io.observe(el)
 
     return () => {
       io.unobserve(el)
       io.disconnect()
     }
-  }, [el, callback, options])
+  }, [el, onIntersectionChange, options])
 
   return (
     <Flex ref={setEl} {...rest}>


### PR DESCRIPTION
### Description
This changes the approach we use to check whether there's enough space to show menu options as expanded or collapsed or whether we need to move menu options to the menu:
1. We keep two "shadow" (hidden) navbars: One is rendering all items as expanded and the other is rendering all items as collapsed.
2. For each of these "shadow" navbars, we keep track of intersections for each rendered item in a dictionary on the format `Record<element.key, {intersecting: boolean, element: ReactElement}>`
3. This enables us to easily check whether we have received the intersections for all the current menu options, which again enables us to defer the first render until we have got all the intersection data we need.

This should also pave the way for future work that let's us track the individual widths (bounding boxes) of each menu element, and improve the navbar by gradually collapsing items from the right.

### What to review
Does the changes look ok?
I've done quite extensive testing in all major browsers (Chrome, Safari, Firefox) and it seems to work great, but there might be edge cases I don't know about here, so please test the cases you know.

### Notes for release

- Improved initial rendering of the Studio navigation toolbar
