### PR TITLE
fix(form): include group name in group tab test id

### DIFF
--- a/packages/sanity/src/core/form/inputs/ObjectInput/fieldGroups/GroupTab.tsx
+++ b/packages/sanity/src/core/form/inputs/ObjectInput/fieldGroups/GroupTab.tsx
@@ -26,7 +26,7 @@ export const GroupTab = forwardRef(function GroupTab(
 
   return (
     <Tab
-      data-testid={`group-tab-${name}`}
+      data-testid={`group-tab-${props.name}`}
       size={1}
       id={`${props.name}-tab`}
       label={props.title}


### PR DESCRIPTION
### Description

Very small change to fix the `data-testid` attribute given to group tab buttons. At the moment, they use the `name` variable, which is undefined.