### PR TITLE
fix(cli): compile esm files in node_modules

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -222,6 +222,7 @@
     "dataloader": "^2.1.0",
     "date-fns": "^2.26.1",
     "debug": "^3.2.7",
+    "es-module-lexer": "^1.4.1",
     "esbuild": "^0.19.8",
     "esbuild-register": "^3.4.1",
     "execa": "^2.0.0",

--- a/packages/sanity/src/_internal/cli/threads/validateDocuments.ts
+++ b/packages/sanity/src/_internal/cli/threads/validateDocuments.ts
@@ -299,7 +299,7 @@ async function validateDocuments() {
   // file gets compiled to CJS at this time
   const {default: pMap} = await import('p-map')
 
-  const cleanup = mockBrowserEnvironment(workDir)
+  const cleanup = await mockBrowserEnvironment(workDir)
 
   let tempFile: string | undefined
 

--- a/packages/sanity/src/_internal/cli/util/getStudioConfig.ts
+++ b/packages/sanity/src/_internal/cli/util/getStudioConfig.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-sync */
 import fs from 'fs'
 import path from 'path'
-import {first} from 'rxjs/operators'
 import {firstValueFrom} from 'rxjs'
 import {mockBrowserEnvironment} from './mockBrowserEnvironment'
 import {resolveConfig, Config, Workspace} from 'sanity'
@@ -24,7 +23,7 @@ export async function getStudioConfig(options: {
 
   let cleanup
   try {
-    cleanup = mockBrowserEnvironment(basePath)
+    cleanup = await mockBrowserEnvironment(basePath)
 
     let configPath = cfgPath
     if (configPath && !fs.existsSync(configPath)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7436,6 +7436,11 @@ es-module-lexer@^1.3.1:
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.3.1.tgz#c1b0dd5ada807a3b3155315911f364dc4e909db1"
   integrity sha512-JUFAyicQV9mXc3YRxPnDlrfBKpqt6hUYzz9/boprUJHs4e4KVr3XwOF70doO6gwXUor6EWZJAyWAfKki84t20Q==
 
+es-module-lexer@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.4.1.tgz#41ea21b43908fe6a287ffcbe4300f790555331f5"
+  integrity sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==
+
 es-set-tostringtag@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz#338d502f6f674301d710b80c8592de8a15f09cd8"


### PR DESCRIPTION
### Description

This PR compiles esm files within `node_modules` for better compatibility. This fixes a bug in the CLI validate command that causes workspaces not to load correctly. In an ideal world with node's conditional exports, this shouldn't be needed. However, we can't guarantee that library authors use conditional exports and also support CJS so this should help bridge the gap in many cases.

This uses `es-module-lexer` to quickly determine if a file is ESM or not and if so, tells esbuild to compile it. `es-module-lexer` is a performant library written in C and compiled to WASM.

### What to review

Take a look at the code and see if everything lines up or if I missed anything. In particular, I had to change the signature of the `mockBrowserEnv` to return a promise. I updated the usage areas however there may be affects I'm unaware of.

### Testing

- I tried this in hyperdrive via the `sanity document validate` command and it correctly loaded the project when it didn't before
- I tried this in our own test-studio and it worked as expected and did not increase the load time significantly
- I tried running a script via `sanity exec` and everything still worked as expected (`mockBrowserEnvironment` is used in `registerBrowserEnv`).

### Notes for release

- Improves compatibility of mock browser environment used in the CLI for GraphQL deploys, document validation, and script execution