### PR TITLE
fix(core): allow `_dataset` for cross-dataset references in templates

### DIFF
--- a/packages/sanity/src/core/templates/__tests__/resolve.test.ts
+++ b/packages/sanity/src/core/templates/__tests__/resolve.test.ts
@@ -58,6 +58,63 @@ describe('resolveInitialValue', () => {
     })
   })
 
+  test('throws on unknown prop in reference', () => {
+    expect(
+      resolveInitialValue(
+        schema,
+        {...example, value: {bestFriend: {_ref: 'grrm', name: 'GRRM'}}},
+        {},
+        mockConfigContext,
+      ),
+    ).rejects.toMatchObject({
+      message:
+        'Template "author" initial value: Disallowed property found in reference: "name" at path "bestFriend"',
+    })
+  })
+
+  test('throws on unknown props in reference', () => {
+    expect(
+      resolveInitialValue(
+        schema,
+        {...example, value: {bestFriend: {_ref: 'grrm', name: 'GRRM', age: 72}}},
+        {},
+        mockConfigContext,
+      ),
+    ).rejects.toMatchObject({
+      message:
+        'Template "author" initial value: Disallowed properties found in reference: "name", "age" at path "bestFriend"',
+    })
+  })
+
+  test('allows setting known reference properties', () => {
+    expect(
+      resolveInitialValue(
+        schema,
+        {...example, value: {bestFriend: {_ref: 'grrm', _type: 'reference', _weak: true}}},
+        {},
+        mockConfigContext,
+      ),
+    ).resolves.toMatchObject({
+      bestFriend: {_ref: 'grrm', _type: 'reference', _weak: true},
+    })
+  })
+
+  test('allows setting _dataset on cross-dataset references', () => {
+    expect(
+      resolveInitialValue(
+        schema,
+        {
+          ...example,
+          value: {bestFriend: {_ref: 'grrm', _type: 'crossDatasetReference', _dataset: 'bffs'}},
+        },
+        {},
+        mockConfigContext,
+      ),
+    ).resolves.toMatchObject({
+      bestFriend: {_ref: 'grrm', _type: 'crossDatasetReference', _dataset: 'bffs'},
+    })
+  })
+
   test('should call sync value resolvers', () => {
     expect(
       resolveInitialValue(schema, {...example, value: () => example.value}, {}, mockConfigContext),

--- a/packages/sanity/src/core/templates/__tests__/schema.ts
+++ b/packages/sanity/src/core/templates/__tests__/schema.ts
@@ -20,6 +20,11 @@ export const schema = SchemaBuilder.compile({
           name: 'role',
           type: 'string',
         },
+        {
+          name: 'bestFriend',
+          type: 'reference',
+          to: [{type: 'author'}],
+        },
       ],
       initialValue: () => ({
         role: 'Developer',

--- a/packages/sanity/src/core/templates/validate.ts
+++ b/packages/sanity/src/core/templates/validate.ts
@@ -5,7 +5,7 @@ import {toString as pathToString} from '@sanity/util/paths'
 import {type Template, type TemplateParameter} from './types'
 import {isRecord} from './util/isRecord'
 
-const ALLOWED_REF_PROPS = ['_key', '_ref', '_weak', '_type']
+const ALLOWED_REF_PROPS = ['_dataset', '_key', '_ref', '_type', '_weak']
 const REQUIRED_TEMPLATE_PROPS: (keyof Template)[] = ['id', 'title', 'schemaType', 'value']
 
 function templateId(template: Template, i: number) {


### PR DESCRIPTION
### Description

It is currently not possible to create a cross-dataset reference from an initial value template, as the template validation runs and disallows unknown properties on references, where `_dataset` was not an allowed prop.

Perhaps we should recurse down the type chain to look for a field that extends from `crossDatasetReference`, but this is beyond what we do for other types - eg we do not check for a `reference` type when encountering `_ref`. Leaving this for a future iteration to improve on if we feel it is worth it.

### What to review

- Can create a cross-dataset reference from an initial value template
- Implementation looks acceptable

### Testing

I added some surrounding tests not only for the `_dataset` case but also for other reference properties, as I could not find any tests for that code path.

### Notes for release

- Fixes an issue where initial value templates could not define a target dataset for cross-dataset references
