### PR TITLE
fix(core): add useClickOutside function to filter buttons

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/addFilter/AddFilterButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/addFilter/AddFilterButton.tsx
@@ -1,5 +1,6 @@
 import {AddIcon} from '@sanity/icons'
 import React, {useCallback, useState} from 'react'
+import {useClickOutside} from '@sanity/ui'
 import {POPOVER_RADIUS, POPOVER_VERTICAL_MARGIN} from '../../../constants'
 import {useSearchState} from '../../../contexts/search/useSearchState'
 import {FilterPopoverWrapper} from '../common/FilterPopoverWrapper'
@@ -10,6 +11,7 @@ import {AddFilterPopoverContent} from './AddFilterPopoverContent'
 export function AddFilterButton() {
   const [open, setOpen] = useState(false)
   const [buttonElement, setButtonElement] = useState<HTMLElement | null>(null)
+  const [popoverElement, setPopoverElement] = useState<HTMLElement | null>(null)
   const {t} = useTranslation()
 
   const {
@@ -18,6 +20,8 @@ export function AddFilterButton() {
 
   const handleClose = useCallback(() => setOpen(false), [])
   const handleOpen = useCallback(() => setOpen(true), [])
+
+  useClickOutside(handleClose, [buttonElement, popoverElement])
 
   return (
     <Popover
@@ -30,6 +34,7 @@ export function AddFilterButton() {
       open={open}
       placement="bottom-start"
       radius={POPOVER_RADIUS}
+      ref={setPopoverElement}
       portal
     >
       <Button

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/FilterButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/FilterButton.tsx
@@ -4,6 +4,7 @@ import {
   Button, // Button with specific styling and children behavior.
   Card,
   rem,
+  useClickOutside,
 } from '@sanity/ui'
 import React, {KeyboardEvent, useCallback, useState} from 'react'
 import styled from 'styled-components'
@@ -46,6 +47,8 @@ const LabelButton = styled(Button)`
 
 export function FilterButton({filter, initialOpen}: FilterButtonProps) {
   const [open, setOpen] = useState(initialOpen)
+  const [buttonElement, setButtonElement] = useState<HTMLElement | null>(null)
+  const [popoverElement, setPopoverElement] = useState<HTMLElement | null>(null)
 
   const {
     dispatch,
@@ -73,6 +76,8 @@ export function FilterButton({filter, initialOpen}: FilterButtonProps) {
     [handleRemove],
   )
 
+  useClickOutside(handleClose, [buttonElement, popoverElement])
+
   const isValid = validateFilter({
     fieldDefinitions: definitions.fields,
     filter,
@@ -84,7 +89,7 @@ export function FilterButton({filter, initialOpen}: FilterButtonProps) {
     <Popover
       __unstable_margins={[POPOVER_VERTICAL_MARGIN, 0, 0, 0]}
       content={
-        <FilterPopoverWrapper onClose={handleClose}>
+        <FilterPopoverWrapper anchorElement={buttonElement} onClose={handleClose}>
           <FilterPopoverContent filter={filter} />
         </FilterPopoverWrapper>
       }
@@ -94,6 +99,7 @@ export function FilterButton({filter, initialOpen}: FilterButtonProps) {
       placement="bottom-start"
       portal
       radius={POPOVER_RADIUS}
+      ref={setPopoverElement}
     >
       <ContainerDiv>
         <Card
@@ -109,6 +115,7 @@ export function FilterButton({filter, initialOpen}: FilterButtonProps) {
             paddingLeft={fullscreen ? 3 : 2}
             paddingRight={fullscreen ? 3 : 5}
             paddingY={fullscreen ? 3 : 2}
+            ref={setButtonElement}
           >
             <FilterLabel filter={filter} showContent={isValid} />
           </LabelButton>


### PR DESCRIPTION
### Description
The global filter button popovers did not close when clicking outside. 
This PR handles click outside events to close the popovers. 

https://github.com/sanity-io/sanity/assets/44635000/004c3180-96dc-433b-b948-fe443599e985


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
That clicking outside of the popover on the `Add filter` button of global search closes the popover. 
Also that when a filter has been added, the popover for the respective filter button also closes when clicked outside. 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fixes regression with global search filter popovers not closing when clicked outside. 
<!--
A description of the change(s) that should be used in the release notes.
-->
