### PR TITLE
fix(desk): add bleed mode to field action button

### DIFF
--- a/packages/sanity/src/desk/components/pane/PaneHeaderActionButton.tsx
+++ b/packages/sanity/src/desk/components/pane/PaneHeaderActionButton.tsx
@@ -123,6 +123,7 @@ function PaneHeaderMenuGroupActionButton(props: PaneHeaderMenuGroupActionButtonP
           disabled={!!node.disabled}
           icon={node.icon ?? UnknownIcon}
           label={title}
+          mode="bleed"
           tooltipProps={{content: node.title, portal: true}}
         />
       }


### PR DESCRIPTION
### Description
The field action button had inverted colour scheme. 

![image (4)](https://github.com/sanity-io/sanity/assets/44635000/ccd03887-636e-4f1a-adf6-e22ab4b673ed)

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Add this to `config` to test: 
```js
document: {
     unstable_fieldActions: (prev, {documentType, schema}) => {
        return [
          ...prev,
          {
            name: 'test',
            useAction: () => ({
              type: 'group',
              title: 'Test',
              icon: RobotIcon,
              children: [{type: 'action', title: 'test'}],
              renderAsButton: true,
            }),
          },
        ]
      },
}
```

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fixes issue with inverted colour for field action buttons
<!--
A description of the change(s) that should be used in the release notes.
-->
