### PR TITLE
fix(pte): add telemetry to invalidvalue error

### DIFF
--- a/packages/sanity/src/core/form/__telemetry__/form.telemetry.ts
+++ b/packages/sanity/src/core/form/__telemetry__/form.telemetry.ts
@@ -2,26 +2,29 @@ import {defineEvent} from '@sanity/telemetry'
 
 export const PortableTextInputExpanded = defineEvent({
   version: 1,
-  name: 'Portable Text Editor expanded',
+  name: 'Portable Text Editor Expanded',
   description: 'The portable text editor was expanded',
 })
 
 export const PortableTextInputCollapsed = defineEvent({
   version: 1,
-  name: 'Portable Text Editor collapsed',
+  name: 'Portable Text Editor Collapsed',
   description: 'The portable text editor was collapsed',
 })
 
 export const PortableTextInvalidValueIgnore = defineEvent({
   version: 1,
-  name: 'Portable Text Editor ignore invalid value ',
+  name: 'Portable Text Editor Ignored Invalid Value ',
   description:
     'The portable text got an invalid value from the form and pressed button to ignore it',
 })
 
-export const PortableTextInvalidValueResolve = defineEvent({
+export const PortableTextInvalidValueResolve = defineEvent<{
+  PTEInvalidValueId: string
+  PTEInvalidValueDescription: string
+}>({
   version: 1,
-  name: 'Portable Text Editor resolve invalid value',
+  name: 'Portable Text Editor Resolved Invalid Value',
   description:
-    'The portable text got an invalid value from the form and pressed button to resolve it',
+    'The portable text got an invalid value from the form and pressed button to resolve it.',
 })

--- a/packages/sanity/src/core/form/__telemetry__/form.telemetry.ts
+++ b/packages/sanity/src/core/form/__telemetry__/form.telemetry.ts
@@ -11,3 +11,17 @@ export const PortableTextInputCollapsed = defineEvent({
   name: 'Portable Text Editor collapsed',
   description: 'The portable text editor was collapsed',
 })
+
+export const PortableTextInvalidValueIgnore = defineEvent({
+  version: 1,
+  name: 'Portable Text Editor ignore invalid value ',
+  description:
+    'The portable text got an invalid value from the form and pressed button to ignore it',
+})
+
+export const PortableTextInvalidValueResolve = defineEvent({
+  version: 1,
+  name: 'Portable Text Editor resolve invalid value',
+  description:
+    'The portable text got an invalid value from the form and pressed button to resolve it',
+})

--- a/packages/sanity/src/core/form/inputs/PortableText/InvalidValue.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/InvalidValue.tsx
@@ -31,11 +31,14 @@ export function InvalidValue(props: InvalidValueProps) {
   const telemetry = useTelemetry()
 
   const {t} = useTranslation()
-  //What do people do when they resolve?
+
   const handleAction = useCallback(() => {
     if (resolution) {
       onChange({type: 'mutation', patches: resolution.patches})
-      telemetry.log(PortableTextInvalidValueResolve)
+      telemetry.log(PortableTextInvalidValueResolve, {
+        PTEInvalidValueId: resolution.i18n.description,
+        PTEInvalidValueDescription: resolution.description,
+      })
     }
   }, [onChange, resolution, telemetry])
 

--- a/packages/sanity/src/core/form/inputs/PortableText/InvalidValue.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/InvalidValue.tsx
@@ -1,4 +1,5 @@
 import {type InvalidValueResolution} from '@sanity/portable-text-editor'
+import {useTelemetry} from '@sanity/telemetry/react'
 import {
   Box,
   // eslint-disable-next-line no-restricted-imports
@@ -12,6 +13,10 @@ import {
 import {useCallback} from 'react'
 
 import {Translate, useTranslation} from '../../../i18n'
+import {
+  PortableTextInvalidValueIgnore,
+  PortableTextInvalidValueResolve,
+} from '../../__telemetry__/form.telemetry'
 import {Alert} from '../../components/Alert'
 
 interface InvalidValueProps {
@@ -23,13 +28,21 @@ interface InvalidValueProps {
 
 export function InvalidValue(props: InvalidValueProps) {
   const {onChange, onIgnore, resolution, readOnly} = props
+  const telemetry = useTelemetry()
 
   const {t} = useTranslation()
+  //What do people do when they resolve?
   const handleAction = useCallback(() => {
     if (resolution) {
       onChange({type: 'mutation', patches: resolution.patches})
+      telemetry.log(PortableTextInvalidValueResolve)
     }
-  }, [onChange, resolution])
+  }, [onChange, resolution, telemetry])
+
+  const handleOnIgnore = useCallback(() => {
+    telemetry.log(PortableTextInvalidValueIgnore)
+    onIgnore()
+  }, [onIgnore, telemetry])
 
   if (!resolution) return null
 
@@ -42,7 +55,7 @@ export function InvalidValue(props: InvalidValueProps) {
             <Grid columns={[1, 2]} gap={1}>
               <Button
                 mode="ghost"
-                onClick={onIgnore}
+                onClick={handleOnIgnore}
                 text={t('inputs.portable-text.invalid-value.ignore-button.text')}
               />
               {/* @todo: use plain string */}

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -230,7 +230,6 @@ export function PortableTextInput(props: PortableTextInputProps) {
     setIgnoreValidationError(true)
   }, [])
 
-  //telemetry på når denne blir kalt og hva grunnen er  Invalidresolutionvalue
   const respondToInvalidContent = useMemo(() => {
     if (invalidValue && invalidValue.resolution) {
       return (

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -230,6 +230,7 @@ export function PortableTextInput(props: PortableTextInputProps) {
     setIgnoreValidationError(true)
   }, [])
 
+  //telemetry på når denne blir kalt og hva grunnen er  Invalidresolutionvalue
   const respondToInvalidContent = useMemo(() => {
     if (invalidValue && invalidValue.resolution) {
       return (


### PR DESCRIPTION
### Description
Adds telemetry events for when the PTE input receives invalid values. 
When the user presses the `Resolve` button, an `id` and `description` is included to easily be able to distinguish the resolve events. Using the `i18n` description field as an `id`. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
