### PR TITLE
fix(core): add missing `assetRequired` type to image and file rule

### DIFF
--- a/packages/@sanity/types/src/schema/definition/type/file.ts
+++ b/packages/@sanity/types/src/schema/definition/type/file.ts
@@ -12,8 +12,22 @@ export interface FileOptions extends ObjectOptions {
 }
 
 /** @public */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface FileRule extends RuleDef<FileRule, FileValue> {}
+export interface FileRule extends RuleDef<FileRule, FileValue> {
+  /**
+   * Require a file field has an asset.
+   *
+   * @example
+   * ```ts
+   * defineField({
+   *  name: 'file',
+   *  title: 'File',
+   *  type: 'file',
+   *  validation: (Rule) => Rule.required().assetRequired(),
+   * })
+   * ```
+   */
+  assetRequired(): FileRule
+}
 
 /** @public */
 export interface FileValue {
@@ -23,10 +37,10 @@ export interface FileValue {
 
 /** @public */
 export interface FileDefinition
-  extends Omit<ObjectDefinition, 'type' | 'fields' | 'options' | 'groups'> {
+  extends Omit<ObjectDefinition, 'type' | 'fields' | 'options' | 'groups' | 'validation'> {
   type: 'file'
   fields?: ObjectDefinition['fields']
   options?: FileOptions
-  validation?: ValidationBuilder<FileRule>
+  validation?: ValidationBuilder<FileRule, FileValue>
   initialValue?: InitialValueProperty<any, FileValue>
 }

--- a/packages/@sanity/types/src/schema/definition/type/image.ts
+++ b/packages/@sanity/types/src/schema/definition/type/image.ts
@@ -22,12 +22,26 @@ export interface ImageValue extends FileValue {
 }
 
 /** @public */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface ImageRule extends RuleDef<ImageRule, ImageValue> {}
+export interface ImageRule extends RuleDef<ImageRule, ImageValue> {
+  /**
+   * Require an image field has an asset.
+   *
+   * @example
+   * ```ts
+   * defineField({
+   *  name: 'image',
+   *  title: 'Image',
+   *  type: 'image',
+   *  validation: (Rule) => Rule.required().assetRequired(),
+   * })
+   * ```
+   */
+  assetRequired(): ImageRule
+}
 
 /** @public */
 export interface ImageDefinition
-  extends Omit<ObjectDefinition, 'type' | 'fields' | 'options' | 'groups'> {
+  extends Omit<ObjectDefinition, 'type' | 'fields' | 'options' | 'groups' | 'validation'> {
   type: 'image'
   fields?: FieldDefinition[]
   options?: ImageOptions


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Adds missing `assetRequired` type to image and file rule interface so you can do this 

```ts
defineField({
  name: 'image',
  title: 'Image',
  type: 'image',
  validation: (Rule) => Rule.required().assetRequired(),
  fields: [
    defineField({
      name: 'alt',
      title: 'Alternativ text',
      type: 'string',
      validation: (Rule) => Rule.required(),
    }),
  ],
}),

defineField({
  name: 'file',
  title: 'File',
  type: 'file',
  validation: (Rule) => Rule.required().assetRequired(),
  fields: [
    defineField({
      name: 'description',
      title: 'Description',
      type: 'string',
      validation: (Rule) => Rule.required(),
    }),
  ],
}),
```

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

If the changes makes sense to the interface

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

- Fixes types for image and file rules to include `assetRequired` rule