### PR TITLE
test(e2e): fix e2e test caching issue

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -69,6 +69,9 @@ jobs:
         if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
 
+      - name: Build CLI
+        run: pnpm build:cli
+
       - name: Build E2E test studio on next
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
         env:
@@ -98,7 +101,9 @@ jobs:
         env:
           cache-name: cache-e2e-build
         with:
-          path: './*'
+          path: |
+            './*'
+            '!**/node_modules/**'
           # Unique key for a workflow run. Should be invalidated in the next run
           key: ${{ runner.os }}-${{ matrix.project }}-${{ env.cache-name }}-${{ github.run_id }}
 
@@ -175,7 +180,9 @@ jobs:
         env:
           cache-name: cache-e2e-build
         with:
-          path: ./*
+          path: |
+            './*'
+            '!**/node_modules/**'
           key: ${{ runner.os }}-${{ matrix.project }}-${{ env.cache-name }}-${{ github.run_id }}
           # If the cached build from the pervious step is not available. Fail the build
           fail-on-cache-miss: true
@@ -224,24 +231,33 @@ jobs:
         with:
           node-version: 18
 
-      - name: Install pnpm
-        run: corepack enable && pnpm --version
+      - uses: pnpm/action-setup@v2
+        name: Install pnpm
+        id: pnpm-install
+        with:
+          version: 8
+          run_install: false
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Cache node modules
         id: cache-node-modules
-        uses: actions/cache/restore@v3
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-modules-${{ env.cache-name }}-
-            ${{ runner.os }}-modules-
-            ${{ runner.os }}-
+            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
+            v1-${{ runner.os }}-pnpm-store-
+            v1-${{ runner.os }}-
 
       - name: Install project dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: pnpm install
 
       - name: Download blob reports from Github Actions Artifacts

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -102,8 +102,8 @@ jobs:
           cache-name: cache-e2e-build
         with:
           path: |
-            './*'
-            '!**/node_modules/**'
+            ./*
+            !**/node_modules/**
           # Unique key for a workflow run. Should be invalidated in the next run
           key: ${{ runner.os }}-${{ matrix.project }}-${{ env.cache-name }}-${{ github.run_id }}
 
@@ -181,8 +181,8 @@ jobs:
           cache-name: cache-e2e-build
         with:
           path: |
-            './*'
-            '!**/node_modules/**'
+            ./*
+            !**/node_modules/**
           key: ${{ runner.os }}-${{ matrix.project }}-${{ env.cache-name }}-${{ github.run_id }}
           # If the cached build from the pervious step is not available. Fail the build
           fail-on-cache-miss: true

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install pnpm
+        run: corepack enable && pnpm --version
+
       - name: Cache node modules
         id: cache-node-modules
         uses: actions/cache@v3

--- a/dev/studio-e2e-testing/turbo.json
+++ b/dev/studio-e2e-testing/turbo.json
@@ -1,9 +1,0 @@
-{
-  "$schema": "https://turbo.build/schema.json",
-  "extends": ["//"],
-  "pipeline": {
-    "build": {
-      "outputs": [".sanity/**", "dist/**"]
-    }
-  }
-}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "docs:report": "node -r dotenv-flow/config -r esbuild-register scripts/doc-report/docReport",
     "docs:report:cleanup": "node -r dotenv-flow/config -r esbuild-register scripts/doc-report/docReportCleanup",
     "docs:report:create": "node -r dotenv-flow/config -r esbuild-register scripts/doc-report/docReportCreate",
-    "e2e:build": "turbo run --filter=studio-e2e-testing build",
+    "e2e:build": "pnpm --filter studio-e2e-testing build",
     "e2e:cleanup": "node -r dotenv-flow/config -r esbuild-register scripts/e2e/cleanup",
     "e2e:codegen": "node -r dotenv-flow/config ./node_modules/.bin/sanity-test codegen",
     "e2e:dev": "pnpm --filter studio-e2e-testing dev",


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

With migrating to pnpm we by mistake enabled turbo build for e2e testing studio which caused an issue where the build was cached until a new remote cache was enabled. This posed a problem as the cache dataset would not match the dataset in the test causing failure. This changes the process to not use turbo for building the testing studio. 

Also fixes the cleanup script to install pnpm so it does not fail

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Changes makes sense, test is passing 

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

N/A