### PR TITLE
fix(core): add icon display as default to documentTypeList

### DIFF
--- a/packages/sanity/src/structure/structureBuilder/documentTypeListItems.ts
+++ b/packages/sanity/src/structure/structureBuilder/documentTypeListItems.ts
@@ -12,11 +12,6 @@ import {List} from './List'
 import {Collection} from './StructureNodes'
 import {StructureContext} from './types'
 
-function shouldShowIcon(schemaType: SchemaType): boolean {
-  const preview = schemaType.preview
-  return Boolean(preview && (preview.prepare || (preview.select && preview.select.media)))
-}
-
 const BUNDLED_DOC_TYPES = ['sanity.imageAsset', 'sanity.fileAsset']
 
 function isBundledDocType(typeName: string) {
@@ -95,7 +90,6 @@ export function getDocumentTypeList(
   }
 
   const title = type.title || startCase(typeName)
-  const showIcons = shouldShowIcon(type)
 
   return new DocumentTypeListBuilder(context)
     .id(spec.id || typeName)
@@ -103,7 +97,6 @@ export function getDocumentTypeList(
     .filter('_type == $type')
     .params({type: typeName})
     .schemaType(type)
-    .showIcons(showIcons)
     .defaultOrdering(DEFAULT_SELECTED_ORDERING_OPTION.by)
     .menuItemGroups(
       spec.menuItemGroups || [


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->
This PR removes the check to show icons from `S.documentTypeList()`. Like all other list types, `S.documentTypeList()` will now fall back to showing icons by default, regardless of preview parameters set. 

In the past, customers were sometimes surprised when they simply defined a `select` selection in a `preview` parameter of a schema type without a `media` parameter, like:
```js
export default defineType({
  name: 'myType',
  type: 'document',
  fields: [...],
  preview: {
    select: {
      title: 'title',
      subtitle: 'description'
    }
  }
})
```
which would change the list view to an icon-less one. However, _not_ setting a `media` parameter in a `prepare` return object still resulted in an icon being shown, which seems inconsistent.

Because an icon or media preview still shows up in all other kinds of desk lists, as well as in other parts of the studio (such as arrays of references), showing the icon here seems more visually consistent.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

- Schema types defined with a `select` that only include `title` and `description` should show an icon.
- setting `.showIcon(false)` on a `documentTypeList` should still omit an icon.

Old:
![Screenshot 2024-02-02 at 10 46 04 AM](https://github.com/sanity-io/sanity/assets/3969996/983cdcdd-be4b-4146-8e7e-9e4c26501e2b)

New:
![Screenshot 2024-02-02 at 10 20 56 AM](https://github.com/sanity-io/sanity/assets/3969996/b700c10a-3470-4e96-a7b2-de8aca87fa1f)


### Testing
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
I do not currently see any test suites for anything around structure builder. I agree this should be tested! But perhaps it makes more sense to decide what tests should look like in another PR.


### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
