### PR TITLE
fix(comments): loading state

### DIFF
--- a/packages/sanity/src/structure/comments/plugin/inspector/CommentsInspector.tsx
+++ b/packages/sanity/src/structure/comments/plugin/inspector/CommentsInspector.tsx
@@ -80,7 +80,7 @@ function CommentsInspectorInner(
 
   const pushToast = useToast().push
   const {isTopLayer} = useLayer()
-  const {onPathOpen, ready} = useDocumentPane()
+  const {onPathOpen, connectionState} = useDocumentPane()
 
   const {scrollToComment, scrollToField, scrollToInlineComment} = useCommentsScroll()
   const {selectedPath, setSelectedPath} = useCommentsSelectedPath()
@@ -93,12 +93,8 @@ function CommentsInspectorInner(
   const currentComments = useMemo(() => comments.data[status], [comments, status])
 
   const loading = useMemo(() => {
-    // The comments and the document are loaded separately which means that
-    // the comments might be ready before the document is ready. Since the user should
-    // be able to interact with the document from the comments inspector, we need to make sure
-    // that the document is ready before we allow the user to interact with the comments.
-    return comments.loading || !ready
-  }, [comments.loading, ready])
+    return comments.loading || connectionState === 'connecting'
+  }, [comments.loading, connectionState])
 
   useEffect(() => {
     if (mode === 'upsell') {


### PR DESCRIPTION
### Description

This pull request changes the behavior to display the comments loading state when:

- Comments are loading
- The `connectionState` of the form is "connecting"

Previously, we utilized the `ready` value from `useDocumentPane`, which caused the comments to show a loading state whenever the form was _reconnecting_. This behavior is undesirable because a comment that a user is in the process of writing will disappear if the form is "reconnecting".

### What to review

- Ensure that the comments list does not load when the `connectionState` is "reconnecting"


### Notes for release

N/A
