### PR TITLE
fix(core): add onDoubleClick to open image crop

### DIFF
--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
@@ -444,6 +444,7 @@ export class BaseImageInput extends PureComponent<BaseImageInputProps, BaseImage
 
     return (
       <ImagePreview
+        onDoubleClick={this.handleOpenDialog}
         drag={!value?._upload && hoveringFiles.length > 0}
         isRejected={rejectedFilesCount > 0 || !directUploads}
         readOnly={readOnly}
@@ -487,7 +488,6 @@ export class BaseImageInput extends PureComponent<BaseImageInputProps, BaseImage
           data-testid="file-input-browse-button"
         />
       )
-
     if (assetSources && assetSources.length > 1) {
       browseMenuItem = assetSources.map((assetSource) => {
         return (


### PR DESCRIPTION
### Description

This PR adds an `onDoubleClick` to the `ImagePreview` component and opens the `Crop image` dialog when the image preview is double clicked. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Go to an asset with an image preview and with the ability to crop this image, and double click on the image - it will open the `Crop image` dialog. 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Adds ability to open 'Crop image' dialog by double clicking image preview 
<!--
A description of the change(s) that should be used in the release notes.
-->
