### PR TITLE
feat(migrate): use autoGenerateKeys=true when submitting mutations

### DIFF
--- a/packages/@sanity/migrate/src/fetch-utils/endpoints.ts
+++ b/packages/@sanity/migrate/src/fetch-utils/endpoints.ts
@@ -34,6 +34,7 @@ export const endpoints = {
       options?: {
         returnIds?: boolean
         returnDocuments?: boolean
+        autoGenerateArrayKeys?: boolean
         visibility?: 'async' | 'sync' | 'deferred'
         dryRun?: boolean
         tag?: string
@@ -43,6 +44,7 @@ export const endpoints = {
         options?.tag && ['tag', options.tag],
         options?.returnIds && ['returnIds', 'true'],
         options?.returnDocuments && ['returnDocuments', 'true'],
+        options?.autoGenerateArrayKeys && ['autoGenerateArrayKeys', 'true'],
         options?.visibility && ['visibility', options.visibility],
         options?.dryRun && ['dryRun', 'true'],
       ].filter(Boolean) as [string, string][]

--- a/packages/@sanity/migrate/src/runner/run.ts
+++ b/packages/@sanity/migrate/src/runner/run.ts
@@ -45,7 +45,11 @@ export async function* toFetchOptionsIterable(
       token: apiConfig.token,
       tag: 'sanity.migration.mutate',
       apiHost: apiConfig.apiHost ?? 'api.sanity.io',
-      endpoint: endpoints.data.mutate(apiConfig.dataset, {returnIds: true, visibility: 'async'}),
+      endpoint: endpoints.data.mutate(apiConfig.dataset, {
+        returnIds: true,
+        visibility: 'async',
+        autoGenerateArrayKeys: true,
+      }),
       body: JSON.stringify(transaction),
     })
   }


### PR DESCRIPTION
### Description

Sets `autoGenerateArrayKeys` to `true` when submitting mutations from the `sanity migraiton run` CLI command.

### What to review

### Testing

Did a quick round of manual testing with a Studio having a document open while a mutation ran that added non-keyed array items to an array field in it, and didn't see any issues.


### Notes for release
- Adding objects without unique `_key`s to an array during a content migration will now automatically generate unique `_key`s