### PR TITLE
fix(form): preserve intrinsic block size of field labels

### DIFF
--- a/packages/sanity/src/core/form/components/formField/FormFieldHeaderText.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldHeaderText.tsx
@@ -1,3 +1,4 @@
+import styled from 'styled-components'
 import type {DeprecatedProperty, FormNodeValidation} from '@sanity/types'
 import {Badge, Box, Flex, Stack, Text} from '@sanity/ui'
 import React, {memo} from 'react'
@@ -5,6 +6,14 @@ import {useTranslation} from '../../../i18n'
 import {createDescriptionId} from '../../members/common/createDescriptionId'
 import {TextWithTone} from '../../../components'
 import {FormFieldValidationStatus} from './FormFieldValidationStatus'
+
+const LabelSuffix = styled(Flex)`
+  /*
+   * Prevent the block size of appended elements (such as the deprecated field badge) affecting
+   * the intrinsic block size of the label.
+   */
+  contain: size;
+`
 
 /** @internal */
 export interface FormFieldHeaderTextProps {
@@ -35,7 +44,7 @@ export const FormFieldHeaderText = memo(function FormFieldHeaderText(
 
   return (
     <Stack space={3}>
-      <Flex align="center">
+      <Flex align="center" paddingY={1}>
         <Text as="label" htmlFor={inputId} weight="medium" size={1}>
           {title || (
             <span style={{color: 'var(--card-muted-fg-color)'}}>
@@ -44,19 +53,21 @@ export const FormFieldHeaderText = memo(function FormFieldHeaderText(
           )}
         </Text>
 
-        {deprecated && (
-          <Box marginLeft={2}>
-            <Badge data-testid={`deprecated-badge-${title}`} tone="caution">
-              {t('form.field.deprecated-label')}
-            </Badge>
-          </Box>
-        )}
+        <LabelSuffix align="center" flex={1}>
+          {deprecated && (
+            <Box marginLeft={2}>
+              <Badge data-testid={`deprecated-badge-${title}`} tone="caution">
+                {t('form.field.deprecated-label')}
+              </Badge>
+            </Box>
+          )}
 
-        {hasValidations && (
-          <Box marginLeft={2}>
-            <FormFieldValidationStatus fontSize={1} placement="top" validation={validation} />
-          </Box>
-        )}
+          {hasValidations && (
+            <Box marginLeft={2}>
+              <FormFieldValidationStatus fontSize={1} placement="top" validation={validation} />
+            </Box>
+          )}
+        </LabelSuffix>
       </Flex>
 
       {deprecated && (

--- a/packages/sanity/src/core/form/components/formField/FormFieldHeaderText.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldHeaderText.tsx
@@ -41,6 +41,7 @@ export const FormFieldHeaderText = memo(function FormFieldHeaderText(
   const {description, inputId, title, deprecated, validation = EMPTY_ARRAY} = props
   const {t} = useTranslation()
   const hasValidations = validation.length > 0
+  const hasLabelSuffix = deprecated || hasValidations
 
   return (
     <Stack space={3}>
@@ -53,21 +54,23 @@ export const FormFieldHeaderText = memo(function FormFieldHeaderText(
           )}
         </Text>
 
-        <LabelSuffix align="center" flex={1}>
-          {deprecated && (
-            <Box marginLeft={2}>
-              <Badge data-testid={`deprecated-badge-${title}`} tone="caution">
-                {t('form.field.deprecated-label')}
-              </Badge>
-            </Box>
-          )}
+        {hasLabelSuffix && (
+          <LabelSuffix align="center" flex={1}>
+            {deprecated && (
+              <Box marginLeft={2}>
+                <Badge data-testid={`deprecated-badge-${title}`} tone="caution">
+                  {t('form.field.deprecated-label')}
+                </Badge>
+              </Box>
+            )}
 
-          {hasValidations && (
-            <Box marginLeft={2}>
-              <FormFieldValidationStatus fontSize={1} placement="top" validation={validation} />
-            </Box>
-          )}
-        </LabelSuffix>
+            {hasValidations && (
+              <Box marginLeft={2}>
+                <FormFieldValidationStatus fontSize={1} placement="top" validation={validation} />
+              </Box>
+            )}
+          </LabelSuffix>
+        )}
       </Flex>
 
       {deprecated && (

--- a/packages/sanity/src/core/form/inputs/BooleanInput.tsx
+++ b/packages/sanity/src/core/form/inputs/BooleanInput.tsx
@@ -4,6 +4,10 @@ import {BooleanInputProps} from '../types'
 import {FormFieldHeaderText} from '../components/formField/FormFieldHeaderText'
 import {FormFieldStatus} from '../components/formField/FormFieldStatus'
 
+const Root = styled(Card)`
+  line-height: 1;
+`
+
 const CenterAlignedBox = styled(Box)`
   align-self: center;
 `
@@ -29,7 +33,7 @@ export function BooleanInput(props: BooleanInputProps) {
   const tone: CardTone | undefined = readOnly ? 'transparent' : undefined
 
   return (
-    <Card border data-testid="boolean-input" radius={2} tone={tone}>
+    <Root border data-testid="boolean-input" radius={2} tone={tone}>
       <Flex>
         <ZeroLineHeightBox padding={3}>
           <LayoutSpecificInput
@@ -56,6 +60,6 @@ export function BooleanInput(props: BooleanInputProps) {
           </FormFieldStatus>
         </CenterAlignedBox>
       </Flex>
-    </Card>
+    </Root>
   )
 }

--- a/packages/sanity/src/core/studio/Studio.test.tsx
+++ b/packages/sanity/src/core/studio/Studio.test.tsx
@@ -45,7 +45,7 @@ describe('Studio', () => {
       const html = renderToStaticMarkup(sheet.collectStyles(<Studio config={config} />))
 
       expect(html).toMatchInlineSnapshot(
-        `"<div class=\\"sc-dDPpIy kJDvPE\\"><div data-ui=\\"Spinner\\" class=\\"sc-ipEzrc eJGegB sc-ksBlXE dyLnEw sc-MApLD ddCDnM\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
+        `"<div class=\\"sc-hQrfjo kOvXLM\\"><div data-ui=\\"Spinner\\" class=\\"sc-ipEzrc eJGegB sc-ksBlXE dyLnEw sc-eZcfmt hmIphr\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
       )
     } finally {
       sheet.seal()
@@ -62,7 +62,7 @@ describe('Studio', () => {
     try {
       const html = renderToString(sheet.collectStyles(<Studio config={config} />))
       expect(html).toMatchInlineSnapshot(
-        `"<div class=\\"sc-dDPpIy kJDvPE\\"><div data-ui=\\"Spinner\\" class=\\"sc-ipEzrc eJGegB sc-ksBlXE dyLnEw sc-MApLD ddCDnM\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
+        `"<div class=\\"sc-hQrfjo kOvXLM\\"><div data-ui=\\"Spinner\\" class=\\"sc-ipEzrc eJGegB sc-ksBlXE dyLnEw sc-eZcfmt hmIphr\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
       )
     } finally {
       sheet.seal()
@@ -82,7 +82,7 @@ describe('Studio', () => {
       const html = renderToString(sheet.collectStyles(<Studio config={config} />))
       node.innerHTML = html
       expect(html).toMatchInlineSnapshot(
-        `"<div class=\\"sc-dDPpIy kJDvPE\\"><div data-ui=\\"Spinner\\" class=\\"sc-ipEzrc eJGegB sc-ksBlXE dyLnEw sc-MApLD ddCDnM\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
+        `"<div class=\\"sc-hQrfjo kOvXLM\\"><div data-ui=\\"Spinner\\" class=\\"sc-ipEzrc eJGegB sc-ksBlXE dyLnEw sc-eZcfmt hmIphr\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
       )
       document.head.innerHTML += sheet.getStyleTags()
 


### PR DESCRIPTION
### Description

This branch improves vertical alignment in boolean fields. It uses CSS size containment to prevent the block size of elements appended to field labels (such as the deprecated field badge) affecting the intrinsic block size of the label.

Closes #5579.

#### Before (non-deprecated booleans)

<img width="677" alt="before" src="https://github.com/sanity-io/sanity/assets/1454914/4de9eb89-a6c4-4b1a-9358-f40f8ab356da">

#### After (non-deprecated booleans)

<img width="677" alt="after" src="https://github.com/sanity-io/sanity/assets/1454914/40353beb-1d03-430e-b245-c1c468062a97">

#### Before (deprecated booleans)

<img width="647" alt="before-deprecated" src="https://github.com/sanity-io/sanity/assets/1454914/5a29365a-f38a-4ef7-9da0-6ee6ff201bd3">

#### After (deprecated booleans)

<img width="647" alt="after-deprecated" src="https://github.com/sanity-io/sanity/assets/1454914/11d897a8-635a-42e3-a66d-9aeaf79d7891">

### What to review

- Does the vertical alignment in boolean fields look better?
- Does general field rendering still look correct?

### Testing

- Take a look at the Test Studio. In particular, booleans (`/test/structure/input-standard;booleansTest`).

### Notes for release

Improve vertical alignment of boolean fields.
