### PR TITLE
fix(structure): disable publish button while loading

### DIFF
--- a/packages/sanity/src/structure/documentActions/PublishAction.tsx
+++ b/packages/sanity/src/structure/documentActions/PublishAction.tsx
@@ -176,7 +176,7 @@ export const PublishAction: DocumentActionComponent = (props) => {
 
   const disabled = Boolean(
     publishScheduled ||
-      editState.ready ||
+      !editState.ready ||
       editState?.transactionSyncLock?.enabled ||
       publishState === 'publishing' ||
       publishState === 'published' ||

--- a/packages/sanity/src/structure/documentActions/PublishAction.tsx
+++ b/packages/sanity/src/structure/documentActions/PublishAction.tsx
@@ -63,6 +63,7 @@ export const PublishAction: DocumentActionComponent = (props) => {
   const [publishScheduled, setPublishScheduled] = useState<boolean>(false)
   const isSyncing = syncState.isSyncing
   const isValidating = validationStatus.isValidating
+  const [initialLoading, setInitialLoading] = useState(true)
   const [permissions, isPermissionsLoading] = useDocumentPairPermissions({
     id,
     type,
@@ -84,6 +85,13 @@ export const PublishAction: DocumentActionComponent = (props) => {
     publish.execute()
     setPublishState('publishing')
   }, [publish])
+
+  // Handle the initial loading state to disable button while loading
+  useEffect(() => {
+    if (!isPermissionsLoading && !isValidating && !isSyncing) {
+      setInitialLoading(false)
+    }
+  }, [isPermissionsLoading, isValidating, isSyncing])
 
   useEffect(() => {
     // make sure the validation status is about the current revision and not an earlier one
@@ -176,6 +184,7 @@ export const PublishAction: DocumentActionComponent = (props) => {
 
   const disabled = Boolean(
     publishScheduled ||
+      initialLoading ||
       editState?.transactionSyncLock?.enabled ||
       publishState === 'publishing' ||
       publishState === 'published' ||

--- a/packages/sanity/src/structure/documentActions/PublishAction.tsx
+++ b/packages/sanity/src/structure/documentActions/PublishAction.tsx
@@ -63,7 +63,6 @@ export const PublishAction: DocumentActionComponent = (props) => {
   const [publishScheduled, setPublishScheduled] = useState<boolean>(false)
   const isSyncing = syncState.isSyncing
   const isValidating = validationStatus.isValidating
-  const [initialLoading, setInitialLoading] = useState(true)
   const [permissions, isPermissionsLoading] = useDocumentPairPermissions({
     id,
     type,
@@ -85,13 +84,6 @@ export const PublishAction: DocumentActionComponent = (props) => {
     publish.execute()
     setPublishState('publishing')
   }, [publish])
-
-  // Handle the initial loading state to disable button while loading
-  useEffect(() => {
-    if (!isPermissionsLoading && !isValidating && !isSyncing) {
-      setInitialLoading(false)
-    }
-  }, [isPermissionsLoading, isValidating, isSyncing])
 
   useEffect(() => {
     // make sure the validation status is about the current revision and not an earlier one
@@ -184,7 +176,7 @@ export const PublishAction: DocumentActionComponent = (props) => {
 
   const disabled = Boolean(
     publishScheduled ||
-      initialLoading ||
+      editState.ready ||
       editState?.transactionSyncLock?.enabled ||
       publishState === 'publishing' ||
       publishState === 'published' ||


### PR DESCRIPTION
### Description
This PR adds the `editState.ready` prop to the `disabled` check and disables the `Publish` button if it's still loading, preventing the user from pressing it when checks aren't completed. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
That the Publish button is disabled when it should be, and not disabled if it shouldn't be
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Disables Publish button while loading document
<!--
A description of the change(s) that should be used in the release notes.
-->
