### PR TITLE
fix(core): error handling in `useFeatureEnabled`

### DIFF
--- a/packages/sanity/src/core/hooks/useFeatureEnabled.ts
+++ b/packages/sanity/src/core/hooks/useFeatureEnabled.ts
@@ -34,7 +34,14 @@ export function useFeatureEnabled(featureKey: string): Features {
   const versionedClient = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
 
   if (!cachedFeatureRequest) {
-    cachedFeatureRequest = fetchFeatures({versionedClient}).pipe(shareReplay())
+    cachedFeatureRequest = fetchFeatures({versionedClient}).pipe(
+      shareReplay(),
+      catchError((error) => {
+        console.error(error)
+        // Return an empty list of features if the request fails
+        return of([])
+      }),
+    )
   }
 
   const featureInfo = useMemoObservable(


### PR DESCRIPTION
### Description

Some features, such as Comments, are only available on specific plans. To determine whether some features should be rendered in Studio, we make an API call to get a list of the project's available features. If this API call fails, currently, an error is thrown and displayed in a toast. This pull request ensures that if an error is thrown, we catch it and instead return an empty list of features.

<img width="617" alt="Screenshot 2024-01-22 at 12 55 09" src="https://github.com/sanity-io/sanity/assets/15094168/2eacb54a-f887-415d-b0e0-ae6a86c4a45b">

### What to review

- Make sure that the toast is not appearing when an error is thrown

### Notes for release

N/A
