### PR TITLE
fix(i18n): invalid key for cdr "copy id to clipboard" button tooltip

### DIFF
--- a/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
+++ b/packages/sanity/src/desk/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
@@ -246,7 +246,7 @@ export function ConfirmDeleteDialogBody({
                                 >
                                   <Button
                                     title={t(
-                                      'confirm-delete-dialog.cdr-table.copy-id-button.title',
+                                      'confirm-delete-dialog.cdr-table.copy-id-button.tooltip',
                                     )}
                                     mode="bleed"
                                     icon={CopyIcon}


### PR DESCRIPTION
### Description

Just an incorrect key being used.

### What to review

CDR table has the correct tooltip title

### Notes for release

None