### PR TITLE
fix(core): box sizing content box in preview elements, free trial popover position

### DIFF
--- a/packages/sanity/src/core/components/previews/general/CompactPreview.tsx
+++ b/packages/sanity/src/core/components/previews/general/CompactPreview.tsx
@@ -21,6 +21,7 @@ const DEFAULT_MEDIA_DIMENSIONS: PreviewMediaDimensions = {
 
 const Root = styled(Flex)`
   height: ${rem(PREVIEW_SIZES.compact.media.height)};
+  box-sizing: content-box;
 `
 
 const TitleSkeleton = styled(TextSkeleton).attrs({animated: true, radius: 1, size: 1})`

--- a/packages/sanity/src/core/components/previews/general/DefaultPreview.tsx
+++ b/packages/sanity/src/core/components/previews/general/DefaultPreview.tsx
@@ -36,6 +36,7 @@ const DEFAULT_MEDIA_DIMENSIONS: PreviewMediaDimensions = {
 
 const Root = styled(Flex)`
   height: ${rem(PREVIEW_SIZES.default.media.height)};
+  box-sizing: content-box;
 `
 
 const TitleSkeleton = styled(TextSkeleton).attrs({animated: true, radius: 1, size: 1})`

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrial.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrial.tsx
@@ -13,8 +13,8 @@ interface FreeTrialProps {
 export function FreeTrial({type}: FreeTrialProps) {
   const {data, showDialog, showOnLoad, toggleShowContent} = useFreeTrialContext()
   const scheme = useColorSchemeValue()
-  //  On mobile, give it some time so the popover doesn't show up until the navbar is open.
-  const [showPopover, setShowPopover] = useState(type !== 'sidebar')
+  //  Give it some time so the popover doesn't show until the element is mounted and the position is calculated.
+  const [showPopover, setShowPopover] = useState(false)
   const ref = useRef<HTMLButtonElement>(null)
 
   useEffect(() => {


### PR DESCRIPTION
### Description

Sanity UI has a default `box-sizing: content-box` but this in some scenarios can be overridden in embebed studios, for example in a NextJS app which includes Tailwind, as it's usual to reset that and use `box-sizing: border-box`.

With these changes, the box sizing will be consisten in a normal studio and an embebed one.


It also adds a delay to mount the popover given that in embebed studios it was positioning in an incorrect place.
Adding this delay, gives time for the element to mount and the popover to position as expected.


<img width="1156" alt="Screenshot 2023-12-21 at 11 04 52" src="https://github.com/sanity-io/sanity/assets/46196328/b6b11b79-bbe5-4ee5-8154-17fbc95c5b19">

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
