### PR TITLE
fix(core): add timestamps to all preview components

### DIFF
--- a/packages/sanity/src/core/form/studio/inputs/client-adapters/reference.ts
+++ b/packages/sanity/src/core/form/studio/inputs/client-adapters/reference.ts
@@ -100,11 +100,7 @@ export function getReferenceInfo(
             } as const)
           }
 
-          const previewPaths = [
-            ...(getPreviewPaths(refSchemaType?.preview) || []),
-            ['_updatedAt'],
-            ['_createdAt'],
-          ]
+          const previewPaths = [...(getPreviewPaths(refSchemaType?.preview) || [])]
 
           const draftPreview$ = documentPreviewStore.observePaths(draftRef, previewPaths).pipe(
             map((result) =>

--- a/packages/sanity/src/core/form/studio/inputs/crossDatasetReference/datastores/getReferenceInfo.ts
+++ b/packages/sanity/src/core/form/studio/inputs/crossDatasetReference/datastores/getReferenceInfo.ts
@@ -74,11 +74,7 @@ export function createGetReferenceInfo(context: {
           (candidate) => candidate.type === resolvedDoc._type,
         )
 
-        const previewPaths = [
-          ...(getPreviewPaths(refSchemaType?.preview) || []),
-          ['_updatedAt'],
-          ['_createdAt'],
-        ]
+        const previewPaths = [...(getPreviewPaths(refSchemaType?.preview) || [])]
 
         const publishedPreview$ = documentPreviewStore
           .observePaths(doc as Previewable, previewPaths, apiConfig)

--- a/packages/sanity/src/core/preview/utils/getPreviewPaths.ts
+++ b/packages/sanity/src/core/preview/utils/getPreviewPaths.ts
@@ -1,15 +1,18 @@
 import {SchemaType} from '@sanity/types'
 import {PreviewPath} from '../types'
 
+const DEFAULT_PREVIEW_PATHS: PreviewPath[] = [['_createdAt'], ['_updatedAt']]
+
 /** @internal */
 export function getPreviewPaths(preview: SchemaType['preview']): PreviewPath[] | undefined {
   const selection = preview?.select
 
   if (!selection) return undefined
 
-  return [
-    ...(Object.values(selection).map((value) => String(value).split('.')) || []),
-    ['_createdAt'],
-    ['_updatedAt'],
-  ]
+  // Transform the selection dot-notation paths into array paths.
+  // Example: ['object.title', 'name'] => [['object', 'title'], ['name']]
+  const paths = Object.keys(selection).map((value) => String(value).split('.')) || []
+
+  // Return the paths with the default preview paths appended.
+  return paths.concat(DEFAULT_PREVIEW_PATHS)
 }

--- a/packages/sanity/src/core/preview/utils/getPreviewPaths.ts
+++ b/packages/sanity/src/core/preview/utils/getPreviewPaths.ts
@@ -7,5 +7,9 @@ export function getPreviewPaths(preview: SchemaType['preview']): PreviewPath[] |
 
   if (!selection) return undefined
 
-  return Object.values(selection).map((value) => String(value).split('.'))
+  return [
+    ...(Object.values(selection).map((value) => String(value).split('.')) || []),
+    ['_createdAt'],
+    ['_updatedAt'],
+  ]
 }


### PR DESCRIPTION
### Description
Unless explicitly added, the `updatedAt` prop was not included in the previews, hence not showing a timestamp for when it was last edited/published.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
That the list previews (and all previews really) show a correct timestamp of last edited/published
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fixes issue where timestamp was not included in last edited/published in list previews 
<!--
A description of the change(s) that should be used in the release notes.
-->
