### PR TITLE
fix(sanity): guard against telemetry not provided from older global CLI versions

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@babel/traverse": "^7.23.5",
-    "@sanity/telemetry": "^0.7.3",
+    "@sanity/telemetry": "^0.7.5",
     "chalk": "^4.1.2",
     "esbuild": "^0.19.8",
     "esbuild-register": "^3.4.1",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -173,7 +173,7 @@
     "@sanity/portable-text-editor": "3.23.1",
     "@sanity/presentation": "1.4.0",
     "@sanity/schema": "3.23.1",
-    "@sanity/telemetry": "^0.7.3",
+    "@sanity/telemetry": "^0.7.5",
     "@sanity/types": "3.23.1",
     "@sanity/ui": "2.0.0-beta.13",
     "@sanity/util": "3.23.1",

--- a/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/build/buildAction.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 import {promisify} from 'util'
 import chalk from 'chalk'
+import {noopLogger} from '@sanity/telemetry'
 import rimrafCallback from 'rimraf'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore This may not yet be built.
@@ -27,7 +28,7 @@ export default async function buildSanityStudio(
   overrides?: {basePath?: string},
 ): Promise<{didCompile: boolean}> {
   const timer = getTimer()
-  const {output, prompt, workDir, cliConfig, telemetry} = context
+  const {output, prompt, workDir, cliConfig, telemetry = noopLogger} = context
   const flags: BuildSanityStudioCommandFlags = {
     minify: true,
     stats: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3778,10 +3778,10 @@
   dependencies:
     "@sanity/uuid" "3.0.2"
 
-"@sanity/telemetry@^0.7.3":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@sanity/telemetry/-/telemetry-0.7.3.tgz#05715dbf3cd7313b6eeeba23faa2bba8b5c8c381"
-  integrity sha512-gzHQJPQ9PjKOS/T/SLqrbSgTGwb2ZTrbBZBH0Yx25P5cP2C9kBGCoHRIJvQU0axBFSBRajVQDKtIUSrZ59XBSw==
+"@sanity/telemetry@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@sanity/telemetry/-/telemetry-0.7.5.tgz#e9c39d35a55892ec230654f33d008f75aa2a398a"
+  integrity sha512-lY1Lmt2zl9YIIXO2bAFGXR542ovpn8jmLmIos1mQU4D+ItbZsPBxt9g72bJCsUZ7yodMf2K4t4Tp7BTv0as9sg==
   dependencies:
     lodash "^4.17.21"
     react "^18.2.0"


### PR DESCRIPTION
### Description
We recently added a `telemetry` instance to the context passed from the global cli to "local" project cli commands. However, if the global CLI is on an older version than the one installed locally in the project folder, the local command implementation will be handed a context from the old version of the global cli which doesn't include telemetry. This again again will cause the CLI to crash. This patch fixes the issue, by falling back to a noop telemetry instance the global CLI doesn't provide it.

### What to review
- A bit tricky to review, but I've verified that it works locally

### Notes for release

- Fix an issue that could occur when using an older version of the CLI globally in combination with a more recent version installed locally