### PR TITLE
fix(portable-text-editor): return unless range count

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -372,7 +372,7 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
     }
     const window = ReactEditor.getWindow(slateEditor)
     const domSelection = window.getSelection()
-    if (!domSelection) {
+    if (!domSelection || domSelection.rangeCount === 0) {
       return
     }
     const existingDOMRange = domSelection.getRangeAt(0)


### PR DESCRIPTION
### Description

This will test the window selection `rangeCount` before calling `getRangeAt(0)`. Calling this without any ranges will result in a JS-error.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Fixed an potential JS-error related to window selections

<!--
A description of the change(s) that should be used in the release notes.
-->
