### PR TITLE
feat(tasks): add assignee property to tasks

### DIFF
--- a/packages/sanity/src/tasks/src/tasks/components/mentionUser/index.ts
+++ b/packages/sanity/src/tasks/src/tasks/components/mentionUser/index.ts
@@ -1,0 +1,1 @@
+export * from './mentionUser'

--- a/packages/sanity/src/tasks/src/tasks/components/mentionUser/mentionUser.tsx
+++ b/packages/sanity/src/tasks/src/tasks/components/mentionUser/mentionUser.tsx
@@ -1,0 +1,127 @@
+import {Autocomplete, Badge, Card, Flex, Text} from '@sanity/ui'
+import {motion} from 'framer-motion'
+import {useCallback, useMemo, useState} from 'react'
+import {UserAvatar} from 'sanity'
+import styled from 'styled-components'
+
+import {type MentionOptionsHookValue, type MentionOptionUser} from '../../types'
+
+type Option = {
+  value: string
+  label: string
+  user: MentionOptionUser
+}
+
+interface MentionUserProps {
+  mentionOptions: MentionOptionsHookValue
+  value?: string
+  onChange: (value: string) => void
+}
+
+const FocusableCard = styled(Card)`
+  &:focus {
+    box-shadow: 0 0 0 1px var(--card-focus-ring-color);
+  }
+`
+export function MentionUser(props: MentionUserProps) {
+  const {mentionOptions, value, onChange} = props
+
+  const asOptions = mentionOptions.data?.map((user) => ({
+    value: user.id,
+    label: user.displayName || user.id,
+    user: user,
+  }))
+
+  const renderOption = useCallback((option: Option) => {
+    const {user} = option
+    return (
+      <Card data-as="button" padding={2} radius={2}>
+        <Flex align="center" gap={3}>
+          <Flex align="center" gap={2} flex={1}>
+            <UserAvatar user={user.id} size={1} />
+            <Text size={1} textOverflow="ellipsis">
+              {user.displayName}
+            </Text>
+          </Flex>
+
+          {!user.canBeMentioned && (
+            <Badge fontSize={1} mode="outline">
+              Unauthorized
+            </Badge>
+          )}
+        </Flex>
+      </Card>
+    )
+  }, [])
+  const filterOption = useCallback(
+    (query: string, option: Option) => option.label.toLowerCase().includes(query.toLowerCase()),
+    [],
+  )
+  const [showMentionOptions, setShowMentionOptions] = useState(false)
+
+  const handleShowMentionOptions = useCallback(() => setShowMentionOptions(true), [])
+  const handleHideMentionOptions = useCallback(() => setShowMentionOptions(false), [])
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === 'Enter' || event.key === ' ') setShowMentionOptions(true)
+      if (event.key === 'Backspace') {
+        onChange('')
+        setShowMentionOptions(true)
+      }
+    },
+    [onChange],
+  )
+
+  const mentionedUser = useMemo(
+    () => mentionOptions.data?.find((u) => u.id === value),
+    [mentionOptions.data, value],
+  )
+  if (value && !showMentionOptions && mentionedUser) {
+    return (
+      <FocusableCard
+        data-as="button"
+        padding={1}
+        radius={2}
+        tabIndex={0}
+        onClick={handleShowMentionOptions}
+        onKeyDown={handleKeyDown}
+      >
+        <Flex align="center" gap={3}>
+          <Flex align="center" gap={2} flex={1}>
+            <motion.div initial={{opacity: 0}} animate={{opacity: 1}}>
+              <UserAvatar user={mentionedUser.id} size={1} />
+            </motion.div>
+
+            <Text size={1} textOverflow="ellipsis">
+              {mentionedUser.displayName}
+            </Text>
+          </Flex>
+
+          {!mentionedUser.canBeMentioned && (
+            <Badge fontSize={1} mode="outline">
+              Unauthorized
+            </Badge>
+          )}
+        </Flex>
+      </FocusableCard>
+    )
+  }
+
+  return (
+    <Autocomplete
+      id="mentionUser"
+      options={asOptions}
+      autoFocus={showMentionOptions}
+      value={value}
+      loading={mentionOptions.isLoading}
+      renderOption={renderOption}
+      // eslint-disable-next-line react/jsx-no-bind
+      renderValue={(_value, option) => option?.label || _value}
+      filterOption={filterOption}
+      onChange={onChange}
+      placeholder="Assign to"
+      fontSize={1}
+      onBlur={handleHideMentionOptions}
+    />
+  )
+}

--- a/packages/sanity/src/tasks/src/tasks/types.ts
+++ b/packages/sanity/src/tasks/src/tasks/types.ts
@@ -127,6 +127,7 @@ export interface TaskCreatePayload {
   title: string
   description: TaskMessage
   status: TaskStatus
+  assignedTo?: string
 }
 
 /**
@@ -138,4 +139,5 @@ export type TaskEditPayload = {
   description?: TaskMessage
   lastEditedAt?: string
   status?: TaskStatus
+  assignedTo?: string
 }


### PR DESCRIPTION
### Description

Adds assignedTo property to tasks.
When a user is assigned, he will see that task in his list of tasks. 

<img width="447" alt="Screenshot 2024-02-15 at 09 30 16" src="https://github.com/sanity-io/sanity/assets/46196328/6d4bc71f-e5a6-43a3-8262-fbeb61c9c525">
<img width="373" alt="Screenshot 2024-02-15 at 09 30 22" src="https://github.com/sanity-io/sanity/assets/46196328/a2deb2c4-4938-494a-bfbe-beb39cb3fd24">


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

AssignedTo property works as expected

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Create a new task, assign yourself or any other user, it should work. 

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
