### PR TITLE
chore(cli): remove beta copy from documents validate command

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/validation/validateAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/validation/validateAction.ts
@@ -61,13 +61,6 @@ export default async function validateAction(
       )
     }
 
-    output.print()
-    output.print(
-      "Note: As it's currently in beta, we encourage users to report any issues encountered here:\n",
-    )
-    output.print('    https://github.com/sanity-io/sanity/issues/5510')
-    output.print()
-
     const confirmed = await prompt.single<boolean>({
       type: 'confirm',
       message: `Are you sure you want to continue?`,

--- a/packages/sanity/src/_internal/cli/commands/documents/validateDocumentsCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/documents/validateDocumentsCommand.ts
@@ -1,16 +1,6 @@
-import chalk from 'chalk'
 import type {CliCommandDefinition} from '@sanity/cli'
 
-const description = `Downloads and validates all document specified in a workspace (beta)${chalk.cyan(
-  '*',
-)}.
-
-${chalk.cyan('*')}Note: As it's currently in beta, some features may not be fully stable.
-We encourage users to report any issues encountered to help us improve.
-Thank you for your understanding and support!
-
-https://github.com/sanity-io/sanity/issues/5510
-`
+const description = `Downloads and validates all document specified in a workspace`
 
 const helpText = `
 Options


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Removes Beta Copy for `sanity documents validate` command

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

When you checkout the branch and run `yarn build && cd dev/test-studio && npx sanity documents validate --help` it does not show beta copy

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

N/A

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

N/A (Need to double check)