### PR TITLE
fix(e2e): Revert "test(e2e): disable dataset creation per PR"

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -79,8 +79,7 @@ jobs:
           # Delete `SANITY_E2E_SESSION_TOKEN_NEW` from github
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
           SANITY_E2E_PROJECT_ID: ${{ secrets.SANITY_E2E_PROJECT_ID }}
-          # FIXME: this is a temp fix to stop creating new datasets for the time being
-          SANITY_E2E_DATASET: pr-${{ secrets.SANITY_E2E_DATASET }}
+          SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}
         run: yarn e2e:setup && yarn e2e:build
 
       # Caches build from either PR or next
@@ -185,8 +184,7 @@ jobs:
           # Delete `SANITY_E2E_SESSION_TOKEN_NEW` from github
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
           SANITY_E2E_PROJECT_ID: ${{ secrets.SANITY_E2E_PROJECT_ID }}
-          # FIXME: this is a temp fix to stop creating new datasets for the time being
-          SANITY_E2E_DATASET: pr-${{ secrets.SANITY_E2E_DATASET }}
+          SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}
         run: yarn test:e2e --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -74,5 +74,4 @@ jobs:
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW }}
           SANITY_E2E_PROJECT_ID: ${{ secrets.SANITY_E2E_PROJECT_ID }}
           SANITY_E2E_DATASET: pr-${{ matrix.project }}-${{ github.event.number }}
-        # FIXME: this is a temp fix to stop creating new datasets for the time being
-        # run: yarn e2e:cleanup
+        run: yarn e2e:cleanup


### PR DESCRIPTION
Reverts sanity-io/sanity#5210

When I was originally investigating the exploding dataset issue, I thought the e2e tests were causing the dataset issue so we merged #5210 to stop the e2e tests from creating a dataset per PR.

In actuality, the e2e tests were well set up and the issue was with the CLI tests so this PR simply reverts #5210