### PR TITLE
fix(core): include cookieless auth token in logout request if it exists

### DIFF
--- a/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
@@ -239,6 +239,7 @@ export function _createAuthStore({
       dataset,
       useCdn: true,
       withCredentials: true,
+      token: getToken(projectId) ?? undefined,
       apiVersion: '2021-06-07',
       requestTagPrefix: 'sanity.studio',
       ...hostOptions,


### PR DESCRIPTION
### Description

The `AuthStore.logout` method doesn't currently pass the token to the `logout` API if cookieless auth is used. Therefore, the token is only invalidated if cookie-based auth is used.

This change adds any cookieless token present for the project to the `Authorization` header of the `logout` request, so the token is invalidated both for cookie-based and cookieless auth.

### What to review

Signing out of the Studio should invalidate the token, regardless of whether cookie-based or cookieless auth is used.