### PR TITLE
feat(tasks): feature bootstrap, add initial setup

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -248,6 +248,15 @@ const config = {
         '@sanity/i18n/no-attribute-template-literals': 'off',
       },
     },
+    // Ignore i18n in Tasks files for now. This will need to be removed before task is completed.
+    {
+      files: ['**/*/Tasks*.{js,ts,tsx}', '**/*/tasks/**/*'],
+      rules: {
+        'i18next/no-literal-string': 'off',
+        '@sanity/i18n/no-attribute-string-literals': 'off',
+        '@sanity/i18n/no-attribute-template-literals': 'off',
+      },
+    },
 
     // Prefer local components vs certain @sanity/ui imports (in sanity package)
     {

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -144,6 +144,9 @@ export default defineConfig([
     plugins: [sharedSettings()],
     basePath: '/test',
     icon: SanityMonogram,
+    unstable_tasks: {
+      enabled: true,
+    },
   },
   {
     name: 'partialIndexing',

--- a/packages/sanity/src/core/config/prepareConfig.ts
+++ b/packages/sanity/src/core/config/prepareConfig.ts
@@ -193,6 +193,7 @@ export function prepareConfig(
       __internal: {
         sources: resolvedSources,
       },
+      tasks: rawWorkspace.unstable_tasks,
     }
     preparedWorkspaces.set(rawWorkspace, workspaceSummary)
     return workspaceSummary

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -422,6 +422,13 @@ export interface WorkspaceOptions extends SourceOptions {
    * @beta
    */
   unstable_sources?: SourceOptions[]
+  /**
+   * @hidden
+   * @beta
+   */
+  unstable_tasks?: {
+    enabled: boolean
+  }
 }
 
 /**
@@ -763,6 +770,7 @@ export interface WorkspaceSummary {
       source: Observable<Source>
     }>
   }
+  tasks: WorkspaceOptions['unstable_tasks']
 }
 
 /**
@@ -789,6 +797,12 @@ export interface Workspace extends Omit<Source, 'type'> {
    * @beta
    */
   unstable_sources: Source[]
+  /**
+   *
+   * @hidden
+   * @beta
+   */
+  tasks: WorkspaceOptions['unstable_tasks']
 }
 
 /**

--- a/packages/sanity/src/core/studio/Studio.test.tsx
+++ b/packages/sanity/src/core/studio/Studio.test.tsx
@@ -45,7 +45,7 @@ describe('Studio', () => {
       const html = renderToStaticMarkup(sheet.collectStyles(<Studio config={config} />))
 
       expect(html).toMatchInlineSnapshot(
-        `"<div class=\\"sc-dDPpIy kJDvPE\\"><div data-ui=\\"Spinner\\" class=\\"sc-ipEzrc eJGegB sc-ksBlXE dyLnEw sc-MApLD ddCDnM\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
+        `"<div class=\\"sc-hQrfjo kOvXLM\\"><div data-ui=\\"Spinner\\" class=\\"sc-ipEzrc eJGegB sc-ksBlXE dyLnEw sc-eZcfmt hmIphr\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
       )
     } finally {
       sheet.seal()
@@ -62,7 +62,7 @@ describe('Studio', () => {
     try {
       const html = renderToString(sheet.collectStyles(<Studio config={config} />))
       expect(html).toMatchInlineSnapshot(
-        `"<div class=\\"sc-dDPpIy kJDvPE\\"><div data-ui=\\"Spinner\\" class=\\"sc-ipEzrc eJGegB sc-ksBlXE dyLnEw sc-MApLD ddCDnM\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
+        `"<div class=\\"sc-hQrfjo kOvXLM\\"><div data-ui=\\"Spinner\\" class=\\"sc-ipEzrc eJGegB sc-ksBlXE dyLnEw sc-eZcfmt hmIphr\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
       )
     } finally {
       sheet.seal()
@@ -82,7 +82,7 @@ describe('Studio', () => {
       const html = renderToString(sheet.collectStyles(<Studio config={config} />))
       node.innerHTML = html
       expect(html).toMatchInlineSnapshot(
-        `"<div class=\\"sc-dDPpIy kJDvPE\\"><div data-ui=\\"Spinner\\" class=\\"sc-ipEzrc eJGegB sc-ksBlXE dyLnEw sc-MApLD ddCDnM\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
+        `"<div class=\\"sc-hQrfjo kOvXLM\\"><div data-ui=\\"Spinner\\" class=\\"sc-ipEzrc eJGegB sc-ksBlXE dyLnEw sc-eZcfmt hmIphr\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
       )
       document.head.innerHTML += sheet.getStyleTags()
 

--- a/packages/sanity/src/core/studio/StudioLayout.tsx
+++ b/packages/sanity/src/core/studio/StudioLayout.tsx
@@ -18,6 +18,7 @@ import {ToolNotFoundScreen} from './screens/ToolNotFoundScreen'
 import {useLayoutComponent, useNavbarComponent} from './studio-components-hooks'
 import {StudioErrorBoundary} from './StudioErrorBoundary'
 import {useWorkspace} from './workspace'
+import {StudioSidebar} from './StudioSidebar'
 import {RouteScope, useRouter, useRouterState} from 'sanity/router'
 
 const SearchFullscreenPortalCard = styled(Card)`
@@ -29,6 +30,10 @@ const SearchFullscreenPortalCard = styled(Card)`
   top: 0;
   width: 100%;
   z-index: 200;
+`
+
+const ActiveToolContainer = styled.div`
+  flex: 1;
 `
 
 /** @internal */
@@ -192,7 +197,12 @@ export function StudioLayoutComponent() {
               }
             >
               <Suspense fallback={<LoadingBlock showText />}>
-                {createElement(activeTool.component, {tool: activeTool})}
+                <Flex height="fill">
+                  <ActiveToolContainer>
+                    {createElement(activeTool.component, {tool: activeTool})}
+                  </ActiveToolContainer>
+                  <StudioSidebar />
+                </Flex>
               </Suspense>
             </RouteScope>
           )}

--- a/packages/sanity/src/core/studio/StudioProvider.tsx
+++ b/packages/sanity/src/core/studio/StudioProvider.tsx
@@ -27,6 +27,7 @@ import {
 import {WorkspaceLoader} from './workspaceLoader'
 import {WorkspacesProvider} from './workspaces'
 import {StudioTelemetryProvider} from './StudioTelemetryProvider'
+import {TasksProvider} from './tasks'
 
 Refractor.registerLanguage(bash)
 Refractor.registerLanguage(javascript)
@@ -57,7 +58,9 @@ export function StudioProvider({
     <WorkspaceLoader LoadingComponent={LoadingBlock} ConfigErrorsComponent={ConfigErrorsScreen}>
       <StudioTelemetryProvider config={config}>
         <LocaleProvider>
-          <ResourceCacheProvider>{children}</ResourceCacheProvider>
+          <ResourceCacheProvider>
+            <TasksProvider>{children}</TasksProvider>
+          </ResourceCacheProvider>
         </LocaleProvider>
       </StudioTelemetryProvider>
     </WorkspaceLoader>

--- a/packages/sanity/src/core/studio/StudioSidebar.tsx
+++ b/packages/sanity/src/core/studio/StudioSidebar.tsx
@@ -1,0 +1,9 @@
+import {TasksStudioSidebar} from './tasks/components'
+
+/**
+ * @beta
+ * @internal
+ */
+export function StudioSidebar() {
+  return <TasksStudioSidebar />
+}

--- a/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
@@ -17,6 +17,7 @@ import {useWorkspace} from '../../workspace'
 import {Button, TooltipDelayGroupProvider} from '../../../../ui-components'
 import {NavbarContext} from '../../StudioLayout'
 import {useToolMenuComponent} from '../../studio-components-hooks'
+import {TasksNavbarButton} from '../../tasks/components'
 import {useTranslation} from '../../../i18n'
 import {UserMenu} from './userMenu'
 import {NewDocumentButton, useNewDocumentOptions} from './new-document'
@@ -100,6 +101,7 @@ export function StudioNavbar() {
       configIssues: mediaIndex > 1 && isDev,
       newDocumentFullscreen: mediaIndex <= 1,
       tools: mediaIndex >= 3,
+      tasks: mediaIndex >= 3,
     }),
     [mediaIndex],
   )
@@ -241,6 +243,7 @@ export function StudioNavbar() {
                       ref={setSearchOpenButtonEl}
                     />
                   )}
+                  {shouldRender.tasks && <TasksNavbarButton />}
                 </Flex>
                 {shouldRender.tools && (
                   <Box flex="none" marginLeft={1}>

--- a/packages/sanity/src/core/studio/tasks/components/TasksNavbarButton/TasksNavbarButton.tsx
+++ b/packages/sanity/src/core/studio/tasks/components/TasksNavbarButton/TasksNavbarButton.tsx
@@ -1,0 +1,19 @@
+import {PanelRightIcon} from '@sanity/icons'
+import {Button} from '../../../../../ui-components'
+import {useTasksEnabled, useTasks} from '../../context'
+
+export function TasksNavbarButton() {
+  const {enabled} = useTasksEnabled()
+  const {handleToggleSidebar, isSidebarOpen} = useTasks()
+
+  if (!enabled) return null
+  return (
+    <Button
+      text="Tasks"
+      mode={'bleed'}
+      selected={isSidebarOpen}
+      iconRight={PanelRightIcon}
+      onClick={handleToggleSidebar}
+    />
+  )
+}

--- a/packages/sanity/src/core/studio/tasks/components/TasksNavbarButton/index.ts
+++ b/packages/sanity/src/core/studio/tasks/components/TasksNavbarButton/index.ts
@@ -1,0 +1,1 @@
+export * from './TasksNavbarButton'

--- a/packages/sanity/src/core/studio/tasks/components/TasksSidebar/TasksSidebar.tsx
+++ b/packages/sanity/src/core/studio/tasks/components/TasksSidebar/TasksSidebar.tsx
@@ -1,0 +1,36 @@
+import {Card} from '@sanity/ui'
+import styled from 'styled-components'
+import {AnimatePresence, motion} from 'framer-motion'
+import {useTasksEnabled, useTasks} from '../../context'
+import {TasksSidebarHeader} from './TasksSidebarHeader'
+
+const SidebarRoot = styled(Card)`
+  height: 100%;
+  width: 360px;
+  margin-left: 4px;
+  box-shadow:
+    0px 6px 8px -4px rgba(134, 144, 160, 0.2),
+    0px -6px 8px -4px rgba(134, 144, 160, 0.2);
+`
+
+export function TasksStudioSidebar() {
+  const {enabled} = useTasksEnabled()
+  const {isSidebarOpen} = useTasks()
+
+  if (!enabled) return null
+  return (
+    <AnimatePresence initial={false}>
+      {isSidebarOpen && (
+        <motion.div
+          initial={{translateX: 16, opacity: 0}}
+          animate={{translateX: 0, opacity: 1}}
+          transition={{duration: 0.2}}
+        >
+          <SidebarRoot borderLeft height="fill">
+            <TasksSidebarHeader />
+          </SidebarRoot>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/packages/sanity/src/core/studio/tasks/components/TasksSidebar/TasksSidebarHeader.tsx
+++ b/packages/sanity/src/core/studio/tasks/components/TasksSidebar/TasksSidebarHeader.tsx
@@ -1,0 +1,39 @@
+import {Box, Flex, Text} from '@sanity/ui'
+import {DoubleChevronRightIcon, AddIcon} from '@sanity/icons'
+import {Button, TooltipDelayGroupProvider} from '../../../../../ui-components'
+import {useTasks} from '../..'
+import {BetaBadge} from '../../../../components'
+
+export function TasksSidebarHeader() {
+  const {handleToggleSidebar} = useTasks()
+
+  return (
+    <Box padding={2}>
+      <Flex padding={1} justify="space-between" align="center" gap={2}>
+        <Flex padding={2} align="center" gap={2} flex={1}>
+          <Text size={2} weight="semibold">
+            Tasks
+          </Text>
+          <BetaBadge />
+        </Flex>
+        <TooltipDelayGroupProvider>
+          <Button
+            tooltipProps={{
+              content: 'Create new task',
+            }}
+            iconRight={AddIcon}
+            mode="bleed"
+          />
+          <Button
+            tooltipProps={{
+              content: 'Close sidebar',
+            }}
+            iconRight={DoubleChevronRightIcon}
+            mode="bleed"
+            onClick={handleToggleSidebar}
+          />
+        </TooltipDelayGroupProvider>
+      </Flex>
+    </Box>
+  )
+}

--- a/packages/sanity/src/core/studio/tasks/components/TasksSidebar/index.ts
+++ b/packages/sanity/src/core/studio/tasks/components/TasksSidebar/index.ts
@@ -1,0 +1,1 @@
+export * from './TasksSidebar'

--- a/packages/sanity/src/core/studio/tasks/components/index.ts
+++ b/packages/sanity/src/core/studio/tasks/components/index.ts
@@ -1,0 +1,2 @@
+export * from './TasksSidebar'
+export * from './TasksNavbarButton'

--- a/packages/sanity/src/core/studio/tasks/context/enabled/TasksEnabledContext.ts
+++ b/packages/sanity/src/core/studio/tasks/context/enabled/TasksEnabledContext.ts
@@ -1,0 +1,4 @@
+import {createContext} from 'react'
+import {TasksEnabledContextValue} from './types'
+
+export const TasksEnabledContext = createContext<TasksEnabledContextValue | null>(null)

--- a/packages/sanity/src/core/studio/tasks/context/enabled/TasksEnabledProvider.tsx
+++ b/packages/sanity/src/core/studio/tasks/context/enabled/TasksEnabledProvider.tsx
@@ -1,0 +1,32 @@
+import {useMemo} from 'react'
+import {useFeatureEnabled} from '../../../../hooks'
+import {useWorkspace} from '../../../workspace'
+import {TasksEnabledContext} from './TasksEnabledContext'
+import {TasksEnabledContextValue} from './types'
+
+interface TaksEnabledProviderProps {
+  children: React.ReactNode
+}
+
+export function TasksEnabledProvider({children}: TaksEnabledProviderProps) {
+  // TODO: Restore this once the feature flag is enabled by the ENTX team, see ENTX-1330.
+  const {enabled: featureEnabled, isLoading} = useFeatureEnabled('studioTasks')
+  const workspace = useWorkspace()
+  const enabled = !!workspace.tasks?.enabled
+
+  const value: TasksEnabledContextValue = useMemo(() => {
+    if (!enabled || isLoading) {
+      return {
+        enabled: false,
+        mode: null,
+      }
+    }
+
+    return {
+      enabled: true,
+      mode: 'default',
+    }
+  }, [enabled, isLoading])
+
+  return <TasksEnabledContext.Provider value={value}>{children}</TasksEnabledContext.Provider>
+}

--- a/packages/sanity/src/core/studio/tasks/context/enabled/index.ts
+++ b/packages/sanity/src/core/studio/tasks/context/enabled/index.ts
@@ -1,0 +1,4 @@
+export * from './TasksEnabledProvider'
+export * from './TasksEnabledContext'
+export * from './useTasksEnabled'
+export * from './types'

--- a/packages/sanity/src/core/studio/tasks/context/enabled/types.ts
+++ b/packages/sanity/src/core/studio/tasks/context/enabled/types.ts
@@ -1,0 +1,9 @@
+export type TasksEnabledContextValue =
+  | {
+      enabled: false
+      mode: null
+    }
+  | {
+      enabled: true
+      mode: 'default' | null // Prepare to support upsell or different modes in a future
+    }

--- a/packages/sanity/src/core/studio/tasks/context/enabled/useTasksEnabled.ts
+++ b/packages/sanity/src/core/studio/tasks/context/enabled/useTasksEnabled.ts
@@ -1,0 +1,11 @@
+import {useContext} from 'react'
+import {TasksEnabledContext} from './TasksEnabledContext'
+import {TasksEnabledContextValue} from './types'
+
+export function useTasksEnabled(): TasksEnabledContextValue {
+  const context = useContext(TasksEnabledContext)
+  if (!context) {
+    throw new Error('useTasks must be used within a TasksEnabledProvider')
+  }
+  return context
+}

--- a/packages/sanity/src/core/studio/tasks/context/index.ts
+++ b/packages/sanity/src/core/studio/tasks/context/index.ts
@@ -1,0 +1,2 @@
+export * from './tasks'
+export * from './enabled'

--- a/packages/sanity/src/core/studio/tasks/context/tasks/TasksContext.ts
+++ b/packages/sanity/src/core/studio/tasks/context/tasks/TasksContext.ts
@@ -1,0 +1,4 @@
+import {createContext} from 'react'
+import {TasksContextValue} from './types'
+
+export const TasksContext = createContext<TasksContextValue | null>(null)

--- a/packages/sanity/src/core/studio/tasks/context/tasks/TasksProvider.tsx
+++ b/packages/sanity/src/core/studio/tasks/context/tasks/TasksProvider.tsx
@@ -1,0 +1,28 @@
+import {useState, useCallback} from 'react'
+import {TasksEnabledProvider} from '../enabled'
+import {TasksContext} from './TasksContext'
+
+interface TasksProviderProps {
+  children: React.ReactNode
+}
+
+/**
+ * @internal
+ */
+export function TasksProvider(props: TasksProviderProps) {
+  const {children} = props
+  // TODO: Get this state into the router?
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false)
+
+  const handleToggleSidebar = useCallback(() => {
+    setIsSidebarOpen((prev) => !prev)
+  }, [])
+
+  return (
+    <TasksEnabledProvider>
+      <TasksContext.Provider value={{isSidebarOpen, handleToggleSidebar}}>
+        {children}
+      </TasksContext.Provider>
+    </TasksEnabledProvider>
+  )
+}

--- a/packages/sanity/src/core/studio/tasks/context/tasks/index.ts
+++ b/packages/sanity/src/core/studio/tasks/context/tasks/index.ts
@@ -1,0 +1,4 @@
+export * from './TasksContext'
+export * from './TasksProvider'
+export * from './useTasks'
+export * from './types'

--- a/packages/sanity/src/core/studio/tasks/context/tasks/types.ts
+++ b/packages/sanity/src/core/studio/tasks/context/tasks/types.ts
@@ -1,0 +1,4 @@
+export interface TasksContextValue {
+  isSidebarOpen: boolean
+  handleToggleSidebar: () => void
+}

--- a/packages/sanity/src/core/studio/tasks/context/tasks/useTasks.ts
+++ b/packages/sanity/src/core/studio/tasks/context/tasks/useTasks.ts
@@ -1,0 +1,11 @@
+import {useContext} from 'react'
+import {TasksContext} from './TasksContext'
+import {TasksContextValue} from './types'
+
+export function useTasks(): TasksContextValue {
+  const context = useContext(TasksContext)
+  if (!context) {
+    throw new Error('useTasks must be used within a TasksProvider')
+  }
+  return context
+}

--- a/packages/sanity/src/core/studio/tasks/index.ts
+++ b/packages/sanity/src/core/studio/tasks/index.ts
@@ -1,0 +1,2 @@
+export * from './context'
+export * from './components'


### PR DESCRIPTION
### Description
Introduces initial setup for `Tasks` feature.

Tasks will be part of `core`
All the code related will live in `packages/sanity/src/core/studio/tasks`
A new config flag is added to Workspaces to enable / disable the feature

```
  unstable_tasks: {
    enabled: boolean
}
```
⚠️ this is **only** an initial setup with the base configuration to get us started, is not intended to be a final production ready integration.
⚠️ It doesn't include support for mobile yet. 
⚠️ It is not translated yet, as it will be a changing feature with no final designs.


<img width="1458" alt="Screenshot 2024-02-02 at 13 52 43" src="https://github.com/sanity-io/sanity/assets/46196328/7fe942a8-05c9-4295-bd9f-98665845d55b">

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Adds: 
- New provider `TasksProvider` is added to the `StudioProvider`
- Studio Sidebar is added to `StudioLayout`. 
- TasksButton is added to the `StudioNavbar`


### What to review

No changes should be introduced outside of the context of `tasks`.
Studio config is unchanged for users.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
- 