### PR TITLE
feat(comments): add optional intent link to comments

### DIFF
--- a/packages/sanity/src/structure/comments/i18n/resources.ts
+++ b/packages/sanity/src/structure/comments/i18n/resources.ts
@@ -96,6 +96,8 @@ const commentsLocaleStrings = defineLocalesResources('comments', {
   'list-item.edit-comment-upsell': 'Upgrade to edit comment',
   /** Aria label for the button that takes you to the field, which wraps a thread/comment */
   'list-item.go-to-field-button.aria-label': 'Go to field',
+  /** The text showing the comment context */
+  'list-item.layout-context': 'on <IntentLink>{{title}}</IntentLink>',
   /** The marker to indicate that a comment has been edited in brackets */
   'list-item.layout-edited': 'edited',
   /** The error text when sending a comment has failed */

--- a/packages/sanity/src/structure/comments/src/__workshop__/CommentsListStory.tsx
+++ b/packages/sanity/src/structure/comments/src/__workshop__/CommentsListStory.tsx
@@ -79,6 +79,45 @@ const BASE: CommentDocument = {
   ],
 }
 
+const INTENT: CommentDocument = {
+  ...BASE,
+  _id: '2',
+  message: [
+    {
+      _type: 'block',
+      _key: '36a3f0d3832d',
+      style: 'normal',
+      markDefs: [],
+      children: [
+        {
+          _type: 'span',
+          _key: '89014dd684cc',
+          text: 'A comment with context',
+          marks: [],
+        },
+      ],
+    },
+  ],
+  context: {
+    payload: {
+      workspace: 'default',
+    },
+    intent: {
+      title: 'Presentation Comments Test',
+      name: 'edit',
+      params: {
+        id: 'd73bb3d8-b1b7-4ca3-8f55-969bba902cd3',
+        path: 'string',
+        type: 'commentsDebug',
+        inspect: 'sanity/structure/comments',
+        mode: 'structure',
+        preview: '/',
+      },
+    },
+    tool: 'structure',
+  },
+}
+
 const MENTION_HOOK_OPTIONS = {
   documentValue: {
     _type: 'author',
@@ -92,7 +131,7 @@ const MENTION_HOOK_OPTIONS = {
 const STATUS_OPTIONS: Record<CommentStatus, CommentStatus> = {open: 'open', resolved: 'resolved'}
 
 export default function CommentsListStory() {
-  const [state, setState] = useState<CommentDocument[]>([BASE])
+  const [state, setState] = useState<CommentDocument[]>([BASE, INTENT])
 
   const error = useBoolean('Error', false, 'Props') || null
   const loading = useBoolean('Loading', false, 'Props') || false

--- a/packages/sanity/src/structure/comments/src/__workshop__/CommentsListStory.tsx
+++ b/packages/sanity/src/structure/comments/src/__workshop__/CommentsListStory.tsx
@@ -82,6 +82,7 @@ const BASE: CommentDocument = {
 const INTENT: CommentDocument = {
   ...BASE,
   _id: '2',
+  threadId: '2',
   message: [
     {
       _type: 'block',
@@ -103,7 +104,7 @@ const INTENT: CommentDocument = {
       workspace: 'default',
     },
     intent: {
-      title: 'Presentation Comments Test',
+      title: 'Page One',
       name: 'edit',
       params: {
         id: 'd73bb3d8-b1b7-4ca3-8f55-969bba902cd3',
@@ -111,7 +112,52 @@ const INTENT: CommentDocument = {
         type: 'commentsDebug',
         inspect: 'sanity/structure/comments',
         mode: 'structure',
-        preview: '/',
+        preview: '/page-one',
+      },
+    },
+    tool: 'structure',
+  },
+}
+
+const INTENT_RESPONSE_SAME = {
+  ...INTENT,
+  _id: '3',
+  parentCommentId: '2',
+  message: [
+    {
+      _type: 'block',
+      _key: '36a3f0d3832d',
+      style: 'normal',
+      markDefs: [],
+      children: [
+        {
+          _type: 'span',
+          _key: '89014dd684cc',
+          text: 'A response with context',
+          marks: [],
+        },
+      ],
+    },
+  ],
+}
+
+const INTENT_RESPONSE_DIFF = {
+  ...INTENT_RESPONSE_SAME,
+  _id: '4',
+  context: {
+    payload: {
+      workspace: 'default',
+    },
+    intent: {
+      title: 'Page Two',
+      name: 'edit',
+      params: {
+        id: 'd73bb3d8-b1b7-4ca3-8f55-969bba902cd3',
+        path: 'string',
+        type: 'commentsDebug',
+        inspect: 'sanity/structure/comments',
+        mode: 'structure',
+        preview: '/page-two',
       },
     },
     tool: 'structure',
@@ -131,7 +177,12 @@ const MENTION_HOOK_OPTIONS = {
 const STATUS_OPTIONS: Record<CommentStatus, CommentStatus> = {open: 'open', resolved: 'resolved'}
 
 export default function CommentsListStory() {
-  const [state, setState] = useState<CommentDocument[]>([BASE, INTENT])
+  const [state, setState] = useState<CommentDocument[]>([
+    BASE,
+    INTENT,
+    INTENT_RESPONSE_DIFF,
+    INTENT_RESPONSE_SAME,
+  ])
 
   const error = useBoolean('Error', false, 'Props') || null
   const loading = useBoolean('Loading', false, 'Props') || false

--- a/packages/sanity/src/structure/comments/src/components/list/CommentsListItem.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CommentsListItem.tsx
@@ -8,7 +8,7 @@ import styled, {css} from 'styled-components'
 import {Button} from '../../../../../ui-components'
 import {commentsLocaleNamespace} from '../../../i18n'
 import {type CommentsSelectedPath} from '../../context'
-import {hasCommentMessageValue} from '../../helpers'
+import {commentIntentIfDiffers, hasCommentMessageValue} from '../../helpers'
 import {
   type CommentCreatePayload,
   type CommentDocument,
@@ -257,6 +257,7 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
             onInputKeyDown={handleInputKeyDown}
             onReactionSelect={onReactionSelect}
             readOnly={readOnly}
+            intent={commentIntentIfDiffers(parentComment, reply)}
           />
         </Stack>
       )),
@@ -269,6 +270,7 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
       onDelete,
       onEdit,
       onReactionSelect,
+      parentComment,
       readOnly,
       splicedReplies,
       mode,
@@ -316,6 +318,7 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
               onReactionSelect={onReactionSelect}
               onStatusChange={onStatusChange}
               readOnly={readOnly}
+              intent={parentComment.context?.intent}
             />
           </Stack>
 

--- a/packages/sanity/src/structure/comments/src/components/list/CommentsListItemLayout.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CommentsListItemLayout.tsx
@@ -342,7 +342,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
 
             {comment.context?.intent && (
               <Box flex={1}>
-                <IntentText muted size={0} textOverflow="ellipsis" title={''}>
+                <IntentText muted size={0} textOverflow="ellipsis">
                   <Translate
                     t={t}
                     i18nKey="list-item.layout-context"

--- a/packages/sanity/src/structure/comments/src/components/list/CommentsListItemLayout.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CommentsListItemLayout.tsx
@@ -4,12 +4,14 @@ import {Box, Card, Flex, Stack, Text, TextSkeleton, useClickOutside} from '@sani
 import {useCallback, useMemo, useRef, useState} from 'react'
 import {
   type RelativeTimeOptions,
+  Translate,
   useDateTimeFormat,
   useDidUpdate,
   useRelativeTime,
   useTranslation,
   useUser,
 } from 'sanity'
+import {IntentLink} from 'sanity/router'
 import styled, {css} from 'styled-components'
 
 import {commentsLocaleNamespace} from '../../../i18n'
@@ -44,6 +46,16 @@ const TimeText = styled(Text)(({theme}) => {
 
   return css`
     min-width: max-content;
+    --card-fg-color: ${fg};
+    color: var(--card-fg-color);
+  `
+})
+
+const IntentText = styled(Text)(({theme}) => {
+  const isDark = theme.sanity.color.dark
+  const fg = hues.gray[isDark ? 200 : 800].hex
+
+  return css`
     --card-fg-color: ${fg};
     color: var(--card-fg-color);
   `
@@ -298,28 +310,58 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
         <Flex align="center" gap={FLEX_GAP} flex={1}>
           <CommentsAvatar user={user} />
 
-          <Flex align="center" paddingBottom={1} sizing="border" flex={1}>
-            <Flex align="flex-end" gap={2}>
-              <Box flex={1}>{name}</Box>
+          <Flex direction="column" gap={2} paddingY={comment.context?.intent ? 2 : 0}>
+            <Flex
+              align="center"
+              paddingBottom={comment.context?.intent ? 0 : 1}
+              sizing="border"
+              flex={1}
+            >
+              <Flex align="flex-end" gap={2}>
+                <Box flex={1}>{name}</Box>
 
-              {!displayError && (
-                <Flex align="center" gap={1}>
-                  <TimeText muted size={0}>
-                    <time dateTime={createdDate.toISOString()} title={formattedCreatedAt}>
-                      {createdTimeAgo}
-                    </time>
-                  </TimeText>
-
-                  {formattedLastEditAt && editedDate && (
-                    <TimeText muted size={0} title={formattedLastEditAt}>
-                      <time dateTime={editedDate.toISOString()} title={formattedLastEditAt}>
-                        ({t('list-item.layout-edited')})
+                {!displayError && (
+                  <Flex align="center" gap={1}>
+                    <TimeText muted size={0}>
+                      <time dateTime={createdDate.toISOString()} title={formattedCreatedAt}>
+                        {createdTimeAgo}
                       </time>
                     </TimeText>
-                  )}
-                </Flex>
-              )}
+
+                    {formattedLastEditAt && editedDate && (
+                      <TimeText muted size={0} title={formattedLastEditAt}>
+                        <time dateTime={editedDate.toISOString()} title={formattedLastEditAt}>
+                          ({t('list-item.layout-edited')})
+                        </time>
+                      </TimeText>
+                    )}
+                  </Flex>
+                )}
+              </Flex>
             </Flex>
+
+            {comment.context?.intent && (
+              <Box flex={1}>
+                <IntentText muted size={0} textOverflow="ellipsis" title={''}>
+                  <Translate
+                    t={t}
+                    i18nKey="list-item.layout-context"
+                    values={{title: comment.context.intent.title, intent: 'edit'}}
+                    components={{
+                      IntentLink: ({children}) =>
+                        comment.context?.intent ? (
+                          <IntentLink
+                            params={comment.context.intent.params}
+                            intent={comment.context.intent.name}
+                          >
+                            {children}
+                          </IntentLink>
+                        ) : undefined,
+                    }}
+                  />
+                </IntentText>
+              </Box>
+            )}
           </Flex>
 
           {!isEditing && !displayError && (

--- a/packages/sanity/src/structure/comments/src/components/list/CommentsListItemLayout.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CommentsListItemLayout.tsx
@@ -17,6 +17,7 @@ import styled, {css} from 'styled-components'
 import {commentsLocaleNamespace} from '../../../i18n'
 import {hasCommentMessageValue, useCommentHasChanged} from '../../helpers'
 import {
+  type CommentContext,
   type CommentDocument,
   type CommentEditPayload,
   type CommentMessage,
@@ -137,6 +138,7 @@ interface CommentsListItemLayoutProps {
   onReactionSelect?: (id: string, reaction: CommentReactionOption) => void
   onStatusChange?: (id: string, status: CommentStatus) => void
   readOnly?: boolean
+  intent?: CommentContext['intent']
 }
 
 const RELATIVE_TIME_OPTIONS: RelativeTimeOptions = {useTemporalPhrase: true}
@@ -148,6 +150,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
     comment,
     currentUser,
     hasError,
+    intent,
     isParent,
     isRetrying,
     mentionOptions,
@@ -310,7 +313,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
         <Flex align="center" gap={FLEX_GAP} flex={1}>
           <CommentsAvatar user={user} />
 
-          <Flex direction="column" gap={2} paddingY={comment.context?.intent ? 2 : 0}>
+          <Flex direction="column" gap={2} paddingY={intent ? 2 : 0}>
             <Flex
               align="center"
               paddingBottom={comment.context?.intent ? 0 : 1}
@@ -340,20 +343,17 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
               </Flex>
             </Flex>
 
-            {comment.context?.intent && (
+            {intent && (
               <Box flex={1}>
                 <IntentText muted size={0} textOverflow="ellipsis">
                   <Translate
                     t={t}
                     i18nKey="list-item.layout-context"
-                    values={{title: comment.context.intent.title, intent: 'edit'}}
+                    values={{title: intent.title, intent: 'edit'}}
                     components={{
                       IntentLink: ({children}) =>
-                        comment.context?.intent ? (
-                          <IntentLink
-                            params={comment.context.intent.params}
-                            intent={comment.context.intent.name}
-                          >
+                        intent ? (
+                          <IntentLink params={intent.params} intent={intent.name}>
                             {children}
                           </IntentLink>
                         ) : undefined,

--- a/packages/sanity/src/structure/comments/src/context/index.ts
+++ b/packages/sanity/src/structure/comments/src/context/index.ts
@@ -1,5 +1,6 @@
 export * from './comments'
 export * from './enabled'
+export * from './intent'
 export * from './onboarding'
 export * from './selected-path'
 export * from './setup'

--- a/packages/sanity/src/structure/comments/src/context/intent/CommentsIntentContext.ts
+++ b/packages/sanity/src/structure/comments/src/context/intent/CommentsIntentContext.ts
@@ -1,0 +1,7 @@
+import {createContext} from 'react'
+
+import {type CommentsIntentContextValue} from './types'
+
+export const CommentsIntentContext = createContext<CommentsIntentContextValue | undefined>(
+  undefined,
+)

--- a/packages/sanity/src/structure/comments/src/context/intent/CommentsIntentProvider.tsx
+++ b/packages/sanity/src/structure/comments/src/context/intent/CommentsIntentProvider.tsx
@@ -1,0 +1,23 @@
+import {memo, type ReactNode} from 'react'
+
+import {type CommentIntentGetter} from '../../types'
+import {CommentsIntentContext} from './CommentsIntentContext'
+
+interface CommentsIntentProviderProps {
+  children: ReactNode
+  getIntent: CommentIntentGetter
+}
+
+/**
+ * @beta
+ * @hidden
+ */
+export const CommentsIntentProvider = memo(function CommentsIntentProvider(
+  props: CommentsIntentProviderProps,
+) {
+  const {children, getIntent} = props
+
+  return (
+    <CommentsIntentContext.Provider value={getIntent}>{children}</CommentsIntentContext.Provider>
+  )
+})

--- a/packages/sanity/src/structure/comments/src/context/intent/index.ts
+++ b/packages/sanity/src/structure/comments/src/context/intent/index.ts
@@ -1,0 +1,2 @@
+export * from './CommentsIntentContext'
+export * from './CommentsIntentProvider'

--- a/packages/sanity/src/structure/comments/src/context/intent/types.ts
+++ b/packages/sanity/src/structure/comments/src/context/intent/types.ts
@@ -1,0 +1,7 @@
+import {type CommentIntentGetter} from '../../types'
+
+/**
+ * @beta
+ * @hidden
+ */
+export type CommentsIntentContextValue = CommentIntentGetter

--- a/packages/sanity/src/structure/comments/src/helpers.ts
+++ b/packages/sanity/src/structure/comments/src/helpers.ts
@@ -2,7 +2,7 @@ import {isEqual} from 'lodash'
 import {useMemo, useRef} from 'react'
 import {isPortableTextSpan, isPortableTextTextBlock} from 'sanity'
 
-import {type CommentMessage} from './types'
+import {type CommentContext, type CommentDocument, type CommentMessage} from './types'
 
 export function useCommentHasChanged(message: CommentMessage): boolean {
   const prevMessage = useRef<CommentMessage>(message)
@@ -18,4 +18,25 @@ export function hasCommentMessageValue(value: CommentMessage): boolean {
       isPortableTextTextBlock(block) &&
       (block?.children || [])?.some((c) => (isPortableTextSpan(c) ? c.text : c.userId)),
   )
+}
+
+export function commentIntentIfDiffers(
+  parent?: CommentDocument,
+  comment?: CommentDocument,
+): CommentContext['intent'] | undefined {
+  const parentIntent = parent?.context?.intent
+  const intent = comment?.context?.intent
+  // If no intent, nothing to return
+  if (!intent) return undefined
+  // If no parent intent, no comparison necessary
+  if (!parentIntent) return intent
+  // If the preview param differs, return the intent
+  if (
+    'preview' in intent.params &&
+    'preview' in parentIntent.params &&
+    intent.params.preview !== parentIntent.params.preview
+  ) {
+    return intent
+  }
+  return undefined
 }

--- a/packages/sanity/src/structure/comments/src/hooks/index.ts
+++ b/packages/sanity/src/structure/comments/src/hooks/index.ts
@@ -1,6 +1,7 @@
 export * from './use-comment-operations'
 export * from './useComments'
 export * from './useCommentsEnabled'
+export * from './useCommentsIntent'
 export * from './useCommentsOnboarding'
 export * from './useCommentsSelectedPath'
 export * from './useCommentsSetup'

--- a/packages/sanity/src/structure/comments/src/hooks/use-comment-operations/createOperation.ts
+++ b/packages/sanity/src/structure/comments/src/hooks/use-comment-operations/createOperation.ts
@@ -6,6 +6,7 @@ import {
   type CommentContext,
   type CommentCreatePayload,
   type CommentDocument,
+  type CommentIntentGetter,
   type CommentPostPayload,
 } from '../../types'
 
@@ -18,6 +19,7 @@ interface CreateOperationProps {
   documentId: string
   documentType: string
   getComment?: (id: string) => CommentDocument | undefined
+  getIntent?: CommentIntentGetter
   getNotificationValue: (comment: {commentId: string}) => CommentContext['notification']
   getThreadLength?: (threadId: string) => number
   onCreate?: (comment: CommentPostPayload) => void
@@ -36,6 +38,7 @@ export async function createOperation(props: CreateOperationProps): Promise<void
     dataset,
     documentId,
     documentType,
+    getIntent,
     getNotificationValue,
     getThreadLength,
     onCreate,
@@ -69,6 +72,8 @@ export async function createOperation(props: CreateOperationProps): Promise<void
     workspaceTitle,
   }
 
+  const intent = getIntent?.({id: documentId, type: documentType, path: comment.fieldPath})
+
   const nextComment: CommentPostPayload = {
     _id: commentId,
     _type: 'comment',
@@ -83,6 +88,7 @@ export async function createOperation(props: CreateOperationProps): Promise<void
       payload: {
         workspace,
       },
+      intent,
       notification,
       tool: activeTool?.name || '',
     },

--- a/packages/sanity/src/structure/comments/src/hooks/use-comment-operations/useCommentOperations.ts
+++ b/packages/sanity/src/structure/comments/src/hooks/use-comment-operations/useCommentOperations.ts
@@ -12,6 +12,7 @@ import {
   type CommentPostPayload,
   type CommentReactionOption,
 } from '../../types'
+import {useCommentsIntent} from '../useCommentsIntent'
 import {useNotificationTarget} from '../useNotificationTarget'
 import {createOperation} from './createOperation'
 import {editOperation} from './editOperation'
@@ -63,6 +64,8 @@ export function useCommentOperations(
     workspace,
   } = opts
 
+  const getIntent = useCommentsIntent()
+
   const activeToolName = useRouterState(
     useCallback(
       (routerState) => (typeof routerState.tool === 'string' ? routerState.tool : undefined),
@@ -93,6 +96,7 @@ export function useCommentOperations(
         dataset,
         documentId,
         documentType,
+        getIntent,
         getNotificationValue,
         getThreadLength,
         onCreate,
@@ -109,6 +113,7 @@ export function useCommentOperations(
       dataset,
       documentId,
       documentType,
+      getIntent,
       getNotificationValue,
       getThreadLength,
       onCreate,

--- a/packages/sanity/src/structure/comments/src/hooks/useCommentsIntent.ts
+++ b/packages/sanity/src/structure/comments/src/hooks/useCommentsIntent.ts
@@ -1,0 +1,12 @@
+import {useContext} from 'react'
+
+import {CommentsIntentContext} from '../context'
+import {type CommentIntentGetter} from '../types'
+
+/**
+ * @beta
+ * @hidden
+ */
+export function useCommentsIntent(): CommentIntentGetter | undefined {
+  return useContext(CommentsIntentContext)
+}

--- a/packages/sanity/src/structure/comments/src/store/useCommentsStore.ts
+++ b/packages/sanity/src/structure/comments/src/store/useCommentsStore.ts
@@ -34,6 +34,7 @@ const QUERY_PROJECTION = `{
   _createdAt,
   _id,
   authorId,
+  context,
   lastEditedAt,
   message,
   parentCommentId,

--- a/packages/sanity/src/structure/comments/src/types.ts
+++ b/packages/sanity/src/structure/comments/src/types.ts
@@ -1,4 +1,5 @@
 import {type PortableTextBlock, type User} from '@sanity/types'
+import {type IntentParameters} from 'sanity/router'
 
 /**
  * @beta
@@ -83,7 +84,22 @@ export interface CommentContext {
     workspaceTitle: string
     currentThreadLength?: number
   }
+  intent?: {
+    title: string
+    name: string
+    params: IntentParameters
+  }
 }
+
+/**
+ * @beta
+ * @hidden
+ */
+export type CommentIntentGetter = (comment: {
+  id: string
+  type: string
+  path: string
+}) => CommentContext['intent']
 
 interface CommentCreateRetryingState {
   type: 'createRetrying'

--- a/packages/sanity/src/structure/index.ts
+++ b/packages/sanity/src/structure/index.ts
@@ -1,7 +1,4 @@
-export {DocumentInspectorHeader} from './panes/document/documentInspector'
-export * from './structureTool'
-
-// Export `DocumentPaneProvider`
+export {type CommentIntentGetter, CommentsIntentProvider} from './comments'
 export type {
   BackLinkProps,
   ChildLinkProps,
@@ -14,10 +11,12 @@ export type {
 export {ConfirmDeleteDialog, PaneLayout, PaneRouterContext, usePaneRouter} from './components'
 export {structureLocaleNamespace, type StructureLocaleResourceKeys} from './i18n'
 export * from './panes/document'
+export {DocumentInspectorHeader} from './panes/document/documentInspector'
 export {type DocumentPaneProviderProps} from './panes/document/types'
 export * from './panes/document/useDocumentPane'
 export * from './panes/documentList'
 export * from './structureBuilder'
+export * from './structureTool'
 export * from './StructureToolProvider'
 export * from './types'
 export * from './useStructureTool'


### PR DESCRIPTION
### Description

This PR adds a mechanism for associating and displaying an intent link alongside a comment. This is so other tools (namely Presentation) can augment comments with added context about where a comment was made.

An optional provider is exported for use in other tools, if this provider is used and intent context is available it will be attached to the comment context payload.

### What to review

The workshop `CommentsListStory` has been updated to include an example of an intent link.

### Testing

No tests added.

### Notes for release

n/a
