### PR TITLE
fix(cli): respect unattended mode

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -174,6 +174,9 @@ export default async function initSanity(
             message: `Coupon "${intendedCoupon}" is not available, use default plan instead?`,
             default: true,
           }))
+        if (unattended) {
+          output.warn(`Coupon "${intendedCoupon}" is not available - using default plan`)
+        }
         trace.log({
           step: 'useDefaultPlanCoupon',
           selectedOption: useDefaultPlan ? 'yes' : 'no',
@@ -200,6 +203,9 @@ export default async function initSanity(
             message: `Project plan "${intendedPlan}" does not exist, use default plan instead?`,
             default: true,
           }))
+        if (unattended) {
+          output.warn(`Project plan "${intendedPlan}" does not exist - using default plan`)
+        }
         trace.log({
           step: 'useDefaultPlanId',
           selectedOption: useDefaultPlan ? 'yes' : 'no',

--- a/packages/@sanity/cli/src/actions/init-project/initProject.ts
+++ b/packages/@sanity/cli/src/actions/init-project/initProject.ts
@@ -167,11 +167,13 @@ export default async function initSanity(
       print(`Coupon "${intendedCoupon}" validated!\n`)
     } catch (err) {
       if (err.statusCode == '404') {
-        const useDefaultPlan = await prompt.single({
-          type: 'confirm',
-          message: `Coupon "${intendedCoupon}" is not available, use default plan instead?`,
-          default: true,
-        })
+        const useDefaultPlan =
+          unattended ??
+          (await prompt.single({
+            type: 'confirm',
+            message: `Coupon "${intendedCoupon}" is not available, use default plan instead?`,
+            default: true,
+          }))
         trace.log({
           step: 'useDefaultPlanCoupon',
           selectedOption: useDefaultPlan ? 'yes' : 'no',
@@ -191,11 +193,13 @@ export default async function initSanity(
       selectedPlan = await getPlanFromId(apiClient, intendedPlan)
     } catch (err) {
       if (err.statusCode == '404') {
-        const useDefaultPlan = await prompt.single({
-          type: 'confirm',
-          message: `Project plan "${intendedPlan}" does not exist, use default plan instead?`,
-          default: true,
-        })
+        const useDefaultPlan =
+          unattended ??
+          (await prompt.single({
+            type: 'confirm',
+            message: `Project plan "${intendedPlan}" does not exist, use default plan instead?`,
+            default: true,
+          }))
         trace.log({
           step: 'useDefaultPlanId',
           selectedOption: useDefaultPlan ? 'yes' : 'no',


### PR DESCRIPTION
### Description

A recent change to the CLI added user prompts when attempting to use a nonexistent coupon (`--coupon`) or a plan (`--project-plan`), however, this change did no respect unattended mode (`-y, --yes`) and would prompt the user regardless. 

### What to review

- Initialising a project using a nonexistent coupon or plan in unattended mode:
  - `init -y --project-plan beep`
  - `init -y --coupon boop`

### Testing

- Does the command proceed without prompting the user?