### PR TITLE
fix(core): add aria label to action button pte toolbar

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/ActionMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/ActionMenu.tsx
@@ -89,7 +89,9 @@ export const ActionMenu = memo(function ActionMenu(props: ActionMenuProps) {
         const active = activeKeys.includes(action.key)
         return (
           <CollapseMenuButton
-            aria-label={t('toolbar.portable-text.action-button-aria-label', {action: action.key})}
+            aria-label={t('toolbar.portable-text.action-button-aria-label', {
+              action: action.title || action.key,
+            })}
             data-testid={`action-button-${action.key}`}
             disabled={disabled || annotationDisabled}
             mode="bleed"

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/ActionMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/ActionMenu.tsx
@@ -89,6 +89,7 @@ export const ActionMenu = memo(function ActionMenu(props: ActionMenuProps) {
         const active = activeKeys.includes(action.key)
         return (
           <CollapseMenuButton
+            aria-label={t('toolbar.portable-text.action-button-aria-label', {action: action.key})}
             data-testid={`action-button-${action.key}`}
             disabled={disabled || annotationDisabled}
             mode="bleed"

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1585,6 +1585,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'timeline.since': 'Since: {{timestamp, datetime}}',
   /** Label for missing change version for timeline menu dropdown are showing */
   'timeline.since-version-missing': 'Since: unknown version',
+  /**Aria label for the action buttons in the PTE toolbar */
+  'toolbar.portable-text.action-button-aria-label': 'Action button for {{action}} formatting',
   /** Label for the button showed after trial ended */
   'user-menu.action.free-trial-finished': 'Upgrade from free',
   /** Label for button showing the free trial days left */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1586,7 +1586,7 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Label for missing change version for timeline menu dropdown are showing */
   'timeline.since-version-missing': 'Since: unknown version',
   /**Aria label for the action buttons in the PTE toolbar */
-  'toolbar.portable-text.action-button-aria-label': 'Action button for {{action}} formatting',
+  'toolbar.portable-text.action-button-aria-label': 'Action button for {{action}}',
   /** Label for the button showed after trial ended */
   'user-menu.action.free-trial-finished': 'Upgrade from free',
   /** Label for button showing the free trial days left */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1586,7 +1586,7 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Label for missing change version for timeline menu dropdown are showing */
   'timeline.since-version-missing': 'Since: unknown version',
   /**Aria label for the action buttons in the PTE toolbar */
-  'toolbar.portable-text.action-button-aria-label': 'Action button for {{action}}',
+  'toolbar.portable-text.action-button-aria-label': '{{action}}',
   /** Label for the button showed after trial ended */
   'user-menu.action.free-trial-finished': 'Upgrade from free',
   /** Label for button showing the free trial days left */


### PR DESCRIPTION
### Description
Adds `aria-label` to the PTE toolbar action menus
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
