### PR TITLE
feat(portable-text-editor): range decorations

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -15,7 +15,14 @@ import {
   useMemo,
   useState,
 } from 'react'
-import {type BaseRange, Editor, type Text, Transforms} from 'slate'
+import {
+  type BaseRange,
+  Editor,
+  type NodeEntry,
+  Range as SlateRange,
+  type Text,
+  Transforms,
+} from 'slate'
 import {
   Editable as SlateEditable,
   ReactEditor,
@@ -30,6 +37,7 @@ import {
   type OnCopyFn,
   type OnPasteFn,
   type OnPasteResult,
+  type RangeDecoration,
   type RenderAnnotationFunction,
   type RenderBlockFunction,
   type RenderChildFunction,
@@ -40,7 +48,7 @@ import {
 } from '../types/editor'
 import {type HotkeyOptions} from '../types/options'
 import {debugWithName} from '../utils/debug'
-import {toPortableTextRange, toSlateRange} from '../utils/ranges'
+import {moveRangeByOperation, toPortableTextRange, toSlateRange} from '../utils/ranges'
 import {normalizeSelection} from '../utils/selection'
 import {fromSlateValue, isEqualToEmptyEditor, toSlateValue} from '../utils/values'
 import {Element} from './components/Element'
@@ -62,7 +70,11 @@ const PLACEHOLDER_STYLE: CSSProperties = {
   right: 0,
 }
 
-const EMPTY_DECORATORS: BaseRange[] = []
+interface BaseRangeWithDecoration extends BaseRange {
+  rangeDecoration: RangeDecoration
+}
+
+const EMPTY_DECORATORS: BaseRangeWithDecoration[] = []
 
 /**
  * @public
@@ -75,6 +87,7 @@ export type PortableTextEditableProps = Omit<
   onBeforeInput?: (event: InputEvent) => void
   onPaste?: OnPasteFn
   onCopy?: OnCopyFn
+  rangeDecorations?: RangeDecoration[]
   renderAnnotation?: RenderAnnotationFunction
   renderBlock?: RenderBlockFunction
   renderChild?: RenderChildFunction
@@ -102,6 +115,7 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
     onBeforeInput,
     onPaste,
     onCopy,
+    rangeDecorations,
     renderAnnotation,
     renderBlock,
     renderChild,
@@ -121,6 +135,8 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
   const ref = useForwardedRef(forwardedRef)
   const [editableElement, setEditableElement] = useState<HTMLDivElement | null>(null)
   const [hasInvalidValue, setHasInvalidValue] = useState(false)
+  const [rangeDecorationState, setRangeDecorationsState] =
+    useState<BaseRangeWithDecoration[]>(EMPTY_DECORATORS)
 
   const {change$, schemaTypes} = portableTextEditor
   const slateEditor = useSlate()
@@ -166,28 +182,39 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
   )
 
   const renderLeaf = useCallback(
-    (lProps: RenderLeafProps & {leaf: Text & {placeholder?: boolean}}) => {
-      const rendered = (
-        <Leaf
-          {...lProps}
-          schemaTypes={schemaTypes}
-          renderAnnotation={renderAnnotation}
-          renderChild={renderChild}
-          renderDecorator={renderDecorator}
-          readOnly={readOnly}
-        />
-      )
-      if (renderPlaceholder && lProps.leaf.placeholder && lProps.text.text === '') {
-        return (
-          <>
-            <span style={PLACEHOLDER_STYLE} contentEditable={false}>
-              {renderPlaceholder()}
-            </span>
-            {rendered}
-          </>
+    (
+      lProps: RenderLeafProps & {
+        leaf: Text & {placeholder?: boolean; rangeDecoration?: RangeDecoration}
+      },
+    ) => {
+      if (lProps.leaf._type === 'span') {
+        let rendered = (
+          <Leaf
+            {...lProps}
+            schemaTypes={schemaTypes}
+            renderAnnotation={renderAnnotation}
+            renderChild={renderChild}
+            renderDecorator={renderDecorator}
+            readOnly={readOnly}
+          />
         )
+        if (renderPlaceholder && lProps.leaf.placeholder && lProps.text.text === '') {
+          return (
+            <>
+              <span style={PLACEHOLDER_STYLE} contentEditable={false}>
+                {renderPlaceholder()}
+              </span>
+              {rendered}
+            </>
+          )
+        }
+        const decoration = lProps.leaf.rangeDecoration
+        if (decoration) {
+          rendered = decoration.component({children: rendered})
+        }
+        return rendered
       }
-      return rendered
+      return lProps.children
     },
     [readOnly, renderAnnotation, renderChild, renderDecorator, renderPlaceholder, schemaTypes],
   )
@@ -215,9 +242,45 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
     }
   }, [propsSelection, slateEditor, blockTypeName, change$])
 
+  const syncRangeDecorations = useCallback(() => {
+    if (rangeDecorations && rangeDecorations.length > 0) {
+      const newSlateRanges: BaseRangeWithDecoration[] = []
+      rangeDecorations.forEach((rangeDecorationItem) => {
+        if (rangeDecorationItem.isRangeInvalid(portableTextEditor)) {
+          return
+        }
+        const slateRange = toSlateRange(rangeDecorationItem.selection, slateEditor)
+        if (!SlateRange.isRange(slateRange)) {
+          return
+        }
+        newSlateRanges.push({...slateRange, rangeDecoration: rangeDecorationItem})
+        let slateRangeCopy = {...slateRange}
+        // eslint-disable-next-line max-nested-callbacks
+        slateEditor.operations.forEach((op) => {
+          const newRange = moveRangeByOperation(slateRangeCopy, op)
+          if (newRange) {
+            const value = PortableTextEditor.getValue(portableTextEditor)
+            const newRangeSelection = toPortableTextRange(value, slateRangeCopy, schemaTypes)
+            change$.next({
+              type: 'rangeDecorationMoved',
+              rangeDecoration: rangeDecorationItem,
+              newRangeSelection,
+            })
+            slateRangeCopy = newRange
+          }
+        })
+      })
+      if (newSlateRanges.length > 0) {
+        setRangeDecorationsState(newSlateRanges)
+        return
+      }
+    }
+    setRangeDecorationsState(EMPTY_DECORATORS)
+  }, [change$, portableTextEditor, rangeDecorations, schemaTypes, slateEditor])
+
   // Subscribe to change$ and restore selection from props when the editor has been initialized properly with it's value
   useEffect(() => {
-    debug('Subscribing to editor changes$')
+    // debug('Subscribing to editor changes$')
     const sub = change$.subscribe((next: EditorChange): void => {
       switch (next.type) {
         case 'ready':
@@ -233,10 +296,10 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
       }
     })
     return () => {
-      debug('Unsubscribing to changes$')
+      // debug('Unsubscribing to changes$')
       sub.unsubscribe()
     }
-  }, [change$, restoreSelectionFromProps])
+  }, [change$, restoreSelectionFromProps, syncRangeDecorations])
 
   // Restore selection from props when it changes
   useEffect(() => {
@@ -244,6 +307,19 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
       restoreSelectionFromProps()
     }
   }, [hasInvalidValue, propsSelection, restoreSelectionFromProps])
+
+  const originalOnChange = useMemo(() => slateEditor.onChange, [slateEditor])
+
+  useEffect(() => {
+    slateEditor.onChange = () => {
+      syncRangeDecorations()
+      originalOnChange()
+    }
+  }, [originalOnChange, slateEditor, syncRangeDecorations])
+
+  useEffect(() => {
+    syncRangeDecorations()
+  }, [rangeDecorations, syncRangeDecorations])
 
   // Handle from props onCopy function
   const handleCopy = useCallback(
@@ -460,24 +536,33 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
     }
   }, [portableTextEditor, scrollSelectionIntoView])
 
-  const decorate = useCallback(() => {
-    if (isEqualToEmptyEditor(slateEditor.children, schemaTypes)) {
-      return [
-        {
-          anchor: {
-            path: [0, 0],
-            offset: 0,
+  const decorate: (entry: NodeEntry) => BaseRange[] = useCallback(
+    ([, path]) => {
+      if (isEqualToEmptyEditor(slateEditor.children, schemaTypes)) {
+        return [
+          {
+            anchor: {
+              path: [0, 0],
+              offset: 0,
+            },
+            focus: {
+              path: [0, 0],
+              offset: 0,
+            },
+            placeholder: true,
           },
-          focus: {
-            path: [0, 0],
-            offset: 0,
-          },
-          placeholder: true,
-        },
-      ]
-    }
-    return EMPTY_DECORATORS
-  }, [schemaTypes, slateEditor])
+        ]
+      }
+      const result = rangeDecorationState.filter(
+        (item) => SlateRange.includes(item, path) && path.length > 0,
+      )
+      if (result.length > 0) {
+        return result
+      }
+      return EMPTY_DECORATORS
+    },
+    [slateEditor.children, schemaTypes, rangeDecorationState],
+  )
 
   // Set the forwarded ref to be the Slate editable DOM element
   // Also set the editable element in a state so that the MutationObserver

--- a/packages/@sanity/portable-text-editor/src/utils/ranges.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/ranges.ts
@@ -1,4 +1,4 @@
-import {type BaseRange, type Editor, Range} from 'slate'
+import {type BaseRange, type Editor, type Operation, Path, Range} from 'slate'
 
 import {
   type EditorSelection,
@@ -55,4 +55,60 @@ export function toSlateRange(selection: EditorSelection, editor: Editor): Range 
   }
   const range = anchor && focus ? {anchor, focus} : null
   return range
+}
+
+export function moveRangeByOperation(range: Range, operation: Operation): Range | undefined {
+  const isOverlapping = 'path' in operation && Range.includes(range, operation.path)
+  if (!isOverlapping) {
+    return undefined
+  }
+  const rangeCopy = {...range}
+  if (
+    operation.type === 'insert_text' &&
+    operation.offset + operation.text.length <= range.anchor.offset &&
+    operation.offset + operation.text.length <= range.focus.offset
+  ) {
+    rangeCopy.anchor.offset += operation.text.length
+    rangeCopy.focus.offset += operation.text.length
+  } else if (
+    operation.type === 'remove_text' &&
+    operation.offset - operation.text.length <= range.anchor.offset &&
+    operation.offset - operation.text.length <= range.focus.offset
+  ) {
+    rangeCopy.anchor.offset -= operation.text.length
+    rangeCopy.focus.offset -= operation.text.length
+  } else if (operation.type === 'split_node') {
+    if (
+      operation.path.length === 2 &&
+      operation.path[0] === range.anchor.path[0] &&
+      operation.path[0] === range.focus.path[0] &&
+      operation.position <= range.anchor.offset &&
+      operation.position <= range.focus.offset
+    ) {
+      rangeCopy.anchor.offset -= operation.position
+      rangeCopy.focus.offset -= operation.position
+      rangeCopy.anchor.path = Path.next(operation.path)
+      rangeCopy.focus.path = range.anchor.path
+    } else if (operation.path.length === 1) {
+      rangeCopy.anchor.path = Path.next(operation.path)
+      rangeCopy.focus.path = Path.next(operation.path)
+    }
+  } else if (operation.type === 'merge_node') {
+    if (
+      operation.path.length === 2 &&
+      operation.path[0] === range.anchor.path[0] &&
+      operation.path[0] === range.focus.path[0] &&
+      operation.position >= range.anchor.offset &&
+      operation.position >= range.focus.offset
+    ) {
+      rangeCopy.anchor.offset += operation.position
+      rangeCopy.focus.offset += operation.position
+      rangeCopy.anchor.path = Path.previous(operation.path)
+      rangeCopy.focus.path = range.anchor.path
+    } else if (operation.path.length === 1) {
+      rangeCopy.anchor.path = Path.previous(operation.path)
+      rangeCopy.focus.path = Path.previous(operation.path)
+    }
+  }
+  return rangeCopy
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -6,6 +6,7 @@ import {
   type HotkeyOptions,
   type OnCopyFn,
   type OnPasteFn,
+  type RangeDecoration,
   usePortableTextEditor,
 } from '@sanity/portable-text-editor'
 import {type Path, type PortableTextBlock, type PortableTextTextBlock} from '@sanity/types'
@@ -36,6 +37,7 @@ interface InputProps extends ArrayOfObjectsInputProps<PortableTextBlock> {
   onPaste?: OnPasteFn
   onToggleFullscreen: () => void
   path: Path
+  rangeDecorations?: RangeDecoration[]
   renderBlockActions?: RenderBlockActionsCallback
   renderCustomMarkers?: RenderCustomMarkers
 }
@@ -63,6 +65,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     onToggleFullscreen,
     path,
     readOnly,
+    rangeDecorations,
     renderAnnotation,
     renderBlock,
     renderBlockActions,
@@ -146,13 +149,12 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     [
       _renderBlockActions,
       _renderCustomMarkers,
-      scrollElement,
+      boundaryElement,
       isFullscreen,
       onItemClose,
       onItemOpen,
       onItemRemove,
       onPathFocus,
-      boundaryElement,
       path,
       readOnly,
       renderAnnotation,
@@ -162,6 +164,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       renderInput,
       renderItem,
       renderPreview,
+      scrollElement,
     ],
   )
 
@@ -278,14 +281,14 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       )
     },
     [
-      boundaryElement,
-      scrollElement,
       editor.schemaTypes.span.name,
+      boundaryElement,
       onItemClose,
       onItemOpen,
       onPathFocus,
       path,
       readOnly,
+      scrollElement,
       renderAnnotation,
       renderBlock,
       renderCustomMarkers,
@@ -394,6 +397,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
         onPaste={onPaste}
         onToggleFullscreen={handleToggleFullscreen}
         path={path}
+        rangeDecorations={rangeDecorations}
         readOnly={readOnly}
         renderAnnotation={editorRenderAnnotation}
         renderBlock={editorRenderBlock}
@@ -408,18 +412,19 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     [
       ariaDescribedBy,
       editorHotkeys,
+      isActive,
+      isFullscreen,
+      onItemOpen,
+      onCopy,
+      onPaste,
+      handleToggleFullscreen,
+      path,
+      rangeDecorations,
+      readOnly,
       editorRenderAnnotation,
       editorRenderBlock,
       editorRenderChild,
-      handleToggleFullscreen,
       initialSelection,
-      isActive,
-      isFullscreen,
-      onCopy,
-      onItemOpen,
-      onPaste,
-      path,
-      readOnly,
       scrollElement,
     ],
   )

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -4,6 +4,7 @@ import {
   type OnCopyFn,
   type OnPasteFn,
   PortableTextEditable,
+  type RangeDecoration,
   type RenderAnnotationFunction,
   type RenderBlockFunction,
   type RenderChildFunction,
@@ -60,6 +61,7 @@ interface EditorProps {
   onToggleFullscreen: () => void
   path: Path
   readOnly?: boolean
+  rangeDecorations?: RangeDecoration[]
   renderAnnotation: RenderAnnotationFunction
   renderBlock: RenderBlockFunction
   renderChild: RenderChildFunction
@@ -95,6 +97,7 @@ export function Editor(props: EditorProps) {
     onToggleFullscreen,
     path,
     readOnly,
+    rangeDecorations,
     renderAnnotation,
     renderBlock,
     renderChild,
@@ -145,6 +148,7 @@ export function Editor(props: EditorProps) {
         onCopy={onCopy}
         onPaste={onPaste}
         ref={editableRef}
+        rangeDecorations={rangeDecorations}
         renderAnnotation={renderAnnotation}
         renderBlock={renderBlock}
         renderChild={renderChild}
@@ -164,6 +168,7 @@ export function Editor(props: EditorProps) {
       initialSelection,
       onCopy,
       onPaste,
+      rangeDecorations,
       renderAnnotation,
       renderBlock,
       renderChild,

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -73,6 +73,7 @@ export function PortableTextInput(props: PortableTextInputProps) {
     onPathFocus,
     path,
     readOnly,
+    rangeDecorations,
     renderBlockActions,
     renderCustomMarkers,
     schemaType,
@@ -288,6 +289,7 @@ export function PortableTextInput(props: PortableTextInputProps) {
                 onInsert={onInsert}
                 onPaste={onPaste}
                 onToggleFullscreen={handleToggleFullscreen}
+                rangeDecorations={rangeDecorations}
                 renderBlockActions={renderBlockActions}
                 renderCustomMarkers={renderCustomMarkers}
               />

--- a/packages/sanity/src/core/form/types/inputProps.ts
+++ b/packages/sanity/src/core/form/types/inputProps.ts
@@ -4,6 +4,7 @@ import {
   type OnCopyFn,
   type OnPasteFn,
   type PortableTextEditor,
+  type RangeDecoration,
 } from '@sanity/portable-text-editor'
 import {
   type ArraySchemaType,
@@ -532,6 +533,10 @@ export interface PortableTextInputProps
    * Use the `renderBlock` interface instead.
    */
   renderCustomMarkers?: RenderCustomMarkers
+  /**
+   * Array of {@link RangeDecoration} that can be used to decorate the content.
+   */
+  rangeDecorations?: RangeDecoration[]
 }
 
 /**


### PR DESCRIPTION
### Description

This will add support for decorating selections inside the Portable Text Editor with custom components. This can be used for search highlighting, validation, and similar.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
