### PR TITLE
fix(vision): use untranslated value for other api version

### DIFF
--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -694,7 +694,7 @@ export class VisionGui extends React.PureComponent<VisionGuiProps, VisionGuiStat
                   {API_VERSIONS.map((version) => (
                     <option key={version}>{version}</option>
                   ))}
-                  <option key="other" value={t('settings.other-api-version-label')}>
+                  <option key="other" value="other">
                     {t('settings.other-api-version-label')}
                   </option>
                 </Select>

--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -687,7 +687,7 @@ export class VisionGui extends React.PureComponent<VisionGuiProps, VisionGuiStat
                 </Card>
                 <Select
                   value={
-                    customApiVersion === false ? apiVersion : t('settings.other-api-version-label')
+                    customApiVersion === false ? apiVersion : 'other'
                   }
                   onChange={this.handleChangeApiVersion}
                 >


### PR DESCRIPTION
Fixes https://github.com/sanity-io/sanity/issues/5432