### PR TITLE
fix(i18n): escape interpolated values inside of <Translate>

### DIFF
--- a/dev/test-studio/components/TranslateExample.tsx
+++ b/dev/test-studio/components/TranslateExample.tsx
@@ -8,11 +8,20 @@ export function TranslateExample() {
     <Card padding={4}>
       <Stack space={4}>
         <Text>{t('use-translation.with-html')}</Text>
-
+        <Text>
+          {t('use-translation.interpolation-example', {
+            spaces: 'spaces',
+            doesNot: 'does not have spaces',
+          })}
+        </Text>
+        <Text>
+          {t('translate.with-formatter', {
+            countries: ['Norway', 'Denmark', 'Sweden'],
+          })}
+        </Text>
         <Text>
           <Translate t={t} i18nKey="use-translation.with-html" />
         </Text>
-
         <Text>
           <Translate
             t={t}
@@ -25,6 +34,26 @@ export function TranslateExample() {
             values={{
               keyword: 'something',
               duration: '30',
+            }}
+          />
+        </Text>
+        <Text>
+          <Translate
+            t={t}
+            i18nKey="translate.with-xml-in-value"
+            values={{
+              value: '<svg>hello</svg>',
+            }}
+          />
+        </Text>
+
+        <Text>
+          <Translate
+            t={t}
+            i18nKey="use-translation.interpolation-example"
+            values={{
+              spaces: 'spaces',
+              doesNot: 'does not have spaces',
             }}
           />
         </Text>

--- a/dev/test-studio/locales/index.ts
+++ b/dev/test-studio/locales/index.ts
@@ -6,7 +6,11 @@ const enUSStrings = {
   'structure.root.title': 'Content 🇺🇸',
   'translate.example':
     '<Icon/> Your search for "<Red>{{keyword}}</Red>" took <Bold>{{duration}}ms</Bold>',
+  'translate.with-xml-in-value':
+    'This value has XML in the interpolated value: <strong>{{value}}</strong>',
+  'translate.with-formatter': 'This value has a list-formatter: {{countries, list}}',
   'use-translation.with-html': 'Apparently, <code>code</code> is an HTML element?',
+  'use-translation.interpolation-example': 'This has {{ spaces }} around it, this one {{doesNot}}',
 }
 
 const enUS = defineLocaleResourceBundle({
@@ -22,6 +26,8 @@ const nbNO = defineLocaleResourceBundle({
     'structure.root.title': 'Innhold 🇳🇴',
     'translate.example':
       '<Icon/> Ditt søk på "<Red>{{keyword}}</Red>" tok <Bold>{{duration}}</Bold> millisekunder',
+    'translate.with-xml-in-value':
+      'Denne verdien har XML i en interpolert verdi: <strong>{{value}}</strong>',
     'use-translation.with-html': 'Faktisk er <code>code</code> et HTML-element?',
   },
 })

--- a/packages/sanity/src/core/i18n/__tests__/Translate.test.tsx
+++ b/packages/sanity/src/core/i18n/__tests__/Translate.test.tsx
@@ -105,4 +105,36 @@ describe('Translate component', () => {
       `Your search for "<span style="color: red;">something</span>" took <b>123ms</b>`,
     )
   })
+
+  it('it interpolates values', async () => {
+    const wrapper = await getWrapper([
+      createBundle({title: 'An <code>{{interpolated}}</code> thing'}),
+    ])
+    const {findByTestId} = render(
+      <TestComponent
+        i18nKey="title"
+        values={{interpolated: 'escaped, interpolated'}}
+        components={{}}
+      />,
+      {wrapper},
+    )
+    expect(await findByTestId('output')).toHaveTextContent('An escaped, interpolated thing')
+  })
+
+  it('it escapes HTML inside of interpolated values', async () => {
+    const wrapper = await getWrapper([
+      createBundle({title: 'An <code>{{interpolated}}</code> thing'}),
+    ])
+    const {findByTestId} = render(
+      <TestComponent
+        i18nKey="title"
+        values={{interpolated: 'escaped, <strong>interpolated</strong> thing'}}
+        components={{}}
+      />,
+      {wrapper},
+    )
+    expect(await findByTestId('output')).toHaveTextContent(
+      'An escaped, <strong>interpolated</strong> thing',
+    )
+  })
 })

--- a/packages/sanity/src/core/i18n/__tests__/simpleParser.test.ts
+++ b/packages/sanity/src/core/i18n/__tests__/simpleParser.test.ts
@@ -98,16 +98,22 @@ describe('simpleParser', () => {
       {type: 'tagOpen', name: 'Icon', selfClosing: true},
       {type: 'text', text: ' Your search for "'},
       {type: 'tagOpen', name: 'Red'},
-      {type: 'text', text: '{{keyword}}'},
+      {type: 'interpolation', variable: 'keyword'},
       {type: 'tagClose', name: 'Red'},
       {type: 'text', text: '" took '},
       {type: 'tagOpen', name: 'Bold'},
-      {type: 'text', text: '{{time}}ms'},
+      {type: 'interpolation', variable: 'time'},
+      {type: 'text', text: 'ms'},
       {type: 'tagClose', name: 'Bold'},
     ])
   })
 })
 describe('simpleParser - errors', () => {
+  test('formatters in interpolations', () => {
+    expect(() => simpleParser('This is not allowed: {{countries, list}}')).toThrow(
+      `Interpolations with formatters are not supported when using <Translate>. Found "countries, list". Utilize "useTranslation" instead, or format the values passed to <Translate> ahead of time.`,
+    )
+  })
   test('unpaired tags', () => {
     expect(() =>
       simpleParser('<Icon/> Your search for "<Red>{{keyword}}" took <Bold>{{time}}ms</Bold>'),


### PR DESCRIPTION
### Description

If using the `<Translate>` component (which utilizes the "simple parser"), and passing it values for interpolation that contained angle brackets (`<`) or full on XML tags (`<svg>`), the parser would treat this as "nested tags" and error out.

Since these interpolated values can contain user input (eg document titles), this can happen without us having control of it (_The document "<3 is in the air" was published_).

Wasn't quite sure about the right approach here, but the implementation I've gone for is one where the parser also tokenizes interpolations, and has the `<Translate>` function replace the values as it goes. One drawback with this approach is that you cannot use formatters from i18next when using the `<Translate>` function, but I felt this was an acceptable shortcoming for now that we can address later. 

### What to review

- Translate function correctly allows `<>` characters inside of values passed to it, both outside of HTML tags and within them
- Parsing approach makes sense

### Testing

Added tests for interpolation to parser, and for rendering the interpolated values (with and without angle brackets) in Translate

### Notes for release

- Fixes an issue where using "angle brackets" (`<`, `>`) in document titles could lead to an error being shown on publish and other operations
