### PR TITLE
feat(i18n): add i18n resources for browser document title

### DIFF
--- a/packages/sanity/src/structure/components/structureTool/StructureTitle.tsx
+++ b/packages/sanity/src/structure/components/structureTool/StructureTitle.tsx
@@ -1,10 +1,16 @@
 import React, {useEffect} from 'react'
 import type {ObjectSchemaType} from '@sanity/types'
 import type {Panes} from '../../structureResolvers'
+import {structureLocaleNamespace} from '../../i18n'
 import type {DocumentPaneNode} from '../../types'
 import {useStructureTool} from '../../useStructureTool'
 import {LOADING_PANE} from '../../constants'
-import {useEditState, useSchema, unstable_useValuePreview as useValuePreview} from 'sanity'
+import {
+  useEditState,
+  useSchema,
+  useTranslation,
+  unstable_useValuePreview as useValuePreview,
+} from 'sanity'
 
 interface StructureTitleProps {
   resolvedPanes: Panes['resolvedPanes']
@@ -14,6 +20,7 @@ const DocumentTitle = (props: {documentId: string; documentType: string}) => {
   const {documentId, documentType} = props
   const editState = useEditState(documentId, documentType)
   const schema = useSchema()
+  const {t} = useTranslation(structureLocaleNamespace)
   const isNewDocument = !editState?.published && !editState?.draft
   const documentValue = editState?.draft || editState?.published
   const schemaType = schema.get(documentType) as ObjectSchemaType | undefined
@@ -25,8 +32,10 @@ const DocumentTitle = (props: {documentId: string; documentType: string}) => {
   })
 
   const documentTitle = isNewDocument
-    ? `New ${schemaType?.title || schemaType?.name}`
-    : value?.title || 'Untitled'
+    ? t('browser-document-title.new-document', {
+        schemaType: schemaType?.title || schemaType?.name,
+      })
+    : value?.title || t('browser-document-title.untitled-document')
 
   const settled = editState.ready && !previewValueIsLoading
   const newTitle = useConstructDocumentTitle(documentTitle)
@@ -81,8 +90,8 @@ export const StructureTitle = (props: StructureTitleProps) => {
  *
  * @param activeTitle - Title of the first segment
  *
- * @returns A pipe delimited title in the format `${activeTitle} | %BASE_DESK_TITLE%`
- * or simply `%BASE_DESK_TITLE` if `activeTitle` is undefined.
+ * @returns A pipe delimited title in the format `${activeTitle} | %BASE_STRUCTURE_TITLE%`
+ * or simply `%BASE_STRUCTURE_TITLE` if `activeTitle` is undefined.
  */
 function useConstructDocumentTitle(activeTitle?: string) {
   const structureToolBaseTitle = useStructureTool().structureContext.title

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -114,6 +114,11 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'banners.reference-changed-banner.reason-removed.text':
     'This reference has been removed since you opened it.',
 
+  /** Browser/tab title when creating a new document of a given type */
+  'browser-document-title.new-document': 'New {{schemaType}}',
+  /** Browser/tab title when editing a document where the title cannot be resolved from preview configuration */
+  'browser-document-title.untitled-document': 'Untitled',
+
   /** The action menu button aria-label */
   'buttons.action-menu-button.aria-label': 'Open document actions',
   /** The action menu button tooltip */


### PR DESCRIPTION
### Description

In the structure tool, the document title was not localized when showing new documents (`New author`) or documents where the preview title cannot be resolved (`Untitled`). This PR introduces new i18n resource keys for the two cases.

### What to review

- Creating a new document still shows "New <schemaTypeTitle>" in document title (eg browser tab)
- Second case is not trivial to reproduce, so carefully read the code - should be safe to assume it has the same behavior as before, only localizable

### Notes for release

- Made the browser document title localizable by locale plugins
