### PR TITLE
fix(migration): fixes an issue where migration command would error sometimes

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "@sanity/tsdoc": "1.0.0-alpha.38",
     "@sanity/uuid": "^3.0.2",
     "@types/jest": "^29.5.6",
-    "@types/mkdirp": "^1.0.2",
     "@types/node": "^14.18.9",
     "@types/react": "^18.2.37",
     "@types/tmp": "^0.2.3",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -263,7 +263,6 @@
     "lodash": "^4.17.21",
     "log-symbols": "^2.2.0",
     "mendoza": "^3.0.0",
-    "mkdirp": "^3.0.1",
     "module-alias": "^2.2.2",
     "nano-pubsub": "^2.0.1",
     "nanoid": "^3.1.30",

--- a/packages/sanity/src/_internal/cli/commands/migration/createMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/createMigrationCommand.ts
@@ -1,9 +1,8 @@
 import path from 'node:path'
 import {writeFile} from 'node:fs/promises'
-import {existsSync} from 'node:fs'
+import {existsSync, mkdirSync} from 'node:fs'
 import type {CliCommandDefinition} from '@sanity/cli'
 import deburr from 'lodash/deburr'
-import mkdirp from 'mkdirp'
 import {MIGRATIONS_DIRECTORY} from './constants'
 import {renameType} from './templates/renameType'
 import {stringToPTE} from './templates/stringToPTE'
@@ -87,7 +86,7 @@ const createMigrationCommand: CliCommandDefinition<CreateMigrationFlags> = {
         return
       }
     }
-    mkdirp.sync(destDir)
+    mkdirSync(destDir, {recursive: true})
 
     const renderedTemplate = (templatesByName[template].template || minimalSimple)({
       migrationName: title,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4339,13 +4339,6 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/mkdirp@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-1.0.2.tgz#8d0bad7aa793abe551860be1f7ae7f3198c16666"
-  integrity sha512-o0K1tSO0Dx5X6xlU5F1D6625FawhC3dU3iqr25lluNv/+/QIVH8RLNEiVokgIZo+mz+87w/3Mkg/VvQS+J51fQ==
-  dependencies:
-    "@types/node" "*"
-
 "@types/moment@^2.13.0":
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/@types/moment/-/moment-2.13.0.tgz#604ebd189bc3bc34a1548689404e61a2a4aac896"


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Removes `mkdirp` package and uses fs to create the directory.

Also removes `mkdirp` and related types from package.json. Search does not yield any other usage.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

migration create command still works as expected

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

- Fixes an issue where migration command would error in some instances