### PR TITLE
fix(comments): performance issue in `CommentField`

### DIFF
--- a/packages/sanity/src/desk/comments/src/context/comments/CommentsProvider.tsx
+++ b/packages/sanity/src/desk/comments/src/context/comments/CommentsProvider.tsx
@@ -40,13 +40,16 @@ export interface CommentsProviderProps {
   children: React.ReactNode
   documentId: string
   documentType: string
+
+  isCommentsOpen?: boolean
+  onCommentsOpen?: () => void
 }
 
 /**
  * @beta
  */
 export const CommentsProvider = memo(function CommentsProvider(props: CommentsProviderProps) {
-  const {children, documentId, documentType} = props
+  const {children, documentId, documentType, isCommentsOpen, onCommentsOpen} = props
   const [status, setStatus] = useState<CommentStatus>('open')
 
   const {client, runSetup, isRunningSetup} = useCommentsSetup()
@@ -224,6 +227,9 @@ export const CommentsProvider = memo(function CommentsProvider(props: CommentsPr
 
       getComment,
 
+      isCommentsOpen,
+      onCommentsOpen,
+
       comments: {
         data: threadItemsByStatus,
         error,
@@ -244,17 +250,19 @@ export const CommentsProvider = memo(function CommentsProvider(props: CommentsPr
       mentionOptions,
     }),
     [
-      isRunningSetup,
-      status,
-      getComment,
-      threadItemsByStatus,
       error,
+      getComment,
+      isCommentsOpen,
+      isRunningSetup,
       loading,
-      operation.create,
-      operation.remove,
-      operation.edit,
-      operation.update,
       mentionOptions,
+      onCommentsOpen,
+      operation.create,
+      operation.edit,
+      operation.remove,
+      operation.update,
+      status,
+      threadItemsByStatus,
     ],
   )
 

--- a/packages/sanity/src/desk/comments/src/context/comments/types.ts
+++ b/packages/sanity/src/desk/comments/src/context/comments/types.ts
@@ -15,6 +15,9 @@ export interface CommentsContextValue {
 
   isRunningSetup: boolean
 
+  isCommentsOpen?: boolean
+  onCommentsOpen?: () => void
+
   comments: {
     data: {
       open: CommentThreadItem[]

--- a/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/desk/panes/document/DocumentPaneProvider.tsx
@@ -15,6 +15,7 @@ import {DocumentPaneProviderProps} from './types'
 import {usePreviewUrl} from './usePreviewUrl'
 import {getInitialValueTemplateOpts} from './getInitialValueTemplateOpts'
 import {
+  COMMENTS_INSPECTOR_NAME,
   DEFAULT_MENU_ITEM_GROUPS,
   EMPTY_PARAMS,
   HISTORY_INSPECTOR_NAME,
@@ -698,16 +699,34 @@ export const DocumentPaneProvider = memo((props: DocumentPaneProviderProps) => {
 
   const commentsEnabled = useCommentsEnabled()
 
+  const handleOpenCommentsInspector = useCallback(() => {
+    if (currentInspector?.name === COMMENTS_INSPECTOR_NAME) return
+
+    openInspector(COMMENTS_INSPECTOR_NAME)
+  }, [currentInspector?.name, openInspector])
+
   const content = useMemo(() => {
     // If comments are not enabled, return children as-is without wrapping in providers
     if (!commentsEnabled) return children
 
     return (
-      <CommentsProvider documentId={documentId} documentType={documentType}>
+      <CommentsProvider
+        documentId={documentId}
+        documentType={documentType}
+        isCommentsOpen={currentInspector?.name === COMMENTS_INSPECTOR_NAME}
+        onCommentsOpen={handleOpenCommentsInspector}
+      >
         <CommentsSelectedPathProvider>{children}</CommentsSelectedPathProvider>
       </CommentsProvider>
     )
-  }, [children, commentsEnabled, documentId, documentType])
+  }, [
+    children,
+    commentsEnabled,
+    currentInspector?.name,
+    documentId,
+    documentType,
+    handleOpenCommentsInspector,
+  ])
 
   return (
     <DocumentPaneContext.Provider value={documentPane}>


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This pull request removes the use of `useDocumentPane` in the `CommentField` component to improve performance. The hook was used to open the comments inspector, which is now replaced with props passed to the `CommentsProvider`. 

### What to review


### Notes for release

