### PR TITLE
fix(comments): experimental API warning for dataset profile request

### DIFF
--- a/dev/test-studio/structure/constants.ts
+++ b/dev/test-studio/structure/constants.ts
@@ -79,7 +79,6 @@ export const DEBUG_INPUT_TYPES = [
   'validationTest',
   'virtualizationDebug',
   'virtualizationInObject',
-  'i18nDocument',
 ]
 
 export const CI_INPUT_TYPES = ['conditionalFieldset', 'validationCI', 'textsTest']

--- a/dev/test-studio/structure/resolveStructure.ts
+++ b/dev/test-studio/structure/resolveStructure.ts
@@ -215,6 +215,7 @@ export const structure: StructureResolver = (S, {schema, documentStore, i18n}) =
                     id: 'authors-and-books',
                     title: 'Authors & Books',
                     options: {
+                      apiVersion: '2023-07-28',
                       filter: '_type == "author" || _type == "book"',
                     },
                   }),

--- a/packages/sanity/src/desk/comments/src/context/setup/CommentsSetupProvider.tsx
+++ b/packages/sanity/src/desk/comments/src/context/setup/CommentsSetupProvider.tsx
@@ -23,7 +23,7 @@ export function CommentsSetupProvider(props: CommentsSetupProviderProps) {
   const [isRunningSetup, setIsRunningSetup] = useState<boolean>(false)
 
   const getAddonDatasetName = useCallback(async (): Promise<string | undefined> => {
-    const res = await originalClient.withConfig({apiVersion: 'vX'}).request({
+    const res = await originalClient.withConfig({apiVersion: API_VERSION}).request({
       uri: `/projects/${projectId}/datasets?datasetProfile=comments&addonFor=${dataset}`,
       tag: 'sanity.studio',
     })


### PR DESCRIPTION
### Description

Fixes a few console warnings:

- Use the new API version for the dataset profile requests - fixes EDX-729.
- Two trivial test-studio issues

### What to review

Not sure if the API version thing was an oversight or if I have overlooked something not having been released under a non-experimental version yet? Please advise.

### Notes for release

- Fixes a console warning being printed about using an experimental API version
