### PR TITLE
refactor(core/inputs): report focusPath on text spans ending with .text

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/usePortableTextMembers.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/usePortableTextMembers.tsx
@@ -66,21 +66,21 @@ const reconcilePortableTextMembers = ({
     renderInlineBlock,
     renderPreview,
   } = props
-
   for (const member of members) {
     if (member.kind === 'item') {
       const isObjectBlock = !isBlockType(member.item.schemaType)
       if (isObjectBlock) {
         result.push({kind: 'objectBlock', member, node: member.item})
       } else {
-        // Also include regular text blocks with validation, presence, changes or that are focused by the user.
+        // Also include regular text blocks with validation, presence, changes or that are open or focused.
         // This is a performance optimization to avoid accounting for blocks that
         // doesn't need to be re-rendered (which usually is most of the blocks).
         if (
           member.item.validation.length > 0 ||
           member.item.changed ||
           member.item.presence?.length ||
-          member.item.focusPath.length > 0
+          member.open ||
+          member.item.focusPath.length
         ) {
           result.push({kind: 'textBlock', member, node: member.item})
         }

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
@@ -50,7 +50,10 @@ export function useTrackFocusPath(props: Props): void {
       }
 
       // Don't do anything if the selection focus path is already equal to the focusPath
-      if (selection?.focus.path && isEqual(selection.focus.path, focusPath)) {
+      if (
+        selection?.focus.path &&
+        isEqual(selection.focus.path, focusPath.slice(0, selection.focus.path.length))
+      ) {
         return
       }
 


### PR DESCRIPTION
### Description

This will make the PT-input report the `focusPath` when the focus is on text spans ending with `text` so that the Presentation Tool can work out of the box without making any exceptions for the PT-input.

With this change, we have a bi-directional mapping of focus with the forms and the presentation tool.

Note that this will not change the PTE `EditorSelection` which will continue reporting as before,  it's only the studio-specific `focusPath` reporting that will be affected by this change.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
* That regular form focus works as expected
* That the Presentation Tool focus handling works as expected
* That features like AI-Assist still works as expected.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
* Improved focus handling with the Presentation tool and Portable Text Inputs.

<!--
A description of the change(s) that should be used in the release notes.
-->
