### PR TITLE
feat(cli): add `schemaId` flag for initialising projects from schema builder

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/bootstrapTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init-project/bootstrapTemplate.ts
@@ -11,10 +11,16 @@ import {createCliConfig} from './createCliConfig'
 import {createStudioConfig, GenerateConfigOptions} from './createStudioConfig'
 import type {ProjectTemplate} from './initProject'
 import templates from './templates'
+import {
+  assembeIndexContent,
+  builderSchemaToFileContents,
+  fetchBuilderSchema,
+} from '../../util/builderSchema'
 
 export interface BootstrapOptions {
   packageName: string
   templateName: string
+  builderId?: string
   outputPath: string
   useTypeScript: boolean
   variables: GenerateConfigOptions['variables']
@@ -47,6 +53,23 @@ export async function bootstrapTemplate(
 
   if (useTypeScript) {
     await fs.copyFile(path.join(sharedDir, 'tsconfig.json'), path.join(outputPath, 'tsconfig.json'))
+  }
+
+  // If we have a builder ID, the template is assembled from the builder schema
+  if (opts.builderId) {
+    debug('Fetching builder schema "%s"', opts.builderId)
+    const documents = await fetchBuilderSchema(opts.builderId)
+    const ext = useTypeScript ? 'ts' : 'js'
+    for (const document of documents) {
+      debug('Writing schema file for "%s"', document.name)
+      const schemaPath = path.join(outputPath, 'schemas', `${document.name}.${ext}`)
+      const fileContents = builderSchemaToFileContents(document)
+      await fs.mkdir(path.dirname(schemaPath), {recursive: true})
+      await fs.writeFile(schemaPath, fileContents)
+    }
+    debug('Assembling and overwriting the existing index file for schemas')
+    const indexContent = assembeIndexContent(documents)
+    await fs.writeFile(path.join(outputPath, 'schemas', `index.${ext}`), indexContent)
   }
 
   spinner.succeed()

--- a/packages/@sanity/cli/src/actions/init-project/bootstrapTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init-project/bootstrapTemplate.ts
@@ -20,6 +20,11 @@ import {
 export interface BootstrapOptions {
   packageName: string
   templateName: string
+  /**
+   * Used for initializing a project from a Schema Builder schema.
+   * This will override the `template` option.
+   * @beta
+   */
   schemaId?: string
   outputPath: string
   useTypeScript: boolean
@@ -55,7 +60,7 @@ export async function bootstrapTemplate(
     await fs.copyFile(path.join(sharedDir, 'tsconfig.json'), path.join(outputPath, 'tsconfig.json'))
   }
 
-  // If we have a builder ID, the template is assembled from the builder schema
+  // If we have a schemaId, the template is assembled from the builder schema
   if (opts.schemaId) {
     debug('Fetching builder schema "%s"', opts.schemaId)
     const documents = await fetchBuilderSchema(opts.schemaId)

--- a/packages/@sanity/cli/src/actions/init-project/bootstrapTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init-project/bootstrapTemplate.ts
@@ -20,7 +20,7 @@ import {
 export interface BootstrapOptions {
   packageName: string
   templateName: string
-  builderId?: string
+  schemaId?: string
   outputPath: string
   useTypeScript: boolean
   variables: GenerateConfigOptions['variables']
@@ -56,9 +56,9 @@ export async function bootstrapTemplate(
   }
 
   // If we have a builder ID, the template is assembled from the builder schema
-  if (opts.builderId) {
-    debug('Fetching builder schema "%s"', opts.builderId)
-    const documents = await fetchBuilderSchema(opts.builderId)
+  if (opts.schemaId) {
+    debug('Fetching builder schema "%s"', opts.schemaId)
+    const documents = await fetchBuilderSchema(opts.schemaId)
     const ext = useTypeScript ? 'ts' : 'js'
     for (const document of documents) {
       debug('Writing schema file for "%s"', document.name)

--- a/packages/@sanity/cli/src/actions/init-project/bootstrapTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init-project/bootstrapTemplate.ts
@@ -12,7 +12,7 @@ import {createStudioConfig, GenerateConfigOptions} from './createStudioConfig'
 import type {ProjectTemplate} from './initProject'
 import templates from './templates'
 import {
-  assembeIndexContent,
+  assembeBuilderIndexContent,
   builderSchemaToFileContents,
   fetchBuilderSchema,
 } from '../../util/builderSchema'
@@ -68,7 +68,7 @@ export async function bootstrapTemplate(
       await fs.writeFile(schemaPath, fileContents)
     }
     debug('Assembling and overwriting the existing index file for schemas')
-    const indexContent = assembeIndexContent(documents)
+    const indexContent = assembeBuilderIndexContent(documents)
     await fs.writeFile(path.join(outputPath, 'schemas', `index.${ext}`), indexContent)
   }
 

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -65,6 +65,7 @@ const isCI = process.env.CI
 
 export interface InitOptions {
   template: string
+  builderId?: string
   outputDir: string
   name: string
   displayName: string
@@ -451,6 +452,7 @@ export default async function initSanity(
     outputPath,
     packageName: sluggedName,
     templateName,
+    builderId: cliFlags.builderId,
     useTypeScript,
     variables: {
       dataset: datasetName,
@@ -813,7 +815,13 @@ export default async function initSanity(
   }
 
   function selectProjectTemplate() {
-    const defaultTemplate = unattended || flags.template ? flags.template || 'clean' : null
+    // Make sure the builderId and the template flag are not used together
+    // Force template to clean if builderId is used
+    if (flags.builderId) {
+      return 'clean'
+    }
+
+    const defaultTemplate = !unattended && !flags.template ? flags.template || 'clean' : null
     if (defaultTemplate) {
       return defaultTemplate
     }

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -821,7 +821,7 @@ export default async function initSanity(
       return 'clean'
     }
 
-    const defaultTemplate = !unattended && !flags.template ? flags.template || 'clean' : null
+    const defaultTemplate = unattended || flags.template ? flags.template || 'clean' : null
     if (defaultTemplate) {
       return defaultTemplate
     }

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -65,7 +65,7 @@ const isCI = process.env.CI
 
 export interface InitOptions {
   template: string
-  builderId?: string
+  schemaId?: string
   outputDir: string
   name: string
   displayName: string
@@ -452,7 +452,7 @@ export default async function initSanity(
     outputPath,
     packageName: sluggedName,
     templateName,
-    builderId: cliFlags.builderId,
+    schemaId: cliFlags.schemaId,
     useTypeScript,
     variables: {
       dataset: datasetName,
@@ -815,9 +815,9 @@ export default async function initSanity(
   }
 
   function selectProjectTemplate() {
-    // Make sure the builderId and the template flag are not used together
-    // Force template to clean if builderId is used
-    if (flags.builderId) {
+    // Make sure the schemaId and the template flag are not used together
+    // Force template to clean if schemaId is used
+    if (flags.schemaId) {
       return 'clean'
     }
 

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -65,6 +65,11 @@ const isCI = process.env.CI
 
 export interface InitOptions {
   template: string
+  /**
+   * Used for initializing a project from a Schema Builder schema.
+   * This will override the `template` option.
+   * @beta
+   */
   schemaId?: string
   outputDir: string
   name: string

--- a/packages/@sanity/cli/src/commands/init/initCommand.ts
+++ b/packages/@sanity/cli/src/commands/init/initCommand.ts
@@ -13,6 +13,7 @@ Options
   --dataset-default Set up a project with a public dataset named "production"
   --output-path <path> Path to write studio project to
   --template <template> Project template to use [default: "clean"]
+  --schemaId <schemaId>: Init studio from a Schema Builder schema. Start your schema design at: https://schema.club. (alpha)
   --bare Skip the Studio initialization and only print the selected project ID and dataset name to stdout
   --env <filename> Write environment variables to file [default: ".env"]
   --provider <provider> Login provider to use

--- a/packages/@sanity/cli/src/commands/init/initCommand.ts
+++ b/packages/@sanity/cli/src/commands/init/initCommand.ts
@@ -51,6 +51,7 @@ export interface InitFlags {
   project?: string
   dataset?: string
   template?: string
+  builderId?: string
   visibility?: string
   typescript?: boolean
   bare?: boolean

--- a/packages/@sanity/cli/src/commands/init/initCommand.ts
+++ b/packages/@sanity/cli/src/commands/init/initCommand.ts
@@ -13,7 +13,6 @@ Options
   --dataset-default Set up a project with a public dataset named "production"
   --output-path <path> Path to write studio project to
   --template <template> Project template to use [default: "clean"]
-  --schemaId <schemaId>: Init studio from a Schema Builder schema. Start your schema design at: https://schema.club (alpha)
   --bare Skip the Studio initialization and only print the selected project ID and dataset name to stdout
   --env <filename> Write environment variables to file [default: ".env"]
   --provider <provider> Login provider to use

--- a/packages/@sanity/cli/src/commands/init/initCommand.ts
+++ b/packages/@sanity/cli/src/commands/init/initCommand.ts
@@ -51,6 +51,11 @@ export interface InitFlags {
   project?: string
   dataset?: string
   template?: string
+  /**
+   * Used for initializing a project from a Schema Builder schema.
+   * This will override the `template` option.
+   * @beta
+   */
   schemaId?: string
   visibility?: string
   typescript?: boolean

--- a/packages/@sanity/cli/src/commands/init/initCommand.ts
+++ b/packages/@sanity/cli/src/commands/init/initCommand.ts
@@ -13,7 +13,7 @@ Options
   --dataset-default Set up a project with a public dataset named "production"
   --output-path <path> Path to write studio project to
   --template <template> Project template to use [default: "clean"]
-  --schemaId <schemaId>: Init studio from a Schema Builder schema. Start your schema design at: https://schema.club. (alpha)
+  --schemaId <schemaId>: Init studio from a Schema Builder schema. Start your schema design at: https://schema.club (alpha)
   --bare Skip the Studio initialization and only print the selected project ID and dataset name to stdout
   --env <filename> Write environment variables to file [default: ".env"]
   --provider <provider> Login provider to use

--- a/packages/@sanity/cli/src/commands/init/initCommand.ts
+++ b/packages/@sanity/cli/src/commands/init/initCommand.ts
@@ -51,7 +51,7 @@ export interface InitFlags {
   project?: string
   dataset?: string
   template?: string
-  builderId?: string
+  schemaId?: string
   visibility?: string
   typescript?: boolean
   bare?: boolean

--- a/packages/@sanity/cli/src/util/builderSchema.ts
+++ b/packages/@sanity/cli/src/util/builderSchema.ts
@@ -1,0 +1,83 @@
+import {DocumentDefinition, ObjectDefinition} from '@sanity/types'
+
+type DocumentOrObject = DocumentDefinition | ObjectDefinition
+
+const BUILDER_URL_BASE = 'https://schema.club/api/get-schema'
+
+/**
+ * Fetch a builder schema from the Sanity schema club API
+ *
+ * @param builderId - The slug of the builder schema to fetch
+ * @returns The builder schema as an array of Sanity document or object definitions
+ */
+export async function fetchBuilderSchema(builderId: string): Promise<DocumentOrObject[]> {
+  if (!builderId) {
+    throw new Error('Builder ID is required')
+  }
+  try {
+    const response = await fetch(`${BUILDER_URL_BASE}/${builderId}`)
+    const text = await response.text()
+    return safeEval(text)
+  } catch (err) {
+    throw new Error(`Failed to fetch builder schema ${builderId}`)
+  }
+}
+
+/**
+ * Pretty print a builder schema as a string
+ *
+ * @param schemas - The builder schema to pretty print
+ * @returns The pretty printed builder schema
+ */
+export function prettyBuilderSchema(schemas: object) {
+  return JSON.stringify(
+    schemas,
+    (_, value: unknown) => {
+      // Replace functions with a string representation since they can't be serialized
+      if (typeof value === 'function') {
+        const fnString = value?.toString().replace(/\s*=>\s*/g, ' => ')
+        return `function:${fnString}`
+      }
+      return value
+    },
+    2,
+  )
+    .replace(/"([^"]+)":/g, '$1:') // Remove quotes around keys
+    .replace(/"function:([^"]+)"/g, '$1') // Remove quotes around functions (and the function: prefix)
+    .replace(/"/g, "'") // Replace double quotes with single quotes
+}
+
+/**
+ * Wrap a builder schema in a module export
+ *
+ * @param schema - The builder schema to wrap in a module export
+ * @returns The builder schema as a module export
+ */
+export function builderSchemaToFileContents(schema: DocumentOrObject): string {
+  const prettySchema = prettyBuilderSchema(schema)
+  return `export const ${schema.name} = ${prettySchema}\n`
+}
+
+/**
+ * Assemble a list of builder schema module exports into a single index file
+ *
+ * @param schemas - The builder schemas to assemble into an index file
+ * @returns The index file as a string
+ */
+export function assembeIndexContent(schemas: DocumentOrObject[]): string {
+  schemas.sort((a, b) => (a.name > b.name ? 1 : -1)) // Sort schemas alphabetically by name
+  const imports = schemas.map((schema) => `import { ${schema.name} } from './${schema.name}'`)
+  const exports = schemas.map((schema) => `\t${schema.name}`).join(',\n')
+  return `${imports.join('\n')}\n\nexport const schemaTypes = [\n${exports}\n]`
+}
+
+/**
+ * Safely evaluate a string as JavaScript
+ *
+ * @param code - The code to evaluate
+ * @returns The result of the evaluation
+ */
+function safeEval(code: string): DocumentOrObject[] {
+  // eslint-disable-next-line no-new-func
+  return Function(`"use strict";return (${code})`)()
+}

--- a/packages/@sanity/cli/src/util/builderSchema.ts
+++ b/packages/@sanity/cli/src/util/builderSchema.ts
@@ -17,7 +17,7 @@ export async function fetchBuilderSchema(builderId: string): Promise<DocumentOrO
   try {
     const response = await fetch(`${BUILDER_URL_BASE}/${builderId}`)
     const text = await response.text()
-    return safeEval(text)
+    return safeishEval(text)
   } catch (err) {
     throw new Error(`Failed to fetch builder schema ${builderId}`)
   }
@@ -77,7 +77,7 @@ export function assembeIndexContent(schemas: DocumentOrObject[]): string {
  * @param code - The code to evaluate
  * @returns The result of the evaluation
  */
-function safeEval(code: string): DocumentOrObject[] {
+function safeishEval(code: string): DocumentOrObject[] {
   // eslint-disable-next-line no-new-func
   return Function(`"use strict";return (${code})`)()
 }

--- a/packages/@sanity/cli/src/util/builderSchema.ts
+++ b/packages/@sanity/cli/src/util/builderSchema.ts
@@ -12,7 +12,7 @@ const BUILDER_URL_BASE = 'https://schema.club/api/get-schema'
  */
 export async function fetchBuilderSchema(schemaId: string): Promise<DocumentOrObject[]> {
   if (!schemaId) {
-    throw new Error('Builder ID is required')
+    throw new Error('SchemaId is required')
   }
   try {
     const response = await fetch(`${BUILDER_URL_BASE}/${schemaId}`)

--- a/packages/@sanity/cli/src/util/builderSchema.ts
+++ b/packages/@sanity/cli/src/util/builderSchema.ts
@@ -7,19 +7,19 @@ const BUILDER_URL_BASE = 'https://schema.club/api/get-schema'
 /**
  * Fetch a builder schema from the Sanity schema club API
  *
- * @param builderId - The slug of the builder schema to fetch
+ * @param schemaId - The slug of the builder schema to fetch
  * @returns The builder schema as an array of Sanity document or object definitions
  */
-export async function fetchBuilderSchema(builderId: string): Promise<DocumentOrObject[]> {
-  if (!builderId) {
+export async function fetchBuilderSchema(schemaId: string): Promise<DocumentOrObject[]> {
+  if (!schemaId) {
     throw new Error('Builder ID is required')
   }
   try {
-    const response = await fetch(`${BUILDER_URL_BASE}/${builderId}`)
+    const response = await fetch(`${BUILDER_URL_BASE}/${schemaId}`)
     const text = await response.text()
     return safeishEval(text)
   } catch (err) {
-    throw new Error(`Failed to fetch builder schema ${builderId}`)
+    throw new Error(`Failed to fetch builder schema ${schemaId}`)
   }
 }
 

--- a/packages/@sanity/cli/src/util/builderSchema.ts
+++ b/packages/@sanity/cli/src/util/builderSchema.ts
@@ -24,30 +24,6 @@ export async function fetchBuilderSchema(builderId: string): Promise<DocumentOrO
 }
 
 /**
- * Pretty print a builder schema as a string
- *
- * @param schemas - The builder schema to pretty print
- * @returns The pretty printed builder schema
- */
-export function prettyBuilderSchema(schemas: object) {
-  return JSON.stringify(
-    schemas,
-    (_, value: unknown) => {
-      // Replace functions with a string representation since they can't be serialized
-      if (typeof value === 'function') {
-        const fnString = value?.toString().replace(/\s*=>\s*/g, ' => ')
-        return `function:${fnString}`
-      }
-      return value
-    },
-    2,
-  )
-    .replace(/"([^"]+)":/g, '$1:') // Remove quotes around keys
-    .replace(/"function:([^"]+)"/g, '$1') // Remove quotes around functions (and the function: prefix)
-    .replace(/"/g, "'") // Replace double quotes with single quotes
-}
-
-/**
  * Wrap a builder schema in a module export
  *
  * @param schema - The builder schema to wrap in a module export
@@ -64,7 +40,7 @@ export function builderSchemaToFileContents(schema: DocumentOrObject): string {
  * @param schemas - The builder schemas to assemble into an index file
  * @returns The index file as a string
  */
-export function assembeIndexContent(schemas: DocumentOrObject[]): string {
+export function assembeBuilderIndexContent(schemas: DocumentOrObject[]): string {
   schemas.sort((a, b) => (a.name > b.name ? 1 : -1)) // Sort schemas alphabetically by name
   const imports = schemas.map((schema) => `import { ${schema.name} } from './${schema.name}'`)
   const exports = schemas.map((schema) => `\t${schema.name}`).join(',\n')
@@ -80,4 +56,28 @@ export function assembeIndexContent(schemas: DocumentOrObject[]): string {
 function safeishEval(code: string): DocumentOrObject[] {
   // eslint-disable-next-line no-new-func
   return Function(`"use strict";return (${code})`)()
+}
+
+/**
+ * Pretty print a builder schema as a string
+ *
+ * @param schemas - The builder schema to pretty print
+ * @returns The pretty printed builder schema
+ */
+function prettyBuilderSchema(schemas: object) {
+  return JSON.stringify(
+    schemas,
+    (_, value: unknown) => {
+      // Replace functions with a string representation since they can't be serialized
+      if (typeof value === 'function') {
+        const fnString = value?.toString().replace(/\s*=>\s*/g, ' => ')
+        return `function:${fnString}`
+      }
+      return value
+    },
+    2,
+  )
+    .replace(/"([^"]+)":/g, '$1:') // Remove quotes around keys
+    .replace(/"function:([^"]+)"/g, '$1') // Remove quotes around functions (and the function: prefix)
+    .replace(/"/g, "'") // Replace double quotes with single quotes
 }

--- a/packages/@sanity/cli/src/workers/getAndWriteBuilderSchema.ts
+++ b/packages/@sanity/cli/src/workers/getAndWriteBuilderSchema.ts
@@ -1,0 +1,6 @@
+import {parentPort, workerData} from 'worker_threads'
+import {getAndWriteBuilderSchema} from '../util/builderSchema'
+
+getAndWriteBuilderSchema(workerData)
+  .then(() => parentPort?.postMessage({type: 'success'}))
+  .catch((error) => parentPort?.postMessage({type: 'error', error}))


### PR DESCRIPTION
### Description

This PR adds a hidden `schemaId` flag to the CLI, specifically for the `init` command. This flag allows a user to initialize a project from the schema builder, overring the default behavior of prompting the user for a template.

This was initially supposed to be a hidden flag, but after discussion I have added a new help text to the `init` command
```shell
--schemaId <schemaId>: Init studio from a Schema Builder schema. Start your schema design at: https://schema.club. (alpha)
```

### What to review

Run `sanity init --schemaId ZaEh6uHn` and verify that the project is initialized from the schema builder.

### Notes for release

~No notes for release. This is a hidden flag, so it should not be documented in the CLI help.~