### PR TITLE
fix(cli) allow cli tests to run with a robot token

### DIFF
--- a/packages/@sanity/cli/test/basics.test.ts
+++ b/packages/@sanity/cli/test/basics.test.ts
@@ -11,7 +11,9 @@ describeCliTest('CLI: basic commands', () => {
 
     testConcurrent('debug', async () => {
       const result = await runSanityCmdCommand(version, ['debug'])
-      expect(result.stdout).toContain(await getCliUserEmail())
+      expect(result.stdout).toContain(
+        `Email: \x1B[1m${(await getCliUserEmail()) || 'null'}\x1B[22m`,
+      )
       expect(result.code).toBe(0)
     })
 


### PR DESCRIPTION
### Description
The CLI test suite have been running with a session token for a test user with a registered email. This token has a short expiry and causes the test suite to suddenly start failing when the token expires. Using a robot token works, but one of the assertions for `sanity debug` output fails because the email of the roboto token is `null`. This fixes the issue by allowing `null` as a valid email, which should not make it matter whether the tests are run using a session token or a robot token.

### What to review
Does it make sense?

### Testing
Self evident

### Notes for release

n/a internal