### PR TITLE
fix(pte): focus error in readonly editor

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -145,6 +145,9 @@ export function PortableTextInput(props: PortableTextInputProps) {
           }
           break
         case 'selection':
+          // In readOnly mode the selection is creating incorrect selections because `blur`is not triggered when opening
+          // a inner dialog.
+          if (readOnly) return
           // This doesn't need to be immediate,
           // call through startTransition
           startTransition(() => {
@@ -177,7 +180,7 @@ export function PortableTextInput(props: PortableTextInputProps) {
         default:
       }
     },
-    [onBlur, onChange, onPathFocus, toast],
+    [onBlur, onChange, onPathFocus, toast, readOnly],
   )
 
   useEffect(() => {


### PR DESCRIPTION
### Description

When the PTE editor is in `readOnly` mode the onBlur event is not triggered when opening a internal dialog, for example, when we want to edit an inner object.
This is causing that when clicking on other object, the focus or selection of the PTE editor changes and creates a strange behaviour, focusing on multiple elements at the same time and showing an error in the screen.

With this changes, I'm disabling the selection when the editor is in readOnly mode.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Is there anything to consider in why we would want to keep the selection in the readOnly mode?
Is there a way to trigger the onBlur event even though the editor is in readOnly mode?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Fixes issue in which the PTE editor throws an error when opening dialogs if the user is viewing old documents.
<!--
A description of the change(s) that should be used in the release notes.
-->
