### PR TITLE
fix(structure): allow sanity.previewUrlSecret in document lists

### DIFF
--- a/dev/test-studio/.depcheckignore.json
+++ b/dev/test-studio/.depcheckignore.json
@@ -2,10 +2,11 @@
   "//": "https://github.com/depcheck/depcheck/pull/756",
   "ignore": [
     "https:",
+    "@portabletext/react",
     "@sanity/client",
-    "@vercel/stega",
-    "@sanity/visual-editing",
+    "@sanity/preview-url-secret",
     "@sanity/react-loader",
-    "@portabletext/react"
+    "@sanity/visual-editing",
+    "@vercel/stega"
   ]
 }

--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -35,6 +35,7 @@
     "@sanity/logos": "^2.1.2",
     "@sanity/migrate": "3.29.1",
     "@sanity/portable-text-editor": "3.29.1",
+    "@sanity/preview-url-secret": "^1.6.1",
     "@sanity/react-loader": "^1.8.3",
     "@sanity/tsdoc": "1.0.0-alpha.38",
     "@sanity/types": "3.29.1",

--- a/dev/test-studio/plugins/router-debug/RouterDebug.tsx
+++ b/dev/test-studio/plugins/router-debug/RouterDebug.tsx
@@ -1,4 +1,6 @@
+import {createPreviewSecret} from '@sanity/preview-url-secret/create-secret'
 import {Button, Card, Code, Flex, Stack, Text} from '@sanity/ui'
+import {useClient} from 'sanity'
 import {IntentLink, RouteScope, StateLink, useRouter, useStateLink} from 'sanity/router'
 
 export function RouterDebug() {
@@ -11,10 +13,16 @@ export function RouterDebug() {
     },
   })
 
+  const client = useClient()
+
   return (
     <Card sizing="border" padding={5}>
       <Flex>
         <Stack space={4}>
+          <Button onClick={() => createPreviewSecret(client, 'test-studio', location.href)}>
+            Create Secret
+          </Button>
+
           <StateLink state={{}}>Tool home</StateLink>
           <StateLink
             state={{

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -7,6 +7,7 @@ import {nnNOLocale} from '@sanity/locale-nn-no'
 import {ptPTLocale} from '@sanity/locale-pt-pt'
 import {svSELocale} from '@sanity/locale-sv-se'
 import {SanityMonogram} from '@sanity/logos'
+import {debugSecrets} from '@sanity/preview-url-secret/sanity-plugin-debug-secrets'
 import {tsdoc} from '@sanity/tsdoc/studio'
 import {visionTool} from '@sanity/vision'
 import {defineConfig, definePlugin} from 'sanity'
@@ -284,6 +285,7 @@ export default defineConfig([
     projectId: 'ppsg7ml5',
     dataset: 'playground',
     plugins: [
+      debugSecrets(),
       presentationTool({
         previewUrl: '/preview/index.html',
       }),

--- a/packages/sanity/src/core/search/common/utils.ts
+++ b/packages/sanity/src/core/search/common/utils.ts
@@ -5,7 +5,8 @@ import {isNonNullable} from '../../util/isNonNullable'
 const isDocumentType = (type: SchemaType): type is ObjectSchemaType =>
   Boolean(type.type && type.type.name === 'document')
 
-const isSanityType = (type: SchemaType): boolean => type.name.startsWith('sanity.')
+const isIgnoredType = (type: SchemaType): boolean =>
+  type.name.startsWith('sanity.') && type.name !== 'sanity.previewUrlSecret'
 
 /**
  * @internal
@@ -16,4 +17,4 @@ export const getSearchableTypes = (schema: Schema): ObjectSchemaType[] =>
     .map((typeName) => schema.get(typeName))
     .filter(isNonNullable)
     .filter((schemaType) => isDocumentType(schemaType))
-    .filter((type) => !isSanityType(type)) as ObjectSchemaType[]
+    .filter((type) => !isIgnoredType(type)) as ObjectSchemaType[]

--- a/packages/sanity/src/structure/panes/documentList/listenSearchQuery.ts
+++ b/packages/sanity/src/structure/panes/documentList/listenSearchQuery.ts
@@ -90,7 +90,7 @@ export function listenSearchQuery(options: ListenQueryOptions): Observable<Sanit
         mergeMap((typeNames: string[]) => {
           const types = getSearchTypesWithMaxDepth(
             getSearchableTypes(schema).filter((type) => {
-              return typeNames.includes(type.name) || type.name === 'sanity.previewUrlSecret'
+              return typeNames.includes(type.name)
             }),
             maxFieldDepth,
           )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -425,6 +425,9 @@ importers:
       '@sanity/portable-text-editor':
         specifier: 3.29.1
         version: link:../../packages/@sanity/portable-text-editor
+      '@sanity/preview-url-secret':
+        specifier: ^1.6.1
+        version: 1.6.1(@sanity/client@6.12.4)
       '@sanity/react-loader':
         specifier: ^1.8.3
         version: 1.8.3(@sanity/client@6.12.4)(react@18.2.0)


### PR DESCRIPTION
### Description

The #5657 PR didn't manage to fix the regression in #5440. With the help of @sjelfull this time it's actually resolved and the fix reproducible on the Test Studio.

### What to review

Adding `sanity.previewUrlSecret` should only have an effect on this particular type, other `sanity.` prefixed types shouldn't show up anywhere, like in global search.

### Testing

In a Studio that has this plugin installed:
```ts
import {debugSecrets} from '@sanity/preview-url-secret/sanity-plugin-debug-secrets'
import {defineConfig} from 'sanity'

export default defineConfig({
  // ...
  plugins: [
    debugSecrets()
  ]
})
```
Then Structure tool should show this menu:
![image](https://github.com/sanity-io/sanity/assets/81981/129c218d-7d33-4b89-be10-10d0888921aa)
And global search should let you filter by the type as well:
![image](https://github.com/sanity-io/sanity/assets/81981/ef4c27d5-ecf1-45f9-90b3-795e956228af)


When the plugin isn't used then these document types should remain hidden:
![image](https://github.com/sanity-io/sanity/assets/81981/95c197ae-9c0e-4cd7-87c3-cfc5e2fc98e6)


### Notes for release

- fixed regression that affected `import {debugSecrets} from '@sanity/preview-url-secret/sanity-plugin-debug-secrets'` from listing secrets
