### PR TITLE
feat(migrate): write a log file of all submitted transactions

### DIFF
--- a/packages/@sanity/migrate/src/runner/run.ts
+++ b/packages/@sanity/migrate/src/runner/run.ts
@@ -56,13 +56,13 @@ export async function* toFetchOptionsIterable(
   }
 }
 
-export async function run(config: MigrationRunnerConfig, migration: Migration) {
+export async function* run(config: MigrationRunnerConfig, migration: Migration) {
   const stats: MigrationProgress = {
     documents: 0,
     mutations: 0,
     pending: 0,
     queuedBatches: 0,
-    completedTransactions: [],
+    completedTransactionsLength: 0,
     currentTransactions: [],
   }
 
@@ -141,10 +141,11 @@ export async function run(config: MigrationRunnerConfig, migration: Migration) {
   )
 
   for await (const result of commits) {
-    stats.completedTransactions.push(result)
+    stats.completedTransactionsLength++
     config.onProgress?.({
       ...stats,
     })
+    yield result
   }
   config.onProgress?.({
     ...stats,

--- a/packages/@sanity/migrate/src/types.ts
+++ b/packages/@sanity/migrate/src/types.ts
@@ -1,4 +1,4 @@
-import {type MultipleMutationResult, type Mutation as RawMutation} from '@sanity/client'
+import {type Mutation as RawMutation} from '@sanity/client'
 import {type Path, type SanityDocument} from '@sanity/types'
 
 import {type JsonArray, type JsonObject, type JsonValue} from './json'
@@ -44,7 +44,7 @@ export type MigrationProgress = {
   pending: number
   queuedBatches: number
   currentTransactions: (Transaction | Mutation)[]
-  completedTransactions: MultipleMutationResult[]
+  completedTransactionsLength: number
   done?: boolean
 }
 


### PR DESCRIPTION
### Description

This writes a log of all transactions submitted during a migration to a file within the migration directory. The logfile consists of newline delimited responses from the [/mutate](https://www.sanity.io/docs/http-mutations#ac77879076d4) API endpoint. I'm going for a tradeoff between minimalistic and valuable here, and did not include [the changed documents](https://www.sanity.io/docs/http-mutations#returnDocuments-369b317dcaa6) this time, because of the potential for filling up lots of disk space if running migrations on high volumes. We can always consider making it configurable behind a flag later.

Example output:
```
? This migration will run on the test dataset in ppsg7ml5 project. Are you sure? Yes
✔ Migration "rename-location-to-address" completed.

  Project id:  ppsg7ml5
  Dataset:     test

  678 documents processed.
  678 mutations generated.
  1 transactions committed.

A log of all submitted transactions has been written to:
./migrations/rename-location-to-address/logs/2024-02-15T16_44_39_628Z-rename-location-to-address.ndjson
```
☝🏼  The last two lines here are new

### What to review
- Does it make sense to make it a default to write a file, or should it be opt-in?
- Does the flag name make sense?


### Testing

- Run a migration and have a look at the logfile.

### Notes for release

- `sanity migrate` now logs all submitted transactions to a file during a migration run.