### PR TITLE
fix(cli): add support for `import.meta.env`

### DIFF
--- a/packages/sanity/src/_internal/cli/util/mockBrowserEnvironment.ts
+++ b/packages/sanity/src/_internal/cli/util/mockBrowserEnvironment.ts
@@ -3,6 +3,7 @@ import jsdomGlobal from 'jsdom-global'
 import resolveFrom from 'resolve-from'
 import {register as registerESBuild} from 'esbuild-register/dist/node'
 import {ResizeObserver} from '@juggle/resize-observer'
+import {getStudioEnvironmentVariables} from '../server/getStudioEnvironmentVariables'
 
 const jsdomDefaultHtml = `<!doctype html>
 <html>
@@ -35,9 +36,10 @@ export function mockBrowserEnvironment(basePath: string): () => void {
     extensions: ['.js', '.jsx', '.ts', '.tsx', '.mjs'],
     jsx: 'automatic',
     define: {
-      // alias usages of import.meta.env to `process.env`.
-      // TODO: consider supporting .env files and mimicking the build + dev command
-      'import.meta.env': 'process.env',
+      // define the `process.env` global
+      ...getStudioEnvironmentVariables({prefix: 'process.env.', jsonEncode: true}),
+      // define the `import.meta.env` global
+      ...getStudioEnvironmentVariables({prefix: 'import.meta.env.', jsonEncode: true}),
     },
   })
 

--- a/packages/sanity/src/_internal/cli/util/mockBrowserEnvironment.ts
+++ b/packages/sanity/src/_internal/cli/util/mockBrowserEnvironment.ts
@@ -34,6 +34,11 @@ export function mockBrowserEnvironment(basePath: string): () => void {
     format: 'cjs',
     extensions: ['.js', '.jsx', '.ts', '.tsx', '.mjs'],
     jsx: 'automatic',
+    define: {
+      // alias usages of import.meta.env to `process.env`.
+      // TODO: consider supporting .env files and mimicking the build + dev command
+      'import.meta.env': 'process.env',
+    },
   })
 
   return function cleanupBrowserEnvironment() {


### PR DESCRIPTION
### Description

The following adds minimal support for `import.meta.env` inside of the mock browser environment used in the CLI.

### What to review

Does it work?

### Testing

I added an import.meta.env usage in the test-studio and ran the command.

### Notes for release

- Fixes a bug that caused uses of `import.meta.env` to break the mock browser environment used in the CLI.