### PR TITLE
fix(deps): update dependency @sanity/presentation to v1.5.3

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -197,7 +197,7 @@
     "@sanity/logos": "^2.0.2",
     "@sanity/mutator": "3.24.1",
     "@sanity/portable-text-editor": "3.24.1",
-    "@sanity/presentation": "1.5.0",
+    "@sanity/presentation": "1.5.3",
     "@sanity/schema": "3.24.1",
     "@sanity/telemetry": "^0.7.5",
     "@sanity/types": "3.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3652,13 +3652,6 @@
     "@sanity/ui" "^1.0.0"
     lodash "^4.17.21"
 
-"@sanity/groq-store@5.3.10":
-  version "5.3.10"
-  resolved "https://registry.yarnpkg.com/@sanity/groq-store/-/groq-store-5.3.10.tgz#ff2030338554984200e42544165b031b5013a61c"
-  integrity sha512-svSSxRcAbJYvhrOxwlYkRgry34aHyCk9o8o1BflaUEKjN5VOJO9wyA8TvDEta+WpGy2oZFrz4jzszNx8rCeDhA==
-  dependencies:
-    mnemonist "0.39.7"
-
 "@sanity/icons@^1.3":
   version "1.3.10"
   resolved "https://registry.yarnpkg.com/@sanity/icons/-/icons-1.3.10.tgz#df934a94ae6669fe6b15515d800afb221cba0498"
@@ -3756,26 +3749,27 @@
     uuid "^9.0.1"
     zod "^3.22.4"
 
-"@sanity/presentation@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@sanity/presentation/-/presentation-1.5.0.tgz#b88cc70de0848672e30174fa29f50ace618f991d"
-  integrity sha512-Q44ta+83/DNwIrJ3hnx66G1xj/qOrreNZ6ZSK7zkCI4AJcPrQjejCoClOJu8yv0b0UNvzNM9cE6X6q5EbHP5Zw==
+"@sanity/presentation@1.5.3":
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/@sanity/presentation/-/presentation-1.5.3.tgz#a144bec7911e326f61060fa5720e5302d4eff765"
+  integrity sha512-A9OiyyPXOkMk3grTtXN6YpyOJ5Gi5pFh8ZKzJ9FJNsZ/8Nv6TeMo0Uthy3s6+tyVUVaR4fQw+kIcS+MJl0kCWA==
   dependencies:
-    "@sanity/groq-store" "5.3.10"
     "@sanity/icons" "^2.8.0"
-    "@sanity/preview-url-secret" "^1.5.0"
-    "@sanity/ui" "2.0.0-beta.16"
+    "@sanity/preview-url-secret" "^1.5.2"
+    "@sanity/ui" "2.0.0-beta.17"
     "@types/lodash.isequal" "^4.5.8"
-    framer-motion "^10.17.12"
+    fast-deep-equal "3.1.3"
+    framer-motion "^10.18.0"
     lodash.isequal "^4.5.0"
     mendoza "3.0.3"
+    mnemonist "0.39.7"
     rxjs "^7.8.1"
     suspend-react "0.1.3"
 
-"@sanity/preview-url-secret@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@sanity/preview-url-secret/-/preview-url-secret-1.5.0.tgz#2d32fbd00b568f7d01604182cdc156787d0022ee"
-  integrity sha512-ygY8oL3k+qwBkbQXCNPKviZcy/+Z177kgs7F4MPkhusefJPTY24kUPKjvKMJzzkuwH3w1EkkZELmmZdrT6zWvw==
+"@sanity/preview-url-secret@^1.5.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@sanity/preview-url-secret/-/preview-url-secret-1.5.2.tgz#0544f0c8583ccd2633d7d5daaf5bf1cd25df8de8"
+  integrity sha512-Gfk8LOaO80mSPhRJimRi1N3++vTQwi+3arTht1oXD3+Xk6qdEppvEKR/VmYI9TbBXbd0hP/gMW53r9acvusK4Q==
   dependencies:
     "@sanity/uuid" "3.0.2"
 
@@ -3859,6 +3853,18 @@
   version "2.0.0-beta.16"
   resolved "https://registry.yarnpkg.com/@sanity/ui/-/ui-2.0.0-beta.16.tgz#2e9c89deb4a1e6c6a7d9b3f76f9b0a3ea0927063"
   integrity sha512-nu+N1ClKv5e3sraBvJnru3/F3Nzl7uI85En3kPWg611GfHlu6x0WGVE/6kB0FQXkwMsaqehduiz9xgE2lKZopg==
+  dependencies:
+    "@floating-ui/react-dom" "^2.0.4"
+    "@sanity/color" "3.0.0-beta.9"
+    "@sanity/icons" "^2.7.0"
+    csstype "^3.1.2"
+    framer-motion "^10.16.5"
+    react-refractor "^2.1.7"
+
+"@sanity/ui@2.0.0-beta.17":
+  version "2.0.0-beta.17"
+  resolved "https://registry.yarnpkg.com/@sanity/ui/-/ui-2.0.0-beta.17.tgz#fb912fe62c2aa4339e1d18c7e9d6a8b536356c34"
+  integrity sha512-AUFlObpuewVOKDGQutijJFn3rKtXS85Nl/MsySHwcH5rzCNojJ2/Z4DKLhl8LSXlj/+pOXVj++AFT/hhNtJ6Wg==
   dependencies:
     "@floating-ui/react-dom" "^2.0.4"
     "@sanity/color" "3.0.0-beta.9"
@@ -8101,7 +8107,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07"
   integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
 
-fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
+fast-deep-equal@3.1.3, fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -8423,10 +8429,10 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-framer-motion@^10.0.0, framer-motion@^10.16.2, framer-motion@^10.16.5, framer-motion@^10.17.12:
-  version "10.17.12"
-  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-10.17.12.tgz#efae01c1a4d8f325a11e64d0c0fc837ec1482dba"
-  integrity sha512-6aaBLN2EgH/GilXwOzEalTfw5Rx9DTQJJjTrxq5bfDbGtPCzXz2GCN6ePGRpTi1ZGugLHxdU273h38ENbcdFKQ==
+framer-motion@^10.0.0, framer-motion@^10.16.2, framer-motion@^10.16.5, framer-motion@^10.18.0:
+  version "10.18.0"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-10.18.0.tgz#1f4fc51403996ea7170af885bd44a7079d255950"
+  integrity sha512-oGlDh1Q1XqYPksuTD/usb0I70hq95OUzmL9+6Zd+Hs4XV0oaISBa/UUMSjYiq6m8EUF32132mOJ8xVZS+I0S6w==
   dependencies:
     tslib "^2.4.0"
   optionalDependencies:


### PR DESCRIPTION
### Notes for release

# Presentation Tool Bug Fixes
* remove problematic peer dependency declarations ([91c1f7d](https://github.com/sanity-io/visual-editing/commit/91c1f7d98748f8d82c873420cab60304bfade518))
* **deps:** update dependency @sanity/client to ^6.11.1 ([#666](https://github.com/sanity-io/visual-editing/issues/666)) ([487d552](https://github.com/sanity-io/visual-editing/commit/487d552ffdef039ab9807a440df3b1a66b9fa064))
* **deps:** Update dependency framer-motion to ^10.18.0 ([#669](https://github.com/sanity-io/visual-editing/issues/669)) ([63496aa](https://github.com/sanity-io/visual-editing/commit/63496aaa671233929bec191b39fc49b86e80b65b))
* handle race condition when `rev` and `id` search params both change ([2b1288c](https://github.com/sanity-io/visual-editing/commit/2b1288c5a74a218133e260f824d06785c5819df4))
* **deps:** Update dependency @sanity/ui to v2.0.0-beta.17 ([#656](https://github.com/sanity-io/visual-editing/issues/656)) ([be117bb](https://github.com/sanity-io/visual-editing/commit/be117bb234a66faffbf166ef8b1dafffdf9ccb7f))
* speed up live query cache store ([#652](https://github.com/sanity-io/visual-editing/issues/652)) ([fa1c034](https://github.com/sanity-io/visual-editing/commit/fa1c034f06ee4b11634a88a4d4f17c568c4212f3))
