### PR TITLE
feat(ci): cache release dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,28 @@ jobs:
         uses: pnpm/action-setup@v3
         with:
           version: 8
-          run_install: true
+          run_install: false
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            v1-${{ runner.os }}-pnpm-store-${{ env.cache-name }}-
+            v1-${{ runner.os }}-pnpm-store-
+            v1-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: pnpm install
 
       - name: Pre-flight
         run: |


### PR DESCRIPTION
### Description

This branch adds caching for pnpm dependencies in the release workflow. It's based on [Binoy's implementation in the e2e workflow](https://github.com/sanity-io/sanity/blob/next/.github/workflows/e2e.yml).

### What to review

- Do you see any issues in the approach?

### Testing

This approach already works for the e2e workflow. If there are any issues when we next release Studio, we can revert this commit. I'm happy to be on hand for the next release.