### PR TITLE
chore: add missing types packages

### DIFF
--- a/packages/@sanity/block-tools/package.json
+++ b/packages/@sanity/block-tools/package.json
@@ -63,6 +63,7 @@
     "@sanity/schema": "3.29.1",
     "@sanity/types": "3.29.1",
     "@types/jsdom": "^20.0.0",
+    "@types/lodash": "^4.14.149",
     "@types/react": "^18.2.37",
     "jsdom": "^23.0.1"
   },

--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -80,6 +80,8 @@
     "@jest/globals": "^29.7.0",
     "@rexxars/gitconfiglocal": "^3.0.1",
     "@types/decompress": "^4.2.4",
+    "@types/lodash": "^4.14.149",
+    "@types/rimraf": "^3.0.2",
     "@types/validate-npm-package-name": "^3.0.3",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@sanity/client": "^6.12.4",

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -77,6 +77,7 @@
   },
   "devDependencies": {
     "@sanity/client": "^6.12.4",
+    "@types/lodash": "^4.14.149",
     "@types/is-hotkey": "^0.1.10",
     "react": "^18.2.0",
     "sanity": "3.29.1",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -323,6 +323,7 @@
     "@types/log-symbols": "^2.0.0",
     "@types/node": "^18.19.8",
     "@types/raf": "^3.4.0",
+    "@types/react-dom": "^18.2.15",
     "@types/refractor": "^3.0.0",
     "@types/resolve-from": "^4.0.0",
     "@types/rimraf": "^3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -610,6 +610,9 @@ importers:
       '@types/jsdom':
         specifier: ^20.0.0
         version: 20.0.1
+      '@types/lodash':
+        specifier: ^4.14.149
+        version: 4.14.202
       '@types/react':
         specifier: ^18.2.37
         version: 18.2.48
@@ -695,12 +698,18 @@ importers:
       '@types/inquirer':
         specifier: ^6.0.0
         version: 6.5.0
+      '@types/lodash':
+        specifier: ^4.14.149
+        version: 4.14.202
       '@types/minimist':
         specifier: ^1.2.5
         version: 1.2.5
       '@types/node':
         specifier: ^18.19.8
         version: 18.19.8
+      '@types/rimraf':
+        specifier: ^3.0.2
+        version: 3.0.2
       '@types/semver':
         specifier: ^7.5.6
         version: 7.5.6
@@ -1284,6 +1293,9 @@ importers:
       '@types/is-hotkey':
         specifier: ^0.1.10
         version: 0.1.10
+      '@types/lodash':
+        specifier: ^4.14.149
+        version: 4.14.202
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -1701,6 +1713,9 @@ importers:
       '@types/raf':
         specifier: ^3.4.0
         version: 3.4.3
+      '@types/react-dom':
+        specifier: ^18.2.15
+        version: 18.2.18
       '@types/refractor':
         specifier: ^3.0.0
         version: 3.4.0


### PR DESCRIPTION
Add missing types for lodash and react-dom in various packages.
