### PR TITLE
build: allow `etl.yml` to be ran manually

### DIFF
--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -1,6 +1,8 @@
 name: Extract, Transform & Load
 
 on:
+  # allow this workflow to be ran manually
+  workflow_dispatch:
   # Build on pushes branches that have a PR (including drafts)
   pull_request:
   # Build on commits pushed to branches without a PR if it's in the allowlist
@@ -49,7 +51,7 @@ jobs:
 
       - name: Extract API docs
         env:
-          EXTRACT_SANITY_PROJECT_ID: "${{(github.event_name == 'push' && github.ref == 'refs/heads/current') && secrets.EXTRACT_SANITY_PROJECT_ID || secrets.DEV_EXTRACT_SANITY_PROJECT_ID}}"
-          EXTRACT_SANITY_DATASET: "${{(github.event_name == 'push' && github.ref == 'refs/heads/current') && secrets.EXTRACT_SANITY_DATASET || secrets.DEV_EXTRACT_SANITY_DATASET}}"
-          EXTRACT_SANITY_API_TOKEN: "${{(github.event_name == 'push' && github.ref == 'refs/heads/current') && secrets.EXTRACT_SANITY_API_TOKEN || secrets.DEV_EXTRACT_SANITY_API_TOKEN}}"
+          EXTRACT_SANITY_PROJECT_ID: "${{((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/current') && secrets.EXTRACT_SANITY_PROJECT_ID || secrets.DEV_EXTRACT_SANITY_PROJECT_ID}}"
+          EXTRACT_SANITY_DATASET: "${{((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/current') && secrets.EXTRACT_SANITY_DATASET || secrets.DEV_EXTRACT_SANITY_DATASET}}"
+          EXTRACT_SANITY_API_TOKEN: "${{((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/current') && secrets.EXTRACT_SANITY_API_TOKEN || secrets.DEV_EXTRACT_SANITY_API_TOKEN}}"
         run: pnpm etl sanity


### PR DESCRIPTION
### Description

This is a follow up to #5855. For now, instead of using the PAT, we'll allow this workflow to be ran manually at this time.

### Notes for release

N/A