### PR TITLE
refactor(migration): move filtered methods to own key, provide a client on migration context

### DIFF
--- a/packages/@sanity/migrate/package.json
+++ b/packages/@sanity/migrate/package.json
@@ -71,7 +71,8 @@
     "debug": "^4.3.4",
     "fast-fifo": "^1.3.2",
     "groq-js": "^1.4.1",
-    "p-map": "^7.0.1"
+    "p-map": "^7.0.1",
+    "rxjs": "^7.8.0"
   },
   "devDependencies": {
     "@types/arrify": "^2.0.1",

--- a/packages/@sanity/migrate/src/runner/utils/client-concurrency-limiter/ConcurrencyLimiter.ts
+++ b/packages/@sanity/migrate/src/runner/utils/client-concurrency-limiter/ConcurrencyLimiter.ts
@@ -1,0 +1,42 @@
+/**
+ * ConcurrencyLimiter manages the number of concurrent operations that can be performed.
+ * It ensures that the number of operations does not exceed a specified maximum limit.
+ */
+export class ConcurrencyLimiter {
+  current = 0
+  resolvers: Array<() => void> = []
+  constructor(public max: number) {}
+
+  /**
+   * Indicates when a slot for a new operation is ready.
+   * If under the limit, it resolves immediately; otherwise, it waits until a slot is free.
+   */
+  ready = (): Promise<void> => {
+    if (this.max === Infinity) return Promise.resolve()
+
+    if (this.current < this.max) {
+      this.current++
+      return Promise.resolve()
+    }
+
+    return new Promise<void>((resolve) => {
+      this.resolvers.push(resolve)
+    })
+  }
+
+  /**
+   * Releases a slot, decrementing the current count of operations if nothing is in the queue.
+   * If there are operations waiting, it allows the next one in the queue to proceed.
+   */
+  release = (): void => {
+    if (this.max === Infinity) return
+
+    const nextResolver = this.resolvers.shift()
+    if (nextResolver) {
+      nextResolver()
+      return
+    }
+
+    this.current = Math.max(0, this.current - 1)
+  }
+}

--- a/packages/@sanity/migrate/src/runner/utils/client-concurrency-limiter/README.md
+++ b/packages/@sanity/migrate/src/runner/utils/client-concurrency-limiter/README.md
@@ -1,0 +1,1 @@
+This is copied verbatim from packages/sanity/src/core/validation/util/createClientConcurrencyLimiter.ts - should be moved to a common place and imported from the same source

--- a/packages/@sanity/migrate/src/runner/utils/client-concurrency-limiter/createClientConcurrencyLimiter.ts
+++ b/packages/@sanity/migrate/src/runner/utils/client-concurrency-limiter/createClientConcurrencyLimiter.ts
@@ -1,0 +1,102 @@
+import type {SanityClient, ObservableSanityClient} from '@sanity/client'
+import {from, switchMap, finalize} from 'rxjs'
+import {ConcurrencyLimiter} from './ConcurrencyLimiter'
+
+/**
+ * Decorates a sanity client to limit the concurrency of `client.fetch`
+ * requests. Keeps the concurrency limit state and returns wrapped clients with
+ * that same state if the `clone` `config` or `withConfig` methods are called.
+ */
+export function createClientConcurrencyLimiter(
+  maxConcurrency: number,
+): (input: SanityClient) => SanityClient {
+  const limiter = new ConcurrencyLimiter(maxConcurrency)
+
+  function wrapClient(client: SanityClient): SanityClient {
+    return new Proxy(client, {
+      get: (target, property) => {
+        switch (property) {
+          case 'fetch': {
+            return async (...args: Parameters<SanityClient['fetch']>) => {
+              await limiter.ready()
+              try {
+                // note we want to await before we return so the finally block
+                // will run after the promise has been fulfilled or rejected
+                return await target.fetch(...args)
+              } finally {
+                limiter.release()
+              }
+            }
+          }
+          case 'clone': {
+            return (...args: Parameters<SanityClient['clone']>) => {
+              return wrapClient(target.clone(...args))
+            }
+          }
+          case 'config': {
+            return (...args: Parameters<SanityClient['config']>) => {
+              const result = target.config(...args)
+
+              // if there is a config, it returns a client so we need to wrap again
+              if (args[0]) return wrapClient(result)
+              return result
+            }
+          }
+          case 'withConfig': {
+            return (...args: Parameters<SanityClient['withConfig']>) => {
+              return wrapClient(target.withConfig(...args))
+            }
+          }
+          case 'observable': {
+            return wrapObservableClient(target.observable)
+          }
+          default: {
+            return target[property as keyof SanityClient]
+          }
+        }
+      },
+    })
+  }
+
+  function wrapObservableClient(
+    observableSanityClient: ObservableSanityClient,
+  ): ObservableSanityClient {
+    return new Proxy(observableSanityClient, {
+      get: (target, property) => {
+        switch (property) {
+          case 'fetch': {
+            return (...args: Parameters<ObservableSanityClient['fetch']>) =>
+              from(limiter.ready()).pipe(
+                switchMap(() => target.fetch(...args)),
+                finalize(() => limiter.release()),
+              )
+          }
+          case 'clone': {
+            return (...args: Parameters<ObservableSanityClient['clone']>) => {
+              return wrapObservableClient(target.clone(...args))
+            }
+          }
+          case 'config': {
+            return (...args: Parameters<ObservableSanityClient['config']>) => {
+              const result = target.config(...args)
+
+              // if there is a config, it returns a client so we need to wrap again
+              if (args[0]) return wrapObservableClient(result)
+              return result
+            }
+          }
+          case 'withConfig': {
+            return (...args: Parameters<ObservableSanityClient['withConfig']>) => {
+              return wrapObservableClient(target.withConfig(...args))
+            }
+          }
+          default: {
+            return target[property as keyof ObservableSanityClient]
+          }
+        }
+      },
+    })
+  }
+
+  return wrapClient
+}

--- a/packages/@sanity/migrate/src/runner/utils/createFilteredDocumentsClient.ts
+++ b/packages/@sanity/migrate/src/runner/utils/createFilteredDocumentsClient.ts
@@ -5,11 +5,11 @@ import {streamToAsyncIterator} from '../../utils/streamToAsyncIterator'
 import {safeJsonParser} from '../../sources/fromExportEndpoint'
 import {groqQuery} from '../../it-utils/groqQuery'
 
-export function createBufferFileContext(
-  getReader: () => ReadableStream<Uint8Array>,
-): MigrationContext {
+export function createFilteredDocumentsClient(
+  getFilteredDocumentsReadableStream: () => ReadableStream<Uint8Array>,
+): MigrationContext['filtered'] {
   function getAllDocumentsFromBuffer<T extends SanityDocument>() {
-    return parse<T>(decodeText(streamToAsyncIterator(getReader())), {
+    return parse<T>(decodeText(streamToAsyncIterator(getFilteredDocumentsReadableStream())), {
       parse: safeJsonParser as JSONParser<T>,
     })
   }

--- a/packages/@sanity/migrate/src/runner/utils/limitClientConcurrency.ts
+++ b/packages/@sanity/migrate/src/runner/utils/limitClientConcurrency.ts
@@ -1,0 +1,7 @@
+// this is the number of requests allowed inflight at once. this is done to prevent
+// the validation library from overwhelming our backend
+import {createClientConcurrencyLimiter} from './client-concurrency-limiter/createClientConcurrencyLimiter'
+
+const MAX_FETCH_CONCURRENCY = 10
+
+export const limitClientConcurrency = createClientConcurrencyLimiter(MAX_FETCH_CONCURRENCY)

--- a/packages/@sanity/migrate/src/types.ts
+++ b/packages/@sanity/migrate/src/types.ts
@@ -1,5 +1,5 @@
-import type {SanityDocument, Path} from '@sanity/types'
-import {MultipleMutationResult, Mutation as RawMutation} from '@sanity/client'
+import type {Path, SanityDocument} from '@sanity/types'
+import {MultipleMutationResult, Mutation as RawMutation, SanityClient} from '@sanity/client'
 import {JsonArray, JsonObject, JsonValue} from './json'
 import {Mutation, NodePatch, Operation, Transaction} from './mutations'
 
@@ -47,9 +47,12 @@ export type MigrationProgress = {
 }
 
 export interface MigrationContext {
-  getDocument<T extends SanityDocument>(id: string): Promise<T | undefined>
-  getDocuments<T extends SanityDocument>(ids: string[]): Promise<T[]>
-  query<T>(query: string, params?: Record<string, unknown>): Promise<T>
+  client: SanityClient
+  filtered: {
+    getDocument<T extends SanityDocument>(id: string): Promise<T | undefined>
+    getDocuments<T extends SanityDocument>(ids: string[]): Promise<T[]>
+    query<T>(query: string, params?: Record<string, unknown>): Promise<T>
+  }
 }
 
 export interface APIConfig {

--- a/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
@@ -181,7 +181,6 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
       token: projectConfig.token!,
       apiVersion: 'v2024-01-29',
     } as const
-
     if (dry) {
       dryRunHandler()
       return


### PR DESCRIPTION
### Description
- Moves `filtered` document methods (getDocument(), getDocuments(), query() to a separate `filtered`-key to better communicate their limitations
- Provides a client instance with limited concurrency on the migration context.

