### PR TITLE
chore(i18n): fixed missing translations with document status pulse

### DIFF
--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -385,6 +385,10 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   /** The text for the "Open preview" action for a document */
   'production-preview.menu-item.title': 'Open preview',
 
+  /** Label for button when status is saved */
+  'status-bar.document-status-pulse.status.saved.text': 'Savedblarg',
+  /** Label for button when status is syncing */
+  'status-bar.document-status-pulse.status.syncing.text': 'Saving...blarg',
   /** Accessibility label indicating when the document was last published, in relative time, eg "3 weeks ago" */
   'status-bar.publish-status-button.last-published-time.aria-label':
     'Last published {{relativeTime}}',

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -386,9 +386,9 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'production-preview.menu-item.title': 'Open preview',
 
   /** Label for button when status is saved */
-  'status-bar.document-status-pulse.status.saved.text': 'Savedblarg',
+  'status-bar.document-status-pulse.status.saved.text': 'Saved',
   /** Label for button when status is syncing */
-  'status-bar.document-status-pulse.status.syncing.text': 'Saving...blarg',
+  'status-bar.document-status-pulse.status.syncing.text': 'Saving...',
   /** Accessibility label indicating when the document was last published, in relative time, eg "3 weeks ago" */
   'status-bar.publish-status-button.last-published-time.aria-label':
     'Last published {{relativeTime}}',

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusPulse/DocumentStatusPulse.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusPulse/DocumentStatusPulse.tsx
@@ -1,26 +1,28 @@
 import {ButtonTone, Flex, Text} from '@sanity/ui'
 import React from 'react'
 import {AnimatedStatusIcon} from './AnimatedStatusIcon'
-import {TextWithTone} from 'sanity'
+import {structureLocaleNamespace} from '../../../../i18n'
+import {TextWithTone, useTranslation} from 'sanity'
 
 type StatusType = 'saved' | 'syncing'
 interface ReviewChangesButtonProps {
   status?: StatusType
 }
 
-const STATUS_DICTIONARY: Record<StatusType, {text: string; tone: ButtonTone}> = {
+const STATUS_DICTIONARY: Record<StatusType, {i18nKey: string; tone: ButtonTone}> = {
   saved: {
-    text: 'Saved',
+    i18nKey: 'status-bar.document-status-pulse.status.saved.text',
     tone: 'positive',
   },
   syncing: {
-    text: 'Saving...',
+    i18nKey: 'status-bar.document-status-pulse.status.syncing.text',
     tone: 'default',
   },
 }
 
 export const DocumentStatusPulse = (props: ReviewChangesButtonProps) => {
   const {status} = props
+  const {t} = useTranslation(structureLocaleNamespace)
 
   if (status !== 'saved' && status !== 'syncing') {
     return null
@@ -35,7 +37,7 @@ export const DocumentStatusPulse = (props: ReviewChangesButtonProps) => {
       </TextWithTone>
 
       <Text muted size={1}>
-        {currentStatus.text}
+        {t(currentStatus.i18nKey)}
       </Text>
     </Flex>
   )


### PR DESCRIPTION
### Description

Fixed two missing translations. 

