### PR TITLE
fix(i18n): add successful document restoration string

### DIFF
--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -346,10 +346,10 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   /** The text when an unpublish operation failed  */
   'panes.document-operation-results.operation-error_unpublish':
     'An error occurred while attempting to unpublish this document. This usually means that there are other documents that refers to it.',
-  /** The text when a generic operation succeded (fallback, generally not shown)  */
+  /** The text when a generic operation succeeded (fallback, generally not shown)  */
   'panes.document-operation-results.operation-success':
     'Successfully performed {{context}} on document',
-  /** The text when a delete operation succeded  */
+  /** The text when a delete operation succeeded  */
   'panes.document-operation-results.operation-success_delete':
     'The document was successfully deleted',
   /** The text when a discard changes operation succeeded  */

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -358,6 +358,9 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   /** The text when a publish operation succeeded  */
   'panes.document-operation-results.operation-success_publish':
     '<Strong>{{title}}</Strong> was published',
+  /** The text when a restore operation succeeded  */
+  'panes.document-operation-results.operation-success_restore':
+    '<Strong>{{title}}</Strong> was restored',
   /** The text when an unpublish operation succeeded  */
   'panes.document-operation-results.operation-success_unpublish':
     '<Strong>{{title}}</Strong> was unpublished. A draft has been created from the latest published version.',


### PR DESCRIPTION
### Description

There is no language string for the `restore` event, which causes the generic toast message to be rendered with a missing `{{context}}` value:

<img width="533" alt="Screenshot 2024-02-22 at 16 50 34" src="https://github.com/sanity-io/sanity/assets/1454914/cbf0dacd-5df2-403a-8fd7-451d25a074ab">

This change adds a dedicated string for successful document restoration:

<img width="465" alt="Screenshot 2024-02-23 at 09 48 38" src="https://github.com/sanity-io/sanity/assets/1454914/1a88b20b-ee03-4b2f-990d-f82cd455253f">

### What to review

- Is the string okay?

### Testing

I don't believe we test document operation toasts at the moment, so it wouldn't make sense to implement just for document restoration.