### PR TITLE
fix(cli): update esbuild options for better compat

### DIFF
--- a/packages/sanity/src/_internal/cli/util/mockBrowserEnvironment.ts
+++ b/packages/sanity/src/_internal/cli/util/mockBrowserEnvironment.ts
@@ -29,7 +29,9 @@ export function mockBrowserEnvironment(basePath: string): () => void {
   )
 
   const {unregister: unregisterESBuild} = registerESBuild({
-    target: 'node14',
+    target: 'node18',
+    format: 'cjs',
+    extensions: ['.js', '.jsx', '.ts', '.tsx', '.mjs'],
   })
 
   return function cleanupBrowserEnvironment() {


### PR DESCRIPTION
### Description

I ran into issues with the `mockBrowserEnvironment` function when re-using in a different branch.

Setting the format to `'cjs'` enforces that esbuild outputs code compatible with the commonjs module loader used to mock the browser environment on the fly and updating the extensions ensures that those files get ran through esbuild and converted into cjs compatible code.

### What to review

- Does the graphql command still work? Does this increase compatibility?

### Notes for release

Fixes an issue where certain files would not get loaded correctly in the mock browser environment used for GraphQL deploys.