### PR TITLE
refactor(portable-text-editor): remove obsolete code

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPatches.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithPatches.ts
@@ -28,7 +28,6 @@ import {PATCHING, isPatching, withoutPatching} from '../../utils/withoutPatching
 import {KEY_TO_VALUE_ELEMENT, IS_PROCESSING_REMOTE_CHANGES} from '../../utils/weakMaps'
 import {createApplyPatch} from '../../utils/applyPatch'
 import {withPreserveKeys} from '../../utils/withPreserveKeys'
-import {removeAllDocumentSelectionRanges} from '../../utils/ranges'
 import {withRemoteChanges} from '../../utils/withChanges'
 import {withoutSaving} from './createWithUndoRedo'
 
@@ -121,9 +120,6 @@ export function createWithPatches({
             withoutSaving(editor, () => {
               withPreserveKeys(editor, () => {
                 patches.forEach((patch) => {
-                  if (patch.type === 'insert' || patch.type === 'unset') {
-                    removeAllDocumentSelectionRanges(!!editor.selection)
-                  }
                   if (debug.enabled) debug(`Handling remote patch ${JSON.stringify(patch)}`)
                   changed = applyPatch(editor, patch)
                 })

--- a/packages/@sanity/portable-text-editor/src/editor/plugins/createWithUndoRedo.ts
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/createWithUndoRedo.ts
@@ -11,7 +11,6 @@ import type {Patch} from '../../types/patch'
 import {PatchObservable, PortableTextSlateEditor} from '../../types/editor'
 import {debugWithName} from '../../utils/debug'
 import {fromSlateValue} from '../../utils/values'
-import {removeAllDocumentSelectionRanges} from '../../utils/ranges'
 
 const debug = debugWithName('plugin:withUndoRedo')
 const debugVerbose = debug.enabled && false
@@ -145,7 +144,6 @@ export function createWithUndoRedo(
               ),
             )
           })
-          removeAllDocumentSelectionRanges(!!editor.selection)
           try {
             Editor.withoutNormalizing(editor, () => {
               withoutSaving(editor, () => {
@@ -192,7 +190,6 @@ export function createWithUndoRedo(
               ),
             )
           })
-          removeAllDocumentSelectionRanges(!!editor.selection)
           try {
             Editor.withoutNormalizing(editor, () => {
               withoutSaving(editor, () => {

--- a/packages/@sanity/portable-text-editor/src/utils/ranges.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/ranges.ts
@@ -50,18 +50,3 @@ export function toSlateRange(selection: EditorSelection, editor: Editor): Range 
   const range = anchor && focus ? {anchor, focus} : null
   return range
 }
-
-/**
- * Remove the document selection range before applying the remote patches.
- * ReactEditor (slate-react) will auto-track it's selection based on the
- * DOM-selection, and we don't want this to trigger at this point.
- * TODO (2023/06/23): refactor this when SlateReact have proper error handling.
- * See: https://github.com/ianstormtaylor/slate/pull/5407
- * @internal
- */
-export function removeAllDocumentSelectionRanges(hasEditorSelection: boolean): void {
-  if (hasEditorSelection) {
-    const domSelection = hasEditorSelection && window.getSelection()
-    domSelection?.removeAllRanges()
-  }
-}


### PR DESCRIPTION
### Description

After #5136 this code is no longer needed as the MutationObserver does what it is supposed to and verifies the selection properly. 

There is also a bug in this removed code that doesn't take into account that the particular editor is focused and selected before removing all the DOM selection ranges, which has side effects in documents with several editors.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
* Improved selection handling for the Portable Text Editor when using several editors in the same document. 
<!--
A description of the change(s) that should be used in the release notes.
-->
