### PR TITLE
fix(cli): improve telemetry exit flushing

### DIFF
--- a/packages/@sanity/cli/src/util/createTelemetryStore.ts
+++ b/packages/@sanity/cli/src/util/createTelemetryStore.ts
@@ -108,6 +108,8 @@ export function createTelemetryStore<UserProperties>(options: {
     resolveConsent,
     sendEvents,
   })
+
+  process.once('SIGINT', () => store.flush().finally(() => process.exit(0)))
   process.once('beforeExit', () => store.flush())
   process.once('unhandledRejection', () => store.flush())
   process.once('uncaughtException', () => store.flush())


### PR DESCRIPTION
### Description

This adds a 2 second timeout to sending telemetry events at process exit. If, for some reason the intake api takes long to respond, we don't want to keep the process going.

In addition, this PR adds a SIGINT (Ctrl+C) listener that flushes the telemetry store before exiting.

### What to review

- Does it make sense?

### Notes for release

N/A