### PR TITLE
Improve asset export retrying 

### DIFF
--- a/packages/@sanity/export/src/AssetHandler.js
+++ b/packages/@sanity/export/src/AssetHandler.js
@@ -180,8 +180,7 @@ class AssetHandler {
     try {
       stream = await requestStream(options)
     } catch (err) {
-      this.reject(err)
-      return false
+      throw new Error('Failed create asset stream', {cause: err})
     }
 
     if (stream.statusCode !== 200) {
@@ -193,8 +192,7 @@ class AssetHandler {
           errMsg = `${errMsg}:\n\n${err}`
         }
 
-        this.reject(new Error(errMsg))
-        return false
+        throw new Error(errMsg)
       } catch (err) {
         throw new Error('Failed to parse error response from asset stream', {cause: err})
       }

--- a/packages/@sanity/export/src/AssetHandler.js
+++ b/packages/@sanity/export/src/AssetHandler.js
@@ -124,7 +124,7 @@ class AssetHandler {
     this.downloading.push(assetDoc.url)
 
     const doDownload = retryHelper(
-      5, // try 5 times
+      10, // try 10 times
       () => this.downloadAsset(assetDoc, dstPath),
       (err, attempt) => {
         debug(


### PR DESCRIPTION
### Description

We are experiencing that our export assets endpoints hangs up the connections, and for some reason the CLI is trying to reuse the dead connection. This PR adds more retry mechanisms to download assets.



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

```
$ npm run build
$ cd dev/test-studio
$ DEBUG=sanity* ../../packages/@sanity/cli/bin/sanity dataset export test --overwrite
```

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
