### PR TITLE
fix(migrate): throw if attempting to iterate over documents producer

### DIFF
--- a/packages/@sanity/migrate/src/runner/collectMigrationMutations.ts
+++ b/packages/@sanity/migrate/src/runner/collectMigrationMutations.ts
@@ -3,11 +3,37 @@ import {type SanityDocument} from '@sanity/types'
 import {type Migration, type MigrationContext} from '../types'
 import {normalizeMigrateDefinition} from './normalizeMigrateDefinition'
 
+async function* empty() {}
+
+function wrapDocumentsIteratorProducer(factory: () => AsyncIterableIterator<SanityDocument>) {
+  function documents() {
+    return factory()
+  }
+
+  ;(documents as any)[Symbol.asyncIterator] = () => {
+    throw new Error(
+      `The migration is attempting to iterate over the "documents" function, please call the function instead:
+
+      // BAD:
+      for await (const document of documents) {
+        // ...
+      }
+
+      // GOOD:                        👇 This is a function and has to be called
+      for await (const document of documents()) {
+        // ...
+      }
+      `,
+    )
+  }
+  return documents
+}
+
 export function collectMigrationMutations(
   migration: Migration,
   documents: () => AsyncIterableIterator<SanityDocument>,
   context: MigrationContext,
 ) {
   const migrate = normalizeMigrateDefinition(migration)
-  return migrate(documents, context)
+  return migrate(wrapDocumentsIteratorProducer(documents), context)
 }


### PR DESCRIPTION
### Description

A tiny DX improvement that catches an attempt to iterate over the provided `documents` function without calling it. (Note that TypeScript will usually catch these too)

### What to review

Is the error message clear?

### Testing

Create an async iterable migration and iterate over documents without calling it:
```tsx
import {defineMigration} from 'sanity/migrate'

export default defineMigration({
  title: 'Demo migration',
  async *migrate(documents, context) {
    for await (const doc of documents) {
      // yield mutations…
    }
  },
})
```


### Notes for release
- Improves error handling for a migration script that attempts to iterate over the passed `document` function without calling it