### PR TITLE
fix(structure): use useDocumentTitle hook for toast message

### DIFF
--- a/packages/sanity/src/structure/panes/document/DocumentOperationResults.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentOperationResults.tsx
@@ -5,20 +5,21 @@ import {Translate, useDocumentOperationEvent, useTranslation} from 'sanity'
 import {usePaneRouter} from '../../components'
 import {structureLocaleNamespace} from '../../i18n'
 import {useDocumentPane} from './useDocumentPane'
+import {useDocumentTitle} from './useDocumentTitle'
 
 const IGNORE_OPS = ['patch', 'commit']
 
 export const DocumentOperationResults = memo(function DocumentOperationResults() {
   const {push: pushToast} = useToast()
-  const {documentId, documentType, displayed} = useDocumentPane()
+  const {documentId, documentType} = useDocumentPane()
+  const {title} = useDocumentTitle()
   const event: any = useDocumentOperationEvent(documentId, documentType)
   const prevEvent = useRef(event)
   const paneRouter = usePaneRouter()
   const {t} = useTranslation(structureLocaleNamespace)
 
   //Truncate the document title and add "..." if it is over 25 characters
-  const documentTitleBase =
-    (displayed?.title as string) || t('panes.document-operation-results.operation-undefined-title')
+  const documentTitleBase = title || t('panes.document-operation-results.operation-undefined-title')
   const documentTitle =
     documentTitleBase.length > 25 ? `${documentTitleBase.slice(0, 25)}...` : documentTitleBase
 


### PR DESCRIPTION
### Description
The toast message for when documents are published or deleted did not use the `useDocumentTitle()` hook. This PR fixes it so that the the toast message uses the same logic that the large title of the document uses. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
The toast message that appears when a document is published/deleted. 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes issue where the toast message always shows the correct title
<!--
A description of the change(s) that should be used in the release notes.
-->
