### PR TITLE
fix: remove circular dependency between `useGlobalPresence` and `usePresenceStore`

### DIFF
--- a/packages/sanity/src/core/store/_legacy/datastores.ts
+++ b/packages/sanity/src/core/store/_legacy/datastores.ts
@@ -13,11 +13,11 @@ import {
 import {createDocumentStore, DocumentStore} from './document'
 import {createGrantsStore, GrantsStore} from './grants'
 import {createHistoryStore, HistoryStore} from './history'
-import {PresenceStore, __tmp_wrap_presenceStore} from './presence'
 import {createProjectStore, ProjectStore} from './project'
 import {useResourceCache} from './ResourceCacheProvider'
 import {createSettingsStore, SettingsStore} from './settings'
 import {createUserStore, UserStore} from './user'
+import {PresenceStore, __tmp_wrap_presenceStore} from './presence/presence-store'
 
 /**
  * @hidden

--- a/packages/sanity/src/core/store/_legacy/presence/useGlobalPresence.tsx
+++ b/packages/sanity/src/core/store/_legacy/presence/useGlobalPresence.tsx
@@ -1,6 +1,6 @@
 import {useState, useEffect} from 'react'
 import {usePresenceStore} from '../datastores'
-import {GlobalPresence} from './types'
+import type {GlobalPresence} from './types'
 
 /** @internal */
 export function useGlobalPresence(): GlobalPresence[] {


### PR DESCRIPTION
### Description

When running the build command on the test studio I noticed this warning:
![image](https://github.com/sanity-io/sanity/assets/81981/4ac11973-abf0-425f-abec-435d820e2169)
It appears to be caused by the circular dependency fixed in this PR.

### What to review

Warning should be gone, and nothing else should break/change as a result. The generated bundle should stay the same as none of the publicly exported paths changed.

### Notes for release

None
