### PR TITLE
fix(cli): telemetry: only log first 10 elements in args array

### DIFF
--- a/packages/@sanity/cli/src/cli.ts
+++ b/packages/@sanity/cli/src/cli.ts
@@ -130,7 +130,7 @@ export async function runCli(cliRoot: string, {cliVersion}: {cliVersion: string}
   const cliCommandTrace = telemetry.trace(CliCommand, {
     groupOrCommand: args.groupOrCommand,
     extraArguments: args.extraArguments,
-    commandArguments: args.argsWithoutOptions,
+    commandArguments: args.argsWithoutOptions.slice(0, 10),
     ...(!args.groupOrCommand && {emptyCommand: true}), // user did not entry a command
   })
 

--- a/packages/@sanity/cli/src/cli.ts
+++ b/packages/@sanity/cli/src/cli.ts
@@ -131,21 +131,15 @@ export async function runCli(cliRoot: string, {cliVersion}: {cliVersion: string}
     groupOrCommand: args.groupOrCommand,
     extraArguments: args.extraArguments,
     commandArguments: args.argsWithoutOptions.slice(0, 10),
-    ...(!args.groupOrCommand && {emptyCommand: true}), // user did not entry a command
-  })
-
-  cliCommandTrace.start()
-  cliCommandTrace.log({
-    groupOrCommand: args.groupOrCommand,
-    extraArguments: args.extraArguments,
-    commandArguments: args.argsWithoutOptions,
     coreOptions: {
       help: args.coreOptions.help || undefined,
       version: args.coreOptions.help || undefined,
       debug: args.coreOptions.help || undefined,
     },
+    ...(!args.groupOrCommand && {emptyCommand: true}), // user did not entry a command
   })
 
+  cliCommandTrace.start()
   cliRunner
     .runCommand(args.groupOrCommand, args, {
       ...options,


### PR DESCRIPTION
### Description
Caps the args list we log at max 10 entries

### What to review

I'm wondering if we could also remove the (duplicated) log statement, see my comment below.


### Notes for release
n/a
