### PR TITLE
fix(portable-text-editor): check that path is lengthy 

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/plugins/__tests__/withEditableAPISelectionsOverlapping.test.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/plugins/__tests__/withEditableAPISelectionsOverlapping.test.tsx
@@ -9,7 +9,7 @@ import {PortableTextEditor} from '../../PortableTextEditor'
 const INITIAL_VALUE: PortableTextBlock[] = [
   {
     _key: 'a',
-    _type: 'block',
+    _type: 'myTestBlockType',
     children: [
       {
         _key: 'a1',

--- a/packages/@sanity/portable-text-editor/src/utils/ranges.ts
+++ b/packages/@sanity/portable-text-editor/src/utils/ranges.ts
@@ -53,6 +53,9 @@ export function toSlateRange(selection: EditorSelection, editor: Editor): Range 
     path: createArrayedPath(selection.focus, editor),
     offset: selection.focus.offset,
   }
+  if (focus.path.length === 0 || anchor.path.length === 0) {
+    return null
+  }
   const range = anchor && focus ? {anchor, focus} : null
   return range
 }


### PR DESCRIPTION
### Description

This will validate that a range path is lengthy before we return a non-null `EditorSelection`. 

Empty Range paths don't make sense in the PTE and will lead to bugs.

Also fixed a test that was using the wrong block type, and was incorrectly passing before this fix.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
That the tests pass.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
See the automatic tests.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A

<!--
A description of the change(s) that should be used in the release notes.
-->
