### PR TITLE
fix: increase space between published date and last updated date

### DIFF
--- a/packages/sanity/src/core/components/documentStatus/DocumentStatus.tsx
+++ b/packages/sanity/src/core/components/documentStatus/DocumentStatus.tsx
@@ -55,7 +55,7 @@ export function DocumentStatus({absoluteDate, draft, published, singleLine}: Doc
     <Flex
       align={singleLine ? 'center' : 'flex-start'}
       direction={singleLine ? 'row' : 'column'}
-      gap={singleLine ? 1 : 2}
+      gap={2}
       wrap="nowrap"
     >
       {!publishedDate && (


### PR DESCRIPTION
### Description

Smol change to increase spacing between both published and last updated dates in the document status bar.

<img src="https://github.com/sanity-io/sanity/assets/209129/c2e2ebb7-f31a-4eb3-aa49-d17f4d3c588c" width="400" />

### What to review

That it looks OK!

### Testing

N/A – trivial visual change

### Notes for release

N/A