### PR TITLE
chore(core): include user agent and screen density in telemetry calls

### DIFF
--- a/packages/@sanity/types/src/validation/types.ts
+++ b/packages/@sanity/types/src/validation/types.ts
@@ -153,8 +153,8 @@ export interface Rule {
   optional(): Rule
   required(): Rule
   custom<T = unknown>(fn: CustomValidator<T>, options?: {bypassConcurrencyLimit?: boolean}): Rule
-  min(len: number | FieldReference): Rule
-  max(len: number | FieldReference): Rule
+  min(len: number | string | FieldReference): Rule
+  max(len: number | string | FieldReference): Rule
   length(len: number | FieldReference): Rule
   valid(value: unknown | unknown[]): Rule
   integer(): Rule
@@ -203,8 +203,8 @@ export type RuleSpec =
   | {flag: 'either'; constraint: Rule[]}
   | {flag: 'presence'; constraint: 'optional' | 'required'}
   | {flag: 'custom'; constraint: CustomValidator}
-  | {flag: 'min'; constraint: number}
-  | {flag: 'max'; constraint: number}
+  | {flag: 'min'; constraint: number | string}
+  | {flag: 'max'; constraint: number | string}
   | {flag: 'length'; constraint: number}
   | {flag: 'valid'; constraint: unknown[]}
   | {flag: 'precision'; constraint: number}

--- a/packages/sanity/src/core/studio/StudioTelemetryProvider.tsx
+++ b/packages/sanity/src/core/studio/StudioTelemetryProvider.tsx
@@ -38,6 +38,14 @@ export function StudioTelemetryProvider(props: {children: ReactNode; config: Con
 
   useEffect(() => {
     store.logger.updateUserProperties({
+      userAgent: navigator.userAgent,
+      screen: {
+        density: window.devicePixelRatio,
+        height: window.screen.height,
+        width: window.screen.width,
+        innerHeight: window.innerHeight,
+        innerWidth: window.innerWidth,
+      },
       studioVersion: SANITY_VERSION,
       plugins: arrify(props.config).flatMap(
         (config) =>

--- a/packages/sanity/src/core/validation/Rule.ts
+++ b/packages/sanity/src/core/validation/Rule.ts
@@ -232,11 +232,11 @@ export const Rule: RuleClass = class Rule implements IRule {
     return this.cloneWithRules([{flag: 'custom', constraint: fn as CustomValidator}])
   }
 
-  min(len: number): Rule {
+  min(len: number | string): Rule {
     return this.cloneWithRules([{flag: 'min', constraint: len}])
   }
 
-  max(len: number): Rule {
+  max(len: number | string): Rule {
     return this.cloneWithRules([{flag: 'max', constraint: len}])
   }
 


### PR DESCRIPTION
### Description

This change adds `userAgent` and `screen` properties to the user identify call for telemetry.

### Testing

- In a telemetry enabled studio, check that calls to the telemetry intake (`/intake/batch`) includes user agent and screen properties

### Notes for release

n/a
