### PR TITLE
fix(portable-text-editor): improve backspace handling on text blocks

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithHotKeys.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithHotKeys.ts
@@ -121,9 +121,28 @@ export function createWithHotkeys(
           debug('Preventing deleting void block above')
           event.preventDefault()
           event.stopPropagation()
-          Transforms.removeNodes(editor, {match: (n) => n === focusBlock})
-          Transforms.select(editor, prevPath)
-          editor.onChange()
+
+          const isTextBlock = isPortableTextTextBlock(focusBlock)
+          const isEmptyFocusBlock =
+            isTextBlock && focusBlock.children.length === 1 && focusBlock.children?.[0]?.text === ''
+
+          // If this is a not an text block or it is empty, simply remove it
+          if (!isTextBlock || isEmptyFocusBlock) {
+            Transforms.removeNodes(editor, {match: (n) => n === focusBlock})
+            Transforms.select(editor, prevPath)
+
+            editor.onChange()
+            return
+          }
+
+          // If the focused block is a text node but it isn't empty, focus on the previous block
+          if (isTextBlock && !isEmptyFocusBlock) {
+            Transforms.select(editor, prevPath)
+
+            editor.onChange()
+            return
+          }
+
           return
         }
       }


### PR DESCRIPTION
### Description

This improves backspace handling when backspacing at the start of text blocks following a void block.

If the text block is empty, it will be deleted as before, and the selection will be set on the void block.
Improved: When the text block is non-empty, we will select the void block but skip deleting the text block.

https://github.com/sanity-io/sanity/assets/10508/d2094ca9-bdb9-420e-9488-6d8e2df064f0

### What to review

- That deleting a empty text block following a void block works as before
- That the new behaviour where backspacing at the start of on a non-empty text block selects the previous void block (and that it feels like a good change)
- That backspacing inside the text block works as before
- That backspacing on a focused void block will delete it as before

### Notes for release

- Improved backspace handling on text blocks that follows a non-text block
