### PR TITLE
fix(core): add missing deprecated tag to workspace logo

### DIFF
--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -397,6 +397,12 @@ export type Plugin<TOptions = void> = (options: TOptions) => PluginOptions
 export interface WorkspaceOptions extends SourceOptions {
   basePath: string
   subtitle?: string
+  /**
+   * The workspace logo
+   *
+   * @deprecated Custom logo components are no longer supported.
+   * Users are encouraged to provide custom components for individual workspace icons instead.
+   */
   logo?: ComponentType
   icon?: ComponentType
 


### PR DESCRIPTION
### Description
The workspace logo was missing deprecated tag, as this is no longer supported
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
