### PR TITLE
fix(desk): use top-start placement of footer tooltips

### DIFF
--- a/packages/sanity/src/desk/panes/document/statusBar/sparkline/PublishStatus.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/sparkline/PublishStatus.tsx
@@ -41,7 +41,7 @@ export function PublishStatus(props: PublishStatusProps) {
     <Root align="center" data-ui="SessionLayout" sizing="border">
       {/* @todo: possible candidate for migrating to Studio UI tooltip */}
       <TooltipWithNodes
-        placement="top"
+        placement="top-start"
         portal
         content={
           <Stack space={3}>

--- a/packages/sanity/src/desk/panes/document/statusBar/sparkline/ReviewChangesButton/ReviewChangesButton.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/sparkline/ReviewChangesButton/ReviewChangesButton.tsx
@@ -48,7 +48,7 @@ const ReviewButton = React.forwardRef(function ReviewButton(
 
   return (
     <TooltipWithNodes
-      placement="top"
+      placement="top-start"
       portal
       disabled={status !== 'changes'}
       content={


### PR DESCRIPTION
### Description
The `top` placement of the tooltip for the footer could cause overflow to occur for the review changes tooltip - I think it looks better with using the `top-start` placement instead so that the tooltip always renders on the top instead of to the left. wdyt? 

With `top`:

https://github.com/sanity-io/sanity/assets/44635000/0aa0a904-c918-4ce1-869a-ebbb46b424d8




<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
The footer tooltips
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
