### PR TITLE
feat(desk): add conditional borders to PaneHeader

### DIFF
--- a/packages/sanity/src/desk/components/pane/Pane.tsx
+++ b/packages/sanity/src/desk/components/pane/Pane.tsx
@@ -69,6 +69,7 @@ export const Pane = forwardRef(function Pane(
   const flex = pane?.flex ?? flexProp
   const currentMinWidth = pane?.currentMinWidth ?? currentMinWidthProp
   const currentMaxWidth = pane?.currentMaxWidth ?? currentMaxWidthProp
+  const [scrollableElement, setScrollableElement] = useState<HTMLElement | null>(null)
 
   const setRef = useCallback(
     (refValue: HTMLDivElement | null) => {
@@ -117,8 +118,20 @@ export const Pane = forwardRef(function Pane(
       index: paneIndex,
       isLast,
       rootElement,
+      scrollableElement,
+      setScrollableElement,
     }),
-    [collapsed, handleCollapse, handleExpand, isLast, layoutCollapsed, paneIndex, rootElement],
+    [
+      collapsed,
+      handleCollapse,
+      handleExpand,
+      isLast,
+      layoutCollapsed,
+      paneIndex,
+      rootElement,
+      scrollableElement,
+      setScrollableElement,
+    ],
   )
 
   const minWidth = useMemo(() => {

--- a/packages/sanity/src/desk/components/pane/PaneHeader.styles.tsx
+++ b/packages/sanity/src/desk/components/pane/PaneHeader.styles.tsx
@@ -1,21 +1,32 @@
-import {Box, Flex, Layer, rgba, TextSkeleton, Text, Theme, Card} from '@sanity/ui'
+import {Box, Flex, Layer, rgba, TextSkeleton, Text, Theme, Card, LayerProps} from '@sanity/ui'
+import {HTMLProps, RefAttributes} from 'react'
 import styled, {css} from 'styled-components'
 
-export const Root = styled(Layer)`
-  line-height: 0;
-  position: sticky;
-  top: 0;
+interface CustomLayerProps extends LayerProps {
+  borderBottom?: boolean
+}
 
-  &:not([data-collapsed]):after {
-    content: '';
-    display: block;
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: -1px;
-    border-bottom: 1px solid var(--card-shadow-outline-color);
-  }
-`
+export const Root = styled(Layer)((
+  props: CustomLayerProps & Omit<HTMLProps<HTMLDivElement>, 'as'> & RefAttributes<HTMLDivElement>,
+) => {
+  const {borderBottom = true} = props
+
+  return css`
+    line-height: 0;
+    position: sticky;
+    top: 0;
+
+    &:not([data-collapsed]):after {
+      content: '';
+      display: block;
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: -1px;
+      border-bottom: ${borderBottom ? '1px solid var(--card-shadow-outline-color)' : 'none'};
+    }
+  `
+})
 
 export const Layout = styled(Flex)`
   transform-origin: calc(51px / 2);

--- a/packages/sanity/src/desk/components/pane/PaneHeader.styles.tsx
+++ b/packages/sanity/src/desk/components/pane/PaneHeader.styles.tsx
@@ -8,17 +8,9 @@ const BORDER_OFFSET_X = 12
 
 interface RootProps {
   $borderBottom?: boolean
-  'data-collapsed'?: string
-  'data-testid'?: string
-  $isContentScrollable?: boolean
-  $hasScrolledFromTop?: boolean
 }
 
-export const Root = styled(Layer)<RootProps>(({
-  $borderBottom = true,
-  $isContentScrollable,
-  $hasScrolledFromTop,
-}) => {
+export const Root = styled(Layer)<RootProps>(({$borderBottom = true}) => {
   return css`
     line-height: 0;
     position: sticky;
@@ -31,9 +23,9 @@ export const Root = styled(Layer)<RootProps>(({
       left: ${BORDER_OFFSET_X}px;
       right: ${BORDER_OFFSET_X}px;
       bottom: -1px;
-      border-bottom: ${$borderBottom ? '1px solid var(--card-shadow-outline-color)' : 'none'};
-      opacity: ${() => ($isContentScrollable && $hasScrolledFromTop ? 1 : 0)};
-      transition: opacity 200ms ease-in;
+      border-bottom: 1px solid ${$borderBottom ? 'var(--card-shadow-outline-color)' : 'transparent'};
+      opacity: 1;
+      transition: border-color 200ms ease-in;
     }
   `
 })

--- a/packages/sanity/src/desk/components/pane/PaneHeader.styles.tsx
+++ b/packages/sanity/src/desk/components/pane/PaneHeader.styles.tsx
@@ -1,16 +1,24 @@
-import {Box, Flex, Layer, rgba, TextSkeleton, Text, Theme, Card, LayerProps} from '@sanity/ui'
-import {HTMLProps, RefAttributes} from 'react'
+import {Box, Flex, Layer, rgba, TextSkeleton, Text, Theme, Card} from '@sanity/ui'
 import styled, {css} from 'styled-components'
 
-interface CustomLayerProps extends LayerProps {
-  borderBottom?: boolean
+/**
+ * Left/right border offsets for header components (in px).
+ */
+const BORDER_OFFSET_X = 12
+
+interface RootProps {
+  $borderBottom?: boolean
+  'data-collapsed'?: string
+  'data-testid'?: string
+  $isContentScrollable?: boolean
+  $hasScrolledFromTop?: boolean
 }
 
-export const Root = styled(Layer)((
-  props: CustomLayerProps & Omit<HTMLProps<HTMLDivElement>, 'as'> & RefAttributes<HTMLDivElement>,
-) => {
-  const {borderBottom = true} = props
-
+export const Root = styled(Layer)<RootProps>(({
+  $borderBottom = true,
+  $isContentScrollable,
+  $hasScrolledFromTop,
+}) => {
   return css`
     line-height: 0;
     position: sticky;
@@ -20,10 +28,12 @@ export const Root = styled(Layer)((
       content: '';
       display: block;
       position: absolute;
-      left: 0;
-      right: 0;
+      left: ${BORDER_OFFSET_X}px;
+      right: ${BORDER_OFFSET_X}px;
       bottom: -1px;
-      border-bottom: ${borderBottom ? '1px solid var(--card-shadow-outline-color)' : 'none'};
+      border-bottom: ${$borderBottom ? '1px solid var(--card-shadow-outline-color)' : 'none'};
+      opacity: ${() => ($isContentScrollable && $hasScrolledFromTop ? 1 : 0)};
+      transition: opacity 200ms ease-in;
     }
   `
 })

--- a/packages/sanity/src/desk/components/pane/PaneHeader.tsx
+++ b/packages/sanity/src/desk/components/pane/PaneHeader.tsx
@@ -1,5 +1,5 @@
 import {useElementRect, Box, Card, Flex, LayerProvider} from '@sanity/ui'
-import React, {useMemo, useCallback, forwardRef} from 'react'
+import React, {useMemo, useCallback, forwardRef, useEffect, useState} from 'react'
 import {usePane} from './usePane'
 import {Layout, Root, TabsBox, TitleCard, TitleTextSkeleton, TitleText} from './PaneHeader.styles'
 import {LegacyLayerProvider} from 'sanity'
@@ -28,8 +28,10 @@ export const PaneHeader = forwardRef(function PaneHeader(
   ref: React.ForwardedRef<HTMLDivElement>,
 ) {
   const {actions, backButton, contentAfter, loading, subActions, tabs, tabIndex, title} = props
-  const {collapse, collapsed, expand, rootElement: paneElement} = usePane()
+  const {collapse, collapsed, expand, rootElement: paneElement, scrollableElement} = usePane()
   const paneRect = useElementRect(paneElement || null)
+  const [isScrollable, setIsScrollable] = useState(false)
+  const [hasScrolledFromTop, setHasScrolledFromTop] = useState(false)
 
   const layoutStyle = useMemo(
     () => ({
@@ -50,9 +52,31 @@ export const PaneHeader = forwardRef(function PaneHeader(
 
   const showTabsOrSubActions = Boolean(!collapsed && (tabs || subActions))
 
+  /*   Used for conditionally rendering border on bottom of the header  */
+  const handleScroll = useCallback((event: Event) => {
+    const target = event.target as HTMLElement
+
+    setIsScrollable(target.scrollHeight > target.clientHeight)
+    setHasScrolledFromTop(target.scrollTop > 0)
+  }, [])
+
+  useEffect(() => {
+    scrollableElement?.addEventListener('scroll', handleScroll)
+    return () => {
+      scrollableElement?.removeEventListener('scroll', handleScroll)
+    }
+  }, [handleScroll, scrollableElement])
+
   return (
     <LayerProvider zOffset={100}>
-      <Root data-collapsed={collapsed ? '' : undefined} data-testid="pane-header" ref={ref}>
+      <Root
+        $borderBottom={isScrollable && hasScrolledFromTop}
+        data-collapsed={collapsed ? '' : undefined}
+        data-testid="pane-header"
+        $hasScrolledFromTop={hasScrolledFromTop}
+        $isContentScrollable={isScrollable}
+        ref={ref}
+      >
         <LegacyLayerProvider zOffset="paneHeader">
           <Card data-collapsed={collapsed ? '' : undefined} tone="inherit">
             <Layout onClick={handleLayoutClick} padding={2} sizing="border" style={layoutStyle}>

--- a/packages/sanity/src/desk/components/pane/PaneHeader.tsx
+++ b/packages/sanity/src/desk/components/pane/PaneHeader.tsx
@@ -73,8 +73,6 @@ export const PaneHeader = forwardRef(function PaneHeader(
         $borderBottom={isScrollable && hasScrolledFromTop}
         data-collapsed={collapsed ? '' : undefined}
         data-testid="pane-header"
-        $hasScrolledFromTop={hasScrolledFromTop}
-        $isContentScrollable={isScrollable}
         ref={ref}
       >
         <LegacyLayerProvider zOffset="paneHeader">

--- a/packages/sanity/src/desk/components/pane/types.ts
+++ b/packages/sanity/src/desk/components/pane/types.ts
@@ -1,4 +1,4 @@
-import {ComponentType, ReactNode} from 'react'
+import {ComponentType, Dispatch, ReactNode, SetStateAction} from 'react'
 import {Intent} from '../../structureBuilder'
 
 /**
@@ -24,6 +24,8 @@ export interface PaneContextValue {
   index?: number
   isLast: boolean
   rootElement: HTMLDivElement | null
+  scrollableElement?: HTMLElement | null
+  setScrollableElement?: Dispatch<SetStateAction<HTMLElement | null>>
 }
 
 /**

--- a/packages/sanity/src/desk/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/DocumentPanel.tsx
@@ -65,7 +65,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     formState,
   } = useDocumentPane()
   const {collapsed: layoutCollapsed} = usePaneLayout()
-  const {collapsed} = usePane()
+  const {collapsed, setScrollableElement} = usePane()
   const parentPortal = usePortal()
   const {features} = useDeskTool()
   const [headerElement, setHeaderElement] = useState<HTMLDivElement | null>(null)
@@ -138,6 +138,13 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
       setDocumentPanelPortalElement(portalElement)
     }
   }, [portalElement, setDocumentPanelPortalElement])
+
+  // Set the scrollable element to conditionally render header border
+  useEffect(() => {
+    if (setScrollableElement) {
+      setScrollableElement(documentScrollElement)
+    }
+  }, [setScrollableElement, documentScrollElement])
 
   const inspectDialog = useMemo(() => {
     return isInspectOpen ? <InspectDialog value={displayed || value} /> : null

--- a/packages/sanity/src/desk/panes/documentList/DocumentListPaneContent.tsx
+++ b/packages/sanity/src/desk/panes/documentList/DocumentListPaneContent.tsx
@@ -87,7 +87,7 @@ export function DocumentListPaneContent(props: DocumentListPaneContentProps) {
   const schema = useSchema()
 
   const {collapsed: layoutCollapsed} = usePaneLayout()
-  const {collapsed, index} = usePane()
+  const {collapsed, index, setScrollableElement} = usePane()
   const [shouldRender, setShouldRender] = useState(false)
 
   const handleEndReached = useCallback(() => {
@@ -95,6 +95,16 @@ export function DocumentListPaneContent(props: DocumentListPaneContentProps) {
 
     onListChange()
   }, [isLazyLoading, isLoading, onListChange, shouldRender])
+
+  //Set scrollable element to virtual list for conditional border
+  const handleVirtualListReady = useCallback(
+    (virtualListElement: HTMLElement) => {
+      if (setScrollableElement) {
+        setScrollableElement(virtualListElement)
+      }
+    },
+    [setScrollableElement],
+  )
 
   useEffect(() => {
     if (collapsed) return undefined
@@ -143,7 +153,7 @@ export function DocumentListPaneContent(props: DocumentListPaneContentProps) {
         </>
       )
     },
-    [childItemId, isActive, items.length, layout, schema, showIcons, hasMaxItems, isLazyLoading],
+    [childItemId, isActive, items.length, isLazyLoading, hasMaxItems, showIcons, layout, schema],
   )
 
   const noDocumentsContent = useMemo(() => {
@@ -232,6 +242,7 @@ export function DocumentListPaneContent(props: DocumentListPaneContentProps) {
             items={items}
             key={key}
             onEndReached={handleEndReached}
+            onListReady={handleVirtualListReady}
             onlyShowSelectionWhenActive
             overscan={10}
             padding={2}
@@ -247,19 +258,21 @@ export function DocumentListPaneContent(props: DocumentListPaneContentProps) {
     // when clearing a search query with no results
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    collapsed,
+    shouldRender,
     error,
-    handleEndReached,
-    index,
     isLoading,
     items,
-    layout,
     loadingVariant,
-    // noDocumentsContent,
-    onRetry,
-    renderItem,
+    index,
+    handleVirtualListReady,
+    collapsed,
+    paneTitle,
     searchInputElement,
-    shouldRender,
+    handleEndReached,
+    renderItem,
+    onRetry,
+    noDocumentsContent,
+    layout,
   ])
 
   return (

--- a/packages/sanity/src/desk/panes/documentList/DocumentListPaneContent.tsx
+++ b/packages/sanity/src/desk/panes/documentList/DocumentListPaneContent.tsx
@@ -153,7 +153,7 @@ export function DocumentListPaneContent(props: DocumentListPaneContentProps) {
         </>
       )
     },
-    [childItemId, isActive, items.length, isLazyLoading, hasMaxItems, showIcons, layout, schema],
+    [childItemId, isActive, items.length, layout, schema, showIcons, hasMaxItems, isLazyLoading],
   )
 
   const noDocumentsContent = useMemo(() => {
@@ -258,21 +258,19 @@ export function DocumentListPaneContent(props: DocumentListPaneContentProps) {
     // when clearing a search query with no results
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    shouldRender,
+    collapsed,
     error,
+    handleEndReached,
+    index,
     isLoading,
     items,
-    loadingVariant,
-    index,
-    handleVirtualListReady,
-    collapsed,
-    paneTitle,
-    searchInputElement,
-    handleEndReached,
-    renderItem,
-    onRetry,
-    noDocumentsContent,
     layout,
+    loadingVariant,
+    // noDocumentsContent,
+    onRetry,
+    renderItem,
+    searchInputElement,
+    shouldRender,
   ])
 
   return (

--- a/packages/sanity/src/desk/panes/list/ListPaneContent.tsx
+++ b/packages/sanity/src/desk/panes/list/ListPaneContent.tsx
@@ -1,7 +1,7 @@
 import React, {useCallback} from 'react'
 import {Box} from '@sanity/ui'
 import styled from 'styled-components'
-import {PaneContent, PaneItem, usePaneLayout} from '../../components'
+import {PaneContent, PaneItem, usePane, usePaneLayout} from '../../components'
 import {PaneListItem, PaneListItemDivider} from '../../types'
 import {CommandList, CommandListItemContext, GeneralPreviewLayoutKey} from 'sanity'
 
@@ -27,6 +27,7 @@ const Divider = styled.hr`
 export function ListPaneContent(props: ListPaneContentProps) {
   const {childItemId, items, isActive, layout, showIcons, title} = props
   const {collapsed: layoutCollapsed} = usePaneLayout()
+  const {setScrollableElement} = usePane()
 
   const getItemDisabled = useCallback(
     (itemIndex: number) => {
@@ -90,6 +91,16 @@ export function ListPaneContent(props: ListPaneContentProps) {
     [childItemId, isActive, layout, shouldShowIconForItem],
   )
 
+  //Set scrollable element to virtual list for conditional border
+  const virtualListReady = useCallback(
+    (virtualListElement: HTMLElement) => {
+      if (setScrollableElement) {
+        setScrollableElement(virtualListElement)
+      }
+    },
+    [setScrollableElement],
+  )
+
   return (
     <PaneContent overflow={layoutCollapsed ? 'hidden' : 'auto'}>
       {items && items.length > 0 && (
@@ -101,6 +112,7 @@ export function ListPaneContent(props: ListPaneContentProps) {
           getItemDisabled={getItemDisabled}
           itemHeight={51}
           items={items}
+          onListReady={virtualListReady}
           onlyShowSelectionWhenActive
           padding={2}
           paddingBottom={1}


### PR DESCRIPTION
### Description
Adds conditional borders to the pane header


https://github.com/sanity-io/sanity/assets/44635000/c088a0e7-bf30-4d45-9462-cf6fd1f137f5



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
The border for lists/documents lists/the document panel

FYI: I haven't added border logic to the components where the content is just one sentence and the scroll wasn't able to trigger (`ErrorPane.tsx `and `UnknownPaneType.tsx`)

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
