### PR TITLE
fix: add custom resize handle icon

### DIFF
--- a/packages/sanity/src/core/studio/GlobalStyle.tsx
+++ b/packages/sanity/src/core/studio/GlobalStyle.tsx
@@ -6,13 +6,30 @@ import {createGlobalStyle, css} from 'styled-components'
 const SCROLLBAR_SIZE = 12 // px
 const SCROLLBAR_BORDER_SIZE = 4 // px
 
+// Construct a resize handle icon as a data URI, to be displayed in browsers that support the `::-webkit-resizer` selector.
+function buildResizeHandleDataUri(hexColor: string) {
+  const encodedStrokeColor = encodeURIComponent(hexColor)
+  const encodedSvg = `%3Csvg width='9' height='9' viewBox='0 0 9 9' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 8L8 1' stroke='${encodedStrokeColor}' stroke-linecap='round'/%3E%3Cpath d='M5 8L8 5' stroke='${encodedStrokeColor}' stroke-linecap='round'/%3E%3C/svg%3E%0A`
+  return `url("data:image/svg+xml,${encodedSvg}")`
+}
+
 export const GlobalStyle = createGlobalStyle((props) => {
   const {color, font} = getTheme_v2(props.theme)
 
   return css`
+    ::-webkit-resizer {
+      background-image: ${buildResizeHandleDataUri(color.icon)};
+      background-repeat: no-repeat;
+      background-position: bottom right;
+    }
+
     ::-webkit-scrollbar {
       width: ${SCROLLBAR_SIZE}px;
       height: ${SCROLLBAR_SIZE}px;
+    }
+
+    ::-webkit-scrollbar-corner {
+      background-color: transparent;
     }
 
     ::-webkit-scrollbar-thumb {
@@ -26,7 +43,7 @@ export const GlobalStyle = createGlobalStyle((props) => {
     }
 
     ::-webkit-scrollbar-track {
-      background: var(--card-bg-color, transparent);
+      background: transparent;
     }
 
     *::selection {


### PR DESCRIPTION
### Description

This PR fixes the following issues:
- custom scrollbars (in browsers that support them) within text fields wouldn't correctly render RHS borders
- resize handles in text fields (with scroll overflow) would render with an unsightly white box on dark mode

**Before** ([link](https://test-studio.sanity.build/test/structure/input-standard;textsTest;61ead1a7-6a4a-489e-8d02-8564528c2d10)):

<img width="636" alt="image" src="https://github.com/sanity-io/sanity/assets/209129/09991a7a-b45e-464a-9e5d-74828ec88f8d">

**After** ([link](https://test-studio-git-fix-add-custom-resize-icon.sanity.build/test/structure/input-standard;textsTest;61ead1a7-6a4a-489e-8d02-8564528c2d10)):

<img width="633" alt="image" src="https://github.com/sanity-io/sanity/assets/209129/6e251892-de7d-4417-b3aa-1dc80facf4aa">

**More context:**

This is accomplished by rendering a custom SVG (as a Data URI) as a background image. Similar to custom scrollbars, this custom resize handle image is only displayed in webkit browsers.

I don't believe it's possible to accomplish this without a custom image – changing the background color in the `::-webkit-scrollbar-corner` selector isn't sufficient, as it'll still render unsightly white borders on both the left and top sides.

### What to review

Drag handles in both dark and light modes should look good.

### Notes for release

N/A