### PR TITLE
test(cli): disable exploding CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,7 +135,8 @@ jobs:
           npm -v
           yarn test --silent --shard=${{ matrix.shardIndex}}/${{ matrix.shardTotal }}
         env:
-          SANITY_CI_CLI_AUTH_TOKEN: ${{ secrets.SANITY_CI_CLI_AUTH_TOKEN }}
+          # FIXME: re-enable CLI tests with this
+          # SANITY_CI_CLI_AUTH_TOKEN: ${{ secrets.SANITY_CI_CLI_AUTH_TOKEN }}
           GITHUB_SHARD_IDENTIFIER: ${{ matrix.shardIndex }}-${{ matrix.shardTotal }}
 
   cleanup:


### PR DESCRIPTION
### Description

This disables the CLI CI tests that create datasets causing an internal issue. (just looking for a quick fix, a better one will come soon)

### What to review

Does this stop the CLI tests while still leaving the normal jest tests in tact?

### Notes for release

N/A