### PR TITLE
fix: opt-out of internal studio ui-components for user facing custom document action dialogs

### DIFF
--- a/packages/sanity/src/core/config/document/actions.ts
+++ b/packages/sanity/src/core/config/document/actions.ts
@@ -1,7 +1,9 @@
-import {type ButtonTone} from '@sanity/ui'
+import {
+  type ButtonTone,
+  type DialogProps, // eslint-disable-line no-restricted-imports
+} from '@sanity/ui'
 import type React from 'react'
 import {type EditStateFor} from '../../store/_legacy'
-import {DialogProps} from '../../../ui-components'
 
 /**
  * @hidden

--- a/packages/sanity/src/desk/__workshop__/DocumentStateStory.tsx
+++ b/packages/sanity/src/desk/__workshop__/DocumentStateStory.tsx
@@ -1,6 +1,11 @@
-import {Box, Code, Stack} from '@sanity/ui'
+import {
+  Box,
+  Button, // eslint-disable-line no-restricted-imports
+  Code,
+  Dialog, // eslint-disable-line no-restricted-imports
+  Stack,
+} from '@sanity/ui'
 import React, {useMemo, useState, useCallback, useEffect} from 'react'
-import {Button, Dialog} from '../../ui-components'
 import {DeskToolProvider} from '../DeskToolProvider'
 import {DocumentPaneProvider} from '../panes'
 import {DocumentPaneNode} from '../types'

--- a/packages/sanity/src/desk/panes/document/statusBar/dialogs/ConfirmDialog.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/dialogs/ConfirmDialog.tsx
@@ -1,7 +1,16 @@
-import {Box, Flex, Grid, Text, useClickOutside, useGlobalKeyDown, useLayer} from '@sanity/ui'
+import {
+  Box,
+  Button, // eslint-disable-line no-restricted-imports
+  Flex,
+  Grid,
+  Popover, // eslint-disable-line no-restricted-imports
+  Text,
+  useClickOutside,
+  useGlobalKeyDown,
+  useLayer,
+} from '@sanity/ui'
 import React, {useCallback, useState} from 'react'
 import {structureLocaleNamespace} from '../../../../i18n'
-import {Button, Popover} from '../../../../../ui-components'
 import {POPOVER_FALLBACK_PLACEMENTS} from './constants'
 import {DocumentActionConfirmDialogProps, useTranslation} from 'sanity'
 
@@ -24,6 +33,10 @@ export function ConfirmDialog(props: {
   )
 }
 
+/**
+ * Dialog rendered by custom document actions of dialog type `confirm`.
+ * As these are user configurable with public facing APIs, internal studio ui-components are not used.
+ */
 function ConfirmDialogContent(props: {dialog: DocumentActionConfirmDialogProps}) {
   const {dialog} = props
   const {

--- a/packages/sanity/src/desk/panes/document/statusBar/dialogs/ModalDialog.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/dialogs/ModalDialog.tsx
@@ -1,17 +1,30 @@
+import {
+  Box,
+  Dialog, // eslint-disable-line no-restricted-imports
+} from '@sanity/ui'
 import React, {useId} from 'react'
-import {Dialog} from '../../../../../ui-components'
 import {DIALOG_WIDTH_TO_UI_WIDTH} from './constants'
 import {DocumentActionModalDialogProps, LegacyLayerProvider} from 'sanity'
 
+/**
+ * Dialog rendered by custom document actions of dialog type `dialog`.
+ * As these are user configurable with public facing APIs, internal studio ui-components are not used.
+ */
 export function ModalDialog(props: {dialog: DocumentActionModalDialogProps}) {
   const {dialog} = props
   const dialogId = useId()
+
+  const footer = dialog.footer && (
+    <Box paddingX={4} paddingY={3}>
+      {dialog.footer}
+    </Box>
+  )
 
   return (
     <LegacyLayerProvider zOffset="fullscreen">
       <Dialog
         __unstable_hideCloseButton={dialog.showCloseButton === false}
-        footer={dialog.footer}
+        footer={footer}
         header={dialog.header}
         id={dialogId}
         // eslint-disable-next-line react/jsx-handler-names
@@ -20,7 +33,7 @@ export function ModalDialog(props: {dialog: DocumentActionModalDialogProps}) {
         onClickOutside={dialog.onClose}
         width={dialog.width === undefined ? 1 : DIALOG_WIDTH_TO_UI_WIDTH[dialog.width]}
       >
-        {dialog.content}
+        <Box padding={4}>{dialog.content}</Box>
       </Dialog>
     </LegacyLayerProvider>
   )

--- a/packages/sanity/src/desk/panes/document/statusBar/dialogs/PopoverDialog.tsx
+++ b/packages/sanity/src/desk/panes/document/statusBar/dialogs/PopoverDialog.tsx
@@ -1,6 +1,10 @@
-import {useClickOutside, useGlobalKeyDown, useLayer} from '@sanity/ui'
+import {
+  Popover, // eslint-disable-line no-restricted-imports
+  useClickOutside,
+  useGlobalKeyDown,
+  useLayer,
+} from '@sanity/ui'
 import React, {useCallback, useState} from 'react'
-import {Popover} from '../../../../../ui-components'
 import {POPOVER_FALLBACK_PLACEMENTS} from './constants'
 import {DocumentActionPopoverDialogProps} from 'sanity'
 
@@ -23,6 +27,10 @@ export function PopoverDialog(props: {
   )
 }
 
+/**
+ * Popover rendered by custom document actions of dialog type `popover`.
+ * As these are user configurable with public facing APIs, internal studio ui-components are not used.
+ */
 function PopoverDialogContent(props: {dialog: DocumentActionPopoverDialogProps}) {
   const {dialog} = props
   const {content, onClose} = dialog


### PR DESCRIPTION
### Description

This PR fixes a regression introduced by Facelift where custom document actions of the `modal` _dialog_ type ([reference](https://www.sanity.io/docs/document-actions-api#037f877ad3f1)) were erroneously using internal ui-components rather than 'vanilla' Sanity UI.

This fix means that custom document actions with `modal` dialogs will now correctly render any supplied footer component, whereas previously they weren't rendering anything at all.

### What to review

Custom document actions with `modal` dialogs should correctly render footer content.

This can be validated by comparing the custom **Test document modal** document action on the test studio ([before](https://test-studio.sanity.build/test/structure/input-debug;documentActionsTest;05bcc930-5e43-41a0-b48b-432b51878567) and [after](https://test-studio-git-edx-962.sanity.build/test/structure/input-debug;documentActionsTest;05bcc930-5e43-41a0-b48b-432b51878567))

**Before:**
<img width="705" alt="image" src="https://github.com/sanity-io/sanity/assets/209129/4339bb48-8111-439f-aff9-464777066f25">

**After:**
<img width="678" alt="image" src="https://github.com/sanity-io/sanity/assets/209129/e89436c5-8ccf-4cf1-a074-8a730fc811db">

### Notes for release

- Fixes a regression where footer content in custom document actions (with the `modal` dialog type) wasn't being rendered properly