### PR TITLE
feat(cli): improve migration runner output

### DIFF
--- a/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
@@ -118,7 +118,7 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
     if (resolvedScripts.length > 1) {
       // todo: consider prompt user about which one to run? note: it's likely a mistake if multiple files resolve to the same name
       throw new Error(
-        `Found multiple migrations for "${id}" in the ${chalk.cyan(migrationsDirectoryPath)} directory: \n - ${candidates
+        `Found multiple migrations for "${id}" in ${chalk.cyan(migrationsDirectoryPath)}: \n - ${candidates
           .map((candidate) => path.relative(migrationsDirectoryPath, candidate.absolutePath))
           .join('\n - ')}`,
       )
@@ -127,7 +127,7 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
     const script = resolvedScripts[0]
     if (!script) {
       throw new Error(
-        `No migration found for "${id}" in the ${chalk.cyan(chalk.cyan(migrationsDirectoryPath))} directory. Make sure that the migration file exists and exports a valid migration as its default export.\n
+        `No migration found for "${id}" in ${chalk.cyan(chalk.cyan(migrationsDirectoryPath))}. Make sure that the migration file exists and exports a valid migration as its default export.\n
  Tried the following files:\n - ${candidates
    .map((candidate) => path.relative(migrationsDirectoryPath, candidate.absolutePath))
    .join('\n - ')}`,

--- a/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
@@ -117,9 +117,9 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
     if (resolvedScripts.length > 1) {
       // todo: consider prompt user about which one to run? note: it's likely a mistake if multiple files resolve to the same name
       throw new Error(
-        `Found multiple migrations for "${id}" in the ${chalk.cyan(path.join(workDir, MIGRATIONS_DIRECTORY))} directory: ${candidates
+        `Found multiple migrations for "${id}" in the ${chalk.cyan(path.join(workDir, MIGRATIONS_DIRECTORY))} directory: \n - ${candidates
           .map((candidate) => path.basename(candidate.relativePath))
-          .join(', ')}`,
+          .join('\n - ')}`,
       )
     }
 

--- a/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
@@ -73,6 +73,7 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
   action: async (args, context) => {
     const {apiClient, output, prompt, chalk, workDir} = context
     const [id] = args.argsWithoutOptions
+    const migrationsDirectoryPath = path.join(workDir, MIGRATIONS_DIRECTORY)
 
     const flags = await parseCliFlags(args)
 
@@ -117,8 +118,8 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
     if (resolvedScripts.length > 1) {
       // todo: consider prompt user about which one to run? note: it's likely a mistake if multiple files resolve to the same name
       throw new Error(
-        `Found multiple migrations for "${id}" in the ${chalk.cyan(path.join(workDir, MIGRATIONS_DIRECTORY))} directory: \n - ${candidates
-          .map((candidate) => path.basename(candidate.relativePath))
+        `Found multiple migrations for "${id}" in the ${chalk.cyan(migrationsDirectoryPath)} directory: \n - ${candidates
+          .map((candidate) => path.relative(migrationsDirectoryPath, candidate.absolutePath))
           .join('\n - ')}`,
       )
     }
@@ -126,9 +127,9 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
     const script = resolvedScripts[0]
     if (!script) {
       throw new Error(
-        `No migration found for "${id}" in the ${chalk.cyan(path.join(workDir, MIGRATIONS_DIRECTORY))} directory. Make sure that the migration file exists and exports a valid migration as its default export.\n
+        `No migration found for "${id}" in the ${chalk.cyan(chalk.cyan(migrationsDirectoryPath))} directory. Make sure that the migration file exists and exports a valid migration as its default export.\n
  Tried the following files:\n - ${candidates
-   .map((candidate) => path.basename(candidate.absolutePath))
+   .map((candidate) => path.relative(migrationsDirectoryPath, candidate.absolutePath))
    .join('\n - ')}`,
       )
     }

--- a/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
@@ -1,3 +1,5 @@
+import path from 'node:path'
+
 import {type CliCommandDefinition} from '@sanity/cli'
 import {
   DEFAULT_MUTATION_CONCURRENCY,
@@ -13,6 +15,7 @@ import {hideBin} from 'yargs/helpers'
 import yargs from 'yargs/yargs'
 
 import {debug} from '../../debug'
+import {MIGRATIONS_DIRECTORY} from './constants'
 import {resolveMigrations} from './listMigrationsCommand'
 import {prettyFormat} from './prettyMutationFormatter'
 import {isLoadableMigrationScript, resolveMigrationScript} from './utils/resolveMigrationScript'
@@ -114,8 +117,8 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
     if (resolvedScripts.length > 1) {
       // todo: consider prompt user about which one to run? note: it's likely a mistake if multiple files resolve to the same name
       throw new Error(
-        `Found multiple migrations for "${id}" in current directory ${candidates
-          .map((candidate) => candidate!.relativePath)
+        `Found multiple migrations for "${id}" in the ${chalk.cyan(path.join(workDir, MIGRATIONS_DIRECTORY))} directory: ${candidates
+          .map((candidate) => path.basename(candidate.relativePath))
           .join(', ')}`,
       )
     }
@@ -123,9 +126,9 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
     const script = resolvedScripts[0]
     if (!script) {
       throw new Error(
-        `No migration found for "${id}" in current directory. Make sure that the migration file exists and exports a valid migration as its default export.\n
+        `No migration found for "${id}" in the ${chalk.cyan(path.join(workDir, MIGRATIONS_DIRECTORY))} directory. Make sure that the migration file exists and exports a valid migration as its default export.\n
  Tried the following files:\n - ${candidates
-   .map((candidate) => candidate.relativePath)
+   .map((candidate) => path.basename(candidate.absolutePath))
    .join('\n - ')}`,
       )
     }


### PR DESCRIPTION
### Description

The `migration run` commands can be run from any Studio project subdirectory, but their output messages currently assume the user is in the project root. This branch  makes the output clearer, and adds consistent list formatting when multiple migrations are found.

#### Before

##### When no migrations found

```
sanity migration run nonexistent
```

```
Not in project directory, assuming context of project at /Users/ash/projects/sanity/dev/test-studio

Error: No migration found for "nonexistent" in current directory. Make sure that the migration file exists and exports a valid migration as its default export.
 Tried the following files:
 - migrations/nonexistent.mjs
 - migrations/nonexistent.js
 - migrations/nonexistent.ts
 - migrations/nonexistent.cjs
 - migrations/nonexistent/index.mjs
 - migrations/nonexistent/index.js
 - migrations/nonexistent/index.ts
 - migrations/nonexistent/index.cjs
 ```

##### When multiple migrations found

```
sanity migration run multiple
```

```
Not in project directory, assuming context of project at /Users/ash/projects/sanity/dev/test-studio

Error: Found multiple migrations for "multiple" in current directory migrations/multiple.mjs, migrations/multiple.js, migrations/multiple.ts, migrations/multiple.cjs, migrations/multiple/index.mjs, migrations/multiple/index.js, migrations/multiple/index.ts, migrations/multiple/index.cjs
```

#### After

##### When no migrations found

```
sanity migration run nonexistent
```

```
Not in project directory, assuming context of project at /Users/ash/projects/sanity/dev/test-studio

Error: No migration found for "nonexistent" in the /Users/ash/projects/sanity/dev/test-studio/migrations directory. Make sure that the migration file exists and exports a valid migration as its default export.
 Tried the following files:
 - nonexistent.mjs
 - nonexistent.js
 - nonexistent.ts
 - nonexistent.cjs
 - nonexistent/index.mjs
 - nonexistent/index.js
 - nonexistent/index.ts
 - nonexistent/index.cjs
 ```

##### When multiple migrations found

```
sanity migration run multiple
```

```
Not in project directory, assuming context of project at /Users/ash/projects/sanity/dev/test-studio

Error: Found multiple migrations for "multiple" in the /Users/ash/projects/sanity/dev/test-studio/migrations directory:
 - multiple.mjs
 - multiple.js
 - multiple.ts
 - multiple.cjs
 - multiple/index.mjs
 - multiple/index.js
 - multiple/index.ts
 - multiple/index.cjs
```

### What to review

Do the adjusted output messages make sense?

### Testing

Attempt to run migrations that are nonexistent, or have multiple matching scripts, from both a Studio project root directory and a Studio project subdirectory.
