### PR TITLE
fix(ui-components): add TooltipDelayGroupProvider to ui-components

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -286,6 +286,8 @@ const config = {
                   'TabProps',
                   'Tooltip',
                   'TooltipProps',
+                  'TooltipDelayGroupProvider',
+                  'TooltipDelayGroupProviderProps',
                 ],
                 message:
                   'Please use the (more opinionated) exported components in sanity/src/ui-components instead.',

--- a/packages/sanity/src/core/form/components/formField/FormFieldBaseHeader.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldBaseHeader.tsx
@@ -1,19 +1,12 @@
 import React, {useCallback, useEffect, useMemo, useState} from 'react'
 import styled, {css} from 'styled-components'
-import {
-  Box,
-  Card,
-  Flex,
-  TooltipDelayGroupProvider,
-  TooltipDelayGroupProviderProps,
-} from '@sanity/ui'
+import {Box, Card, Flex} from '@sanity/ui'
 import {FieldPresence, FormNodePresence} from '../../../presence'
 import {DocumentFieldActionNode} from '../../../config'
 import {calcAvatarStackWidth} from '../../../presence/utils'
 import {FieldActionMenu} from '../../field'
 import {FieldCommentsProps} from '../../types'
-
-const TOOLTIP_GROUP_DELAY: TooltipDelayGroupProviderProps['delay'] = {open: 500}
+import {TooltipDelayGroupProvider} from '../../../../ui-components'
 
 const Root = styled(Flex)<{
   $floatingCardWidth: number
@@ -256,7 +249,7 @@ export function FormFieldBaseHeader(props: FormFieldBaseHeaderProps) {
       {slotEl}
 
       {(hasCommentsButtonOrActions || hasComments) && (
-        <TooltipDelayGroupProvider delay={TOOLTIP_GROUP_DELAY}>
+        <TooltipDelayGroupProvider>
           <FieldActionsFloatingCard
             data-actions-visible={showFieldActions ? 'true' : 'false'}
             data-has-actions={hasActions ? 'true' : 'false'}

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -12,15 +12,9 @@ import {
   type RenderStyleFunction,
 } from '@sanity/portable-text-editor'
 import type {Path} from '@sanity/types'
-import {
-  BoundaryElementProvider,
-  TooltipDelayGroupProvider,
-  useBoundaryElement,
-  useGlobalKeyDown,
-  useLayer,
-} from '@sanity/ui'
+import {BoundaryElementProvider, useBoundaryElement, useGlobalKeyDown, useLayer} from '@sanity/ui'
 import React, {useCallback, useMemo, useRef} from 'react'
-import {TOOLTIP_DELAY_PROPS} from '../../../../ui-components'
+import {TooltipDelayGroupProvider} from '../../../../ui-components'
 import {useTranslation} from '../../../i18n'
 import {Toolbar} from './toolbar'
 import {Decorator} from './text'
@@ -170,7 +164,7 @@ export function Editor(props: EditorProps) {
   return (
     <Root $fullscreen={isFullscreen} data-testid="pt-editor">
       {isActive && (
-        <TooltipDelayGroupProvider delay={TOOLTIP_DELAY_PROPS}>
+        <TooltipDelayGroupProvider>
           <ToolbarCard data-testid="pt-editor__toolbar-card" shadow={1}>
             <Toolbar
               hotkeys={hotkeys}

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceField.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceField.tsx
@@ -8,16 +8,7 @@ import React, {
   useState,
 } from 'react'
 import type {Reference, ReferenceSchemaType} from '@sanity/types'
-import {
-  Box,
-  Card,
-  CardTone,
-  Flex,
-  Menu,
-  MenuDivider,
-  Stack,
-  TooltipDelayGroupProvider,
-} from '@sanity/ui'
+import {Box, Card, CardTone, Flex, Menu, MenuDivider, Stack} from '@sanity/ui'
 import {LaunchIcon as OpenInNewTabIcon, SyncIcon as ReplaceIcon, TrashIcon} from '@sanity/icons'
 import type {ObjectFieldProps, RenderPreviewCallback} from '../../types'
 import {FormField} from '../../components'
@@ -28,7 +19,7 @@ import {FieldActionsProvider, FieldActionsResolver} from '../../field'
 import {DocumentFieldActionNode} from '../../../config'
 import {usePublishedId} from '../../contexts/DocumentIdProvider'
 import {useTranslation} from '../../../i18n'
-import {MenuButton, MenuItem, TOOLTIP_DELAY_PROPS} from '../../../../ui-components'
+import {MenuButton, MenuItem, TooltipDelayGroupProvider} from '../../../../ui-components'
 import {ContextMenuButton} from '../../../components/contextMenuButton'
 import {useReferenceInput} from './useReferenceInput'
 import {useReferenceInfo} from './useReferenceInfo'
@@ -264,7 +255,7 @@ export function ReferenceField(props: ReferenceFieldProps) {
             <Card border radius={2} padding={1} tone={tone}>
               <Stack space={1}>
                 <Flex gap={1} align="center" style={{lineHeight: 0}}>
-                  <TooltipDelayGroupProvider delay={TOOLTIP_DELAY_PROPS}>
+                  <TooltipDelayGroupProvider>
                     <ReferenceLinkCard
                       __unstable_focusRing
                       as={EditReferenceLink}

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageActionsMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageActionsMenu.tsx
@@ -1,14 +1,8 @@
 import React, {MouseEventHandler, ReactNode, useCallback, useEffect, useState} from 'react'
 import {CropIcon} from '@sanity/icons'
-import {
-  Inline,
-  Menu,
-  TooltipDelayGroupProvider,
-  useClickOutside,
-  useGlobalKeyDown,
-} from '@sanity/ui'
+import {Inline, Menu, useClickOutside, useGlobalKeyDown} from '@sanity/ui'
 import styled from 'styled-components'
-import {Button, Popover, TOOLTIP_DELAY_PROPS} from '../../../../../ui-components'
+import {Button, Popover, TooltipDelayGroupProvider} from '../../../../../ui-components'
 import {useTranslation} from '../../../../i18n'
 import {ContextMenuButton} from '../../../../components/contextMenuButton'
 
@@ -90,7 +84,7 @@ export function ImageActionsMenu(props: ImageActionsMenuProps) {
 
   const {t} = useTranslation()
   return (
-    <TooltipDelayGroupProvider delay={TOOLTIP_DELAY_PROPS}>
+    <TooltipDelayGroupProvider>
       <MenuActionsWrapper data-buttons space={1} padding={2}>
         {showEdit && (
           <Button

--- a/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
@@ -7,7 +7,6 @@ import {
   LayerProvider,
   PortalProvider,
   useMediaIndex,
-  TooltipDelayGroupProvider,
   Box,
   Grid,
 } from '@sanity/ui'
@@ -15,7 +14,7 @@ import {useCallback, useState, useMemo, useEffect, useRef, useContext} from 'rea
 import styled from 'styled-components'
 import {isDev} from '../../../environment'
 import {useWorkspace} from '../../workspace'
-import {Button, TOOLTIP_DELAY_PROPS} from '../../../../ui-components'
+import {Button, TooltipDelayGroupProvider} from '../../../../ui-components'
 import {NavbarContext} from '../../StudioLayout'
 import {useToolMenuComponent} from '../../studio-components-hooks'
 import {useTranslation} from '../../../i18n'
@@ -159,7 +158,7 @@ export function StudioNavbar() {
         >
           <NavGrid gap={1}>
             {/** Left flex */}
-            <TooltipDelayGroupProvider delay={TOOLTIP_DELAY_PROPS}>
+            <TooltipDelayGroupProvider>
               <Flex align="center" gap={2} justify="flex-start">
                 <Flex align="center" gap={2}>
                   {/* Menu button */}
@@ -205,7 +204,7 @@ export function StudioNavbar() {
             </Flex>
 
             {/** Right flex */}
-            <TooltipDelayGroupProvider delay={TOOLTIP_DELAY_PROPS}>
+            <TooltipDelayGroupProvider>
               <Flex align="center" gap={1} justify="flex-end">
                 <Flex gap={1}>
                   {/* Search */}

--- a/packages/sanity/src/structure/comments/src/components/list/CommentsListItemContextMenu.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CommentsListItemContextMenu.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
 import {CheckmarkCircleIcon, UndoIcon, EditIcon, TrashIcon, LinkIcon} from '@sanity/icons'
-import {Card, Flex, Menu, MenuDivider, TooltipDelayGroupProvider} from '@sanity/ui'
+import {Card, Flex, Menu, MenuDivider} from '@sanity/ui'
 import styled from 'styled-components'
 import {
   Button,
   MenuButton,
   MenuButtonProps,
   MenuItem,
-  TOOLTIP_DELAY_PROPS,
+  TooltipDelayGroupProvider,
 } from '../../../../../ui-components'
 import {CommentStatus} from '../../types'
 import {ContextMenuButton} from 'sanity'
@@ -54,7 +54,7 @@ export function CommentsListItemContextMenu(props: CommentsListItemContextMenuPr
   const showMenuButton = Boolean(onCopyLink || onDeleteStart || onEditStart)
 
   return (
-    <TooltipDelayGroupProvider delay={TOOLTIP_DELAY_PROPS}>
+    <TooltipDelayGroupProvider>
       <Flex>
         <FloatingCard display="flex" shadow={2} padding={1} radius={2} sizing="border">
           {isParent && (

--- a/packages/sanity/src/structure/comments/src/components/pte/comment-input/CommentInputInner.tsx
+++ b/packages/sanity/src/structure/comments/src/components/pte/comment-input/CommentInputInner.tsx
@@ -1,10 +1,10 @@
 import React, {useCallback} from 'react'
-import {Flex, MenuDivider, Box, Card, Stack, TooltipDelayGroupProvider} from '@sanity/ui'
+import {Flex, MenuDivider, Box, Card, Stack} from '@sanity/ui'
 import styled, {css} from 'styled-components'
 import {CurrentUser} from '@sanity/types'
 import {MentionIcon, SendIcon} from '../../icons'
 import {CommentsAvatar} from '../../avatars/CommentsAvatar'
-import {Button, TOOLTIP_DELAY_PROPS} from '../../../../../../ui-components'
+import {Button, TooltipDelayGroupProvider} from '../../../../../../ui-components'
 import {useCommentInput} from './useCommentInput'
 import {Editable} from './Editable'
 import {useUser} from 'sanity'
@@ -119,7 +119,7 @@ export function CommentInputInner(props: CommentInputInnerProps) {
           </EditableWrap>
 
           <Flex align="center" data-ui="CommentInputActions" gap={1} justify="flex-end" padding={1}>
-            <TooltipDelayGroupProvider delay={TOOLTIP_DELAY_PROPS}>
+            <TooltipDelayGroupProvider>
               <Button
                 aria-label="Mention user"
                 data-testid="comment-mention-button"

--- a/packages/sanity/src/structure/components/paneItem/PaneItemPreview.tsx
+++ b/packages/sanity/src/structure/components/paneItem/PaneItemPreview.tsx
@@ -1,9 +1,9 @@
 import type {SanityDocument, SchemaType} from '@sanity/types'
 import React, {isValidElement} from 'react'
 import {isNumber, isString} from 'lodash'
-import {Flex, TooltipDelayGroupProvider} from '@sanity/ui'
+import {Flex} from '@sanity/ui'
 import {useMemoObservable} from 'react-rx'
-import {TOOLTIP_DELAY_PROPS} from '../../../ui-components'
+import {TooltipDelayGroupProvider} from '../../../ui-components'
 import type {PaneItemPreviewState} from './types'
 import {
   DocumentPresence,
@@ -51,7 +51,7 @@ export function PaneItemPreview(props: PaneItemPreviewProps) {
   )!
 
   const status = isLoading ? null : (
-    <TooltipDelayGroupProvider delay={TOOLTIP_DELAY_PROPS}>
+    <TooltipDelayGroupProvider>
       <Flex align="center" gap={3}>
         {presence && presence.length > 0 && <DocumentPreviewPresence presence={presence} />}
         <DocumentStatusIndicator draft={draft} published={published} />

--- a/packages/sanity/src/structure/panes/document/document-layout/DocumentLayout.tsx
+++ b/packages/sanity/src/structure/panes/document/document-layout/DocumentLayout.tsx
@@ -1,11 +1,4 @@
-import {
-  useElementRect,
-  DialogProvider,
-  Flex,
-  PortalProvider,
-  DialogProviderProps,
-  TooltipDelayGroupProvider,
-} from '@sanity/ui'
+import {useElementRect, DialogProvider, Flex, PortalProvider, DialogProviderProps} from '@sanity/ui'
 import {useState, useCallback, useMemo} from 'react'
 import {useTranslation} from 'react-i18next'
 import {Path} from 'sanity-diff-patch'
@@ -28,7 +21,7 @@ import {useDocumentPane} from '../useDocumentPane'
 import {DocumentPanelHeader} from '../documentPanel/header'
 import {DocumentInspectorMenuItemsResolver} from '../DocumentInspectorMenuItemsResolver'
 import {usePreviewUrl} from '../usePreviewUrl'
-import {TOOLTIP_DELAY_PROPS} from '../../../../ui-components'
+import {TooltipDelayGroupProvider} from '../../../../ui-components'
 import {getMenuItems} from '../menuItems'
 import {DocumentLayoutError} from './DocumentLayoutError'
 import {
@@ -221,7 +214,7 @@ export function DocumentLayout() {
           >
             <DialogProvider position={DIALOG_PROVIDER_POSITION} zOffset={zOffsets.portal}>
               <PaneFooter ref={setFooterElement}>
-                <TooltipDelayGroupProvider delay={TOOLTIP_DELAY_PROPS}>
+                <TooltipDelayGroupProvider>
                   <DocumentStatusBar actionsBoxRef={setActionsBoxElement} />
                 </TooltipDelayGroupProvider>
               </PaneFooter>

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
@@ -1,5 +1,5 @@
 import {ArrowLeftIcon, CloseIcon, SplitVerticalIcon} from '@sanity/icons'
-import {Flex, TooltipDelayGroupProvider} from '@sanity/ui'
+import {Flex} from '@sanity/ui'
 import React, {createElement, memo, forwardRef, useMemo} from 'react'
 import {
   PaneContextMenuButton,
@@ -13,7 +13,7 @@ import {useDocumentPane} from '../../useDocumentPane'
 import {isMenuNodeButton, isNotMenuNodeButton, resolveMenuNodes} from '../../../../menuNodes'
 import {useStructureTool} from '../../../../useStructureTool'
 import {PaneMenuItem} from '../../../../types'
-import {Button, TOOLTIP_DELAY_PROPS} from '../../../../../ui-components'
+import {Button, TooltipDelayGroupProvider} from '../../../../../ui-components'
 import {structureLocaleNamespace} from '../../../../i18n'
 import {DocumentHeaderTabs} from './DocumentHeaderTabs'
 import {DocumentHeaderTitle} from './DocumentHeaderTitle'
@@ -84,7 +84,7 @@ export const DocumentPanelHeader = memo(
     const {t} = useTranslation(structureLocaleNamespace)
 
     return (
-      <TooltipDelayGroupProvider delay={TOOLTIP_DELAY_PROPS}>
+      <TooltipDelayGroupProvider>
         <PaneHeader
           border
           ref={ref}

--- a/packages/sanity/src/structure/panes/documentList/DocumentListPaneHeader.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentListPaneHeader.tsx
@@ -1,9 +1,8 @@
 import {ArrowLeftIcon} from '@sanity/icons'
 import React, {memo, useMemo} from 'react'
-import {TooltipDelayGroupProvider} from '@sanity/ui'
 import type {PaneMenuItem, PaneMenuItemGroup, StructureToolPaneActionHandler} from '../../types'
 import {BackLink, PaneHeader, PaneHeaderActions, usePane} from '../../components'
-import {Button, TOOLTIP_DELAY_PROPS} from '../../../ui-components'
+import {Button, TooltipDelayGroupProvider} from '../../../ui-components'
 import {useStructureTool} from '../../useStructureTool'
 import type {SortOrder} from './types'
 import type {GeneralPreviewLayoutKey, InitialValueTemplateItem} from 'sanity'
@@ -47,7 +46,7 @@ export const DocumentListPaneHeader = memo(
     }, [setLayout, setSortOrder])
 
     return (
-      <TooltipDelayGroupProvider delay={TOOLTIP_DELAY_PROPS}>
+      <TooltipDelayGroupProvider>
         <PaneHeader
           actions={
             <PaneHeaderActions

--- a/packages/sanity/src/ui-components/index.ts
+++ b/packages/sanity/src/ui-components/index.ts
@@ -6,5 +6,6 @@ export * from './menuItem'
 export * from './popover'
 export * from './tab'
 export * from './tooltip'
+export * from './tooltipDelayGroupProvider'
 
 // @todo: consider an alternative pattern for non studio ui components, avoiding circular dependencies

--- a/packages/sanity/src/ui-components/tooltipDelayGroupProvider/TooltipDelayGroupProvider.tsx
+++ b/packages/sanity/src/ui-components/tooltipDelayGroupProvider/TooltipDelayGroupProvider.tsx
@@ -1,0 +1,22 @@
+/* eslint-disable no-restricted-imports */
+import {
+  TooltipDelayGroupProvider as UITooltipDelayGroupProvider,
+  TooltipDelayGroupProviderProps as UITooltipDelayGroupProviderProps,
+} from '@sanity/ui'
+import {TOOLTIP_DELAY_PROPS} from '../tooltip/constants'
+
+/** @internal */
+export type TooltipDelayGroupProviderProps = Omit<UITooltipDelayGroupProviderProps, 'delay'>
+
+/**
+ * Opinionated Sanity UI <TooltipDelayGroupProvider> which forces the same delay to all tooltips.
+ *
+ * @internal
+ */
+export const TooltipDelayGroupProvider = (props: TooltipDelayGroupProviderProps) => {
+  return (
+    <UITooltipDelayGroupProvider delay={TOOLTIP_DELAY_PROPS}>
+      {props.children}
+    </UITooltipDelayGroupProvider>
+  )
+}

--- a/packages/sanity/src/ui-components/tooltipDelayGroupProvider/index.ts
+++ b/packages/sanity/src/ui-components/tooltipDelayGroupProvider/index.ts
@@ -1,0 +1,1 @@
+export * from './TooltipDelayGroupProvider'


### PR DESCRIPTION
### Description

Adds internal `<TooltipDelayGroupProvider>` to ui-components, forcing delay consistency for all uses of tooltips and delay groups.
Refactors uses of `<TooltipDelayGroupProvider>` to consume from internal ui-components.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Tooltip delay groups still work as expected. 

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
Add a test script, if that makes sense.
-->

### Notes for release

Refactors uses of `<TooltipDelayGroupProvider>` to consume from internal ui-components.

<!--
A description of the change(s) that should be used in the release notes.
-->
