### PR TITLE
fix(cli): project root resolution

### DIFF
--- a/packages/@sanity/cli/src/util/resolveRootDir.ts
+++ b/packages/@sanity/cli/src/util/resolveRootDir.ts
@@ -17,8 +17,8 @@ export function resolveRootDir(cwd: string): string {
 
 function hasStudioConfig(basePath: string): boolean {
   const buildConfigs = [
-    fileExists(path.join(basePath, 'studio.config.js')),
-    fileExists(path.join(basePath, 'studio.config.ts')),
+    fileExists(path.join(basePath, 'sanity.config.js')),
+    fileExists(path.join(basePath, 'sanity.config.ts')),
     isSanityV2StudioRoot(basePath),
   ]
 

--- a/packages/@sanity/cli/test/basics.test.ts
+++ b/packages/@sanity/cli/test/basics.test.ts
@@ -1,3 +1,5 @@
+import path from 'node:path'
+
 import {describeCliTest, testConcurrent} from './shared/describe'
 import {getCliUserEmail, runSanityCmdCommand, studioVersions} from './shared/environment'
 
@@ -19,6 +21,15 @@ describeCliTest('CLI: basic commands', () => {
 
     testConcurrent('help', async () => {
       const result = await runSanityCmdCommand(version, ['help'])
+      expect(result.stdout).toMatch(/usage:/i)
+      expect(result.code).toBe(0)
+    })
+
+    testConcurrent('help (from subdirectory)', async () => {
+      const result = await runSanityCmdCommand(version, ['help'], {
+        cwd: (cwd) => path.join(cwd, 'components'),
+      })
+      expect(result.stdout).toContain('Not in project directory')
       expect(result.stdout).toMatch(/usage:/i)
       expect(result.code).toBe(0)
     })

--- a/packages/@sanity/cli/test/shared/environment.ts
+++ b/packages/@sanity/cli/test/shared/environment.ts
@@ -125,14 +125,16 @@ export const getTestRunArgs = (version: string) => {
 export function runSanityCmdCommand(
   version: string,
   args: string[],
-  options: {env?: Record<string, string | undefined>} = {},
+  options: {env?: Record<string, string | undefined>; cwd?: (cwd: string) => string} = {},
 ): Promise<{
   code: number | null
   stdout: string
   stderr: string
 }> {
+  const cwd = options.cwd ?? ((currentCwd) => currentCwd)
+
   return exec(process.argv[0], [cliBinPath, ...args], {
-    cwd: path.join(studiosPath, version),
+    cwd: cwd(path.join(studiosPath, version)),
     env: {...sanityEnv, ...options.env},
   })
 }


### PR DESCRIPTION
### Description

The CLI is intended to automatically resolve the project root if it's used inside the subdirectory of a Studio project. This behaviour has been broken for v3, because the resolution code mistakenly searches for `studio.config.{ts,js}` files, rather than `sanity.config.{ts,js}`. Therefore, it never finds the project root.

This was discovered and discussed in #5684.

### What to review

- That it's possible to use the CLI inside the subdirectory of a Studio project.
- That when doing so, a warning is printed: "Not in project directory, assuming context of project at ${path}".

### Testing

- I've added a basic CLI unit test to ensure the `help` command can be executed inside Studio project subdirectories, and that the warning is printed.

### Notes for release

Fixed a bug that prevented the CLI being used inside Studio project subdirectories.
