### PR TITLE
chore(edx-903): track errors caught by ErrorLogger

### DIFF
--- a/packages/sanity/src/core/error/ErrorLogger.tsx
+++ b/packages/sanity/src/core/error/ErrorLogger.tsx
@@ -3,6 +3,7 @@ import {useEffect} from 'react'
 import {ConfigResolutionError, SchemaError} from '../config'
 import {CorsOriginError} from '../store'
 import {globalScope} from '../util'
+import {useTelemetryErrorLogger} from './useTelemetryErrorLogger'
 
 const errorChannel = globalScope.__sanityErrorChannel
 
@@ -14,7 +15,7 @@ const errorChannel = globalScope.__sanityErrorChannel
  */
 export function ErrorLogger(): null {
   const {push: pushToast} = useToast()
-
+  const {logErrorToTelemetry} = useTelemetryErrorLogger()
   useEffect(() => {
     if (!errorChannel) return undefined
 
@@ -32,6 +33,8 @@ export function ErrorLogger(): null {
         return
       }
 
+      logErrorToTelemetry(msg.error)
+
       console.error(msg.error)
 
       pushToast({
@@ -45,7 +48,7 @@ export function ErrorLogger(): null {
         status: 'error',
       })
     })
-  }, [pushToast])
+  }, [pushToast, logErrorToTelemetry])
 
   return null
 }

--- a/packages/sanity/src/core/error/__telemetry__/error.telemetry.ts
+++ b/packages/sanity/src/core/error/__telemetry__/error.telemetry.ts
@@ -1,0 +1,11 @@
+import {defineEvent} from '@sanity/telemetry'
+
+interface ErrorLoggerEvent {
+  stack: string
+  message: string
+}
+export const ErrorLoggerCatch = defineEvent<ErrorLoggerEvent>({
+  version: 1,
+  name: 'ErrorLogger catch',
+  description: 'An error was detected by the error logger',
+})

--- a/packages/sanity/src/core/error/useTelemetryErrorLogger.tsx
+++ b/packages/sanity/src/core/error/useTelemetryErrorLogger.tsx
@@ -1,0 +1,24 @@
+import {useTelemetry} from '@sanity/telemetry/react'
+import {useCallback} from 'react'
+import {isProd} from '../environment'
+import {ErrorLoggerCatch} from './__telemetry__/error.telemetry'
+
+export function useTelemetryErrorLogger(): {
+  logErrorToTelemetry: (error: Error) => void
+} {
+  const telemetry = useTelemetry()
+
+  const logErrorToTelemetry = useCallback(
+    (error: Error) => {
+      // Track errors produced in production only
+      if (isProd) {
+        telemetry.log(ErrorLoggerCatch, {
+          stack: error.stack,
+          message: error.message,
+        })
+      }
+    },
+    [telemetry],
+  )
+  return {logErrorToTelemetry}
+}

--- a/packages/sanity/src/core/studio/StudioProvider.tsx
+++ b/packages/sanity/src/core/studio/StudioProvider.tsx
@@ -56,6 +56,7 @@ export function StudioProvider({
   const _children = (
     <WorkspaceLoader LoadingComponent={LoadingBlock} ConfigErrorsComponent={ConfigErrorsScreen}>
       <StudioTelemetryProvider config={config}>
+        <ErrorLogger />
         <LocaleProvider>
           <ResourceCacheProvider>{children}</ResourceCacheProvider>
         </LocaleProvider>
@@ -66,7 +67,6 @@ export function StudioProvider({
   return (
     <ColorSchemeProvider onSchemeChange={onSchemeChange} scheme={scheme}>
       <ToastProvider paddingY={7} zOffset={Z_OFFSET.toast}>
-        <ErrorLogger />
         <StudioErrorBoundary>
           <WorkspacesProvider config={config} basePath={basePath}>
             <ActiveWorkspaceMatcher


### PR DESCRIPTION
### Description

Tracks errors caught by `ErrorLogger`.
`ErrorLogger` is inserted as a global listener and catch all the errors generated inside the Studio, showing the error toast. With this addition, it will also post this errors to `Telemetry`. 
First intention is to gather information about errors generated in Portable Text Editor, but will also be useful to detect other type of errors generated anywhere. 

It will track errors only when the studio is in production mode. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
