### PR TITLE
feat(cli): add pretty mutation formatting to migration runner

### DIFF
--- a/packages/@sanity/migrate/src/runner/dryRun.ts
+++ b/packages/@sanity/migrate/src/runner/dryRun.ts
@@ -64,6 +64,13 @@ export async function dryRun(config: MigrationRunnerOptions, migration: Migratio
     },
   )
 
+  // yield *
+  //   collectMigrationMutations(
+  //     migration,
+  //     () => parse(decodeText(streamToAsyncIterator(createReader())), {parse: safeJsonParser}),
+  //     context,
+  //   )
+
   for await (const mutation of await toArray(mutations)) {
     config.onProgress?.({
       ...stats,

--- a/packages/@sanity/migrate/src/runner/dryRun.ts
+++ b/packages/@sanity/migrate/src/runner/dryRun.ts
@@ -1,13 +1,11 @@
-import arrify from 'arrify'
 import {SanityDocument} from '@sanity/types'
 import {APIConfig, Migration, MigrationProgress} from '../types'
 import {fromExportEndpoint, safeJsonParser} from '../sources/fromExportEndpoint'
 import {streamToAsyncIterator} from '../utils/streamToAsyncIterator'
 import {bufferThroughFile} from '../fs-webstream/bufferThroughFile'
 import {asyncIterableToStream} from '../utils/asyncIterableToStream'
-import {tap} from '../it-utils/tap'
 import {parse, stringify} from '../it-utils/ndjson'
-import {decodeText, toArray} from '../it-utils'
+import {decodeText} from '../it-utils'
 import {collectMigrationMutations} from './collectMigrationMutations'
 import {getBufferFilePath} from './utils/getBufferFile'
 import {createBufferFileContext} from './utils/createBufferFileContext'
@@ -18,16 +16,7 @@ interface MigrationRunnerOptions {
   onProgress?: (event: MigrationProgress) => void
 }
 
-export async function dryRun(config: MigrationRunnerOptions, migration: Migration) {
-  const stats: MigrationProgress = {
-    documents: 0,
-    mutations: 0,
-    pending: 0,
-    queuedBatches: 0,
-    completedTransactions: [],
-    currentTransactions: [],
-  }
-
+export async function* dryRun(config: MigrationRunnerOptions, migration: Migration) {
   const filteredDocuments = applyFilters(
     migration,
     parse<SanityDocument>(
@@ -41,6 +30,7 @@ export async function dryRun(config: MigrationRunnerOptions, migration: Migratio
   )
 
   const abortController = new AbortController()
+
   const createReader = bufferThroughFile(
     asyncIterableToStream(stringify(filteredDocuments)),
     getBufferFilePath(),
@@ -49,38 +39,12 @@ export async function dryRun(config: MigrationRunnerOptions, migration: Migratio
 
   const context = createBufferFileContext(createReader)
 
-  const mutations = tap(
-    collectMigrationMutations(
-      migration,
-      () => parse(decodeText(streamToAsyncIterator(createReader())), {parse: safeJsonParser}),
-      context,
-    ),
-    (muts) => {
-      stats.currentTransactions = arrify(muts)
-      config.onProgress?.({
-        ...stats,
-        mutations: ++stats.mutations,
-      })
-    },
+  yield* collectMigrationMutations(
+    migration,
+    () => parse(decodeText(streamToAsyncIterator(createReader())), {parse: safeJsonParser}),
+    context,
   )
 
-  // yield *
-  //   collectMigrationMutations(
-  //     migration,
-  //     () => parse(decodeText(streamToAsyncIterator(createReader())), {parse: safeJsonParser}),
-  //     context,
-  //   )
-
-  for await (const mutation of await toArray(mutations)) {
-    config.onProgress?.({
-      ...stats,
-    })
-  }
-
-  config.onProgress?.({
-    ...stats,
-    done: true,
-  })
   // stop buffering the export once we're done collecting all mutations
   abortController.abort()
 }

--- a/packages/sanity/src/_internal/cli/actions/validation/reporters/prettyReporter/formatDocumentValidation.ts
+++ b/packages/sanity/src/_internal/cli/actions/validation/reporters/prettyReporter/formatDocumentValidation.ts
@@ -1,18 +1,19 @@
 import chalk from 'chalk'
-import {ValidationMarker} from '@sanity/types'
+import {ValidationMarker, Path} from '@sanity/types'
 import logSymbols from 'log-symbols'
+import {Tree, convertToTree, formatTree, maxKeyLength} from '../../../../util/tree'
 import {DocumentValidationResult, Level, isTty, levelValues} from './util'
-import {pathToString} from 'sanity'
 
 export interface FormatDocumentValidationOptions extends DocumentValidationResult {
   studioHost: string | null
   basePath: string
 }
 
-interface ValidationTree {
-  markers?: Pick<ValidationMarker, 'level' | 'message'>[]
-  children?: Record<string, ValidationTree>
+interface Marker extends Pick<ValidationMarker, 'level' | 'message'> {
+  path: Path
 }
+
+type ValidationTree = Tree<Marker>
 
 const levelHeaders = {
   error: isTty ? chalk.bold(chalk.bgRed(chalk.black(' ERROR '))) : chalk.red('[ERROR]'),
@@ -27,72 +28,18 @@ const link = (text: string, url: string) =>
   isTty ? `\u001b]8;;${url}\u0007${text}\u001b]8;;\u0007` : chalk.underline(text)
 
 /**
- * Recursively calculates the max length of all the keys in the given validation
- * tree respecting extra length due to indentation depth. Used to calculate the
- * padding for the rest of the tree.
- */
-const maxKeyLength = (children: Record<string, ValidationTree> = {}, depth = 0): number => {
-  return Object.entries(children)
-    .map(([key, child]) =>
-      Math.max(key.length + depth * 2, maxKeyLength(child.children, depth + 1)),
-    )
-    .reduce((max, next) => (next > max ? next : max), 0)
-}
-
-/**
  * For sorting markers
  */
 const compareLevels = <T extends {level: Level; message: string}>(a: T, b: T) =>
   levelValues[a.level] - levelValues[b.level]
 
 /**
- * Recursively formats a given tree into a printed user-friendly tree structure
- */
-const formatTree = (
-  node: Record<string, ValidationTree> = {},
-  paddingLength: number,
-  indent = '',
-): string => {
-  const entries = Object.entries(node)
-
-  return entries
-    .map(([key, child], index) => {
-      const isLast = index === entries.length - 1
-      const nextIndent = `${indent}${isLast ? '  ' : '│ '}`
-      const nested = formatTree(child.children, paddingLength, nextIndent)
-
-      if (!child.markers?.length) {
-        const current = `${indent}${isLast ? '└' : '├'}─ ${key}`
-        return [current, nested].filter(Boolean).join('\n')
-      }
-
-      const [first, ...rest] = child.markers.slice().sort(compareLevels)
-      const firstPadding = '.'.repeat(paddingLength - indent.length - key.length)
-      const elbow = isLast ? '└' : '├'
-      const firstBullet = logSymbols[first.level]
-      const subsequentPadding = ' '.repeat(paddingLength - indent.length + 2)
-
-      const firstMessage = `${indent}${elbow}─ ${key} ${firstPadding} ${firstBullet} ${first.message}`
-      const subsequentMessages = rest
-        .map(
-          (marker) =>
-            `${nextIndent}${subsequentPadding} ${logSymbols[marker.level]} ${marker.message}`,
-        )
-        .join('\n')
-
-      const current = [firstMessage, subsequentMessages].filter(Boolean).join('\n')
-      return [current, nested].filter(Boolean).join('\n')
-    })
-    .join('\n')
-}
-
-/**
  * Formats the markers at the root of the validation tree
  */
 const formatRootErrors = (root: ValidationTree, hasChildren: boolean, paddingLength: number) => {
-  if (!root.markers) return ''
+  if (!root.nodes) return ''
 
-  const [first, ...rest] = root.markers.slice().sort(compareLevels)
+  const [first, ...rest] = root.nodes.slice().sort(compareLevels)
   if (!first) return ''
 
   const firstElbow = hasChildren ? '│ ' : '└─'
@@ -113,38 +60,6 @@ const formatRootErrors = (root: ValidationTree, hasChildren: boolean, paddingLen
 }
 
 /**
- * Converts a set of markers with paths into a tree of markers where the paths
- * are embedded in the tree
- */
-function convertToTree(markers: ValidationMarker[]): ValidationTree {
-  const root: ValidationTree = {}
-
-  // add the markers to the tree
-  function addMarker(marker: ValidationMarker, node: ValidationTree = root) {
-    // if we've traversed the whole path
-    if (!marker.path.length) {
-      if (!node.markers) node.markers = [] // ensure markers is defined
-
-      // then add the marker to the front
-      node.markers.push({level: marker.level, message: marker.message})
-      return
-    }
-
-    const [current, ...rest] = marker.path
-    const key = pathToString([current])
-
-    // ensure the current node has children and the next node
-    if (!node.children) node.children = {}
-    if (!(key in node.children)) node.children[key] = {}
-
-    addMarker({...marker, path: rest}, node.children[key])
-  }
-
-  for (const marker of markers) addMarker(marker)
-  return root
-}
-
-/**
  * Formats document validation results into a user-friendly tree structure
  */
 export function formatDocumentValidation({
@@ -155,7 +70,7 @@ export function formatDocumentValidation({
   studioHost,
   markers,
 }: FormatDocumentValidationOptions): string {
-  const tree = convertToTree(markers)
+  const tree = convertToTree<Marker>(markers)
   const editLink =
     studioHost &&
     `${studioHost}${basePath}/intent/edit/id=${encodeURIComponent(
@@ -171,7 +86,14 @@ export function formatDocumentValidation({
   }`
 
   const paddingLength = Math.max(maxKeyLength(tree.children) + 2, 30)
-  const childErrors = formatTree(tree.children, paddingLength)
+
+  const childErrors = formatTree<Marker>({
+    node: tree.children,
+    paddingLength,
+    getNodes: ({nodes}) => (nodes ?? []).slice().sort(compareLevels),
+    getMessage: (marker) => [logSymbols[marker.level], marker.message].join(' '),
+  })
+
   const rootErrors = formatRootErrors(tree, childErrors.length > 0, paddingLength)
 
   return [header, rootErrors, childErrors].filter(Boolean).join('\n')

--- a/packages/sanity/src/_internal/cli/commands/migration/prettyMutationFormatter.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/prettyMutationFormatter.ts
@@ -17,7 +17,7 @@ interface FormatterOptions {
 }
 
 export function prettyFormat({chalk, mutations, migration}: FormatterOptions): string {
-  return `${[...mutations].flatMap((m) => prettyFormatMutation(chalk, m, migration)).join('\n')}\n`
+  return `${[...mutations].flatMap((m) => prettyFormatMutation(chalk, m, migration)).join('\n')}`
 }
 
 function encodeItemRef(ref: number | KeyedSegment): ItemRef {

--- a/packages/sanity/src/_internal/cli/commands/migration/prettyMutationFormatter.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/prettyMutationFormatter.ts
@@ -82,7 +82,9 @@ function mutationHeader(chalk: Chalk, mutation: Mutation, migration: Migration):
       : null
 
   // TODO: Should we list documentType when a mutation can be yielded for any document type?
-  return [mutationType, documentType, documentId(mutation)].filter(Boolean).join(' ')
+  return [mutationType, documentType, chalk.underline(documentId(mutation))]
+    .filter(Boolean)
+    .join(' ')
 }
 
 export function prettyFormatMutation(

--- a/packages/sanity/src/_internal/cli/commands/migration/prettyMutationFormatter.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/prettyMutationFormatter.ts
@@ -63,13 +63,23 @@ function documentId(mutation: Mutation): string | undefined {
   return undefined
 }
 
+const listFormatter = new Intl.ListFormat('en-US', {
+  type: 'disjunction',
+})
+
 function mutationHeader(chalk: Chalk, mutation: Mutation, migration: Migration): string {
   const mutationType = badge(mutation.type, mutationImpact[mutation.type], chalk)
-  const documentType = badge(
-    'document' in mutation ? mutation.document._type : migration.documentType,
-    'info',
-    chalk,
-  )
+
+  const documentType =
+    'document' in mutation || migration.documentTypes
+      ? badge(
+          'document' in mutation
+            ? mutation.document._type
+            : listFormatter.format(migration.documentTypes ?? []),
+          'info',
+          chalk,
+        )
+      : null
 
   // TODO: Should we list documentType when a mutation can be yielded for any document type?
   return [mutationType, documentType, documentId(mutation)].filter(Boolean).join(' ')

--- a/packages/sanity/src/_internal/cli/commands/migration/prettyMutationFormatter.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/prettyMutationFormatter.ts
@@ -79,18 +79,26 @@ export function prettyFormatMutation(
   chalk: Chalk,
   mutation: Mutation,
   migration: Migration,
-  indent = 0,
+  indentSize = 0,
 ): string {
   const lock =
     'options' in mutation ? chalk.cyan(`(if revision==${mutation.options?.ifRevision})`) : ''
   const header = [mutationHeader(chalk, mutation, migration), lock].join(' ')
+  const indent = ' '.repeat(indentSize)
 
   if (
     mutation.type === 'create' ||
     mutation.type === 'createIfNotExists' ||
     mutation.type === 'createOrReplace'
   ) {
-    return [header, '\n', JSON.stringify(mutation.document, null, 2)].join('')
+    return [
+      header,
+      '\n',
+      JSON.stringify(mutation.document, null, 2)
+        .split('\n')
+        .map((line) => indent + line)
+        .join('\n'),
+    ].join('')
   }
 
   if (mutation.type === 'patch') {
@@ -99,7 +107,7 @@ export function prettyFormatMutation(
     return [
       header,
       '\n',
-      formatTree(tree.children, paddingLength, ' '.repeat(indent), (patch) =>
+      formatTree(tree.children, paddingLength, indent, (patch) =>
         formatPatchMutation(chalk, patch),
       ),
     ].join('')

--- a/packages/sanity/src/_internal/cli/commands/migration/prettyMutationFormatter.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/prettyMutationFormatter.ts
@@ -1,0 +1,242 @@
+import {isatty} from 'tty'
+import {Migration, Mutation, NodePatch, NodePatchList} from '@sanity/migrate'
+import {KeyedSegment} from '@sanity/types'
+import {Chalk} from 'chalk'
+import {pathToString} from 'sanity'
+
+type ItemRef = string | number
+type Impact = 'destructive' | 'maybeDestructive' | 'incremental'
+type Variant = Impact | 'info'
+
+const isTty = isatty(1)
+
+interface FormatterOptions {
+  chalk: Chalk
+  mutations: Mutation[]
+  migration: Migration
+}
+
+export function prettyFormat({chalk, mutations, migration}: FormatterOptions): string {
+  return `${[...mutations].flatMap((m) => prettyFormatMutation(chalk, m, migration)).join('\n')}\n`
+}
+
+function encodeItemRef(ref: number | KeyedSegment): ItemRef {
+  return typeof ref === 'number' ? ref : ref._key
+}
+
+function badgeStyle(chalk: Chalk, variant: Variant): Chalk {
+  const styles: Record<Variant, Chalk> = {
+    info: chalk.bgWhite.black,
+    incremental: chalk.bgGreen.black.bold,
+    maybeDestructive: chalk.bgYellow.black.bold,
+    destructive: chalk.bgRed.black.bold,
+  }
+
+  return styles[variant]
+}
+
+function badge(label: string, variant: Variant, chalk: Chalk): string {
+  if (!isTty) {
+    return `[${label}]`
+  }
+
+  return badgeStyle(chalk, variant)(` ${label} `)
+}
+
+const mutationImpact: Record<Mutation['type'], Impact> = {
+  create: 'incremental',
+  createIfNotExists: 'incremental',
+  createOrReplace: 'maybeDestructive',
+  delete: 'destructive',
+  patch: 'maybeDestructive',
+}
+
+function documentId(mutation: Mutation): string | undefined {
+  if ('id' in mutation) {
+    return mutation.id
+  }
+
+  if ('document' in mutation) {
+    return mutation.document._id
+  }
+
+  return undefined
+}
+
+function mutationHeader(chalk: Chalk, mutation: Mutation, migration: Migration): string {
+  const mutationType = badge(mutation.type, mutationImpact[mutation.type], chalk)
+  const documentType = badge(
+    'document' in mutation ? mutation.document._type : migration.documentType,
+    'info',
+    chalk,
+  )
+
+  // TODO: Should we list documentType when a mutation can be yielded for any document type?
+  return [mutationType, documentType, documentId(mutation)].filter(Boolean).join(' ')
+}
+
+export function prettyFormatMutation(
+  chalk: Chalk,
+  mutation: Mutation,
+  migration: Migration,
+): string {
+  const lock =
+    'options' in mutation ? chalk.cyan(`(if revision==${mutation.options?.ifRevision})`) : ''
+  const header = [mutationHeader(chalk, mutation, migration), lock].join(' ')
+
+  if (
+    mutation.type === 'create' ||
+    mutation.type === 'createIfNotExists' ||
+    mutation.type === 'createOrReplace'
+  ) {
+    return [header, '\n', JSON.stringify(mutation.document, null, 2)].join('')
+  }
+
+  if (mutation.type === 'patch') {
+    const tree = convertToTree(mutation.patches)
+    const paddingLength = Math.max(maxKeyLength(tree.children) + 2, 30)
+    return [
+      header,
+      '\n',
+      formatTree(tree.children, paddingLength, '', (patch) => formatPatchMutation(chalk, patch)),
+    ].join('')
+  }
+
+  return header
+}
+
+function formatPatchMutation(chalk: Chalk, patch: NodePatch): string {
+  const {op} = patch
+  const formattedType = chalk.bold(op.type)
+  if (op.type === 'unset') {
+    return `${chalk.red(formattedType)}()`
+  }
+  if (op.type === 'diffMatchPatch') {
+    return `${chalk.yellow(formattedType)}(${op.value})`
+  }
+  if (op.type === 'inc' || op.type === 'dec') {
+    return `${chalk.yellow(formattedType)}(${op.amount})`
+  }
+  if (op.type === 'set') {
+    return `${chalk.yellow(formattedType)}(${JSON.stringify(op.value)})`
+  }
+  if (op.type === 'setIfMissing') {
+    return `${chalk.green(formattedType)}(${JSON.stringify(op.value)})`
+  }
+  if (op.type === 'assign') {
+    return `${chalk.yellow(formattedType)}(${JSON.stringify(op.value)})`
+  }
+  if (op.type === 'unassign') {
+    return `${chalk.red(formattedType)}(${JSON.stringify(op.keys)})`
+  }
+  if (op.type === 'insert') {
+    return `${chalk.green(formattedType)}(${op.position}, ${encodeItemRef(
+      op.referenceItem,
+    )}, ${JSON.stringify(op.items)})`
+  }
+  if (op.type === 'upsert') {
+    return `${chalk.yellow(formattedType)}(${op.position}, ${encodeItemRef(
+      op.referenceItem,
+    )}, ${JSON.stringify(op.items)})`
+  }
+  if (op.type === 'replace') {
+    return `${chalk.yellow(formattedType)}(${encodeItemRef(op.referenceItem)}, ${JSON.stringify(
+      op.items,
+    )})`
+  }
+  if (op.type === 'truncate') {
+    return `${chalk.red(formattedType)}(${op.startIndex}, ${op.endIndex})`
+  }
+  // @ts-expect-error all cases are covered
+  throw new Error(`Invalid operation type: ${op.type}`)
+}
+
+interface PatchTree {
+  patches?: Extract<NodePatchList, [NodePatch, ...NodePatch[]] | NodePatch[]>
+  children?: Record<string, PatchTree>
+}
+
+/**
+ * Converts a set of markers with paths into a tree of markers where the paths
+ * are embedded in the tree
+ */
+function convertToTree(patches: NodePatchList): PatchTree {
+  const root: PatchTree = {}
+
+  // add the markers to the tree
+  function addPatch(patch: NodePatch, node: PatchTree = root) {
+    // if we've traversed the whole path
+    if (!patch.path.length) {
+      if (!node.patches) node.patches = [] // ensure markers is defined
+
+      // then add the marker to the front
+      node.patches.push(patch)
+      return
+    }
+
+    const [current, ...rest] = patch.path
+    const key = pathToString([current])
+
+    // ensure the current node has children and the next node
+    if (!node.children) node.children = {}
+    if (!(key in node.children)) node.children[key] = {}
+
+    addPatch({...patch, path: rest}, node.children[key])
+  }
+
+  for (const patch of patches.flat()) addPatch(patch)
+  return root
+}
+
+/**
+ * Recursively formats a given tree into a printed user-friendly tree structure
+ *
+ * TODO: Handle multiline output.
+ */
+function formatTree(
+  node: Record<string, PatchTree> = {},
+  paddingLength: number,
+  indent = '',
+  formatPatch: (patch: NodePatch) => string = (patch) => patch.op.type,
+): string {
+  const entries = Object.entries(node)
+
+  return entries
+    .map(([key, child], index) => {
+      const isLast = index === entries.length - 1
+      const nextIndent = `${indent}${isLast ? '  ' : '│ '}`
+      const nested = formatTree(child.children, paddingLength, nextIndent, formatPatch)
+
+      if (!child.patches?.length) {
+        const current = `${indent}${isLast ? '└' : '├'}─ ${key}`
+        return [current, nested].filter(Boolean).join('\n')
+      }
+
+      const [first, ...rest] = child.patches
+      const firstPadding = '.'.repeat(paddingLength - indent.length - key.length)
+      const elbow = isLast ? '└' : '├'
+      const subsequentPadding = ' '.repeat(paddingLength - indent.length + 2)
+
+      const firstMessage = `${indent}${elbow}─ ${key} ${firstPadding} ${formatPatch(first)}`
+      const subsequentMessages = rest
+        .map((patch) => `${nextIndent}${subsequentPadding} ${formatPatch(patch)}`)
+        .join('\n')
+
+      const current = [firstMessage, subsequentMessages].filter(Boolean).join('\n')
+      return [current, nested].filter(Boolean).join('\n')
+    })
+    .join('\n')
+}
+
+/**
+ * Recursively calculates the max length of all the keys in the given validation
+ * tree respecting extra length due to indentation depth. Used to calculate the
+ * padding for the rest of the tree.
+ */
+const maxKeyLength = (children: Record<string, PatchTree> = {}, depth = 0): number => {
+  return Object.entries(children)
+    .map(([key, child]) =>
+      Math.max(key.length + depth * 2, maxKeyLength(child.children, depth + 1)),
+    )
+    .reduce((max, next) => (next > max ? next : max), 0)
+}

--- a/packages/sanity/src/_internal/cli/commands/migration/prettyMutationFormatter.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/prettyMutationFormatter.ts
@@ -79,6 +79,7 @@ export function prettyFormatMutation(
   chalk: Chalk,
   mutation: Mutation,
   migration: Migration,
+  indent = 0,
 ): string {
   const lock =
     'options' in mutation ? chalk.cyan(`(if revision==${mutation.options?.ifRevision})`) : ''
@@ -98,7 +99,9 @@ export function prettyFormatMutation(
     return [
       header,
       '\n',
-      formatTree(tree.children, paddingLength, '', (patch) => formatPatchMutation(chalk, patch)),
+      formatTree(tree.children, paddingLength, ' '.repeat(indent), (patch) =>
+        formatPatchMutation(chalk, patch),
+      ),
     ].join('')
   }
 

--- a/packages/sanity/src/_internal/cli/commands/migration/prettyMutationFormatter.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/prettyMutationFormatter.ts
@@ -1,5 +1,5 @@
 import {isatty} from 'tty'
-import {Migration, Mutation, NodePatch, NodePatchList} from '@sanity/migrate'
+import {Migration, Mutation, NodePatch} from '@sanity/migrate'
 import {KeyedSegment} from '@sanity/types'
 import {Chalk} from 'chalk'
 import {convertToTree, formatTree, maxKeyLength} from '../../util/tree'

--- a/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
@@ -15,6 +15,7 @@ import {Table} from 'console-table-printer'
 import {debug} from '../../debug'
 import {formatTransaction} from './utils/mutationFormatter'
 import {resolveMigrations} from './listMigrationsCommand'
+import {prettyFormat, prettyFormatMutation} from './prettyMutationFormatter'
 
 const helpText = `
 Options
@@ -185,6 +186,7 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
     if (dry) {
       const spinner = output.spinner(`Running migration "${id}" in dry mode`).start()
       if (fromExport) {
+        // TODO: Dry run output when using archive source.
         await runFromArchive(migration, fromExport, {
           api: apiConfig,
           concurrency,
@@ -193,6 +195,18 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
       } else {
         await dryRun({api: apiConfig, onProgress: createProgress(spinner)}, migration)
       }
+
+      // for await (const mutation of dryRun({api: apiConfig}, migration)) {
+      //   if (!mutation) continue
+      //   output.print()
+      //   output.print(
+      //     prettyFormat({
+      //       chalk,
+      //       mutations: Array.isArray(mutation) ? mutation : [mutation],
+      //       migration,
+      //     }),
+      //   )
+      // }
 
       spinner.stop()
     } else {

--- a/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
@@ -13,7 +13,6 @@ import {
 
 import {Table} from 'console-table-printer'
 import {debug} from '../../debug'
-import {formatTransaction} from './utils/mutationFormatter'
 import {resolveMigrations} from './listMigrationsCommand'
 import {prettyFormat} from './prettyMutationFormatter'
 
@@ -237,7 +236,11 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
   ${chalk.blue(progress.pending)} requests pending…
   ${chalk.green(progress.completedTransactions.length)} transactions committed.
 
-  ${transaction && !progress.done ? `» ${chalk.grey(formatTransaction(chalk, transaction))}` : ''}`
+  ${
+    transaction && !progress.done
+      ? `» ${prettyFormat({chalk, subject: transaction, migration, indentSize: 2})}`
+      : ''
+  }`
         })
       }
     }

--- a/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
@@ -207,7 +207,7 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
           output.print(
             prettyFormat({
               chalk,
-              mutations: Array.isArray(mutation) ? mutation : [mutation],
+              subject: mutation,
               migration,
             }),
           )

--- a/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
@@ -185,6 +185,7 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
 
     if (dry) {
       const spinner = output.spinner(`Running migration "${id}" in dry mode`).start()
+
       if (fromExport) {
         // TODO: Dry run output when using archive source.
         await runFromArchive(migration, fromExport, {
@@ -195,6 +196,11 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
       } else {
         await dryRun({api: apiConfig, onProgress: createProgress(spinner)}, migration)
       }
+
+      // output.print(`Running migration "${migrationName}" in dry mode`)
+      // output.print()
+      // output.print(`Project id:  ${chalk.bold(projectId)}`)
+      // output.print(`Dataset:     ${chalk.bold(dataset)}`)
 
       // for await (const mutation of dryRun({api: apiConfig}, migration)) {
       //   if (!mutation) continue

--- a/packages/sanity/src/_internal/cli/commands/migration/utils/mutationFormatter.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/utils/mutationFormatter.ts
@@ -83,7 +83,7 @@ function formatPatchMutation(chalk: Chalk, patch: NodePatch<any>): string {
     ].join(': ')
   }
   if (op.type === 'truncate') {
-    return [path, `${formattedType}(${op.startIndex}, ${op.endIndex}`].join(': ')
+    return [path, `${formattedType}(${op.startIndex}, ${op.endIndex})`].join(': ')
   }
   // @ts-expect-error all cases are covered
   throw new Error(`Invalid operation type: ${op.type}`)

--- a/packages/sanity/src/_internal/cli/util/tree.ts
+++ b/packages/sanity/src/_internal/cli/util/tree.ts
@@ -1,0 +1,110 @@
+import {type Path, pathToString} from 'sanity'
+
+interface BaseNode {
+  path: Path
+}
+
+export interface Tree<Node extends BaseNode> {
+  nodes?: Node[]
+  children?: Record<string, Tree<Node>>
+}
+
+/**
+ * Recursively calculates the max length of all the keys in the given validation
+ * tree respecting extra length due to indentation depth. Used to calculate the
+ * padding for the rest of the tree.
+ */
+export const maxKeyLength = (children: Record<string, Tree<BaseNode>> = {}, depth = 0): number => {
+  return Object.entries(children)
+    .map(([key, child]) =>
+      Math.max(key.length + depth * 2, maxKeyLength(child.children, depth + 1)),
+    )
+    .reduce((max, next) => (next > max ? next : max), 0)
+}
+
+interface Options<Node extends BaseNode> {
+  node?: Record<string, Tree<Node>>
+  paddingLength: number
+  indent?: string
+  getNodes?: (node: Tree<Node>) => Node[] | undefined
+  getMessage: (node: Node) => string
+}
+
+/**
+ * Recursively formats a given tree into a printed user-friendly tree structure
+ */
+export const formatTree = <Node extends BaseNode>({
+  node = {},
+  paddingLength,
+  indent = '',
+  getNodes: getLeaves = ({nodes}) => nodes,
+  getMessage,
+}: Options<Node>): string => {
+  const entries = Object.entries(node)
+
+  return entries
+    .map(([key, child], index) => {
+      const isLast = index === entries.length - 1
+      const nextIndent = `${indent}${isLast ? '  ' : '│ '}`
+      const leaves = getLeaves(child)
+
+      const nested = formatTree({
+        node: child.children,
+        paddingLength,
+        indent: nextIndent,
+        getNodes: getLeaves,
+        getMessage,
+      })
+
+      if (!leaves?.length) {
+        const current = `${indent}${isLast ? '└' : '├'}─ ${key}`
+        return [current, nested].filter(Boolean).join('\n')
+      }
+
+      const [first, ...rest] = leaves
+      const firstPadding = '.'.repeat(paddingLength - indent.length - key.length)
+      const elbow = isLast ? '└' : '├'
+      const subsequentPadding = ' '.repeat(paddingLength - indent.length + 2)
+
+      const firstMessage = `${indent}${elbow}─ ${key} ${firstPadding} ${getMessage(first)}`
+      const subsequentMessages = rest
+        .map((marker) => `${nextIndent}${subsequentPadding} ${getMessage(marker)}`)
+        .join('\n')
+
+      const current = [firstMessage, subsequentMessages].filter(Boolean).join('\n')
+      return [current, nested].filter(Boolean).join('\n')
+    })
+    .join('\n')
+}
+
+/**
+ * Converts a set of markers with paths into a tree of markers where the paths
+ * are embedded in the tree
+ */
+export function convertToTree<const Node extends BaseNode>(nodes: Node[]): Tree<Node> {
+  const root: Tree<Node> = {}
+
+  // add the markers to the tree
+  function addNode(node: Node, tree: Tree<Node> = root) {
+    // if we've traversed the whole path
+    if (!node.path.length) {
+      if (!tree.nodes) tree.nodes = [] // ensure markers is defined
+
+      // then add the marker to the front
+      tree.nodes.push(node)
+      return
+    }
+
+    const [current, ...rest] = node.path
+    const key = pathToString([current])
+
+    // ensure the current node has children and the next node
+    if (!tree.children) tree.children = {}
+    if (!(key in tree.children)) tree.children[key] = {}
+
+    addNode({...node, path: rest}, tree.children[key])
+  }
+
+  for (const node of nodes) addNode(node)
+  return root
+}


### PR DESCRIPTION
### Description

This branch adds pretty formatting when running migrations (both in dry-run and commit mode). This uses the same tree style report that is used when reporting document validation results.

### What to review

- Pretty formatting looks good when running migrations.
- Validation output is still correct (the tree generator code has been abstracted in this branch).

### Testing

- Run some migrations in dry-run and commit mode.
- Run some document validation checks.
