### PR TITLE
fix: prevent props that are unknown html attributes from passing through

### DIFF
--- a/packages/sanity/src/core/form/inputs/ReferenceInput/CreateButton.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/CreateButton.tsx
@@ -25,7 +25,7 @@ const POPOVER_PROPS: MenuButtonProps['popover'] = {
 }
 
 export function CreateButton(props: Props) {
-  const {createOptions, onCreate, id, ...rest} = props
+  const {createOptions, onCreate, id, menuRef, ...rest} = props
 
   const canCreateAny = createOptions.some((option) => option.permission.granted)
   if (!canCreateAny) {
@@ -58,7 +58,7 @@ export function CreateButton(props: Props) {
       }
       id={id}
       menu={
-        <Menu ref={props.menuRef}>
+        <Menu ref={menuRef}>
           {createOptions.map((createOption) => (
             <Tooltip
               disabled={createOption.permission.granted}

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceAutocomplete.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceAutocomplete.tsx
@@ -23,6 +23,7 @@ export const ReferenceAutocomplete = forwardRef(function ReferenceAutocomplete(
   },
   ref: React.ForwardedRef<HTMLInputElement>,
 ) {
+  const {searchString, loading, portalRef, referenceElement, ...restProps} = props
   const hasResults = props.options && props.options.length > 0
   const renderPopover = useCallback(
     (
@@ -56,8 +57,8 @@ export const ReferenceAutocomplete = forwardRef(function ReferenceAutocomplete(
               <Box padding={4}>
                 <Flex align="center" height="fill" justify="center">
                   <StyledText align="center" muted>
-                    No results for <strong>“{props.searchString}”</strong>
-                    {props.searchString?.toLowerCase() === 'capybara' ? (
+                    No results for <strong>“{searchString}”</strong>
+                    {searchString?.toLowerCase() === 'capybara' ? (
                       <>. What a shame. There should be more Capybaras.</>
                     ) : null}
                   </StyledText>
@@ -66,14 +67,14 @@ export const ReferenceAutocomplete = forwardRef(function ReferenceAutocomplete(
             )}
           </div>
         }
-        open={!props.loading && !hidden}
-        ref={props.portalRef}
+        open={!loading && !hidden}
+        ref={portalRef}
         portal
-        referenceElement={props.referenceElement || inputElement}
+        referenceElement={referenceElement || inputElement}
         matchReferenceWidth
       />
     ),
-    [hasResults, props.searchString, props.loading, props.portalRef, props.referenceElement],
+    [hasResults, searchString, loading, portalRef, referenceElement],
   )
-  return <Autocomplete {...props} ref={ref} renderPopover={renderPopover} />
+  return <Autocomplete {...restProps} loading={loading} ref={ref} renderPopover={renderPopover} />
 })

--- a/packages/sanity/src/core/studio/components/navbar/search/components/common/CustomTextInput.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/common/CustomTextInput.tsx
@@ -12,7 +12,7 @@ export const CustomTextInput = forwardRef<HTMLInputElement, CustomTextInputProps
     const {background, smallClearButton, ...rest} = props
 
     return (
-      <CustomTextInputBox background={background} smallClearButton={smallClearButton}>
+      <CustomTextInputBox $background={background} $smallClearButton={smallClearButton}>
         <TextInput {...rest} ref={ref} />
       </CustomTextInputBox>
     )

--- a/packages/sanity/src/core/studio/components/navbar/search/components/common/CustomTextInputBox.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/common/CustomTextInputBox.tsx
@@ -2,22 +2,22 @@ import {Box} from '@sanity/ui'
 import styled, {css} from 'styled-components'
 
 export const CustomTextInputBox = styled(Box)<{
-  background?: boolean
-  smallClearButton?: boolean
-}>(({background, smallClearButton}) => {
+  $background?: boolean
+  $smallClearButton?: boolean
+}>(({$background, $smallClearButton}) => {
   return css`
     width: 100%;
 
     input + span {
       background: ${({theme}) =>
-        background ? theme.sanity.color.card.disabled.bg2 : 'transparent'};
+        $background ? theme.sanity.color.card.disabled.bg2 : 'transparent'};
     }
 
     [data-qa='clear-button'] {
       background: none;
       box-shadow: none;
       display: flex; /* TODO: hack, currently used to vertically center <TextInput>'s clearButton */
-      transform: ${smallClearButton ? 'scale(0.8)' : 'scale(1)'};
+      transform: ${$smallClearButton ? 'scale(0.8)' : 'scale(1)'};
       &:hover {
         opacity: 0.5;
       }

--- a/packages/sanity/src/desk/components/IntentButton.tsx
+++ b/packages/sanity/src/desk/components/IntentButton.tsx
@@ -26,7 +26,7 @@ export const IntentButton = forwardRef(function IntentButton(
   )
 
   return props.disabled ? (
-    <Button {...props} as="a" role="link" aria-disabled="true" />
+    <Button {...restProps} as="a" role="link" aria-disabled="true" />
   ) : (
     <Button
       {...restProps}


### PR DESCRIPTION
### Description

Sometimes huge chonkers console warnings will fill up your devtools:
![image](https://github.com/sanity-io/sanity/assets/81981/436c2610-01f8-4c35-bb94-45c99c592e6e)


### What to review

No more chonkers when running `yarn dev` on the monorepo or `sanity dev`.

### Notes for release

Fixed console warnings about passing through non-DOM properties to styled-components
