### PR TITLE
fix: only fully collapse PTE toolbars in 'root' FormBuilder instances

### DIFF
--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/Toolbar.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/Toolbar.spec.tsx
@@ -35,5 +35,62 @@ test.describe('Portable Text Input', () => {
         ).toContainText('Inline Object')
       })
     })
+
+    test.describe('Collapsible toolbar', () => {
+      test.describe('Root <FormBuilder>', () => {
+        test('Toolbar should collapse when element width is less than 400px', async ({
+          mount,
+          page,
+        }) => {
+          const {getFocusedPortableTextInput} = testHelpers({page})
+          await mount(<ToolbarStory id="root" />)
+          const $portableTextInput = await getFocusedPortableTextInput('field-body')
+
+          // Adjust viewport size to enable auto collapsing toolbar menus
+          await page.setViewportSize({width: 450, height: 500})
+
+          const $actionMenuAutoCollapseMenu = $portableTextInput.getByTestId(
+            'action-menu-auto-collapse-menu',
+          )
+          const $insertMenuAutoCollapseMenu = $portableTextInput.getByTestId(
+            'insert-menu-auto-collapse-menu',
+          )
+
+          // Assertion: all auto collapsing menu buttons should be visible
+          await expect($actionMenuAutoCollapseMenu).toBeVisible()
+          await expect($insertMenuAutoCollapseMenu).toBeVisible()
+
+          // Adjust viewport size to disable auto collapsing toolbar menus
+          await page.setViewportSize({width: 350, height: 500})
+
+          // Assertion: all auto collapsing menu buttons should be hidden
+          await expect($actionMenuAutoCollapseMenu).toBeHidden()
+          await expect($insertMenuAutoCollapseMenu).toBeHidden()
+        })
+      })
+      test.describe('Non-root <FormBuilder>', () => {
+        test('Toolbar should not collapse when element width is less than 400px', async ({
+          mount,
+          page,
+        }) => {
+          const {getFocusedPortableTextInput} = testHelpers({page})
+          await mount(<ToolbarStory id="inspector-panel" />)
+          const $portableTextInput = await getFocusedPortableTextInput('field-body')
+
+          await page.setViewportSize({width: 350, height: 500})
+
+          const $actionMenuAutoCollapseMenu = $portableTextInput.getByTestId(
+            'action-menu-auto-collapse-menu',
+          )
+          const $insertMenuAutoCollapseMenu = $portableTextInput.getByTestId(
+            'insert-menu-auto-collapse-menu',
+          )
+
+          // Assertion: all auto collapsing menu buttons should be visible
+          await expect($actionMenuAutoCollapseMenu).toBeVisible()
+          await expect($insertMenuAutoCollapseMenu).toBeVisible()
+        })
+      })
+    })
   })
 })

--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/ToolbarStory.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/ToolbarStory.tsx
@@ -56,10 +56,10 @@ const SCHEMA_TYPES = [
   }),
 ]
 
-export function ToolbarStory() {
+export function ToolbarStory({id = 'root'}: {id?: string}) {
   return (
     <TestWrapper schemaTypes={SCHEMA_TYPES}>
-      <TestForm />
+      <TestForm id={id} />
     </TestWrapper>
   )
 }

--- a/packages/sanity/playwright-ct/tests/formBuilder/utils/TestForm.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/utils/TestForm.tsx
@@ -29,9 +29,11 @@ declare global {
 export function TestForm({
   focusPath: focusPathFromProps,
   document: documentFromProps,
+  id: idFromProps = 'root',
 }: {
   focusPath?: Path
   document?: SanityDocument
+  id?: string
 }) {
   const [validation, setValidation] = useState<ValidationMarker[]>([])
   const [openPath, onSetOpenPath] = useState<Path>([])
@@ -176,7 +178,7 @@ export function TestForm({
       focused: formState?.focused,
       focusPath: formState?.focusPath || EMPTY_ARRAY,
       groups: formState?.groups || EMPTY_ARRAY,
-      id: formState?.id || '',
+      id: idFromProps,
       level: formState?.level || 0,
       members: formState?.members || EMPTY_ARRAY,
       onChange: handleChange,
@@ -197,7 +199,6 @@ export function TestForm({
       formState?.focusPath,
       formState?.focused,
       formState?.groups,
-      formState?.id,
       formState?.level,
       formState?.members,
       formState?.schemaType,
@@ -208,6 +209,7 @@ export function TestForm({
       handleOnSetCollapsedFieldSet,
       handleOnSetCollapsedPath,
       handleSetActiveFieldGroup,
+      idFromProps,
       patchChannel,
       schemaType,
       setOpenPath,

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -16,6 +16,7 @@ import {BoundaryElementProvider, useBoundaryElement, useGlobalKeyDown, useLayer}
 import React, {useCallback, useMemo, useRef} from 'react'
 import {TooltipDelayGroupProvider} from '../../../../ui-components'
 import {useTranslation} from '../../../i18n'
+import {useFormBuilder} from '../../useFormBuilder'
 import {Toolbar} from './toolbar'
 import {Decorator} from './text'
 import {
@@ -32,6 +33,10 @@ import {Style} from './text/Style'
 import {ListItem} from './text/ListItem'
 
 const noOutlineStyle = {outline: 'none'} as const
+
+// The <FormBuilder> id that represents the default (document pane) form layout.
+// This is used to determine whether this editor should apply document pane specific styling.
+const FORM_BUILDER_DEFAULT_ID = 'root'
 
 interface EditorProps {
   hotkeys: HotkeyOptions
@@ -87,6 +92,7 @@ export function Editor(props: EditorProps) {
     setScrollElement,
     ariaDescribedBy,
   } = props
+  const {id} = useFormBuilder()
   const {t} = useTranslation()
   const {isTopLayer} = useLayer()
   const editableRef = useRef<HTMLDivElement | null>(null)
@@ -161,12 +167,16 @@ export function Editor(props: EditorProps) {
     [onItemOpen, path],
   )
 
+  // Always collapse toolbars at smaller container widths when in 'default' (document pane) FormBuilder instances
+  const collapsibleToolbar = id === FORM_BUILDER_DEFAULT_ID
+
   return (
     <Root $fullscreen={isFullscreen} data-testid="pt-editor">
       {isActive && (
         <TooltipDelayGroupProvider>
           <ToolbarCard data-testid="pt-editor__toolbar-card" shadow={1}>
             <Toolbar
+              collapsible={collapsibleToolbar}
               hotkeys={hotkeys}
               isFullscreen={isFullscreen}
               onMemberOpen={handleToolBarOnMemberOpen}

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/ActionMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/ActionMenu.tsx
@@ -134,6 +134,7 @@ export const ActionMenu = memo(function ActionMenu(props: ActionMenuProps) {
 
   return (
     <CollapseMenuMemo
+      data-testid="action-menu-auto-collapse-menu"
       collapsed={collapsed}
       disableRestoreFocusOnClose
       gap={1}

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/InsertMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/InsertMenu.tsx
@@ -84,6 +84,7 @@ export const InsertMenu = memo(function InsertMenu(props: InsertMenuProps) {
 
   return (
     <CollapseMenuMemo
+      data-testid="insert-menu-auto-collapse-menu"
       collapsed={collapsed}
       collapseText={false}
       disableRestoreFocusOnClose

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/Toolbar.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/Toolbar.tsx
@@ -21,6 +21,8 @@ import {useActionGroups} from './hooks'
 import {BlockItem, BlockStyleItem, PTEToolbarActionGroup} from './types'
 
 interface ToolbarProps {
+  /** Whether annotation and block menu buttons should fully collapse at smaller element widths */
+  collapsible?: boolean
   hotkeys: HotkeyOptions
   isFullscreen: boolean
   onMemberOpen: (relativePath: Path) => void
@@ -61,6 +63,7 @@ const IS_MAC =
 const InnerToolbar = memo(function InnerToolbar({
   actionGroups,
   blockStyles,
+  collapsible,
   disabled,
   insertMenuItems,
   isFullscreen,
@@ -68,6 +71,7 @@ const InnerToolbar = memo(function InnerToolbar({
 }: {
   actionGroups: PTEToolbarActionGroup[]
   blockStyles: BlockStyleItem[]
+  collapsible?: boolean
   disabled: boolean
   insertMenuItems: BlockItem[]
   isFullscreen: boolean
@@ -80,7 +84,7 @@ const InnerToolbar = memo(function InnerToolbar({
   const [rootElement, setRootElement] = useState<HTMLDivElement | null>(null)
   const rootElementRect = useElementRect(rootElement)
 
-  const collapsed = rootElementRect ? rootElementRect?.width < 400 : false
+  const collapsed = collapsible && rootElementRect ? rootElementRect?.width < 400 : false
   const showBlockStyleSelect = blockStyles.length > 1
 
   useRovingFocus({
@@ -151,7 +155,7 @@ const InnerToolbar = memo(function InnerToolbar({
 })
 
 export function Toolbar(props: ToolbarProps) {
-  const {hotkeys, isFullscreen, readOnly, onMemberOpen, onToggleFullscreen} = props
+  const {collapsible, hotkeys, isFullscreen, readOnly, onMemberOpen, onToggleFullscreen} = props
   const editor = usePortableTextEditor()
   const selection = usePortableTextEditorSelection()
   const resolveInitialValueForType = useResolveInitialValueForType()
@@ -239,6 +243,7 @@ export function Toolbar(props: ToolbarProps) {
     <InnerToolbar
       actionGroups={actionGroups}
       blockStyles={blockStyles}
+      collapsible={collapsible}
       disabled={disabled}
       insertMenuItems={insertMenuItems}
       isFullscreen={isFullscreen}


### PR DESCRIPTION
### Description

This PR updates PTE Toolbars to conditionally collapse at smaller element widths _only_ when displayed in a `<FormBuilder>` instance with `id="root"` (the default ID assigned within the document pane).

**Current behaviour:**

https://github.com/sanity-io/sanity/assets/209129/681ae41e-56a3-45a9-a956-a54c558098b2

**The problem:**

https://github.com/sanity-io/sanity/assets/209129/3929ef4b-5ff8-43dc-8e77-a9fc29e85271

**Approach:**

- We only apply this behaviour when the form builder context within the current PTE component has `id === "root"` (the default)
- This felt like the simplest option that avoids adding extra layout-specific props to `<FormBuilder>`. 
- It felt reasonable to add an extra `FormBuilderContext` dependency in `Editor.tsx`, given that PTE objects are also dependent on this.
- This will be removed when we eventually revisit the UI for PTE fixed toolbars

**Questions:**

- Could this be done in a better way?
- Are there any side effects of giving a `<FormBuilder>` a non "root" ID? (None that I can tell)

### What to review

- Default toolbar behaviour in the studio is unchanged
- That `playwright-ct` tests pass
- Specifying a non "root" `<FormBuilder>` id disables toolbars from automatically collapsing.

### Testing

`playwright-ct` tests have been aded to validate behaviour in `<FormBuilder>` instances with root and non-root ids.

### Notes for release

N/A