### PR TITLE
fix(comments): context menu layer issue

### DIFF
--- a/packages/sanity/src/desk/comments/src/components/list/CommentsListItem.tsx
+++ b/packages/sanity/src/desk/comments/src/components/list/CommentsListItem.tsx
@@ -22,6 +22,8 @@ const EMPTY_ARRAY: [] = []
 
 const MAX_COLLAPSED_REPLIES = 5
 
+// data-active = when the comment is selected
+// data-hovered = when the mouse is over the comment
 const StyledThreadCard = styled(ThreadCard)(({theme}) => {
   const {hovered} = theme.sanity.color.button.bleed.default
 
@@ -35,21 +37,19 @@ const StyledThreadCard = styled(ThreadCard)(({theme}) => {
         0 0 0 3px var(--card-focus-ring-color);
     }
 
-    @media (hover: hover) {
-      &:hover {
-        // When hovering over the thread root we want to display the parent comments menu.
-        // The data-root-menu attribute is used to target the menu and is applied in
-        // the CommentsListItemLayout component.
-        [data-root-menu='true'] {
-          opacity: 1;
-        }
-      }
-    }
-
+    // When the comment is not selected, we want to apply hover styles.
+    // The hover styles is managed with the [data-hovered] attribute instead of the :hover pseudo class
+    // since we want to show the hover styles when hovering over the menu items in the context menu as well.
+    // The context menu is rendered using a portal, so the :hover pseudo class won't work when hovering over
+    // the menu items.
     &:not([data-active='true']) {
       @media (hover: hover) {
-        &:hover {
+        &[data-hovered='true'] {
           --card-bg-color: ${hovered.bg2};
+        }
+
+        [data-root-menu='true'] {
+          opacity: 1;
         }
       }
     }
@@ -115,6 +115,11 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
   const replyInputRef = useRef<CommentInputHandle>(null)
 
   const hasValue = useMemo(() => hasCommentMessageValue(value), [value])
+
+  const [mouseOver, setMouseOver] = useState<boolean>(false)
+
+  const handleMouseEnter = useCallback(() => setMouseOver(true), [])
+  const handleMouseLeave = useCallback(() => setMouseOver(false), [])
 
   const handleReplySubmit = useCallback(() => {
     const nextComment: CommentCreatePayload = {
@@ -251,7 +256,10 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
     <Stack space={2}>
       <StyledThreadCard
         data-active={isSelected ? 'true' : 'false'}
+        data-hovered={mouseOver ? 'true' : 'false'}
         onClick={handleThreadRootClick}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
         tone={isSelected ? 'primary' : undefined}
       >
         <GhostButton data-ui="GhostButton" aria-label="Go to field" />

--- a/packages/sanity/src/desk/comments/src/components/list/CommentsListItem.tsx
+++ b/packages/sanity/src/desk/comments/src/components/list/CommentsListItem.tsx
@@ -46,10 +46,10 @@ const StyledThreadCard = styled(ThreadCard)(({theme}) => {
       @media (hover: hover) {
         &[data-hovered='true'] {
           --card-bg-color: ${hovered.bg2};
-        }
 
-        [data-root-menu='true'] {
-          opacity: 1;
+          [data-root-menu='true'] {
+            opacity: 1;
+          }
         }
       }
     }

--- a/packages/sanity/src/desk/comments/src/components/list/CommentsListItem.tsx
+++ b/packages/sanity/src/desk/comments/src/components/list/CommentsListItem.tsx
@@ -35,17 +35,21 @@ const StyledThreadCard = styled(ThreadCard)(({theme}) => {
         0 0 0 3px var(--card-focus-ring-color);
     }
 
-    // When hovering over the thread root we want to display the parent comments menu.
-    // The data-root-menu attribute is used to target the menu and is applied in
-    // the CommentsListItemLayout component.
+    @media (hover: hover) {
+      &:hover {
+        // When hovering over the thread root we want to display the parent comments menu.
+        // The data-root-menu attribute is used to target the menu and is applied in
+        // the CommentsListItemLayout component.
+        [data-root-menu='true'] {
+          opacity: 1;
+        }
+      }
+    }
+
     &:not([data-active='true']) {
       @media (hover: hover) {
         &:hover {
           --card-bg-color: ${hovered.bg2};
-
-          [data-root-menu='true'] {
-            opacity: 1;
-          }
         }
       }
     }

--- a/packages/sanity/src/desk/comments/src/components/list/CommentsListItemContextMenu.tsx
+++ b/packages/sanity/src/desk/comments/src/components/list/CommentsListItemContextMenu.tsx
@@ -71,14 +71,13 @@ export function CommentsListItemContextMenu(props: CommentsListItemContextMenuPr
     onStatusChange,
     readOnly,
     status,
-    ...rest
   } = props
 
   const showMenuButton = Boolean(onCopyLink || onDeleteStart || onEditStart)
 
   return (
     <TooltipDelayGroupProvider delay={TOOLTIP_GROUP_DELAY}>
-      <Flex data-root-menu={isParent ? 'true' : 'false'} {...rest}>
+      <Flex>
         <FloatingCard display="flex" shadow={2} padding={1} radius={2} sizing="border">
           {isParent && (
             <TextTooltip text={status === 'open' ? 'Mark as resolved' : 'Re-open'}>

--- a/packages/sanity/src/desk/comments/src/components/list/CommentsListItemContextMenu.tsx
+++ b/packages/sanity/src/desk/comments/src/components/list/CommentsListItemContextMenu.tsx
@@ -24,11 +24,9 @@ import {CommentStatus} from '../../types'
 import {TextTooltip} from '../TextTooltip'
 
 const TOOLTIP_GROUP_DELAY: TooltipDelayGroupProviderProps['delay'] = {open: 500}
+
 const POPOVER_PROPS: MenuButtonProps['popover'] = {
   placement: 'bottom-end',
-  // We don't have to use portal since that interferes with click outside handling.
-  // This is because the element will be rendered outside root element if we use portal.
-  portal: false,
 }
 
 const FloatingCard = styled(Card)(({theme}) => {

--- a/packages/sanity/src/desk/comments/src/components/list/CommentsListItemLayout.tsx
+++ b/packages/sanity/src/desk/comments/src/components/list/CommentsListItemLayout.tsx
@@ -1,15 +1,5 @@
 import {hues} from '@sanity/color'
-import {
-  TextSkeleton,
-  Flex,
-  Stack,
-  Text,
-  Card,
-  useGlobalKeyDown,
-  useClickOutside,
-  Box,
-  Layer,
-} from '@sanity/ui'
+import {TextSkeleton, Flex, Stack, Text, Card, useClickOutside, Box, Layer} from '@sanity/ui'
 import React, {useCallback, useMemo, useRef, useState} from 'react'
 import {CurrentUser} from '@sanity/types'
 import styled, {css} from 'styled-components'
@@ -31,14 +21,18 @@ import {TimeAgoOpts, useTimeAgo, useUser, useDidUpdate} from 'sanity'
 
 const ContextMenuLayer = styled(Layer)``
 
-function StopPropagationLayer(props: React.PropsWithChildren) {
-  const {children} = props
+function StopPropagationLayer(props: React.PropsWithChildren<{isParent?: boolean}>) {
+  const {children, isParent} = props
 
   const handleClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
     event.stopPropagation()
   }, [])
 
-  return <ContextMenuLayer onClick={handleClick}>{children}</ContextMenuLayer>
+  return (
+    <ContextMenuLayer data-root-menu={isParent ? 'true' : 'false'} onClick={handleClick}>
+      {children}
+    </ContextMenuLayer>
+  )
 }
 
 const SKELETON_INLINE_STYLE: React.CSSProperties = {width: '50%'}
@@ -88,7 +82,6 @@ const RootStack = styled(Stack)(({theme}) => {
         position: absolute;
         right: 0;
         top: 0;
-
         transform: translate(${space[1]}px, -${space[1]}px);
       }
 
@@ -298,7 +291,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
           </Flex>
 
           {!isEditing && !displayError && (
-            <StopPropagationLayer>
+            <StopPropagationLayer isParent={isParent}>
               <CommentsListItemContextMenu
                 canDelete={canDelete}
                 canEdit={canEdit}

--- a/packages/sanity/src/desk/comments/src/components/list/CommentsListItemLayout.tsx
+++ b/packages/sanity/src/desk/comments/src/components/list/CommentsListItemLayout.tsx
@@ -1,5 +1,5 @@
 import {hues} from '@sanity/color'
-import {TextSkeleton, Flex, Stack, Text, Card, useClickOutside, Box, Layer} from '@sanity/ui'
+import {TextSkeleton, Flex, Stack, Text, Card, useClickOutside, Box} from '@sanity/ui'
 import React, {useCallback, useMemo, useRef, useState} from 'react'
 import {CurrentUser} from '@sanity/types'
 import styled, {css} from 'styled-components'
@@ -19,9 +19,9 @@ import {AVATAR_HEIGHT, CommentsAvatar, SpacerAvatar} from '../avatars'
 import {CommentsListItemContextMenu} from './CommentsListItemContextMenu'
 import {TimeAgoOpts, useTimeAgo, useUser, useDidUpdate} from 'sanity'
 
-const ContextMenuLayer = styled(Layer)``
+const ContextMenuBox = styled(Box)``
 
-function StopPropagationLayer(props: React.PropsWithChildren<{isParent?: boolean}>) {
+function StopPropagationWrap(props: React.PropsWithChildren<{isParent?: boolean}>) {
   const {children, isParent} = props
 
   const handleClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
@@ -29,9 +29,9 @@ function StopPropagationLayer(props: React.PropsWithChildren<{isParent?: boolean
   }, [])
 
   return (
-    <ContextMenuLayer data-root-menu={isParent ? 'true' : 'false'} onClick={handleClick}>
+    <ContextMenuBox data-root-menu={isParent ? 'true' : 'false'} onClick={handleClick}>
       {children}
-    </ContextMenuLayer>
+    </ContextMenuBox>
   )
 }
 
@@ -77,7 +77,7 @@ const RootStack = styled(Stack)(({theme}) => {
     // Only show the floating layer on hover when hover is supported.
     // Else, the layer is always visible.
     @media (hover: hover) {
-      ${ContextMenuLayer} {
+      ${ContextMenuBox} {
         opacity: 0;
         position: absolute;
         right: 0;
@@ -85,21 +85,21 @@ const RootStack = styled(Stack)(({theme}) => {
         transform: translate(${space[1]}px, -${space[1]}px);
       }
 
-      ${ContextMenuLayer} {
+      ${ContextMenuBox} {
         &:focus-within {
           opacity: 1;
         }
       }
 
       &:hover {
-        ${ContextMenuLayer} {
+        ${ContextMenuBox} {
           opacity: 1;
         }
       }
     }
 
     &[data-menu-open='true'] {
-      ${ContextMenuLayer} {
+      ${ContextMenuBox} {
         opacity: 1;
       }
     }
@@ -291,7 +291,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
           </Flex>
 
           {!isEditing && !displayError && (
-            <StopPropagationLayer isParent={isParent}>
+            <StopPropagationWrap isParent={isParent}>
               <CommentsListItemContextMenu
                 canDelete={canDelete}
                 canEdit={canEdit}
@@ -305,7 +305,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
                 readOnly={readOnly}
                 status={comment.status}
               />
-            </StopPropagationLayer>
+            </StopPropagationWrap>
           )}
         </Flex>
 


### PR DESCRIPTION
### Description

This pull request fixes a layer issue, as can be seen in the screenshot. The solution here is to render the popover in the `MenuButton` in a portal, and we rely on the `isTopLayer` boolean from `useLayer` to determine whether we should deselect the selected comment in `CommentsInspector`.

This pull request also makes sure that the menu of the root comment is always visible when hovering over the thread item card.

<img width="216" alt="Screenshot 2023-11-15 at 17 05 12" src="https://github.com/sanity-io/sanity/assets/15094168/d01a5efb-ac16-481b-af40-ad64169ba651">


### What to review

- Make sure that the hover styles are correctly applied to the thread item card
- Make sure that the menu of root comment is always visible when hovering over the thread item card

### Notes for release

n/a
