### PR TITLE
DRAFT: feat(cli): new dataset backup enable/disable commands

### DIFF
--- a/packages/sanity/src/_internal/cli/commands/dataset/backup/disableDatasetBackup.ts
+++ b/packages/sanity/src/_internal/cli/commands/dataset/backup/disableDatasetBackup.ts
@@ -1,0 +1,20 @@
+import type {CliCommandDefinition} from '@sanity/cli'
+import toggleDatasetBackup from './toggleDatasetBackup'
+
+const disableHelpText = `
+Examples
+  sanity dataset backups disable <name>
+`
+
+const disableDatasetBackupCommand: CliCommandDefinition = {
+  name: 'backup disable',
+  group: 'dataset',
+  signature: '[datasetName]',
+  helpText: disableHelpText,
+  description: 'Disable dataset backups for this dataset',
+  action: async (args: any, context: any) => {
+    await toggleDatasetBackup(false, args, context)
+  },
+}
+
+export default disableDatasetBackupCommand

--- a/packages/sanity/src/_internal/cli/commands/dataset/backup/enableDatasetBackup.ts
+++ b/packages/sanity/src/_internal/cli/commands/dataset/backup/enableDatasetBackup.ts
@@ -1,0 +1,20 @@
+import type {CliCommandDefinition} from '@sanity/cli'
+import toggleDatasetBackup from './toggleDatasetBackup'
+
+const enableHelpText = `
+Examples
+  sanity dataset backup enable <name>
+`
+
+const enableDatasetBackupCommand: CliCommandDefinition = {
+  name: 'backup enable',
+  group: 'dataset',
+  signature: '[datasetName]',
+  helpText: enableHelpText,
+  description: 'Enable dataset backups for this dataset',
+  action: async (args: any, context: any) => {
+    await toggleDatasetBackup(true, args, context)
+  },
+}
+
+export default enableDatasetBackupCommand

--- a/packages/sanity/src/_internal/cli/commands/dataset/backup/toggleDatasetBackup.ts
+++ b/packages/sanity/src/_internal/cli/commands/dataset/backup/toggleDatasetBackup.ts
@@ -1,0 +1,35 @@
+import {promptForDatasetName} from '../../../actions/dataset/datasetNamePrompt'
+
+const toggleDatasetBackup = async (enableBackups: boolean, args: any, context: any) => {
+  const {apiClient, output, prompt, chalk} = context
+  const [dataset] = args.argsWithoutOptions
+  let client = apiClient()
+
+  const projectFeatures = await client.request({uri: '/features'})
+  if (!projectFeatures.includes('backups')) {
+    const action = enableBackups ? 'enable' : 'disable'
+    throw new Error(
+      `Could not ${action} backup: backup configuration is not allowed for this project`
+    )
+  }
+
+  const datasetName = await (dataset || promptForDatasetName(prompt))
+  client = client.clone().config({dataset: datasetName})
+  try {
+    await client.request({
+      method: 'PUT',
+      uri: `/datasets/${datasetName}/settings/backups`,
+      body: {
+        enable: enableBackups,
+      },
+    })
+    const action = enableBackups ? 'enabled' : 'disabled'
+    output.print(`${chalk.green(`Dataset backup ${action}\n`)}`)
+  } catch (error) {
+    const action = enableBackups ? 'Enabling' : 'Disabling'
+    const msg = error.statusCode ? error.response.body.message : error.message
+    output.print(`${chalk.red(`${action} dataset backup failed::\n${msg}`)}\n`)
+  }
+}
+
+export default toggleDatasetBackup

--- a/packages/sanity/src/_internal/cli/commands/index.ts
+++ b/packages/sanity/src/_internal/cli/commands/index.ts
@@ -40,6 +40,8 @@ import deleteGraphQLAPICommand from './graphql/deleteGraphQLAPICommand'
 import usersGroup from './users/usersGroup'
 import inviteUserCommand from './users/inviteUserCommand'
 import listUsersCommand from './users/listUsersCommand'
+import enableDatasetBackupCommand from './dataset/backup/enableDatasetBackup'
+import disableDatasetBackupCommand from './dataset/backup/disableDatasetBackup'
 
 const commands: (CliCommandDefinition | CliCommandGroupDefinition)[] = [
   buildCommand,
@@ -56,6 +58,8 @@ const commands: (CliCommandDefinition | CliCommandGroupDefinition)[] = [
   deleteDatasetCommand,
   copyDatasetCommand,
   aliasDatasetCommand,
+  enableDatasetBackupCommand,
+  disableDatasetBackupCommand,
   corsGroup,
   listCorsOriginsCommand,
   addCorsOriginCommand,


### PR DESCRIPTION
Not ready for Studio review! Need to run some things by CLDX, as well as ensure changes follow project conventions.
### Description

This PR adds commands to enable and disable dataset backups. Backups are a Content Lake project, but we'd like the primary user interface to be the Sanity CLI.

We're adding two comamnds, one to enable and one to disable backups:

```
sanity dataset backup enable <name>
sanity dataset backup disable <name>
```

I briefly considered using a flag to disable backups instead of a whole other command, but decided `sanity dataset backup enable --disable` is too confusing. There's precedence for using separate commands in `sanity dataset alias {link|unlink}`.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Please review general style, I'm not familiar with the Studio codebase at all.
Also keen to hear thoughts on the format of the commands (i.e. using two commands instead of combining into one with a toggle).

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
TODO. I need to follow up on what the process is for merging CLI changes for backend functionality we haven't released/announced yet.

<!--
A description of the change(s) that should be used in the release notes.
-->
