### PR TITLE
feat(desk): add __experimental_formPreviewTitle to documents

### DIFF
--- a/dev/test-studio/schema/playlist.ts
+++ b/dev/test-studio/schema/playlist.ts
@@ -5,7 +5,7 @@ export default defineType({
   title: 'Playlist',
   type: 'document',
   // eslint-disable-next-line camelcase
-  __experimental_form_preview_title: false,
+  __experimental_formPreviewTitle: false,
   liveEdit: true,
   fields: [
     {

--- a/dev/test-studio/schema/playlist.ts
+++ b/dev/test-studio/schema/playlist.ts
@@ -4,6 +4,8 @@ export default defineType({
   name: 'playlist',
   title: 'Playlist',
   type: 'document',
+  // eslint-disable-next-line camelcase
+  __experimental_hide_form_title: true,
   liveEdit: true,
   fields: [
     {

--- a/dev/test-studio/schema/playlist.ts
+++ b/dev/test-studio/schema/playlist.ts
@@ -5,7 +5,7 @@ export default defineType({
   title: 'Playlist',
   type: 'document',
   // eslint-disable-next-line camelcase
-  __experimental_hide_form_title: true,
+  __experimental_form_preview_title: false,
   liveEdit: true,
   fields: [
     {

--- a/packages/@sanity/types/src/schema/definition/type/document.ts
+++ b/packages/@sanity/types/src/schema/definition/type/document.ts
@@ -29,8 +29,8 @@ export interface DocumentDefinition extends Omit<ObjectDefinition, 'type'> {
   /** @alpha */
   __experimental_omnisearch_visibility?: boolean
   /**
-   * Hides the document title introduced at the document pane
+   * Determines whether the large preview title is displayed in the document pane form
    * @alpha
    * */
-  __experimental_hide_form_title?: boolean
+  __experimental_form_preview_title?: boolean
 }

--- a/packages/@sanity/types/src/schema/definition/type/document.ts
+++ b/packages/@sanity/types/src/schema/definition/type/document.ts
@@ -32,5 +32,5 @@ export interface DocumentDefinition extends Omit<ObjectDefinition, 'type'> {
    * Determines whether the large preview title is displayed in the document pane form
    * @alpha
    * */
-  __experimental_form_preview_title?: boolean
+  __experimental_formPreviewTitle?: boolean
 }

--- a/packages/@sanity/types/src/schema/definition/type/document.ts
+++ b/packages/@sanity/types/src/schema/definition/type/document.ts
@@ -28,4 +28,9 @@ export interface DocumentDefinition extends Omit<ObjectDefinition, 'type'> {
   __experimental_search?: {path: string; weight: number; mapWith?: string}[]
   /** @alpha */
   __experimental_omnisearch_visibility?: boolean
+  /**
+   * Hides the document title introduced at the document pane
+   * @alpha
+   * */
+  __experimental_hide_form_title?: boolean
 }

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -381,7 +381,7 @@ export interface ObjectSchemaType extends BaseSchemaType {
   /** @alpha */
   __experimental_actions?: string[]
   /** @alpha */
-  __experimental_form_preview_title?: boolean
+  __experimental_formPreviewTitle?: boolean
   /**
    * @beta
    */

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -381,7 +381,7 @@ export interface ObjectSchemaType extends BaseSchemaType {
   /** @alpha */
   __experimental_actions?: string[]
   /** @alpha */
-  __experimental_hide_form_title?: boolean
+  __experimental_form_preview_title?: boolean
   /**
    * @beta
    */

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -380,7 +380,8 @@ export interface ObjectSchemaType extends BaseSchemaType {
   __experimental_omnisearch_visibility?: boolean
   /** @alpha */
   __experimental_actions?: string[]
-
+  /** @alpha */
+  __experimental_hide_form_title?: boolean
   /**
    * @beta
    */

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormHeader.tsx
@@ -61,7 +61,7 @@ export const FormHeader = ({documentId, schemaType, title}: DocumentHeaderProps)
   const isSingleton = documentId === schemaType.name
   const {t} = useTranslation(structureLocaleNamespace)
 
-  if (schemaType.__experimental_hide_form_title) {
+  if (schemaType.__experimental_form_preview_title === false) {
     return null
   }
 

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormHeader.tsx
@@ -1,4 +1,4 @@
-import {SchemaType} from '@sanity/types'
+import {ObjectSchemaType, SchemaType} from '@sanity/types'
 import {Heading, Stack, Text} from '@sanity/ui'
 import {useTranslation} from 'react-i18next'
 import styled, {css} from 'styled-components'
@@ -6,7 +6,7 @@ import {structureLocaleNamespace} from '../../../../i18n'
 
 interface DocumentHeaderProps {
   documentId: string
-  schemaType: SchemaType
+  schemaType: ObjectSchemaType
   title?: string
 }
 
@@ -60,6 +60,10 @@ export const TitleContainer = styled(Stack)`
 export const FormHeader = ({documentId, schemaType, title}: DocumentHeaderProps) => {
   const isSingleton = documentId === schemaType.name
   const {t} = useTranslation(structureLocaleNamespace)
+
+  if (schemaType.__experimental_hide_form_title) {
+    return null
+  }
 
   return (
     <TitleContainer marginBottom={6} space={4}>

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormHeader.tsx
@@ -61,7 +61,7 @@ export const FormHeader = ({documentId, schemaType, title}: DocumentHeaderProps)
   const isSingleton = documentId === schemaType.name
   const {t} = useTranslation(structureLocaleNamespace)
 
-  if (schemaType.__experimental_form_preview_title === false) {
+  if (schemaType.__experimental_formPreviewTitle === false) {
     return null
   }
 


### PR DESCRIPTION
### Description

With facelift a new title was introduced to all the documents, this title takes some space and doesn't work well with some custom implementations users have done to the document pane.

With this new flag `__experimental_form_preview_title ` users will be able to opt out from the new title.
![__experimental_form_preview_title](https://github.com/sanity-io/sanity/assets/46196328/b893aebf-4a36-4187-90c5-10478c55ffee)


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Allows users to hide the the large preview title is displayed in the document pane form
<!--
A description of the change(s) that should be used in the release notes.
-->
