### PR TITLE
fix(form): recalculate virtualized descendants when selected group changes

### DIFF
--- a/packages/sanity/src/core/form/inputs/ObjectInput/ObjectInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ObjectInput/ObjectInput.tsx
@@ -1,4 +1,4 @@
-import React, {memo, useCallback, useMemo} from 'react'
+import React, {Fragment, memo, useCallback, useMemo} from 'react'
 import {Grid, Stack} from '@sanity/ui'
 import {ObjectInputProps} from '../../types'
 import {ObjectInputMembers} from '../../members'
@@ -47,6 +47,8 @@ export const ObjectInput = memo(function ObjectInput(props: ObjectInputProps) {
     return <UnknownFields fieldNames={unknownFields} value={value} onChange={onChange} />
   }, [onChange, schemaType.fields, value])
 
+  const selectedGroup = useMemo(() => groups.find(({selected}) => selected), [groups])
+
   const renderObjectMembers = useCallback(
     () => (
       <ObjectInputMembers
@@ -89,13 +91,19 @@ export const ObjectInput = memo(function ObjectInput(props: ObjectInputProps) {
         </FieldGroupTabsWrapper>
       ) : null}
 
-      {columns ? (
-        <Grid columns={columns} gap={4} marginTop={1}>
-          {renderObjectMembers()}
-        </Grid>
-      ) : (
-        renderObjectMembers()
-      )}
+      <Fragment
+        // A key is used here to create a unique element for each selected group. This ensures
+        // virtualized descendants are recalculated when the selected group changes.
+        key={selectedGroup?.name}
+      >
+        {columns ? (
+          <Grid columns={columns} gap={4} marginTop={1}>
+            {renderObjectMembers()}
+          </Grid>
+        ) : (
+          renderObjectMembers()
+        )}
+      </Fragment>
 
       {renderedUnknownFields}
     </Stack>

--- a/packages/sanity/src/desk/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/desk/panes/document/documentPanel/DocumentPanel.tsx
@@ -62,7 +62,6 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     isDeleting,
     isDeleted,
     timelineStore,
-    formState,
   } = useDocumentPane()
   const {collapsed: layoutCollapsed} = usePaneLayout()
   const {collapsed} = usePane()
@@ -75,12 +74,6 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
   const formContainerElement = useRef<HTMLDivElement | null>(null)
 
   const requiredPermission = value._createdAt ? 'update' : 'create'
-
-  const selectedGroup = useMemo(() => {
-    if (!formState) return undefined
-
-    return formState.groups.find((group) => group.selected)
-  }, [formState])
 
   const activeView = useMemo(
     () => views.find((view) => view.id === activeViewId) || views[0] || {type: 'form'},
@@ -179,10 +172,6 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
                       $disabled={layoutCollapsed || false}
                       data-testid="document-panel-scroller"
                       ref={setDocumentScrollElement}
-                      // Note: this is to make sure the scroll container is changed
-                      // when the selected group changes which causes virtualization
-                      // to re-render and re-measure the scroll container
-                      key={`${selectedGroup?.name}-${documentId}}`}
                     >
                       <FormView
                         hidden={formViewHidden}


### PR DESCRIPTION
### Description

This branch uses the same approach Binoy employed to fix list virtualisation at the document level, but applies it to all object inputs. It wraps object inputs in a React fragment that uses the selected group name as its key. This causes a unique element to be rendered for each selected group, and therefore all virtualised descendants are recalculated when the selected tab changes.

Adding the key at this level solves the problem both at the document level, and inside modals.

This branch also removes Binoy's fix, which is now redundant.

Fixes #4687.

**Top-level groups before fix**

https://github.com/sanity-io/sanity/assets/1454914/6529d228-63c7-4770-9a09-2e3e0c997a5d

**Top-level groups after fix**

https://github.com/sanity-io/sanity/assets/1454914/573e66ca-17e1-486f-b816-f334058e2772

**Modal groups before fix**

https://github.com/sanity-io/sanity/assets/1454914/508ff955-778f-43bb-b099-4dc66dc51a8b

**Modal groups after fix**

https://github.com/sanity-io/sanity/assets/1454914/84b2f08d-9d49-401a-b389-f05b2da3f1b8

### What to review

Open [the "Virtualisation Debug" section](http://localhost:3333/test/structure/input-debug;virtualizationDebug;01de0cf0-1686-49f5-8212-a33b94edbfbf) in the Test Studio, and navigate between groups inside the example documents. Regardless of whether viewing a top-level document or a modal, there should never be any erroneously hidden array items. This is demonstrated in the videos above.

### Notes for release

Fixed virtualization issue which caused array items to erroneously be hidden when navigating between groups inside a modal.