### PR TITLE
chore(cli): pin next-sanity to v7

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -410,11 +410,11 @@ export default async function initSanity(
     }
 
     if (chosen === 'npm') {
-      await execa('npm', ['install', 'next-sanity@5'], execOptions)
+      await execa('npm', ['install', 'next-sanity@7'], execOptions)
     } else if (chosen === 'yarn') {
-      await execa('npx', ['install-peerdeps', '--yarn', 'next-sanity@5'], execOptions)
+      await execa('npx', ['install-peerdeps', '--yarn', 'next-sanity@7'], execOptions)
     } else if (chosen === 'pnpm') {
-      await execa('pnpm', ['install', 'next-sanity@5'], execOptions)
+      await execa('pnpm', ['install', 'next-sanity@7'], execOptions)
     }
 
     print(


### PR DESCRIPTION
### Description

Pins `next-sanity` to latest version.

### What to review

- That installing a vanilla Next.js app + studio works
- That v7 is intended to be the latest version

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
