### PR TITLE
fix(core): update PortableTextInput doc reference

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -51,7 +51,7 @@ export interface PortableTextMemberItem {
  * Supports multi-user real-time block content editing on larger documents.
  *
  * This component can be configured and customized extensively.
- * {@link https://www.sanity.io/docs/portable-text-features | Go to the documentation for more details}.
+ * {@link https://www.sanity.io/docs/customizing-the-portable-text-editor | Go to the documentation for more details}.
  *
  * @public
  * @param props - {@link PortableTextInputProps} component props.


### PR DESCRIPTION
### Description

Internal TS reference for PortableTextInput customisation returns a 404.

https://www.sanity.io/docs/portable-text-features

This PR updates to the correct place in the documentation.

https://www.sanity.io/docs/customizing-the-portable-text-editor

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
 update PortableTextInput doc reference
<!--
A description of the change(s) that should be used in the release notes.
-->
