### PR TITLE
fix(core): incorrect week day names for calendar

### DIFF
--- a/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/CalendarMonth.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/CalendarMonth.tsx
@@ -11,13 +11,13 @@ interface CalendarMonthProps {
   onSelect: (date: Date) => void
   hidden?: boolean
   weekDayNames: [
+    sun: string,
     mon: string,
     tue: string,
     wed: string,
     thu: string,
     fri: string,
     sat: string,
-    sun: string,
   ]
 }
 

--- a/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/types.ts
+++ b/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/types.ts
@@ -15,13 +15,13 @@ export interface CalendarLabels {
 }
 
 export type WeekDayNames = [
+  sun: string,
   mon: string,
   tue: string,
   wed: string,
   thu: string,
   fri: string,
   sat: string,
-  sun: string,
 ]
 
 export type MonthNames = [

--- a/packages/sanity/src/core/form/inputs/DateInputs/utils.ts
+++ b/packages/sanity/src/core/form/inputs/DateInputs/utils.ts
@@ -33,13 +33,13 @@ export function getCalendarLabels(
       t('calendar.month-names.december'),
     ],
     weekDayNamesShort: [
+      t('calendar.weekday-names.short.sunday'),
       t('calendar.weekday-names.short.monday'),
       t('calendar.weekday-names.short.tuesday'),
       t('calendar.weekday-names.short.wednesday'),
       t('calendar.weekday-names.short.thursday'),
       t('calendar.weekday-names.short.friday'),
       t('calendar.weekday-names.short.saturday'),
-      t('calendar.weekday-names.short.sunday'),
     ],
     setToTimePreset: (time, date) => t('calendar.action.set-to-time-preset', {time, date}),
   }


### PR DESCRIPTION
### Description

As part of the i18n work, we localized the week day names, but we put the names in monday-sunday order, while the calendar expects sunday-saturday. By switching the localized input so sunday is the first entry, it should fix this.

### What to review

- In date/datetime inputs, the week days should be showing the right week day in the header

### Notes for release

- Fixed an issue where the wrong week day was shown for a date in date inputs
