### PR TITLE
fix(desk): change link to help article about the Desk - Structure rename

### DIFF
--- a/packages/sanity/src/desk/deskRename/deskRenamedIcon.tsx
+++ b/packages/sanity/src/desk/deskRename/deskRenamedIcon.tsx
@@ -1,9 +1,10 @@
 import React, {useCallback, useState} from 'react'
 import {CheckmarkIcon, LaunchIcon} from '@sanity/icons'
 import {Button, Flex, Grid, Popover, Stack, Text} from '@sanity/ui'
+import {generateHelpUrl} from '@sanity/generate-help-url'
 import {useDeskRenameOnboarding} from './onboardingStore'
 
-const RENAME_ANNOUNCEMENT_URL = 'https://sanity.io/blog/desk-is-now-structure'
+const RENAME_ANNOUNCEMENT_URL = generateHelpUrl('desk-is-now-structure')
 
 /**
  * @internal


### PR DESCRIPTION
### Description

Changes the URL of the article explaining the rationale behind renaming Desk to Structure. Instead of a hard coded full url, it uses the `@sanity/generate-help-url` package.

### What to review


### Notes for release

N/A