### PR TITLE
dev(test-studio): add staging project workspace

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -146,6 +146,16 @@ export default defineConfig([
     icon: SanityMonogram,
   },
   {
+    name: 'testStudioStaging',
+    title: 'Test Studio (staging)',
+    projectId: 'dl41hj45',
+    dataset: 'test',
+    plugins: [sharedSettings()],
+    basePath: '/test-staging',
+    icon: SanityMonogram,
+    apiHost: 'https://api.sanity.work',
+  },
+  {
     name: 'partialIndexing',
     title: 'Partial Indexing',
     projectId: 'ppsg7ml5',


### PR DESCRIPTION
### Description

This adds a new staging workspace to the test studio. It will be used for testing features against staging.

The project used for this workspace is titled Sanity Staging Test Studio, and is part of the Sanity Staging Corp org.

### Notes for release

n/a