### PR TITLE
chore: prevent tests, workshop files from being published

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -119,7 +119,10 @@
     "router.js",
     "presentation.js",
     "src",
-    "static"
+    "static",
+    "!**/__test__/**",
+    "!**/__tests__/**",
+    "!**/__workshop__/**"
   ],
   "scripts": {
     "prebuild": "run-s clean",


### PR DESCRIPTION
### Description

Currently we are publishing the entire `src` folder, which contains some stuff we don't really need to publish:

```
npm notice 132B    src/desk/panes/document/statusBar/__workshop__/.eslintrc
npm notice 960B    src/desk/panes/document/statusBar/__workshop__/DocumentActionsStory.tsx
npm notice 960B    src/desk/panes/document/statusBar/__workshop__/DocumentBadgesStory.tsx
npm notice 613B    src/desk/panes/document/statusBar/__workshop__/index.ts
npm notice 751B    src/desk/panes/document/statusBar/__workshop__/ReviewChangesButtonStory.tsx
npm notice 3.2kB   src/router/__test__/api.test.ts
npm notice 1.2kB   src/router/__test__/base64url.test.ts
npm notice 320B    src/router/__test__/basepath.test.ts
npm notice 803B    src/router/__test__/errors.test.ts
npm notice 1.4kB   src/router/__test__/examples.ts
...
```

Not a huge deal, but figured it is worth ignoring these.

### What to review

Patterns look correct

### Notes for release

None
