### PR TITLE
fix(deps): update dependency `@sanity/presentation` to `v1.6.0`

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -197,7 +197,7 @@
     "@sanity/logos": "^2.0.2",
     "@sanity/mutator": "3.24.1",
     "@sanity/portable-text-editor": "3.24.1",
-    "@sanity/presentation": "1.5.3",
+    "@sanity/presentation": "1.6.0",
     "@sanity/schema": "3.24.1",
     "@sanity/telemetry": "^0.7.5",
     "@sanity/types": "3.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3580,11 +3580,6 @@
     get-it "^8.4.4"
     rxjs "^7.0.0"
 
-"@sanity/color@3.0.0-beta.9":
-  version "3.0.0-beta.9"
-  resolved "https://registry.yarnpkg.com/@sanity/color/-/color-3.0.0-beta.9.tgz#e33a2138f71ca8cec2c264fb9ac44c680be50a9c"
-  integrity sha512-Mk7FRDtxz/U2SRlRM0BvUI62jU26W62aYsipaKFt/dk0rOyYa9yzfaojSM/QmW0E4W/nOw74RBA/HrapXUw+2Q==
-
 "@sanity/color@^2.2.5":
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/@sanity/color/-/color-2.2.5.tgz#6b28578573859495ed1ffd5491322cb8e90b3e07"
@@ -3754,14 +3749,13 @@
     uuid "^9.0.1"
     zod "^3.22.4"
 
-"@sanity/presentation@1.5.3":
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/@sanity/presentation/-/presentation-1.5.3.tgz#a144bec7911e326f61060fa5720e5302d4eff765"
-  integrity sha512-A9OiyyPXOkMk3grTtXN6YpyOJ5Gi5pFh8ZKzJ9FJNsZ/8Nv6TeMo0Uthy3s6+tyVUVaR4fQw+kIcS+MJl0kCWA==
+"@sanity/presentation@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@sanity/presentation/-/presentation-1.6.0.tgz#c31f0ba96897820d4c660a2f80a159b3cc9b077d"
+  integrity sha512-prFbEzSZ0t6MJKFPi27ZIqrN31z3A/nF2gMqFC7ewiiOf202XT6YnMlt3YkYgeElSD4sSOEh/UhkRvkTdyAO2A==
   dependencies:
     "@sanity/icons" "^2.8.0"
     "@sanity/preview-url-secret" "^1.5.2"
-    "@sanity/ui" "2.0.0-beta.17"
     "@types/lodash.isequal" "^4.5.8"
     fast-deep-equal "3.1.3"
     framer-motion "^10.18.0"
@@ -3853,18 +3847,6 @@
     pako "^2.1.0"
     segmented-property "^3.0.3"
     vite "^4.4.9"
-
-"@sanity/ui@2.0.0-beta.17":
-  version "2.0.0-beta.17"
-  resolved "https://registry.yarnpkg.com/@sanity/ui/-/ui-2.0.0-beta.17.tgz#fb912fe62c2aa4339e1d18c7e9d6a8b536356c34"
-  integrity sha512-AUFlObpuewVOKDGQutijJFn3rKtXS85Nl/MsySHwcH5rzCNojJ2/Z4DKLhl8LSXlj/+pOXVj++AFT/hhNtJ6Wg==
-  dependencies:
-    "@floating-ui/react-dom" "^2.0.4"
-    "@sanity/color" "3.0.0-beta.9"
-    "@sanity/icons" "^2.7.0"
-    csstype "^3.1.2"
-    framer-motion "^10.16.5"
-    react-refractor "^2.1.7"
 
 "@sanity/ui@^1", "@sanity/ui@^1.0.0", "@sanity/ui@^1.6.0", "@sanity/ui@^1.7.2":
   version "1.9.3"


### PR DESCRIPTION
### Notes for release

### Features

* enable new URL sharing menu ([83fe01f](https://github.com/sanity-io/visual-editing/commit/83fe01fbe4ee3128a49401e2882e04463b5b1540))


### Bug Fixes

* always use the same `@sanity/ui` version as `sanity` ([e61312d](https://github.com/sanity-io/visual-editing/commit/e61312d9a2d8ebcce8f0b06a62b0bcd5ca42522f))
* **presentation:** allow forward navigation ([#686](https://github.com/sanity-io/visual-editing/issues/686)) ([f9099e8](https://github.com/sanity-io/visual-editing/commit/f9099e88f5d3f4158fbe26737e0b1c6987df29f9))
* **presentation:** derive params from routerState to fix focus ([175efe0](https://github.com/sanity-io/visual-editing/commit/175efe0a3881c288c8ea30086e427a1de21c60cd))
* remove MetaBanner as it's now part of `sanity` ([c920188](https://github.com/sanity-io/visual-editing/commit/c920188859200770d31ff3e679e86563bcc4e52e))