### PR TITLE
feat(cli): ensure CWD is project root when running migration commands

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -67,7 +67,7 @@
     "chalk": "^4.1.2",
     "esbuild": "^0.19.8",
     "esbuild-register": "^3.4.1",
-    "find-up": "^7.0.0",
+    "find-up": "^5.0.0",
     "get-it": "^8.4.4",
     "golden-fleece": "^1.0.9",
     "node-machine-id": "^1.1.12",

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -67,6 +67,7 @@
     "chalk": "^4.1.2",
     "esbuild": "^0.19.8",
     "esbuild-register": "^3.4.1",
+    "find-up": "^7.0.0",
     "get-it": "^8.4.4",
     "golden-fleece": "^1.0.9",
     "node-machine-id": "^1.1.12",

--- a/packages/@sanity/cli/src/CommandRunner.ts
+++ b/packages/@sanity/cli/src/CommandRunner.ts
@@ -97,7 +97,7 @@ export class CommandRunner {
       ...commandOptions,
       commandRunner: this,
       yarn: getYarnStub({output, workDir: commandOptions.workDir}),
-      ...getVersionedContextParams(cliConfig),
+      ...getVersionedContextParams(cliConfig, options),
     }
 
     if (isCommandGroup(command)) {
@@ -203,9 +203,15 @@ export function getCliRunner(commands: CommandOrGroup[]): CommandRunner {
 
 function getVersionedContextParams(
   cliConfig: CliConfigResult | null,
+  options: CommandRunnerOptions,
 ):
   | {sanityMajorVersion: 2; cliConfig?: SanityJson; cliConfigPath?: string}
-  | {sanityMajorVersion: 3; cliConfig?: CliConfig; cliConfigPath?: string} {
+  | {
+      sanityMajorVersion: 3
+      cliConfig?: CliConfig
+      cliConfigPath?: string
+      projectRootPath?: string
+    } {
   return cliConfig?.version === 2
     ? {
         sanityMajorVersion: 2,
@@ -216,5 +222,6 @@ function getVersionedContextParams(
         sanityMajorVersion: 3,
         cliConfig: cliConfig?.config || undefined,
         cliConfigPath: cliConfig?.path || undefined,
+        projectRootPath: options.projectRootPath,
       }
 }

--- a/packages/@sanity/cli/src/cli.ts
+++ b/packages/@sanity/cli/src/cli.ts
@@ -23,6 +23,7 @@ import {parseArguments} from './util/parseArguments'
 import {resolveRootDir} from './util/resolveRootDir'
 import {telemetryDisclosure} from './util/telemetryDisclosure'
 import {runUpdateCheck} from './util/updateNotifier'
+import {getProjectRoot} from './util/getProjectRoot'
 
 const sanityEnv = process.env.SANITY_INTERNAL_ENV || 'production' // eslint-disable-line no-process-env
 const knownEnvs = ['development', 'staging', 'production']
@@ -98,6 +99,7 @@ export async function runCli(cliRoot: string, {cliVersion}: {cliVersion: string}
     cliRoot: cliRoot,
     workDir: workDir,
     corePath: await getCoreModulePath(workDir, cliConfig),
+    projectRootPath: cliConfig ? workDir : await getProjectRoot(),
     cliConfig,
     telemetry,
   }

--- a/packages/@sanity/cli/src/cli.ts
+++ b/packages/@sanity/cli/src/cli.ts
@@ -16,6 +16,7 @@ import {type CommandRunnerOptions, type TelemetryUserProperties} from './types'
 import {createTelemetryStore} from './util/createTelemetryStore'
 import {detectRuntime} from './util/detectRuntime'
 import {type CliConfigResult, getCliConfig} from './util/getCliConfig'
+import {getProjectRoot} from './util/getProjectRoot'
 import {loadEnv} from './util/loadEnv'
 import {mergeCommands} from './util/mergeCommands'
 import {neatStack} from './util/neatStack'
@@ -23,7 +24,6 @@ import {parseArguments} from './util/parseArguments'
 import {resolveRootDir} from './util/resolveRootDir'
 import {telemetryDisclosure} from './util/telemetryDisclosure'
 import {runUpdateCheck} from './util/updateNotifier'
-import {getProjectRoot} from './util/getProjectRoot'
 
 const sanityEnv = process.env.SANITY_INTERNAL_ENV || 'production' // eslint-disable-line no-process-env
 const knownEnvs = ['development', 'staging', 'production']

--- a/packages/@sanity/cli/src/types.ts
+++ b/packages/@sanity/cli/src/types.ts
@@ -116,6 +116,7 @@ export interface CliV3CommandContext extends CliBaseCommandContext {
   cliConfig?: CliConfig
   cliPackageManager: CliPackageManager
   telemetry: TelemetryLogger<TelemetryUserProperties>
+  projectRootPath?: string
 }
 
 export interface CliCommandRunner {
@@ -147,6 +148,7 @@ export interface CommandRunnerOptions {
   cliRoot: string
   workDir: string
   corePath: string | undefined
+  projectRootPath: string | undefined
   telemetry: TelemetryLogger<TelemetryUserProperties>
 }
 

--- a/packages/@sanity/cli/src/util/getProjectRoot.ts
+++ b/packages/@sanity/cli/src/util/getProjectRoot.ts
@@ -1,0 +1,14 @@
+import {dirname} from 'node:path'
+
+const CONFIG_FILENAMES = ['sanity.config.ts', 'sanity.config.js', 'sanity.cli.ts', 'sanity.cli.js']
+
+export async function getProjectRoot(): Promise<string | undefined> {
+  const {findUp} = await import('find-up')
+  const rootConfigPath = await findUp(CONFIG_FILENAMES)
+
+  if (rootConfigPath) {
+    return dirname(rootConfigPath)
+  }
+
+  return undefined
+}

--- a/packages/@sanity/cli/src/util/getProjectRoot.ts
+++ b/packages/@sanity/cli/src/util/getProjectRoot.ts
@@ -1,4 +1,5 @@
 import {dirname} from 'node:path'
+
 import findUp from 'find-up'
 
 const CONFIG_FILENAMES = ['sanity.config.ts', 'sanity.config.js', 'sanity.cli.ts', 'sanity.cli.js']

--- a/packages/@sanity/cli/src/util/getProjectRoot.ts
+++ b/packages/@sanity/cli/src/util/getProjectRoot.ts
@@ -1,9 +1,9 @@
 import {dirname} from 'node:path'
+import findUp from 'find-up'
 
 const CONFIG_FILENAMES = ['sanity.config.ts', 'sanity.config.js', 'sanity.cli.ts', 'sanity.cli.js']
 
 export async function getProjectRoot(): Promise<string | undefined> {
-  const {findUp} = await import('find-up')
   const rootConfigPath = await findUp(CONFIG_FILENAMES)
 
   if (rootConfigPath) {

--- a/packages/sanity/src/_internal/cli/actions/graphql/getGraphQLAPIs.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/getGraphQLAPIs.ts
@@ -1,6 +1,7 @@
 import {type CliCommandContext, type CliV3CommandContext} from '@sanity/cli'
 import path from 'path'
 import readPkgUp from 'read-pkg-up'
+import {isModernCliConfig} from '../../util/isModernCliConfig'
 import {createSchema} from 'sanity'
 import {isMainThread, Worker} from 'worker_threads'
 
@@ -56,10 +57,6 @@ function getApisWithSchemaTypes(cliContext: CliCommandContext): Promise<TypeReso
       if (code !== 0) reject(new Error(`Worker stopped with exit code ${code}`))
     })
   })
-}
-
-function isModernCliConfig(config: CliCommandContext): config is CliV3CommandContext {
-  return config.sanityMajorVersion >= 3
 }
 
 function serialize<T>(obj: T): T {

--- a/packages/sanity/src/_internal/cli/actions/graphql/getGraphQLAPIs.ts
+++ b/packages/sanity/src/_internal/cli/actions/graphql/getGraphQLAPIs.ts
@@ -1,10 +1,10 @@
-import {type CliCommandContext, type CliV3CommandContext} from '@sanity/cli'
+import {type CliCommandContext} from '@sanity/cli'
 import path from 'path'
 import readPkgUp from 'read-pkg-up'
-import {isModernCliConfig} from '../../util/isModernCliConfig'
 import {createSchema} from 'sanity'
 import {isMainThread, Worker} from 'worker_threads'
 
+import {isModernCliConfig} from '../../util/isModernCliConfig'
 import {
   type ResolvedGraphQLAPI,
   type ResolvedSourceProperties,

--- a/packages/sanity/src/_internal/cli/commands/migration/createMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/createMigrationCommand.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import {type CliCommandDefinition} from '@sanity/cli'
 import deburr from 'lodash/deburr'
 
+import {ensureCwdIsProjectRoot} from '../../util/ensureCwdIsProjectRoot'
 import {MIGRATIONS_DIRECTORY} from './constants'
 import {minimalAdvanced} from './templates/minimalAdvanced'
 import {minimalSimple} from './templates/minimalSimple'
@@ -45,6 +46,13 @@ const createMigrationCommand: CliCommandDefinition<CreateMigrationFlags> = {
     const {output, prompt, workDir, chalk} = context
 
     let [title] = args.argsWithoutOptions
+
+    const {cwdIsProjectRoot, printCwdProjectRootWarning} = ensureCwdIsProjectRoot(context)
+
+    if (!cwdIsProjectRoot) {
+      printCwdProjectRootWarning()
+      return
+    }
 
     while (!title?.trim()) {
       title = await prompt.single({

--- a/packages/sanity/src/_internal/cli/commands/migration/listMigrationsCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/listMigrationsCommand.ts
@@ -7,6 +7,7 @@ import {Table} from 'console-table-printer'
 import {register} from 'esbuild-register/dist/node'
 
 import {MIGRATION_SCRIPT_EXTENSIONS, MIGRATIONS_DIRECTORY} from './constants'
+import {ensureCwdIsProjectRoot} from '../../util/ensureCwdIsProjectRoot'
 import {isLoadableMigrationScript, resolveMigrationScript} from './utils/resolveMigrationScript'
 
 const helpText = ``
@@ -19,6 +20,13 @@ const listMigrationCommand: CliCommandDefinition = {
   description: 'List available migrations',
   action: async (_, context) => {
     const {workDir, output, chalk} = context
+    const {cwdIsProjectRoot, printCwdProjectRootWarning} = ensureCwdIsProjectRoot(context)
+
+    if (!cwdIsProjectRoot) {
+      printCwdProjectRootWarning()
+      return
+    }
+
     try {
       const migrations = await resolveMigrations(workDir)
 

--- a/packages/sanity/src/_internal/cli/commands/migration/listMigrationsCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/listMigrationsCommand.ts
@@ -6,8 +6,8 @@ import {type Migration} from '@sanity/migrate'
 import {Table} from 'console-table-printer'
 import {register} from 'esbuild-register/dist/node'
 
-import {MIGRATION_SCRIPT_EXTENSIONS, MIGRATIONS_DIRECTORY} from './constants'
 import {ensureCwdIsProjectRoot} from '../../util/ensureCwdIsProjectRoot'
+import {MIGRATION_SCRIPT_EXTENSIONS, MIGRATIONS_DIRECTORY} from './constants'
 import {isLoadableMigrationScript, resolveMigrationScript} from './utils/resolveMigrationScript'
 
 const helpText = ``

--- a/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
@@ -13,6 +13,7 @@ import {hideBin} from 'yargs/helpers'
 import yargs from 'yargs/yargs'
 
 import {debug} from '../../debug'
+import {ensureCwdIsProjectRoot} from '../../util/ensureCwdIsProjectRoot'
 import {resolveMigrations} from './listMigrationsCommand'
 import {prettyFormat} from './prettyMutationFormatter'
 import {isLoadableMigrationScript, resolveMigrationScript} from './utils/resolveMigrationScript'
@@ -77,6 +78,13 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
     const dry = flags.dryRun
     const dataset = flags.dataset
     const project = flags.project
+
+    const {cwdIsProjectRoot, printCwdProjectRootWarning} = ensureCwdIsProjectRoot(context)
+
+    if (!cwdIsProjectRoot) {
+      printCwdProjectRootWarning()
+      return
+    }
 
     if ((dataset && !project) || (project && !dataset)) {
       throw new Error('If either --dataset or --project is provided, both must be provided')

--- a/packages/sanity/src/_internal/cli/util/ensureCwdIsProjectRoot.ts
+++ b/packages/sanity/src/_internal/cli/util/ensureCwdIsProjectRoot.ts
@@ -1,5 +1,7 @@
 import path from 'node:path'
+
 import {type CliCommandContext} from '@sanity/cli'
+
 import {isModernCliConfig} from './isModernCliConfig'
 
 interface EnsureCwdIsProjectRootApi {

--- a/packages/sanity/src/_internal/cli/util/ensureCwdIsProjectRoot.ts
+++ b/packages/sanity/src/_internal/cli/util/ensureCwdIsProjectRoot.ts
@@ -1,0 +1,26 @@
+import {type CliCommandContext} from '@sanity/cli'
+
+interface EnsureCwdIsProjectRootApi {
+  cwdIsProjectRoot: boolean
+  printCwdProjectRootWarning: () => void
+}
+
+export function ensureCwdIsProjectRoot({
+  cliConfig,
+  output,
+  chalk,
+}: CliCommandContext): EnsureCwdIsProjectRootApi {
+  return {
+    cwdIsProjectRoot: typeof cliConfig !== 'undefined',
+    printCwdProjectRootWarning() {
+      output.warn(
+        chalk.yellow(
+          [
+            'No CLI configuration file (sanity.cli.ts/sanity.cli.js) found.',
+            'This command must be run from the root of a Studio project.',
+          ].join('\n'),
+        ),
+      )
+    },
+  }
+}

--- a/packages/sanity/src/_internal/cli/util/ensureCwdIsProjectRoot.ts
+++ b/packages/sanity/src/_internal/cli/util/ensureCwdIsProjectRoot.ts
@@ -24,15 +24,11 @@ export function ensureCwdIsProjectRoot(context: CliCommandContext): EnsureCwdIsP
 
       if (isModernCliConfig(context) && context.projectRootPath) {
         output.print()
+        output.print(`We found a Studio project at ${chalk.cyan(context.projectRootPath)}.`)
         output.print(
-          chalk.grey(`We found a Studio project at ${chalk.cyan(context.projectRootPath)}.`),
-        )
-        output.print(
-          chalk.grey(
-            `Run ${chalk.cyan(
-              `cd ${path.relative(workDir, context.projectRootPath)}`,
-            )} to move there, and then try this command again.`,
-          ),
+          `Run ${chalk.cyan(
+            `cd ${path.relative(workDir, context.projectRootPath)}`,
+          )} to move there, and then try this command again.`,
         )
       }
     },

--- a/packages/sanity/src/_internal/cli/util/ensureCwdIsProjectRoot.ts
+++ b/packages/sanity/src/_internal/cli/util/ensureCwdIsProjectRoot.ts
@@ -1,15 +1,15 @@
+import path from 'node:path'
 import {type CliCommandContext} from '@sanity/cli'
+import {isModernCliConfig} from './isModernCliConfig'
 
 interface EnsureCwdIsProjectRootApi {
   cwdIsProjectRoot: boolean
   printCwdProjectRootWarning: () => void
 }
 
-export function ensureCwdIsProjectRoot({
-  cliConfig,
-  output,
-  chalk,
-}: CliCommandContext): EnsureCwdIsProjectRootApi {
+export function ensureCwdIsProjectRoot(context: CliCommandContext): EnsureCwdIsProjectRootApi {
+  const {cliConfig, output, chalk, workDir} = context
+
   return {
     cwdIsProjectRoot: typeof cliConfig !== 'undefined',
     printCwdProjectRootWarning() {
@@ -21,6 +21,20 @@ export function ensureCwdIsProjectRoot({
           ].join('\n'),
         ),
       )
+
+      if (isModernCliConfig(context) && context.projectRootPath) {
+        output.print()
+        output.print(
+          chalk.grey(`We found a Studio project at ${chalk.cyan(context.projectRootPath)}.`),
+        )
+        output.print(
+          chalk.grey(
+            `Run ${chalk.cyan(
+              `cd ${path.relative(workDir, context.projectRootPath)}`,
+            )} to move there, and then try this command again.`,
+          ),
+        )
+      }
     },
   }
 }

--- a/packages/sanity/src/_internal/cli/util/isModernCliConfig.ts
+++ b/packages/sanity/src/_internal/cli/util/isModernCliConfig.ts
@@ -1,0 +1,5 @@
+import {CliV3CommandContext, type CliCommandContext} from '@sanity/cli'
+
+export function isModernCliConfig(config: CliCommandContext): config is CliV3CommandContext {
+  return config.sanityMajorVersion >= 3
+}

--- a/packages/sanity/src/_internal/cli/util/isModernCliConfig.ts
+++ b/packages/sanity/src/_internal/cli/util/isModernCliConfig.ts
@@ -1,4 +1,4 @@
-import {CliV3CommandContext, type CliCommandContext} from '@sanity/cli'
+import {type CliCommandContext, type CliV3CommandContext} from '@sanity/cli'
 
 export function isModernCliConfig(config: CliCommandContext): config is CliV3CommandContext {
   return config.sanityMajorVersion >= 3

--- a/yarn.lock
+++ b/yarn.lock
@@ -8420,6 +8420,15 @@ find-up@^5.0.0:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
 
+find-up@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-7.0.0.tgz#e8dec1455f74f78d888ad65bf7ca13dd2b4e66fb"
+  integrity sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==
+  dependencies:
+    locate-path "^7.2.0"
+    path-exists "^5.0.0"
+    unicorn-magic "^0.1.0"
+
 find-yarn-workspace-root2@1.2.16:
   version "1.2.16"
   resolved "https://registry.yarnpkg.com/find-yarn-workspace-root2/-/find-yarn-workspace-root2-1.2.16.tgz#60287009dd2f324f59646bdb4b7610a6b301c2a9"
@@ -11236,6 +11245,13 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+locate-path@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-7.2.0.tgz#69cb1779bd90b35ab1e771e1f2f89a202c2a8a8a"
+  integrity sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==
+  dependencies:
+    p-locate "^6.0.0"
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -12661,6 +12677,13 @@ p-limit@^3.0.2, p-limit@^3.1.0:
   dependencies:
     yocto-queue "^0.1.0"
 
+p-limit@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-4.0.0.tgz#914af6544ed32bfa54670b061cafcbd04984b644"
+  integrity sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==
+  dependencies:
+    yocto-queue "^1.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -12688,6 +12711,13 @@ p-locate@^5.0.0:
   integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
   dependencies:
     p-limit "^3.0.2"
+
+p-locate@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-6.0.0.tgz#3da9a49d4934b901089dca3302fa65dc5a05c04f"
+  integrity sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==
+  dependencies:
+    p-limit "^4.0.0"
 
 p-map-series@^2.1.0:
   version "2.1.0"
@@ -12952,6 +12982,11 @@ path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
+path-exists@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-5.0.0.tgz#a6aad9489200b21fab31e49cf09277e5116fb9e7"
+  integrity sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -15903,6 +15938,11 @@ unicode-property-aliases-ecmascript@^2.0.0:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz#43d41e3be698bd493ef911077c9b131f827e8ccd"
   integrity sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==
 
+unicorn-magic@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/unicorn-magic/-/unicorn-magic-0.1.0.tgz#1bb9a51c823aaf9d73a8bfcd3d1a23dde94b0ce4"
+  integrity sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==
+
 union-value@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.1.tgz#0b6fe7b835aecda61c6ea4d4f02c14221e109847"
@@ -16647,6 +16687,11 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yocto-queue@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
+  integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
 
 z-schema@~5.0.2:
   version "5.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8420,15 +8420,6 @@ find-up@^5.0.0:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
 
-find-up@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-7.0.0.tgz#e8dec1455f74f78d888ad65bf7ca13dd2b4e66fb"
-  integrity sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==
-  dependencies:
-    locate-path "^7.2.0"
-    path-exists "^5.0.0"
-    unicorn-magic "^0.1.0"
-
 find-yarn-workspace-root2@1.2.16:
   version "1.2.16"
   resolved "https://registry.yarnpkg.com/find-yarn-workspace-root2/-/find-yarn-workspace-root2-1.2.16.tgz#60287009dd2f324f59646bdb4b7610a6b301c2a9"
@@ -11245,13 +11236,6 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-locate-path@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-7.2.0.tgz#69cb1779bd90b35ab1e771e1f2f89a202c2a8a8a"
-  integrity sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==
-  dependencies:
-    p-locate "^6.0.0"
-
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -12677,13 +12661,6 @@ p-limit@^3.0.2, p-limit@^3.1.0:
   dependencies:
     yocto-queue "^0.1.0"
 
-p-limit@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-4.0.0.tgz#914af6544ed32bfa54670b061cafcbd04984b644"
-  integrity sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==
-  dependencies:
-    yocto-queue "^1.0.0"
-
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -12711,13 +12688,6 @@ p-locate@^5.0.0:
   integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
   dependencies:
     p-limit "^3.0.2"
-
-p-locate@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-6.0.0.tgz#3da9a49d4934b901089dca3302fa65dc5a05c04f"
-  integrity sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==
-  dependencies:
-    p-limit "^4.0.0"
 
 p-map-series@^2.1.0:
   version "2.1.0"
@@ -12982,11 +12952,6 @@ path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
-
-path-exists@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-5.0.0.tgz#a6aad9489200b21fab31e49cf09277e5116fb9e7"
-  integrity sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -15938,11 +15903,6 @@ unicode-property-aliases-ecmascript@^2.0.0:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz#43d41e3be698bd493ef911077c9b131f827e8ccd"
   integrity sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==
 
-unicorn-magic@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/unicorn-magic/-/unicorn-magic-0.1.0.tgz#1bb9a51c823aaf9d73a8bfcd3d1a23dde94b0ce4"
-  integrity sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==
-
 union-value@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.1.tgz#0b6fe7b835aecda61c6ea4d4f02c14221e109847"
@@ -16687,11 +16647,6 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
-
-yocto-queue@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
-  integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
 
 z-schema@~5.0.2:
   version "5.0.6"


### PR DESCRIPTION
### Description

This branch adds an `ensureCwdIsProjectRoot` function that can be used by CLI commands to improve UX when the Sanity CLI is mistakenly used outside of a Studio project root.

If no CLI configuration can be resolved, the CLI will now search parent directories for any Studio or CLI configuration file. If It finds one, it will infer that it is the project root directory and print a notice that the user should move there and try the command again.

This change doesn't affect the way the CLI configuration is resolved; it's only used to print a notice.

I've initially added this to the `migration` commands (`create`, `list`, and `run`).

<img width="867" alt="Screenshot 2024-02-07 at 14 05 41" src="https://github.com/sanity-io/sanity/assets/1454914/3f796c11-f4d2-4fd1-bc38-4be8bcde137a">


### What to review

- That the output printed makes sense.
- That the change doesn't introduce unnecessary overhead (it shouldn't; we only search for config files if one could not already be resolved in the CWD).

### Testing

Run the `migration` commands (`create`, `list`, and `run`) from a subdirectory of a Studio project. For example, the test Studio migrations directory (`dev/test-studio/migrations`). The CLI can be invoked here by running `../../.bin/sanity migration list` etc.