### PR TITLE
chore(ci): turn off "require dashboard approval" renovatebot req

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>sanity-io/renovate-config", ":dependencyDashboardApproval"],
+  "extends": ["github>sanity-io/renovate-config"],
   "ignorePresets": ["github>sanity-io/renovate-config:group-non-major"],
   "packageRules": [
     {


### PR DESCRIPTION
### Description

Enables Renovatebot to open PRs without requiring approving the PR on https://github.com/sanity-io/sanity/issues/4030
