### PR TITLE
fix(vision): prevent crashes when pasting certain URLs

### DIFF
--- a/packages/@sanity/vision/src/SanityVision.tsx
+++ b/packages/@sanity/vision/src/SanityVision.tsx
@@ -3,6 +3,7 @@ import {type Tool, useClient} from 'sanity'
 import {type VisionConfig} from './types'
 import {DEFAULT_API_VERSION} from './apiVersions'
 import {VisionContainer} from './containers/VisionContainer'
+import {VisionErrorBoundary} from './containers/VisionErrorBoundary'
 
 interface SanityVisionProps {
   tool: Tool<VisionConfig>
@@ -15,7 +16,11 @@ function SanityVision(props: SanityVisionProps) {
     ...props.tool.options,
   }
 
-  return <VisionContainer client={client} config={config} />
+  return (
+    <VisionErrorBoundary>
+      <VisionContainer client={client} config={config} />
+    </VisionErrorBoundary>
+  )
 }
 
 export default SanityVision

--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -643,22 +643,24 @@ export class VisionGui extends React.PureComponent<VisionGuiProps, VisionGuiStat
   render() {
     const {datasets, t} = this.props
     const {
-      error,
-      queryResult,
-      url,
-      queryInProgress,
-      listenInProgress,
-      paneSizeOptions,
-      queryTime,
-      e2eTime,
-      listenMutations,
       apiVersion,
-      dataset,
       customApiVersion,
-      isValidApiVersion,
+      dataset,
+      e2eTime,
+      error,
       hasValidParams,
+      isValidApiVersion,
+      listenInProgress,
+      listenMutations,
+      paneSizeOptions,
       paramsError,
       perspective,
+      query,
+      queryInProgress,
+      queryResult,
+      queryTime,
+      rawParams,
+      url,
     } = this.state
     const hasResult = !error && !queryInProgress && typeof queryResult !== 'undefined'
 
@@ -825,7 +827,7 @@ export class VisionGui extends React.PureComponent<VisionGuiProps, VisionGuiStat
                         <StyledLabel muted>{t('query.label')}</StyledLabel>
                       </Flex>
                     </InputBackgroundContainerLeft>
-                    <VisionCodeMirror value={this.state.query} onChange={this.handleQueryChange} />
+                    <VisionCodeMirror value={query} onChange={this.handleQueryChange} />
                   </Box>
                 </InputContainer>
                 <InputContainer display="flex" ref={this._paramsEditorContainer}>
@@ -844,7 +846,7 @@ export class VisionGui extends React.PureComponent<VisionGuiProps, VisionGuiStat
                         )}
                       </Flex>
                     </InputBackgroundContainerLeft>
-                    <ParamsEditor value={this.state.rawParams} onChange={this.handleParamsChange} />
+                    <ParamsEditor value={rawParams} onChange={this.handleParamsChange} />
                   </Card>
                   {/* Controls (listen/run) */}
                   <ControlsContainer>

--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -345,7 +345,7 @@ export class VisionGui extends React.PureComponent<VisionGuiProps, VisionGuiStat
       () => {
         this._localStorage.merge({
           query: this.state.query,
-          params: this.state.params,
+          params: this.state.rawParams,
           dataset: this.state.dataset,
           apiVersion: customApiVersion || apiVersion,
           perspective: this.state.perspective,

--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -1,57 +1,57 @@
 /* eslint-disable complexity */
-import React, {ChangeEvent, type RefObject} from 'react'
 import SplitPane from '@rexxars/react-split-pane'
-import type {ListenEvent, MutationEvent, SanityClient, ClientPerspective} from '@sanity/client'
-import {PlayIcon, StopIcon, CopyIcon, ErrorOutlineIcon} from '@sanity/icons'
-import isHotkey from 'is-hotkey'
+import type {ClientPerspective, ListenEvent, MutationEvent, SanityClient} from '@sanity/client'
+import {CopyIcon, ErrorOutlineIcon, PlayIcon, StopIcon} from '@sanity/icons'
 import {
-  Flex,
-  Card,
-  Stack,
   Box,
+  Button,
+  Card,
+  Flex,
+  Grid,
   Hotkeys,
+  Inline,
   Select,
+  Stack,
   Text,
   TextInput,
-  Tooltip,
-  Grid,
-  Button,
   ToastContextValue,
-  Inline,
+  Tooltip,
 } from '@sanity/ui'
+import isHotkey from 'is-hotkey'
+import React, {ChangeEvent, type RefObject} from 'react'
 import {TFunction} from 'sanity'
-import {VisionCodeMirror} from '../codemirror/VisionCodeMirror'
-import {getLocalStorage, LocalStorageish} from '../util/localStorage'
-import {parseApiQueryString, ParsedApiQueryString} from '../util/parseApiQueryString'
-import {validateApiVersion} from '../util/validateApiVersion'
-import {prefixApiVersion} from '../util/prefixApiVersion'
-import {tryParseParams} from '../util/tryParseParams'
-import {encodeQueryString} from '../util/encodeQueryString'
 import {API_VERSIONS, DEFAULT_API_VERSION} from '../apiVersions'
-import {PERSPECTIVES, DEFAULT_PERSPECTIVE, isPerspective} from '../perspectives'
-import {ResizeObserver} from '../util/resizeObserver'
+import {VisionCodeMirror} from '../codemirror/VisionCodeMirror'
+import {DEFAULT_PERSPECTIVE, PERSPECTIVES, isPerspective} from '../perspectives'
 import type {VisionProps} from '../types'
+import {encodeQueryString} from '../util/encodeQueryString'
+import {getLocalStorage, type LocalStorageish} from '../util/localStorage'
+import {parseApiQueryString, type ParsedApiQueryString} from '../util/parseApiQueryString'
+import {prefixApiVersion} from '../util/prefixApiVersion'
+import {ResizeObserver} from '../util/resizeObserver'
+import {tryParseParams} from '../util/tryParseParams'
+import {validateApiVersion} from '../util/validateApiVersion'
 import {DelayedSpinner} from './DelayedSpinner'
 import {ParamsEditor, type ParamsEditorChangeEvent} from './ParamsEditor'
-import {ResultView} from './ResultView'
-import {QueryErrorDialog} from './QueryErrorDialog'
 import {PerspectivePopover} from './PerspectivePopover'
+import {QueryErrorDialog} from './QueryErrorDialog'
+import {ResultView} from './ResultView'
 import {
-  Root,
+  ControlsContainer,
   Header,
-  SplitpaneContainer,
-  QueryCopyLink,
   InputBackgroundContainer,
   InputBackgroundContainerLeft,
   InputContainer,
-  StyledLabel,
-  ResultOuterContainer,
-  ResultInnerContainer,
-  ResultContainer,
+  QueryCopyLink,
   Result,
-  ControlsContainer,
-  TimingsFooter,
+  ResultContainer,
+  ResultInnerContainer,
+  ResultOuterContainer,
+  Root,
+  SplitpaneContainer,
+  StyledLabel,
   TimingsCard,
+  TimingsFooter,
   TimingsTextContainer,
 } from './VisionGui.styled'
 

--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -158,15 +158,14 @@ export class VisionGui extends React.PureComponent<VisionGuiProps, VisionGuiStat
     const {client, datasets, config} = props
     this._localStorage = getLocalStorage(client.config().projectId || 'default')
 
-    const lastQuery = this._localStorage.get('query', '')
-    const lastParams = this._localStorage.get('params', '{\n  \n}')
-
     const defaultDataset = config.defaultDataset || client.config().dataset || datasets[0]
     const defaultApiVersion = prefixApiVersion(`${config.defaultApiVersion}`)
     const defaultPerspective = DEFAULT_PERSPECTIVE
 
     let dataset = this._localStorage.get('dataset', defaultDataset)
     let apiVersion = this._localStorage.get('apiVersion', defaultApiVersion)
+    let lastQuery = this._localStorage.get('query', '')
+    let lastParams = this._localStorage.get('params', '{\n  \n}')
     const customApiVersion = API_VERSIONS.includes(apiVersion) ? false : apiVersion
     let perspective = this._localStorage.get('perspective', defaultPerspective)
 
@@ -180,6 +179,14 @@ export class VisionGui extends React.PureComponent<VisionGuiProps, VisionGuiStat
 
     if (!PERSPECTIVES.includes(perspective)) {
       perspective = DEFAULT_PERSPECTIVE
+    }
+
+    if (typeof lastQuery !== 'string') {
+      lastQuery = ''
+    }
+
+    if (typeof lastParams !== 'string') {
+      lastParams = '{\n  \n}'
     }
 
     this._visionRoot = React.createRef()

--- a/packages/@sanity/vision/src/containers/VisionErrorBoundary.tsx
+++ b/packages/@sanity/vision/src/containers/VisionErrorBoundary.tsx
@@ -1,0 +1,87 @@
+/* eslint-disable @sanity/i18n/no-attribute-string-literals */
+/* eslint-disable i18next/no-literal-string */
+import {Button, Card, Code, Container, Heading, Stack} from '@sanity/ui'
+import {Component, type PropsWithChildren} from 'react'
+import {clearLocalStorage} from '../util/localStorage'
+
+/**
+ * @internal
+ */
+export type VisionErrorBoundaryProps = PropsWithChildren
+
+/**
+ * @internal
+ */
+interface VisionErrorBoundaryState {
+  error: string | null
+  numRetries: number
+}
+
+/**
+ * @internal
+ */
+export class VisionErrorBoundary extends Component<
+  VisionErrorBoundaryProps,
+  VisionErrorBoundaryState
+> {
+  constructor(props: VisionErrorBoundaryProps) {
+    super(props)
+    this.state = {error: null, numRetries: 0}
+  }
+
+  static getDerivedStateFromError(error: unknown) {
+    return {error: error instanceof Error ? error.message : `${error}`}
+  }
+
+  handleRetryRender = () =>
+    this.setState((prev) => ({error: null, numRetries: prev.numRetries + 1}))
+
+  handleRetryWithCacheClear = () => {
+    clearLocalStorage()
+    this.handleRetryRender()
+  }
+
+  render() {
+    if (!this.state.error) {
+      return this.props.children
+    }
+
+    const message = this.state.error
+    const withCacheClear = this.state.numRetries > 0
+
+    return (
+      <Card
+        height="fill"
+        overflow="auto"
+        paddingY={[4, 5, 6, 7]}
+        paddingX={4}
+        sizing="border"
+        tone="critical"
+      >
+        <Container width={3}>
+          <Stack space={4}>
+            <div>
+              <Button
+                onClick={withCacheClear ? this.handleRetryWithCacheClear : this.handleRetryRender}
+                text={withCacheClear ? 'Clear cache and retry' : 'Retry'}
+                tone="default"
+              />
+            </div>
+
+            <Heading>An error occured</Heading>
+
+            <Card border radius={2} overflow="auto" padding={4} tone="inherit">
+              <Stack space={4}>
+                {message && (
+                  <Code size={1}>
+                    <strong>Error: {message}</strong>
+                  </Code>
+                )}
+              </Stack>
+            </Card>
+          </Stack>
+        </Container>
+      </Card>
+    )
+  }
+}

--- a/packages/@sanity/vision/src/util/localStorage.ts
+++ b/packages/@sanity/vision/src/util/localStorage.ts
@@ -1,6 +1,7 @@
 import {isPlainObject} from './isPlainObject'
 
 const hasLocalStorage = supportsLocalStorage()
+const keyPrefix = 'sanityVision:'
 
 export interface LocalStorageish {
   get: <T>(key: string, defaultVal: T) => T
@@ -8,8 +9,21 @@ export interface LocalStorageish {
   merge: <T>(props: T) => T
 }
 
+export function clearLocalStorage() {
+  if (!hasLocalStorage) {
+    return
+  }
+
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i)
+    if (key?.startsWith(keyPrefix)) {
+      localStorage.removeItem(key)
+    }
+  }
+}
+
 export function getLocalStorage(namespace: string): LocalStorageish {
-  const storageKey = `sanityVision:${namespace}`
+  const storageKey = `${keyPrefix}${namespace}`
   let loadedState: Record<string, unknown> | null = null
 
   return {get, set, merge}

--- a/packages/@sanity/vision/src/util/validateApiVersion.ts
+++ b/packages/@sanity/vision/src/util/validateApiVersion.ts
@@ -4,6 +4,7 @@ export function validateApiVersion(apiVersion: string): boolean {
   const isValidApiVersion =
     parseableApiVersion.length > 0 &&
     (parseableApiVersion === 'X' ||
+      parseableApiVersion === '1' ||
       (/^\d{4}-\d{2}-\d{2}$/.test(parseableApiVersion) && !isNaN(Date.parse(parseableApiVersion))))
 
   return isValidApiVersion


### PR DESCRIPTION
### Description

When pasting certain URLs (see testing section for one), vision crashes, and worse - stores a value to localStorage that makes it impossible to get vision working again unless you clear localStorage.

This PR:
- Fixes the paste handling (by persisting the "raw" (_string_) parameters instead of a parsed representation
- Fixes handling pasting of a URL with `v1` not being treated as a valid API version
- Adds stricter checking of the localStorage value
- Wraps in an error boundary that (upon one failed retried render) offers to clear cache (localStorage) and retry

While I hope we do not have any more mismatches in expected vs actual values (and thus the error boundary should not be needed), there's always the odd chance that someone already has an invalid localStorage value, or that it is somehow mangled outside of our control.

### What to review

Paste the below URL (and a few others, preferably) and see that it gracefully reflects the pasted URL.

### Testing

Test URL:
```
https://ppsg7ml5.api.sanity.io/v1/data/query/test?query=%5B*%5B_id+in+%5B%22drafts.68af5a9d-838f-4e91-bd31-86ad3809533c%22%2C%2268af5a9d-838f-4e91-bd31-86ad3809533c%22%2C%22drafts.dbfcc04d-34f6-446b-94c4-66d7307a87c5%22%2C%22dbfcc04d-34f6-446b-94c4-66d7307a87c5%22%5D%5D%5B0...4%5D%7B_id%2C_rev%2C_type%2Cstring%2Cimage%2C_createdAt%2C_updatedAt%7D%2C*%5B_id+in+%5B%22drafts.9774e0ad-5e8a-4010-9a74-0a6da6e48745%22%2C%229774e0ad-5e8a-4010-9a74-0a6da6e48745%22%2C%22drafts.88cc1a95-7620-4bd8-aab4-9dace0225108%22%2C%2288cc1a95-7620-4bd8-aab4-9dace0225108%22%2C%22drafts.cc779682-be44-4c05-85a1-d149da933f03%22%2C%22cc779682-be44-4c05-85a1-d149da933f03%22%2C%22drafts.87a247fd-5a7a-4389-b243-e5eb5fde8ad5%22%2C%2287a247fd-5a7a-4389-b243-e5eb5fde8ad5%22%2C%22drafts.59bad8ea-bf9b-4172-bebd-98bea1d8a268%22%2C%2259bad8ea-bf9b-4172-bebd-98bea1d8a268%22%2C%22drafts.56ce3843-4c32-42a6-bbdb-677f6c7852be%22%2C%2256ce3843-4c32-42a6-bbdb-677f6c7852be%22%2C%22drafts.f372794d-d19e-4b3d-a540-0ed764ac683c%22%2C%22f372794d-d19e-4b3d-a540-0ed764ac683c%22%2C%22drafts.0dd9cfe5-398e-4fb8-9f48-b964434d89d2%22%2C%220dd9cfe5-398e-4fb8-9f48-b964434d89d2%22%2C%22drafts.f6824fd3-3805-448a-b974-992594be44b7%22%2C%22f6824fd3-3805-448a-b974-992594be44b7%22%2C%22drafts.534c2cfa-0ed1-433a-b5c8-6f1f2c7dcb8e%22%2C%22534c2cfa-0ed1-433a-b5c8-6f1f2c7dcb8e%22%5D%5D%5B0...20%5D%7B_id%2C_rev%2C_type%2Ctitle%2C_createdAt%2C_updatedAt%7D%2C*%5B_id+in+%5B%22drafts.ecb1e267-e2d8-408a-865a-34c9f4063233%22%2C%22ecb1e267-e2d8-408a-865a-34c9f4063233%22%5D%5D%5B0...2%5D%7B_id%2C_rev%2C_type%2Cname%2Cawards%2Crole%2CrelatedAuthors%2C_updatedAt%2Cimage%2C_createdAt%7D%2C*%5B_id+in+%5B%22drafts.703c5035-a09b-484f-94a2-2c5ccdef78f9%22%2C%22703c5035-a09b-484f-94a2-2c5ccdef78f9%22%5D%5D%5B0...2%5D%7B_id%2C_rev%2C_type%2Ctitle%2Cimage%2C_createdAt%2C_updatedAt%7D%2C*%5B_id+in+%5B%22drafts.presence-test%22%2C%22presence-test%22%5D%5D%5B0...2%5D%7B_id%2C_rev%2C_type%2Ctitle%2CcoverImage%2C_createdAt%2C_updatedAt%7D%5D%5B0...5%5D&tag=sanity.studio.preview.document-paths
```

### Notes for release

- Fixes an issue where the vision tool might crash when pasting a query URL

