### PR TITLE
docs(core): update `components.logo` deprecation note to correctly point to `workspace.icons`

### DIFF
--- a/packages/sanity/src/core/config/studio/types.ts
+++ b/packages/sanity/src/core/config/studio/types.ts
@@ -52,7 +52,10 @@ export interface StudioComponents {
  * @beta */
 export interface StudioComponentsPluginOptions {
   layout?: React.ComponentType<LayoutProps>
-  /** @deprecated Use logoMark instead */
+  /**
+   * @deprecated Add custom icons on a per-workspace basis by customizing workspace `icon` instead.
+   * @see {@link https://www.sanity.io/docs/workspaces}
+   */
   logo?: React.ComponentType<LogoProps>
   navbar?: React.ComponentType<NavbarProps>
   toolMenu?: React.ComponentType<ToolMenuProps>


### PR DESCRIPTION
### Description

Tiny TSDoc change to update the `components.logo` deprecation message. 

### What to review

N/A 

### Testing

N/A 

### Notes for release

N/A 