### PR TITLE
fix(i18n): key being used instead of translated value

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1464,18 +1464,34 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'timeline.operation.created': 'Created',
   /** Label shown in review changes timeline when a document was initially created */
   'timeline.operation.created-initial': 'Created',
+  /** Label shown in review changes timeline when a document was initially created, with a timestamp */
+  'timeline.operation.created-initial_timestamp': 'Created: {{timestamp, datetime}}',
+  /** Label shown in review changes timeline when a document has been created, with a timestamp */
+  'timeline.operation.created_timestamp': 'Created: {{timestamp, datetime}}',
   /** Label shown in review changes timeline when a document has been deleted */
   'timeline.operation.deleted': 'Deleted',
+  /** Label shown in review changes timeline when a document has been deleted, with a timestamp */
+  'timeline.operation.deleted_timestamp': 'Deleted: {{timestamp, datetime}}',
   /** Label shown in review changes timeline when a draft has been discarded */
   'timeline.operation.draft-discarded': 'Discarded draft',
+  /** Label shown in review changes timeline when a draft has been discarded, with a timestamp */
+  'timeline.operation.draft-discarded_timestamp': 'Discarded draft: {{timestamp, datetime}}',
   /** Label shown in review changes timeline when a draft has been edited */
   'timeline.operation.edited-draft': 'Edited',
+  /** Label shown in review changes timeline when a draft has been edited, with a timestamp */
+  'timeline.operation.edited-draft_timestamp': 'Edited: {{timestamp, datetime}}',
   /** Label shown in review changes timeline when a document has been edited live */
   'timeline.operation.edited-live': 'Live edited',
+  /** Label shown in review changes timeline when a document has been edited live, with a timestamp */
+  'timeline.operation.edited-live_timestamp': 'Live edited: {{timestamp, datetime}}',
   /** Label shown in review changes timeline when a document was published */
   'timeline.operation.published': 'Published',
+  /** Label shown in review changes timeline when a document was published, with a timestamp */
+  'timeline.operation.published_timestamp': 'Published: {{timestamp, datetime}}',
   /** Label shown in review changes timeline when a document was unpublished */
   'timeline.operation.unpublished': 'Unpublished',
+  /** Label shown in review changes timeline when a document was unpublished, with a timestamp */
+  'timeline.operation.unpublished_timestamp': 'Unpublished: {{timestamp, datetime}}',
   /**
    * Label for determining since which version the changes for timeline menu dropdown are showing.
    * Receives the time label as a parameter (`timestamp`).

--- a/packages/sanity/src/desk/panes/document/timeline/timelineMenu.tsx
+++ b/packages/sanity/src/desk/panes/document/timeline/timelineMenu.tsx
@@ -133,7 +133,9 @@ export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {
     </>
   )
 
-  const revLabel = chunk ? TIMELINE_ITEM_I18N_KEY_MAPPING[chunk.type] : t('timeline.latest-version')
+  const revLabel = chunk
+    ? t(TIMELINE_ITEM_I18N_KEY_MAPPING[chunk.type])
+    : t('timeline.latest-version')
 
   const sinceLabel = chunk
     ? t('timeline.since', {

--- a/packages/sanity/src/desk/panes/document/timeline/timelineMenu.tsx
+++ b/packages/sanity/src/desk/panes/document/timeline/timelineMenu.tsx
@@ -133,16 +133,22 @@ export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {
     </>
   )
 
+  const formatParams = {
+    timestamp: {dateStyle: 'medium', timeStyle: 'short'},
+  }
+
   const revLabel = chunk
-    ? t(TIMELINE_ITEM_I18N_KEY_MAPPING[chunk.type])
+    ? t(TIMELINE_ITEM_I18N_KEY_MAPPING[chunk.type], {
+        context: 'timestamp',
+        timestamp: new Date(chunk?.endTimestamp),
+        formatParams,
+      })
     : t('timeline.latest-version')
 
   const sinceLabel = chunk
     ? t('timeline.since', {
         timestamp: new Date(chunk?.endTimestamp),
-        formatParams: {
-          timestamp: {dateStyle: 'medium', timeStyle: 'short'},
-        },
+        formatParams,
       })
     : t('timeline.since-version-missing')
 


### PR DESCRIPTION
### Description

An oversight on my part - when selecting a revision, we were not actually passing the i18n key to the `t` function, but rather showing it as-is. This fixes that.

### What to review

Review changes shows the correct label when selecting an operation.

### Notes for release

None
