### PR TITLE
fix(facelift): add wrapper to publish action button

### DIFF
--- a/packages/sanity/src/desk/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -1,4 +1,4 @@
-import {Box, Flex, Hotkeys, LayerProvider, Text} from '@sanity/ui'
+import {Box, Flex, Hotkeys, LayerProvider, Stack, Text} from '@sanity/ui'
 import React, {memo, useMemo, useState} from 'react'
 import {RenderActionCollectionState} from '../../../components'
 import {HistoryRestoreAction} from '../../../documentActions'
@@ -42,22 +42,19 @@ function DocumentStatusBarActionsInner(props: DocumentStatusBarActionsInnerProps
     <Flex flex={1} justify="flex-end" gap={2}>
       {firstActionState && (
         <LayerProvider zOffset={200}>
-          <TooltipWithNodes
-            disabled={!tooltipContent}
-            content={tooltipContent}
-            portal
-            placement="top"
-          >
-            <Button
-              data-testid={`action-${firstActionState.label}`}
-              disabled={disabled || Boolean(firstActionState.disabled)}
-              icon={firstActionState.icon}
-              // eslint-disable-next-line react/jsx-handler-names
-              onClick={firstActionState.onHandle}
-              ref={setButtonElement}
-              text={firstActionState.label}
-              tone={firstActionState.tone || 'primary'}
-            />
+          <TooltipWithNodes disabled={!tooltipContent} content={tooltipContent} placement="top">
+            <Stack>
+              <Button
+                data-testid={`action-${firstActionState.label}`}
+                disabled={disabled || Boolean(firstActionState.disabled)}
+                icon={firstActionState.icon}
+                // eslint-disable-next-line react/jsx-handler-names
+                onClick={firstActionState.onHandle}
+                ref={setButtonElement}
+                text={firstActionState.label}
+                tone={firstActionState.tone || 'primary'}
+              />
+            </Stack>
           </TooltipWithNodes>
         </LayerProvider>
       )}


### PR DESCRIPTION
### Description
Adds wrapper to Publish Action button, it's needed to render the Tooltip correctly.
The button was the direct child of the tooltip, so the modified onMouseEnter action was passed to that button, given the button is disabled, the onMouseEnter action won't be triggered.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
