### PR TITLE
test(ci): move cli test to separate workflow without sharding

### DIFF
--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   cli-test:
     timeout-minutes: 60
-    name: Install (${{ matrix.os }} / node ${{ matrix.node }})
+    name: CLI Tests (${{ matrix.os }} / node ${{ matrix.node }})
     runs-on: ${{ matrix.os }}
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -63,6 +63,5 @@ jobs:
           node -v
           npm -v
           yarn test --silent --selectProjects=@sanity/cli
-        # env:
-        # FIXME: re-enable CLI tests with this
-        # SANITY_CI_CLI_AUTH_TOKEN: ${{ secrets.SANITY_CI_CLI_AUTH_TOKEN }}
+        env:
+          SANITY_CI_CLI_AUTH_TOKEN: ${{ secrets.SANITY_CI_CLI_AUTH_TOKEN }}

--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -1,0 +1,68 @@
+name: CLI Unit tests
+
+on:
+  # Build on pushes branches that have a PR (including drafts)
+  pull_request:
+  # Build on commits pushed to branches without a PR if it's in the allowlist
+  push:
+    branches: [next]
+
+jobs:
+  cli-test:
+    timeout-minutes: 60
+    name: Install (${{ matrix.os }} / node ${{ matrix.node }})
+    runs-on: ${{ matrix.os }}
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+    continue-on-error: ${{ matrix.experimental }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        node: [18, 20]
+        experimental: [false]
+        # include:
+        #   - os: windows-latest
+        #     node: 16
+        #     experimental: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-modules-${{ env.cache-name }}-
+            ${{ runner.os }}-modules-
+            ${{ runner.os }}-
+
+      - name: Install project dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
+
+      - name: Build CLI
+        run: yarn build:cli # Needed for CLI tests
+
+      - name: Test
+        id: test
+        run: |
+          node -v
+          npm -v
+          yarn test --silent --selectProjects=@sanity/cli
+        # env:
+        # FIXME: re-enable CLI tests with this
+        # SANITY_CI_CLI_AUTH_TOKEN: ${{ secrets.SANITY_CI_CLI_AUTH_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,10 +133,8 @@ jobs:
         run: |
           node -v
           npm -v
-          yarn test --silent --shard=${{ matrix.shardIndex}}/${{ matrix.shardTotal }}
+          yarn test --silent --shard=${{ matrix.shardIndex}}/${{ matrix.shardTotal }} --ignoreProjects=@sanity/cli
         env:
-          # FIXME: re-enable CLI tests with this
-          # SANITY_CI_CLI_AUTH_TOKEN: ${{ secrets.SANITY_CI_CLI_AUTH_TOKEN }}
           GITHUB_SHARD_IDENTIFIER: ${{ matrix.shardIndex }}-${{ matrix.shardTotal }}
 
   cleanup:


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR moves the CLI tests to it's own workflow without jest sharding so that it does not create a lot of datasets. The total number of datasets it should create per PR should be  (datasets(5) + copy) * studio version (2) * node versions (2) = **24** which is not ideal and hence long term solution would be moving some of the API calls but this should make the tests functional

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

If the changes makes sense

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

N/A
