### PR TITLE
test(cli): fix flaky dev server test

### DIFF
--- a/packages/@sanity/cli/test/dev.test.ts
+++ b/packages/@sanity/cli/test/dev.test.ts
@@ -15,6 +15,7 @@ describeCliTest('CLI: `sanity dev`', () => {
       const {html: startHtml, fileHashes} = await testServerCommand({
         command: version === 'v2' ? 'start' : 'dev',
         port: testRunArgs.port,
+        args: ['--port', `${testRunArgs.port}`],
         cwd: path.join(studiosPath, version),
         expectedTitle: version === 'v2' ? `${version} studio` : 'Sanity Studio',
         expectedFiles,

--- a/packages/@sanity/cli/test/shared/devServer.ts
+++ b/packages/@sanity/cli/test/shared/devServer.ts
@@ -26,7 +26,7 @@ export function testServerCommand({
   stderr: string
 }> {
   return new Promise(async (resolve, reject) => {
-    const maxWaitForServer = 120000
+    const maxWaitForServer = 50_000
     const startedAt = Date.now()
     let hasSucceeded = false
     let timer: ReturnType<typeof setTimeout>

--- a/packages/@sanity/cli/test/shared/devServer.ts
+++ b/packages/@sanity/cli/test/shared/devServer.ts
@@ -3,7 +3,7 @@ import {createHash} from 'crypto'
 import {cliBinPath, sanityEnv} from './environment'
 import {request, ResponseData} from './request'
 
-export function testServerCommand({
+export async function testServerCommand({
   command,
   port,
   cwd,
@@ -25,17 +25,16 @@ export function testServerCommand({
   stdout: string
   stderr: string
 }> {
-  return new Promise(async (resolve, reject) => {
+  const connect = await request(`http://localhost:${port}/`).catch(() => null)
+  if (connect !== null && 'statusCode' in connect) {
+    throw new Error(`Something is already listening on :${port}`)
+  }
+
+  return new Promise((resolve, reject) => {
     const maxWaitForServer = 50_000
     const startedAt = Date.now()
     let hasSucceeded = false
     let timer: ReturnType<typeof setTimeout>
-
-    const connect = await request(`http://localhost:${port}/`).catch((err) => err as Error)
-    if ('statusCode' in connect) {
-      reject(new Error(`Something is already listening on :${port}`))
-      return
-    }
 
     const proc = spawn(process.argv[0], [cliBinPath, command, ...(args || [])], {
       cwd,

--- a/packages/@sanity/cli/test/shared/environment.ts
+++ b/packages/@sanity/cli/test/shared/environment.ts
@@ -73,6 +73,25 @@ const getTestId = () => {
   return cachedTestId
 }
 
+/**
+ * The dev server runs on a different port for each node version being tested. This is to avoid
+ * port collisions when running tests in multiple versions of node simultaneously.
+ *
+ * The port is selected based on the assumption that the tests will be run once for node LTS and
+ * once for node current.
+ */
+function getPort(version: string): number {
+  if (version === 'v2') {
+    return 3334
+  }
+
+  if (process.release.lts) {
+    return 4333
+  }
+
+  return 3333
+}
+
 export const testClient = createClient({
   apiVersion: '2022-09-09',
   projectId: cliProjectId,
@@ -87,7 +106,6 @@ export const getCliUserEmail = (): Promise<string> =>
 
 export const getTestRunArgs = (version: string) => {
   const testId = getTestId()
-  const v3Port = process.versions.node.split('.')[0] === '20' ? 4333 : 3333
   return {
     corsOrigin: `https://${testId}-${version}.sanity.build`,
     sourceDataset: 'production',
@@ -100,7 +118,7 @@ export const getTestRunArgs = (version: string) => {
     graphqlTag: testId,
     exportTarball: 'production.tar.gz',
     importTarballPath: path.join(__dirname, '..', '__fixtures__', 'production.tar.gz'),
-    port: version === 'v2' ? 3334 : v3Port,
+    port: getPort(version),
   }
 }
 

--- a/packages/@sanity/cli/test/shared/environment.ts
+++ b/packages/@sanity/cli/test/shared/environment.ts
@@ -87,6 +87,7 @@ export const getCliUserEmail = (): Promise<string> =>
 
 export const getTestRunArgs = (version: string) => {
   const testId = getTestId()
+  const v3Port = process.versions.node.split('.')[0] === '20' ? 4333 : 3333
   return {
     corsOrigin: `https://${testId}-${version}.sanity.build`,
     sourceDataset: 'production',
@@ -99,7 +100,7 @@ export const getTestRunArgs = (version: string) => {
     graphqlTag: testId,
     exportTarball: 'production.tar.gz',
     importTarballPath: path.join(__dirname, '..', '__fixtures__', 'production.tar.gz'),
-    port: version === 'v2' ? 3334 : 3333,
+    port: version === 'v2' ? 3334 : v3Port,
   }
 }
 


### PR DESCRIPTION
### Description

We've experienced some flakiness in the CLI dev server tests when they run in CI. This appears to be caused by port collisions that can occur when running the tests using multiple versions of node simultaneously.

The dev server now uses a different port depending on whether it's running in node LTS or node current.

### What to review

That the CLI tests pass in CI.
