### PR TITLE
Feat: draggable text blocks

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -8,7 +8,7 @@ import {
   useSlate,
 } from 'slate-react'
 import {noop} from 'lodash'
-import {PortableTextBlock} from '@sanity/types'
+import {PortableTextBlock, SchemaType} from '@sanity/types'
 import {
   EditorChange,
   EditorSelection,
@@ -58,6 +58,7 @@ export type PortableTextEditableProps = Omit<
   'onPaste' | 'onCopy' | 'onBeforeInput'
 > & {
   hotkeys?: HotkeyOptions
+  isDraggableType?: (schemaType: SchemaType) => boolean
   onBeforeInput?: (event: InputEvent) => void
   onPaste?: OnPasteFn
   onCopy?: OnCopyFn
@@ -83,6 +84,7 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
 ) {
   const {
     hotkeys,
+    isDraggableType,
     onBlur,
     onFocus,
     onBeforeInput,
@@ -139,6 +141,7 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
     (eProps: RenderElementProps) => (
       <Element
         {...eProps}
+        isDraggableType={isDraggableType}
         readOnly={readOnly}
         renderBlock={renderBlock}
         renderChild={renderChild}
@@ -148,7 +151,16 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
         spellCheck={spellCheck}
       />
     ),
-    [schemaTypes, spellCheck, readOnly, renderBlock, renderChild, renderListItem, renderStyle],
+    [
+      schemaTypes,
+      spellCheck,
+      readOnly,
+      renderBlock,
+      renderChild,
+      renderListItem,
+      renderStyle,
+      isDraggableType,
+    ],
   )
 
   const renderLeaf = useCallback(

--- a/packages/@sanity/portable-text-editor/src/editor/components/DraggableBlock.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/components/DraggableBlock.tsx
@@ -30,7 +30,6 @@ export const DraggableBlock = ({children, element, readOnly, blockRef}: Draggabl
   const editor = useSlateStatic()
   const dragGhostRef: React.MutableRefObject<undefined | HTMLElement> = useRef()
   const [isDragOver, setIsDragOver] = useState(false)
-  const isVoid = useMemo(() => Editor.isVoid(editor, element), [editor, element])
   const isInline = useMemo(() => Editor.isInline(editor, element), [editor, element])
 
   const [blockElement, setBlockElement] = useState<HTMLElement | null>(null)
@@ -154,10 +153,6 @@ export const DraggableBlock = ({children, element, readOnly, blockRef}: Draggabl
   // Note: this is called for the dragging block
   const handleDrag = useCallback(
     (event: DragEvent) => {
-      if (!isVoid) {
-        IS_DRAGGING_BLOCK_ELEMENT.delete(editor)
-        return
-      }
       IS_DRAGGING.set(editor, true)
       IS_DRAGGING_BLOCK_ELEMENT.set(editor, element)
       event.stopPropagation() // Stop propagation so that leafs don't get this and take focus/selection!
@@ -168,13 +163,13 @@ export const DraggableBlock = ({children, element, readOnly, blockRef}: Draggabl
         target.style.opacity = '1'
       }
     },
-    [editor, element, isVoid],
+    [editor, element],
   )
 
   // Note: this is called for the dragging block
   const handleDragStart = useCallback(
     (event: DragEvent) => {
-      if (!isVoid || isInline) {
+      if (isInline) {
         debug('Not dragging block')
         IS_DRAGGING_BLOCK_ELEMENT.delete(editor)
         IS_DRAGGING.set(editor, false)
@@ -215,7 +210,7 @@ export const DraggableBlock = ({children, element, readOnly, blockRef}: Draggabl
       }
       handleDrag(event)
     },
-    [blockElement, editor, handleDrag, isInline, isVoid],
+    [blockElement, editor, handleDrag, isInline],
   )
 
   const isDraggingOverFirstBlock =
@@ -261,7 +256,7 @@ export const DraggableBlock = ({children, element, readOnly, blockRef}: Draggabl
 
   return (
     <div
-      draggable={isVoid}
+      draggable
       onDragStart={handleDragStart}
       onDrag={handleDrag}
       onDragOver={handleDragOver}

--- a/packages/@sanity/portable-text-editor/src/editor/components/DraggableBlock.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/components/DraggableBlock.tsx
@@ -17,6 +17,7 @@ const debugRenders = false
  */
 export interface DraggableBlockProps {
   children: React.ReactNode
+  draggable?: boolean
   element: SlateElement
   readOnly: boolean
   blockRef: React.MutableRefObject<HTMLDivElement | null>
@@ -26,7 +27,13 @@ export interface DraggableBlockProps {
  * Implements drag and drop functionality on editor block nodes
  * @internal
  */
-export const DraggableBlock = ({children, element, readOnly, blockRef}: DraggableBlockProps) => {
+export const DraggableBlock = ({
+  children,
+  element,
+  readOnly,
+  blockRef,
+  draggable,
+}: DraggableBlockProps) => {
   const editor = useSlateStatic()
   const dragGhostRef: React.MutableRefObject<undefined | HTMLElement> = useRef()
   const [isDragOver, setIsDragOver] = useState(false)
@@ -256,7 +263,7 @@ export const DraggableBlock = ({children, element, readOnly, blockRef}: Draggabl
 
   return (
     <div
-      draggable
+      draggable={draggable}
       onDragStart={handleDragStart}
       onDrag={handleDrag}
       onDragOver={handleDragOver}

--- a/packages/@sanity/portable-text-editor/src/editor/components/Element.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/components/Element.tsx
@@ -2,7 +2,13 @@
 /* eslint-disable max-statements */
 import React, {ReactElement, FunctionComponent, useRef, useMemo} from 'react'
 import {Element as SlateElement, Editor, Range} from 'slate'
-import {Path, PortableTextChild, PortableTextObject, PortableTextTextBlock} from '@sanity/types'
+import {
+  Path,
+  PortableTextChild,
+  PortableTextObject,
+  PortableTextTextBlock,
+  SchemaType,
+} from '@sanity/types'
 import {useSelected, useSlateStatic, ReactEditor, RenderElementProps} from 'slate-react'
 import {
   BlockRenderProps,
@@ -30,12 +36,13 @@ export interface ElementProps {
   attributes: RenderElementProps['attributes']
   children: ReactElement
   element: SlateElement
-  schemaTypes: PortableTextMemberSchemaTypes
+  isDraggableType?: (schemaType: SchemaType) => boolean
   readOnly: boolean
   renderBlock?: RenderBlockFunction
   renderChild?: RenderChildFunction
   renderListItem?: RenderListItemFunction
   renderStyle?: RenderStyleFunction
+  schemaTypes: PortableTextMemberSchemaTypes
   spellCheck?: boolean
 }
 
@@ -49,12 +56,13 @@ export const Element: FunctionComponent<ElementProps> = ({
   attributes,
   children,
   element,
-  schemaTypes,
+  isDraggableType,
   readOnly,
   renderBlock,
   renderChild,
   renderListItem,
   renderStyle,
+  schemaTypes,
   spellCheck,
 }) => {
   const editor = useSlateStatic()
@@ -208,9 +216,18 @@ export const Element: FunctionComponent<ElementProps> = ({
     const propsOrDefaultRendered = renderBlock
       ? renderBlock(renderProps as BlockRenderProps)
       : children
+
+    const isDraggableTextBlock =
+      isDraggableType === undefined ? false : isDraggableType(schemaTypes.block)
+
     return (
       <div key={element._key} {...attributes} className={className} spellCheck={spellCheck}>
-        <DraggableBlock element={element} readOnly={readOnly} blockRef={blockRef}>
+        <DraggableBlock
+          element={element}
+          readOnly={readOnly}
+          blockRef={blockRef}
+          draggable={isDraggableTextBlock}
+        >
           <div ref={blockRef}>{propsOrDefaultRendered}</div>
         </DraggableBlock>
       </div>
@@ -252,10 +269,18 @@ export const Element: FunctionComponent<ElementProps> = ({
     )
     renderedBlockFromProps = renderBlock(_props as BlockRenderProps)
   }
+
+  const isDraggableVoidBlock = isDraggableType === undefined ? true : isDraggableType(schemaType)
+
   return (
     <div key={element._key} {...attributes} className={className}>
       {children}
-      <DraggableBlock element={element} readOnly={readOnly} blockRef={blockRef}>
+      <DraggableBlock
+        element={element}
+        readOnly={readOnly}
+        blockRef={blockRef}
+        draggable={isDraggableVoidBlock}
+      >
         {renderedBlockFromProps && (
           <div ref={blockRef} contentEditable={false}>
             {renderedBlockFromProps}


### PR DESCRIPTION
### Description

This change will allow any object type to be draggable in the PTE by returning `true` from `isDraggableType(schemaType)` which can be passed to the `Editable` props.

This will allow us to implement custom drag handles on regular text blocks, but not change the default.

It could be implemented for text blocks like this with the `renderBlock` prop for `Editable`:

```
renderBlock: (blockProps) => {
    return (
      <BlockDragWrapper draggable onDragStart={handleBlockDragStart}>
        <span data-custom-block-drag-handle="true" />
        {blockProps.children}
      </BlockDragWrapper>
    )
},
```

And the handleBlockDragStart

```
  // Only allow our own block drag handle to initiate block dragging.
  const handleBlockDragStart = useCallback((event: React.DragEvent<HTMLDivElement>) => {
    if (
      event.target === event.currentTarget &&
      !event.currentTarget.getAttribute('data-custom-block-drag-handle')
    ) {
      event.preventDefault()
    }
  }, [])
```

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
