### PR TITLE
fix(portable-text-editor): fix safari focus issue on empty editor

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -166,10 +166,10 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
       if (renderPlaceholder && lProps.leaf.placeholder && lProps.text.text === '') {
         return (
           <>
+            {rendered}
             <span style={PLACEHOLDER_STYLE} contentEditable={false}>
               {renderPlaceholder()}
             </span>
-            {rendered}
           </>
         )
       }


### PR DESCRIPTION
### Description

This fixes a issue in Safari where focus in a activated, empty PTE input a second time won't allow you to type unless you click the "Empty" placeholder precisely.

### What to review

- That focus behaviour behaves the same was as before in all the normal browsers
- That focus activates properly on repeated tabbing into the same empty input

### Notes for release

- Fixes an issue where focus on a empty Portable Text Input won't work consistently in Safari
