### PR TITLE
fix(migration): list file-based migrations in list command

### DIFF
--- a/packages/sanity/src/_internal/cli/commands/migration/createMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/createMigrationCommand.ts
@@ -1,5 +1,5 @@
-import path from 'path'
-import fs from 'node:fs/promises'
+import path from 'node:path'
+import {writeFile} from 'node:fs/promises'
 import {existsSync} from 'node:fs'
 import type {CliCommandDefinition} from '@sanity/cli'
 import deburr from 'lodash/deburr'
@@ -101,7 +101,7 @@ const createMigrationCommand: CliCommandDefinition<CreateMigrationFlags> = {
 
     const definitionFile = path.join(destDir, 'index.ts')
 
-    await fs.writeFile(path.join(workDir, definitionFile), renderedTemplate)
+    await writeFile(path.join(workDir, definitionFile), renderedTemplate)
     // To dry run it, run \`sanity migration run ${sluggedName}\``)
     output.print()
     output.print(`${chalk.green('✓')} Migration created!`)

--- a/packages/sanity/src/_internal/cli/commands/migration/listMigrationsCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/listMigrationsCommand.ts
@@ -2,7 +2,6 @@ import {readdir} from 'node:fs/promises'
 import path from 'node:path'
 import type {CliCommandDefinition} from '@sanity/cli'
 import type {Migration} from '@sanity/migrate'
-import chalk from 'chalk'
 import {Table} from 'console-table-printer'
 import {register} from 'esbuild-register/dist/node'
 import {MIGRATIONS_DIRECTORY, MIGRATION_SCRIPT_EXTENSIONS} from './constants'
@@ -17,7 +16,7 @@ const listMigrationCommand: CliCommandDefinition = {
   helpText,
   description: 'List available migrations',
   action: async (_, context) => {
-    const {workDir, output} = context
+    const {workDir, output, chalk} = context
     try {
       const migrations = await resolveMigrations(workDir)
 

--- a/packages/sanity/src/_internal/cli/commands/migration/listMigrationsCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/listMigrationsCommand.ts
@@ -5,7 +5,7 @@ import type {Migration} from '@sanity/migrate'
 import {Table} from 'console-table-printer'
 import {register} from 'esbuild-register/dist/node'
 import {MIGRATIONS_DIRECTORY, MIGRATION_SCRIPT_EXTENSIONS} from './constants'
-import {resolveMigrationScript} from './utils'
+import {isLoadableMigrationScript, resolveMigrationScript} from './utils'
 
 const helpText = ``
 
@@ -85,13 +85,9 @@ export async function resolveMigrations(workDir: string): Promise<ResolvedMigrat
   const migrations: ResolvedMigration[] = []
   for (const entry of migrationEntries) {
     const entryName = entry.isDirectory() ? entry.name : removeMigrationScriptExtension(entry.name)
-    const candidates = resolveMigrationScript(workDir, entryName)
+    const candidates = resolveMigrationScript(workDir, entryName).filter(isLoadableMigrationScript)
 
     for (const candidate of candidates) {
-      if (!candidate.mod?.default) {
-        continue
-      }
-
       migrations.push({
         id: entryName,
         migration: candidate.mod.default,

--- a/packages/sanity/src/_internal/cli/commands/migration/listMigrationsCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/listMigrationsCommand.ts
@@ -5,7 +5,7 @@ import type {Migration} from '@sanity/migrate'
 import {Table} from 'console-table-printer'
 import {register} from 'esbuild-register/dist/node'
 import {MIGRATIONS_DIRECTORY, MIGRATION_SCRIPT_EXTENSIONS} from './constants'
-import {isLoadableMigrationScript, resolveMigrationScript} from './utils'
+import {isLoadableMigrationScript, resolveMigrationScript} from './utils/resolveMigrationScript'
 
 const helpText = ``
 

--- a/packages/sanity/src/_internal/cli/commands/migration/listMigrationsCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/listMigrationsCommand.ts
@@ -1,12 +1,12 @@
-import path from 'path'
 import {readdir} from 'node:fs/promises'
-import chalk from 'chalk'
+import path from 'node:path'
 import type {CliCommandDefinition} from '@sanity/cli'
-import {register} from 'esbuild-register/dist/node'
-import {Migration} from '@sanity/migrate'
+import type {Migration} from '@sanity/migrate'
+import chalk from 'chalk'
 import {Table} from 'console-table-printer'
-import {resolveMigrationScript} from './utils'
+import {register} from 'esbuild-register/dist/node'
 import {MIGRATIONS_DIRECTORY} from './constants'
+import {resolveMigrationScript} from './utils'
 
 const helpText = ``
 

--- a/packages/sanity/src/_internal/cli/commands/migration/prettyMutationFormatter.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/prettyMutationFormatter.ts
@@ -1,7 +1,7 @@
-import {isatty} from 'tty'
-import {Migration, Mutation, NodePatch, Transaction} from '@sanity/migrate'
-import {KeyedSegment} from '@sanity/types'
-import {Chalk} from 'chalk'
+import {isatty} from 'node:tty'
+import type {Migration, Mutation, NodePatch, Transaction} from '@sanity/migrate'
+import type {KeyedSegment} from '@sanity/types'
+import type {Chalk} from 'chalk'
 import {convertToTree, formatTree, maxKeyLength} from '../../util/tree'
 
 type ItemRef = string | number

--- a/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
@@ -1,17 +1,17 @@
-import path from 'path'
+import path from 'node:path'
 import type {CliCommandDefinition} from '@sanity/cli'
-import {register} from 'esbuild-register/dist/node'
 import {
   DEFAULT_MUTATION_CONCURRENCY,
-  dryRun,
   MAX_MUTATION_CONCURRENCY,
-  Migration,
-  MigrationProgress,
+  dryRun,
   run,
+  type Migration,
+  type MigrationProgress,
 } from '@sanity/migrate'
-import yargs from 'yargs/yargs'
-import {hideBin} from 'yargs/helpers'
 import {Table} from 'console-table-printer'
+import {register} from 'esbuild-register/dist/node'
+import {hideBin} from 'yargs/helpers'
+import yargs from 'yargs/yargs'
 import {debug} from '../../debug'
 import {resolveMigrations} from './listMigrationsCommand'
 import {prettyFormat} from './prettyMutationFormatter'

--- a/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
@@ -108,7 +108,7 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
       })
 
       migrations.forEach((definedMigration) => {
-        table.addRow({id: definedMigration.dirname, title: definedMigration.migration.title})
+        table.addRow({id: definedMigration.id, title: definedMigration.migration.title})
       })
       table.printTable()
       output.print('\nRun `sanity migration run <ID>` to run a migration')

--- a/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
@@ -14,7 +14,7 @@ import yargs from 'yargs/yargs'
 import {debug} from '../../debug'
 import {resolveMigrations} from './listMigrationsCommand'
 import {prettyFormat} from './prettyMutationFormatter'
-import {isLoadableMigrationScript, resolveMigrationScript} from './utils'
+import {isLoadableMigrationScript, resolveMigrationScript} from './utils/resolveMigrationScript'
 
 const helpText = `
 Options

--- a/packages/sanity/src/_internal/cli/commands/migration/utils.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/utils.ts
@@ -1,8 +1,43 @@
 import path from 'path'
-
+import type {Migration} from '@sanity/migrate'
 import {MIGRATION_SCRIPT_EXTENSIONS, MIGRATIONS_DIRECTORY} from './constants'
 
-export function resolveMigrationScript(workDir: string, migrationName: string) {
+interface ResolvedMigrationScript {
+  /**
+   * Relative path from the working directory to the migration script
+   */
+  relativePath: string
+
+  /**
+   * Absolute path to the migration script
+   */
+  absolutePath: string
+
+  /**
+   * The migration module, if it could be resolved - otherwise `undefined`
+   */
+  mod?: {default: Migration}
+}
+
+/**
+ * Resolves the potential paths to a migration script.
+ * Considers the following paths (where `<ext>` is 'mjs', 'js', 'ts' or 'cjs'):
+ *
+ * - `<migrationsDir>/<migrationName>.<ext>`
+ * - `<migrationsDir>/<migrationName>/index.<ext>`
+ *
+ * Note that all possible paths are returned, even if the files do not exist.
+ * Check the `mod` property to see if a module could actually be loaded.
+ *
+ * @param workDir - Working directory of the studio
+ * @param migrationName - The name of the migration directory to resolve
+ * @returns An array of potential migration scripts
+ * @internal
+ */
+export function resolveMigrationScript(
+  workDir: string,
+  migrationName: string,
+): ResolvedMigrationScript[] {
   return [migrationName, path.join(migrationName, 'index')].flatMap((location) =>
     MIGRATION_SCRIPT_EXTENSIONS.map((ext) => {
       const relativePath = path.join(MIGRATIONS_DIRECTORY, `${location}.${ext}`)
@@ -12,7 +47,9 @@ export function resolveMigrationScript(workDir: string, migrationName: string) {
         // eslint-disable-next-line import/no-dynamic-require
         mod = require(absolutePath)
       } catch (err) {
-        // console.error(err)
+        if (err.code !== 'MODULE_NOT_FOUND') {
+          throw new Error(`Error: ${err.message}"`)
+        }
       }
       return {relativePath, absolutePath, mod}
     }),

--- a/packages/sanity/src/_internal/cli/commands/migration/utils/mutationFormatter.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/utils/mutationFormatter.ts
@@ -1,9 +1,9 @@
 // An example of a compact formatter
 
-import {Mutation, NodePatch, Transaction} from '@sanity/migrate'
+import type {Mutation, NodePatch, Transaction} from '@sanity/migrate'
 
-import {Chalk} from 'chalk'
-import {KeyedSegment} from '@sanity/types'
+import type {Chalk} from 'chalk'
+import type {KeyedSegment} from '@sanity/types'
 import {toString as pathToString} from '@sanity/util/paths'
 
 export type ItemRef = string | number

--- a/packages/sanity/src/_internal/cli/commands/migration/utils/resolveMigrationScript.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/utils/resolveMigrationScript.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import {isPlainObject} from 'lodash'
 import type {Migration} from '@sanity/migrate'
-import {MIGRATION_SCRIPT_EXTENSIONS, MIGRATIONS_DIRECTORY} from './constants'
+import {MIGRATION_SCRIPT_EXTENSIONS, MIGRATIONS_DIRECTORY} from '../constants'
 
 interface ResolvedMigrationScript {
   /**


### PR DESCRIPTION
### Description

When running `sanity migration list`, it would not include migrations defined as `migrations/some-migration.ts` and similar, only those in directories. This PR fixes that.

Also snuck in some code cleanup:
- Clean up after esbuild-register once done using it
- Sorting imports and using type-only imports where possible
- Use `chalk` from context where possible (I see there are other ocurences in other commands, but lets address later)
- Aligned and reused the logic for finding defined migrations, use them across list and run commands
- Moved the `utils.ts` file into the `utils` folder and gave it a descriptive name

### What to review

- `sanity migration list` works both with `migrations/someFile.ts` and `migrations/someMigration/index.ts`
- `sanity migration run <id>` works both with `migrations/someFile.ts` and `migrations/someMigration/index.ts`

### Notes for release

- Fixed an issue where migrations not placed in a subfolder would not appear in the output of `sanity migration list`
