### PR TITLE
fix(form): only allow one PTE toolbar menu to be open

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/Toolbar.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/Toolbar.tsx
@@ -86,7 +86,6 @@ const InnerToolbar = memo(function InnerToolbar({
 
   const preventEditorBlurOnToolbarMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault()
-    e.stopPropagation()
   }, [])
 
   return (


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This pull request addresses an issue where two menus in the PTE toolbar could be open simultaneously.

### What to review

1. Open one menu in the PTE toolbar.
2. Open the second menu.
3. Confirm that the first menu closes when the second one is opened.

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
