### PR TITLE
feat(tasks): add document navigation from tasks

### DIFF
--- a/packages/sanity/src/tasks/__workshop__/TasksCreateStory.tsx
+++ b/packages/sanity/src/tasks/__workshop__/TasksCreateStory.tsx
@@ -7,7 +7,7 @@ export default function TasksCreateStory() {
   return (
     <TasksSetupProvider>
       <TasksProvider>
-        <TasksCreate onCancel={noop} />
+        <TasksCreate onCancel={noop} mode="create" />
       </TasksProvider>
     </TasksSetupProvider>
   )

--- a/packages/sanity/src/tasks/plugin/TasksDocumentInputLayout.tsx
+++ b/packages/sanity/src/tasks/plugin/TasksDocumentInputLayout.tsx
@@ -1,7 +1,5 @@
-import {TasksEnabledProvider, TasksProvider, TasksSetupProvider} from '../src'
-import {DocumentLayoutProps, FieldProps, InputProps, ObjectInputProps, getPublishedId} from 'sanity'
 import {SetActiveDocument} from '../src/tasks/components/SetActiveDocument'
-import {useMemo} from 'react'
+import {ObjectInputProps} from 'sanity'
 
 export function TasksDocumentInputLayout(props: ObjectInputProps) {
   const documentId = props.value?._id

--- a/packages/sanity/src/tasks/src/tasks/components/create/TasksCreate.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/create/TasksCreate.tsx
@@ -4,10 +4,10 @@ import {PortableTextBlock} from '@sanity/types'
 import {Button} from '../../../../../ui-components'
 import {useTasks} from '../../context'
 import {CommentInput, useMentionOptions} from '../../../../../structure/comments'
-import {useCurrentUser} from '../../../../../core'
 import {TaskDocument} from '../../types'
 import {RemoveTask} from '../remove/RemoveTask'
 import {WarningText} from './WarningText'
+import {useCurrentUser} from 'sanity'
 
 type ModeProps =
   | {

--- a/packages/sanity/src/tasks/src/tasks/components/sidebar/TasksSidebarContent.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/sidebar/TasksSidebarContent.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react'
+import {Dispatch, SetStateAction, useMemo} from 'react'
 import {Box, Card} from '@sanity/ui'
 import {TaskDocument} from '../../types'
 import {TasksList} from '../list/TasksList'
@@ -20,7 +20,7 @@ export function TaskSidebarContent({
   activeDocumentId?: string
   onTaskSelect: (id: string) => void
   activeTabId: SidebarTabsIds
-  setActiveTabId: (id: SidebarTabsIds) => void
+  setActiveTabId: Dispatch<SetStateAction<SidebarTabsIds>>
 }) {
   const currentUser = useCurrentUser()
   const filteredList = useMemo(() => {

--- a/packages/sanity/src/tasks/src/tasks/types.ts
+++ b/packages/sanity/src/tasks/src/tasks/types.ts
@@ -87,6 +87,7 @@ type TaskState = TaskCreateFailedState | TaskCreateRetryingState | undefined
 export interface TaskDocument {
   _type: 'tasks.task'
   _createdAt: string
+  _updatedAt: string
   _id: string
   _rev: string
   _state?: TaskState


### PR DESCRIPTION
### Description

Clicking on the task document reference will navigate to that document. 

<img width="354" alt="Screenshot 2024-02-14 at 09 07 56" src="https://github.com/sanity-io/sanity/assets/46196328/3533fa2c-e44e-489d-b26f-944dec359409">

Updates some imports and refactors some types.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
