### PR TITLE
fix(studio): center studio nav

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
@@ -48,7 +48,7 @@ const RootCard = styled(Card)`
 `
 
 const NavGrid = styled(Grid)`
-  grid-template-columns: auto auto auto;
+  grid-template-columns: auto 1fr auto;
 `
 
 /**

--- a/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
@@ -48,7 +48,7 @@ const RootCard = styled(Card)`
 `
 
 const NavGrid = styled(Grid)`
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: 1fr auto 1fr;
 `
 
 /**

--- a/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
@@ -48,7 +48,10 @@ const RootCard = styled(Card)`
 `
 
 const NavGrid = styled(Grid)`
-  grid-template-columns: 1fr auto 1fr;
+  grid-template-columns: auto auto auto;
+  @media screen and (min-width: ${({theme}) => `${theme.sanity.media[3]}px`}) {
+    grid-template-columns: 1fr auto 1fr;
+  }
 `
 
 /**


### PR DESCRIPTION
### Description

Centered the navigation menu in Studio

Edit: After a discussion with @robinpyon, the navigation menu is now only centering on large screens (1200px and up).

#### Before:
![image](https://github.com/sanity-io/sanity/assets/25268506/9156540d-31bf-4cb4-9e8e-d42056e7f421)
#### After:
![image](https://github.com/sanity-io/sanity/assets/25268506/48f51676-67d7-4e4f-9551-0d671255487d)

### What to review

Check that the navigation menu is centered independently from surrounding items

### Testing

- Verified that layout does not break when adding a bunch of menu items
- Verified that nav stays the same on breakpoints below 1200px

### Notes for release

- Centered navigation in Studio