### PR TITLE
fix(i18n): fix incorrect menu items; localize default group titles

### DIFF
--- a/packages/@sanity/schema/src/legacy/ordering/guessOrderingConfig.ts
+++ b/packages/@sanity/schema/src/legacy/ordering/guessOrderingConfig.ts
@@ -1,4 +1,5 @@
 import {capitalize, startCase} from 'lodash'
+import {SortOrdering} from '@sanity/types'
 
 const CANDIDATES = ['title', 'name', 'label', 'heading', 'header', 'caption', 'description']
 
@@ -6,7 +7,7 @@ const PRIMITIVES = ['string', 'boolean', 'number']
 
 const isPrimitive = (field) => PRIMITIVES.includes(field.type)
 
-export default function guessOrderingConfig(objectTypeDef) {
+export default function guessOrderingConfig(objectTypeDef): SortOrdering[] {
   let candidates = CANDIDATES.filter((candidate) =>
     objectTypeDef.fields.some((field) => isPrimitive(field) && field.name === candidate),
   )
@@ -16,13 +17,14 @@ export default function guessOrderingConfig(objectTypeDef) {
     candidates = objectTypeDef.fields.filter(isPrimitive).map((field) => field.name)
   }
 
-  return candidates.map((name) => ({
-    name: name,
-    i18n: {
-      key: `default-orderings.${name}`,
-      ns: 'studio',
-    },
-    title: capitalize(startCase(name)),
-    by: [{field: name, direction: 'asc'}],
-  }))
+  return candidates.map(
+    (name): SortOrdering => ({
+      name: name,
+      i18n: {
+        title: {key: `default-orderings.${name}`, ns: 'studio'},
+      },
+      title: capitalize(startCase(name)),
+      by: [{field: name, direction: 'asc'}],
+    }),
+  )
 }

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -300,6 +300,9 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Title for the Review Changes pane */
   'changes.title': 'Review changes',
 
+  /** The fallback title for an ordering menu item if no localized titles are provided. */
+  'default-menu-item.fallback-title': 'Sort by {{title}}',
+
   /** Title for the default ordering/SortOrder if no orderings are provided and the caption field is found */
   'default-orderings.caption': 'Sort by Caption',
   /** Title for the default ordering/SortOrder if no orderings are provided and the description field is found */

--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -251,6 +251,13 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'insufficient-permissions-message-tooltip.loading-text': 'Loading…',
 
   /** --- Menu items --- */
+  /** The menu item group title to use for the Action menu items */
+  'menu-item-groups.actions-group': 'Actions',
+  /** The menu item group title to use for the Layout menu items */
+  'menu-item-groups.layout-group': 'Layout',
+  /** The menu item group title to use for the Sort menu items */
+  'menu-item-groups.sorting-group': 'Sort',
+
   /** The menu item title to use the compact view */
   'menu-items.layout.compact-view': 'Compact view',
   /** The menu item title to use the detailed view */

--- a/packages/sanity/src/desk/structureBuilder/MenuItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/MenuItem.ts
@@ -285,7 +285,14 @@ export function getOrderingMenuItem(
 ): MenuItemBuilder {
   let builder = new MenuItemBuilder(context)
     .group('sorting')
-    .title(`Sort by ${title}`) // fallback title
+    .title(
+      context.i18n.t('default-menu-item.fallback-title', {
+        // note this lives in the `studio` bundle because that one is loaded by default
+        ns: 'studio',
+        defaultValue: `Sort by ${title}`, // fallback value
+        replace: {title}, // replaces the `{{title}}` option
+      }),
+    ) // fallback title
     .icon(SortIcon)
     .action('setSortOrder')
     .params({by, extendedProjection})

--- a/packages/sanity/src/desk/structureBuilder/MenuItem.ts
+++ b/packages/sanity/src/desk/structureBuilder/MenuItem.ts
@@ -289,7 +289,6 @@ export function getOrderingMenuItem(
       context.i18n.t('default-menu-item.fallback-title', {
         // note this lives in the `studio` bundle because that one is loaded by default
         ns: 'studio',
-        defaultValue: `Sort by ${title}`, // fallback value
         replace: {title}, // replaces the `{{title}}` option
       }),
     ) // fallback title

--- a/packages/sanity/src/desk/structureBuilder/documentTypeListItems.ts
+++ b/packages/sanity/src/desk/structureBuilder/documentTypeListItems.ts
@@ -107,9 +107,21 @@ export function getDocumentTypeList(
     .defaultOrdering(DEFAULT_SELECTED_ORDERING_OPTION.by)
     .menuItemGroups(
       spec.menuItemGroups || [
-        {id: 'sorting', title: 'Sort'},
-        {id: 'layout', title: 'Layout'},
-        {id: 'actions', title: 'Actions'},
+        {
+          id: 'sorting',
+          title: 'Sort',
+          i18n: {title: {key: 'menu-item-groups.actions-group', ns: structureLocaleNamespace}},
+        },
+        {
+          id: 'layout',
+          title: 'Layout',
+          i18n: {title: {key: 'menu-item-groups.layout-group', ns: structureLocaleNamespace}},
+        },
+        {
+          id: 'actions',
+          title: 'Actions',
+          i18n: {title: {key: 'menu-item-groups.sorting-group', ns: structureLocaleNamespace}},
+        },
       ],
     )
     .child(


### PR DESCRIPTION
### Description

This PR:
- fixes an incorrect configuration causing the default orderings to not be localized
- adds a fallback localization for menu items that takes in the legacy sorting item title
- localizes the default group titles (actions, layout, sort)

### What to review

- Does the orderings appear localized for you?
- Does the new menu item groups appear localized?

### Notes for release

N/A
