### PR TITLE
fix: ensure list array card focusRing isn't cropped

### DIFF
--- a/packages/sanity/src/core/form/components/withFocusRing/withFocusRing.ts
+++ b/packages/sanity/src/core/form/components/withFocusRing/withFocusRing.ts
@@ -7,9 +7,9 @@ import {getTheme_v2} from '@sanity/ui/theme'
 import {focusRingBorderStyle, focusRingStyle} from './helpers'
 
 export function withFocusRing<Props>(component: ComponentType<Props>) {
-  return styled(component)<Props & {$border?: boolean}>(
-    (props: {theme: Theme; $border?: boolean}) => {
-      const {$border} = props
+  return styled(component)<Props & {$border?: boolean; $radius?: number}>(
+    (props: {theme: Theme; $border?: boolean; $radius?: number}) => {
+      const {$border, $radius} = props
       const {card, color, radius} = getTheme_v2(props.theme)
 
       const border = {width: $border ? 1 : 0, color: 'var(--card-border-color)'}
@@ -17,7 +17,7 @@ export function withFocusRing<Props>(component: ComponentType<Props>) {
       return css`
         --card-focus-box-shadow: ${focusRingBorderStyle(border)};
 
-        border-radius: ${rem(radius[1])};
+        border-radius: ${rem(radius[$radius ?? 1])};
         outline: none;
         box-shadow: var(--card-focus-box-shadow);
 

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.tsx
@@ -185,10 +185,12 @@ export function ListArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
 
   const listGridGap = 1
   const paddingY = 1
+  const radius = 2
 
   return (
     <Stack space={2} ref={parentRef}>
       <UploadTargetCard
+        $radius={radius}
         types={schemaType.of}
         resolveUploader={resolveUploader}
         onUpload={onUpload}
@@ -205,10 +207,11 @@ export function ListArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
           ) : (
             <Card
               border
-              radius={2}
+              radius={radius}
               style={{
                 // This is not memoized since it changes on scroll so it will change anyways making memo useless
                 // Account for grid gap
+                boxSizing: 'border-box',
                 height: `${
                   virtualizer.getTotalSize() + items.length * space[listGridGap] + space[paddingY]
                 }px`,


### PR DESCRIPTION
### Description

This PR fixes a tiny visual issue where the focus ring in array items were appearing slightly cropped and weren't using the correct radius.

![image](https://github.com/sanity-io/sanity/assets/209129/bc9bcfad-8138-4abf-a589-b583e9cff31b)

### What to review

That the focus ring for array items appear in full.

### Notes for release

N/A