### PR TITLE
fix: derive document title from current formState value

### DIFF
--- a/packages/sanity/src/core/components/userAvatar/UserAvatar.tsx
+++ b/packages/sanity/src/core/components/userAvatar/UserAvatar.tsx
@@ -74,7 +74,7 @@ const StaticUserAvatar = forwardRef(function StaticUserAvatar(
   props: Omit<UserAvatarProps, 'user'> & {user: User},
   ref: React.ForwardedRef<HTMLDivElement>,
 ) {
-  const {user, animateArrowFrom, position, size, status, tone, ...restProps} = props
+  const {user, animateArrowFrom, position, size, status, tone} = props
   const [imageLoadError, setImageLoadError] = useState<null | Error>(null)
   const userColor = useUserColor(user.id)
   const imageUrl = imageLoadError ? undefined : user?.imageUrl
@@ -93,7 +93,6 @@ const StaticUserAvatar = forwardRef(function StaticUserAvatar(
       size={typeof size === 'string' ? LEGACY_TO_UI_AVATAR_SIZES[size] : size}
       status={status}
       title={user?.displayName}
-      {...restProps}
     />
   )
 })

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormHeader.tsx
@@ -31,6 +31,7 @@ export const TitleContainer = styled(Stack)`
         font-size: ${theme.sanity.fonts.heading.sizes[4].fontSize}px;
         line-height: ${theme.sanity.fonts.heading.sizes[4].lineHeight}px;
         overflow-wrap: break-word;
+        text-wrap: balance;
       }
 
       @container (max-width: 560px) {

--- a/packages/sanity/src/structure/panes/document/useDocumentTitle.ts
+++ b/packages/sanity/src/structure/panes/document/useDocumentTitle.ts
@@ -13,7 +13,8 @@ interface UseDocumentTitle {
 }
 
 /**
- * React hook that returns the document title for the current document in the document pane.
+ * React hook that returns the _preview_ title for the current document in the document pane
+ * based off the current `formState` value.
  *
  * @beta
  * @hidden
@@ -21,25 +22,25 @@ interface UseDocumentTitle {
  * @returns The document title or error. See {@link UseDocumentTitle}
  */
 export function useDocumentTitle(): UseDocumentTitle {
-  const {connectionState, schemaType, title, value: documentValue} = useDocumentPane()
-  const subscribed = Boolean(documentValue) && connectionState === 'connected'
+  const {connectionState, formState, schemaType} = useDocumentPane()
+  const formStateValue = formState?.value
+
+  const subscribed = Boolean(formStateValue) && connectionState === 'connected'
 
   const {error, value} = useValuePreview({
     enabled: subscribed,
     schemaType,
-    value: documentValue,
+    value: formStateValue,
   })
 
-  if (connectionState !== 'connected') {
-    return {error: undefined, title: undefined}
-  }
-
-  if (title) {
-    return {error: undefined, title}
-  }
-
-  if (!documentValue) {
-    return {error: undefined, title: `New ${schemaType?.title || schemaType?.name}`}
+  // Don't return a title if unable to retrieve the current preview
+  // or if the `formState` value doesn't contain `_updatedAt` - indicating
+  // that the current `formState` represents a newly created document.
+  if (connectionState !== 'connected' || !formStateValue?._updatedAt) {
+    return {
+      error: undefined,
+      title: undefined,
+    }
   }
 
   if (error) {


### PR DESCRIPTION
### Description

This PR fixes an issue where large document preview titles weren't correctly updating when viewing previous document revisions. 

This is achieved by deriving this title from the current document's `formState` value rather than that of the the saved document. 

This also introduces a minor improvement to rendering these titles, using `text-wrap: balance` to ensure longer titles feel a little more optically even.

### What to review

- Large document preview titles should correctly update when navigating between document revisions
- Large document preview titles should correctly display 'Untitled' when selecting the very first revision of a document
- Large document preview titles across multiple lines should feel more optically balanced

### Notes for release

Fixes an issue where document header titles weren't updating correctly when viewing previous document revisions