### PR TITLE
Optimize graphql deployment

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/graphql/deployApiAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/deployApiAction.ts
@@ -55,6 +55,7 @@ export default async function deployGraphQLApiAction(
     playground: playgroundFlag,
     generation: generationFlag,
     'non-null-document-fields': nonNullDocumentFieldsFlag,
+    withUnionCache,
   } = flags
 
   const {apiClient, output, prompt} = context
@@ -200,6 +201,7 @@ export default async function deployGraphQLApiAction(
           typeof nonNullDocumentFieldsFlag === 'undefined'
             ? nonNullDocumentFields
             : nonNullDocumentFieldsFlag,
+        withUnionCache,
       })
 
       apiSpec = generateSchema(extracted, {filterSuffix: apiDef.filterSuffix})
@@ -404,6 +406,7 @@ function parseCliFlags(args: {argv?: string[]}) {
     .option('generation', {type: 'string'})
     .option('non-null-document-fields', {type: 'boolean'})
     .option('playground', {type: 'boolean'})
+    .option('with-union-cache', {type: 'boolean'})
     .option('force', {type: 'boolean'}).argv
 }
 

--- a/packages/sanity/src/_internal/cli/actions/graphql/extractFromSanitySchema.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/extractFromSanitySchema.ts
@@ -237,7 +237,7 @@ export function extractFromSanitySchema(
     }
 
     if (isReference(type)) {
-      return getReferenceDefinition(type as ReferenceSchemaType, parent)
+      return getReferenceDefinition(type, parent)
     }
 
     if (isArrayType(type)) {
@@ -372,9 +372,12 @@ export function extractFromSanitySchema(
       throw new Error('No candidates for reference')
     }
 
-    return candidates.length === 1
-      ? {type: getTypeName(candidates[0].type.name), ...base}
-      : {...getUnionDefinition(candidates, def, {grandParent: parent}), ...base}
+    if (candidates.length === 1) {
+      return {type: getTypeName(candidates[0].type.name), ...base}
+    }
+
+    const unionDefinition = getUnionDefinition(candidates, def, {grandParent: parent})
+    return {...unionDefinition, ...base}
   }
 
   function getArrayDefinition(

--- a/packages/sanity/src/_internal/cli/commands/graphql/deployGraphQLAPICommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/graphql/deployGraphQLAPICommand.ts
@@ -16,6 +16,7 @@ configuration file. Tread with caution!
   --non-null-document-fields Use non-null document fields (_id, _type etc)
   --playground Enable GraphQL playground for easier debugging
   --no-playground Disable GraphQL playground
+  --with-union-cache *Experimental:* Enable union cache that optimizes schema generation for schemas with many self referencing types
 
 Examples
   # Deploy all defined GraphQL APIs

--- a/packages/sanity/test/cli/graphql/__snapshots__/gen3.test.ts.snap
+++ b/packages/sanity/test/cli/graphql/__snapshots__/gen3.test.ts.snap
@@ -9129,3 +9129,29777 @@ Object {
   ],
 }
 `;
+
+exports[`GraphQL - Generation 3 Union cache: sanitySchema: manySelfRefsSchema Should be able to generate graphql schema, withUnionCache: false 1`] = `
+Object {
+  "generation": "gen3",
+  "interfaces": Array [
+    Object {
+      "description": "A Sanity document",
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+      ],
+      "kind": "Interface",
+      "name": "Document",
+    },
+  ],
+  "queries": Array [
+    Object {
+      "args": Array [
+        Object {
+          "description": "Document document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "Document",
+      "type": "Document",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SanityFileAsset document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SanityFileAsset",
+      "type": "SanityFileAsset",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SanityImageAsset document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SanityImageAsset",
+      "type": "SanityImageAsset",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType0 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType0",
+      "type": "SchemaType0",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType1 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType1",
+      "type": "SchemaType1",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType10 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType10",
+      "type": "SchemaType10",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType11 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType11",
+      "type": "SchemaType11",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType12 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType12",
+      "type": "SchemaType12",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType13 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType13",
+      "type": "SchemaType13",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType14 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType14",
+      "type": "SchemaType14",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType15 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType15",
+      "type": "SchemaType15",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType16 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType16",
+      "type": "SchemaType16",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType17 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType17",
+      "type": "SchemaType17",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType18 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType18",
+      "type": "SchemaType18",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType19 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType19",
+      "type": "SchemaType19",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType2 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType2",
+      "type": "SchemaType2",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType20 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType20",
+      "type": "SchemaType20",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType21 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType21",
+      "type": "SchemaType21",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType22 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType22",
+      "type": "SchemaType22",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType23 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType23",
+      "type": "SchemaType23",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType24 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType24",
+      "type": "SchemaType24",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType25 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType25",
+      "type": "SchemaType25",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType26 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType26",
+      "type": "SchemaType26",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType27 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType27",
+      "type": "SchemaType27",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType28 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType28",
+      "type": "SchemaType28",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType29 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType29",
+      "type": "SchemaType29",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType3 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType3",
+      "type": "SchemaType3",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType30 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType30",
+      "type": "SchemaType30",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType31 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType31",
+      "type": "SchemaType31",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType32 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType32",
+      "type": "SchemaType32",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType33 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType33",
+      "type": "SchemaType33",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType34 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType34",
+      "type": "SchemaType34",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType35 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType35",
+      "type": "SchemaType35",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType36 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType36",
+      "type": "SchemaType36",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType37 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType37",
+      "type": "SchemaType37",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType38 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType38",
+      "type": "SchemaType38",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType39 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType39",
+      "type": "SchemaType39",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType4 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType4",
+      "type": "SchemaType4",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType5 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType5",
+      "type": "SchemaType5",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType6 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType6",
+      "type": "SchemaType6",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType7 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType7",
+      "type": "SchemaType7",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType8 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType8",
+      "type": "SchemaType8",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType9 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType9",
+      "type": "SchemaType9",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "DocumentSorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "DocumentFilter",
+        },
+      ],
+      "fieldName": "allDocument",
+      "filter": "_type in [\\"sanity.fileAsset\\", \\"sanity.imageAsset\\", \\"schemaType0\\", \\"schemaType1\\", \\"schemaType2\\", \\"schemaType3\\", \\"schemaType4\\", \\"schemaType5\\", \\"schemaType6\\", \\"schemaType7\\", \\"schemaType8\\", \\"schemaType9\\", \\"schemaType10\\", \\"schemaType11\\", \\"schemaType12\\", \\"schemaType13\\", \\"schemaType14\\", \\"schemaType15\\", \\"schemaType16\\", \\"schemaType17\\", \\"schemaType18\\", \\"schemaType19\\", \\"schemaType20\\", \\"schemaType21\\", \\"schemaType22\\", \\"schemaType23\\", \\"schemaType24\\", \\"schemaType25\\", \\"schemaType26\\", \\"schemaType27\\", \\"schemaType28\\", \\"schemaType29\\", \\"schemaType30\\", \\"schemaType31\\", \\"schemaType32\\", \\"schemaType33\\", \\"schemaType34\\", \\"schemaType35\\", \\"schemaType36\\", \\"schemaType37\\", \\"schemaType38\\", \\"schemaType39\\"]",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "Document",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SanityFileAssetSorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SanityFileAssetFilter",
+        },
+      ],
+      "fieldName": "allSanityFileAsset",
+      "filter": "_type == \\"sanity.fileAsset\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SanityFileAsset",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SanityImageAssetSorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SanityImageAssetFilter",
+        },
+      ],
+      "fieldName": "allSanityImageAsset",
+      "filter": "_type == \\"sanity.imageAsset\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SanityImageAsset",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType0Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType0Filter",
+        },
+      ],
+      "fieldName": "allSchemaType0",
+      "filter": "_type == \\"schemaType0\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType0",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType1Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType1Filter",
+        },
+      ],
+      "fieldName": "allSchemaType1",
+      "filter": "_type == \\"schemaType1\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType1",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType10Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType10Filter",
+        },
+      ],
+      "fieldName": "allSchemaType10",
+      "filter": "_type == \\"schemaType10\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType10",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType11Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType11Filter",
+        },
+      ],
+      "fieldName": "allSchemaType11",
+      "filter": "_type == \\"schemaType11\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType11",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType12Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType12Filter",
+        },
+      ],
+      "fieldName": "allSchemaType12",
+      "filter": "_type == \\"schemaType12\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType12",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType13Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType13Filter",
+        },
+      ],
+      "fieldName": "allSchemaType13",
+      "filter": "_type == \\"schemaType13\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType13",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType14Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType14Filter",
+        },
+      ],
+      "fieldName": "allSchemaType14",
+      "filter": "_type == \\"schemaType14\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType14",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType15Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType15Filter",
+        },
+      ],
+      "fieldName": "allSchemaType15",
+      "filter": "_type == \\"schemaType15\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType15",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType16Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType16Filter",
+        },
+      ],
+      "fieldName": "allSchemaType16",
+      "filter": "_type == \\"schemaType16\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType16",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType17Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType17Filter",
+        },
+      ],
+      "fieldName": "allSchemaType17",
+      "filter": "_type == \\"schemaType17\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType17",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType18Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType18Filter",
+        },
+      ],
+      "fieldName": "allSchemaType18",
+      "filter": "_type == \\"schemaType18\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType18",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType19Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType19Filter",
+        },
+      ],
+      "fieldName": "allSchemaType19",
+      "filter": "_type == \\"schemaType19\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType19",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType2Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType2Filter",
+        },
+      ],
+      "fieldName": "allSchemaType2",
+      "filter": "_type == \\"schemaType2\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType2",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType20Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType20Filter",
+        },
+      ],
+      "fieldName": "allSchemaType20",
+      "filter": "_type == \\"schemaType20\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType20",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType21Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType21Filter",
+        },
+      ],
+      "fieldName": "allSchemaType21",
+      "filter": "_type == \\"schemaType21\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType21",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType22Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType22Filter",
+        },
+      ],
+      "fieldName": "allSchemaType22",
+      "filter": "_type == \\"schemaType22\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType22",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType23Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType23Filter",
+        },
+      ],
+      "fieldName": "allSchemaType23",
+      "filter": "_type == \\"schemaType23\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType23",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType24Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType24Filter",
+        },
+      ],
+      "fieldName": "allSchemaType24",
+      "filter": "_type == \\"schemaType24\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType24",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType25Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType25Filter",
+        },
+      ],
+      "fieldName": "allSchemaType25",
+      "filter": "_type == \\"schemaType25\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType25",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType26Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType26Filter",
+        },
+      ],
+      "fieldName": "allSchemaType26",
+      "filter": "_type == \\"schemaType26\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType26",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType27Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType27Filter",
+        },
+      ],
+      "fieldName": "allSchemaType27",
+      "filter": "_type == \\"schemaType27\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType27",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType28Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType28Filter",
+        },
+      ],
+      "fieldName": "allSchemaType28",
+      "filter": "_type == \\"schemaType28\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType28",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType29Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType29Filter",
+        },
+      ],
+      "fieldName": "allSchemaType29",
+      "filter": "_type == \\"schemaType29\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType29",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType3Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType3Filter",
+        },
+      ],
+      "fieldName": "allSchemaType3",
+      "filter": "_type == \\"schemaType3\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType3",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType30Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType30Filter",
+        },
+      ],
+      "fieldName": "allSchemaType30",
+      "filter": "_type == \\"schemaType30\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType30",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType31Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType31Filter",
+        },
+      ],
+      "fieldName": "allSchemaType31",
+      "filter": "_type == \\"schemaType31\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType31",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType32Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType32Filter",
+        },
+      ],
+      "fieldName": "allSchemaType32",
+      "filter": "_type == \\"schemaType32\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType32",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType33Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType33Filter",
+        },
+      ],
+      "fieldName": "allSchemaType33",
+      "filter": "_type == \\"schemaType33\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType33",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType34Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType34Filter",
+        },
+      ],
+      "fieldName": "allSchemaType34",
+      "filter": "_type == \\"schemaType34\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType34",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType35Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType35Filter",
+        },
+      ],
+      "fieldName": "allSchemaType35",
+      "filter": "_type == \\"schemaType35\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType35",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType36Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType36Filter",
+        },
+      ],
+      "fieldName": "allSchemaType36",
+      "filter": "_type == \\"schemaType36\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType36",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType37Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType37Filter",
+        },
+      ],
+      "fieldName": "allSchemaType37",
+      "filter": "_type == \\"schemaType37\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType37",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType38Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType38Filter",
+        },
+      ],
+      "fieldName": "allSchemaType38",
+      "filter": "_type == \\"schemaType38\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType38",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType39Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType39Filter",
+        },
+      ],
+      "fieldName": "allSchemaType39",
+      "filter": "_type == \\"schemaType39\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType39",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType4Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType4Filter",
+        },
+      ],
+      "fieldName": "allSchemaType4",
+      "filter": "_type == \\"schemaType4\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType4",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType5Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType5Filter",
+        },
+      ],
+      "fieldName": "allSchemaType5",
+      "filter": "_type == \\"schemaType5\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType5",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType6Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType6Filter",
+        },
+      ],
+      "fieldName": "allSchemaType6",
+      "filter": "_type == \\"schemaType6\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType6",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType7Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType7Filter",
+        },
+      ],
+      "fieldName": "allSchemaType7",
+      "filter": "_type == \\"schemaType7\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType7",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType8Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType8Filter",
+        },
+      ],
+      "fieldName": "allSchemaType8",
+      "filter": "_type == \\"schemaType8\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType8",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType9Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType9Filter",
+        },
+      ],
+      "fieldName": "allSchemaType9",
+      "filter": "_type == \\"schemaType9\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType9",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+  ],
+  "types": Array [
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "children": Object {
+            "type": "Span",
+          },
+          "description": undefined,
+          "fieldName": "children",
+          "kind": "List",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "level",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "listItem",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "style",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "Block",
+      "originalName": "block",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "Boolean",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "BooleanFilter",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_dataset",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_projectId",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_ref",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_weak",
+          "type": "Boolean",
+        },
+      ],
+      "kind": "Type",
+      "name": "CrossDatasetReference",
+      "originalName": "crossDatasetReference",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_dataset",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_projectId",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_ref",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_weak",
+          "isReference": undefined,
+          "type": "BooleanFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "CrossDatasetReferenceFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_dataset",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_projectId",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_ref",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_weak",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "CrossDatasetReferenceSorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "Date",
+        },
+        Object {
+          "description": "Checks if the value is greater than the given input.",
+          "fieldName": "gt",
+          "type": "Date",
+        },
+        Object {
+          "description": "Checks if the value is greater than or equal to the given input.",
+          "fieldName": "gte",
+          "type": "Date",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value is lesser than the given input.",
+          "fieldName": "lt",
+          "type": "Date",
+        },
+        Object {
+          "description": "Checks if the value is lesser than or equal to the given input.",
+          "fieldName": "lte",
+          "type": "Date",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "Date",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "DateFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Checks if the value is greater than the given input.",
+          "fieldName": "gt",
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Checks if the value is greater than or equal to the given input.",
+          "fieldName": "gte",
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value is lesser than the given input.",
+          "fieldName": "lt",
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Checks if the value is lesser than or equal to the given input.",
+          "fieldName": "lte",
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "Datetime",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "DatetimeFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "DocumentFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "DocumentSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "asset",
+          "isReference": true,
+          "type": "SanityFileAsset",
+        },
+      ],
+      "kind": "Type",
+      "name": "File",
+      "originalName": "file",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "asset",
+          "isReference": true,
+          "type": "SanityFileAssetFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "FileFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "FileSorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "Float",
+        },
+        Object {
+          "description": "Checks if the value is greater than the given input.",
+          "fieldName": "gt",
+          "type": "Float",
+        },
+        Object {
+          "description": "Checks if the value is greater than or equal to the given input.",
+          "fieldName": "gte",
+          "type": "Float",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value is lesser than the given input.",
+          "fieldName": "lt",
+          "type": "Float",
+        },
+        Object {
+          "description": "Checks if the value is lesser than or equal to the given input.",
+          "fieldName": "lte",
+          "type": "Float",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "Float",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "FloatFilter",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "alt",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "lat",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "lng",
+          "type": "Float",
+        },
+      ],
+      "kind": "Type",
+      "name": "Geopoint",
+      "originalName": "geopoint",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "alt",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "lat",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "lng",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "GeopointFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "alt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "lat",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "lng",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "GeopointSorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "ID",
+        },
+        Object {
+          "children": Object {
+            "isNullable": false,
+            "type": "ID",
+          },
+          "description": "Checks if the value is equal to one of the given values.",
+          "fieldName": "in",
+          "kind": "List",
+        },
+        Object {
+          "description": "Checks if the value matches the given word/words.",
+          "fieldName": "matches",
+          "type": "ID",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "ID",
+        },
+        Object {
+          "children": Object {
+            "isNullable": false,
+            "type": "ID",
+          },
+          "description": "Checks if the value is not equal to one of the given values.",
+          "fieldName": "nin",
+          "kind": "List",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "IDFilter",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "asset",
+          "isReference": true,
+          "type": "SanityImageAsset",
+        },
+        Object {
+          "fieldName": "crop",
+          "type": "SanityImageCrop",
+        },
+        Object {
+          "fieldName": "hotspot",
+          "type": "SanityImageHotspot",
+        },
+      ],
+      "kind": "Type",
+      "name": "Image",
+      "originalName": "image",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "asset",
+          "isReference": true,
+          "type": "SanityImageAssetFilter",
+        },
+        Object {
+          "fieldName": "crop",
+          "isReference": undefined,
+          "type": "SanityImageCropFilter",
+        },
+        Object {
+          "fieldName": "hotspot",
+          "isReference": undefined,
+          "type": "SanityImageHotspotFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "ImageFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "crop",
+          "type": "SanityImageCropSorting",
+        },
+        Object {
+          "fieldName": "hotspot",
+          "type": "SanityImageHotspotSorting",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "ImageSorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "Int",
+        },
+        Object {
+          "description": "Checks if the value is greater than the given input.",
+          "fieldName": "gt",
+          "type": "Int",
+        },
+        Object {
+          "description": "Checks if the value is greater than or equal to the given input.",
+          "fieldName": "gte",
+          "type": "Int",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value is lesser than the given input.",
+          "fieldName": "lt",
+          "type": "Int",
+        },
+        Object {
+          "description": "Checks if the value is lesser than or equal to the given input.",
+          "fieldName": "lte",
+          "type": "Int",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "Int",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "IntFilter",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": "The unique ID for the asset within the originating source so you can programatically find back to it",
+          "fieldName": "id",
+          "type": "String",
+        },
+        Object {
+          "description": "A canonical name for the source this asset is originating from",
+          "fieldName": "name",
+          "type": "String",
+        },
+        Object {
+          "description": "A URL to find more information about this asset in the originating source",
+          "fieldName": "url",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityAssetSourceData",
+      "originalName": "sanity.assetSourceData",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "id",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "name",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "url",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityAssetSourceDataFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "name",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "url",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityAssetSourceDataSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "altText",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "assetId",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "description",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "extension",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "label",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "mimeType",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "originalFilename",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "path",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "sha1hash",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "size",
+          "type": "Float",
+        },
+        Object {
+          "fieldName": "source",
+          "type": "SanityAssetSourceData",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "title",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "url",
+          "type": "String",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SanityFileAsset",
+      "originalName": "sanity.fileAsset",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "altText",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "assetId",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "description",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "extension",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "label",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "mimeType",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "originalFilename",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "path",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "sha1hash",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "size",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "source",
+          "isReference": undefined,
+          "type": "SanityAssetSourceDataFilter",
+        },
+        Object {
+          "fieldName": "title",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "url",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityFileAssetFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "altText",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "assetId",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "description",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "extension",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "label",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "mimeType",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "originalFilename",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "path",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "sha1hash",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "size",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "source",
+          "type": "SanityAssetSourceDataSorting",
+        },
+        Object {
+          "fieldName": "title",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "url",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityFileAssetSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "altText",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "assetId",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "description",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "extension",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "label",
+          "type": "String",
+        },
+        Object {
+          "fieldName": "metadata",
+          "type": "SanityImageMetadata",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "mimeType",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "originalFilename",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "path",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "sha1hash",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "size",
+          "type": "Float",
+        },
+        Object {
+          "fieldName": "source",
+          "type": "SanityAssetSourceData",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "title",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "uploadId",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "url",
+          "type": "String",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SanityImageAsset",
+      "originalName": "sanity.imageAsset",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "altText",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "assetId",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "description",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "extension",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "label",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "metadata",
+          "isReference": undefined,
+          "type": "SanityImageMetadataFilter",
+        },
+        Object {
+          "fieldName": "mimeType",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "originalFilename",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "path",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "sha1hash",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "size",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "source",
+          "isReference": undefined,
+          "type": "SanityAssetSourceDataFilter",
+        },
+        Object {
+          "fieldName": "title",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "uploadId",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "url",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageAssetFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "altText",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "assetId",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "description",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "extension",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "label",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "metadata",
+          "type": "SanityImageMetadataSorting",
+        },
+        Object {
+          "fieldName": "mimeType",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "originalFilename",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "path",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "sha1hash",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "size",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "source",
+          "type": "SanityAssetSourceDataSorting",
+        },
+        Object {
+          "fieldName": "title",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "uploadId",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "url",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageAssetSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "bottom",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "left",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "right",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "top",
+          "type": "Float",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityImageCrop",
+      "originalName": "sanity.imageCrop",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "bottom",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "left",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "right",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "top",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageCropFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "bottom",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "left",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "right",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "top",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageCropSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "aspectRatio",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "height",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "width",
+          "type": "Float",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityImageDimensions",
+      "originalName": "sanity.imageDimensions",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "aspectRatio",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "height",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "width",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageDimensionsFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "aspectRatio",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "height",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "width",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageDimensionsSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "height",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "width",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "x",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "y",
+          "type": "Float",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityImageHotspot",
+      "originalName": "sanity.imageHotspot",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "height",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "width",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "x",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "y",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageHotspotFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "height",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "width",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "x",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "y",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageHotspotSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "blurHash",
+          "type": "String",
+        },
+        Object {
+          "fieldName": "dimensions",
+          "type": "SanityImageDimensions",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "hasAlpha",
+          "type": "Boolean",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "isOpaque",
+          "type": "Boolean",
+        },
+        Object {
+          "fieldName": "location",
+          "type": "Geopoint",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "lqip",
+          "type": "String",
+        },
+        Object {
+          "fieldName": "palette",
+          "type": "SanityImagePalette",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityImageMetadata",
+      "originalName": "sanity.imageMetadata",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "blurHash",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "dimensions",
+          "isReference": undefined,
+          "type": "SanityImageDimensionsFilter",
+        },
+        Object {
+          "fieldName": "hasAlpha",
+          "isReference": undefined,
+          "type": "BooleanFilter",
+        },
+        Object {
+          "fieldName": "isOpaque",
+          "isReference": undefined,
+          "type": "BooleanFilter",
+        },
+        Object {
+          "fieldName": "location",
+          "isReference": undefined,
+          "type": "GeopointFilter",
+        },
+        Object {
+          "fieldName": "lqip",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "palette",
+          "isReference": undefined,
+          "type": "SanityImagePaletteFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageMetadataFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "blurHash",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "dimensions",
+          "type": "SanityImageDimensionsSorting",
+        },
+        Object {
+          "fieldName": "hasAlpha",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "isOpaque",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "location",
+          "type": "GeopointSorting",
+        },
+        Object {
+          "fieldName": "lqip",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "palette",
+          "type": "SanityImagePaletteSorting",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageMetadataSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "fieldName": "darkMuted",
+          "type": "SanityImagePaletteSwatch",
+        },
+        Object {
+          "fieldName": "darkVibrant",
+          "type": "SanityImagePaletteSwatch",
+        },
+        Object {
+          "fieldName": "dominant",
+          "type": "SanityImagePaletteSwatch",
+        },
+        Object {
+          "fieldName": "lightMuted",
+          "type": "SanityImagePaletteSwatch",
+        },
+        Object {
+          "fieldName": "lightVibrant",
+          "type": "SanityImagePaletteSwatch",
+        },
+        Object {
+          "fieldName": "muted",
+          "type": "SanityImagePaletteSwatch",
+        },
+        Object {
+          "fieldName": "vibrant",
+          "type": "SanityImagePaletteSwatch",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityImagePalette",
+      "originalName": "sanity.imagePalette",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "darkMuted",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+        Object {
+          "fieldName": "darkVibrant",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+        Object {
+          "fieldName": "dominant",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+        Object {
+          "fieldName": "lightMuted",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+        Object {
+          "fieldName": "lightVibrant",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+        Object {
+          "fieldName": "muted",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+        Object {
+          "fieldName": "vibrant",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImagePaletteFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "darkMuted",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+        Object {
+          "fieldName": "darkVibrant",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+        Object {
+          "fieldName": "dominant",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+        Object {
+          "fieldName": "lightMuted",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+        Object {
+          "fieldName": "lightVibrant",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+        Object {
+          "fieldName": "muted",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+        Object {
+          "fieldName": "vibrant",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImagePaletteSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "background",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "foreground",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "population",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "title",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityImagePaletteSwatch",
+      "originalName": "sanity.imagePaletteSwatch",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "background",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "foreground",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "population",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "title",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImagePaletteSwatchFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "background",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "foreground",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "population",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "title",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImagePaletteSwatchSorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "All documents that are drafts.",
+          "fieldName": "is_draft",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "All documents referencing the given document ID.",
+          "fieldName": "references",
+          "type": "ID",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "Sanity_DocumentFilter",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType0",
+      "originalName": "schemaType0",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType0Filter",
+    },
+    Object {
+      "fields": Array [],
+      "interfaces": undefined,
+      "kind": "Union",
+      "name": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+      "types": Array [
+        "SchemaType0",
+        "SchemaType1",
+        "SchemaType10",
+        "SchemaType11",
+        "SchemaType12",
+        "SchemaType13",
+        "SchemaType14",
+        "SchemaType15",
+        "SchemaType16",
+        "SchemaType17",
+        "SchemaType18",
+        "SchemaType19",
+        "SchemaType2",
+        "SchemaType20",
+        "SchemaType21",
+        "SchemaType22",
+        "SchemaType23",
+        "SchemaType24",
+        "SchemaType25",
+        "SchemaType26",
+        "SchemaType27",
+        "SchemaType28",
+        "SchemaType29",
+        "SchemaType3",
+        "SchemaType30",
+        "SchemaType31",
+        "SchemaType32",
+        "SchemaType33",
+        "SchemaType34",
+        "SchemaType35",
+        "SchemaType36",
+        "SchemaType37",
+        "SchemaType38",
+        "SchemaType39",
+        "SchemaType4",
+        "SchemaType5",
+        "SchemaType6",
+        "SchemaType7",
+        "SchemaType8",
+        "SchemaType9",
+      ],
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType0Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType1",
+      "originalName": "schemaType1",
+      "type": "Object",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType10",
+      "originalName": "schemaType10",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType10Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType10Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType11",
+      "originalName": "schemaType11",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType11Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType11Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType12",
+      "originalName": "schemaType12",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType12Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType12Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType13",
+      "originalName": "schemaType13",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType13Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType13Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType14",
+      "originalName": "schemaType14",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType14Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType14Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType15",
+      "originalName": "schemaType15",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType15Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType15Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType16",
+      "originalName": "schemaType16",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType16Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType16Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType17",
+      "originalName": "schemaType17",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType17Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType17Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType18",
+      "originalName": "schemaType18",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType18Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType18Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType19",
+      "originalName": "schemaType19",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType19Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType19Sorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType1Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType1Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType2",
+      "originalName": "schemaType2",
+      "type": "Object",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType20",
+      "originalName": "schemaType20",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType20Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType20Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType21",
+      "originalName": "schemaType21",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType21Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType21Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType22",
+      "originalName": "schemaType22",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType22Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType22Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType23",
+      "originalName": "schemaType23",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType23Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType23Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType24",
+      "originalName": "schemaType24",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType24Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType24Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType25",
+      "originalName": "schemaType25",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType25Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType25Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType26",
+      "originalName": "schemaType26",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType26Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType26Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType27",
+      "originalName": "schemaType27",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType27Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType27Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType28",
+      "originalName": "schemaType28",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType28Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType28Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType29",
+      "originalName": "schemaType29",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType29Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType29Sorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType2Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType2Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType3",
+      "originalName": "schemaType3",
+      "type": "Object",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType30",
+      "originalName": "schemaType30",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType30Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType30Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType31",
+      "originalName": "schemaType31",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType31Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType31Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType32",
+      "originalName": "schemaType32",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType32Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType32Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType33",
+      "originalName": "schemaType33",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType33Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType33Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType34",
+      "originalName": "schemaType34",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType34Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType34Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType35",
+      "originalName": "schemaType35",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType35Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType35Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType36",
+      "originalName": "schemaType36",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType36Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType36Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType37",
+      "originalName": "schemaType37",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType37Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType37Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType38",
+      "originalName": "schemaType38",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType38Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType38Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType39",
+      "originalName": "schemaType39",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType39Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType39Sorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType3Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType3Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType4",
+      "originalName": "schemaType4",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType4Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType4Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType5",
+      "originalName": "schemaType5",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType5Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType5Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType6",
+      "originalName": "schemaType6",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType6Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType6Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType7",
+      "originalName": "schemaType7",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType7Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType7Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType8",
+      "originalName": "schemaType8",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType8Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType8Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType9",
+      "originalName": "schemaType9",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType9Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType9Sorting",
+    },
+    Object {
+      "fields": Array [],
+      "kind": "Enum",
+      "name": "SortOrder",
+      "values": Array [
+        Object {
+          "description": "Sorts on the value in ascending order.",
+          "name": "ASC",
+          "value": 1,
+        },
+        Object {
+          "description": "Sorts on the value in descending order.",
+          "name": "DESC",
+          "value": 2,
+        },
+      ],
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "children": Object {
+            "type": "String",
+          },
+          "description": undefined,
+          "fieldName": "marks",
+          "kind": "List",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "text",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "Span",
+      "originalName": "span",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "String",
+        },
+        Object {
+          "children": Object {
+            "isNullable": false,
+            "type": "String",
+          },
+          "description": "Checks if the value is equal to one of the given values.",
+          "fieldName": "in",
+          "kind": "List",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value matches the given word/words.",
+          "fieldName": "matches",
+          "type": "String",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "String",
+        },
+        Object {
+          "children": Object {
+            "isNullable": false,
+            "type": "String",
+          },
+          "description": "Checks if the value is not equal to one of the given values.",
+          "fieldName": "nin",
+          "kind": "List",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "StringFilter",
+    },
+  ],
+}
+`;
+
+exports[`GraphQL - Generation 3 Union cache: sanitySchema: manySelfRefsSchema Should be able to generate graphql schema, withUnionCache: true 1`] = `
+Object {
+  "generation": "gen3",
+  "interfaces": Array [
+    Object {
+      "description": "A Sanity document",
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+      ],
+      "kind": "Interface",
+      "name": "Document",
+    },
+  ],
+  "queries": Array [
+    Object {
+      "args": Array [
+        Object {
+          "description": "Document document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "Document",
+      "type": "Document",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SanityFileAsset document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SanityFileAsset",
+      "type": "SanityFileAsset",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SanityImageAsset document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SanityImageAsset",
+      "type": "SanityImageAsset",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType0 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType0",
+      "type": "SchemaType0",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType1 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType1",
+      "type": "SchemaType1",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType10 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType10",
+      "type": "SchemaType10",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType11 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType11",
+      "type": "SchemaType11",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType12 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType12",
+      "type": "SchemaType12",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType13 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType13",
+      "type": "SchemaType13",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType14 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType14",
+      "type": "SchemaType14",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType15 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType15",
+      "type": "SchemaType15",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType16 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType16",
+      "type": "SchemaType16",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType17 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType17",
+      "type": "SchemaType17",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType18 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType18",
+      "type": "SchemaType18",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType19 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType19",
+      "type": "SchemaType19",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType2 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType2",
+      "type": "SchemaType2",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType20 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType20",
+      "type": "SchemaType20",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType21 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType21",
+      "type": "SchemaType21",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType22 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType22",
+      "type": "SchemaType22",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType23 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType23",
+      "type": "SchemaType23",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType24 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType24",
+      "type": "SchemaType24",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType25 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType25",
+      "type": "SchemaType25",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType26 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType26",
+      "type": "SchemaType26",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType27 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType27",
+      "type": "SchemaType27",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType28 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType28",
+      "type": "SchemaType28",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType29 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType29",
+      "type": "SchemaType29",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType3 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType3",
+      "type": "SchemaType3",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType30 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType30",
+      "type": "SchemaType30",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType31 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType31",
+      "type": "SchemaType31",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType32 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType32",
+      "type": "SchemaType32",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType33 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType33",
+      "type": "SchemaType33",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType34 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType34",
+      "type": "SchemaType34",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType35 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType35",
+      "type": "SchemaType35",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType36 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType36",
+      "type": "SchemaType36",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType37 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType37",
+      "type": "SchemaType37",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType38 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType38",
+      "type": "SchemaType38",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType39 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType39",
+      "type": "SchemaType39",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType4 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType4",
+      "type": "SchemaType4",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType5 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType5",
+      "type": "SchemaType5",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType6 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType6",
+      "type": "SchemaType6",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType7 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType7",
+      "type": "SchemaType7",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType8 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType8",
+      "type": "SchemaType8",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SchemaType9 document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SchemaType9",
+      "type": "SchemaType9",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "DocumentSorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "DocumentFilter",
+        },
+      ],
+      "fieldName": "allDocument",
+      "filter": "_type in [\\"sanity.fileAsset\\", \\"sanity.imageAsset\\", \\"schemaType0\\", \\"schemaType1\\", \\"schemaType2\\", \\"schemaType3\\", \\"schemaType4\\", \\"schemaType5\\", \\"schemaType6\\", \\"schemaType7\\", \\"schemaType8\\", \\"schemaType9\\", \\"schemaType10\\", \\"schemaType11\\", \\"schemaType12\\", \\"schemaType13\\", \\"schemaType14\\", \\"schemaType15\\", \\"schemaType16\\", \\"schemaType17\\", \\"schemaType18\\", \\"schemaType19\\", \\"schemaType20\\", \\"schemaType21\\", \\"schemaType22\\", \\"schemaType23\\", \\"schemaType24\\", \\"schemaType25\\", \\"schemaType26\\", \\"schemaType27\\", \\"schemaType28\\", \\"schemaType29\\", \\"schemaType30\\", \\"schemaType31\\", \\"schemaType32\\", \\"schemaType33\\", \\"schemaType34\\", \\"schemaType35\\", \\"schemaType36\\", \\"schemaType37\\", \\"schemaType38\\", \\"schemaType39\\"]",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "Document",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SanityFileAssetSorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SanityFileAssetFilter",
+        },
+      ],
+      "fieldName": "allSanityFileAsset",
+      "filter": "_type == \\"sanity.fileAsset\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SanityFileAsset",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SanityImageAssetSorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SanityImageAssetFilter",
+        },
+      ],
+      "fieldName": "allSanityImageAsset",
+      "filter": "_type == \\"sanity.imageAsset\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SanityImageAsset",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType0Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType0Filter",
+        },
+      ],
+      "fieldName": "allSchemaType0",
+      "filter": "_type == \\"schemaType0\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType0",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType1Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType1Filter",
+        },
+      ],
+      "fieldName": "allSchemaType1",
+      "filter": "_type == \\"schemaType1\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType1",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType10Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType10Filter",
+        },
+      ],
+      "fieldName": "allSchemaType10",
+      "filter": "_type == \\"schemaType10\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType10",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType11Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType11Filter",
+        },
+      ],
+      "fieldName": "allSchemaType11",
+      "filter": "_type == \\"schemaType11\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType11",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType12Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType12Filter",
+        },
+      ],
+      "fieldName": "allSchemaType12",
+      "filter": "_type == \\"schemaType12\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType12",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType13Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType13Filter",
+        },
+      ],
+      "fieldName": "allSchemaType13",
+      "filter": "_type == \\"schemaType13\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType13",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType14Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType14Filter",
+        },
+      ],
+      "fieldName": "allSchemaType14",
+      "filter": "_type == \\"schemaType14\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType14",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType15Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType15Filter",
+        },
+      ],
+      "fieldName": "allSchemaType15",
+      "filter": "_type == \\"schemaType15\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType15",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType16Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType16Filter",
+        },
+      ],
+      "fieldName": "allSchemaType16",
+      "filter": "_type == \\"schemaType16\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType16",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType17Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType17Filter",
+        },
+      ],
+      "fieldName": "allSchemaType17",
+      "filter": "_type == \\"schemaType17\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType17",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType18Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType18Filter",
+        },
+      ],
+      "fieldName": "allSchemaType18",
+      "filter": "_type == \\"schemaType18\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType18",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType19Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType19Filter",
+        },
+      ],
+      "fieldName": "allSchemaType19",
+      "filter": "_type == \\"schemaType19\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType19",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType2Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType2Filter",
+        },
+      ],
+      "fieldName": "allSchemaType2",
+      "filter": "_type == \\"schemaType2\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType2",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType20Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType20Filter",
+        },
+      ],
+      "fieldName": "allSchemaType20",
+      "filter": "_type == \\"schemaType20\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType20",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType21Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType21Filter",
+        },
+      ],
+      "fieldName": "allSchemaType21",
+      "filter": "_type == \\"schemaType21\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType21",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType22Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType22Filter",
+        },
+      ],
+      "fieldName": "allSchemaType22",
+      "filter": "_type == \\"schemaType22\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType22",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType23Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType23Filter",
+        },
+      ],
+      "fieldName": "allSchemaType23",
+      "filter": "_type == \\"schemaType23\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType23",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType24Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType24Filter",
+        },
+      ],
+      "fieldName": "allSchemaType24",
+      "filter": "_type == \\"schemaType24\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType24",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType25Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType25Filter",
+        },
+      ],
+      "fieldName": "allSchemaType25",
+      "filter": "_type == \\"schemaType25\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType25",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType26Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType26Filter",
+        },
+      ],
+      "fieldName": "allSchemaType26",
+      "filter": "_type == \\"schemaType26\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType26",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType27Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType27Filter",
+        },
+      ],
+      "fieldName": "allSchemaType27",
+      "filter": "_type == \\"schemaType27\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType27",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType28Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType28Filter",
+        },
+      ],
+      "fieldName": "allSchemaType28",
+      "filter": "_type == \\"schemaType28\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType28",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType29Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType29Filter",
+        },
+      ],
+      "fieldName": "allSchemaType29",
+      "filter": "_type == \\"schemaType29\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType29",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType3Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType3Filter",
+        },
+      ],
+      "fieldName": "allSchemaType3",
+      "filter": "_type == \\"schemaType3\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType3",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType30Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType30Filter",
+        },
+      ],
+      "fieldName": "allSchemaType30",
+      "filter": "_type == \\"schemaType30\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType30",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType31Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType31Filter",
+        },
+      ],
+      "fieldName": "allSchemaType31",
+      "filter": "_type == \\"schemaType31\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType31",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType32Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType32Filter",
+        },
+      ],
+      "fieldName": "allSchemaType32",
+      "filter": "_type == \\"schemaType32\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType32",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType33Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType33Filter",
+        },
+      ],
+      "fieldName": "allSchemaType33",
+      "filter": "_type == \\"schemaType33\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType33",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType34Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType34Filter",
+        },
+      ],
+      "fieldName": "allSchemaType34",
+      "filter": "_type == \\"schemaType34\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType34",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType35Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType35Filter",
+        },
+      ],
+      "fieldName": "allSchemaType35",
+      "filter": "_type == \\"schemaType35\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType35",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType36Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType36Filter",
+        },
+      ],
+      "fieldName": "allSchemaType36",
+      "filter": "_type == \\"schemaType36\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType36",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType37Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType37Filter",
+        },
+      ],
+      "fieldName": "allSchemaType37",
+      "filter": "_type == \\"schemaType37\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType37",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType38Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType38Filter",
+        },
+      ],
+      "fieldName": "allSchemaType38",
+      "filter": "_type == \\"schemaType38\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType38",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType39Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType39Filter",
+        },
+      ],
+      "fieldName": "allSchemaType39",
+      "filter": "_type == \\"schemaType39\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType39",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType4Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType4Filter",
+        },
+      ],
+      "fieldName": "allSchemaType4",
+      "filter": "_type == \\"schemaType4\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType4",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType5Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType5Filter",
+        },
+      ],
+      "fieldName": "allSchemaType5",
+      "filter": "_type == \\"schemaType5\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType5",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType6Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType6Filter",
+        },
+      ],
+      "fieldName": "allSchemaType6",
+      "filter": "_type == \\"schemaType6\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType6",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType7Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType7Filter",
+        },
+      ],
+      "fieldName": "allSchemaType7",
+      "filter": "_type == \\"schemaType7\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType7",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType8Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType8Filter",
+        },
+      ],
+      "fieldName": "allSchemaType8",
+      "filter": "_type == \\"schemaType8\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType8",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SchemaType9Sorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SchemaType9Filter",
+        },
+      ],
+      "fieldName": "allSchemaType9",
+      "filter": "_type == \\"schemaType9\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SchemaType9",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+  ],
+  "types": Array [
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "children": Object {
+            "type": "Span",
+          },
+          "description": undefined,
+          "fieldName": "children",
+          "kind": "List",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "level",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "listItem",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "style",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "Block",
+      "originalName": "block",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "Boolean",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "BooleanFilter",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_dataset",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_projectId",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_ref",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_weak",
+          "type": "Boolean",
+        },
+      ],
+      "kind": "Type",
+      "name": "CrossDatasetReference",
+      "originalName": "crossDatasetReference",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_dataset",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_projectId",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_ref",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_weak",
+          "isReference": undefined,
+          "type": "BooleanFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "CrossDatasetReferenceFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_dataset",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_projectId",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_ref",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_weak",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "CrossDatasetReferenceSorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "Date",
+        },
+        Object {
+          "description": "Checks if the value is greater than the given input.",
+          "fieldName": "gt",
+          "type": "Date",
+        },
+        Object {
+          "description": "Checks if the value is greater than or equal to the given input.",
+          "fieldName": "gte",
+          "type": "Date",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value is lesser than the given input.",
+          "fieldName": "lt",
+          "type": "Date",
+        },
+        Object {
+          "description": "Checks if the value is lesser than or equal to the given input.",
+          "fieldName": "lte",
+          "type": "Date",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "Date",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "DateFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Checks if the value is greater than the given input.",
+          "fieldName": "gt",
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Checks if the value is greater than or equal to the given input.",
+          "fieldName": "gte",
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value is lesser than the given input.",
+          "fieldName": "lt",
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Checks if the value is lesser than or equal to the given input.",
+          "fieldName": "lte",
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "Datetime",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "DatetimeFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "DocumentFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "DocumentSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "asset",
+          "isReference": true,
+          "type": "SanityFileAsset",
+        },
+      ],
+      "kind": "Type",
+      "name": "File",
+      "originalName": "file",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "asset",
+          "isReference": true,
+          "type": "SanityFileAssetFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "FileFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "FileSorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "Float",
+        },
+        Object {
+          "description": "Checks if the value is greater than the given input.",
+          "fieldName": "gt",
+          "type": "Float",
+        },
+        Object {
+          "description": "Checks if the value is greater than or equal to the given input.",
+          "fieldName": "gte",
+          "type": "Float",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value is lesser than the given input.",
+          "fieldName": "lt",
+          "type": "Float",
+        },
+        Object {
+          "description": "Checks if the value is lesser than or equal to the given input.",
+          "fieldName": "lte",
+          "type": "Float",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "Float",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "FloatFilter",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "alt",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "lat",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "lng",
+          "type": "Float",
+        },
+      ],
+      "kind": "Type",
+      "name": "Geopoint",
+      "originalName": "geopoint",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "alt",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "lat",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "lng",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "GeopointFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "alt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "lat",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "lng",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "GeopointSorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "ID",
+        },
+        Object {
+          "children": Object {
+            "isNullable": false,
+            "type": "ID",
+          },
+          "description": "Checks if the value is equal to one of the given values.",
+          "fieldName": "in",
+          "kind": "List",
+        },
+        Object {
+          "description": "Checks if the value matches the given word/words.",
+          "fieldName": "matches",
+          "type": "ID",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "ID",
+        },
+        Object {
+          "children": Object {
+            "isNullable": false,
+            "type": "ID",
+          },
+          "description": "Checks if the value is not equal to one of the given values.",
+          "fieldName": "nin",
+          "kind": "List",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "IDFilter",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "asset",
+          "isReference": true,
+          "type": "SanityImageAsset",
+        },
+        Object {
+          "fieldName": "crop",
+          "type": "SanityImageCrop",
+        },
+        Object {
+          "fieldName": "hotspot",
+          "type": "SanityImageHotspot",
+        },
+      ],
+      "kind": "Type",
+      "name": "Image",
+      "originalName": "image",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "asset",
+          "isReference": true,
+          "type": "SanityImageAssetFilter",
+        },
+        Object {
+          "fieldName": "crop",
+          "isReference": undefined,
+          "type": "SanityImageCropFilter",
+        },
+        Object {
+          "fieldName": "hotspot",
+          "isReference": undefined,
+          "type": "SanityImageHotspotFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "ImageFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "crop",
+          "type": "SanityImageCropSorting",
+        },
+        Object {
+          "fieldName": "hotspot",
+          "type": "SanityImageHotspotSorting",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "ImageSorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "Int",
+        },
+        Object {
+          "description": "Checks if the value is greater than the given input.",
+          "fieldName": "gt",
+          "type": "Int",
+        },
+        Object {
+          "description": "Checks if the value is greater than or equal to the given input.",
+          "fieldName": "gte",
+          "type": "Int",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value is lesser than the given input.",
+          "fieldName": "lt",
+          "type": "Int",
+        },
+        Object {
+          "description": "Checks if the value is lesser than or equal to the given input.",
+          "fieldName": "lte",
+          "type": "Int",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "Int",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "IntFilter",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": "The unique ID for the asset within the originating source so you can programatically find back to it",
+          "fieldName": "id",
+          "type": "String",
+        },
+        Object {
+          "description": "A canonical name for the source this asset is originating from",
+          "fieldName": "name",
+          "type": "String",
+        },
+        Object {
+          "description": "A URL to find more information about this asset in the originating source",
+          "fieldName": "url",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityAssetSourceData",
+      "originalName": "sanity.assetSourceData",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "id",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "name",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "url",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityAssetSourceDataFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "name",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "url",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityAssetSourceDataSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "altText",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "assetId",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "description",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "extension",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "label",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "mimeType",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "originalFilename",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "path",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "sha1hash",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "size",
+          "type": "Float",
+        },
+        Object {
+          "fieldName": "source",
+          "type": "SanityAssetSourceData",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "title",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "url",
+          "type": "String",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SanityFileAsset",
+      "originalName": "sanity.fileAsset",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "altText",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "assetId",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "description",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "extension",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "label",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "mimeType",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "originalFilename",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "path",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "sha1hash",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "size",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "source",
+          "isReference": undefined,
+          "type": "SanityAssetSourceDataFilter",
+        },
+        Object {
+          "fieldName": "title",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "url",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityFileAssetFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "altText",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "assetId",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "description",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "extension",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "label",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "mimeType",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "originalFilename",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "path",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "sha1hash",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "size",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "source",
+          "type": "SanityAssetSourceDataSorting",
+        },
+        Object {
+          "fieldName": "title",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "url",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityFileAssetSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "altText",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "assetId",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "description",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "extension",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "label",
+          "type": "String",
+        },
+        Object {
+          "fieldName": "metadata",
+          "type": "SanityImageMetadata",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "mimeType",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "originalFilename",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "path",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "sha1hash",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "size",
+          "type": "Float",
+        },
+        Object {
+          "fieldName": "source",
+          "type": "SanityAssetSourceData",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "title",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "uploadId",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "url",
+          "type": "String",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SanityImageAsset",
+      "originalName": "sanity.imageAsset",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "altText",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "assetId",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "description",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "extension",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "label",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "metadata",
+          "isReference": undefined,
+          "type": "SanityImageMetadataFilter",
+        },
+        Object {
+          "fieldName": "mimeType",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "originalFilename",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "path",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "sha1hash",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "size",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "source",
+          "isReference": undefined,
+          "type": "SanityAssetSourceDataFilter",
+        },
+        Object {
+          "fieldName": "title",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "uploadId",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "url",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageAssetFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "altText",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "assetId",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "description",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "extension",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "label",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "metadata",
+          "type": "SanityImageMetadataSorting",
+        },
+        Object {
+          "fieldName": "mimeType",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "originalFilename",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "path",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "sha1hash",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "size",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "source",
+          "type": "SanityAssetSourceDataSorting",
+        },
+        Object {
+          "fieldName": "title",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "uploadId",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "url",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageAssetSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "bottom",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "left",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "right",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "top",
+          "type": "Float",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityImageCrop",
+      "originalName": "sanity.imageCrop",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "bottom",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "left",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "right",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "top",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageCropFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "bottom",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "left",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "right",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "top",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageCropSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "aspectRatio",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "height",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "width",
+          "type": "Float",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityImageDimensions",
+      "originalName": "sanity.imageDimensions",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "aspectRatio",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "height",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "width",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageDimensionsFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "aspectRatio",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "height",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "width",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageDimensionsSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "height",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "width",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "x",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "y",
+          "type": "Float",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityImageHotspot",
+      "originalName": "sanity.imageHotspot",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "height",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "width",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "x",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "y",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageHotspotFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "height",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "width",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "x",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "y",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageHotspotSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "blurHash",
+          "type": "String",
+        },
+        Object {
+          "fieldName": "dimensions",
+          "type": "SanityImageDimensions",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "hasAlpha",
+          "type": "Boolean",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "isOpaque",
+          "type": "Boolean",
+        },
+        Object {
+          "fieldName": "location",
+          "type": "Geopoint",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "lqip",
+          "type": "String",
+        },
+        Object {
+          "fieldName": "palette",
+          "type": "SanityImagePalette",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityImageMetadata",
+      "originalName": "sanity.imageMetadata",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "blurHash",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "dimensions",
+          "isReference": undefined,
+          "type": "SanityImageDimensionsFilter",
+        },
+        Object {
+          "fieldName": "hasAlpha",
+          "isReference": undefined,
+          "type": "BooleanFilter",
+        },
+        Object {
+          "fieldName": "isOpaque",
+          "isReference": undefined,
+          "type": "BooleanFilter",
+        },
+        Object {
+          "fieldName": "location",
+          "isReference": undefined,
+          "type": "GeopointFilter",
+        },
+        Object {
+          "fieldName": "lqip",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "palette",
+          "isReference": undefined,
+          "type": "SanityImagePaletteFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageMetadataFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "blurHash",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "dimensions",
+          "type": "SanityImageDimensionsSorting",
+        },
+        Object {
+          "fieldName": "hasAlpha",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "isOpaque",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "location",
+          "type": "GeopointSorting",
+        },
+        Object {
+          "fieldName": "lqip",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "palette",
+          "type": "SanityImagePaletteSorting",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageMetadataSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "fieldName": "darkMuted",
+          "type": "SanityImagePaletteSwatch",
+        },
+        Object {
+          "fieldName": "darkVibrant",
+          "type": "SanityImagePaletteSwatch",
+        },
+        Object {
+          "fieldName": "dominant",
+          "type": "SanityImagePaletteSwatch",
+        },
+        Object {
+          "fieldName": "lightMuted",
+          "type": "SanityImagePaletteSwatch",
+        },
+        Object {
+          "fieldName": "lightVibrant",
+          "type": "SanityImagePaletteSwatch",
+        },
+        Object {
+          "fieldName": "muted",
+          "type": "SanityImagePaletteSwatch",
+        },
+        Object {
+          "fieldName": "vibrant",
+          "type": "SanityImagePaletteSwatch",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityImagePalette",
+      "originalName": "sanity.imagePalette",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "darkMuted",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+        Object {
+          "fieldName": "darkVibrant",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+        Object {
+          "fieldName": "dominant",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+        Object {
+          "fieldName": "lightMuted",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+        Object {
+          "fieldName": "lightVibrant",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+        Object {
+          "fieldName": "muted",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+        Object {
+          "fieldName": "vibrant",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImagePaletteFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "darkMuted",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+        Object {
+          "fieldName": "darkVibrant",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+        Object {
+          "fieldName": "dominant",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+        Object {
+          "fieldName": "lightMuted",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+        Object {
+          "fieldName": "lightVibrant",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+        Object {
+          "fieldName": "muted",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+        Object {
+          "fieldName": "vibrant",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImagePaletteSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "background",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "foreground",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "population",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "title",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityImagePaletteSwatch",
+      "originalName": "sanity.imagePaletteSwatch",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "background",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "foreground",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "population",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "title",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImagePaletteSwatchFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "background",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "foreground",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "population",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "title",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImagePaletteSwatchSorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "All documents that are drafts.",
+          "fieldName": "is_draft",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "All documents referencing the given document ID.",
+          "fieldName": "references",
+          "type": "ID",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "Sanity_DocumentFilter",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType0",
+      "originalName": "schemaType0",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType0Filter",
+    },
+    Object {
+      "fields": Array [],
+      "interfaces": undefined,
+      "kind": "Union",
+      "name": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+      "types": Array [
+        "SchemaType0",
+        "SchemaType1",
+        "SchemaType10",
+        "SchemaType11",
+        "SchemaType12",
+        "SchemaType13",
+        "SchemaType14",
+        "SchemaType15",
+        "SchemaType16",
+        "SchemaType17",
+        "SchemaType18",
+        "SchemaType19",
+        "SchemaType2",
+        "SchemaType20",
+        "SchemaType21",
+        "SchemaType22",
+        "SchemaType23",
+        "SchemaType24",
+        "SchemaType25",
+        "SchemaType26",
+        "SchemaType27",
+        "SchemaType28",
+        "SchemaType29",
+        "SchemaType3",
+        "SchemaType30",
+        "SchemaType31",
+        "SchemaType32",
+        "SchemaType33",
+        "SchemaType34",
+        "SchemaType35",
+        "SchemaType36",
+        "SchemaType37",
+        "SchemaType38",
+        "SchemaType39",
+        "SchemaType4",
+        "SchemaType5",
+        "SchemaType6",
+        "SchemaType7",
+        "SchemaType8",
+        "SchemaType9",
+      ],
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType0Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType1",
+      "originalName": "schemaType1",
+      "type": "Object",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType10",
+      "originalName": "schemaType10",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType10Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType10Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType11",
+      "originalName": "schemaType11",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType11Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType11Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType12",
+      "originalName": "schemaType12",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType12Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType12Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType13",
+      "originalName": "schemaType13",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType13Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType13Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType14",
+      "originalName": "schemaType14",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType14Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType14Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType15",
+      "originalName": "schemaType15",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType15Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType15Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType16",
+      "originalName": "schemaType16",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType16Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType16Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType17",
+      "originalName": "schemaType17",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType17Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType17Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType18",
+      "originalName": "schemaType18",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType18Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType18Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType19",
+      "originalName": "schemaType19",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType19Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType19Sorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType1Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType1Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType2",
+      "originalName": "schemaType2",
+      "type": "Object",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType20",
+      "originalName": "schemaType20",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType20Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType20Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType21",
+      "originalName": "schemaType21",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType21Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType21Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType22",
+      "originalName": "schemaType22",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType22Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType22Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType23",
+      "originalName": "schemaType23",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType23Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType23Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType24",
+      "originalName": "schemaType24",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType24Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType24Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType25",
+      "originalName": "schemaType25",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType25Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType25Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType26",
+      "originalName": "schemaType26",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType26Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType26Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType27",
+      "originalName": "schemaType27",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType27Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType27Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType28",
+      "originalName": "schemaType28",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType28Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType28Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType29",
+      "originalName": "schemaType29",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType29Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType29Sorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType2Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType2Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType3",
+      "originalName": "schemaType3",
+      "type": "Object",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType30",
+      "originalName": "schemaType30",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType30Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType30Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType31",
+      "originalName": "schemaType31",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType31Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType31Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType32",
+      "originalName": "schemaType32",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType32Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType32Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType33",
+      "originalName": "schemaType33",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType33Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType33Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType34",
+      "originalName": "schemaType34",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType34Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType34Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType35",
+      "originalName": "schemaType35",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType35Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType35Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType36",
+      "originalName": "schemaType36",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType36Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType36Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType37",
+      "originalName": "schemaType37",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType37Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType37Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType38",
+      "originalName": "schemaType38",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType38Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType38Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType39",
+      "originalName": "schemaType39",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType39Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType39Sorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType3Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType3Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType4",
+      "originalName": "schemaType4",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType4Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType4Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType5",
+      "originalName": "schemaType5",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType5Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType5Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType6",
+      "originalName": "schemaType6",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType6Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType6Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType7",
+      "originalName": "schemaType7",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType7Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType7Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType8",
+      "originalName": "schemaType8",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType8Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType8Sorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference0",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "reference1",
+          "isReference": true,
+          "references": undefined,
+          "type": "SchemaType0OrSchemaType1OrSchemaType10OrSchemaType11OrSchemaType12OrSchemaType13OrSchemaType14OrSchemaType15OrSchemaType16OrSchemaType17OrSchemaType18OrSchemaType19OrSchemaType2OrSchemaType20OrSchemaType21OrSchemaType22OrSchemaType23OrSchemaType24OrSchemaType25OrSchemaType26OrSchemaType27OrSchemaType28OrSchemaType29OrSchemaType3OrSchemaType30OrSchemaType31OrSchemaType32OrSchemaType33OrSchemaType34OrSchemaType35OrSchemaType36OrSchemaType37OrSchemaType38OrSchemaType39OrSchemaType4OrSchemaType5OrSchemaType6OrSchemaType7OrSchemaType8OrSchemaType9",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SchemaType9",
+      "originalName": "schemaType9",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType9Filter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SchemaType9Sorting",
+    },
+    Object {
+      "fields": Array [],
+      "kind": "Enum",
+      "name": "SortOrder",
+      "values": Array [
+        Object {
+          "description": "Sorts on the value in ascending order.",
+          "name": "ASC",
+          "value": 1,
+        },
+        Object {
+          "description": "Sorts on the value in descending order.",
+          "name": "DESC",
+          "value": 2,
+        },
+      ],
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "children": Object {
+            "type": "String",
+          },
+          "description": undefined,
+          "fieldName": "marks",
+          "kind": "List",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "text",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "Span",
+      "originalName": "span",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "String",
+        },
+        Object {
+          "children": Object {
+            "isNullable": false,
+            "type": "String",
+          },
+          "description": "Checks if the value is equal to one of the given values.",
+          "fieldName": "in",
+          "kind": "List",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value matches the given word/words.",
+          "fieldName": "matches",
+          "type": "String",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "String",
+        },
+        Object {
+          "children": Object {
+            "isNullable": false,
+            "type": "String",
+          },
+          "description": "Checks if the value is not equal to one of the given values.",
+          "fieldName": "nin",
+          "kind": "List",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "StringFilter",
+    },
+  ],
+}
+`;
+
+exports[`GraphQL - Generation 3 Union cache: sanitySchema: testStudioSchema Should be able to generate graphql schema, withUnionCache: false 1`] = `
+Object {
+  "generation": "gen3",
+  "interfaces": Array [
+    Object {
+      "description": "A Sanity document",
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+      ],
+      "kind": "Interface",
+      "name": "Document",
+    },
+  ],
+  "queries": Array [
+    Object {
+      "args": Array [
+        Object {
+          "description": "Author document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "Author",
+      "type": "Author",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Document document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "Document",
+      "type": "Document",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "DocumentActionsTest document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "DocumentActionsTest",
+      "type": "DocumentActionsTest",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "DocumentWithCdrField document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "DocumentWithCdrField",
+      "type": "DocumentWithCdrField",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Poppers document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "Poppers",
+      "type": "Poppers",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SanityFileAsset document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SanityFileAsset",
+      "type": "SanityFileAsset",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SanityImageAsset document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SanityImageAsset",
+      "type": "SanityImageAsset",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "AuthorSorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "AuthorFilter",
+        },
+      ],
+      "fieldName": "allAuthor",
+      "filter": "_type == \\"author\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "Author",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "DocumentSorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "DocumentFilter",
+        },
+      ],
+      "fieldName": "allDocument",
+      "filter": "_type in [\\"sanity.imageAsset\\", \\"sanity.fileAsset\\", \\"documentActionsTest\\", \\"poppers\\", \\"author\\", \\"documentWithCdrField\\"]",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "Document",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "DocumentActionsTestSorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "DocumentActionsTestFilter",
+        },
+      ],
+      "fieldName": "allDocumentActionsTest",
+      "filter": "_type == \\"documentActionsTest\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "DocumentActionsTest",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "DocumentWithCdrFieldSorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "DocumentWithCdrFieldFilter",
+        },
+      ],
+      "fieldName": "allDocumentWithCdrField",
+      "filter": "_type == \\"documentWithCdrField\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "DocumentWithCdrField",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "PoppersSorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "PoppersFilter",
+        },
+      ],
+      "fieldName": "allPoppers",
+      "filter": "_type == \\"poppers\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "Poppers",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SanityFileAssetSorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SanityFileAssetFilter",
+        },
+      ],
+      "fieldName": "allSanityFileAsset",
+      "filter": "_type == \\"sanity.fileAsset\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SanityFileAsset",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SanityImageAssetSorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SanityImageAssetFilter",
+        },
+      ],
+      "fieldName": "allSanityImageAsset",
+      "filter": "_type == \\"sanity.imageAsset\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SanityImageAsset",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+  ],
+  "types": Array [
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "children": Object {
+            "type": "String",
+          },
+          "description": undefined,
+          "fieldName": "awards",
+          "kind": "List",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "bestFriend",
+          "isReference": true,
+          "type": "Author",
+        },
+        Object {
+          "fieldName": "image",
+          "type": "Image",
+        },
+        Object {
+          "children": Object {
+            "type": "Block",
+          },
+          "description": undefined,
+          "fieldName": "minimalBlockRaw",
+          "isRawAlias": true,
+          "kind": "List",
+          "originalName": "minimalBlock",
+          "type": "JSON",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "name",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "role",
+          "type": "String",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "Author",
+      "originalName": "author",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "bestFriend",
+          "isReference": true,
+          "type": "AuthorFilter",
+        },
+        Object {
+          "fieldName": "image",
+          "isReference": undefined,
+          "type": "ImageFilter",
+        },
+        Object {
+          "fieldName": "name",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "role",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "AuthorFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "image",
+          "type": "ImageSorting",
+        },
+        Object {
+          "fieldName": "name",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "role",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "AuthorSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "children": Object {
+            "type": "Span",
+          },
+          "description": undefined,
+          "fieldName": "children",
+          "kind": "List",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "level",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "listItem",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "style",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "Block",
+      "originalName": "block",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "Boolean",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "BooleanFilter",
+    },
+    Object {
+      "crossDatasetReferenceMetadata": Object {
+        "dataset": "production",
+        "typeNames": Array [
+          "person",
+        ],
+      },
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_dataset",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_projectId",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_ref",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_weak",
+          "type": "Boolean",
+        },
+      ],
+      "kind": "Type",
+      "name": "CdrPersonReference",
+      "originalName": "cdrPersonReference",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_dataset",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_projectId",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_ref",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_weak",
+          "isReference": undefined,
+          "type": "BooleanFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "CdrPersonReferenceFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_dataset",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_projectId",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_ref",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_weak",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "CdrPersonReferenceSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "code",
+          "type": "Text",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "filename",
+          "type": "String",
+        },
+        Object {
+          "children": Object {
+            "type": "Float",
+          },
+          "description": undefined,
+          "fieldName": "highlightedLines",
+          "kind": "List",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "language",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "Code",
+      "originalName": "code",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "code",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "filename",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "language",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "CodeFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "code",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "filename",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "language",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "CodeSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "alpha",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "hex",
+          "type": "String",
+        },
+        Object {
+          "fieldName": "hsl",
+          "type": "HslaColor",
+        },
+        Object {
+          "fieldName": "hsv",
+          "type": "HsvaColor",
+        },
+        Object {
+          "fieldName": "rgb",
+          "type": "RgbaColor",
+        },
+      ],
+      "kind": "Type",
+      "name": "Color",
+      "originalName": "color",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "alpha",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "hex",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "hsl",
+          "isReference": undefined,
+          "type": "HslaColorFilter",
+        },
+        Object {
+          "fieldName": "hsv",
+          "isReference": undefined,
+          "type": "HsvaColorFilter",
+        },
+        Object {
+          "fieldName": "rgb",
+          "isReference": undefined,
+          "type": "RgbaColorFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "ColorFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "alpha",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "hex",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "hsl",
+          "type": "HslaColorSorting",
+        },
+        Object {
+          "fieldName": "hsv",
+          "type": "HsvaColorSorting",
+        },
+        Object {
+          "fieldName": "rgb",
+          "type": "RgbaColorSorting",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "ColorSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_dataset",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_projectId",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_ref",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_weak",
+          "type": "Boolean",
+        },
+      ],
+      "kind": "Type",
+      "name": "CrossDatasetReference",
+      "originalName": "crossDatasetReference",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_dataset",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_projectId",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_ref",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_weak",
+          "isReference": undefined,
+          "type": "BooleanFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "CrossDatasetReferenceFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_dataset",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_projectId",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_ref",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_weak",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "CrossDatasetReferenceSorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "Date",
+        },
+        Object {
+          "description": "Checks if the value is greater than the given input.",
+          "fieldName": "gt",
+          "type": "Date",
+        },
+        Object {
+          "description": "Checks if the value is greater than or equal to the given input.",
+          "fieldName": "gte",
+          "type": "Date",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value is lesser than the given input.",
+          "fieldName": "lt",
+          "type": "Date",
+        },
+        Object {
+          "description": "Checks if the value is lesser than or equal to the given input.",
+          "fieldName": "lte",
+          "type": "Date",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "Date",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "DateFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Checks if the value is greater than the given input.",
+          "fieldName": "gt",
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Checks if the value is greater than or equal to the given input.",
+          "fieldName": "gte",
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value is lesser than the given input.",
+          "fieldName": "lt",
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Checks if the value is lesser than or equal to the given input.",
+          "fieldName": "lte",
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "Datetime",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "DatetimeFilter",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "title",
+          "type": "String",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "DocumentActionsTest",
+      "originalName": "documentActionsTest",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "title",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "DocumentActionsTestFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "title",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "DocumentActionsTestSorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "DocumentFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "DocumentSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "crossDatasetReferenceMetadata": Object {
+            "dataset": "production",
+            "typeNames": Array [
+              "person",
+              "place",
+            ],
+          },
+          "fieldName": "cdrFieldInline",
+          "type": "CrossDatasetReference",
+        },
+        Object {
+          "crossDatasetReferenceMetadata": Object {
+            "dataset": "production",
+            "typeNames": Array [
+              "person",
+            ],
+          },
+          "fieldName": "cdrFieldNamed",
+          "type": "CdrPersonReference",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "DocumentWithCdrField",
+      "originalName": "documentWithCdrField",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "cdrFieldInline",
+          "isReference": undefined,
+          "type": "CrossDatasetReferenceFilter",
+        },
+        Object {
+          "fieldName": "cdrFieldNamed",
+          "isReference": undefined,
+          "type": "CdrPersonReferenceFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "DocumentWithCdrFieldFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "cdrFieldInline",
+          "type": "CrossDatasetReferenceSorting",
+        },
+        Object {
+          "fieldName": "cdrFieldNamed",
+          "type": "CdrPersonReferenceSorting",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "DocumentWithCdrFieldSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "asset",
+          "isReference": true,
+          "type": "SanityFileAsset",
+        },
+      ],
+      "kind": "Type",
+      "name": "File",
+      "originalName": "file",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "asset",
+          "isReference": true,
+          "type": "SanityFileAssetFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "FileFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "FileSorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "Float",
+        },
+        Object {
+          "description": "Checks if the value is greater than the given input.",
+          "fieldName": "gt",
+          "type": "Float",
+        },
+        Object {
+          "description": "Checks if the value is greater than or equal to the given input.",
+          "fieldName": "gte",
+          "type": "Float",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value is lesser than the given input.",
+          "fieldName": "lt",
+          "type": "Float",
+        },
+        Object {
+          "description": "Checks if the value is lesser than or equal to the given input.",
+          "fieldName": "lte",
+          "type": "Float",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "Float",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "FloatFilter",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "alt",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "lat",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "lng",
+          "type": "Float",
+        },
+      ],
+      "kind": "Type",
+      "name": "Geopoint",
+      "originalName": "geopoint",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "alt",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "lat",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "lng",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "GeopointFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "alt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "lat",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "lng",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "GeopointSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "a",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "h",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "l",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "s",
+          "type": "Float",
+        },
+      ],
+      "kind": "Type",
+      "name": "HslaColor",
+      "originalName": "hslaColor",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "a",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "h",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "l",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "s",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "HslaColorFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "a",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "h",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "l",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "s",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "HslaColorSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "a",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "h",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "s",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "v",
+          "type": "Float",
+        },
+      ],
+      "kind": "Type",
+      "name": "HsvaColor",
+      "originalName": "hsvaColor",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "a",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "h",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "s",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "v",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "HsvaColorFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "a",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "h",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "s",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "v",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "HsvaColorSorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "ID",
+        },
+        Object {
+          "children": Object {
+            "isNullable": false,
+            "type": "ID",
+          },
+          "description": "Checks if the value is equal to one of the given values.",
+          "fieldName": "in",
+          "kind": "List",
+        },
+        Object {
+          "description": "Checks if the value matches the given word/words.",
+          "fieldName": "matches",
+          "type": "ID",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "ID",
+        },
+        Object {
+          "children": Object {
+            "isNullable": false,
+            "type": "ID",
+          },
+          "description": "Checks if the value is not equal to one of the given values.",
+          "fieldName": "nin",
+          "kind": "List",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "IDFilter",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "asset",
+          "isReference": true,
+          "type": "SanityImageAsset",
+        },
+        Object {
+          "fieldName": "crop",
+          "type": "SanityImageCrop",
+        },
+        Object {
+          "fieldName": "hotspot",
+          "type": "SanityImageHotspot",
+        },
+      ],
+      "kind": "Type",
+      "name": "Image",
+      "originalName": "image",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "asset",
+          "isReference": true,
+          "type": "SanityImageAssetFilter",
+        },
+        Object {
+          "fieldName": "crop",
+          "isReference": undefined,
+          "type": "SanityImageCropFilter",
+        },
+        Object {
+          "fieldName": "hotspot",
+          "isReference": undefined,
+          "type": "SanityImageHotspotFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "ImageFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "crop",
+          "type": "SanityImageCropSorting",
+        },
+        Object {
+          "fieldName": "hotspot",
+          "type": "SanityImageHotspotSorting",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "ImageSorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "Int",
+        },
+        Object {
+          "description": "Checks if the value is greater than the given input.",
+          "fieldName": "gt",
+          "type": "Int",
+        },
+        Object {
+          "description": "Checks if the value is greater than or equal to the given input.",
+          "fieldName": "gte",
+          "type": "Int",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value is lesser than the given input.",
+          "fieldName": "lt",
+          "type": "Int",
+        },
+        Object {
+          "description": "Checks if the value is lesser than or equal to the given input.",
+          "fieldName": "lte",
+          "type": "Int",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "Int",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "IntFilter",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "asset",
+          "isReference": true,
+          "type": "MuxVideoAsset",
+        },
+      ],
+      "kind": "Type",
+      "name": "MuxVideo",
+      "originalName": "mux.video",
+      "type": "Object",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "assetId",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "filename",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "playbackId",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "status",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "thumbTime",
+          "type": "Float",
+        },
+      ],
+      "kind": "Type",
+      "name": "MuxVideoAsset",
+      "originalName": "mux.videoAsset",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "assetId",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "filename",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "playbackId",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "status",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "thumbTime",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "MuxVideoAssetFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "assetId",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "filename",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "playbackId",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "status",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "thumbTime",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "MuxVideoAssetSorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "asset",
+          "isReference": true,
+          "type": "MuxVideoAssetFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "MuxVideoFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "MuxVideoSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "children": Object {
+            "type": "ObjectWithNestedArray",
+          },
+          "description": undefined,
+          "fieldName": "arrayNo1",
+          "kind": "List",
+        },
+        Object {
+          "children": Object {
+            "type": "ObjectWithNestedArray",
+          },
+          "description": undefined,
+          "fieldName": "arrayNo11",
+          "kind": "List",
+        },
+        Object {
+          "children": Object {
+            "type": "ObjectWithNestedArray",
+          },
+          "description": undefined,
+          "fieldName": "arrayNo13",
+          "kind": "List",
+        },
+        Object {
+          "children": Object {
+            "type": "ObjectWithNestedArray",
+          },
+          "description": undefined,
+          "fieldName": "arrayNo15",
+          "kind": "List",
+        },
+        Object {
+          "children": Object {
+            "type": "ObjectWithNestedArray",
+          },
+          "description": undefined,
+          "fieldName": "arrayNo17",
+          "kind": "List",
+        },
+        Object {
+          "children": Object {
+            "type": "ObjectWithNestedArray",
+          },
+          "description": undefined,
+          "fieldName": "arrayNo19",
+          "kind": "List",
+        },
+        Object {
+          "children": Object {
+            "type": "ObjectWithNestedArray",
+          },
+          "description": undefined,
+          "fieldName": "arrayNo3",
+          "kind": "List",
+        },
+        Object {
+          "children": Object {
+            "type": "ObjectWithNestedArray",
+          },
+          "description": undefined,
+          "fieldName": "arrayNo5",
+          "kind": "List",
+        },
+        Object {
+          "children": Object {
+            "type": "ObjectWithNestedArray",
+          },
+          "description": undefined,
+          "fieldName": "arrayNo7",
+          "kind": "List",
+        },
+        Object {
+          "children": Object {
+            "type": "ObjectWithNestedArray",
+          },
+          "description": undefined,
+          "fieldName": "arrayNo9",
+          "kind": "List",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "fieldNo0",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "fieldNo10",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "fieldNo12",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "fieldNo14",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "fieldNo16",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "fieldNo18",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "fieldNo2",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "fieldNo4",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "fieldNo6",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "fieldNo8",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "ObjectWithNestedArray",
+      "originalName": "objectWithNestedArray",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "fieldNo0",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "fieldNo10",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "fieldNo12",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "fieldNo14",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "fieldNo16",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "fieldNo18",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "fieldNo2",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "fieldNo4",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "fieldNo6",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "fieldNo8",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "ObjectWithNestedArrayFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "fieldNo0",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "fieldNo10",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "fieldNo12",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "fieldNo14",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "fieldNo16",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "fieldNo18",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "fieldNo2",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "fieldNo4",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "fieldNo6",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "fieldNo8",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "ObjectWithNestedArraySorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "calculated",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "nominal",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "optimistic",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "pessimistic",
+          "type": "Float",
+        },
+      ],
+      "kind": "Type",
+      "name": "PertEstimate",
+      "originalName": "pertEstimate",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "calculated",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "nominal",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "optimistic",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "pessimistic",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "PertEstimateFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "calculated",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "nominal",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "optimistic",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "pessimistic",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "PertEstimateSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "children": Object {
+            "type": "String",
+          },
+          "description": undefined,
+          "fieldName": "primitives",
+          "kind": "List",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "title",
+          "type": "String",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "Poppers",
+      "originalName": "poppers",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "title",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "PoppersFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "title",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "PoppersSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "a",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "b",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "g",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "r",
+          "type": "Float",
+        },
+      ],
+      "kind": "Type",
+      "name": "RgbaColor",
+      "originalName": "rgbaColor",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "a",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "b",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "g",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "r",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "RgbaColorFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "a",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "b",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "g",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "r",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "RgbaColorSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": "The unique ID for the asset within the originating source so you can programatically find back to it",
+          "fieldName": "id",
+          "type": "String",
+        },
+        Object {
+          "description": "A canonical name for the source this asset is originating from",
+          "fieldName": "name",
+          "type": "String",
+        },
+        Object {
+          "description": "A URL to find more information about this asset in the originating source",
+          "fieldName": "url",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityAssetSourceData",
+      "originalName": "sanity.assetSourceData",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "id",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "name",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "url",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityAssetSourceDataFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "name",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "url",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityAssetSourceDataSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "altText",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "assetId",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "description",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "extension",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "label",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "mimeType",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "originalFilename",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "path",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "sha1hash",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "size",
+          "type": "Float",
+        },
+        Object {
+          "fieldName": "source",
+          "type": "SanityAssetSourceData",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "title",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "url",
+          "type": "String",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SanityFileAsset",
+      "originalName": "sanity.fileAsset",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "altText",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "assetId",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "description",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "extension",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "label",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "mimeType",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "originalFilename",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "path",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "sha1hash",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "size",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "source",
+          "isReference": undefined,
+          "type": "SanityAssetSourceDataFilter",
+        },
+        Object {
+          "fieldName": "title",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "url",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityFileAssetFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "altText",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "assetId",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "description",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "extension",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "label",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "mimeType",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "originalFilename",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "path",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "sha1hash",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "size",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "source",
+          "type": "SanityAssetSourceDataSorting",
+        },
+        Object {
+          "fieldName": "title",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "url",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityFileAssetSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "altText",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "assetId",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "description",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "extension",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "label",
+          "type": "String",
+        },
+        Object {
+          "fieldName": "metadata",
+          "type": "SanityImageMetadata",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "mimeType",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "originalFilename",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "path",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "sha1hash",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "size",
+          "type": "Float",
+        },
+        Object {
+          "fieldName": "source",
+          "type": "SanityAssetSourceData",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "title",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "uploadId",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "url",
+          "type": "String",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SanityImageAsset",
+      "originalName": "sanity.imageAsset",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "altText",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "assetId",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "description",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "extension",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "label",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "metadata",
+          "isReference": undefined,
+          "type": "SanityImageMetadataFilter",
+        },
+        Object {
+          "fieldName": "mimeType",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "originalFilename",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "path",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "sha1hash",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "size",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "source",
+          "isReference": undefined,
+          "type": "SanityAssetSourceDataFilter",
+        },
+        Object {
+          "fieldName": "title",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "uploadId",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "url",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageAssetFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "altText",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "assetId",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "description",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "extension",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "label",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "metadata",
+          "type": "SanityImageMetadataSorting",
+        },
+        Object {
+          "fieldName": "mimeType",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "originalFilename",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "path",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "sha1hash",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "size",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "source",
+          "type": "SanityAssetSourceDataSorting",
+        },
+        Object {
+          "fieldName": "title",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "uploadId",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "url",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageAssetSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "bottom",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "left",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "right",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "top",
+          "type": "Float",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityImageCrop",
+      "originalName": "sanity.imageCrop",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "bottom",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "left",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "right",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "top",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageCropFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "bottom",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "left",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "right",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "top",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageCropSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "aspectRatio",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "height",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "width",
+          "type": "Float",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityImageDimensions",
+      "originalName": "sanity.imageDimensions",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "aspectRatio",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "height",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "width",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageDimensionsFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "aspectRatio",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "height",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "width",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageDimensionsSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "height",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "width",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "x",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "y",
+          "type": "Float",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityImageHotspot",
+      "originalName": "sanity.imageHotspot",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "height",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "width",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "x",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "y",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageHotspotFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "height",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "width",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "x",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "y",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageHotspotSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "blurHash",
+          "type": "String",
+        },
+        Object {
+          "fieldName": "dimensions",
+          "type": "SanityImageDimensions",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "hasAlpha",
+          "type": "Boolean",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "isOpaque",
+          "type": "Boolean",
+        },
+        Object {
+          "fieldName": "location",
+          "type": "Geopoint",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "lqip",
+          "type": "String",
+        },
+        Object {
+          "fieldName": "palette",
+          "type": "SanityImagePalette",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityImageMetadata",
+      "originalName": "sanity.imageMetadata",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "blurHash",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "dimensions",
+          "isReference": undefined,
+          "type": "SanityImageDimensionsFilter",
+        },
+        Object {
+          "fieldName": "hasAlpha",
+          "isReference": undefined,
+          "type": "BooleanFilter",
+        },
+        Object {
+          "fieldName": "isOpaque",
+          "isReference": undefined,
+          "type": "BooleanFilter",
+        },
+        Object {
+          "fieldName": "location",
+          "isReference": undefined,
+          "type": "GeopointFilter",
+        },
+        Object {
+          "fieldName": "lqip",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "palette",
+          "isReference": undefined,
+          "type": "SanityImagePaletteFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageMetadataFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "blurHash",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "dimensions",
+          "type": "SanityImageDimensionsSorting",
+        },
+        Object {
+          "fieldName": "hasAlpha",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "isOpaque",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "location",
+          "type": "GeopointSorting",
+        },
+        Object {
+          "fieldName": "lqip",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "palette",
+          "type": "SanityImagePaletteSorting",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageMetadataSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "fieldName": "darkMuted",
+          "type": "SanityImagePaletteSwatch",
+        },
+        Object {
+          "fieldName": "darkVibrant",
+          "type": "SanityImagePaletteSwatch",
+        },
+        Object {
+          "fieldName": "dominant",
+          "type": "SanityImagePaletteSwatch",
+        },
+        Object {
+          "fieldName": "lightMuted",
+          "type": "SanityImagePaletteSwatch",
+        },
+        Object {
+          "fieldName": "lightVibrant",
+          "type": "SanityImagePaletteSwatch",
+        },
+        Object {
+          "fieldName": "muted",
+          "type": "SanityImagePaletteSwatch",
+        },
+        Object {
+          "fieldName": "vibrant",
+          "type": "SanityImagePaletteSwatch",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityImagePalette",
+      "originalName": "sanity.imagePalette",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "darkMuted",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+        Object {
+          "fieldName": "darkVibrant",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+        Object {
+          "fieldName": "dominant",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+        Object {
+          "fieldName": "lightMuted",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+        Object {
+          "fieldName": "lightVibrant",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+        Object {
+          "fieldName": "muted",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+        Object {
+          "fieldName": "vibrant",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImagePaletteFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "darkMuted",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+        Object {
+          "fieldName": "darkVibrant",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+        Object {
+          "fieldName": "dominant",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+        Object {
+          "fieldName": "lightMuted",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+        Object {
+          "fieldName": "lightVibrant",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+        Object {
+          "fieldName": "muted",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+        Object {
+          "fieldName": "vibrant",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImagePaletteSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "background",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "foreground",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "population",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "title",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityImagePaletteSwatch",
+      "originalName": "sanity.imagePaletteSwatch",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "background",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "foreground",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "population",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "title",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImagePaletteSwatchFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "background",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "foreground",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "population",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "title",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImagePaletteSwatchSorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "All documents that are drafts.",
+          "fieldName": "is_draft",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "All documents referencing the given document ID.",
+          "fieldName": "references",
+          "type": "ID",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "Sanity_DocumentFilter",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "current",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "Slug",
+      "originalName": "slug",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "current",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SlugFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "current",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SlugSorting",
+    },
+    Object {
+      "fields": Array [],
+      "kind": "Enum",
+      "name": "SortOrder",
+      "values": Array [
+        Object {
+          "description": "Sorts on the value in ascending order.",
+          "name": "ASC",
+          "value": 1,
+        },
+        Object {
+          "description": "Sorts on the value in descending order.",
+          "name": "DESC",
+          "value": 2,
+        },
+      ],
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "children": Object {
+            "type": "String",
+          },
+          "description": undefined,
+          "fieldName": "marks",
+          "kind": "List",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "text",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "Span",
+      "originalName": "span",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "String",
+        },
+        Object {
+          "children": Object {
+            "isNullable": false,
+            "type": "String",
+          },
+          "description": "Checks if the value is equal to one of the given values.",
+          "fieldName": "in",
+          "kind": "List",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value matches the given word/words.",
+          "fieldName": "matches",
+          "type": "String",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "String",
+        },
+        Object {
+          "children": Object {
+            "isNullable": false,
+            "type": "String",
+          },
+          "description": "Checks if the value is not equal to one of the given values.",
+          "fieldName": "nin",
+          "kind": "List",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "StringFilter",
+    },
+  ],
+}
+`;
+
+exports[`GraphQL - Generation 3 Union cache: sanitySchema: testStudioSchema Should be able to generate graphql schema, withUnionCache: true 1`] = `
+Object {
+  "generation": "gen3",
+  "interfaces": Array [
+    Object {
+      "description": "A Sanity document",
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+      ],
+      "kind": "Interface",
+      "name": "Document",
+    },
+  ],
+  "queries": Array [
+    Object {
+      "args": Array [
+        Object {
+          "description": "Author document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "Author",
+      "type": "Author",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Document document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "Document",
+      "type": "Document",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "DocumentActionsTest document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "DocumentActionsTest",
+      "type": "DocumentActionsTest",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "DocumentWithCdrField document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "DocumentWithCdrField",
+      "type": "DocumentWithCdrField",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Poppers document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "Poppers",
+      "type": "Poppers",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SanityFileAsset document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SanityFileAsset",
+      "type": "SanityFileAsset",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "SanityImageAsset document ID",
+          "isNullable": false,
+          "name": "id",
+          "type": "ID",
+        },
+      ],
+      "constraints": Array [
+        Object {
+          "comparator": "eq",
+          "field": "_id",
+          "value": Object {
+            "argName": "id",
+            "kind": "argumentValue",
+          },
+        },
+      ],
+      "fieldName": "SanityImageAsset",
+      "type": "SanityImageAsset",
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "AuthorSorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "AuthorFilter",
+        },
+      ],
+      "fieldName": "allAuthor",
+      "filter": "_type == \\"author\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "Author",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "DocumentSorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "DocumentFilter",
+        },
+      ],
+      "fieldName": "allDocument",
+      "filter": "_type in [\\"sanity.imageAsset\\", \\"sanity.fileAsset\\", \\"documentActionsTest\\", \\"poppers\\", \\"author\\", \\"documentWithCdrField\\"]",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "Document",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "DocumentActionsTestSorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "DocumentActionsTestFilter",
+        },
+      ],
+      "fieldName": "allDocumentActionsTest",
+      "filter": "_type == \\"documentActionsTest\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "DocumentActionsTest",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "DocumentWithCdrFieldSorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "DocumentWithCdrFieldFilter",
+        },
+      ],
+      "fieldName": "allDocumentWithCdrField",
+      "filter": "_type == \\"documentWithCdrField\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "DocumentWithCdrField",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "PoppersSorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "PoppersFilter",
+        },
+      ],
+      "fieldName": "allPoppers",
+      "filter": "_type == \\"poppers\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "Poppers",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SanityFileAssetSorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SanityFileAssetFilter",
+        },
+      ],
+      "fieldName": "allSanityFileAsset",
+      "filter": "_type == \\"sanity.fileAsset\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SanityFileAsset",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "description": "Max documents to return",
+          "isFieldFilter": false,
+          "name": "limit",
+          "type": "Int",
+        },
+        Object {
+          "description": "Offset at which to start returning documents from",
+          "isFieldFilter": false,
+          "name": "offset",
+          "type": "Int",
+        },
+        Object {
+          "name": "sort",
+          "type": Object {
+            "children": Object {
+              "isNullable": false,
+              "type": "SanityImageAssetSorting",
+            },
+            "isNullable": true,
+            "kind": "List",
+          },
+        },
+        Object {
+          "isFieldFilter": true,
+          "name": "where",
+          "type": "SanityImageAssetFilter",
+        },
+      ],
+      "fieldName": "allSanityImageAsset",
+      "filter": "_type == \\"sanity.imageAsset\\"",
+      "type": Object {
+        "children": Object {
+          "isNullable": false,
+          "type": "SanityImageAsset",
+        },
+        "isNullable": false,
+        "kind": "List",
+      },
+    },
+  ],
+  "types": Array [
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "children": Object {
+            "type": "String",
+          },
+          "description": undefined,
+          "fieldName": "awards",
+          "kind": "List",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "bestFriend",
+          "isReference": true,
+          "type": "Author",
+        },
+        Object {
+          "fieldName": "image",
+          "type": "Image",
+        },
+        Object {
+          "children": Object {
+            "type": "Block",
+          },
+          "description": undefined,
+          "fieldName": "minimalBlockRaw",
+          "isRawAlias": true,
+          "kind": "List",
+          "originalName": "minimalBlock",
+          "type": "JSON",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "name",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "role",
+          "type": "String",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "Author",
+      "originalName": "author",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "bestFriend",
+          "isReference": true,
+          "type": "AuthorFilter",
+        },
+        Object {
+          "fieldName": "image",
+          "isReference": undefined,
+          "type": "ImageFilter",
+        },
+        Object {
+          "fieldName": "name",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "role",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "AuthorFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "image",
+          "type": "ImageSorting",
+        },
+        Object {
+          "fieldName": "name",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "role",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "AuthorSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "children": Object {
+            "type": "Span",
+          },
+          "description": undefined,
+          "fieldName": "children",
+          "kind": "List",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "level",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "listItem",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "style",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "Block",
+      "originalName": "block",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "Boolean",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "BooleanFilter",
+    },
+    Object {
+      "crossDatasetReferenceMetadata": Object {
+        "dataset": "production",
+        "typeNames": Array [
+          "person",
+        ],
+      },
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_dataset",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_projectId",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_ref",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_weak",
+          "type": "Boolean",
+        },
+      ],
+      "kind": "Type",
+      "name": "CdrPersonReference",
+      "originalName": "cdrPersonReference",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_dataset",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_projectId",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_ref",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_weak",
+          "isReference": undefined,
+          "type": "BooleanFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "CdrPersonReferenceFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_dataset",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_projectId",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_ref",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_weak",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "CdrPersonReferenceSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "code",
+          "type": "Text",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "filename",
+          "type": "String",
+        },
+        Object {
+          "children": Object {
+            "type": "Float",
+          },
+          "description": undefined,
+          "fieldName": "highlightedLines",
+          "kind": "List",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "language",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "Code",
+      "originalName": "code",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "code",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "filename",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "language",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "CodeFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "code",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "filename",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "language",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "CodeSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "alpha",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "hex",
+          "type": "String",
+        },
+        Object {
+          "fieldName": "hsl",
+          "type": "HslaColor",
+        },
+        Object {
+          "fieldName": "hsv",
+          "type": "HsvaColor",
+        },
+        Object {
+          "fieldName": "rgb",
+          "type": "RgbaColor",
+        },
+      ],
+      "kind": "Type",
+      "name": "Color",
+      "originalName": "color",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "alpha",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "hex",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "hsl",
+          "isReference": undefined,
+          "type": "HslaColorFilter",
+        },
+        Object {
+          "fieldName": "hsv",
+          "isReference": undefined,
+          "type": "HsvaColorFilter",
+        },
+        Object {
+          "fieldName": "rgb",
+          "isReference": undefined,
+          "type": "RgbaColorFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "ColorFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "alpha",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "hex",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "hsl",
+          "type": "HslaColorSorting",
+        },
+        Object {
+          "fieldName": "hsv",
+          "type": "HsvaColorSorting",
+        },
+        Object {
+          "fieldName": "rgb",
+          "type": "RgbaColorSorting",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "ColorSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_dataset",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_projectId",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_ref",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_weak",
+          "type": "Boolean",
+        },
+      ],
+      "kind": "Type",
+      "name": "CrossDatasetReference",
+      "originalName": "crossDatasetReference",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_dataset",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_projectId",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_ref",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_weak",
+          "isReference": undefined,
+          "type": "BooleanFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "CrossDatasetReferenceFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_dataset",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_projectId",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_ref",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_weak",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "CrossDatasetReferenceSorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "Date",
+        },
+        Object {
+          "description": "Checks if the value is greater than the given input.",
+          "fieldName": "gt",
+          "type": "Date",
+        },
+        Object {
+          "description": "Checks if the value is greater than or equal to the given input.",
+          "fieldName": "gte",
+          "type": "Date",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value is lesser than the given input.",
+          "fieldName": "lt",
+          "type": "Date",
+        },
+        Object {
+          "description": "Checks if the value is lesser than or equal to the given input.",
+          "fieldName": "lte",
+          "type": "Date",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "Date",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "DateFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Checks if the value is greater than the given input.",
+          "fieldName": "gt",
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Checks if the value is greater than or equal to the given input.",
+          "fieldName": "gte",
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value is lesser than the given input.",
+          "fieldName": "lt",
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Checks if the value is lesser than or equal to the given input.",
+          "fieldName": "lte",
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "Datetime",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "DatetimeFilter",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "title",
+          "type": "String",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "DocumentActionsTest",
+      "originalName": "documentActionsTest",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "title",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "DocumentActionsTestFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "title",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "DocumentActionsTestSorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "DocumentFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "DocumentSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "crossDatasetReferenceMetadata": Object {
+            "dataset": "production",
+            "typeNames": Array [
+              "person",
+              "place",
+            ],
+          },
+          "fieldName": "cdrFieldInline",
+          "type": "CrossDatasetReference",
+        },
+        Object {
+          "crossDatasetReferenceMetadata": Object {
+            "dataset": "production",
+            "typeNames": Array [
+              "person",
+            ],
+          },
+          "fieldName": "cdrFieldNamed",
+          "type": "CdrPersonReference",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "DocumentWithCdrField",
+      "originalName": "documentWithCdrField",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "cdrFieldInline",
+          "isReference": undefined,
+          "type": "CrossDatasetReferenceFilter",
+        },
+        Object {
+          "fieldName": "cdrFieldNamed",
+          "isReference": undefined,
+          "type": "CdrPersonReferenceFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "DocumentWithCdrFieldFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "cdrFieldInline",
+          "type": "CrossDatasetReferenceSorting",
+        },
+        Object {
+          "fieldName": "cdrFieldNamed",
+          "type": "CdrPersonReferenceSorting",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "DocumentWithCdrFieldSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "asset",
+          "isReference": true,
+          "type": "SanityFileAsset",
+        },
+      ],
+      "kind": "Type",
+      "name": "File",
+      "originalName": "file",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "asset",
+          "isReference": true,
+          "type": "SanityFileAssetFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "FileFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "FileSorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "Float",
+        },
+        Object {
+          "description": "Checks if the value is greater than the given input.",
+          "fieldName": "gt",
+          "type": "Float",
+        },
+        Object {
+          "description": "Checks if the value is greater than or equal to the given input.",
+          "fieldName": "gte",
+          "type": "Float",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value is lesser than the given input.",
+          "fieldName": "lt",
+          "type": "Float",
+        },
+        Object {
+          "description": "Checks if the value is lesser than or equal to the given input.",
+          "fieldName": "lte",
+          "type": "Float",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "Float",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "FloatFilter",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "alt",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "lat",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "lng",
+          "type": "Float",
+        },
+      ],
+      "kind": "Type",
+      "name": "Geopoint",
+      "originalName": "geopoint",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "alt",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "lat",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "lng",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "GeopointFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "alt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "lat",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "lng",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "GeopointSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "a",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "h",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "l",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "s",
+          "type": "Float",
+        },
+      ],
+      "kind": "Type",
+      "name": "HslaColor",
+      "originalName": "hslaColor",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "a",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "h",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "l",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "s",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "HslaColorFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "a",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "h",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "l",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "s",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "HslaColorSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "a",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "h",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "s",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "v",
+          "type": "Float",
+        },
+      ],
+      "kind": "Type",
+      "name": "HsvaColor",
+      "originalName": "hsvaColor",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "a",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "h",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "s",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "v",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "HsvaColorFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "a",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "h",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "s",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "v",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "HsvaColorSorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "ID",
+        },
+        Object {
+          "children": Object {
+            "isNullable": false,
+            "type": "ID",
+          },
+          "description": "Checks if the value is equal to one of the given values.",
+          "fieldName": "in",
+          "kind": "List",
+        },
+        Object {
+          "description": "Checks if the value matches the given word/words.",
+          "fieldName": "matches",
+          "type": "ID",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "ID",
+        },
+        Object {
+          "children": Object {
+            "isNullable": false,
+            "type": "ID",
+          },
+          "description": "Checks if the value is not equal to one of the given values.",
+          "fieldName": "nin",
+          "kind": "List",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "IDFilter",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "asset",
+          "isReference": true,
+          "type": "SanityImageAsset",
+        },
+        Object {
+          "fieldName": "crop",
+          "type": "SanityImageCrop",
+        },
+        Object {
+          "fieldName": "hotspot",
+          "type": "SanityImageHotspot",
+        },
+      ],
+      "kind": "Type",
+      "name": "Image",
+      "originalName": "image",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "asset",
+          "isReference": true,
+          "type": "SanityImageAssetFilter",
+        },
+        Object {
+          "fieldName": "crop",
+          "isReference": undefined,
+          "type": "SanityImageCropFilter",
+        },
+        Object {
+          "fieldName": "hotspot",
+          "isReference": undefined,
+          "type": "SanityImageHotspotFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "ImageFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "crop",
+          "type": "SanityImageCropSorting",
+        },
+        Object {
+          "fieldName": "hotspot",
+          "type": "SanityImageHotspotSorting",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "ImageSorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "Int",
+        },
+        Object {
+          "description": "Checks if the value is greater than the given input.",
+          "fieldName": "gt",
+          "type": "Int",
+        },
+        Object {
+          "description": "Checks if the value is greater than or equal to the given input.",
+          "fieldName": "gte",
+          "type": "Int",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value is lesser than the given input.",
+          "fieldName": "lt",
+          "type": "Int",
+        },
+        Object {
+          "description": "Checks if the value is lesser than or equal to the given input.",
+          "fieldName": "lte",
+          "type": "Int",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "Int",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "IntFilter",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "asset",
+          "isReference": true,
+          "type": "MuxVideoAsset",
+        },
+      ],
+      "kind": "Type",
+      "name": "MuxVideo",
+      "originalName": "mux.video",
+      "type": "Object",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "assetId",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "filename",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "playbackId",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "status",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "thumbTime",
+          "type": "Float",
+        },
+      ],
+      "kind": "Type",
+      "name": "MuxVideoAsset",
+      "originalName": "mux.videoAsset",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "assetId",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "filename",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "playbackId",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "status",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "thumbTime",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "MuxVideoAssetFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "assetId",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "filename",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "playbackId",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "status",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "thumbTime",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "MuxVideoAssetSorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "asset",
+          "isReference": true,
+          "type": "MuxVideoAssetFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "MuxVideoFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "MuxVideoSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "children": Object {
+            "type": "ObjectWithNestedArray",
+          },
+          "description": undefined,
+          "fieldName": "arrayNo1",
+          "kind": "List",
+        },
+        Object {
+          "children": Object {
+            "type": "ObjectWithNestedArray",
+          },
+          "description": undefined,
+          "fieldName": "arrayNo11",
+          "kind": "List",
+        },
+        Object {
+          "children": Object {
+            "type": "ObjectWithNestedArray",
+          },
+          "description": undefined,
+          "fieldName": "arrayNo13",
+          "kind": "List",
+        },
+        Object {
+          "children": Object {
+            "type": "ObjectWithNestedArray",
+          },
+          "description": undefined,
+          "fieldName": "arrayNo15",
+          "kind": "List",
+        },
+        Object {
+          "children": Object {
+            "type": "ObjectWithNestedArray",
+          },
+          "description": undefined,
+          "fieldName": "arrayNo17",
+          "kind": "List",
+        },
+        Object {
+          "children": Object {
+            "type": "ObjectWithNestedArray",
+          },
+          "description": undefined,
+          "fieldName": "arrayNo19",
+          "kind": "List",
+        },
+        Object {
+          "children": Object {
+            "type": "ObjectWithNestedArray",
+          },
+          "description": undefined,
+          "fieldName": "arrayNo3",
+          "kind": "List",
+        },
+        Object {
+          "children": Object {
+            "type": "ObjectWithNestedArray",
+          },
+          "description": undefined,
+          "fieldName": "arrayNo5",
+          "kind": "List",
+        },
+        Object {
+          "children": Object {
+            "type": "ObjectWithNestedArray",
+          },
+          "description": undefined,
+          "fieldName": "arrayNo7",
+          "kind": "List",
+        },
+        Object {
+          "children": Object {
+            "type": "ObjectWithNestedArray",
+          },
+          "description": undefined,
+          "fieldName": "arrayNo9",
+          "kind": "List",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "fieldNo0",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "fieldNo10",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "fieldNo12",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "fieldNo14",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "fieldNo16",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "fieldNo18",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "fieldNo2",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "fieldNo4",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "fieldNo6",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "fieldNo8",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "ObjectWithNestedArray",
+      "originalName": "objectWithNestedArray",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "fieldNo0",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "fieldNo10",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "fieldNo12",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "fieldNo14",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "fieldNo16",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "fieldNo18",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "fieldNo2",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "fieldNo4",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "fieldNo6",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "fieldNo8",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "ObjectWithNestedArrayFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "fieldNo0",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "fieldNo10",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "fieldNo12",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "fieldNo14",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "fieldNo16",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "fieldNo18",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "fieldNo2",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "fieldNo4",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "fieldNo6",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "fieldNo8",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "ObjectWithNestedArraySorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "calculated",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "nominal",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "optimistic",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "pessimistic",
+          "type": "Float",
+        },
+      ],
+      "kind": "Type",
+      "name": "PertEstimate",
+      "originalName": "pertEstimate",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "calculated",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "nominal",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "optimistic",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "pessimistic",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "PertEstimateFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "calculated",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "nominal",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "optimistic",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "pessimistic",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "PertEstimateSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "children": Object {
+            "type": "String",
+          },
+          "description": undefined,
+          "fieldName": "primitives",
+          "kind": "List",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "title",
+          "type": "String",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "Poppers",
+      "originalName": "poppers",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "title",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "PoppersFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "title",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "PoppersSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "a",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "b",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "g",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "r",
+          "type": "Float",
+        },
+      ],
+      "kind": "Type",
+      "name": "RgbaColor",
+      "originalName": "rgbaColor",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "a",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "b",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "g",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "r",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "RgbaColorFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "a",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "b",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "g",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "r",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "RgbaColorSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": "The unique ID for the asset within the originating source so you can programatically find back to it",
+          "fieldName": "id",
+          "type": "String",
+        },
+        Object {
+          "description": "A canonical name for the source this asset is originating from",
+          "fieldName": "name",
+          "type": "String",
+        },
+        Object {
+          "description": "A URL to find more information about this asset in the originating source",
+          "fieldName": "url",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityAssetSourceData",
+      "originalName": "sanity.assetSourceData",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "id",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "name",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "url",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityAssetSourceDataFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "name",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "url",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityAssetSourceDataSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "altText",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "assetId",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "description",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "extension",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "label",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "mimeType",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "originalFilename",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "path",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "sha1hash",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "size",
+          "type": "Float",
+        },
+        Object {
+          "fieldName": "source",
+          "type": "SanityAssetSourceData",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "title",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "url",
+          "type": "String",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SanityFileAsset",
+      "originalName": "sanity.fileAsset",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "altText",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "assetId",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "description",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "extension",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "label",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "mimeType",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "originalFilename",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "path",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "sha1hash",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "size",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "source",
+          "isReference": undefined,
+          "type": "SanityAssetSourceDataFilter",
+        },
+        Object {
+          "fieldName": "title",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "url",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityFileAssetFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "altText",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "assetId",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "description",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "extension",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "label",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "mimeType",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "originalFilename",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "path",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "sha1hash",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "size",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "source",
+          "type": "SanityAssetSourceDataSorting",
+        },
+        Object {
+          "fieldName": "title",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "url",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityFileAssetSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": "Date the document was created",
+          "fieldName": "_createdAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": "Document ID",
+          "fieldName": "_id",
+          "isNullable": true,
+          "type": "ID",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": "Current document revision",
+          "fieldName": "_rev",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Document type",
+          "fieldName": "_type",
+          "isNullable": true,
+          "type": "String",
+        },
+        Object {
+          "description": "Date the document was last modified",
+          "fieldName": "_updatedAt",
+          "isNullable": true,
+          "type": "Datetime",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "altText",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "assetId",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "description",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "extension",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "label",
+          "type": "String",
+        },
+        Object {
+          "fieldName": "metadata",
+          "type": "SanityImageMetadata",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "mimeType",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "originalFilename",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "path",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "sha1hash",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "size",
+          "type": "Float",
+        },
+        Object {
+          "fieldName": "source",
+          "type": "SanityAssetSourceData",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "title",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "uploadId",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "url",
+          "type": "String",
+        },
+      ],
+      "interfaces": Array [
+        "Document",
+      ],
+      "kind": "Type",
+      "name": "SanityImageAsset",
+      "originalName": "sanity.imageAsset",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Apply filters on document level",
+          "fieldName": "_",
+          "type": "Sanity_DocumentFilter",
+        },
+        Object {
+          "fieldName": "_createdAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "_id",
+          "isReference": undefined,
+          "type": "IDFilter",
+        },
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_rev",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "isReference": undefined,
+          "type": "DatetimeFilter",
+        },
+        Object {
+          "fieldName": "altText",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "assetId",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "description",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "extension",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "label",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "metadata",
+          "isReference": undefined,
+          "type": "SanityImageMetadataFilter",
+        },
+        Object {
+          "fieldName": "mimeType",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "originalFilename",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "path",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "sha1hash",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "size",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "source",
+          "isReference": undefined,
+          "type": "SanityAssetSourceDataFilter",
+        },
+        Object {
+          "fieldName": "title",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "uploadId",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "url",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageAssetFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_createdAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_id",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_rev",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "altText",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "assetId",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "description",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "extension",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "label",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "metadata",
+          "type": "SanityImageMetadataSorting",
+        },
+        Object {
+          "fieldName": "mimeType",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "originalFilename",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "path",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "sha1hash",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "size",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "source",
+          "type": "SanityAssetSourceDataSorting",
+        },
+        Object {
+          "fieldName": "title",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "uploadId",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "url",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageAssetSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "bottom",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "left",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "right",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "top",
+          "type": "Float",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityImageCrop",
+      "originalName": "sanity.imageCrop",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "bottom",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "left",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "right",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "top",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageCropFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "bottom",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "left",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "right",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "top",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageCropSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "aspectRatio",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "height",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "width",
+          "type": "Float",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityImageDimensions",
+      "originalName": "sanity.imageDimensions",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "aspectRatio",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "height",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "width",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageDimensionsFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "aspectRatio",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "height",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "width",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageDimensionsSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "height",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "width",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "x",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "y",
+          "type": "Float",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityImageHotspot",
+      "originalName": "sanity.imageHotspot",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "height",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "width",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "x",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "y",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageHotspotFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "height",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "width",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "x",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "y",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageHotspotSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "blurHash",
+          "type": "String",
+        },
+        Object {
+          "fieldName": "dimensions",
+          "type": "SanityImageDimensions",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "hasAlpha",
+          "type": "Boolean",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "isOpaque",
+          "type": "Boolean",
+        },
+        Object {
+          "fieldName": "location",
+          "type": "Geopoint",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "lqip",
+          "type": "String",
+        },
+        Object {
+          "fieldName": "palette",
+          "type": "SanityImagePalette",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityImageMetadata",
+      "originalName": "sanity.imageMetadata",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "blurHash",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "dimensions",
+          "isReference": undefined,
+          "type": "SanityImageDimensionsFilter",
+        },
+        Object {
+          "fieldName": "hasAlpha",
+          "isReference": undefined,
+          "type": "BooleanFilter",
+        },
+        Object {
+          "fieldName": "isOpaque",
+          "isReference": undefined,
+          "type": "BooleanFilter",
+        },
+        Object {
+          "fieldName": "location",
+          "isReference": undefined,
+          "type": "GeopointFilter",
+        },
+        Object {
+          "fieldName": "lqip",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "palette",
+          "isReference": undefined,
+          "type": "SanityImagePaletteFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageMetadataFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "blurHash",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "dimensions",
+          "type": "SanityImageDimensionsSorting",
+        },
+        Object {
+          "fieldName": "hasAlpha",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "isOpaque",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "location",
+          "type": "GeopointSorting",
+        },
+        Object {
+          "fieldName": "lqip",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "palette",
+          "type": "SanityImagePaletteSorting",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImageMetadataSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "fieldName": "darkMuted",
+          "type": "SanityImagePaletteSwatch",
+        },
+        Object {
+          "fieldName": "darkVibrant",
+          "type": "SanityImagePaletteSwatch",
+        },
+        Object {
+          "fieldName": "dominant",
+          "type": "SanityImagePaletteSwatch",
+        },
+        Object {
+          "fieldName": "lightMuted",
+          "type": "SanityImagePaletteSwatch",
+        },
+        Object {
+          "fieldName": "lightVibrant",
+          "type": "SanityImagePaletteSwatch",
+        },
+        Object {
+          "fieldName": "muted",
+          "type": "SanityImagePaletteSwatch",
+        },
+        Object {
+          "fieldName": "vibrant",
+          "type": "SanityImagePaletteSwatch",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityImagePalette",
+      "originalName": "sanity.imagePalette",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "darkMuted",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+        Object {
+          "fieldName": "darkVibrant",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+        Object {
+          "fieldName": "dominant",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+        Object {
+          "fieldName": "lightMuted",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+        Object {
+          "fieldName": "lightVibrant",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+        Object {
+          "fieldName": "muted",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+        Object {
+          "fieldName": "vibrant",
+          "isReference": undefined,
+          "type": "SanityImagePaletteSwatchFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImagePaletteFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "darkMuted",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+        Object {
+          "fieldName": "darkVibrant",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+        Object {
+          "fieldName": "dominant",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+        Object {
+          "fieldName": "lightMuted",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+        Object {
+          "fieldName": "lightVibrant",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+        Object {
+          "fieldName": "muted",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+        Object {
+          "fieldName": "vibrant",
+          "type": "SanityImagePaletteSwatchSorting",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImagePaletteSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "background",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "foreground",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "population",
+          "type": "Float",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "title",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "SanityImagePaletteSwatch",
+      "originalName": "sanity.imagePaletteSwatch",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "background",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "foreground",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "population",
+          "isReference": undefined,
+          "type": "FloatFilter",
+        },
+        Object {
+          "fieldName": "title",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImagePaletteSwatchFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "background",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "foreground",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "population",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "title",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SanityImagePaletteSwatchSorting",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "All documents that are drafts.",
+          "fieldName": "is_draft",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "All documents referencing the given document ID.",
+          "fieldName": "references",
+          "type": "ID",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "Sanity_DocumentFilter",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "current",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "Slug",
+      "originalName": "slug",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "current",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SlugFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "current",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "SlugSorting",
+    },
+    Object {
+      "fields": Array [],
+      "kind": "Enum",
+      "name": "SortOrder",
+      "values": Array [
+        Object {
+          "description": "Sorts on the value in ascending order.",
+          "name": "ASC",
+          "value": 1,
+        },
+        Object {
+          "description": "Sorts on the value in descending order.",
+          "name": "DESC",
+          "value": 2,
+        },
+      ],
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "children": Object {
+            "type": "String",
+          },
+          "description": undefined,
+          "fieldName": "marks",
+          "kind": "List",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "text",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "Span",
+      "originalName": "span",
+      "type": "Object",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "description": "Checks if the value is equal to the given input.",
+          "fieldName": "eq",
+          "type": "String",
+        },
+        Object {
+          "children": Object {
+            "isNullable": false,
+            "type": "String",
+          },
+          "description": "Checks if the value is equal to one of the given values.",
+          "fieldName": "in",
+          "kind": "List",
+        },
+        Object {
+          "description": "Checks if the value is defined.",
+          "fieldName": "is_defined",
+          "type": "Boolean",
+        },
+        Object {
+          "description": "Checks if the value matches the given word/words.",
+          "fieldName": "matches",
+          "type": "String",
+        },
+        Object {
+          "description": "Checks if the value is not equal to the given input.",
+          "fieldName": "neq",
+          "type": "String",
+        },
+        Object {
+          "children": Object {
+            "isNullable": false,
+            "type": "String",
+          },
+          "description": "Checks if the value is not equal to one of the given values.",
+          "fieldName": "nin",
+          "kind": "List",
+        },
+      ],
+      "isConstraintFilter": true,
+      "kind": "InputObject",
+      "name": "StringFilter",
+    },
+  ],
+}
+`;

--- a/packages/sanity/test/cli/graphql/fixtures/many-self-refs.ts
+++ b/packages/sanity/test/cli/graphql/fixtures/many-self-refs.ts
@@ -1,0 +1,460 @@
+import {Schema} from '@sanity/schema'
+
+const repeat = <T>(times: number, callback: (index: number) => T) =>
+  Array(times)
+    .fill(1)
+    .map((_, index) => callback(index))
+
+const allSchemaTypeNames = repeat(40, (index) => `schemaType${index}`)
+
+const numReferenceFields = 2
+
+export const schemaTypes = allSchemaTypeNames.map((name, index) => ({
+  name,
+  type: 'document',
+  title: `Schema type ${index}`,
+  fields: repeat(numReferenceFields, (fieldIndex) => ({
+    name: `reference${fieldIndex}`,
+    type: 'reference',
+    title: `Reference ${fieldIndex}`,
+    to: allSchemaTypeNames.map((schemaTypeName) => ({type: schemaTypeName})),
+  })),
+}))
+
+export default Schema.compile({
+  types: [
+    {
+      title: 'Geographical Point',
+      name: 'geopoint',
+      type: 'object',
+      fields: [
+        {
+          name: 'lat',
+          type: 'number',
+          title: 'Latitude',
+        },
+        {
+          name: 'lng',
+          type: 'number',
+          title: 'Longitude',
+        },
+        {
+          name: 'alt',
+          type: 'number',
+          title: 'Altitude',
+        },
+      ],
+    },
+    {
+      name: 'sanity.fileAsset',
+      title: 'File',
+      type: 'document',
+      fieldsets: [
+        {
+          name: 'system',
+          title: 'System fields',
+          description: 'These fields are managed by the system and not editable',
+        },
+      ],
+      fields: [
+        {
+          name: 'originalFilename',
+          type: 'string',
+          title: 'Original file name',
+          readOnly: true,
+        },
+        {
+          name: 'label',
+          type: 'string',
+          title: 'Label',
+        },
+        {
+          name: 'title',
+          type: 'string',
+          title: 'Title',
+        },
+        {
+          name: 'description',
+          type: 'string',
+          title: 'Description',
+        },
+        {
+          name: 'altText',
+          type: 'string',
+          title: 'Alternative text',
+        },
+        {
+          name: 'sha1hash',
+          type: 'string',
+          title: 'SHA1 hash',
+          readOnly: true,
+          fieldset: 'system',
+        },
+        {
+          name: 'extension',
+          type: 'string',
+          title: 'File extension',
+          readOnly: true,
+          fieldset: 'system',
+        },
+        {
+          name: 'mimeType',
+          type: 'string',
+          title: 'Mime type',
+          readOnly: true,
+          fieldset: 'system',
+        },
+        {
+          name: 'size',
+          type: 'number',
+          title: 'File size in bytes',
+          readOnly: true,
+          fieldset: 'system',
+        },
+        {
+          name: 'assetId',
+          type: 'string',
+          title: 'Asset ID',
+          readOnly: true,
+          fieldset: 'system',
+        },
+        {
+          name: 'path',
+          type: 'string',
+          title: 'Path',
+          readOnly: true,
+          fieldset: 'system',
+        },
+        {
+          name: 'url',
+          type: 'string',
+          title: 'Url',
+          readOnly: true,
+          fieldset: 'system',
+        },
+        {
+          name: 'source',
+          type: 'sanity.assetSourceData',
+          title: 'Source',
+          readOnly: true,
+          fieldset: 'system',
+        },
+      ],
+      preview: {
+        select: {
+          title: 'originalFilename',
+          path: 'path',
+          mimeType: 'mimeType',
+          size: 'size',
+        },
+        prepare(doc: any) {
+          return {
+            title: doc.title || doc.path.split('/').slice(-1)[0],
+            subtitle: `${doc.mimeType} (${(doc.size / 1024 / 1024).toFixed(2)} MB)`,
+          }
+        },
+      },
+      orderings: [
+        {
+          title: 'File size',
+          name: 'fileSizeDesc',
+          by: [{field: 'size', direction: 'desc'}],
+        },
+      ],
+    },
+    {
+      name: 'sanity.imageHotspot',
+      title: 'Image hotspot',
+      type: 'object',
+      fields: [
+        {
+          name: 'x',
+          type: 'number',
+        },
+        {
+          name: 'y',
+          type: 'number',
+        },
+        {
+          name: 'height',
+          type: 'number',
+        },
+        {
+          name: 'width',
+          type: 'number',
+        },
+      ],
+    },
+    {
+      name: 'sanity.imageMetadata',
+      title: 'Image metadata',
+      type: 'object',
+      fieldsets: [
+        {
+          name: 'extra',
+          title: 'Extra metadata…',
+          options: {
+            collapsable: true,
+          },
+        },
+      ],
+      fields: [
+        {
+          name: 'location',
+          type: 'geopoint',
+        },
+        {
+          name: 'dimensions',
+          title: 'Dimensions',
+          type: 'sanity.imageDimensions',
+          fieldset: 'extra',
+        },
+        {
+          name: 'palette',
+          type: 'sanity.imagePalette',
+          title: 'Palette',
+          fieldset: 'extra',
+        },
+        {
+          name: 'lqip',
+          title: 'LQIP (Low-Quality Image Placeholder)',
+          type: 'string',
+          readOnly: true,
+        },
+        {
+          name: 'blurHash',
+          title: 'BlurHash',
+          type: 'string',
+          readOnly: true,
+        },
+        {
+          name: 'hasAlpha',
+          title: 'Has alpha channel',
+          type: 'boolean',
+          readOnly: true,
+        },
+        {
+          name: 'isOpaque',
+          title: 'Is opaque',
+          type: 'boolean',
+          readOnly: true,
+        },
+      ],
+    },
+    {
+      name: 'sanity.assetSourceData',
+      title: 'Asset Source Data',
+      type: 'object',
+      fields: [
+        {
+          name: 'name',
+          title: 'Source name',
+          description: 'A canonical name for the source this asset is originating from',
+          type: 'string',
+        },
+        {
+          name: 'id',
+          title: 'Asset Source ID',
+          description:
+            'The unique ID for the asset within the originating source so you can programatically find back to it',
+          type: 'string',
+        },
+        {
+          name: 'url',
+          title: 'Asset information URL',
+          description: 'A URL to find more information about this asset in the originating source',
+          type: 'string',
+        },
+      ],
+    },
+    {
+      name: 'sanity.imageCrop',
+      title: 'Image crop',
+      type: 'object',
+      fields: [
+        {
+          name: 'top',
+          type: 'number',
+        },
+        {
+          name: 'bottom',
+          type: 'number',
+        },
+        {
+          name: 'left',
+          type: 'number',
+        },
+        {
+          name: 'right',
+          type: 'number',
+        },
+      ],
+    },
+    {
+      name: 'sanity.imageDimensions',
+      type: 'object',
+      title: 'Image dimensions',
+      fields: [
+        {name: 'height', type: 'number', title: 'Height', readOnly: true},
+        {name: 'width', type: 'number', title: 'Width', readOnly: true},
+        {name: 'aspectRatio', type: 'number', title: 'Aspect ratio', readOnly: true},
+      ],
+    },
+    {
+      name: 'sanity.imagePalette',
+      title: 'Image palette',
+      type: 'object',
+      fields: [
+        {name: 'darkMuted', type: 'sanity.imagePaletteSwatch', title: 'Dark Muted'},
+        {name: 'lightVibrant', type: 'sanity.imagePaletteSwatch', title: 'Light Vibrant'},
+        {name: 'darkVibrant', type: 'sanity.imagePaletteSwatch', title: 'Dark Vibrant'},
+        {name: 'vibrant', type: 'sanity.imagePaletteSwatch', title: 'Vibrant'},
+        {name: 'dominant', type: 'sanity.imagePaletteSwatch', title: 'Dominant'},
+        {name: 'lightMuted', type: 'sanity.imagePaletteSwatch', title: 'Light Muted'},
+        {name: 'muted', type: 'sanity.imagePaletteSwatch', title: 'Muted'},
+      ],
+    },
+    {
+      name: 'sanity.imagePaletteSwatch',
+      title: 'Image palette swatch',
+      type: 'object',
+      fields: [
+        {name: 'background', type: 'string', title: 'Background', readOnly: true},
+        {name: 'foreground', type: 'string', title: 'Foreground', readOnly: true},
+        {name: 'population', type: 'number', title: 'Population', readOnly: true},
+        {name: 'title', type: 'string', title: 'String', readOnly: true},
+      ],
+    },
+    {
+      name: 'sanity.imageAsset',
+      title: 'Image',
+      type: 'document',
+      fieldsets: [
+        {
+          name: 'system',
+          title: 'System fields',
+          description: 'These fields are managed by the system and not editable',
+        },
+      ],
+      fields: [
+        {
+          name: 'originalFilename',
+          type: 'string',
+          title: 'Original file name',
+          readOnly: true,
+        },
+        {
+          name: 'label',
+          type: 'string',
+          title: 'Label',
+        },
+        {
+          name: 'title',
+          type: 'string',
+          title: 'Title',
+        },
+        {
+          name: 'description',
+          type: 'string',
+          title: 'Description',
+        },
+        {
+          name: 'altText',
+          type: 'string',
+          title: 'Alternative text',
+        },
+        {
+          name: 'sha1hash',
+          type: 'string',
+          title: 'SHA1 hash',
+          readOnly: true,
+          fieldset: 'system',
+        },
+        {
+          name: 'extension',
+          type: 'string',
+          readOnly: true,
+          title: 'File extension',
+          fieldset: 'system',
+        },
+        {
+          name: 'mimeType',
+          type: 'string',
+          readOnly: true,
+          title: 'Mime type',
+          fieldset: 'system',
+        },
+        {
+          name: 'size',
+          type: 'number',
+          title: 'File size in bytes',
+          readOnly: true,
+          fieldset: 'system',
+        },
+        {
+          name: 'assetId',
+          type: 'string',
+          title: 'Asset ID',
+          readOnly: true,
+          fieldset: 'system',
+        },
+        {
+          name: 'uploadId',
+          type: 'string',
+          readOnly: true,
+          hidden: true,
+          fieldset: 'system',
+        },
+        {
+          name: 'path',
+          type: 'string',
+          title: 'Path',
+          readOnly: true,
+          fieldset: 'system',
+        },
+        {
+          name: 'url',
+          type: 'string',
+          title: 'Url',
+          readOnly: true,
+          fieldset: 'system',
+        },
+        {
+          name: 'metadata',
+          type: 'sanity.imageMetadata',
+          title: 'Metadata',
+        },
+        {
+          name: 'source',
+          type: 'sanity.assetSourceData',
+          title: 'Source',
+          readOnly: true,
+          fieldset: 'system',
+        },
+      ],
+      preview: {
+        select: {
+          id: '_id',
+          title: 'originalFilename',
+          mimeType: 'mimeType',
+          size: 'size',
+        },
+        prepare(doc: any) {
+          return {
+            title: doc.title || doc.path.split('/').slice(-1)[0],
+            media: {asset: {_ref: doc.id}},
+            subtitle: `${doc.mimeType} (${(doc.size / 1024 / 1024).toFixed(2)} MB)`,
+          }
+        },
+      },
+      orderings: [
+        {
+          title: 'File size',
+          name: 'fileSizeDesc',
+          by: [{field: 'size', direction: 'desc'}],
+        },
+      ],
+    },
+    ...schemaTypes,
+  ],
+})


### PR DESCRIPTION
### Description

We're seeing an exponential slowdown when we are generating graphql schemas for sanity schemas that has many types referering to each other. This PR adds an, opt-in, cache that speeds up generating these schemas. Don't be alarmed by the diff, it's 95% snapshots 😅 

In the test schema case there's a 95% performance gain when generating with the cache:
```
withUnionCache: true:  88 ms
withUnionCache: false: 1732 ms
```

---

There were also some cases of looping over the same objects multiple times, I refactored the code into single loops.


### What to review

This change should, even with the flag on, generate the same schema. Is there a case where it might not? Any other test cases that might be beneficial?

### Notes for release

GraphQL: Add mode to optimize GraphQL deployment when schemas has many self referencing documents
