### PR TITLE
feat(comments): enable by default

### DIFF
--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -528,7 +528,7 @@ function resolveSource({
           return documentCommentsEnabledReducer({
             context: partialContext,
             config,
-            initialValue: false,
+            initialValue: true,
           })
         },
       },


### PR DESCRIPTION
### Description

This pull request changes the comments feature from being an opt-in feature to be an opt-out feature by making it enabled by default. 

### What to review

- Make sure that the `document.unstable_comments.enabled` config works as expected

### Notes for release

Make comments enabled by default
