### PR TITLE
perf(form): improve form state reconciliation

### DIFF
--- a/packages/sanity/src/core/form/store/formState.ts
+++ b/packages/sanity/src/core/form/store/formState.ts
@@ -739,7 +739,7 @@ function prepareObjectInputState<T>(
     },
   )
 
-  return {
+  const node = {
     value: props.value as Record<string, unknown> | undefined,
     changed: isChangedValue(props.value, props.comparisonValue),
     schemaType: props.schemaType,
@@ -753,10 +753,14 @@ function prepareObjectInputState<T>(
     validation,
     // this is currently needed by getExpandOperations which needs to know about hidden members
     // (e.g. members not matching current group filter) in order to determine what to expand
-    _allMembers: members,
     members: filtereredMembers,
     groups: visibleGroups,
   }
+  Object.defineProperty(node, '_allMembers', {
+    value: members,
+    enumerable: false,
+  })
+  return node
 }
 
 function prepareArrayOfPrimitivesInputState<T extends (boolean | string | number)[]>(

--- a/packages/sanity/src/core/form/store/types/nodes.ts
+++ b/packages/sanity/src/core/form/store/types/nodes.ts
@@ -68,8 +68,6 @@ export interface ObjectFormNode<
    * @hidden
    * @beta */
   members: ObjectMember[]
-  /** @internal */
-  _allMembers: (ObjectMember | HiddenField)[]
 }
 
 /** @public */
@@ -90,8 +88,6 @@ export interface ObjectArrayFormNode<
    * @beta */
   members: ObjectMember[]
 
-  /** @internal */
-  _allMembers: ObjectMember[]
   changesOpen?: boolean
 }
 

--- a/packages/sanity/src/core/form/store/utils/immutableReconcile.ts
+++ b/packages/sanity/src/core/form/store/utils/immutableReconcile.ts
@@ -47,6 +47,7 @@ function _immutableReconcile<T>(
       }
       result[index] = nextItem
     }
+    parents.delete(next)
     return (allEqual ? previous : result) as any
   }
 
@@ -65,6 +66,7 @@ function _immutableReconcile<T>(
       }
       result[key] = nextValue
     }
+    parents.delete(next)
     return (allEqual ? previous : result) as T
   }
   return next


### PR DESCRIPTION
### Description
This fixes a couple of perf related issues.
1. 3ada4852f06cf4c8f6e156c39dd133e909aeff48 – When traversing over the previous + next formState to see what values are unchanged, we previously had a circular reference detection that added parents to a set as it went over it. When arriving at a node that's in the set of parents, it will short-circuit and return the next value. After done traversing over a subtree, the parent was still kept around in the set, which made it appear in parents of sibling subtrees, sometimes short-cirquiting (and returning the next) value in cases where it could have re-used the previous value (by referential identity). This PR fixes the issue by removing a node from parents after done iterating over a subtree.
2. d9f22ba762d91e6525f6ed6300e3539ec36a6d50 – Fixing the above revealed that we had another issue introduced by adding `_allMembers` to formstate (introduced by #4477), causing the reconciliation to become super slow. This fixes the issue by making `_allMembers` non-enumerable, which prevents immutableReconcile from iterating over it.

### What to review
- This should fix an issue that could sometimes produce different value identities for form state nodes that are identical between renders

### Notes for release

- N/A internal (although it likely has a noticeable impact on editing performance)