### PR TITLE
refactor(free-trial): fault tolerance, code conventions

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
@@ -33,7 +33,7 @@ import {SearchDialog, SearchField} from './search'
 import {SearchProvider} from './search/contexts/search/SearchProvider'
 import {ResourcesButton} from './resources/ResourcesButton'
 import {FreeTrial} from './free-trial'
-import {FreeTrialProvider} from './free-trial/FreeTrialContext'
+import {FreeTrialProvider} from './free-trial/FreeTrialProvider'
 import {RouterState, useRouterState, useStateLink} from 'sanity/router'
 
 const RootLayer = styled(Layer)`

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/DescriptionSerializer.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/DescriptionSerializer.tsx
@@ -1,6 +1,6 @@
-import {PortableText, PortableTextComponents} from '@portabletext/react'
+import {PortableText, type PortableTextComponents} from '@portabletext/react'
 import {LinkIcon} from '@sanity/icons'
-import {PortableTextBlock} from '@sanity/types'
+import type {PortableTextBlock} from '@sanity/types'
 import {Box, Card, Flex, Text} from '@sanity/ui'
 import styled from 'styled-components'
 import React, {useEffect, useState} from 'react'
@@ -144,7 +144,12 @@ export function DescriptionSerializer(props: DescriptionSerializerProps) {
   return (
     <Card tone="default">
       <SerializerContainer>
-        <PortableText value={props.blocks} components={components} />
+        <PortableText
+          value={props.blocks}
+          components={components}
+          /* Disable warnings on missing components */
+          onMissingComponent={false}
+        />
       </SerializerContainer>
     </Card>
   )

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialContext.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialContext.tsx
@@ -1,10 +1,10 @@
-import React, {createContext, useContext, useState, useCallback, useEffect} from 'react'
-import {supportsLocalStorage} from '../../../../util/supportsLocalStorage'
-import {useClient} from '../../../../hooks'
-import {SANITY_VERSION} from '../../../../version'
+import {createContext, useContext} from 'react'
 import type {FreeTrialResponse} from './types'
 
-interface FreeTrialContextProps {
+/**
+ * @internal
+ */
+export interface FreeTrialContextProps {
   data: FreeTrialResponse | null
   showDialog: boolean
   showOnLoad: boolean
@@ -14,70 +14,18 @@ interface FreeTrialContextProps {
   toggleShowContent: (closeAndReOpen?: boolean) => void
 }
 
-const FreeTrialContext = createContext<FreeTrialContextProps | undefined>(undefined)
+/**
+ * @internal
+ */
+export const FreeTrialContext = createContext<FreeTrialContextProps | undefined>(undefined)
 
-interface FreeTrialProviderProps {
-  children: React.ReactNode
-}
-export const FreeTrialProvider = ({children}: FreeTrialProviderProps) => {
-  const [data, setData] = useState<FreeTrialResponse | null>(null)
-  const [showDialog, setShowDialog] = useState(false)
-  const [showOnLoad, setShowOnLoad] = useState(false)
-  const client = useClient({apiVersion: '2023-12-11'})
-
-  useEffect(() => {
-    const request = client.observable
-      .request<FreeTrialResponse | null>({
-        url: `/journey/trial?studioVersion=${SANITY_VERSION}`,
-      })
-      .subscribe((response) => {
-        setData(response)
-        // Validates if the user has seen the "structure rename modal" before showing this one. To avoid multiple popovers at same time.
-        const deskRenameSeen = isDeskRenameOnboardingDismissed()
-        if (deskRenameSeen && response?.showOnLoad) {
-          setShowOnLoad(true)
-          setShowDialog(true)
-        }
-      })
-
-    return () => {
-      request.unsubscribe()
-    }
-  }, [client])
-
-  const toggleShowContent = useCallback(
-    (closeAndReOpen = false) => {
-      if (showOnLoad) {
-        setShowOnLoad(false)
-        // If the user clicks on the button, while the show on load is open, we want to trigger the modal.
-        setShowDialog(closeAndReOpen)
-        if (data?.showOnLoad?.id) {
-          client.request({url: `/journey/trial/${data?.showOnLoad.id}`, method: 'POST'})
-        }
-      } else {
-        setShowDialog((p) => !p)
-      }
-    },
-    [client, showOnLoad, data?.showOnLoad?.id],
-  )
-
-  return (
-    <FreeTrialContext.Provider value={{data, showDialog, toggleShowContent, showOnLoad}}>
-      {children}
-    </FreeTrialContext.Provider>
-  )
-}
-
+/**
+ * @internal
+ */
 export const useFreeTrialContext = (): FreeTrialContextProps => {
   const context = useContext(FreeTrialContext)
   if (!context) {
     throw new Error('useFreeTrial must be used within a FreeTrialProvider')
   }
   return context
-}
-
-function isDeskRenameOnboardingDismissed() {
-  return supportsLocalStorage
-    ? localStorage.getItem('sanityStudio:desk:renameDismissed') === '1'
-    : true
 }

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialContext.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialContext.tsx
@@ -1,4 +1,5 @@
 import React, {createContext, useContext, useState, useCallback, useEffect} from 'react'
+import {supportsLocalStorage} from '../../../../util/supportsLocalStorage'
 import {useClient} from '../../../../hooks'
 import {SANITY_VERSION} from '../../../../version'
 import {FreeTrialResponse} from './types'
@@ -32,7 +33,7 @@ export const FreeTrialProvider = ({children}: FreeTrialProviderProps) => {
 
       setData(response)
       // Validates if the user has seen the "structure rename modal" before showing this one. To avoid multiple popovers at same time.
-      const deskRenameSeen = localStorage.getItem('sanityStudio:desk:renameDismissed') === '1'
+      const deskRenameSeen = isDeskRenameOnboardingDismissed()
       if (deskRenameSeen && response?.showOnLoad) {
         setShowOnLoad(true)
         setShowDialog(true)
@@ -70,4 +71,10 @@ export const useFreeTrialContext = (): FreeTrialContextProps => {
     throw new Error('useFreeTrial must be used within a FreeTrialProvider')
   }
   return context
+}
+
+function isDeskRenameOnboardingDismissed() {
+  return supportsLocalStorage
+    ? localStorage.getItem('sanityStudio:desk:renameDismissed') === '1'
+    : true
 }

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialProvider.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialProvider.tsx
@@ -1,0 +1,71 @@
+import {useCallback, useEffect, useState} from 'react'
+import {useClient} from '../../../../hooks'
+import {SANITY_VERSION} from '../../../../version'
+import {supportsLocalStorage} from '../../../../util/supportsLocalStorage'
+import {FreeTrialContext} from './FreeTrialContext'
+import type {FreeTrialResponse} from './types'
+
+/**
+ * @internal
+ */
+export interface FreeTrialProviderProps {
+  children: React.ReactNode
+}
+
+/**
+ * @internal
+ */
+export const FreeTrialProvider = ({children}: FreeTrialProviderProps) => {
+  const [data, setData] = useState<FreeTrialResponse | null>(null)
+  const [showDialog, setShowDialog] = useState(false)
+  const [showOnLoad, setShowOnLoad] = useState(false)
+  const client = useClient({apiVersion: '2023-12-11'})
+
+  useEffect(() => {
+    const request = client.observable
+      .request<FreeTrialResponse | null>({
+        url: `/journey/trial?studioVersion=${SANITY_VERSION}`,
+      })
+      .subscribe((response) => {
+        setData(response)
+        // Validates if the user has seen the "structure rename modal" before showing this one. To avoid multiple popovers at same time.
+        const deskRenameSeen = isDeskRenameOnboardingDismissed()
+        if (deskRenameSeen && response?.showOnLoad) {
+          setShowOnLoad(true)
+          setShowDialog(true)
+        }
+      })
+
+    return () => {
+      request.unsubscribe()
+    }
+  }, [client])
+
+  const toggleShowContent = useCallback(
+    (closeAndReOpen = false) => {
+      if (showOnLoad) {
+        setShowOnLoad(false)
+        // If the user clicks on the button, while the show on load is open, we want to trigger the modal.
+        setShowDialog(closeAndReOpen)
+        if (data?.showOnLoad?.id) {
+          client.request({url: `/journey/trial/${data?.showOnLoad.id}`, method: 'POST'})
+        }
+      } else {
+        setShowDialog((p) => !p)
+      }
+    },
+    [client, showOnLoad, data?.showOnLoad?.id],
+  )
+
+  return (
+    <FreeTrialContext.Provider value={{data, showDialog, toggleShowContent, showOnLoad}}>
+      {children}
+    </FreeTrialContext.Provider>
+  )
+}
+
+function isDeskRenameOnboardingDismissed() {
+  return supportsLocalStorage
+    ? localStorage.getItem('sanityStudio:desk:renameDismissed') === '1'
+    : true
+}

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialProvider.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialProvider.tsx
@@ -26,15 +26,20 @@ export const FreeTrialProvider = ({children}: FreeTrialProviderProps) => {
       .request<FreeTrialResponse | null>({
         url: `/journey/trial?studioVersion=${SANITY_VERSION}`,
       })
-      .subscribe((response) => {
-        setData(response)
-        // Validates if the user has seen the "structure rename modal" before showing this one. To avoid multiple popovers at same time.
-        const deskRenameSeen = isDeskRenameOnboardingDismissed()
-        if (deskRenameSeen && response?.showOnLoad) {
-          setShowOnLoad(true)
-          setShowDialog(true)
-        }
-      })
+      .subscribe(
+        (response) => {
+          setData(response)
+          // Validates if the user has seen the "structure rename modal" before showing this one. To avoid multiple popovers at same time.
+          const deskRenameSeen = isDeskRenameOnboardingDismissed()
+          if (deskRenameSeen && response?.showOnLoad) {
+            setShowOnLoad(true)
+            setShowDialog(true)
+          }
+        },
+        () => {
+          /* silently ignore any error */
+        },
+      )
 
     return () => {
       request.unsubscribe()


### PR DESCRIPTION
### Description

Few refactorings;

- We should always check for the presence and ability to use localStorage before calling it. Strict browsers will throw an error when you try to access it with localStorage disabled.
- The request for the trial endpoint should be cancelled on unmount
- If the trial endpoint returns Portable Text blocks/marks/annotations that are not known, the default behavior is to warn. This warning is not something we want to expose to third-party users of the studio however, so lets disable it.
- We generally try to keep the context and providers as separate files, and have their exports match the filename where applicable. Also, the preferred naming convention is `SomethingContext` (actual React context returned from `createContext`) and `SomethingContextValue` (the interface/type that defines the shape of the context). 
- If an error occurs on the backend request, we don't want to emit a warning to the user - instead, let us suppress the error

### What to review

- Code changes make sense and is understood
- Code still does what was originally intended

### Notes for release

None
