### PR TITLE
feat: expose all locale info from `useCurrentLocale` hook

### DIFF
--- a/packages/sanity/src/core/hooks/useFormattedDuration.ts
+++ b/packages/sanity/src/core/hooks/useFormattedDuration.ts
@@ -71,7 +71,7 @@ export function useFormattedDuration(
 ): FormattedDuration {
   const {style = 'short', resolution = 'seconds'} = options || {}
   const unitDisplay = style
-  const locale = useCurrentLocale()
+  const locale = useCurrentLocale().id
   const listFormat = useIntlListFormat({type: 'unit', style})
   const isNegative = durationMs < 0
   const duration = parseMilliseconds(Math.abs(durationMs))

--- a/packages/sanity/src/core/hooks/useRelativeTime.ts
+++ b/packages/sanity/src/core/hooks/useRelativeTime.ts
@@ -85,7 +85,7 @@ export function useRelativeTime(time: Date | string, options: RelativeTimeOption
 
 function useFormatRelativeTime(date: Date | string, opts: RelativeTimeOptions = {}): TimeSpec {
   const {t} = useTranslation()
-  const currentLocale = useCurrentLocale()
+  const currentLocale = useCurrentLocale().id
 
   const {timeZone, minimal} = opts
   const parsedDate = date instanceof Date ? date : new Date(date)

--- a/packages/sanity/src/core/hooks/useUnitFormatter.ts
+++ b/packages/sanity/src/core/hooks/useUnitFormatter.ts
@@ -96,7 +96,7 @@ export type UnitFormatter = (value: number, unit: FormattableMeasurementUnit) =>
  * @public
  */
 export function useUnitFormatter(options: UseUnitFormatterOptions = {}): UnitFormatter {
-  const currentLocale = useCurrentLocale()
+  const currentLocale = useCurrentLocale().id
   const defaultOptions: Intl.NumberFormatOptions = {
     unitDisplay: 'long',
     ...options,

--- a/packages/sanity/src/core/i18n/LocaleContext.ts
+++ b/packages/sanity/src/core/i18n/LocaleContext.ts
@@ -1,5 +1,6 @@
 import {createContext} from 'react'
 import {i18n} from 'i18next'
+import type {Locale} from './types'
 
 /**
  * @internal
@@ -10,8 +11,8 @@ export const LocaleContext = createContext<LocaleContextValue | undefined>(undef
  * @internal
  */
 export interface LocaleContextValue {
-  locales: {id: string; title: string}[]
-  currentLocale: string
+  locales: Locale[]
+  currentLocale: Locale
   __internal: {i18next: i18n}
   changeLocale: (newLocale: string) => Promise<void>
 }

--- a/packages/sanity/src/core/i18n/components/LocaleProvider.tsx
+++ b/packages/sanity/src/core/i18n/components/LocaleProvider.tsx
@@ -5,6 +5,8 @@ import {useSource} from '../../studio'
 import {LoadingScreen} from '../../studio/screens'
 import {storePreferredLocale} from '../localeStore'
 import {LocaleContext, type LocaleContextValue} from '../LocaleContext'
+import type {Locale} from '../types'
+import {defaultLocale} from '../locales'
 
 /**
  * @internal
@@ -41,7 +43,7 @@ export function LocaleProviderBase({
 }: PropsWithChildren<{
   projectId: string
   sourceId: string
-  locales: {id: string; title: string}[]
+  locales: Locale[]
   i18next: i18n
 }>) {
   const subscribe = useCallback(
@@ -51,7 +53,10 @@ export function LocaleProviderBase({
     },
     [i18next],
   )
-  const currentLocale = useSyncExternalStore(subscribe, () => i18next.language)
+  const currentLocale = useSyncExternalStore(
+    subscribe,
+    () => locales.find((candidate) => i18next.language === candidate.id) || defaultLocale,
+  )
 
   const context = useMemo<LocaleContextValue>(
     () => ({
@@ -70,7 +75,7 @@ export function LocaleProviderBase({
     <Suspense fallback={<LoadingScreen />}>
       <I18nextProvider i18n={i18next}>
         {/* Use locale as key to force re-render, updating non-reactive parts */}
-        <LocaleContext.Provider value={context} key={currentLocale}>
+        <LocaleContext.Provider value={context} key={currentLocale.id}>
           {children}
         </LocaleContext.Provider>
       </I18nextProvider>

--- a/packages/sanity/src/core/i18n/fallback.ts
+++ b/packages/sanity/src/core/i18n/fallback.ts
@@ -6,9 +6,7 @@ import {defaultLocale, usEnglishLocale} from './locales'
 import {isStaticResourceBundle} from './helpers'
 
 const shouldEscape = typeof window === 'undefined' || typeof document === 'undefined'
-const fallbackLocales: LocaleSource['locales'] = [
-  {id: defaultLocale.id, title: defaultLocale.title},
-]
+const fallbackLocales: LocaleSource['locales'] = [defaultLocale]
 
 /**
  * Returns a fallback source for internationalization that can be used in cases where you need
@@ -26,7 +24,7 @@ export const getFallbackLocaleSource: () => LocaleSource = memoize(
     const i18n = getFallbackI18nInstance()
     i18n.init()
     return {
-      currentLocale: defaultLocale.id,
+      currentLocale: defaultLocale,
       locales: fallbackLocales,
       loadNamespaces: i18n.loadNamespaces,
       t: i18n.t,

--- a/packages/sanity/src/core/i18n/hooks/useIntlDateTimeFormat.ts
+++ b/packages/sanity/src/core/i18n/hooks/useIntlDateTimeFormat.ts
@@ -22,6 +22,6 @@ export type UseIntlDateTimeFormatOptions = Omit<
 export function useIntlDateTimeFormat(
   options: UseIntlDateTimeFormatOptions = {},
 ): Intl.DateTimeFormat {
-  const currentLocale = useCurrentLocale()
+  const currentLocale = useCurrentLocale().id
   return intlCache.dateTimeFormat(currentLocale, options)
 }

--- a/packages/sanity/src/core/i18n/hooks/useIntlListFormat.ts
+++ b/packages/sanity/src/core/i18n/hooks/useIntlListFormat.ts
@@ -34,6 +34,6 @@ export interface UseIntlListFormatOptions {
  * @public
  */
 export function useIntlListFormat(options: UseIntlListFormatOptions = {}): Intl.ListFormat {
-  const currentLocale = useCurrentLocale()
+  const currentLocale = useCurrentLocale().id
   return intlCache.listFormat(currentLocale, options)
 }

--- a/packages/sanity/src/core/i18n/hooks/useIntlNumberFormat.ts
+++ b/packages/sanity/src/core/i18n/hooks/useIntlNumberFormat.ts
@@ -17,6 +17,6 @@ export type UseIntlNumberFormatOptions = Intl.NumberFormatOptions
  * @public
  */
 export function useIntlNumberFormat(options: UseIntlNumberFormatOptions = {}): Intl.NumberFormat {
-  const currentLocale = useCurrentLocale()
+  const currentLocale = useCurrentLocale().id
   return intlCache.numberFormat(currentLocale, options)
 }

--- a/packages/sanity/src/core/i18n/hooks/useLocale.ts
+++ b/packages/sanity/src/core/i18n/hooks/useLocale.ts
@@ -1,10 +1,11 @@
 import {useContext} from 'react'
 import {LocaleContext, type LocaleContextValue} from '../LocaleContext'
+import type {Locale} from '../types'
 
 /**
  * @internal
  */
-export function useCurrentLocale(): string {
+export function useCurrentLocale(): Locale {
   return useLocale().currentLocale
 }
 

--- a/packages/sanity/src/core/i18n/i18nConfig.ts
+++ b/packages/sanity/src/core/i18n/i18nConfig.ts
@@ -67,7 +67,7 @@ function createI18nApi({
     /** @public */
     source: {
       get currentLocale() {
-        return i18nInstance.language
+        return reducedLocales.find((locale) => locale.id === i18nInstance.language) ?? defaultLocale
       },
       loadNamespaces(namespaces: string[]): Promise<void> {
         const missing = namespaces.filter((ns) => !i18nInstance.hasLoadedNamespace(ns))

--- a/packages/sanity/src/core/i18n/types.ts
+++ b/packages/sanity/src/core/i18n/types.ts
@@ -121,12 +121,11 @@ export type StaticLocaleResourceBundle = Omit<ImplicitLocaleResourceBundle, 'res
 }
 
 /**
- * A locale definition, which describes a locale and its resources.
+ * A locale representation
  *
- * @beta
- * @hidden
+ * @public
  */
-export interface LocaleDefinition {
+export interface Locale {
   /**
    * The ID of the locale, eg `en-US`, `nb-NO`, `th-TH`…
    */
@@ -136,7 +135,15 @@ export interface LocaleDefinition {
    * The title of locale, eg `English (US)`, `Norsk (bokmål)`, `ไทย`…
    */
   title: string
+}
 
+/**
+ * A locale definition, which describes a locale and its resources.
+ *
+ * @beta
+ * @hidden
+ */
+export interface LocaleDefinition extends Locale {
   /**
    * Array of resource bundles for this locale, if any.
    *
@@ -146,8 +153,6 @@ export interface LocaleDefinition {
    * function that imports the resources, in order to lazy load them on use.
    */
   bundles?: (ImplicitLocaleResourceBundle | LocaleResourceBundle)[]
-
-  // @todo allow fallback locales? eg [no-nn, no-nb, en]
 }
 
 /** @public */
@@ -155,12 +160,12 @@ export interface LocaleSource {
   /**
    * Current locale ID (eg `en-US`, `nb-NO`, `th-TH`…)
    */
-  currentLocale: string
+  currentLocale: Locale
 
   /**
    * Array of locale definitions
    */
-  locales: {id: string; title: string}[]
+  locales: Locale[]
 
   /**
    * Loads the given namespaces, if not already done.

--- a/packages/sanity/src/core/studio/components/navbar/resources/helper-functions/hooks.ts
+++ b/packages/sanity/src/core/studio/components/navbar/resources/helper-functions/hooks.ts
@@ -13,7 +13,7 @@ import {getHelpResources} from './helpResources'
  */
 export function useGetHelpResources(): LoadableState<ResourcesResponse | undefined> {
   const client = useClient({apiVersion: '1'})
-  const locale = useCurrentLocale()
+  const locale = useCurrentLocale().id
 
   const moduleStatus$ = useMemo(() => getHelpResources(client, locale), [client, locale])
 

--- a/packages/sanity/src/core/studio/components/navbar/userMenu/LocaleMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/userMenu/LocaleMenu.tsx
@@ -26,7 +26,7 @@ export function LocaleMenu() {
           key={item.id}
           locale={item}
           changeLocale={changeLocale}
-          selectedLocale={currentLocale}
+          selectedLocale={currentLocale.id}
         />
       ))}
     </>

--- a/packages/sanity/src/core/validation/util/localizeMessage.ts
+++ b/packages/sanity/src/core/validation/util/localizeMessage.ts
@@ -1,6 +1,6 @@
 import {isPlainObject} from 'lodash'
 import type {CustomValidatorResult, LocalizedValidationMessages} from '@sanity/types'
-import {LocaleSource} from '../../i18n'
+import type {LocaleSource} from '../../i18n'
 
 /**
  * Extracts the correct localized validation message based on given locale source
@@ -11,7 +11,8 @@ import {LocaleSource} from '../../i18n'
  * @internal
  */
 export function localizeMessage(message: LocalizedValidationMessages, i18n: LocaleSource): string {
-  const {currentLocale: locale} = i18n
+  const {currentLocale} = i18n
+  const locale = currentLocale.id
 
   // Obviously, try direct match first (`no-NB`)
   if (message[locale]) {


### PR DESCRIPTION
### Description

The `useCurrentLocale` hook currently only exposes the locales' ID. As we mature the API, this won't be all the information we want to get from it, and thus we should change this now so we can expand in the future.

Introduces a new `Locale` type that is basically `LocaleDefinition` but without `bundles`. Again, as we mature we may want to split what the user passes as input for the locale from what the framework exposes, such as computed values (calendar info, date formatting rules, pluralization info etc)

### Notes for release

None (not yet public)
