### PR TITLE
test(core): add tests for sort order local storage values

### DIFF
--- a/packages/sanity/src/structure/components/pane/PaneContextMenuButton.tsx
+++ b/packages/sanity/src/structure/components/pane/PaneContextMenuButton.tsx
@@ -43,6 +43,7 @@ export function PaneContextMenuButton(props: PaneContextMenuButtonProps) {
         <ContextMenuButton
           // eslint-disable-next-line no-nested-ternary
           tone={hasCritical ? 'critical' : hasCaution ? 'caution' : undefined}
+          data-testid="pane-context-menu-button"
         />
       }
       id={id}

--- a/test/e2e/tests/desk/documentTypeListContextMenu.spec.ts
+++ b/test/e2e/tests/desk/documentTypeListContextMenu.spec.ts
@@ -1,0 +1,48 @@
+import {expect} from '@playwright/test'
+import {test} from '@sanity/test'
+
+//we should also check for custom sort orders`
+test('clicking sort order and direction sets value in storage', async ({page}) => {
+  await page.goto('/test/content/author')
+  await page.getByTestId('pane').getByTestId('pane-context-menu-button').click()
+  await page.getByRole('menuitem', {name: 'Sort by Name'}).click()
+  const localStorage = await page.evaluate(() => window.localStorage)
+
+  expect(localStorage['structure-tool::author::sortOrder']).toBe(
+    '{"by":[{"field":"name","direction":"asc"}],"extendedProjection":"name"}',
+  )
+
+  await page.getByTestId('pane').getByTestId('pane-context-menu-button').click()
+  await page.getByRole('menuitem', {name: 'Sort by Last Edited'}).click()
+  const lastEditedLocalStorage = await page.evaluate(() => window.localStorage)
+
+  expect(lastEditedLocalStorage['structure-tool::author::sortOrder']).toBe(
+    '{"by":[{"field":"_updatedAt","direction":"desc"}],"extendedProjection":""}',
+  )
+})
+
+test('clicking list view sets value in storage', async ({page}) => {
+  await page.goto('/test/content/author')
+  await page.getByTestId('pane').getByTestId('pane-context-menu-button').click()
+  await page.getByRole('menuitem', {name: 'Detailed view'}).click()
+  const localStorage = await page.evaluate(() => window.localStorage)
+
+  expect(localStorage['structure-tool::author::layout']).toBe('"detail"')
+
+  await page.getByTestId('pane').getByTestId('pane-context-menu-button').click()
+  await page.getByRole('menuitem', {name: 'Compact view'}).click()
+  const compactLocalStorage = await page.evaluate(() => window.localStorage)
+
+  expect(compactLocalStorage['structure-tool::author::layout']).toBe('"default"')
+})
+
+test('values persist after navigating away and back', async ({page}) => {
+  await page.goto('/test/content/author')
+  await page.getByTestId('pane').getByTestId('pane-context-menu-button').click()
+  await page.getByRole('menuitem', {name: 'Detailed view'}).click()
+  await page.goto('https://example.com')
+  await page.goto('/test/content/author')
+  const localStorage = await page.evaluate(() => window.localStorage)
+
+  expect(localStorage['structure-tool::author::layout']).toBe('"detail"')
+})


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

As we start to re-organize how we think about storing our settings, it's important to write tests first to ensure we're not losing any old functionality, especially during a transition period.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

The new test file and the small change to add a data-testid to a component that would have been brittle to reach without it.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Feel free to run the tests locally as needed.

It would have been nice to _also_ test, in true end-to-end fashion, whether or not these parameters have the desired effect on the in-studio experience. However, that would require us to create multiple documents to sort and check, which our current testing strategy makes a bit difficult, because it runs parallel workers. I think it would be an excellent idea in the future!

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
