### PR TITLE
fix(comments): allow ranges to be collapsed

### DIFF
--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -249,7 +249,7 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
         const newSlateRanges: BaseRangeWithDecoration[] = []
         rangeDecorations.forEach((rangeDecorationItem) => {
           const slateRange = toSlateRange(rangeDecorationItem.selection, slateEditor)
-          if (!SlateRange.isRange(slateRange) || !SlateRange.isExpanded(slateRange)) {
+          if (!SlateRange.isRange(slateRange)) {
             if (rangeDecorationItem.onMoved) {
               rangeDecorationItem.onMoved({
                 newSelection: null,

--- a/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
+++ b/packages/@sanity/portable-text-editor/src/editor/Editable.tsx
@@ -574,9 +574,7 @@ export const PortableTextEditable = forwardRef(function PortableTextEditable(
           },
         ]
       }
-      const result = rangeDecorationState.filter(
-        (item) => path.length > 1 && SlateRange.includes(item, path),
-      )
+      const result = rangeDecorationState.filter((item) => SlateRange.includes(item, path))
       if (result.length > 0) {
         return result
       }

--- a/packages/sanity/src/structure/comments/src/utils/inline-comments/buildRangeDecorationSelectionsFromComments.ts
+++ b/packages/sanity/src/structure/comments/src/utils/inline-comments/buildRangeDecorationSelectionsFromComments.ts
@@ -137,31 +137,26 @@ export function buildRangeDecorationSelectionsFromComments(
             break
           }
         }
-        // If range is now collapsed, don't create a decoration
-        if (anchorOffset === focusOffset && childIndexFocus === childIndexAnchor) {
-          nullSelection = true
-        }
+
         decorators.push({
-          selection: nullSelection
-            ? null
-            : {
-                anchor: {
-                  path: [
-                    {_key: matchedBlock._key},
-                    'children',
-                    {_key: matchedBlock.children[childIndexAnchor]._key},
-                  ],
-                  offset: anchorOffset,
-                },
-                focus: {
-                  path: [
-                    {_key: matchedBlock._key},
-                    'children',
-                    {_key: matchedBlock.children[childIndexFocus]._key},
-                  ],
-                  offset: focusOffset,
-                },
-              },
+          selection: {
+            anchor: {
+              path: [
+                {_key: matchedBlock._key},
+                'children',
+                {_key: matchedBlock.children[childIndexAnchor]._key},
+              ],
+              offset: anchorOffset,
+            },
+            focus: {
+              path: [
+                {_key: matchedBlock._key},
+                'children',
+                {_key: matchedBlock.children[childIndexFocus]._key},
+              ],
+              offset: focusOffset,
+            },
+          },
           comment,
           range: {_key: matchedBlock._key, text: nullSelection ? '' : diffedText},
         })


### PR DESCRIPTION
### Description
This is needed to support including empty blocks within the commented range.

Two first commits here are part of #5891

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A

<!--
A description of the change(s) that should be used in the release notes.
-->
