### PR TITLE
fix(core): updates to not show "cannot upload" on hover 

### DIFF
--- a/packages/sanity/src/core/form/studio/uploads/accepts.ts
+++ b/packages/sanity/src/core/form/studio/uploads/accepts.ts
@@ -28,7 +28,14 @@ export function accepts(file: FileLike, acceptedFiles: string | string[]): boole
     const validType = type.trim().toLowerCase()
 
     if (validType.charAt(0) === '.') {
-      return fileName.toLowerCase().endsWith(validType)
+      if (fileName) {
+        return fileName.toLowerCase().endsWith(validType)
+      }
+      // If we do not have a valid fileName and validType is an extension, we
+      // should fail open. This happens because when hovering a file, the browser
+      // does not pass the name of the file but it will pass the file name when the
+      // file is dropped on the file upload input
+      return true
     }
 
     if (validType.endsWith('/*')) {


### PR DESCRIPTION
when using extension based accepts settings

Fixes EDX-795

### Description

When configuring a file input that restricts file types, we accept either extensions `'.pdf'` or mime type `'application/pdf'`.  When using drag and drop, while hovering, if the file type is not accepted, we display an error message. In order for the extension based restriction to work, we need the file name, which is not passed by the browser when hovering, but is when the file is dropped. Because of this, when an extension rule was used, we were incorrectly showing the error message but then accepting the file when it was dropped. The correct fix is to update the rule to be based on mime type. For the case where extension rules are used, we should not show an error on hover.

Before:

https://github.com/sanity-io/sanity/assets/6889008/08c11d54-00f4-4666-abce-42f0fb4796aa

After:

https://github.com/sanity-io/sanity/assets/6889008/231119d8-ff28-4639-a6dd-23f5b907af0e


### What to review

Are there any side effects of this change that I did not consider?

### Testing

Manually tested

### Notes for release

