### PR TITLE
fix(form): pte activate overlay

### DIFF
--- a/packages/sanity/src/core/form/components/ActivateOnFocus/ActivateOnFocus.styles.tsx
+++ b/packages/sanity/src/core/form/components/ActivateOnFocus/ActivateOnFocus.styles.tsx
@@ -31,8 +31,8 @@ export const FlexContainer = styled(Flex)`
   width: 100%;
   height: 100%;
 
-  :hover,
-  :focus {
+  &:hover,
+  &:focus {
     & ${CardContainer} {
       opacity: 0.9;
     }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This pull request fixes an issue where the "activate overlay" for the PTE input was not visible.

### What to review

- Make sure that the overlay is shown on hover/focus

### Notes for release

N/A