### PR TITLE
fix(tasks): utilise document preview store for document titles

### DIFF
--- a/packages/sanity/src/tasks/src/tasks/components/list/DocumentPreview.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/list/DocumentPreview.tsx
@@ -47,10 +47,11 @@ export function DocumentPreview({
   if (!documentSchema) {
     return null
   }
+
   return (
     <Flex align="center" gap={1}>
       <DocumentIcon />
-      {isLoading || !value?.title ? (
+      {isLoading ? (
         <TextSkeleton size={1} muted />
       ) : (
         <Text size={1} muted as={Link}>

--- a/packages/sanity/src/tasks/src/tasks/components/list/DocumentPreview.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/list/DocumentPreview.tsx
@@ -2,9 +2,18 @@ import {DocumentIcon} from '@sanity/icons'
 import {Flex, Text, TextSkeleton} from '@sanity/ui'
 import {forwardRef, useMemo} from 'react'
 import {useSchema} from 'sanity'
+import {IntentLink} from 'sanity/router'
+import styled from 'styled-components'
 
 import {useDocumentPreviewValues} from '../../hooks/useDocumentPreviewValues'
-import {StyledIntentLink} from './TasksListItem'
+
+const StyledIntentLink = styled(IntentLink)`
+  text-decoration: none;
+
+  :hover {
+    text-decoration: underline;
+  }
+`
 
 export function DocumentPreview({
   documentId,

--- a/packages/sanity/src/tasks/src/tasks/components/list/DocumentPreview.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/list/DocumentPreview.tsx
@@ -1,0 +1,53 @@
+import {DocumentIcon} from '@sanity/icons'
+import {Flex, Text, TextSkeleton} from '@sanity/ui'
+import {forwardRef, useMemo} from 'react'
+import {useSchema} from 'sanity'
+
+import {useDocumentPreviewValues} from '../../hooks/useDocumentPreviewValues'
+import {StyledIntentLink} from './TasksListItem'
+
+export function DocumentPreview({
+  documentId,
+  documentType,
+}: {
+  documentId: string
+  documentType: string
+}) {
+  const schema = useSchema()
+  const documentSchema = schema.get(documentType)
+  const {isLoading, value} = useDocumentPreviewValues({
+    documentId,
+    documentType,
+  })
+
+  const Link = useMemo(
+    () =>
+      forwardRef(function LinkComponent(linkProps, ref: React.ForwardedRef<HTMLAnchorElement>) {
+        return (
+          <StyledIntentLink
+            {...linkProps}
+            intent="edit"
+            params={{id: documentId, type: documentType}}
+            ref={ref}
+          />
+        )
+      }),
+    [documentId, documentType],
+  )
+
+  if (!documentSchema) {
+    return null
+  }
+  return (
+    <Flex align="center" gap={1}>
+      <DocumentIcon />
+      {isLoading || !value?.title ? (
+        <TextSkeleton size={1} muted />
+      ) : (
+        <Text size={1} muted as={Link}>
+          {value?.title || 'Untitled'}
+        </Text>
+      )}
+    </Flex>
+  )
+}

--- a/packages/sanity/src/tasks/src/tasks/components/list/TasksListItem.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/list/TasksListItem.tsx
@@ -2,7 +2,6 @@ import {CalendarIcon, UserIcon} from '@sanity/icons'
 import {Card, type CardProps, Flex, Stack, Text, TextSkeleton} from '@sanity/ui'
 import {useMemo} from 'react'
 import {useDateTimeFormat, useUser} from 'sanity'
-import {IntentLink} from 'sanity/router'
 import styled from 'styled-components'
 
 import {type TaskDocument} from '../../types'
@@ -26,14 +25,6 @@ export const ThreadCard = styled(Card).attrs<CardProps>(({tone}) => ({
 
 const Title = styled(Text)`
   &:hover {
-    text-decoration: underline;
-  }
-`
-
-export const StyledIntentLink = styled(IntentLink)`
-  text-decoration: none;
-
-  :hover {
     text-decoration: underline;
   }
 `

--- a/packages/sanity/src/tasks/src/tasks/components/sidebar/TasksListTabs.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/sidebar/TasksListTabs.tsx
@@ -10,7 +10,7 @@ const LIST_STYLES: CSSProperties = {marginLeft: '-0.5em'}
 
 interface TasksListTabsProps {
   activeTabId: string
-  onChange: (id: SidebarTabsIds) => void
+  onChange: Dispatch<SetStateAction<SidebarTabsIds>>
 }
 
 interface TasksListTab {

--- a/packages/sanity/src/tasks/src/tasks/components/sidebar/TasksListTabs.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/sidebar/TasksListTabs.tsx
@@ -10,7 +10,7 @@ const LIST_STYLES: CSSProperties = {marginLeft: '-0.5em'}
 
 interface TasksListTabsProps {
   activeTabId: string
-  onChange: Dispatch<SetStateAction<SidebarTabsIds>>
+  onChange: (id: SidebarTabsIds) => void
 }
 
 interface TasksListTab {

--- a/packages/sanity/src/tasks/src/tasks/components/sidebar/TasksSidebar.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/sidebar/TasksSidebar.tsx
@@ -63,7 +63,7 @@ export function TasksStudioSidebar() {
               <>
                 {isLoading ? (
                   <Box padding={3}>
-                    <Flex align="center">
+                    <Flex align="center" justify="center">
                       <Spinner />
                     </Flex>
                   </Box>

--- a/packages/sanity/src/tasks/src/tasks/hooks/useDocumentPreviewValues.ts
+++ b/packages/sanity/src/tasks/src/tasks/hooks/useDocumentPreviewValues.ts
@@ -1,0 +1,50 @@
+import {type ElementType, type ReactNode} from 'react'
+import {useMemoObservable} from 'react-rx'
+import {of} from 'rxjs'
+import {
+  getPreviewStateObservable,
+  type PreviewValue,
+  useDocumentPreviewStore,
+  useSchema,
+} from 'sanity'
+
+interface PreviewHookOptions {
+  documentId: string
+  documentType: string
+}
+
+interface PreviewHookValue {
+  isLoading: boolean
+  value: Partial<PreviewValue> | null
+}
+
+/** @internal */
+export function useDocumentPreviewValues(options: PreviewHookOptions): PreviewHookValue {
+  const {documentId, documentType} = options || {}
+  const schemaType = useSchema().get(documentType)
+
+  const documentPreviewStore = useDocumentPreviewStore()
+
+  const previewState = useMemoObservable(() => {
+    if (!documentId || !schemaType) return of(null)
+    return getPreviewStateObservable(documentPreviewStore, schemaType, documentId, '')
+  }, [documentId, documentPreviewStore, schemaType])
+
+  const isLoading = previewState?.isLoading ?? true
+
+  const {published, draft} = previewState || {}
+  const documentTitle = (draft?.title || published?.title) as string | undefined
+  const subtitle = (draft?.subtitle || published?.subtitle) as string | undefined
+  const description = (draft?.description || published?.description) as string | undefined
+  const media = (draft?.media || published?.media) as ReactNode | ElementType | undefined
+
+  return {
+    isLoading,
+    value: {
+      title: documentTitle,
+      subtitle,
+      media,
+      description,
+    },
+  }
+}


### PR DESCRIPTION
### Description

This fixes document previews in tasks by utilising the same drafts-aware preview store as the document lists.