### PR TITLE
fix(dialog): drag events in editPortal are applied to underlying elements

### DIFF
--- a/packages/sanity/src/core/form/components/EditPortal.tsx
+++ b/packages/sanity/src/core/form/components/EditPortal.tsx
@@ -18,6 +18,10 @@ interface Props {
   autofocus?: boolean
 }
 
+function onDragEnter(event: React.DragEvent<HTMLDivElement>) {
+  return event.stopPropagation()
+}
+
 export function EditPortal(props: Props): React.ReactElement {
   const {
     children,
@@ -51,6 +55,7 @@ export function EditPortal(props: Props): React.ReactElement {
           id={id || ''}
           onClickOutside={onClose}
           onClose={onClose}
+          onDragEnter={onDragEnter}
           width={width}
           contentRef={setDocumentScrollElement}
           __unstable_autoFocus={autofocus}


### PR DESCRIPTION
### Description

Contain onDragEnter event to the dialog only, as it's propagating to the elements behind it causing unexpected behaviours in the elements.


## With error

https://github.com/sanity-io/ui/assets/46196328/c2661532-44de-4fd5-bef9-a693e34eb224

## Fixed:

https://github.com/sanity-io/ui/assets/46196328/c6b317b1-cd5e-42a8-997b-93263ede1c06

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

EditPortal modal behaviour. 

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Fix error in which working in a PTE which is opened in a modal over an array, drag'n'dropping blocks will affect the underlying array (error:"Can't upload this file here")

<!--
A description of the change(s) that should be used in the release notes.
-->
