### PR TITLE
chore(cli): move dataset copy flags to end of cli examples

### DIFF
--- a/packages/sanity/src/_internal/cli/commands/dataset/copyDatasetCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/dataset/copyDatasetCommand.ts
@@ -23,8 +23,8 @@ Examples
   sanity dataset copy
   sanity dataset copy <source-dataset>
   sanity dataset copy <source-dataset> <target-dataset>
-  sanity dataset copy --skip-history <source-dataset> <target-dataset>
-  sanity dataset copy --detach <source-dataset> <target-dataset>
+  sanity dataset copy <source-dataset> <target-dataset> --skip-history 
+  sanity dataset copy <source-dataset> <target-dataset> --detach 
   sanity dataset copy --attach <job-id>
   sanity dataset copy --list
   sanity dataset copy --list --offset=2


### PR DESCRIPTION
### Description

Small tweak to dataset copy cli examples

### What to review

That the commands still perform the same action

### Notes for release

Reordered dataset copy cli example flags