### PR TITLE
feat: apply text balance to document titles

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormHeader.tsx
@@ -33,6 +33,7 @@ export const TitleContainer = styled(Stack)`
         font-size: ${theme.sanity.fonts.heading.sizes[4].fontSize}px;
         line-height: ${theme.sanity.fonts.heading.sizes[4].lineHeight}px;
         overflow-wrap: break-word;
+        text-wrap: pretty;
       }
 
       @container (max-width: 560px) {


### PR DESCRIPTION
### Description

Pretty-fies document titles

### What to review

CSS

### Testing

I have tested this by editing inline styles of an existing Studio to double-check the desired outcome of prettier titles.

### Notes for release

Balanced text in document titles