### PR TITLE
fix(test): fix breaking annotation popover test

### DIFF
--- a/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/Annotations.spec.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/inputs/PortableText/Annotations.spec.tsx
@@ -24,17 +24,23 @@ test.describe('Portable Text Input', () => {
       // Assertion: the annotation toolbar popover should not be visible
       await expect(page.getByTestId('annotation-toolbar-popover')).not.toBeVisible()
 
+      const $linkEditPopover = page.getByTestId('popover-edit-dialog')
+      const $linkInput = $linkEditPopover.getByLabel('Link').first()
+
       // Now we check if the edit popover shows automatically
-      await expect(page.getByLabel('Link').first()).toBeAttached({timeout: 10000})
+      await expect($linkInput).toBeAttached({timeout: 10000})
 
       // Focus the URL input
-      await page.getByLabel('Link').first().focus()
+      await $linkInput.focus()
 
       // Assertion: The URL input should be focused
-      await expect(page.getByLabel('Link').first()).toBeFocused()
+      await expect($linkInput).toBeFocused()
 
       // Type in the URL
       await page.keyboard.type('https://www.sanity.io')
+
+      // Assetion: The URL input should have the correct value
+      await expect($linkInput).toHaveValue('https://www.sanity.io')
 
       // Close the popover
       await page.keyboard.press('Escape')

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
@@ -40,6 +40,7 @@ export function PopoverEditDialog(props: PopoverEditDialogProps) {
     <RootPopover
       content={<Content {...props} />}
       constrainSize
+      data-testid="popover-edit-dialog"
       data-ui="PopoverEditDialog"
       fallbackPlacements={POPOVER_FALLBACK_PLACEMENTS}
       floatingBoundary={floatingBoundary}


### PR DESCRIPTION
### Description

Fixes breaking annotation test by changing some of the locators to target elements specifically within the object edit popover. The test broke since we added aria labels to the PTE toolbar, meaning the locator `page.getByLabel('Link').first()` would target the toolbar button instead of the Link input inside the popover.

### What to review

- That tests runs successfully again
