### PR TITLE
fix(cli): add (experimental) support for bun as package manager

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -503,6 +503,7 @@ export default async function initSanity(
     yarn: 'yarn dev',
     npm: 'npm run dev',
     pnpm: 'pnpm dev',
+    bun: 'bun dev # experimental',
     manual: 'npm run dev',
   }
   const devCommand = devCommandMap[pkgManager.chosen]

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -503,7 +503,7 @@ export default async function initSanity(
     yarn: 'yarn dev',
     npm: 'npm run dev',
     pnpm: 'pnpm dev',
-    bun: 'bun dev # experimental',
+    bun: 'bun dev',
     manual: 'npm run dev',
   }
   const devCommand = devCommandMap[pkgManager.chosen]

--- a/packages/@sanity/cli/src/packageManager/installPackages.ts
+++ b/packages/@sanity/cli/src/packageManager/installPackages.ts
@@ -33,6 +33,10 @@ export async function installDeclaredPackages(
     const pnpmArgs = ['install']
     output.print(`Running 'pnpm ${pnpmArgs.join(' ')}'`)
     result = await execa('pnpm', pnpmArgs, execOptions)
+  } else if (packageManager === 'bun') {
+    const bunArgs = ['install']
+    output.print(`Running 'bun ${bunArgs.join(' ')}'`)
+    result = await execa('bun', bunArgs, execOptions)
   } else if (packageManager === 'manual') {
     output.print(`Manual installation selected - run 'npm ${npmArgs.join(' ')}' or similar`)
   }
@@ -68,6 +72,10 @@ export async function installNewPackages(
     const pnpmArgs = ['add', '--save-prod', ...packages]
     output.print(`Running 'pnpm ${pnpmArgs.join(' ')}'`)
     result = await execa('pnpm', pnpmArgs, execOptions)
+  } else if (packageManager === 'bun') {
+    const bunArgs = ['add', ...packages]
+    output.print(`Running 'bun ${bunArgs.join(' ')}'`)
+    result = await execa('bun', bunArgs, execOptions)
   } else if (packageManager === 'manual') {
     output.print(`Manual installation selected - run 'npm ${npmArgs.join(' ')}' or equivalent`)
   }

--- a/packages/@sanity/cli/src/packageManager/packageManagerChoice.ts
+++ b/packages/@sanity/cli/src/packageManager/packageManagerChoice.ts
@@ -5,7 +5,7 @@ import preferredPM from 'preferred-pm'
 import {isInteractive} from '../util/isInteractive'
 import {CliPrompter} from '../types'
 
-export type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'manual'
+export type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun' | 'manual'
 
 /**
  * Attempts to resolve the most optimal package manager to use to install/upgrade
@@ -79,17 +79,28 @@ async function getFallback(cwd: string): Promise<PackageManager> {
     return 'pnpm'
   }
 
+  if (await hasBunInstalled(cwd)) {
+    return 'bun'
+  }
+
   return 'manual'
 }
 
 async function getAvailablePackageManagers(cwd: string): Promise<PackageManager[]> {
-  const [npm, yarn, pnpm] = await Promise.all([
+  const [npm, yarn, pnpm, bun] = await Promise.all([
     hasNpmInstalled(cwd),
     hasYarnInstalled(cwd),
     hasPnpmInstalled(cwd),
+    hasBunInstalled(cwd),
   ])
 
-  const choices = [npm && 'npm', yarn && 'yarn', pnpm && 'pnpm', 'manual']
+  const choices = [
+    npm && 'npm',
+    yarn && 'yarn',
+    pnpm && 'pnpm',
+    bun && 'bun (experimental)',
+    'manual',
+  ]
   return choices.filter((pm): pm is PackageManager => pm !== false)
 }
 
@@ -103,6 +114,10 @@ export function hasYarnInstalled(cwd?: string): Promise<boolean> {
 
 export function hasPnpmInstalled(cwd?: string): Promise<boolean> {
   return hasCommand('pnpm', cwd)
+}
+
+export function hasBunInstalled(cwd?: string): Promise<boolean> {
+  return hasCommand('bun', cwd)
 }
 
 export function getNpmRunPath(cwd: string): string {


### PR DESCRIPTION
### Description
Adds bun as (experimental) package manager to use for sanity projects

![image](https://github.com/sanity-io/sanity/assets/876086/defd9a25-39f5-401a-b8c9-8af74f819fc2)

### What to review
Is marking it as experimental necessary? My reasoning was that we don't expclitly test with `bun` and (afaik) haven't aquired much data/confidence about adoption/error rates.

### Notes for release

- Add bun as possible package manager to use for new sanity projects