### PR TITLE
fix(portable-text-editor): handle undefined block children

### DIFF
--- a/packages/@sanity/portable-text-editor/src/utils/__tests__/values.test.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/__tests__/values.test.ts
@@ -58,22 +58,23 @@ describe('toSlateValue', () => {
       {schemaTypes},
     )
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "_key": "123",
-          "_type": "myTestBlockType",
-          "children": Array [
-            Object {
-              "_key": "1231",
-              "_type": "span",
-              "text": "123",
-            },
-          ],
-          "markDefs": Array [],
-          "style": "normal",
-        },
-      ]
-    `)
+Array [
+  Object {
+    "_key": "123",
+    "_type": "myTestBlockType",
+    "children": Array [
+      Object {
+        "_key": "1231",
+        "_type": "span",
+        "marks": Array [],
+        "text": "123",
+      },
+    ],
+    "markDefs": Array [],
+    "style": "normal",
+  },
+]
+`)
   })
 
   it('given type is block and has custom object in children', () => {
@@ -101,40 +102,41 @@ describe('toSlateValue', () => {
       {schemaTypes},
     )
     expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "_key": "123",
-          "_type": "myTestBlockType",
-          "children": Array [
-            Object {
-              "_key": "1231",
-              "_type": "span",
-              "text": "123",
-            },
-            Object {
-              "__inline": true,
-              "_key": "1232",
-              "_type": "image",
-              "children": Array [
-                Object {
-                  "_key": "${VOID_CHILD_KEY}",
-                  "_type": "span",
-                  "marks": Array [],
-                  "text": "",
-                },
-              ],
-              "value": Object {
-                "asset": Object {
-                  "_ref": "ref-123",
-                },
-              },
-            },
-          ],
-          "markDefs": Array [],
-          "style": "normal",
+Array [
+  Object {
+    "_key": "123",
+    "_type": "myTestBlockType",
+    "children": Array [
+      Object {
+        "_key": "1231",
+        "_type": "span",
+        "marks": Array [],
+        "text": "123",
+      },
+      Object {
+        "__inline": true,
+        "_key": "1232",
+        "_type": "image",
+        "children": Array [
+          Object {
+            "_key": "void-child",
+            "_type": "span",
+            "marks": Array [],
+            "text": "",
+          },
+        ],
+        "value": Object {
+          "asset": Object {
+            "_ref": "ref-123",
+          },
         },
-      ]
-    `)
+      },
+    ],
+    "markDefs": Array [],
+    "style": "normal",
+  },
+]
+`)
   })
 })
 

--- a/packages/@sanity/portable-text-editor/src/utils/values.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/values.ts
@@ -8,8 +8,10 @@ import {
   PortableTextTextBlock,
 } from '@sanity/types'
 import {PortableTextMemberSchemaTypes} from '../types/editor'
+import {defaultKeyGenerator as keyGenerator} from '../editor/hooks/usePortableTextEditorKeyGenerator'
 
 const EMPTY_MARKDEFS: PortableTextObject[] = []
+const EMPTY_MARKS: string[] = []
 
 export const VOID_CHILD_KEY = 'void-child'
 
@@ -44,25 +46,48 @@ export function toSlateValue(
         let hasInlines = false
         const hasMissingStyle = typeof textBlock.style === 'undefined'
         const hasMissingMarkDefs = typeof textBlock.markDefs === 'undefined'
-        const children = textBlock.children.map((child) => {
-          const {_type: cType, _key: cKey, ...cRest} = child
-          if (cType !== 'span') {
-            hasInlines = true
-            return keepObjectEquality(
-              {
-                _type: cType,
-                _key: cKey,
-                children: voidChildren,
-                value: cRest,
-                __inline: true,
-              },
-              keyMap,
-            )
-          }
-          // Original object
-          return child
-        })
-        if (!hasMissingStyle && !hasMissingMarkDefs && !hasInlines && Element.isElement(block)) {
+        const hasMissingChildren = typeof textBlock.children === 'undefined'
+
+        const children = hasMissingChildren
+          ? [{_type: schemaTypes.span.name, _key: keyGenerator(), text: '', marks: []}]
+          : textBlock.children.map((child) => {
+              const {_type: cType, _key: cKey, ...cRest} = child
+              // Return 'slate' version of inline object where the actual
+              // value is stored in the `value` property.
+              // In slate, inline objects are represented as regular
+              // children with actual text node in order to be able to
+              // be selected the same way as the rest of the (text) content.
+              if (cType !== 'span') {
+                hasInlines = true
+                return keepObjectEquality(
+                  {
+                    _type: cType,
+                    _key: cKey,
+                    children: voidChildren,
+                    value: cRest,
+                    __inline: true,
+                  },
+                  keyMap,
+                )
+              }
+              // If this is a span, and it's missing 'marks', add an empty marks array
+              if (cType === 'span' && !('marks' in cRest)) {
+                return keepObjectEquality(
+                  {_key: cKey, _type: cType, ...cRest, marks: EMPTY_MARKS},
+                  keyMap,
+                )
+              }
+              // Original child object (span)
+              return child
+            })
+        // Return original block
+        if (
+          !hasMissingStyle &&
+          !hasMissingMarkDefs &&
+          !hasMissingChildren &&
+          !hasInlines &&
+          Element.isElement(block)
+        ) {
           // Original object
           return block
         }


### PR DESCRIPTION
### Description

This fixes an issue where the PTE would crash if you inserted a block with undefined `children`.

We will now show the correct "Invalid Portable Text Editor value" message.

![CleanShot 2023-11-21 at 15 38 51](https://github.com/sanity-io/sanity/assets/10508/eb361112-eece-4c4f-9b96-bac9e358c89b)

How to reproduce:

```typescript
// someScript.ts
import {getCliClient} from 'sanity/cli'

getCliClient().create({
  _type: 'blocksTest',
  first: [{_key: 'a', _type: 'block'}],
})
```

```bash
// In the test studio folder
sanity exec someScript.ts --with-user-token
```

### What to review

- Create a document with the repro above
- Navigate to the document in Standard inputs -> Portable Text -> Blocks and find your document
- See the "Invalid Portable Text Editor value" message

### Notes for release

- Fixed a issue where the PTE would crash  if you inserted a block with undefined `children`