### PR TITLE
test(e2e): disable dataset creation per PR

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -185,7 +185,8 @@ jobs:
           # Delete `SANITY_E2E_SESSION_TOKEN_NEW` from github
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
           SANITY_E2E_PROJECT_ID: ${{ secrets.SANITY_E2E_PROJECT_ID }}
-          SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}
+          # FIXME: this is a temp fix to stop creating new datasets for the time being
+          SANITY_E2E_DATASET: pr-${{ secrets.SANITY_E2E_DATASET }}
         run: yarn test:e2e --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -79,7 +79,8 @@ jobs:
           # Delete `SANITY_E2E_SESSION_TOKEN_NEW` from github
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
           SANITY_E2E_PROJECT_ID: ${{ secrets.SANITY_E2E_PROJECT_ID }}
-          SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}
+          # FIXME: this is a temp fix to stop creating new datasets for the time being
+          SANITY_E2E_DATASET: pr-${{ secrets.SANITY_E2E_DATASET }}
         run: yarn e2e:setup && yarn e2e:build
 
       # Caches build from either PR or next

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -74,4 +74,5 @@ jobs:
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
           SANITY_E2E_PROJECT_ID: ${{ secrets.SANITY_E2E_PROJECT_ID }}
           SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}
-        run: yarn e2e:cleanup
+        # FIXME: this is a temp fix to stop creating new datasets for the time being
+        # run: yarn e2e:cleanup


### PR DESCRIPTION
### Description

This is a temporary change to prevent explosive dataset growth in our CI tests.

### What to review

Do the CI the tests still pass? We wanted each run to have nearly its own dataset but our current suite should work fine with just one.

### Notes for release

N/A