### PR TITLE
fix(migrate): submit mutations with visibility=async

### DIFF
--- a/packages/@sanity/migrate/src/fetch-utils/endpoints.ts
+++ b/packages/@sanity/migrate/src/fetch-utils/endpoints.ts
@@ -34,7 +34,7 @@ export const endpoints = {
       options?: {
         returnIds?: boolean
         returnDocuments?: boolean
-        visiblity?: 'async' | 'sync' | 'deferred'
+        visibility?: 'async' | 'sync' | 'deferred'
         dryRun?: boolean
         tag?: string
       },
@@ -43,7 +43,7 @@ export const endpoints = {
         options?.tag && ['tag', options.tag],
         options?.returnIds && ['returnIds', 'true'],
         options?.returnDocuments && ['returnDocuments', 'true'],
-        options?.visiblity && ['visibility', options.visiblity],
+        options?.visibility && ['visibility', options.visibility],
         options?.dryRun && ['dryRun', 'true'],
       ].filter(Boolean) as [string, string][]
 

--- a/packages/@sanity/migrate/src/runner/run.ts
+++ b/packages/@sanity/migrate/src/runner/run.ts
@@ -45,7 +45,7 @@ export async function* toFetchOptionsIterable(
       token: apiConfig.token,
       tag: 'sanity.migration.mutate',
       apiHost: apiConfig.apiHost ?? 'api.sanity.io',
-      endpoint: endpoints.data.mutate(apiConfig.dataset, {returnIds: true}),
+      endpoint: endpoints.data.mutate(apiConfig.dataset, {returnIds: true, visibility: 'async'}),
       body: JSON.stringify(transaction),
     })
   }


### PR DESCRIPTION
### Description
Sets visibility to `async` when submitting mutations from `sanity migraiton run`.

### What to review
- Any considerations I'm missing? I based it on the visibility used by `sanity import`

### Notes for release

n/a