### PR TITLE
fix(block-tools): more robust formatting detection on copy paste in Safari

### DIFF
--- a/packages/@sanity/block-tools/src/HtmlDeserializer/rules/gdocs.ts
+++ b/packages/@sanity/block-tools/src/HtmlDeserializer/rules/gdocs.ts
@@ -15,25 +15,30 @@ const LIST_CONTAINER_TAGS = Object.keys(HTML_LIST_CONTAINER_TAGS)
 // font-style:italic seems like the most important rule for italic / emphasis in their html
 function isEmphasis(el: Node): boolean {
   const style = isElement(el) && el.getAttribute('style')
-  return /font-style:italic/.test(style || '')
+  return /font-style\s*:\s*italic/.test(style || '')
 }
 
 // font-weight:700 seems like the most important rule for bold in their html
 function isStrong(el: Node): boolean {
   const style = isElement(el) && el.getAttribute('style')
-  return /font-weight:700/.test(style || '')
+  return /font-weight\s*:\s*700/.test(style || '')
 }
 
 // text-decoration seems like the most important rule for underline in their html
 function isUnderline(el: Node): boolean {
+  if (!isElement(el) || tagName(el.parentNode) === 'a') {
+    return false
+  }
+
   const style = isElement(el) && el.getAttribute('style')
-  return /text-decoration:underline/.test(style || '')
+
+  return /text-decoration\s*:\s*underline/.test(style || '')
 }
 
 // text-decoration seems like the most important rule for strike-through in their html
 function isStrikethrough(el: Node): boolean {
   const style = isElement(el) && el.getAttribute('style')
-  return /text-decoration:line-through/.test(style || '')
+  return /text-decoration\s*:\s*line-through/.test(style || '')
 }
 
 // Check for attribute given by the gdocs preprocessor

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/gdocs/output.json
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/gdocs/output.json
@@ -1288,7 +1288,7 @@
       },
       {
         "_type": "span",
-        "marks": ["randomKey0", "underline"],
+        "marks": ["randomKey0"],
         "text": "Lorem Lorem",
         "_key": "randomKey881"
       },

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/gdocsFirefox/output.json
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/gdocsFirefox/output.json
@@ -1288,7 +1288,7 @@
       },
       {
         "_type": "span",
-        "marks": ["randomKey0", "underline"],
+        "marks": ["randomKey0"],
         "text": "Lorem Lorem",
         "_key": "randomKey881"
       },

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/gdocsWhitespaceNormalize/output.json
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/gdocsWhitespaceNormalize/output.json
@@ -1442,7 +1442,7 @@
       },
       {
         "_type": "span",
-        "marks": ["randomKey0", "underline"],
+        "marks": ["randomKey0"],
         "text": "Lorem Lorem",
         "_key": "randomKey991"
       },

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/gdocsWhitespaceRemove/output.json
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/gdocsWhitespaceRemove/output.json
@@ -910,7 +910,7 @@
       },
       {
         "_type": "span",
-        "marks": ["randomKey0", "underline"],
+        "marks": ["randomKey0"],
         "text": "Lorem Lorem",
         "_key": "randomKey611"
       },

--- a/packages/@sanity/block-tools/test/tests/HtmlDeserializer/gdocsWhitespaceRemoveFirefox/output.json
+++ b/packages/@sanity/block-tools/test/tests/HtmlDeserializer/gdocsWhitespaceRemoveFirefox/output.json
@@ -910,7 +910,7 @@
       },
       {
         "_type": "span",
-        "marks": ["randomKey0", "underline"],
+        "marks": ["randomKey0"],
         "text": "Lorem Lorem",
         "_key": "randomKey611"
       },


### PR DESCRIPTION
### Description

This updates the regexes we use to detect basic formatting when copy pasting text from Google Docs. In Safari these would be rendered with an extra space between the rule and value.

As part of the work we also discovered that Google Docs by default adds a underline to all links. The logic has been updated to skip underline decorators where the text node is inside a link.

Fixes #5483, fixes #5463 
Fixes EDX-1011

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

- That pasting from Google Docs to the PTE retains formatting
- That underline decorators is not applied when pasting links

### Notes for release

- Fixed an issue in Safari where formatting would not carry over when copy pasting from Google Docs in Safari
- Fixed an issue where copy pasting links from Google Docs would have a underline decorator applied