### PR TITLE
feat(cli): add telemetry cli commands

### DIFF
--- a/packages/@sanity/cli/src/actions/login/login.ts
+++ b/packages/@sanity/cli/src/actions/login/login.ts
@@ -9,6 +9,7 @@ import {getCliToken} from '../../util/clientWrapper'
 import {getUserConfig} from '../../util/getUserConfig'
 import {canLaunchBrowser} from '../../util/canLaunchBrowser'
 import type {CliApiClient, CliCommandArguments, CliCommandContext, CliPrompter} from '../../types'
+import {TELEMETRY_CONSENT_CONFIG_KEY} from '../../util/createTelemetryStore'
 import type {LoginProvider, ProvidersResponse, SamlLoginProvider} from './types'
 import {LoginTrace} from './login.telemetry'
 
@@ -121,6 +122,9 @@ export async function login(
     authToken: authToken,
     authType: 'normal',
   })
+
+  // Clear cached telemetry consent
+  getUserConfig().delete(TELEMETRY_CONSENT_CONFIG_KEY)
 
   // If we had a session previously, attempt to clear it
   if (hasExistingToken) {

--- a/packages/@sanity/cli/src/actions/telemetry/setTelemetryConsent.ts
+++ b/packages/@sanity/cli/src/actions/telemetry/setTelemetryConsent.ts
@@ -1,6 +1,7 @@
 import {type ConsentStatus} from '@sanity/telemetry'
 import {ClientError, ServerError} from '@sanity/client'
 import {type CliCommandAction} from '../../types'
+import {debug} from '../../debug'
 
 type SettableConsentStatus = Extract<ConsentStatus, 'granted' | 'denied'>
 
@@ -109,14 +110,20 @@ export function createSetTelemetryConsentAction(status: SettableConsentStatus): 
 
     const mock = getMock()
 
+    debug('Setting telemetry consent to "%s"', status)
+
     try {
       if (mock) {
+        debug('Mocking telemetry consent request')
         await mock()
       } else {
         // TODO: Finalise API request.
+        const uri = `/users/me/consents/telemetry/status/${status}`
+        debug('Sending telemetry consent status to %s', uri)
+
         await client.request({
           method: 'PUT',
-          uri: `/users/me/consents/telemetry/status/${status}`,
+          uri,
         })
       }
 

--- a/packages/@sanity/cli/src/actions/telemetry/setTelemetryConsent.ts
+++ b/packages/@sanity/cli/src/actions/telemetry/setTelemetryConsent.ts
@@ -2,6 +2,8 @@ import {type ConsentStatus} from '@sanity/telemetry'
 import {ClientError, ServerError} from '@sanity/client'
 import {type CliCommandAction} from '../../types'
 import {debug} from '../../debug'
+import {getUserConfig} from '../../util/getUserConfig'
+import {TELEMETRY_CONSENT_CONFIG_KEY} from '../../util/createTelemetryStore'
 
 type SettableConsentStatus = Extract<ConsentStatus, 'granted' | 'denied'>
 
@@ -99,6 +101,8 @@ function getMock(): Mock | undefined {
 
 export function createSetTelemetryConsentAction(status: SettableConsentStatus): CliCommandAction {
   return async function setTelemetryConsentAction(_, {apiClient, output, chalk}) {
+    const config = getUserConfig()
+
     const client = apiClient({
       requireUser: true,
       requireProject: false,
@@ -126,6 +130,9 @@ export function createSetTelemetryConsentAction(status: SettableConsentStatus): 
           uri,
         })
       }
+
+      // Clear cached telemetry consent
+      config.delete(TELEMETRY_CONSENT_CONFIG_KEY)
 
       output.print(chalk.green(resultMessages[status].success()))
     } catch (err) {

--- a/packages/@sanity/cli/src/actions/telemetry/setTelemetryConsent.ts
+++ b/packages/@sanity/cli/src/actions/telemetry/setTelemetryConsent.ts
@@ -125,8 +125,7 @@ export function createSetTelemetryConsentAction(status: SettableConsentStatus): 
       requireUser: true,
       requireProject: false,
     }).withConfig({
-      // todo: change vX to stable
-      apiVersion: 'vX',
+      apiVersion: '2023-12-18',
       useProjectHostname: false,
     })
 

--- a/packages/@sanity/cli/src/actions/telemetry/setTelemetryConsent.ts
+++ b/packages/@sanity/cli/src/actions/telemetry/setTelemetryConsent.ts
@@ -1,0 +1,130 @@
+import {type ConsentStatus} from '@sanity/telemetry'
+import {ClientError, ServerError} from '@sanity/client'
+import {type CliCommandContext} from '../../types'
+
+type SettableConsentStatus = Extract<ConsentStatus, 'granted' | 'denied'>
+
+const MOCK_MODES = ['success', 'failure:server', 'failure:msa'] as const
+type MockMode = (typeof MOCK_MODES)[number]
+
+interface SetConsentResponse<Type = string> {
+  type: Type
+  status: ConsentStatus
+  updatedAt: string
+}
+
+type Mock = () => Promise<SetConsentResponse<'telemetry'>>
+
+interface ResultMessage {
+  success: () => string
+  failure: (message?: string) => string
+}
+
+const resultMessages: Record<SettableConsentStatus, ResultMessage> = {
+  granted: {
+    success: () => 'Telemetry enabled',
+    failure: (message) => {
+      if (message) {
+        return `Failed to enable telemetry: ${message}`
+      }
+      return 'Failed to enable telemetry'
+    },
+  },
+  denied: {
+    success: () => 'Telemetry disabled',
+    failure: () => 'Failed to disable telemetry',
+  },
+}
+
+const mocks: Record<MockMode, Mock> = {
+  success: () =>
+    Promise.resolve({
+      type: 'telemetry',
+      status: 'granted',
+      updatedAt: '2023-08-08T13:40:30.801847Z',
+    }),
+  'failure:server': () => {
+    throw new ServerError({
+      statusCode: 500,
+      headers: {},
+      body: {},
+    })
+  },
+  'failure:msa': () => {
+    throw new ClientError({
+      statusCode: 403,
+      headers: {},
+      body: {
+        message: 'User cannot give consent',
+      },
+    })
+  },
+}
+
+function isMockMode(mode?: string): mode is MockMode {
+  return MOCK_MODES.includes(mode as MockMode)
+}
+
+function validateMockMode() {
+  // eslint-disable-next-line no-process-env
+  if (process.env.MOCK_TELEMETRY_CONSENT_MODE) {
+    // eslint-disable-next-line no-process-env
+    const mode = process.env.MOCK_TELEMETRY_CONSENT_MODE.toLowerCase()
+
+    if (!isMockMode(mode)) {
+      const validModes = new Intl.ListFormat('en-US', {
+        style: 'long',
+        type: 'disjunction',
+      }).format(MOCK_MODES.map((name) => `"${name}"`))
+
+      throw new Error(
+        `Invalid value provided for environment variable MOCK_TELEMETRY_CONSENT_MODE. Must be either ${validModes}`,
+      )
+    }
+  }
+}
+
+// eslint-disable-next-line consistent-return
+function getMock(): Mock | undefined {
+  validateMockMode()
+
+  // eslint-disable-next-line no-process-env
+  const mode = process.env.MOCK_TELEMETRY_CONSENT_MODE?.toLowerCase()
+
+  if (isMockMode(mode)) {
+    return mocks[mode]
+  }
+}
+
+// TODO: Adopt `CliCommandAction` type.
+export async function setTelemetryConsent(
+  status: SettableConsentStatus,
+  {apiClient, output, chalk}: CliCommandContext,
+): Promise<void> {
+  const client = apiClient({
+    requireUser: true,
+    requireProject: false,
+  }).withConfig({
+    apiVersion: '2023-10-22',
+    useProjectHostname: false,
+  })
+
+  const mock = getMock()
+
+  try {
+    if (mock) {
+      await mock()
+    } else {
+      // TODO: Finalise API request.
+      await client.request({
+        method: 'PUT',
+        uri: `/users/me/consents/telemetry/status/${status}`,
+      })
+    }
+
+    output.print(chalk.green(resultMessages[status].success()))
+  } catch (err) {
+    err.message = resultMessages[status].failure(err?.responseBody?.message)
+    throw err
+  }
+}

--- a/packages/@sanity/cli/src/cli.ts
+++ b/packages/@sanity/cli/src/cli.ts
@@ -20,6 +20,7 @@ import {CommandRunnerOptions, TelemetryUserProperties} from './types'
 import {debug} from './debug'
 import {createTelemetryStore} from './util/createTelemetryStore'
 import {detectRuntime} from './util/detectRuntime'
+import {telemetryDisclosure} from './util/telemetryDisclosure'
 import {CliCommand} from './__telemetry__/cli.telemetry'
 
 const sanityEnv = process.env.SANITY_INTERNAL_ENV || 'production' // eslint-disable-line no-process-env
@@ -55,6 +56,9 @@ export async function runCli(cliRoot: string, {cliVersion}: {cliVersion: string}
 
   // Check if there are updates available for the CLI, and notify if there is
   await runUpdateCheck({pkg, cwd, workDir}).notify()
+
+  // If the telemetry disclosure message has not yet been shown, show it.
+  telemetryDisclosure()
 
   // Try to figure out if we're in a v2 or v3 context by finding a config
   debug(`Reading CLI config from "${workDir}"`)

--- a/packages/@sanity/cli/src/commands/index.ts
+++ b/packages/@sanity/cli/src/commands/index.ts
@@ -12,6 +12,9 @@ import manageCommand from './manage/manageCommand'
 import upgradeCommand from './upgrade/upgradeCommand'
 import versionsCommand from './versions/versionsCommand'
 import codemodCommand from './codemod/codemodCommand'
+import telemetryGroup from './telemetry/telemetryGroup'
+import disableTelemetryCommand from './telemetry/disableTelemetryCommand'
+import enableTelemetryCommand from './telemetry/enableTelemetryCommand'
 
 export const baseCommands: (CliCommandDefinition | CliCommandGroupDefinition)[] = [
   initCommand,
@@ -27,4 +30,7 @@ export const baseCommands: (CliCommandDefinition | CliCommandGroupDefinition)[] 
   projectsGroup,
   listProjectsCommand,
   codemodCommand,
+  telemetryGroup,
+  disableTelemetryCommand,
+  enableTelemetryCommand,
 ]

--- a/packages/@sanity/cli/src/commands/index.ts
+++ b/packages/@sanity/cli/src/commands/index.ts
@@ -15,6 +15,7 @@ import codemodCommand from './codemod/codemodCommand'
 import telemetryGroup from './telemetry/telemetryGroup'
 import disableTelemetryCommand from './telemetry/disableTelemetryCommand'
 import enableTelemetryCommand from './telemetry/enableTelemetryCommand'
+import telemetryStatusCommand from './telemetry/telemetryStatusCommand'
 
 export const baseCommands: (CliCommandDefinition | CliCommandGroupDefinition)[] = [
   initCommand,
@@ -33,4 +34,5 @@ export const baseCommands: (CliCommandDefinition | CliCommandGroupDefinition)[] 
   telemetryGroup,
   disableTelemetryCommand,
   enableTelemetryCommand,
+  telemetryStatusCommand,
 ]

--- a/packages/@sanity/cli/src/commands/logout/logoutCommand.ts
+++ b/packages/@sanity/cli/src/commands/logout/logoutCommand.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk'
 import type {CliCommandDefinition} from '../../types'
 import {getUserConfig} from '../../util/getUserConfig'
+import {TELEMETRY_CONSENT_CONFIG_KEY} from '../../util/createTelemetryStore'
 
 const helpText = `
 Examples
@@ -39,6 +40,9 @@ const logoutCommand: CliCommandDefinition = {
 
     cfg.delete('authType')
     cfg.delete('authToken')
+
+    // Clear cached telemetry consent
+    cfg.delete(TELEMETRY_CONSENT_CONFIG_KEY)
 
     output.print(chalk.green('Logged out'))
   },

--- a/packages/@sanity/cli/src/commands/telemetry/disableTelemetryCommand.ts
+++ b/packages/@sanity/cli/src/commands/telemetry/disableTelemetryCommand.ts
@@ -1,0 +1,36 @@
+import type {CliCommandDefinition} from '../../types'
+
+const helpText = `
+Examples
+  # Disable telemetry for your logged in user
+  sanity telemetry disable
+`
+
+const disableTelemetryCommand: CliCommandDefinition = {
+  name: 'disable',
+  group: 'telemetry',
+  helpText,
+  signature: '',
+  description: 'Disable telemetry for your logged in user',
+  action: async (_, {apiClient, output, chalk}) => {
+    const client = apiClient({
+      requireUser: true,
+      requireProject: false,
+    })
+
+    try {
+      // TODO: Finalise API request.
+      await client.request({
+        method: 'PUT',
+        uri: '/users/me/consents/telemetry/status/denied',
+      })
+    } catch (err) {
+      err.message = 'Failed to disable telemetry'
+      throw err
+    }
+
+    output.print(chalk.green('Telemetry disabled'))
+  },
+}
+
+export default disableTelemetryCommand

--- a/packages/@sanity/cli/src/commands/telemetry/disableTelemetryCommand.ts
+++ b/packages/@sanity/cli/src/commands/telemetry/disableTelemetryCommand.ts
@@ -1,4 +1,5 @@
 import type {CliCommandDefinition} from '../../types'
+import {setTelemetryConsent} from '../../actions/telemetry/setTelemetryConsent'
 
 const helpText = `
 Examples
@@ -12,25 +13,7 @@ const disableTelemetryCommand: CliCommandDefinition = {
   helpText,
   signature: '',
   description: 'Disable telemetry for your logged in user',
-  action: async (_, {apiClient, output, chalk}) => {
-    const client = apiClient({
-      requireUser: true,
-      requireProject: false,
-    })
-
-    try {
-      // TODO: Finalise API request.
-      await client.request({
-        method: 'PUT',
-        uri: '/users/me/consents/telemetry/status/denied',
-      })
-    } catch (err) {
-      err.message = 'Failed to disable telemetry'
-      throw err
-    }
-
-    output.print(chalk.green('Telemetry disabled'))
-  },
+  action: (_, context) => setTelemetryConsent('denied', context),
 }
 
 export default disableTelemetryCommand

--- a/packages/@sanity/cli/src/commands/telemetry/disableTelemetryCommand.ts
+++ b/packages/@sanity/cli/src/commands/telemetry/disableTelemetryCommand.ts
@@ -1,5 +1,5 @@
 import type {CliCommandDefinition} from '../../types'
-import {setTelemetryConsent} from '../../actions/telemetry/setTelemetryConsent'
+import {createSetTelemetryConsentAction} from '../../actions/telemetry/setTelemetryConsent'
 
 const helpText = `
 Examples
@@ -13,7 +13,7 @@ const disableTelemetryCommand: CliCommandDefinition = {
   helpText,
   signature: '',
   description: 'Disable telemetry for your logged in user',
-  action: (_, context) => setTelemetryConsent('denied', context),
+  action: createSetTelemetryConsentAction('denied'),
 }
 
 export default disableTelemetryCommand

--- a/packages/@sanity/cli/src/commands/telemetry/enableTelemetryCommand.ts
+++ b/packages/@sanity/cli/src/commands/telemetry/enableTelemetryCommand.ts
@@ -1,0 +1,36 @@
+import type {CliCommandDefinition} from '../../types'
+
+const helpText = `
+Examples
+  # Enable telemetry for your logged in user
+  sanity telemetry enable
+`
+
+const enableTelemetryCommand: CliCommandDefinition = {
+  name: 'enable',
+  group: 'telemetry',
+  helpText,
+  signature: '',
+  description: 'Enable telemetry for your logged in user',
+  action: async (_, {apiClient, output, chalk}) => {
+    const client = apiClient({
+      requireUser: true,
+      requireProject: false,
+    })
+
+    try {
+      // TODO: Finalise API request.
+      await client.request({
+        method: 'PUT',
+        uri: '/users/me/consents/telemetry/status/granted',
+      })
+    } catch (err) {
+      err.message = 'Failed to enable telemetry'
+      throw err
+    }
+
+    output.print(chalk.green('Telemetry enabled'))
+  },
+}
+
+export default enableTelemetryCommand

--- a/packages/@sanity/cli/src/commands/telemetry/enableTelemetryCommand.ts
+++ b/packages/@sanity/cli/src/commands/telemetry/enableTelemetryCommand.ts
@@ -1,4 +1,5 @@
 import type {CliCommandDefinition} from '../../types'
+import {setTelemetryConsent} from '../../actions/telemetry/setTelemetryConsent'
 
 const helpText = `
 Examples
@@ -12,25 +13,7 @@ const enableTelemetryCommand: CliCommandDefinition = {
   helpText,
   signature: '',
   description: 'Enable telemetry for your logged in user',
-  action: async (_, {apiClient, output, chalk}) => {
-    const client = apiClient({
-      requireUser: true,
-      requireProject: false,
-    })
-
-    try {
-      // TODO: Finalise API request.
-      await client.request({
-        method: 'PUT',
-        uri: '/users/me/consents/telemetry/status/granted',
-      })
-    } catch (err) {
-      err.message = 'Failed to enable telemetry'
-      throw err
-    }
-
-    output.print(chalk.green('Telemetry enabled'))
-  },
+  action: (_, context) => setTelemetryConsent('granted', context),
 }
 
 export default enableTelemetryCommand

--- a/packages/@sanity/cli/src/commands/telemetry/enableTelemetryCommand.ts
+++ b/packages/@sanity/cli/src/commands/telemetry/enableTelemetryCommand.ts
@@ -1,5 +1,5 @@
 import type {CliCommandDefinition} from '../../types'
-import {setTelemetryConsent} from '../../actions/telemetry/setTelemetryConsent'
+import {createSetTelemetryConsentAction} from '../../actions/telemetry/setTelemetryConsent'
 
 const helpText = `
 Examples
@@ -13,7 +13,7 @@ const enableTelemetryCommand: CliCommandDefinition = {
   helpText,
   signature: '',
   description: 'Enable telemetry for your logged in user',
-  action: (_, context) => setTelemetryConsent('granted', context),
+  action: createSetTelemetryConsentAction('granted'),
 }
 
 export default enableTelemetryCommand

--- a/packages/@sanity/cli/src/commands/telemetry/telemetryGroup.ts
+++ b/packages/@sanity/cli/src/commands/telemetry/telemetryGroup.ts
@@ -1,0 +1,10 @@
+import type {CliCommandGroupDefinition} from '../../types'
+
+const telemetryGroup: CliCommandGroupDefinition = {
+  name: 'telemetry',
+  signature: '[COMMAND]',
+  isGroupRoot: true,
+  description: 'Interact with telemetry settings for your logged in user',
+}
+
+export default telemetryGroup

--- a/packages/@sanity/cli/src/commands/telemetry/telemetryStatusCommand.ts
+++ b/packages/@sanity/cli/src/commands/telemetry/telemetryStatusCommand.ts
@@ -1,0 +1,56 @@
+import type {CliCommandDefinition} from '../../types'
+import {resolveConsent} from '../../util/initTelemetry'
+import {getCliToken} from '../../util/clientWrapper'
+
+const helpText = `
+Examples
+  # Check telemetry consent status for your logged in user
+  sanity telemetry status
+`
+
+const telemetryStatusCommand: CliCommandDefinition = {
+  name: 'status',
+  group: 'telemetry',
+  helpText,
+  signature: '',
+  description: 'Check telemetry consent status for your logged in user',
+  action: async (_, {chalk, output}) => {
+    // eslint-disable-next-line no-process-env
+    const {status} = await resolveConsent({env: process.env})
+    const token = getCliToken()
+
+    if (status === 'undetermined' && !token) {
+      output.print('You are not logged in.')
+      return
+    }
+
+    switch (status) {
+      case 'undetermined':
+        output.print(chalk.yellow('Could not fetch telemetry consent status.'))
+        break
+      case 'denied':
+        output.print(`Telemetry consent is ${chalk.red('denied')}.`)
+        break
+      case 'granted':
+        output.print(`Telemetry consent is ${chalk.green('granted')}.`)
+        break
+      case 'unset':
+        output.print('You have not set telemetry consent.\n')
+        output.print(
+          `Run ${chalk.cyan('sanity telemetry enable')} or ${chalk.cyan(
+            'sanity telemetry disable',
+          )} to control telemetry collection.`,
+        )
+        output.print(
+          `You can alternatively use the ${chalk.cyan('DO_NOT_TRACK')} environment variable.`,
+        )
+        break
+      default:
+        break
+    }
+
+    output.print('\nLearn more: https://sanity.io/telemetry')
+  },
+}
+
+export default telemetryStatusCommand

--- a/packages/@sanity/cli/src/commands/telemetry/telemetryStatusCommand.ts
+++ b/packages/@sanity/cli/src/commands/telemetry/telemetryStatusCommand.ts
@@ -20,7 +20,7 @@ const telemetryStatusCommand: CliCommandDefinition = {
     const token = getCliToken()
 
     if (status === 'undetermined' && !token) {
-      output.print('You are not logged in.')
+      output.print('You need to log in first to see telemetry status.')
       return
     }
 

--- a/packages/@sanity/cli/src/commands/telemetry/telemetryStatusCommand.ts
+++ b/packages/@sanity/cli/src/commands/telemetry/telemetryStatusCommand.ts
@@ -1,5 +1,5 @@
 import type {CliCommandDefinition} from '../../types'
-import {resolveConsent} from '../../util/initTelemetry'
+import {resolveConsent} from '../../util/createTelemetryStore'
 
 const helpText = `
 Examples

--- a/packages/@sanity/cli/src/commands/telemetry/telemetryStatusCommand.ts
+++ b/packages/@sanity/cli/src/commands/telemetry/telemetryStatusCommand.ts
@@ -55,7 +55,7 @@ const telemetryStatusCommand: CliCommandDefinition = {
         output.print(
           `You've opted out of telemetry data collection.\nNo data will be collected from your machine.\n`,
         )
-        output.print(`Using ${chalk.cyan('DO_NOT_TRACK')} environment variable.\n`)
+        output.print(`Using ${chalk.cyan('DO_NOT_TRACK')} environment variable.`)
         break
       case status === 'denied':
         output.print(`${telemetryStatusMessage(status, context)}\n`)

--- a/packages/@sanity/cli/src/util/createExpiringConfig.ts
+++ b/packages/@sanity/cli/src/util/createExpiringConfig.ts
@@ -41,6 +41,7 @@ export function createExpiringConfig<Type>({
   onFetch = () => null,
   onCacheHit = () => null,
 }: ExpiringConfigOptions<Type>): ExpiringConfigApi<Type> {
+  let currentFetch: Promise<Type> | null = null
   return {
     async get() {
       const {value, updatedAt} = store.get(key) ?? {}
@@ -56,8 +57,14 @@ export function createExpiringConfig<Type>({
         onRevalidate()
       }
 
+      if (currentFetch) {
+        return currentFetch
+      }
       onFetch()
-      const nextValue = await fetchValue()
+
+      currentFetch = Promise.resolve(fetchValue())
+      const nextValue = await currentFetch
+      currentFetch = null
 
       store.set(key, {
         value: nextValue,

--- a/packages/@sanity/cli/src/util/createExpiringConfig.ts
+++ b/packages/@sanity/cli/src/util/createExpiringConfig.ts
@@ -50,7 +50,7 @@ export function createExpiringConfig<Type>({
 
         if (!hasExpired) {
           onCacheHit()
-          return value as Type
+          return value
         }
 
         onRevalidate()
@@ -64,7 +64,7 @@ export function createExpiringConfig<Type>({
         updatedAt: Date.now(),
       })
 
-      return nextValue as Type
+      return nextValue
     },
     delete() {
       store.delete(key)

--- a/packages/@sanity/cli/src/util/createExpiringConfig.ts
+++ b/packages/@sanity/cli/src/util/createExpiringConfig.ts
@@ -1,0 +1,73 @@
+import type ConfigStore from 'configstore'
+
+export interface ExpiringConfigOptions<Type> {
+  /** Config store */
+  store: ConfigStore
+  /** Config key */
+  key: string
+  /** TTL (milliseconds) */
+  ttl: number
+  /** Fetch value */
+  fetchValue: () => Type | Promise<Type>
+  /** Subscribe to revalidate event */
+  onRevalidate?: () => void
+  /** Subscribe to fetch event */
+  onFetch?: () => void
+  /** Subscribe to cache hit event */
+  onCacheHit?: () => void
+}
+
+export interface ExpiringConfigApi<Type> {
+  /**
+   * Attempt to get the cached value. If there is no cached value, or the cached value has expired,
+   * fetch, cache, and return the value.
+   */
+  get: () => Promise<Type>
+  /**
+   * Delete the cached value.
+   */
+  delete: () => void
+}
+
+/**
+ * Create a config in the provided config store that expires after the provided TTL.
+ */
+export function createExpiringConfig<Type>({
+  key,
+  ttl,
+  store,
+  fetchValue,
+  onRevalidate = () => null,
+  onFetch = () => null,
+  onCacheHit = () => null,
+}: ExpiringConfigOptions<Type>): ExpiringConfigApi<Type> {
+  return {
+    async get() {
+      const {value, updatedAt} = store.get(key) ?? {}
+
+      if (value && updatedAt) {
+        const hasExpired = Date.now() - updatedAt > ttl
+
+        if (!hasExpired) {
+          onCacheHit()
+          return value as Type
+        }
+
+        onRevalidate()
+      }
+
+      onFetch()
+      const nextValue = await fetchValue()
+
+      store.set(key, {
+        value: nextValue,
+        updatedAt: Date.now(),
+      })
+
+      return nextValue as Type
+    },
+    delete() {
+      store.delete(key)
+    },
+  }
+}

--- a/packages/@sanity/cli/src/util/createTelemetryStore.ts
+++ b/packages/@sanity/cli/src/util/createTelemetryStore.ts
@@ -27,7 +27,6 @@ function parseApiConsentStatus(value: unknown): ValidApiConsentStatus {
   throw new Error(`Invalid consent status. Must be one of: ${VALID_API_STATUSES.join(', ')}`)
 }
 
-
 function createTelemetryClient(token: string) {
   const getClient = getClientWrapper(null, 'sanity.cli.js')
   return getClient({requireUser: false, requireProject: false}).config({

--- a/packages/@sanity/cli/src/util/createTelemetryStore.ts
+++ b/packages/@sanity/cli/src/util/createTelemetryStore.ts
@@ -54,7 +54,7 @@ interface Options {
   env: Env
 }
 
-type ConsentInformation =
+export type ConsentInformation =
   | {
       status: Extract<ConsentStatus, 'granted'>
       reason?: never

--- a/packages/@sanity/cli/src/util/telemetryDisclosure.ts
+++ b/packages/@sanity/cli/src/util/telemetryDisclosure.ts
@@ -1,0 +1,44 @@
+import boxen from 'boxen'
+import chalk from 'chalk'
+import {debug} from '../debug'
+import {telemetryLearnMoreMessage} from '../commands/telemetry/telemetryStatusCommand'
+import {getUserConfig} from './getUserConfig'
+import {isCi} from './isCi'
+
+const TELEMETRY_DISCLOSED_CONFIG_KEY = 'telemetryConsentDisclosed'
+
+export function telemetryDisclosure(): void {
+  const userConfig = getUserConfig()
+
+  if (isCi) {
+    debug('CI environment detected, skipping telemetry disclosure')
+    return
+  }
+
+  if (userConfig.get(TELEMETRY_DISCLOSED_CONFIG_KEY)) {
+    debug('Telemetry disclosure has already been shown')
+    return
+  }
+
+  // Print to stderr to prevent garbling command output
+  console.error(
+    boxen(
+      `The Sanity CLI now collects telemetry data on general usage and errors.
+This helps us improve Sanity and prioritize features.
+
+To opt in/out, run ${chalk.cyan('npx sanity telemetry enable/disable')}.
+
+${telemetryLearnMoreMessage('unset')}`,
+      {
+        padding: 1,
+        margin: 1,
+        borderColor: 'yellow',
+
+        // Typescript issues forcing these to any
+        borderStyle: 'round' as any,
+      },
+    ),
+  )
+
+  userConfig.set(TELEMETRY_DISCLOSED_CONFIG_KEY, Date.now())
+}

--- a/packages/@sanity/cli/src/util/telemetryDisclosure.ts
+++ b/packages/@sanity/cli/src/util/telemetryDisclosure.ts
@@ -5,7 +5,7 @@ import {telemetryLearnMoreMessage} from '../commands/telemetry/telemetryStatusCo
 import {getUserConfig} from './getUserConfig'
 import {isCi} from './isCi'
 
-const TELEMETRY_DISCLOSED_CONFIG_KEY = 'telemetryConsentDisclosed'
+const TELEMETRY_DISCLOSED_CONFIG_KEY = 'telemetryDisclosed'
 
 export function telemetryDisclosure(): void {
   const userConfig = getUserConfig()

--- a/packages/@sanity/cli/test/telemetry.test.ts
+++ b/packages/@sanity/cli/test/telemetry.test.ts
@@ -33,7 +33,7 @@ https://www.sanity.io/telemetry
 `)
   })
 
-  testConcurrent('sanity telemetry status: denied using DO_NOT_TRACK', async () => {
+  test('sanity telemetry status: denied using DO_NOT_TRACK', async () => {
     const result = await runSanityCmdCommand('v3', ['telemetry', 'status'], {
       env: {
         DO_NOT_TRACK: '1',
@@ -118,16 +118,14 @@ https://www.sanity.io/telemetry
 `)
   })
 
-  testConcurrent(
-    'sanity telemetry disable: success (already denied using DO_NOT_TRACK)',
-    async () => {
-      const result = await runSanityCmdCommand('v3', ['telemetry', 'disable'], {
-        env: {
-          DO_NOT_TRACK: '1',
-        },
-      })
+  test('sanity telemetry disable: success (already denied using DO_NOT_TRACK)', async () => {
+    const result = await runSanityCmdCommand('v3', ['telemetry', 'disable'], {
+      env: {
+        DO_NOT_TRACK: '1',
+      },
+    })
 
-      expect(result.stdout).toMatchInlineSnapshot(`
+    expect(result.stdout).toMatchInlineSnapshot(`
 "Status: Disabled
 
 You've already opted out of telemetry data collection.
@@ -139,6 +137,5 @@ Learn more here:
 https://www.sanity.io/telemetry
 "
 `)
-    },
-  )
+  })
 })

--- a/packages/@sanity/cli/test/telemetry.test.ts
+++ b/packages/@sanity/cli/test/telemetry.test.ts
@@ -133,3 +133,65 @@ https://www.sanity.io/telemetry
 `)
   })
 })
+
+describeCliTest('CLI: `sanity telemetry disable`', () => {
+  testConcurrent('sanity telemetry disable: success', async () => {
+    const result = await runSanityCmdCommand('v3', ['telemetry', 'disable'], {
+      env: {
+        MOCK_TELEMETRY_CONSENT_MODE: 'success',
+      },
+    })
+
+    expect(result.stdout).toMatchInlineSnapshot(`
+"Status: Disabled
+
+You've opted out of telemetry data collection.
+No data will be collected from your Sanity account.
+
+Learn more here:
+https://www.sanity.io/telemetry
+"
+`)
+  })
+
+  testConcurrent('sanity telemetry disable: success (already denied)', async () => {
+    const result = await runSanityCmdCommand('v3', ['telemetry', 'disable'], {
+      env: {
+        MOCK_CONSENT: 'denied',
+      },
+    })
+
+    expect(result.stdout).toMatchInlineSnapshot(`
+"Status: Disabled
+
+You've already opted out of telemetry data collection.
+No data is collected from your Sanity account.
+
+Learn more here:
+https://www.sanity.io/telemetry
+"
+`)
+  })
+
+  testConcurrent(
+    'sanity telemetry disable: success (already denied using DO_NOT_TRACK)',
+    async () => {
+      const result = await runSanityCmdCommand('v3', ['telemetry', 'disable'], {
+        env: {
+          DO_NOT_TRACK: '1',
+        },
+      })
+
+      expect(result.stdout).toMatchInlineSnapshot(`
+"Status: Disabled
+
+You've already opted out of telemetry data collection.
+No data is collected from your Sanity account.
+
+Learn more here:
+https://www.sanity.io/telemetry
+"
+`)
+    },
+  )
+})

--- a/packages/@sanity/cli/test/telemetry.test.ts
+++ b/packages/@sanity/cli/test/telemetry.test.ts
@@ -88,7 +88,6 @@ No data will be collected from your machine.
 
 Using DO_NOT_TRACK environment variable.
 
-
 Learn more here:
 https://www.sanity.io/telemetry
 "

--- a/packages/@sanity/cli/test/telemetry.test.ts
+++ b/packages/@sanity/cli/test/telemetry.test.ts
@@ -1,0 +1,135 @@
+import {describeCliTest, testConcurrent} from './shared/describe'
+import {runSanityCmdCommand} from './shared/environment'
+
+describeCliTest('CLI: `sanity telemetry status`', () => {
+  testConcurrent('sanity telemetry status: fetch error', async () => {
+    const result = await runSanityCmdCommand('v3', ['telemetry', 'status'])
+
+    // TODO: Test successful request.
+    expect(result.stdout).toMatchInlineSnapshot(`
+"Could not fetch telemetry consent status.
+
+Learn more here:
+https://sanity.io/telemetry
+"
+`)
+  })
+
+  testConcurrent('sanity telemetry status: unset', async () => {
+    const result = await runSanityCmdCommand('v3', ['telemetry', 'status'], {
+      env: {
+        MOCK_CONSENT: 'unset',
+      },
+    })
+
+    expect(result.stdout).toMatchInlineSnapshot(`
+"Status: Not set
+
+You've not set your preference for telemetry collection.
+
+Run npx sanity telemetry enable/disable to opt in or out.
+You can also use the DO_NOT_TRACK environment variable to opt out.
+
+Learn more here:
+https://sanity.io/telemetry
+"
+`)
+  })
+
+  testConcurrent('sanity telemetry status: granted', async () => {
+    const result = await runSanityCmdCommand('v3', ['telemetry', 'status'], {
+      env: {
+        MOCK_CONSENT: 'granted',
+      },
+    })
+
+    expect(result.stdout).toMatchInlineSnapshot(`
+"Status: Enabled
+
+Telemetry data on general usage and errors is collected to help us improve Sanity.
+
+Learn more about the data being collected here:
+https://www.sanity.io/telemetry
+"
+`)
+  })
+
+  testConcurrent('sanity telemetry status: denied', async () => {
+    const result = await runSanityCmdCommand('v3', ['telemetry', 'status'], {
+      env: {
+        MOCK_CONSENT: 'denied',
+      },
+    })
+
+    expect(result.stdout).toMatchInlineSnapshot(`
+"Status: Disabled
+
+You've opted out of telemetry data collection.
+No data will be collected from your Sanity account.
+
+Learn more here:
+https://www.sanity.io/telemetry
+"
+`)
+  })
+
+  testConcurrent('sanity telemetry status: denied using DO_NOT_TRACK', async () => {
+    const result = await runSanityCmdCommand('v3', ['telemetry', 'status'], {
+      env: {
+        DO_NOT_TRACK: '1',
+      },
+    })
+
+    expect(result.stdout).toMatchInlineSnapshot(`
+"Status: Disabled
+
+You've opted out of telemetry data collection.
+No data will be collected from your machine.
+
+Using DO_NOT_TRACK environment variable.
+
+
+Learn more here:
+https://www.sanity.io/telemetry
+"
+`)
+  })
+})
+
+describeCliTest('CLI: `sanity telemetry enable`', () => {
+  testConcurrent('sanity telemetry enable: success', async () => {
+    const result = await runSanityCmdCommand('v3', ['telemetry', 'enable'], {
+      env: {
+        MOCK_TELEMETRY_CONSENT_MODE: 'success',
+      },
+    })
+
+    expect(result.stdout).toMatchInlineSnapshot(`
+"Status: Enabled
+
+You've now enabled telemetry data collection to help us improve Sanity.
+
+Learn more about the data being collected here:
+https://www.sanity.io/telemetry
+"
+`)
+  })
+
+  testConcurrent('sanity telemetry enable: success (already enabled)', async () => {
+    const result = await runSanityCmdCommand('v3', ['telemetry', 'enable'], {
+      env: {
+        MOCK_CONSENT: 'granted',
+      },
+    })
+
+    expect(result.stdout).toMatchInlineSnapshot(`
+"Status: Enabled
+
+You've already enabled telemetry data collection to help us improve Sanity.
+
+Learn more about the data being collected here:
+https://www.sanity.io/telemetry
+"
+`)
+  })
+})

--- a/packages/@sanity/cli/test/telemetry.test.ts
+++ b/packages/@sanity/cli/test/telemetry.test.ts
@@ -2,46 +2,9 @@ import {describeCliTest, testConcurrent} from './shared/describe'
 import {runSanityCmdCommand} from './shared/environment'
 
 describeCliTest('CLI: `sanity telemetry status`', () => {
-  testConcurrent('sanity telemetry status: fetch error', async () => {
+  test('sanity telemetry status: granted', async () => {
+    await runSanityCmdCommand('v3', ['telemetry', 'enable'])
     const result = await runSanityCmdCommand('v3', ['telemetry', 'status'])
-
-    // TODO: Test successful request.
-    expect(result.stdout).toMatchInlineSnapshot(`
-"Could not fetch telemetry consent status.
-
-Learn more here:
-https://sanity.io/telemetry
-"
-`)
-  })
-
-  testConcurrent('sanity telemetry status: unset', async () => {
-    const result = await runSanityCmdCommand('v3', ['telemetry', 'status'], {
-      env: {
-        MOCK_CONSENT: 'unset',
-      },
-    })
-
-    expect(result.stdout).toMatchInlineSnapshot(`
-"Status: Not set
-
-You've not set your preference for telemetry collection.
-
-Run npx sanity telemetry enable/disable to opt in or out.
-You can also use the DO_NOT_TRACK environment variable to opt out.
-
-Learn more here:
-https://sanity.io/telemetry
-"
-`)
-  })
-
-  testConcurrent('sanity telemetry status: granted', async () => {
-    const result = await runSanityCmdCommand('v3', ['telemetry', 'status'], {
-      env: {
-        MOCK_CONSENT: 'granted',
-      },
-    })
 
     expect(result.stdout).toMatchInlineSnapshot(`
 "Status: Enabled
@@ -54,12 +17,9 @@ https://www.sanity.io/telemetry
 `)
   })
 
-  testConcurrent('sanity telemetry status: denied', async () => {
-    const result = await runSanityCmdCommand('v3', ['telemetry', 'status'], {
-      env: {
-        MOCK_CONSENT: 'denied',
-      },
-    })
+  test('sanity telemetry status: denied', async () => {
+    await runSanityCmdCommand('v3', ['telemetry', 'disable'])
+    const result = await runSanityCmdCommand('v3', ['telemetry', 'status'])
 
     expect(result.stdout).toMatchInlineSnapshot(`
 "Status: Disabled
@@ -96,12 +56,9 @@ https://www.sanity.io/telemetry
 })
 
 describeCliTest('CLI: `sanity telemetry enable`', () => {
-  testConcurrent('sanity telemetry enable: success', async () => {
-    const result = await runSanityCmdCommand('v3', ['telemetry', 'enable'], {
-      env: {
-        MOCK_TELEMETRY_CONSENT_MODE: 'success',
-      },
-    })
+  test('sanity telemetry enable: success', async () => {
+    await runSanityCmdCommand('v3', ['telemetry', 'disable'])
+    const result = await runSanityCmdCommand('v3', ['telemetry', 'enable'])
 
     expect(result.stdout).toMatchInlineSnapshot(`
 "Status: Enabled
@@ -114,12 +71,8 @@ https://www.sanity.io/telemetry
 `)
   })
 
-  testConcurrent('sanity telemetry enable: success (already enabled)', async () => {
-    const result = await runSanityCmdCommand('v3', ['telemetry', 'enable'], {
-      env: {
-        MOCK_CONSENT: 'granted',
-      },
-    })
+  test('sanity telemetry enable: success (already enabled)', async () => {
+    const result = await runSanityCmdCommand('v3', ['telemetry', 'enable'])
 
     expect(result.stdout).toMatchInlineSnapshot(`
 "Status: Enabled
@@ -134,12 +87,9 @@ https://www.sanity.io/telemetry
 })
 
 describeCliTest('CLI: `sanity telemetry disable`', () => {
-  testConcurrent('sanity telemetry disable: success', async () => {
-    const result = await runSanityCmdCommand('v3', ['telemetry', 'disable'], {
-      env: {
-        MOCK_TELEMETRY_CONSENT_MODE: 'success',
-      },
-    })
+  test('sanity telemetry disable: success', async () => {
+    await runSanityCmdCommand('v3', ['telemetry', 'enable'])
+    const result = await runSanityCmdCommand('v3', ['telemetry', 'disable'])
 
     expect(result.stdout).toMatchInlineSnapshot(`
 "Status: Disabled
@@ -153,12 +103,8 @@ https://www.sanity.io/telemetry
 `)
   })
 
-  testConcurrent('sanity telemetry disable: success (already denied)', async () => {
-    const result = await runSanityCmdCommand('v3', ['telemetry', 'disable'], {
-      env: {
-        MOCK_CONSENT: 'denied',
-      },
-    })
+  test('sanity telemetry disable: success (already denied)', async () => {
+    const result = await runSanityCmdCommand('v3', ['telemetry', 'disable'])
 
     expect(result.stdout).toMatchInlineSnapshot(`
 "Status: Disabled

--- a/packages/@sanity/cli/test/telemetry.test.ts
+++ b/packages/@sanity/cli/test/telemetry.test.ts
@@ -1,10 +1,19 @@
-import {describeCliTest, testConcurrent} from './shared/describe'
+import {describeCliTest} from './shared/describe'
 import {runSanityCmdCommand} from './shared/environment'
 
 describeCliTest('CLI: `sanity telemetry status`', () => {
   test('sanity telemetry status: granted', async () => {
-    await runSanityCmdCommand('v3', ['telemetry', 'enable'])
-    const result = await runSanityCmdCommand('v3', ['telemetry', 'status'])
+    await runSanityCmdCommand('v3', ['telemetry', 'enable'], {
+      env: {
+        CI: 'false',
+      },
+    })
+
+    const result = await runSanityCmdCommand('v3', ['telemetry', 'status'], {
+      env: {
+        CI: 'false',
+      },
+    })
 
     expect(result.stdout).toMatchInlineSnapshot(`
 "Status: Enabled
@@ -18,8 +27,17 @@ https://www.sanity.io/telemetry
   })
 
   test('sanity telemetry status: denied', async () => {
-    await runSanityCmdCommand('v3', ['telemetry', 'disable'])
-    const result = await runSanityCmdCommand('v3', ['telemetry', 'status'])
+    await runSanityCmdCommand('v3', ['telemetry', 'disable'], {
+      env: {
+        CI: 'false',
+      },
+    })
+
+    const result = await runSanityCmdCommand('v3', ['telemetry', 'status'], {
+      env: {
+        CI: 'false',
+      },
+    })
 
     expect(result.stdout).toMatchInlineSnapshot(`
 "Status: Disabled
@@ -36,6 +54,7 @@ https://www.sanity.io/telemetry
   test('sanity telemetry status: denied using DO_NOT_TRACK', async () => {
     const result = await runSanityCmdCommand('v3', ['telemetry', 'status'], {
       env: {
+        CI: 'false',
         DO_NOT_TRACK: '1',
       },
     })
@@ -57,8 +76,17 @@ https://www.sanity.io/telemetry
 
 describeCliTest('CLI: `sanity telemetry enable`', () => {
   test('sanity telemetry enable: success', async () => {
-    await runSanityCmdCommand('v3', ['telemetry', 'disable'])
-    const result = await runSanityCmdCommand('v3', ['telemetry', 'enable'])
+    await runSanityCmdCommand('v3', ['telemetry', 'disable'], {
+      env: {
+        CI: 'false',
+      },
+    })
+
+    const result = await runSanityCmdCommand('v3', ['telemetry', 'enable'], {
+      env: {
+        CI: 'false',
+      },
+    })
 
     expect(result.stdout).toMatchInlineSnapshot(`
 "Status: Enabled
@@ -72,7 +100,11 @@ https://www.sanity.io/telemetry
   })
 
   test('sanity telemetry enable: success (already enabled)', async () => {
-    const result = await runSanityCmdCommand('v3', ['telemetry', 'enable'])
+    const result = await runSanityCmdCommand('v3', ['telemetry', 'enable'], {
+      env: {
+        CI: 'false',
+      },
+    })
 
     expect(result.stdout).toMatchInlineSnapshot(`
 "Status: Enabled
@@ -88,8 +120,17 @@ https://www.sanity.io/telemetry
 
 describeCliTest('CLI: `sanity telemetry disable`', () => {
   test('sanity telemetry disable: success', async () => {
-    await runSanityCmdCommand('v3', ['telemetry', 'enable'])
-    const result = await runSanityCmdCommand('v3', ['telemetry', 'disable'])
+    await runSanityCmdCommand('v3', ['telemetry', 'enable'], {
+      env: {
+        CI: 'false',
+      },
+    })
+
+    const result = await runSanityCmdCommand('v3', ['telemetry', 'disable'], {
+      env: {
+        CI: 'false',
+      },
+    })
 
     expect(result.stdout).toMatchInlineSnapshot(`
 "Status: Disabled
@@ -104,7 +145,11 @@ https://www.sanity.io/telemetry
   })
 
   test('sanity telemetry disable: success (already denied)', async () => {
-    const result = await runSanityCmdCommand('v3', ['telemetry', 'disable'])
+    const result = await runSanityCmdCommand('v3', ['telemetry', 'disable'], {
+      env: {
+        CI: 'false',
+      },
+    })
 
     expect(result.stdout).toMatchInlineSnapshot(`
 "Status: Disabled
@@ -121,6 +166,7 @@ https://www.sanity.io/telemetry
   test('sanity telemetry disable: success (already denied using DO_NOT_TRACK)', async () => {
     const result = await runSanityCmdCommand('v3', ['telemetry', 'disable'], {
       env: {
+        CI: 'false',
         DO_NOT_TRACK: '1',
       },
     })

--- a/packages/@sanity/cli/test/telemetry.test.ts
+++ b/packages/@sanity/cli/test/telemetry.test.ts
@@ -186,7 +186,9 @@ https://www.sanity.io/telemetry
 "Status: Disabled
 
 You've already opted out of telemetry data collection.
-No data is collected from your Sanity account.
+No data is collected from your machine.
+
+Using DO_NOT_TRACK environment variable.
 
 Learn more here:
 https://www.sanity.io/telemetry


### PR DESCRIPTION
### Description
Adds three new CLI commands for managing telemetry consent, and also adds caching of telemetry consent status.
- `sanity telemetry status` – view consent status
- `sanity telemetry disable` – disable telemetry by withdrawing consent
- `sanity telemetry enable` – enable telemetry by granting consent

In addition:
- Adds a short lived cache of consent status (to avoid excessive api calls in case of serial cli usages)
- Adds information about telemetry that will appear the first time the cli is run after upgrading (or on new machines)

### What to review
- Does the changes look ok?

### Notes for release
TBD
