### PR TITLE
fix(core): add aria-label to expand PTE button

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/Toolbar.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/Toolbar.tsx
@@ -130,6 +130,7 @@ const InnerToolbar = memo(function InnerToolbar({
       </Flex>
       <FullscreenButtonBox padding={isFullscreen ? 2 : 1}>
         <Button
+          aria-label={t('inputs.portable-text.action.expand-editor')}
           icon={isFullscreen ? CollapseIcon : ExpandIcon}
           mode="bleed"
           onClick={onToggleFullscreen}


### PR DESCRIPTION
### Description
Adds missing aria-label to `Expand editor` button in PTE
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
