### PR TITLE
feat(i18n): resolve preferred locale from browser languages

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -95,7 +95,7 @@ const sharedSettings = definePlugin({
     },
   },
   plugins: [
-    // ...localePlugins,
+    ...localePlugins,
     deskTool({
       icon: BookIcon,
       structure,

--- a/packages/sanity/src/core/config/configPropertyReducers.ts
+++ b/packages/sanity/src/core/config/configPropertyReducers.ts
@@ -115,6 +115,22 @@ export const schemaTemplatesReducer: ConfigPropertyReducer<Template[], ConfigCon
   )
 }
 
+export const preferredLocalesReducer: ConfigPropertyReducer<string[], LocaleConfigContext> = (
+  prev,
+  {i18n},
+  context,
+) => {
+  const preferred = i18n?.preferredLocales
+  if (!preferred) return prev
+  if (typeof preferred === 'function') return preferred(prev, context)
+  if (Array.isArray(preferred)) return preferred
+  throw new Error(
+    `Expected \`i18n.preferredLocales\` to be an array or a function, but received ${getPrintableType(
+      preferred,
+    )}`,
+  )
+}
+
 export const localeDefReducer: ConfigPropertyReducer<LocaleDefinition[], LocaleConfigContext> = (
   prev,
   {i18n},

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -363,8 +363,6 @@ export interface PluginOptions {
      */
     components?: StudioComponentsPluginOptions
   }
-
-  /** @beta @hidden */
   i18n?: LocalePluginOptions
 }
 

--- a/packages/sanity/src/core/i18n/localeStore.ts
+++ b/packages/sanity/src/core/i18n/localeStore.ts
@@ -7,7 +7,7 @@ import {supportsLocalStorage} from '../util/supportsLocalStorage'
 const LOCAL_STORAGE_PREFIX = 'sanity-locale'
 
 /**
- * Get the users' preferred locale, if any
+ * Get the users' stored, preferred locale, if any
  *
  * @param projectId - Project ID to segment on
  * @param sourceId - Source ID to segment on
@@ -15,7 +15,7 @@ const LOCAL_STORAGE_PREFIX = 'sanity-locale'
  * @internal
  * @hidden
  */
-export function getPreferredLocale(projectId: string, sourceId: string): string | undefined {
+export function getStoredLocale(projectId: string, sourceId: string): string | undefined {
   if (!supportsLocalStorage) {
     return undefined
   }

--- a/packages/sanity/src/core/i18n/types.ts
+++ b/packages/sanity/src/core/i18n/types.ts
@@ -34,6 +34,15 @@ export interface LocaleConfigContext {
 }
 
 /**
+ * Either an array of preferred locale IDs, or a resolver that returns one.
+ *
+ * @public
+ */
+export type PreferredLocalesOption =
+  | ((prev: string[], context: LocaleConfigContext) => string[])
+  | string[]
+
+/**
  * Either an array of locale definitions, or a resolver that returns one.
  *
  * @public
@@ -58,9 +67,19 @@ export type LocalesBundlesOption =
  */
 export interface LocalePluginOptions {
   /**
+   * Array of preferred locales, eg `en-US`, `nb-NO`, `th-TH`…
+   *
+   * If not provided, will try using the browsers reported preferred locales, and fall back to
+   * US English if no matches are found. Can also be specified as a reducer function, in which
+   * the first argument is the currently resolved preferred locales, and the function should
+   * return an array of preferred locales.
+   */
+  preferredLocales?: PreferredLocalesOption
+
+  /**
    * Locales available for user selection.
    *
-   * Titles and icons can be changed by using a function (reducer pattern) and transforming values.
+   * Titles can be changed by using a function (reducer pattern) and transforming values.
    */
   locales?: LocalesOption
 
@@ -144,6 +163,14 @@ export interface Locale {
    * The ID of the locale, eg `en-US`, `nb-NO`, `th-TH`…
    */
   id: string
+
+  /**
+   * Optional macro language code. For `nb-NO`, the macro language is `no`, for instance.
+   * Note that this is _not_ the same as a region code - for `pt-BR`,
+   * `br` is _not_ the macro language, but a _region_.
+   *
+   */
+  macroLanguage?: string
 
   /**
    * The title of locale, eg `English (US)`, `Norsk (bokmål)`, `ไทย`…

--- a/packages/sanity/src/core/studio/components/navbar/userMenu/LocaleMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/userMenu/LocaleMenu.tsx
@@ -3,15 +3,9 @@ import React, {useCallback} from 'react'
 import {useTranslation} from '../../../../i18n'
 import {useLocale} from '../../../../i18n/hooks/useLocale'
 
-const LOCALE_SELECTION_DISABLED = true
-
 export function LocaleMenu() {
   const {changeLocale, currentLocale, locales} = useLocale()
   const {t} = useTranslation()
-
-  if (LOCALE_SELECTION_DISABLED) {
-    return null
-  }
 
   if (!locales || locales.length < 2) {
     return null


### PR DESCRIPTION
### Description

Note: builds on #5381 

Uses browsers' `navigator.languages` to resolve the preferred locale to use. Explicit user preference still has preference, and we still fall back to the default locale (English (US)) if none of the preferred locales can be found.  

It also adds the ability for users to explicitly set an array of preferred languages (in order of preference), or use the reducer pattern we've established in configuration to "dynamically" resolve it.

Made somewhat more complicated than I hoped because browsers use macro languages such as `no` if not explicitly setting "Norwegian (Bokmål)" for instance, so had to introduced a `macroLanguage` prop to locales that will need to be set for `nb-NO` and `nn-NO` packs (and possibly others).

Note: This also reverts back to showing all available locales, and is likely to linger here until we land schema localization, thus marked as draft.
