### PR TITLE
fix(i18n): use correct locale string for document restore confirmation

### DIFF
--- a/packages/sanity/src/desk/i18n/resources.ts
+++ b/packages/sanity/src/desk/i18n/resources.ts
@@ -68,8 +68,7 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'action.publish.waiting': 'Waiting for tasks to finish before publishing',
 
   /** Message prompting the user to confirm that they want to restore to an earlier version*/
-  'action.restore.confirm-dialog.confirm-discard-changes':
-    'Are you sure you want to restore this document?',
+  'action.restore.confirm.message': 'Are you sure you want to restore this document?',
   /** Fallback tooltip for when user is looking at the initial version */
   'action.restore.disabled.cannot-restore-initial': "You can't restore to the initial version",
 


### PR DESCRIPTION
### Description

This PR updates the locale string key for the document restore confirmation message.

Currently, if you try and restore a previous document revision, you'll be greeted with the following:

<img width="320" alt="image" src="https://github.com/sanity-io/sanity/assets/209129/88ec4c14-9a05-4a62-a881-4a8f2fde2984">

Updating this key will now display the correct message:

<img width="399" alt="image" src="https://github.com/sanity-io/sanity/assets/209129/915df294-0e37-4482-8ae0-65146d1fbacb">

It appears the previous key (`action.restore.confirm-dialog.confirm-discard-changes`) isn't used anywhere throughout the codebase, and its name doesn't align with its value. Possible that it may have been accidentally mangled in a previous rebase?

### What to review

Restoring a previous document revision should display correct localized text.

### Notes for release

N/A