### PR TITLE
feat(core/inputs): support custom editor change callback

### DIFF
--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/Input.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/Input.spec.tsx
@@ -1,5 +1,5 @@
 import {expect, test} from '@playwright/experimental-ct-react'
-import {type PortableTextEditor} from '@sanity/portable-text-editor'
+import {type EditorChange, type PortableTextEditor} from '@sanity/portable-text-editor'
 import {type RefObject} from 'react'
 
 import {testHelpers} from '../../../utils/testHelpers'
@@ -58,6 +58,17 @@ test.describe('Portable Text Input', () => {
       await expect($editor).toBeVisible()
       // If the ref has .schemaTypes.block, it means the editorRef was set correctly
       expect(ref?.current?.schemaTypes.block).toBeDefined()
+    })
+  })
+
+  test.describe('onEditorChange', () => {
+    test(`Supports own handler of editor changes through props`, async ({mount, page}) => {
+      const changes: EditorChange[] = []
+      const pushChange = (change: EditorChange) => changes.push(change)
+      await mount(<InputStory onEditorChange={pushChange} />)
+      const $editor = page.getByTestId('pt-input-with-editor-ref')
+      await expect($editor).toBeVisible()
+      expect(changes.slice(-1)[0].type).toEqual('ready')
     })
   })
 })

--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/InputStory.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/InputStory.tsx
@@ -1,4 +1,4 @@
-import {type PortableTextEditor} from '@sanity/portable-text-editor'
+import {type EditorChange, type PortableTextEditor} from '@sanity/portable-text-editor'
 import {defineArrayMember, defineField, defineType} from '@sanity/types'
 import {createRef, type RefObject, useMemo, useState} from 'react'
 import {type InputProps, type PortableTextInputProps} from 'sanity'
@@ -8,6 +8,7 @@ import {TestWrapper} from '../../utils/TestWrapper'
 
 export function InputStory(props: {
   getRef?: (editorRef: RefObject<PortableTextEditor | null>) => void
+  onEditorChange?: (change: EditorChange) => void
 }) {
   // Use a state as ref here to be make sure we are able to call the ref callback when
   // the ref is ready
@@ -35,6 +36,7 @@ export function InputStory(props: {
               input: (inputProps: InputProps) => {
                 const editorProps = {
                   ...inputProps,
+                  onEditorChange: props.onEditorChange,
                   editorRef: createRef(),
                 } as PortableTextInputProps
                 if (editorProps.editorRef) {
@@ -51,7 +53,7 @@ export function InputStory(props: {
         ],
       }),
     ],
-    [],
+    [props.onEditorChange],
   )
 
   return (

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -65,6 +65,7 @@ export function PortableTextInput(props: PortableTextInputProps) {
     hotkeys,
     markers = EMPTY_ARRAY,
     onChange,
+    onEditorChange,
     onCopy,
     onInsert,
     onItemRemove,
@@ -220,8 +221,11 @@ export function PortableTextInput(props: PortableTextInputProps) {
           break
         default:
       }
+      if (editorRef.current && onEditorChange) {
+        onEditorChange(change, editorRef.current)
+      }
     },
-    [onBlur, onChange, setFocusPathFromEditorSelection, toast],
+    [editorRef, onBlur, onChange, onEditorChange, setFocusPathFromEditorSelection, toast],
   )
 
   useEffect(() => {

--- a/packages/sanity/src/core/form/types/inputProps.ts
+++ b/packages/sanity/src/core/form/types/inputProps.ts
@@ -1,4 +1,5 @@
 import {
+  type EditorChange,
   type HotkeyOptions,
   type OnCopyFn,
   type OnPasteFn,
@@ -507,6 +508,10 @@ export interface PortableTextInputProps
    * Use the `renderBlock` interface instead.
    */
   markers?: PortableTextMarker[]
+  /**
+   * Returns changes from the underlying editor
+   */
+  onEditorChange?: (change: EditorChange, editor: PortableTextEditor) => void
   /**
    * Custom copy function
    */


### PR DESCRIPTION
### Description

This will support providing your own PortableTextEditor change callback to the PortableTextInput through props.

Handy for making custom functionality through the component extensions API.

Also provided a Playwright CT test for this.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
That the change is ok.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
See Playwright CT test

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
* PortableTextInput now supports providing a custom editor change callback.

<!--
A description of the change(s) that should be used in the release notes.
-->
