### PR TITLE
fix(sanity): preserve form (as readOnly) when reconnecting

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
@@ -10,7 +10,6 @@ import {
   FormBuilder,
   type FormDocumentValue,
   fromMutationPatches,
-  LoadingBlock,
   type PatchMsg,
   PresenceOverlay,
   useDocumentPresence,
@@ -48,6 +47,7 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
     ready,
     formState,
     onFocus,
+    connectionState,
     onBlur,
     onSetCollapsedPath,
     onPathOpen,
@@ -148,10 +148,6 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
   //   [documentId]
   // )
 
-  if (!ready) {
-    return <LoadingBlock showText />
-  }
-
   return (
     <Container
       hidden={hidden}
@@ -163,49 +159,7 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
     >
       <PresenceOverlay margins={margins}>
         <Box as="form" onSubmit={preventDefault} ref={setRef}>
-          {ready ? (
-            formState === null || hidden ? (
-              <Box padding={2}>
-                <Text>{t('document-view.form-view.form-hidden')}</Text>
-              </Box>
-            ) : (
-              <>
-                <FormHeader
-                  documentId={documentId}
-                  schemaType={formState.schemaType}
-                  title={title}
-                />
-                <FormBuilder
-                  __internal_fieldActions={fieldActions}
-                  __internal_patchChannel={patchChannel}
-                  collapsedFieldSets={collapsedFieldSets}
-                  collapsedPaths={collapsedPaths}
-                  focusPath={formState.focusPath}
-                  changed={formState.changed}
-                  focused={formState.focused}
-                  groups={formState.groups}
-                  id="root"
-                  members={formState.members}
-                  onChange={onChange}
-                  onFieldGroupSelect={onSetActiveFieldGroup}
-                  onPathBlur={onBlur}
-                  onPathFocus={onFocus}
-                  onPathOpen={onPathOpen}
-                  onSetFieldSetCollapsed={onSetCollapsedFieldSet}
-                  onSetPathCollapsed={onSetCollapsedPath}
-                  presence={presence}
-                  readOnly={formState.readOnly}
-                  schemaType={formState.schemaType}
-                  validation={validation}
-                  value={
-                    // note: the form state doesn't have a typed concept of a "document" value
-                    // but these should be compatible
-                    formState.value as FormDocumentValue
-                  }
-                />
-              </>
-            )
-          ) : (
+          {connectionState === 'connecting' ? (
             <Delay ms={300}>
               {/* TODO: replace with loading block */}
               <Flex align="center" direction="column" height="fill" justify="center">
@@ -217,6 +171,42 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
                 </Box>
               </Flex>
             </Delay>
+          ) : formState === null || hidden ? (
+            <Box padding={2}>
+              <Text>{t('document-view.form-view.form-hidden')}</Text>
+            </Box>
+          ) : (
+            <>
+              <FormHeader documentId={documentId} schemaType={formState.schemaType} title={title} />
+              <FormBuilder
+                __internal_fieldActions={fieldActions}
+                __internal_patchChannel={patchChannel}
+                collapsedFieldSets={collapsedFieldSets}
+                collapsedPaths={collapsedPaths}
+                focusPath={formState.focusPath}
+                changed={formState.changed}
+                focused={formState.focused}
+                groups={formState.groups}
+                id="root"
+                members={formState.members}
+                onChange={onChange}
+                onFieldGroupSelect={onSetActiveFieldGroup}
+                onPathBlur={onBlur}
+                onPathFocus={onFocus}
+                onPathOpen={onPathOpen}
+                onSetFieldSetCollapsed={onSetCollapsedFieldSet}
+                onSetPathCollapsed={onSetCollapsedPath}
+                presence={presence}
+                readOnly={connectionState === 'reconnecting' || formState.readOnly}
+                schemaType={formState.schemaType}
+                validation={validation}
+                value={
+                  // note: the form state doesn't have a typed concept of a "document" value
+                  // but these should be compatible
+                  formState.value as FormDocumentValue
+                }
+              />
+            </>
           )}
         </Box>
       </PresenceOverlay>

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTitle.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTitle.tsx
@@ -6,7 +6,7 @@ import {useDocumentPane} from '../../useDocumentPane'
 
 export function DocumentHeaderTitle(): ReactElement {
   const {connectionState, schemaType, title, value: documentValue} = useDocumentPane()
-  const subscribed = Boolean(documentValue) && connectionState === 'connected'
+  const subscribed = Boolean(documentValue) && connectionState !== 'connecting'
 
   const {error, value} = useValuePreview({
     enabled: subscribed,
@@ -15,7 +15,7 @@ export function DocumentHeaderTitle(): ReactElement {
   })
   const {t} = useTranslation(structureLocaleNamespace)
 
-  if (connectionState !== 'connected') {
+  if (connectionState === 'connecting') {
     return <></>
   }
 

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
@@ -39,7 +39,7 @@ export const DocumentPanelHeader = memo(
       menuItemGroups,
       schemaType,
       timelineStore,
-      ready,
+      connectionState,
       views,
       unstable_languageFilter,
     } = useDocumentPane()
@@ -96,7 +96,7 @@ export const DocumentPanelHeader = memo(
         <PaneHeader
           border
           ref={ref}
-          loading={!ready}
+          loading={connectionState === 'connecting'}
           title={<DocumentHeaderTitle />}
           tabs={showTabs && <DocumentHeaderTabs />}
           tabIndex={tabIndex}

--- a/packages/sanity/src/structure/panes/document/useDocumentTitle.ts
+++ b/packages/sanity/src/structure/panes/document/useDocumentTitle.ts
@@ -23,7 +23,7 @@ interface UseDocumentTitle {
  */
 export function useDocumentTitle(): UseDocumentTitle {
   const {connectionState, schemaType, title, value: documentValue} = useDocumentPane()
-  const subscribed = Boolean(documentValue) && connectionState === 'connected'
+  const subscribed = Boolean(documentValue) && connectionState !== 'connecting'
 
   const {error, value} = useValuePreview({
     enabled: subscribed,
@@ -31,7 +31,7 @@ export function useDocumentTitle(): UseDocumentTitle {
     value: documentValue,
   })
 
-  if (connectionState !== 'connected') {
+  if (connectionState === 'connecting') {
     return {error: undefined, title: undefined}
   }
 


### PR DESCRIPTION
### Description
Currently, if the connection drops while you're editing a document, the whole pane reloads and the react tree inside it will unmount/remount, loosing all its state. Since we're introducing more transient state in these components (comments, etc), we're running a bigger risk of losing people's stuff when this happens. Short disconnects happens quite often, so it can be pretty disruptive to the end-user. This PR makes sure that instead of taking over the pane when the listener disconnects (technically, is in a "reconnecting" state), we retain the form  component instance, but set it as readonly to prevent the editor for making edits without being connected.

### What to review
- I've changed a few places to use `connectionState !== 'reconnecting'` instead of `connectionState === 'connected'`. 
- Is there anything I'm missing here?


Note: this is not a "perfect solution", and I noticed during testing that any open comments dialog gets closed when the document flips to read-only, which is still not great. However, this PR should make things a little bit less disruptive.

### Testing
Manual testing is a bit tricky, because you will have to force a listener disconnect. However, I added a few lines to simulate the behavior during disconnect

## Repro _current_ behavior during disconnect
Open [this deployment](https://test-studio-git-fix-sdx-532repro-before.sanity.build), which simulates connection drop 5 seconds after you stop editing a document (try making some edits to e.g. [this document](https://test-studio-git-fix-sdx-532repro-before.sanity.build/test/structure/input-standard;textsTest;2283476b-0481-4303-89d3-27b09c24f8dd%2Ctemplate%3DtextsTest) and wait for 5 seconds)

## Test _new_ behavior during disconnect
Open [this deployment](https://test-studio-git-fix-sdx-532repro-after.sanity.build), which simulates connection drop 5 seconds after you stop editing, but also includes the changes in this PR (try making some edits to the [same document](https://test-studio-git-fix-sdx-532repro-after.sanity.build/test/structure/input-standard;textsTest;2283476b-0481-4303-89d3-27b09c24f8dd%2Ctemplate%3DtextsTest) on this deployment and wait for 5 seconds)

### Notes for release
- Improved how the editor handles intermittent disconnects. Instead of replacing the current form with a loading screen, the form will now instead be set "read only"