### PR TITLE
fix(validation): filter system documents when running validation

### DIFF
--- a/packages/sanity/src/_internal/cli/threads/validateDocuments.ts
+++ b/packages/sanity/src/_internal/cli/threads/validateDocuments.ts
@@ -108,7 +108,10 @@ const idRegex = /^[^-][A-Z0-9._-]*$/i
 
 // during testing, the `doc` endpoint 502'ed if given an invalid ID
 const isValidId = (id: unknown) => typeof id === 'string' && idRegex.test(id)
-const shouldIncludeDocument = (document: SanityDocument) => !document._id.startsWith('system.')
+const shouldIncludeDocument = (document: SanityDocument) => {
+  // Filter out system documents
+  return !document._type.startsWith('system.')
+}
 
 async function* readerToGenerator(reader: ReadableStreamDefaultReader<Uint8Array>) {
   while (true) {


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Fixes issue with logic of filtering out system documents when running `sanity documents validate` 

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

To test it on the branch run `yarn build && cd dev/test-studio && npx sanity documents validate` and check if there are any system documents in there

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

N/A