### PR TITLE
feat(cli): treat telemetry consent as denied when running in CI

### DIFF
--- a/packages/@sanity/cli/src/util/createTelemetryStore.ts
+++ b/packages/@sanity/cli/src/util/createTelemetryStore.ts
@@ -2,6 +2,7 @@ import {createClient, SanityClient} from '@sanity/client'
 import {ConsentStatus, createBatchedStore, createSessionId, TelemetryEvent} from '@sanity/telemetry'
 import {debug as baseDebug} from '../debug'
 import {getCliToken} from './clientWrapper'
+import {isCi} from './isCi'
 
 const debug = baseDebug.extend('telemetry')
 
@@ -60,6 +61,10 @@ export function createTelemetryStore(options: {env: {[key: string]: string | und
 
   function resolveConsent(): Promise<{status: ConsentStatus}> {
     debug('Resolving consent…')
+    if (isCi) {
+      debug('CI environment detected, treating telemetry consent as denied')
+      return Promise.resolve({status: 'denied'})
+    }
     if (isTrueish(env.DO_NOT_TRACK)) {
       debug('DO_NOT_TRACK is set, consent is denied')
       return Promise.resolve({status: 'denied'})
@@ -118,6 +123,7 @@ export function createTelemetryStore(options: {env: {[key: string]: string | und
     resolveConsent,
     sendEvents,
   })
+
   process.once('beforeExit', () => store.flush())
   return store
 }

--- a/packages/@sanity/cli/src/util/isCi.ts
+++ b/packages/@sanity/cli/src/util/isCi.ts
@@ -1,0 +1,5 @@
+/* eslint-disable no-process-env */
+export const isCi =
+  process.env.CI || // Travis CI, CircleCI, Gitlab CI, Appveyor, CodeShip
+  process.env.CONTINUOUS_INTEGRATION || // Travis CI
+  process.env.BUILD_NUMBER // Jenkins, TeamCity

--- a/packages/@sanity/cli/src/util/updateNotifier.ts
+++ b/packages/@sanity/cli/src/util/updateNotifier.ts
@@ -8,13 +8,12 @@ import type {PackageJson} from '../types'
 import {getCliUpgradeCommand} from '../packageManager'
 import {debug} from '../debug'
 import {getUserConfig} from './getUserConfig'
+import {isCi} from './isCi'
 
 const MAX_BLOCKING_TIME = 300
 const TWELVE_HOURS = 1000 * 60 * 60 * 12
 const isDisabled =
-  process.env.CI || // Travis CI, CircleCI, Gitlab CI, Appveyor, CodeShip
-  process.env.CONTINUOUS_INTEGRATION || // Travis CI
-  process.env.BUILD_NUMBER || // Jenkins, TeamCity
+  isCi || // Running in CI environment
   process.env.NO_UPDATE_NOTIFIER // Explicitly disabled
 
 interface UpdateCheckOptions {


### PR DESCRIPTION
### Description

Telemetry consent is now treated as denied if the CLI appears to be running in a CI environment. This causes consent resolution and data submission to be skipped.

Primarily this is useful because it reduces collection of irrelevant data.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
