### PR TITLE
fix: globally replace compose with add icon

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.tsx
@@ -14,7 +14,7 @@ import {
   Flex,
   Button,
 } from '@sanity/ui'
-import {ComposeIcon, SearchIcon} from '@sanity/icons'
+import {AddIcon, SearchIcon} from '@sanity/icons'
 import ReactFocusLock from 'react-focus-lock'
 import {InsufficientPermissionsMessage} from '../../../../components'
 import {useCurrentUser} from '../../../../store'
@@ -145,7 +145,7 @@ export function NewDocumentButton(props: NewDocumentButtonProps) {
     () => ({
       'aria-label': title,
       disabled: disabled || loading,
-      icon: ComposeIcon,
+      icon: AddIcon,
       mode: 'bleed',
       onClick: handleToggleOpen,
       ref: setButtonElement,

--- a/packages/sanity/src/desk/components/paneHeaderActions/PaneHeaderCreateButton.tsx
+++ b/packages/sanity/src/desk/components/paneHeaderActions/PaneHeaderCreateButton.tsx
@@ -1,4 +1,4 @@
-import {ComposeIcon} from '@sanity/icons'
+import {AddIcon} from '@sanity/icons'
 import React, {useMemo, forwardRef} from 'react'
 import {Box, Button, Label, Menu, MenuButton, MenuItem, PopoverProps} from '@sanity/ui'
 import {Schema} from '@sanity/types'
@@ -77,7 +77,7 @@ export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonPr
       <InsufficientPermissionsMessageTooltip reveal loading={isTemplatePermissionsLoading}>
         <Button
           aria-label="Insufficient permissions"
-          icon={ComposeIcon}
+          icon={AddIcon}
           mode="bleed"
           disabled
           data-testid="action-intent-button"
@@ -100,7 +100,7 @@ export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonPr
       >
         <IntentButton
           aria-label={firstItem.title}
-          icon={firstItem.icon || ComposeIcon}
+          icon={firstItem.icon || AddIcon}
           intent={intent}
           mode="bleed"
           disabled={disabled}
@@ -112,7 +112,7 @@ export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonPr
 
   return (
     <MenuButton
-      button={<Button icon={ComposeIcon} mode="bleed" data-testid="multi-action-intent-button" />}
+      button={<Button icon={AddIcon} mode="bleed" data-testid="multi-action-intent-button" />}
       id="create-menu"
       menu={
         <Menu>

--- a/packages/sanity/src/desk/structureBuilder/DocumentList.ts
+++ b/packages/sanity/src/desk/structureBuilder/DocumentList.ts
@@ -1,5 +1,5 @@
 import {SchemaType, SortOrderingItem} from '@sanity/types'
-import {ComposeIcon} from '@sanity/icons'
+import {AddIcon} from '@sanity/icons'
 import {generateHelpUrl} from '@sanity/generate-help-url'
 import {resolveTypeForDocument} from './util/resolveTypeForDocument'
 import {SerializeError, HELP_URL} from './SerializeError'
@@ -302,7 +302,7 @@ function inferInitialValueTemplates(
         schemaType,
       }),
     )
-    .map((option) => ({...option, icon: ComposeIcon}))
+    .map((option) => ({...option, icon: AddIcon}))
 }
 
 function inferTypeName(spec: PartialDocumentList): string | undefined {

--- a/packages/sanity/src/desk/structureBuilder/InitialValueTemplateItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/InitialValueTemplateItem.ts
@@ -1,4 +1,4 @@
-import {ComposeIcon} from '@sanity/icons'
+import {AddIcon} from '@sanity/icons'
 import {HELP_URL, SerializeError} from './SerializeError'
 import type {Serializable, SerializeOptions, SerializePath} from './StructureNodes'
 import type {BaseIntentParams, IntentParams} from './Intent'
@@ -218,7 +218,7 @@ export function menuItemsFromInitialValueTemplateItems(
 
     return new MenuItemBuilder(context)
       .title(title)
-      .icon((template && template.icon) || schemaType?.icon || ComposeIcon)
+      .icon((template && template.icon) || schemaType?.icon || AddIcon)
       .intent({type: 'create', params: intentParams})
       .serialize()
   })


### PR DESCRIPTION
### Description

This PR changes the icon for create new document buttons (from the 'compose' to the 'add' icon). This button is found in the studio navbar and document lists.

This was a proposed change in upcoming facelift work, but has been brought forward to reduce ambiguity with the just released _Presentation_ tool, as that also uses the compose icon.

### What to review

That the correct 'add' icon is being rendered in the above instances.

### Notes for release

N/A