### PR TITLE
fix(core): update getPreviewPaths function

### DIFF
--- a/packages/sanity/src/core/preview/utils/getPreviewPaths.test.ts
+++ b/packages/sanity/src/core/preview/utils/getPreviewPaths.test.ts
@@ -1,0 +1,35 @@
+import {SchemaType} from '@sanity/types'
+import {getPreviewPaths} from './getPreviewPaths'
+
+const preview: SchemaType['preview'] = {
+  select: {
+    title: 'name',
+    awards: 'awards',
+    role: 'role',
+    relatedAuthors: 'relatedAuthors',
+    lastUpdated: '_updatedAt',
+    media: 'image',
+  },
+}
+
+describe('getPreviewPaths', () => {
+  it('Should return undefined if no selection is provided', () => {
+    const paths = getPreviewPaths({
+      select: undefined,
+    })
+    expect(paths).toBeUndefined()
+  })
+  it('should return the default preview paths', () => {
+    const paths = getPreviewPaths(preview)
+    expect(paths).toEqual([
+      ['name'],
+      ['awards'],
+      ['role'],
+      ['relatedAuthors'],
+      ['_updatedAt'],
+      ['image'],
+      ['_createdAt'],
+      ['_updatedAt'],
+    ])
+  })
+})

--- a/packages/sanity/src/core/preview/utils/getPreviewPaths.ts
+++ b/packages/sanity/src/core/preview/utils/getPreviewPaths.ts
@@ -11,7 +11,7 @@ export function getPreviewPaths(preview: SchemaType['preview']): PreviewPath[] |
 
   // Transform the selection dot-notation paths into array paths.
   // Example: ['object.title', 'name'] => [['object', 'title'], ['name']]
-  const paths = Object.keys(selection).map((value) => String(value).split('.')) || []
+  const paths = Object.values(selection).map((value) => String(value).split('.')) || []
 
   // Return the paths with the default preview paths appended.
   return paths.concat(DEFAULT_PREVIEW_PATHS)


### PR DESCRIPTION
### Description

Fixes issue introduced in which the custom previews are not showing the values, introduced by this changes https://github.com/sanity-io/sanity/pull/5352/files#diff-82e6260f1ef4bafb24e139098b0b68d038a73f2043aa977530bd59749b025228R14

![Screenshot 2023-12-13 at 16 35 06](https://github.com/sanity-io/sanity/assets/46196328/4570696f-eb67-436e-b523-9a20719df298)

![Screenshot 2023-12-13 at 16 35 35](https://github.com/sanity-io/sanity/assets/46196328/eee06065-eeca-4a28-81a9-05392b68cda3)

Should be using `Object.values` instead of `Object.keys`


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
