### PR TITLE
fix(cli): use inferred project root when creating migrations from subdirectory

### DIFF
--- a/packages/sanity/src/_internal/cli/commands/migration/createMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/createMigrationCommand.ts
@@ -76,12 +76,12 @@ const createMigrationCommand: CliCommandDefinition<CreateMigrationFlags> = {
       .replace(/\s+/g, '-')
       .replace(/[^a-z0-9-]/g, '')
 
-    const destDir = path.join(MIGRATIONS_DIRECTORY, sluggedName)
+    const destDir = path.join(workDir, MIGRATIONS_DIRECTORY, sluggedName)
     if (existsSync(destDir)) {
       if (
         !(await prompt.single({
           type: 'confirm',
-          message: `Migration directory ./${destDir} already exists. Overwrite?`,
+          message: `Migration directory ${chalk.cyan(destDir)} already exists. Overwrite?`,
           default: false,
         }))
       ) {
@@ -100,14 +100,14 @@ const createMigrationCommand: CliCommandDefinition<CreateMigrationFlags> = {
 
     const definitionFile = path.join(destDir, 'index.ts')
 
-    await writeFile(path.join(workDir, definitionFile), renderedTemplate)
+    await writeFile(definitionFile, renderedTemplate)
     // To dry run it, run \`sanity migration run ${sluggedName}\``)
     output.print()
     output.print(`${chalk.green('✓')} Migration created!`)
     output.print()
     output.print('Next steps:')
     output.print(
-      `Open ./${chalk.bold(
+      `Open ${chalk.bold(
         definitionFile,
       )} in your code editor and write the code for your migration.`,
     )


### PR DESCRIPTION
### Description

When used inside a Studio project subdirectory, the CLI searches parent directories in order to infer the project root. The `migration create` command doesn't currently respect the inferred root, and will attempt to create/use a `migrations` directory in the current working directory. This behaviour is incorrect; it's impossible to run migrations located anywhere other than the `migrations` directory in the project root.

This branch makes `migration create` command respect the inferred project root.

### What to review

Does this fix make sense?

### Testing

Attempt to create a migration from a Studio project subdirectory. The migration should always be added to the `migrations` directory in the project root.