### PR TITLE
fix(migrate): various naming consistency fixes

### DIFF
--- a/packages/sanity/src/_internal/cli/commands/migration/createMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/createMigrationCommand.ts
@@ -32,20 +32,21 @@ const TEMPLATES = [
 const createMigrationCommand: CliCommandDefinition<CreateMigrationFlags> = {
   name: 'create',
   group: 'migration',
-  signature: '[NAME]',
+  signature: '[TITLE]',
   helpText,
   description: 'Create a new content migration within your project',
   action: async (args, context) => {
     const {output, prompt, workDir, chalk} = context
 
-    let name = ''
-    while (!name.trim()) {
-      name = await prompt.single({
+    let [title] = args.argsWithoutOptions
+
+    while (!title.trim()) {
+      title = await prompt.single({
         type: 'input',
-        suffix: ' (e.g. rename field from location to address)',
-        message: 'Name of migration',
+        suffix: ' (e.g. "Rename field from location to address")',
+        message: 'Title of migration',
       })
-      if (!name.trim()) {
+      if (!title.trim()) {
         output.print(chalk.red('Name cannot be empty'))
       }
     }
@@ -65,7 +66,7 @@ const createMigrationCommand: CliCommandDefinition<CreateMigrationFlags> = {
       })),
     })
 
-    const sluggedName = deburr(name.toLowerCase())
+    const sluggedName = deburr(title.toLowerCase())
       .replace(/\s+/g, '-')
       .replace(/[^a-z0-9-]/g, '')
 
@@ -84,7 +85,7 @@ const createMigrationCommand: CliCommandDefinition<CreateMigrationFlags> = {
     mkdirp.sync(destDir)
 
     const renderedTemplate = (templatesByName[template].template || minimalSimple)({
-      migrationName: name,
+      migrationName: title,
       documentTypes: types
         .split(',')
         .map((t) => t.trim())

--- a/packages/sanity/src/_internal/cli/commands/migration/listMigrationsCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/listMigrationsCommand.ts
@@ -50,7 +50,7 @@ const createMigrationCommand: CliCommandDefinition<CreateFlags> = {
       title: `Found ${migrationModules.length} migrations in project`,
       columns: [
         {name: 'id', title: 'ID', alignment: 'left'},
-        {name: 'name', title: 'Title', alignment: 'left'},
+        {name: 'title', title: 'Title', alignment: 'left'},
       ],
     })
 


### PR DESCRIPTION
### Description

Various consistency fixes,
- consistent use of migration _title_ instead of Migration _name_
- consistent use of migration _id_ instead of migration _name_

### What to review


### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
