### PR TITLE
fix(core): change modalWidth of inlineObjects to 1 by default

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
@@ -285,6 +285,8 @@ export const DefaultInlineObjectComponent = (props: BlockProps) => {
     setPopoverOpen(false)
   }, [])
 
+  const modalWidth = schemaType?.type?.name === 'reference' ? 1 : undefined
+
   return (
     <>
       <Root
@@ -331,6 +333,7 @@ export const DefaultInlineObjectComponent = (props: BlockProps) => {
           referenceBoundary={referenceBoundary}
           referenceElement={referenceElement}
           schemaType={schemaType}
+          width={modalWidth}
         >
           {children}
         </ObjectEditModal>

--- a/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
@@ -285,8 +285,6 @@ export const DefaultInlineObjectComponent = (props: BlockProps) => {
     setPopoverOpen(false)
   }, [])
 
-  const modalWidth = schemaType?.type?.name === 'reference' ? 1 : undefined
-
   return (
     <>
       <Root
@@ -333,7 +331,6 @@ export const DefaultInlineObjectComponent = (props: BlockProps) => {
           referenceBoundary={referenceBoundary}
           referenceElement={referenceElement}
           schemaType={schemaType}
-          width={modalWidth}
         >
           {children}
         </ObjectEditModal>

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx
@@ -15,7 +15,6 @@ export function ObjectEditModal(props: {
   referenceBoundary: HTMLElement | null
   referenceElement: HTMLElement | null
   schemaType: ObjectSchemaType & {i18nTitleKey?: string}
-  width?: number
 }) {
   const {
     autoFocus,
@@ -25,7 +24,6 @@ export function ObjectEditModal(props: {
     referenceBoundary,
     referenceElement,
     schemaType,
-    width,
   } = props
 
   const {t} = useTranslation()
@@ -44,7 +42,7 @@ export function ObjectEditModal(props: {
     onClose()
   }, [onClose])
 
-  const modalWidth = schemaModalOption?.width || width
+  const modalWidth = schemaModalOption?.width || 1
 
   if (modalType === 'popover') {
     return (

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx
@@ -15,6 +15,7 @@ export function ObjectEditModal(props: {
   referenceBoundary: HTMLElement | null
   referenceElement: HTMLElement | null
   schemaType: ObjectSchemaType & {i18nTitleKey?: string}
+  width?: number
 }) {
   const {
     autoFocus,
@@ -24,6 +25,7 @@ export function ObjectEditModal(props: {
     referenceBoundary,
     referenceElement,
     schemaType,
+    width,
   } = props
 
   const {t} = useTranslation()
@@ -42,7 +44,7 @@ export function ObjectEditModal(props: {
     onClose()
   }, [onClose])
 
-  const modalWidth = schemaModalOption?.width
+  const modalWidth = schemaModalOption?.width || width
 
   if (modalType === 'popover') {
     return (


### PR DESCRIPTION
### Description

This PR changes the inline objects in portable text to be wider by default. 
There has been a lot of signal of the reference picker being too narrow. After talking with design, the decision landed on making the default width of _all_ inline objects larger (but might revisit later) 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
The reference picker/objects popovers in for example in the portable text in Standard inputs - Portable text - All the editors!
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Increases default size of inline objects in portable text
<!--
A description of the change(s) that should be used in the release notes.
-->
