### PR TITLE
feat(core): add badge for deprecated fields

### DIFF
--- a/dev/test-studio/schema/debug/deprecatedFields.ts
+++ b/dev/test-studio/schema/debug/deprecatedFields.ts
@@ -125,8 +125,11 @@ export const deprecatedFields = defineType({
       fields: [
         defineField({
           name: 'alt',
-          title: 'Alt',
+          title: 'Alt Deprecated',
           type: 'string',
+          deprecated: {
+            reason: 'This alt is deprecated',
+          },
         }),
       ],
     }),

--- a/dev/test-studio/schema/debug/deprecatedFields.ts
+++ b/dev/test-studio/schema/debug/deprecatedFields.ts
@@ -7,10 +7,13 @@ export const deprecatedFields = defineType({
   fields: [
     defineField({
       deprecated: {
-        reason: 'This string field is deprecated',
+        reason:
+          'Use the non deprecated string field for new content, this field was originally for the old frontend',
       },
+      description: 'This field is used to create the header for the site',
+      validation: (Rule) => Rule.required(),
       name: 'string',
-      title: 'Deprecated String',
+      title: 'String',
       type: 'string',
     }),
     defineField({
@@ -19,7 +22,7 @@ export const deprecatedFields = defineType({
       },
       name: 'type',
       type: 'string',
-      title: 'Deprecated List',
+      title: 'List',
       initialValue: 'foo',
       options: {list: ['Frukt', 'Dyr', 'Fjell']},
     }),
@@ -28,7 +31,7 @@ export const deprecatedFields = defineType({
         reason: 'This number field is deprecated',
       },
       name: 'number',
-      title: 'Deprecated Number',
+      title: 'Number',
       type: 'number',
     }),
     defineField({
@@ -36,7 +39,7 @@ export const deprecatedFields = defineType({
         reason: 'This boolean field is deprecated',
       },
       name: 'boolean',
-      title: 'Deprecated Boolean',
+      title: 'Boolean',
       type: 'boolean',
     }),
     defineField({
@@ -44,7 +47,7 @@ export const deprecatedFields = defineType({
         reason: 'This email field is deprecated',
       },
       name: 'email',
-      title: 'Deprecated Email',
+      title: 'Email',
       type: 'email',
     }),
     defineField({
@@ -52,13 +55,13 @@ export const deprecatedFields = defineType({
         reason: 'This array is deprecated',
       },
       name: 'array',
-      title: 'Deprecated Array String',
+      title: 'Array String',
       type: 'array',
       of: [{type: 'string'}],
     }),
     defineField({
       name: 'notDeprecatedObject',
-      title: 'Not Deprecated Object',
+      title: 'Not Object',
       type: 'object',
       fields: [
         defineField({
@@ -71,14 +74,14 @@ export const deprecatedFields = defineType({
           deprecated: {
             reason: 'This field in object is deprecated',
           },
-          title: 'Deprecated in Object',
+          title: 'in Object',
           type: 'string',
         }),
       ],
     }),
     defineField({
       name: 'DeprecatedObject',
-      title: 'Deprecated Object',
+      title: 'Object',
       deprecated: {
         reason: 'This object is deprecated',
       },
@@ -91,7 +94,7 @@ export const deprecatedFields = defineType({
         }),
         defineField({
           name: 'deprecated',
-          title: 'Deprecated in Object',
+          title: 'in Object',
           type: 'string',
         }),
       ],
@@ -101,7 +104,7 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This reference is deprecated',
       },
-      title: 'Deprecated Reference',
+      title: 'Reference',
       type: 'reference',
       to: [{type: 'author'}, {type: 'book'}],
     }),
@@ -110,7 +113,7 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This cross dataset reference is deprecated',
       },
-      title: 'Deprecated CDR',
+      title: 'CDR',
       type: 'crossDatasetReference',
       dataset: 'blog',
       to: [{type: 'author', preview: {select: {title: 'name'}}}],
@@ -120,7 +123,7 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This image is deprecated',
       },
-      title: 'Deprecated Image',
+      title: 'Image',
       type: 'image',
       fields: [
         defineField({
@@ -138,7 +141,7 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This file is deprecated',
       },
-      title: 'Deprecated File',
+      title: 'File',
       type: 'file',
       fields: [
         defineField({
@@ -153,7 +156,7 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This date is deprecated',
       },
-      title: 'Deprecated Date',
+      title: 'Date',
       type: 'date',
     }),
     defineField({
@@ -161,7 +164,7 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This datetime is deprecated',
       },
-      title: 'Deprecated DateTime',
+      title: 'DateTime',
       type: 'datetime',
     }),
     defineField({
@@ -169,12 +172,12 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This geopoint is deprecated',
       },
-      title: 'Deprecated Geopoint',
+      title: 'Geopoint',
       type: 'geopoint',
     }),
     defineField({
       name: 'url',
-      title: 'Deprecated URL',
+      title: 'URL',
       type: 'url',
       deprecated: {
         reason: 'This url is deprecated',
@@ -185,7 +188,7 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This slug is deprecated',
       },
-      title: 'Deprecated Slug',
+      title: 'Slug',
       type: 'slug',
       options: {source: 'string'},
     }),
@@ -194,7 +197,7 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This text is deprecated',
       },
-      title: 'Deprecated Text',
+      title: 'Text',
       type: 'text',
     }),
     defineField({
@@ -202,7 +205,7 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This blocks is deprecated',
       },
-      title: 'Deprecated Blocks',
+      title: 'Blocks',
       type: 'array',
       of: [{type: 'block'}, {type: 'image'}],
     }),

--- a/packages/sanity/src/core/form/components/formField/FormField.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormField.tsx
@@ -64,8 +64,6 @@ export const FormField = memo(function FormField(
   } = props
   const {focused, hovered, onMouseEnter, onMouseLeave} = useFieldActions()
 
-  const isDeprecated = Boolean(deprecated?.reason)
-
   return (
     <Stack
       {...restProps}
@@ -73,11 +71,7 @@ export const FormField = memo(function FormField(
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       space={2}
-      style={{
-        opacity: isDeprecated ? 0.5 : undefined,
-      }}
     >
-      {isDeprecated && <p style={{margin: 0, color: 'red'}}>{deprecated?.reason}</p>}
       {/*
         NOTE: It’s not ideal to hide validation, presence and description when there's no `title`.
         So we might want to separate the concerns of input vs formfield components later on.
@@ -96,6 +90,7 @@ export const FormField = memo(function FormField(
               inputId={inputId}
               title={title}
               validation={validation}
+              deprecated={deprecated}
             />
           }
         />

--- a/packages/sanity/src/core/form/components/formField/FormFieldHeaderText.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldHeaderText.tsx
@@ -1,8 +1,9 @@
-import type {FormNodeValidation} from '@sanity/types'
-import {Box, Flex, Stack, Text} from '@sanity/ui'
+import type {DeprecatedProperty, FormNodeValidation} from '@sanity/types'
+import {Badge, Box, Flex, Stack, Text} from '@sanity/ui'
 import React, {memo} from 'react'
 import {useTranslation} from '../../../i18n'
 import {createDescriptionId} from '../../members/common/createDescriptionId'
+import {Tooltip} from '../../../../ui-components'
 import {FormFieldValidationStatus} from './FormFieldValidationStatus'
 
 /** @internal */
@@ -19,6 +20,7 @@ export interface FormFieldHeaderTextProps {
    */
   inputId?: string
   title?: React.ReactNode
+  deprecated?: DeprecatedProperty
 }
 
 const EMPTY_ARRAY: never[] = []
@@ -27,13 +29,13 @@ const EMPTY_ARRAY: never[] = []
 export const FormFieldHeaderText = memo(function FormFieldHeaderText(
   props: FormFieldHeaderTextProps,
 ) {
-  const {description, inputId, title, validation = EMPTY_ARRAY} = props
+  const {description, inputId, title, deprecated, validation = EMPTY_ARRAY} = props
   const {t} = useTranslation()
   const hasValidations = validation.length > 0
 
   return (
     <Stack space={3}>
-      <Flex>
+      <Flex align="center">
         <Text as="label" htmlFor={inputId} weight="medium" size={1}>
           {title || (
             <span style={{color: 'var(--card-muted-fg-color)'}}>
@@ -41,6 +43,16 @@ export const FormFieldHeaderText = memo(function FormFieldHeaderText(
             </span>
           )}
         </Text>
+
+        {deprecated && (
+          <Tooltip content={deprecated?.reason}>
+            <Box marginLeft={2}>
+              <Badge style={{width: 'fit-content'}} tone="critical">
+                {t('form.field.deprecated-label')}
+              </Badge>
+            </Box>
+          </Tooltip>
+        )}
 
         {hasValidations && (
           <Box marginLeft={2}>

--- a/packages/sanity/src/core/form/components/formField/FormFieldHeaderText.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldHeaderText.tsx
@@ -3,7 +3,7 @@ import {Badge, Box, Flex, Stack, Text} from '@sanity/ui'
 import React, {memo} from 'react'
 import {useTranslation} from '../../../i18n'
 import {createDescriptionId} from '../../members/common/createDescriptionId'
-import {Tooltip} from '../../../../ui-components'
+import {TextWithTone} from '../../../components'
 import {FormFieldValidationStatus} from './FormFieldValidationStatus'
 
 /** @internal */
@@ -45,13 +45,9 @@ export const FormFieldHeaderText = memo(function FormFieldHeaderText(
         </Text>
 
         {deprecated && (
-          <Tooltip content={deprecated?.reason}>
-            <Box marginLeft={2}>
-              <Badge style={{width: 'fit-content'}} tone="critical">
-                {t('form.field.deprecated-label')}
-              </Badge>
-            </Box>
-          </Tooltip>
+          <Box marginLeft={2}>
+            <Badge tone="caution">{t('form.field.deprecated-label')}</Badge>
+          </Box>
         )}
 
         {hasValidations && (
@@ -60,6 +56,12 @@ export const FormFieldHeaderText = memo(function FormFieldHeaderText(
           </Box>
         )}
       </Flex>
+
+      {deprecated && (
+        <TextWithTone tone="caution" size={1}>
+          {deprecated.reason}
+        </TextWithTone>
+      )}
 
       {description && (
         <Text muted size={1} id={createDescriptionId(inputId, description)}>

--- a/packages/sanity/src/core/form/components/formField/FormFieldSet.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldSet.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import {Box, Flex, Grid, rem, Stack, Text, Theme, useForwardedRef} from '@sanity/ui'
+import {Badge, Box, Flex, Grid, rem, Stack, Text, Theme, useForwardedRef} from '@sanity/ui'
 import React, {forwardRef, useCallback, useMemo} from 'react'
 import styled, {css} from 'styled-components'
 import {DeprecatedProperty, FormNodeValidation} from '@sanity/types'
@@ -8,6 +8,8 @@ import {DocumentFieldActionNode} from '../../../config'
 import {useFieldActions} from '../../field'
 import {createDescriptionId} from '../../members/common/createDescriptionId'
 import {FieldCommentsProps} from '../../types'
+import {Tooltip} from '../../../../ui-components'
+import {useTranslation} from '../../../i18n'
 import {FormFieldValidationStatus} from './FormFieldValidationStatus'
 import {FormFieldSetLegend} from './FormFieldSetLegend'
 import {focusRingStyle} from './styles'
@@ -124,6 +126,7 @@ export const FormFieldSet = forwardRef(function FormFieldSet(
 
   const hasValidationMarkers = validation.length > 0
   const forwardedRef = useForwardedRef(ref)
+  const {t} = useTranslation()
 
   const handleFocus = useCallback(
     (event: React.FocusEvent<HTMLDivElement>) => {
@@ -152,8 +155,6 @@ export const FormFieldSet = forwardRef(function FormFieldSet(
     )
   }, [children, collapsed, columns])
 
-  const isDeprecated = typeof deprecated !== 'undefined'
-
   return (
     <Root
       data-level={level}
@@ -170,20 +171,23 @@ export const FormFieldSet = forwardRef(function FormFieldSet(
         fieldHovered={hovered}
         presence={presence}
         content={
-          <Stack
-            space={3}
-            style={{
-              opacity: isDeprecated ? 0.5 : undefined,
-            }}
-          >
-            {isDeprecated && <p style={{margin: 0, color: 'red'}}>{deprecated.reason}</p>}
-            <Flex>
+          <Stack space={3}>
+            <Flex align="center">
               <FormFieldSetLegend
                 collapsed={Boolean(collapsed)}
                 collapsible={collapsible}
                 onClick={collapsible ? handleToggle : undefined}
                 title={title}
               />
+              {deprecated && (
+                <Tooltip content={deprecated?.reason}>
+                  <Box marginLeft={2}>
+                    <Badge style={{width: 'fit-content'}} tone="critical">
+                      {t('form.field.deprecated-label')}
+                    </Badge>
+                  </Box>
+                </Tooltip>
+              )}
               {hasValidationMarkers && (
                 <Box marginLeft={2}>
                   <FormFieldValidationStatus fontSize={1} placement="top" validation={validation} />

--- a/packages/sanity/src/core/form/components/formField/FormFieldSet.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldSet.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import {Badge, Box, Flex, Grid, rem, Stack, Text, Theme, useForwardedRef} from '@sanity/ui'
+import {Badge, Box, Flex, Grid, Stack, Text, Theme, useForwardedRef} from '@sanity/ui'
 import React, {forwardRef, useCallback, useMemo} from 'react'
 import styled, {css} from 'styled-components'
 import {DeprecatedProperty, FormNodeValidation} from '@sanity/types'
@@ -8,7 +8,7 @@ import {DocumentFieldActionNode} from '../../../config'
 import {useFieldActions} from '../../field'
 import {createDescriptionId} from '../../members/common/createDescriptionId'
 import {FieldCommentsProps} from '../../types'
-import {Tooltip} from '../../../../ui-components'
+import {TextWithTone} from '../../../components'
 import {useTranslation} from '../../../i18n'
 import {FormFieldValidationStatus} from './FormFieldValidationStatus'
 import {FormFieldSetLegend} from './FormFieldSetLegend'
@@ -180,13 +180,9 @@ export const FormFieldSet = forwardRef(function FormFieldSet(
                 title={title}
               />
               {deprecated && (
-                <Tooltip content={deprecated?.reason}>
-                  <Box marginLeft={2}>
-                    <Badge style={{width: 'fit-content'}} tone="critical">
-                      {t('form.field.deprecated-label')}
-                    </Badge>
-                  </Box>
-                </Tooltip>
+                <Box marginLeft={2}>
+                  <Badge tone="caution">{t('form.field.deprecated-label')}</Badge>
+                </Box>
               )}
               {hasValidationMarkers && (
                 <Box marginLeft={2}>
@@ -194,6 +190,12 @@ export const FormFieldSet = forwardRef(function FormFieldSet(
                 </Box>
               )}
             </Flex>
+
+            {deprecated && (
+              <TextWithTone tone="caution" size={1}>
+                {deprecated.reason}
+              </TextWithTone>
+            )}
 
             {description && (
               <Text muted size={1} id={createDescriptionId(inputId, description)}>

--- a/packages/sanity/src/core/form/inputs/BooleanInput.tsx
+++ b/packages/sanity/src/core/form/inputs/BooleanInput.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled from 'styled-components'
 import {Box, Card, CardTone, Checkbox, Flex, Switch} from '@sanity/ui'
 import {BooleanInputProps} from '../types'
@@ -29,20 +28,9 @@ export function BooleanInput(props: BooleanInputProps) {
 
   const tone: CardTone | undefined = readOnly ? 'transparent' : undefined
 
-  const isDeprecated = Boolean(schemaType.deprecated)
-
   return (
     <>
-      {isDeprecated && <p style={{margin: 0, color: 'red'}}>{schemaType.deprecated?.reason}</p>}
-      <Card
-        style={{
-          opacity: isDeprecated ? 0.5 : undefined,
-        }}
-        border
-        data-testid="boolean-input"
-        radius={2}
-        tone={tone}
-      >
+      <Card border data-testid="boolean-input" radius={2} tone={tone}>
         <Flex>
           <ZeroLineHeightBox padding={3}>
             <LayoutSpecificInput
@@ -60,6 +48,7 @@ export function BooleanInput(props: BooleanInputProps) {
               inputId={id}
               validation={validation}
               title={schemaType.title}
+              deprecated={schemaType.deprecated}
             />
           </Box>
           <CenterAlignedBox paddingX={3} paddingY={1}>

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -395,7 +395,7 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'form.error.no-array-item-at-key':
     'No array item with `_key` <code>"{{key}}"</code> found at path <code>{{path}}</code>',
   /** Form field deprecated label */
-  'form.field.deprecated-label': 'Deprecated',
+  'form.field.deprecated-label': 'deprecated',
   /** Fallback title shown above field if it has no defined title */
   'form.field.untitled-field-label': 'Untitled',
   /** Fallback title shown above fieldset if it has no defined title */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -394,6 +394,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Error text shown when form is unable to find an array item at a given keyed path */
   'form.error.no-array-item-at-key':
     'No array item with `_key` <code>"{{key}}"</code> found at path <code>{{path}}</code>',
+  /** Form field deprecated label */
+  'form.field.deprecated-label': 'Deprecated',
   /** Fallback title shown above field if it has no defined title */
   'form.field.untitled-field-label': 'Untitled',
   /** Fallback title shown above fieldset if it has no defined title */


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->
Adds a badge for deprecated fields

![Screenshot 2024-01-09 at 2 00 44 PM](https://github.com/sanity-io/sanity/assets/6476108/3f0651ec-3e6a-4a51-9a20-b7d4e30e46ba)


### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

To test check preview [here](https://test-studio-git-feat-field-deprecation-badge.sanity.build/test/structure/input-debug;deprecatedFields;9e3da168-ae3a-46b6-8359-9befeb3829e7)

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

- N/A