### PR TITLE
fix: use help icon for help + resources button

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/resources/ResourcesButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/ResourcesButton.tsx
@@ -1,4 +1,4 @@
-import {InfoOutlineIcon} from '@sanity/icons'
+import {HelpCircleIcon} from '@sanity/icons'
 import {Menu} from '@sanity/ui'
 import React from 'react'
 import styled from 'styled-components'
@@ -22,7 +22,7 @@ export function ResourcesButton() {
       button={
         <Button
           aria-label={t('help-resources.title')}
-          icon={InfoOutlineIcon}
+          icon={HelpCircleIcon}
           mode="bleed"
           tooltipProps={{content: t('help-resources.title')}}
         />


### PR DESCRIPTION
### Description

This PR updates the help + resources button to use the correct icon (`HelpCircleIcon`)

![image](https://github.com/sanity-io/sanity/assets/209129/3ee9fb0f-a24a-45f3-b0bc-ff52630bb70f)

### What to review

The icon for help + resources should look correct (and as it was prior to facelift)

### Notes for release

Fixes an issue where the help and resource button was using the incorrect icon