### PR TITLE
fix(pte): disable multiple blocks annotations

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/ActionMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/ActionMenu.tsx
@@ -1,7 +1,12 @@
 import React, {memo, useCallback, useMemo} from 'react'
 import {Button, ButtonProps, PopoverProps} from '@sanity/ui'
 import {EllipsisVerticalIcon} from '@sanity/icons'
-import {PortableTextEditor, usePortableTextEditor} from '@sanity/portable-text-editor'
+import {
+  PortableTextEditor,
+  usePortableTextEditor,
+  usePortableTextEditorSelection,
+} from '@sanity/portable-text-editor'
+import {isKeySegment} from '@sanity/types'
 import {CollapseMenu, CollapseMenuButton} from '../../../../components/collapseMenu'
 import {PTEToolbarAction, PTEToolbarActionGroup} from './types'
 import {useActiveActionKeys, useFocusBlock} from './hooks'
@@ -22,7 +27,16 @@ interface ActionMenuProps {
 export const ActionMenu = memo(function ActionMenu(props: ActionMenuProps) {
   const {disabled: disabledProp, groups, isFullscreen, collapsed} = props
   const focusBlock = useFocusBlock()
+
   const editor = usePortableTextEditor()
+  const selection = usePortableTextEditorSelection()
+  const isSelectingMultipleBlocks =
+    // Path at 0 is the block level, by comparing those we can detect if the user is selecting multiple blocks
+    selection && isKeySegment(selection.anchor.path[0]) && isKeySegment(selection.focus.path[0])
+      ? // In case of keyed segments
+        selection.anchor.path[0]._key !== selection?.focus.path[0]._key
+      : // In case of non-keyed segments
+        selection?.anchor.path[0] !== selection?.focus.path[0]
 
   const isVoidBlock = focusBlock?._type !== editor.schemaTypes.block.name
   const isEmptyTextBlock =
@@ -58,7 +72,8 @@ export const ActionMenu = memo(function ActionMenu(props: ActionMenuProps) {
   const children = useMemo(
     () =>
       actions.map((action) => {
-        const annotationDisabled = action.type === 'annotation' && isEmptyTextBlock
+        const annotationDisabled =
+          action.type === 'annotation' && (isEmptyTextBlock || isSelectingMultipleBlocks)
         const active = activeKeys.includes(action.key)
         return (
           <CollapseMenuButton
@@ -81,7 +96,7 @@ export const ActionMenu = memo(function ActionMenu(props: ActionMenuProps) {
           />
         )
       }),
-    [actions, activeKeys, disabled, isEmptyTextBlock, isFullscreen],
+    [actions, activeKeys, disabled, isEmptyTextBlock, isFullscreen, isSelectingMultipleBlocks],
   )
 
   const menuButtonProps = useMemo(

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/ActionMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/ActionMenu.tsx
@@ -87,9 +87,15 @@ export const ActionMenu = memo(function ActionMenu(props: ActionMenuProps) {
             onClick={() => action.handle(active)}
             selected={active}
             text={action.title || action.key}
-            tooltipText={action.title || action.key}
+            tooltipText={
+              annotationDisabled
+                ? `Cannot apply ${action.title || action.key} to ${
+                    isEmptyTextBlock ? 'empty block' : 'multiple blocks'
+                  }`
+                : action.title || action.key
+            }
             tooltipProps={{
-              disabled: disabled || annotationDisabled,
+              disabled: disabled,
               placement: isFullscreen ? 'bottom' : 'top',
               portal: 'default',
             }}


### PR DESCRIPTION
### Description
When selecting multiple blocks in the PTE editor and then adding an annotation to it, the PTE editor breaks, because annotations are not meant to be multi-block.

Annotations require a `markDef` and that `markDef` needs to exist in the block in which the annotation is referred. 
To avoid issues, disable the `annotations` when selecting multiple blocks

- If block is empty, annotations will be disabled (this is already happening) and will show a tooltip message : Cannot apply {{annotationTitle}} to empty block
- If is selecting multiple blocks, annotation will be disabled and will show tooltip message Cannot apply {{annotationTitle}} to multiple blocks
- Selecting 1 block with content, annotation enabled and message: {{annotationTitle}}


<img width="859" alt="Screenshot 2023-11-22 at 13 02 56" src="https://github.com/sanity-io/sanity/assets/46196328/91b32bac-567a-433c-8e26-29fdf98e3d3b">
<img width="855" alt="Screenshot 2023-11-22 at 13 02 49" src="https://github.com/sanity-io/sanity/assets/46196328/f3cffef0-e64e-439f-8451-090f1f49a58c">
<img width="852" alt="Screenshot 2023-11-22 at 13 02 40" src="https://github.com/sanity-io/sanity/assets/46196328/d08ecd5a-44d9-4d97-9195-b88e192814b1">

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Annotations behaviour

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Disabled multiple blocks annotations, adds disabled annotations information on tooltip.
<!--
A description of the change(s) that should be used in the release notes.
-->
