### PR TITLE
feat(codegen): add 'Result' to query type names

### DIFF
--- a/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
@@ -12,7 +12,7 @@ describe('findQueries', () => {
     `
 
       const queries = findQueriesInSource(source, 'test.ts')
-      const queryResult = queries.get('postQuery')
+      const queryResult = queries.get('postQueryResult')
 
       expect(queryResult?.result).toEqual('*[_type == "author"]')
     })
@@ -26,7 +26,7 @@ describe('findQueries', () => {
     `
 
       const queries = findQueriesInSource(source, 'test.ts')
-      const queryResult = queries.get('authorQuery')
+      const queryResult = queries.get('authorQueryResult')
 
       expect(queryResult?.result).toEqual('*[_type == "author"]')
     })
@@ -41,7 +41,7 @@ describe('findQueries', () => {
 
       const queries = findQueriesInSource(source, 'test.ts')
 
-      const queryResult = queries.get('query')
+      const queryResult = queries.get('queryResult')
 
       expect(queryResult?.result).toEqual('*[_type == "author"]')
     })
@@ -62,7 +62,7 @@ describe('findQueries', () => {
     `
 
       const queries = findQueriesInSource(source, 'test.ts')
-      const queryResult = queries.get('query')
+      const queryResult = queries.get('queryResult')
 
       expect(queryResult?.result).toEqual('*[_type == "foo" || _type == "bar"]')
     })
@@ -93,7 +93,7 @@ describe('findQueries', () => {
     `
 
       const queries = findQueriesInSource(source, 'test.ts')
-      const queryResult = queries.get('query')
+      const queryResult = queries.get('queryResult')
 
       expect(queryResult?.result).toEqual('*[_type == "author"]')
     })
@@ -119,7 +119,7 @@ describe('findQueries', () => {
     `
 
       const queries = findQueriesInSource(source, 'test.ts')
-      const queryResult = queries.get('query')
+      const queryResult = queries.get('queryResult')
 
       expect(queryResult?.result).toEqual('*[_type == "author" && _id == "id"]')
     })
@@ -140,7 +140,7 @@ describe('findQueries', () => {
     `
 
       const queries = findQueriesInSource(source, 'test.ts')
-      const queryResult = queries.get('query')
+      const queryResult = queries.get('queryResult')
 
       expect(queryResult?.result).toEqual('*[_type == "author"]')
     })
@@ -154,22 +154,33 @@ describe('findQueries', () => {
       `
 
       const queries = findQueriesInSource(source, 'test.ts')
-      const queryResult = queries.get('query')
+      const queryResult = queries.get('queryResult')
 
       expect(queryResult?.result).toEqual('*[_type == "author"]')
     })
   })
 
-  describe('should not find inline queries in source', () => {
-    test('with block comment', () => {
-      const source = `
-          import { groq } from "groq";
-          const res = sanity.fetch(groq\`*[_type == "author"]\`);
-        `
+  test('should not find inline queries in source', () => {
+    const source = `
+        import { groq } from "groq";
+        const res = sanity.fetch(groq\`*[_type == "author"]\`);
+      `
 
-      const queries = findQueriesInSource(source, 'test.ts')
+    const queries = findQueriesInSource(source, 'test.ts')
 
-      expect(queries.size).toBe(0)
-    })
+    expect(queries.size).toBe(0)
+  })
+
+  test("should name queries with 'Result' at the end", () => {
+    const source = `
+      import { groq } from "groq";
+      const postQuery = groq\`*[_type == "author"]\`
+      const res = sanity.fetch(postQueryResult);
+    `
+
+    const queries = findQueriesInSource(source, 'test.ts')
+    const queryResult = queries.get('postQueryResult')
+
+    expect(queryResult?.name).toBe('postQueryResult')
   })
 })

--- a/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/findQueriesInSource.test.ts
@@ -181,6 +181,6 @@ describe('findQueries', () => {
     const queries = findQueriesInSource(source, 'test.ts')
     const queryResult = queries.get('postQueryResult')
 
-    expect(queryResult?.name).toBe('postQueryResult')
+    expect(queryResult?.name.substr(-6)).toBe('Result')
   })
 })

--- a/packages/@sanity/codegen/src/typescript/findQueriesInSource.ts
+++ b/packages/@sanity/codegen/src/typescript/findQueriesInSource.ts
@@ -33,7 +33,7 @@ export function findQueriesInSource(
         babelTypes.isIdentifier(node.id) &&
         init.tag.name === groqTagName
       ) {
-        const queryName = node.id.name
+        const queryName = `${node.id.name}Result`
         const queryResult = resolveExpression({
           node: init,
           file,


### PR DESCRIPTION
### Description

Codegen generates query types named after the query variable name. This change only adds the word 'Result' at the end of the type name to differentiate between the variable name and the imported type.
E.g.

```js
import {postsResult} from './types.d.ts'

const posts = groq`*[_type="post"]`

export async function getPosts(client: SanityClient): postsResult {
  return await client.fetch(posts)
}
```

