### PR TITLE
fix(form/inputs): include focused text blocks in PT-members array

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/usePortableTextMembers.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/usePortableTextMembers.tsx
@@ -72,11 +72,14 @@ const reconcilePortableTextMembers = ({
       if (isObjectBlock) {
         result.push({kind: 'objectBlock', member, node: member.item})
       } else {
-        // Also include regular text blocks with validation, presence or changes.
+        // Also include regular text blocks with validation, presence, changes or that are focused by the user.
+        // This is a performance optimization to avoid accounting for blocks that
+        // doesn't need to be re-rendered (which usually is most of the blocks).
         if (
           member.item.validation.length > 0 ||
           member.item.changed ||
-          member.item.presence?.length
+          member.item.presence?.length ||
+          member.item.focusPath.length > 0
         ) {
           result.push({kind: 'textBlock', member, node: member.item})
         }


### PR DESCRIPTION
### Description

Regular text blocks must be included in the PT-member array when they are focused too, or they can't be focused by pointing the focusPath to them if none of the other requirements are met.

This will fix an issue where text blocks cannot be focused by setting the `focusPath` from the outside.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Visual editing can take you to a specific block when working on a published document.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release
Fix a bug where clicking to edit in the presentation mode didn't focus the relevant block in the Portable Text Editor.

<!--
A description of the change(s) that should be used in the release notes.
-->
