### PR TITLE
fix(test): use `"runtime": "automatic"` for `"@babel/preset-react"`

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -13,7 +13,7 @@
       }
     ],
     "@babel/preset-typescript",
-    "@babel/preset-react"
+    ["@babel/preset-react", {"runtime": "automatic"}]
   ],
   "plugins": ["@babel/plugin-proposal-class-properties"]
 }


### PR DESCRIPTION
### Description

This PR allows us to use JSX without importing react. Seems like the last thing not to support this was just our jest tests which uses babel to compile on the fly.

Later we should open a PR that removes all unused react imports as well but that can come at a later time.

### What to review

- Everything still work? Does this have any effect on the build system?

### Notes for release

N/A