### PR TITLE
fix next template image url builder not returning a url

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/templates/nextjs/index.ts
+++ b/packages/@sanity/cli/src/actions/init-project/templates/nextjs/index.ts
@@ -145,7 +145,7 @@ const imageBuilder = createImageUrlBuilder({
 })
 
 export const urlForImage = (source: Image) => {
-  return imageBuilder?.image(source).auto('format').fit('max')
+  return imageBuilder?.image(source).auto('format').fit('max').url()
 }
 `
 
@@ -159,7 +159,7 @@ const imageBuilder = createImageUrlBuilder({
 })
 
 export const urlForImage = (source) => {
-  return imageBuilder?.image(source).auto('format').fit('max')
+  return imageBuilder?.image(source).auto('format').fit('max').url()
 }
 `
 


### PR DESCRIPTION
### Description

Fixes an issue in the bootstrapped Next.js template where the `urlForImage` function wouldn't return a url. It would instead return a class and cause the following error:
`Error: Only plain objects, and a few built-ins, can be passed to Client Components from Server Components. Classes or null prototypes are not supported.`

### What to review
The addition of the `url()` method resolves the error and allows the builder to work properly without further configuration on the user's part. To test that this fix is needed, try to use the builder without this addition by bootstrapping a template inside of a Next project. 


### Notes for release
Fixes an issue in the Next.js template where the urlForImage function would return a class instead of a url.
