### PR TITLE
feat(migration): support async hooks in migration nodes

### DIFF
--- a/packages/@sanity/migrate/src/types.ts
+++ b/packages/@sanity/migrate/src/types.ts
@@ -69,40 +69,40 @@ export interface NodeMigration {
   document?: <Doc extends SanityDocument>(
     doc: Doc,
     context: MigrationContext,
-  ) => DocumentMigrationReturnValue
+  ) => DocumentMigrationReturnValue | Promise<DocumentMigrationReturnValue>
   node?: <Node extends JsonValue>(
     node: Node,
     path: Path,
     context: MigrationContext,
-  ) => NodeMigrationReturnValue
+  ) => NodeMigrationReturnValue | Promise<NodeMigrationReturnValue>
   object?: <Node extends JsonObject>(
     node: Node,
     path: Path,
     context: MigrationContext,
-  ) => NodeMigrationReturnValue
+  ) => NodeMigrationReturnValue | Promise<NodeMigrationReturnValue>
   array?: <Node extends JsonArray>(
     node: Node,
     path: Path,
     context: MigrationContext,
-  ) => NodeMigrationReturnValue
+  ) => NodeMigrationReturnValue | Promise<NodeMigrationReturnValue>
   string?: <Node extends string>(
     node: Node,
     path: Path,
     context: MigrationContext,
-  ) => NodeMigrationReturnValue
+  ) => NodeMigrationReturnValue | Promise<NodeMigrationReturnValue>
   number?: <Node extends number>(
     node: Node,
     path: Path,
     context: MigrationContext,
-  ) => NodeMigrationReturnValue
+  ) => NodeMigrationReturnValue | Promise<NodeMigrationReturnValue>
   boolean?: <Node extends boolean>(
     node: Node,
     path: Path,
     context: MigrationContext,
-  ) => NodeMigrationReturnValue
+  ) => NodeMigrationReturnValue | Promise<NodeMigrationReturnValue>
   null?: <Node extends null>(
     node: Node,
     path: Path,
     context: MigrationContext,
-  ) => NodeMigrationReturnValue
+  ) => NodeMigrationReturnValue | Promise<NodeMigrationReturnValue>
 }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Adds support for async hooks in migration nodes for instance you can do the following thing

```ts
export default defineMigration({
  name: 'Cleanup empty values',
  documentType: 'playlist',
  migrate: {
    async object(node) {
      if (Object.keys(node).filter((k) => !k.startsWith('_')).length) {
        await setTimeout(() => console.log('waiting object'), 1000)
        return unset()
      }
    },
    async array(node) {
      if (node.length === 0) {
        await setTimeout(() => console.log('waiting array'), 1000)
        return unset()
      }
    },
    async string(node) {
      if (node.length === 0) {
        await setTimeout(() => console.log('waiting string'), 1000)
        return unset()
      }
    },
  },
})
```

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

If everything still works

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

- [ ] Add unit tests for the functions in `normalizeMigrateDefinition`
- [ ] Investigate how easy/hard is to write integration tests for migration CLI

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

N/A
