### PR TITLE
fix(core): fix aligning of columnar objects/fieldsets

### DIFF
--- a/dev/test-studio/schema/debug/fieldsets.js
+++ b/dev/test-studio/schema/debug/fieldsets.js
@@ -70,6 +70,8 @@ export default {
       type: 'number',
       name: 'x',
       title: 'X position',
+      description:
+        'This is a number field. Lets try with a longer description. How does this look? ',
       fieldset: 'settings',
       group: 'group1',
       validation: (Rule) => Rule.required(),

--- a/dev/test-studio/schema/standard/objects.tsx
+++ b/dev/test-studio/schema/standard/objects.tsx
@@ -72,6 +72,7 @@ export default defineType({
         {
           type: 'string',
           title: 'String 1',
+          description: 'this is a king kong description',
           name: 'string1',
         },
         {

--- a/packages/sanity/src/core/form/components/formField/FormFieldSet.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldSet.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import {Badge, Box, Flex, Grid, Stack, Text, Theme, useForwardedRef} from '@sanity/ui'
+import {Badge, Box, Flex, Stack, Text, Theme, useForwardedRef} from '@sanity/ui'
 import React, {forwardRef, useCallback, useMemo} from 'react'
 import styled, {css} from 'styled-components'
 import {DeprecatedProperty, FormNodeValidation} from '@sanity/types'
@@ -12,7 +12,7 @@ import {TextWithTone} from '../../../components'
 import {useTranslation} from '../../../i18n'
 import {FormFieldValidationStatus} from './FormFieldValidationStatus'
 import {FormFieldSetLegend} from './FormFieldSetLegend'
-import {focusRingStyle} from './styles'
+import {focusRingStyle, StyledGrid} from './styles'
 import {FormFieldBaseHeader} from './FormFieldBaseHeader'
 
 /** @internal */
@@ -149,9 +149,9 @@ export const FormFieldSet = forwardRef(function FormFieldSet(
       return null
     }
     return (
-      <Grid columns={columns} gapX={4} gapY={5}>
+      <StyledGrid columns={columns} gapX={4} gapY={5}>
         {getChildren(children)}
-      </Grid>
+      </StyledGrid>
     )
   }, [children, collapsed, columns])
 

--- a/packages/sanity/src/core/form/components/formField/FormFieldSet.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldSet.tsx
@@ -12,7 +12,7 @@ import {TextWithTone} from '../../../components'
 import {useTranslation} from '../../../i18n'
 import {FormFieldValidationStatus} from './FormFieldValidationStatus'
 import {FormFieldSetLegend} from './FormFieldSetLegend'
-import {focusRingStyle, StyledGrid} from './styles'
+import {focusRingStyle, AlignedBottomGrid} from './styles'
 import {FormFieldBaseHeader} from './FormFieldBaseHeader'
 
 /** @internal */
@@ -149,9 +149,9 @@ export const FormFieldSet = forwardRef(function FormFieldSet(
       return null
     }
     return (
-      <StyledGrid columns={columns} gapX={4} gapY={5}>
+      <AlignedBottomGrid columns={columns} gapX={4} gapY={5}>
         {getChildren(children)}
-      </StyledGrid>
+      </AlignedBottomGrid>
     )
   }, [children, collapsed, columns])
 

--- a/packages/sanity/src/core/form/components/formField/styles.ts
+++ b/packages/sanity/src/core/form/components/formField/styles.ts
@@ -5,7 +5,7 @@ function focusRingBorderStyle(border: {color: string; width: number}): string {
   return `inset 0 0 0 ${border.width}px ${border.color}`
 }
 
-export const StyledGrid = styled(Grid)`
+export const AlignedBottomGrid = styled(Grid)`
   align-items: flex-end;
 `
 

--- a/packages/sanity/src/core/form/components/formField/styles.ts
+++ b/packages/sanity/src/core/form/components/formField/styles.ts
@@ -1,6 +1,13 @@
+import {Grid} from '@sanity/ui'
+import styled from 'styled-components'
+
 function focusRingBorderStyle(border: {color: string; width: number}): string {
   return `inset 0 0 0 ${border.width}px ${border.color}`
 }
+
+export const StyledGrid = styled(Grid)`
+  align-items: flex-end;
+`
 
 export function focusRingStyle(opts: {
   base?: {bg: string}

--- a/packages/sanity/src/core/form/inputs/ObjectInput/ObjectInput.styled.tsx
+++ b/packages/sanity/src/core/form/inputs/ObjectInput/ObjectInput.styled.tsx
@@ -1,4 +1,4 @@
-import {Card} from '@sanity/ui'
+import {Card, Grid} from '@sanity/ui'
 import styled from 'styled-components'
 
 // The negative margins here removes the extra space between the tabs and the fields when inside of a grid
@@ -6,4 +6,7 @@ export const FieldGroupTabsWrapper = styled(Card)<{$level?: number}>`
   margin-bottom: ${({$level, theme}) => ($level === 0 ? 0 : theme.sanity.space[5] * -1)}px;
   padding-bottom: ${({$level, theme}) =>
     $level === 0 ? theme.sanity.space[4] : theme.sanity.space[4]}px;
+`
+export const StyledGrid = styled(Grid)`
+  align-items: flex-end;
 `

--- a/packages/sanity/src/core/form/inputs/ObjectInput/ObjectInput.styled.tsx
+++ b/packages/sanity/src/core/form/inputs/ObjectInput/ObjectInput.styled.tsx
@@ -7,6 +7,6 @@ export const FieldGroupTabsWrapper = styled(Card)<{$level?: number}>`
   padding-bottom: ${({$level, theme}) =>
     $level === 0 ? theme.sanity.space[4] : theme.sanity.space[4]}px;
 `
-export const StyledGrid = styled(Grid)`
+export const AlignedBottomGrid = styled(Grid)`
   align-items: flex-end;
 `

--- a/packages/sanity/src/core/form/inputs/ObjectInput/ObjectInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ObjectInput/ObjectInput.tsx
@@ -3,7 +3,7 @@ import {Stack} from '@sanity/ui'
 import {ObjectInputProps} from '../../types'
 import {ObjectInputMembers} from '../../members'
 import {UnknownFields} from './UnknownFields'
-import {FieldGroupTabsWrapper, StyledGrid} from './ObjectInput.styled'
+import {FieldGroupTabsWrapper, AlignedBottomGrid} from './ObjectInput.styled'
 import {FieldGroupTabs} from './fieldGroups/FieldGroupTabs'
 
 /**
@@ -97,9 +97,9 @@ export const ObjectInput = memo(function ObjectInput(props: ObjectInputProps) {
         key={selectedGroup?.name}
       >
         {columns ? (
-          <StyledGrid columns={columns} gap={4} marginTop={1}>
+          <AlignedBottomGrid columns={columns} gap={4} marginTop={1}>
             {renderObjectMembers()}
-          </StyledGrid>
+          </AlignedBottomGrid>
         ) : (
           renderObjectMembers()
         )}

--- a/packages/sanity/src/core/form/inputs/ObjectInput/ObjectInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ObjectInput/ObjectInput.tsx
@@ -1,9 +1,9 @@
 import React, {Fragment, memo, useCallback, useMemo} from 'react'
-import {Grid, Stack} from '@sanity/ui'
+import {Stack} from '@sanity/ui'
 import {ObjectInputProps} from '../../types'
 import {ObjectInputMembers} from '../../members'
 import {UnknownFields} from './UnknownFields'
-import {FieldGroupTabsWrapper} from './ObjectInput.styled'
+import {FieldGroupTabsWrapper, StyledGrid} from './ObjectInput.styled'
 import {FieldGroupTabs} from './fieldGroups/FieldGroupTabs'
 
 /**
@@ -97,9 +97,9 @@ export const ObjectInput = memo(function ObjectInput(props: ObjectInputProps) {
         key={selectedGroup?.name}
       >
         {columns ? (
-          <Grid columns={columns} gap={4} marginTop={1}>
+          <StyledGrid columns={columns} gap={4} marginTop={1}>
             {renderObjectMembers()}
-          </Grid>
+          </StyledGrid>
         ) : (
           renderObjectMembers()
         )}

--- a/packages/sanity/src/core/studio/Studio.test.tsx
+++ b/packages/sanity/src/core/studio/Studio.test.tsx
@@ -45,7 +45,7 @@ describe('Studio', () => {
       const html = renderToStaticMarkup(sheet.collectStyles(<Studio config={config} />))
 
       expect(html).toMatchInlineSnapshot(
-        `"<div class=\\"sc-hQrfjo kOvXLM\\"><div data-ui=\\"Spinner\\" class=\\"sc-ipEzrc eJGegB sc-ksBlXE dyLnEw sc-eZcfmt hmIphr\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
+        `"<div class=\\"sc-hixiyu kZPJxs\\"><div data-ui=\\"Spinner\\" class=\\"sc-ipEzrc eJGegB sc-ksBlXE dyLnEw sc-eriiBz dEwFQj\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
       )
     } finally {
       sheet.seal()
@@ -62,7 +62,7 @@ describe('Studio', () => {
     try {
       const html = renderToString(sheet.collectStyles(<Studio config={config} />))
       expect(html).toMatchInlineSnapshot(
-        `"<div class=\\"sc-hQrfjo kOvXLM\\"><div data-ui=\\"Spinner\\" class=\\"sc-ipEzrc eJGegB sc-ksBlXE dyLnEw sc-eZcfmt hmIphr\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
+        `"<div class=\\"sc-hixiyu kZPJxs\\"><div data-ui=\\"Spinner\\" class=\\"sc-ipEzrc eJGegB sc-ksBlXE dyLnEw sc-eriiBz dEwFQj\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
       )
     } finally {
       sheet.seal()
@@ -82,7 +82,7 @@ describe('Studio', () => {
       const html = renderToString(sheet.collectStyles(<Studio config={config} />))
       node.innerHTML = html
       expect(html).toMatchInlineSnapshot(
-        `"<div class=\\"sc-hQrfjo kOvXLM\\"><div data-ui=\\"Spinner\\" class=\\"sc-ipEzrc eJGegB sc-ksBlXE dyLnEw sc-eZcfmt hmIphr\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
+        `"<div class=\\"sc-hixiyu kZPJxs\\"><div data-ui=\\"Spinner\\" class=\\"sc-ipEzrc eJGegB sc-ksBlXE dyLnEw sc-eriiBz dEwFQj\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
       )
       document.head.innerHTML += sheet.getStyleTags()
 


### PR DESCRIPTION
### Description
Fixes alignments of columnar fieldsets/objects. When some objects/fields have a description, the alignments seemed off. 
Have added `align-items: flex-end` to the `Grid`. 

![Screenshot 2024-01-31 at 13 22 04](https://github.com/sanity-io/sanity/assets/44635000/8add7a6c-3a9c-4589-926f-eca5785dc3a5)
![Screenshot 2024-01-31 at 13 20 51](https://github.com/sanity-io/sanity/assets/44635000/f3297f71-8590-4faa-a6da-c3f7bbe537af)

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Make sure it looks as expected in debug inputs -> fieldsets test 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes alignment of fieldsets/objects 
<!--
A description of the change(s) that should be used in the release notes.
-->
