### PR TITLE
fix(tooltips): wrap button collections within a TooltipDelayGroupProvider

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -12,8 +12,15 @@ import {
   RenderListItemFunction,
 } from '@sanity/portable-text-editor'
 import {Path} from '@sanity/types'
-import {BoundaryElementProvider, useBoundaryElement, useGlobalKeyDown, useLayer} from '@sanity/ui'
+import {
+  BoundaryElementProvider,
+  TooltipDelayGroupProvider,
+  useBoundaryElement,
+  useGlobalKeyDown,
+  useLayer,
+} from '@sanity/ui'
 import React, {useCallback, useMemo, useRef} from 'react'
+import {TOOLTIP_DELAY_PROPS} from '../../../../ui/tooltip/constants'
 import {Toolbar} from './toolbar'
 import {Decorator} from './text'
 import {
@@ -159,15 +166,17 @@ export function Editor(props: EditorProps) {
   return (
     <Root $fullscreen={isFullscreen} data-testid="pt-editor">
       {isActive && (
-        <ToolbarCard data-testid="pt-editor__toolbar-card" shadow={1}>
-          <Toolbar
-            hotkeys={hotkeys}
-            isFullscreen={isFullscreen}
-            onMemberOpen={handleToolBarOnMemberOpen}
-            onToggleFullscreen={onToggleFullscreen}
-            readOnly={readOnly}
-          />
-        </ToolbarCard>
+        <TooltipDelayGroupProvider delay={TOOLTIP_DELAY_PROPS}>
+          <ToolbarCard data-testid="pt-editor__toolbar-card" shadow={1}>
+            <Toolbar
+              hotkeys={hotkeys}
+              isFullscreen={isFullscreen}
+              onMemberOpen={handleToolBarOnMemberOpen}
+              onToggleFullscreen={onToggleFullscreen}
+              readOnly={readOnly}
+            />
+          </ToolbarCard>
+        </TooltipDelayGroupProvider>
       )}
 
       <EditableCard flex={1} tone={readOnly ? 'transparent' : 'default'}>

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceField.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceField.tsx
@@ -8,7 +8,18 @@ import React, {
   useState,
 } from 'react'
 import {Reference, ReferenceSchemaType} from '@sanity/types'
-import {Box, Card, CardTone, Flex, Menu, MenuButton, MenuDivider, Stack, Text} from '@sanity/ui'
+import {
+  Box,
+  Card,
+  CardTone,
+  Flex,
+  Menu,
+  MenuButton,
+  MenuDivider,
+  Stack,
+  Text,
+  TooltipDelayGroupProvider,
+} from '@sanity/ui'
 import {
   EllipsisHorizontalIcon,
   LaunchIcon as OpenInNewTabIcon,
@@ -25,6 +36,7 @@ import {FieldActionsProvider, FieldActionsResolver} from '../../field'
 import {DocumentFieldActionNode} from '../../../config'
 import {useFormPublishedId} from '../../useFormPublishedId'
 import {Button, MenuItem} from '../../../../ui'
+import {TOOLTIP_DELAY_PROPS} from '../../../../ui/tooltip/constants'
 import {useReferenceInput} from './useReferenceInput'
 import {useReferenceInfo} from './useReferenceInfo'
 import {PreviewReferenceValue} from './PreviewReferenceValue'
@@ -317,30 +329,32 @@ export function ReferenceField(props: ReferenceFieldProps) {
             <Card shadow={1} radius={1} padding={1} tone={tone}>
               <Stack space={1}>
                 <Flex gap={1} align="center">
-                  <ReferenceLinkCard
-                    __unstable_focusRing
-                    as={EditReferenceLink}
-                    data-pressed={pressed ? true : undefined}
-                    data-selected={selected ? true : undefined}
-                    documentId={value?._ref}
-                    documentType={refType?.name}
-                    flex={1}
-                    paddingX={2}
-                    paddingY={1}
-                    pressed={pressed}
-                    radius={2}
-                    ref={elementRef}
-                    selected={selected}
-                    tone="inherit"
-                  >
-                    <PreviewReferenceValue
-                      value={value}
-                      referenceInfo={loadableReferenceInfo}
-                      renderPreview={renderPreview}
-                      type={schemaType}
-                    />
-                  </ReferenceLinkCard>
-                  <Box>{menu}</Box>
+                  <TooltipDelayGroupProvider delay={TOOLTIP_DELAY_PROPS}>
+                    <ReferenceLinkCard
+                      __unstable_focusRing
+                      as={EditReferenceLink}
+                      data-pressed={pressed ? true : undefined}
+                      data-selected={selected ? true : undefined}
+                      documentId={value?._ref}
+                      documentType={refType?.name}
+                      flex={1}
+                      paddingX={2}
+                      paddingY={1}
+                      pressed={pressed}
+                      radius={2}
+                      ref={elementRef}
+                      selected={selected}
+                      tone="inherit"
+                    >
+                      <PreviewReferenceValue
+                        value={value}
+                        referenceInfo={loadableReferenceInfo}
+                        renderPreview={renderPreview}
+                        type={schemaType}
+                      />
+                    </ReferenceLinkCard>
+                    <Box>{menu}</Box>
+                  </TooltipDelayGroupProvider>
                 </Flex>
                 {footer}
               </Stack>

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/addFilter/items/MenuItemFilter.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/addFilter/items/MenuItemFilter.tsx
@@ -50,21 +50,15 @@ export const MenuItemFilter = React.memo(function MenuItemFilter({
         tabIndex={-1}
         tone={item?.tone}
       >
-        {tooltipEnabled ? (
-          <FilterTooltip
-            fieldDefinition={item.fieldDefinition}
-            filterDefinition={item.filterDefinition}
-            visible={tooltipEnabled}
-          >
-            <Box padding={3}>
-              <FilterDetails filter={item.filter} />
-            </Box>
-          </FilterTooltip>
-        ) : (
+        <FilterTooltip
+          fieldDefinition={item.fieldDefinition}
+          filterDefinition={item.filterDefinition}
+          visible={tooltipEnabled}
+        >
           <Box padding={3}>
             <FilterDetails filter={item.filter} />
           </Box>
-        )}
+        </FilterTooltip>
       </Button>
     </Box>
   )

--- a/packages/sanity/src/desk/comments/src/components/pte/comment-input/CommentInputInner.tsx
+++ b/packages/sanity/src/desk/comments/src/components/pte/comment-input/CommentInputInner.tsx
@@ -1,10 +1,11 @@
 import React, {useCallback} from 'react'
-import {Flex, MenuDivider, Box, Card, Stack} from '@sanity/ui'
+import {Flex, MenuDivider, Box, Card, Stack, TooltipDelayGroupProvider} from '@sanity/ui'
 import styled, {css} from 'styled-components'
 import {CurrentUser} from '@sanity/types'
 import {MentionIcon, SendIcon} from '../../icons'
 import {CommentsAvatar} from '../../avatars/CommentsAvatar'
 import {Button} from '../../../../../../ui'
+import {TOOLTIP_DELAY_PROPS} from '../../../../../../ui/tooltip/constants'
 import {useCommentInput} from './useCommentInput'
 import {Editable} from './Editable'
 import {useUser} from 'sanity'
@@ -122,29 +123,31 @@ export function CommentInputInner(props: CommentInputInnerProps) {
           </EditableWrap>
 
           <Flex align="center" data-ui="CommentInputActions" gap={1} justify="flex-end" padding={1}>
-            <Button
-              aria-label="Mention user"
-              data-testid="comment-mention-button"
-              disabled={readOnly}
-              icon={MentionIcon}
-              mode="bleed"
-              onClick={handleMentionButtonClicked}
-              size="small"
-              tooltipProps={{content: 'Mention user'}}
-            />
+            <TooltipDelayGroupProvider delay={TOOLTIP_DELAY_PROPS}>
+              <Button
+                aria-label="Mention user"
+                data-testid="comment-mention-button"
+                disabled={readOnly}
+                icon={MentionIcon}
+                mode="bleed"
+                onClick={handleMentionButtonClicked}
+                size="small"
+                tooltipProps={{content: 'Mention user'}}
+              />
 
-            <ButtonDivider />
+              <ButtonDivider />
 
-            <Button
-              aria-label="Send comment"
-              disabled={!canSubmit || !hasChanges || readOnly}
-              icon={SendIcon}
-              mode={hasChanges && canSubmit ? 'default' : 'bleed'}
-              onClick={onSubmit}
-              size="small"
-              tone={hasChanges && canSubmit ? 'primary' : 'default'}
-              tooltipProps={{content: 'Send comment'}}
-            />
+              <Button
+                aria-label="Send comment"
+                disabled={!canSubmit || !hasChanges || readOnly}
+                icon={SendIcon}
+                mode={hasChanges && canSubmit ? 'default' : 'bleed'}
+                onClick={onSubmit}
+                size="small"
+                tone={hasChanges && canSubmit ? 'primary' : 'default'}
+                tooltipProps={{content: 'Send comment'}}
+              />
+            </TooltipDelayGroupProvider>
           </Flex>
         </Stack>
       </RootCard>

--- a/packages/sanity/src/desk/components/paneHeaderActions/PaneHeaderActions.tsx
+++ b/packages/sanity/src/desk/components/paneHeaderActions/PaneHeaderActions.tsx
@@ -1,11 +1,10 @@
-import {Flex, TooltipDelayGroupProvider} from '@sanity/ui'
+import {Flex} from '@sanity/ui'
 import {uniqBy} from 'lodash'
 import React, {memo, useCallback, useMemo} from 'react'
 import {isMenuNodeButton, isNotMenuNodeButton, resolveMenuNodes} from '../../menuNodes'
 import {DeskToolPaneActionHandler, PaneMenuItem, PaneMenuItemGroup} from '../../types'
 import {PaneContextMenuButton} from '../pane/PaneContextMenuButton'
 import {PaneHeaderActionButton} from '../pane/PaneHeaderActionButton'
-import {TOOLTIP_DELAY_PROPS} from '../../../ui/tooltip/constants'
 import {PaneHeaderCreateButton} from './PaneHeaderCreateButton'
 import {useTemplates, InitialValueTemplateItem, EMPTY_ARRAY, EMPTY_OBJECT} from 'sanity'
 
@@ -145,18 +144,16 @@ export const PaneHeaderActions = memo(function PaneHeaderActions(props: PaneHead
   }, [initialValueTemplateItemFromMenuItems, initialValueTemplateItemsFromStructure])
 
   return (
-    <TooltipDelayGroupProvider delay={TOOLTIP_DELAY_PROPS}>
-      <Flex gap={1}>
-        {combinedInitialValueTemplates.length > 0 && (
-          <PaneHeaderCreateButton templateItems={combinedInitialValueTemplates} />
-        )}
+    <Flex gap={1}>
+      {combinedInitialValueTemplates.length > 0 && (
+        <PaneHeaderCreateButton templateItems={combinedInitialValueTemplates} />
+      )}
 
-        {actionNodes.map((node) => (
-          <PaneHeaderActionButton key={node.key} node={node} />
-        ))}
+      {actionNodes.map((node) => (
+        <PaneHeaderActionButton key={node.key} node={node} />
+      ))}
 
-        {contextMenuNodes.length > 0 && <PaneContextMenuButton nodes={contextMenuNodes} />}
-      </Flex>
-    </TooltipDelayGroupProvider>
+      {contextMenuNodes.length > 0 && <PaneContextMenuButton nodes={contextMenuNodes} />}
+    </Flex>
   )
 })

--- a/packages/sanity/src/desk/components/paneItem/PaneItemPreview.tsx
+++ b/packages/sanity/src/desk/components/paneItem/PaneItemPreview.tsx
@@ -1,9 +1,10 @@
 import type {SanityDocument, SchemaType} from '@sanity/types'
 import React, {isValidElement} from 'react'
 import {isNumber, isString} from 'lodash'
-import {Inline} from '@sanity/ui'
+import {Inline, TooltipDelayGroupProvider} from '@sanity/ui'
 import {useMemoObservable} from 'react-rx'
 import {DocumentStatus} from '../../../ui/documentStatus'
+import {TOOLTIP_DELAY_PROPS} from '../../../ui/tooltip/constants'
 import type {PaneItemPreviewState} from './types'
 import {
   DocumentPresence,
@@ -42,11 +43,13 @@ export function PaneItemPreview(props: PaneItemPreviewProps) {
   )!
 
   const status = isLoading ? null : (
-    <Inline space={4}>
-      {presence && presence.length > 0 && <DocumentPreviewPresence presence={presence} />}
-      <DocumentStatus document={published} type="published" />
-      <DocumentStatus document={draft} type="draft" />
-    </Inline>
+    <TooltipDelayGroupProvider delay={TOOLTIP_DELAY_PROPS}>
+      <Inline space={4}>
+        {presence && presence.length > 0 && <DocumentPreviewPresence presence={presence} />}
+        <DocumentStatus document={published} type="published" />
+        <DocumentStatus document={draft} type="draft" />
+      </Inline>
+    </TooltipDelayGroupProvider>
   )
 
   return (

--- a/packages/sanity/src/desk/panes/document/DocumentPane.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentPane.tsx
@@ -7,6 +7,7 @@ import {
   PortalProvider,
   Stack,
   Text,
+  TooltipDelayGroupProvider,
   useElementRect,
 } from '@sanity/ui'
 import React, {memo, useCallback, useMemo, useState} from 'react'
@@ -18,6 +19,7 @@ import {Pane, PaneFooter, usePaneRouter} from '../../components'
 import {usePaneLayout} from '../../components/pane/usePaneLayout'
 import {ErrorPane} from '../error'
 import {LoadingPane} from '../loading'
+import {TOOLTIP_DELAY_PROPS} from '../../../ui/tooltip/constants'
 import {DOCUMENT_PANEL_PORTAL_ELEMENT} from '../../constants'
 import {DocumentOperationResults} from './DocumentOperationResults'
 import {DocumentPaneProvider} from './DocumentPaneProvider'
@@ -324,7 +326,9 @@ function InnerDocumentPane() {
       >
         <DialogProvider position={DIALOG_PROVIDER_POSITION} zOffset={zOffsets.portal}>
           <PaneFooter ref={setFooterElement}>
-            <DocumentStatusBar actionsBoxRef={setActionsBoxElement} />
+            <TooltipDelayGroupProvider delay={TOOLTIP_DELAY_PROPS}>
+              <DocumentStatusBar actionsBoxRef={setActionsBoxElement} />
+            </TooltipDelayGroupProvider>
           </PaneFooter>
         </DialogProvider>
       </PortalProvider>

--- a/packages/sanity/src/desk/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -1,4 +1,4 @@
-import {Box, Flex, Hotkeys, LayerProvider, Stack, Text} from '@sanity/ui'
+import {Flex, Hotkeys, LayerProvider, Stack, Text} from '@sanity/ui'
 import React, {memo, useMemo, useState} from 'react'
 import {RenderActionCollectionState} from '../../../components'
 import {HistoryRestoreAction} from '../../../documentActions'
@@ -19,20 +19,21 @@ function DocumentStatusBarActionsInner(props: DocumentStatusBarActionsInnerProps
   const [firstActionState, ...menuActionStates] = states
   const [buttonElement, setButtonElement] = useState<HTMLButtonElement | null>(null)
 
+  // TODO: This could be refactored to use the tooltip from the button if the firstAction.title was updated to a string.
   const tooltipContent = useMemo(() => {
     if (!firstActionState || (!firstActionState.title && !firstActionState.shortcut)) return null
 
     return (
-      <Flex style={{maxWidth: 300}} align="center">
-        <Text size={1}>{firstActionState.title}</Text>
+      <Flex style={{maxWidth: 300}} align="center" gap={3}>
+        {firstActionState.title && <Text size={1}>{firstActionState.title}</Text>}
         {firstActionState.shortcut && (
-          <Box marginLeft={firstActionState.title ? 2 : 0}>
-            <Hotkeys
-              keys={String(firstActionState.shortcut)
-                .split('+')
-                .map((s) => s.slice(0, 1).toUpperCase() + s.slice(1).toLowerCase())}
-            />
-          </Box>
+          <Hotkeys
+            fontSize={1}
+            style={{marginTop: -4, marginBottom: -4}}
+            keys={String(firstActionState.shortcut)
+              .split('+')
+              .map((s) => s.slice(0, 1).toUpperCase() + s.slice(1).toLowerCase())}
+          />
         )}
       </Flex>
     )

--- a/packages/sanity/src/desk/panes/documentList/DocumentListPaneHeader.tsx
+++ b/packages/sanity/src/desk/panes/documentList/DocumentListPaneHeader.tsx
@@ -1,8 +1,10 @@
 import {ArrowLeftIcon} from '@sanity/icons'
 import React, {memo, useMemo} from 'react'
+import {TooltipDelayGroupProvider} from '@sanity/ui'
 import {PaneMenuItem, PaneMenuItemGroup, DeskToolPaneActionHandler} from '../../types'
 import {BackLink, PaneHeader, PaneHeaderActions, usePane} from '../../components'
 import {Button} from '../../../ui'
+import {TOOLTIP_DELAY_PROPS} from '../../../ui/tooltip/constants'
 import {useDeskTool} from '../../useDeskTool'
 import {SortOrder} from './types'
 import {GeneralPreviewLayoutKey, InitialValueTemplateItem} from 'sanity'
@@ -46,31 +48,33 @@ export const DocumentListPaneHeader = memo(
     }, [setLayout, setSortOrder])
 
     return (
-      <PaneHeader
-        actions={
-          <PaneHeaderActions
-            initialValueTemplateItems={initialValueTemplates}
-            actionHandlers={actionHandlers}
-            menuItemGroups={menuItemGroups}
-            menuItems={menuItems}
-          />
-        }
-        backButton={
-          features.backButton &&
-          index > 0 && (
-            <Button
-              as={BackLink}
-              data-as="a"
-              icon={ArrowLeftIcon}
-              mode="bleed"
-              tooltipProps={{content: 'Back'}}
+      <TooltipDelayGroupProvider delay={TOOLTIP_DELAY_PROPS}>
+        <PaneHeader
+          actions={
+            <PaneHeaderActions
+              initialValueTemplateItems={initialValueTemplates}
+              actionHandlers={actionHandlers}
+              menuItemGroups={menuItemGroups}
+              menuItems={menuItems}
             />
-          )
-        }
-        contentAfter={contentAfter}
-        tabIndex={tabIndex}
-        title={title}
-      />
+          }
+          backButton={
+            features.backButton &&
+            index > 0 && (
+              <Button
+                as={BackLink}
+                data-as="a"
+                icon={ArrowLeftIcon}
+                mode="bleed"
+                tooltipProps={{content: 'Back'}}
+              />
+            )
+          }
+          contentAfter={contentAfter}
+          tabIndex={tabIndex}
+          title={title}
+        />
+      </TooltipDelayGroupProvider>
     )
   },
 )

--- a/packages/sanity/src/ui/tooltip/Tooltip.tsx
+++ b/packages/sanity/src/ui/tooltip/Tooltip.tsx
@@ -44,7 +44,7 @@ export const Tooltip = forwardRef(function Tooltip(
       boundaryElement={null}
       content={
         <Flex align="center" gap={3}>
-          <Text size={1}>{content}</Text>
+          {content && <Text size={1}>{content}</Text>}
           {hotkeys && (
             <Hotkeys fontSize={1} keys={hotkeys} style={{marginTop: -4, marginBottom: -4}} />
           )}


### PR DESCRIPTION
### Description

Wraps button collections within a `<TooltipDelayGroupProvider>`
Wrapped tooltips will only have a open delay for the first tooltip that opens from the group, for an improved experience, related buttons are wrapped together, so once the first tooltip shows, hovering on the next ones will show the tooltip without delays. 

Groups the following:

- Navbar – LHS (workspace, create new)
- Navbar – RHS (search, help, presence)
- Document pane header actions
- Document list pane header actions
- Document footer - publish button / review changes buttons
- Document actions - menu items
- PortableText toolbar.
- Comments input actions. (mention user and send message)
- Reference preview
- Pane preview item

https://github.com/sanity-io/sanity/assets/46196328/5f858887-3176-44b6-a4da-e4d85e7a2470



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Is there a missing group that should also be wrapped?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
