### PR TITLE
feat(i18n): use last registered locale as default

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -49,6 +49,8 @@ import {routerDebugTool} from './plugins/router-debug'
 import {StegaDebugger} from './schema/debug/components/DebugStega'
 import {testStudioLocaleBundles} from './locales'
 
+const localePlugins = [koKRLocale(), nbNOLocale(), nnNOLocale(), ptPTLocale(), svSELocale()]
+
 const sharedSettings = definePlugin({
   name: 'sharedSettings',
   schema: {
@@ -93,11 +95,7 @@ const sharedSettings = definePlugin({
     },
   },
   plugins: [
-    koKRLocale(),
-    nbNOLocale(),
-    nnNOLocale(),
-    ptPTLocale(),
-    svSELocale(),
+    // ...localePlugins,
     deskTool({
       icon: BookIcon,
       structure,

--- a/packages/sanity/src/core/i18n/i18nConfig.ts
+++ b/packages/sanity/src/core/i18n/i18nConfig.ts
@@ -167,7 +167,8 @@ function getI18NextOptions(
 ): InitOptions & {lng: string} {
   const preferredLocaleId = getPreferredLocale(projectId, sourceName)
   const preferredLocale = locales.find((l) => l.id === preferredLocaleId)
-  const locale = preferredLocale?.id ?? locales[0]?.id ?? defaultOptions.lng
+  const lastLocale = locales[locales.length - 1]
+  const locale = preferredLocale?.id ?? lastLocale.id ?? defaultOptions.lng
   return {
     ...defaultOptions,
     lng: locale,

--- a/packages/sanity/src/core/studio/components/navbar/userMenu/LocaleMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/userMenu/LocaleMenu.tsx
@@ -3,9 +3,15 @@ import React, {useCallback} from 'react'
 import {useTranslation} from '../../../../i18n'
 import {useLocale} from '../../../../i18n/hooks/useLocale'
 
+const LOCALE_SELECTION_DISABLED = true
+
 export function LocaleMenu() {
   const {changeLocale, currentLocale, locales} = useLocale()
   const {t} = useTranslation()
+
+  if (LOCALE_SELECTION_DISABLED) {
+    return null
+  }
 
   if (!locales || locales.length < 2) {
     return null


### PR DESCRIPTION
### Description

Until we land schema localization, choosing a different language has limited value. For now, select the last registered locale and use that, disabling the choice. Will fall back to English (US) on missing strings.

### What to review

- Enabling a locale plugin will use that as the default (last one defined wins)

### Notes for release

None.
