### PR TITLE
fix(block-tools): keep strike-through formatting when pasting from gdocs

### DIFF
--- a/packages/@sanity/block-tools/src/HtmlDeserializer/rules/gdocs.ts
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/rules/gdocs.ts
@@ -30,6 +30,12 @@ function isUnderline(el: Node): boolean {
   return /text-decoration:underline/.test(style || '')
 }
 
+// text-decoration seems like the most important rule for strike-through in their html
+function isStrikethrough(el: Node): boolean {
+  const style = isElement(el) && el.getAttribute('style')
+  return /text-decoration:line-through/.test(style || '')
+}
+
 // Check for attribute given by the gdocs preprocessor
 function isGoogleDocs(el: Node): boolean {
   return isElement(el) && Boolean(el.getAttribute('data-is-google-docs'))
@@ -99,6 +105,9 @@ export default function createGDocsRules(
           }
           if (isUnderline(el)) {
             span.marks.push('underline')
+          }
+          if (isStrikethrough(el)) {
+            span.marks.push('strike-through')
           }
           if (isEmphasis(el)) {
             span.marks.push('em')

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/gdocsLists/output.json
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/gdocsLists/output.json
@@ -66,7 +66,7 @@
     "children": [
       {
         "_type": "span",
-        "marks": [],
+        "marks": ["strike-through"],
         "text": "Level 2",
         "_key": "randomKey40"
       }
@@ -130,7 +130,7 @@
     "children": [
       {
         "_type": "span",
-        "marks": [],
+        "marks": ["strike-through"],
         "text": "Level 2",
         "_key": "randomKey80"
       }


### PR DESCRIPTION
### Description

This PR preserves strike-through formatting when pasting from Google Docs.

Fixes #5290 

### What to review

- That text formatted with strike-through is preserved when copy pasting from a Google doc

### Notes for release

- Fixed issue with strike-through formatting being lost when copy-pasting from Google Docs into a PTE field