### PR TITLE
fix(core): fields actions position shift

### DIFF
--- a/packages/sanity/src/core/form/components/formField/FormFieldBaseHeader.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldBaseHeader.tsx
@@ -15,19 +15,29 @@ import {FieldCommentsProps} from '../../types'
 
 const TOOLTIP_GROUP_DELAY: TooltipDelayGroupProviderProps['delay'] = {open: 500}
 
-const Root = styled(Flex)`
-  /* Prevent buttons from taking up extra vertical space */
-  line-height: 1;
-  /* For floating actions menu */
-  position: relative;
-`
-
-const PresenceBox = styled(Box)<{$right: number}>(({theme, $right}) => {
+const Root = styled(Flex)<{
+  $floatingCardWidth: number
+  $slotWidth: number
+  $floatingCardVisible: boolean
+}>(({theme, $floatingCardWidth, $slotWidth, $floatingCardVisible}) => {
   const {space} = theme.sanity
   return css`
-    position: absolute;
-    bottom: 0;
-    right: ${$right + space[1]}px;
+    /* Prevent buttons from taking up extra vertical space */
+    line-height: 1;
+    width: 100%;
+    /* For floating actions menu */
+    position: relative;
+
+    [data-ui='PresenceBox'] {
+      position: absolute;
+      bottom: 0;
+      right: ${$slotWidth + ($floatingCardVisible ? $floatingCardWidth : 0) + space[1]}px;
+    }
+    &:focus-within {
+      [data-ui='PresenceBox'] {
+        right: ${$floatingCardWidth + $slotWidth + space[1]}px;
+      }
+    }
   `
 })
 
@@ -67,11 +77,9 @@ const FieldActionsFloatingCard = styled(Card)`
     // and only show it when it has focus within or when the field is hovered or focused.
     opacity: 0;
     pointer-events: none;
-    width: 0;
 
     [data-ui='FieldActionsFlex'] {
       opacity: 0;
-      width: 0;
     }
 
     &[data-actions-visible='false']:not(:focus-within) {
@@ -223,15 +231,21 @@ export function FormFieldBaseHeader(props: FormFieldBaseHeaderProps) {
   }, [floatingCardWidth, showFieldActions, slot])
 
   return (
-    <Root align="flex-end">
+    <Root
+      align="flex-end"
+      justify="space-between"
+      $floatingCardVisible={showFieldActions || shouldShowFloatingCard}
+      $floatingCardWidth={floatingCardWidth}
+      $slotWidth={slotWidth}
+    >
       <ContentBox flex={1} paddingY={2} $presenceMaxWidth={calcAvatarStackWidth(MAX_AVATARS)}>
         {content}
       </ContentBox>
 
       {presence && presence.length > 0 && (
-        <PresenceBox data-ui="PresenceBox" flex="none" $right={floatingCardWidth + slotWidth}>
+        <Box data-ui="PresenceBox" flex="none">
           <FieldPresence maxAvatars={MAX_AVATARS} presence={presence} />
-        </PresenceBox>
+        </Box>
       )}
 
       {slotEl}

--- a/packages/sanity/src/core/form/components/formField/FormFieldBaseHeader.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldBaseHeader.tsx
@@ -31,11 +31,14 @@ const Root = styled(Flex)<{
     [data-ui='PresenceBox'] {
       position: absolute;
       bottom: 0;
-      right: ${$slotWidth + ($floatingCardVisible ? $floatingCardWidth : 0) + space[1]}px;
+      right: ${$slotWidth + $floatingCardWidth + space[1]}px;
     }
-    &:focus-within {
+    @media (hover: hover) {
+      // If hover is supported, we hide the floating card by default, so only add space for it when it's visible.
       [data-ui='PresenceBox'] {
-        right: ${$floatingCardWidth + $slotWidth + space[1]}px;
+        position: absolute;
+        bottom: 0;
+        right: ${$slotWidth + ($floatingCardVisible ? $floatingCardWidth : 0) + space[1]}px;
       }
     }
   `
@@ -153,7 +156,7 @@ export function FormFieldBaseHeader(props: FormFieldBaseHeaderProps) {
     fieldHovered,
     presence,
   } = props
-
+  const [focused, setFocused] = useState<boolean>(false)
   // State for if an actions menu is open
   const [menuOpen, setMenuOpen] = useState<boolean>(false)
 
@@ -171,7 +174,6 @@ export function FormFieldBaseHeader(props: FormFieldBaseHeaderProps) {
     button: commentButton = null,
     isAddingComment = false,
   } = comments || {}
-
   // Determine if actions exist and if field actions should be shown
   const hasActions = actions && actions.length > 0
   const showFieldActions = fieldFocused || fieldHovered || menuOpen || isAddingComment
@@ -182,7 +184,7 @@ export function FormFieldBaseHeader(props: FormFieldBaseHeaderProps) {
   const hasCommentsButtonOrActions = comments?.button || hasActions
 
   // Determine if floating card with actions should be shown
-  const shouldShowFloatingCard = showFieldActions || hasComments
+  const shouldShowFloatingCard = focused || showFieldActions || hasComments
 
   const handleSetFloatingCardElementWidth = useCallback(() => {
     if (floatingCardElement) {
@@ -195,12 +197,15 @@ export function FormFieldBaseHeader(props: FormFieldBaseHeaderProps) {
   // This is because presence should be positioned relative to the floating card.
   // We need this because we don't conditionally render the floating card and rely on CSS to
   // show/hide it, and therefore the width calculation won't be triggered when the card is shown or hidden.
-  const handleFocusCapture = useCallback(handleSetFloatingCardElementWidth, [
-    handleSetFloatingCardElementWidth,
-  ])
-  const handleBlurCapture = useCallback(handleSetFloatingCardElementWidth, [
-    handleSetFloatingCardElementWidth,
-  ])
+  const handleFocusCapture = useCallback(() => {
+    handleSetFloatingCardElementWidth()
+    setFocused(true)
+  }, [handleSetFloatingCardElementWidth])
+
+  const handleBlurCapture = useCallback(() => {
+    handleSetFloatingCardElementWidth()
+    setFocused(false)
+  }, [handleSetFloatingCardElementWidth])
 
   // Calculate floating card's width
   useEffect(() => {
@@ -234,7 +239,7 @@ export function FormFieldBaseHeader(props: FormFieldBaseHeaderProps) {
     <Root
       align="flex-end"
       justify="space-between"
-      $floatingCardVisible={showFieldActions || shouldShowFloatingCard}
+      $floatingCardVisible={shouldShowFloatingCard}
       $floatingCardWidth={floatingCardWidth}
       $slotWidth={slotWidth}
     >

--- a/packages/sanity/src/core/studio/Studio.test.tsx
+++ b/packages/sanity/src/core/studio/Studio.test.tsx
@@ -45,7 +45,7 @@ describe('Studio', () => {
       const html = renderToStaticMarkup(sheet.collectStyles(<Studio config={config} />))
 
       expect(html).toMatchInlineSnapshot(
-        `"<div class=\\"sc-dYZCwJ bKLSYK\\"><div data-ui=\\"Spinner\\" class=\\"sc-iqHXzD gpIjtP sc-kstpWv yLrdd sc-jWETjw fAjdm\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
+        `"<div class=\\"sc-jMliHe bmMQoc\\"><div data-ui=\\"Spinner\\" class=\\"sc-iqHXzD gpIjtP sc-kstpWv yLrdd sc-dYZCwJ VAhrS\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
       )
     } finally {
       sheet.seal()
@@ -62,7 +62,7 @@ describe('Studio', () => {
     try {
       const html = renderToString(sheet.collectStyles(<Studio config={config} />))
       expect(html).toMatchInlineSnapshot(
-        `"<div class=\\"sc-dYZCwJ bKLSYK\\"><div data-ui=\\"Spinner\\" class=\\"sc-iqHXzD gpIjtP sc-kstpWv yLrdd sc-jWETjw fAjdm\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
+        `"<div class=\\"sc-jMliHe bmMQoc\\"><div data-ui=\\"Spinner\\" class=\\"sc-iqHXzD gpIjtP sc-kstpWv yLrdd sc-dYZCwJ VAhrS\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
       )
     } finally {
       sheet.seal()
@@ -82,7 +82,7 @@ describe('Studio', () => {
       const html = renderToString(sheet.collectStyles(<Studio config={config} />))
       node.innerHTML = html
       expect(html).toMatchInlineSnapshot(
-        `"<div class=\\"sc-dYZCwJ bKLSYK\\"><div data-ui=\\"Spinner\\" class=\\"sc-iqHXzD gpIjtP sc-kstpWv yLrdd sc-jWETjw fAjdm\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
+        `"<div class=\\"sc-jMliHe bmMQoc\\"><div data-ui=\\"Spinner\\" class=\\"sc-iqHXzD gpIjtP sc-kstpWv yLrdd sc-dYZCwJ VAhrS\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
       )
       document.head.innerHTML += sheet.getStyleTags()
 


### PR DESCRIPTION
### Description

Update how the`<FieldPresence>` element is positioned and remove the` width:0 `from the `<FieldActionFloatingCard>` as it is causing layout to shift in an unexpected way.

Now the Root will add the position to the field presence element, this was moved to the Root because we need to handle the case of focus-within. This is the nearest parent we can choose. 


https://github.com/sanity-io/sanity/assets/46196328/cff41096-dc96-4ca6-92c8-57af45ce98ae


https://github.com/sanity-io/sanity/assets/46196328/e6fce327-1f37-4283-ade3-35b04751bd78


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
