### PR TITLE
fix(comments): discard dialog z-offset

### DIFF
--- a/packages/sanity/src/desk/comments/src/components/pte/comment-input/CommentInputDiscardDialog.tsx
+++ b/packages/sanity/src/desk/comments/src/components/pte/comment-input/CommentInputDiscardDialog.tsx
@@ -5,9 +5,10 @@ import {
   Stack,
   Text,
   ThemeColorProvider,
-  useBoundaryElement,
   PortalProvider,
   DialogProvider,
+  usePortal,
+  useLayer,
 } from '@sanity/ui'
 import React, {useCallback} from 'react'
 
@@ -28,8 +29,6 @@ export interface CommentInputDiscardDialogProps {
  */
 export function CommentInputDiscardDialog(props: CommentInputDiscardDialogProps) {
   const {onClose, onConfirm} = props
-
-  const portal = useBoundaryElement()
 
   const handleCancelClick = useCallback(
     (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -53,28 +52,25 @@ export function CommentInputDiscardDialog(props: CommentInputDiscardDialogProps)
   // rendered fullscreen and not scoped to the form view.
   return (
     <ThemeColorProvider tone="default">
-      <PortalProvider __unstable_elements={{boundary: portal.element}}>
-        <DialogProvider zOffset={Z_OFFSET}>
-          <Dialog
-            portal="boundary"
-            header="Discard comment?"
-            id="discard-comment-dialog"
-            onClose={onClose}
-            width={0}
-            onClickOutside={onClose}
-            footer={
-              <Grid columns={2} padding={2} gap={2}>
-                <Button text="Cancel" mode="ghost" onClick={handleCancelClick} />
-                <Button onClick={handleConfirmClick} text="Discard" tone="critical" />
-              </Grid>
-            }
-          >
-            <Stack padding={4}>
-              <Text>Do you want to discard the comment?</Text>
-            </Stack>
-          </Dialog>
-        </DialogProvider>
-      </PortalProvider>
+      <DialogProvider zOffset={Z_OFFSET}>
+        <Dialog
+          header="Discard comment?"
+          id="discard-comment-dialog"
+          onClose={onClose}
+          width={0}
+          onClickOutside={onClose}
+          footer={
+            <Grid columns={2} padding={2} gap={2}>
+              <Button text="Cancel" mode="ghost" onClick={handleCancelClick} />
+              <Button onClick={handleConfirmClick} text="Discard" tone="critical" />
+            </Grid>
+          }
+        >
+          <Stack padding={4}>
+            <Text>Do you want to discard the comment?</Text>
+          </Stack>
+        </Dialog>
+      </DialogProvider>
     </ThemeColorProvider>
   )
 }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This pull request fixes a z-index issue with the comment discard dialog where it was positioned below the document pane footer and document pane headers.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

- Make sure that the comment discard dialog is positioned at the top

### Notes for release

n/a
