### PR TITLE
fix(i18n): missing translations for structure, tag input, loading pane

### DIFF
--- a/dev/design-studio/structure.ts
+++ b/dev/design-studio/structure.ts
@@ -1,4 +1,4 @@
-import {StructureResolver, DefaultDocumentNodeResolver} from 'sanity'
+import {StructureResolver, DefaultDocumentNodeResolver} from 'sanity/desk'
 import {CogIcon} from '@sanity/icons'
 import {CustomPane} from './components/CustomPane'
 import {IFrameView} from './components/IframeView'

--- a/dev/test-studio/locales/index.ts
+++ b/dev/test-studio/locales/index.ts
@@ -16,8 +16,8 @@ const enUS = defineLocaleResourceBundle({
   resources: enUSStrings,
 })
 
-const noNB = defineLocaleResourceBundle({
-  locale: 'no-NB',
+const nbNO = defineLocaleResourceBundle({
+  locale: 'nb-NO',
   namespace: testStudioLocaleNamespace,
   resources: {
     'studio.logo.title': 'Norsk logo',
@@ -28,6 +28,14 @@ const noNB = defineLocaleResourceBundle({
   },
 })
 
+const nbNOBStructureOverrides = defineLocaleResourceBundle({
+  locale: 'nb-NO',
+  namespace: 'structure',
+  resources: {
+    'default-definition.content-title': 'Innhold 🇳🇴',
+  },
+})
+
 export type TestStudioLocaleResourceKeys = keyof typeof enUSStrings
 
-export const testStudioLocaleBundles = [enUS, noNB]
+export const testStudioLocaleBundles = [enUS, nbNO, nbNOBStructureOverrides]

--- a/dev/test-studio/schema/allTypes.ts
+++ b/dev/test-studio/schema/allTypes.ts
@@ -48,6 +48,15 @@ export const allTypes = defineType({
       validation: (Rule) => Rule.required().min(2).unique(),
     }),
     defineField({
+      name: 'tagsArray',
+      title: 'Liste med tæggs',
+      type: 'array',
+      of: [{type: 'string'}],
+      options: {
+        layout: 'tags',
+      },
+    }),
+    defineField({
       name: 'object',
       title: 'Objekt',
       type: 'object',

--- a/packages/sanity/src/core/form/components/tagInput/tagInput.tsx
+++ b/packages/sanity/src/core/form/components/tagInput/tagInput.tsx
@@ -3,16 +3,18 @@ import {
   Box,
   Button,
   Card,
-  CSSObject,
   Flex,
   isHTMLElement,
   rem,
   Text,
-  Theme,
+  type CSSObject,
+  type Theme,
   useForwardedRef,
 } from '@sanity/ui'
-import React, {forwardRef, useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import React, {forwardRef, useCallback, useEffect, useRef, useState} from 'react'
 import styled, {css} from 'styled-components'
+import {useTranslation} from '../../../i18n'
+import {studioLocaleNamespace} from '../../../i18n/localeNamespaces'
 import {focusRingBorderStyle, focusRingStyle} from './styles'
 
 const Root = styled(Card)((props: {theme: Theme}): CSSObject => {
@@ -153,13 +155,8 @@ export const TagInput = forwardRef(
       value = [],
       ...restProps
     } = props
-    const placeholder = useMemo(() => {
-      if (placeholderProp) return placeholderProp
-      if (typeof window !== 'undefined' && 'ontouchstart' in window) {
-        return 'Enter tag…'
-      }
-      return 'Enter tag and press ENTER…'
-    }, [placeholderProp])
+
+    const {t} = useTranslation(studioLocaleNamespace)
     const [inputValue, setInputValue] = useState('')
     const enabled = !disabled && !readOnly
     const [focused, setFocused] = useState(false)
@@ -250,7 +247,16 @@ export const TagInput = forwardRef(
       >
         {enabled && (
           <Placeholder hidden={Boolean(inputValue || value.length)} padding={3}>
-            <Text textOverflow="ellipsis">{placeholder}</Text>
+            <Text textOverflow="ellipsis">
+              {placeholderProp
+                ? placeholderProp
+                : t('inputs.tags.placeholder', {
+                    context:
+                      typeof window !== 'undefined' && 'ontouchstart' in window
+                        ? 'touch'
+                        : undefined,
+                  })}
+            </Text>
           </Placeholder>
         )}
 

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -919,6 +919,10 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Error message for when the source to generate a slug from is missing */
   'inputs.slug.error.missing-source':
     'Source is missing. Check source on type {{schemaType}} in schema',
+  /** Placeholder for an empty tag input */
+  'inputs.tags.placeholder': 'Enter tag and press ENTER…',
+  /** Placeholder for an empty tag input on touch devices */
+  'inputs.tags.placeholder_touch': 'Enter tag…',
   /** Convert to <code>`{{targetType}}`</code> */
   'inputs.untyped-value.convert-button.text': 'Convert to <code>{{targetType}}</code>',
   /** Encountered an object value without a <code>_type</code> property. */

--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -217,6 +217,9 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   /** The text for the confirm button in the confirm dialog used in document action shortcuts if none is provided */
   'confirm-dialog.confirm-button.fallback-text': 'Confirm',
 
+  /** For the default structure definition, the title for the "Content" pane */
+  'default-definition.content-title': 'Content',
+
   /** The text shown if there was an error while getting the document's title via a preview value */
   'doc-title.error.text': 'Error: {{errorMessage}}',
   /** The text shown if the preview value for a document is non-existent or empty */

--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -364,6 +364,10 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   /** The title of the document not found pane if the schema is unknown */
   'panes.document-pane.document-unknown-type.without-schema.text':
     'This document does not exist, and no schema type was specified for it.',
+  /** Default message shown while resolving the structure definition for an asynchronous node */
+  'panes.resolving.default-message': 'Loading…',
+  /** Message shown while resolving the structure definition for an asynchronous node and it is taking a while (more than 5s) */
+  'panes.resolving.slow-resolve-message': 'Still loading…',
   /** The text to display when type is missing */
   'panes.unknown-pane-type.missing-type.text':
     'Structure item is missing required <Code>type</Code> property.',

--- a/packages/sanity/src/desk/structureBuilder/createStructureBuilder.ts
+++ b/packages/sanity/src/desk/structureBuilder/createStructureBuilder.ts
@@ -1,6 +1,7 @@
 import {uniqueId} from 'lodash'
 import type {SchemaType} from '@sanity/types'
 import {isValidElementType} from 'react-is'
+import {structureLocaleNamespace} from '../i18n'
 import {ListBuilder} from './List'
 import {
   getDocumentTypeListItems,
@@ -48,6 +49,7 @@ function getDefaultStructure(context: StructureContext): ListBuilder {
   return new ListBuilder(context)
     .id('__root__')
     .title('Content')
+    .i18n({title: {key: 'default-definition.content-title', ns: structureLocaleNamespace}})
     .items(items)
     .showIcons(items.some((item) => hasIcon(item.getSchemaType())))
 }


### PR DESCRIPTION
Fixes a few missing translation surfaces:

- Root structure node ("Content")
- Placeholder text for tag input ("Type tag and press enter")
- Structure tool loading pane (not the skeleton, but shown while async panes are resolving)
