### PR TITLE
fix(core): adds consistent padding to document footer

### DIFF
--- a/packages/sanity/src/desk/panes/document/statusBar/DocumentStatusBar.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/DocumentStatusBar.tsx
@@ -35,16 +35,15 @@ export function DocumentStatusBar(props: DocumentStatusBarProps) {
   return (
     <Flex direction="column" ref={setRootElement} sizing="border">
       {shouldRender && (
-        <Flex align="stretch" gap={1} justify="space-between">
-          <Flex
-            align="center"
-            flex={1}
-            gap={collapsed ? 2 : 3}
-            paddingLeft={4}
-            paddingRight={3}
-            paddingY={2}
-            wrap="wrap"
-          >
+        <Flex
+          align="stretch"
+          gap={1}
+          justify="space-between"
+          paddingY={2}
+          paddingLeft={4}
+          paddingRight={3}
+        >
+          <Flex align="center" flex={1} gap={collapsed ? 2 : 3} wrap="wrap" paddingRight={3}>
             <Flex align="center">
               <DocumentStatusLine singleLine={!collapsed} />
               <SpacerButton size="large" />
@@ -55,7 +54,6 @@ export function DocumentStatusBar(props: DocumentStatusBarProps) {
           <Flex
             align="flex-start"
             justify="flex-end"
-            paddingY={2}
             ref={actionsBoxRef}
             style={{flexShrink: 0, marginLeft: 'auto'}}
           >


### PR DESCRIPTION
### Description

<img width="878" alt="Screenshot 2023-12-21 at 10 04 31" src="https://github.com/sanity-io/sanity/assets/46196328/6efefb10-c7ae-471f-bd49-7fa2601ea8b2">
<img width="876" alt="Screenshot 2023-12-21 at 10 04 24" src="https://github.com/sanity-io/sanity/assets/46196328/4a784054-d143-442c-9661-3e5967af308d">
<img width="379" alt="Screenshot 2023-12-21 at 10 03 07" src="https://github.com/sanity-io/sanity/assets/46196328/84d61754-a06b-4a72-bd14-48af7ed5ee44">
<img width="405" alt="Screenshot 2023-12-21 at 10 02 56" src="https://github.com/sanity-io/sanity/assets/46196328/11114b6b-79a5-4ac5-a251-25af0febd2ac">

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
