### PR TITLE
fix(cli): always treat arguments without options as strings

### DIFF
--- a/packages/@sanity/cli/src/util/parseArguments.ts
+++ b/packages/@sanity/cli/src/util/parseArguments.ts
@@ -51,7 +51,8 @@ export function parseArguments(argv = process.argv): ParsedArguments {
     ...extOptions
   } = minimist(argv.slice(2), {
     '--': true,
-    boolean: ['h', 'help', 'd', 'debug', 'v', 'version']
+    boolean: ['h', 'help', 'd', 'debug', 'v', 'version'],
+    string: ['_']
   })
 
   const [groupOrCommand, ...argsWithoutOptions] = _

--- a/packages/sanity/src/_internal/cli/commands/documents/getDocumentsCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/documents/getDocumentsCommand.ts
@@ -41,7 +41,7 @@ const getDocumentsCommand: CliCommandDefinition<GetDocumentFlags> = {
     try {
       const doc = await client.getDocument(docId)
       if (!doc) {
-        throw new Error('Document not found')
+        throw new Error(`Document ${docId} not found`)
       }
 
       output.print(pretty ? colorizeJson(doc, chalk) : JSON.stringify(doc, null, 2))


### PR DESCRIPTION
### Description

Fixes SDX-951

Fixes an issue where number-like string arguments were converted to numbers by the option parser, resulting in large document ids getting truncated. This forces all arguments without specific options to always be treated as strings.

### What to review

Would this have any unwanted side-effects for other commands?

### Notes for release

Fixes an issue where number-like string arguments were converted to numbers by the option parser
