### PR TITLE
fix(comments): localize all strings

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -249,16 +249,6 @@ const config = {
       },
     },
 
-    // Ignore i18n in Comments files for now. This will need to be removed before Comments feature is GA
-    {
-      files: ['**/*/Comment*.{js,ts,tsx}', '**/*/comments/**/*'],
-      rules: {
-        'i18next/no-literal-string': 'off',
-        '@sanity/i18n/no-attribute-string-literals': 'off',
-        '@sanity/i18n/no-attribute-template-literals': 'off',
-      },
-    },
-
     // Prefer local components vs certain @sanity/ui imports (in sanity package)
     {
       files: ['packages/sanity/**'],

--- a/packages/sanity/playwright-ct/tests/comments/CommentInputStory.tsx
+++ b/packages/sanity/playwright-ct/tests/comments/CommentInputStory.tsx
@@ -46,6 +46,7 @@ export function CommentsInputStory({
     <TestWrapper schemaTypes={SCHEMA_TYPES}>
       <CommentInput
         focusOnMount
+        // eslint-disable-next-line @sanity/i18n/no-attribute-string-literals
         placeholder="Your comment..."
         focusLock
         currentUser={currentUser}

--- a/packages/sanity/src/structure/comments/i18n/index.ts
+++ b/packages/sanity/src/structure/comments/i18n/index.ts
@@ -1,0 +1,27 @@
+import {defineLocaleResourceBundle} from 'sanity'
+
+/**
+ * The locale namespace for the comments plugin
+ *
+ * @public
+ */
+export const commentsLocaleNamespace = 'comments' as const
+
+/**
+ * The default locale bundle for the comments plugin, which is US English.
+ *
+ * @internal
+ */
+export const commentsUsEnglishLocaleBundle = defineLocaleResourceBundle({
+  locale: 'en-US',
+  namespace: commentsLocaleNamespace,
+  resources: () => import('./resources'),
+})
+
+/**
+ * The locale resource keys for the comments plugin.
+ *
+ * @alpha
+ * @hidden
+ */
+export type {CommentsLocaleResourceKeys} from './resources'

--- a/packages/sanity/src/structure/comments/i18n/resources.ts
+++ b/packages/sanity/src/structure/comments/i18n/resources.ts
@@ -120,6 +120,8 @@ const commentsLocaleStrings = defineLocalesResources('comments', {
   /**The list status message for loading status */
   'comments.list-status-loading': 'Loading comments',
 
+  /**The inline mention loading state */
+  'comments.mention-inline-block': '@Loading',
   /**The text for no users found for mentions */
   'comments.mentions-not-found': 'No users found',
   /**The text for unauthorized mentions */
@@ -148,6 +150,10 @@ const commentsLocaleStrings = defineLocalesResources('comments', {
 
   /**The tooltip text for unknown user */
   'comments.reaction-unknown-user': 'Unknown user',
+  /**The aria label for the reactions menu button */
+  'comments.reactions-menu-button-aria-label': 'React with {{reaction}}',
+  /**The thread breadcrumb button aria label */
+  'comments.thread-breadcrumb-layout-aria-label': 'Go to {{lastCrumb}} field',
   /**The tooltip text for mentioning a user */
   'comments.tooltip-mention-user': 'Mention user',
   /**The tooltip aria label for mentioning a user */

--- a/packages/sanity/src/structure/comments/i18n/resources.ts
+++ b/packages/sanity/src/structure/comments/i18n/resources.ts
@@ -1,0 +1,169 @@
+/* eslint sort-keys: "error" */
+import {defineLocalesResources} from 'sanity'
+
+/**
+ * Defined locale strings for the comments plugin, in US English.
+ *
+ * @internal
+ */
+const commentsLocaleStrings = defineLocalesResources('comments', {
+  /**The close comments button text */
+  'comments.button-close-pane-text': 'Close comments',
+  /**The aria label for the close comments button */
+  'comments.button-close-pane-text-aria-label': 'Close comments',
+  /**The text for the button to go to the correct field */
+  'comments.button-go-to-field-aria-label': 'Go to field',
+
+  /**The delete dialog body for a comment */
+  'comments.delete-comment-body': 'Once deleted, a comment cannot be recovered.',
+  /**The delete dialog confirm button text for a comment */
+  'comments.delete-comment-confirm': 'Delete comment',
+  /**The delete dialog title for a comment */
+  'comments.delete-comment-title': 'Delete this comment?',
+  /**The delete dialog error */
+  'comments.delete-dialog-error': 'An error occurred while deleting the comment. Please try again.',
+  /**The delete dialog body for a thread */
+  'comments.delete-thread-body':
+    'This comment and its replies will be deleted, and once deleted cannot be recovered.',
+  /**The delete dialog conform button text for a thread */
+  'comments.delete-thread-confirm': 'Delete thread',
+  /**The delete dialog title for a thread */
+  'comments.delete-thread-title': 'Delete this comment thread?',
+
+  /**The button text for confirming discard */
+  'comments.discard-button-confirm': 'Discard',
+  /**The header for discard comment dialog */
+  'comments.discard-header': 'Discard comment?',
+  /**The text for discard comment dialog */
+  'comments.discard-text': 'Do you want to discard the comment?',
+
+  /**The document inspector title for comments */
+  'comments.document-inspector-title': 'Comments',
+
+  /**The text for dropdown menu item for open comments */
+  'comments.dropdown-item-open': 'Open comments',
+  /**The text for dropdown menu item for resolved comments */
+  'comments.dropdown-item-resolved': 'Resolved comments',
+  /**The title for dropdown for open comments */
+  'comments.dropdown-title-open': 'Open',
+  /**The title for dropdown for resolved comments */
+  'comments.dropdown-title-resolved': 'Resolved',
+
+  /**The feedback form footer link to sharing feedback */
+  'comments.feedback-footer-link': 'Share your feedback',
+  /**The feedback form footer title */
+  'comments.feedback-footer-title': 'Help improve comments.',
+
+  /**The field button aria-label for add comment */
+  'comments.field-button-aria-label-add': 'Add comment',
+  /**The field button aria label for open comments*/
+  'comments.field-button-aria-label-open': 'Open comments',
+  /**The field button popover text when there is one comment */
+  'comments.field-button-content_one': 'View comment',
+  /**The field button popover text when there are several comments*/
+  'comments.field-button-content_other': 'View comments',
+  /**The field button placeholder text */
+  'comments.field-button-placeholder-text': 'Add comment to',
+  /**The field button text for adding a comment */
+  'comments.field-button-title': 'Add comment',
+
+  /**The comments pane header title */
+  'comments.header-title': 'Comments',
+
+  /**The inspector copied link text */
+  'comments.inspector-copy-title': 'Copied link to clipboard',
+  /**The inspector text when error copying link */
+  'comments.inspector-copy-title-error': 'Unable to copy link to clipboard',
+
+  /**The button tooltip content for the add reaction button*/
+  'comments.list-item-context-menu-add-reaction': 'Add reaction',
+  /**The button tooltip aria label for adding a reaction */
+  'comments.list-item-context-menu-add-reaction-aria-label': 'Add reaction',
+  /**The action menu item for copying a comment link */
+  'comments.list-item-copy-link': 'Copy link to comment',
+  /**The action menu item for deleting a comment */
+  'comments.list-item-delete-comment': 'Delete comment',
+  /**The action menu item for editing a comment */
+  'comments.list-item-edit-comment': 'Edit comment',
+  /**The marker to indicate that a comment has been edited in brackets */
+  'comments.list-item-layout-edited': 'edited',
+  /**The error text when sending a comment has failed */
+  'comments.list-item-layout-failed-sent': 'Failed to send.',
+  /**The loading message when posting a comment is in progress */
+  'comments.list-item-layout-posting': 'Posting...',
+  /**The text for retrying posting a comment */
+  'comments.list-item-layout-retry': 'Retry',
+  /**The aria label for the comments menu button to open the actions menu */
+  'comments.list-item-open-menu-aria-label': 'Open comment actions menu',
+
+  /**The button text to re-open a resolved comment  */
+  'comments.list-item-re-open-resolved': 'Re-open',
+  /**The button aria label to re-open a comment that is resolved */
+  'comments.list-item-re-open-resolved-aria-label': 'Re-open',
+  /**The button aria label to mark a comment as resolved */
+  'comments.list-item-resolved-tooltip-aria-label': 'Mark comment as resolved',
+  /**The button text to mark a comment as resolved */
+  'comments.list-item-resolved-tooltip-content': 'Mark as resolved',
+
+  /**The empty state text for open comments */
+  'comments.list-status-empty-state-open-text':
+    'Open comments on this document will be shown here.',
+  /**The empty state title for open comments */
+  'comments.list-status-empty-state-open-title': 'No open comments yet',
+  /**The empty state text for resolved comments */
+  'comments.list-status-empty-state-resolved-text':
+    'Resolved comments on this document will be shown here.',
+  /**The empty state title for resolved comments */
+  'comments.list-status-empty-state-resolved-title': 'No resolved comments yet',
+  /**The list status message for error */
+  'comments.list-status-error': 'Something went wrong',
+  /**The list status message for loading status */
+  'comments.list-status-loading': 'Loading comments',
+
+  /**The text for no users found for mentions */
+  'comments.mentions-not-found': 'No users found',
+  /**The text for unauthorized mentions */
+  'comments.mentions-unauthorized': 'Unauthorized',
+  /**The aria label for the command list for users to mention */
+  'comments.mentions-user-list-aria-label': 'List of users to mention',
+
+  /**The comments onboarding popover text */
+  'comments.onboarding-popover-body':
+    'You can add comments to any field in a document. They`ll show up here, grouped by field.',
+  /**The comments onboarding dismiss text */
+  'comments.onboarding-popover-dismiss': 'Got it',
+  /**The comments onboarding popover header text */
+  'comments.onboarding-popover-header': 'Document fields now have comments',
+
+  /**The placeholder for adding a comment to a field title */
+  'comments.placeholder-add-comment-field-title': 'Add comment to <Strong>{{fieldTitle}}</Strong>',
+  /**The placeholder for creating a new thread to the field name */
+  'comments.placeholder-create-thread': 'Add comment to <Strong>{{fieldName}}</Strong>',
+  /**The placeholder for replying to a comment */
+  'comments.placeholder-reply': 'Reply',
+  /**The comment reaction bar tooltip text */
+  'comments.reaction-bar-tooltip': 'Add reaction',
+  /**Separator for several reactions */
+  'comments.reaction-separator': 'and ',
+
+  /**The tooltip text for unknown user */
+  'comments.reaction-unknown-user': 'Unknown user',
+  /**The tooltip text for mentioning a user */
+  'comments.tooltip-mention-user': 'Mention user',
+  /**The tooltip aria label for mentioning a user */
+  'comments.tooltip-mention-user-aria-label': 'Mention user',
+  /**The tooltip text for sending a comment*/
+  'comments.tooltip-send-comment': 'Send comment',
+  /**The tooltip aria label for sending a comment*/
+  'comments.tooltip-send-comment-aria-label': 'Send comment',
+  /**The reactions that the user has reacted with */
+  'comments.user-reacted-with':
+    '<Content/> <Text>reacted with </Text> <ReactionName>{{reactionName}}</ReactionName>',
+})
+
+/**
+ * @alpha
+ */
+export type CommentsLocaleResourceKeys = keyof typeof commentsLocaleStrings
+
+export default commentsLocaleStrings

--- a/packages/sanity/src/structure/comments/i18n/resources.ts
+++ b/packages/sanity/src/structure/comments/i18n/resources.ts
@@ -120,8 +120,6 @@ const commentsLocaleStrings = defineLocalesResources('comments', {
   /**The list status message for loading status */
   'comments.list-status-loading': 'Loading comments',
 
-  /**The inline mention loading state */
-  'comments.mention-inline-block': '@Loading',
   /**The text for no users found for mentions */
   'comments.mentions-not-found': 'No users found',
   /**The text for unauthorized mentions */

--- a/packages/sanity/src/structure/comments/i18n/resources.ts
+++ b/packages/sanity/src/structure/comments/i18n/resources.ts
@@ -14,6 +14,11 @@ const commentsLocaleStrings = defineLocalesResources('comments', {
   /**The text for the button to go to the correct field */
   'comments.button-go-to-field-aria-label': 'Go to field',
 
+  /**The inspector text when error copying link */
+  'comments.copy-link-error-message': 'Unable to copy link to clipboard',
+  /**The inspector successfully copied link text */
+  'comments.copy-link-success-message': 'Copied link to clipboard',
+
   /**The delete dialog body for a comment */
   'comments.delete-comment-body': 'Once deleted, a comment cannot be recovered.',
   /**The delete dialog confirm button text for a comment */
@@ -69,11 +74,6 @@ const commentsLocaleStrings = defineLocalesResources('comments', {
 
   /**The comments pane header title */
   'comments.header-title': 'Comments',
-
-  /**The inspector copied link text */
-  'comments.inspector-copy-title': 'Copied link to clipboard',
-  /**The inspector text when error copying link */
-  'comments.inspector-copy-title-error': 'Unable to copy link to clipboard',
 
   /**The button tooltip content for the add reaction button*/
   'comments.list-item-context-menu-add-reaction': 'Add reaction',
@@ -148,6 +148,10 @@ const commentsLocaleStrings = defineLocalesResources('comments', {
 
   /**The tooltip text for unknown user */
   'comments.reaction-unknown-user': 'Unknown user',
+  /**This is the tooltip text for when you are the user that has reacted */
+  'comments.reaction-user-you': 'You',
+  /**This is the tooltip lowercase text for when you are the user that has reacted */
+  'comments.reaction-user-you-lowercase': 'you',
   /**The aria label for the reactions menu button */
   'comments.reactions-menu-button-aria-label': 'React with {{reaction}}',
   /**The thread breadcrumb button aria label */

--- a/packages/sanity/src/structure/comments/plugin/field/CommentsFieldButton.tsx
+++ b/packages/sanity/src/structure/comments/plugin/field/CommentsFieldButton.tsx
@@ -189,15 +189,7 @@ export function CommentsFieldButton(props: CommentsFieldButtonProps) {
   }
 
   return (
-    <Tooltip
-      portal
-      placement="top"
-      content={
-        count > 1
-          ? t('comments.field-button-content_other')
-          : t('comments.field-button-content_one')
-      }
-    >
+    <Tooltip portal placement="top" content={t('comments.field-button-content', {count: count})}>
       <SanityUIButton
         aria-label={t('comments.field-button-aria-label-open')}
         mode="bleed"

--- a/packages/sanity/src/structure/comments/plugin/field/CommentsFieldButton.tsx
+++ b/packages/sanity/src/structure/comments/plugin/field/CommentsFieldButton.tsx
@@ -18,7 +18,8 @@ import {
   MentionOptionsHookValue,
 } from '../../src'
 import {Button, Popover, Tooltip} from '../../../../ui-components'
-import {CurrentUser, PortableTextBlock} from 'sanity'
+import {commentsLocaleNamespace} from '../../i18n'
+import {CurrentUser, PortableTextBlock, Translate, useTranslation} from 'sanity'
 
 const ContentStack = styled(Stack)`
   width: 320px;
@@ -56,6 +57,7 @@ export function CommentsFieldButton(props: CommentsFieldButtonProps) {
     setOpen,
     value,
   } = props
+  const {t} = useTranslation(commentsLocaleNamespace)
   const [popoverElement, setPopoverElement] = useState<HTMLDivElement | null>(null)
   const [addCommentButtonElement, setAddCommentButtonElement] = useState<HTMLButtonElement | null>(
     null,
@@ -129,9 +131,11 @@ export function CommentsFieldButton(props: CommentsFieldButtonProps) {
 
   if (!hasComments) {
     const placeholder = (
-      <>
-        Add comment to <b>{fieldTitle}</b>
-      </>
+      <Translate
+        t={t}
+        i18nKey="comments.placeholder-add-comment-field-title"
+        components={{Strong: () => <b>{fieldTitle}</b>}}
+      />
     )
 
     const content = (
@@ -167,7 +171,7 @@ export function CommentsFieldButton(props: CommentsFieldButtonProps) {
       >
         <div>
           <Button
-            aria-label="Add comment"
+            aria-label={t('comments.field-button-aria-label-add')}
             disabled={isRunningSetup}
             icon={AddCommentIcon}
             mode="bleed"
@@ -175,7 +179,7 @@ export function CommentsFieldButton(props: CommentsFieldButtonProps) {
             ref={setAddCommentButtonElement}
             selected={open}
             tooltipProps={{
-              content: 'Add comment',
+              content: t('comments.field-button-title'),
               placement: 'top',
             }}
           />
@@ -185,9 +189,17 @@ export function CommentsFieldButton(props: CommentsFieldButtonProps) {
   }
 
   return (
-    <Tooltip portal placement="top" content={`View comment${count > 1 ? 's' : ''}`}>
+    <Tooltip
+      portal
+      placement="top"
+      content={
+        count > 1
+          ? t('comments.field-button-content_other')
+          : t('comments.field-button-content_one')
+      }
+    >
       <SanityUIButton
-        aria-label="Open comments"
+        aria-label={t('comments.field-button-aria-label-open')}
         mode="bleed"
         onClick={onClick}
         padding={2}

--- a/packages/sanity/src/structure/comments/plugin/index.ts
+++ b/packages/sanity/src/structure/comments/plugin/index.ts
@@ -1,3 +1,4 @@
+import {commentsUsEnglishLocaleBundle} from '../i18n'
 import {commentsInspector} from './inspector'
 import {CommentsField} from './field'
 import {CommentsDocumentLayout} from './document-layout'
@@ -25,4 +26,6 @@ export const comments = definePlugin({
       layout: CommentsStudioLayout,
     },
   },
+
+  i18n: {bundles: [commentsUsEnglishLocaleBundle]},
 })

--- a/packages/sanity/src/structure/comments/plugin/inspector/CommentsInspector.tsx
+++ b/packages/sanity/src/structure/comments/plugin/inspector/CommentsInspector.tsx
@@ -20,9 +20,10 @@ import {
   useCommentsOnboarding,
   useCommentsSelectedPath,
 } from '../../src'
+import {commentsLocaleNamespace} from '../../i18n'
 import {CommentsInspectorHeader} from './CommentsInspectorHeader'
 import {CommentsInspectorFeedbackFooter} from './CommentsInspectorFeedbackFooter'
-import {DocumentInspectorProps, useCurrentUser, useUnique} from 'sanity'
+import {DocumentInspectorProps, useCurrentUser, useTranslation, useUnique} from 'sanity'
 
 interface CommentToDelete {
   commentId: string
@@ -52,6 +53,7 @@ export function CommentsInspector(props: DocumentInspectorProps) {
 }
 
 function CommentsInspectorInner(props: DocumentInspectorProps) {
+  const {t} = useTranslation(commentsLocaleNamespace)
   const {onClose} = props
 
   const [showDeleteDialog, setShowDeleteDialog] = useState<boolean>(false)
@@ -119,18 +121,18 @@ function CommentsInspectorInner(props: DocumentInspectorProps) {
           pushToast({
             closable: true,
             status: 'info',
-            title: 'Copied link to clipboard',
+            title: t('comments.inspector-copy-title'),
           })
         })
         .catch(() => {
           pushToast({
             closable: true,
             status: 'error',
-            title: 'Unable to copy link to clipboard',
+            title: t('comments.inspector-copy-title-error'),
           })
         })
     },
-    [createPathWithParams, params, pushToast],
+    [createPathWithParams, params, pushToast, t],
   )
 
   const handleCreateRetry = useCallback(

--- a/packages/sanity/src/structure/comments/plugin/inspector/CommentsInspector.tsx
+++ b/packages/sanity/src/structure/comments/plugin/inspector/CommentsInspector.tsx
@@ -121,14 +121,14 @@ function CommentsInspectorInner(props: DocumentInspectorProps) {
           pushToast({
             closable: true,
             status: 'info',
-            title: t('comments.inspector-copy-title'),
+            title: t('comments.copy-link-success-message'),
           })
         })
         .catch(() => {
           pushToast({
             closable: true,
             status: 'error',
-            title: t('comments.inspector-copy-title-error'),
+            title: t('comments.copy-link-error-message'),
           })
         })
     },

--- a/packages/sanity/src/structure/comments/plugin/inspector/CommentsInspectorFeedbackFooter.tsx
+++ b/packages/sanity/src/structure/comments/plugin/inspector/CommentsInspectorFeedbackFooter.tsx
@@ -2,6 +2,8 @@ import {LaunchIcon} from '@sanity/icons'
 import {Card, Text} from '@sanity/ui'
 import React from 'react'
 import styled from 'styled-components'
+import {commentsLocaleNamespace} from '../../i18n'
+import {useTranslation} from 'sanity'
 
 const FEEDBACK_FORM_LINK = 'https://snty.link/comments-beta-feedback'
 
@@ -19,12 +21,13 @@ const FooterCard = styled(Card)({
 })
 
 export function CommentsInspectorFeedbackFooter() {
+  const {t} = useTranslation(commentsLocaleNamespace)
   return (
     <FooterCard padding={4}>
       <Text muted size={1}>
-        Help improve comments.{' '}
+        {t('comments.feedback-footer-title')}{' '}
         <Link href={FEEDBACK_FORM_LINK} target="_blank" rel="noreferrer">
-          <Span>Share your feedback </Span> <LaunchIcon />
+          <Span>{t('comments.feedback-footer-link')} </Span> <LaunchIcon />
         </Link>
       </Text>
     </FooterCard>

--- a/packages/sanity/src/structure/comments/plugin/inspector/CommentsInspectorHeader.tsx
+++ b/packages/sanity/src/structure/comments/plugin/inspector/CommentsInspectorHeader.tsx
@@ -1,11 +1,11 @@
 import {CheckmarkIcon, ChevronDownIcon, DoubleChevronRightIcon} from '@sanity/icons'
 import {Card, Flex, Menu, Text} from '@sanity/ui'
-import {startCase} from 'lodash'
 import React, {forwardRef, useCallback} from 'react'
 import styled from 'styled-components'
 import {Button, MenuButton, MenuItem} from '../../../../ui-components'
+import {commentsLocaleNamespace} from '../../i18n'
 import {CommentStatus} from '../../src'
-import {BetaBadge} from 'sanity'
+import {BetaBadge, useTranslation} from 'sanity'
 
 const Root = styled(Card)({
   position: 'relative',
@@ -23,6 +23,7 @@ export const CommentsInspectorHeader = forwardRef(function CommentsInspectorHead
   props: CommentsInspectorHeaderProps,
   ref: React.ForwardedRef<HTMLDivElement>,
 ) {
+  const {t} = useTranslation(commentsLocaleNamespace)
   const {onClose, onViewChange, view} = props
 
   const handleSetOpenView = useCallback(() => onViewChange('open'), [onViewChange])
@@ -33,7 +34,7 @@ export const CommentsInspectorHeader = forwardRef(function CommentsInspectorHead
       <Flex padding={2}>
         <Flex align="center" flex={1} gap={2} paddingY={2} padding={3}>
           <Text as="h1" size={1} weight="medium">
-            Comments
+            {t('comments.header-title')}
           </Text>
 
           <BetaBadge />
@@ -42,18 +43,28 @@ export const CommentsInspectorHeader = forwardRef(function CommentsInspectorHead
         <Flex flex="none" padding={1} gap={2}>
           <MenuButton
             id="comment-status-menu-button"
-            button={<Button text={startCase(view)} mode="bleed" iconRight={ChevronDownIcon} />}
+            button={
+              <Button
+                text={
+                  view === 'open'
+                    ? t('comments.dropdown-title-open')
+                    : t('comments.dropdown-title-resolved')
+                }
+                mode="bleed"
+                iconRight={ChevronDownIcon}
+              />
+            } //this startcase needs to be fixed
             menu={
               <Menu style={{width: '180px'}}>
                 <MenuItem
                   iconRight={view === 'open' ? CheckmarkIcon : undefined}
                   onClick={handleSetOpenView}
-                  text="Open comments"
+                  text={t('comments.dropdown-item-open')}
                 />
                 <MenuItem
                   iconRight={view === 'resolved' ? CheckmarkIcon : undefined}
                   onClick={handleSetResolvedView}
-                  text="Resolved comments"
+                  text={t('comments.dropdown-item-resolved')}
                 />
               </Menu>
             }
@@ -61,11 +72,11 @@ export const CommentsInspectorHeader = forwardRef(function CommentsInspectorHead
           />
 
           <Button
-            aria-label="Close comments"
+            aria-label={t('comments.button-close-pane-text-aria-label')}
             icon={DoubleChevronRightIcon}
             mode="bleed"
             onClick={onClose}
-            tooltipProps={{content: 'Close comments'}}
+            tooltipProps={{content: t('comments.button-close-pane-text')}}
           />
         </Flex>
       </Flex>

--- a/packages/sanity/src/structure/comments/plugin/inspector/index.ts
+++ b/packages/sanity/src/structure/comments/plugin/inspector/index.ts
@@ -1,17 +1,19 @@
 import {CommentIcon} from '@sanity/icons'
 import {COMMENTS_INSPECTOR_NAME} from '../../../panes/document/constants'
+import {commentsLocaleNamespace} from '../../i18n'
 import {useCommentsEnabled} from '../../src'
 import {CommentsInspector} from './CommentsInspector'
-import {DocumentInspectorMenuItem, defineDocumentInspector} from 'sanity'
+import {DocumentInspectorMenuItem, defineDocumentInspector, useTranslation} from 'sanity'
 
 function useMenuItem(): DocumentInspectorMenuItem {
   const isEnabled = useCommentsEnabled()
+  const {t} = useTranslation(commentsLocaleNamespace)
 
   return {
     hidden: !isEnabled,
     icon: CommentIcon,
     showAsAction: true,
-    title: 'Comments',
+    title: t('comments.document-inspector-title'),
   }
 }
 

--- a/packages/sanity/src/structure/comments/src/components/CommentDeleteDialog.tsx
+++ b/packages/sanity/src/structure/comments/src/components/CommentDeleteDialog.tsx
@@ -1,22 +1,24 @@
 import {Stack, Text} from '@sanity/ui'
 import React, {useCallback} from 'react'
 import {Dialog} from '../../../../ui-components'
-import {TextWithTone} from 'sanity'
+import {commentsLocaleNamespace} from '../../i18n'
+import {TFunction, TextWithTone, useTranslation} from 'sanity'
 
-const DIALOG_COPY: Record<
-  'thread' | 'comment',
-  {title: string; body: string; confirmButtonText: string}
-> = {
-  thread: {
-    title: 'Delete this comment thread?',
-    body: 'This comment and its replies will be deleted, and once deleted cannot be recovered.',
-    confirmButtonText: 'Delete thread',
-  },
-  comment: {
-    title: 'Delete this comment?',
-    body: 'Once deleted, a comment cannot be recovered.',
-    confirmButtonText: 'Delete comment',
-  },
+function getDialogCopy(
+  t: TFunction,
+): Record<'thread' | 'comment', {title: string; body: string; confirmButtonText: string}> {
+  return {
+    thread: {
+      title: t('comments.delete-thread-title'),
+      body: t('comments.delete-thread-body'),
+      confirmButtonText: t('comments.delete-thread-confirm'),
+    },
+    comment: {
+      title: t('comments.delete-comment-title'),
+      body: t('comments.delete-comment-body'),
+      confirmButtonText: t('comments.delete-comment-confirm'),
+    },
+  }
 }
 
 /**
@@ -38,7 +40,9 @@ export interface CommentDeleteDialogProps {
  */
 export function CommentDeleteDialog(props: CommentDeleteDialogProps) {
   const {isParent, onClose, commentId, onConfirm, loading, error} = props
-  const {title, body, confirmButtonText} = DIALOG_COPY[isParent ? 'thread' : 'comment']
+  const {t} = useTranslation(commentsLocaleNamespace)
+  const dialogCopy = getDialogCopy(t)
+  const {title, body, confirmButtonText} = dialogCopy[isParent ? 'thread' : 'comment']
 
   const handleDelete = useCallback(() => {
     onConfirm(commentId)
@@ -65,11 +69,7 @@ export function CommentDeleteDialog(props: CommentDeleteDialogProps) {
       <Stack space={4}>
         <Text size={1}>{body}</Text>
 
-        {error && (
-          <TextWithTone tone="critical">
-            An error occurred while deleting the comment. Please try again.
-          </TextWithTone>
-        )}
+        {error && <TextWithTone tone="critical">{t('comments.delete-dialog-error')}</TextWithTone>}
       </Stack>
     </Dialog>
   )

--- a/packages/sanity/src/structure/comments/src/components/list/CommentThreadLayout.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CommentThreadLayout.tsx
@@ -16,8 +16,10 @@ import {
 } from '../../types'
 import {CommentBreadcrumbs} from '../CommentBreadcrumbs'
 import {CommentsSelectedPath} from '../../context'
+import {commentsLocaleNamespace} from '../../../i18n'
 import {CreateNewThreadInput} from './CreateNewThreadInput'
 import {ThreadCard} from './styles'
+import {useTranslation} from 'sanity'
 
 const HeaderFlex = styled(Flex)`
   min-height: 25px;
@@ -60,6 +62,8 @@ export function CommentThreadLayout(props: CommentThreadLayoutProps) {
     onPathSelect,
     readOnly,
   } = props
+
+  const {t} = useTranslation(commentsLocaleNamespace)
 
   const handleNewThreadCreate = useCallback(
     (payload: CommentMessage) => {
@@ -118,7 +122,7 @@ export function CommentThreadLayout(props: CommentThreadLayoutProps) {
         <Stack flex={1}>
           <Flex align="center">
             <BreadcrumbsButton
-              aria-label={`Go to ${lastCrumb} field`}
+              aria-label={t('comments.thread-breadcrumb-layout-aria-label', {lastCrumb: lastCrumb})}
               mode="bleed"
               onClick={handleBreadcrumbsClick}
               padding={2}

--- a/packages/sanity/src/structure/comments/src/components/list/CommentsListItem.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CommentsListItem.tsx
@@ -17,8 +17,10 @@ import {SpacerAvatar} from '../avatars'
 import {hasCommentMessageValue} from '../../helpers'
 import {CommentsSelectedPath} from '../../context'
 import {Button} from '../../../../../ui-components'
+import {commentsLocaleNamespace} from '../../../i18n'
 import {CommentsListItemLayout} from './CommentsListItemLayout'
 import {ThreadCard} from './styles'
+import {useTranslation} from 'sanity'
 
 const EMPTY_ARRAY: [] = []
 
@@ -113,6 +115,7 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
     readOnly,
     replies = EMPTY_ARRAY,
   } = props
+  const {t} = useTranslation(commentsLocaleNamespace)
   const [value, setValue] = useState<CommentMessage>(EMPTY_ARRAY)
   const [collapsed, setCollapsed] = useState<boolean>(true)
   const didExpand = useRef<boolean>(false)
@@ -276,7 +279,10 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
         onMouseLeave={handleMouseLeave}
         tone={isSelected ? 'caution' : undefined}
       >
-        <GhostButton data-ui="GhostButton" aria-label="Go to field" />
+        <GhostButton
+          data-ui="GhostButton"
+          aria-label={t('comments.button-go-to-field-aria-label')}
+        />
 
         <Stack
           as="ul"
@@ -331,7 +337,7 @@ export const CommentsListItem = React.memo(function CommentsListItem(props: Comm
               onDiscardConfirm={confirmDiscard}
               onKeyDown={handleInputKeyDown}
               onSubmit={handleReplySubmit}
-              placeholder="Reply"
+              placeholder={t('comments.placeholder-reply')}
               readOnly={readOnly}
               ref={replyInputRef}
               value={value}

--- a/packages/sanity/src/structure/comments/src/components/list/CommentsListItemContextMenu.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CommentsListItemContextMenu.tsx
@@ -12,15 +12,16 @@ import {CommentReactionOption, CommentStatus} from '../../types'
 import {CommentReactionsMenuButton} from '../reactions'
 import {COMMENT_REACTION_OPTIONS} from '../../constants'
 import {ReactionIcon} from '../icons'
-import {ContextMenuButton} from 'sanity'
+import {commentsLocaleNamespace} from '../../../i18n'
+import {ContextMenuButton, TFunction, useTranslation} from 'sanity'
 
-const renderMenuButton = ({open}: {open: boolean}) => (
+const renderMenuButton = ({open, t}: {open: boolean; t: TFunction}) => (
   <Button
-    aria-label="Add reaction"
+    aria-label={t('comments.list-item-context-menu-add-reaction-aria-label')}
     icon={ReactionIcon}
     mode="bleed"
     selected={open}
-    tooltipProps={{content: 'Add reaction'}}
+    tooltipProps={{content: t('comments.list-item-context-menu-add-reaction')}}
   />
 )
 
@@ -67,6 +68,8 @@ export function CommentsListItemContextMenu(props: CommentsListItemContextMenuPr
 
   const showMenuButton = Boolean(onCopyLink || onDeleteStart || onEditStart)
 
+  const {t} = useTranslation(commentsLocaleNamespace)
+
   return (
     <TooltipDelayGroupProvider>
       <Flex>
@@ -84,12 +87,21 @@ export function CommentsListItemContextMenu(props: CommentsListItemContextMenuPr
 
           {isParent && (
             <Button
-              aria-label={status === 'open' ? 'Mark comment as resolved' : 'Re-open'}
+              aria-label={
+                status === 'open'
+                  ? t('comments.list-item-resolved-tooltip-aria-label')
+                  : t('comments.list-item-re-open-resolved-aria-label')
+              }
               disabled={readOnly}
               icon={status === 'open' ? CheckmarkCircleIcon : UndoIcon}
               mode="bleed"
               onClick={onStatusChange}
-              tooltipProps={{content: status === 'open' ? 'Mark as resolved' : 'Re-open'}}
+              tooltipProps={{
+                content:
+                  status === 'open'
+                    ? t('comments.list-item-resolved-tooltip-content')
+                    : t('comments.list-item-re-open-resolved'),
+              }}
             />
           )}
 
@@ -97,7 +109,7 @@ export function CommentsListItemContextMenu(props: CommentsListItemContextMenuPr
             id="comment-actions-menu"
             button={
               <ContextMenuButton
-                aria-label="Open comment actions menu"
+                aria-label={t('comments.list-item-open-menu-aria-label')}
                 disabled={readOnly}
                 hidden={!showMenuButton}
               />
@@ -110,14 +122,14 @@ export function CommentsListItemContextMenu(props: CommentsListItemContextMenuPr
                   hidden={!canEdit}
                   icon={EditIcon}
                   onClick={onEditStart}
-                  text="Edit comment"
+                  text={t('comments.list-item-edit-comment')}
                 />
 
                 <MenuItem
                   hidden={!canDelete}
                   icon={TrashIcon}
                   onClick={onDeleteStart}
-                  text="Delete comment"
+                  text={t('comments.list-item-delete-comment')}
                   tone="critical"
                 />
 
@@ -127,7 +139,7 @@ export function CommentsListItemContextMenu(props: CommentsListItemContextMenuPr
                   hidden={!onCopyLink}
                   icon={LinkIcon}
                   onClick={onCopyLink}
-                  text="Copy link to comment"
+                  text={t('comments.list-item-copy-link')}
                 />
               </Menu>
             }

--- a/packages/sanity/src/structure/comments/src/components/list/CommentsListItemLayout.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CommentsListItemLayout.tsx
@@ -299,7 +299,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
 
                   {formattedLastEditAt && (
                     <TimeText muted size={0} title={formattedLastEditAt}>
-                      {`(${t('comments.list-item-layout-edited')})`}
+                      ({t('comments.list-item-layout-edited')})
                     </TimeText>
                   )}
                 </Flex>

--- a/packages/sanity/src/structure/comments/src/components/list/CommentsListItemLayout.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CommentsListItemLayout.tsx
@@ -18,8 +18,9 @@ import {FLEX_GAP} from '../constants'
 import {hasCommentMessageValue, useCommentHasChanged} from '../../helpers'
 import {AVATAR_HEIGHT, CommentsAvatar, SpacerAvatar} from '../avatars'
 import {CommentReactionsBar} from '../reactions'
+import {commentsLocaleNamespace} from '../../../i18n'
 import {CommentsListItemContextMenu} from './CommentsListItemContextMenu'
-import {TimeAgoOpts, useTimeAgo, useUser, useDidUpdate} from 'sanity'
+import {TimeAgoOpts, useTimeAgo, useUser, useDidUpdate, useTranslation} from 'sanity'
 
 const stopPropagation = (e: React.MouseEvent<HTMLDivElement>) => e.stopPropagation()
 
@@ -140,6 +141,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
   } = props
   const {_createdAt, authorId, message, _id, lastEditedAt} = comment
   const [user] = useUser(authorId)
+  const {t} = useTranslation(commentsLocaleNamespace)
 
   const [value, setValue] = useState<CommentMessage>(message)
   const [isEditing, setIsEditing] = useState<boolean>(false)
@@ -297,7 +299,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
 
                   {formattedLastEditAt && (
                     <TimeText muted size={0} title={formattedLastEditAt}>
-                      (edited)
+                      {`(${t('comments.list-item-layout-edited')})`}
                     </TimeText>
                   )}
                 </Flex>
@@ -378,8 +380,8 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
 
           <Flex align="center" gap={1} flex={1}>
             <Text muted size={1}>
-              {hasError && 'Failed to send.'}
-              {isRetrying && 'Posting...'}
+              {hasError && t('comments.list-item-layout-failed-sent')}
+              {isRetrying && t('comments.list-item-layout-posting')}
             </Text>
 
             <Flex hidden={isRetrying}>
@@ -393,7 +395,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
                 tone="primary"
               >
                 <Text size={1} muted>
-                  Retry
+                  {t('comments.list-item-layout-retry')}
                 </Text>
               </RetryCardButton>
             </Flex>

--- a/packages/sanity/src/structure/comments/src/components/list/CommentsListStatus.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CommentsListStatus.tsx
@@ -1,32 +1,25 @@
 import {Flex, Container, Stack, Text} from '@sanity/ui'
 import React from 'react'
+import {commentsLocaleNamespace} from '../../../i18n'
 import {CommentStatus} from '../../types'
-import {LoadingBlock} from 'sanity'
+import {LoadingBlock, TFunction, useTranslation} from 'sanity'
 
 interface EmptyStateMessage {
   title: string
   message: React.ReactNode
 }
 
-export const EMPTY_STATE_MESSAGES: Record<CommentStatus, EmptyStateMessage> = {
-  open: {
-    title: 'No open comments yet',
-    message: (
-      <span>
-        Open comments on this document <br />
-        will be shown here.
-      </span>
-    ),
-  },
-  resolved: {
-    title: 'No resolved comments yet',
-    message: (
-      <>
-        Resolved comments on this document <br />
-        will be shown here.
-      </>
-    ),
-  },
+export function getEmptyStateMessages(t: TFunction): Record<CommentStatus, EmptyStateMessage> {
+  return {
+    open: {
+      title: t('comments.list-status-empty-state-open-title'),
+      message: t('comments.list-status-empty-state-open-text'),
+    },
+    resolved: {
+      title: t('comments.list-status-empty-state-resolved-title'),
+      message: t('comments.list-status-empty-state-resolved-text'),
+    },
+  }
 }
 
 interface CommentsListStatusProps {
@@ -38,13 +31,15 @@ interface CommentsListStatusProps {
 
 export function CommentsListStatus(props: CommentsListStatusProps) {
   const {status, error, loading, hasNoComments} = props
+  const {t} = useTranslation(commentsLocaleNamespace)
+  const emptyStateMessages = getEmptyStateMessages(t)
 
   if (error) {
     return (
       <Flex align="center" justify="center" flex={1} padding={4}>
         <Flex align="center">
           <Text size={1} muted>
-            Something went wrong
+            {t('comments.list-status-error')}
           </Text>
         </Flex>
       </Flex>
@@ -52,8 +47,7 @@ export function CommentsListStatus(props: CommentsListStatusProps) {
   }
 
   if (loading) {
-    // @todo: localize
-    return <LoadingBlock showText title="Loading comments" />
+    return <LoadingBlock showText title={t('comments.list-status-loading')} />
   }
 
   if (hasNoComments) {
@@ -62,11 +56,11 @@ export function CommentsListStatus(props: CommentsListStatusProps) {
         <Container width={0} padding={4}>
           <Stack space={3}>
             <Text align="center" size={1} muted weight="medium">
-              {EMPTY_STATE_MESSAGES[status].title}
+              {emptyStateMessages[status].title}
             </Text>
 
             <Text align="center" size={1} muted>
-              {EMPTY_STATE_MESSAGES[status].message}
+              {emptyStateMessages[status].message}
             </Text>
           </Stack>
         </Container>

--- a/packages/sanity/src/structure/comments/src/components/list/CreateNewThreadInput.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CreateNewThreadInput.tsx
@@ -2,8 +2,9 @@ import type {CurrentUser} from '@sanity/types'
 import React, {useState, useCallback, useRef, useMemo} from 'react'
 import type {CommentMessage, MentionOptionsHookValue} from '../../types'
 import {CommentInput, CommentInputHandle, CommentInputProps} from '../pte'
+import {commentsLocaleNamespace} from '../../../i18n'
 import {hasCommentMessageValue} from '../../helpers'
-import {EMPTY_ARRAY} from 'sanity'
+import {EMPTY_ARRAY, Translate, useTranslation} from 'sanity'
 
 interface CreateNewThreadInputProps {
   currentUser: CurrentUser
@@ -27,6 +28,7 @@ export function CreateNewThreadInput(props: CreateNewThreadInputProps) {
     onNewThreadCreate,
     readOnly,
   } = props
+  const {t} = useTranslation(commentsLocaleNamespace)
 
   const [value, setValue] = useState<CommentMessage>(EMPTY_ARRAY)
   const commentInputHandle = useRef<CommentInputHandle | null>(null)
@@ -74,9 +76,11 @@ export function CreateNewThreadInput(props: CreateNewThreadInputProps) {
   }, [])
 
   const placeholder = (
-    <>
-      Add comment to <b>{fieldName}</b>
-    </>
+    <Translate
+      t={t}
+      i18nKey="comments.placeholder-create-thread"
+      components={{Strong: () => <b>{fieldName}</b>}}
+    />
   )
 
   return (

--- a/packages/sanity/src/structure/comments/src/components/mentions/MentionsMenu.tsx
+++ b/packages/sanity/src/structure/comments/src/components/mentions/MentionsMenu.tsx
@@ -3,8 +3,9 @@ import styled from 'styled-components'
 import React, {useCallback, useImperativeHandle, useMemo, useRef, useState} from 'react'
 import {deburr} from 'lodash'
 import {MentionOptionUser} from '../../types'
+import {commentsLocaleNamespace} from '../../../i18n'
 import {MentionsMenuItem} from './MentionsMenuItem'
-import {CommandList, CommandListHandle, LoadingBlock} from 'sanity'
+import {CommandList, CommandListHandle, LoadingBlock, useTranslation} from 'sanity'
 
 const EMPTY_ARRAY: MentionOptionUser[] = []
 
@@ -34,6 +35,7 @@ export const MentionsMenu = React.forwardRef(function MentionsMenu(
   props: MentionsMenuProps,
   ref: React.Ref<MentionsMenuHandle>,
 ) {
+  const {t} = useTranslation(commentsLocaleNamespace)
   const {loading, onSelect, options = [], inputElement} = props
   const [searchTerm, setSearchTerm] = useState<string>('')
   const commandListRef = useRef<CommandListHandle>(null)
@@ -111,7 +113,7 @@ export const MentionsMenu = React.forwardRef(function MentionsMenu(
       {filteredOptions.length === 0 && (
         <Box padding={5}>
           <Text align="center" size={1} muted>
-            No users found
+            {t('comments.mentions-not-found')}
           </Text>
         </Box>
       )}
@@ -120,7 +122,7 @@ export const MentionsMenu = React.forwardRef(function MentionsMenu(
         <FlexWrap direction="column" flex={1} overflow="hidden">
           <CommandList
             activeItemDataAttr="data-hovered"
-            ariaLabel="List of users to mention"
+            ariaLabel={t('comments.mentions-user-list-aria-label')}
             fixedHeight
             getItemDisabled={getItemDisabled}
             inputElement={_inputElement}

--- a/packages/sanity/src/structure/comments/src/components/mentions/MentionsMenuItem.tsx
+++ b/packages/sanity/src/structure/comments/src/components/mentions/MentionsMenuItem.tsx
@@ -2,8 +2,9 @@ import {TextSkeleton, Flex, Text, Card, Box, Badge} from '@sanity/ui'
 import React, {useCallback} from 'react'
 import styled from 'styled-components'
 import {MentionOptionUser} from '../../types'
+import {commentsLocaleNamespace} from '../../../i18n'
 import {CommentsAvatar} from '../avatars'
-import {useUser} from 'sanity'
+import {useUser, useTranslation} from 'sanity'
 
 const InnerFlex = styled(Flex)``
 
@@ -17,6 +18,7 @@ interface MentionsItemProps {
 export function MentionsMenuItem(props: MentionsItemProps) {
   const {user, onSelect} = props
   const [loadedUser] = useUser(user.id)
+  const {t} = useTranslation(commentsLocaleNamespace)
 
   const avatar = (
     <CommentsAvatar user={loadedUser} status={user.canBeMentioned ? undefined : 'inactive'} />
@@ -44,7 +46,7 @@ export function MentionsMenuItem(props: MentionsItemProps) {
 
         {!user.canBeMentioned && (
           <Badge fontSize={1} mode="outline">
-            Unauthorized
+            {t('comments.mentions-unauthorized')}
           </Badge>
         )}
       </Flex>

--- a/packages/sanity/src/structure/comments/src/components/onboarding/CommentsOnboardingPopover.tsx
+++ b/packages/sanity/src/structure/comments/src/components/onboarding/CommentsOnboardingPopover.tsx
@@ -2,6 +2,8 @@ import {Box, Flex, Stack, Text} from '@sanity/ui'
 import React from 'react'
 import styled, {keyframes} from 'styled-components'
 import {Button, Popover, PopoverProps} from '../../../../../ui-components'
+import {commentsLocaleNamespace} from '../../../i18n'
+import {useTranslation} from 'sanity'
 
 const Root = styled(Box)`
   max-width: 280px;
@@ -29,6 +31,7 @@ interface CommentsOnboardingPopoverProps extends Omit<PopoverProps, 'content'> {
 
 export function CommentsOnboardingPopover(props: CommentsOnboardingPopoverProps) {
   const {onDismiss} = props
+  const {t} = useTranslation(commentsLocaleNamespace)
 
   return (
     <StyledPopover
@@ -36,16 +39,17 @@ export function CommentsOnboardingPopover(props: CommentsOnboardingPopoverProps)
         <Root padding={4}>
           <Stack space={3}>
             <Text weight="medium" size={1}>
-              Document fields now have comments
+              {t('comments.onboarding-popover-header')}
             </Text>
 
-            <Text size={1}>
-              You can add comments to any field in a document. They'll show up here, grouped by
-              field.
-            </Text>
+            <Text size={1}>{t('comments.onboarding-popover-body')}</Text>
 
             <Flex justify="flex-end" marginTop={2}>
-              <Button text="Got it" tone="primary" onClick={onDismiss} />
+              <Button
+                text={t('comments.onboarding-popover-dismiss')}
+                tone="primary"
+                onClick={onDismiss}
+              />
             </Flex>
           </Stack>
         </Root>

--- a/packages/sanity/src/structure/comments/src/components/pte/blocks/MentionInlineBlock.tsx
+++ b/packages/sanity/src/structure/comments/src/components/pte/blocks/MentionInlineBlock.tsx
@@ -36,7 +36,8 @@ export function MentionInlineBlock(props: MentionInlineBlockProps) {
   const currentUser = useCurrentUser()
   const {t} = useTranslation(commentsLocaleNamespace)
 
-  if (!user || loading) return <Span>{t('comments.mention-inline-block')}</Span> // todo: improve
+  // eslint-disable-next-line i18next/no-literal-string
+  if (!user || loading) return <Span>@Loading</Span> // todo: improve
 
   return (
     <Tooltip

--- a/packages/sanity/src/structure/comments/src/components/pte/blocks/MentionInlineBlock.tsx
+++ b/packages/sanity/src/structure/comments/src/components/pte/blocks/MentionInlineBlock.tsx
@@ -2,8 +2,9 @@ import React from 'react'
 import {Flex, Text} from '@sanity/ui'
 import styled, {css} from 'styled-components'
 import {Tooltip} from '../../../../../../ui-components'
+import {commentsLocaleNamespace} from '../../../../i18n'
 import {CommentsAvatar} from '../../avatars'
-import {useCurrentUser, useUser} from 'sanity'
+import {useCurrentUser, useTranslation, useUser} from 'sanity'
 
 const Span = styled.span(({theme}) => {
   const {regular} = theme.sanity.fonts?.text.weights
@@ -33,8 +34,9 @@ export function MentionInlineBlock(props: MentionInlineBlockProps) {
   const {selected, userId} = props
   const [user, loading] = useUser(userId)
   const currentUser = useCurrentUser()
+  const {t} = useTranslation(commentsLocaleNamespace)
 
-  if (!user || loading) return <Span>@Loading</Span> // todo: improve
+  if (!user || loading) return <Span>{t('comments.mention-inline-block')}</Span> // todo: improve
 
   return (
     <Tooltip

--- a/packages/sanity/src/structure/comments/src/components/pte/comment-input/CommentInputDiscardDialog.tsx
+++ b/packages/sanity/src/structure/comments/src/components/pte/comment-input/CommentInputDiscardDialog.tsx
@@ -1,6 +1,8 @@
 import {DialogProvider, Text, ThemeColorProvider} from '@sanity/ui'
 import React, {useCallback} from 'react'
 import {Dialog} from '../../../../../../ui-components'
+import {commentsLocaleNamespace} from '../../../../i18n'
+import {useTranslation} from 'sanity'
 
 const Z_OFFSET = 9999999 // Change to appropriate z-offset
 
@@ -18,6 +20,7 @@ export interface CommentInputDiscardDialogProps {
  * @hidden
  */
 export function CommentInputDiscardDialog(props: CommentInputDiscardDialogProps) {
+  const {t} = useTranslation(commentsLocaleNamespace)
   const {onClose, onConfirm} = props
 
   const handleCancelClick = useCallback(
@@ -44,7 +47,7 @@ export function CommentInputDiscardDialog(props: CommentInputDiscardDialogProps)
     <ThemeColorProvider tone="default">
       <DialogProvider zOffset={Z_OFFSET}>
         <Dialog
-          header="Discard comment?"
+          header={t('comments.discard-header')}
           id="discard-comment-dialog"
           onClose={onClose}
           width={0}
@@ -55,12 +58,12 @@ export function CommentInputDiscardDialog(props: CommentInputDiscardDialogProps)
             },
             confirmButton: {
               onClick: handleConfirmClick,
-              text: 'Discard',
+              text: t('comments.discard-button-confirm'),
               tone: 'critical',
             },
           }}
         >
-          <Text size={1}>Do you want to discard the comment?</Text>
+          <Text size={1}>{t('comments.discard-text')}</Text>
         </Dialog>
       </DialogProvider>
     </ThemeColorProvider>

--- a/packages/sanity/src/structure/comments/src/components/pte/comment-input/CommentInputInner.tsx
+++ b/packages/sanity/src/structure/comments/src/components/pte/comment-input/CommentInputInner.tsx
@@ -5,9 +5,10 @@ import {CurrentUser} from '@sanity/types'
 import {MentionIcon, SendIcon} from '../../icons'
 import {CommentsAvatar} from '../../avatars/CommentsAvatar'
 import {Button, TooltipDelayGroupProvider} from '../../../../../../ui-components'
+import {commentsLocaleNamespace} from '../../../../i18n'
 import {useCommentInput} from './useCommentInput'
 import {Editable} from './Editable'
-import {useUser} from 'sanity'
+import {useTranslation, useUser} from 'sanity'
 
 const EditableWrap = styled(Box)`
   max-height: 20vh;
@@ -83,6 +84,7 @@ export function CommentInputInner(props: CommentInputInnerProps) {
   const {canSubmit, expandOnFocus, focused, hasChanges, insertAtChar, openMentions, readOnly} =
     useCommentInput()
 
+  const {t} = useTranslation(commentsLocaleNamespace)
   const avatar = withAvatar ? <CommentsAvatar user={user} /> : null
 
   const handleMentionButtonClicked = useCallback(
@@ -121,25 +123,25 @@ export function CommentInputInner(props: CommentInputInnerProps) {
           <Flex align="center" data-ui="CommentInputActions" gap={1} justify="flex-end" padding={1}>
             <TooltipDelayGroupProvider>
               <Button
-                aria-label="Mention user"
+                aria-label={t('comments.tooltip-mention-user-aria-label')}
                 data-testid="comment-mention-button"
                 disabled={readOnly}
                 icon={MentionIcon}
                 mode="bleed"
                 onClick={handleMentionButtonClicked}
-                tooltipProps={{content: 'Mention user'}}
+                tooltipProps={{content: t('comments.tooltip-mention-user')}}
               />
 
               <ButtonDivider />
 
               <Button
-                aria-label="Send comment"
+                aria-label={t('comments.tooltip-send-comment-aria-label')}
                 disabled={!canSubmit || !hasChanges || readOnly}
                 icon={SendIcon}
                 mode={hasChanges && canSubmit ? 'default' : 'bleed'}
                 onClick={onSubmit}
                 tone={hasChanges && canSubmit ? 'primary' : 'default'}
-                tooltipProps={{content: 'Send comment'}}
+                tooltipProps={{content: t('comments.tooltip-send-comment')}}
               />
             </TooltipDelayGroupProvider>
           </Flex>

--- a/packages/sanity/src/structure/comments/src/components/reactions/CommentReactionsBar.tsx
+++ b/packages/sanity/src/structure/comments/src/components/reactions/CommentReactionsBar.tsx
@@ -14,6 +14,7 @@ import {CommentReactionsMenuButton} from './CommentReactionsMenuButton'
 import {CommentReactionsUsersTooltip} from './CommentReactionsUsersTooltip'
 import {EmojiText} from './EmojiText.styled'
 import {TransparentCard} from './TransparentCard.styled'
+import {TFunction} from 'sanity'
 
 /**
  * A function that groups reactions by name. For example:
@@ -54,11 +55,11 @@ function groupReactionsByName(reactions: CommentReactionItem[]) {
   return sorted as [CommentReactionShortNames, CommentReactionItem[]][]
 }
 
-const renderMenuButton = ({open}: {open: boolean}) => {
+const renderMenuButton = ({open, t}: {open: boolean; t: TFunction}) => {
   return (
     <UIButton fontSize={1} mode="ghost" padding={0} radius="full" selected={open}>
       <Flex paddingX={3} paddingY={2}>
-        <Tooltip animate content="Add reaction" disabled={open}>
+        <Tooltip animate content={t('comments.reaction-bar-tooltip')} disabled={open}>
           <Text size={1}>
             <ReactionIcon />
           </Text>

--- a/packages/sanity/src/structure/comments/src/components/reactions/CommentReactionsMenu.tsx
+++ b/packages/sanity/src/structure/comments/src/components/reactions/CommentReactionsMenu.tsx
@@ -2,8 +2,10 @@
 import {Button as UIButton, Grid} from '@sanity/ui'
 import React, {useCallback, useEffect, useState} from 'react'
 import {CommentReactionOption} from '../../types'
+import {commentsLocaleNamespace} from '../../../i18n'
 import {COMMENT_REACTION_EMOJIS} from '../../constants'
 import {EmojiText} from './EmojiText.styled'
+import {useTranslation} from 'sanity'
 
 const GRID_COLUMNS = 6
 
@@ -14,7 +16,7 @@ interface CommentReactionsMenuProps {
 
 export function CommentReactionsMenu(props: CommentReactionsMenuProps) {
   const {options, onSelect} = props
-
+  const {t} = useTranslation(commentsLocaleNamespace)
   const [focusableElements, setFocusableElements] = useState<HTMLButtonElement[]>([])
   const [rootElement, setRootElement] = useState<HTMLDivElement | null>(null)
   const [focusedIndex, setFocusedIndex] = useState<number>(0)
@@ -76,7 +78,9 @@ export function CommentReactionsMenu(props: CommentReactionsMenuProps) {
 
         return (
           <UIButton
-            aria-label={`React with ${o.title || o.shortName}`}
+            aria-label={t('comments.reactions-menu-button-aria-label', {
+              reaction: o.title || o.shortName,
+            })}
             key={o.shortName}
             mode="bleed"
             onClick={handleOptionClick}

--- a/packages/sanity/src/structure/comments/src/components/reactions/CommentReactionsMenuButton.tsx
+++ b/packages/sanity/src/structure/comments/src/components/reactions/CommentReactionsMenuButton.tsx
@@ -1,8 +1,11 @@
+import {TFunction} from 'i18next'
 import React, {cloneElement, useCallback, useMemo, useState} from 'react'
 import {Card, useClickOutside} from '@sanity/ui'
 import {CommentReactionOption} from '../../types'
 import {Popover, PopoverProps} from '../../../../../ui-components'
+import {commentsLocaleNamespace} from '../../../i18n'
 import {CommentReactionsMenu} from './CommentReactionsMenu'
+import {useTranslation} from 'sanity'
 
 const POPOVER_FALLBACK_PLACEMENTS: PopoverProps['fallbackPlacements'] = ['top', 'bottom']
 
@@ -12,7 +15,7 @@ export interface CommentReactionsMenuButtonProps {
   onSelect: (option: CommentReactionOption) => void
   options: CommentReactionOption[]
   readOnly?: boolean
-  renderMenuButton: (props: {open: boolean}) => React.ReactElement
+  renderMenuButton: (props: {open: boolean; t: TFunction}) => React.ReactElement
 }
 
 export function CommentReactionsMenuButton(props: CommentReactionsMenuButtonProps) {
@@ -21,6 +24,7 @@ export function CommentReactionsMenuButton(props: CommentReactionsMenuButtonProp
   const [popoverElement, setPopoverElement] = useState<HTMLDivElement | null>(null)
 
   const [open, setOpen] = useState<boolean>(false)
+  const {t} = useTranslation(commentsLocaleNamespace)
 
   const handleClick = useCallback(() => {
     const next = !open
@@ -66,7 +70,7 @@ export function CommentReactionsMenuButton(props: CommentReactionsMenuButtonProp
 
   const button = useMemo(() => {
     // Get the button element from the renderMenuButton function.
-    const btn = renderMenuButton({open})
+    const btn = renderMenuButton({open, t})
 
     // Clone the button element and add the necessary props.
     return cloneElement(btn, {
@@ -76,8 +80,9 @@ export function CommentReactionsMenuButton(props: CommentReactionsMenuButtonProp
       id: 'reactions-menu-button',
       onClick: handleClick,
       ref: setButtonElement,
+      t: t,
     })
-  }, [handleClick, open, readOnly, renderMenuButton])
+  }, [handleClick, open, readOnly, renderMenuButton, t])
 
   const popoverContent = (
     <Card

--- a/packages/sanity/src/structure/comments/src/components/reactions/CommentReactionsUsersTooltip.tsx
+++ b/packages/sanity/src/structure/comments/src/components/reactions/CommentReactionsUsersTooltip.tsx
@@ -36,7 +36,7 @@ function UserDisplayName(props: UserDisplayNameProps) {
   const {t} = useTranslation(commentsLocaleNamespace)
 
   const isCurrentUser = currentUserId === userId
-  const you = isFirst ? 'You' : 'you'
+  const you = isFirst ? t('comments.reaction-user-you') : t('comments.reaction-user-you-lowercase')
   const content = isCurrentUser ? you : user?.displayName ?? t('comments.reaction-unknown-user')
   const text = separator ? `${content}, ` : content
 

--- a/packages/sanity/src/structure/comments/src/components/reactions/CommentReactionsUsersTooltip.tsx
+++ b/packages/sanity/src/structure/comments/src/components/reactions/CommentReactionsUsersTooltip.tsx
@@ -4,8 +4,9 @@ import styled from 'styled-components'
 import {COMMENT_REACTION_EMOJIS} from '../../constants'
 import {CommentReactionShortNames} from '../../types'
 import {Tooltip} from '../../../../../ui-components'
+import {commentsLocaleNamespace} from '../../../i18n'
 import {EmojiText} from './EmojiText.styled'
-import {CurrentUser, useUser} from 'sanity'
+import {CurrentUser, Translate, useTranslation, useUser} from 'sanity'
 
 const TEXT_SIZE: number | number[] = 1
 
@@ -32,10 +33,11 @@ interface UserDisplayNameProps {
 function UserDisplayName(props: UserDisplayNameProps) {
   const {currentUserId, isFirst, userId, separator} = props
   const [user] = useUser(userId)
+  const {t} = useTranslation(commentsLocaleNamespace)
 
   const isCurrentUser = currentUserId === userId
   const you = isFirst ? 'You' : 'you'
-  const content = isCurrentUser ? you : user?.displayName ?? 'Unknown user'
+  const content = isCurrentUser ? you : user?.displayName ?? t('comments.reaction-unknown-user')
   const text = separator ? `${content}, ` : content
 
   return <InlineText weight="medium"> {text} </InlineText>
@@ -66,7 +68,7 @@ export function CommentReactionsUsersTooltipContent(
   props: Omit<CommentReactionsUsersTooltipProps, 'children'>,
 ) {
   const {currentUser, reactionName, userIds} = props
-
+  const {t} = useTranslation(commentsLocaleNamespace)
   const content = useMemo(() => {
     const len = userIds.length
 
@@ -80,7 +82,7 @@ export function CommentReactionsUsersTooltipContent(
         <Fragment key={id}>
           {showAnd && (
             <>
-              <InlineText>and </InlineText>{' '}
+              <InlineText>{t('comments.reaction-separator')} </InlineText>{' '}
             </>
           )}
           <UserDisplayName
@@ -92,7 +94,7 @@ export function CommentReactionsUsersTooltipContent(
         </Fragment>
       )
     })
-  }, [currentUser, userIds])
+  }, [currentUser, userIds, t])
 
   return (
     <ContentStack padding={1}>
@@ -101,8 +103,20 @@ export function CommentReactionsUsersTooltipContent(
       </Flex>
 
       <TextBox>
-        {content} <InlineText muted>reacted with </InlineText> <wbr />{' '}
-        <InlineText muted>{reactionName}</InlineText>
+        <Translate
+          t={t}
+          i18nKey="comments.user-reacted-with"
+          values={{reactionName: reactionName}}
+          components={{
+            Content: () => <>{content}</>,
+            Text: ({children}) => (
+              <>
+                <InlineText muted>{children}</InlineText> <wbr />{' '}
+              </>
+            ),
+            ReactionName: ({children}) => <InlineText muted>{children}</InlineText>,
+          }}
+        />
       </TextBox>
     </ContentStack>
   )


### PR DESCRIPTION
### Description
This PR adds a resource file to the comments plugin with all the strings and localizes every string in the comments plugin. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
All strings for the comments plugin feature 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Adds localization to the comments plugin
<!--
A description of the change(s) that should be used in the release notes.
-->
