### PR TITLE
fix(sanity): delay reconnect events from document pair listener to downstream consumers

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/getPairListener.ts
+++ b/packages/sanity/src/core/store/_legacy/document/getPairListener.ts
@@ -2,8 +2,8 @@
 import {type SanityClient} from '@sanity/client'
 import {type SanityDocument} from '@sanity/types'
 import {groupBy} from 'lodash'
-import {defer, type Observable, of as observableOf} from 'rxjs'
-import {concatMap, map, mergeMap, scan} from 'rxjs/operators'
+import {defer, type Observable, of as observableOf, of, timer} from 'rxjs'
+import {concatMap, map, mergeMap, scan, switchMap} from 'rxjs/operators'
 
 import {
   type IdPair,
@@ -90,6 +90,9 @@ export function getPairListener(
             ]),
           )
         : observableOf(event),
+    ),
+    switchMap((event) =>
+      event.type === 'reconnect' ? timer(1000).pipe(map(() => event)) : of(event),
     ),
     scan(
       (acc: {next: ListenerEvent[]; buffer: ListenerEvent[]}, msg) => {


### PR DESCRIPTION
### Description

This adds a little delay to reconnect events emitted from the document pair listener. The effect of this change is that any downstream subscribers will be notified a second later than they currently are.

This means that in the case of an intermittent connection drops, the reconnect event may not be seen by downstream subscribers at all. We currently respond to intermittent disconnects by e.g. making forms read-only, which can feel a bit heavy handed if the connection is restored quickly, so this change should make it less disruptive.

I _think_ this should be a fairly safe change, given that connection drop can always take some time to reach the program anyway, but open to reconsider the approach (e.g. make it a UI concern)

### What to review
- Is a second a sensible delay, or should we give it a little more time? 
 
### Testing
A bit tricky to test properly, as the connection has to drop for less than 1000ms before being restored.

### Notes for release

- Add a grace period before turning forms into read-only when connection drops.