### PR TITLE
test(core): add test for storing color scheme preference and search

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/SearchResults.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/SearchResults.tsx
@@ -91,6 +91,7 @@ export function SearchResults({inputElement}: SearchResultsProps) {
                   <CommandList
                     activeItemDataAttr="data-hovered"
                     ariaLabel={t('search.search-results-label')}
+                    data-testid="search-results"
                     fixedHeight
                     initialIndex={lastActiveIndex}
                     inputElement={inputElement}

--- a/test/e2e/tests/desk/documentTypeListContextMenu.spec.ts
+++ b/test/e2e/tests/desk/documentTypeListContextMenu.spec.ts
@@ -1,14 +1,17 @@
 import {expect} from '@playwright/test'
 import {test} from '@sanity/test'
 
-//we should also check for custom sort orders`
+const SORT_KEY = 'structure-tool::author::sortOrder'
+const LAYOUT_KEY = 'structure-tool::author::layout'
+
+//we should also check for custom sort orders
 test('clicking sort order and direction sets value in storage', async ({page}) => {
   await page.goto('/test/content/author')
   await page.getByTestId('pane').getByTestId('pane-context-menu-button').click()
   await page.getByRole('menuitem', {name: 'Sort by Name'}).click()
   const localStorage = await page.evaluate(() => window.localStorage)
 
-  expect(localStorage['structure-tool::author::sortOrder']).toBe(
+  expect(localStorage[SORT_KEY]).toBe(
     '{"by":[{"field":"name","direction":"asc"}],"extendedProjection":"name"}',
   )
 
@@ -16,7 +19,7 @@ test('clicking sort order and direction sets value in storage', async ({page}) =
   await page.getByRole('menuitem', {name: 'Sort by Last Edited'}).click()
   const lastEditedLocalStorage = await page.evaluate(() => window.localStorage)
 
-  expect(lastEditedLocalStorage['structure-tool::author::sortOrder']).toBe(
+  expect(lastEditedLocalStorage[SORT_KEY]).toBe(
     '{"by":[{"field":"_updatedAt","direction":"desc"}],"extendedProjection":""}',
   )
 })
@@ -27,13 +30,13 @@ test('clicking list view sets value in storage', async ({page}) => {
   await page.getByRole('menuitem', {name: 'Detailed view'}).click()
   const localStorage = await page.evaluate(() => window.localStorage)
 
-  expect(localStorage['structure-tool::author::layout']).toBe('"detail"')
+  expect(localStorage[LAYOUT_KEY]).toBe('"detail"')
 
   await page.getByTestId('pane').getByTestId('pane-context-menu-button').click()
   await page.getByRole('menuitem', {name: 'Compact view'}).click()
   const compactLocalStorage = await page.evaluate(() => window.localStorage)
 
-  expect(compactLocalStorage['structure-tool::author::layout']).toBe('"default"')
+  expect(compactLocalStorage[LAYOUT_KEY]).toBe('"default"')
 })
 
 test('values persist after navigating away and back', async ({page}) => {
@@ -44,5 +47,5 @@ test('values persist after navigating away and back', async ({page}) => {
   await page.goto('/test/content/author')
   const localStorage = await page.evaluate(() => window.localStorage)
 
-  expect(localStorage['structure-tool::author::layout']).toBe('"detail"')
+  expect(localStorage[LAYOUT_KEY]).toBe('"detail"')
 })

--- a/test/e2e/tests/navbar/appearanceMenu.spec.ts
+++ b/test/e2e/tests/navbar/appearanceMenu.spec.ts
@@ -1,0 +1,35 @@
+import {expect} from '@playwright/test'
+import {test} from '@sanity/test'
+
+const COLOR_SCHEME_KEY = 'sanityStudio:ui:colorScheme'
+
+//some flakiness around local storage initial state, so add timeout and isolate
+test('default color scheme is system', async ({page, baseURL}) => {
+  await page.goto(baseURL ?? '/test/content')
+  await page.waitForTimeout(2000)
+  const localStorage = await page.evaluate(() => window.localStorage)
+  expect(localStorage[COLOR_SCHEME_KEY]).toBe('system')
+})
+
+test('color scheme changes and persists', async ({page, baseURL}) => {
+  await page.goto(baseURL ?? '/test/content')
+
+  await page.locator(`[id='user-menu']`).click()
+  await page.getByLabel('Use dark appearance').click()
+
+  const darkModeLocalStorage = await page.evaluate(() => window.localStorage)
+
+  expect(darkModeLocalStorage[COLOR_SCHEME_KEY]).toBe('dark')
+
+  await page.locator(`[id='user-menu']`).click()
+  await page.getByLabel('Use light appearance').click()
+
+  const lightModeLocalStorage = await page.evaluate(() => window.localStorage)
+  expect(lightModeLocalStorage[COLOR_SCHEME_KEY]).toBe('light')
+
+  await page.goto('https://example.com')
+  await page.goto(baseURL ?? '/test/content')
+  const postNavigationLocalStorage = await page.evaluate(() => window.localStorage)
+  //also include going to other studio / project id?
+  expect(postNavigationLocalStorage[COLOR_SCHEME_KEY]).toBe('light')
+})

--- a/test/e2e/tests/navbar/search.spec.ts
+++ b/test/e2e/tests/navbar/search.spec.ts
@@ -1,0 +1,36 @@
+import {expect} from '@playwright/test'
+import {test} from '@sanity/test'
+
+test('searching creates saved searches', async ({page, createDraftDocument, baseURL}) => {
+  await createDraftDocument('/test/content/book')
+  await page.getByTestId('field-title').getByTestId('string-input').fill('A searchable title')
+  await page.getByTestId('studio-search').click()
+
+  await page.getByPlaceholder('Search', {exact: true}).fill('A search')
+  await page.getByTestId('search-results').isVisible()
+  await page.getByTestId('search-results').click()
+
+  const localStorage = await page.evaluate(() => window.localStorage)
+  const keyMatch = Object.keys(localStorage).find((key) => key.startsWith('search::recent'))
+  const savedSearches = JSON.parse(localStorage[keyMatch!]).recentSearches
+  expect(savedSearches[0].terms.query).toBe('A search')
+
+  await page.goto('https://example.com')
+  await page.goto(baseURL ?? '/test/content')
+  const postNavigationLocalStorage = await page.evaluate(() => window.localStorage)
+
+  //also include going to other studio / project id?
+  const postNavigationSearches = JSON.parse(postNavigationLocalStorage[keyMatch!]).recentSearches
+  expect(postNavigationSearches[0].terms.query).toBe('A search')
+
+  await page.getByTestId('studio-search').click()
+
+  await page.getByPlaceholder('Search', {exact: true}).fill('A searchable')
+  await page.getByTestId('search-results').isVisible()
+  await page.getByTestId('search-results').click()
+
+  const secondSearchStorage = await page.evaluate(() => window.localStorage)
+
+  const secondSearches = JSON.parse(secondSearchStorage[keyMatch!]).recentSearches
+  expect(secondSearches[0].terms.query).toBe('A searchable')
+})


### PR DESCRIPTION
### Description
As we start to re-organize how we think about storing our settings, it's important to write tests first to ensure we're not losing any old functionality, especially during a transition period.

### What to review
The new test files and the small change to add a data-testid to a component that would have been brittle to reach without it.

### Testing
Feel free to run the tests locally as needed.