### PR TITLE
fix(core): icon size in previews with custom icon

### DIFF
--- a/packages/sanity/src/core/components/previews/_common/Media.styled.ts
+++ b/packages/sanity/src/core/components/previews/_common/Media.styled.ts
@@ -37,15 +37,24 @@ export const MediaWrapper = styled.span<{
     }
 
     & svg {
+      // Shared styles for SVG icons
       color: var(--card-icon-color);
       display: block;
       flex: 1;
-      font-size: calc(21 / 16 * 1em);
-    }
 
-    & [data-sanity-icon] {
-      display: block;
-      font-size: calc(${iconSize} / 16 * 1em);
+      // Specific styles for non Sanity icons
+      &:not([data-sanity-icon]) {
+        height: 1em;
+        width: 1em;
+        max-width: 1em;
+        max-height: 1em;
+      }
+
+      // Specific styles for Sanity icons
+      &[data-sanity-icon] {
+        display: block;
+        font-size: calc(${iconSize} / 16 * 1em);
+      }
     }
 
     & > span[data-border] {


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This pull request makes sure that custom icons have the correct sizing in previews.

<img width="1487" alt="Screenshot 2023-12-22 at 17 59 48" src="https://github.com/sanity-io/sanity/assets/15094168/5ec4cc78-90d3-4b35-9e69-d46b2ef29314">


### What to review

- Make sure that icons have the correct size

### Notes for release

Fix icon size issue in previews
