### PR TITLE
fix: regression caused by #5440

### DIFF
--- a/packages/sanity/src/structure/panes/documentList/listenSearchQuery.ts
+++ b/packages/sanity/src/structure/panes/documentList/listenSearchQuery.ts
@@ -83,7 +83,7 @@ export function listenSearchQuery(options: ListenQueryOptions): Observable<Sanit
         mergeMap((typeNames: string[]) => {
           const types = getSearchTypesWithMaxDepth(
             getSearchableTypes(schema).filter((type) => {
-              return typeNames.includes(type.name) || type.name === "sanity.previewUrlSecret"
+              return typeNames.includes(type.name) || type.name === 'sanity.previewUrlSecret'
             }),
             maxFieldDepth,
           )

--- a/packages/sanity/src/structure/panes/documentList/listenSearchQuery.ts
+++ b/packages/sanity/src/structure/panes/documentList/listenSearchQuery.ts
@@ -83,7 +83,7 @@ export function listenSearchQuery(options: ListenQueryOptions): Observable<Sanit
         mergeMap((typeNames: string[]) => {
           const types = getSearchTypesWithMaxDepth(
             getSearchableTypes(schema).filter((type) => {
-              return typeNames.includes(type.name)
+              return typeNames.includes(type.name) || type.name === "sanity.previewUrlSecret"
             }),
             maxFieldDepth,
           )


### PR DESCRIPTION
### Description

In #5440, released in `v3.24.1`, the debug URL secrets feature broke.
When using `sanity/presentation` it's possible to [view generated URL secrets](https://github.com/sanity-io/visual-editing/tree/main/packages/preview-url-secret#debugging-generated-secrets).

On versions `3.23.4` and older it works fine:
![image](https://github.com/sanity-io/sanity/assets/81981/7abbc902-65f8-49fd-852e-2a01b61649da)

Updating to `v3.24.1`, or all the way up to `v3.27.1`, then the list is empty:
![image](https://github.com/sanity-io/sanity/assets/81981/773e12ab-c702-4ae5-a4b1-f71e7d104c25)



### What to review

The regression fix shouldn't cause further regressions. For example it's not desirable that url preview secrets shows up in the global search. We just want a way for it to show up when the debug plugin is added to the config:
```ts
import { defineConfig } from 'sanity'
import { debugSecrets } from '@sanity/preview-url-secret/sanity-plugin-debug-secrets'

export default defineConfig({
  // ... other options
  plugins: [
    // Makes the url secrets visible in the Sanity Studio like any other documents defined in your schema
    debugSecrets(),
  ],
})
```

[The plugin loads this schema.](https://github.com/sanity-io/visual-editing/blob/12c63b512f452de75ff439a0771d136d260365b5/packages/preview-url-secret/src/sanityPluginDebugSecrets/debugUrlSecrets.tsx)

### Testing

Create a document of the `sanity.previewUrlSecret` type, and after loading the plugin as outlined above the document should show up in the Structure document list.

### Notes for release

fix: regression that broke `@sanity/preview-url-secret/sanity-plugin-debug-secrets` in `v3.24.1`
