### PR TITLE
fix(i18n): import i18n utils from relative path/sanity module

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@optimize-lodash/rollup-plugin": "^4.0.4",
     "@playwright/test": "^1.39.0",
     "@sanity/client": "^6.11.1",
-    "@sanity/eslint-config-i18n": "^1.0.0",
+    "@sanity/eslint-config-i18n": "^1.1.0",
     "@sanity/pkg-utils": "^3.3.2",
     "@sanity/test": "0.0.1-alpha.1",
     "@sanity/tsdoc": "1.0.0-alpha.38",

--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -6,6 +6,7 @@ import {startCase} from 'lodash'
 import {fromUrl} from '@sanity/bifur-client'
 import {createElement, isValidElement} from 'react'
 import {isValidElementType} from 'react-is'
+// eslint-disable-next-line @sanity/i18n/no-i18next-import
 import type {i18n} from 'i18next'
 import {createSchema} from '../schema'
 import {type AuthStore, createAuthStore, isAuthStore} from '../store/_legacy'

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -11,6 +11,7 @@ import type {
 } from '@sanity/types'
 import type {ComponentType, ReactNode} from 'react'
 import type {Observable} from 'rxjs'
+// eslint-disable-next-line @sanity/i18n/no-i18next-import
 import type {i18n} from 'i18next'
 import type {FormBuilderCustomMarkersComponent, FormBuilderMarkersComponent} from '../form'
 import type {LocalePluginOptions, LocaleSource} from '../i18n/types'

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/ActionMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/ActionMenu.tsx
@@ -1,11 +1,11 @@
 import React, {memo, useCallback, useMemo} from 'react'
-import {useTranslation} from 'react-i18next'
 import {
   PortableTextEditor,
   usePortableTextEditor,
   usePortableTextEditorSelection,
 } from '@sanity/portable-text-editor'
 import {isKeySegment} from '@sanity/types'
+import {useTranslation} from '../../../../i18n'
 import {PopoverProps} from '../../../../../ui-components'
 import {CollapseMenu, CollapseMenuButton} from '../../../../components/collapseMenu'
 import {ContextMenuButton} from '../../../../components/contextMenuButton'

--- a/packages/sanity/src/core/i18n/.eslintrc
+++ b/packages/sanity/src/core/i18n/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "@sanity/i18n/no-i18next-import": "off"
+  }
+}

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialButton.tsx
@@ -3,8 +3,8 @@ import styled from 'styled-components'
 import {Card, Text} from '@sanity/ui'
 import {BoltIcon} from '@sanity/icons'
 import {purple, yellow} from '@sanity/color'
-import {useTranslation} from 'react-i18next'
 import {forwardRef} from 'react'
+import {useTranslation} from '../../../../i18n'
 import {Button} from '../../../../../ui-components'
 
 const CenteredStroke = styled.div`

--- a/packages/sanity/src/core/studio/components/navbar/search/SearchButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/SearchButton.tsx
@@ -1,6 +1,6 @@
 import {SearchIcon} from '@sanity/icons'
 import React, {forwardRef} from 'react'
-import {useTranslation} from 'react-i18next'
+import {useTranslation} from '../../../../i18n'
 import {Button} from '../../../../../ui-components'
 import {GLOBAL_SEARCH_KEY, GLOBAL_SEARCH_KEY_MODIFIER} from './constants'
 

--- a/packages/sanity/src/structure/panes/document/document-layout/DocumentLayout.tsx
+++ b/packages/sanity/src/structure/panes/document/document-layout/DocumentLayout.tsx
@@ -1,6 +1,5 @@
 import {useElementRect, DialogProvider, Flex, PortalProvider, DialogProviderProps} from '@sanity/ui'
 import {useState, useCallback, useMemo} from 'react'
-import {useTranslation} from 'react-i18next'
 import {Path} from 'sanity-diff-patch'
 import styled from 'styled-components'
 import isHotkey from 'is-hotkey'
@@ -25,6 +24,7 @@ import {TooltipDelayGroupProvider} from '../../../../ui-components'
 import {getMenuItems} from '../menuItems'
 import {DocumentLayoutError} from './DocumentLayoutError'
 import {
+  useTranslation,
   useZIndex,
   ChangeConnectorRoot,
   DocumentInspectorMenuItem,

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormHeader.tsx
@@ -1,8 +1,8 @@
-import {ObjectSchemaType, SchemaType} from '@sanity/types'
+import type {ObjectSchemaType} from '@sanity/types'
 import {Heading, Stack, Text} from '@sanity/ui'
-import {useTranslation} from 'react-i18next'
 import styled, {css} from 'styled-components'
 import {structureLocaleNamespace} from '../../../../i18n'
+import {useTranslation} from 'sanity'
 
 interface DocumentHeaderProps {
   documentId: string

--- a/packages/sanity/src/ui-components/dialog/Dialog.tsx
+++ b/packages/sanity/src/ui-components/dialog/Dialog.tsx
@@ -8,7 +8,7 @@ import {
   BoxHeight,
 } from '@sanity/ui'
 import React, {ComponentProps, forwardRef} from 'react'
-import {useTranslation} from 'react-i18next'
+import {useTranslation} from 'sanity'
 
 /** @internal */
 export type DialogProps = Pick<

--- a/yarn.lock
+++ b/yarn.lock
@@ -3595,13 +3595,13 @@
   resolved "https://registry.yarnpkg.com/@sanity/diff-match-patch/-/diff-match-patch-3.1.1.tgz#16514d3a550d880bae1f59cc3ffe6865f5a4b58a"
   integrity sha512-dSZqGeYjHKGIkqAzGqLcG92LZyJGX+nYbs/FWawhBbTBDWi21kvQ0hsL3DJThuFVWtZMWTQijN3z6Cnd44Pf2g==
 
-"@sanity/eslint-config-i18n@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@sanity/eslint-config-i18n/-/eslint-config-i18n-1.0.0.tgz#19b89c05f3bc78a8025936d71d79c4ebda51ce56"
-  integrity sha512-BIeD9IVT7O5I6vDyDaICoidN02qeImdXDRAW062iHY9gV4JrGScWBFio2HQLso7C+Z6SrQB8jOft6SzeYqDhdQ==
+"@sanity/eslint-config-i18n@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@sanity/eslint-config-i18n/-/eslint-config-i18n-1.1.0.tgz#f7a94d513f0bbe7c7478188de80272a7a2231764"
+  integrity sha512-mMD0CB1R3n9vN+wWpmjIge1EW2yVYlNIO/N4LJd1kNZUs5FhyT4ZeFoJT79wj3lmr9K+yoHjqjTQ5HuZkRCSXw==
   dependencies:
     "@rushstack/eslint-patch" "^1.3.2"
-    "@sanity/eslint-plugin-i18n" "^1.0.0"
+    "@sanity/eslint-plugin-i18n" "^1.1.0"
     "@typescript-eslint/parser" "^6.2.1"
     eslint-plugin-i18next "^6.0.3"
 
@@ -3622,10 +3622,10 @@
     eslint-plugin-react "^7.32.2"
     eslint-plugin-react-hooks "^4.6.0"
 
-"@sanity/eslint-plugin-i18n@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@sanity/eslint-plugin-i18n/-/eslint-plugin-i18n-1.0.0.tgz#b7838e83ebda73a6853c2d6c52525dd62e6f3380"
-  integrity sha512-ibPaZttafAWLRz2SXAk8LOBr+nykU4BoMUYjdQVIx/N3D2deZdJp0s1c0lmljkrE2B3LmB0B7oTzF9CUrw3Kyg==
+"@sanity/eslint-plugin-i18n@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@sanity/eslint-plugin-i18n/-/eslint-plugin-i18n-1.1.0.tgz#5fb1d97d030dd28545475cd0394b4dba71d87197"
+  integrity sha512-EpoqPVqaP2NSmG8vGa4zsD6BuyBTVHwmD3VigOya7roHB8GZXuJjDg6+SXzhb+cTVuZtWaAjt8NMYVYx4uWCIQ==
 
 "@sanity/eventsource@^5.0.0":
   version "5.0.1"


### PR DESCRIPTION
### Description

The only place we should be importing from `i18next`/`react-i18next` is from the `i18n` folder, as the usage of it is an implementation detail and may change with time. This PR upgrades our `@sanity/eslint-config-i18n` module to enforce this, and also fixes the locations in the codebase where we were not currently following this pattern.

### What to review

Things still works/builds.

### Testing

ESLint passes, and the tests for the ESLint config/plugin has been updated in the respective repos.

### Notes for release

None
