### PR TITLE
chore(codeowners): add growth team as owners of telemetry definitions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,3 +39,6 @@
 # Shopify templates
 /packages/@sanity/cli/src/actions/init-project/templates/shopify* @thebiggianthead
 /packages/@sanity/cli/templates/shopify* @thebiggianthead
+
+# Telemetry definitions
+*.telemetry.ts @sanity-io/growth


### PR DESCRIPTION
### Description

Adds growth as codeowners for `*.telemetry.ts` files.

### Notes for release

n/a