### PR TITLE
fix(core): not open popover when clicking link icon

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
@@ -264,6 +264,7 @@ export const DefaultAnnotationComponent = (props: BlockAnnotationProps) => {
   const hasError = validation.some((v) => v.level === 'error')
   const hasWarning = validation.some((v) => v.level === 'warning')
   const hasMarkers = markers.length > 0
+  const [showPopover, setShowPopover] = useState(false)
 
   const {t} = useTranslation()
   const toneKey = useMemo(() => {
@@ -281,6 +282,10 @@ export const DefaultAnnotationComponent = (props: BlockAnnotationProps) => {
     return 'default'
   }, [isLink, hasError, hasWarning])
 
+  const handleOnClick = useCallback(() => {
+    setShowPopover(true)
+  }, [])
+
   return (
     <Root
       $toneKey={toneKey}
@@ -288,21 +293,25 @@ export const DefaultAnnotationComponent = (props: BlockAnnotationProps) => {
       data-error={hasError ? '' : undefined}
       data-warning={hasWarning ? '' : undefined}
       data-markers={hasMarkers || undefined}
-      onClick={readOnly ? onOpen : undefined}
+      onClick={readOnly ? onOpen : handleOnClick}
     >
       {textElement}
-      <AnnotationToolbarPopover
-        annotationOpen={open}
-        floatingBoundary={floatingBoundary}
-        onOpen={onOpen}
-        onRemove={onRemove}
-        referenceBoundary={referenceBoundary}
-        referenceElement={referenceElement}
-        selected={selected}
-        title={
-          schemaType.i18nTitleKey ? t(schemaType.i18nTitleKey) : schemaType.title || schemaType.name
-        }
-      />
+      {showPopover && (
+        <AnnotationToolbarPopover
+          annotationOpen={open}
+          floatingBoundary={floatingBoundary}
+          onOpen={onOpen}
+          onRemove={onRemove}
+          referenceBoundary={referenceBoundary}
+          referenceElement={referenceElement}
+          selected={selected}
+          title={
+            schemaType.i18nTitleKey
+              ? t(schemaType.i18nTitleKey)
+              : schemaType.title || schemaType.name
+          }
+        />
+      )}
       {open && (
         <ObjectEditModal
           defaultType="popover"


### PR DESCRIPTION
### Description


Creating an annotation will briefly show a non-editable popover, before then showing the 'full' popover. 

Steps to recreate:
- Select any text in a PTE field and click the 'link' button
- Observe how you'll see an initial popover, then it'll disappear and another one will appear in its place

The second popover (with editable fields) should appear immediately. When the editable popover is visible, clicking anywhere outside (even the selected text) should dismiss it.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
That the annotation popover and the `Edit link` dialog show when expected. 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
