### PR TITLE
chore(deps): bump @sanity/tsdoc to 1.0.0-alpha.42

### DIFF
--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -37,7 +37,7 @@
     "@sanity/portable-text-editor": "3.29.1",
     "@sanity/preview-url-secret": "^1.6.1",
     "@sanity/react-loader": "^1.8.3",
-    "@sanity/tsdoc": "1.0.0-alpha.38",
+    "@sanity/tsdoc": "1.0.0-alpha.42",
     "@sanity/types": "3.29.1",
     "@sanity/ui": "^2.0.1",
     "@sanity/ui-workshop": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@sanity/eslint-config-studio": "^3.0.1",
     "@sanity/pkg-utils": "^3.3.2",
     "@sanity/test": "0.0.1-alpha.1",
-    "@sanity/tsdoc": "1.0.0-alpha.38",
+    "@sanity/tsdoc": "1.0.0-alpha.42",
     "@sanity/uuid": "^3.0.2",
     "@types/glob": "^7.2.0",
     "@types/lodash": "^4.14.149",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -309,7 +309,7 @@
     "@jest/globals": "^29.7.0",
     "@playwright/experimental-ct-react": "^1.39.0",
     "@playwright/test": "^1.39.0",
-    "@sanity/tsdoc": "1.0.0-alpha.38",
+    "@sanity/tsdoc": "1.0.0-alpha.42",
     "@sanity/ui-workshop": "^1.2.11",
     "@testing-library/jest-dom": "^6.2.0",
     "@testing-library/react": "^13.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ importers:
         specifier: 0.0.1-alpha.1
         version: 0.0.1-alpha.1
       '@sanity/tsdoc':
-        specifier: 1.0.0-alpha.38
-        version: 1.0.0-alpha.38(@sanity/pkg-utils@3.3.8)(@types/node@18.19.8)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@packages+sanity)(styled-components@5.3.11)
+        specifier: 1.0.0-alpha.42
+        version: 1.0.0-alpha.42(@sanity/pkg-utils@3.3.8)(@types/node@18.19.8)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@packages+sanity)(styled-components@5.3.11)
       '@sanity/uuid':
         specifier: ^3.0.2
         version: 3.0.2
@@ -432,8 +432,8 @@ importers:
         specifier: ^1.8.3
         version: 1.8.3(@sanity/client@6.13.3)(react@18.2.0)
       '@sanity/tsdoc':
-        specifier: 1.0.0-alpha.38
-        version: 1.0.0-alpha.38(@sanity/pkg-utils@2.4.10)(@types/node@18.19.8)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@packages+sanity)(styled-components@6.1.8)
+        specifier: 1.0.0-alpha.42
+        version: 1.0.0-alpha.42(@sanity/pkg-utils@2.4.10)(@types/node@18.19.8)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@packages+sanity)(styled-components@6.1.8)
       '@sanity/types':
         specifier: 3.29.1
         version: link:../../packages/@sanity/types
@@ -1678,8 +1678,8 @@ importers:
         specifier: ^1.39.0
         version: 1.41.0
       '@sanity/tsdoc':
-        specifier: 1.0.0-alpha.38
-        version: 1.0.0-alpha.38(@sanity/pkg-utils@2.4.10)(@types/node@18.19.8)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@packages+sanity)(styled-components@6.1.8)
+        specifier: 1.0.0-alpha.42
+        version: 1.0.0-alpha.42(@sanity/pkg-utils@2.4.10)(@types/node@18.19.8)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@packages+sanity)(styled-components@6.1.8)
       '@sanity/ui-workshop':
         specifier: ^1.2.11
         version: 1.2.11(@sanity/icons@2.10.2)(@sanity/ui@2.0.3)(@types/node@18.19.8)(react-dom@18.2.0)(react@18.2.0)(styled-components@6.1.8)
@@ -6106,8 +6106,8 @@ packages:
       - supports-color
     dev: true
 
-  /@sanity/tsdoc@1.0.0-alpha.38(@sanity/pkg-utils@2.4.10)(@types/node@18.19.8)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@packages+sanity)(styled-components@6.1.8):
-    resolution: {integrity: sha512-ZC5oMEP4Cfg9KOfPVGtf5EbbLfSkiojy46KfQ4k3nJx0NQIwVB2lmVB6ZVYYqVtQH35okrW6WMV4DXzQp2fhCQ==}
+  /@sanity/tsdoc@1.0.0-alpha.42(@sanity/pkg-utils@2.4.10)(@types/node@18.19.8)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@packages+sanity)(styled-components@6.1.8):
+    resolution: {integrity: sha512-iAEYkdWqE75JMpLn3KNIY3TfMzjmVMyLgi/KHq/zLFUjqXMrNwvljZIk9STnwKPP8C6fBGNOz7JO6Lpx9x7l1g==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     peerDependencies:
@@ -6162,8 +6162,8 @@ packages:
       - supports-color
       - terser
 
-  /@sanity/tsdoc@1.0.0-alpha.38(@sanity/pkg-utils@3.3.8)(@types/node@18.19.8)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@packages+sanity)(styled-components@5.3.11):
-    resolution: {integrity: sha512-ZC5oMEP4Cfg9KOfPVGtf5EbbLfSkiojy46KfQ4k3nJx0NQIwVB2lmVB6ZVYYqVtQH35okrW6WMV4DXzQp2fhCQ==}
+  /@sanity/tsdoc@1.0.0-alpha.42(@sanity/pkg-utils@3.3.8)(@types/node@18.19.8)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@packages+sanity)(styled-components@5.3.11):
+    resolution: {integrity: sha512-iAEYkdWqE75JMpLn3KNIY3TfMzjmVMyLgi/KHq/zLFUjqXMrNwvljZIk9STnwKPP8C6fBGNOz7JO6Lpx9x7l1g==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     peerDependencies:


### PR DESCRIPTION
Fixes SDX-1090

### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

#### Changelog
```
1.0.0-alpha.42 (2024-02-15)
Bug Fixes
regex to rewrite JSX_2 to JSX 

1.0.0-alpha.41 
Bug Fixes
fix issue with reference to properties not being saved 

1.0.0-alpha.40 
Bug Fixes
url path for reference document links 

1.0.0-alpha.39 
Bug Fixes
UI issues and trigger path update when clicking internal links (#28) (0d88f39)
```
### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->

N/A
