### PR TITLE
chore: remove outdated beta docs URLs

### DIFF
--- a/packages/@sanity/cli/src/commands/docs/docsCommand.ts
+++ b/packages/@sanity/cli/src/commands/docs/docsCommand.ts
@@ -9,7 +9,7 @@ const docsCommand: CliCommandDefinition = {
   async action(args, context) {
     const {output} = context
     const {print} = output
-    const url = 'https://beta.sanity.io/docs'
+    const url = 'https://www.sanity.io/docs'
 
     print(`Opening ${url}`)
     await open(url)

--- a/packages/sanity/src/core/studio/components/navbar/workspace/constants.ts
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/constants.ts
@@ -1,1 +1,1 @@
-export const WORKSPACES_DOCS_URL = 'https://beta.sanity.io/docs/platform/studio/config/workspaces'
+export const WORKSPACES_DOCS_URL = 'https://www.sanity.io/docs/workspaces'


### PR DESCRIPTION
* Updated which URL is opened by `sanity docs`
* Removed a reference to v3 preview beta in `create-sanity` module README
* updated a workspace docs URL

Please review that the URLs are as expected