### PR TITLE
fix(core): update placeholder text to be more clear and accessible

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1034,7 +1034,7 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
    */
   'new-document.create-new-document-label': 'New document…',
   /** Placeholder for the "filter" input within the new document menu */
-  'new-document.filter-placeholder': 'Filter',
+  'new-document.filter-placeholder': 'Search document types',
   /** Loading indicator text within the new document menu */
   'new-document.loading': 'Loading…',
   /** Accessibility label for the list displaying options in the new document menu */


### PR DESCRIPTION
### Description

Fixes EDX-1123

Updates copy for placeholder text

Before:
<img width="365" alt="image" src="https://github.com/sanity-io/sanity/assets/6889008/7cef3ddd-8a44-4ef4-97b7-7a17034ad92a">

After:
<img width="334" alt="image" src="https://github.com/sanity-io/sanity/assets/6889008/bf61d12f-077e-4949-ad18-d087ac6eda4e">

### What to review

Typos?

### Testing

Copy only change, no functional change

