### PR TITLE
chore(telemetry): track expand and collapse pte actions

### DIFF
--- a/packages/sanity/src/core/form/__telemetry__/form.telemetry.ts
+++ b/packages/sanity/src/core/form/__telemetry__/form.telemetry.ts
@@ -1,0 +1,13 @@
+import {defineEvent} from '@sanity/telemetry'
+
+export const ExpandPortableTextInput = defineEvent({
+  version: 1,
+  name: 'Expand PTE',
+  description: 'The portable text editor was expanded',
+})
+
+export const CollapsePortableTextInput = defineEvent({
+  version: 1,
+  name: 'Collapse PTE',
+  description: 'The portable text editor was collapsed',
+})

--- a/packages/sanity/src/core/form/__telemetry__/form.telemetry.ts
+++ b/packages/sanity/src/core/form/__telemetry__/form.telemetry.ts
@@ -1,13 +1,13 @@
 import {defineEvent} from '@sanity/telemetry'
 
-export const ExpandPortableTextInput = defineEvent({
+export const PortableTextInputExpanded = defineEvent({
   version: 1,
-  name: 'Expand PTE',
+  name: 'Portable Text Editor expanded',
   description: 'The portable text editor was expanded',
 })
 
-export const CollapsePortableTextInput = defineEvent({
+export const PortableTextInputCollapsed = defineEvent({
   version: 1,
-  name: 'Collapse PTE',
+  name: 'Portable Text Editor collapsed',
   description: 'The portable text editor was collapsed',
 })

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -24,8 +24,8 @@ import {ArrayOfObjectsItemMember, ObjectFormNode} from '../../store'
 import type {PortableTextInputProps} from '../../types'
 import {EMPTY_ARRAY} from '../../../util'
 import {
-  CollapsePortableTextInput,
-  ExpandPortableTextInput,
+  PortableTextInputCollapsed,
+  PortableTextInputExpanded,
 } from '../../__telemetry__/form.telemetry'
 import {Compositor, PortableTextEditorElement} from './Compositor'
 import {InvalidValue as RespondToInvalidContent} from './InvalidValue'
@@ -112,9 +112,9 @@ export function PortableTextInput(props: PortableTextInputProps) {
       setIsFullscreen((v) => {
         const next = !v
         if (next) {
-          telemetry.log(ExpandPortableTextInput)
+          telemetry.log(PortableTextInputExpanded)
         } else {
-          telemetry.log(CollapsePortableTextInput)
+          telemetry.log(PortableTextInputCollapsed)
         }
         return next
       })

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -18,10 +18,15 @@ import React, {
 } from 'react'
 import {Subject} from 'rxjs'
 import {Box, useToast} from '@sanity/ui'
+import {useTelemetry} from '@sanity/telemetry/react'
 import {SANITY_PATCH_TYPE} from '../../patch'
 import {ArrayOfObjectsItemMember, ObjectFormNode} from '../../store'
 import type {PortableTextInputProps} from '../../types'
 import {EMPTY_ARRAY} from '../../../util'
+import {
+  CollapsePortableTextInput,
+  ExpandPortableTextInput,
+} from '../../__telemetry__/form.telemetry'
 import {Compositor, PortableTextEditorElement} from './Compositor'
 import {InvalidValue as RespondToInvalidContent} from './InvalidValue'
 import {usePatches} from './usePatches'
@@ -89,6 +94,7 @@ export function PortableTextInput(props: PortableTextInputProps) {
   const [isActive, setIsActive] = useState(false)
   const [isOffline, setIsOffline] = useState(false)
   const [hasFocusWithin, setHasFocusWithin] = useState(false)
+  const telemetry = useTelemetry()
 
   const toast = useToast()
 
@@ -103,9 +109,17 @@ export function PortableTextInput(props: PortableTextInputProps) {
 
   const handleToggleFullscreen = useCallback(() => {
     if (editorRef.current) {
-      setIsFullscreen((v) => !v)
+      setIsFullscreen((v) => {
+        const next = !v
+        if (next) {
+          telemetry.log(ExpandPortableTextInput)
+        } else {
+          telemetry.log(CollapsePortableTextInput)
+        }
+        return next
+      })
     }
-  }, [])
+  }, [telemetry])
 
   // Reset invalidValue if new value is coming in from props
   useEffect(() => {


### PR DESCRIPTION
### Description

Track expand and collapse editor in portable text.

🟡 This PR is not using `next` as base branch given that it requires the changes from https://github.com/sanity-io/sanity/pull/5503 🟡  
will be updated once the base branch is merged


Example of event sent:
```
{
  "projectId": "xxxxxx",
  "batch": [
    {
      "sessionId": "xxxxxx",
      "type": "log",
      "version": 1,
      "name": "Portable Text Editor expanded",
      "createdAt": "2024-01-22T10:25:24.839Z"
    },
    {
      "sessionId": "xxxxxxx",
      "type": "log",
      "version": 1,
      "name": "Portable Text Editor collapsed",
      "createdAt": "2024-01-22T10:25:27.538Z"
    }
  ]
}


```

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
