### PR TITLE
feat(cli): improve reporting when dry running from export

### DIFF
--- a/packages/@sanity/migrate/src/runner/dryRun.ts
+++ b/packages/@sanity/migrate/src/runner/dryRun.ts
@@ -1,5 +1,5 @@
 import {SanityDocument} from '@sanity/types'
-import {APIConfig, Migration, MigrationProgress} from '../types'
+import {APIConfig, Migration} from '../types'
 import {fromExportEndpoint, safeJsonParser} from '../sources/fromExportEndpoint'
 import {streamToAsyncIterator} from '../utils/streamToAsyncIterator'
 import {bufferThroughFile} from '../fs-webstream/bufferThroughFile'
@@ -14,7 +14,6 @@ import {createContextClient} from './utils/createContextClient'
 
 interface MigrationRunnerOptions {
   api: APIConfig
-  onProgress?: (event: MigrationProgress) => void
 }
 
 export async function* dryRun(config: MigrationRunnerOptions, migration: Migration) {


### PR DESCRIPTION
### Description

This branch unifies the way migration dry runs are executed, regardless of whether the export endpoint or an archive is used as a source. The `dryRun` runner now accepts an optional export path, and the CLI formats output for all dry runs the same.

### What to review

- The output when dry running migrations is consistent, regardless of whether the `--from-export` flag is used.

### Testing

- Is the output okay?