### PR TITLE
fix(facelift): update pane header create button tooltip

### DIFF
--- a/packages/sanity/src/desk/components/paneHeaderActions/PaneHeaderCreateButton.tsx
+++ b/packages/sanity/src/desk/components/paneHeaderActions/PaneHeaderCreateButton.tsx
@@ -108,8 +108,7 @@ export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonPr
           mode="bleed"
           disabled={disabled}
           data-testid="action-intent-button"
-          // This button handles the tooltip in a special way, couldn't reuse the forced tooltip.
-          tooltipProps={null}
+          tooltipProps={disabled ? null : {content: 'Create new document'}}
         />
       </InsufficientPermissionsMessageTooltip>
     )


### PR DESCRIPTION
### Description
Update the PaneHeaderCreateButton to include the tooltip in cases where it has only 1 template item type.
Incorrectly assumed in latest changes that the `<InsufficientPermissionsMessageTooltip >` was rendering in both cases. 

Now, if it doesn't have permissions it will render that template, in case it has permissions it will show the `Create new document` tooltip
<img width="500" alt="Screenshot 2023-11-17 at 09 47 01" src="https://github.com/sanity-io/sanity/assets/46196328/89450374-7954-4ea0-a9fd-e71da57cb754">


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
