### PR TITLE
Dataset Backups: Handle API Error and update text output when backups are enabled

### DIFF
--- a/packages/sanity/src/_internal/cli/commands/backup/disableBackupCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/backup/disableBackupCommand.ts
@@ -1,5 +1,6 @@
 import {type CliCommandDefinition} from '@sanity/cli'
 
+import parseApiErr from '../../actions/backup/parseApiErr'
 import resolveApiClient from '../../actions/backup/resolveApiClient'
 import {defaultApiVersion} from './backupGroup'
 
@@ -34,10 +35,8 @@ const disableDatasetBackupCommand: CliCommandDefinition = {
       })
       output.print(`${chalk.green(`Disabled daily backups for dataset ${datasetName}\n`)}`)
     } catch (error) {
-      const msg = error.statusCode
-        ? error.response.body.message
-        : error.message || error.statusMessage
-      output.print(`${chalk.red(`Disabling dataset backup failed: ${msg}`)}\n`)
+      const {message} = parseApiErr(error)
+      output.print(`${chalk.red(`Disabling dataset backup failed: ${message}`)}\n`)
     }
   },
 }

--- a/packages/sanity/src/_internal/cli/commands/backup/enableBackupCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/backup/enableBackupCommand.ts
@@ -1,5 +1,6 @@
 import {type CliCommandDefinition} from '@sanity/cli'
 
+import parseApiErr from '../../actions/backup/parseApiErr'
 import resolveApiClient from '../../actions/backup/resolveApiClient'
 import {defaultApiVersion} from './backupGroup'
 
@@ -39,10 +40,8 @@ const enableDatasetBackupCommand: CliCommandDefinition = {
         `${chalk.bold(`Retention policies may apply depending on your plan and agreement.\n`)}`,
       )
     } catch (error) {
-      const msg = error.statusCode
-        ? error.response.body.message
-        : error.message || error.statusMessage
-      output.print(`${chalk.red(`Enabling dataset backup failed: ${msg}`)}\n`)
+      const {message} = parseApiErr(error)
+      output.print(`${chalk.red(`Enabling dataset backup failed: ${message}`)}\n`)
     }
   },
 }

--- a/packages/sanity/src/_internal/cli/commands/backup/enableBackupCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/backup/enableBackupCommand.ts
@@ -34,7 +34,11 @@ const enableDatasetBackupCommand: CliCommandDefinition = {
         },
       })
 
-      output.print(`${chalk.green(`Enabled backups for dataset ${datasetName}.\n`)}`)
+      output.print(
+        `${chalk.green(
+          `Enabled backups for dataset ${datasetName}.\nPlease note that it may take up to 24 hours before the first backup is created.\n`,
+        )}`,
+      )
 
       output.print(
         `${chalk.bold(`Retention policies may apply depending on your plan and agreement.\n`)}`,


### PR DESCRIPTION
### Description

This PR adds two minor changes:
1. At the moment, error parsing is being done inline in a few place where the logic is incorrect. We are getting undefined in error message. So, first change replaces this inline code with common error parser.
2. Second change is update CLI text when backups are enabled to meet expectations.

### What to review

I have tested API error parsing locally. So, a general overview of changes may suffice.

### Testing

### Notes for release

These commits should not included in release notes because dataset backup is an unreleased feature.
