### PR TITLE
fix(pte): removes empty text block when inserting a new block in that position

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/plugins/__tests__/withEditableAPIInsert.test.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/__tests__/withEditableAPIInsert.test.tsx
@@ -20,10 +20,30 @@ const initialValue = [
     style: 'normal',
   },
 ]
-
 const initialSelection = {
   focus: {path: [{_key: 'a'}, 'children', {_key: 'a1'}], offset: 7},
   anchor: {path: [{_key: 'a'}, 'children', {_key: 'a1'}], offset: 7},
+}
+
+const emptyTextBlock = [
+  {
+    _key: 'emptyBlock',
+    _type: 'myTestBlockType',
+    children: [
+      {
+        _key: 'emptySpan',
+        _type: 'span',
+        marks: [],
+        text: '',
+      },
+    ],
+    markDefs: [],
+    style: 'normal',
+  },
+]
+const emptyBlockSelection = {
+  focus: {path: [{_key: 'emptyBlock'}, 'children', {_key: 'emptySpan'}], offset: 0},
+  anchor: {path: [{_key: 'emptyBlock'}, 'children', {_key: 'emptySpan'}], offset: 0},
 }
 
 describe('plugin:withEditableAPI: .insertChild()', () => {
@@ -133,6 +153,191 @@ describe('plugin:withEditableAPI: .insertChild()', () => {
             },
           }
         `)
+      }
+    })
+  })
+})
+
+describe('plugin:withEditableAPI: .insertBlock()', () => {
+  it('should not add empty blank blocks: empty block', async () => {
+    const editorRef: React.RefObject<PortableTextEditor> = React.createRef()
+    const onChange = jest.fn()
+    render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        schemaType={schemaType}
+        value={emptyTextBlock}
+      />,
+    )
+    const editor = editorRef.current
+    const someObject = editor?.schemaTypes.inlineObjects.find((t) => t.name === 'someObject')
+
+    await waitFor(() => {
+      if (editorRef.current && someObject) {
+        PortableTextEditor.focus(editorRef.current)
+        PortableTextEditor.select(editorRef.current, emptyBlockSelection)
+        PortableTextEditor.insertBlock(editorRef.current, someObject, {color: 'red'})
+
+        expect(PortableTextEditor.getValue(editorRef.current)).toEqual([
+          {_key: '2', _type: 'someObject', color: 'red'},
+        ])
+      } else {
+        throw new Error('No editor or someObject')
+      }
+    })
+  })
+
+  it('should not add empty blank blocks: non-empty block', async () => {
+    const editorRef: React.RefObject<PortableTextEditor> = React.createRef()
+    const onChange = jest.fn()
+    render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        schemaType={schemaType}
+        value={initialValue}
+      />,
+    )
+    const editor = editorRef.current
+    const someObject = editor?.schemaTypes.inlineObjects.find((t) => t.name === 'someObject')
+
+    await waitFor(() => {
+      if (editorRef.current && someObject) {
+        PortableTextEditor.focus(editorRef.current)
+        PortableTextEditor.select(editorRef.current, initialSelection)
+        PortableTextEditor.insertBlock(editorRef.current, someObject, {color: 'red'})
+        expect(PortableTextEditor.getValue(editorRef.current)).toEqual([
+          ...initialValue,
+          {_key: '2', _type: 'someObject', color: 'red'},
+        ])
+      } else {
+        throw new Error('No editor or someObject')
+      }
+    })
+  })
+  it('should be inserted before if focus is on start of block', async () => {
+    const editorRef: React.RefObject<PortableTextEditor> = React.createRef()
+    const onChange = jest.fn()
+    render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        schemaType={schemaType}
+        value={initialValue}
+      />,
+    )
+    const editor = editorRef.current
+    const someObject = editor?.schemaTypes.inlineObjects.find((t) => t.name === 'someObject')
+
+    await waitFor(() => {
+      if (editorRef.current && someObject) {
+        PortableTextEditor.focus(editorRef.current)
+        PortableTextEditor.select(editorRef.current, {
+          focus: {path: [{_key: 'a'}, 'children', {_key: 'a1'}], offset: 0},
+          anchor: {path: [{_key: 'a'}, 'children', {_key: 'a1'}], offset: 0},
+        })
+        PortableTextEditor.insertBlock(editorRef.current, someObject, {color: 'red'})
+        expect(PortableTextEditor.getValue(editorRef.current)).toEqual([
+          {_key: '2', _type: 'someObject', color: 'red'},
+          ...initialValue,
+        ])
+      } else {
+        throw new Error('No editor or someObject')
+      }
+    })
+  })
+  it('should not add empty blank blocks: non text block', async () => {
+    const editorRef: React.RefObject<PortableTextEditor> = React.createRef()
+    const onChange = jest.fn()
+    const value = [...initialValue, {_key: 'b', _type: 'someObject', color: 'red'}]
+    render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        schemaType={schemaType}
+        value={value}
+      />,
+    )
+    const editor = editorRef.current
+    const someObject = editor?.schemaTypes.inlineObjects.find((t) => t.name === 'someObject')
+
+    await waitFor(() => {
+      if (editorRef.current && someObject) {
+        PortableTextEditor.focus(editorRef.current)
+        // Focus the `someObject` block
+        PortableTextEditor.select(editorRef.current, {
+          focus: {path: [{_key: 'b'}], offset: 0},
+          anchor: {path: [{_key: 'b'}], offset: 0},
+        })
+        PortableTextEditor.insertBlock(editorRef.current, someObject, {color: 'yellow'})
+        expect(PortableTextEditor.getValue(editorRef.current)).toEqual([
+          ...value,
+          {_key: '2', _type: 'someObject', color: 'yellow'},
+        ])
+      } else {
+        throw new Error('No editor or someObject')
+      }
+    })
+  })
+  it('should not add empty blank blocks: in between blocks', async () => {
+    const editorRef: React.RefObject<PortableTextEditor> = React.createRef()
+    const onChange = jest.fn()
+    const value = [...initialValue, {_key: 'b', _type: 'someObject', color: 'red'}]
+    render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        schemaType={schemaType}
+        value={value}
+      />,
+    )
+    const editor = editorRef.current
+    const someObject = editor?.schemaTypes.inlineObjects.find((t) => t.name === 'someObject')
+
+    await waitFor(() => {
+      if (editorRef.current && someObject) {
+        PortableTextEditor.focus(editorRef.current)
+        // Focus the `text` block
+        PortableTextEditor.select(editorRef.current, initialSelection)
+        PortableTextEditor.insertBlock(editorRef.current, someObject, {color: 'yellow'})
+        expect(PortableTextEditor.getValue(editorRef.current)).toEqual([
+          value[0],
+          {_key: '2', _type: 'someObject', color: 'yellow'},
+          value[1],
+        ])
+      } else {
+        throw new Error('No editor or someObject')
+      }
+    })
+  })
+  it('should not add empty blank blocks: in new empty text block', async () => {
+    const editorRef: React.RefObject<PortableTextEditor> = React.createRef()
+    const onChange = jest.fn()
+    const value = [...initialValue, ...emptyTextBlock]
+    render(
+      <PortableTextEditorTester
+        onChange={onChange}
+        ref={editorRef}
+        schemaType={schemaType}
+        value={value}
+      />,
+    )
+    const editor = editorRef.current
+    const someObject = editor?.schemaTypes.inlineObjects.find((t) => t.name === 'someObject')
+
+    await waitFor(() => {
+      if (editorRef.current && someObject) {
+        PortableTextEditor.focus(editorRef.current)
+        // Focus the empty `text` block
+        PortableTextEditor.select(editorRef.current, emptyBlockSelection)
+        PortableTextEditor.insertBlock(editorRef.current, someObject, {color: 'yellow'})
+        expect(PortableTextEditor.getValue(editorRef.current)).toEqual([
+          value[0],
+          {_key: '2', _type: 'someObject', color: 'yellow'},
+        ])
+      } else {
+        throw new Error('No editor or someObject')
       }
     })
   })

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithEditableAPI.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithEditableAPI.ts
@@ -180,6 +180,24 @@ export function createWithEditableAPI(
           ],
           portableTextEditor,
         )[0] as unknown as Node
+        const [focusBlock] = Array.from(
+          Editor.nodes(editor, {
+            at: editor.selection.focus.path.slice(0, 1),
+            match: (n) => n._type === types.block.name,
+          }),
+        )[0] || [undefined]
+
+        const isEmptyTextBlock =
+          focusBlock &&
+          editor.isTextBlock(focusBlock) &&
+          focusBlock.children.length === 1 &&
+          focusBlock.children[0].text === ''
+
+        if (isEmptyTextBlock) {
+          // If the text block is empty, remove it before inserting the new block.
+          Transforms.removeNodes(editor, {at: editor.selection})
+        }
+
         Editor.insertNode(editor, block)
         editor.onChange()
         return (

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithEditableAPI.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithEditableAPI.ts
@@ -24,7 +24,7 @@ import {
   PortableTextMemberSchemaTypes,
   PortableTextSlateEditor,
 } from '../../types/editor'
-import {toSlateValue, fromSlateValue} from '../../utils/values'
+import {toSlateValue, fromSlateValue, isEqualToEmptyEditor} from '../../utils/values'
 import {toSlateRange, toPortableTextRange} from '../../utils/ranges'
 import {PortableTextEditor} from '../PortableTextEditor'
 
@@ -187,11 +187,7 @@ export function createWithEditableAPI(
           }),
         )[0] || [undefined]
 
-        const isEmptyTextBlock =
-          focusBlock &&
-          editor.isTextBlock(focusBlock) &&
-          focusBlock.children.length === 1 &&
-          focusBlock.children[0].text === ''
+        const isEmptyTextBlock = focusBlock && isEqualToEmptyEditor([focusBlock], types)
 
         if (isEmptyTextBlock) {
           // If the text block is empty, remove it before inserting the new block.


### PR DESCRIPTION
### Description

When inserting a new block the PTE editor was creating empty text blocks.
This PR adds a check to remove the text block in the user selection if it's empty before inserting a new block.
So, if you have a empty editor and try to insert any new block, no empty text blocks will be created.
If the editor has values, and you are in an empty text block, no new blocks will be added.


https://github.com/sanity-io/sanity/assets/46196328/03afca8c-5f02-439b-87ef-58fd07e8a568



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Adding text blocks should continue working as expected.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Fixes issue in which new empty text blocks where added when adding a block in the portable text editor.
<!--
A description of the change(s) that should be used in the release notes.
-->
