### PR TITLE
fix(core): clean up edit state listeners

### DIFF
--- a/packages/sanity/src/core/hooks/useEditState.ts
+++ b/packages/sanity/src/core/hooks/useEditState.ts
@@ -1,6 +1,5 @@
 import {useMemoObservable} from 'react-rx'
-import {merge, timer} from 'rxjs'
-import {debounce, share, skip, take} from 'rxjs/operators'
+import {debounce, merge, share, skip, take, timer} from 'rxjs'
 
 import {type EditStateFor, useDocumentStore} from '../store'
 
@@ -13,8 +12,9 @@ export function useEditState(
   const documentStore = useDocumentStore()
 
   return useMemoObservable(() => {
-    const base = documentStore.pair.editState(publishedDocId, docTypeName).pipe(share())
     if (priority === 'low') {
+      const base = documentStore.pair.editState(publishedDocId, docTypeName).pipe(share())
+
       return merge(
         base.pipe(take(1)),
         base.pipe(
@@ -23,6 +23,7 @@ export function useEditState(
         ),
       )
     }
+
     return documentStore.pair.editState(publishedDocId, docTypeName)
   }, [documentStore.pair, publishedDocId, docTypeName, priority]) as EditStateFor
 }

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/memoizedPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/memoizedPair.ts
@@ -14,7 +14,10 @@ export const memoizedPair: (
 ) => Observable<Pair> = memoize(
   (client: SanityClient, idPair: IdPair, _typeName: string): Observable<Pair> => {
     return new Observable<Pair>((subscriber) => {
-      subscriber.next(checkoutPair(client, idPair))
+      const pair = checkoutPair(client, idPair)
+      subscriber.next(pair)
+
+      return pair.complete
     }).pipe(publishReplay(1), refCount())
   },
   memoizeKeyGen,


### PR DESCRIPTION
### Description

The following PR adds a `complete()` method to the document pair interface so that `memoizedPair` can close open connections.

Before:

https://github.com/sanity-io/sanity/assets/10551026/c035a6cf-3bac-4b93-be47-390d49ae3374

After:

https://github.com/sanity-io/sanity/assets/10551026/008fc3c3-ea64-4155-b393-a51eb70b428f

### What to review

Try reproducing the related bug. You should not be able to see it any more.

### Testing

Did lots of manual testing and debugging. We should get

### Notes for release

Fixes a bug that caused listener to stay open causing slow document lists and other related crashes.
