### PR TITLE
fix(migrate): scope node path to the current node

### DIFF
--- a/packages/@sanity/migrate/src/mutations/asserters.ts
+++ b/packages/@sanity/migrate/src/mutations/asserters.ts
@@ -1,5 +1,6 @@
-import {Mutation} from './types'
+import {Mutation, NodePatch} from './types'
 import {Transaction} from './transaction'
+import {Operation} from './operations/types'
 
 export function isMutation(mutation: unknown): mutation is Mutation {
   return (
@@ -20,5 +21,34 @@ export function isTransaction(mutation: unknown): mutation is Transaction {
     typeof mutation === 'object' &&
     'type' in mutation &&
     mutation.type === 'transaction'
+  )
+}
+
+export function isOperation(value: unknown): value is Operation {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    'type' in value &&
+    (value.type === 'set' ||
+      value.type === 'unset' ||
+      value.type === 'insert' ||
+      value.type === 'diffMatchPatch' ||
+      value.type === 'dec' ||
+      value.type === 'inc' ||
+      value.type === 'upsert' ||
+      value.type === 'unassign' ||
+      value.type === 'truncate' ||
+      value.type === 'setIfMissing')
+  )
+}
+
+export function isNodePatch(change: unknown): change is NodePatch {
+  return (
+    change !== null &&
+    typeof change === 'object' &&
+    'path' in change &&
+    Array.isArray(change.path) &&
+    'op' in change &&
+    isOperation(change.op)
   )
 }


### PR DESCRIPTION
### Description

Last one from me today 🤞🏼 

This makes sure any node patch returned from a visitor-style migration is relative to the node path itself.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
