### PR TITLE
fix(structure): intent menu item nodes not rendering

### DIFF
--- a/dev/test-studio/structure/resolveStructure.ts
+++ b/dev/test-studio/structure/resolveStructure.ts
@@ -1,5 +1,6 @@
 import {
   CodeIcon,
+  CogIcon,
   EarthGlobeIcon,
   ImagesIcon,
   JoystickIcon,
@@ -48,6 +49,19 @@ export const structure: StructureResolver = (S, {schema, documentStore, i18n}) =
         .child(
           S.list()
             .title('Untitled repro')
+            .menuItems([
+              S.menuItem()
+                .title('Edit GRRM')
+                .icon(CogIcon)
+                .showAsAction(true)
+                .intent({
+                  type: 'edit',
+                  params: {
+                    id: 'grrm',
+                    type: 'author',
+                  },
+                }),
+            ])
             .items([
               S.documentListItem().id('grrm').schemaType('author'),
               S.listItem()

--- a/packages/sanity/src/core/components/StatusButton.tsx
+++ b/packages/sanity/src/core/components/StatusButton.tsx
@@ -6,6 +6,7 @@ import {Button, type ButtonProps} from '../../ui-components'
 
 /** @hidden @beta */
 export type StatusButtonProps = ButtonProps & {
+  forwardedAs?: string
   disabled?: boolean | {reason: ReactNode}
   mode?: ButtonProps['mode']
   iconRight?: undefined

--- a/packages/sanity/src/structure/components/pane/PaneHeaderActionButton.tsx
+++ b/packages/sanity/src/structure/components/pane/PaneHeaderActionButton.tsx
@@ -95,7 +95,7 @@ function PaneHeaderActionIntentButton(props: {intent: Intent; node: _PaneMenuIte
 
   return (
     <StatusButton
-      as="a"
+      forwardedAs="a"
       disabled={isDisabled}
       href={intentLink.href}
       icon={node.icon}

--- a/packages/sanity/src/structure/components/pane/PaneHeaderActionButton.tsx
+++ b/packages/sanity/src/structure/components/pane/PaneHeaderActionButton.tsx
@@ -10,6 +10,10 @@ import {PaneMenuButtonItem} from './PaneMenuButtonItem'
 import {type _PaneMenuGroup, type _PaneMenuItem} from './types'
 
 function getDisabledReason(node: _PaneMenuItem) {
+  if (!node.disabled) {
+    return {disabledReason: undefined, ariaLabel: undefined, isDisabled: false}
+  }
+
   /**
    * This component supports receiving a `reason: string | react.ReactNode`.
    * We are casting it as string, to avoid the ts error, as content will be rendered into the tooltip which only accepts string, but it won't crash if it's a ReactNode.
@@ -60,7 +64,7 @@ export function PaneHeaderMenuItemActionButton(props: PaneHeaderMenuItemActionBu
 
   return (
     <StatusButton
-      disabled={Boolean(node.disabled)}
+      disabled={isDisabled}
       icon={node.icon}
       // eslint-disable-next-line react/jsx-handler-names
       onClick={node.onAction}

--- a/packages/sanity/src/structure/menuNodes.ts
+++ b/packages/sanity/src/structure/menuNodes.ts
@@ -78,6 +78,7 @@ export function resolveMenuNodes(params: {
 
         hotkey: item.shortcut,
         icon: item.icon,
+        intent: item.intent,
         onAction: () => params.actionHandler(item),
         renderAsButton: item.showAsAction ?? false,
         selected: item.selected,
@@ -92,6 +93,7 @@ export function resolveMenuNodes(params: {
 
         hotkey: item.shortcut,
         icon: item.icon,
+        intent: item.intent,
         onAction: () => params.actionHandler(item),
         renderAsButton: item.showAsAction ?? false,
         selected: item.selected,


### PR DESCRIPTION
### Description

Fixes #4891

Menu items in structure nodes that defined an intent instead of an action handler did not work after the facelift launch. There appears to be multiple different issues that caused this - I have addressed them in separate commits:

1. The `intent` definition was not actually passed onto the structure nodes, leading to them being treated as a menu button without an action handler instead of an intent button
2. The intent buttons did not actually render, because the `as="a"` rendered the entire button as a single link without any styling. I've modified it to use `forwardedAs`, but I am not confident that this approach is correct, or needs adjustment.

While investigating, I also found that the menu buttons got an aria label of `This is disabled`, even when not disabled. For now, I have disabled the aria label when not disabled, and will follow up with a PR to localize this string as well.

### What to review

1. Intent buttons work as expected. There is a test case in the test studio under the `Untitled repro` item: click the cogwheel in the next pane, which _should_ open GRRM in a document editor if this works as intended.


### Notes for release

- Fixes an issue where menu items defined in structure that used intents would not work
