### PR TITLE
fix(form): fix missing subtitles in array previews

### DIFF
--- a/dev/test-studio/schema/standard/arrays.tsx
+++ b/dev/test-studio/schema/standard/arrays.tsx
@@ -126,6 +126,12 @@ export default defineType({
           type: 'object',
           name: 'color',
           title: 'Color with a long title',
+          preview: {
+            select: {
+              title: 'title',
+              subtitle: 'name',
+            },
+          },
           fields: [
             {
               name: 'title',

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
@@ -328,7 +328,6 @@ export function ReferenceItem<Item extends ReferenceItemValue = ReferenceItemVal
             {...elementProps}
           >
             <PreviewReferenceValue
-              layout="compact"
               value={value}
               referenceInfo={loadableReferenceInfo}
               renderPreview={renderPreview}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
@@ -171,7 +171,7 @@ export function PreviewItem<Item extends ObjectItem = ObjectItem>(props: Preview
         {renderPreview({
           schemaType: props.schemaType,
           value: props.value,
-          layout: 'compact',
+          layout: 'default',
           // Don't do visibility check for virtualized items as the calculation will be incorrect causing it to scroll
           skipVisibilityCheck: true,
         })}


### PR DESCRIPTION
### Description

Fixes missing subtitle in object and reference previews inside arrays.

References:
![CleanShot 2023-12-21 at 11 13 26](https://github.com/sanity-io/sanity/assets/10508/80dc7ae3-f1d8-4886-b512-7100b90c75a3)

Objects:
![CleanShot 2023-12-21 at 11 11 36](https://github.com/sanity-io/sanity/assets/10508/f7c4ddd0-93ef-4570-bd70-95358e731f06)


### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

- Fix missing subtitle in object and reference previews inside arrays