### PR TITLE
fix(legacy-theme): update buildLegacyTheme to support custom colors

### DIFF
--- a/packages/sanity/src/core/theme/_legacy/theme.ts
+++ b/packages/sanity/src/core/theme/_legacy/theme.ts
@@ -1,5 +1,7 @@
 import {black, blue, gray, green, red, white, yellow} from '@sanity/color'
 import {studioTheme as defaults} from '@sanity/ui'
+// eslint-disable-next-line camelcase
+import {v0_v2} from '@sanity/ui/theme'
 import {StudioTheme} from '../types'
 import {buildColor} from './color'
 import {buildFonts} from './fonts'
@@ -38,11 +40,11 @@ export function buildLegacyTheme(partialLegacyTheme: Partial<LegacyThemeProps>):
 
   const color = buildColor(legacyPalette, legacyTones)
   const fonts = buildFonts(legacyTheme)
-
-  return {
+  const theme: StudioTheme = {
     __dark: _isDark(color.light.default.base.bg, color.light.default.base.fg),
     __legacy: true,
     ...defaults,
+    v2: undefined,
     color,
     focusRing: {
       offset: -1,
@@ -56,6 +58,9 @@ export function buildLegacyTheme(partialLegacyTheme: Partial<LegacyThemeProps>):
       parseInt(legacyTheme['--screen-xlarge-break'], 10) || 1600,
     ],
   }
+  // Override v2 default theme with the adapter from v0 theme to v2 theme
+  theme.v2 = v0_v2(theme)
+  return theme
 }
 
 const defaultCustomProperties: LegacyThemeProps = {


### PR DESCRIPTION
### Description

Sanity UI v2 introduced the `v2` object into the theme. 
This `v2` is included as part of the studioTheme, which we are spreading by using the defaults in the `buildLegacyTheme` function, but those are the default values, that's the reason why the legacy theme colors were lost.

With this updates, the theme v2 will be generated by the `v0_v2` function that converts v0 to v2 and it won't use the default studio theme v2 values.

### Before 
<img width="600" alt="Screenshot 2024-01-02 at 19 09 52" src="https://github.com/sanity-io/sanity/assets/46196328/a081dd62-2b96-431d-813f-74dc33afaf8f">
### After
<img width="600" alt="Screenshot 2024-01-02 at 19 09 21" src="https://github.com/sanity-io/sanity/assets/46196328/8fb8fcb7-4305-4e8b-9d3e-72983677c9d2">



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Theme works as expected.
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

update buildLegacyTheme to support custom colors

<!--
A description of the change(s) that should be used in the release notes.
-->
