### PR TITLE
fix(core): increase default width of PT inline popovers

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/object/AnnotationToolbarPopover.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/AnnotationToolbarPopover.tsx
@@ -209,6 +209,7 @@ export function AnnotationToolbarPopover(props: AnnotationToolbarPopoverProps) {
       referenceBoundary={referenceBoundary}
       referenceElement={cursorElement}
       scheme={popoverScheme}
+      {...(annotationOpen ? {width: 1} : {})}
     />
   )
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/object/AnnotationToolbarPopover.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/AnnotationToolbarPopover.tsx
@@ -209,7 +209,6 @@ export function AnnotationToolbarPopover(props: AnnotationToolbarPopoverProps) {
       referenceBoundary={referenceBoundary}
       referenceElement={cursorElement}
       scheme={popoverScheme}
-      {...(annotationOpen ? {width: 1} : {})}
     />
   )
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx
@@ -42,7 +42,7 @@ export function ObjectEditModal(props: {
     onClose()
   }, [onClose])
 
-  const modalWidth = schemaModalOption?.width || 1
+  const modalWidth = schemaModalOption?.width
 
   if (modalType === 'popover') {
     return (

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
@@ -25,7 +25,7 @@ interface PopoverEditDialogProps {
 const POPOVER_FALLBACK_PLACEMENTS: PopoverProps['fallbackPlacements'] = ['top', 'bottom']
 
 export function PopoverEditDialog(props: PopoverEditDialogProps) {
-  const {floatingBoundary, referenceBoundary, referenceElement, width = 0} = props
+  const {floatingBoundary, referenceBoundary, referenceElement, width = 1} = props
   const [open, setOpen] = useState(false)
 
   // This hook is here to set open after the initial render.


### PR DESCRIPTION
### Description
It was decided that the width of the reference selectors in the PT should be increased - this has already been merged.
For consistency, the default width of the **all** inline popovers in PT is increased to match the other inline popovers in portable text. I've therefore now set the default width in the `RootPopover` instead and removed it from the `InlineObjects` popover. 
This default width can be overwritten in the schema. 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
That the width of all inline objects in the PT has a default width that is wider. 
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Increased width of all inline PT popovers. 
<!--
A description of the change(s) that should be used in the release notes.
-->
