### PR TITLE
fix: update search button navbar position

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
@@ -181,6 +181,10 @@ export function StudioNavbar() {
                   {...newDocumentOptions}
                   modal={shouldRender.newDocumentFullscreen ? 'dialog' : 'popover'}
                 />
+                {/* Search button (desktop) */}
+                {!shouldRender.searchFullscreen && (
+                  <SearchButton onClick={handleOpenSearch} ref={setSearchOpenButtonEl} />
+                )}
               </Flex>
             </TooltipDelayGroupProvider>
 
@@ -225,11 +229,6 @@ export function StudioNavbar() {
                   </LayerProvider>
 
                   {shouldRender.tools && <FreeTrial type="topbar" />}
-                  {/* Search button (desktop) */}
-                  {!shouldRender.searchFullscreen && (
-                    <SearchButton onClick={handleOpenSearch} ref={setSearchOpenButtonEl} />
-                  )}
-
                   {shouldRender.configIssues && <ConfigIssuesButton />}
                   {shouldRender.resources && <ResourcesButton />}
                   <PresenceMenu />


### PR DESCRIPTION
### Description

This PR moves the navbar search button to the LHS (next to the create new button) in order to make it a little more discoverable. Mobile lockup is unchanged. That's it!

### What to review

That the search button appears on the LHS in the navbar.

### Notes for release

Updated search button navbar position to aid discoverability