### PR TITLE
fix(core): form fieldset border

### DIFF
--- a/packages/sanity/src/core/form/components/formField/FormFieldSet.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldSet.tsx
@@ -73,13 +73,12 @@ const Content = styled(Box)<{
   theme: Theme
 }>((props) => {
   const {$borderLeft, theme} = props
-  const {focusRing, radius} = theme.sanity
+  const {focusRing} = theme.sanity
   const {base} = theme.sanity.color
 
   return css`
     outline: none;
     border-left: ${$borderLeft ? '1px solid var(--card-border-color)' : undefined};
-    border-radius: ${rem(radius[2])};
 
     &:focus {
       box-shadow: ${focusRingStyle({base, focusRing: {...focusRing, offset: 2}})};


### PR DESCRIPTION
### Description

This pull request addresses an issue with the left border of fieldsets.

<img width="814" alt="Screenshot 2024-01-08 at 14 18 33" src="https://github.com/sanity-io/sanity/assets/15094168/c4076522-b557-4cc9-8215-8194943f2100">

### What to review
- Is there any situation when we want border radius on the field set?

### Notes for release

N/A