### PR TITLE
chore(core): update CODEOWNERS file to use teams over individuals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,29 +1,31 @@
-# These owners can be changed and added to in the future,
-# for now these are the main people that we are required to have eyes on PRs
-# that changed items in the given spaces
+# By default, assign the studio developer experience team.
+# Later matching rules will take precedence.
+* @sanity-io/studio-dx
 
-# ------------- Packages
-# Espen owns any file in `/packages/@sanity/cli/`
-# directory in the root of your repository and any of its
-# subdirectories.
-/packages/@sanity/cli/ @rexxars
+# For areas of responsibility, assign the specific team 
+# that is responsible. It is possible to assign to individuals,
+# however it is preferable that a team is responsible for large
+# areas to improve maintainablitly and availability
 
-/packages/sanity/src/core/preview/ @bjoerge @RitaDias
+# -- CLI --
+/packages/@sanity/cli/ @sanity-io/studio-dx
 
-# Bjørge owns any file in `/packages/sanity/src/core/form/`
-# directory in the root of your repository and any of its
-# subdirectories.
-/packages/sanity/src/core/form/ @bjoerge
-/packages/sanity/src/core/form/inputs/files/ @bjoerge @RitaDias
+# -- Preview --
+/packages/sanity/src/core/preview/ @sanity-io/studio-dx
 
-# PK owns any file related to PTE
-# They are spread across different directories and subdirectories
-/packages/@sanity/portable-text-editor/ @skogsmaskin
-/packages/sanity/src/core/field/types/portableText/ @skogsmaskin
-/packages/sanity/src/core/form/inputs/PortableText/ @skogsmaskin
+# -- Form --
+/packages/sanity/src/core/form/ @sanity-io/studio-dx
 
-# Tom owns the Shopify templates
+# -- PTE --
+/packages/@sanity/portable-text-editor/ @sanity-io/studio-ex
+/packages/sanity/src/core/field/types/portableText/ @sanity-io/studio-ex
+/packages/sanity/src/core/form/inputs/PortableText/ @sanity-io/studio-ex
+
+# -- Comments --
+/packages/sanity/src/desk/comments/ @sanity-io/studio-ex
+
+# -- Others --
+
+# Shopify templates
 /packages/@sanity/cli/src/actions/init-project/templates/shopify* @thebiggianthead
 /packages/@sanity/cli/templates/shopify* @thebiggianthead
-
-/packages/sanity/src/desk/comments/ @hermanwikner


### PR DESCRIPTION
### Description

Updating CODEOWNERS file to use teams over individuals and added a default rule to add Studio DX to reviews.

