### PR TITLE
feat(core): make calendars aware of locale week start day

### DIFF
--- a/packages/sanity/src/core/form/inputs/DateInputs/__tests__/CommonDateTimeInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/__tests__/CommonDateTimeInput.test.tsx
@@ -54,7 +54,7 @@ const CALENDAR_LABELS: CalendarLabels = {
     'November',
     'December',
   ],
-  weekDayNamesShort: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+  weekDayNamesShort: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
   setToTimePreset: (time: string, date: Date) => `${time} on ${format(date, 'yyyy-MM-dd')}`,
 }
 

--- a/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/Calendar.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/Calendar.tsx
@@ -112,12 +112,12 @@ export const Calendar = forwardRef(function Calendar(
   }, [ref])
 
   const handleKeyDown = useCallback(
-    (event: any) => {
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
       if (!ARROW_KEYS.includes(event.key)) {
         return
       }
       event.preventDefault()
-      if (event.target.hasAttribute('data-calendar-grid')) {
+      if (event.target instanceof HTMLElement && event.target.hasAttribute('data-calendar-grid')) {
         focusCurrentWeekDay()
         return
       }

--- a/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/CalendarMonth.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/CalendarMonth.tsx
@@ -1,8 +1,9 @@
 import {Box, Grid, Text} from '@sanity/ui'
 import {isSameDay, isSameMonth} from 'date-fns'
 import React from 'react'
+import {useCurrentLocale} from '../../../../../i18n/hooks/useLocale'
 import {CalendarDay} from './CalendarDay'
-import {getWeeksOfMonth} from './utils'
+import {useWeeksOfMonth} from './utils'
 
 interface CalendarMonthProps {
   date: Date
@@ -11,21 +12,30 @@ interface CalendarMonthProps {
   onSelect: (date: Date) => void
   hidden?: boolean
   weekDayNames: [
-    sun: string,
     mon: string,
     tue: string,
     wed: string,
     thu: string,
     fri: string,
     sat: string,
+    sun: string,
   ]
 }
 
 export function CalendarMonth(props: CalendarMonthProps) {
+  const {
+    weekInfo: {firstDay: weekStartDay},
+  } = useCurrentLocale()
+
+  const weekDayNames =
+    weekStartDay === 1
+      ? props.weekDayNames
+      : [props.weekDayNames[6], ...props.weekDayNames.slice(0, 6)]
+
   return (
     <Box aria-hidden={props.hidden || false} data-ui="CalendarMonth">
       <Grid gap={1} style={{gridTemplateColumns: 'repeat(7, minmax(44px, 46px))'}}>
-        {props.weekDayNames.map((weekday) => (
+        {weekDayNames.map((weekday) => (
           <Box key={weekday} paddingY={2}>
             <Text size={1} weight="medium" style={{textAlign: 'center'}}>
               {weekday}
@@ -33,7 +43,7 @@ export function CalendarMonth(props: CalendarMonthProps) {
           </Box>
         ))}
 
-        {getWeeksOfMonth(props.date).map((week, weekIdx) =>
+        {useWeeksOfMonth(props.date).map((week, weekIdx) =>
           week.days.map((date, dayIdx) => {
             const focused = props.focused && isSameDay(date, props.focused)
             const selected = props.selected && isSameDay(date, props.selected)

--- a/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/types.ts
+++ b/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/types.ts
@@ -15,13 +15,13 @@ export interface CalendarLabels {
 }
 
 export type WeekDayNames = [
-  sun: string,
   mon: string,
   tue: string,
   wed: string,
   thu: string,
   fri: string,
   sat: string,
+  sun: string,
 ]
 
 export type MonthNames = [

--- a/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/utils.ts
+++ b/packages/sanity/src/core/form/inputs/DateInputs/base/calendar/utils.ts
@@ -1,15 +1,24 @@
 import {addDays, eachWeekOfInterval, getWeek, lastDayOfMonth, startOfMonth} from 'date-fns'
+import {useCurrentLocale} from '../../../../../i18n/hooks/useLocale'
 import {TAIL_WEEKDAYS} from './constants'
 
-export const getWeekStartsOfMonth = (date: Date): Date[] => {
+/**
+ * NOTE: `weekStartsOn` uses 1 for Monday, 7 for Sunday. date-fns wants 0 for Sunday, 6 for Saturday.
+ */
+const getWeekStartsOfMonth = (date: Date, weekStartsOn: 1 | 2 | 3 | 4 | 5 | 6 | 7): Date[] => {
   const firstDay = startOfMonth(date)
-  return eachWeekOfInterval({
-    start: firstDay,
-    end: lastDayOfMonth(firstDay),
-  })
+  return eachWeekOfInterval(
+    {
+      start: firstDay,
+      end: lastDayOfMonth(firstDay),
+    },
+    {
+      weekStartsOn: weekStartsOn === 7 ? 0 : weekStartsOn,
+    },
+  )
 }
 
-export const getWeekDaysFromWeekStarts = (weekStarts: Date[]): Date[][] => {
+const getWeekDaysFromWeekStarts = (weekStarts: Date[]): Date[][] => {
   return weekStarts.map((weekStart) => [
     weekStart,
     ...TAIL_WEEKDAYS.map((d) => addDays(weekStart, d)),
@@ -21,13 +30,15 @@ type Week = {
   days: Date[]
 }
 
-export const getWeeksOfMonth = (date: Date): Week[] =>
-  getWeekDaysFromWeekStarts(getWeekStartsOfMonth(date)).map(
+export const useWeeksOfMonth = (date: Date): Week[] => {
+  const {weekInfo} = useCurrentLocale()
+  return getWeekDaysFromWeekStarts(getWeekStartsOfMonth(date, weekInfo.firstDay)).map(
     (days): Week => ({
       number: getWeek(days[0]),
       days,
     }),
   )
+}
 
 export const formatTime = (hours: number, minutes: number): string =>
   `${`${hours}`.padStart(2, '0')}:${`${minutes}`.padStart(2, '0')}`

--- a/packages/sanity/src/core/form/inputs/DateInputs/utils.ts
+++ b/packages/sanity/src/core/form/inputs/DateInputs/utils.ts
@@ -33,13 +33,13 @@ export function getCalendarLabels(
       t('calendar.month-names.december'),
     ],
     weekDayNamesShort: [
-      t('calendar.weekday-names.short.sunday'),
       t('calendar.weekday-names.short.monday'),
       t('calendar.weekday-names.short.tuesday'),
       t('calendar.weekday-names.short.wednesday'),
       t('calendar.weekday-names.short.thursday'),
       t('calendar.weekday-names.short.friday'),
       t('calendar.weekday-names.short.saturday'),
+      t('calendar.weekday-names.short.sunday'),
     ],
     setToTimePreset: (time, date) => t('calendar.action.set-to-time-preset', {time, date}),
   }

--- a/packages/sanity/src/core/hooks/__tests__/useUnitFormatter.test.tsx
+++ b/packages/sanity/src/core/hooks/__tests__/useUnitFormatter.test.tsx
@@ -17,7 +17,14 @@ describe('useUnitFormatter', () => {
   const wrapper = ({children}: {children: ReactElement}) => (
     <ThemeProvider theme={studioTheme}>
       <LocaleProviderBase
-        locales={[usEnglishLocale, {id: 'fr-FR', title: 'Français'}]}
+        locales={[
+          usEnglishLocale,
+          {
+            id: 'fr-FR',
+            title: 'Français',
+            weekInfo: {firstDay: 1, minimalDays: 2, weekend: [6, 7]},
+          },
+        ]}
         i18next={i18next}
         projectId="test"
         sourceId="test"

--- a/packages/sanity/src/core/i18n/__tests__/Translate.test.tsx
+++ b/packages/sanity/src/core/i18n/__tests__/Translate.test.tsx
@@ -34,7 +34,13 @@ async function getWrapper(bundles: LocaleResourceBundle[]) {
     return (
       <ThemeProvider theme={studioTheme}>
         <LocaleProviderBase
-          locales={[{id: 'en-US', title: 'English'}]}
+          locales={[
+            {
+              id: 'en-US',
+              title: 'English',
+              weekInfo: {firstDay: 1, minimalDays: 2, weekend: [6, 7]},
+            },
+          ]}
           i18next={i18next}
           projectId="test"
           sourceId="test"

--- a/packages/sanity/src/core/i18n/i18nConfig.ts
+++ b/packages/sanity/src/core/i18n/i18nConfig.ts
@@ -5,7 +5,7 @@ import {resolveConfigProperty} from '../config/resolveConfigProperty'
 import {localeBundlesReducer, localeDefReducer} from '../config/configPropertyReducers'
 import {defaultLocale} from './locales'
 import {createSanityI18nBackend} from './backend'
-import {LocaleSource, LocaleDefinition, LocaleResourceBundle} from './types'
+import type {LocaleSource, LocaleDefinition, LocaleResourceBundle, Locale} from './types'
 import {studioLocaleNamespace} from './localeNamespaces'
 import {getPreferredLocale} from './localeStore'
 import {DEBUG_I18N, maybeWrapT} from './debug'
@@ -62,7 +62,7 @@ function createI18nApi({
     console.error('Failed to initialize i18n backend: %s', err)
   })
 
-  const reducedLocales = locales.map(({id, title}) => ({id, title}))
+  const reducedLocales = locales.map(reduceLocaleDefinition)
 
   return {
     /** @public */
@@ -173,4 +173,17 @@ function getI18NextOptions(
     lng: locale,
     supportedLngs: locales.map((def) => def.id),
   }
+}
+
+/**
+ * Reduce a locale definition to a Locale instance
+ *
+ * @param definition - The locale definition to reduce
+ * @returns A Locale instance
+ * @internal
+ */
+function reduceLocaleDefinition(definition: LocaleDefinition): Locale {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const {bundles, ...locale} = definition
+  return locale
 }

--- a/packages/sanity/src/core/i18n/locales.ts
+++ b/packages/sanity/src/core/i18n/locales.ts
@@ -12,6 +12,12 @@ export const usEnglishLocale = defineLocale({
   id: 'en-US',
   title: 'English (US)',
   bundles: [studioDefaultLocaleResources, validationLocaleResources],
+
+  weekInfo: {
+    firstDay: 7, // Sunday
+    weekend: [6, 7], // Saturday, Sunday
+    minimalDays: 1,
+  },
 })
 
 /**

--- a/packages/sanity/src/core/i18n/types.ts
+++ b/packages/sanity/src/core/i18n/types.ts
@@ -149,6 +149,34 @@ export interface Locale {
    * The title of locale, eg `English (US)`, `Norsk (bokmål)`, `ไทย`…
    */
   title: string
+
+  /**
+   * Week information for this locale. Based on the `Intl.Locale['weekInfo']` type.
+   */
+  weekInfo: LocaleWeekInfo
+}
+
+/**
+ * An object representing week information associated with the Locale data specified in
+ * {@link https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Patterns_Week_Elements | UTS 35's Week Elements }
+ *
+ * @public
+ */
+export interface LocaleWeekInfo {
+  /**
+   * An integer indicating the first day of the week for the locale. Can be either 1 (Monday) or 7 (Sunday).
+   */
+  firstDay: 1 | 7
+
+  /**
+   * An array of integers indicating the weekend days for the locale, where 1 is Monday and 7 is Sunday.
+   */
+  weekend: (1 | 2 | 3 | 4 | 5 | 6 | 7)[]
+
+  /**
+   * An integer between 1 and 7 indicating the minimal days required in the first week of a month or year, for calendar purposes.
+   */
+  minimalDays: 1 | 2 | 3 | 4 | 5 | 6 | 7
 }
 
 /**

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/date/datePicker/calendar/Calendar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/date/datePicker/calendar/Calendar.tsx
@@ -1,6 +1,7 @@
 import {Box, Flex} from '@sanity/ui'
 import {addDays, addMonths, isAfter, isBefore, set} from 'date-fns'
 import React, {KeyboardEvent, useCallback, useEffect, useRef, useState} from 'react'
+import {useCurrentLocale} from '../../../../../../../../../../../i18n/hooks/useLocale'
 import {CalendarContext} from './contexts/CalendarContext'
 import {CalendarHeader} from './CalendarHeader'
 import {CalendarMonth} from './CalendarMonth'
@@ -39,6 +40,10 @@ export function Calendar(props: CalendarProps) {
 
   const previousDate = useRef<Date | null>(date || null)
   const previousEndDate = useRef<Date | null>(endDate || null)
+
+  const {
+    weekInfo: {firstDay: firstWeekDay},
+  } = useCurrentLocale()
 
   const focusCurrentWeekDay = useCallback(() => {
     calendarElement?.querySelector<HTMLElement>(`[data-focused="true"]`)?.focus()
@@ -182,6 +187,7 @@ export function Calendar(props: CalendarProps) {
         fontSize,
         selectRange,
         selectTime,
+        firstWeekDay,
       }}
     >
       <Box data-ui="Calendar" ref={setCalendarElement}>

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/date/datePicker/calendar/CalendarMonth.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/date/datePicker/calendar/CalendarMonth.tsx
@@ -5,7 +5,15 @@ import {useTranslation} from '../../../../../../../../../../../i18n'
 import {CalendarDay} from './CalendarDay'
 import {SHORT_WEEK_DAY_KEYS} from './constants'
 import {useCalendar} from './contexts/useDatePicker'
-import {getWeeksOfMonth} from './utils'
+import {useWeeksOfMonth} from './utils'
+
+const WEEK_DAY_NAME_KEYS = {
+  // Monday is start of the week
+  1: SHORT_WEEK_DAY_KEYS,
+
+  // Sunday is start of the week
+  7: [SHORT_WEEK_DAY_KEYS[6], ...SHORT_WEEK_DAY_KEYS.slice(0, 6)],
+}
 
 interface CalendarMonthProps {
   hidden?: boolean
@@ -17,13 +25,13 @@ const CustomGrid = styled(Grid)`
 `
 
 export function CalendarMonth({hidden, onSelect}: CalendarMonthProps) {
-  const {focusedDate, fontSize} = useCalendar()
+  const {focusedDate, fontSize, firstWeekDay} = useCalendar()
   const {t} = useTranslation()
 
   return (
     <Box aria-hidden={hidden || false} data-ui="CalendarMonth">
       <CustomGrid>
-        {SHORT_WEEK_DAY_KEYS.map((weekdayDay) => (
+        {WEEK_DAY_NAME_KEYS[firstWeekDay].map((weekdayDay) => (
           <Box key={weekdayDay} paddingBottom={3} paddingTop={2}>
             <Text align="center" size={fontSize} weight="medium">
               {t(weekdayDay)}
@@ -31,7 +39,7 @@ export function CalendarMonth({hidden, onSelect}: CalendarMonthProps) {
           </Box>
         ))}
 
-        {getWeeksOfMonth(focusedDate).map((week, weekIdx) =>
+        {useWeeksOfMonth(focusedDate).map((week, weekIdx) =>
           week.days.map((weekDayDate, dayIdx) => {
             return (
               <CalendarDay

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/date/datePicker/calendar/constants.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/date/datePicker/calendar/constants.ts
@@ -17,13 +17,13 @@ export const MONTH_NAME_KEYS: StudioLocaleResourceKeys[] = [
 ]
 
 export const SHORT_WEEK_DAY_KEYS: StudioLocaleResourceKeys[] = [
-  'calendar.weekday-names.short.sunday',
   'calendar.weekday-names.short.monday',
   'calendar.weekday-names.short.tuesday',
   'calendar.weekday-names.short.wednesday',
   'calendar.weekday-names.short.thursday',
   'calendar.weekday-names.short.friday',
   'calendar.weekday-names.short.saturday',
+  'calendar.weekday-names.short.sunday',
 ]
 
 export const HOURS_24 = range(0, 24)

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/date/datePicker/calendar/contexts/CalendarContext.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/date/datePicker/calendar/contexts/CalendarContext.ts
@@ -7,6 +7,12 @@ export interface CalendarContextValue {
   fontSize: number
   selectRange?: boolean
   selectTime?: boolean
+
+  /**
+   * An integer indicating the first day of the week.
+   * Can be either 1 (Monday) or 7 (Sunday).
+   */
+  firstWeekDay: 1 | 7
 }
 
 export const CalendarContext = createContext<CalendarContextValue | undefined>(undefined)

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/date/datePicker/calendar/utils.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/date/datePicker/calendar/utils.ts
@@ -1,15 +1,24 @@
 import {addDays, eachWeekOfInterval, getWeek, lastDayOfMonth, startOfMonth} from 'date-fns'
+import {useCurrentLocale} from '../../../../../../../../../../../i18n/hooks/useLocale'
 import {TAIL_WEEKDAYS} from './constants'
 
-export const getWeekStartsOfMonth = (date: Date): Date[] => {
+/**
+ * NOTE: `weekStartsOn` uses 1 for Monday, 7 for Sunday. date-fns wants 0 for Sunday, 6 for Saturday.
+ */
+const getWeekStartsOfMonth = (date: Date, weekStartsOn: 1 | 2 | 3 | 4 | 5 | 6 | 7): Date[] => {
   const firstDay = startOfMonth(date)
-  return eachWeekOfInterval({
-    start: firstDay,
-    end: lastDayOfMonth(firstDay),
-  })
+  return eachWeekOfInterval(
+    {
+      start: firstDay,
+      end: lastDayOfMonth(firstDay),
+    },
+    {
+      weekStartsOn: weekStartsOn === 7 ? 0 : weekStartsOn,
+    },
+  )
 }
 
-export const getWeekDaysFromWeekStarts = (weekStarts: Date[]): Date[][] => {
+const getWeekDaysFromWeekStarts = (weekStarts: Date[]): Date[][] => {
   return weekStarts.map((weekStart) => [
     weekStart,
     ...TAIL_WEEKDAYS.map((d) => addDays(weekStart, d)),
@@ -21,13 +30,15 @@ type Week = {
   days: Date[]
 }
 
-export const getWeeksOfMonth = (date: Date): Week[] =>
-  getWeekDaysFromWeekStarts(getWeekStartsOfMonth(date)).map(
+export const useWeeksOfMonth = (date: Date): Week[] => {
+  const {weekInfo} = useCurrentLocale()
+  return getWeekDaysFromWeekStarts(getWeekStartsOfMonth(date, weekInfo.firstDay)).map(
     (days): Week => ({
       number: getWeek(days[0]),
       days,
     }),
   )
+}
 
 export const formatTime = (hours: number, minutes: number): string =>
   `${`${hours}`.padStart(2, '0')}:${`${minutes}`.padStart(2, '0')}`


### PR DESCRIPTION
### Description

*Note*: builds on #5343

Currently, the date/datetime/date filter calendars always start the shown weeks on Sundays. This is fine for some locales, but  for others it is more natural to show the week starting on Mondays.

This PR introduces a `weekInfo` object to locale definitions. Theoretically it should be inferable using `new Intl.Locale('en-US').weekInfo` / `new Intl.Locale('en-US').getWeekInfo()`, but it seems browser support is less than ideal, to say the least, so better to define this up front.

### What to review

Calendars still start on Sunday (test studio currently does not have additional locales installed, so hard to test).

### Notes for release

None
