### PR TITLE
feat(core): fetch structure tool settings from backend

### DIFF
--- a/packages/sanity/src/core/store/_legacy/datastores.ts
+++ b/packages/sanity/src/core/store/_legacy/datastores.ts
@@ -233,13 +233,14 @@ export function useProjectStore(): ProjectStore {
 export function useKeyValueStore(): KeyValueStore {
   const resourceCache = useResourceCache()
   const workspace = useWorkspace()
+  const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
 
   return useMemo(() => {
     const keyValueStore =
       resourceCache.get<KeyValueStore>({
         dependencies: [workspace],
         namespace: 'KeyValueStore',
-      }) || createKeyValueStore()
+      }) || createKeyValueStore({client})
 
     resourceCache.set({
       dependencies: [workspace],
@@ -248,5 +249,5 @@ export function useKeyValueStore(): KeyValueStore {
     })
 
     return keyValueStore
-  }, [resourceCache, workspace])
+  }, [client, resourceCache, workspace])
 }

--- a/packages/sanity/src/core/store/key-value/KeyValueStore.ts
+++ b/packages/sanity/src/core/store/key-value/KeyValueStore.ts
@@ -13,7 +13,7 @@ export function createKeyValueStore({client}: {client: SanityClient}): KeyValueS
 
   const updates$ = setKey$.pipe(
     switchMap((event) =>
-      storageBackend.set(event.key, event.value).pipe(
+      storageBackend.setKey(event.key, event.value).pipe(
         map((nextValue) => ({
           key: event.key,
           value: nextValue,
@@ -27,7 +27,7 @@ export function createKeyValueStore({client}: {client: SanityClient}): KeyValueS
     defaultValue: KeyValueStoreValue,
   ): Observable<KeyValueStoreValue> => {
     return merge(
-      storageBackend.get(key, defaultValue),
+      storageBackend.getKey(key, defaultValue),
       updates$.pipe(
         filter((update) => update.key === key),
         map((update) => update.value),

--- a/packages/sanity/src/core/store/key-value/KeyValueStore.ts
+++ b/packages/sanity/src/core/store/key-value/KeyValueStore.ts
@@ -1,12 +1,13 @@
+import {type SanityClient} from '@sanity/client'
 import {merge, type Observable, Subject} from 'rxjs'
 import {filter, map, switchMap} from 'rxjs/operators'
 
-import {resolveBackend} from './backends/resolve'
+import {serverBackend} from './backends/server'
 import {type KeyValueStore, type KeyValueStoreValue} from './types'
 
 /** @internal */
-export function createKeyValueStore(): KeyValueStore {
-  const storageBackend = resolveBackend()
+export function createKeyValueStore({client}: {client: SanityClient}): KeyValueStore {
+  const storageBackend = serverBackend({client})
 
   const setKey$ = new Subject<{key: string; value: KeyValueStoreValue}>()
 

--- a/packages/sanity/src/core/store/key-value/backends/localStorage.ts
+++ b/packages/sanity/src/core/store/key-value/backends/localStorage.ts
@@ -12,10 +12,10 @@ const tryParse = (val: string, defValue: unknown) => {
   }
 }
 
-const get = (key: string, defValue: unknown): Observable<unknown> => {
+const get = (key: string, defaultValue: unknown): Observable<unknown> => {
   const val = localStorage.getItem(key)
 
-  return observableOf(val === null ? defValue : tryParse(val, defValue))
+  return observableOf(val === null ? defaultValue : tryParse(val, defaultValue))
 }
 
 const set = (key: string, nextValue: unknown): Observable<unknown> => {

--- a/packages/sanity/src/core/store/key-value/backends/localStorage.ts
+++ b/packages/sanity/src/core/store/key-value/backends/localStorage.ts
@@ -2,20 +2,20 @@ import {type Observable, of as observableOf} from 'rxjs'
 
 import {type Backend, type KeyValuePair} from './types'
 
-const tryParse = (val: string, defValue: unknown) => {
+const tryParse = (val: string) => {
   try {
     return JSON.parse(val)
   } catch (err) {
     // eslint-disable-next-line no-console
     console.warn(`Failed to parse settings: ${err.message}`)
-    return defValue
+    return null
   }
 }
 
-const getKey = (key: string, defaultValue: unknown): Observable<unknown> => {
+const getKey = (key: string): Observable<unknown> => {
   const val = localStorage.getItem(key)
 
-  return observableOf(val === null ? defaultValue : tryParse(val, defaultValue))
+  return observableOf(val === null ? null : tryParse(val))
 }
 
 const setKey = (key: string, nextValue: unknown): Observable<unknown> => {
@@ -30,10 +30,10 @@ const setKey = (key: string, nextValue: unknown): Observable<unknown> => {
   return observableOf(nextValue)
 }
 
-const getKeys = (keys: string[], defaultValues: unknown[]): Observable<unknown[]> => {
+const getKeys = (keys: string[]): Observable<unknown[]> => {
   const values = keys.map((key, i) => {
     const val = localStorage.getItem(key)
-    return val === null ? defaultValues[i] : tryParse(val, defaultValues[i])
+    return val === null ? null : tryParse(val)
   })
 
   return observableOf(values)

--- a/packages/sanity/src/core/store/key-value/backends/memory.ts
+++ b/packages/sanity/src/core/store/key-value/backends/memory.ts
@@ -4,16 +4,15 @@ import {type Backend, type KeyValuePair} from './types'
 
 const DB = Object.create(null)
 
-const getKey = (key: string, defaultValue: unknown): Observable<unknown> =>
-  observableOf(key in DB ? DB[key] : defaultValue)
+const getKey = (key: string): Observable<unknown> => observableOf(key in DB ? DB[key] : null)
 
 const setKey = (key: string, nextValue: unknown): Observable<unknown> => {
   DB[key] = nextValue
   return observableOf(nextValue)
 }
 
-const getKeys = (keys: string[], defaultValues: unknown[]): Observable<unknown[]> => {
-  return observableOf(keys.map((key, i) => (key in DB ? DB[key] : defaultValues[i])))
+const getKeys = (keys: string[]): Observable<unknown[]> => {
+  return observableOf(keys.map((key, i) => (key in DB ? DB[key] : null)))
 }
 
 const setKeys = (keyValuePairs: KeyValuePair[]): Observable<unknown[]> => {

--- a/packages/sanity/src/core/store/key-value/backends/memory.ts
+++ b/packages/sanity/src/core/store/key-value/backends/memory.ts
@@ -1,20 +1,27 @@
 import {type Observable, of as observableOf} from 'rxjs'
 
-import {type Backend} from './types'
+import {type Backend, type KeyValuePair} from './types'
 
 const DB = Object.create(null)
 
-const get = (key: string, defValue: unknown): Observable<unknown> =>
-  observableOf(key in DB ? DB[key] : defValue)
+const getKey = (key: string, defaultValue: unknown): Observable<unknown> =>
+  observableOf(key in DB ? DB[key] : defaultValue)
 
-const set = (key: string, nextValue: unknown): Observable<unknown> => {
-  if (typeof nextValue === 'undefined' || nextValue === null) {
-    delete DB[key]
-  } else {
-    DB[key] = nextValue
-  }
-
+const setKey = (key: string, nextValue: unknown): Observable<unknown> => {
+  DB[key] = nextValue
   return observableOf(nextValue)
 }
 
-export const memoryBackend: Backend = {get, set}
+const getKeys = (keys: string[], defaultValues: unknown[]): Observable<unknown[]> => {
+  return observableOf(keys.map((key, i) => (key in DB ? DB[key] : defaultValues[i])))
+}
+
+const setKeys = (keyValuePairs: KeyValuePair[]): Observable<unknown[]> => {
+  keyValuePairs.forEach((pair) => {
+    DB[pair.key] = pair.value
+  })
+
+  return observableOf(keyValuePairs.map((pair) => pair.value))
+}
+
+export const memoryBackend: Backend = {getKey, setKey, getKeys, setKeys}

--- a/packages/sanity/src/core/store/key-value/backends/resolve.ts
+++ b/packages/sanity/src/core/store/key-value/backends/resolve.ts
@@ -4,5 +4,6 @@ import {memoryBackend} from './memory'
 import {type Backend} from './types'
 
 export function resolveBackend(): Backend {
+  //TODO: add check for "server"
   return supportsLocalStorage ? localStorageBackend : memoryBackend
 }

--- a/packages/sanity/src/core/store/key-value/backends/server.ts
+++ b/packages/sanity/src/core/store/key-value/backends/server.ts
@@ -58,11 +58,12 @@ export function serverBackend({client: _client}: ServerBackendOptions): Backend 
       }),
     ).pipe(
       map((response) => {
-        response.forEach((pair) => {
+        return response.map((pair) => {
           keyValueLoader.clear(pair.key)
           keyValueLoader.prime(pair.key, pair.value)
+
+          return pair.value
         })
-        return response.map((pair) => pair.value)
       }),
       catchError((error) => {
         console.error('Error setting data:', error)

--- a/packages/sanity/src/core/store/key-value/backends/server.ts
+++ b/packages/sanity/src/core/store/key-value/backends/server.ts
@@ -1,0 +1,88 @@
+import {type SanityClient} from '@sanity/client'
+import DataLoader from 'dataloader'
+import {catchError, from, map, of} from 'rxjs'
+
+import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../studioClient'
+import {type KeyValueStoreValue} from '../types'
+import {type Backend} from './types'
+
+/** @internal */
+export interface ServerBackendOptions {
+  client: SanityClient
+}
+
+interface KeyValuePair {
+  key: string
+  value: KeyValueStoreValue
+}
+
+/**
+ * One of serveral possible backends for KeyValueStore. This backend uses the
+ * Sanity client to store and retrieve key-value pairs from the /users/me/keyvalue endpoint.
+ * @internal
+ */
+export function serverBackend({client: _client}: ServerBackendOptions): Backend {
+  const client = _client.withConfig({...DEFAULT_STUDIO_CLIENT_OPTIONS, apiVersion: 'vX'})
+
+  const keyValueLoader = new DataLoader<string, KeyValueStoreValue | null>(async (keys) => {
+    const value = await client
+      .request<(KeyValuePair | null)[]>({
+        uri: `/users/me/keyvalue/${keys.join(',')}`,
+        withCredentials: true,
+      })
+      .catch((error) => {
+        // const value = await fetch(`http://localhost:5000/vX/users/me/keyvalue/${keys.join(',')}`)
+        // .catch((error) => {
+        if (error.response?.statusCode === 404) {
+          return Array(keys.length).fill(null)
+        }
+        throw error
+      })
+    const response = Array.isArray(value) ? value : [value]
+    const keyValuePairs = response.reduce(
+      (acc, next) => {
+        if (next?.key) {
+          acc[next.key] = next.value
+        }
+        return acc
+      },
+      {} as Record<string, KeyValueStoreValue | null>,
+    )
+    return keys.map((key) => keyValuePairs[key] || null)
+  })
+
+  return {
+    get: (key: string, defaultValue: unknown) => {
+      return from(keyValueLoader.load(key)).pipe(
+        map((value) => value ?? defaultValue),
+        catchError((error) => {
+          if (error.statusCode !== 404) {
+            console.error('Error fetching data:', error)
+          }
+
+          return of(defaultValue) // Return the default value in case of error
+        }),
+      )
+    },
+    set: (key: string, nextValue: unknown) => {
+      return from(
+        client.request({
+          method: 'PUT',
+          uri: `/users/me/keyvalue`,
+          body: [{key, value: nextValue}],
+          withCredentials: true,
+        }),
+      ).pipe(
+        map((response) => {
+          keyValueLoader.clear(key) // Clear the cache for this key
+          keyValueLoader.prime(key, response.value) // Prime the cache with the new value
+          return response.value
+        }),
+        catchError((error) => {
+          console.error('Error setting data:', error)
+          return of(null) // Handle error (possibly return null or throw an error)
+        }),
+      )
+    },
+  }
+}

--- a/packages/sanity/src/core/store/key-value/backends/server.ts
+++ b/packages/sanity/src/core/store/key-value/backends/server.ts
@@ -4,16 +4,11 @@ import {catchError, from, map, of} from 'rxjs'
 
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../studioClient'
 import {type KeyValueStoreValue} from '../types'
-import {type Backend} from './types'
+import {type Backend, type KeyValuePair} from './types'
 
 /** @internal */
 export interface ServerBackendOptions {
   client: SanityClient
-}
-
-interface KeyValuePair {
-  key: string
-  value: KeyValueStoreValue
 }
 
 /**
@@ -26,20 +21,17 @@ export function serverBackend({client: _client}: ServerBackendOptions): Backend 
 
   const keyValueLoader = new DataLoader<string, KeyValueStoreValue | null>(async (keys) => {
     const value = await client
-      .request<(KeyValuePair | null)[]>({
+      .request<KeyValuePair[]>({
         uri: `/users/me/keyvalue/${keys.join(',')}`,
         withCredentials: true,
       })
       .catch((error) => {
-        // const value = await fetch(`http://localhost:5000/vX/users/me/keyvalue/${keys.join(',')}`)
-        // .catch((error) => {
         if (error.response?.statusCode === 404) {
           return Array(keys.length).fill(null)
         }
         throw error
       })
-    const response = Array.isArray(value) ? value : [value]
-    const keyValuePairs = response.reduce(
+    const keyValuePairs = value.reduce(
       (acc, next) => {
         if (next?.key) {
           acc[next.key] = next.value
@@ -48,25 +40,26 @@ export function serverBackend({client: _client}: ServerBackendOptions): Backend 
       },
       {} as Record<string, KeyValueStoreValue | null>,
     )
-    return keys.map((key) => keyValuePairs[key] || null)
+
+    const result = keys.map((key) => keyValuePairs[key] || null)
+    return result
   })
 
   return {
-    get: (key: string, defaultValue: unknown) => {
+    getKey: (key: string, defaultValue: unknown) => {
       return from(keyValueLoader.load(key)).pipe(
-        map((value) => value ?? defaultValue),
+        map((value) => {
+          return value ?? defaultValue
+        }),
         catchError((error) => {
-          if (error.statusCode !== 404) {
-            console.error('Error fetching data:', error)
-          }
-
-          return of(defaultValue) // Return the default value in case of error
+          console.error('Error fetching data:', error)
+          return of(defaultValue)
         }),
       )
     },
-    set: (key: string, nextValue: unknown) => {
+    setKey: (key: string, nextValue: unknown) => {
       return from(
-        client.request({
+        client.request<KeyValuePair[]>({
           method: 'PUT',
           uri: `/users/me/keyvalue`,
           body: [{key, value: nextValue}],
@@ -74,13 +67,49 @@ export function serverBackend({client: _client}: ServerBackendOptions): Backend 
         }),
       ).pipe(
         map((response) => {
-          keyValueLoader.clear(key) // Clear the cache for this key
-          keyValueLoader.prime(key, response.value) // Prime the cache with the new value
-          return response.value
+          const newValue = response[0].value
+          if (newValue) {
+            keyValueLoader.clear(key)
+            keyValueLoader.prime(key, newValue)
+          }
+          return newValue
         }),
         catchError((error) => {
           console.error('Error setting data:', error)
-          return of(null) // Handle error (possibly return null or throw an error)
+          return of(null)
+        }),
+      )
+    },
+    getKeys: (keys: string[], defValues: unknown[]) => {
+      return from(keyValueLoader.loadMany(keys)).pipe(
+        map((values) => {
+          return values.map((value, i) => value ?? defValues[i])
+        }),
+        catchError((error) => {
+          console.error('Error fetching data:', error)
+          return of(defValues)
+        }),
+      )
+    },
+    setKeys: (keyValuePairs: KeyValuePair[]) => {
+      return from(
+        client.request<KeyValuePair[]>({
+          method: 'PUT',
+          uri: `/users/me/keyvalue`,
+          body: keyValuePairs,
+          withCredentials: true,
+        }),
+      ).pipe(
+        map((response) => {
+          response.forEach((pair) => {
+            keyValueLoader.clear(pair.key)
+            keyValueLoader.prime(pair.key, pair.value)
+          })
+          return response.map((pair: KeyValuePair) => pair.value)
+        }),
+        catchError((error) => {
+          console.error('Error setting data:', error)
+          return of(Array(keyValuePairs.length).fill(null))
         }),
       )
     },

--- a/packages/sanity/src/core/store/key-value/backends/server.ts
+++ b/packages/sanity/src/core/store/key-value/backends/server.ts
@@ -20,98 +20,56 @@ export function serverBackend({client: _client}: ServerBackendOptions): Backend 
   const client = _client.withConfig({...DEFAULT_STUDIO_CLIENT_OPTIONS, apiVersion: 'vX'})
 
   const keyValueLoader = new DataLoader<string, KeyValueStoreValue | null>(async (keys) => {
-    const value = await client
+    const keyValuePairs = await client
       .request<KeyValuePair[]>({
         uri: `/users/me/keyvalue/${keys.join(',')}`,
         withCredentials: true,
       })
       .catch((error) => {
-        if (error.response?.statusCode === 404) {
-          return Array(keys.length).fill(null)
-        }
-        throw error
+        console.error('Error fetching data:', error)
+        return Array(keys.length).fill(null)
       })
-    const keyValuePairs = value.reduce(
-      (acc, next) => {
-        if (next?.key) {
-          acc[next.key] = next.value
-        }
-        return acc
-      },
-      {} as Record<string, KeyValueStoreValue | null>,
-    )
 
-    const result = keys.map((key) => keyValuePairs[key] || null)
-    return result
+    return keyValuePairs.map((pair) => pair.value)
   })
 
+  const getKeys = (keys: string[]) => {
+    return from(keyValueLoader.loadMany(keys))
+  }
+
+  const setKeys = (keyValuePairs: KeyValuePair[]) => {
+    return from(
+      client.request<KeyValuePair[]>({
+        method: 'PUT',
+        uri: `/users/me/keyvalue`,
+        body: keyValuePairs,
+        withCredentials: true,
+      }),
+    ).pipe(
+      map((response) => {
+        response.forEach((pair) => {
+          keyValueLoader.clear(pair.key)
+          keyValueLoader.prime(pair.key, pair.value)
+        })
+        return response.map((pair) => pair.value)
+      }),
+      catchError((error) => {
+        console.error('Error setting data:', error)
+        return of(Array(keyValuePairs.length).fill(null))
+      }),
+    )
+  }
+
   return {
-    getKey: (key: string, defaultValue: unknown) => {
-      return from(keyValueLoader.load(key)).pipe(
-        map((value) => {
-          return value ?? defaultValue
-        }),
-        catchError((error) => {
-          console.error('Error fetching data:', error)
-          return of(defaultValue)
-        }),
-      )
+    getKey: (key: string) => {
+      return getKeys([key]).pipe(map((values) => values[0]))
     },
     setKey: (key: string, nextValue: unknown) => {
-      return from(
-        client.request<KeyValuePair[]>({
-          method: 'PUT',
-          uri: `/users/me/keyvalue`,
-          body: [{key, value: nextValue}],
-          withCredentials: true,
-        }),
-      ).pipe(
-        map((response) => {
-          const newValue = response[0].value
-          if (newValue) {
-            keyValueLoader.clear(key)
-            keyValueLoader.prime(key, newValue)
-          }
-          return newValue
-        }),
-        catchError((error) => {
-          console.error('Error setting data:', error)
-          return of(null)
-        }),
+      return setKeys([{key, value: nextValue as KeyValueStoreValue}]).pipe(
+        map((values) => values[0]),
       )
     },
-    getKeys: (keys: string[], defValues: unknown[]) => {
-      return from(keyValueLoader.loadMany(keys)).pipe(
-        map((values) => {
-          return values.map((value, i) => value ?? defValues[i])
-        }),
-        catchError((error) => {
-          console.error('Error fetching data:', error)
-          return of(defValues)
-        }),
-      )
-    },
-    setKeys: (keyValuePairs: KeyValuePair[]) => {
-      return from(
-        client.request<KeyValuePair[]>({
-          method: 'PUT',
-          uri: `/users/me/keyvalue`,
-          body: keyValuePairs,
-          withCredentials: true,
-        }),
-      ).pipe(
-        map((response) => {
-          response.forEach((pair) => {
-            keyValueLoader.clear(pair.key)
-            keyValueLoader.prime(pair.key, pair.value)
-          })
-          return response.map((pair: KeyValuePair) => pair.value)
-        }),
-        catchError((error) => {
-          console.error('Error setting data:', error)
-          return of(Array(keyValuePairs.length).fill(null))
-        }),
-      )
-    },
+    getKeys,
+    setKeys,
   }
 }

--- a/packages/sanity/src/core/store/key-value/backends/types.ts
+++ b/packages/sanity/src/core/store/key-value/backends/types.ts
@@ -8,8 +8,8 @@ export interface KeyValuePair {
 }
 
 export interface Backend {
-  getKey: (key: string, defValue: unknown) => Observable<unknown>
+  getKey: (key: string) => Observable<unknown>
   setKey: (key: string, nextValue: unknown) => Observable<unknown>
-  getKeys: (keys: string[], defValues: unknown[]) => Observable<unknown[]>
+  getKeys: (keys: string[]) => Observable<unknown[]>
   setKeys: (keyValuePairs: KeyValuePair[]) => Observable<unknown[]>
 }

--- a/packages/sanity/src/core/store/key-value/backends/types.ts
+++ b/packages/sanity/src/core/store/key-value/backends/types.ts
@@ -1,6 +1,15 @@
 import {type Observable} from 'rxjs'
 
+import {type KeyValueStoreValue} from '../types'
+
+export interface KeyValuePair {
+  key: string
+  value: KeyValueStoreValue | null
+}
+
 export interface Backend {
-  get: (key: string, defValue: unknown) => Observable<unknown>
-  set: (key: string, nextValue: unknown) => Observable<unknown>
+  getKey: (key: string, defValue: unknown) => Observable<unknown>
+  setKey: (key: string, nextValue: unknown) => Observable<unknown>
+  getKeys: (keys: string[], defValues: unknown[]) => Observable<unknown[]>
+  setKeys: (keyValuePairs: KeyValuePair[]) => Observable<unknown[]>
 }

--- a/packages/sanity/src/core/store/key-value/types.ts
+++ b/packages/sanity/src/core/store/key-value/types.ts
@@ -11,6 +11,6 @@ export type KeyValueStoreValue = JsonPrimitive | JsonObject | JsonArray
 
 /** @internal */
 export interface KeyValueStore {
-  getKey(key: string, defaultValue?: KeyValueStoreValue): Observable<KeyValueStoreValue | undefined>
-  setKey(key: string, value: KeyValueStoreValue): void
+  getKey(key: string): Observable<KeyValueStoreValue | null>
+  setKey(key: string, value: KeyValueStoreValue): Observable<KeyValueStoreValue>
 }

--- a/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
@@ -109,8 +109,8 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
   const typeName = useMemo(() => getTypeNameFromSingleTypeFilter(filter, params), [filter, params])
   const showIcons = displayOptions?.showIcons !== false
   const [layout, setLayout] = useStructureToolSetting<GeneralPreviewLayoutKey>(
-    typeName,
     'layout',
+    typeName,
     defaultLayout,
   )
 
@@ -132,8 +132,8 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
   }, [defaultOrdering])
 
   const [sortOrderRaw, setSortOrder] = useStructureToolSetting<SortOrder>(
+    'sort-order',
     typeName,
-    'sortOrder',
     defaultSortOrder,
   )
 

--- a/packages/sanity/src/structure/useStructureToolSetting.ts
+++ b/packages/sanity/src/structure/useStructureToolSetting.ts
@@ -1,8 +1,9 @@
 import {useCallback, useEffect, useMemo, useState} from 'react'
-import {startWith} from 'rxjs/operators'
+import {map, startWith} from 'rxjs/operators'
 import {useKeyValueStore} from 'sanity'
 
 const STRUCTURE_TOOL_NAMESPACE = 'studio.structure-tool'
+
 /**
  * @internal
  */
@@ -21,9 +22,16 @@ export function useStructureToolSetting<ValueType>(
   }, [keyValueStore, keyValueStoreKey])
 
   useEffect(() => {
-    const sub = settings.pipe(startWith(defaultValue)).subscribe({
-      next: setValue as any,
-    })
+    const sub = settings
+      .pipe(
+        startWith(defaultValue),
+        map((fetchedValue) => {
+          return fetchedValue === null ? defaultValue : fetchedValue
+        }),
+      )
+      .subscribe({
+        next: setValue as any,
+      })
 
     return () => sub?.unsubscribe()
   }, [defaultValue, keyValueStoreKey, settings])

--- a/packages/sanity/src/structure/useStructureToolSetting.ts
+++ b/packages/sanity/src/structure/useStructureToolSetting.ts
@@ -2,20 +2,19 @@ import {useCallback, useEffect, useMemo, useState} from 'react'
 import {startWith} from 'rxjs/operators'
 import {useKeyValueStore} from 'sanity'
 
+const STRUCTURE_TOOL_NAMESPACE = 'studio.structure-tool'
 /**
  * @internal
  */
 export function useStructureToolSetting<ValueType>(
   namespace: string | null,
-  key: string,
+  key: string | null,
   defaultValue?: ValueType,
 ): [ValueType | undefined, (_value: ValueType) => void] {
   const keyValueStore = useKeyValueStore()
   const [value, setValue] = useState<ValueType | undefined>(defaultValue)
 
-  const keyValueStoreKey = namespace
-    ? `structure-tool::${namespace}::${key}`
-    : `structure-tool::${key}`
+  const keyValueStoreKey = `${STRUCTURE_TOOL_NAMESPACE}.${namespace}.${key}`
 
   const settings = useMemo(() => {
     return keyValueStore.getKey(keyValueStoreKey)

--- a/test/e2e/tests/desk/documentTypeListContextMenu.spec.ts
+++ b/test/e2e/tests/desk/documentTypeListContextMenu.spec.ts
@@ -1,51 +1,63 @@
 import {expect} from '@playwright/test'
 import {test} from '@sanity/test'
 
-const SORT_KEY = 'structure-tool::author::sortOrder'
-const LAYOUT_KEY = 'structure-tool::author::layout'
+const SORT_KEY = 'studio.structure-tool.sort-order.author'
+const LAYOUT_KEY = 'studio.structure-tool.layout.author'
 
 //we should also check for custom sort orders
-test('clicking sort order and direction sets value in storage', async ({page}) => {
+test('clicking sort order and direction sets value in storage', async ({page, sanityClient}) => {
   await page.goto('/test/content/author')
   await page.getByTestId('pane').getByTestId('pane-context-menu-button').click()
   await page.getByRole('menuitem', {name: 'Sort by Name'}).click()
-  const localStorage = await page.evaluate(() => window.localStorage)
-
-  expect(localStorage[SORT_KEY]).toBe(
-    '{"by":[{"field":"name","direction":"asc"}],"extendedProjection":"name"}',
-  )
+  const nameResult = await sanityClient.request({
+    uri: `/users/me/keyvalue/${SORT_KEY}`,
+    withCredentials: true,
+  })
+  expect(nameResult[0]).toMatchObject({
+    key: SORT_KEY,
+    value: {
+      by: [{field: 'name', direction: 'asc'}],
+      extendedProjection: 'name',
+    },
+  })
 
   await page.getByTestId('pane').getByTestId('pane-context-menu-button').click()
   await page.getByRole('menuitem', {name: 'Sort by Last Edited'}).click()
-  const lastEditedLocalStorage = await page.evaluate(() => window.localStorage)
+  const lastEditedResult = await sanityClient.request({
+    uri: `/users/me/keyvalue/${SORT_KEY}`,
+    withCredentials: true,
+  })
 
-  expect(lastEditedLocalStorage[SORT_KEY]).toBe(
-    '{"by":[{"field":"_updatedAt","direction":"desc"}],"extendedProjection":""}',
-  )
+  expect(lastEditedResult[0]).toMatchObject({
+    key: SORT_KEY,
+    value: {
+      by: [{field: '_updatedAt', direction: 'desc'}],
+      extendedProjection: '',
+    },
+  })
 })
 
-test('clicking list view sets value in storage', async ({page}) => {
+test('clicking list view sets value in storage', async ({page, sanityClient}) => {
   await page.goto('/test/content/author')
   await page.getByTestId('pane').getByTestId('pane-context-menu-button').click()
   await page.getByRole('menuitem', {name: 'Detailed view'}).click()
-  const localStorage = await page.evaluate(() => window.localStorage)
-
-  expect(localStorage[LAYOUT_KEY]).toBe('"detail"')
+  const detailResult = await sanityClient.request({
+    uri: `/users/me/keyvalue/${LAYOUT_KEY}`,
+    withCredentials: true,
+  })
+  expect(detailResult[0]).toMatchObject({
+    key: LAYOUT_KEY,
+    value: 'detail',
+  })
 
   await page.getByTestId('pane').getByTestId('pane-context-menu-button').click()
   await page.getByRole('menuitem', {name: 'Compact view'}).click()
-  const compactLocalStorage = await page.evaluate(() => window.localStorage)
-
-  expect(compactLocalStorage[LAYOUT_KEY]).toBe('"default"')
-})
-
-test('values persist after navigating away and back', async ({page}) => {
-  await page.goto('/test/content/author')
-  await page.getByTestId('pane').getByTestId('pane-context-menu-button').click()
-  await page.getByRole('menuitem', {name: 'Detailed view'}).click()
-  await page.goto('https://example.com')
-  await page.goto('/test/content/author')
-  const localStorage = await page.evaluate(() => window.localStorage)
-
-  expect(localStorage[LAYOUT_KEY]).toBe('"detail"')
+  const compactResult = await sanityClient.request({
+    uri: `/users/me/keyvalue/${LAYOUT_KEY}`,
+    withCredentials: true,
+  })
+  expect(detailResult[0]).toMatchObject({
+    key: LAYOUT_KEY,
+    value: 'default',
+  })
 })


### PR DESCRIPTION
### Description
Scaffolds a Dataloader that hits an API endpoint for user settings -- in this case, specifically those settings relevant to structure tools.

This is meant to be just a scaffold. In the following day, please expect:
- unit tests for hooks to handle malformed or null data
- any additional error handling that can be called out here
- possible fallbacks for situations if the API is not available.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

The Dataloader backend specifically -- does it work as we expect? Any gotchas? Are errors being handled correctly?

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

End-to-end tests are already in place. They've been refactored since they referred to localStorage changes.
