### PR TITLE
fix(desk): translate when form title is missing

### DIFF
--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -243,6 +243,8 @@ const structureLocaleStrings = defineLocalesResources('structure', {
 
   /** The text for when a form is hidden */
   'document-view.form-view.form-hidden': 'This form is hidden',
+  /** Fallback title shown when a form title is not provided */
+  'document-view.form-view.form-title-fallback': 'Untitled',
   /** The text for when the form view is loading a document */
   'document-view.form-view.loading': 'Loading document…',
   /** The description of the sync lock toast on the form view */

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormHeader.tsx
@@ -1,6 +1,8 @@
 import {SchemaType} from '@sanity/types'
 import {Heading, Stack, Text} from '@sanity/ui'
+import {useTranslation} from 'react-i18next'
 import styled, {css} from 'styled-components'
+import {structureLocaleNamespace} from '../../../../i18n'
 
 interface DocumentHeaderProps {
   documentId: string
@@ -57,6 +59,7 @@ export const TitleContainer = styled(Stack)`
  */
 export const FormHeader = ({documentId, schemaType, title}: DocumentHeaderProps) => {
   const isSingleton = documentId === schemaType.name
+  const {t} = useTranslation(structureLocaleNamespace)
 
   return (
     <TitleContainer marginBottom={6} space={4}>
@@ -67,7 +70,7 @@ export const FormHeader = ({documentId, schemaType, title}: DocumentHeaderProps)
       )}
 
       <Heading as="h2" data-heading muted={!title}>
-        {title ?? 'Untitled'}
+        {title ?? t('document-view.form-view.form-title-fallback')}
       </Heading>
     </TitleContainer>
   )


### PR DESCRIPTION
### Description
Adds new resource for missing form view title 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
The document form view title - if it is missing, it should say `Untitled` in the respective language 

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Adds translation to untitled document titles
<!--
A description of the change(s) that should be used in the release notes.
-->
