### PR TITLE
fix(src): add textskeleton to loading state of mentions

### DIFF
--- a/packages/sanity/playwright-ct/tests/comments/CommentInput.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/comments/CommentInput.spec.tsx
@@ -30,6 +30,7 @@ test.describe('Comments', () => {
       await page.keyboard.press('Enter')
       await expect(page.getByTestId('comments-mentions-menu')).not.toBeVisible()
       // TODO: find a way to mock `useUser`!
+      await expect(page.getByTestId('comment-mentions-loading-skeleton')).toBeVisible()
     })
 
     test('Should bring up mentions menu when pressing the @ button, whilst retaining focus on PTE', async ({

--- a/packages/sanity/playwright-ct/tests/comments/CommentInput.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/comments/CommentInput.spec.tsx
@@ -30,7 +30,6 @@ test.describe('Comments', () => {
       await page.keyboard.press('Enter')
       await expect(page.getByTestId('comments-mentions-menu')).not.toBeVisible()
       // TODO: find a way to mock `useUser`!
-      await expect($editable).toHaveText('@Loading')
     })
 
     test('Should bring up mentions menu when pressing the @ button, whilst retaining focus on PTE', async ({

--- a/packages/sanity/src/structure/comments/src/components/pte/blocks/MentionInlineBlock.tsx
+++ b/packages/sanity/src/structure/comments/src/components/pte/blocks/MentionInlineBlock.tsx
@@ -2,9 +2,8 @@ import React from 'react'
 import {Flex, Text, TextSkeleton} from '@sanity/ui'
 import styled, {css} from 'styled-components'
 import {Tooltip} from '../../../../../../ui-components'
-import {commentsLocaleNamespace} from '../../../../i18n'
 import {CommentsAvatar} from '../../avatars'
-import {useCurrentUser, useTranslation, useUser} from 'sanity'
+import {useCurrentUser, useUser} from 'sanity'
 
 const Span = styled.span(({theme}) => {
   const {regular} = theme.sanity.fonts?.text.weights
@@ -34,10 +33,18 @@ export function MentionInlineBlock(props: MentionInlineBlockProps) {
   const {selected, userId} = props
   const [user, loading] = useUser(userId)
   const currentUser = useCurrentUser()
-  const {t} = useTranslation(commentsLocaleNamespace)
 
   if (!user || loading)
-    return <TextSkeleton style={{width: '10ch'}} size={0} muted radius={1} animated />
+    return (
+      <TextSkeleton
+        data-testid="comment-mentions-loading-skeleton"
+        style={{width: '10ch'}}
+        size={0}
+        muted
+        radius={1}
+        animated
+      />
+    )
 
   return (
     <Tooltip

--- a/packages/sanity/src/structure/comments/src/components/pte/blocks/MentionInlineBlock.tsx
+++ b/packages/sanity/src/structure/comments/src/components/pte/blocks/MentionInlineBlock.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {Flex, Text} from '@sanity/ui'
+import {Flex, Text, TextSkeleton} from '@sanity/ui'
 import styled, {css} from 'styled-components'
 import {Tooltip} from '../../../../../../ui-components'
 import {commentsLocaleNamespace} from '../../../../i18n'
@@ -36,8 +36,8 @@ export function MentionInlineBlock(props: MentionInlineBlockProps) {
   const currentUser = useCurrentUser()
   const {t} = useTranslation(commentsLocaleNamespace)
 
-  // eslint-disable-next-line i18next/no-literal-string
-  if (!user || loading) return <Span>@Loading</Span> // todo: improve
+  if (!user || loading)
+    return <TextSkeleton style={{width: '10ch'}} size={0} muted radius={1} animated />
 
   return (
     <Tooltip


### PR DESCRIPTION
### Description

Added skeleton to loading state when mentioning users in comment. 
![Screenshot 2024-01-29 at 15 06 22](https://github.com/sanity-io/sanity/assets/44635000/1e547520-363b-44f1-9914-d6584d12d979)

The test for the hardcoded `@Loading` text when it is loading is no longer applicable, as this also created some issues with the current localisation work that is in progress for comments 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
The loading state when mentioning a user in a comment
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
