### PR TITLE
fix(core): fixes issue where `assetRequired`  rule works without  `required` rule

### DIFF
--- a/dev/test-studio/schema/allTypes.ts
+++ b/dev/test-studio/schema/allTypes.ts
@@ -85,7 +85,7 @@ export const allTypes = defineType({
       name: 'image',
       title: 'Bilde',
       type: 'image',
-      validation: (Rule) => Rule.required().assetRequired(),
+      validation: (Rule) => Rule.assetRequired(),
       fields: [
         defineField({
           name: 'alt',
@@ -99,7 +99,7 @@ export const allTypes = defineType({
       name: 'file',
       title: 'Fil',
       type: 'file',
-      validation: (Rule) => Rule.required().assetRequired(),
+      validation: (Rule) => Rule.assetRequired(),
       fields: [
         defineField({
           name: 'description',

--- a/packages/sanity/src/core/validation/Rule.ts
+++ b/packages/sanity/src/core/validation/Rule.ts
@@ -363,7 +363,9 @@ export const Rule: RuleClass = class Rule implements IRule {
       assetType = 'asset'
     }
 
-    return this.cloneWithRules([{flag: 'assetRequired', constraint: {assetType}}])
+    const rule = this.cloneWithRules([{flag: 'assetRequired', constraint: {assetType}}])
+    rule._required = 'required'
+    return rule
   }
 
   async validate(value: unknown, context: ValidationContext): Promise<ValidationMarker[]> {


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

`assetRequired` rule does not work without `required()` this seems counterintuitive to the name and it makes a better DX to make it work without required

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

Anything I am missing? Is this a breaking change?

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
- Fixes issue where `assetRequired` rule required `require` rule to be present to work properly 