### PR TITLE
feat(core): weight `mode` param on create intents

### DIFF
--- a/packages/sanity/src/core/studio/router/helpers.ts
+++ b/packages/sanity/src/core/studio/router/helpers.ts
@@ -5,7 +5,7 @@ import {isRecord} from '../../util/isRecord'
 import {type RouterEvent, type RouterStateEvent} from './types'
 import {getOrderedTools} from './util/getOrderedTools'
 
-const WEIGHTED_CREATE_INTENT_PARAMS = ['template']
+const WEIGHTED_CREATE_INTENT_PARAMS = ['mode', 'template']
 const WEIGHTED_EDIT_INTENT_PARAMS = ['mode']
 
 function resolveUrlStateWithDefaultTool(tools: Tool[], state: Record<string, unknown> | null) {

--- a/packages/sanity/src/structure/structureTool.ts
+++ b/packages/sanity/src/structure/structureTool.ts
@@ -134,9 +134,14 @@ function canHandleCreateIntent(params: Record<string, unknown>) {
     return false
   }
 
-  // We can handle any create intent as long as it has a `type` parameter,
-  // but we also know how to deal with templates, where other tools might not
-  return 'template' in params ? {template: true} : true
+  const handle: Record<string, boolean> = {}
+  // We can handle any create intent as long as it has a `type` parameter
+  // but we are best at `structure` mode
+  if ('mode' in params) handle.mode = params.mode === 'structure'
+  // we also know how to deal with templates, where other tools might not
+  if ('template' in params) handle.template = true
+
+  return Object.keys(handle).length ? handle : true
 }
 
 function canHandleEditIntent(params: Record<string, unknown>) {


### PR DESCRIPTION
### Description

This adds `mode` as a weighted create intent param when resolving intent state. This is to differentiate between multiple tools that are able to handle the weighted `template` param.

### What to review

The `mode` parameter should be able to resolve the correct tool if multiple tools that handle the `template` param exist.

### Testing

A structure tool and presentation tool can both handle `template` params. Use the `mode` parameter in a create intent link to resolve each tool, using e.g:

/workspace/intent/create/type=*;template=*;mode=*

### Notes for release

@todo if accepted
