### PR TITLE
fix(desk): add tooltip on menuitem when disabled only

### DIFF
--- a/packages/sanity/src/desk/panes/document/statusBar/ActionMenuButton.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/ActionMenuButton.tsx
@@ -106,9 +106,7 @@ function ActionMenuListItem(props: ActionMenuListItemProps) {
       onClick={handleClick}
       text={actionState.label}
       tone={actionState.tone}
-      tooltipProps={{
-        content: actionState.title,
-      }}
+      {...(actionState.disabled && {tooltipProps: {content: actionState.title}})}
     />
   )
 }


### PR DESCRIPTION
### Description
A tooltip should only be visible if the menu item is disabled 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
