### PR TITLE
fix(cli): misc sanity documents validate fixes

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/validation/reporters/prettyReporter/__tests__/formatDocumentValidation.test.ts
+++ b/packages/sanity/src/_internal/cli/actions/validation/reporters/prettyReporter/__tests__/formatDocumentValidation.test.ts
@@ -2,11 +2,6 @@ import {formatDocumentValidation} from '../formatDocumentValidation'
 
 // disables some terminal specific things that are typically auto detected
 jest.mock('tty', () => ({isatty: () => false}))
-jest.mock('chalk', () => {
-  const chalk = jest.requireActual('chalk')
-  chalk.level = 0
-  return chalk
-})
 
 describe('formatDocumentValidation', () => {
   it('formats a set of markers in to a printed tree, sorting markers, and adding spacing', () => {

--- a/packages/sanity/src/_internal/cli/actions/validation/reporters/prettyReporter/formatDocumentValidation.ts
+++ b/packages/sanity/src/_internal/cli/actions/validation/reporters/prettyReporter/formatDocumentValidation.ts
@@ -15,9 +15,9 @@ interface ValidationTree {
 }
 
 const levelHeaders = {
-  error: isTty ? chalk.bold(chalk.bgRed(' ERROR ')) : chalk.red('[ERROR]'),
-  warning: isTty ? chalk.bold(chalk.bgYellow(' WARN ')) : chalk.yellow('[WARN]'),
-  info: isTty ? chalk.bold(chalk.cyan(' INFO ')) : chalk.cyan('[INFO]'),
+  error: isTty ? chalk.bold(chalk.bgRed(chalk.black(' ERROR '))) : chalk.red('[ERROR]'),
+  warning: isTty ? chalk.bold(chalk.bgYellow(chalk.black(' WARN '))) : chalk.yellow('[WARN]'),
+  info: isTty ? chalk.bold(chalk.cyan(chalk.black(' INFO '))) : chalk.cyan('[INFO]'),
 }
 /**
  * Creates a terminal hyperlink. Only outputs a hyperlink if the output is
@@ -162,7 +162,9 @@ export function formatDocumentValidation({
       documentId,
     )};type=${encodeURIComponent(documentType)}`
 
-  const documentTypeHeader = isTty ? chalk.bgWhite(` ${documentType} `) : `[${documentType}]`
+  const documentTypeHeader = isTty
+    ? chalk.bgWhite(chalk.black(` ${documentType} `))
+    : `[${documentType}]`
 
   const header = `${levelHeaders[level]} ${documentTypeHeader} ${
     editLink ? link(documentId, editLink) : chalk.underline(documentId)

--- a/packages/sanity/src/_internal/cli/actions/validation/reporters/prettyReporter/prettyReporter.ts
+++ b/packages/sanity/src/_internal/cli/actions/validation/reporters/prettyReporter/prettyReporter.ts
@@ -39,6 +39,7 @@ export const pretty: BuiltInValidationReporter = async ({output, worker, flags})
     spinner.text = `Downloading ${count(documentCount, 'documents')}… ${percentage}`
   }
   spinner.succeed(`Downloaded ${count(documentCount, 'documents')} ${seconds(downloadStart)}`)
+  const {totalDocumentsToValidate} = await worker.event.exportFinished()
 
   const referenceIntegrityStart = Date.now()
   spinner.start(`Checking reference existence…`)
@@ -47,7 +48,7 @@ export const pretty: BuiltInValidationReporter = async ({output, worker, flags})
 
   // Report validation progress
   const validationStart = Date.now()
-  spinner.start(`Validating ${count(documentCount, 'documents')}…`)
+  spinner.start(`Validating ${count(totalDocumentsToValidate, 'documents')}…`)
 
   const results: DocumentValidationResult[] = []
 
@@ -89,9 +90,9 @@ export const pretty: BuiltInValidationReporter = async ({output, worker, flags})
     }
 
     spinner.text =
-      `Validating ${count(documentCount, 'documents')}…\n\n` +
+      `Validating ${count(totalDocumentsToValidate, 'documents')}…\n\n` +
       `Processed ${count(validatedCount, 'documents')} (${percent(
-        validatedCount / documentCount,
+        validatedCount / totalDocumentsToValidate,
       )}):\n${summary(totals, flags.level)}`
   }
 

--- a/packages/sanity/src/_internal/cli/actions/validation/reporters/prettyReporter/util.ts
+++ b/packages/sanity/src/_internal/cli/actions/validation/reporters/prettyReporter/util.ts
@@ -24,14 +24,16 @@ export const count = (amount: number, subject: string): string =>
     amount === 1 ? subject.substring(0, subject.length - 1) : subject
   }`
 
-/**
- * Given a decimal, this will return that number formatted as a percentage
- */
-export const percent = new Intl.NumberFormat('en-US', {
+const percentageFormatter = new Intl.NumberFormat('en-US', {
   style: 'percent',
   minimumFractionDigits: 1,
   maximumFractionDigits: 1,
-}).format.bind(Intl.NumberFormat)
+})
+
+/**
+ * Given a decimal, this will return that number formatted as a percentage
+ */
+export const percent = (value: number): string => percentageFormatter.format(Math.max(value, 1))
 
 const secondFormatter = new Intl.NumberFormat('en-US', {
   minimumFractionDigits: 1,

--- a/packages/sanity/src/_internal/cli/commands/documents/validateDocumentsCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/documents/validateDocumentsCommand.ts
@@ -19,10 +19,10 @@ Options
   --dataset <name> Override the dataset used. By default, this is derived from the given workspace
   --format <pretty|ndjson|json> The output format used to print the found validation markers and report progress
   --level <error|warning|info> The minimum level reported out. Defaults to warning.
-  --max-custom-validation-concurrent <number> Specify how many custom validators can run concurrently. Defaults to 5.
+  --max-custom-validation-concurrency <number> Specify how many custom validators can run concurrently. Defaults to 5.
 
 Examples
-  # Validates all documents in a sanity project with one workspace
+  # Validates all documents in a sanity project with more than one workspace
   sanity documents validate --workspace default
 
   # Override the dataset specified in the workspace
@@ -32,7 +32,7 @@ Examples
   sanity documents validate > report.txt
 
   # Report out info level validation markers too
-  sanity document validate --level info
+  sanity documents validate --level info
 `
 
 const validateDocumentsCommand: CliCommandDefinition = {

--- a/packages/sanity/src/_internal/cli/threads/__tests__/sanity.config.ts
+++ b/packages/sanity/src/_internal/cli/threads/__tests__/sanity.config.ts
@@ -1,0 +1,38 @@
+import {defineConfig, defineType, defineField} from 'sanity'
+
+export default defineConfig({
+  projectId: 'ppsg7ml5',
+  dataset: 'test',
+  schema: {
+    types: [
+      defineType({
+        name: 'author',
+        type: 'document' as const,
+        fields: [
+          defineField({
+            name: 'name',
+            type: 'string',
+            validation: (rule) => rule.required(),
+          }),
+        ],
+      }),
+      defineType({
+        name: 'book',
+        type: 'document' as const,
+        fields: [
+          defineField({
+            name: 'title',
+            type: 'string',
+            validation: (rule) => rule.required(),
+          }),
+          defineField({
+            name: 'author',
+            type: 'reference',
+            to: [{type: 'author'}],
+            validation: (rule) => rule.required(),
+          }),
+        ],
+      }),
+    ],
+  },
+})

--- a/packages/sanity/src/_internal/cli/threads/__tests__/validateDocuments.test.ts
+++ b/packages/sanity/src/_internal/cli/threads/__tests__/validateDocuments.test.ts
@@ -1,0 +1,296 @@
+import {Worker} from 'worker_threads'
+import {Server, createServer} from 'http'
+import type {SanityDocument, SanityProject} from '@sanity/client'
+import {parse, evaluate} from 'groq-js'
+import type {ValidateDocumentsWorkerData, ValidationWorkerChannel} from '../validateDocuments'
+import {WorkerChannelReceiver, createReceiver} from '../../util/workerChannels'
+
+async function toArray<T>(asyncIterator: AsyncIterable<T>) {
+  const arr: T[] = []
+  for await (const i of asyncIterator) arr.push(i)
+  return arr
+}
+
+const documents: SanityDocument[] = [
+  {
+    _id: 'valid-author',
+    _type: 'author',
+    _rev: 'rev1',
+    _createdAt: '2024-01-18T19:18:39.048Z',
+    _updatedAt: '2024-01-18T19:18:39.048Z',
+    name: 'a valid author',
+  },
+  {
+    _id: 'author-no-name',
+    _type: 'author',
+    _rev: 'rev2',
+    _createdAt: '2024-01-18T19:18:39.048Z',
+    _updatedAt: '2024-01-18T19:18:39.048Z',
+  },
+  {
+    _id: 'valid-book',
+    _type: 'book',
+    _rev: 'rev3',
+    _createdAt: '2024-01-18T19:18:39.048Z',
+    _updatedAt: '2024-01-18T19:18:39.048Z',
+    title: 'valid book',
+    author: {
+      _type: 'reference',
+      _ref: 'valid-author',
+    },
+  },
+  {
+    _id: 'book-no-title-no-author',
+    _type: 'book',
+    _rev: 'rev4',
+    _createdAt: '2024-01-18T19:18:39.048Z',
+    _updatedAt: '2024-01-18T19:18:39.048Z',
+  },
+  {
+    _id: 'book-ref-not-published',
+    _type: 'book',
+    _createdAt: '2024-01-18T19:18:39.048Z',
+    _updatedAt: '2024-01-18T19:18:39.048Z',
+    _rev: 'rev5',
+    title: 'book with unpublished reference',
+    author: {
+      _type: 'reference',
+      _ref: 'document-does-not-exist',
+    },
+  },
+  {
+    _id: 'system.some-system-document.foo',
+    _rev: 'rev6',
+    _type: 'system.some-system-document',
+    _createdAt: '2024-01-18T19:18:39.048Z',
+    _updatedAt: '2024-01-18T19:18:39.048Z',
+  },
+]
+
+describe('validateDocuments', () => {
+  jest.setTimeout(30000)
+
+  let server!: Server
+  let receiver!: WorkerChannelReceiver<ValidationWorkerChannel>
+  let localhost!: string
+
+  beforeAll(async () => {
+    server = createServer(async (req, res) => {
+      const {pathname, searchParams} = new URL(req.url!, localhost)
+      const [resource, ...rest] = pathname.split('/').slice(2)
+
+      const json = (obj: object) => {
+        res.setHeader('Content-Type', 'application/json')
+        res.write(JSON.stringify(obj))
+        res.statusCode = 200
+        res.end()
+      }
+
+      const ndjson = (objs: object[]) => {
+        for (const obj of objs) {
+          res.write(`${JSON.stringify(obj)}\n`)
+        }
+        res.statusCode = 200
+        res.end()
+      }
+
+      const getGroqQueryOptions = async () => {
+        if (req.method === 'POST') {
+          const {query, variables} = JSON.parse(
+            (await toArray(req)).map((chunk) => chunk.toString()).join(''),
+          )
+          return {
+            query: query as string,
+            params: variables as Record<string, string | string[]>,
+          }
+        }
+
+        const query = searchParams.get('query')
+        if (!query) throw new Error('No query')
+
+        const params = Array.from(searchParams.keys())
+          .filter((key) => key.startsWith('$'))
+          .reduce<Record<string, string | string[]>>((acc, key) => {
+            const values = searchParams.getAll(key)
+            acc[key.substring(1)] = values.length === 1 ? values[0] : values
+            return acc
+          }, {})
+
+        return {query, params}
+      }
+
+      switch (resource) {
+        case 'projects': {
+          json({
+            studioHost: 'https://example.sanity.studio',
+            metadata: {externalStudioHost: localhost},
+          } satisfies Partial<SanityProject>)
+          return
+        }
+
+        case 'data': {
+          const [method] = rest
+          switch (method) {
+            case 'export': {
+              ndjson(documents)
+              return
+            }
+            case 'doc': {
+              const ids = rest[1].split(',')
+              const nonExistentIds = ids.filter((id) => !documents.find((doc) => doc._id === id))
+
+              json({omitted: nonExistentIds.map((id) => ({id, reason: 'existence'}))})
+              return
+            }
+            case 'query': {
+              const start = Date.now()
+              const {params, query} = await getGroqQueryOptions()
+
+              const tree = parse(query)
+              const value = await evaluate(tree, {params, dataset: documents})
+              const result = await value.get()
+
+              json({ms: start - Date.now(), query, result})
+              return
+            }
+            default: {
+              console.error(`Could not handle request ${req.url}`)
+              res.statusCode = 400
+              res.end()
+              return
+            }
+          }
+        }
+        default: {
+          console.error(`Could not handle request ${req.url}`)
+          res.statusCode = 400
+          res.end()
+        }
+      }
+    })
+
+    localhost = await new Promise<string>((resolve, reject) => {
+      server?.listen(() => {
+        const address = server?.address()
+        if (typeof address === 'object' && address) {
+          resolve(`http://localhost:${address.port}`)
+        } else {
+          reject(new Error('Could not get ephemeral port'))
+        }
+      })
+    })
+
+    const workerData: ValidateDocumentsWorkerData = {
+      workDir: __dirname,
+      clientConfig: {
+        apiHost: localhost,
+        apiVersion: '1',
+        projectId: 'ppsg7ml5',
+        dataset: 'test',
+        useCdn: true,
+        useProjectHostname: false,
+      },
+    }
+
+    const filepath = require.resolve('../validateDocuments')
+
+    const worker = new Worker(
+      `
+        const { register } = require('esbuild-register/dist/node')
+
+        const { unregister } = register({
+          target: 'node18',
+          format: 'cjs',
+          extensions: ['.js', '.jsx', '.ts', '.tsx', '.mjs'],
+          jsx: 'automatic',
+        })
+
+        require(${JSON.stringify(filepath)})
+
+      `,
+      {eval: true, env: {...process.env, API_HOST: localhost}, workerData},
+    )
+
+    receiver = createReceiver<ValidationWorkerChannel>(worker)
+  })
+
+  afterAll(async () => {
+    await receiver?.dispose()
+
+    await new Promise<void>(
+      (resolve, reject) =>
+        server?.close((err) => {
+          if (err) reject(err)
+          else resolve()
+        }),
+    )
+  })
+
+  it('works', async () => {
+    expect(await receiver.event.loadedWorkspace()).toMatchObject({
+      basePath: '/',
+      dataset: 'test',
+      name: undefined,
+      projectId: 'ppsg7ml5',
+    })
+    expect(await receiver.event.loadedDocumentCount()).toEqual({documentCount: documents.length})
+
+    let downloadedCount = 0
+    for await (const emission of receiver.stream.exportProgress()) {
+      downloadedCount++
+      expect(emission).toEqual({documentCount: documents.length, downloadedCount})
+    }
+
+    expect(await receiver.event.exportFinished()).toEqual({
+      totalDocumentsToValidate:
+        documents.length - documents.filter((doc) => doc._id.startsWith('system.')).length,
+    })
+    await receiver.event.loadedReferenceIntegrity()
+
+    expect(await toArray(receiver.stream.validation())).toEqual([
+      {
+        documentId: 'valid-author',
+        documentType: 'author',
+        level: 'info',
+        markers: [],
+        revision: 'rev1',
+        validatedCount: 1,
+      },
+      {
+        documentId: 'author-no-name',
+        documentType: 'author',
+        level: 'error',
+        markers: [{level: 'error', message: 'Required', path: ['name']}],
+        revision: 'rev2',
+        validatedCount: 2,
+      },
+      {
+        documentId: 'valid-book',
+        documentType: 'book',
+        level: 'info',
+        markers: [],
+        revision: 'rev3',
+        validatedCount: 3,
+      },
+      {
+        documentId: 'book-no-title-no-author',
+        documentType: 'book',
+        level: 'error',
+        markers: [
+          {level: 'error', message: 'Required', path: ['title']},
+          {level: 'error', message: 'Required', path: ['author']},
+        ],
+        revision: 'rev4',
+        validatedCount: 4,
+      },
+      {
+        documentId: 'book-ref-not-published',
+        documentType: 'book',
+        level: 'info',
+        markers: [],
+        revision: 'rev5',
+        validatedCount: 5,
+      },
+    ])
+  })
+})

--- a/packages/sanity/src/_internal/cli/threads/validateDocuments.ts
+++ b/packages/sanity/src/_internal/cli/threads/validateDocuments.ts
@@ -265,7 +265,7 @@ async function checkReferenceExistence({
     },
     Array.from<string[]>({
       length: Math.ceil(idsToCheck.length / REFERENCE_INTEGRITY_BATCH_SIZE),
-    }).fill([]),
+    }).map(() => []),
   )
 
   for (const batch of batches) {

--- a/packages/sanity/src/_internal/cli/threads/validateDocuments.ts
+++ b/packages/sanity/src/_internal/cli/threads/validateDocuments.ts
@@ -146,14 +146,6 @@ async function loadWorkspace() {
     ...clientConfig,
     dataset: dataset || workspace.dataset,
     projectId: projectId || workspace.projectId,
-    // we set this explictly to true because the default client configuration
-    // from the CLI comes configured with `useProjectHostname: false` when
-    // `requireProject` is set to false
-    useProjectHostname: true,
-    // we set this explictly to true because we pass in a token via the
-    // `clientConfiguration` object and also mock a browser environment in
-    // this worker which triggers the browser warning
-    ignoreBrowserTokenWarning: true,
     requestTagPrefix: 'sanity.cli.validate',
   }).config({apiVersion: 'v2021-03-25'})
 

--- a/packages/sanity/src/_internal/cli/threads/validateDocuments.ts
+++ b/packages/sanity/src/_internal/cli/threads/validateDocuments.ts
@@ -50,6 +50,7 @@ export type ValidationWorkerChannel = WorkerChannel<{
   }>
   loadedDocumentCount: WorkerChannelEvent<{documentCount: number}>
   exportProgress: WorkerChannelStream<{downloadedCount: number; documentCount: number}>
+  exportFinished: WorkerChannelEvent<{totalDocumentsToValidate: number}>
   loadedReferenceIntegrity: WorkerChannelEvent
   validation: WorkerChannelStream<{
     validatedCount: number
@@ -223,6 +224,8 @@ async function downloadDocuments(client: SanityClient) {
   await new Promise<void>((resolve, reject) =>
     outputStream.close((err) => (err ? reject(err) : resolve())),
   )
+
+  report.event.exportFinished({totalDocumentsToValidate: documentIds.size})
 
   async function* getDocuments() {
     const rl = readline.createInterface({input: fs.createReadStream(tempOutputFile)})

--- a/packages/sanity/src/_internal/cli/threads/validateDocuments.ts
+++ b/packages/sanity/src/_internal/cli/threads/validateDocuments.ts
@@ -385,7 +385,7 @@ async function validateDocuments() {
       report.stream.validation.emit({
         documentId: document._id,
         documentType: document._type,
-        revision: document.rev,
+        revision: document._rev,
         markers,
         validatedCount,
         level: getLevel(markers),

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,6 +1,9 @@
 import path from 'path'
 import dotenv from 'dotenv'
 
+// eslint-disable-next-line no-process-env
+process.env.FORCE_COLOR = '0'
+
 dotenv.config({path: path.resolve(__dirname, '../.env')})
 
 if (typeof window !== 'undefined') {


### PR DESCRIPTION
### Description

Includes various fixes for the CLI validate command including:
- fixes typos in the help command
- fixes a bug where the document type would not be visible due to a gray background
- no longer shows validation for `system.` and `sanity.` prefixed documents
- fixes an issue where local tests runs would fail due to colored chalk output
- fixes a missing document revision in the NDJSON and JSON reporters
- fixes a bug where the batches for the reference checks were not separated correctly
- also adds a test for the `validateDocuments` command

### What to review

Take a look at the changed code and see if I missed anything. Also review the copy because of typos!

### Testing

Tests were added via the `validateDocuments.test.ts` file.

### Notes for release

- Fixes typos with `sanity documents validate --help`
- Fixes a bug where the document type in the `sanity documents validate` command would not be visible
- Fixes a bug where system documents would appear in validation reports