### PR TITLE
fix(core): presence menu ui

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/presence/PresenceMenu.tsx
@@ -6,6 +6,7 @@ import {
   Card,
   Menu,
   MenuButton,
+  MenuButtonProps,
   MenuDivider,
   MenuItem,
   Stack,
@@ -34,6 +35,7 @@ const StyledMenu = styled(Menu)`
 const FooterStack = styled(Stack)`
   position: sticky;
   bottom: 0;
+  background-color: var(--card-bg-color);
 `
 
 interface PresenceMenuProps {
@@ -83,8 +85,10 @@ export function PresenceMenu(props: PresenceMenuProps) {
   }, [collapse, hasPresence, presence, t])
 
   const popoverProps = useMemo(
-    () => ({
+    (): MenuButtonProps['popover'] => ({
       constrainSize: true,
+      fallbackPlacements: ['bottom'],
+      placement: 'bottom',
       portal: true,
       scheme: scheme,
     }),
@@ -97,7 +101,7 @@ export function PresenceMenu(props: PresenceMenuProps) {
       id="global-presence-menu"
       onClose={handleClearFocusedItem}
       menu={
-        <StyledMenu padding={1}>
+        <StyledMenu padding={1} paddingBottom={0}>
           {hasPresence && (
             <Stack>
               {presence.map((item) => (
@@ -125,7 +129,7 @@ export function PresenceMenu(props: PresenceMenuProps) {
             </Box>
           )}
 
-          <FooterStack space={1}>
+          <FooterStack space={1} paddingBottom={1}>
             <MenuDivider />
 
             <MenuItem


### PR DESCRIPTION
### Description

This pull request addresses small UI issues in the global presence menu:
- Ensures that the menu is always positioned at the bottom
- Fixes a background issue with the footer in the popover (see image below)

<img width="953" alt="Screenshot 2023-11-29 at 15 50 23" src="https://github.com/sanity-io/sanity/assets/15094168/36e21478-acb9-438f-836c-13c31e327a8b">

### What to review

- Make sure that it looks good

### Notes for release

N/A
