### PR TITLE
feat(core): add studioActiveToolLayout and navbar rightSectionNode prop

### DIFF
--- a/packages/sanity/src/core/config/studio/types.ts
+++ b/packages/sanity/src/core/config/studio/types.ts
@@ -28,6 +28,14 @@ export interface NavbarProps {
 /**
  * @hidden
  * @beta */
+export interface ActiveToolLayoutProps {
+  renderDefault: (props: ActiveToolLayoutProps) => React.ReactElement
+  activeTool: Tool
+}
+
+/**
+ * @hidden
+ * @beta */
 export interface ToolMenuProps {
   activeToolName?: string
   closeSidebar: () => void
@@ -52,6 +60,7 @@ export interface StudioComponents {
  * @hidden
  * @beta */
 export interface StudioComponentsPluginOptions {
+  activeToolLayout?: ComponentType<ActiveToolLayoutProps>
   layout?: ComponentType<LayoutProps>
   /**
    * @deprecated Add custom icons on a per-workspace basis by customizing workspace `icon` instead.

--- a/packages/sanity/src/core/config/studio/types.ts
+++ b/packages/sanity/src/core/config/studio/types.ts
@@ -1,4 +1,4 @@
-import {type ComponentType, type ReactElement} from 'react'
+import {type ComponentType, type ReactElement, type ReactNode} from 'react'
 
 import {type Tool} from '../types'
 
@@ -23,6 +23,10 @@ export interface LogoProps {
  * @beta */
 export interface NavbarProps {
   renderDefault: (props: NavbarProps) => ReactElement
+  /**
+   * @internal
+   * @beta */
+  __internal_rightSectionNode?: ReactNode
 }
 
 /**

--- a/packages/sanity/src/core/studio/StudioLayout.tsx
+++ b/packages/sanity/src/core/studio/StudioLayout.tsx
@@ -1,15 +1,7 @@
 /* eslint-disable i18next/no-literal-string, @sanity/i18n/no-attribute-template-literals */
 import {Card, Flex} from '@sanity/ui'
 import {startCase} from 'lodash'
-import {
-  createContext,
-  createElement,
-  Suspense,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react'
+import {createContext, Suspense, useCallback, useEffect, useMemo, useState} from 'react'
 import {RouteScope, useRouter, useRouterState} from 'sanity/router'
 import styled from 'styled-components'
 
@@ -17,7 +9,11 @@ import {LoadingBlock} from '../components/loadingBlock'
 import {NoToolsScreen} from './screens/NoToolsScreen'
 import {RedirectingScreen} from './screens/RedirectingScreen'
 import {ToolNotFoundScreen} from './screens/ToolNotFoundScreen'
-import {useLayoutComponent, useNavbarComponent} from './studio-components-hooks'
+import {
+  useActiveToolLayoutComponent,
+  useLayoutComponent,
+  useNavbarComponent,
+} from './studio-components-hooks'
 import {StudioErrorBoundary} from './StudioErrorBoundary'
 import {useWorkspace} from './workspace'
 
@@ -146,6 +142,7 @@ export function StudioLayoutComponent() {
   )
 
   const Navbar = useNavbarComponent()
+  const ActiveToolLayout = useActiveToolLayoutComponent()
 
   /**
    * Handle legacy URL redirects from `/desk` to `/structure`
@@ -193,7 +190,7 @@ export function StudioLayoutComponent() {
               }
             >
               <Suspense fallback={<LoadingBlock showText />}>
-                {createElement(activeTool.component, {tool: activeTool})}
+                <ActiveToolLayout activeTool={activeTool} />
               </Suspense>
             </RouteScope>
           )}

--- a/packages/sanity/src/core/studio/components/navbar/StudioActiveToolLayout.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioActiveToolLayout.tsx
@@ -1,0 +1,12 @@
+import {createElement} from 'react'
+
+import {type Tool} from '../../../config'
+
+interface StudioActiveToolLayoutProps {
+  activeTool: Tool
+}
+
+export function StudioActiveToolLayout(props: StudioActiveToolLayoutProps) {
+  const {activeTool} = props
+  return createElement(activeTool.component, {tool: activeTool})
+}

--- a/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
@@ -15,6 +15,7 @@ import {type RouterState, useRouterState} from 'sanity/router'
 import styled from 'styled-components'
 
 import {Button, TooltipDelayGroupProvider} from '../../../../ui-components'
+import {type NavbarProps} from '../../../config/studio/types'
 import {isDev} from '../../../environment'
 import {useTranslation} from '../../../i18n'
 import {useToolMenuComponent} from '../../studio-components-hooks'
@@ -58,7 +59,9 @@ const NavGrid = styled(Grid)`
 /**
  * @hidden
  * @beta */
-export function StudioNavbar() {
+export function StudioNavbar(props: Omit<NavbarProps, 'renderDefault'>) {
+  // eslint-disable-next-line camelcase
+  const {__internal_rightSectionNode = null} = props
   const {name, tools} = useWorkspace()
   const routerState = useRouterState()
   const mediaIndex = useMediaIndex()
@@ -233,7 +236,6 @@ export function StudioNavbar() {
                       </BoundaryElementProvider>
                     </SearchProvider>
                   </LayerProvider>
-
                   {shouldRender.tools && <FreeTrial type="topbar" />}
                   {shouldRender.configIssues && <ConfigIssuesButton />}
                   {shouldRender.resources && <ResourcesButton />}
@@ -245,6 +247,11 @@ export function StudioNavbar() {
                       ref={setSearchOpenButtonEl}
                     />
                   )}
+
+                  {
+                    // eslint-disable-next-line camelcase
+                    __internal_rightSectionNode
+                  }
                 </Flex>
                 {shouldRender.tools && (
                   <Box flex="none" marginLeft={1}>

--- a/packages/sanity/src/core/studio/studio-components-hooks/componentHooks.ts
+++ b/packages/sanity/src/core/studio/studio-components-hooks/componentHooks.ts
@@ -2,14 +2,17 @@ import {type ComponentType} from 'react'
 
 import {useMiddlewareComponents} from '../../config'
 import {
+  type ActiveToolLayoutProps,
   type LayoutProps,
   type LogoProps,
   type NavbarProps,
   type ToolMenuProps,
 } from '../../config/studio'
 import {StudioLogo, StudioNavbar, StudioToolMenu} from '../components'
+import {StudioActiveToolLayout} from '../components/navbar/StudioActiveToolLayout'
 import {StudioLayoutComponent} from '../StudioLayout'
 import {
+  pickActiveToolLayoutComponent,
   pickLayoutComponent,
   pickLogoComponent,
   pickNavbarComponent,
@@ -54,5 +57,19 @@ export function useLayoutComponent(): ComponentType<Omit<LayoutProps, 'renderDef
   return useMiddlewareComponents({
     defaultComponent: StudioLayoutComponent as ComponentType<Omit<LayoutProps, 'renderDefault'>>,
     pick: pickLayoutComponent,
+  })
+}
+
+/**
+ * @internal
+ */
+export function useActiveToolLayoutComponent(): ComponentType<
+  Omit<ActiveToolLayoutProps, 'renderDefault'>
+> {
+  return useMiddlewareComponents({
+    defaultComponent: StudioActiveToolLayout as ComponentType<
+      Omit<ActiveToolLayoutProps, 'renderDefault'>
+    >,
+    pick: pickActiveToolLayoutComponent,
   })
 }

--- a/packages/sanity/src/core/studio/studio-components-hooks/picks.ts
+++ b/packages/sanity/src/core/studio/studio-components-hooks/picks.ts
@@ -1,6 +1,7 @@
 import {type ComponentType} from 'react'
 
 import {
+  type ActiveToolLayoutProps,
   type LayoutProps,
   type LogoProps,
   type NavbarProps,
@@ -30,4 +31,12 @@ export function pickLogoComponent(
   plugin: PluginOptions,
 ): ComponentType<Omit<LogoProps, 'renderDefault'>> {
   return plugin.studio?.components?.logo as ComponentType<Omit<LogoProps, 'renderDefault'>>
+}
+
+export function pickActiveToolLayoutComponent(
+  plugin: PluginOptions,
+): ComponentType<Omit<ActiveToolLayoutProps, 'renderDefault'>> {
+  return plugin.studio?.components?.activeToolLayout as ComponentType<
+    Omit<ActiveToolLayoutProps, 'renderDefault'>
+  >
 }


### PR DESCRIPTION
### Description

This PR adds two necessary core changes for the `tasks` feature. 

#### Studio Active Tool Layout.

It's intention is to wrap the `ActiveTool` and allow plugins to modify the layout around it. 

The red border shows how it wraps the active tool.
<img width="1069" alt="Screenshot 2024-02-15 at 11 11 07" src="https://github.com/sanity-io/sanity/assets/46196328/4086c63e-6061-4662-a428-b12f550f1228">


```
// Plugin implementation
export const tasks = definePlugin({
  name: 'sanity/tasks',
  studio: {
    components: {
			...
      activeToolLayout: TasksStudioActiveToolLayout,
    },
  },
})

// Usage
export function TasksStudioActiveToolLayout(props: ActiveToolLayoutProps) {
  const {isOpen} = useTasks()
  const {enabled} = useTasksEnabled()
  if (!enabled) return props.renderDefault(props)

  return (
    <Flex height="fill">
      <div style={{minHeight: '100%', width: '100%'}}>{props.renderDefault(props)}</div>
      {isOpen && <TasksStudioSidebar />}
    </Flex>
  )
}
```

#### Navbar rightSectionNode

Adds a prop to the studio navbar prop which will be used to insert the TasksNabarButton in the correct position. 

The red border shows where the rightSectionNode will be rendered.
<img width="177" alt="Screenshot 2024-02-15 at 11 13 07" src="https://github.com/sanity-io/sanity/assets/46196328/13035302-e195-4a1b-ad15-6bd05d70aeaa">


```
// Plugin 
export const tasks = definePlugin({
  name: 'sanity/tasks',
  studio: {
    components: {
			...
      navbar: TasksStudioNavbar,
    },
  },
})

// Usage
export function TasksStudioNavbar(props: NavbarProps) {
  const {enabled} = useTasksEnabled()

  if (!enabled) return props.renderDefault(props)
  return props.renderDefault({
    ...props,
    __internal_rightSectionNode: <TasksNavbarButton />,
  })
}
```
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Implementation follows the expected guidelines.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Create a plugin which uses this new api and the navbar api.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

Implements new studio API, ActiveToolLayout which allows plugin authors to have more flexibility by wrapping the active tool.
Adds __internal_rightSectionNode navbar prop.

<!--
A description of the change(s) that should be used in the release notes.
-->
