### PR TITLE
fix(comments): addon dataset creation

### DIFF
--- a/packages/sanity/src/structure/comments/src/hooks/use-comment-operations/createOperation.ts
+++ b/packages/sanity/src/structure/comments/src/hooks/use-comment-operations/createOperation.ts
@@ -10,7 +10,7 @@ import {CurrentUser, Tool} from 'sanity'
 
 interface CreateOperationProps {
   activeTool: Tool | undefined
-  client: SanityClient
+  client: SanityClient | null
   comment: CommentCreatePayload
   currentUser: CurrentUser
   dataset: string

--- a/packages/sanity/src/structure/comments/src/hooks/use-comment-operations/useCommentOperations.ts
+++ b/packages/sanity/src/structure/comments/src/hooks/use-comment-operations/useCommentOperations.ts
@@ -78,7 +78,11 @@ export function useCommentOperations(
 
   const handleCreate = useCallback(
     async (comment: CommentCreatePayload) => {
-      if (!client || !currentUser?.id) return
+      // Unlike the other operations, we want to proceed with create operation even
+      // though there is no client available. This is because if there is no client for the
+      // comments addon dataset, it will be created in the `createOperation`, and the
+      // comment will be created in that dataset when the client is eventually created.
+      if (!currentUser?.id) return
 
       await createOperation({
         activeTool,


### PR DESCRIPTION
### Description

This pull request fixes an issue introduced in `v3.26.0` when the comments reactions feature was added. The issue is that when the first comment is made in a project without an addon dataset, the dataset isn't created, and the comment isn't posted.

### What to review

- Ensure the addon dataset is created and the comment is posted when the first comment is made in a project without an addon dataset.

### Notes for release

Fixes issue introduced in `v3.26.0` where, upon the first comment in a project lacking an addon dataset, the dataset fails to be created, and the comment remains unposted.
