### PR TITLE
fix(studio): fallback to <unnamed> when logging installed plugins

### DIFF
--- a/packages/sanity/src/core/studio/StudioTelemetryProvider.tsx
+++ b/packages/sanity/src/core/studio/StudioTelemetryProvider.tsx
@@ -50,7 +50,7 @@ export function StudioTelemetryProvider(props: {children: ReactNode; config: Con
       plugins: arrify(props.config).flatMap(
         (config) =>
           config.plugins?.flatMap((plugin) => ({
-            name: plugin.name,
+            name: plugin.name || '<unnamed>',
           })) || [],
       ),
     })


### PR DESCRIPTION
### Description
Telemetry currently logs `undefined` as the name for plugins without a name. This fallbacks to `<unnamed>` instead.

### What to review
Does it make sense?

### Testing
n/a

### Notes for release

n/a