### PR TITLE
fix: temporarily disable locale selection in nav drawer

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/navDrawer/LocaleMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/navDrawer/LocaleMenu.tsx
@@ -4,8 +4,15 @@ import React, {useCallback} from 'react'
 import {useLocale} from '../../../../i18n/hooks/useLocale'
 import {Button} from '../../../../../ui-components'
 
+// TODO: re-enable locale selection once schema localization is available
+const LOCALE_SELECTION_DISABLED = true
+
 export function LocaleMenu() {
   const {changeLocale, currentLocale, locales} = useLocale()
+
+  if (LOCALE_SELECTION_DISABLED) {
+    return null
+  }
 
   if (!locales || locales.length < 2) {
     return null

--- a/packages/sanity/src/core/studio/components/navbar/userMenu/LocaleMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/userMenu/LocaleMenu.tsx
@@ -4,6 +4,7 @@ import React, {useCallback} from 'react'
 import {useLocale} from '../../../../i18n/hooks/useLocale'
 import {MenuItem} from '../../../../../ui-components'
 
+// TODO: re-enable locale selection once schema localization is available
 const LOCALE_SELECTION_DISABLED = true
 
 export function LocaleMenu() {


### PR DESCRIPTION
### Description

This PR removes the locale selection menu in the nav drawer ('burger' menu on smaller breakpoints). The locale menu was introduced here in facelift, as there was no way to switch between locales on smaller viewports.

Given that it's been [temporarily disabled in the user menu](https://github.com/sanity-io/sanity/blob/bb0377aa732786dac500dbfe529ef7c6c5177471/packages/sanity/src/core/studio/components/navbar/userMenu/LocaleMenu.tsx#L7-L14) in #5381, it only makes sense that we disable it here too.

Note: there is a bit a duplication between both nav 'drawer' and nav 'bar' menus, since they both technically use different child components and props. This could / should certainly be optimised in future.

### What to review

The locale switcher menu should _not_ be visible in the nav drawer menu on smaller breakpoints, if running a studio with multiple locale definitions.

### Notes for release

N/A