### PR TITLE
feat(core): schema and field deprecation

### DIFF
--- a/dev/test-studio/schema/debug/deprecatedDocument.ts
+++ b/dev/test-studio/schema/debug/deprecatedDocument.ts
@@ -1,0 +1,19 @@
+import {defineField, defineType} from 'sanity'
+
+export const deprecatedDocument = defineType({
+  name: 'deprecatedDocument',
+  title: 'Deprecated Document',
+  type: 'document',
+  deprecated: {
+    reason: 'This document type is deprecated, use the author document',
+  },
+  fields: [
+    defineField({
+      description: 'This field is used to create the header for the site',
+      validation: (Rule) => Rule.required(),
+      name: 'string',
+      title: 'string',
+      type: 'string',
+    }),
+  ],
+})

--- a/dev/test-studio/schema/debug/deprecatedFields.ts
+++ b/dev/test-studio/schema/debug/deprecatedFields.ts
@@ -106,7 +106,7 @@ export const deprecatedFields = defineType({
       },
       title: 'reference',
       type: 'reference',
-      to: [{type: 'author'}, {type: 'book'}],
+      to: [{type: 'author'}, {type: 'book'}, {type: 'deprecatedDocument'}],
     }),
     defineField({
       name: 'cdReference',

--- a/dev/test-studio/schema/debug/deprecatedFields.ts
+++ b/dev/test-studio/schema/debug/deprecatedFields.ts
@@ -7,10 +7,13 @@ export const deprecatedFields = defineType({
   fields: [
     defineField({
       deprecated: {
-        reason: 'This string field is deprecated',
+        reason:
+          'Use the non deprecated string field for new content, this field was originally for the old frontend',
       },
+      description: 'This field is used to create the header for the site',
+      validation: (Rule) => Rule.required(),
       name: 'string',
-      title: 'Deprecated String',
+      title: 'String',
       type: 'string',
     }),
     defineField({
@@ -19,7 +22,7 @@ export const deprecatedFields = defineType({
       },
       name: 'type',
       type: 'string',
-      title: 'Deprecated List',
+      title: 'List',
       initialValue: 'foo',
       options: {list: ['Frukt', 'Dyr', 'Fjell']},
     }),
@@ -28,7 +31,7 @@ export const deprecatedFields = defineType({
         reason: 'This number field is deprecated',
       },
       name: 'number',
-      title: 'Deprecated Number',
+      title: 'Number',
       type: 'number',
     }),
     defineField({
@@ -36,7 +39,7 @@ export const deprecatedFields = defineType({
         reason: 'This boolean field is deprecated',
       },
       name: 'boolean',
-      title: 'Deprecated Boolean',
+      title: 'Boolean',
       type: 'boolean',
     }),
     defineField({
@@ -44,7 +47,7 @@ export const deprecatedFields = defineType({
         reason: 'This email field is deprecated',
       },
       name: 'email',
-      title: 'Deprecated Email',
+      title: 'Email',
       type: 'email',
     }),
     defineField({
@@ -52,13 +55,13 @@ export const deprecatedFields = defineType({
         reason: 'This array is deprecated',
       },
       name: 'array',
-      title: 'Deprecated Array String',
+      title: 'Array String',
       type: 'array',
       of: [{type: 'string'}],
     }),
     defineField({
       name: 'notDeprecatedObject',
-      title: 'Not Deprecated Object',
+      title: 'Not Object',
       type: 'object',
       fields: [
         defineField({
@@ -71,14 +74,14 @@ export const deprecatedFields = defineType({
           deprecated: {
             reason: 'This field in object is deprecated',
           },
-          title: 'Deprecated in Object',
+          title: 'in Object',
           type: 'string',
         }),
       ],
     }),
     defineField({
       name: 'DeprecatedObject',
-      title: 'Deprecated Object',
+      title: 'Object',
       deprecated: {
         reason: 'This object is deprecated',
       },
@@ -91,7 +94,7 @@ export const deprecatedFields = defineType({
         }),
         defineField({
           name: 'deprecated',
-          title: 'Deprecated in Object',
+          title: 'in Object',
           type: 'string',
         }),
       ],
@@ -101,7 +104,7 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This reference is deprecated',
       },
-      title: 'Deprecated Reference',
+      title: 'Reference',
       type: 'reference',
       to: [{type: 'author'}, {type: 'book'}],
     }),
@@ -110,7 +113,7 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This cross dataset reference is deprecated',
       },
-      title: 'Deprecated CDR',
+      title: 'CDR',
       type: 'crossDatasetReference',
       dataset: 'blog',
       to: [{type: 'author', preview: {select: {title: 'name'}}}],
@@ -120,13 +123,16 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This image is deprecated',
       },
-      title: 'Deprecated Image',
+      title: 'Image',
       type: 'image',
       fields: [
         defineField({
           name: 'alt',
-          title: 'Alt',
+          title: 'Alt Deprecated',
           type: 'string',
+          deprecated: {
+            reason: 'This alt is deprecated',
+          },
         }),
       ],
     }),
@@ -135,7 +141,7 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This file is deprecated',
       },
-      title: 'Deprecated File',
+      title: 'File',
       type: 'file',
       fields: [
         defineField({
@@ -150,7 +156,7 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This date is deprecated',
       },
-      title: 'Deprecated Date',
+      title: 'Date',
       type: 'date',
     }),
     defineField({
@@ -158,7 +164,7 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This datetime is deprecated',
       },
-      title: 'Deprecated DateTime',
+      title: 'DateTime',
       type: 'datetime',
     }),
     defineField({
@@ -166,12 +172,12 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This geopoint is deprecated',
       },
-      title: 'Deprecated Geopoint',
+      title: 'Geopoint',
       type: 'geopoint',
     }),
     defineField({
       name: 'url',
-      title: 'Deprecated URL',
+      title: 'URL',
       type: 'url',
       deprecated: {
         reason: 'This url is deprecated',
@@ -182,7 +188,7 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This slug is deprecated',
       },
-      title: 'Deprecated Slug',
+      title: 'Slug',
       type: 'slug',
       options: {source: 'string'},
     }),
@@ -191,7 +197,7 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This text is deprecated',
       },
-      title: 'Deprecated Text',
+      title: 'Text',
       type: 'text',
     }),
     defineField({
@@ -199,7 +205,7 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This blocks is deprecated',
       },
-      title: 'Deprecated Blocks',
+      title: 'Blocks',
       type: 'array',
       of: [{type: 'block'}, {type: 'image'}],
     }),

--- a/dev/test-studio/schema/debug/deprecatedFields.ts
+++ b/dev/test-studio/schema/debug/deprecatedFields.ts
@@ -1,9 +1,15 @@
 import {defineField, defineType} from 'sanity'
 
-export const someObject = {
+export const namedDeprecatedObject = {
   type: 'object',
-  name: 'someObject',
+  name: 'namedDeprecatedObject',
   fields: [{type: 'string', name: 'foo'}],
+}
+
+export const namedDeprecatedArray = {
+  type: 'array',
+  name: 'namedDeprecatedArray',
+  of: [{type: 'string'}],
 }
 
 export const deprecatedFields = defineType({
@@ -12,11 +18,20 @@ export const deprecatedFields = defineType({
   type: 'document',
   fields: [
     defineField({
-      name: 'someObject',
+      name: 'namedDeprecatedObject',
+      title: 'namedDeprecatedObject',
       deprecated: {
         reason: 'This string field is deprecated',
       },
-      type: 'someObject',
+      type: 'namedDeprecatedObject',
+    }),
+    defineField({
+      name: 'namedDeprecatedArray',
+      title: 'namedDeprecatedArray',
+      deprecated: {
+        reason: 'This string field is deprecated',
+      },
+      type: 'namedDeprecatedArray',
     }),
     defineField({
       deprecated: {

--- a/dev/test-studio/schema/debug/deprecatedFields.ts
+++ b/dev/test-studio/schema/debug/deprecatedFields.ts
@@ -1,0 +1,103 @@
+import {defineType} from 'sanity'
+
+export const deprecatedFields = defineType({
+  name: 'deprecatedFields',
+  title: 'Deprecated Fields',
+  type: 'document',
+  fields: [
+    {
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      deprecated: {
+        reason: 'This string field is deprecated',
+      },
+    },
+    {
+      title: 'Number',
+      name: 'number',
+      type: 'number',
+      deprecated: {
+        reason: 'This number field is deprecated',
+      },
+    },
+    {
+      title: 'Boolean',
+      name: 'boolean',
+      type: 'boolean',
+      deprecated: {
+        reason: 'This boolean field is deprecated',
+      },
+    },
+    {
+      title: 'Date',
+      name: 'date',
+      type: 'date',
+      deprecated: {
+        reason: 'This date field is deprecated',
+      },
+    },
+    {
+      name: 'arrayOfReferences',
+      title: 'Array of References',
+      type: 'array',
+      deprecated: {
+        reason: 'This array of references field is deprecated',
+      },
+      of: [
+        {
+          type: 'reference',
+          to: [{type: 'author'}],
+        },
+      ],
+    },
+    {
+      name: 'arrayOfStrings',
+      title: 'Array of Strings',
+      type: 'array',
+      deprecated: {
+        reason: 'This array of strings field is deprecated',
+      },
+      of: [
+        {
+          type: 'string',
+        },
+      ],
+    },
+    {
+      name: 'objectFullDeprecated',
+      title: 'Object Complete Deprecated',
+      type: 'object',
+      deprecated: {
+        reason: 'This object field is deprecated',
+      },
+      fields: [
+        {
+          name: 'title',
+          title: 'Title',
+          type: 'string',
+        },
+      ],
+    },
+    {
+      name: 'objectFieldDeprecated',
+      title: 'Object Field Deprecated',
+      type: 'object',
+      fields: [
+        {
+          name: 'notDeprecated',
+          title: 'Not Deprecated',
+          type: 'string',
+        },
+        {
+          name: 'deprecated',
+          title: 'Deprecated',
+          type: 'string',
+          deprecated: {
+            reason: 'This object field is deprecated',
+          },
+        },
+      ],
+    },
+  ],
+})

--- a/dev/test-studio/schema/debug/deprecatedFields.ts
+++ b/dev/test-studio/schema/debug/deprecatedFields.ts
@@ -1,103 +1,204 @@
-import {defineType} from 'sanity'
+import {defineField, defineType} from 'sanity'
 
 export const deprecatedFields = defineType({
   name: 'deprecatedFields',
   title: 'Deprecated Fields',
   type: 'document',
   fields: [
-    {
-      name: 'title',
-      title: 'Title',
-      type: 'string',
+    defineField({
       deprecated: {
         reason: 'This string field is deprecated',
       },
-    },
-    {
-      title: 'Number',
-      name: 'number',
-      type: 'number',
+      name: 'string',
+      title: 'Deprecated String',
+      type: 'string',
+    }),
+    defineField({
+      deprecated: {
+        reason: 'This string list is deprecated',
+      },
+      name: 'type',
+      type: 'string',
+      title: 'Deprecated List',
+      initialValue: 'foo',
+      options: {list: ['Frukt', 'Dyr', 'Fjell']},
+    }),
+    defineField({
       deprecated: {
         reason: 'This number field is deprecated',
       },
-    },
-    {
-      title: 'Boolean',
-      name: 'boolean',
-      type: 'boolean',
+      name: 'number',
+      title: 'Deprecated Number',
+      type: 'number',
+    }),
+    defineField({
       deprecated: {
         reason: 'This boolean field is deprecated',
       },
-    },
-    {
-      title: 'Date',
-      name: 'date',
-      type: 'date',
+      name: 'boolean',
+      title: 'Deprecated Boolean',
+      type: 'boolean',
+    }),
+    defineField({
       deprecated: {
-        reason: 'This date field is deprecated',
+        reason: 'This email field is deprecated',
       },
-    },
-    {
-      name: 'arrayOfReferences',
-      title: 'Array of References',
+      name: 'email',
+      title: 'Deprecated Email',
+      type: 'email',
+    }),
+    defineField({
+      deprecated: {
+        reason: 'This array is deprecated',
+      },
+      name: 'array',
+      title: 'Deprecated Array String',
       type: 'array',
-      deprecated: {
-        reason: 'This array of references field is deprecated',
-      },
-      of: [
-        {
-          type: 'reference',
-          to: [{type: 'author'}],
-        },
-      ],
-    },
-    {
-      name: 'arrayOfStrings',
-      title: 'Array of Strings',
-      type: 'array',
-      deprecated: {
-        reason: 'This array of strings field is deprecated',
-      },
-      of: [
-        {
-          type: 'string',
-        },
-      ],
-    },
-    {
-      name: 'objectFullDeprecated',
-      title: 'Object Complete Deprecated',
-      type: 'object',
-      deprecated: {
-        reason: 'This object field is deprecated',
-      },
-      fields: [
-        {
-          name: 'title',
-          title: 'Title',
-          type: 'string',
-        },
-      ],
-    },
-    {
-      name: 'objectFieldDeprecated',
-      title: 'Object Field Deprecated',
+      of: [{type: 'string'}],
+    }),
+    defineField({
+      name: 'notDeprecatedObject',
+      title: 'Not Deprecated Object',
       type: 'object',
       fields: [
-        {
+        defineField({
           name: 'notDeprecated',
-          title: 'Not Deprecated',
-          type: 'string',
-        },
-        {
+          title: 'Not deprecated',
+          type: 'email',
+        }),
+        defineField({
           name: 'deprecated',
-          title: 'Deprecated',
-          type: 'string',
           deprecated: {
-            reason: 'This object field is deprecated',
+            reason: 'This field in object is deprecated',
           },
-        },
+          title: 'Deprecated in Object',
+          type: 'string',
+        }),
       ],
-    },
+    }),
+    defineField({
+      name: 'DeprecatedObject',
+      title: 'Deprecated Object',
+      deprecated: {
+        reason: 'This object is deprecated',
+      },
+      type: 'object',
+      fields: [
+        defineField({
+          name: 'notDeprecated',
+          title: 'Not deprecated',
+          type: 'email',
+        }),
+        defineField({
+          name: 'deprecated',
+          title: 'Deprecated in Object',
+          type: 'string',
+        }),
+      ],
+    }),
+    defineField({
+      name: 'reference',
+      deprecated: {
+        reason: 'This reference is deprecated',
+      },
+      title: 'Deprecated Reference',
+      type: 'reference',
+      to: [{type: 'author'}, {type: 'book'}],
+    }),
+    defineField({
+      name: 'cdReference',
+      deprecated: {
+        reason: 'This cross dataset reference is deprecated',
+      },
+      title: 'Deprecated CDR',
+      type: 'crossDatasetReference',
+      dataset: 'blog',
+      to: [{type: 'author', preview: {select: {title: 'name'}}}],
+    }),
+    defineField({
+      name: 'image',
+      deprecated: {
+        reason: 'This image is deprecated',
+      },
+      title: 'Deprecated Image',
+      type: 'image',
+      fields: [
+        defineField({
+          name: 'alt',
+          title: 'Alt',
+          type: 'string',
+        }),
+      ],
+    }),
+    defineField({
+      name: 'file',
+      deprecated: {
+        reason: 'This file is deprecated',
+      },
+      title: 'Deprecated File',
+      type: 'file',
+      fields: [
+        defineField({
+          name: 'description',
+          title: 'description',
+          type: 'string',
+        }),
+      ],
+    }),
+    defineField({
+      name: 'date',
+      deprecated: {
+        reason: 'This date is deprecated',
+      },
+      title: 'Deprecated Date',
+      type: 'date',
+    }),
+    defineField({
+      name: 'datetime',
+      deprecated: {
+        reason: 'This datetime is deprecated',
+      },
+      title: 'Deprecated DateTime',
+      type: 'datetime',
+    }),
+    defineField({
+      name: 'geopoint',
+      deprecated: {
+        reason: 'This geopoint is deprecated',
+      },
+      title: 'Deprecated Geopoint',
+      type: 'geopoint',
+    }),
+    defineField({
+      name: 'url',
+      title: 'Deprecated URL',
+      type: 'url',
+    }),
+    defineField({
+      name: 'slug',
+      deprecated: {
+        reason: 'This slug is deprecated',
+      },
+      title: 'Deprecated Slug',
+      type: 'slug',
+      options: {source: 'string'},
+    }),
+    defineField({
+      name: 'text',
+      deprecated: {
+        reason: 'This text is deprecated',
+      },
+      title: 'Deprecated Text',
+      type: 'text',
+    }),
+    defineField({
+      name: 'blocks',
+      deprecated: {
+        reason: 'This blocks is deprecated',
+      },
+      title: 'Deprecated Blocks',
+      type: 'array',
+      of: [{type: 'block'}, {type: 'image'}],
+    }),
   ],
 })

--- a/dev/test-studio/schema/debug/deprecatedFields.ts
+++ b/dev/test-studio/schema/debug/deprecatedFields.ts
@@ -1,10 +1,23 @@
 import {defineField, defineType} from 'sanity'
 
+export const someObject = {
+  type: 'object',
+  name: 'someObject',
+  fields: [{type: 'string', name: 'foo'}],
+}
+
 export const deprecatedFields = defineType({
   name: 'deprecatedFields',
   title: 'Deprecated Fields',
   type: 'document',
   fields: [
+    defineField({
+      name: 'someObject',
+      deprecated: {
+        reason: 'This string field is deprecated',
+      },
+      type: 'someObject',
+    }),
     defineField({
       deprecated: {
         reason:

--- a/dev/test-studio/schema/debug/deprecatedFields.ts
+++ b/dev/test-studio/schema/debug/deprecatedFields.ts
@@ -173,6 +173,9 @@ export const deprecatedFields = defineType({
       name: 'url',
       title: 'Deprecated URL',
       type: 'url',
+      deprecated: {
+        reason: 'This url is deprecated',
+      },
     }),
     defineField({
       name: 'slug',

--- a/dev/test-studio/schema/debug/deprecatedFields.ts
+++ b/dev/test-studio/schema/debug/deprecatedFields.ts
@@ -13,7 +13,7 @@ export const deprecatedFields = defineType({
       description: 'This field is used to create the header for the site',
       validation: (Rule) => Rule.required(),
       name: 'string',
-      title: 'String',
+      title: 'string',
       type: 'string',
     }),
     defineField({
@@ -22,7 +22,7 @@ export const deprecatedFields = defineType({
       },
       name: 'type',
       type: 'string',
-      title: 'List',
+      title: 'list',
       initialValue: 'foo',
       options: {list: ['Frukt', 'Dyr', 'Fjell']},
     }),
@@ -31,7 +31,7 @@ export const deprecatedFields = defineType({
         reason: 'This number field is deprecated',
       },
       name: 'number',
-      title: 'Number',
+      title: 'number',
       type: 'number',
     }),
     defineField({
@@ -39,7 +39,7 @@ export const deprecatedFields = defineType({
         reason: 'This boolean field is deprecated',
       },
       name: 'boolean',
-      title: 'Boolean',
+      title: 'boolean',
       type: 'boolean',
     }),
     defineField({
@@ -47,7 +47,7 @@ export const deprecatedFields = defineType({
         reason: 'This email field is deprecated',
       },
       name: 'email',
-      title: 'Email',
+      title: 'email',
       type: 'email',
     }),
     defineField({
@@ -55,7 +55,7 @@ export const deprecatedFields = defineType({
         reason: 'This array is deprecated',
       },
       name: 'array',
-      title: 'Array String',
+      title: 'array',
       type: 'array',
       of: [{type: 'string'}],
     }),
@@ -81,7 +81,7 @@ export const deprecatedFields = defineType({
     }),
     defineField({
       name: 'DeprecatedObject',
-      title: 'Object',
+      title: 'object',
       deprecated: {
         reason: 'This object is deprecated',
       },
@@ -104,7 +104,7 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This reference is deprecated',
       },
-      title: 'Reference',
+      title: 'reference',
       type: 'reference',
       to: [{type: 'author'}, {type: 'book'}],
     }),
@@ -113,7 +113,7 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This cross dataset reference is deprecated',
       },
-      title: 'CDR',
+      title: 'crossDatasetReference',
       type: 'crossDatasetReference',
       dataset: 'blog',
       to: [{type: 'author', preview: {select: {title: 'name'}}}],
@@ -123,7 +123,7 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This image is deprecated',
       },
-      title: 'Image',
+      title: 'image',
       type: 'image',
       fields: [
         defineField({
@@ -141,7 +141,7 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This file is deprecated',
       },
-      title: 'File',
+      title: 'file',
       type: 'file',
       fields: [
         defineField({
@@ -156,7 +156,7 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This date is deprecated',
       },
-      title: 'Date',
+      title: 'date',
       type: 'date',
     }),
     defineField({
@@ -164,7 +164,7 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This datetime is deprecated',
       },
-      title: 'DateTime',
+      title: 'datetime',
       type: 'datetime',
     }),
     defineField({
@@ -172,12 +172,12 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This geopoint is deprecated',
       },
-      title: 'Geopoint',
+      title: 'geopoint',
       type: 'geopoint',
     }),
     defineField({
       name: 'url',
-      title: 'URL',
+      title: 'url',
       type: 'url',
       deprecated: {
         reason: 'This url is deprecated',
@@ -188,7 +188,7 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This slug is deprecated',
       },
-      title: 'Slug',
+      title: 'slug',
       type: 'slug',
       options: {source: 'string'},
     }),
@@ -197,7 +197,7 @@ export const deprecatedFields = defineType({
       deprecated: {
         reason: 'This text is deprecated',
       },
-      title: 'Text',
+      title: 'text',
       type: 'text',
     }),
     defineField({

--- a/dev/test-studio/schema/index.ts
+++ b/dev/test-studio/schema/index.ts
@@ -115,7 +115,7 @@ import fieldGroupsWithFieldsets from './debug/fieldGroupsWithFieldsets'
 import ptReference from './debug/ptReference'
 import {commentsDebug} from './debug/comments'
 import {allTypes} from './allTypes'
-import {deprecatedFields} from './debug/deprecatedFields'
+import {deprecatedFields, someObject} from './debug/deprecatedFields'
 import {deprecatedDocument} from './debug/deprecatedDocument'
 
 // @todo temporary, until code input is v3 compatible
@@ -173,6 +173,7 @@ export const schemaTypes = [
   date,
   datetime,
   deprecatedFields,
+  someObject,
   deprecatedDocument,
   documentActions,
   emails,

--- a/dev/test-studio/schema/index.ts
+++ b/dev/test-studio/schema/index.ts
@@ -116,6 +116,7 @@ import ptReference from './debug/ptReference'
 import {commentsDebug} from './debug/comments'
 import {allTypes} from './allTypes'
 import {deprecatedFields} from './debug/deprecatedFields'
+import {deprecatedDocument} from './debug/deprecatedDocument'
 
 // @todo temporary, until code input is v3 compatible
 const codeInputType = {
@@ -172,6 +173,7 @@ export const schemaTypes = [
   date,
   datetime,
   deprecatedFields,
+  deprecatedDocument,
   documentActions,
   emails,
   empty,

--- a/dev/test-studio/schema/index.ts
+++ b/dev/test-studio/schema/index.ts
@@ -115,7 +115,11 @@ import fieldGroupsWithFieldsets from './debug/fieldGroupsWithFieldsets'
 import ptReference from './debug/ptReference'
 import {commentsDebug} from './debug/comments'
 import {allTypes} from './allTypes'
-import {deprecatedFields, someObject} from './debug/deprecatedFields'
+import {
+  deprecatedFields,
+  namedDeprecatedArray,
+  namedDeprecatedObject,
+} from './debug/deprecatedFields'
 import {deprecatedDocument} from './debug/deprecatedDocument'
 
 // @todo temporary, until code input is v3 compatible
@@ -173,7 +177,6 @@ export const schemaTypes = [
   date,
   datetime,
   deprecatedFields,
-  someObject,
   deprecatedDocument,
   documentActions,
   emails,
@@ -202,6 +205,8 @@ export const schemaTypes = [
   mux,
   myImage,
   myObject,
+  namedDeprecatedObject,
+  namedDeprecatedArray,
   notitle,
   numbers,
   objectWithNestedArray,

--- a/dev/test-studio/schema/index.ts
+++ b/dev/test-studio/schema/index.ts
@@ -115,6 +115,7 @@ import fieldGroupsWithFieldsets from './debug/fieldGroupsWithFieldsets'
 import ptReference from './debug/ptReference'
 import {commentsDebug} from './debug/comments'
 import {allTypes} from './allTypes'
+import {deprecatedFields} from './debug/deprecatedFields'
 
 // @todo temporary, until code input is v3 compatible
 const codeInputType = {
@@ -170,6 +171,7 @@ export const schemaTypes = [
   customNumber,
   date,
   datetime,
+  deprecatedFields,
   documentActions,
   emails,
   empty,

--- a/dev/test-studio/structure/constants.ts
+++ b/dev/test-studio/structure/constants.ts
@@ -42,6 +42,7 @@ export const DEBUG_INPUT_TYPES = [
   'customInputsTest',
   'customInputsWithPatches',
   'deprecatedFields',
+  'deprecatedDocument',
   'documentActionsTest',
   'documentWithHoistedPt',
   'empty',

--- a/dev/test-studio/structure/constants.ts
+++ b/dev/test-studio/structure/constants.ts
@@ -41,6 +41,7 @@ export const DEBUG_INPUT_TYPES = [
   'conditionalFieldsTest',
   'customInputsTest',
   'customInputsWithPatches',
+  'deprecatedFields',
   'documentActionsTest',
   'documentWithHoistedPt',
   'empty',

--- a/packages/@sanity/schema/src/legacy/types/constants.ts
+++ b/packages/@sanity/schema/src/legacy/types/constants.ts
@@ -12,4 +12,5 @@ export const DEFAULT_OVERRIDEABLE_FIELDS = [
   'components',
   'diffComponent',
   'initialValue',
+  'deprecated',
 ]

--- a/packages/@sanity/types/src/schema/asserters.ts
+++ b/packages/@sanity/types/src/schema/asserters.ts
@@ -2,12 +2,14 @@ import type {CrossDatasetReferenceSchemaType} from '../crossDatasetReference'
 import type {TitledListValue} from './definition'
 import type {
   ArraySchemaType,
+  BaseSchemaType,
   BlockChildrenObjectField,
   BlockListObjectField,
   BlockSchemaType,
   BlockStyleObjectField,
   BooleanSchemaType,
   DeprecatedSchemaType,
+  DeprecationConfiguration,
   NumberSchemaType,
   ObjectSchemaType,
   ReferenceSchemaType,
@@ -107,7 +109,15 @@ export function isReferenceSchemaType(type: unknown): type is ReferenceSchemaTyp
 }
 
 /** @internal */
-export function isDeprecatedSchemaType(type: unknown): type is DeprecatedSchemaType {
+export function isDeprecatedSchemaType<TSchemaType extends BaseSchemaType>(
+  type: TSchemaType,
+): type is DeprecatedSchemaType<TSchemaType> {
+  if (!isRecord(type)) return false
+  return typeof type.deprecated !== 'undefined'
+}
+
+/** @internal */
+export function isDeprecationConfiguration(type: unknown): type is DeprecationConfiguration {
   if (!isRecord(type)) return false
   return typeof type.deprecated !== 'undefined'
 }

--- a/packages/@sanity/types/src/schema/asserters.ts
+++ b/packages/@sanity/types/src/schema/asserters.ts
@@ -7,6 +7,7 @@ import type {
   BlockSchemaType,
   BlockStyleObjectField,
   BooleanSchemaType,
+  DeprecatedSchemaType,
   NumberSchemaType,
   ObjectSchemaType,
   ReferenceSchemaType,
@@ -103,6 +104,12 @@ export function isPrimitiveSchemaType(
 /** @internal */
 export function isReferenceSchemaType(type: unknown): type is ReferenceSchemaType {
   return isRecord(type) && (type.name === 'reference' || isReferenceSchemaType(type.type))
+}
+
+/** @internal */
+export function isDeprecatedSchemaType(type: unknown): type is DeprecatedSchemaType {
+  if (!isRecord(type)) return false
+  return typeof type.deprecated !== 'undefined'
 }
 
 /** @internal */

--- a/packages/@sanity/types/src/schema/definition/type/common.ts
+++ b/packages/@sanity/types/src/schema/definition/type/common.ts
@@ -1,5 +1,5 @@
 import type {ComponentType, ReactElement, ReactNode} from 'react'
-import type {ConditionalProperty} from '../../types'
+import type {ConditionalProperty, DeprecatedProperty} from '../../types'
 import type {ObjectOptions} from './object'
 
 /** @public */
@@ -32,6 +32,7 @@ export interface BaseSchemaDefinition {
   icon?: ComponentType | ReactNode
   validation?: unknown
   initialValue?: unknown
+  deprecated?: DeprecatedProperty
   /*
    * These are not the properties you are looking for.
    * To avoid cyclic dependencies on Prop-types, the components property is

--- a/packages/@sanity/types/src/schema/test/document.test.ts
+++ b/packages/@sanity/types/src/schema/test/document.test.ts
@@ -196,6 +196,9 @@ describe('document types', () => {
       const documentDef = defineType({
         type: 'document',
         name: 'custom-document',
+        deprecated: {
+          reason: `This document type has been superseded by a shiny new one.`,
+        },
         fields: [
           {
             type: 'string',
@@ -207,6 +210,9 @@ describe('document types', () => {
             group: 'test',
             validation: (Rule) => Rule.max(45),
             initialValue: 'string',
+            deprecated: {
+              reason: `Strings are overrated.`,
+            },
             options: {
               layout: 'dropdown',
             },
@@ -215,6 +221,8 @@ describe('document types', () => {
             type: 'array',
             name: 'arrayField',
             of: [{type: 'string'}],
+            // @ts-expect-error reason is required
+            deprecated: {},
           },
           {
             type: 'alias-type',

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -123,6 +123,13 @@ export interface DeprecatedProperty {
   reason: string
 }
 
+/**
+ * @public
+ */
+export interface DeprecationConfiguration {
+  deprecated: DeprecatedProperty
+}
+
 /** @public */
 export interface InitialValueResolverContext {
   projectId: string
@@ -177,12 +184,11 @@ export type SchemaValidationValue =
   | ((rule: Rule) => SchemaValidationValue)
 
 /** @public */
-export interface DeprecatedSchemaType {
-  deprecated: DeprecatedProperty
-}
+export type DeprecatedSchemaType<TSchemaType extends BaseSchemaType = BaseSchemaType> =
+  TSchemaType & DeprecationConfiguration
 
 /** @public */
-export interface BaseSchemaType extends Partial<DeprecatedSchemaType> {
+export interface BaseSchemaType extends Partial<DeprecationConfiguration> {
   name: string
   title?: string
   description?: string

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -119,6 +119,11 @@ export type ConditionalPropertyCallback = (context: ConditionalPropertyCallbackC
 export type ConditionalProperty = boolean | ConditionalPropertyCallback | undefined
 
 /** @public */
+export interface DeprecatedProperty {
+  reason: string
+}
+
+/** @public */
 export interface InitialValueResolverContext {
   projectId: string
   dataset: string

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -177,7 +177,12 @@ export type SchemaValidationValue =
   | ((rule: Rule) => SchemaValidationValue)
 
 /** @public */
-export interface BaseSchemaType {
+export interface DeprecatedSchemaType {
+  deprecated: DeprecatedProperty
+}
+
+/** @public */
+export interface BaseSchemaType extends Partial<DeprecatedSchemaType> {
   name: string
   title?: string
   description?: string

--- a/packages/sanity/src/_internal/cli/actions/graphql/extractFromSanitySchema.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/extractFromSanitySchema.ts
@@ -569,7 +569,7 @@ export function extractFromSanitySchema(
 
   function getDocumentDefinition(def: ObjectSchemaType) {
     const objectDef = getObjectDefinition(def)
-    const fields = getDocumentInterfaceFields().concat(objectDef.fields)
+    const fields = getDocumentInterfaceFields(def).concat(objectDef.fields)
 
     return {...objectDef, fields, interfaces: ['Document']}
   }
@@ -583,7 +583,7 @@ export function extractFromSanitySchema(
     }
   }
 
-  function getDocumentInterfaceFields(): ConvertedFieldDefinition[] {
+  function getDocumentInterfaceFields(type?: ObjectSchemaType): ConvertedFieldDefinition[] {
     const isNullable = typeof nonNullDocumentFields === 'boolean' ? !nonNullDocumentFields : true
     return [
       {
@@ -591,30 +591,35 @@ export function extractFromSanitySchema(
         type: 'ID',
         isNullable,
         description: 'Document ID',
+        ...getDeprecation(type),
       },
       {
         fieldName: '_type',
         type: 'String',
         isNullable,
         description: 'Document type',
+        ...getDeprecation(type),
       },
       {
         fieldName: '_createdAt',
         type: 'Datetime',
         isNullable,
         description: 'Date the document was created',
+        ...getDeprecation(type),
       },
       {
         fieldName: '_updatedAt',
         type: 'Datetime',
         isNullable,
         description: 'Date the document was last modified',
+        ...getDeprecation(type),
       },
       {
         fieldName: '_rev',
         type: 'String',
         isNullable,
         description: 'Current document revision',
+        ...getDeprecation(type),
       },
     ]
   }

--- a/packages/sanity/src/_internal/cli/actions/graphql/extractFromSanitySchema.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/extractFromSanitySchema.ts
@@ -274,7 +274,7 @@ export function extractFromSanitySchema(
   function convertType(
     type: SchemaType | ObjectField,
     parent?: string,
-    props: {fieldName?: string} = {},
+    props: {fieldName?: string} & Partial<Deprecation> = {},
   ): ConvertedType {
     const mapped = _convertType(type, parent || '', {isField: Boolean(props.fieldName)})
     const gqlName = props.fieldName || mapped.name
@@ -283,10 +283,10 @@ export function extractFromSanitySchema(
     const crossDatasetReferenceMetadata = getCrossDatasetReferenceMetadata(type)
 
     return {
+      ...getDeprecation(type.type),
       ...props,
       ...mapped,
       ...original,
-      ...getDeprecation(type.type),
       ...(crossDatasetReferenceMetadata && {crossDatasetReferenceMetadata}),
     }
   }
@@ -341,7 +341,10 @@ export function extractFromSanitySchema(
       fields: objectFields.map((field) =>
         isArrayOfBlocks(field)
           ? buildRawField(field, name)
-          : (convertType(field, name, {fieldName: field.name}) as any),
+          : (convertType(field, name, {
+              fieldName: field.name,
+              ...getDeprecation(def),
+            }) as any),
       ),
       [internal]: {
         ...getDeprecation(def),

--- a/packages/sanity/src/_internal/cli/actions/graphql/extractFromSanitySchema.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/extractFromSanitySchema.ts
@@ -9,7 +9,7 @@ import {
   type ArraySchemaType,
   type IntrinsicTypeName,
   type CrossDatasetReferenceSchemaType,
-  isDeprecatedSchemaType,
+  isDeprecationConfiguration,
 } from '@sanity/types'
 import {generateHelpUrl} from '@sanity/generate-help-url'
 import {Schema} from '@sanity/schema'
@@ -728,9 +728,9 @@ class HelpfulError extends Error {
 }
 
 function getDeprecation(
-  type?: SchemaType | ConvertedType | ObjectFieldType<SchemaType> | ObjectField<SchemaType>,
+  type?: SchemaType | ObjectFieldType<SchemaType> | ObjectField<SchemaType>,
 ): Partial<Deprecation> {
-  return isDeprecatedSchemaType(type)
+  return isDeprecationConfiguration(type)
     ? {
         deprecationReason: type.deprecated.reason,
       }

--- a/packages/sanity/src/_internal/cli/actions/graphql/gen3/generateTypeQueries.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/gen3/generateTypeQueries.ts
@@ -4,9 +4,11 @@ import type {
   ApiCustomizationOptions,
   ConvertedType,
   ConvertedUnion,
+  Deprecation,
   InputObjectType,
   QueryDefinition,
 } from '../types'
+import {internal} from '../extractFromSanitySchema'
 import {getFilterFieldName} from './utils'
 
 export function generateTypeQueries(
@@ -52,6 +54,7 @@ export function generateTypeQueries(
           isNullable: false,
         },
       ],
+      ...getDeprecation(type),
     })
   })
 
@@ -103,8 +106,17 @@ export function generateTypeQueries(
           isFieldFilter: false,
         },
       ],
+      ...getDeprecation(type),
     })
   })
 
   return queries
+}
+
+function getDeprecation(type: ConvertedType): Partial<Deprecation> {
+  return type[internal]?.deprecationReason
+    ? {
+        deprecationReason: type[internal].deprecationReason,
+      }
+    : {}
 }

--- a/packages/sanity/src/_internal/cli/actions/graphql/types.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/types.ts
@@ -1,5 +1,6 @@
 import type {GraphQLAPIConfig} from '@sanity/cli'
 import type {Schema} from '@sanity/types'
+import {internal} from './extractFromSanitySchema'
 
 export interface GeneratedApiSpecification {
   types: (ConvertedType | ConvertedUnion | ConvertedEnum | InputObjectType)[]
@@ -32,6 +33,10 @@ export interface ApiCustomizationOptions {
   filterSuffix?: string
 }
 
+export interface Deprecation {
+  deprecationReason: string
+}
+
 export interface ConvertedNode {
   kind: 'Type' | 'List' | 'Union' | 'Interface'
   name: string
@@ -40,7 +45,7 @@ export interface ConvertedNode {
   fields: ConvertedFieldDefinition[]
 }
 
-export interface ConvertedType {
+export interface ConvertedType extends Partial<Deprecation> {
   kind: 'Type' | 'Interface'
   name: string
   type: string
@@ -53,6 +58,7 @@ export interface ConvertedType {
     dataset: string
     typeNames: string[]
   }
+  [internal]?: Partial<Deprecation>
 }
 
 export interface ConvertedDocumentType extends ConvertedType {
@@ -77,7 +83,7 @@ export type FieldArg =
   | {name: string; type: string; isFieldFilter?: boolean}
   | {name: string; type: ConvertedNode}
 
-export interface ConvertedField {
+export interface ConvertedField extends Partial<Deprecation> {
   fieldName: string
   type: string
   filter?: string
@@ -113,7 +119,7 @@ export interface ListDefinition {
   children: {type: string; isNullable?: boolean}
 }
 
-export interface QueryDefinition {
+export interface QueryDefinition extends Partial<Deprecation> {
   fieldName: string
   type: string | ListDefinition
 

--- a/packages/sanity/src/core/form/components/formField/FormField.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormField.tsx
@@ -1,4 +1,4 @@
-import {FormNodeValidation} from '@sanity/types'
+import {DeprecatedProperty, FormNodeValidation} from '@sanity/types'
 import {Stack} from '@sanity/ui'
 import React, {memo} from 'react'
 import {FormNodePresence} from '../../../presence'
@@ -41,6 +41,7 @@ export interface FormFieldProps {
    * @beta
    */
   validation?: FormNodeValidation[]
+  deprecated?: DeprecatedProperty
 }
 
 /** @internal */
@@ -58,9 +59,12 @@ export const FormField = memo(function FormField(
     level,
     title,
     validation,
+    deprecated,
     ...restProps
   } = props
   const {focused, hovered, onMouseEnter, onMouseLeave} = useFieldActions()
+
+  const isDeprecated = Boolean(deprecated?.reason)
 
   return (
     <Stack
@@ -69,7 +73,11 @@ export const FormField = memo(function FormField(
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       space={2}
+      style={{
+        opacity: isDeprecated ? 0.5 : undefined,
+      }}
     >
+      {isDeprecated && <p style={{margin: 0, color: 'red'}}>{deprecated?.reason}</p>}
       {/*
         NOTE: It’s not ideal to hide validation, presence and description when there's no `title`.
         So we might want to separate the concerns of input vs formfield components later on.
@@ -92,7 +100,6 @@ export const FormField = memo(function FormField(
           }
         />
       )}
-
       <div>{children}</div>
     </Stack>
   )

--- a/packages/sanity/src/core/form/components/formField/FormField.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormField.tsx
@@ -64,8 +64,6 @@ export const FormField = memo(function FormField(
   } = props
   const {focused, hovered, onMouseEnter, onMouseLeave} = useFieldActions()
 
-  const isDeprecated = Boolean(deprecated?.reason)
-
   return (
     <Stack
       {...restProps}
@@ -73,11 +71,7 @@ export const FormField = memo(function FormField(
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       space={2}
-      style={{
-        opacity: isDeprecated ? 0.5 : undefined,
-      }}
     >
-      {isDeprecated && <p style={{margin: 0, color: 'red'}}>{deprecated?.reason}</p>}
       {/*
         NOTE: It’s not ideal to hide validation, presence and description when there's no `title`.
         So we might want to separate the concerns of input vs formfield components later on.
@@ -96,6 +90,7 @@ export const FormField = memo(function FormField(
               inputId={inputId}
               title={title}
               validation={validation}
+              deprecated={deprecated}
             />
           }
         />

--- a/packages/sanity/src/core/form/components/formField/FormFieldHeaderText.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldHeaderText.tsx
@@ -1,8 +1,9 @@
-import type {FormNodeValidation} from '@sanity/types'
-import {Box, Flex, Stack, Text} from '@sanity/ui'
+import type {DeprecatedProperty, FormNodeValidation} from '@sanity/types'
+import {Badge, Box, Flex, Stack, Text} from '@sanity/ui'
 import React, {memo} from 'react'
 import {useTranslation} from '../../../i18n'
 import {createDescriptionId} from '../../members/common/createDescriptionId'
+import {TextWithTone} from '../../../components'
 import {FormFieldValidationStatus} from './FormFieldValidationStatus'
 
 /** @internal */
@@ -19,6 +20,7 @@ export interface FormFieldHeaderTextProps {
    */
   inputId?: string
   title?: React.ReactNode
+  deprecated?: DeprecatedProperty
 }
 
 const EMPTY_ARRAY: never[] = []
@@ -27,13 +29,13 @@ const EMPTY_ARRAY: never[] = []
 export const FormFieldHeaderText = memo(function FormFieldHeaderText(
   props: FormFieldHeaderTextProps,
 ) {
-  const {description, inputId, title, validation = EMPTY_ARRAY} = props
+  const {description, inputId, title, deprecated, validation = EMPTY_ARRAY} = props
   const {t} = useTranslation()
   const hasValidations = validation.length > 0
 
   return (
     <Stack space={3}>
-      <Flex>
+      <Flex align="center">
         <Text as="label" htmlFor={inputId} weight="medium" size={1}>
           {title || (
             <span style={{color: 'var(--card-muted-fg-color)'}}>
@@ -42,12 +44,24 @@ export const FormFieldHeaderText = memo(function FormFieldHeaderText(
           )}
         </Text>
 
+        {deprecated && (
+          <Box marginLeft={2}>
+            <Badge tone="caution">{t('form.field.deprecated-label')}</Badge>
+          </Box>
+        )}
+
         {hasValidations && (
           <Box marginLeft={2}>
             <FormFieldValidationStatus fontSize={1} placement="top" validation={validation} />
           </Box>
         )}
       </Flex>
+
+      {deprecated && (
+        <TextWithTone tone="caution" size={1}>
+          {deprecated.reason}
+        </TextWithTone>
+      )}
 
       {description && (
         <Text muted size={1} id={createDescriptionId(inputId, description)}>

--- a/packages/sanity/src/core/form/components/formField/FormFieldHeaderText.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldHeaderText.tsx
@@ -46,7 +46,9 @@ export const FormFieldHeaderText = memo(function FormFieldHeaderText(
 
         {deprecated && (
           <Box marginLeft={2}>
-            <Badge tone="caution">{t('form.field.deprecated-label')}</Badge>
+            <Badge data-testid={`deprecated-badge-${title}`} tone="caution">
+              {t('form.field.deprecated-label')}
+            </Badge>
           </Box>
         )}
 
@@ -58,7 +60,7 @@ export const FormFieldHeaderText = memo(function FormFieldHeaderText(
       </Flex>
 
       {deprecated && (
-        <TextWithTone tone="caution" size={1}>
+        <TextWithTone data-testid={`deprecated-message-${title}`} tone="caution" size={1}>
           {deprecated.reason}
         </TextWithTone>
       )}

--- a/packages/sanity/src/core/form/components/formField/FormFieldSet.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldSet.tsx
@@ -152,7 +152,7 @@ export const FormFieldSet = forwardRef(function FormFieldSet(
     )
   }, [children, collapsed, columns])
 
-  const isDeprecated = Boolean(deprecated?.reason)
+  const isDeprecated = typeof deprecated !== 'undefined'
 
   return (
     <Root

--- a/packages/sanity/src/core/form/components/formField/FormFieldSet.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldSet.tsx
@@ -2,7 +2,7 @@
 import {Box, Flex, Grid, rem, Stack, Text, Theme, useForwardedRef} from '@sanity/ui'
 import React, {forwardRef, useCallback, useMemo} from 'react'
 import styled, {css} from 'styled-components'
-import {FormNodeValidation} from '@sanity/types'
+import {DeprecatedProperty, FormNodeValidation} from '@sanity/types'
 import {FormNodePresence} from '../../../presence'
 import {DocumentFieldActionNode} from '../../../config'
 import {useFieldActions} from '../../field'
@@ -48,6 +48,7 @@ export interface FormFieldSetProps {
    */
   validation?: FormNodeValidation[]
   inputId: string
+  deprecated?: DeprecatedProperty
 }
 
 function getChildren(children: React.ReactNode | (() => React.ReactNode)): React.ReactNode {
@@ -115,6 +116,7 @@ export const FormFieldSet = forwardRef(function FormFieldSet(
     title,
     validation = EMPTY_ARRAY,
     inputId,
+    deprecated,
     ...restProps
   } = props
 
@@ -150,6 +152,8 @@ export const FormFieldSet = forwardRef(function FormFieldSet(
     )
   }, [children, collapsed, columns])
 
+  const isDeprecated = Boolean(deprecated?.reason)
+
   return (
     <Root
       data-level={level}
@@ -166,7 +170,13 @@ export const FormFieldSet = forwardRef(function FormFieldSet(
         fieldHovered={hovered}
         presence={presence}
         content={
-          <Stack space={3}>
+          <Stack
+            space={3}
+            style={{
+              opacity: isDeprecated ? 0.5 : undefined,
+            }}
+          >
+            {isDeprecated && <p style={{margin: 0, color: 'red'}}>{deprecated.reason}</p>}
             <Flex>
               <FormFieldSetLegend
                 collapsed={Boolean(collapsed)}
@@ -174,7 +184,6 @@ export const FormFieldSet = forwardRef(function FormFieldSet(
                 onClick={collapsible ? handleToggle : undefined}
                 title={title}
               />
-
               {hasValidationMarkers && (
                 <Box marginLeft={2}>
                   <FormFieldValidationStatus fontSize={1} placement="top" validation={validation} />

--- a/packages/sanity/src/core/form/components/formField/FormFieldSet.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldSet.tsx
@@ -181,7 +181,9 @@ export const FormFieldSet = forwardRef(function FormFieldSet(
               />
               {deprecated && (
                 <Box marginLeft={2}>
-                  <Badge tone="caution">{t('form.field.deprecated-label')}</Badge>
+                  <Badge data-testid={`deprecated-badge-${title}`} tone="caution">
+                    {t('form.field.deprecated-label')}
+                  </Badge>
                 </Box>
               )}
               {hasValidationMarkers && (
@@ -192,7 +194,7 @@ export const FormFieldSet = forwardRef(function FormFieldSet(
             </Flex>
 
             {deprecated && (
-              <TextWithTone tone="caution" size={1}>
+              <TextWithTone data-testid={`deprecated-message-${title}`} tone="caution" size={1}>
                 {deprecated.reason}
               </TextWithTone>
             )}

--- a/packages/sanity/src/core/form/components/formField/FormFieldSet.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldSet.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import {Box, Flex, Grid, rem, Stack, Text, Theme, useForwardedRef} from '@sanity/ui'
+import {Badge, Box, Flex, Grid, Stack, Text, Theme, useForwardedRef} from '@sanity/ui'
 import React, {forwardRef, useCallback, useMemo} from 'react'
 import styled, {css} from 'styled-components'
 import {DeprecatedProperty, FormNodeValidation} from '@sanity/types'
@@ -8,6 +8,8 @@ import {DocumentFieldActionNode} from '../../../config'
 import {useFieldActions} from '../../field'
 import {createDescriptionId} from '../../members/common/createDescriptionId'
 import {FieldCommentsProps} from '../../types'
+import {TextWithTone} from '../../../components'
+import {useTranslation} from '../../../i18n'
 import {FormFieldValidationStatus} from './FormFieldValidationStatus'
 import {FormFieldSetLegend} from './FormFieldSetLegend'
 import {focusRingStyle} from './styles'
@@ -124,6 +126,7 @@ export const FormFieldSet = forwardRef(function FormFieldSet(
 
   const hasValidationMarkers = validation.length > 0
   const forwardedRef = useForwardedRef(ref)
+  const {t} = useTranslation()
 
   const handleFocus = useCallback(
     (event: React.FocusEvent<HTMLDivElement>) => {
@@ -152,8 +155,6 @@ export const FormFieldSet = forwardRef(function FormFieldSet(
     )
   }, [children, collapsed, columns])
 
-  const isDeprecated = typeof deprecated !== 'undefined'
-
   return (
     <Root
       data-level={level}
@@ -170,26 +171,31 @@ export const FormFieldSet = forwardRef(function FormFieldSet(
         fieldHovered={hovered}
         presence={presence}
         content={
-          <Stack
-            space={3}
-            style={{
-              opacity: isDeprecated ? 0.5 : undefined,
-            }}
-          >
-            {isDeprecated && <p style={{margin: 0, color: 'red'}}>{deprecated.reason}</p>}
-            <Flex>
+          <Stack space={3}>
+            <Flex align="center">
               <FormFieldSetLegend
                 collapsed={Boolean(collapsed)}
                 collapsible={collapsible}
                 onClick={collapsible ? handleToggle : undefined}
                 title={title}
               />
+              {deprecated && (
+                <Box marginLeft={2}>
+                  <Badge tone="caution">{t('form.field.deprecated-label')}</Badge>
+                </Box>
+              )}
               {hasValidationMarkers && (
                 <Box marginLeft={2}>
                   <FormFieldValidationStatus fontSize={1} placement="top" validation={validation} />
                 </Box>
               )}
             </Flex>
+
+            {deprecated && (
+              <TextWithTone tone="caution" size={1}>
+                {deprecated.reason}
+              </TextWithTone>
+            )}
 
             {description && (
               <Text muted size={1} id={createDescriptionId(inputId, description)}>

--- a/packages/sanity/src/core/form/inputs/BooleanInput.tsx
+++ b/packages/sanity/src/core/form/inputs/BooleanInput.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled from 'styled-components'
 import {Box, Card, CardTone, Checkbox, Flex, Switch} from '@sanity/ui'
 import {BooleanInputProps} from '../types'
@@ -29,20 +28,9 @@ export function BooleanInput(props: BooleanInputProps) {
 
   const tone: CardTone | undefined = readOnly ? 'transparent' : undefined
 
-  const isDeprecated = Boolean(schemaType.deprecated)
-
   return (
     <>
-      {isDeprecated && <p style={{margin: 0, color: 'red'}}>{schemaType.deprecated?.reason}</p>}
-      <Card
-        style={{
-          opacity: isDeprecated ? 0.5 : undefined,
-        }}
-        border
-        data-testid="boolean-input"
-        radius={2}
-        tone={tone}
-      >
+      <Card border data-testid="boolean-input" radius={2} tone={tone}>
         <Flex>
           <ZeroLineHeightBox padding={3}>
             <LayoutSpecificInput
@@ -60,6 +48,7 @@ export function BooleanInput(props: BooleanInputProps) {
               inputId={id}
               validation={validation}
               title={schemaType.title}
+              deprecated={schemaType.deprecated}
             />
           </Box>
           <CenterAlignedBox paddingX={3} paddingY={1}>

--- a/packages/sanity/src/core/form/inputs/BooleanInput.tsx
+++ b/packages/sanity/src/core/form/inputs/BooleanInput.tsx
@@ -29,35 +29,33 @@ export function BooleanInput(props: BooleanInputProps) {
   const tone: CardTone | undefined = readOnly ? 'transparent' : undefined
 
   return (
-    <>
-      <Card border data-testid="boolean-input" radius={2} tone={tone}>
-        <Flex>
-          <ZeroLineHeightBox padding={3}>
-            <LayoutSpecificInput
-              label={schemaType.title}
-              {...elementProps}
-              checked={checked}
-              disabled={readOnly}
-              indeterminate={indeterminate}
-              style={{margin: -4}}
-            />
-          </ZeroLineHeightBox>
-          <Box flex={1} paddingY={3}>
-            <FormFieldHeaderText
-              description={schemaType.description}
-              inputId={id}
-              validation={validation}
-              title={schemaType.title}
-              deprecated={schemaType.deprecated}
-            />
-          </Box>
-          <CenterAlignedBox paddingX={3} paddingY={1}>
-            <FormFieldStatus maxAvatars={1} position="top">
-              {/*<FieldPresence maxAvatars={1} presence={presence} />*/}
-            </FormFieldStatus>
-          </CenterAlignedBox>
-        </Flex>
-      </Card>
-    </>
+    <Card border data-testid="boolean-input" radius={2} tone={tone}>
+      <Flex>
+        <ZeroLineHeightBox padding={3}>
+          <LayoutSpecificInput
+            label={schemaType.title}
+            {...elementProps}
+            checked={checked}
+            disabled={readOnly}
+            indeterminate={indeterminate}
+            style={{margin: -4}}
+          />
+        </ZeroLineHeightBox>
+        <Box flex={1} paddingY={3}>
+          <FormFieldHeaderText
+            description={schemaType.description}
+            inputId={id}
+            validation={validation}
+            title={schemaType.title}
+            deprecated={schemaType.deprecated}
+          />
+        </Box>
+        <CenterAlignedBox paddingX={3} paddingY={1}>
+          <FormFieldStatus maxAvatars={1} position="top">
+            {/*<FieldPresence maxAvatars={1} presence={presence} />*/}
+          </FormFieldStatus>
+        </CenterAlignedBox>
+      </Flex>
+    </Card>
   )
 }

--- a/packages/sanity/src/core/form/inputs/BooleanInput.tsx
+++ b/packages/sanity/src/core/form/inputs/BooleanInput.tsx
@@ -41,13 +41,13 @@ export function BooleanInput(props: BooleanInputProps) {
             style={{margin: -4}}
           />
         </ZeroLineHeightBox>
-        <Box flex={1} paddingY={3}>
+        <Box flex={1} paddingY={2}>
           <FormFieldHeaderText
+            deprecated={schemaType.deprecated}
             description={schemaType.description}
             inputId={id}
             validation={validation}
             title={schemaType.title}
-            deprecated={schemaType.deprecated}
           />
         </Box>
         <CenterAlignedBox paddingX={3} paddingY={1}>

--- a/packages/sanity/src/core/form/inputs/BooleanInput.tsx
+++ b/packages/sanity/src/core/form/inputs/BooleanInput.tsx
@@ -29,33 +29,46 @@ export function BooleanInput(props: BooleanInputProps) {
 
   const tone: CardTone | undefined = readOnly ? 'transparent' : undefined
 
+  const isDeprecated = Boolean(schemaType.deprecated)
+
   return (
-    <Card border data-testid="boolean-input" radius={2} tone={tone}>
-      <Flex>
-        <ZeroLineHeightBox padding={3}>
-          <LayoutSpecificInput
-            label={schemaType.title}
-            {...elementProps}
-            checked={checked}
-            disabled={readOnly}
-            indeterminate={indeterminate}
-            style={{margin: -4}}
-          />
-        </ZeroLineHeightBox>
-        <Box flex={1} paddingY={3}>
-          <FormFieldHeaderText
-            description={schemaType.description}
-            inputId={id}
-            validation={validation}
-            title={schemaType.title}
-          />
-        </Box>
-        <CenterAlignedBox paddingX={3} paddingY={1}>
-          <FormFieldStatus maxAvatars={1} position="top">
-            {/*<FieldPresence maxAvatars={1} presence={presence} />*/}
-          </FormFieldStatus>
-        </CenterAlignedBox>
-      </Flex>
-    </Card>
+    <>
+      {isDeprecated && <p style={{margin: 0, color: 'red'}}>{schemaType.deprecated?.reason}</p>}
+      <Card
+        style={{
+          opacity: isDeprecated ? 0.5 : undefined,
+        }}
+        border
+        data-testid="boolean-input"
+        radius={2}
+        tone={tone}
+      >
+        <Flex>
+          <ZeroLineHeightBox padding={3}>
+            <LayoutSpecificInput
+              label={schemaType.title}
+              {...elementProps}
+              checked={checked}
+              disabled={readOnly}
+              indeterminate={indeterminate}
+              style={{margin: -4}}
+            />
+          </ZeroLineHeightBox>
+          <Box flex={1} paddingY={3}>
+            <FormFieldHeaderText
+              description={schemaType.description}
+              inputId={id}
+              validation={validation}
+              title={schemaType.title}
+            />
+          </Box>
+          <CenterAlignedBox paddingX={3} paddingY={1}>
+            <FormFieldStatus maxAvatars={1} position="top">
+              {/*<FieldPresence maxAvatars={1} presence={presence} />*/}
+            </FormFieldStatus>
+          </CenterAlignedBox>
+        </Flex>
+      </Card>
+    </>
   )
 }

--- a/packages/sanity/src/core/form/inputs/NumberInput.tsx
+++ b/packages/sanity/src/core/form/inputs/NumberInput.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import {TextInput} from '@sanity/ui'
 import {getValidationRule} from '../utils/getValidationRule'
 import {NumberInputProps} from '../types'

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceField.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceField.tsx
@@ -248,6 +248,7 @@ export function ReferenceField(props: ReferenceFieldProps) {
           level={props.level}
           title={props.title}
           validation={props.validation}
+          deprecated={props.schemaType.deprecated}
         >
           {isEditing ? (
             <Box>{children}</Box>

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
@@ -308,6 +308,7 @@ export function ReferenceItem<Item extends ReferenceItemValue = ReferenceItemVal
               __unstable_presence={presence}
               validation={validation}
               inputId={inputId}
+              deprecated={schemaType.deprecated}
             >
               {children}
             </FormFieldSet>

--- a/packages/sanity/src/core/form/inputs/files/ImageToolInput/ImageToolInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageToolInput/ImageToolInput.tsx
@@ -116,6 +116,7 @@ export function ImageToolInput(props: ImageToolInputProps) {
       title={t('inputs.imagetool.title')}
       level={level}
       description={t('inputs.imagetool.description')}
+      deprecated={schemaType.deprecated}
       __unstable_presence={presence}
     >
       <div>

--- a/packages/sanity/src/core/form/studio/inputResolver/fieldResolver.tsx
+++ b/packages/sanity/src/core/form/studio/inputResolver/fieldResolver.tsx
@@ -60,6 +60,7 @@ function PrimitiveField(field: FieldProps) {
           level={field.level}
           title={field.title}
           validation={field.validation}
+          deprecated={field.schemaType.deprecated}
         >
           <ChangeIndicator
             hasFocus={focused}
@@ -108,6 +109,7 @@ function ObjectOrArrayField(field: ObjectFieldProps | ArrayFieldProps) {
           title={field.title}
           validation={field.validation}
           inputId={field.inputId}
+          deprecated={field.schemaType.deprecated}
         >
           {field.children}
         </FormFieldSet>
@@ -157,6 +159,7 @@ function ImageOrFileField(field: ObjectFieldProps) {
           title={field.title}
           validation={field.validation}
           inputId={field.inputId}
+          deprecated={field.schemaType.deprecated}
         >
           {field.children}
         </FormFieldSet>

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -394,6 +394,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Error text shown when form is unable to find an array item at a given keyed path */
   'form.error.no-array-item-at-key':
     'No array item with `_key` <code>"{{key}}"</code> found at path <code>{{path}}</code>',
+  /** Form field deprecated label */
+  'form.field.deprecated-label': 'deprecated',
   /** Fallback title shown above field if it has no defined title */
   'form.field.untitled-field-label': 'Untitled',
   /** Fallback title shown above fieldset if it has no defined title */

--- a/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.tsx
@@ -2,11 +2,13 @@ import React, {useCallback, useMemo, useState} from 'react'
 import {Text, useClickOutside, Stack, TextInput, TextInputProps, Card, Flex} from '@sanity/ui'
 import {AddIcon, SearchIcon} from '@sanity/icons'
 import ReactFocusLock from 'react-focus-lock'
+import {isDeprecatedSchemaType} from '@sanity/types'
 import {useGetI18nText, useTranslation} from '../../../../i18n'
 import {InsufficientPermissionsMessage} from '../../../../components'
 import {useCurrentUser} from '../../../../store'
 import {useColorScheme} from '../../../colorScheme'
 import {Button, ButtonProps, Tooltip, TooltipProps} from '../../../../../ui-components'
+import {useSchema} from '../../../../hooks'
 import {NewDocumentList, NewDocumentListProps} from './NewDocumentList'
 import {ModalType, NewDocumentOption} from './types'
 import {filterOptions} from './filter'
@@ -46,6 +48,7 @@ export function NewDocumentButton(props: NewDocumentButtonProps) {
 
   const {scheme} = useColorScheme()
   const currentUser = useCurrentUser()
+  const schema = useSchema()
 
   const hasNewDocumentOptions = options.length > 0
   const disabled = !canCreateDocument || !hasNewDocumentOptions
@@ -53,10 +56,15 @@ export function NewDocumentButton(props: NewDocumentButtonProps) {
   const title = t('new-document.title')
   const openDialogAriaLabel = t('new-document.open-dialog-aria-label')
 
-  // Filter options based on search query
+  // Filter options based on search query and document type deprecations
   const filteredOptions = useMemo(
-    () => filterOptions(options, searchQuery, getI18nText),
-    [options, searchQuery, getI18nText],
+    () =>
+      filterOptions(
+        options.filter((option) => !isDeprecatedSchemaType(schema.get(option.schemaType))),
+        searchQuery,
+        getI18nText,
+      ),
+    [options, searchQuery, getI18nText, schema],
   )
 
   const handleSearchChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.tsx
@@ -56,15 +56,15 @@ export function NewDocumentButton(props: NewDocumentButtonProps) {
   const title = t('new-document.title')
   const openDialogAriaLabel = t('new-document.open-dialog-aria-label')
 
-  // Filter options based on search query and document type deprecations
+  const validOptions = useMemo(
+    () => options.filter((option) => !isDeprecatedSchemaType(schema.get(option.schemaType))),
+    [options, schema],
+  )
+
+  // Filter options based on search query
   const filteredOptions = useMemo(
-    () =>
-      filterOptions(
-        options.filter((option) => !isDeprecatedSchemaType(schema.get(option.schemaType))),
-        searchQuery,
-        getI18nText,
-      ),
-    [options, searchQuery, getI18nText, schema],
+    () => filterOptions(validOptions, searchQuery, getI18nText),
+    [validOptions, searchQuery, getI18nText],
   )
 
   const handleSearchChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentButton.tsx
@@ -57,7 +57,11 @@ export function NewDocumentButton(props: NewDocumentButtonProps) {
   const openDialogAriaLabel = t('new-document.open-dialog-aria-label')
 
   const validOptions = useMemo(
-    () => options.filter((option) => !isDeprecatedSchemaType(schema.get(option.schemaType))),
+    () =>
+      options.filter((option) => {
+        const optionSchema = schema.get(option.schemaType)
+        return optionSchema && !isDeprecatedSchemaType(optionSchema)
+      }),
     [options, schema],
   )
 

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -91,6 +91,8 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'banners.deleted-document-banner.restore-button.text': 'Restore most recent version',
   /** The text content for the deleted document banner */
   'banners.deleted-document-banner.text': 'This document has been deleted.',
+  /** The text content for the deprecated document type banner */
+  'banners.deprecated-document-type-banner.text': 'This document type has been deprecated.',
   /** The text for the permission check banner if the user only has one role, and it does not allow updating this document */
   'banners.permission-check-banner.missing-permission_create_one':
     'Your role <Roles/> does not have permissions to create this document.',

--- a/packages/sanity/src/structure/panes/document/documentPanel/DeprecatedDocumentTypeBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DeprecatedDocumentTypeBanner.tsx
@@ -10,6 +10,7 @@ const Root = styled(Card)`
   z-index: 50;
 `
 
+// TODO: Move into `banners` dir and adopt `Banner` component.
 export function DeprecatedDocumentTypeBanner() {
   const {schemaType} = useDocumentPane()
   const {t} = useTranslation(structureLocaleNamespace)

--- a/packages/sanity/src/structure/panes/document/documentPanel/DeprecatedDocumentTypeBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DeprecatedDocumentTypeBanner.tsx
@@ -1,0 +1,40 @@
+import {Box, Card, Container, Flex, Stack, Text} from '@sanity/ui'
+import {ErrorOutlineIcon} from '@sanity/icons'
+import styled from 'styled-components'
+import {useDocumentPane} from '../useDocumentPane'
+import {structureLocaleNamespace} from '../../../i18n'
+import {isDeprecatedSchemaType, useTranslation} from 'sanity'
+
+const Root = styled(Card)`
+  position: relative;
+  z-index: 50;
+`
+
+export function DeprecatedDocumentTypeBanner() {
+  const {schemaType} = useDocumentPane()
+  const {t} = useTranslation(structureLocaleNamespace)
+
+  if (!isDeprecatedSchemaType(schemaType)) {
+    return null
+  }
+
+  return (
+    <Root data-testid="deprecated-document-type-banner" shadow={1} tone="transparent">
+      <Container paddingX={4} paddingY={3} sizing="border" width={1}>
+        <Flex align="center">
+          <Text size={1}>
+            <ErrorOutlineIcon />
+          </Text>
+          <Box marginLeft={3}>
+            <Stack space={2}>
+              <Text size={1} weight="bold">
+                {t('banners.deprecated-document-type-banner.text')}
+              </Text>
+              <Text size={1}>{schemaType.deprecated.reason}</Text>
+            </Stack>
+          </Box>
+        </Flex>
+      </Container>
+    </Root>
+  )
+}

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -6,9 +6,13 @@ import {useDocumentPane} from '../useDocumentPane'
 import {useStructureTool} from '../../../useStructureTool'
 import {DocumentInspectorPanel} from '../documentInspector'
 import {InspectDialog} from '../inspectDialog'
-import {DeletedDocumentBanner, PermissionCheckBanner, ReferenceChangedBanner} from './banners'
+import {
+  DeletedDocumentBanner,
+  DeprecatedDocumentTypeBanner,
+  PermissionCheckBanner,
+  ReferenceChangedBanner,
+} from './banners'
 import {FormView} from './documentViews'
-import {DeprecatedDocumentTypeBanner} from './DeprecatedDocumentTypeBanner'
 import {ScrollContainer, useTimelineSelector, VirtualizerScrollInstanceProvider} from 'sanity'
 
 interface DocumentPanelProps {

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -8,6 +8,7 @@ import {DocumentInspectorPanel} from '../documentInspector'
 import {InspectDialog} from '../inspectDialog'
 import {DeletedDocumentBanner, PermissionCheckBanner, ReferenceChangedBanner} from './banners'
 import {FormView} from './documentViews'
+import {DeprecatedDocumentTypeBanner} from './DeprecatedDocumentTypeBanner'
 import {ScrollContainer, useTimelineSelector, VirtualizerScrollInstanceProvider} from 'sanity'
 
 interface DocumentPanelProps {
@@ -152,6 +153,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
                         <DeletedDocumentBanner revisionId={lastNonDeletedRevId} />
                       )}
                       <ReferenceChangedBanner />
+                      <DeprecatedDocumentTypeBanner />
                     </>
                   )}
 

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/DeprecatedDocumentTypeBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/DeprecatedDocumentTypeBanner.tsx
@@ -1,8 +1,8 @@
 import {Box, Card, Container, Flex, Stack, Text} from '@sanity/ui'
 import {ErrorOutlineIcon} from '@sanity/icons'
 import styled from 'styled-components'
-import {useDocumentPane} from '../useDocumentPane'
-import {structureLocaleNamespace} from '../../../i18n'
+import {useDocumentPane} from '../../useDocumentPane'
+import {structureLocaleNamespace} from '../../../../i18n'
 import {isDeprecatedSchemaType, useTranslation} from 'sanity'
 
 const Root = styled(Card)`
@@ -10,7 +10,7 @@ const Root = styled(Card)`
   z-index: 50;
 `
 
-// TODO: Move into `banners` dir and adopt `Banner` component.
+// TODO: Adopt `Banner` component.
 export function DeprecatedDocumentTypeBanner() {
   const {schemaType} = useDocumentPane()
   const {t} = useTranslation(structureLocaleNamespace)

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/DeprecatedDocumentTypeBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/DeprecatedDocumentTypeBanner.tsx
@@ -1,16 +1,10 @@
-import {Box, Card, Container, Flex, Stack, Text} from '@sanity/ui'
+import {Text} from '@sanity/ui'
 import {ErrorOutlineIcon} from '@sanity/icons'
-import styled from 'styled-components'
 import {useDocumentPane} from '../../useDocumentPane'
 import {structureLocaleNamespace} from '../../../../i18n'
-import {isDeprecatedSchemaType, useTranslation} from 'sanity'
+import {Banner} from './Banner'
+import {Translate, isDeprecatedSchemaType, useTranslation} from 'sanity'
 
-const Root = styled(Card)`
-  position: relative;
-  z-index: 50;
-`
-
-// TODO: Adopt `Banner` component.
 export function DeprecatedDocumentTypeBanner() {
   const {schemaType} = useDocumentPane()
   const {t} = useTranslation(structureLocaleNamespace)
@@ -20,22 +14,15 @@ export function DeprecatedDocumentTypeBanner() {
   }
 
   return (
-    <Root data-testid="deprecated-document-type-banner" shadow={1} tone="transparent">
-      <Container paddingX={4} paddingY={3} sizing="border" width={1}>
-        <Flex align="center">
-          <Text size={1}>
-            <ErrorOutlineIcon />
-          </Text>
-          <Box marginLeft={3}>
-            <Stack space={2}>
-              <Text size={1} weight="bold">
-                {t('banners.deprecated-document-type-banner.text')}
-              </Text>
-              <Text size={1}>{schemaType.deprecated.reason}</Text>
-            </Stack>
-          </Box>
-        </Flex>
-      </Container>
-    </Root>
+    <Banner
+      content={
+        <Text size={1} weight="medium">
+          <Translate t={t} i18nKey="banners.deprecated-document-type-banner.text" />{' '}
+          {schemaType.deprecated.reason}
+        </Text>
+      }
+      data-testid="deprecated-document-type-banner"
+      icon={ErrorOutlineIcon}
+    />
   )
 }

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/index.ts
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/index.ts
@@ -1,3 +1,4 @@
 export * from './DeletedDocumentBanner'
+export * from './DeprecatedDocumentTypeBanner'
 export * from './PermissionCheckBanner'
 export * from './ReferenceChangedBanner'

--- a/packages/sanity/test/cli/graphql/__snapshots__/extract.test.ts.snap
+++ b/packages/sanity/test/cli/graphql/__snapshots__/extract.test.ts.snap
@@ -127,6 +127,7 @@ Object {
       "name": "Author",
       "originalName": "author",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -169,6 +170,7 @@ Object {
       "name": "Block",
       "originalName": "block",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "crossDatasetReferenceMetadata": Object {
@@ -214,6 +216,7 @@ Object {
       "name": "CdrPersonReference",
       "originalName": "cdrPersonReference",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -256,6 +259,7 @@ Object {
       "name": "Code",
       "originalName": "code",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -297,6 +301,7 @@ Object {
       "name": "Color",
       "originalName": "color",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -336,6 +341,46 @@ Object {
       "name": "CrossDatasetReference",
       "originalName": "crossDatasetReference",
       "type": "Object",
+      Symbol(internal): Object {},
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "deprecationReason": "This field is no longer used",
+          "description": undefined,
+          "fieldName": "description",
+          "type": "String",
+        },
+        Object {
+          "deprecationReason": "This string type has been deprecated",
+          "description": undefined,
+          "fieldName": "excerpt",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "name",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "DeprecatedObject",
+      "originalName": "deprecatedObject",
+      "type": "Object",
+      Symbol(internal): Object {
+        "deprecationReason": "This object type has been deprecated",
+      },
     },
     Object {
       "description": undefined,
@@ -388,6 +433,9 @@ Object {
       "name": "DocumentActionsTest",
       "originalName": "documentActionsTest",
       "type": "Object",
+      Symbol(internal): Object {
+        "deprecationReason": "Entire \`Document actions\` document type deprecated",
+      },
     },
     Object {
       "description": undefined,
@@ -456,6 +504,7 @@ Object {
       "name": "DocumentWithCdrField",
       "originalName": "documentWithCdrField",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -481,6 +530,7 @@ Object {
       "name": "File",
       "originalName": "file",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -515,6 +565,7 @@ Object {
       "name": "Geopoint",
       "originalName": "geopoint",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -554,6 +605,7 @@ Object {
       "name": "HslaColor",
       "originalName": "hslaColor",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -593,6 +645,7 @@ Object {
       "name": "HsvaColor",
       "originalName": "hsvaColor",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -626,6 +679,7 @@ Object {
       "name": "Image",
       "originalName": "image",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -651,6 +705,7 @@ Object {
       "name": "MuxVideo",
       "originalName": "mux.video",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -695,6 +750,7 @@ Object {
       "name": "MuxVideoAsset",
       "originalName": "mux.videoAsset",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -844,6 +900,7 @@ Object {
       "name": "ObjectWithNestedArray",
       "originalName": "objectWithNestedArray",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -883,6 +940,7 @@ Object {
       "name": "PertEstimate",
       "originalName": "pertEstimate",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -931,6 +989,17 @@ Object {
           "kind": "List",
         },
         Object {
+          "deprecationReason": "This object type has been deprecated",
+          "fieldName": "someObject",
+          "type": "DeprecatedObject",
+        },
+        Object {
+          "deprecationReason": "This string type has been deprecated",
+          "description": undefined,
+          "fieldName": "someString",
+          "type": "String",
+        },
+        Object {
           "description": undefined,
           "fieldName": "title",
           "type": "String",
@@ -943,6 +1012,7 @@ Object {
       "name": "Poppers",
       "originalName": "poppers",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -982,6 +1052,7 @@ Object {
       "name": "RgbaColor",
       "originalName": "rgbaColor",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -1002,6 +1073,7 @@ Object {
           "type": "String",
         },
         Object {
+          "deprecationReason": "This field is no longer used",
           "description": "A canonical name for the source this asset is originating from",
           "fieldName": "name",
           "type": "String",
@@ -1016,6 +1088,7 @@ Object {
       "name": "SanityAssetSourceData",
       "originalName": "sanity.assetSourceData",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -1127,6 +1200,7 @@ Object {
       "name": "SanityFileAsset",
       "originalName": "sanity.fileAsset",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -1247,6 +1321,7 @@ Object {
       "name": "SanityImageAsset",
       "originalName": "sanity.imageAsset",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -1286,6 +1361,7 @@ Object {
       "name": "SanityImageCrop",
       "originalName": "sanity.imageCrop",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -1320,6 +1396,7 @@ Object {
       "name": "SanityImageDimensions",
       "originalName": "sanity.imageDimensions",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -1359,6 +1436,7 @@ Object {
       "name": "SanityImageHotspot",
       "originalName": "sanity.imageHotspot",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -1410,6 +1488,7 @@ Object {
       "name": "SanityImageMetadata",
       "originalName": "sanity.imageMetadata",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -1457,6 +1536,7 @@ Object {
       "name": "SanityImagePalette",
       "originalName": "sanity.imagePalette",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -1496,6 +1576,7 @@ Object {
       "name": "SanityImagePaletteSwatch",
       "originalName": "sanity.imagePaletteSwatch",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -1520,6 +1601,7 @@ Object {
       "name": "Slug",
       "originalName": "slug",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -1552,6 +1634,7 @@ Object {
       "name": "Span",
       "originalName": "span",
       "type": "Object",
+      Symbol(internal): Object {},
     },
   ],
 }

--- a/packages/sanity/test/cli/graphql/__snapshots__/extract.test.ts.snap
+++ b/packages/sanity/test/cli/graphql/__snapshots__/extract.test.ts.snap
@@ -347,28 +347,31 @@ Object {
       "description": undefined,
       "fields": Array [
         Object {
+          "deprecationReason": "This object type has been deprecated",
           "description": undefined,
           "fieldName": "_key",
           "type": "String",
         },
         Object {
+          "deprecationReason": "This object type has been deprecated",
           "description": undefined,
           "fieldName": "_type",
           "type": "String",
         },
         Object {
-          "deprecationReason": "This field is no longer used",
+          "deprecationReason": "This object type has been deprecated",
           "description": undefined,
           "fieldName": "description",
           "type": "String",
         },
         Object {
-          "deprecationReason": "This string type has been deprecated",
+          "deprecationReason": "This object type has been deprecated",
           "description": undefined,
           "fieldName": "excerpt",
           "type": "String",
         },
         Object {
+          "deprecationReason": "This object type has been deprecated",
           "description": undefined,
           "fieldName": "name",
           "type": "String",
@@ -386,41 +389,48 @@ Object {
       "description": undefined,
       "fields": Array [
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Date the document was created",
           "fieldName": "_createdAt",
           "isNullable": true,
           "type": "Datetime",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Document ID",
           "fieldName": "_id",
           "isNullable": true,
           "type": "ID",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": undefined,
           "fieldName": "_key",
           "type": "String",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Current document revision",
           "fieldName": "_rev",
           "isNullable": true,
           "type": "String",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Document type",
           "fieldName": "_type",
           "isNullable": true,
           "type": "String",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Date the document was last modified",
           "fieldName": "_updatedAt",
           "isNullable": true,
           "type": "Datetime",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": undefined,
           "fieldName": "title",
           "type": "String",

--- a/packages/sanity/test/cli/graphql/__snapshots__/gen2.test.ts.snap
+++ b/packages/sanity/test/cli/graphql/__snapshots__/gen2.test.ts.snap
@@ -536,6 +536,7 @@ Object {
       "name": "Author",
       "originalName": "author",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -681,6 +682,7 @@ Object {
       "name": "Block",
       "originalName": "block",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -748,6 +750,7 @@ Object {
       "name": "CdrPersonReference",
       "originalName": "cdrPersonReference",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -856,6 +859,7 @@ Object {
       "name": "Code",
       "originalName": "code",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -954,6 +958,7 @@ Object {
       "name": "Color",
       "originalName": "color",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -1068,6 +1073,7 @@ Object {
       "name": "CrossDatasetReference",
       "originalName": "crossDatasetReference",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -1223,41 +1229,147 @@ Object {
       "description": undefined,
       "fields": Array [
         Object {
+          "deprecationReason": "This object type has been deprecated",
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "deprecationReason": "This object type has been deprecated",
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "deprecationReason": "This object type has been deprecated",
+          "description": undefined,
+          "fieldName": "description",
+          "type": "String",
+        },
+        Object {
+          "deprecationReason": "This object type has been deprecated",
+          "description": undefined,
+          "fieldName": "excerpt",
+          "type": "String",
+        },
+        Object {
+          "deprecationReason": "This object type has been deprecated",
+          "description": undefined,
+          "fieldName": "name",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "DeprecatedObject",
+      "originalName": "deprecatedObject",
+      "type": "Object",
+      Symbol(internal): Object {
+        "deprecationReason": "This object type has been deprecated",
+      },
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "description",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "excerpt",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "name",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "DeprecatedObjectFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "description",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "excerpt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "name",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "DeprecatedObjectSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Date the document was created",
           "fieldName": "_createdAt",
           "isNullable": true,
           "type": "Datetime",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Document ID",
           "fieldName": "_id",
           "isNullable": true,
           "type": "ID",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": undefined,
           "fieldName": "_key",
           "type": "String",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Current document revision",
           "fieldName": "_rev",
           "isNullable": true,
           "type": "String",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Document type",
           "fieldName": "_type",
           "isNullable": true,
           "type": "String",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Date the document was last modified",
           "fieldName": "_updatedAt",
           "isNullable": true,
           "type": "Datetime",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": undefined,
           "fieldName": "title",
           "type": "String",
@@ -1270,6 +1382,9 @@ Object {
       "name": "DocumentActionsTest",
       "originalName": "documentActionsTest",
       "type": "Object",
+      Symbol(internal): Object {
+        "deprecationReason": "Entire \`Document actions\` document type deprecated",
+      },
     },
     Object {
       "fields": Array [
@@ -1435,6 +1550,7 @@ Object {
       "name": "DocumentWithCdrField",
       "originalName": "documentWithCdrField",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -1549,6 +1665,7 @@ Object {
       "name": "File",
       "originalName": "file",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -1660,6 +1777,7 @@ Object {
       "name": "Geopoint",
       "originalName": "geopoint",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -1756,6 +1874,7 @@ Object {
       "name": "HslaColor",
       "originalName": "hslaColor",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -1861,6 +1980,7 @@ Object {
       "name": "HsvaColor",
       "originalName": "hsvaColor",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -2000,6 +2120,7 @@ Object {
       "name": "Image",
       "originalName": "image",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -2120,6 +2241,7 @@ Object {
       "name": "MuxVideo",
       "originalName": "mux.video",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -2164,6 +2286,7 @@ Object {
       "name": "MuxVideoAsset",
       "originalName": "mux.videoAsset",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -2423,6 +2546,7 @@ Object {
       "name": "ObjectWithNestedArray",
       "originalName": "objectWithNestedArray",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -2582,6 +2706,7 @@ Object {
       "name": "PertEstimate",
       "originalName": "pertEstimate",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -2696,6 +2821,17 @@ Object {
           "kind": "List",
         },
         Object {
+          "deprecationReason": "This object type has been deprecated",
+          "fieldName": "someObject",
+          "type": "DeprecatedObject",
+        },
+        Object {
+          "deprecationReason": "This string type has been deprecated",
+          "description": undefined,
+          "fieldName": "someString",
+          "type": "String",
+        },
+        Object {
           "description": undefined,
           "fieldName": "title",
           "type": "String",
@@ -2708,6 +2844,7 @@ Object {
       "name": "Poppers",
       "originalName": "poppers",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -2747,6 +2884,16 @@ Object {
           "type": "DatetimeFilter",
         },
         Object {
+          "fieldName": "someObject",
+          "isReference": undefined,
+          "type": "DeprecatedObjectFilter",
+        },
+        Object {
+          "fieldName": "someString",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
           "fieldName": "title",
           "isReference": undefined,
           "type": "StringFilter",
@@ -2779,6 +2926,14 @@ Object {
         },
         Object {
           "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "someObject",
+          "type": "DeprecatedObjectSorting",
+        },
+        Object {
+          "fieldName": "someString",
           "type": "SortOrder",
         },
         Object {
@@ -2827,6 +2982,7 @@ Object {
       "name": "RgbaColor",
       "originalName": "rgbaColor",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -2913,6 +3069,7 @@ Object {
           "type": "String",
         },
         Object {
+          "deprecationReason": "This field is no longer used",
           "description": "A canonical name for the source this asset is originating from",
           "fieldName": "name",
           "type": "String",
@@ -2927,6 +3084,7 @@ Object {
       "name": "SanityAssetSourceData",
       "originalName": "sanity.assetSourceData",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -3095,6 +3253,7 @@ Object {
       "name": "SanityFileAsset",
       "originalName": "sanity.fileAsset",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -3403,6 +3562,7 @@ Object {
       "name": "SanityImageAsset",
       "originalName": "sanity.imageAsset",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -3648,6 +3808,7 @@ Object {
       "name": "SanityImageCrop",
       "originalName": "sanity.imageCrop",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -3748,6 +3909,7 @@ Object {
       "name": "SanityImageDimensions",
       "originalName": "sanity.imageDimensions",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -3844,6 +4006,7 @@ Object {
       "name": "SanityImageHotspot",
       "originalName": "sanity.imageHotspot",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -3961,6 +4124,7 @@ Object {
       "name": "SanityImageMetadata",
       "originalName": "sanity.imageMetadata",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -4101,6 +4265,7 @@ Object {
       "name": "SanityImagePalette",
       "originalName": "sanity.imagePalette",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -4233,6 +4398,7 @@ Object {
       "name": "SanityImagePaletteSwatch",
       "originalName": "sanity.imagePaletteSwatch",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -4323,6 +4489,7 @@ Object {
       "name": "Slug",
       "originalName": "slug",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -4411,6 +4578,7 @@ Object {
       "name": "Span",
       "originalName": "span",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [

--- a/packages/sanity/test/cli/graphql/__snapshots__/gen3.test.ts.snap
+++ b/packages/sanity/test/cli/graphql/__snapshots__/gen3.test.ts.snap
@@ -1273,28 +1273,31 @@ Object {
       "description": undefined,
       "fields": Array [
         Object {
+          "deprecationReason": "This object type has been deprecated",
           "description": undefined,
           "fieldName": "_key",
           "type": "String",
         },
         Object {
+          "deprecationReason": "This object type has been deprecated",
           "description": undefined,
           "fieldName": "_type",
           "type": "String",
         },
         Object {
-          "deprecationReason": "This field is no longer used",
+          "deprecationReason": "This object type has been deprecated",
           "description": undefined,
           "fieldName": "description",
           "type": "String",
         },
         Object {
-          "deprecationReason": "This string type has been deprecated",
+          "deprecationReason": "This object type has been deprecated",
           "description": undefined,
           "fieldName": "excerpt",
           "type": "String",
         },
         Object {
+          "deprecationReason": "This object type has been deprecated",
           "description": undefined,
           "fieldName": "name",
           "type": "String",
@@ -1381,6 +1384,7 @@ Object {
           "type": "ID",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": undefined,
           "fieldName": "_key",
           "type": "String",
@@ -1404,6 +1408,7 @@ Object {
           "type": "Datetime",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": undefined,
           "fieldName": "title",
           "type": "String",
@@ -5998,28 +6003,31 @@ Object {
       "description": undefined,
       "fields": Array [
         Object {
+          "deprecationReason": "This object type has been deprecated",
           "description": undefined,
           "fieldName": "_key",
           "type": "String",
         },
         Object {
+          "deprecationReason": "This object type has been deprecated",
           "description": undefined,
           "fieldName": "_type",
           "type": "String",
         },
         Object {
-          "deprecationReason": "This field is no longer used",
+          "deprecationReason": "This object type has been deprecated",
           "description": undefined,
           "fieldName": "description",
           "type": "String",
         },
         Object {
-          "deprecationReason": "This string type has been deprecated",
+          "deprecationReason": "This object type has been deprecated",
           "description": undefined,
           "fieldName": "excerpt",
           "type": "String",
         },
         Object {
+          "deprecationReason": "This object type has been deprecated",
           "description": undefined,
           "fieldName": "name",
           "type": "String",
@@ -6106,6 +6114,7 @@ Object {
           "type": "ID",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": undefined,
           "fieldName": "_key",
           "type": "String",
@@ -6129,6 +6138,7 @@ Object {
           "type": "Datetime",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": undefined,
           "fieldName": "title",
           "type": "String",

--- a/packages/sanity/test/cli/graphql/__snapshots__/gen3.test.ts.snap
+++ b/packages/sanity/test/cli/graphql/__snapshots__/gen3.test.ts.snap
@@ -106,6 +106,7 @@ Object {
           },
         },
       ],
+      "deprecationReason": "Entire \`Document actions\` document type deprecated",
       "fieldName": "DocumentActionsTest",
       "type": "DocumentActionsTest",
     },
@@ -312,6 +313,7 @@ Object {
           "type": "DocumentActionsTestFilter",
         },
       ],
+      "deprecationReason": "Entire \`Document actions\` document type deprecated",
       "fieldName": "allDocumentActionsTest",
       "filter": "_type == \\"documentActionsTest\\"",
       "type": Object {
@@ -578,6 +580,7 @@ Object {
       "name": "Author",
       "originalName": "author",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -723,6 +726,7 @@ Object {
       "name": "Block",
       "originalName": "block",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -790,6 +794,7 @@ Object {
       "name": "CdrPersonReference",
       "originalName": "cdrPersonReference",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -898,6 +903,7 @@ Object {
       "name": "Code",
       "originalName": "code",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -996,6 +1002,7 @@ Object {
       "name": "Color",
       "originalName": "color",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -1110,6 +1117,7 @@ Object {
       "name": "CrossDatasetReference",
       "originalName": "crossDatasetReference",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -1265,6 +1273,102 @@ Object {
       "description": undefined,
       "fields": Array [
         Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "deprecationReason": "This field is no longer used",
+          "description": undefined,
+          "fieldName": "description",
+          "type": "String",
+        },
+        Object {
+          "deprecationReason": "This string type has been deprecated",
+          "description": undefined,
+          "fieldName": "excerpt",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "name",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "DeprecatedObject",
+      "originalName": "deprecatedObject",
+      "type": "Object",
+      Symbol(internal): Object {
+        "deprecationReason": "This object type has been deprecated",
+      },
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "description",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "excerpt",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "name",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "DeprecatedObjectFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "description",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "excerpt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "name",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "DeprecatedObjectSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
           "description": "Date the document was created",
           "fieldName": "_createdAt",
           "isNullable": true,
@@ -1312,6 +1416,9 @@ Object {
       "name": "DocumentActionsTest",
       "originalName": "documentActionsTest",
       "type": "Object",
+      Symbol(internal): Object {
+        "deprecationReason": "Entire \`Document actions\` document type deprecated",
+      },
     },
     Object {
       "fields": Array [
@@ -1522,6 +1629,7 @@ Object {
       "name": "DocumentWithCdrField",
       "originalName": "documentWithCdrField",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -1636,6 +1744,7 @@ Object {
       "name": "File",
       "originalName": "file",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -1747,6 +1856,7 @@ Object {
       "name": "Geopoint",
       "originalName": "geopoint",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -1843,6 +1953,7 @@ Object {
       "name": "HslaColor",
       "originalName": "hslaColor",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -1948,6 +2059,7 @@ Object {
       "name": "HsvaColor",
       "originalName": "hsvaColor",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -2087,6 +2199,7 @@ Object {
       "name": "Image",
       "originalName": "image",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -2207,6 +2320,7 @@ Object {
       "name": "MuxVideo",
       "originalName": "mux.video",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -2251,6 +2365,7 @@ Object {
       "name": "MuxVideoAsset",
       "originalName": "mux.videoAsset",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -2510,6 +2625,7 @@ Object {
       "name": "ObjectWithNestedArray",
       "originalName": "objectWithNestedArray",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -2669,6 +2785,7 @@ Object {
       "name": "PertEstimate",
       "originalName": "pertEstimate",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -2783,6 +2900,17 @@ Object {
           "kind": "List",
         },
         Object {
+          "deprecationReason": "This object type has been deprecated",
+          "fieldName": "someObject",
+          "type": "DeprecatedObject",
+        },
+        Object {
+          "deprecationReason": "This string type has been deprecated",
+          "description": undefined,
+          "fieldName": "someString",
+          "type": "String",
+        },
+        Object {
           "description": undefined,
           "fieldName": "title",
           "type": "String",
@@ -2795,6 +2923,7 @@ Object {
       "name": "Poppers",
       "originalName": "poppers",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -2834,6 +2963,16 @@ Object {
           "type": "DatetimeFilter",
         },
         Object {
+          "fieldName": "someObject",
+          "isReference": undefined,
+          "type": "DeprecatedObjectFilter",
+        },
+        Object {
+          "fieldName": "someString",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
           "fieldName": "title",
           "isReference": undefined,
           "type": "StringFilter",
@@ -2866,6 +3005,14 @@ Object {
         },
         Object {
           "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "someObject",
+          "type": "DeprecatedObjectSorting",
+        },
+        Object {
+          "fieldName": "someString",
           "type": "SortOrder",
         },
         Object {
@@ -2914,6 +3061,7 @@ Object {
       "name": "RgbaColor",
       "originalName": "rgbaColor",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -3000,6 +3148,7 @@ Object {
           "type": "String",
         },
         Object {
+          "deprecationReason": "This field is no longer used",
           "description": "A canonical name for the source this asset is originating from",
           "fieldName": "name",
           "type": "String",
@@ -3014,6 +3163,7 @@ Object {
       "name": "SanityAssetSourceData",
       "originalName": "sanity.assetSourceData",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -3182,6 +3332,7 @@ Object {
       "name": "SanityFileAsset",
       "originalName": "sanity.fileAsset",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -3490,6 +3641,7 @@ Object {
       "name": "SanityImageAsset",
       "originalName": "sanity.imageAsset",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -3735,6 +3887,7 @@ Object {
       "name": "SanityImageCrop",
       "originalName": "sanity.imageCrop",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -3835,6 +3988,7 @@ Object {
       "name": "SanityImageDimensions",
       "originalName": "sanity.imageDimensions",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -3931,6 +4085,7 @@ Object {
       "name": "SanityImageHotspot",
       "originalName": "sanity.imageHotspot",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -4048,6 +4203,7 @@ Object {
       "name": "SanityImageMetadata",
       "originalName": "sanity.imageMetadata",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -4188,6 +4344,7 @@ Object {
       "name": "SanityImagePalette",
       "originalName": "sanity.imagePalette",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -4320,6 +4477,7 @@ Object {
       "name": "SanityImagePaletteSwatch",
       "originalName": "sanity.imagePaletteSwatch",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -4427,6 +4585,7 @@ Object {
       "name": "Slug",
       "originalName": "slug",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -4515,6 +4674,7 @@ Object {
       "name": "Span",
       "originalName": "span",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -4671,6 +4831,7 @@ Object {
           },
         },
       ],
+      "deprecationReason": "Entire \`Document actions\` document type deprecated",
       "fieldName": "DocumentActionsTest",
       "type": "DocumentActionsTest",
     },
@@ -4877,6 +5038,7 @@ Object {
           "type": "DocumentActionsTestCustomFilterSuffix",
         },
       ],
+      "deprecationReason": "Entire \`Document actions\` document type deprecated",
       "fieldName": "allDocumentActionsTest",
       "filter": "_type == \\"documentActionsTest\\"",
       "type": Object {
@@ -5143,6 +5305,7 @@ Object {
       "name": "Author",
       "originalName": "author",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -5288,6 +5451,7 @@ Object {
       "name": "Block",
       "originalName": "block",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -5355,6 +5519,7 @@ Object {
       "name": "CdrPersonReference",
       "originalName": "cdrPersonReference",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -5463,6 +5628,7 @@ Object {
       "name": "Code",
       "originalName": "code",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -5561,6 +5727,7 @@ Object {
       "name": "Color",
       "originalName": "color",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -5675,6 +5842,7 @@ Object {
       "name": "CrossDatasetReference",
       "originalName": "crossDatasetReference",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -5830,6 +5998,102 @@ Object {
       "description": undefined,
       "fields": Array [
         Object {
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "deprecationReason": "This field is no longer used",
+          "description": undefined,
+          "fieldName": "description",
+          "type": "String",
+        },
+        Object {
+          "deprecationReason": "This string type has been deprecated",
+          "description": undefined,
+          "fieldName": "excerpt",
+          "type": "String",
+        },
+        Object {
+          "description": undefined,
+          "fieldName": "name",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "DeprecatedObject",
+      "originalName": "deprecatedObject",
+      "type": "Object",
+      Symbol(internal): Object {
+        "deprecationReason": "This object type has been deprecated",
+      },
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "description",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "excerpt",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "name",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "DeprecatedObjectCustomFilterSuffix",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "description",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "excerpt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "name",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "DeprecatedObjectSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
           "description": "Date the document was created",
           "fieldName": "_createdAt",
           "isNullable": true,
@@ -5877,6 +6141,9 @@ Object {
       "name": "DocumentActionsTest",
       "originalName": "documentActionsTest",
       "type": "Object",
+      Symbol(internal): Object {
+        "deprecationReason": "Entire \`Document actions\` document type deprecated",
+      },
     },
     Object {
       "fields": Array [
@@ -6087,6 +6354,7 @@ Object {
       "name": "DocumentWithCdrField",
       "originalName": "documentWithCdrField",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -6201,6 +6469,7 @@ Object {
       "name": "File",
       "originalName": "file",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -6312,6 +6581,7 @@ Object {
       "name": "Geopoint",
       "originalName": "geopoint",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -6408,6 +6678,7 @@ Object {
       "name": "HslaColor",
       "originalName": "hslaColor",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -6513,6 +6784,7 @@ Object {
       "name": "HsvaColor",
       "originalName": "hsvaColor",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -6652,6 +6924,7 @@ Object {
       "name": "Image",
       "originalName": "image",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -6772,6 +7045,7 @@ Object {
       "name": "MuxVideo",
       "originalName": "mux.video",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -6816,6 +7090,7 @@ Object {
       "name": "MuxVideoAsset",
       "originalName": "mux.videoAsset",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -7075,6 +7350,7 @@ Object {
       "name": "ObjectWithNestedArray",
       "originalName": "objectWithNestedArray",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -7234,6 +7510,7 @@ Object {
       "name": "PertEstimate",
       "originalName": "pertEstimate",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -7348,6 +7625,17 @@ Object {
           "kind": "List",
         },
         Object {
+          "deprecationReason": "This object type has been deprecated",
+          "fieldName": "someObject",
+          "type": "DeprecatedObject",
+        },
+        Object {
+          "deprecationReason": "This string type has been deprecated",
+          "description": undefined,
+          "fieldName": "someString",
+          "type": "String",
+        },
+        Object {
           "description": undefined,
           "fieldName": "title",
           "type": "String",
@@ -7360,6 +7648,7 @@ Object {
       "name": "Poppers",
       "originalName": "poppers",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -7399,6 +7688,16 @@ Object {
           "type": "DatetimeFilter",
         },
         Object {
+          "fieldName": "someObject",
+          "isReference": undefined,
+          "type": "DeprecatedObjectCustomFilterSuffix",
+        },
+        Object {
+          "fieldName": "someString",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
           "fieldName": "title",
           "isReference": undefined,
           "type": "StringFilter",
@@ -7431,6 +7730,14 @@ Object {
         },
         Object {
           "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "someObject",
+          "type": "DeprecatedObjectSorting",
+        },
+        Object {
+          "fieldName": "someString",
           "type": "SortOrder",
         },
         Object {
@@ -7479,6 +7786,7 @@ Object {
       "name": "RgbaColor",
       "originalName": "rgbaColor",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -7565,6 +7873,7 @@ Object {
           "type": "String",
         },
         Object {
+          "deprecationReason": "This field is no longer used",
           "description": "A canonical name for the source this asset is originating from",
           "fieldName": "name",
           "type": "String",
@@ -7579,6 +7888,7 @@ Object {
       "name": "SanityAssetSourceData",
       "originalName": "sanity.assetSourceData",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -7747,6 +8057,7 @@ Object {
       "name": "SanityFileAsset",
       "originalName": "sanity.fileAsset",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -8055,6 +8366,7 @@ Object {
       "name": "SanityImageAsset",
       "originalName": "sanity.imageAsset",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -8300,6 +8612,7 @@ Object {
       "name": "SanityImageCrop",
       "originalName": "sanity.imageCrop",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -8400,6 +8713,7 @@ Object {
       "name": "SanityImageDimensions",
       "originalName": "sanity.imageDimensions",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -8496,6 +8810,7 @@ Object {
       "name": "SanityImageHotspot",
       "originalName": "sanity.imageHotspot",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -8613,6 +8928,7 @@ Object {
       "name": "SanityImageMetadata",
       "originalName": "sanity.imageMetadata",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -8753,6 +9069,7 @@ Object {
       "name": "SanityImagePalette",
       "originalName": "sanity.imagePalette",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -8885,6 +9202,7 @@ Object {
       "name": "SanityImagePaletteSwatch",
       "originalName": "sanity.imagePaletteSwatch",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -8992,6 +9310,7 @@ Object {
       "name": "Slug",
       "originalName": "slug",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -9080,6 +9399,7 @@ Object {
       "name": "Span",
       "originalName": "span",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [

--- a/packages/sanity/test/cli/graphql/__snapshots__/gen3.test.ts.snap
+++ b/packages/sanity/test/cli/graphql/__snapshots__/gen3.test.ts.snap
@@ -12308,6 +12308,7 @@ Object {
       "name": "Block",
       "originalName": "block",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -12369,6 +12370,7 @@ Object {
       "name": "CrossDatasetReference",
       "originalName": "crossDatasetReference",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -12606,6 +12608,7 @@ Object {
       "name": "File",
       "originalName": "file",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -12717,6 +12720,7 @@ Object {
       "name": "Geopoint",
       "originalName": "geopoint",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -12847,6 +12851,7 @@ Object {
       "name": "Image",
       "originalName": "image",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -12976,6 +12981,7 @@ Object {
       "name": "SanityAssetSourceData",
       "originalName": "sanity.assetSourceData",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -13144,6 +13150,7 @@ Object {
       "name": "SanityFileAsset",
       "originalName": "sanity.fileAsset",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -13452,6 +13459,7 @@ Object {
       "name": "SanityImageAsset",
       "originalName": "sanity.imageAsset",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -13697,6 +13705,7 @@ Object {
       "name": "SanityImageCrop",
       "originalName": "sanity.imageCrop",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -13797,6 +13806,7 @@ Object {
       "name": "SanityImageDimensions",
       "originalName": "sanity.imageDimensions",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -13893,6 +13903,7 @@ Object {
       "name": "SanityImageHotspot",
       "originalName": "sanity.imageHotspot",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -14010,6 +14021,7 @@ Object {
       "name": "SanityImageMetadata",
       "originalName": "sanity.imageMetadata",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -14150,6 +14162,7 @@ Object {
       "name": "SanityImagePalette",
       "originalName": "sanity.imagePalette",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -14282,6 +14295,7 @@ Object {
       "name": "SanityImagePaletteSwatch",
       "originalName": "sanity.imagePaletteSwatch",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -14426,6 +14440,7 @@ Object {
       "name": "SchemaType0",
       "originalName": "schemaType0",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -14606,6 +14621,7 @@ Object {
       "name": "SchemaType1",
       "originalName": "schemaType1",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -14667,6 +14683,7 @@ Object {
       "name": "SchemaType10",
       "originalName": "schemaType10",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -14799,6 +14816,7 @@ Object {
       "name": "SchemaType11",
       "originalName": "schemaType11",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -14931,6 +14949,7 @@ Object {
       "name": "SchemaType12",
       "originalName": "schemaType12",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -15063,6 +15082,7 @@ Object {
       "name": "SchemaType13",
       "originalName": "schemaType13",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -15195,6 +15215,7 @@ Object {
       "name": "SchemaType14",
       "originalName": "schemaType14",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -15327,6 +15348,7 @@ Object {
       "name": "SchemaType15",
       "originalName": "schemaType15",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -15459,6 +15481,7 @@ Object {
       "name": "SchemaType16",
       "originalName": "schemaType16",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -15591,6 +15614,7 @@ Object {
       "name": "SchemaType17",
       "originalName": "schemaType17",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -15723,6 +15747,7 @@ Object {
       "name": "SchemaType18",
       "originalName": "schemaType18",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -15855,6 +15880,7 @@ Object {
       "name": "SchemaType19",
       "originalName": "schemaType19",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -16058,6 +16084,7 @@ Object {
       "name": "SchemaType2",
       "originalName": "schemaType2",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -16119,6 +16146,7 @@ Object {
       "name": "SchemaType20",
       "originalName": "schemaType20",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -16251,6 +16279,7 @@ Object {
       "name": "SchemaType21",
       "originalName": "schemaType21",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -16383,6 +16412,7 @@ Object {
       "name": "SchemaType22",
       "originalName": "schemaType22",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -16515,6 +16545,7 @@ Object {
       "name": "SchemaType23",
       "originalName": "schemaType23",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -16647,6 +16678,7 @@ Object {
       "name": "SchemaType24",
       "originalName": "schemaType24",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -16779,6 +16811,7 @@ Object {
       "name": "SchemaType25",
       "originalName": "schemaType25",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -16911,6 +16944,7 @@ Object {
       "name": "SchemaType26",
       "originalName": "schemaType26",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -17043,6 +17077,7 @@ Object {
       "name": "SchemaType27",
       "originalName": "schemaType27",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -17175,6 +17210,7 @@ Object {
       "name": "SchemaType28",
       "originalName": "schemaType28",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -17307,6 +17343,7 @@ Object {
       "name": "SchemaType29",
       "originalName": "schemaType29",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -17510,6 +17547,7 @@ Object {
       "name": "SchemaType3",
       "originalName": "schemaType3",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -17571,6 +17609,7 @@ Object {
       "name": "SchemaType30",
       "originalName": "schemaType30",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -17703,6 +17742,7 @@ Object {
       "name": "SchemaType31",
       "originalName": "schemaType31",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -17835,6 +17875,7 @@ Object {
       "name": "SchemaType32",
       "originalName": "schemaType32",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -17967,6 +18008,7 @@ Object {
       "name": "SchemaType33",
       "originalName": "schemaType33",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -18099,6 +18141,7 @@ Object {
       "name": "SchemaType34",
       "originalName": "schemaType34",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -18231,6 +18274,7 @@ Object {
       "name": "SchemaType35",
       "originalName": "schemaType35",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -18363,6 +18407,7 @@ Object {
       "name": "SchemaType36",
       "originalName": "schemaType36",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -18495,6 +18540,7 @@ Object {
       "name": "SchemaType37",
       "originalName": "schemaType37",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -18627,6 +18673,7 @@ Object {
       "name": "SchemaType38",
       "originalName": "schemaType38",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -18759,6 +18806,7 @@ Object {
       "name": "SchemaType39",
       "originalName": "schemaType39",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -18962,6 +19010,7 @@ Object {
       "name": "SchemaType4",
       "originalName": "schemaType4",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -19094,6 +19143,7 @@ Object {
       "name": "SchemaType5",
       "originalName": "schemaType5",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -19226,6 +19276,7 @@ Object {
       "name": "SchemaType6",
       "originalName": "schemaType6",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -19358,6 +19409,7 @@ Object {
       "name": "SchemaType7",
       "originalName": "schemaType7",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -19490,6 +19542,7 @@ Object {
       "name": "SchemaType8",
       "originalName": "schemaType8",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -19622,6 +19675,7 @@ Object {
       "name": "SchemaType9",
       "originalName": "schemaType9",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -19742,6 +19796,7 @@ Object {
       "name": "Span",
       "originalName": "span",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -22630,6 +22685,7 @@ Object {
       "name": "Block",
       "originalName": "block",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -22691,6 +22747,7 @@ Object {
       "name": "CrossDatasetReference",
       "originalName": "crossDatasetReference",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -22928,6 +22985,7 @@ Object {
       "name": "File",
       "originalName": "file",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -23039,6 +23097,7 @@ Object {
       "name": "Geopoint",
       "originalName": "geopoint",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -23169,6 +23228,7 @@ Object {
       "name": "Image",
       "originalName": "image",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -23298,6 +23358,7 @@ Object {
       "name": "SanityAssetSourceData",
       "originalName": "sanity.assetSourceData",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -23466,6 +23527,7 @@ Object {
       "name": "SanityFileAsset",
       "originalName": "sanity.fileAsset",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -23774,6 +23836,7 @@ Object {
       "name": "SanityImageAsset",
       "originalName": "sanity.imageAsset",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -24019,6 +24082,7 @@ Object {
       "name": "SanityImageCrop",
       "originalName": "sanity.imageCrop",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -24119,6 +24183,7 @@ Object {
       "name": "SanityImageDimensions",
       "originalName": "sanity.imageDimensions",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -24215,6 +24280,7 @@ Object {
       "name": "SanityImageHotspot",
       "originalName": "sanity.imageHotspot",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -24332,6 +24398,7 @@ Object {
       "name": "SanityImageMetadata",
       "originalName": "sanity.imageMetadata",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -24472,6 +24539,7 @@ Object {
       "name": "SanityImagePalette",
       "originalName": "sanity.imagePalette",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -24604,6 +24672,7 @@ Object {
       "name": "SanityImagePaletteSwatch",
       "originalName": "sanity.imagePaletteSwatch",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -24748,6 +24817,7 @@ Object {
       "name": "SchemaType0",
       "originalName": "schemaType0",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -24928,6 +24998,7 @@ Object {
       "name": "SchemaType1",
       "originalName": "schemaType1",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -24989,6 +25060,7 @@ Object {
       "name": "SchemaType10",
       "originalName": "schemaType10",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -25121,6 +25193,7 @@ Object {
       "name": "SchemaType11",
       "originalName": "schemaType11",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -25253,6 +25326,7 @@ Object {
       "name": "SchemaType12",
       "originalName": "schemaType12",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -25385,6 +25459,7 @@ Object {
       "name": "SchemaType13",
       "originalName": "schemaType13",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -25517,6 +25592,7 @@ Object {
       "name": "SchemaType14",
       "originalName": "schemaType14",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -25649,6 +25725,7 @@ Object {
       "name": "SchemaType15",
       "originalName": "schemaType15",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -25781,6 +25858,7 @@ Object {
       "name": "SchemaType16",
       "originalName": "schemaType16",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -25913,6 +25991,7 @@ Object {
       "name": "SchemaType17",
       "originalName": "schemaType17",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -26045,6 +26124,7 @@ Object {
       "name": "SchemaType18",
       "originalName": "schemaType18",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -26177,6 +26257,7 @@ Object {
       "name": "SchemaType19",
       "originalName": "schemaType19",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -26380,6 +26461,7 @@ Object {
       "name": "SchemaType2",
       "originalName": "schemaType2",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -26441,6 +26523,7 @@ Object {
       "name": "SchemaType20",
       "originalName": "schemaType20",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -26573,6 +26656,7 @@ Object {
       "name": "SchemaType21",
       "originalName": "schemaType21",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -26705,6 +26789,7 @@ Object {
       "name": "SchemaType22",
       "originalName": "schemaType22",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -26837,6 +26922,7 @@ Object {
       "name": "SchemaType23",
       "originalName": "schemaType23",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -26969,6 +27055,7 @@ Object {
       "name": "SchemaType24",
       "originalName": "schemaType24",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -27101,6 +27188,7 @@ Object {
       "name": "SchemaType25",
       "originalName": "schemaType25",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -27233,6 +27321,7 @@ Object {
       "name": "SchemaType26",
       "originalName": "schemaType26",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -27365,6 +27454,7 @@ Object {
       "name": "SchemaType27",
       "originalName": "schemaType27",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -27497,6 +27587,7 @@ Object {
       "name": "SchemaType28",
       "originalName": "schemaType28",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -27629,6 +27720,7 @@ Object {
       "name": "SchemaType29",
       "originalName": "schemaType29",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -27832,6 +27924,7 @@ Object {
       "name": "SchemaType3",
       "originalName": "schemaType3",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -27893,6 +27986,7 @@ Object {
       "name": "SchemaType30",
       "originalName": "schemaType30",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -28025,6 +28119,7 @@ Object {
       "name": "SchemaType31",
       "originalName": "schemaType31",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -28157,6 +28252,7 @@ Object {
       "name": "SchemaType32",
       "originalName": "schemaType32",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -28289,6 +28385,7 @@ Object {
       "name": "SchemaType33",
       "originalName": "schemaType33",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -28421,6 +28518,7 @@ Object {
       "name": "SchemaType34",
       "originalName": "schemaType34",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -28553,6 +28651,7 @@ Object {
       "name": "SchemaType35",
       "originalName": "schemaType35",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -28685,6 +28784,7 @@ Object {
       "name": "SchemaType36",
       "originalName": "schemaType36",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -28817,6 +28917,7 @@ Object {
       "name": "SchemaType37",
       "originalName": "schemaType37",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -28949,6 +29050,7 @@ Object {
       "name": "SchemaType38",
       "originalName": "schemaType38",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -29081,6 +29183,7 @@ Object {
       "name": "SchemaType39",
       "originalName": "schemaType39",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -29284,6 +29387,7 @@ Object {
       "name": "SchemaType4",
       "originalName": "schemaType4",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -29416,6 +29520,7 @@ Object {
       "name": "SchemaType5",
       "originalName": "schemaType5",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -29548,6 +29653,7 @@ Object {
       "name": "SchemaType6",
       "originalName": "schemaType6",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -29680,6 +29786,7 @@ Object {
       "name": "SchemaType7",
       "originalName": "schemaType7",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -29812,6 +29919,7 @@ Object {
       "name": "SchemaType8",
       "originalName": "schemaType8",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -29944,6 +30052,7 @@ Object {
       "name": "SchemaType9",
       "originalName": "schemaType9",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -30064,6 +30173,7 @@ Object {
       "name": "Span",
       "originalName": "span",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -30220,6 +30330,7 @@ Object {
           },
         },
       ],
+      "deprecationReason": "Entire \`Document actions\` document type deprecated",
       "fieldName": "DocumentActionsTest",
       "type": "DocumentActionsTest",
     },
@@ -30426,6 +30537,7 @@ Object {
           "type": "DocumentActionsTestFilter",
         },
       ],
+      "deprecationReason": "Entire \`Document actions\` document type deprecated",
       "fieldName": "allDocumentActionsTest",
       "filter": "_type == \\"documentActionsTest\\"",
       "type": Object {
@@ -30692,6 +30804,7 @@ Object {
       "name": "Author",
       "originalName": "author",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -30837,6 +30950,7 @@ Object {
       "name": "Block",
       "originalName": "block",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -30904,6 +31018,7 @@ Object {
       "name": "CdrPersonReference",
       "originalName": "cdrPersonReference",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -31012,6 +31127,7 @@ Object {
       "name": "Code",
       "originalName": "code",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -31110,6 +31226,7 @@ Object {
       "name": "Color",
       "originalName": "color",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -31224,6 +31341,7 @@ Object {
       "name": "CrossDatasetReference",
       "originalName": "crossDatasetReference",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -31379,41 +31497,147 @@ Object {
       "description": undefined,
       "fields": Array [
         Object {
+          "deprecationReason": "This object type has been deprecated",
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "deprecationReason": "This object type has been deprecated",
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "deprecationReason": "This object type has been deprecated",
+          "description": undefined,
+          "fieldName": "description",
+          "type": "String",
+        },
+        Object {
+          "deprecationReason": "This object type has been deprecated",
+          "description": undefined,
+          "fieldName": "excerpt",
+          "type": "String",
+        },
+        Object {
+          "deprecationReason": "This object type has been deprecated",
+          "description": undefined,
+          "fieldName": "name",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "DeprecatedObject",
+      "originalName": "deprecatedObject",
+      "type": "Object",
+      Symbol(internal): Object {
+        "deprecationReason": "This object type has been deprecated",
+      },
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "description",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "excerpt",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "name",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "DeprecatedObjectFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "description",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "excerpt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "name",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "DeprecatedObjectSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Date the document was created",
           "fieldName": "_createdAt",
           "isNullable": true,
           "type": "Datetime",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Document ID",
           "fieldName": "_id",
           "isNullable": true,
           "type": "ID",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": undefined,
           "fieldName": "_key",
           "type": "String",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Current document revision",
           "fieldName": "_rev",
           "isNullable": true,
           "type": "String",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Document type",
           "fieldName": "_type",
           "isNullable": true,
           "type": "String",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Date the document was last modified",
           "fieldName": "_updatedAt",
           "isNullable": true,
           "type": "Datetime",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": undefined,
           "fieldName": "title",
           "type": "String",
@@ -31426,6 +31650,9 @@ Object {
       "name": "DocumentActionsTest",
       "originalName": "documentActionsTest",
       "type": "Object",
+      Symbol(internal): Object {
+        "deprecationReason": "Entire \`Document actions\` document type deprecated",
+      },
     },
     Object {
       "fields": Array [
@@ -31636,6 +31863,7 @@ Object {
       "name": "DocumentWithCdrField",
       "originalName": "documentWithCdrField",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -31750,6 +31978,7 @@ Object {
       "name": "File",
       "originalName": "file",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -31861,6 +32090,7 @@ Object {
       "name": "Geopoint",
       "originalName": "geopoint",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -31957,6 +32187,7 @@ Object {
       "name": "HslaColor",
       "originalName": "hslaColor",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -32062,6 +32293,7 @@ Object {
       "name": "HsvaColor",
       "originalName": "hsvaColor",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -32201,6 +32433,7 @@ Object {
       "name": "Image",
       "originalName": "image",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -32321,6 +32554,7 @@ Object {
       "name": "MuxVideo",
       "originalName": "mux.video",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -32365,6 +32599,7 @@ Object {
       "name": "MuxVideoAsset",
       "originalName": "mux.videoAsset",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -32624,6 +32859,7 @@ Object {
       "name": "ObjectWithNestedArray",
       "originalName": "objectWithNestedArray",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -32783,6 +33019,7 @@ Object {
       "name": "PertEstimate",
       "originalName": "pertEstimate",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -32897,6 +33134,17 @@ Object {
           "kind": "List",
         },
         Object {
+          "deprecationReason": "This object type has been deprecated",
+          "fieldName": "someObject",
+          "type": "DeprecatedObject",
+        },
+        Object {
+          "deprecationReason": "This string type has been deprecated",
+          "description": undefined,
+          "fieldName": "someString",
+          "type": "String",
+        },
+        Object {
           "description": undefined,
           "fieldName": "title",
           "type": "String",
@@ -32909,6 +33157,7 @@ Object {
       "name": "Poppers",
       "originalName": "poppers",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -32948,6 +33197,16 @@ Object {
           "type": "DatetimeFilter",
         },
         Object {
+          "fieldName": "someObject",
+          "isReference": undefined,
+          "type": "DeprecatedObjectFilter",
+        },
+        Object {
+          "fieldName": "someString",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
           "fieldName": "title",
           "isReference": undefined,
           "type": "StringFilter",
@@ -32980,6 +33239,14 @@ Object {
         },
         Object {
           "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "someObject",
+          "type": "DeprecatedObjectSorting",
+        },
+        Object {
+          "fieldName": "someString",
           "type": "SortOrder",
         },
         Object {
@@ -33028,6 +33295,7 @@ Object {
       "name": "RgbaColor",
       "originalName": "rgbaColor",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -33114,6 +33382,7 @@ Object {
           "type": "String",
         },
         Object {
+          "deprecationReason": "This field is no longer used",
           "description": "A canonical name for the source this asset is originating from",
           "fieldName": "name",
           "type": "String",
@@ -33128,6 +33397,7 @@ Object {
       "name": "SanityAssetSourceData",
       "originalName": "sanity.assetSourceData",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -33296,6 +33566,7 @@ Object {
       "name": "SanityFileAsset",
       "originalName": "sanity.fileAsset",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -33604,6 +33875,7 @@ Object {
       "name": "SanityImageAsset",
       "originalName": "sanity.imageAsset",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -33849,6 +34121,7 @@ Object {
       "name": "SanityImageCrop",
       "originalName": "sanity.imageCrop",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -33949,6 +34222,7 @@ Object {
       "name": "SanityImageDimensions",
       "originalName": "sanity.imageDimensions",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -34045,6 +34319,7 @@ Object {
       "name": "SanityImageHotspot",
       "originalName": "sanity.imageHotspot",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -34162,6 +34437,7 @@ Object {
       "name": "SanityImageMetadata",
       "originalName": "sanity.imageMetadata",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -34302,6 +34578,7 @@ Object {
       "name": "SanityImagePalette",
       "originalName": "sanity.imagePalette",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -34434,6 +34711,7 @@ Object {
       "name": "SanityImagePaletteSwatch",
       "originalName": "sanity.imagePaletteSwatch",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -34541,6 +34819,7 @@ Object {
       "name": "Slug",
       "originalName": "slug",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -34629,6 +34908,7 @@ Object {
       "name": "Span",
       "originalName": "span",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -34785,6 +35065,7 @@ Object {
           },
         },
       ],
+      "deprecationReason": "Entire \`Document actions\` document type deprecated",
       "fieldName": "DocumentActionsTest",
       "type": "DocumentActionsTest",
     },
@@ -34991,6 +35272,7 @@ Object {
           "type": "DocumentActionsTestFilter",
         },
       ],
+      "deprecationReason": "Entire \`Document actions\` document type deprecated",
       "fieldName": "allDocumentActionsTest",
       "filter": "_type == \\"documentActionsTest\\"",
       "type": Object {
@@ -35257,6 +35539,7 @@ Object {
       "name": "Author",
       "originalName": "author",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -35402,6 +35685,7 @@ Object {
       "name": "Block",
       "originalName": "block",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -35469,6 +35753,7 @@ Object {
       "name": "CdrPersonReference",
       "originalName": "cdrPersonReference",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -35577,6 +35862,7 @@ Object {
       "name": "Code",
       "originalName": "code",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -35675,6 +35961,7 @@ Object {
       "name": "Color",
       "originalName": "color",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -35789,6 +36076,7 @@ Object {
       "name": "CrossDatasetReference",
       "originalName": "crossDatasetReference",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -35944,41 +36232,147 @@ Object {
       "description": undefined,
       "fields": Array [
         Object {
+          "deprecationReason": "This object type has been deprecated",
+          "description": undefined,
+          "fieldName": "_key",
+          "type": "String",
+        },
+        Object {
+          "deprecationReason": "This object type has been deprecated",
+          "description": undefined,
+          "fieldName": "_type",
+          "type": "String",
+        },
+        Object {
+          "deprecationReason": "This object type has been deprecated",
+          "description": undefined,
+          "fieldName": "description",
+          "type": "String",
+        },
+        Object {
+          "deprecationReason": "This object type has been deprecated",
+          "description": undefined,
+          "fieldName": "excerpt",
+          "type": "String",
+        },
+        Object {
+          "deprecationReason": "This object type has been deprecated",
+          "description": undefined,
+          "fieldName": "name",
+          "type": "String",
+        },
+      ],
+      "kind": "Type",
+      "name": "DeprecatedObject",
+      "originalName": "deprecatedObject",
+      "type": "Object",
+      Symbol(internal): Object {
+        "deprecationReason": "This object type has been deprecated",
+      },
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "_type",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "description",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "excerpt",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
+          "fieldName": "name",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "DeprecatedObjectFilter",
+    },
+    Object {
+      "fields": Array [
+        Object {
+          "fieldName": "_key",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "_type",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "description",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "excerpt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "name",
+          "type": "SortOrder",
+        },
+      ],
+      "kind": "InputObject",
+      "name": "DeprecatedObjectSorting",
+    },
+    Object {
+      "description": undefined,
+      "fields": Array [
+        Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Date the document was created",
           "fieldName": "_createdAt",
           "isNullable": true,
           "type": "Datetime",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Document ID",
           "fieldName": "_id",
           "isNullable": true,
           "type": "ID",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": undefined,
           "fieldName": "_key",
           "type": "String",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Current document revision",
           "fieldName": "_rev",
           "isNullable": true,
           "type": "String",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Document type",
           "fieldName": "_type",
           "isNullable": true,
           "type": "String",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Date the document was last modified",
           "fieldName": "_updatedAt",
           "isNullable": true,
           "type": "Datetime",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": undefined,
           "fieldName": "title",
           "type": "String",
@@ -35991,6 +36385,9 @@ Object {
       "name": "DocumentActionsTest",
       "originalName": "documentActionsTest",
       "type": "Object",
+      Symbol(internal): Object {
+        "deprecationReason": "Entire \`Document actions\` document type deprecated",
+      },
     },
     Object {
       "fields": Array [
@@ -36201,6 +36598,7 @@ Object {
       "name": "DocumentWithCdrField",
       "originalName": "documentWithCdrField",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -36315,6 +36713,7 @@ Object {
       "name": "File",
       "originalName": "file",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -36426,6 +36825,7 @@ Object {
       "name": "Geopoint",
       "originalName": "geopoint",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -36522,6 +36922,7 @@ Object {
       "name": "HslaColor",
       "originalName": "hslaColor",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -36627,6 +37028,7 @@ Object {
       "name": "HsvaColor",
       "originalName": "hsvaColor",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -36766,6 +37168,7 @@ Object {
       "name": "Image",
       "originalName": "image",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -36886,6 +37289,7 @@ Object {
       "name": "MuxVideo",
       "originalName": "mux.video",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "description": undefined,
@@ -36930,6 +37334,7 @@ Object {
       "name": "MuxVideoAsset",
       "originalName": "mux.videoAsset",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -37189,6 +37594,7 @@ Object {
       "name": "ObjectWithNestedArray",
       "originalName": "objectWithNestedArray",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -37348,6 +37754,7 @@ Object {
       "name": "PertEstimate",
       "originalName": "pertEstimate",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -37462,6 +37869,17 @@ Object {
           "kind": "List",
         },
         Object {
+          "deprecationReason": "This object type has been deprecated",
+          "fieldName": "someObject",
+          "type": "DeprecatedObject",
+        },
+        Object {
+          "deprecationReason": "This string type has been deprecated",
+          "description": undefined,
+          "fieldName": "someString",
+          "type": "String",
+        },
+        Object {
           "description": undefined,
           "fieldName": "title",
           "type": "String",
@@ -37474,6 +37892,7 @@ Object {
       "name": "Poppers",
       "originalName": "poppers",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -37513,6 +37932,16 @@ Object {
           "type": "DatetimeFilter",
         },
         Object {
+          "fieldName": "someObject",
+          "isReference": undefined,
+          "type": "DeprecatedObjectFilter",
+        },
+        Object {
+          "fieldName": "someString",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
+        Object {
           "fieldName": "title",
           "isReference": undefined,
           "type": "StringFilter",
@@ -37545,6 +37974,14 @@ Object {
         },
         Object {
           "fieldName": "_updatedAt",
+          "type": "SortOrder",
+        },
+        Object {
+          "fieldName": "someObject",
+          "type": "DeprecatedObjectSorting",
+        },
+        Object {
+          "fieldName": "someString",
           "type": "SortOrder",
         },
         Object {
@@ -37593,6 +38030,7 @@ Object {
       "name": "RgbaColor",
       "originalName": "rgbaColor",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -37679,6 +38117,7 @@ Object {
           "type": "String",
         },
         Object {
+          "deprecationReason": "This field is no longer used",
           "description": "A canonical name for the source this asset is originating from",
           "fieldName": "name",
           "type": "String",
@@ -37693,6 +38132,7 @@ Object {
       "name": "SanityAssetSourceData",
       "originalName": "sanity.assetSourceData",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -37861,6 +38301,7 @@ Object {
       "name": "SanityFileAsset",
       "originalName": "sanity.fileAsset",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -38169,6 +38610,7 @@ Object {
       "name": "SanityImageAsset",
       "originalName": "sanity.imageAsset",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -38414,6 +38856,7 @@ Object {
       "name": "SanityImageCrop",
       "originalName": "sanity.imageCrop",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -38514,6 +38957,7 @@ Object {
       "name": "SanityImageDimensions",
       "originalName": "sanity.imageDimensions",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -38610,6 +39054,7 @@ Object {
       "name": "SanityImageHotspot",
       "originalName": "sanity.imageHotspot",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -38727,6 +39172,7 @@ Object {
       "name": "SanityImageMetadata",
       "originalName": "sanity.imageMetadata",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -38867,6 +39313,7 @@ Object {
       "name": "SanityImagePalette",
       "originalName": "sanity.imagePalette",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -38999,6 +39446,7 @@ Object {
       "name": "SanityImagePaletteSwatch",
       "originalName": "sanity.imagePaletteSwatch",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -39106,6 +39554,7 @@ Object {
       "name": "Slug",
       "originalName": "slug",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [
@@ -39194,6 +39643,7 @@ Object {
       "name": "Span",
       "originalName": "span",
       "type": "Object",
+      Symbol(internal): Object {},
     },
     Object {
       "fields": Array [

--- a/packages/sanity/test/cli/graphql/__snapshots__/gen3.test.ts.snap
+++ b/packages/sanity/test/cli/graphql/__snapshots__/gen3.test.ts.snap
@@ -1372,12 +1372,14 @@ Object {
       "description": undefined,
       "fields": Array [
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Date the document was created",
           "fieldName": "_createdAt",
           "isNullable": true,
           "type": "Datetime",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Document ID",
           "fieldName": "_id",
           "isNullable": true,
@@ -1390,18 +1392,21 @@ Object {
           "type": "String",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Current document revision",
           "fieldName": "_rev",
           "isNullable": true,
           "type": "String",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Document type",
           "fieldName": "_type",
           "isNullable": true,
           "type": "String",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Date the document was last modified",
           "fieldName": "_updatedAt",
           "isNullable": true,
@@ -6102,12 +6107,14 @@ Object {
       "description": undefined,
       "fields": Array [
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Date the document was created",
           "fieldName": "_createdAt",
           "isNullable": true,
           "type": "Datetime",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Document ID",
           "fieldName": "_id",
           "isNullable": true,
@@ -6120,18 +6127,21 @@ Object {
           "type": "String",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Current document revision",
           "fieldName": "_rev",
           "isNullable": true,
           "type": "String",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Document type",
           "fieldName": "_type",
           "isNullable": true,
           "type": "String",
         },
         Object {
+          "deprecationReason": "Entire \`Document actions\` document type deprecated",
           "description": "Date the document was last modified",
           "fieldName": "_updatedAt",
           "isNullable": true,

--- a/packages/sanity/test/cli/graphql/fixtures/test-studio.ts
+++ b/packages/sanity/test/cli/graphql/fixtures/test-studio.ts
@@ -12,6 +12,9 @@ export default Schema.compile({
           title: 'Source name',
           description: 'A canonical name for the source this asset is originating from',
           type: 'string',
+          deprecated: {
+            reason: 'This field is no longer used',
+          },
         },
         {
           name: 'id',
@@ -570,6 +573,9 @@ export default Schema.compile({
       name: 'documentActionsTest',
       title: 'Document actions',
       fields: [{type: 'string', name: 'title', title: 'Title'}],
+      deprecated: {
+        reason: 'Entire `Document actions` document type deprecated',
+      },
     },
     {
       type: 'document',
@@ -577,6 +583,8 @@ export default Schema.compile({
       title: 'Poppers',
       fields: [
         {type: 'string', name: 'title', title: 'Title'},
+        {type: 'deprecatedString', name: 'someString', title: 'Some String'},
+        {type: 'deprecatedObject', name: 'someObject', title: 'Some Object'},
         {type: 'array', name: 'primitives', title: 'Primitives', of: [{type: 'string'}]},
       ],
     },
@@ -690,6 +698,42 @@ export default Schema.compile({
         {
           name: 'cdrFieldNamed',
           type: 'cdrPersonReference',
+        },
+      ],
+    },
+    {
+      title: 'Deprecated String',
+      name: 'deprecatedString',
+      type: 'string',
+      deprecated: {
+        reason: 'This string type has been deprecated',
+      },
+    },
+    {
+      title: 'Deprecated Object',
+      name: 'deprecatedObject',
+      type: 'object',
+      deprecated: {
+        reason: 'This object type has been deprecated',
+      },
+      fields: [
+        {
+          title: 'Name',
+          name: 'name',
+          type: 'string',
+        },
+        {
+          title: 'Description',
+          name: 'description',
+          type: 'string',
+          deprecated: {
+            reason: 'This field is no longer used',
+          },
+        },
+        {
+          title: 'Excerpt',
+          name: 'excerpt',
+          type: 'deprecatedString',
         },
       ],
     },

--- a/test/e2e/tests/desk/deprecatedDocument.spec.ts
+++ b/test/e2e/tests/desk/deprecatedDocument.spec.ts
@@ -1,0 +1,12 @@
+import {test} from '@sanity/test'
+import {expect} from '@playwright/test'
+
+test(`deprecated document type shows deprecated message`, async ({page, createDraftDocument}) => {
+  await createDraftDocument('/test/content/input-debug;deprecatedDocument')
+
+  await page.waitForSelector(`data-testid=deprecated-document-type-banner`)
+
+  const deprecatedBadge = await page.getByTestId(`deprecated-document-type-banner`)
+
+  expect(deprecatedBadge).toBeVisible()
+})

--- a/test/e2e/tests/desk/deprecatedFields.spec.ts
+++ b/test/e2e/tests/desk/deprecatedFields.spec.ts
@@ -21,7 +21,7 @@ const allTypes = [
 ]
 
 for (const type of allTypes) {
-  test(`${type} type shows deprecated message`, async ({page, baseURL, createDraftDocument}) => {
+  test(`${type} type shows deprecated message`, async ({page, createDraftDocument}) => {
     await createDraftDocument('/test/content/input-debug;deprecatedFields')
 
     await page.waitForSelector(`data-testid=deprecated-badge-${type}`)

--- a/test/e2e/tests/desk/deprecatedFields.spec.ts
+++ b/test/e2e/tests/desk/deprecatedFields.spec.ts
@@ -18,6 +18,8 @@ const allTypes = [
   'slug',
   'text',
   'geopoint',
+  'namedDeprecatedObject',
+  'namedDeprecatedArray',
 ]
 
 for (const type of allTypes) {

--- a/test/e2e/tests/desk/deprecatedFields.spec.ts
+++ b/test/e2e/tests/desk/deprecatedFields.spec.ts
@@ -1,0 +1,35 @@
+import {expect} from '@playwright/test'
+import {test} from '@sanity/test'
+
+const allTypes = [
+  'string',
+  'number',
+  'boolean',
+  'email',
+  'array',
+  'object',
+  'reference',
+  'crossDatasetReference',
+  'image',
+  'file',
+  'date',
+  'datetime',
+  'url',
+  'slug',
+  'text',
+  'geopoint',
+]
+
+for (const type of allTypes) {
+  test(`${type} type shows deprecated message`, async ({page, baseURL, createDraftDocument}) => {
+    await createDraftDocument('/test/content/input-debug;deprecatedFields')
+
+    await page.waitForSelector(`data-testid=deprecated-badge-${type}`)
+
+    const deprecatedBadge = await page.getByTestId(`deprecated-badge-${type}`)
+    const deprecatedMessage = await page.getByTestId(`deprecated-message-${type}`)
+
+    expect(deprecatedBadge).toHaveText('deprecated')
+    expect(deprecatedMessage).toBeVisible()
+  })
+}


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR adds ability to deprecate documents and fields. 

#### Example to deprecate a document 
```tsx
defineType({
  name: 'deprecatedDocument',
  title: 'Deprecated Document',
  type: 'document',
  deprecated: {
    reason: 'This document type is deprecated, use the author document',
  },
})
```
![Screenshot 2024-01-11 at 10 58 32 AM](https://github.com/sanity-io/sanity/assets/6476108/a76cd1f3-43f8-4805-8d6b-850690205842)

#### Example to deprecate a field
```tsx
defineField({
  deprecated: {
    reason:
      'Use the non deprecated string field for new content, this field was originally for the old frontend',
  },
  description: 'This field is used to create the header for the site',
  validation: (Rule) => Rule.required(),
  name: 'string',
  title: 'string',
  type: 'string',
}),
```
![Screenshot 2024-01-09 at 2 00 44 PM](https://github.com/sanity-io/sanity/assets/6476108/6845a35c-38aa-4c37-8f34-6e06ebf0fa85)

The deprecation messages also gets carried over to the graphql schema

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

[Test](https://test-studio-git-feat-type-deprecation.sanity.build/test/structure/input-debug;deprecatedFields) for deprecated fields 
[Test](https://test-studio-git-feat-type-deprecation.sanity.build/test/structure/input-debug;deprecatedDocument) for deprecated document

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

- Adds support for deprecating fields and document types
