### PR TITLE
fix(pte): PTE modal re-render on validation state change due to tooltip disabled change

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
@@ -287,7 +287,8 @@ export function BlockObject(props: BlockObjectProps) {
             <Tooltip
               placement="top"
               portal="editor"
-              disabled={!tooltipEnabled}
+              // If the object modal is open, disable the tooltip to avoid it rerendering the inner items when the validation changes.
+              disabled={isOpen ? true : !tooltipEnabled}
               content={toolTipContent}
             >
               <PreviewContainer {...innerPaddingProps}>
@@ -342,6 +343,7 @@ export function BlockObject(props: BlockObjectProps) {
       toolTipContent,
       tooltipEnabled,
       value,
+      isOpen,
     ],
   )
 }


### PR DESCRIPTION
### Description

When there are validation errors the tooltip is enabled, when validation errors disappear the tooltip is disabled.
Making that update when the modal is rendered it will trigger a "unmount" and "re-mount" of the BlockObject causing the  modal to unmount and remount, triggering the animation again and losing the input focus.

By checking if the modal is open to **enable / disable** the tooltip, we can be sure that this component won't unmount and mount causing this unwanted issues. 

https://github.com/sanity-io/sanity/assets/46196328/41f3e428-fb9c-4390-a374-0e77f469388e



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

PTE dialogs and tooltips work as always

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Create a new object within pte with validation eror 
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
