### PR TITLE
fix(core): `token` login method session restoration

### DIFF
--- a/packages/sanity/src/core/config/auth/types.ts
+++ b/packages/sanity/src/core/config/auth/types.ts
@@ -1,4 +1,18 @@
 /**
+ * Login methods that may be used for Studio authentication.
+ *
+ * @public
+ */
+export type LoginMethod = 'dual' | 'cookie' | 'token'
+
+/**
+ * Login methods that acknowledge cookieless authentication tokens.
+ *
+ * @public
+ */
+export type CookielessCompatibleLoginMethod = Extract<LoginMethod, 'dual' | 'token'>
+
+/**
  * Authentication options
  *
  * @public
@@ -12,7 +26,7 @@ export interface AuthConfig {
    *   to cookies being treated as third-party cookies in some browsers, thus the default is `dual`.
    * - `token` - explicitly disable cookies, relying only on `localStorage` method
    */
-  loginMethod?: 'dual' | 'cookie' | 'token'
+  loginMethod?: LoginMethod
 
   /**
    * Whether to append the providers specified in `providers` with the default providers from the

--- a/packages/sanity/src/core/config/auth/types.ts
+++ b/packages/sanity/src/core/config/auth/types.ts
@@ -5,7 +5,7 @@
  */
 export interface AuthConfig {
   /**
-   * Login method to use for the studio the studio. Can be one of:
+   * Login method to use for the studio. Can be one of:
    * - `dual` (default) - attempt to use cookies where possible, falling back to
    *   storing authentication token in `localStorage` otherwise
    * - `cookie` - explicitly disable `localStorage` method, relying only on cookies. May fail due

--- a/packages/sanity/src/core/config/auth/types.ts
+++ b/packages/sanity/src/core/config/auth/types.ts
@@ -8,7 +8,8 @@ export type LoginMethod = 'dual' | 'cookie' | 'token'
 /**
  * Login methods that acknowledge cookieless authentication tokens.
  *
- * @public
+ * @internal
+ * @hidden
  */
 export type CookielessCompatibleLoginMethod = Extract<LoginMethod, 'dual' | 'token'>
 

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -823,4 +823,9 @@ export interface PreparedConfig {
   workspaces: WorkspaceSummary[]
 }
 
-export type {AuthConfig, AuthProvider} from './auth/types'
+export type {
+  AuthConfig,
+  AuthProvider,
+  LoginMethod,
+  CookielessCompatibleLoginMethod,
+} from './auth/types'

--- a/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
@@ -13,7 +13,6 @@ import {createBroadcastChannel} from './createBroadcastChannel'
 import {getSessionId} from './sessionId'
 import * as storage from './storage'
 import {createLoginComponent} from './createLoginComponent'
-import {isRecord} from '../../../util'
 import {isCookielessCompatibleLoginMethod} from './utils/asserters'
 
 /** @internal */
@@ -285,20 +284,3 @@ function hash(value: unknown): string {
  * @internal
  */
 export const createAuthStore = memoize(_createAuthStore, hash)
-
-/**
- * Duck-type check for whether or not this looks like an auth store
- *
- * @param maybeStore - Item to check if matches the AuthStore interface
- * @returns True if auth store, false otherwise
- * @internal
- */
-export function isAuthStore(maybeStore: unknown): maybeStore is AuthStore {
-  return (
-    isRecord(maybeStore) &&
-    'state' in maybeStore &&
-    isRecord(maybeStore.state) &&
-    'subscribe' in maybeStore.state &&
-    typeof maybeStore.state.subscribe === 'function'
-  )
-}

--- a/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
@@ -14,6 +14,7 @@ import {getSessionId} from './sessionId'
 import * as storage from './storage'
 import {createLoginComponent} from './createLoginComponent'
 import {isRecord} from '../../../util'
+import {isCookielessCompatibleLoginMethod} from './utils/asserters'
 
 /** @internal */
 export interface AuthStoreOptions extends AuthConfig {
@@ -135,7 +136,9 @@ export function _createAuthStore({
   // // emitting `state$` until the session ID has been converted to a token
   // const firstMessage = messages.pipe(first())
 
-  const token$ = messages.pipe(startWith(loginMethod === 'dual' ? getToken(projectId) : null))
+  const token$ = messages.pipe(
+    startWith(isCookielessCompatibleLoginMethod(loginMethod) ? getToken(projectId) : null),
+  )
 
   // Allow configuration of `apiHost` through source configuration
   const hostOptions: {apiHost?: string} = {}

--- a/packages/sanity/src/core/store/_legacy/authStore/index.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/index.ts
@@ -1,3 +1,4 @@
+export * from './utils/asserters'
 export * from './types'
 export * from './createAuthStore'
 export * from './createMockAuthStore'

--- a/packages/sanity/src/core/store/_legacy/authStore/utils/asserters.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/utils/asserters.ts
@@ -1,0 +1,14 @@
+import type {LoginMethod, CookielessCompatibleLoginMethod} from '../../../../config'
+
+/**
+ * Check whether the provided login method is compatible with cookieless auth, e.g. whether any
+ * authentication token found in localStorage should be acknowledged.
+ *
+ * @internal
+ */
+export function isCookielessCompatibleLoginMethod(
+  loginMethod: LoginMethod,
+): loginMethod is CookielessCompatibleLoginMethod {
+  const cookielessCompatibleLoginMethods = ['dual', 'token']
+  return cookielessCompatibleLoginMethods.includes(loginMethod as CookielessCompatibleLoginMethod)
+}

--- a/packages/sanity/src/core/store/_legacy/authStore/utils/asserters.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/utils/asserters.ts
@@ -1,4 +1,23 @@
+import type {AuthStore} from '../types'
 import type {LoginMethod, CookielessCompatibleLoginMethod} from '../../../../config'
+import {isRecord} from '../../../../util'
+
+/**
+ * Duck-type check for whether or not this looks like an auth store
+ *
+ * @param maybeStore - Item to check if matches the AuthStore interface
+ * @returns True if auth store, false otherwise
+ * @internal
+ */
+export function isAuthStore(maybeStore: unknown): maybeStore is AuthStore {
+  return (
+    isRecord(maybeStore) &&
+    'state' in maybeStore &&
+    isRecord(maybeStore.state) &&
+    'subscribe' in maybeStore.state &&
+    typeof maybeStore.state.subscribe === 'function'
+  )
+}
 
 /**
  * Check whether the provided login method is compatible with cookieless auth, e.g. whether any


### PR DESCRIPTION
### Description

When initialising `AuthStore`, Studio only attempts to read the cookieless auth token from localStorage if the login method is `dual`. If the login method is `token` (e.g. cookie-based auth is explicitly disabled), Studio **does not** attempt to read the cookieless auth token from localStorage. This means that the active session is not restored when Studio initialises (e.g. when reloading the host webpage after signing in).

[The fix is quite small](https://github.com/sanity-io/sanity/pull/5497/commits/5b3afd39d1acd10f026477c97757d8a0bcaaceb6). As part of this work, I've also taken care of a few small chores.

### What to review

Configure a Studio workspace to authenticate using the `token` method:

```ts
{
  auth: {
    loginMethod: 'token',
   },
}
```

Sign into the Studio, and then reload the webpage. The active session should be restored (prior to this fix, the user is shown the sign-in UI at this point).

Note that when using the test-studio inside the Sanity monorepo, this issue only occurs in production builds. You can test the production build using the `serve` npm package (`npm i -g serve`):

```
cd dev/test-studio
yarn sanity:build
serve -s -l 3333 dist
```

### Notes for release

Correctly restore the active session when the `token` login method is used.
