### PR TITLE
feat(i18n): localize PTE activation message

### DIFF
--- a/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
@@ -794,7 +794,7 @@ const studioResources: Record<StudioLocaleResourceKeys, string> = {
 
   /** Label for activate on focus with context of click and focused */
   'inputs.portable-text.activate-on-focus-message_click-focused':
-    'Klikk eller trykk mellomromstasten for å aktivere',
+    'Klikk eller trykk mellomrom for å aktivere',
 
   /** Label for activate on focus with context of tap and not focused */
   'inputs.portable-text.activate-on-focus-message_tap': 'Trykk for å aktivere',

--- a/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
@@ -789,6 +789,18 @@ const studioResources: Record<StudioLocaleResourceKeys, string> = {
   /** Accessibility label for action to insert a block of a given type (`{{typeName}}`) */
   'inputs.portable-text.action.insert-block-aria-label': 'Sett inn {{typeName}} (blokk)',
 
+  /** Label for activate click verb */
+  'inputs.portable-text.activate-on-focus.click-verb': 'Klikk',
+
+  /** Label for activate focused verb */
+  'inputs.portable-text.activate-on-focus.focused-verb': ' eller trykk mellomrom',
+
+  /** Message for activate on focus */
+  'inputs.portable-text.activate-on-focus.message': '{{activateVerb}} å aktivere',
+
+  /** Label for activate tap verb */
+  'inputs.portable-text.activate-on-focus.tap-verb': 'Trykk på',
+
   /** Accessibility label for the button that opens the actions menu on blocks */
   'inputs.portable-text.block.open-menu-aria-label': 'Åpne meny',
 

--- a/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
+++ b/dev/test-studio/plugins/locale-no-nb/bundles/studio.ts
@@ -789,17 +789,15 @@ const studioResources: Record<StudioLocaleResourceKeys, string> = {
   /** Accessibility label for action to insert a block of a given type (`{{typeName}}`) */
   'inputs.portable-text.action.insert-block-aria-label': 'Sett inn {{typeName}} (blokk)',
 
-  /** Label for activate click verb */
-  'inputs.portable-text.activate-on-focus.click-verb': 'Klikk',
+  /** Label for activate on focus with context of click and not focused */
+  'inputs.portable-text.activate-on-focus-message_click': 'Klikk for å aktivere',
 
-  /** Label for activate focused verb */
-  'inputs.portable-text.activate-on-focus.focused-verb': ' eller trykk mellomrom',
+  /** Label for activate on focus with context of click and focused */
+  'inputs.portable-text.activate-on-focus-message_click-focused':
+    'Klikk eller trykk mellomromstasten for å aktivere',
 
-  /** Message for activate on focus */
-  'inputs.portable-text.activate-on-focus.message': '{{activateVerb}} å aktivere',
-
-  /** Label for activate tap verb */
-  'inputs.portable-text.activate-on-focus.tap-verb': 'Trykk på',
+  /** Label for activate on focus with context of tap and not focused */
+  'inputs.portable-text.activate-on-focus-message_tap': 'Trykk for å aktivere',
 
   /** Accessibility label for the button that opens the actions menu on blocks */
   'inputs.portable-text.block.open-menu-aria-label': 'Åpne meny',

--- a/packages/sanity/src/core/form/components/ActivateOnFocus/ActivateOnFocus.tsx
+++ b/packages/sanity/src/core/form/components/ActivateOnFocus/ActivateOnFocus.tsx
@@ -61,16 +61,20 @@ export function ActivateOnFocus(props: ActivateOnFocusProps) {
 
   const msg = useMemo(() => {
     const isTouch = isTouchDevice()
-    let activateVerb = isTouch
-      ? t('inputs.portable-text.activate-on-focus.tap-verb')
-      : t('inputs.portable-text.activate-on-focus.click-verb')
-    if (focused && !isTouch) {
-      activateVerb += t('inputs.portable-text.activate-on-focus.focused-verb')
+    let messageContext
+
+    if (isTouch) {
+      messageContext = 'tap'
+    } else if (focused) {
+      messageContext = 'click-focused'
+    } else {
+      messageContext = 'click'
     }
+
     const text =
       message ||
-      t('inputs.portable-text.activate-on-focus.message', {
-        activateVerb,
+      t('inputs.portable-text.activate-on-focus-message', {
+        context: messageContext,
       })
     return <Text weight="semibold">{text}</Text>
   }, [focused, message, t])

--- a/packages/sanity/src/core/form/components/ActivateOnFocus/ActivateOnFocus.tsx
+++ b/packages/sanity/src/core/form/components/ActivateOnFocus/ActivateOnFocus.tsx
@@ -1,6 +1,7 @@
 // This is transitional in order to track usage of the ActivateOnFocusPart part from within the form-builder package
 import React, {KeyboardEvent, useCallback, useMemo, useState} from 'react'
 import {Text} from '@sanity/ui'
+import {useTranslation} from '../../../i18n'
 import {
   OverlayContainer,
   FlexContainer,
@@ -29,6 +30,7 @@ export interface ActivateOnFocusProps {
 export function ActivateOnFocus(props: ActivateOnFocusProps) {
   const {children, message, onActivate, isOverlayActive} = props
   const [focused, setFocused] = useState(false)
+  const {t} = useTranslation()
 
   const handleClick = useCallback(() => {
     if (onActivate) {
@@ -59,13 +61,19 @@ export function ActivateOnFocus(props: ActivateOnFocusProps) {
 
   const msg = useMemo(() => {
     const isTouch = isTouchDevice()
-    let activateVerb = isTouch ? 'Tap' : 'Click'
+    let activateVerb = isTouch
+      ? t('inputs.portable-text.activate-on-focus.tap-verb')
+      : t('inputs.portable-text.activate-on-focus.click-verb')
     if (focused && !isTouch) {
-      activateVerb += ' or press space'
+      activateVerb += t('inputs.portable-text.activate-on-focus.focused-verb')
     }
-    const text = message || `${activateVerb} to activate`
+    const text =
+      message ||
+      t('inputs.portable-text.activate-on-focus.message', {
+        activateVerb,
+      })
     return <Text weight="semibold">{text}</Text>
-  }, [focused, message])
+  }, [focused, message, t])
 
   return (
     <OverlayContainer

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -622,6 +622,14 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'inputs.portable-text.action.insert-inline-object-aria-label': 'Insert {{typeName}} (inline)',
   /** Label for action to remove an annotation */
   'inputs.portable-text.action.remove-annotation': 'Remove annotation',
+  /** Label for activate click verb */
+  'inputs.portable-text.activate-on-focus.click-verb': 'Click',
+  /** Label for activate focused verb */
+  'inputs.portable-text.activate-on-focus.focused-verb': ' or press space',
+  /** Message for activate on focus */
+  'inputs.portable-text.activate-on-focus.message': '{{activateVerb}} to activate',
+  /** Label for activate tap verb */
+  'inputs.portable-text.activate-on-focus.tap-verb': 'Tap',
   /** Title for dialog that allows editing an annotation */
   'inputs.portable-text.annotation-editor.title': 'Edit {{schemaType}}',
   /** Title of the default "link" annotation */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -622,14 +622,13 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'inputs.portable-text.action.insert-inline-object-aria-label': 'Insert {{typeName}} (inline)',
   /** Label for action to remove an annotation */
   'inputs.portable-text.action.remove-annotation': 'Remove annotation',
-  /** Label for activate click verb */
-  'inputs.portable-text.activate-on-focus.click-verb': 'Click',
-  /** Label for activate focused verb */
-  'inputs.portable-text.activate-on-focus.focused-verb': ' or press space',
-  /** Message for activate on focus */
-  'inputs.portable-text.activate-on-focus.message': '{{activateVerb}} to activate',
-  /** Label for activate tap verb */
-  'inputs.portable-text.activate-on-focus.tap-verb': 'Tap',
+  /** Label for activate on focus with context of click and not focused */
+  'inputs.portable-text.activate-on-focus-message_click': 'Click to activate',
+  /** Label for activate on focus with context of click and focused */
+  'inputs.portable-text.activate-on-focus-message_click-focused':
+    'Click or press spacebar to activate',
+  /** Label for activate on focus with context of tap and not focused */
+  'inputs.portable-text.activate-on-focus-message_tap': 'Tap to activate',
   /** Title for dialog that allows editing an annotation */
   'inputs.portable-text.annotation-editor.title': 'Edit {{schemaType}}',
   /** Title of the default "link" annotation */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -626,7 +626,7 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'inputs.portable-text.activate-on-focus-message_click': 'Click to activate',
   /** Label for activate on focus with context of click and focused */
   'inputs.portable-text.activate-on-focus-message_click-focused':
-    'Click or press spacebar to activate',
+    'Click or press space to activate',
   /** Label for activate on focus with context of tap and not focused */
   'inputs.portable-text.activate-on-focus-message_tap': 'Tap to activate',
   /** Title for dialog that allows editing an annotation */


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Localizes activation message for PTE on hover or on tap hover.

There seems to be uncommitted `yarn.lock` from next that got included as well

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

If keys makes sense and logic makes sense

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
(probably part of larger i18n release notes)