### PR TITLE
chore: upgrade @playwright/test to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@bjoerge/mutiny": "^0.5.1",
     "@jest/globals": "^29.7.0",
     "@optimize-lodash/rollup-plugin": "^4.0.4",
-    "@playwright/test": "^1.39.0",
+    "@playwright/test": "^1.41.2",
     "@sanity/client": "^6.13.3",
     "@sanity/eslint-config-i18n": "^1.0.0",
     "@sanity/eslint-config-studio": "^3.0.1",

--- a/packages/@sanity/portable-text-editor/package.json
+++ b/packages/@sanity/portable-text-editor/package.json
@@ -76,7 +76,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",
-    "@playwright/test": "^1.39.0",
+    "@playwright/test": "^1.41.2",
     "@portabletext/toolkit": "^2.0.10",
     "@sanity/diff-match-patch": "^3.1.1",
     "@sanity/ui": "^2.0.3",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -307,8 +307,8 @@
   "devDependencies": {
     "@jest/expect": "^29.7.0",
     "@jest/globals": "^29.7.0",
-    "@playwright/experimental-ct-react": "^1.39.0",
-    "@playwright/test": "^1.39.0",
+    "@playwright/experimental-ct-react": "^1.41.2",
+    "@playwright/test": "^1.41.2",
     "@sanity/tsdoc": "1.0.0-alpha.42",
     "@sanity/ui-workshop": "^1.2.11",
     "@testing-library/jest-dom": "^6.2.0",

--- a/perf/tests/package.json
+++ b/perf/tests/package.json
@@ -23,7 +23,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@playwright/test": "^1.39.0",
+    "@playwright/test": "^1.41.2",
     "@sanity/client": "^6.13.3",
     "@sanity/uuid": "^3.0.1",
     "dotenv": "^16.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ importers:
         specifier: ^4.0.4
         version: 4.0.4(rollup@4.9.5)
       '@playwright/test':
-        specifier: ^1.39.0
-        version: 1.41.0
+        specifier: ^1.41.2
+        version: 1.41.2
       '@sanity/client':
         specifier: ^6.13.3
         version: 6.13.3
@@ -1074,8 +1074,8 @@ importers:
         specifier: ^29.7.0
         version: 29.7.0
       '@playwright/test':
-        specifier: ^1.39.0
-        version: 1.41.0
+        specifier: ^1.41.2
+        version: 1.41.2
       '@portabletext/toolkit':
         specifier: ^2.0.10
         version: 2.0.10
@@ -1672,11 +1672,11 @@ importers:
         specifier: ^29.7.0
         version: 29.7.0
       '@playwright/experimental-ct-react':
-        specifier: ^1.39.0
-        version: 1.41.0(@types/node@18.19.8)(vite@4.5.2)
+        specifier: ^1.41.2
+        version: 1.41.2(@types/node@18.19.8)(vite@4.5.2)
       '@playwright/test':
-        specifier: ^1.39.0
-        version: 1.41.0
+        specifier: ^1.41.2
+        version: 1.41.2
       '@sanity/tsdoc':
         specifier: 1.0.0-alpha.42
         version: 1.0.0-alpha.42(@sanity/pkg-utils@2.4.10)(@types/node@18.19.8)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@packages+sanity)(styled-components@6.1.8)
@@ -4660,13 +4660,13 @@ packages:
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  /@playwright/experimental-ct-core@1.41.0(@types/node@18.19.8):
-    resolution: {integrity: sha512-nshYXeACzQRmxHH2IfEP9tdl30tnsUXq5I5WMJtwaza2d4GOntqOUTeMHUq/HziG3XKZO4zc7Kn5tOo1L+BsLw==}
+  /@playwright/experimental-ct-core@1.41.2(@types/node@18.19.8):
+    resolution: {integrity: sha512-JtW7gjmBCeHWKmZcOPuoJ15i2ergVX9PnyYUrAvBbWL8l4X9B7Sblro8nE49hO9baANfEGl4BbRUaj+pA67F6w==}
     engines: {node: '>=16'}
     hasBin: true
     dependencies:
-      playwright: 1.41.0
-      playwright-core: 1.41.0
+      playwright: 1.41.2
+      playwright-core: 1.41.2
       vite: 4.5.2(@types/node@18.19.8)
     transitivePeerDependencies:
       - '@types/node'
@@ -4678,12 +4678,12 @@ packages:
       - terser
     dev: true
 
-  /@playwright/experimental-ct-react@1.41.0(@types/node@18.19.8)(vite@4.5.2):
-    resolution: {integrity: sha512-F9L45wmSoU8ojLk/sZyusVKmzkAFdCos3lgUwTh1VPeI1FQLlow7UUlqcOBYOehYgwAFwX19RRm8fhzK5+qpkw==}
+  /@playwright/experimental-ct-react@1.41.2(@types/node@18.19.8)(vite@4.5.2):
+    resolution: {integrity: sha512-BMcxh2DM3t8nMgUJKWMWAXGIzcYY/4w1ibckGP48edHU/cmZCbI5W7mUXfxMhYCt4mQJ1NuYcFIg5Jt+QVIuRQ==}
     engines: {node: '>=16'}
     hasBin: true
     dependencies:
-      '@playwright/experimental-ct-core': 1.41.0(@types/node@18.19.8)
+      '@playwright/experimental-ct-core': 1.41.2(@types/node@18.19.8)
       '@vitejs/plugin-react': 4.2.1(vite@4.5.2)
     transitivePeerDependencies:
       - '@types/node'
@@ -4697,12 +4697,12 @@ packages:
       - vite
     dev: true
 
-  /@playwright/test@1.41.0:
-    resolution: {integrity: sha512-Grvzj841THwtpBOrfiHOeYTJQxDRnKofMSzCiV8XeyLWu3o89qftQ4BCKfkziJhSUQRd0utKhrddtIsiraIwmw==}
+  /@playwright/test@1.41.2:
+    resolution: {integrity: sha512-qQB9h7KbibJzrDpkXkYvsmiDJK14FULCCZgEcoe2AvFAS64oCirWTwzTlAYEbKaRxWs5TFesE1Na6izMv3HfGg==}
     engines: {node: '>=16'}
     hasBin: true
     dependencies:
-      playwright: 1.41.0
+      playwright: 1.41.2
     dev: true
 
   /@pmndrs/cannon-worker-api@2.4.0(three@0.157.0):
@@ -6098,7 +6098,7 @@ packages:
     resolution: {integrity: sha512-o2X2Veh9YWyVK/Iou/cToSS6ufcTLREoCVMcvBQbSqCFUIGaN1Ko3zxChJMWdf39dyaJ/ixMKtc8pciF/tL6Sw==}
     hasBin: true
     dependencies:
-      '@playwright/test': 1.41.0
+      '@playwright/test': 1.41.2
       '@sanity/client': 6.13.3
       '@sanity/uuid': 3.0.2
       cac: 6.7.14
@@ -15325,18 +15325,18 @@ packages:
     dependencies:
       find-up: 3.0.0
 
-  /playwright-core@1.41.0:
-    resolution: {integrity: sha512-UGKASUhXmvqm2Lxa1fNr8sFwAtqjpgBRr9jQ7XBI8Rn5uFiEowGUGwrruUQsVPIom4bk7Lt+oLGpXobnXzrBIw==}
+  /playwright-core@1.41.2:
+    resolution: {integrity: sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==}
     engines: {node: '>=16'}
     hasBin: true
     dev: true
 
-  /playwright@1.41.0:
-    resolution: {integrity: sha512-XOsfl5ZtAik/T9oek4V0jAypNlaCNzuKOwVhqhgYT3os6kH34PzbRb74F0VWcLYa5WFdnmxl7qyAHBXvPv7lqQ==}
+  /playwright@1.41.2:
+    resolution: {integrity: sha512-v0bOa6H2GJChDL8pAeLa/LZC4feoAMbSQm1/jF/ySsWWoaNItvrMP7GEkvEEFyCTUYKMxjQKaTSg5up7nR6/8A==}
     engines: {node: '>=16'}
     hasBin: true
     dependencies:
-      playwright-core: 1.41.0
+      playwright-core: 1.41.2
     optionalDependencies:
       fsevents: 2.3.2
     dev: true


### PR DESCRIPTION
### Description

The Playwright version we are using currently has a bug as [described here.](https://github.com/microsoft/playwright/issues/29028)

I got hit by it trying to pass a ref made by `createRef` to the mounted test component in playwright-ct. Upgrading Playwright to latest fixes the issue.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
The Playwright tests work as expected.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
