### PR TITLE
build: remove last rebase step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,13 +100,3 @@ jobs:
             --exact               \
             --yes                 \
             from-package
-
-      - name: Rebase 'next'
-        run: |
-          # Ensure branches are up to date
-          git fetch origin current:current -u
-          git fetch origin next:next -u
-
-          git checkout next
-          git rebase current
-          git push --set-upstream origin next


### PR DESCRIPTION
### Description

This removes the final rebase step in the release workflow. This step will always fail because of our branch protection rules so for now we'll run this step locally.

### Notes for release

N/A