### PR TITLE
feat(import): add --allow-system-documents to dataset import

### DIFF
--- a/packages/@sanity/import/README.md
+++ b/packages/@sanity/import/README.md
@@ -85,6 +85,16 @@ const options = {
    * Optional, defaults to `false`.
    */
   skipCrossDatasetReferences: false,
+
+  /**
+   * Whether or not to import system documents (like permissions and custom retention). This
+   * is usually not necessary, and may cause conflicts if the target dataset
+   * already contains these documents. On a new dataset, it is recommended that roles are re-created
+   * manually, and that any custom retention policies are re-created manually.
+   *
+   * Optional, defaults to `false`.
+   */
+  allowSystemDocuments: false,
 }
 
 sanityImport(input, options)

--- a/packages/@sanity/import/src/importFromArray.js
+++ b/packages/@sanity/import/src/importFromArray.js
@@ -30,9 +30,15 @@ async function importDocuments(documents, options) {
     validateCdrDatasets(documents, options)
   }
 
+  let filteredDocuments = documents
+  // Always filter out system documents unless explicitly allowed.
+  if (options.allowSystemDocuments !== true) {
+    filteredDocuments = documents.filter((doc) => !doc._id?.startsWith('_.'))
+  }
+
   // Replace relative asset paths if one is defined
   // (file://./images/foo-bar.png -> file:///abs/olute/images/foo-bar.png)
-  const absPathed = documents.map((doc) => absolutifyPaths(doc, options.assetsBase))
+  const absPathed = filteredDocuments.map((doc) => absolutifyPaths(doc, options.assetsBase))
 
   // Assign document IDs for document that do not have one. This is necessary
   // for us to strengthen references and import assets properly.

--- a/packages/@sanity/import/src/validateOptions.js
+++ b/packages/@sanity/import/src/validateOptions.js
@@ -14,6 +14,7 @@ function validateOptions(input, opts) {
     allowAssetsInDifferentDataset: false,
     replaceAssets: false,
     skipCrossDatasetReferences: false,
+    allowSystemDocuments: false,
   })
 
   if (!isValidInput(input)) {

--- a/packages/@sanity/import/test/__snapshots__/import.test.js.snap
+++ b/packages/@sanity/import/test/__snapshots__/import.test.js.snap
@@ -47,3 +47,85 @@ exports[`rejects on missing asset type prefix 1`] = `
 \`_sanityAsset\` values must be prefixed with a type, eg image@url or file@url.
 See document with ID "deadpool", path: image._sanityAsset]
 `;
+
+exports[`skips system documents if asked: employee creation 1`] = `
+Object {
+  "mutations": Array [
+    Object {
+      "create": Object {
+        "_id": "_.retention.maximum",
+        "_type": "system.retention",
+        "days": 90,
+        "maximum": true,
+        "preferShorter": true,
+      },
+    },
+    Object {
+      "create": Object {
+        "_id": "_.retention.normal",
+        "_type": "system.retention",
+        "days": 3,
+      },
+    },
+    Object {
+      "create": Object {
+        "_id": "_.groups.user",
+        "_type": "system.group",
+        "grants": Array [],
+        "members": Array [
+          "user",
+        ],
+      },
+    },
+    Object {
+      "create": Object {
+        "_id": "radhe",
+        "_type": "employee",
+        "name": "Radhe",
+      },
+    },
+    Object {
+      "create": Object {
+        "_id": "robin",
+        "_type": "employee",
+        "name": "Robin",
+      },
+    },
+    Object {
+      "create": Object {
+        "_id": "matt",
+        "_type": "employee",
+        "name": "Matt",
+      },
+    },
+  ],
+}
+`;
+
+exports[`skips system documents if asked: employee creation 2`] = `
+Object {
+  "mutations": Array [
+    Object {
+      "create": Object {
+        "_id": "radhe",
+        "_type": "employee",
+        "name": "Radhe",
+      },
+    },
+    Object {
+      "create": Object {
+        "_id": "robin",
+        "_type": "employee",
+        "name": "Robin",
+      },
+    },
+    Object {
+      "create": Object {
+        "_id": "matt",
+        "_type": "employee",
+        "name": "Matt",
+      },
+    },
+  ],
+}
+`;

--- a/packages/@sanity/import/test/fixtures/system-documents.ndjson
+++ b/packages/@sanity/import/test/fixtures/system-documents.ndjson
@@ -1,0 +1,6 @@
+{"_id": "_.retention.maximum", "_type": "system.retention", "days": 90, "maximum": true, "preferShorter": true}
+{"_id": "_.retention.normal", "_type": "system.retention", "days": 3}
+{"_id": "_.groups.user", "_type": "system.group", "members": ["user"], "grants": []}
+{"_id": "radhe", "_type": "employee", "name": "Radhe"}
+{"_id": "robin", "_type": "employee", "name": "Robin"}
+{"_id": "matt", "_type": "employee", "name": "Matt"}

--- a/packages/@sanity/import/test/import.test.js
+++ b/packages/@sanity/import/test/import.test.js
@@ -158,6 +158,20 @@ test('can drop cross-dataset references', async () => {
   expect(res).toMatchObject({numDocs: 6, warnings: []})
 })
 
+test('skips system documents if asked', async () => {
+  const client = getSanityClient(getMockMutationHandler())
+  let res = await importer(getFixtureStream('system-documents'), {
+    client,
+    allowSystemDocuments: true,
+  })
+  expect(res).toMatchObject({numDocs: 6, warnings: []})
+
+  res = await importer(getFixtureStream('system-documents'), {
+    client,
+  })
+  expect(res).toMatchObject({numDocs: 3, warnings: []})
+})
+
 function getMockMutationHandler(match = 'employee creation') {
   return (req) => {
     const options = req.context.options

--- a/packages/sanity/src/_internal/cli/commands/dataset/importDatasetCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/dataset/importDatasetCommand.ts
@@ -23,6 +23,7 @@ Options
 
 Rarely used options (should generally not be used)
   --allow-assets-in-different-dataset Allow asset documents to reference different project/dataset
+  --allow-system-documents Allow system documents like dataset permissions and custom retention to be imported
 
 Examples
   # Import "moviedb.ndjson" from the current directory to the dataset called "moviedb"
@@ -47,6 +48,7 @@ interface ImportFlags {
   'asset-concurrency'?: boolean
   'replace-assets'?: boolean
   'skip-cross-dataset-references'?: boolean
+  'allow-system-documents'?: boolean
   replace?: boolean
   missing?: boolean
 }
@@ -56,6 +58,7 @@ interface ParsedImportFlags {
   allowFailingAssets?: boolean
   assetConcurrency?: boolean
   skipCrossDatasetReferences?: boolean
+  allowSystemDocuments?: boolean
   replaceAssets?: boolean
   replace?: boolean
   missing?: boolean
@@ -82,6 +85,7 @@ function parseFlags(rawFlags: ImportFlags): ParsedImportFlags {
   const assetConcurrency = toBoolIfSet(rawFlags['asset-concurrency'])
   const replaceAssets = toBoolIfSet(rawFlags['replace-assets'])
   const skipCrossDatasetReferences = toBoolIfSet(rawFlags['skip-cross-dataset-references'])
+  const allowSystemDocuments = toBoolIfSet(rawFlags['allow-system-documents'])
   const replace = toBoolIfSet(rawFlags.replace)
   const missing = toBoolIfSet(rawFlags.missing)
   return {
@@ -89,6 +93,7 @@ function parseFlags(rawFlags: ImportFlags): ParsedImportFlags {
     allowFailingAssets,
     assetConcurrency,
     skipCrossDatasetReferences,
+    allowSystemDocuments,
     replaceAssets,
     replace,
     missing,
@@ -110,6 +115,7 @@ const importDatasetCommand: CliCommandDefinition = {
       allowFailingAssets,
       assetConcurrency,
       skipCrossDatasetReferences,
+      allowSystemDocuments,
       replaceAssets,
     } = flags
 
@@ -248,6 +254,7 @@ const importDatasetCommand: CliCommandDefinition = {
         allowFailingAssets,
         allowAssetsInDifferentDataset,
         skipCrossDatasetReferences,
+        allowSystemDocuments,
         assetConcurrency,
         replaceAssets,
       })


### PR DESCRIPTION
### Description

As part of the import process through CLI and `@sanity/import` package, we prefer that users do not send in system documents. These documents are considering to be an internal detail and if imported, their interaction with existing system documents is undefined.

This PR attempts at adding a new flag `--allow-system-documents` to `sanity dataset import` CLI and an option `allowSystemDocument` to `@sanity/import` package, to explicitly permit system document import if the user knows what they are doing.

This can be considered to be a breaking change since it by default skips system documents from import, but I highly doubt anyone is importing system documents from CLI. And, if they are, they should stop doing that. Ideally, I should add data to my gut-feeling and figure out how many users are importing system documents directly from CLI but it's not trivial to get these numbers. Let me know if this needs to be done.

Background for change is present in #prj-dataset-backups.

### Bikeshedding

Two appropriate names for the flag are `--import-system-documents` or `--allow-system-documents`. I have weak preference for the latter since it aligns with existing options on the same subcommand.

### Testing
Two unit tests are added where import with and without this flag is tested.

### Notes for Release
It should okay to add commit message as it is to release notes.