### PR TITLE
Fix/group name all fields

### DIFF
--- a/packages/sanity/src/core/form/store/formState.ts
+++ b/packages/sanity/src/core/form/store/formState.ts
@@ -551,7 +551,8 @@ function prepareObjectInputState<T>(
     props.readOnly ||
     resolveConditionalProperty(props.schemaType.readOnly, conditionalPropertyContext)
 
-  const schemaTypeGroupConfig = props.schemaType.groups.filter(group => group?.name !== ALL_FIELDS_GROUP?.name) || []
+  const schemaTypeGroupConfig =
+    props.schemaType.groups?.filter((group) => group.name !== ALL_FIELDS_GROUP.name) || []
   const defaultGroupName = (schemaTypeGroupConfig.find((g) => g.default) || ALL_FIELDS_GROUP)?.name
 
   const groups = [ALL_FIELDS_GROUP, ...schemaTypeGroupConfig].flatMap((group): FormFieldGroup[] => {

--- a/packages/sanity/src/core/form/store/formState.ts
+++ b/packages/sanity/src/core/form/store/formState.ts
@@ -551,7 +551,7 @@ function prepareObjectInputState<T>(
     props.readOnly ||
     resolveConditionalProperty(props.schemaType.readOnly, conditionalPropertyContext)
 
-  const schemaTypeGroupConfig = props.schemaType.groups || []
+  const schemaTypeGroupConfig = props.schemaType.groups.filter(group => group?.name !== ALL_FIELDS_GROUP?.name) || []
   const defaultGroupName = (schemaTypeGroupConfig.find((g) => g.default) || ALL_FIELDS_GROUP)?.name
 
   const groups = [ALL_FIELDS_GROUP, ...schemaTypeGroupConfig].flatMap((group): FormFieldGroup[] => {


### PR DESCRIPTION
### Description

**What changes are introduced?** Filter out group with name 'all-items' from array.
**Why are these changes introduced?** It's a sugestion of how to fix problem if schema has a group with name 'all-items'
**What issue(s) does this solve? [issue](https://github.com/sanity-io/sanity/issues/5536)** 

### What to review
a maybe another way to fix the [issue](https://github.com/sanity-io/sanity/issues/5536)
i add a small changes to packages/sanity/src/core/form/store/formState.ts, but it looks like a 'dirty' hack

### Testing

I tested it with my own project dataset with yarn link to my fork of sanity, and it resolve the problem. I wasn't writing any tests  becouse i doesn't now how, and it's a second day of my expirience with saniti) 
More information in the [issue](https://github.com/sanity-io/sanity/issues/5536)
