### PR TITLE
fix(pte): fix object block popover unexpectedly closing

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/usePortableTextMembers.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/usePortableTextMembers.tsx
@@ -80,7 +80,10 @@ const reconcilePortableTextMembers = ({
           member.item.validation.length > 0 ||
           member.item.changed ||
           member.item.presence?.length ||
-          member.item.focusPath.length > 0
+          // set focusPath in the studio to a node inside the editor and have the relevant text node focused inside
+          (member.item.focusPath[0] === 'children' &&
+            (member.item.focusPath.length === 2 ||
+              (member.item.focusPath.length === 3 && member.item.focusPath[2] === 'text')))
         ) {
           result.push({kind: 'textBlock', member, node: member.item})
         }


### PR DESCRIPTION
### Description
Fixes an issue in which clicking object fields in a PTE annotation popover (AI Assist), produces it to close unexpectedly.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
