### PR TITLE
feat(cli): add `intentUrl` to `json` and `ndjson` reporters

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/validation/reporters/jsonReporter.ts
+++ b/packages/sanity/src/_internal/cli/actions/validation/reporters/jsonReporter.ts
@@ -1,39 +1,30 @@
-import type {ValidationMarker} from '@sanity/types'
 import type {BuiltInValidationReporter} from '../validateAction'
 
+// TODO: replace with Array.fromAsync when it's out of stage3
+async function arrayFromAsync<T>(iterable: AsyncIterable<T>) {
+  const results: T[] = []
+  for await (const item of iterable) results.push(item)
+  return results
+}
+
 export const json: BuiltInValidationReporter = async ({output, worker}) => {
-  let overallLevel: 'error' | 'warning' | 'info' = 'info'
-
-  const results: Array<{
-    documentId: string
-    documentType: string
-    revision: string
-    level: 'error' | 'warning' | 'info'
-    markers: ValidationMarker[]
-  }> = []
-
-  for await (const {
-    documentId,
-    documentType,
-    markers,
-    revision,
-    level,
-  } of worker.stream.validation()) {
-    if (level === 'error') overallLevel = 'error'
-    if (level === 'warning' && overallLevel !== 'error') overallLevel = 'warning'
-
-    results.push({
-      documentId,
-      documentType,
-      revision,
-      level,
-      markers,
-    })
-  }
+  const results = await arrayFromAsync(worker.stream.validation())
+  const formatted = results
+    // report out only documents with some markers
+    .filter(({markers}) => markers.length)
+    // remove validatedCount from the results
+    .map(({validatedCount, ...result}) => result)
 
   await worker.dispose()
 
-  output.print(JSON.stringify(results))
+  output.print(JSON.stringify(formatted))
+
+  let overallLevel: 'error' | 'warning' | 'info' = 'info'
+
+  for (const {level} of formatted) {
+    if (level === 'error') overallLevel = 'error'
+    if (level === 'warning' && overallLevel !== 'error') overallLevel = 'warning'
+  }
 
   return overallLevel
 }

--- a/packages/sanity/src/_internal/cli/actions/validation/reporters/ndjsonReporter.ts
+++ b/packages/sanity/src/_internal/cli/actions/validation/reporters/ndjsonReporter.ts
@@ -3,18 +3,12 @@ import type {BuiltInValidationReporter} from '../validateAction'
 export const ndjson: BuiltInValidationReporter = async ({output, worker}) => {
   let overallLevel: 'error' | 'warning' | 'info' = 'info'
 
-  for await (const {
-    documentId,
-    documentType,
-    markers,
-    revision,
-    level,
-  } of worker.stream.validation()) {
-    if (level === 'error') overallLevel = 'error'
-    if (level === 'warning' && overallLevel !== 'error') overallLevel = 'warning'
+  for await (const {validatedCount, ...result} of worker.stream.validation()) {
+    if (result.level === 'error') overallLevel = 'error'
+    if (result.level === 'warning' && overallLevel !== 'error') overallLevel = 'warning'
 
-    if (markers.length) {
-      output.print(JSON.stringify({documentId, documentType, revision, level, markers}))
+    if (result.markers.length) {
+      output.print(JSON.stringify(result))
     }
   }
 

--- a/packages/sanity/src/_internal/cli/actions/validation/reporters/prettyReporter/__tests__/formatDocumentValidation.test.ts
+++ b/packages/sanity/src/_internal/cli/actions/validation/reporters/prettyReporter/__tests__/formatDocumentValidation.test.ts
@@ -6,12 +6,10 @@ jest.mock('tty', () => ({isatty: () => false}))
 describe('formatDocumentValidation', () => {
   it('formats a set of markers in to a printed tree, sorting markers, and adding spacing', () => {
     const result = formatDocumentValidation({
-      basePath: '/test',
       documentId: 'my-document-id',
       documentType: 'person',
       level: 'error',
       revision: 'rev',
-      studioHost: null,
       markers: [
         {level: 'error', message: 'Top-level marker', path: []},
         {level: 'error', message: '2nd top-level marker', path: []},
@@ -42,12 +40,10 @@ describe('formatDocumentValidation', () => {
 
   it('formats a set of top-level markers only (should have an elbow at first message)', () => {
     const result = formatDocumentValidation({
-      basePath: '/test',
       documentId: 'my-document-id',
       documentType: 'person',
       level: 'error',
       revision: 'rev',
-      studioHost: null,
       markers: [
         {level: 'info', message: '2nd top-level marker (should come last)', path: []},
         {level: 'error', message: 'Lone top-level marker (should get elbow)', path: []},

--- a/packages/sanity/src/_internal/cli/actions/validation/reporters/prettyReporter/formatDocumentValidation.ts
+++ b/packages/sanity/src/_internal/cli/actions/validation/reporters/prettyReporter/formatDocumentValidation.ts
@@ -4,11 +4,6 @@ import logSymbols from 'log-symbols'
 import {DocumentValidationResult, Level, isTty, levelValues} from './util'
 import {pathToString} from 'sanity'
 
-export interface FormatDocumentValidationOptions extends DocumentValidationResult {
-  studioHost: string | null
-  basePath: string
-}
-
 interface ValidationTree {
   markers?: Pick<ValidationMarker, 'level' | 'message'>[]
   children?: Record<string, ValidationTree>
@@ -148,26 +143,20 @@ function convertToTree(markers: ValidationMarker[]): ValidationTree {
  * Formats document validation results into a user-friendly tree structure
  */
 export function formatDocumentValidation({
-  basePath,
   documentId,
   documentType,
   level,
-  studioHost,
   markers,
-}: FormatDocumentValidationOptions): string {
+  intentUrl,
+}: DocumentValidationResult): string {
   const tree = convertToTree(markers)
-  const editLink =
-    studioHost &&
-    `${studioHost}${basePath}/intent/edit/id=${encodeURIComponent(
-      documentId,
-    )};type=${encodeURIComponent(documentType)}`
 
   const documentTypeHeader = isTty
     ? chalk.bgWhite(chalk.black(` ${documentType} `))
     : `[${documentType}]`
 
   const header = `${levelHeaders[level]} ${documentTypeHeader} ${
-    editLink ? link(documentId, editLink) : chalk.underline(documentId)
+    intentUrl ? link(documentId, intentUrl) : chalk.underline(documentId)
   }`
 
   const paddingLength = Math.max(maxKeyLength(tree.children) + 2, 30)

--- a/packages/sanity/src/_internal/cli/actions/validation/reporters/prettyReporter/prettyReporter.ts
+++ b/packages/sanity/src/_internal/cli/actions/validation/reporters/prettyReporter/prettyReporter.ts
@@ -116,13 +116,7 @@ export const pretty: BuiltInValidationReporter = async ({output, worker, flags})
     if (result.level === 'error') overallLevel = 'error'
     if (result.level === 'warning' && overallLevel !== 'error') overallLevel = 'warning'
 
-    output.print(
-      `${formatDocumentValidation({
-        basePath: workspace.basePath,
-        studioHost: workspace.studioHost,
-        ...result,
-      })}\n`,
-    )
+    output.print(`${formatDocumentValidation(result)}\n`)
   }
 
   await worker.dispose()

--- a/packages/sanity/src/_internal/cli/actions/validation/reporters/prettyReporter/util.ts
+++ b/packages/sanity/src/_internal/cli/actions/validation/reporters/prettyReporter/util.ts
@@ -8,6 +8,7 @@ export interface DocumentValidationResult {
   revision: string
   documentId: string
   documentType: string
+  intentUrl?: string
   level: ValidationMarker['level']
   markers: ValidationMarker[]
 }

--- a/packages/sanity/src/_internal/cli/threads/__tests__/validateDocuments.test.ts
+++ b/packages/sanity/src/_internal/cli/threads/__tests__/validateDocuments.test.ts
@@ -59,11 +59,11 @@ const documents: SanityDocument[] = [
     },
   },
   {
-    _id: 'system.some-system-document.foo',
-    _rev: 'rev6',
+    _id: 'some-system-document.foo',
     _type: 'system.some-system-document',
     _createdAt: '2024-01-18T19:18:39.048Z',
     _updatedAt: '2024-01-18T19:18:39.048Z',
+    _rev: 'rev6',
   },
 ]
 
@@ -243,14 +243,15 @@ describe('validateDocuments', () => {
 
     expect(await receiver.event.exportFinished()).toEqual({
       totalDocumentsToValidate:
-        documents.length - documents.filter((doc) => doc._id.startsWith('system.')).length,
+        documents.length - documents.filter((doc) => doc._type.startsWith('system.')).length,
     })
     await receiver.event.loadedReferenceIntegrity()
 
-    expect(await toArray(receiver.stream.validation())).toEqual([
+    expect(await toArray(receiver.stream.validation())).toMatchObject([
       {
         documentId: 'valid-author',
         documentType: 'author',
+        intentUrl: `${localhost}/intent/edit/id=valid-author;type=author`,
         level: 'info',
         markers: [],
         revision: 'rev1',
@@ -259,6 +260,7 @@ describe('validateDocuments', () => {
       {
         documentId: 'author-no-name',
         documentType: 'author',
+        intentUrl: `${localhost}/intent/edit/id=author-no-name;type=author`,
         level: 'error',
         markers: [{level: 'error', message: 'Required', path: ['name']}],
         revision: 'rev2',
@@ -267,6 +269,7 @@ describe('validateDocuments', () => {
       {
         documentId: 'valid-book',
         documentType: 'book',
+        intentUrl: `${localhost}/intent/edit/id=valid-book;type=book`,
         level: 'info',
         markers: [],
         revision: 'rev3',
@@ -275,6 +278,7 @@ describe('validateDocuments', () => {
       {
         documentId: 'book-no-title-no-author',
         documentType: 'book',
+        intentUrl: `${localhost}/intent/edit/id=book-no-title-no-author;type=book`,
         level: 'error',
         markers: [
           {level: 'error', message: 'Required', path: ['title']},
@@ -286,6 +290,7 @@ describe('validateDocuments', () => {
       {
         documentId: 'book-ref-not-published',
         documentType: 'book',
+        intentUrl: `${localhost}/intent/edit/id=book-ref-not-published;type=book`,
         level: 'info',
         markers: [],
         revision: 'rev5',


### PR DESCRIPTION
### Description

- Adds `intentUrl` to the results of `sanity documents validate --format json` and `--format ndjson`
- Fixes an edge case where there is an unnecessary leading slash in the intentUrl
- Fixes the logic in `validateDocument.test.ts` that failed to catch the documents with `system.` types to show up bug.
- Fixes a bug where valid documents would be reported in `sanity documents validate --format json`

### What to review

Take a look at the logic and ensure nothing else changes.

### Testing

- I ran the build and tried out the command for myself.

### Notes for release

- Includes `intentUrl` in `json` and `ndjson` formats for `sanity documents validate`
- Fixes a bug where valid documents would be reported in `sanity documents validate --format json`

