### PR TITLE
fix(core): bring back subtitle in workspace list view

### DIFF
--- a/packages/sanity/src/core/studio/Studio.test.tsx
+++ b/packages/sanity/src/core/studio/Studio.test.tsx
@@ -45,7 +45,7 @@ describe('Studio', () => {
       const html = renderToStaticMarkup(sheet.collectStyles(<Studio config={config} />))
 
       expect(html).toMatchInlineSnapshot(
-        `"<div class=\\"sc-eXNUIU epyZiw\\"><div data-ui=\\"Spinner\\" class=\\"sc-irLvIq kqiGuJ sc-ktwOfi bQiRGJ sc-cgyULZ eaOuUM\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
+        `"<div class=\\"sc-cgyULZ dvXoSs\\"><div data-ui=\\"Spinner\\" class=\\"sc-irLvIq kqiGuJ sc-ktwOfi bQiRGJ sc-kxJlZZ hpxhyL\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
       )
     } finally {
       sheet.seal()
@@ -62,7 +62,7 @@ describe('Studio', () => {
     try {
       const html = renderToString(sheet.collectStyles(<Studio config={config} />))
       expect(html).toMatchInlineSnapshot(
-        `"<div class=\\"sc-eXNUIU epyZiw\\"><div data-ui=\\"Spinner\\" class=\\"sc-irLvIq kqiGuJ sc-ktwOfi bQiRGJ sc-cgyULZ eaOuUM\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
+        `"<div class=\\"sc-cgyULZ dvXoSs\\"><div data-ui=\\"Spinner\\" class=\\"sc-irLvIq kqiGuJ sc-ktwOfi bQiRGJ sc-kxJlZZ hpxhyL\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
       )
     } finally {
       sheet.seal()
@@ -82,7 +82,7 @@ describe('Studio', () => {
       const html = renderToString(sheet.collectStyles(<Studio config={config} />))
       node.innerHTML = html
       expect(html).toMatchInlineSnapshot(
-        `"<div class=\\"sc-eXNUIU epyZiw\\"><div data-ui=\\"Spinner\\" class=\\"sc-irLvIq kqiGuJ sc-ktwOfi bQiRGJ sc-cgyULZ eaOuUM\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
+        `"<div class=\\"sc-cgyULZ dvXoSs\\"><div data-ui=\\"Spinner\\" class=\\"sc-irLvIq kqiGuJ sc-ktwOfi bQiRGJ sc-kxJlZZ hpxhyL\\"><span><svg data-sanity-icon=\\"spinner\\" width=\\"1em\\" height=\\"1em\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"><path d=\\"M4.5 12.5C4.5 16.9183 8.08172 20.5 12.5 20.5C16.9183 20.5 20.5 16.9183 20.5 12.5C20.5 8.08172 16.9183 4.5 12.5 4.5\\" stroke=\\"currentColor\\" stroke-width=\\"1.2\\" stroke-linejoin=\\"round\\"></path></svg></span></div></div>"`,
       )
       document.head.innerHTML += sheet.getStyleTags()
 

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
@@ -15,7 +15,7 @@ import {useTranslation} from '../../../../i18n'
 import {useActiveWorkspace} from '../../../activeWorkspaceMatcher'
 import {useWorkspaces} from '../../../workspaces'
 import {useWorkspaceAuthStates} from './hooks'
-import {STATE_TITLES, TitleTextBox, WorkspacePreviewIcon} from './WorkspacePreview'
+import {STATE_TITLES, WorkspacePreviewIcon} from './WorkspacePreview'
 
 const StyledMenu = styled(Menu)`
   max-width: 350px;
@@ -98,7 +98,8 @@ export function WorkspaceMenuButton() {
                   pressed={isSelected}
                   preview={<WorkspacePreviewIcon icon={workspace.icon} size="small" />}
                   selected={isSelected}
-                  text={<TitleTextBox title={workspace.title} subtitle={workspace.subtitle} />}
+                  subtitle={workspace.subtitle}
+                  text={workspace?.title || workspace.name}
                 />
               )
             })}

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
@@ -99,6 +99,7 @@ export function WorkspaceMenuButton() {
                   preview={<WorkspacePreviewIcon icon={workspace.icon} size="small" />}
                   selected={isSelected}
                   subtitle={workspace.subtitle}
+                  space
                   text={workspace?.title || workspace.name}
                 />
               )

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
@@ -5,6 +5,7 @@ import {
   Button as UIButton,
   Flex,
   Menu,
+  Stack,
   Text,
 } from '@sanity/ui'
 import {useRouter} from 'sanity/router'
@@ -15,7 +16,7 @@ import {useTranslation} from '../../../../i18n'
 import {useActiveWorkspace} from '../../../activeWorkspaceMatcher'
 import {useWorkspaces} from '../../../workspaces'
 import {useWorkspaceAuthStates} from './hooks'
-import {STATE_TITLES, WorkspacePreviewIcon} from './WorkspacePreview'
+import {STATE_TITLES, TitleTextBox, WorkspacePreviewIcon} from './WorkspacePreview'
 
 const StyledMenu = styled(Menu)`
   max-width: 350px;
@@ -98,14 +99,10 @@ export function WorkspaceMenuButton() {
                   pressed={isSelected}
                   preview={<WorkspacePreviewIcon icon={workspace.icon} size="small" />}
                   selected={isSelected}
-                  text={workspace?.title || workspace.name}
-                  tooltipProps={
-                    workspace?.subtitle
-                      ? {
-                          content: workspace.subtitle,
-                          placement: 'right',
-                        }
-                      : undefined
+                  text={
+                    <Stack flex={1} space={2} paddingY={3}>
+                      <TitleTextBox title={workspace.title} subtitle={workspace.subtitle} />
+                    </Stack>
                   }
                 />
               )

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
@@ -100,7 +100,7 @@ export function WorkspaceMenuButton() {
                   preview={<WorkspacePreviewIcon icon={workspace.icon} size="small" />}
                   selected={isSelected}
                   text={
-                    <Stack flex={1} space={2} paddingY={3}>
+                    <Stack flex={1} space={1} paddingY={2}>
                       <TitleTextBox title={workspace.title} subtitle={workspace.subtitle} />
                     </Stack>
                   }

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
@@ -5,7 +5,6 @@ import {
   Button as UIButton,
   Flex,
   Menu,
-  Stack,
   Text,
 } from '@sanity/ui'
 import {useRouter} from 'sanity/router'
@@ -99,11 +98,7 @@ export function WorkspaceMenuButton() {
                   pressed={isSelected}
                   preview={<WorkspacePreviewIcon icon={workspace.icon} size="small" />}
                   selected={isSelected}
-                  text={
-                    <Stack flex={1} space={1} paddingY={2}>
-                      <TitleTextBox title={workspace.title} subtitle={workspace.subtitle} />
-                    </Stack>
-                  }
+                  text={<TitleTextBox title={workspace.title} subtitle={workspace.subtitle} />}
                 />
               )
             })}

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
@@ -98,8 +98,8 @@ export function WorkspaceMenuButton() {
                   pressed={isSelected}
                   preview={<WorkspacePreviewIcon icon={workspace.icon} size="small" />}
                   selected={isSelected}
-                  subtitle={workspace.subtitle}
-                  space
+                  __unstable_subtitle={workspace.subtitle}
+                  __unstable_space={1}
                   text={workspace?.title || workspace.name}
                 />
               )

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspacePreview.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspacePreview.tsx
@@ -43,32 +43,6 @@ const createIcon = (icon: ComponentType | ReactNode) => {
   return undefined
 }
 
-interface TitleTextBoxProps {
-  title: string
-  subtitle?: string
-}
-
-const StyledText = styled(Text)`
-  margin-top: 2px;
-`
-
-export const TitleTextBox = (props: TitleTextBoxProps) => {
-  const {title, subtitle} = props
-  return (
-    <Stack flex={1} space={1} paddingY={1} paddingLeft={1}>
-      <Text size={1} textOverflow="ellipsis" weight="medium">
-        {title}
-      </Text>
-
-      {subtitle && (
-        <StyledText muted size={0} textOverflow="ellipsis">
-          {subtitle}
-        </StyledText>
-      )}
-    </Stack>
-  )
-}
-
 export interface WorkspacePreviewProps {
   icon?: ComponentType | ReactNode
   iconRight?: ComponentType | ReactNode
@@ -87,7 +61,17 @@ export function WorkspacePreview(props: WorkspacePreviewProps) {
     <Flex align="center" flex="none" gap={3}>
       <WorkspacePreviewIcon icon={icon} size="small" />
 
-      <TitleTextBox title={title} subtitle={subtitle} />
+      <Stack flex={1} space={2}>
+        <Text size={1} textOverflow="ellipsis" weight="medium">
+          {title}
+        </Text>
+
+        {subtitle && (
+          <Text muted size={1} textOverflow="ellipsis">
+            {subtitle}
+          </Text>
+        )}
+      </Stack>
 
       {state && STATE_TITLES[state] && (
         <Box paddingLeft={1}>

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspacePreview.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspacePreview.tsx
@@ -55,7 +55,7 @@ const StyledText = styled(Text)`
 export const TitleTextBox = (props: TitleTextBoxProps) => {
   const {title, subtitle} = props
   return (
-    <Stack flex={1} space={1} paddingY={1}>
+    <Stack flex={1} space={1} paddingY={1} paddingLeft={1}>
       <Text size={1} textOverflow="ellipsis" weight="medium">
         {title}
       </Text>

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspacePreview.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspacePreview.tsx
@@ -57,7 +57,7 @@ export const TitleTextBox = (props: TitleTextBoxProps) => {
       </Text>
 
       {subtitle && (
-        <Text muted size={1} textOverflow="ellipsis">
+        <Text muted size={0} textOverflow="ellipsis">
           {subtitle}
         </Text>
       )}

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspacePreview.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspacePreview.tsx
@@ -43,6 +43,28 @@ const createIcon = (icon: ComponentType | ReactNode) => {
   return undefined
 }
 
+interface TitleTextBoxProps {
+  title: string
+  subtitle?: string
+}
+
+export const TitleTextBox = (props: TitleTextBoxProps) => {
+  const {title, subtitle} = props
+  return (
+    <>
+      <Text size={1} textOverflow="ellipsis" weight="medium">
+        {title}
+      </Text>
+
+      {subtitle && (
+        <Text muted size={1} textOverflow="ellipsis">
+          {subtitle}
+        </Text>
+      )}
+    </>
+  )
+}
+
 export interface WorkspacePreviewProps {
   icon?: ComponentType | ReactNode
   iconRight?: ComponentType | ReactNode
@@ -62,17 +84,8 @@ export function WorkspacePreview(props: WorkspacePreviewProps) {
       <WorkspacePreviewIcon icon={icon} size="small" />
 
       <Stack flex={1} space={2}>
-        <Text size={1} textOverflow="ellipsis" weight="medium">
-          {title}
-        </Text>
-
-        {subtitle && (
-          <Text muted size={1} textOverflow="ellipsis">
-            {subtitle}
-          </Text>
-        )}
+        <TitleTextBox title={title} subtitle={subtitle} />
       </Stack>
-
       {state && STATE_TITLES[state] && (
         <Box paddingLeft={1}>
           <Text size={1} muted textOverflow="ellipsis">

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspacePreview.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspacePreview.tsx
@@ -48,20 +48,24 @@ interface TitleTextBoxProps {
   subtitle?: string
 }
 
+const StyledText = styled(Text)`
+  margin-top: 2px;
+`
+
 export const TitleTextBox = (props: TitleTextBoxProps) => {
   const {title, subtitle} = props
   return (
-    <>
+    <Stack flex={1} space={1} paddingY={1}>
       <Text size={1} textOverflow="ellipsis" weight="medium">
         {title}
       </Text>
 
       {subtitle && (
-        <Text muted size={0} textOverflow="ellipsis">
+        <StyledText muted size={0} textOverflow="ellipsis">
           {subtitle}
-        </Text>
+        </StyledText>
       )}
-    </>
+    </Stack>
   )
 }
 
@@ -83,9 +87,8 @@ export function WorkspacePreview(props: WorkspacePreviewProps) {
     <Flex align="center" flex="none" gap={3}>
       <WorkspacePreviewIcon icon={icon} size="small" />
 
-      <Stack flex={1} space={2}>
-        <TitleTextBox title={title} subtitle={subtitle} />
-      </Stack>
+      <TitleTextBox title={title} subtitle={subtitle} />
+
       {state && STATE_TITLES[state] && (
         <Box paddingLeft={1}>
           <Text size={1} muted textOverflow="ellipsis">

--- a/packages/sanity/src/ui-components/__workshop__/MenuItemStory.tsx
+++ b/packages/sanity/src/ui-components/__workshop__/MenuItemStory.tsx
@@ -29,15 +29,11 @@ export default function MenuItemStory() {
           </Box>
           <Menu>
             <MenuItem text={`${text} (with tooltip)`} tooltipProps={{content: 'Example tooltip'}} />
-            <MenuItem text={text} subtitle="With a subtitle" />
+            <MenuItem text={text} />
             <MenuItem icon={CircleIcon} text={text} />
             <MenuItem iconRight={CheckmarkIcon} text={text} />
             <MenuItem hotkeys={HOTKEYS} text={text} />
-            <MenuItem
-              preview={<Avatar initials={AVATAR_INITIALS} size={1} />}
-              subtitle="With a subtitle"
-              text={text}
-            />
+            <MenuItem preview={<Avatar initials={AVATAR_INITIALS} size={1} />} text={text} />
             <MenuItem
               preview={<Avatar initials={AVATAR_INITIALS} size={1} />}
               text={text}
@@ -92,17 +88,21 @@ export default function MenuItemStory() {
             <MenuItem icon={CircleIcon} text={text} hotkeys={HOTKEYS} badgeText={'badge'} />
             <Box paddingX={2} paddingTop={2}>
               <Text muted size={1}>
-                Don't use everything at once
+                Subtitle and spacing is not recommended
               </Text>
             </Box>
             <MenuItem
               icon={CircleIcon}
               text={text}
-              hotkeys={HOTKEYS}
-              badgeText={'badge'}
               iconRight={CheckmarkIcon}
-              subtitle="With a subtitle"
+              __unstable_subtitle="With a subtitle"
+              __unstable_space={1}
             />
+            <Box paddingX={2} paddingTop={2}>
+              <Text muted size={1}>
+                Don't use everything at once
+              </Text>
+            </Box>
             <MenuItem
               preview={<Avatar initials={AVATAR_INITIALS} size={1} />}
               icon={CircleIcon}
@@ -110,7 +110,7 @@ export default function MenuItemStory() {
               hotkeys={HOTKEYS}
               badgeText={'badge'}
               iconRight={CheckmarkIcon}
-              subtitle="With a subtitle"
+              __unstable_subtitle="With a subtitle"
             />
           </Menu>
         </Card>

--- a/packages/sanity/src/ui-components/__workshop__/MenuItemStory.tsx
+++ b/packages/sanity/src/ui-components/__workshop__/MenuItemStory.tsx
@@ -29,11 +29,15 @@ export default function MenuItemStory() {
           </Box>
           <Menu>
             <MenuItem text={`${text} (with tooltip)`} tooltipProps={{content: 'Example tooltip'}} />
-            <MenuItem text={text} />
+            <MenuItem text={text} subtitle="With a subtitle" />
             <MenuItem icon={CircleIcon} text={text} />
             <MenuItem iconRight={CheckmarkIcon} text={text} />
             <MenuItem hotkeys={HOTKEYS} text={text} />
-            <MenuItem preview={<Avatar initials={AVATAR_INITIALS} size={1} />} text={text} />
+            <MenuItem
+              preview={<Avatar initials={AVATAR_INITIALS} size={1} />}
+              subtitle="With a subtitle"
+              text={text}
+            />
             <MenuItem
               preview={<Avatar initials={AVATAR_INITIALS} size={1} />}
               text={text}
@@ -97,6 +101,7 @@ export default function MenuItemStory() {
               hotkeys={HOTKEYS}
               badgeText={'badge'}
               iconRight={CheckmarkIcon}
+              subtitle="With a subtitle"
             />
             <MenuItem
               preview={<Avatar initials={AVATAR_INITIALS} size={1} />}
@@ -105,6 +110,7 @@ export default function MenuItemStory() {
               hotkeys={HOTKEYS}
               badgeText={'badge'}
               iconRight={CheckmarkIcon}
+              subtitle="With a subtitle"
             />
           </Menu>
         </Card>

--- a/packages/sanity/src/ui-components/menuItem/MenuItem.tsx
+++ b/packages/sanity/src/ui-components/menuItem/MenuItem.tsx
@@ -23,6 +23,7 @@ import {
 const FONT_SIZE = 1
 const SUBTITLE_FONT_SIZE = 0
 
+/* Using px value here to make title/subtitles align with icon */
 const SubtitleText = styled(Text)`
   margin-top: 2px;
 `
@@ -48,15 +49,14 @@ export type MenuItemProps = Pick<
   tooltipProps?: TooltipProps | null
   /**
    * Optional subtitle prop for the menu item.
-   * It is not recommended, but it is used for the workspace menu button.
+   * While not recommended, it is utilized for the workspace menu button.
    */
-  subtitle?: string
+  __unstable_subtitle?: string
   /**
-   * Optional space prop for the menu item.
-   * It is not recommended, but it is used for the workspace menu button.
-   * This is the space between the icon and the text in the preview component.
+   * An optional property to adjust spacing in the preview between the icon and the text.
+   * Not recommended, but is applied to the workspace menu button..
    */
-  space?: boolean
+  __unstable_space?: number
 }
 
 const PreviewWrapper = styled(Box)`
@@ -88,8 +88,8 @@ export const MenuItem = forwardRef(function MenuItem(
     renderMenuItem,
     text,
     tooltipProps,
-    subtitle,
-    space = false,
+    __unstable_subtitle,
+    __unstable_space,
     ...rest
   }: MenuItemProps &
     Omit<
@@ -103,7 +103,8 @@ export const MenuItem = forwardRef(function MenuItem(
       <Flex align="center" gap={2}>
         {preview && (
           <PreviewWrapper
-            style={{opacity: disabled ? 0.25 : undefined, paddingRight: space ? '4px' : '0'}}
+            style={{opacity: disabled ? 0.25 : undefined}}
+            paddingRight={__unstable_space ? 1 : 0}
           >
             <Flex align="center" height="fill" justify="center">
               {preview}
@@ -119,13 +120,17 @@ export const MenuItem = forwardRef(function MenuItem(
           </Box>
         )}
         {text && (
-          <Stack flex={1} space={subtitle ? 1 : 2} paddingLeft={subtitle ? 1 : 0}>
+          <Stack
+            flex={1}
+            space={__unstable_subtitle ? 1 : 2}
+            paddingLeft={__unstable_subtitle ? 1 : 0}
+          >
             <Text size={FONT_SIZE} textOverflow="ellipsis" weight="medium">
               {text}
             </Text>
-            {subtitle && (
+            {__unstable_subtitle && (
               <SubtitleText size={SUBTITLE_FONT_SIZE} textOverflow="ellipsis" weight="medium" muted>
-                {subtitle}
+                {__unstable_subtitle}
               </SubtitleText>
             )}
           </Stack>
@@ -150,7 +155,17 @@ export const MenuItem = forwardRef(function MenuItem(
         )}
       </Flex>
     )
-  }, [badgeText, disabled, hotkeys, icon, iconRight, preview, text, subtitle, space])
+  }, [
+    preview,
+    disabled,
+    __unstable_space,
+    icon,
+    text,
+    __unstable_subtitle,
+    badgeText,
+    hotkeys,
+    iconRight,
+  ])
 
   const renderWrapper = useCallback<ConditionalWrapperRenderWrapperCallback>(
     (children) => {

--- a/packages/sanity/src/ui-components/menuItem/MenuItem.tsx
+++ b/packages/sanity/src/ui-components/menuItem/MenuItem.tsx
@@ -51,13 +51,18 @@ export type MenuItemProps = Pick<
    * It is not recommended, but it is used for the workspace menu button.
    */
   subtitle?: string
+  /**
+   * Optional space prop for the menu item.
+   * It is not recommended, but it is used for the workspace menu button.
+   * This is the space between the icon and the text in the preview component.
+   */
+  space?: boolean
 }
 
 const PreviewWrapper = styled(Box)`
   height: 25px;
   width: 25px;
   overflow: hidden;
-  padding-right: 4px;
 `
 
 /**
@@ -84,6 +89,7 @@ export const MenuItem = forwardRef(function MenuItem(
     text,
     tooltipProps,
     subtitle,
+    space = false,
     ...rest
   }: MenuItemProps &
     Omit<
@@ -96,7 +102,9 @@ export const MenuItem = forwardRef(function MenuItem(
     return (
       <Flex align="center" gap={2}>
         {preview && (
-          <PreviewWrapper style={{opacity: disabled ? 0.25 : undefined}}>
+          <PreviewWrapper
+            style={{opacity: disabled ? 0.25 : undefined, paddingRight: space ? '4px' : '0'}}
+          >
             <Flex align="center" height="fill" justify="center">
               {preview}
             </Flex>
@@ -142,7 +150,7 @@ export const MenuItem = forwardRef(function MenuItem(
         )}
       </Flex>
     )
-  }, [badgeText, disabled, hotkeys, icon, iconRight, preview, text, subtitle])
+  }, [badgeText, disabled, hotkeys, icon, iconRight, preview, text, subtitle, space])
 
   const renderWrapper = useCallback<ConditionalWrapperRenderWrapperCallback>(
     (children) => {

--- a/packages/sanity/src/ui-components/menuItem/MenuItem.tsx
+++ b/packages/sanity/src/ui-components/menuItem/MenuItem.tsx
@@ -31,7 +31,7 @@ const SubtitleText = styled(Text)`
 /** @internal */
 export type MenuItemProps = Pick<
   UIMenuItemProps,
-  'as' | 'icon' | 'iconRight' | 'pressed' | 'selected' | 'text' | 'tone' | 'hotkeys'
+  'as' | 'icon' | 'iconRight' | 'pressed' | 'selected' | 'tone' | 'hotkeys'
 > & {
   badgeText?: string
   /**
@@ -46,6 +46,7 @@ export type MenuItemProps = Pick<
    * Optional render callback which receives menu item content.
    */
   renderMenuItem?: (menuItemContent: React.JSX.Element) => React.ReactNode
+  text?: string
   tooltipProps?: TooltipProps | null
   /**
    * Optional subtitle prop for the menu item.

--- a/packages/sanity/src/ui-components/menuItem/MenuItem.tsx
+++ b/packages/sanity/src/ui-components/menuItem/MenuItem.tsx
@@ -21,6 +21,11 @@ import {
 } from '../conditionalWrapper'
 
 const FONT_SIZE = 1
+const SUBTITLE_FONT_SIZE = 0
+
+const SubtitleText = styled(Text)`
+  margin-top: 2px;
+`
 
 /** @internal */
 export type MenuItemProps = Pick<
@@ -41,17 +46,26 @@ export type MenuItemProps = Pick<
    */
   renderMenuItem?: (menuItemContent: React.JSX.Element) => React.ReactNode
   tooltipProps?: TooltipProps | null
+  /**
+   * Optional subtitle prop for the menu item.
+   * It is not recommended, but it is used for the workspace menu button.
+   */
+  subtitle?: string
 }
 
 const PreviewWrapper = styled(Box)`
   height: 25px;
   width: 25px;
   overflow: hidden;
+  padding-right: 4px;
 `
 
 /**
  * Customized Sanity UI <MenuItem> that restricts usage of `children` to encourage simple,
  * single line menu items.
+ *
+ * The workspace menu button needed a subtitle - hence, the StudioUI MenuIten now takes a subtitle prop.
+ * This is only an escape hatch for the workspace menu button and is not recommended for general use.
  *
  * It also accepts a prop to attach tooltips as well as custom badges too.
  *
@@ -69,6 +83,7 @@ export const MenuItem = forwardRef(function MenuItem(
     renderMenuItem,
     text,
     tooltipProps,
+    subtitle,
     ...rest
   }: MenuItemProps &
     Omit<
@@ -96,10 +111,15 @@ export const MenuItem = forwardRef(function MenuItem(
           </Box>
         )}
         {text && (
-          <Stack flex={1} space={2}>
+          <Stack flex={1} space={subtitle ? 1 : 2} paddingLeft={subtitle ? 1 : 0}>
             <Text size={FONT_SIZE} textOverflow="ellipsis" weight="medium">
               {text}
             </Text>
+            {subtitle && (
+              <SubtitleText size={SUBTITLE_FONT_SIZE} textOverflow="ellipsis" weight="medium" muted>
+                {subtitle}
+              </SubtitleText>
+            )}
           </Stack>
         )}
         {(badgeText || hotkeys || iconRight) && (
@@ -122,7 +142,7 @@ export const MenuItem = forwardRef(function MenuItem(
         )}
       </Flex>
     )
-  }, [badgeText, disabled, hotkeys, icon, iconRight, preview, text])
+  }, [badgeText, disabled, hotkeys, icon, iconRight, preview, text, subtitle])
 
   const renderWrapper = useCallback<ConditionalWrapperRenderWrapperCallback>(
     (children) => {


### PR DESCRIPTION
### Description
This PR reintroduces the `subtitle` in the list view for the workspace list. 

<!--
![Screenshot 2024-02-19 at 15 31 05](https://github.com/sanity-io/sanity/assets/44635000/06d91246-ca9c-406f-b472-f37d2193185e)

What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
The workspaces list view and that it looks good with and without subtitles. 


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Reintroduces subtitle field for workspace list views
<!--
A description of the change(s) that should be used in the release notes.
-->
