### PR TITLE
fix(pte): removing annotations cleans incorrect path

### DIFF
--- a/dev/test-studio/schema/standard/portableText/allTheBellsAndWhistles.ts
+++ b/dev/test-studio/schema/standard/portableText/allTheBellsAndWhistles.ts
@@ -1,4 +1,4 @@
-import {BellIcon, ImageIcon, InfoOutlineIcon} from '@sanity/icons'
+import {BellIcon, ColorWheelIcon, ImageIcon, InfoOutlineIcon} from '@sanity/icons'
 import {Rule} from '@sanity/types'
 import {defineArrayMember, defineField, defineType} from 'sanity'
 import {InfoBoxPreview} from './InfoBoxPreview'
@@ -67,6 +67,19 @@ export const ptAllTheBellsAndWhistlesType = defineType({
                     title: 'Open in new tab?',
                     description: 'Will open the link in a new tab when checked.',
                     initialValue: false,
+                  },
+                ],
+              },
+              {
+                type: 'object',
+                name: 'color',
+                title: 'Color',
+                icon: ColorWheelIcon,
+                fields: [
+                  {
+                    type: 'string',
+                    name: 'color',
+                    title: 'Color',
                   },
                 ],
               },

--- a/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditorTester.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/__tests__/PortableTextEditorTester.tsx
@@ -38,9 +38,33 @@ const portableTextType = defineArrayMember({
   of: [blockType, someObject],
 })
 
+const colorAndLink = defineArrayMember({
+  type: 'array',
+  name: 'colorAndLink',
+  of: [
+    {
+      ...blockType,
+      marks: {
+        annotations: [
+          {
+            name: 'link',
+            type: 'object',
+            fields: [{type: 'string', name: 'color'}],
+          },
+          {
+            name: 'color',
+            type: 'object',
+            fields: [{type: 'string', name: 'color'}],
+          },
+        ],
+      },
+    },
+  ],
+})
+
 const schema = Schema.compile({
   name: 'test',
-  types: [portableTextType],
+  types: [portableTextType, colorAndLink],
 })
 
 let key = 0
@@ -80,3 +104,5 @@ export const PortableTextEditorTester = forwardRef(function PortableTextEditorTe
 })
 
 export const schemaType = schema.get('body')
+
+export const schemaTypeWithColorAndLink = schema.get('colorAndLink')


### PR DESCRIPTION

### Description
Fixes issue in which splitting the paths when removing annotations and creating new spans was not always selecting the correct span to remove the annotations from.
See video:


https://github.com/sanity-io/sanity/assets/46196328/ee99bd69-be52-4a29-99e0-30d70ac3d996


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Annotations, adding and removing.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fixes issue in which splitting the paths when removing annotations and creating new spans was not always selecting the correct span to remove the annotations from
<!--
A description of the change(s) that should be used in the release notes.
-->
