### PR TITLE
feat(block-tools): add notion handling for single block decorators

### DIFF
--- a/packages/@sanity/block-tools/src/HtmlDeserializer/preprocessors/index.ts
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/preprocessors/index.ts
@@ -2,5 +2,12 @@ import preprocessWhitespace from './whitespace'
 import preprocessHTML from './html'
 import preprocessWord from './word'
 import preprocessGDocs from './gdocs'
+import preprocessNotion from './notion'
 
-export default [preprocessWhitespace, preprocessWord, preprocessGDocs, preprocessHTML]
+export default [
+  preprocessWhitespace,
+  preprocessNotion,
+  preprocessWord,
+  preprocessGDocs,
+  preprocessHTML,
+]

--- a/packages/@sanity/block-tools/src/HtmlDeserializer/preprocessors/notion.ts
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/preprocessors/notion.ts
@@ -1,0 +1,25 @@
+import {_XPathResult} from './xpathResult'
+
+export default (html: string, doc: Document): Document => {
+  const NOTION_REGEX = /<!-- notionvc:.*?-->/g
+
+  if (html.match(NOTION_REGEX)) {
+    // Tag every child with attribute 'is-notion' so that the Notion rule-set can
+    // work exclusivly on these children
+    const childNodes = doc.evaluate(
+      '//*',
+      doc,
+      null,
+      _XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE,
+      null,
+    )
+
+    for (let i = childNodes.snapshotLength - 1; i >= 0; i--) {
+      const elm = childNodes.snapshotItem(i) as HTMLElement
+      elm?.setAttribute('data-is-notion', 'true')
+    }
+
+    return doc
+  }
+  return doc
+}

--- a/packages/@sanity/block-tools/src/HtmlDeserializer/rules/index.ts
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/rules/index.ts
@@ -3,6 +3,7 @@ import type {BlockEnabledFeatures, DeserializerRule} from '../../types'
 import createHTMLRules from './html'
 import createGDocsRules from './gdocs'
 import createWordRules from './word'
+import createNotionRules from './notion'
 
 export function createRules(
   blockContentType: ArraySchemaType,
@@ -10,6 +11,7 @@ export function createRules(
 ): DeserializerRule[] {
   return [
     ...createWordRules(),
+    ...createNotionRules(blockContentType),
     ...createGDocsRules(blockContentType, options),
     ...createHTMLRules(blockContentType, options),
   ]

--- a/packages/@sanity/block-tools/src/HtmlDeserializer/rules/notion.ts
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/rules/notion.ts
@@ -1,0 +1,61 @@
+import type {ArraySchemaType} from '@sanity/types'
+import type {DeserializerRule} from '../../types'
+import {DEFAULT_SPAN, HTML_BLOCK_TAGS, HTML_HEADER_TAGS} from '../../constants'
+import {isElement, tagName} from '../helpers'
+
+// font-style:italic seems like the most important rule for italic / emphasis in their html
+function isEmphasis(el: Node): boolean {
+  const style = isElement(el) && el.getAttribute('style')
+  return /font-style:italic/.test(style || '')
+}
+
+// font-weight:700 or 600 seems like the most important rule for bold in their html
+function isStrong(el: Node): boolean {
+  const style = isElement(el) && el.getAttribute('style')
+  return /font-weight:700/.test(style || '') || /font-weight:600/.test(style || '')
+}
+
+// text-decoration seems like the most important rule for underline in their html
+function isUnderline(el: Node): boolean {
+  const style = isElement(el) && el.getAttribute('style')
+  return /text-decoration:underline/.test(style || '')
+}
+
+// Check for attribute given by the Notion preprocessor
+function isNotion(el: Node): boolean {
+  return isElement(el) && Boolean(el.getAttribute('data-is-notion'))
+}
+
+const blocks: Record<string, {style: string} | undefined> = {
+  ...HTML_BLOCK_TAGS,
+  ...HTML_HEADER_TAGS,
+}
+
+export default function createNotionRules(_blockContentType: ArraySchemaType): DeserializerRule[] {
+  return [
+    {
+      deserialize(el) {
+        // Notion normally exports semantic HTML. However, if you copy a single block, the formatting will be inline styles
+        // This handles a limited set of styles
+        if (isElement(el) && tagName(el) === 'span' && isNotion(el)) {
+          const span = {
+            ...DEFAULT_SPAN,
+            marks: [] as string[],
+            text: el.textContent,
+          }
+          if (isStrong(el)) {
+            span.marks.push('strong')
+          }
+          if (isUnderline(el)) {
+            span.marks.push('underline')
+          }
+          if (isEmphasis(el)) {
+            span.marks.push('em')
+          }
+          return span
+        }
+        return undefined
+      },
+    },
+  ]
+}


### PR DESCRIPTION
### Description

This creates a new ruleset for Notion, and handles block decorators for bold/emphasis/italic.

Normally Notion will export semantic HTML, but this behaviour changes when you have only copied a single block.

Then the exported HTML will contain spans with inline styles.

Fixes EDX-818.

### What to review

- That copy pasting a single block from Notion containing italic, emphasis or bold will be correctly formatted 

### Notes for release

- Fixed bold/emphasis/italic formatting in PTE when copying a single block from Notion
