### PR TITLE
chore: add ui component workshop stories, simplify internal tab component

### DIFF
--- a/packages/sanity/src/ui-components/__workshop__/ButtonStory.tsx
+++ b/packages/sanity/src/ui-components/__workshop__/ButtonStory.tsx
@@ -1,0 +1,75 @@
+import {EditIcon, PublishIcon} from '@sanity/icons'
+import {Box, Card, Container, Stack, Text} from '@sanity/ui'
+import {useString} from '@sanity/ui-workshop'
+import {Button} from '../button'
+
+export default function ButtonStory() {
+  const text = useString('Text', 'Text', 'Props') || ''
+
+  return (
+    <Container width={0} padding={4}>
+      <Stack space={4}>
+        <Card>
+          <Text size={1}>
+            <code>Button</code> components are limited to ensure consistency. Padding and font sizes
+            are fixed, and tooltips are enforced on icon-only buttons.
+          </Text>
+        </Card>
+
+        <Card border radius={2}>
+          <Box marginBottom={3} padding={3}>
+            <Text size={2} weight="medium">
+              Usage examples
+            </Text>
+          </Box>
+          <Stack padding={3} space={4}>
+            <Stack space={3}>
+              <Text muted size={1}>
+                Default button
+              </Text>
+              <Box>
+                <Button text={text} />
+              </Box>
+            </Stack>
+
+            <Stack space={3}>
+              <Text muted size={1}>
+                Loading button with custom <code>mode</code>
+              </Text>
+              <Box>
+                <Button loading mode="ghost" text={text} />
+              </Box>
+            </Stack>
+
+            <Stack space={2}>
+              <Text muted size={1}>
+                Default button with icon
+              </Text>
+              <Box>
+                <Button icon={EditIcon} text={text} />
+              </Box>
+            </Stack>
+
+            <Stack space={2}>
+              <Text muted size={1}>
+                Icon only button with tooltip (enforced)
+              </Text>
+              <Box>
+                <Button icon={EditIcon} tooltipProps={{content: 'Example tooltip'}} />
+              </Box>
+            </Stack>
+
+            <Stack space={2}>
+              <Text muted size={1}>
+                Large buttons should be sparingly used
+              </Text>
+              <Box>
+                <Button icon={PublishIcon} size="large" text="Publish" />
+              </Box>
+            </Stack>
+          </Stack>
+        </Card>
+      </Stack>
+    </Container>
+  )
+}

--- a/packages/sanity/src/ui-components/__workshop__/DialogStory.tsx
+++ b/packages/sanity/src/ui-components/__workshop__/DialogStory.tsx
@@ -1,0 +1,78 @@
+/* eslint-disable react/jsx-no-bind */
+
+import {Box, Card, Container, Stack, Text} from '@sanity/ui'
+import {useState} from 'react'
+import {Button} from '../button'
+import {Dialog} from '../dialog'
+
+export default function DialogStory() {
+  const [dialogDefaultOpen, setDialogDefaultOpen] = useState(false)
+  const [dialogPaddingOpen, setDialogPaddingOpen] = useState(false)
+
+  return (
+    <Container width={0} padding={4}>
+      <Stack space={4}>
+        <Card>
+          <Text size={1}>
+            <code>Dialog</code> components enforce a limited footer with an opinionated layout
+            (consisting of a max of two buttons: a cancel and confirm button).
+          </Text>
+        </Card>
+
+        <Card border radius={2}>
+          <Box marginBottom={3} padding={3}>
+            <Text size={2} weight="medium">
+              Usage examples
+            </Text>
+          </Box>
+          <Stack padding={3} space={4}>
+            <Stack space={3}>
+              {dialogDefaultOpen && (
+                <Dialog
+                  footer={{
+                    cancelButton: {text: 'Cancel'},
+                    confirmButton: {text: 'Confirm'},
+                  }}
+                  header="Footer"
+                  id="dialog-default"
+                  onClose={() => setDialogDefaultOpen(false)}
+                >
+                  <Text>Footer button styling is non-configurable.</Text>
+                </Dialog>
+              )}
+              <Text muted size={1}>
+                Default dialog with footer
+              </Text>
+              <Box>
+                <Button onClick={() => setDialogDefaultOpen(true)} text="Open" />
+              </Box>
+            </Stack>
+            <Stack space={3}>
+              {dialogPaddingOpen && (
+                <Dialog
+                  header="Padding"
+                  id="dialog-default"
+                  onClose={() => setDialogPaddingOpen(false)}
+                  padding={false}
+                >
+                  <Card padding={4} style={{height: '300px'}} tone="positive">
+                    <Text>
+                      Disabling padding can be useful when dealing with custom dialog content that
+                      requires overflow
+                    </Text>
+                  </Card>
+                </Dialog>
+              )}
+              <Text muted size={1}>
+                Dialog with padding disabled
+              </Text>
+              <Box>
+                <Button onClick={() => setDialogPaddingOpen(true)} text="Open" />
+              </Box>
+            </Stack>
+          </Stack>
+        </Card>
+      </Stack>
+    </Container>
+  )
+}

--- a/packages/sanity/src/ui-components/__workshop__/MenuButtonStory.tsx
+++ b/packages/sanity/src/ui-components/__workshop__/MenuButtonStory.tsx
@@ -1,0 +1,47 @@
+import {Box, Card, Container, Menu, Stack, Text} from '@sanity/ui'
+import {Button} from '../button'
+import {MenuItem} from '../menuItem'
+import {MenuButton} from '../menuButton'
+
+export default function MenuButtonStory() {
+  return (
+    <Container width={0} padding={4}>
+      <Stack space={4}>
+        <Card>
+          <Text size={1}>
+            All menus in the Studio should be consistently animated, and the <code>MenuButton</code>{' '}
+            component enforces this.
+          </Text>
+        </Card>
+
+        <Card border radius={2}>
+          <Box marginBottom={3} padding={3}>
+            <Text size={2} weight="medium">
+              Usage examples
+            </Text>
+          </Box>
+          <Stack padding={3} space={4}>
+            <Stack space={3}>
+              <Text muted size={1}>
+                Default
+              </Text>
+              <Box>
+                <MenuButton
+                  button={<Button text="Menu with animation" />}
+                  id="menu-button-1"
+                  menu={
+                    <Menu>
+                      <MenuItem text="Menu Item 1" />
+                      <MenuItem text="Menu Item 2" />
+                      <MenuItem text="Menu Item 3" />
+                    </Menu>
+                  }
+                />
+              </Box>
+            </Stack>
+          </Stack>
+        </Card>
+      </Stack>
+    </Container>
+  )
+}

--- a/packages/sanity/src/ui-components/__workshop__/MenuGroupStory.tsx
+++ b/packages/sanity/src/ui-components/__workshop__/MenuGroupStory.tsx
@@ -1,0 +1,48 @@
+import {EditIcon, EllipsisHorizontalIcon, PublishIcon, TrashIcon} from '@sanity/icons'
+import {Box, Card, Container, Menu, Stack, Text} from '@sanity/ui'
+import {MenuGroup} from '../menuGroup'
+import {MenuItem} from '../menuItem'
+
+export default function MenuGroupStory() {
+  return (
+    <Container width={0} padding={4}>
+      <Stack space={4}>
+        <Card>
+          <Text size={1}>
+            The <code>MenuGroup</code> component enforces font size and padding of the group{' '}
+            <code>MenuItem</code>. Group popovers are not animated.
+          </Text>
+        </Card>
+
+        <Card border radius={2}>
+          <Box marginBottom={3} padding={3}>
+            <Text size={2} weight="medium">
+              Usage examples
+            </Text>
+          </Box>
+          <Stack padding={3} space={4}>
+            <Stack space={3}>
+              <Text muted size={1}>
+                Default
+              </Text>
+              <Menu>
+                <MenuItem icon={PublishIcon} text="Menu Item 1" />
+                <MenuItem icon={EditIcon} text="Menu Item 2" />
+                <MenuItem icon={TrashIcon} text="Menu Item 3" />
+                <MenuGroup
+                  icon={EllipsisHorizontalIcon}
+                  popover={{placement: 'right-start'}}
+                  text="Group"
+                >
+                  <MenuItem text="Nested Menu Item 1" />
+                  <MenuItem text="Nested Menu Item 2" />
+                  <MenuItem text="Nested Menu Item 3" />
+                </MenuGroup>
+              </Menu>
+            </Stack>
+          </Stack>
+        </Card>
+      </Stack>
+    </Container>
+  )
+}

--- a/packages/sanity/src/ui-components/__workshop__/MenuItemStory.tsx
+++ b/packages/sanity/src/ui-components/__workshop__/MenuItemStory.tsx
@@ -2,7 +2,6 @@ import {hues} from '@sanity/color'
 import {CheckmarkIcon, CircleIcon} from '@sanity/icons'
 import {Avatar, Box, Card, Container, Menu, Stack, Text} from '@sanity/ui'
 import {useString} from '@sanity/ui-workshop'
-import React from 'react'
 import {MenuItem} from '../menuItem'
 
 const HOTKEYS = ['Ctrl', 'Alt', 'P']
@@ -13,7 +12,14 @@ export default function MenuItemStory() {
 
   return (
     <Container width={0} padding={4}>
-      <Stack space={2}>
+      <Stack space={4}>
+        <Card>
+          <Text size={1}>
+            <code>MenuItem</code> components enforce a single line of content with pre-determined
+            font size and padding, and also prevents custom children.
+          </Text>
+        </Card>
+
         <Card border radius={2}>
           <Box marginBottom={3} padding={3}>
             <Text size={2} weight="medium">
@@ -21,6 +27,7 @@ export default function MenuItemStory() {
             </Text>
           </Box>
           <Menu>
+            <MenuItem text={`${text} (with tooltip)`} tooltipProps={{content: 'Example tooltip'}} />
             <MenuItem text={text} />
             <MenuItem icon={CircleIcon} text={text} />
             <MenuItem iconRight={CheckmarkIcon} text={text} />

--- a/packages/sanity/src/ui-components/__workshop__/PopoverStory.tsx
+++ b/packages/sanity/src/ui-components/__workshop__/PopoverStory.tsx
@@ -1,0 +1,49 @@
+/* eslint-disable react/jsx-no-bind */
+import {Box, Card, Container, Stack, Text} from '@sanity/ui'
+import {useState} from 'react'
+import {Button} from '../button'
+import {Popover} from '../popover'
+
+export default function PopoverStory() {
+  const [popoverOpen, setPopoverOpen] = useState(false)
+
+  return (
+    <Container width={0} padding={4}>
+      <Stack space={4}>
+        <Card>
+          <Text size={1}>
+            All popvers in the Studio should be consistently animated, and the <code>Popover</code>{' '}
+            component enforces this.
+          </Text>
+        </Card>
+
+        <Card border radius={2}>
+          <Box marginBottom={3} padding={3}>
+            <Text size={2} weight="medium">
+              Usage examples
+            </Text>
+          </Box>
+          <Stack padding={3} space={4}>
+            <Stack space={3}>
+              <Text muted size={1}>
+                Default
+              </Text>
+              <Box>
+                <Popover
+                  content={
+                    <Box padding={3}>
+                      <Text>Popover content</Text>
+                    </Box>
+                  }
+                  open={popoverOpen}
+                >
+                  <Button onClick={() => setPopoverOpen(!popoverOpen)} text="Toggle popover" />
+                </Popover>
+              </Box>
+            </Stack>
+          </Stack>
+        </Card>
+      </Stack>
+    </Container>
+  )
+}

--- a/packages/sanity/src/ui-components/__workshop__/TabStory.tsx
+++ b/packages/sanity/src/ui-components/__workshop__/TabStory.tsx
@@ -1,0 +1,37 @@
+import {Box, Card, Container, Stack, TabList, Text} from '@sanity/ui'
+import {Tab} from '../tab'
+
+export default function TabStory() {
+  return (
+    <Container width={0} padding={4}>
+      <Stack space={4}>
+        <Card>
+          <Text size={1}>
+            The <code>Tab</code> component enforces font size and padding.
+          </Text>
+        </Card>
+
+        <Card border radius={2}>
+          <Box marginBottom={3} padding={3}>
+            <Text size={2} weight="medium">
+              Usage examples
+            </Text>
+          </Box>
+          <Stack padding={3} space={4}>
+            <Stack space={3}>
+              <Text muted size={1}>
+                Default
+              </Text>
+              <TabList>
+                <Tab aria-controls="tab-controls" id="tab-1" label="Tab 1" />
+                <Tab aria-controls="tab-controls" id="tab-2" label="Tab 2" />
+                <Tab aria-controls="tab-controls" id="tab-3" label="Tab 3" />
+                <Tab aria-controls="tab-controls" id="tab-4" label="Tab 4" />
+              </TabList>
+            </Stack>
+          </Stack>
+        </Card>
+      </Stack>
+    </Container>
+  )
+}

--- a/packages/sanity/src/ui-components/__workshop__/TooltipDelayGroupProviderStory.tsx
+++ b/packages/sanity/src/ui-components/__workshop__/TooltipDelayGroupProviderStory.tsx
@@ -1,0 +1,50 @@
+import {Box, Card, Container, Flex, Stack, Text} from '@sanity/ui'
+import {useString} from '@sanity/ui-workshop'
+import {Tooltip} from '../tooltip'
+import {TooltipDelayGroupProvider} from '../tooltipDelayGroupProvider'
+import {Button} from '../button'
+
+export default function TooltipDelayGroupProviderStory() {
+  const text = useString('Tooltip content', 'Tooltip content', 'Props') || ''
+
+  return (
+    <Container width={0} padding={4}>
+      <Stack space={4}>
+        <Card>
+          <Text size={1}>
+            The <code>TooltipDelayGroupProvider</code> component enforces shared tooltip delay
+            values in use throughout the Studio.
+          </Text>
+        </Card>
+
+        <Card border radius={2}>
+          <Box marginBottom={3} padding={3}>
+            <Text size={2} weight="medium">
+              Usage examples
+            </Text>
+          </Box>
+          <Stack padding={3} space={4}>
+            <Stack space={3}>
+              <Text muted size={1}>
+                Default
+              </Text>
+              <TooltipDelayGroupProvider>
+                <Flex gap={2}>
+                  <Tooltip content={text}>
+                    <Button text="Button 1" />
+                  </Tooltip>
+                  <Tooltip content={text}>
+                    <Button text="Button 2" />
+                  </Tooltip>
+                  <Tooltip content={text}>
+                    <Button text="Button 3" />
+                  </Tooltip>
+                </Flex>
+              </TooltipDelayGroupProvider>
+            </Stack>
+          </Stack>
+        </Card>
+      </Stack>
+    </Container>
+  )
+}

--- a/packages/sanity/src/ui-components/__workshop__/TooltipStory.tsx
+++ b/packages/sanity/src/ui-components/__workshop__/TooltipStory.tsx
@@ -1,0 +1,78 @@
+import {Box, Card, Container, Stack, Text} from '@sanity/ui'
+import {useString} from '@sanity/ui-workshop'
+import {Tooltip} from '../tooltip'
+import {Button} from '../button'
+
+export default function TooltipStory() {
+  const text = useString('Tooltip content', 'Tooltip content', 'Props') || ''
+
+  return (
+    <Container width={0} padding={4}>
+      <Stack space={4}>
+        <Card>
+          <Text size={1}>
+            The <code>Tooltip</code> component enforces animation and will correctly style tooltip
+            content when provided as a string (recommended). It also provides affordances for
+            displaying hotkeys.
+          </Text>
+        </Card>
+
+        <Card border radius={2}>
+          <Box marginBottom={3} padding={3}>
+            <Text size={2} weight="medium">
+              Recommended
+            </Text>
+          </Box>
+          <Stack padding={3} space={4}>
+            <Stack space={3}>
+              <Text muted size={1}>
+                String content
+              </Text>
+              <Tooltip content={text}>
+                <Box>
+                  <Button text="Text" />
+                </Box>
+              </Tooltip>
+            </Stack>
+            <Stack space={3}>
+              <Text muted size={1}>
+                String content with hotkeys
+              </Text>
+              <Tooltip content={text} hotkeys={['Ctrl', 'Alt', 'P']}>
+                <Box>
+                  <Button text="Text" />
+                </Box>
+              </Tooltip>
+            </Stack>
+          </Stack>
+        </Card>
+
+        <Card border radius={2} tone="caution">
+          <Box marginBottom={3} padding={3}>
+            <Text size={2} weight="medium">
+              Not recommended
+            </Text>
+          </Box>
+          <Stack padding={3} space={4}>
+            <Stack space={3}>
+              <Text muted size={1}>
+                Content as <code>React.Node</code>
+              </Text>
+              <Tooltip
+                content={
+                  <Card padding={4}>
+                    <Text weight="semibold">{text}</Text>
+                  </Card>
+                }
+              >
+                <Box>
+                  <Button text="Text" />
+                </Box>
+              </Tooltip>
+            </Stack>
+          </Stack>
+        </Card>
+      </Stack>
+    </Container>
+  )
+}

--- a/packages/sanity/src/ui-components/__workshop__/index.ts
+++ b/packages/sanity/src/ui-components/__workshop__/index.ts
@@ -6,9 +6,49 @@ export default defineScope({
   title: 'Studio UI',
   stories: [
     {
+      name: 'button',
+      title: 'Button',
+      component: lazy(() => import('./ButtonStory')),
+    },
+    {
+      name: 'dialog',
+      title: 'Dialog',
+      component: lazy(() => import('./DialogStory')),
+    },
+    {
+      name: 'menu-button',
+      title: 'MenuButton',
+      component: lazy(() => import('./MenuButtonStory')),
+    },
+    {
+      name: 'menu-group',
+      title: 'MenuGroup',
+      component: lazy(() => import('./MenuGroupStory')),
+    },
+    {
       name: 'menu-item',
       title: 'MenuItem',
       component: lazy(() => import('./MenuItemStory')),
+    },
+    {
+      name: 'popover',
+      title: 'Popover',
+      component: lazy(() => import('./PopoverStory')),
+    },
+    {
+      name: 'tab',
+      title: 'Tab',
+      component: lazy(() => import('./TabStory')),
+    },
+    {
+      name: 'tooltip',
+      title: 'Tooltip',
+      component: lazy(() => import('./TooltipStory')),
+    },
+    {
+      name: 'tooltip-delay-group-provider',
+      title: 'TooltipDelayGroupProvider',
+      component: lazy(() => import('./TooltipDelayGroupProviderStory')),
     },
   ],
 })

--- a/packages/sanity/src/ui-components/tab/Tab.tsx
+++ b/packages/sanity/src/ui-components/tab/Tab.tsx
@@ -10,17 +10,7 @@ import React, {forwardRef} from 'react'
 export type TabProps = Pick<
   UITabProps,
   'aria-controls' | 'focused' | 'icon' | 'id' | 'label' | 'selected' | 'tone'
-> & {
-  size?: 'default' | 'small'
-}
-
-const SMALL_TAB_PROPS = {
-  padding: 2,
-}
-
-const DEFAULT_TAB_PROPS = {
-  padding: 3,
-}
+>
 
 /**
  * Customized Sanity UI <Tab> with limited layout options.
@@ -28,20 +18,8 @@ const DEFAULT_TAB_PROPS = {
  * @internal
  */
 export const Tab = forwardRef(function Tab(
-  {
-    size = 'small',
-    tone = 'default',
-    ...props
-  }: TabProps & Omit<React.HTMLProps<HTMLButtonElement>, 'as' | 'size'>,
+  {tone = 'default', ...props}: TabProps & Omit<React.HTMLProps<HTMLButtonElement>, 'as' | 'size'>,
   ref: React.ForwardedRef<HTMLButtonElement>,
 ) {
-  return (
-    <UITab
-      {...props}
-      {...(size === 'default' ? DEFAULT_TAB_PROPS : SMALL_TAB_PROPS)}
-      muted
-      ref={ref}
-      tone={tone}
-    />
-  )
+  return <UITab {...props} muted padding={2} ref={ref} tone={tone} />
 })


### PR DESCRIPTION
### Description

This PR adds some basic workshop stories outlining usage guidelines for internal components, and is intended to be expanded on in future.

This also simplifies the internal `<Tab>` component and removes the `size` prop, since these are only ever rendered in a single size throughout.

### What to review

Workshop stories are accessible and make sense.

### Testing

These stories act as a simple reference and facilitate spot testing.

### Notes for release

N/A