### PR TITLE
feat(telemetry): add telemetry for Trial Dialogs

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/free-trial/DialogContent.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/DialogContent.tsx
@@ -6,6 +6,7 @@ import {Button, Dialog} from '../../../../../ui-components'
 import {useColorSchemeValue} from '../../../colorScheme'
 import {UpsellDescriptionSerializer} from '../../../upsell'
 import {type FreeTrialDialog} from './types'
+import {TrialDialogDismissedInfo} from './__telemetry__/trialDialogEvents.telemetry'
 
 /**
  * Absolute positioned button to close the dialog.
@@ -39,19 +40,35 @@ const StyledDialog = styled(Dialog)`
 `
 interface ModalContentProps {
   content: FreeTrialDialog
-  handleClose: () => void
+  handleClose: (action?: TrialDialogDismissedInfo['dialogDismissAction']) => void
   handleOpenNext: () => void
+  handleOpenUrlCallback: () => void
   open: boolean
 }
 
-export function DialogContent({handleClose, handleOpenNext, content, open}: ModalContentProps) {
+export function DialogContent({
+  handleClose,
+  handleOpenNext,
+  handleOpenUrlCallback,
+  content,
+  open,
+}: ModalContentProps) {
+  function onClose() {
+    handleClose('x_click')
+  }
+  function onClickOutside() {
+    handleClose('outside_click')
+  }
+  function onCTAClose() {
+    handleClose('cta_clicked')
+  }
   const schemeValue = useColorSchemeValue()
   if (!open) return null
   return (
     <StyledDialog
       id="free-trial-modal"
-      onClose={handleClose}
-      onClickOutside={handleClose}
+      onClose={onClose}
+      onClickOutside={onClickOutside}
       padding={false}
       __unstable_hideCloseButton
       scheme={schemeValue}
@@ -61,7 +78,7 @@ export function DialogContent({handleClose, handleOpenNext, content, open}: Moda
               text: content.secondaryButton.text,
               mode: 'bleed',
               tone: 'default',
-              onClick: handleClose,
+              onClick: onClose,
             }
           : undefined,
         confirmButton: {
@@ -74,9 +91,10 @@ export function DialogContent({handleClose, handleOpenNext, content, open}: Moda
                 target: '_blank',
                 rel: 'noopener noreferrer',
                 as: 'a',
+                onClick: handleOpenUrlCallback,
               }
             : {
-                onClick: content.ctaButton?.action === 'openNext' ? handleOpenNext : handleClose,
+                onClick: content.ctaButton?.action === 'openNext' ? handleOpenNext : onCTAClose,
               }),
         },
       }}
@@ -85,7 +103,7 @@ export function DialogContent({handleClose, handleOpenNext, content, open}: Moda
         icon={CloseIcon}
         mode="bleed"
         tone="default"
-        onClick={handleClose}
+        onClick={onClose}
         tabIndex={-1}
         tooltipProps={null}
       />

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/DialogContent.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/DialogContent.tsx
@@ -5,8 +5,8 @@ import styled from 'styled-components'
 import {Button, Dialog} from '../../../../../ui-components'
 import {useColorSchemeValue} from '../../../colorScheme'
 import {UpsellDescriptionSerializer} from '../../../upsell'
+import {type TrialDialogDismissedInfo} from './__telemetry__/trialDialogEvents.telemetry'
 import {type FreeTrialDialog} from './types'
-import {TrialDialogDismissedInfo} from './__telemetry__/trialDialogEvents.telemetry'
 
 /**
  * Absolute positioned button to close the dialog.

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/DialogContent.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/DialogContent.tsx
@@ -54,13 +54,13 @@ export function DialogContent({
   open,
 }: ModalContentProps) {
   function handleClose() {
-    onClose('x_click')
+    onClose('xClick')
   }
   function handleClickOutside() {
-    onClose('outside_click')
+    onClose('outsideClick')
   }
   function handleCTAClose() {
-    onClose('cta_clicked')
+    onClose('ctaClicked')
   }
   const schemeValue = useColorSchemeValue()
   if (!open) return null

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/DialogContent.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/DialogContent.tsx
@@ -40,27 +40,27 @@ const StyledDialog = styled(Dialog)`
 `
 interface ModalContentProps {
   content: FreeTrialDialog
-  handleClose: (action?: TrialDialogDismissedInfo['dialogDismissAction']) => void
-  handleOpenNext: () => void
-  handleOpenUrlCallback: () => void
+  onClose: (action?: TrialDialogDismissedInfo['dialogDismissAction']) => void
+  onOpenNext: () => void
+  onOpenUrlCallback: () => void
   open: boolean
 }
 
 export function DialogContent({
-  handleClose,
-  handleOpenNext,
-  handleOpenUrlCallback,
+  onClose,
+  onOpenNext,
+  onOpenUrlCallback,
   content,
   open,
 }: ModalContentProps) {
-  function onClose() {
-    handleClose('x_click')
+  function handleClose() {
+    onClose('x_click')
   }
-  function onClickOutside() {
-    handleClose('outside_click')
+  function handleClickOutside() {
+    onClose('outside_click')
   }
-  function onCTAClose() {
-    handleClose('cta_clicked')
+  function handleCTAClose() {
+    onClose('cta_clicked')
   }
   const schemeValue = useColorSchemeValue()
   if (!open) return null
@@ -68,7 +68,7 @@ export function DialogContent({
     <StyledDialog
       id="free-trial-modal"
       onClose={onClose}
-      onClickOutside={onClickOutside}
+      onClickOutside={handleClickOutside}
       padding={false}
       __unstable_hideCloseButton
       scheme={schemeValue}
@@ -78,7 +78,7 @@ export function DialogContent({
               text: content.secondaryButton.text,
               mode: 'bleed',
               tone: 'default',
-              onClick: onClose,
+              onClick: handleClose,
             }
           : undefined,
         confirmButton: {
@@ -91,10 +91,10 @@ export function DialogContent({
                 target: '_blank',
                 rel: 'noopener noreferrer',
                 as: 'a',
-                onClick: handleOpenUrlCallback,
+                onClick: onOpenUrlCallback,
               }
             : {
-                onClick: content.ctaButton?.action === 'openNext' ? handleOpenNext : onCTAClose,
+                onClick: content.ctaButton?.action === 'openNext' ? onOpenNext : handleCTAClose,
               }),
         },
       }}
@@ -103,7 +103,7 @@ export function DialogContent({
         icon={CloseIcon}
         mode="bleed"
         tone="default"
-        onClick={onClose}
+        onClick={handleClose}
         tabIndex={-1}
         tooltipProps={null}
       />

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrial.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrial.tsx
@@ -158,9 +158,9 @@ export function FreeTrial({type}: FreeTrialProps) {
       {button}
       <DialogContent
         content={dialogToRender}
-        handleClose={handleClose('modal')}
-        handleOpenNext={handleDialogCTAClick('openNext')}
-        handleOpenUrlCallback={handleDialogCTAClick('openURL')}
+        onClose={handleClose('modal')}
+        onOpenNext={handleDialogCTAClick('openNext')}
+        onOpenUrlCallback={handleDialogCTAClick('openURL')}
         open={showDialog}
       />
     </>

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrial.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrial.tsx
@@ -75,7 +75,7 @@ export function FreeTrial({type}: FreeTrialProps) {
             source: 'studio',
             trialDaysLeft: data.daysLeft,
             dialogTrialStage: getTrialStage({showOnLoad, dialogId: dialog.id}),
-            dialogCtaType: action === 'openURL' ? 'upgrade' : 'learn_more',
+            dialogCtaType: action === 'openURL' ? 'upgrade' : 'learnMore',
           })
         closeAndReOpen()
       }
@@ -92,7 +92,7 @@ export function FreeTrial({type}: FreeTrialProps) {
         source: 'studio',
         trialDaysLeft: data.daysLeft,
         dialogTrialStage: getTrialStage({showOnLoad: true, dialogId: data.showOnLoad.id}),
-        dialogCtaType: 'learn_more',
+        dialogCtaType: 'learnMore',
       })
     closeAndReOpen()
   }, [data?.showOnLoad, data?.daysLeft, closeAndReOpen, telemetry])
@@ -102,7 +102,7 @@ export function FreeTrial({type}: FreeTrialProps) {
       telemetry.log(TrialDialogViewed, {
         dialogId: data.showOnClick.id,
         dialogRevision: data.showOnClick._rev,
-        dialogTrigger: 'from_click',
+        dialogTrigger: 'fromClick',
         dialogType: 'modal',
         source: 'studio',
         trialDaysLeft: data.daysLeft,

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrial.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrial.tsx
@@ -43,7 +43,6 @@ export function FreeTrial({type}: FreeTrialProps) {
 
   function handleClose(dialogType?: 'modal' | 'popover') {
     return (action?: TrialDialogDismissedInfo['dialogDismissAction']) => {
-      toggleDialog()
       const dialog = data?.showOnLoad || data?.showOnClick
       if (dialog)
         telemetry.log(TrialDialogDismissed, {
@@ -55,13 +54,13 @@ export function FreeTrial({type}: FreeTrialProps) {
           dialogTrialStage: getTrialStage({showOnLoad, dialogId: dialog.id}),
           dialogDismissAction: action,
         })
+      toggleDialog()
     }
   }
 
   const handleDialogCTAClick = useCallback(
     (action?: 'openURL' | 'openNext') => {
       return () => {
-        closeAndReOpen()
         const dialog = data?.showOnLoad || data?.showOnClick
         if (dialog)
           telemetry.log(TrialDialogCTAClicked, {
@@ -73,13 +72,13 @@ export function FreeTrial({type}: FreeTrialProps) {
             dialogTrialStage: getTrialStage({showOnLoad, dialogId: dialog.id}),
             dialogCtaType: action === 'openURL' ? 'upgrade' : 'learn_more',
           })
+        closeAndReOpen()
       }
     },
     [data, closeAndReOpen, telemetry, showOnLoad],
   )
 
   const handlePopoverCTAClick = useCallback(() => {
-    closeAndReOpen()
     if (data?.showOnLoad)
       telemetry.log(TrialDialogCTAClicked, {
         dialogId: data.showOnLoad.id,
@@ -90,10 +89,10 @@ export function FreeTrial({type}: FreeTrialProps) {
         dialogTrialStage: getTrialStage({showOnLoad: true, dialogId: data.showOnLoad.id}),
         dialogCtaType: 'learn_more',
       })
+    closeAndReOpen()
   }, [data, closeAndReOpen, telemetry])
 
   const handleOnTrialButtonClick = useCallback(() => {
-    closeAndReOpen()
     if (data?.showOnClick)
       telemetry.log(TrialDialogViewed, {
         dialogId: data.showOnClick.id,
@@ -104,6 +103,7 @@ export function FreeTrial({type}: FreeTrialProps) {
         trialDaysLeft: data.daysLeft,
         dialogTrialStage: getTrialStage({showOnLoad: true, dialogId: data.showOnClick.id}),
       })
+    closeAndReOpen()
   }, [data, telemetry, closeAndReOpen])
 
   if (!data?.id) return null

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrial.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrial.tsx
@@ -1,18 +1,18 @@
+import {useTelemetry} from '@sanity/telemetry/react'
 import {useCallback, useEffect, useState} from 'react'
 
 import {Popover} from '../../../../../ui-components'
 import {useColorSchemeValue} from '../../../colorScheme'
+import {
+  getTrialStage,
+  TrialDialogCTAClicked,
+  TrialDialogDismissed,
+  type TrialDialogDismissedInfo,
+  TrialDialogViewed,
+} from './__telemetry__/trialDialogEvents.telemetry'
 import {DialogContent} from './DialogContent'
 import {FreeTrialButtonSidebar, FreeTrialButtonTopbar} from './FreeTrialButton'
 import {useFreeTrialContext} from './FreeTrialContext'
-import {useTelemetry} from '@sanity/telemetry/react'
-import {
-  TrialDialogCTAClicked,
-  TrialDialogDismissed,
-  TrialDialogDismissedInfo,
-  TrialDialogViewed,
-  getTrialStage,
-} from './__telemetry__/trialDialogEvents.telemetry'
 import {PopoverContent} from './PopoverContent'
 
 interface FreeTrialProps {

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrial.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrial.tsx
@@ -41,22 +41,27 @@ export function FreeTrial({type}: FreeTrialProps) {
     toggleShowContent(false)
   }, [toggleShowContent, ref])
 
-  function handleClose(dialogType?: 'modal' | 'popover') {
-    return (action?: TrialDialogDismissedInfo['dialogDismissAction']) => {
-      const dialog = data?.showOnLoad || data?.showOnClick
-      if (dialog)
-        telemetry.log(TrialDialogDismissed, {
-          dialogId: dialog.id,
-          dialogRevision: dialog._rev,
-          dialogType,
-          source: 'studio',
-          trialDaysLeft: data.daysLeft,
-          dialogTrialStage: getTrialStage({showOnLoad, dialogId: dialog.id}),
-          dialogDismissAction: action,
-        })
-      toggleDialog()
-    }
-  }
+  const handleClose = useCallback(
+    (dialogType?: 'modal' | 'popover') => {
+      return (action?: TrialDialogDismissedInfo['dialogDismissAction']) => {
+        const dialog = data?.showOnLoad || data?.showOnClick
+
+        if (dialog)
+          telemetry.log(TrialDialogDismissed, {
+            dialogId: dialog.id,
+            dialogRevision: dialog._rev,
+            dialogType,
+            source: 'studio',
+            trialDaysLeft: data.daysLeft,
+            dialogTrialStage: getTrialStage({showOnLoad, dialogId: dialog.id}),
+            dialogDismissAction: action,
+          })
+
+        toggleDialog()
+      }
+    },
+    [data, toggleDialog, showOnLoad, telemetry],
+  )
 
   const handleDialogCTAClick = useCallback(
     (action?: 'openURL' | 'openNext') => {
@@ -90,7 +95,7 @@ export function FreeTrial({type}: FreeTrialProps) {
         dialogCtaType: 'learn_more',
       })
     closeAndReOpen()
-  }, [data, closeAndReOpen, telemetry])
+  }, [data?.showOnLoad, data?.daysLeft, closeAndReOpen, telemetry])
 
   const handleOnTrialButtonClick = useCallback(() => {
     if (data?.showOnClick)
@@ -104,7 +109,7 @@ export function FreeTrial({type}: FreeTrialProps) {
         dialogTrialStage: getTrialStage({showOnLoad: true, dialogId: data.showOnClick.id}),
       })
     closeAndReOpen()
-  }, [data, telemetry, closeAndReOpen])
+  }, [data?.showOnClick, data?.daysLeft, telemetry, closeAndReOpen])
 
   if (!data?.id) return null
   const dialogToRender = showOnLoad ? data.showOnLoad : data.showOnClick

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialProvider.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialProvider.tsx
@@ -28,8 +28,8 @@ export const FreeTrialProvider = ({children}: FreeTrialProviderProps) => {
   // Whenever showDialog changes, run effect to track
   // the dialog view
   useEffect(() => {
-    const dialog = data?.showOnLoad || data?.showOnClick
-    if (showDialog && dialog) {
+    const dialog = data?.showOnLoad
+    if (showDialog && showOnLoad && dialog) {
       telemetry.log(TrialDialogViewed, {
         dialogId: dialog.id,
         dialogRevision: dialog._rev,
@@ -41,7 +41,7 @@ export const FreeTrialProvider = ({children}: FreeTrialProviderProps) => {
       })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showDialog])
+  }, [showDialog, data, showOnLoad])
 
   useEffect(() => {
     // See if we have any parameters from the current route

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialProvider.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialProvider.tsx
@@ -34,7 +34,7 @@ export const FreeTrialProvider = ({children}: FreeTrialProviderProps) => {
         dialogId: dialog.id,
         dialogRevision: dialog._rev,
         dialogTrialStage: getTrialStage({showOnLoad, dialogId: dialog.id}),
-        dialogTrigger: showOnLoad ? 'auto' : 'from_click',
+        dialogTrigger: showOnLoad ? 'auto' : 'fromClick',
         dialogType: dialog.dialogType,
         source: 'studio',
         trialDaysLeft: data.daysLeft,

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialProvider.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialProvider.tsx
@@ -1,12 +1,12 @@
-import {type ReactNode, useCallback, useEffect, useState} from 'react'
 import {useTelemetry} from '@sanity/telemetry/react'
+import {type ReactNode, useCallback, useEffect, useState} from 'react'
+import {useRouter} from 'sanity/router'
 
 import {useClient} from '../../../../hooks'
 import {SANITY_VERSION} from '../../../../version'
+import {getTrialStage, TrialDialogViewed} from './__telemetry__/trialDialogEvents.telemetry'
 import {FreeTrialContext} from './FreeTrialContext'
 import {type FreeTrialResponse} from './types'
-import {TrialDialogViewed, getTrialStage} from './__telemetry__/trialDialogEvents.telemetry'
-import {useRouter} from 'sanity/router'
 /**
  * @internal
  */

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialProvider.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialProvider.tsx
@@ -40,8 +40,7 @@ export const FreeTrialProvider = ({children}: FreeTrialProviderProps) => {
         trialDaysLeft: data.daysLeft,
       })
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showDialog, data, showOnLoad])
+  }, [showDialog, data, showOnLoad, telemetry])
 
   useEffect(() => {
     // See if we have any parameters from the current route

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialProvider.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialProvider.tsx
@@ -6,7 +6,7 @@ import {SANITY_VERSION} from '../../../../version'
 import {FreeTrialContext} from './FreeTrialContext'
 import {type FreeTrialResponse} from './types'
 import {TrialDialogViewed, getTrialStage} from './__telemetry__/trialDialogEvents.telemetry'
-
+import {useRouter} from 'sanity/router'
 /**
  * @internal
  */
@@ -18,6 +18,7 @@ export interface FreeTrialProviderProps {
  * @internal
  */
 export const FreeTrialProvider = ({children}: FreeTrialProviderProps) => {
+  const router = useRouter()
   const [data, setData] = useState<FreeTrialResponse | null>(null)
   const [showDialog, setShowDialog] = useState(false)
   const [showOnLoad, setShowOnLoad] = useState(false)
@@ -43,9 +44,27 @@ export const FreeTrialProvider = ({children}: FreeTrialProviderProps) => {
   }, [showDialog])
 
   useEffect(() => {
+    // See if we have any parameters from the current route
+    // to pass onto our query
+    const searchParams = new URLSearchParams(router.state._searchParams)
+
+    const queryParams = new URLSearchParams()
+    queryParams.append('studioVersion', SANITY_VERSION)
+    // Allows us to override the current state of the trial to
+    // get back certain modals based on the current experience
+    // can be 'growth-trial', 'growth-trial-ending', or 'post-growth-trial'
+    const trialState = searchParams.get('trialState')
+    if (trialState) queryParams.append('trialState', trialState)
+    // Allows us to set whether we've seen the modals before
+    // or whether this is our first time seeing them (i.e. show a popup)
+    const seenBefore = searchParams.get('seenBefore')
+    if (seenBefore) queryParams.append('seenBefore', seenBefore)
+    // If we have trialState, query the override endpoint so that we
+    // get back trial modals for that state
+    const queryURL = queryParams.get('trialState') ? `/journey/trial/override` : `/journey/trial`
     const request = client.observable
       .request<FreeTrialResponse | null>({
-        url: `/journey/trial?studioVersion=${SANITY_VERSION}`,
+        url: `${queryURL}?${queryParams.toString()}`,
       })
       .subscribe(
         (response) => {
@@ -63,7 +82,7 @@ export const FreeTrialProvider = ({children}: FreeTrialProviderProps) => {
     return () => {
       request.unsubscribe()
     }
-  }, [client])
+  }, [client, router])
 
   const toggleShowContent = useCallback(
     (closeAndReOpen = false) => {

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/PopoverContent.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/PopoverContent.tsx
@@ -3,8 +3,8 @@ import styled from 'styled-components'
 
 import {Button} from '../../../../../ui-components'
 import {UpsellDescriptionSerializer} from '../../../upsell'
+import {type TrialDialogDismissedInfo} from './__telemetry__/trialDialogEvents.telemetry'
 import {type FreeTrialDialog} from './types'
-import {TrialDialogDismissedInfo} from './__telemetry__/trialDialogEvents.telemetry'
 
 const Image = styled.img`
   object-fit: cover;

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/PopoverContent.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/PopoverContent.tsx
@@ -40,7 +40,7 @@ export function PopoverContent({content, handleClose, handleOpenNext}: PopoverCo
               mode="bleed"
               text={content.secondaryButton.text}
               tone="default"
-              onClick={() => handleClose('x_click')}
+              onClick={() => handleClose('xClick')}
             />
           )}
           <Button
@@ -60,7 +60,7 @@ export function PopoverContent({content, handleClose, handleOpenNext}: PopoverCo
                   onClick:
                     content.ctaButton?.action === 'openNext'
                       ? handleOpenNext
-                      : () => handleClose('cta_clicked'),
+                      : () => handleClose('ctaClicked'),
                 })}
           />
         </Flex>

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/PopoverContent.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/PopoverContent.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import {Button} from '../../../../../ui-components'
 import {UpsellDescriptionSerializer} from '../../../upsell'
 import {type FreeTrialDialog} from './types'
+import {TrialDialogDismissedInfo} from './__telemetry__/trialDialogEvents.telemetry'
 
 const Image = styled.img`
   object-fit: cover;
@@ -14,7 +15,7 @@ const Image = styled.img`
 
 interface PopoverContentProps {
   content: FreeTrialDialog
-  handleClose: () => void
+  handleClose: (action?: TrialDialogDismissedInfo['dialogDismissAction']) => void
   handleOpenNext: () => void
 }
 
@@ -39,7 +40,7 @@ export function PopoverContent({content, handleClose, handleOpenNext}: PopoverCo
               mode="bleed"
               text={content.secondaryButton.text}
               tone="default"
-              onClick={handleClose}
+              onClick={() => handleClose('x_click')}
             />
           )}
           <Button
@@ -56,7 +57,10 @@ export function PopoverContent({content, handleClose, handleOpenNext}: PopoverCo
                   as: 'a',
                 }
               : {
-                  onClick: content.ctaButton?.action === 'openNext' ? handleOpenNext : handleClose,
+                  onClick:
+                    content.ctaButton?.action === 'openNext'
+                      ? handleOpenNext
+                      : () => handleClose('cta_clicked'),
                 })}
           />
         </Flex>

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/__telemetry__/trialDialogEvents.telemetry.ts
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/__telemetry__/trialDialogEvents.telemetry.ts
@@ -1,12 +1,11 @@
 import {defineEvent} from '@sanity/telemetry'
-import {FreeTrialDialog} from '../types'
 
 type BaseDialogEventAttributes = {
   source: 'studio'
   trialDaysLeft: number
-  dialogType: FreeTrialDialog['dialogType']
-  dialogId: FreeTrialDialog['id']
-  dialogRevision: FreeTrialDialog['_rev']
+  dialogType: 'modal' | 'popover'
+  dialogId: string
+  dialogRevision: string
   dialogTrialStage:
     | 'trial_started'
     | 'trial_active'

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/__telemetry__/trialDialogEvents.telemetry.ts
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/__telemetry__/trialDialogEvents.telemetry.ts
@@ -1,0 +1,60 @@
+import {defineEvent} from '@sanity/telemetry'
+import {FreeTrialDialog} from '../types'
+
+type BaseDialogEventAttributes = {
+  source: 'studio'
+  trialDaysLeft: number
+  dialogType: FreeTrialDialog['dialogType']
+  dialogId: FreeTrialDialog['id']
+  dialogRevision: FreeTrialDialog['_rev']
+  dialogTrialStage:
+    | 'trial_started'
+    | 'trial_active'
+    | 'trial_ending_soon'
+    | 'trial_ended'
+    | 'post_trial'
+}
+
+export interface TrialDialogViewedInfo extends BaseDialogEventAttributes {
+  dialogTrigger: 'from_click' | 'auto'
+}
+
+export const TrialDialogViewed = defineEvent<TrialDialogViewedInfo>({
+  name: 'TrialDialogViewed',
+  version: 1,
+  description: 'User viewed a dialog or popover related to free trial',
+})
+
+export interface TrialDialogDismissedInfo extends BaseDialogEventAttributes {
+  dialogDismissAction: 'cta_clicked' | 'x_click' | 'outside_click'
+}
+
+export const TrialDialogDismissed = defineEvent<TrialDialogDismissedInfo>({
+  name: 'TrialDialogDismissed',
+  version: 1,
+  description: 'User dismissed a dialog or popover related to free trial',
+})
+
+export interface TrialDialogCTAClickedInfo extends BaseDialogEventAttributes {
+  dialogCtaType: 'upgrade' | 'learn_more'
+}
+
+export const TrialDialogCTAClicked = defineEvent<TrialDialogCTAClickedInfo>({
+  name: 'TrialDialogCTAClicked',
+  version: 1,
+  description: 'User clicked a CTA in a dialog or popover related to free trial',
+})
+
+export function getTrialStage({
+  showOnLoad,
+  dialogId,
+}: {
+  showOnLoad: boolean
+  dialogId: string
+}): 'trial_started' | 'trial_ending_soon' | 'trial_ended' | 'post_trial' | 'trial_active' {
+  if (showOnLoad && dialogId === 'Free-upgrade-popover') return 'trial_started'
+  if (showOnLoad && dialogId === 'trial-ending-popover') return 'trial_ending_soon'
+  if (showOnLoad && dialogId === 'project-downgraded-to-free') return 'trial_ended'
+  if (!showOnLoad && dialogId === 'after-trial-upgrade') return 'post_trial'
+  return 'trial_active'
+}

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/__telemetry__/trialDialogEvents.telemetry.ts
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/__telemetry__/trialDialogEvents.telemetry.ts
@@ -48,9 +48,11 @@ export function getTrialStage({
   showOnLoad: boolean
   dialogId: string
 }): TrialStage {
-  if (showOnLoad && dialogId === 'Free-upgrade-popover') return 'trialStarted'
-  if (showOnLoad && dialogId === 'trial-ending-popover') return 'trialEndingSoon'
-  if (showOnLoad && dialogId === 'project-downgraded-to-free') return 'trialEnded'
-  if (!showOnLoad && dialogId === 'after-trial-upgrade') return 'postTrial'
+  // Note: some of the ids in the trial experience studio have uppercase letters
+  // so the toLowerCase is important here
+  if (showOnLoad && dialogId.toLowerCase() === 'free-upgrade-popover') return 'trialStarted'
+  if (showOnLoad && dialogId.toLowerCase() === 'trial-ending-popover') return 'trialEndingSoon'
+  if (showOnLoad && dialogId.toLowerCase() === 'project-downgraded-to-free') return 'trialEnded'
+  if (!showOnLoad && dialogId.toLowerCase() === 'after-trial-upgrade') return 'postTrial'
   return 'trialActive'
 }

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/__telemetry__/trialDialogEvents.telemetry.ts
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/__telemetry__/trialDialogEvents.telemetry.ts
@@ -1,21 +1,18 @@
 import {defineEvent} from '@sanity/telemetry'
 
+type TrialStage = 'trialStarted' | 'trialActive' | 'trialEndingSoon' | 'trialEnded' | 'postTrial'
+
 type BaseDialogEventAttributes = {
   source: 'studio'
   trialDaysLeft: number
   dialogType: 'modal' | 'popover'
   dialogId: string
   dialogRevision: string
-  dialogTrialStage:
-    | 'trial_started'
-    | 'trial_active'
-    | 'trial_ending_soon'
-    | 'trial_ended'
-    | 'post_trial'
+  dialogTrialStage: TrialStage
 }
 
 export interface TrialDialogViewedInfo extends BaseDialogEventAttributes {
-  dialogTrigger: 'from_click' | 'auto'
+  dialogTrigger: 'fromClick' | 'auto'
 }
 
 export const TrialDialogViewed = defineEvent<TrialDialogViewedInfo>({
@@ -25,7 +22,7 @@ export const TrialDialogViewed = defineEvent<TrialDialogViewedInfo>({
 })
 
 export interface TrialDialogDismissedInfo extends BaseDialogEventAttributes {
-  dialogDismissAction: 'cta_clicked' | 'x_click' | 'outside_click'
+  dialogDismissAction: 'ctaClicked' | 'xClick' | 'outsideClick'
 }
 
 export const TrialDialogDismissed = defineEvent<TrialDialogDismissedInfo>({
@@ -35,7 +32,7 @@ export const TrialDialogDismissed = defineEvent<TrialDialogDismissedInfo>({
 })
 
 export interface TrialDialogCTAClickedInfo extends BaseDialogEventAttributes {
-  dialogCtaType: 'upgrade' | 'learn_more'
+  dialogCtaType: 'upgrade' | 'learnMore'
 }
 
 export const TrialDialogCTAClicked = defineEvent<TrialDialogCTAClickedInfo>({
@@ -50,10 +47,10 @@ export function getTrialStage({
 }: {
   showOnLoad: boolean
   dialogId: string
-}): 'trial_started' | 'trial_ending_soon' | 'trial_ended' | 'post_trial' | 'trial_active' {
-  if (showOnLoad && dialogId === 'Free-upgrade-popover') return 'trial_started'
-  if (showOnLoad && dialogId === 'trial-ending-popover') return 'trial_ending_soon'
-  if (showOnLoad && dialogId === 'project-downgraded-to-free') return 'trial_ended'
-  if (!showOnLoad && dialogId === 'after-trial-upgrade') return 'post_trial'
-  return 'trial_active'
+}): TrialStage {
+  if (showOnLoad && dialogId === 'Free-upgrade-popover') return 'trialStarted'
+  if (showOnLoad && dialogId === 'trial-ending-popover') return 'trialEndingSoon'
+  if (showOnLoad && dialogId === 'project-downgraded-to-free') return 'trialEnded'
+  if (!showOnLoad && dialogId === 'after-trial-upgrade') return 'postTrial'
+  return 'trialActive'
 }

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/__telemetry__/trialDialogEvents.telemetry.ts
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/__telemetry__/trialDialogEvents.telemetry.ts
@@ -20,7 +20,7 @@ export interface TrialDialogViewedInfo extends BaseDialogEventAttributes {
 }
 
 export const TrialDialogViewed = defineEvent<TrialDialogViewedInfo>({
-  name: 'TrialDialogViewed',
+  name: 'Trial Dialog Viewed',
   version: 1,
   description: 'User viewed a dialog or popover related to free trial',
 })
@@ -29,8 +29,9 @@ export interface TrialDialogDismissedInfo extends BaseDialogEventAttributes {
   dialogDismissAction: 'cta_clicked' | 'x_click' | 'outside_click'
 }
 
+// TODO: space the names of these
 export const TrialDialogDismissed = defineEvent<TrialDialogDismissedInfo>({
-  name: 'TrialDialogDismissed',
+  name: 'Trial Dialog Dismissed',
   version: 1,
   description: 'User dismissed a dialog or popover related to free trial',
 })
@@ -40,7 +41,7 @@ export interface TrialDialogCTAClickedInfo extends BaseDialogEventAttributes {
 }
 
 export const TrialDialogCTAClicked = defineEvent<TrialDialogCTAClickedInfo>({
-  name: 'TrialDialogCTAClicked',
+  name: 'Trial Dialog CTA Clicked',
   version: 1,
   description: 'User clicked a CTA in a dialog or popover related to free trial',
 })

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/__telemetry__/trialDialogEvents.telemetry.ts
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/__telemetry__/trialDialogEvents.telemetry.ts
@@ -29,7 +29,6 @@ export interface TrialDialogDismissedInfo extends BaseDialogEventAttributes {
   dialogDismissAction: 'cta_clicked' | 'x_click' | 'outside_click'
 }
 
-// TODO: space the names of these
 export const TrialDialogDismissed = defineEvent<TrialDialogDismissedInfo>({
   name: 'Trial Dialog Dismissed',
   version: 1,


### PR DESCRIPTION
### Description

Adds view and activity telemetry for Dialogs and Popovers related to the Growth Trial. Equivalent PR in Manage: https://github.com/sanity-io/manage/pull/429

### What to review

The areas affected are isolated to the FreeTrial components - including the FreeTrialProvider. The code also adds a new `.telemetry` file for defining the Trial-related events.

There is also some work done to pass query parameters from the URL bar to the `personalization-forge` service calls (i.e. `/journey/trial`). This allows us to more easily test the look and behavior of each of the dialogs without needing a project to be in that specific trial state.

### Testing

To test this PR, you can inspect the network calls while using the `trialState` and `seenBefore` query parameters for showing different sets of dialogs. You should see the telemetry logs appear in the `batch` call every 30 seconds.

| param      | values |
| ----------- | ----------- |
| `trialState` | `growth-trial`, `growth-trial-ending`, `post-growth-trial`  | 
| `seenBefore` | `true`, `false`  | 

Little video explaining how the query params work:

https://github.com/sanity-io/sanity/assets/31733517/1a55e3f8-c072-4b4b-aec7-c410fc1e9cca



### Notes for release

🤷‍♂️ Not sure if we need to specify in release notes that we've added these new events?
