### PR TITLE
fix: use event.pull_request.number instead

### DIFF
--- a/.github/workflows/docReport.yml
+++ b/.github/workflows/docReport.yml
@@ -51,14 +51,14 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         env:
           DOCS_REPORT_TOKEN: ${{ secrets.DOCS_REPORT_DATASET_TOKEN }}
-          DOCS_REPORT_DATASET: pr-${{ github.event.number }}
+          DOCS_REPORT_DATASET: pr-${{ github.event.pull_request.number }}
         run: yarn docs:report:create
 
       - name: Compare Docs Coverage on PR
         if: ${{ github.event_name == 'pull_request' }}
         env:
           DOCS_REPORT_TOKEN: ${{ secrets.DOCS_REPORT_DATASET_TOKEN }}
-          DOCS_REPORT_DATASET: pr-${{ github.event.number }}
+          DOCS_REPORT_DATASET: pr-${{ github.event.pull_request.number }}
         run: yarn docs:report
 
       - name: PR comment with report

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -79,7 +79,7 @@ jobs:
           # Delete `SANITY_E2E_SESSION_TOKEN_NEW` from github
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
           SANITY_E2E_PROJECT_ID: ${{ secrets.SANITY_E2E_PROJECT_ID }}
-          SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}
+          SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.pull_request.number }}
         run: yarn e2e:setup && yarn e2e:build
 
       # Caches build from either PR or next
@@ -184,7 +184,7 @@ jobs:
           # Delete `SANITY_E2E_SESSION_TOKEN_NEW` from github
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
           SANITY_E2E_PROJECT_ID: ${{ secrets.SANITY_E2E_PROJECT_ID }}
-          SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}
+          SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.pull_request.number }}
         run: yarn test:e2e --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Remove docs report datasets for closed PRs
         env:
           DOCS_REPORT_TOKEN: ${{ secrets.DOCS_REPORT_DATASET_TOKEN }}
-          DOCS_REPORT_DATASET: pr-${{ github.event.number }}
+          DOCS_REPORT_DATASET: pr-${{ github.event.pull_request.number }}
         run: yarn docs:report:cleanup
 
   e2e-cleanup:
@@ -73,5 +73,5 @@ jobs:
         env:
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
           SANITY_E2E_PROJECT_ID: ${{ secrets.SANITY_E2E_PROJECT_ID }}
-          SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}
+          SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.pull_request.number }}
         run: yarn e2e:cleanup

--- a/scripts/e2e/setup.ts
+++ b/scripts/e2e/setup.ts
@@ -9,8 +9,10 @@ const studioE2EClient = createE2EClient(readEnv<KnownEnvVar>('SANITY_E2E_DATASET
 
 studioE2EClient.datasets.list().then(async (datasets) => {
   // If the dataset doesn't exist, create it
-  if (!datasets.find((ds) => ds.name === dataset)) {
-    const timer = startTimer(`Creating dataset ${dataset}`)
+  if (datasets.find((ds) => ds.name === dataset)) {
+    console.log(`Reusing dataset ${dataset}`)
+  } else {
+    const timer = startTimer(`Creating new dataset ${dataset}`)
     await studioE2EClient.datasets.create(dataset, {
       aclMode: 'public',
     })


### PR DESCRIPTION
### Description

It seems like we've been creating too many datasets due to usage of `github.event.number`. It seems like the intent was to use `github.event.pull_request.number` instead.

### What to review

Take a look at the logs when the dataset is created. You should see the same PR dataset used on every run. Additionally when this PR is closed, the dataset should be deleted as well.

### Notes for release

N/A (internal only)