### PR TITLE
feat: added string/text to block converters

### DIFF
--- a/packages/sanity/src/core/form/inputs/InvalidValueInput/converters.ts
+++ b/packages/sanity/src/core/form/inputs/InvalidValueInput/converters.ts
@@ -1,4 +1,5 @@
 import isValidDate from 'date-fns/isValid'
+import {randomKey} from '@sanity/block-tools'
 
 const TRUTHY_STRINGS = ['yes', 'true', '1']
 const FALSEY_STRINGS = ['false', 'no', 'false', '0', 'null']
@@ -55,6 +56,32 @@ export const converters: {[fromType: string]: {[toType: string]: ValueConverter}
           offset: new Date().getTimezoneOffset(),
         }
       },
+    },
+    portableText: {
+      test: TRUE,
+      convert: (value: string) => [
+        {
+          _type: 'block',
+          _key: randomKey(12),
+          children: [{_type: 'span', text: value, _key: randomKey(12)}],
+          markDefs: [],
+        },
+      ],
+    },
+  },
+  text: {
+    portableText: {
+      test: TRUE,
+      convert: (value: string) => [
+        {
+          _type: 'block',
+          _key: randomKey(12),
+          children: value
+            .split('\n')
+            .map((line) => ({_type: 'span', text: line, _key: randomKey(12)})),
+          markDefs: [],
+        },
+      ],
     },
   },
   date: {

--- a/packages/sanity/src/core/form/members/object/MemberFieldError.tsx
+++ b/packages/sanity/src/core/form/members/object/MemberFieldError.tsx
@@ -4,6 +4,7 @@ import {FieldError} from '../../store/types/memberErrors'
 import {useFormCallbacks} from '../../studio/contexts/FormCallbacks'
 import {PatchEvent} from '../../patch'
 import {InvalidValueInput} from '../../inputs/InvalidValueInput'
+import {isBlockType} from '../../inputs/PortableText/_helpers'
 import {MissingKeysAlert} from './errors/MissingKeysAlert'
 import {DuplicateKeysAlert} from './errors/DuplicateKeysAlert'
 import {MixedArrayAlert} from './errors/MixedArrayAlert'
@@ -20,12 +21,16 @@ export function MemberFieldError(props: {member: FieldError}) {
     [onChange, member.fieldName],
   )
   if (member.error.type === 'INCOMPATIBLE_TYPE') {
+    const hasBlockType =
+      member.error.expectedSchemaType.jsonType === 'array' &&
+      member.error.expectedSchemaType.of.some((t) => isBlockType(t))
+
     return (
       <InvalidValueInput
         value={member.error.value}
         onChange={handleChange}
         actualType={member.error.resolvedValueType}
-        validTypes={[member.error.expectedSchemaType.name]}
+        validTypes={hasBlockType ? ['portableText'] : [member.error.expectedSchemaType.name]}
       />
     )
   }


### PR DESCRIPTION
### Description

Added converter for when a schema field changes  type from string/text to portable text

### What to review

- Create a field of type string/test
- Add content to the field
- Publish document
- Change field type to array with of  type 'block'
- You should now see a "Convert to portableText" button
- Click it
- The data should be transformed into portable text spans

For text that is multiline, there should be multiple portable text spans.

### Notes for release

tbd
