### PR TITLE
fix(src): add document title to publosh/unpublish success message in toast

### DIFF
--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -356,10 +356,13 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'panes.document-operation-results.operation-success_discardChanges':
     'All changes since last publish has now been discarded. The discarded draft can still be recovered from history',
   /** The text when a publish operation succeeded  */
-  'panes.document-operation-results.operation-success_publish': 'The document was published',
+  'panes.document-operation-results.operation-success_publish':
+    '<Strong>{{title}}</Strong> was published',
   /** The text when an unpublish operation succeeded  */
   'panes.document-operation-results.operation-success_unpublish':
-    'The document was unpublished. A draft has been created from the latest published version.',
+    '<Strong>{{title}}</Strong> was unpublished. A draft has been created from the latest published version.',
+  /** The document title shown when document title is "undefined" in operation message */
+  'panes.document-operation-results.operation-undefined-title': 'Untitled',
   /** The title of the reconnecting toast */
   'panes.document-pane-provider.reconnecting.title': 'Connection lost. Reconnecting…',
   /** The loading message for the document not found pane */


### PR DESCRIPTION
### Description

This PR adds the document title name to the toast messages that appear when you publish or unpublish a document. 
It truncates the title if it is above 25 characters. 

![Screenshot 2024-01-30 at 13 58 18](https://github.com/sanity-io/sanity/assets/44635000/88dc7a9c-a7bf-4284-8180-454b9617d2a8)

![Screenshot 2024-01-30 at 13 58 08](https://github.com/sanity-io/sanity/assets/44635000/99a9e2a0-9580-4c7d-971f-318964bd9df1)

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
The toast messages that appear for document actions
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
