### PR TITLE
fix(migrate): run migration against all documents if documentTypes is omitted

### DIFF
--- a/packages/@sanity/migrate/src/runner/normalizeMigrateDefinition.ts
+++ b/packages/@sanity/migrate/src/runner/normalizeMigrateDefinition.ts
@@ -89,7 +89,7 @@ export function createAsyncIterableMutation(
 
   return async function* run(docs, context) {
     for await (const doc of docs()) {
-      if (!documentTypesSet.has(doc._type)) continue
+      if (opts.documentTypes && !documentTypesSet.has(doc._type)) continue
 
       const documentMutations = await collectDocumentMutations(migration, doc, context)
       if (documentMutations.length > 0) {


### PR DESCRIPTION

### Description

`documentTypes` should act like a filter, just like ?types=foo,bar does on the export endpoint (no types=all documents)

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
