### PR TITLE
fix(i18n): correct permission check banner interpolation

### DIFF
--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -92,12 +92,18 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'banners.deleted-document-banner.restore-button.text': 'Restore most recent version',
   /** The text content for the deleted document banner */
   'banners.deleted-document-banner.text': 'This document has been deleted.',
-  /** The text for the permission check banner if there is are multiple roles */
-  'banners.permission-check-banner.plural-roles.text':
-    'Your roles {{roles}} do not have permissions to {{requiredPermission}} this document.',
-  /** The text for the permission check banner if there is only one role */
-  'banners.permission-check-banner.singular-role.text':
-    'Your role {{roles}} does not have permissions to {{requiredPermission}} this document.',
+  /** The text for the permission check banner if the user only has one role, and it does not allow updating this document */
+  'banners.permission-check-banner.missing-permission_create_one':
+    'Your role <Roles/> does not have permissions to create this document.',
+  /** The text for the permission check banner if the user only has multiple roles, but they do not allow updating this document */
+  'banners.permission-check-banner.missing-permission_create_other':
+    'Your roles <Roles/> do not have permissions to create this document.',
+  /** The text for the permission check banner if the user only has one role, and it does not allow updating this document */
+  'banners.permission-check-banner.missing-permission_update_one':
+    'Your role <Roles/> does not have permissions to update this document.',
+  /** The text for the permission check banner if the user only has multiple roles, but they do not allow updating this document */
+  'banners.permission-check-banner.missing-permission_update_other':
+    'Your roles <Roles/> do not have permissions to update this document.',
   /** The text for the reload button */
   'banners.reference-changed-banner.reason-changed.reload-button.text': 'Reload reference',
   /** The text for the reference change banner if the reason is that the reference has been changed */


### PR DESCRIPTION
### Description

Fixes the "permission check" banner at the top of a document when you do not have the sufficient permissions to create or edit a document. Previously it showed something like this:

![image](https://github.com/sanity-io/sanity/assets/48200/17c0ed6b-8616-4760-8ae2-2708265230d6)

This is because interpolating JSX elements won't work.

This PR:

1. Uses the list formatter to split into parts and makes it available as `<Roles/>`
2. Uses context to define the different permissions available (`create`, `update`) so they can be translated to other languages
3. Uses the `count` parameter to differentiate between one and multiple roles, to align with other pluralization keys

### What to review

Permission checks now render correctly

### Notes for release

None
