### PR TITLE
feat(structure): support closing first collapsed `DocumentPanel`

### DIFF
--- a/packages/sanity/src/structure/components/paneRouter/PaneRouterProvider.tsx
+++ b/packages/sanity/src/structure/components/paneRouter/PaneRouterProvider.tsx
@@ -149,7 +149,8 @@ export function PaneRouterProvider(props: {
       ChildLink,
 
       // Curried StateLink that pops off the last pane group
-      BackLink,
+      // Only pass if this is not the first pane
+      BackLink: flatIndex ? BackLink : undefined,
 
       // A specialized `ChildLink` that takes in the needed props to open a
       // referenced document to the right

--- a/packages/sanity/src/structure/components/paneRouter/types.ts
+++ b/packages/sanity/src/structure/components/paneRouter/types.ts
@@ -101,7 +101,7 @@ export interface PaneRouterContextValue {
   /**
    * Curried StateLink that pops off the last pane group
    */
-  BackLink: React.ComponentType<BackLinkProps>
+  BackLink?: React.ComponentType<BackLinkProps>
 
   /**
    * A specialized `ChildLink` that takes in the needed props to open a

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
@@ -78,11 +78,17 @@ export const DocumentPanelHeader = memo(
     // and there is more than one split pane open (aka has-siblings)
     const showSplitPaneCloseButton = showSplitPaneButton && hasGroupSiblings
 
+    // show the back button if both the feature is enabled and the current pane
+    // is not the first
+    const showBackButton = features.backButton && index > 0
+
     // show the pane group close button if the `showSplitPaneCloseButton` is
     // _not_ showing (the split pane button replaces the group close button)
     // and if the back button is not showing (the back button and the close
-    // button) do the same thing and shouldn't be shown at the same time)
-    const showPaneGroupCloseButton = !showSplitPaneCloseButton && !features.backButton
+    // button do the same thing and shouldn't be shown at the same time)
+    // and if a BackLink component was provided
+    const showPaneGroupCloseButton = !showSplitPaneCloseButton && !showBackButton && !!BackLink
+
     const {t} = useTranslation(structureLocaleNamespace)
 
     return (
@@ -95,8 +101,7 @@ export const DocumentPanelHeader = memo(
           tabs={showTabs && <DocumentHeaderTabs />}
           tabIndex={tabIndex}
           backButton={
-            features.backButton &&
-            index > 0 && (
+            showBackButton && (
               <Button
                 as={BackLink}
                 data-as="a"


### PR DESCRIPTION
### Description

Presently, if a `DocumentPanel` is both in its collapsed state and also the first pane, neither a back button nor a close button can be displayed.

Presentation tool uses the `DocumentPanel` without any other panes, but also needs to support a collapsed state to prevent the inspector causing overflow issues.

This PR lifts some logic for displaying the `DocumentPanel` close button, relying on the presence of a provided `BackLink`, which Structure's `PaneRouterProvider` will now only pass if the pane is not the first. Presentation's router provider can therefore _always_ pass a `BackLink` and display a close button even in a collapsed state.

### What to review

There should be no changes within Structure tool, with the close and back buttons rendering as expected. The buttons should also both still be hidden if a user defines structure without multiple panes, e.g.

```ts
structureTool({
  structure: (S) =>
    S.document()
      .schemaType('page')
      .documentId('some-id'),
})
```

### Testing

### Notes for release

N/A. This is an internal feature.
