### PR TITLE
fix(validation): update min and max to include string for dates

### DIFF
--- a/packages/@sanity/types/src/validation/types.ts
+++ b/packages/@sanity/types/src/validation/types.ts
@@ -153,8 +153,8 @@ export interface Rule {
   optional(): Rule
   required(): Rule
   custom<T = unknown>(fn: CustomValidator<T>, options?: {bypassConcurrencyLimit?: boolean}): Rule
-  min(len: number | FieldReference): Rule
-  max(len: number | FieldReference): Rule
+  min(len: number | string | FieldReference): Rule
+  max(len: number | string | FieldReference): Rule
   length(len: number | FieldReference): Rule
   valid(value: unknown | unknown[]): Rule
   integer(): Rule
@@ -203,8 +203,8 @@ export type RuleSpec =
   | {flag: 'either'; constraint: Rule[]}
   | {flag: 'presence'; constraint: 'optional' | 'required'}
   | {flag: 'custom'; constraint: CustomValidator}
-  | {flag: 'min'; constraint: number}
-  | {flag: 'max'; constraint: number}
+  | {flag: 'min'; constraint: number | string}
+  | {flag: 'max'; constraint: number | string}
   | {flag: 'length'; constraint: number}
   | {flag: 'valid'; constraint: unknown[]}
   | {flag: 'precision'; constraint: number}

--- a/packages/sanity/src/core/validation/Rule.ts
+++ b/packages/sanity/src/core/validation/Rule.ts
@@ -232,11 +232,11 @@ export const Rule: RuleClass = class Rule implements IRule {
     return this.cloneWithRules([{flag: 'custom', constraint: fn as CustomValidator}])
   }
 
-  min(len: number): Rule {
+  min(len: number | string): Rule {
     return this.cloneWithRules([{flag: 'min', constraint: len}])
   }
 
-  max(len: number): Rule {
+  max(len: number | string): Rule {
     return this.cloneWithRules([{flag: 'max', constraint: len}])
   }
 


### PR DESCRIPTION
### Description

Related to #5551.

This fixes the types for `rule.min` and `rule.max` to include strings because the date validator allows them. This was just an oversight on types when this part of the codebase was converted to TS (by me lol)

### What to review

Can you use `rule.min()` and `rule.max()` with a string now?

### Testing

Re-ran `npm run type-check` and tried out using a string in rule.min and it worked as expected

### Notes for release

- Fixes an type bug where `Rule.min` and `Rule.max` did not allow strings