### PR TITLE
fix(core): remove variable fonts in global styles

### DIFF
--- a/packages/sanity/src/core/components/DefaultDocument.tsx
+++ b/packages/sanity/src/core/components/DefaultDocument.tsx
@@ -6,20 +6,60 @@ import {Favicons} from './Favicons'
 
 const globalStyles = `
   @font-face {
-    font-family: 'Inter';
+    font-family: Inter;
     font-style: normal;
-    font-weight: 100 900;
+    font-weight: 400;
     font-display: swap;
-    src: url('https://studio-static.sanity.io/InterVariable.ttf');
-    font-named-instance: 'Regular';
+    src: url("https://studio-static.sanity.io/Inter-Regular.woff2") format("woff2");
   }
   @font-face {
-    font-family: 'Inter';
+    font-family: Inter;
     font-style: italic;
-    font-weight: 100 900;
+    font-weight: 400;
     font-display: swap;
-    src: url('https://studio-static.sanity.io/InterVariable-Italic.ttf');
-    font-named-instance: 'Italic';
+    src: url("https://studio-static.sanity.io/Inter-Italic.woff2") format("woff2");
+  }
+  @font-face {
+    font-family: Inter;
+    font-style: normal;
+    font-weight: 500;
+    font-display: swap;
+    src: url("https://studio-static.sanity.io/Inter-Medium.woff2") format("woff2");
+  }
+  @font-face {
+    font-family: Inter;
+    font-style: italic;
+    font-weight: 500;
+    font-display: swap;
+    src: url("https://studio-static.sanity.io/Inter-MediumItalic.woff2") format("woff2");
+  }
+  @font-face {
+    font-family: Inter;
+    font-style: normal;
+    font-weight: 600;
+    font-display: swap;
+    src: url("https://studio-static.sanity.io/Inter-SemiBold.woff2") format("woff2");
+  }
+  @font-face {
+    font-family: Inter;
+    font-style: italic;
+    font-weight: 600;
+    font-display: swap;
+    src: url("https://studio-static.sanity.io/Inter-SemiBoldItalic.woff2") format("woff2");
+  }
+  @font-face {
+    font-family: Inter;
+    font-style: normal;
+    font-weight: 700;
+    font-display: swap;
+    src: url("https://studio-static.sanity.io/Inter-Bold.woff2") format("woff2");
+  }
+  @font-face {
+    font-family: Inter;
+    font-style: italic;
+    font-weight: 700;
+    font-display: swap;
+    src: url("https://studio-static.sanity.io/Inter-BoldItalic.woff2") format("woff2");
   }
   html {
     background-color: #f1f3f6;


### PR DESCRIPTION
### Description
There was an issue with font rendering in iOS16, resulting in a very thin font weight. This seemingly had to do with font variables. This PR adds a separate font-face for each font weight used. 

Before: 

<img width="502" alt="image (5)" src="https://github.com/sanity-io/sanity/assets/44635000/5378743b-f319-4724-9f1a-a8a3930257e6">

After: 

![Screenshot 2024-01-04 at 20 09 37](https://github.com/sanity-io/sanity/assets/44635000/38d5db4f-5c05-48a7-bf33-cdec2a20ac1e)

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
The font weights on iOS16 in Xcode. 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fixes font weights in iOS16
<!--
A description of the change(s) that should be used in the release notes.
-->
