### PR TITLE
fix(comments): show parent comment menu when hovering over thread

### DIFF
--- a/packages/sanity/src/desk/comments/src/components/list/CommentsListItem.tsx
+++ b/packages/sanity/src/desk/comments/src/components/list/CommentsListItem.tsx
@@ -35,17 +35,21 @@ const StyledThreadCard = styled(ThreadCard)(({theme}) => {
         0 0 0 3px var(--card-focus-ring-color);
     }
 
-    // When hovering over the thread root we want to display the parent comments menu.
-    // The data-root-menu attribute is used to target the menu and is applied in
-    // the CommentsListItemLayout component.
+    @media (hover: hover) {
+      &:hover {
+        // When hovering over the thread root we want to display the parent comments menu.
+        // The data-root-menu attribute is used to target the menu and is applied in
+        // the CommentsListItemLayout component.
+        [data-root-menu='true'] {
+          opacity: 1;
+        }
+      }
+    }
+
     &:not([data-active='true']) {
       @media (hover: hover) {
         &:hover {
           --card-bg-color: ${hovered.bg2};
-
-          [data-root-menu='true'] {
-            opacity: 1;
-          }
         }
       }
     }

--- a/packages/sanity/src/desk/comments/src/components/list/CommentsListItemContextMenu.tsx
+++ b/packages/sanity/src/desk/comments/src/components/list/CommentsListItemContextMenu.tsx
@@ -71,14 +71,13 @@ export function CommentsListItemContextMenu(props: CommentsListItemContextMenuPr
     onStatusChange,
     readOnly,
     status,
-    ...rest
   } = props
 
   const showMenuButton = Boolean(onCopyLink || onDeleteStart || onEditStart)
 
   return (
     <TooltipDelayGroupProvider delay={TOOLTIP_GROUP_DELAY}>
-      <Flex data-root-menu={isParent ? 'true' : 'false'} {...rest}>
+      <Flex>
         <FloatingCard display="flex" shadow={2} padding={1} radius={2} sizing="border">
           {isParent && (
             <TextTooltip text={status === 'open' ? 'Mark as resolved' : 'Re-open'}>

--- a/packages/sanity/src/desk/comments/src/components/list/CommentsListItemLayout.tsx
+++ b/packages/sanity/src/desk/comments/src/components/list/CommentsListItemLayout.tsx
@@ -1,15 +1,5 @@
 import {hues} from '@sanity/color'
-import {
-  TextSkeleton,
-  Flex,
-  Stack,
-  Text,
-  Card,
-  useGlobalKeyDown,
-  useClickOutside,
-  Box,
-  Layer,
-} from '@sanity/ui'
+import {TextSkeleton, Flex, Stack, Text, Card, useClickOutside, Box, Layer} from '@sanity/ui'
 import React, {useCallback, useMemo, useRef, useState} from 'react'
 import {CurrentUser} from '@sanity/types'
 import styled, {css} from 'styled-components'
@@ -31,14 +21,18 @@ import {TimeAgoOpts, useTimeAgo, useUser, useDidUpdate} from 'sanity'
 
 const ContextMenuLayer = styled(Layer)``
 
-function StopPropagationLayer(props: React.PropsWithChildren) {
-  const {children} = props
+function StopPropagationLayer(props: React.PropsWithChildren<{isParent?: boolean}>) {
+  const {children, isParent} = props
 
   const handleClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
     event.stopPropagation()
   }, [])
 
-  return <ContextMenuLayer onClick={handleClick}>{children}</ContextMenuLayer>
+  return (
+    <ContextMenuLayer data-root-menu={isParent ? 'true' : 'false'} onClick={handleClick}>
+      {children}
+    </ContextMenuLayer>
+  )
 }
 
 const SKELETON_INLINE_STYLE: React.CSSProperties = {width: '50%'}
@@ -88,7 +82,6 @@ const RootStack = styled(Stack)(({theme}) => {
         position: absolute;
         right: 0;
         top: 0;
-
         transform: translate(${space[1]}px, -${space[1]}px);
       }
 
@@ -298,7 +291,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
           </Flex>
 
           {!isEditing && !displayError && (
-            <StopPropagationLayer>
+            <StopPropagationLayer isParent={isParent}>
               <CommentsListItemContextMenu
                 canDelete={canDelete}
                 canEdit={canEdit}


### PR DESCRIPTION
### Description

This pull request ensures that the menu of the parent comment in a thread is always visible when hovering over the thread item.

### What to review

- Hover over a thread item and make sure that the parent comment menu is always visible

### Notes for release

N/A
