### PR TITLE
fix(core): update changes revert confirmation popovers

### DIFF
--- a/packages/sanity/src/core/field/diff/components/ChangeList.tsx
+++ b/packages/sanity/src/core/field/diff/components/ChangeList.tsx
@@ -1,4 +1,4 @@
-import {Box, Card, Grid, Stack, Text, useClickOutside} from '@sanity/ui'
+import {Box, Card, Flex, Stack, Text, useClickOutside} from '@sanity/ui'
 import {RevertIcon} from '@sanity/icons'
 import React, {useCallback, useContext, useMemo, useState} from 'react'
 import {SanityDocument} from '@sanity/client'
@@ -118,15 +118,15 @@ export function ChangeList({diff, fields, schemaType}: ChangeListProps): React.R
         {showFooter && isComparingCurrent && !isPermissionsLoading && permissions?.granted && (
           <Popover
             content={
-              <Stack space={1}>
-                <Box padding={1}>
+              <Stack space={3}>
+                <Box paddingY={3}>
                   <Text size={1}>
                     {t('changes.action.revert-all-description', {
                       count: changes.length,
                     })}
                   </Text>
                 </Box>
-                <Grid columns={2} gap={2} marginTop={2}>
+                <Flex gap={3} justify="flex-end">
                   <Button
                     mode="ghost"
                     text={t('changes.action.revert-all-cancel')}
@@ -137,7 +137,7 @@ export function ChangeList({diff, fields, schemaType}: ChangeListProps): React.R
                     text={t('changes.action.revert-all-confirm')}
                     onClick={revertAllChanges}
                   />
-                </Grid>
+                </Flex>
               </Stack>
             }
             open={confirmRevertAllOpen}

--- a/packages/sanity/src/core/field/diff/components/FieldChange.tsx
+++ b/packages/sanity/src/core/field/diff/components/FieldChange.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useMemo, useState} from 'react'
-import {Box, Grid, Stack, Text, useClickOutside} from '@sanity/ui'
+import {Box, Flex, Stack, Text, useClickOutside} from '@sanity/ui'
 import {ObjectSchemaType} from '@sanity/types'
 import {useDocumentOperation} from '../../../hooks'
 import {Button, Popover} from '../../../../ui-components'
@@ -109,13 +109,13 @@ export function FieldChange(
               {isComparingCurrent && !isPermissionsLoading && permissions?.granted && (
                 <Popover
                   content={
-                    <Stack space={1}>
-                      <Box padding={1}>
+                    <Stack space={3}>
+                      <Box paddingY={3}>
                         <Text size={1}>
                           {t('changes.action.revert-changes-description', {count: 1})}
                         </Text>
                       </Box>
-                      <Grid columns={2} gap={2} marginTop={2}>
+                      <Flex gap={3} justify="flex-end">
                         <Button
                           mode="ghost"
                           onClick={closeRevertChangesConfirmDialog}
@@ -126,7 +126,7 @@ export function FieldChange(
                           onClick={handleRevertChanges}
                           text={t('changes.action.revert-changes-confirm-change', {count: 1})}
                         />
-                      </Grid>
+                      </Flex>
                     </Stack>
                   }
                   open={confirmRevertOpen}

--- a/packages/sanity/src/core/field/diff/components/GroupChange.tsx
+++ b/packages/sanity/src/core/field/diff/components/GroupChange.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useContext, useMemo, useState} from 'react'
-import {Box, Grid, Stack, Text, useClickOutside} from '@sanity/ui'
+import {Box, Flex, Stack, Text, useClickOutside} from '@sanity/ui'
 import {Button, Popover} from '../../../../ui-components'
 import {useDocumentOperation} from '../../../hooks'
 import {undoChange} from '../changes/undoChange'
@@ -85,13 +85,13 @@ export function GroupChange(
           {isComparingCurrent && !isPermissionsLoading && permissions?.granted && (
             <Popover
               content={
-                <Stack space={1}>
-                  <Box padding={1}>
+                <Stack space={3}>
+                  <Box paddingY={3}>
                     <Text size={1}>
                       {t('changes.action.revert-changes-description', {count: changes.length})}
                     </Text>
                   </Box>
-                  <Grid columns={2} gap={2} marginTop={2}>
+                  <Flex gap={3} justify="flex-end">
                     <Button
                       mode="ghost"
                       onClick={closeRevertChangesConfirmDialog}
@@ -102,7 +102,7 @@ export function GroupChange(
                       onClick={handleRevertChanges}
                       text={t('changes.action.revert-changes-confirm-change', {count: 1})}
                     />
-                  </Grid>
+                  </Flex>
                 </Stack>
               }
               padding={3}


### PR DESCRIPTION
### Description
Updates the revert changes popover to match with the new facelift designs.
### New
<img width="347" alt="Screenshot 2023-12-19 at 16 40 01" src="https://github.com/sanity-io/sanity/assets/46196328/611dd192-fb8e-4e50-8f61-784269409852">

### Previous
<img width="351" alt="Screenshot 2023-12-19 at 16 40 20" src="https://github.com/sanity-io/sanity/assets/46196328/7c5a882b-66a1-4d89-a83e-842a21c0b326">

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
