### PR TITLE
chore(search): refactor search to export necessary components and providers.

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/search/components/SearchPopover.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/SearchPopover.tsx
@@ -18,6 +18,7 @@ import {SearchWrapper} from './common/SearchWrapper'
 import {Filters} from './filters/Filters'
 import {RecentSearches} from './recentSearches/RecentSearches'
 import {SearchHeader} from './SearchHeader'
+import {type ItemSelectHandler} from './searchResults/item/SearchResultItem'
 import {SearchResults} from './searchResults/SearchResults'
 
 /**
@@ -27,7 +28,7 @@ export interface SearchPopoverProps {
   disableFocusLock?: boolean
   disableIntentLink?: boolean
   onClose: () => void
-  onItemSelect?: (item: {documentId: string; documentType: string}) => void
+  onItemSelect?: ItemSelectHandler
   onOpen: () => void
   open: boolean
 }

--- a/packages/sanity/src/core/studio/components/navbar/search/components/SearchPopover.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/SearchPopover.tsx
@@ -20,9 +20,14 @@ import {RecentSearches} from './recentSearches/RecentSearches'
 import {SearchHeader} from './SearchHeader'
 import {SearchResults} from './searchResults/SearchResults'
 
+/**
+ * @internal
+ */
 export interface SearchPopoverProps {
   disableFocusLock?: boolean
+  disableIntentLink?: boolean
   onClose: () => void
+  onItemSelect?: (item: {documentId: string; documentType: string}) => void
   onOpen: () => void
   open: boolean
 }
@@ -66,7 +71,17 @@ const SearchMotionCard = styled(motion(Card))`
   width: min(calc(100vw - ${POPOVER_INPUT_PADDING * 2}px), ${POPOVER_MAX_WIDTH}px);
 `
 
-export function SearchPopover({disableFocusLock, onClose, onOpen, open}: SearchPopoverProps) {
+/**
+ * @internal
+ */
+export function SearchPopover({
+  disableFocusLock,
+  disableIntentLink,
+  onClose,
+  onItemSelect,
+  onOpen,
+  open,
+}: SearchPopoverProps) {
   const [inputElement, setInputElement] = useState<HTMLInputElement | null>(null)
 
   const popoverElement = useRef<HTMLElement | null>(null)
@@ -134,7 +149,11 @@ export function SearchPopover({disableFocusLock, onClose, onOpen, open}: SearchP
                   </Card>
                 )}
                 {hasValidTerms ? (
-                  <SearchResults inputElement={inputElement} />
+                  <SearchResults
+                    inputElement={inputElement}
+                    onItemSelect={onItemSelect}
+                    disableIntentLink={disableIntentLink}
+                  />
                 ) : (
                   <RecentSearches inputElement={inputElement} />
                 )}

--- a/packages/sanity/src/core/studio/components/navbar/search/components/index.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/index.ts
@@ -1,0 +1,2 @@
+export * from './SearchPopover'
+export * from './searchResults'

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/SearchResults.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/SearchResults.tsx
@@ -11,7 +11,7 @@ import {NoResults} from '../NoResults'
 import {SearchError} from '../SearchError'
 import {SortMenu} from '../SortMenu'
 import {DebugOverlay} from './item/DebugOverlay'
-import {SearchResultItem} from './item/SearchResultItem'
+import {type ItemSelectHandler, SearchResultItem} from './item/SearchResultItem'
 
 const VIRTUAL_LIST_SEARCH_RESULT_ITEM_HEIGHT = 57 // px
 const VIRTUAL_LIST_OVERSCAN = 4
@@ -28,7 +28,7 @@ const SearchResultsInnerFlex = styled(Flex)<{$loading: boolean}>`
 interface SearchResultsProps {
   disableIntentLink?: boolean
   inputElement: HTMLInputElement | null
-  onItemSelect?: (item: {documentId: string; documentType: string}) => void
+  onItemSelect?: ItemSelectHandler
 }
 
 export function SearchResults({disableIntentLink, inputElement, onItemSelect}: SearchResultsProps) {

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/SearchResults.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/SearchResults.tsx
@@ -26,10 +26,12 @@ const SearchResultsInnerFlex = styled(Flex)<{$loading: boolean}>`
 `
 
 interface SearchResultsProps {
+  disableIntentLink?: boolean
   inputElement: HTMLInputElement | null
+  onItemSelect?: (item: {documentId: string; documentType: string}) => void
 }
 
-export function SearchResults({inputElement}: SearchResultsProps) {
+export function SearchResults({disableIntentLink, inputElement, onItemSelect}: SearchResultsProps) {
   const {
     dispatch,
     onClose,
@@ -59,16 +61,18 @@ export function SearchResults({inputElement}: SearchResultsProps) {
       return (
         <>
           <SearchResultItem
+            disableIntentLink={disableIntentLink}
             documentId={getPublishedId(item.hit._id) || ''}
             documentType={item.hit._type}
             onClick={handleSearchResultClick}
+            onItemSelect={onItemSelect}
             paddingY={1}
           />
           {debug && <DebugOverlay data={item} />}
         </>
       )
     },
-    [debug, handleSearchResultClick],
+    [debug, disableIntentLink, handleSearchResultClick, onItemSelect],
   )
 
   return (

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/index.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/index.ts
@@ -1,0 +1,1 @@
+export * from './item'

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItem.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItem.tsx
@@ -1,3 +1,4 @@
+import {type SanityDocumentLike} from '@sanity/types'
 import {Box, type ResponsiveMarginProps, type ResponsivePaddingProps} from '@sanity/ui'
 import {type MouseEvent, useCallback, useMemo} from 'react'
 import {useIntentLink} from 'sanity/router'
@@ -7,13 +8,15 @@ import {useSchema} from '../../../../../../../hooks'
 import {useDocumentPresence} from '../../../../../../../store'
 import {SearchResultItemPreview} from './SearchResultItemPreview'
 
+export type ItemSelectHandler = (item: Pick<SanityDocumentLike, '_id' | '_type'>) => void
+
 interface SearchResultItemProps extends ResponsiveMarginProps, ResponsivePaddingProps {
   disableIntentLink?: boolean
   documentId: string
   documentType: string
   layout?: GeneralPreviewLayoutKey
   onClick?: () => void
-  onItemSelect?: (item: {documentId: string; documentType: string}) => void
+  onItemSelect?: ItemSelectHandler
 }
 
 export function SearchResultItem({
@@ -37,7 +40,7 @@ export function SearchResultItem({
 
   const handleClick = useCallback(
     (e: MouseEvent<HTMLElement>) => {
-      onItemSelect?.({documentId, documentType})
+      onItemSelect?.({_id: documentId, _type: documentType})
       if (!disableIntentLink) {
         onIntentClick(e)
       }

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItem.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItem.tsx
@@ -5,7 +5,7 @@ import {useIntentLink} from 'sanity/router'
 import {type GeneralPreviewLayoutKey, PreviewCard} from '../../../../../../../components'
 import {useSchema} from '../../../../../../../hooks'
 import {useDocumentPresence} from '../../../../../../../store'
-import SearchResultItemPreview from './SearchResultItemPreview'
+import {SearchResultItemPreview} from './SearchResultItemPreview'
 
 interface SearchResultItemProps extends ResponsiveMarginProps, ResponsivePaddingProps {
   disableIntentLink?: boolean
@@ -13,6 +13,7 @@ interface SearchResultItemProps extends ResponsiveMarginProps, ResponsivePadding
   documentType: string
   layout?: GeneralPreviewLayoutKey
   onClick?: () => void
+  onItemSelect?: (item: {documentId: string; documentType: string}) => void
 }
 
 export function SearchResultItem({
@@ -21,6 +22,7 @@ export function SearchResultItem({
   documentType,
   layout,
   onClick,
+  onItemSelect,
   ...rest
 }: SearchResultItemProps) {
   const schema = useSchema()
@@ -35,12 +37,13 @@ export function SearchResultItem({
 
   const handleClick = useCallback(
     (e: MouseEvent<HTMLElement>) => {
+      onItemSelect?.({documentId, documentType})
       if (!disableIntentLink) {
         onIntentClick(e)
       }
       onClick?.()
     },
-    [disableIntentLink, onClick, onIntentClick],
+    [onItemSelect, documentId, documentType, disableIntentLink, onClick, onIntentClick],
   )
 
   if (!type) return null

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItemPreview.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItemPreview.tsx
@@ -35,7 +35,10 @@ const SearchResultItemPreviewBox = styled(Box)`
   }
 `
 
-export default function SearchResultItemPreview({
+/**
+ * @internal
+ */
+export function SearchResultItemPreview({
   documentId,
   layout,
   presence,

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/index.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/index.ts
@@ -1,0 +1,1 @@
+export * from './SearchResultItemPreview'

--- a/packages/sanity/src/core/studio/components/navbar/search/contexts/index.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/contexts/index.ts
@@ -1,0 +1,1 @@
+export * from './search'

--- a/packages/sanity/src/core/studio/components/navbar/search/contexts/search/SearchContext.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/contexts/search/SearchContext.ts
@@ -4,6 +4,9 @@ import {type CommandListHandle} from '../../../../../../components/commandList/t
 import {type RecentSearchesStore} from '../../datastores/recentSearches'
 import {type SearchAction, type SearchReducerState} from './reducer'
 
+/**
+ * @internal
+ */
 export interface SearchContextValue {
   dispatch: Dispatch<SearchAction>
   onClose: (() => void) | null
@@ -14,4 +17,7 @@ export interface SearchContextValue {
   state: SearchReducerState
 }
 
+/**
+ * @internal
+ */
 export const SearchContext = createContext<SearchContextValue | undefined>(undefined)

--- a/packages/sanity/src/core/studio/components/navbar/search/contexts/search/index.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/contexts/search/index.ts
@@ -1,0 +1,3 @@
+export * from './SearchContext'
+export * from './SearchProvider'
+export * from './useSearchState'

--- a/packages/sanity/src/core/studio/components/navbar/search/contexts/search/useSearchState.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/contexts/search/useSearchState.ts
@@ -2,6 +2,9 @@ import {useContext} from 'react'
 
 import {SearchContext, type SearchContextValue} from './SearchContext'
 
+/**
+ * @internal
+ */
 export function useSearchState(): SearchContextValue {
   const context = useContext(SearchContext)
 

--- a/packages/sanity/src/core/studio/components/navbar/search/index.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/index.ts
@@ -1,3 +1,5 @@
+export * from './components'
+export * from './contexts'
 export {
   defineSearchFilter,
   defineSearchFilterOperators,


### PR DESCRIPTION
### Description

This PR exports some search components and providers that are necessary for the `tasks` feature.
We will reuse the logic from this search to allow users to search and assign tasks to content.

To reuse the search, we will do it as follows, importing the `SearchProvider` and the `SearchPopover`  [see dependant PR here](https://github.com/sanity-io/sanity/pull/5897/files#diff-f4ee5e22fae5b72d23163ee05278e3eda58dd1b2791f84f199a97e79900b4f37R220)
```
    <SearchProvider>
      <SearchPopover
        open={open}
        onClose={handleCloseSearch}
        onOpen={handleOpenSearch}
        onItemSelect={handleItemSelect}
        disableIntentLink
      />
   </SearchProvider>
```

The `SearchPopover` props have been extended to support and `onItemSelect` and `disableIntentLink` props.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
A description of the change(s) that should be used in the release notes.
-->
