### PR TITLE
fix(i18n): use correct keys for file asset source headings and accepted types

### DIFF
--- a/packages/sanity/src/core/form/studio/assetSource/file/AssetRow.tsx
+++ b/packages/sanity/src/core/form/studio/assetSource/file/AssetRow.tsx
@@ -274,7 +274,7 @@ export const AssetRow = (props: RowProps) => {
             <Grid marginTop={3} columns={3} gap={1}>
               <Stack space={2}>
                 <Label size={1} muted>
-                  {t('asset-source.asset-list.details.size')}
+                  {t('asset-source.file.asset-list.header.size')}
                 </Label>
                 <Text size={1} muted>
                   {formattedSize}
@@ -282,7 +282,7 @@ export const AssetRow = (props: RowProps) => {
               </Stack>
               <Stack space={2}>
                 <Label size={1} muted>
-                  {t('asset-source.asset-list.details.type')}
+                  {t('asset-source.file.asset-list.header.type')}
                 </Label>
                 <Text size={1} muted>
                   {formattedMimeType}
@@ -290,7 +290,7 @@ export const AssetRow = (props: RowProps) => {
               </Stack>
               <Stack space={2}>
                 <Label size={1} muted>
-                  {t('asset-source.asset-list.details.date-added')}
+                  {t('asset-source.file.asset-list.header.date-added')}
                 </Label>
                 <Text size={1} muted>
                   {formattedTime}
@@ -302,7 +302,7 @@ export const AssetRow = (props: RowProps) => {
                 fontSize={1}
                 tone="default"
                 mode="ghost"
-                text={t('asset-source.asset-list.actions.show-uses')}
+                text={t('asset-source.file.asset-list.action.show-usage.title')}
                 onClick={handleToggleUsageDialog}
                 icon={LinkIcon}
               />

--- a/packages/sanity/src/core/form/studio/assetSource/file/FileListView.tsx
+++ b/packages/sanity/src/core/form/studio/assetSource/file/FileListView.tsx
@@ -29,7 +29,7 @@ export function FileListView(props: Props) {
           <Grid style={STYLES_GRID}>
             <Box flex={2} paddingLeft={5}>
               <Label muted size={1}>
-                {t('asset-source.file.asset-table.compact.filename')}
+                {t('asset-source.file.asset-list.header.filename')}
               </Label>
             </Box>
           </Grid>

--- a/packages/sanity/src/core/form/studio/assetSource/shared/DefaultSource.tsx
+++ b/packages/sanity/src/core/form/studio/assetSource/shared/DefaultSource.tsx
@@ -233,7 +233,7 @@ const DefaultAssetSource = function DefaultAssetSource(
                 t={t}
                 i18nKey="asset-source.dialog.accept-message"
                 values={{
-                  acceptedTypes: listFormat.format(accept.split(',').map((type) => type.trim())),
+                  acceptTypes: listFormat.format(accept.split(',').map((type) => type.trim())),
                 }}
               />
             </Text>

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -73,6 +73,7 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'asset-source.file.asset-list.action.delete.text': 'Delete',
   'asset-source.file.asset-list.action.delete.title': 'Delete file',
   'asset-source.file.asset-list.action.select-file.title': 'Select the file {{filename}}',
+  'asset-source.file.asset-list.action.show-usage.title': 'Show usage',
   'asset-source.file.asset-list.delete-failed': 'File could not be deleted',
   'asset-source.file.asset-list.delete-successful': 'File was deleted',
   'asset-source.file.asset-list.header.date-added': 'Date added',


### PR DESCRIPTION
### Description

This PR ensures correct i18n keys are used within the default file asset source. It also fixes an issue with accepted types not displaying correctly.

### What to review

- When browsing assets in the default file asset source (on mobile breakpoints) – file headers and the show usage button should render correct localized text
- Accepted types should also render correctly

**Before**

<img width="497" alt="image" src="https://github.com/sanity-io/sanity/assets/209129/a16e0849-a55d-4916-b75d-6b84fe255d3b">

**After**

<img width="492" alt="image" src="https://github.com/sanity-io/sanity/assets/209129/73fb81da-869d-4424-a273-107f40308b26">

### Notes for release

N/A