### PR TITLE
Update fieldProps.ts

### DIFF
--- a/packages/sanity/src/core/form/types/fieldProps.ts
+++ b/packages/sanity/src/core/form/types/fieldProps.ts
@@ -66,9 +66,9 @@ export interface BaseFieldProps {
 /**
  * @hidden
  * @public */
-export interface ObjectFieldProps<T = Record<string, any>> extends BaseFieldProps {
+export interface ObjectFieldProps<T = Record<string, unknown>> extends BaseFieldProps {
   schemaType: ObjectSchemaType
-  value: {[field in string]: unknown} | undefined
+  value: T | undefined
   collapsed?: boolean
   collapsible?: boolean
   onCollapse: () => void


### PR DESCRIPTION
### Description

#### What changes are introduced?
I changed some TS typing information related to custom schema component props.

#### Why are these changes introduced?
It intends to fix some TS type errors.

#### What issue(s) does this solve? (with link, if possible)
The changes were to address something like this:
```ts
defineField({
  name: 'path',
  type: 'slug',
  components: {
    field: (props: ObjectFieldProps<SlugValue>) => {
      const doSomething = (value?: string) => {
        // something
      }
      return (
        <Stack padding={0} space={[3, 3, 4, 5]}>
          {props.renderDefault(props)}
          <Button disabled={!props.value} onClick={() => doSomething(props.value?.current)}>example</Button>
        </Stack>
      );
    }
  }
}),
```

I initially tried using the broader `FieldProps` type for `props` parameter but trying to use `props.value?.current` gives this TS error:
```
Property 'current' does not exist on type 'string | number | boolean | SlugValue | CrossDatasetReferenceValue | FileValue | GeopointValue | ImageValue | Record<...> | Reference | unknown[]'.
  Property 'current' does not exist on type 'string'.ts(2339)
```

So I changed it to use the more specific `ObjectFieldProps<SlugValue>` props value, however this had the issue where the `current` value is set as `unknown` even though it's type should be known via `SlugValue` type.

I changed the `ObjectFieldProps` definition to apply the `T` template variable type to the `value` object so that it's type can be inferred based on the provided Object type (`SlugValue` in this case).

### What to review

The changes only apply to TS error messages related to custom schema components' field props. The example above should be good enough to reproduce the issue, just adding this to your schema. The example above includes some components from `@sanity/ui` as is described in the docs.

### Testing

I didn't really test beyond my specific use case with `ObjectFieldProps<SlugValue>`. Someone should probably have a look that these changes apply properly to the rest of the `FieldProps` generic type options:
```
  | ObjectFieldProps
  | ObjectFieldProps<CrossDatasetReferenceValue>
  | ObjectFieldProps<FileValue>
  | ObjectFieldProps<GeopointValue>
  | ObjectFieldProps<ImageValue>
  | ObjectFieldProps<ReferenceValue>
  | ObjectFieldProps<SlugValue>
```

Apologies if I've done this wrong. I don't typically send out pull requests like this 🤷 ✌️ 