### PR TITLE
feat(core): add `onFullScreenChange ` to Portable Text Input 

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -65,8 +65,9 @@ export function PortableTextInput(props: PortableTextInputProps) {
     hotkeys,
     markers = EMPTY_ARRAY,
     onChange,
-    onEditorChange,
     onCopy,
+    onEditorChange,
+    onFullScreenChange,
     onInsert,
     onItemRemove,
     onPaste,
@@ -122,9 +123,11 @@ export function PortableTextInput(props: PortableTextInputProps) {
       } else {
         telemetry.log(PortableTextInputCollapsed)
       }
+
+      onFullScreenChange?.(next)
       return next
     })
-  }, [telemetry])
+  }, [onFullScreenChange, telemetry])
 
   // Reset invalidValue if new value is coming in from props
   useEffect(() => {

--- a/packages/sanity/src/core/form/types/inputProps.ts
+++ b/packages/sanity/src/core/form/types/inputProps.ts
@@ -513,6 +513,12 @@ export interface PortableTextInputProps
    */
   onEditorChange?: (change: EditorChange, editor: PortableTextEditor) => void
   /**
+   * Optional callback for when the editor goes into or out of full screen mode
+   * @hidden
+   * @beta
+   */
+  onFullScreenChange?: (isFullScreen: boolean) => void
+  /**
    * Custom copy function
    */
   onCopy?: OnCopyFn


### PR DESCRIPTION
### Description

This pull request adds an `onFullScreenChange` callback to the Portable Text Input.

### What to review

- Make sure that the callback returns the correct value.

### Notes for release

N/A