### PR TITLE
feat(comments): omit inline comments without referenced value

### DIFF
--- a/packages/sanity/src/structure/comments/plugin/field/CommentsField.tsx
+++ b/packages/sanity/src/structure/comments/plugin/field/CommentsField.tsx
@@ -12,6 +12,7 @@ import {
   applyCommentsFieldAttr,
   type CommentCreatePayload,
   type CommentsUIMode,
+  isTextSelectionComment,
   useComments,
   useCommentsEnabled,
   useCommentsScroll,
@@ -109,7 +110,7 @@ function CommentFieldInner(
   const isInlineCommentThread = useMemo(() => {
     return comments.data.open
       .filter((c) => c.threadId === selectedPath?.threadId)
-      .some((x) => x.selection?.type === 'text')
+      .some((x) => isTextSelectionComment(x.parentComment))
   }, [comments.data.open, selectedPath?.threadId])
 
   // Total number of comments for the current field

--- a/packages/sanity/src/structure/comments/plugin/input/components/CommentsPortableTextInput.tsx
+++ b/packages/sanity/src/structure/comments/plugin/input/components/CommentsPortableTextInput.tsx
@@ -25,6 +25,7 @@ import {
   type CommentUpdatePayload,
   currentSelectionIsOverlappingWithComment,
   hasCommentMessageValue,
+  isTextSelectionComment,
   useComments,
   useCommentsEnabled,
   useCommentsScroll,
@@ -114,7 +115,7 @@ export const CommentsPortableTextInputInner = React.memo(function CommentsPortab
   const textComments = useMemo(() => {
     return comments.data.open
       .filter((comment) => comment.fieldPath === stringFieldPath)
-      .filter((c) => c.selection?.type === 'text')
+      .filter((c) => isTextSelectionComment(c.parentComment))
   }, [comments.data.open, stringFieldPath])
 
   const getFragment = useCallback(() => {
@@ -217,8 +218,10 @@ export const CommentsPortableTextInputInner = React.memo(function CommentsPortab
     // to finish.
     const editorStateValue = PortableTextEditor.getValue(editorRef.current)
 
+    const parentComments = textComments.map((c) => c.parentComment)
+
     const decorators = buildRangeDecorations({
-      comments: textComments,
+      comments: parentComments,
       currentHoveredCommentId,
       onDecoratorClick: handleDecoratorClick,
       onDecoratorHoverEnd: setCurrentHoveredCommentId,

--- a/packages/sanity/src/structure/comments/plugin/inspector/CommentsInspector.tsx
+++ b/packages/sanity/src/structure/comments/plugin/inspector/CommentsInspector.tsx
@@ -19,6 +19,7 @@ import {
   type CommentsUIMode,
   CommentsUpsellPanel,
   type CommentUpdatePayload,
+  isTextSelectionComment,
   useComments,
   useCommentsEnabled,
   useCommentsOnboarding,
@@ -195,7 +196,7 @@ function CommentsInspectorInner(
 
         const isInlineComment = comments.data.open
           .filter((c) => c.threadId === nextPath?.threadId)
-          .some((x) => x.selection?.type === 'text')
+          .some((x) => isTextSelectionComment(x.parentComment))
 
         if (isInlineComment && nextPath.threadId) {
           scrollToInlineComment(nextPath.threadId)

--- a/packages/sanity/src/structure/comments/src/__tests__/buildRangeDecorationSelectionsFromComments.test.ts
+++ b/packages/sanity/src/structure/comments/src/__tests__/buildRangeDecorationSelectionsFromComments.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from '@jest/globals'
 
-import {type CommentThreadItem} from '../types'
+import {type CommentDocument} from '../types'
 import {buildRangeDecorationSelectionsFromComments} from '../utils'
 
 describe('comments: buildRangeDecorationSelectionsFromComments', () => {
@@ -132,45 +132,38 @@ const boldedInsideAndOutsideValue = [
   },
 ]
 
-const initialComments: CommentThreadItem[] = [
+const initialComments: CommentDocument[] = [
   {
-    selection: {
-      type: 'text',
-      value: [
-        {
-          _key: '6222e4072b6e',
-          text: 'Hello <comment>there</comment> world',
-        },
-      ],
-    },
-    breadcrumbs: [],
-    commentsCount: 0,
-    fieldPath: '',
-    replies: [],
-    parentComment: {
-      _id: 'a14fb200-a4c4-4c44-b2c1-c17aa6d79aa8',
-      _type: 'comment',
-      _createdAt: '',
-      _rev: '',
-      authorId: '',
-      message: null,
-      threadId: '',
-      status: 'open',
-      reactions: null,
-      target: {
-        path: {
-          field: '',
-        },
-        documentType: '',
-        document: {
-          _dataset: '',
-          _projectId: '',
-          _ref: '',
-          _type: 'crossDatasetReference',
-          _weak: false,
+    _id: 'a14fb200-a4c4-4c44-b2c1-c17aa6d79aa8',
+    _type: 'comment',
+    _createdAt: '',
+    _rev: '',
+    authorId: '',
+    message: null,
+    threadId: '',
+    status: 'open',
+    reactions: null,
+    target: {
+      path: {
+        field: '',
+        selection: {
+          type: 'text',
+          value: [
+            {
+              _key: '6222e4072b6e',
+              text: 'Hello <comment>there</comment> world',
+            },
+          ],
         },
       },
+      documentType: '',
+      document: {
+        _dataset: '',
+        _projectId: '',
+        _ref: '',
+        _type: 'crossDatasetReference',
+        _weak: false,
+      },
     },
-    threadId: 'de1f947c-93a7-4f71-9b9c-5f20023f9c98',
   },
 ]

--- a/packages/sanity/src/structure/comments/src/__workshop__/CommentInlineHighlightDebugStory.tsx
+++ b/packages/sanity/src/structure/comments/src/__workshop__/CommentInlineHighlightDebugStory.tsx
@@ -150,7 +150,7 @@ export default function CommentInlineHighlightDebugStory() {
   const buildRangeDecorationsCallback = useCallback(
     () =>
       buildRangeDecorations({
-        comments,
+        comments: comments.map((c) => c.parentComment),
         value,
         onDecoratorHoverStart: setCurrentHoveredCommentId,
         onDecoratorHoverEnd: setCurrentHoveredCommentId,

--- a/packages/sanity/src/structure/comments/src/components/list/CommentsListItemLayout.tsx
+++ b/packages/sanity/src/structure/comments/src/components/list/CommentsListItemLayout.tsx
@@ -15,7 +15,7 @@ import {IntentLink} from 'sanity/router'
 import styled, {css} from 'styled-components'
 
 import {commentsLocaleNamespace} from '../../../i18n'
-import {hasCommentMessageValue, useCommentHasChanged} from '../../helpers'
+import {hasCommentMessageValue, isTextSelectionComment, useCommentHasChanged} from '../../helpers'
 import {
   type CommentContext,
   type CommentDocument,
@@ -396,7 +396,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
           )}
         </Flex>
 
-        {comment.target.path.selection?.type === 'text' && Boolean(comment?.contentSnapshot) && (
+        {isTextSelectionComment(comment) && Boolean(comment?.contentSnapshot) && (
           <Flex gap={FLEX_GAP} marginBottom={3}>
             <SpacerAvatar />
 

--- a/packages/sanity/src/structure/comments/src/helpers.ts
+++ b/packages/sanity/src/structure/comments/src/helpers.ts
@@ -40,3 +40,14 @@ export function commentIntentIfDiffers(
   }
   return undefined
 }
+
+/**
+ * A function that checks whether a comment is a text selection comment
+ */
+export function isTextSelectionComment(comment: CommentDocument): boolean {
+  if (!comment) return false
+
+  return Boolean(
+    comment?.target?.path?.selection?.type === 'text' && comment?.target?.path?.selection?.value,
+  )
+}

--- a/packages/sanity/src/structure/comments/src/types.ts
+++ b/packages/sanity/src/structure/comments/src/types.ts
@@ -58,7 +58,6 @@ export interface CommentThreadItem {
   fieldPath: string
   parentComment: CommentDocument
   replies: CommentDocument[]
-  selection: CommentPathSelection | undefined
   threadId: string
 }
 

--- a/packages/sanity/src/structure/comments/src/utils/buildCommentThreadItems.ts
+++ b/packages/sanity/src/structure/comments/src/utils/buildCommentThreadItems.ts
@@ -1,8 +1,14 @@
 import {type SanityDocument} from '@sanity/client'
-import {type CurrentUser, type SchemaType} from '@sanity/types'
+import {type CurrentUser, type PortableTextBlock, type SchemaType} from '@sanity/types'
+import * as PathUtils from '@sanity/util/paths'
+import {getValueAtPath} from 'sanity'
 
+import {isTextSelectionComment} from '../helpers'
 import {type CommentDocument, type CommentThreadItem} from '../types'
 import {buildCommentBreadcrumbs} from './buildCommentBreadcrumbs'
+import {validateTextSelectionComment} from './inline-comments'
+
+const EMPTY_ARRAY: [] = []
 
 interface BuildCommentThreadItemsProps {
   comments: CommentDocument[]
@@ -21,34 +27,65 @@ export function buildCommentThreadItems(props: BuildCommentThreadItemsProps): Co
   const {comments, currentUser, documentValue, schemaType} = props
   const parentComments = comments?.filter((c) => !c.parentCommentId)
 
-  const items = parentComments
-    .map((parentComment) => {
-      const crumbs = buildCommentBreadcrumbs({
-        currentUser,
+  const items = parentComments.map((parentComment) => {
+    const crumbs = buildCommentBreadcrumbs({
+      currentUser,
+      documentValue,
+      fieldPath: parentComment.target.path.field,
+      schemaType,
+    })
+
+    let hasValidTextSelection = false
+
+    // If the comment is a text selection comment, we need to make sure that
+    // we can successfully build a range decoration selection from it.
+    // This is important as we don't want to include comments in the the list that
+    // has no reference to the document value.
+    // If we are unable to build a selection, we will omit the comment from the list.
+    // The selection will fail to be built if the text that the comment is targeting
+    // has been removed or been modified to an extent that the matching algorithm
+    // cannot find the correct range in the document value.
+    if (isTextSelectionComment(parentComment)) {
+      // Get the value of the field that the comment is targeting
+      // to validate the selection against it.
+      const value = getValueAtPath(
         documentValue,
-        fieldPath: parentComment.target.path.field,
-        schemaType,
+        PathUtils.fromString(parentComment.target.path.field),
+      )
+
+      // Validate the comment against the document value
+      const isValid = validateTextSelectionComment({
+        comment: parentComment,
+        value: (value || EMPTY_ARRAY) as PortableTextBlock[],
       })
 
-      const hasInvalidBreadcrumb = crumbs.some((bc) => bc.invalid)
+      hasValidTextSelection = isValid
+    }
 
-      if (hasInvalidBreadcrumb) return undefined
+    // Check if the comment has an invalid breadcrumb. The breadcrumbs can be invalid if:
+    // - The field is hidden by conditional fields
+    // - The field is not found in the schema type
+    // - The field is not found in the document value (array items only)
+    const hasInvalidBreadcrumb = crumbs.some((bc) => bc.invalid)
 
-      const replies = comments?.filter((r) => r.parentCommentId === parentComment._id)
+    // If the comment has an invalid breadcrumb or selection, we will omit it from the list.
+    if (hasInvalidBreadcrumb) return undefined
+    if (!hasValidTextSelection) return undefined
 
-      const commentsCount = [parentComment, ...replies].length
+    const replies = comments?.filter((r) => r.parentCommentId === parentComment._id)
 
-      return {
-        breadcrumbs: crumbs,
-        commentsCount,
-        fieldPath: parentComment.target.path.field,
-        parentComment,
-        replies,
-        selection: parentComment.target.path.selection,
-        threadId: parentComment.threadId,
-      }
-    })
-    .filter(Boolean) as CommentThreadItem[]
+    const commentsCount = [parentComment, ...replies].length
 
-  return items
+    return {
+      breadcrumbs: crumbs,
+      commentsCount,
+      fieldPath: parentComment.target.path.field,
+      parentComment,
+      replies,
+      threadId: parentComment.threadId,
+    }
+  })
+
+  // We use the `Boolean` function to filter out any `undefined` items from the array.
+  return items.filter(Boolean) as CommentThreadItem[]
 }

--- a/packages/sanity/src/structure/comments/src/utils/inline-comments/buildRangeDecorations.tsx
+++ b/packages/sanity/src/structure/comments/src/utils/inline-comments/buildRangeDecorations.tsx
@@ -1,9 +1,10 @@
 import {type RangeDecoration} from '@sanity/portable-text-editor'
 import {memo, useCallback, useEffect, useRef} from 'react'
+import {type PortableTextBlock} from 'sanity'
 
 import {CommentInlineHighlightSpan} from '../../components'
 import {applyInlineCommentIdAttr} from '../../hooks'
-import {type CommentMessage, type CommentThreadItem} from '../../types'
+import {type CommentDocument} from '../../types'
 import {buildRangeDecorationSelectionsFromComments} from './buildRangeDecorationSelectionsFromComments'
 
 interface CommentRangeDecorationProps {
@@ -91,13 +92,13 @@ function isRangeInvalid() {
 }
 
 interface BuildRangeDecorationsProps {
-  comments: CommentThreadItem[]
+  comments: CommentDocument[]
   currentHoveredCommentId: string | null
   onDecoratorClick: (commentId: string) => void
   onDecoratorHoverEnd: (commentId: null) => void
   onDecoratorHoverStart: (commentId: string) => void
   selectedThreadId: string | null
-  value: CommentMessage | undefined
+  value: PortableTextBlock[] | undefined
 }
 
 export function buildRangeDecorations(props: BuildRangeDecorationsProps) {
@@ -116,7 +117,7 @@ export function buildRangeDecorations(props: BuildRangeDecorationsProps) {
     const decoration: RangeDecoration = {
       component: ({children}) => (
         <CommentRangeDecoration
-          commentId={comment.parentComment._id}
+          commentId={comment._id}
           currentHoveredCommentId={currentHoveredCommentId}
           onClick={onDecoratorClick}
           onHoverEnd={onDecoratorHoverEnd}
@@ -130,7 +131,7 @@ export function buildRangeDecorations(props: BuildRangeDecorationsProps) {
       isRangeInvalid,
       selection,
       payload: {
-        commentId: comment.parentComment._id,
+        commentId: comment._id,
         range,
       },
     }


### PR DESCRIPTION
### Description

This pull request implements logic that omits inline comments if we are unable to find a match in the current value of the Portable Text.

### What to review

### Testing

### Notes for release
