### PR TITLE
fix(sanity): improve error handling on 'sanity migration run' without id

### DIFF
--- a/packages/sanity/src/_internal/cli/commands/migration/createMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/createMigrationCommand.ts
@@ -40,14 +40,14 @@ const createMigrationCommand: CliCommandDefinition<CreateMigrationFlags> = {
 
     let [title] = args.argsWithoutOptions
 
-    while (!title.trim()) {
+    while (!title?.trim()) {
       title = await prompt.single({
         type: 'input',
         suffix: ' (e.g. "Rename field from location to address")',
         message: 'Title of migration',
       })
       if (!title.trim()) {
-        output.print(chalk.red('Name cannot be empty'))
+        output.error(chalk.red('Name cannot be empty'))
       }
     }
     const types = await prompt.single({

--- a/packages/sanity/src/_internal/cli/commands/migration/listMigrationsCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/listMigrationsCommand.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import {readdir} from 'node:fs/promises'
-import type {CliCommandDefinition} from '@sanity/cli'
+import type {CliCommandContext, CliCommandDefinition} from '@sanity/cli'
 import {register} from 'esbuild-register/dist/node'
 import {Migration} from '@sanity/migrate'
 import {Table} from 'console-table-printer'
@@ -21,45 +21,48 @@ const createMigrationCommand: CliCommandDefinition<CreateFlags> = {
   helpText,
   description: 'List available migrations',
   action: async (args, context) => {
-    const {output, workDir} = context
-
-    if (!__DEV__) {
-      register({
-        target: `node${process.version.slice(1)}`,
-      })
-    }
-
-    const directories = (
-      await readdir(path.join(workDir, MIGRATIONS_DIRECTORY), {withFileTypes: true})
-    ).filter((ent) => ent.isDirectory())
-
-    const migrationModules = directories
-      .map((ent) => {
-        const candidates = resolveMigrationScript(workDir, ent.name)
-        const found = candidates.find((candidate) => candidate.mod?.default)
-        if (!found) {
-          return null
-        }
-        return {
-          dirname: ent.name,
-          migration: found.mod.default as Migration,
-        }
-      })
-      .filter(Boolean) as {dirname: string; migration: Migration}[]
+    const {workDir, output} = context
+    const migrations = await resolveMigrations(workDir)
     const table = new Table({
-      title: `Found ${migrationModules.length} migrations in project`,
+      title: `Found ${migrations.length} migrations in project`,
       columns: [
         {name: 'id', title: 'ID', alignment: 'left'},
         {name: 'title', title: 'Title', alignment: 'left'},
       ],
     })
 
-    migrationModules.forEach((definedMigration) => {
+    migrations.forEach((definedMigration) => {
       table.addRow({id: definedMigration.dirname, title: definedMigration.migration.title})
     })
     table.printTable()
-    output.print(`\nRun "sanity migration run <MIGRATION ID>" to run a migration`)
+    output.print('\nRun `sanity migration run <ID>` to run a migration')
   },
+}
+
+export async function resolveMigrations(workDir: string) {
+  if (!__DEV__) {
+    register({
+      target: `node${process.version.slice(1)}`,
+    })
+  }
+
+  const directories = (
+    await readdir(path.join(workDir, MIGRATIONS_DIRECTORY), {withFileTypes: true})
+  ).filter((ent) => ent.isDirectory())
+
+  return directories
+    .map((ent) => {
+      const candidates = resolveMigrationScript(workDir, ent.name)
+      const found = candidates.find((candidate) => candidate.mod?.default)
+      if (!found) {
+        return null
+      }
+      return {
+        dirname: ent.name,
+        migration: found.mod.default as Migration,
+      }
+    })
+    .filter(Boolean) as {dirname: string; migration: Migration}[]
 }
 
 export default createMigrationCommand

--- a/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
@@ -11,8 +11,10 @@ import {
   runFromArchive,
 } from '@sanity/migrate'
 
+import {Table} from 'console-table-printer'
 import {debug} from '../../debug'
 import {formatTransaction} from './utils/mutationFormatter'
+import {resolveMigrations} from './listMigrationsCommand'
 
 const helpText = `
 Options
@@ -91,9 +93,23 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
     }
 
     if (!id) {
-      throw new Error(
-        "Migration ID must be provided. `sanity migration run <ID>`. To see a list of available migrations and their ID's, run `sanity migration list`",
-      )
+      output.error(chalk.red('Error: Migration ID must be provided'))
+      const migrations = await resolveMigrations(workDir)
+      const table = new Table({
+        title: `Migrations found in project`,
+        columns: [
+          {name: 'id', title: 'ID', alignment: 'left'},
+          {name: 'title', title: 'Title', alignment: 'left'},
+        ],
+      })
+
+      migrations.forEach((definedMigration) => {
+        table.addRow({id: definedMigration.dirname, title: definedMigration.migration.title})
+      })
+      table.printTable()
+      output.print('\nRun `sanity migration run <ID>` to run a migration')
+
+      return
     }
 
     if (!__DEV__) {


### PR DESCRIPTION
### Description
Smaller error handling improvements, listing available migrations if you run `sanity migration run` without specifying migration id

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
