### PR TITLE
fix(core): field actions hidden state

### DIFF
--- a/packages/sanity/src/core/form/components/formField/FormFieldBaseHeader.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldBaseHeader.tsx
@@ -71,6 +71,7 @@ const FieldActionsFloatingCard = styled(Card)(({theme}: {theme: Theme}) => {
       // and only show it when it has focus within or when the field is hovered or focused.
       opacity: 0;
       pointer-events: none;
+      width: 0;
 
       [data-ui='FieldActionsFlex'] {
         opacity: 0;


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This pull request ensures that field actions do not impact the layout within the field when they are not visible. Currently, the field actions are hidden using opacity, resulting in presence avatars being pushed to the left even when the field actions are not visible.

<img width="886" alt="Screenshot 2023-12-04 at 11 53 11" src="https://github.com/sanity-io/sanity/assets/15094168/6079c990-ce46-4743-86bd-f7164af6de1d">


### What to review

- Make sure that it looks good

### Notes for release

N/A
